### PR TITLE
Add party page for Claude Code Birthday event

### DIFF
--- a/.claude/skills/clerk
+++ b/.claude/skills/clerk
@@ -1,1 +1,0 @@
-../../.agents/skills/clerk

--- a/.claude/skills/clerk-custom-ui
+++ b/.claude/skills/clerk-custom-ui
@@ -1,1 +1,0 @@
-../../.agents/skills/clerk-custom-ui

--- a/.claude/skills/clerk-nextjs-patterns
+++ b/.claude/skills/clerk-nextjs-patterns
@@ -1,1 +1,0 @@
-../../.agents/skills/clerk-nextjs-patterns

--- a/.claude/skills/clerk-orgs
+++ b/.claude/skills/clerk-orgs
@@ -1,1 +1,0 @@
-../../.agents/skills/clerk-orgs

--- a/.claude/skills/clerk-setup
+++ b/.claude/skills/clerk-setup
@@ -1,1 +1,0 @@
-../../.agents/skills/clerk-setup

--- a/.claude/skills/clerk-testing
+++ b/.claude/skills/clerk-testing
@@ -1,1 +1,0 @@
-../../.agents/skills/clerk-testing

--- a/.claude/skills/clerk-webhooks
+++ b/.claude/skills/clerk-webhooks
@@ -1,1 +1,0 @@
-../../.agents/skills/clerk-webhooks

--- a/shell/src/app/globals.css
+++ b/shell/src/app/globals.css
@@ -35,14 +35,15 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: #f0eaf4;
-  --sidebar-foreground: #1c1917;
-  --sidebar-primary: #c2703a;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #ece5f0;
-  --sidebar-accent-foreground: #44403c;
-  --sidebar-border: #d8d0de;
-  --sidebar-ring: #c2703a;
+  /* Sidebar vars derive from theme -- updated dynamically via useTheme */
+  --sidebar: var(--secondary);
+  --sidebar-foreground: var(--foreground);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: var(--accent);
+  --sidebar-accent-foreground: var(--accent-foreground);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
 }
 
 @theme inline {

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -73,6 +73,7 @@ interface ModuleMeta {
   name: string;
   entry?: string;
   entryPoint?: string;
+  icon?: string;
   version?: string;
 }
 
@@ -294,13 +295,15 @@ export function Desktop({ storeOpen, onToggleStore }: DesktopProps) {
       .finally(() => generatingRef.current.delete(slug));
   }, []);
 
