### PR TITLE
Fix Dockerfile cache permissions and add capacity-based eviction

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -292,7 +292,8 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     extraEnv,
   });
 
-  const lifecycle = createLifecycleManager({ db, orchestrator });
+  const maxRunning = Number(process.env.MAX_RUNNING_CONTAINERS) || 20;
+  const lifecycle = createLifecycleManager({ db, orchestrator, maxRunning });
   lifecycle.start();
 
   // Clerk JWT verification (optional -- only active when CLERK_SECRET_KEY is set)


### PR DESCRIPTION
## Summary
- Fix Dockerfile: merge build stages and fix .next cache permissions (resolves EACCES errors in user containers)
- Add capacity-based container eviction instead of fixed idle timeout

## Test plan
- [ ] Verify new containers no longer show EACCES permission errors for .next cache
- [ ] Verify container eviction triggers based on capacity thresholds
- [ ] Confirm existing containers remain healthy after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container lifecycle management now enforces a maximum running containers limit with a safety floor for idle container eviction.

* **Chores**
  * Optimized Docker multi-stage build process with version metadata tracking.
  * Added MAX_RUNNING_CONTAINERS environment variable configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->