-  const addApp = useCallback((name: string, path: string) => {
+  const addApp = useCallback((name: string, path: string, moduleIconUrl?: string) => {
     setApps((prev) => {
       if (prev.find((a) => a.path === path)) return prev;
-      return [...prev, { name, path }];
+      return [...prev, { name, path, iconUrl: moduleIconUrl }];
     });
-    const slug = nameToSlug(name);
-    checkAndGenerateIcon(slug);
+    if (!moduleIconUrl) {
+      const slug = nameToSlug(name);
+      checkAndGenerateIcon(slug);
+    }
   }, [checkAndGenerateIcon]);
 
   const openWindow = useCallback((name: string, path: string) => {
@@ -365,7 +368,10 @@ export function Desktop({ storeOpen, onToggleStore }: DesktopProps) {
           const entryFile = meta.entry ?? meta.entryPoint ?? "index.html";
           const path = `modules/${mod.name}/${entryFile}`;
 
-          addApp(meta.name, path);
+          const moduleIconUrl = meta.icon
+            ? `${GATEWAY_URL}/files/modules/${mod.name}/${meta.icon}`
+            : undefined;
+          addApp(meta.name, path, moduleIconUrl);
 
           const saved = layoutMap.get(path);
           if (saved) {

--- a/shell/src/lib/theme-presets.ts
+++ b/shell/src/lib/theme-presets.ts
@@ -8,6 +8,7 @@ const FONTS = {
 export const THEME_PRESETS: Theme[] = [
   {
     name: "default",
+    mode: "light",
     colors: {
       background: "#ece5f0",
       foreground: "#1c1917",
@@ -35,33 +36,35 @@ export const THEME_PRESETS: Theme[] = [
   },
   {
     name: "dark",
+    mode: "dark",
     colors: {
-      background: "#0a0a0a",
-      foreground: "#fafafa",
-      card: "#171717",
-      "card-foreground": "#fafafa",
-      popover: "#171717",
-      "popover-foreground": "#fafafa",
-      primary: "#3b82f6",
+      background: "#1a1a2e",
+      foreground: "#e0e0e0",
+      card: "#232340",
+      "card-foreground": "#e0e0e0",
+      popover: "#232340",
+      "popover-foreground": "#e0e0e0",
+      primary: "#7c6ff7",
       "primary-foreground": "#ffffff",
-      secondary: "#262626",
-      "secondary-foreground": "#a3a3a3",
-      muted: "#262626",
-      "muted-foreground": "#737373",
-      accent: "#262626",
-      "accent-foreground": "#a3a3a3",
+      secondary: "#2a2a45",
+      "secondary-foreground": "#b0b0c0",
+      muted: "#2a2a45",
+      "muted-foreground": "#8888a0",
+      accent: "#2a2a45",
+      "accent-foreground": "#b0b0c0",
       destructive: "#ef4444",
-      success: "#22c55e",
-      warning: "#eab308",
-      border: "#262626",
-      input: "#262626",
-      ring: "#3b82f6",
+      success: "#34d399",
+      warning: "#fbbf24",
+      border: "#3a3a5c",
+      input: "#3a3a5c",
+      ring: "#7c6ff7",
     },
     fonts: { ...FONTS },
     radius: "0.75rem",
   },
   {
     name: "nord",
+    mode: "dark",
     colors: {
       background: "#2e3440",
       foreground: "#eceff4",
@@ -89,6 +92,7 @@ export const THEME_PRESETS: Theme[] = [
   },
   {
     name: "dracula",
+    mode: "dark",
     colors: {
       background: "#282a36",
       foreground: "#f8f8f2",
@@ -116,6 +120,7 @@ export const THEME_PRESETS: Theme[] = [
   },
   {
     name: "solarized-light",
+    mode: "light",
     colors: {
       background: "#fdf6e3",
       foreground: "#073642",
@@ -143,6 +148,7 @@ export const THEME_PRESETS: Theme[] = [
   },
   {
     name: "solarized-dark",
+    mode: "dark",
     colors: {
       background: "#002b36",
       foreground: "#fdf6e3",

--- a/tests/shell/theme-presets.test.ts
+++ b/tests/shell/theme-presets.test.ts
@@ -71,7 +71,7 @@ describe("getPreset", () => {
     const dark = getPreset("dark");
     expect(dark).toBeDefined();
     expect(dark!.name).toBe("dark");
-    expect(dark!.colors.background).toBe("#0a0a0a");
+    expect(dark!.colors.background).toBe("#1a1a2e");
   });
 
   it("returns default preset", () => {

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -329,7 +329,7 @@ function OsMockup() {
 
 function TechStrip() {
   const items = [
-    "926 Tests Passing",
+    "1,012 Tests Passing",
     "26 IPC Tools",
     "20 Skills",
     "6 Agents",
@@ -719,14 +719,14 @@ function BentoFeatures() {
           <div className="md:col-span-2 rounded-2xl border border-border bg-card p-6 hover:shadow-lg hover:border-primary/20 transition-all duration-300 flex flex-col">
             <h3 className="text-lg font-semibold mb-1">Test-driven</h3>
             <p className="text-sm text-muted-foreground leading-relaxed flex-1">
-              Every component is tested before it ships. 993 tests across 85
+              Every component is tested before it ships. 1,012 tests across 86
               files. The OS trusts itself because it verifies itself.
             </p>
             <div className="mt-4 rounded-lg bg-secondary/70 border border-border/50 px-3 py-2 font-mono text-[11px] text-muted-foreground space-y-0.5">
               <div><span className="text-success">PASS</span> kernel/spawn.test.ts</div>
               <div><span className="text-success">PASS</span> gateway/dispatch.test.ts</div>
               <div><span className="text-success">PASS</span> cli/cli.test.ts</div>
-              <div className="pt-1 text-success">993 tests passed</div>
+              <div className="pt-1 text-success">1,012 tests passed</div>
             </div>
           </div>
 
@@ -1247,7 +1247,7 @@ function CTA() {
             />
           </a>
           <Badge variant="outline" className="text-xs font-mono">
-            926 tests passing
+            1,012 tests passing
           </Badge>
         </div>
 

--- a/www/src/app/party/page.tsx
+++ b/www/src/app/party/page.tsx
@@ -1,0 +1,201 @@
+import type { Metadata } from "next";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { GithubIcon } from "lucide-react";
+import { WaitlistButton } from "./waitlist-button";
+
+export const metadata: Metadata = {
+  title: "Matrix OS | Claude Code Birthday Party",
+  description:
+    "Matrix OS: the AI operating system where software writes itself. Featured at Claude Code's 1st Birthday Party.",
+  openGraph: {
+    title: "Matrix OS at Claude Code's Birthday Party",
+    description:
+      "The OS that builds itself. Featured at Claude Code's 1st Birthday Party in SF.",
+    url: "https://matrix-os.com/party",
+  },
+};
+
+const QR_SITE =
+  "https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=https%3A%2F%2Fmatrix-os.com&format=svg&margin=0&color=1c1917";
+const QR_X =
+  "https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=https%3A%2F%2Fx.com%2Fhamedmp&format=svg&margin=0&color=1c1917";
+
+const VIDEO_ID = "9ScmvifjV9s";
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className}>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+export default function PartyPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      {/* Minimal top bar */}
+      <nav className="px-6 pt-5 pb-2">
+        <div className="mx-auto max-w-4xl flex items-center justify-between">
+          <a href="/" className="flex items-center gap-2.5 group">
+            <img
+              src="/logo.png"
+              alt="Matrix OS"
+              className="size-7 rounded-lg shadow-sm"
+            />
+            <span className="text-sm font-semibold tracking-tight">
+              Matrix OS
+            </span>
+          </a>
+          <Badge
+            variant="outline"
+            className="border-primary/30 bg-card/80 text-primary font-mono text-[10px] tracking-[0.2em] uppercase backdrop-blur-sm py-1 px-3"
+          >
+            Claude Code Birthday
+          </Badge>
+        </div>
+      </nav>
+
+      {/* Main content */}
+      <main className="flex-1 flex items-center justify-center px-6 py-6 sm:py-4">
+        <div className="w-full max-w-4xl">
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_240px] gap-8 md:gap-10 items-start">
+
+            {/* Left: video + info */}
+            <div>
+              {/* Headline */}
+              <div className="mb-5">
+                <h1 className="text-3xl sm:text-4xl font-bold tracking-tight leading-[1.1] mb-2">
+                  The OS that{" "}
+                  <span className="font-[family-name:var(--font-caveat)] text-primary text-[1.15em]">
+                    builds itself.
+                  </span>
+                </h1>
+                <p className="text-sm text-muted-foreground leading-relaxed max-w-lg">
+                  Describe what you need. Watch it appear. Everything is a file you own.
+                </p>
+              </div>
+
+              {/* Video */}
+              <div className="rounded-2xl overflow-hidden border border-border bg-card shadow-lg aspect-video mb-5">
+                <iframe
+                  src={`https://www.youtube.com/embed/${VIDEO_ID}?rel=0&modestbranding=1`}
+                  title="Matrix OS Demo"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                  className="w-full h-full"
+                />
+              </div>
+
+              {/* Stats */}
+              <div className="flex flex-wrap gap-2 mb-5">
+                {["1,012 Tests", "6 Agents", "26 Tools", "20 Skills", "Opus 4.6"].map(
+                  (stat) => (
+                    <span
+                      key={stat}
+                      className="text-[10px] font-mono tracking-wider uppercase px-2.5 py-1 rounded-full border border-border bg-card/80 text-muted-foreground"
+                    >
+                      {stat}
+                    </span>
+                  )
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex flex-wrap gap-3">
+                <WaitlistButton />
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="h-10 px-5 text-sm rounded-xl bg-card/60 backdrop-blur-sm"
+                  asChild
+                >
+                  <a
+                    href="https://github.com/HamedMP/matrix-os"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <GithubIcon className="size-4" />
+                    Star on GitHub
+                  </a>
+                </Button>
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="h-10 px-5 text-sm rounded-xl bg-card/60 backdrop-blur-sm"
+                  asChild
+                >
+                  <a href="/whitepaper">Whitepaper</a>
+                </Button>
+              </div>
+            </div>
+
+            {/* Right: QR codes + contact */}
+            <div className="flex flex-col items-center gap-6">
+              {/* Site QR */}
+              <div className="rounded-2xl border border-border bg-card/80 backdrop-blur-sm p-5 text-center w-full">
+                <p className="text-[10px] font-mono text-muted-foreground uppercase tracking-widest mb-3">
+                  Website
+                </p>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={QR_SITE}
+                  alt="QR: matrix-os.com"
+                  width={148}
+                  height={148}
+                  className="mx-auto mb-2.5"
+                />
+                <p className="text-xs text-muted-foreground font-mono">
+                  matrix-os.com
+                </p>
+              </div>
+
+              {/* X QR */}
+              <div className="rounded-2xl border border-border bg-card/80 backdrop-blur-sm p-5 text-center w-full">
+                <p className="text-[10px] font-mono text-muted-foreground uppercase tracking-widest mb-3 flex items-center justify-center gap-1.5">
+                  <XIcon className="size-3 fill-current" />
+                  Follow / DM
+                </p>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={QR_X}
+                  alt="QR: x.com/hamedmp"
+                  width={128}
+                  height={128}
+                  className="mx-auto mb-2.5"
+                />
+                <p className="text-xs text-muted-foreground font-mono">
+                  @hamedmp
+                </p>
+              </div>
+
+              {/* Built by */}
+              <div className="rounded-2xl border border-border bg-card/80 backdrop-blur-sm p-4 text-center w-full">
+                <p className="text-[10px] text-muted-foreground uppercase tracking-widest font-mono mb-2">
+                  Built by
+                </p>
+                <p className="text-sm font-semibold mb-1">Hamed</p>
+                <a
+                  href="https://x.com/hamedmp"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+                >
+                  <XIcon className="size-3 fill-current" />
+                  @hamedmp
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="py-3 text-center">
+        <p className="text-[10px] text-muted-foreground/50">
+          Featured at Claude Code&apos;s 1st Birthday Party &middot; SF &middot; Feb 2026
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/www/src/app/party/qr/page.tsx
+++ b/www/src/app/party/qr/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Matrix OS - QR Code",
+};
+
+export default function QRPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-white px-6 py-12">
+      <img
+        src="/logo.png"
+        alt="Matrix OS"
+        className="size-12 rounded-xl mb-6"
+      />
+      <h1 className="text-lg font-bold tracking-tight text-[#111] mb-1">
+        Matrix OS
+      </h1>
+      <p className="text-xs text-[#999] mb-8">
+        Scan to learn more
+      </p>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src="https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=https%3A%2F%2Fmatrix-os.com%2Fparty&format=svg&margin=0"
+        alt="QR code to matrix-os.com/party"
+        width={300}
+        height={300}
+        className="mb-6"
+      />
+      <p className="text-xs font-mono text-[#999]">
+        matrix-os.com/party
+      </p>
+    </div>
+  );
+}

--- a/www/src/app/party/waitlist-button.tsx
+++ b/www/src/app/party/waitlist-button.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { MailIcon, XIcon } from "lucide-react";
+
+export function WaitlistButton() {
+  const [open, setOpen] = useState(false);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, close]);
+
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  // Load Tally widget script once
+  useEffect(() => {
+    if (!open) return;
+    if (document.querySelector('script[src="https://tally.so/widgets/embed.js"]')) {
+      // Script already loaded, re-trigger Tally to process new iframes
+      if (typeof window !== "undefined" && (window as any).Tally) {
+        (window as any).Tally.loadEmbeds();
+      }
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = "https://tally.so/widgets/embed.js";
+    script.async = true;
+    document.head.appendChild(script);
+  }, [open]);
+
+  return (
+    <>
+      <Button
+        size="lg"
+        className="h-10 px-6 text-sm rounded-xl"
+        onClick={() => setOpen(true)}
+      >
+        <MailIcon className="size-4" />
+        Join waitlist
+      </Button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex flex-col bg-card">
+          {/* Header */}
+          <div className="flex items-center justify-between px-5 py-3 border-b border-border shrink-0">
+            <span className="text-sm font-semibold">Join the waitlist</span>
+            <button
+              onClick={close}
+              className="size-9 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            >
+              <XIcon className="size-5" />
+            </button>
+          </div>
+          {/* Tally embed — uses their official widget script */}
+          <div className="flex-1 relative">
+            <iframe
+              data-tally-src="https://tally.so/r/rj6pl5?formEventsForwarding=1"
+              width="100%"
+              height="100%"
+              frameBorder={0}
+              marginHeight={0}
+              marginWidth={0}
+              title="Matrix Signup"
+              className="absolute inset-0 border-0"
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/party` event page: iPad-first layout with demo video embed, QR codes (site + X), and Tally waitlist form
- Add `/party/qr` standalone QR display for booth
- Waitlist opens as full-page modal using Tally's official embed widget
- Update landing page test counts to 1,012

## Pages
- `matrix-os.com/party` - main event page (iPad + mobile)
- `matrix-os.com/party/qr` - QR code display for booth

## Test plan
- [x] `next build` passes, both pages statically generated
- [ ] Verify on iPad: video plays, QR codes scan, waitlist modal opens/closes
- [ ] Verify on mobile: single-column layout, form usable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added party landing page for Matrix OS with stats and multimedia content
  * Added QR code page with embedded QR code display
  * Implemented waitlist button with modal form integration
  * Enabled module icon support for app display
  * Enhanced theme system with automatic light/dark mode detection

* **Chores**
  * Removed deprecated Clerk skill references
  * Updated test count metrics to 1,012 tests

* **Style**
  * Migrated sidebar styling to dynamic theme variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->