### PR TITLE
Raise container memory limit from 256MB to 1GB

### DIFF
--- a/distro/monitor.sh
+++ b/distro/monitor.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../.env"
+
+if [[ -f "$ENV_FILE" ]]; then
+  PLATFORM_SECRET=$(grep '^PLATFORM_SECRET=' "$ENV_FILE" | cut -d= -f2-)
+fi
+
+PLATFORM_SECRET="${PLATFORM_SECRET:-}"
+PLATFORM_URL="${PLATFORM_URL:-http://localhost:9000}"
+
+if [[ -z "$PLATFORM_SECRET" ]]; then
+  echo "Error: PLATFORM_SECRET not found in .env or environment" >&2
+  exit 1
+fi
+
+RAW=$(curl -sf -H "Authorization: Bearer ${PLATFORM_SECRET}" "${PLATFORM_URL}/admin/dashboard")
+
+if [[ $? -ne 0 || -z "$RAW" ]]; then
+  echo "Error: failed to reach platform at ${PLATFORM_URL}/admin/dashboard" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--json" ]]; then
+  echo "$RAW" | jq .
+  exit 0
+fi
+
+TOTAL=$(echo "$RAW" | jq -r '.summary.total')
+RUNNING=$(echo "$RAW" | jq -r '.summary.running')
+STOPPED=$(echo "$RAW" | jq -r '.summary.stopped')
+TIMESTAMP=$(echo "$RAW" | jq -r '.timestamp')
+
+echo "Matrix OS Platform Dashboard"
+echo "Time: ${TIMESTAMP}"
+echo "Containers: ${RUNNING} running / ${STOPPED} stopped / ${TOTAL} total"
+echo ""
+
+printf "%-16s %-10s %-8s %-8s %-10s %-20s\n" "HANDLE" "STATUS" "MODULES" "CONVOS" "COST" "LAST ACTIVE"
+printf "%-16s %-10s %-8s %-8s %-10s %-20s\n" "------" "------" "-------" "------" "----" "-----------"
+
+echo "$RAW" | jq -c '.containers[]' 2>/dev/null | while IFS= read -r row; do
+  handle=$(echo "$row" | jq -r '.handle')
+  status=$(echo "$row" | jq -r '.status')
+  modules=$(echo "$row" | jq -r '.systemInfo.modules // "-"')
+  convos=$(echo "$row" | jq -r '.conversationCount // "-"')
+  cost=$(echo "$row" | jq -r 'if .systemInfo.todayCost then (.systemInfo.todayCost | tostring | .[0:6]) else "-" end')
+  lastActive=$(echo "$row" | jq -r '.lastActive // "-" | .[0:19]')
+
+  printf "%-16s %-10s %-8s %-8s %-10s %-20s\n" "$handle" "$status" "$modules" "$convos" "\$${cost}" "$lastActive"
+done
+
+if echo "$RAW" | jq -e '.stoppedContainers | length > 0' >/dev/null 2>&1; then
+  echo ""
+  echo "Stopped:"
+  echo "$RAW" | jq -c '.stoppedContainers[]' 2>/dev/null | while IFS= read -r row; do
+    handle=$(echo "$row" | jq -r '.handle')
+    lastActive=$(echo "$row" | jq -r '.lastActive // "-" | .[0:19]')
+    printf "  %-16s last active: %s\n" "$handle" "$lastActive"
+  done
+fi

--- a/packages/gateway/src/channels/format.ts
+++ b/packages/gateway/src/channels/format.ts
@@ -68,5 +68,7 @@ export function formatForChannel(channelId: ChannelId, text: string): string {
       return toSlackMrkdwn(text);
     case "whatsapp":
       return toWhatsApp(text);
+    default:
+      return text;
   }
 }

--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -8,7 +8,7 @@ try { process.loadEnvFile(resolve(dirname(fileURLToPath(import.meta.url)), "../.
 const homePath = ensureHome(process.env.MATRIX_HOME || undefined);
 const port = Number(process.env.PORT ?? 4000);
 
-const gateway = createGateway({ homePath, port });
+const gateway = await createGateway({ homePath, port });
 
 console.log(`Matrix OS gateway running on http://localhost:${port}`);
 console.log(`Home directory: ${homePath}`);

--- a/packages/gateway/src/voice.ts
+++ b/packages/gateway/src/voice.ts
@@ -105,7 +105,7 @@ export function createVoiceService(
       const url = "https://api.elevenlabs.io/v1/speech-to-text";
 
       const formData = new FormData();
-      const blob = new Blob([audioBuffer], { type: "audio/webm" });
+      const blob = new Blob([new Uint8Array(audioBuffer)], { type: "audio/webm" });
       formData.append("audio", blob, "recording.webm");
       formData.append("model_id", "scribe_v1");
 

--- a/packages/kernel/src/kernel.ts
+++ b/packages/kernel/src/kernel.ts
@@ -31,7 +31,7 @@ export async function* spawnKernel(
       options: {
         ...options,
         includePartialMessages: true,
-      },
+      } as Parameters<typeof query>[0]["options"],
     });
 
     let activeTool: string | null = null;

--- a/packages/kernel/src/options.ts
+++ b/packages/kernel/src/options.ts
@@ -115,42 +115,44 @@ export function kernelOptions(config: KernelConfig) {
       PreToolUse: [
         {
           matcher: "Bash|Write|Edit",
-          hooks: [safetyGuardHook],
+          hooks: [safetyGuardHook as (...args: unknown[]) => Promise<unknown>],
         },
         {
           matcher: "Write|Edit",
-          hooks: [protectedFilesHook],
+          hooks: [protectedFilesHook as (...args: unknown[]) => Promise<unknown>],
         },
       ],
       PostToolUse: [
         {
           matcher: "Write|Edit",
-          hooks: [updateStateHook, gitSnapshotHook, notifyShellHook],
+          hooks: [updateStateHook, gitSnapshotHook, notifyShellHook].map(
+            (h) => h as (...args: unknown[]) => Promise<unknown>,
+          ),
         },
         {
           matcher: "Bash",
-          hooks: [logActivityHook],
+          hooks: [logActivityHook as (...args: unknown[]) => Promise<unknown>],
         },
       ],
       Stop: [
         {
           matcher: ".*",
-          hooks: [persistSessionHook],
+          hooks: [persistSessionHook as (...args: unknown[]) => Promise<unknown>],
         },
       ],
       SubagentStop: [
         {
           matcher: ".*",
-          hooks: [onSubagentComplete],
+          hooks: [onSubagentComplete as (...args: unknown[]) => Promise<unknown>],
         },
       ],
       PreCompact: [
         {
           matcher: ".*",
-          hooks: [preCompactHook],
+          hooks: [preCompactHook as (...args: unknown[]) => Promise<unknown>],
         },
       ],
-    },
+    } as Record<string, { matcher: string; hooks: ((...args: unknown[]) => Promise<unknown>)[] }[]>,
     ...(sessionId && { resume: sessionId }),
   };
 }

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -13,7 +13,7 @@ const DB_PATH = process.env.PLATFORM_DB_PATH ?? '/data/platform.db';
 let _db: PlatformDB;
 let _sqlite: InstanceType<typeof Database>;
 
-export function createPlatformDb(path: string = DB_PATH): PlatformDB {
+export function createPlatformDb(path: string = DB_PATH) {
   if (path !== ':memory:') {
     const dir = dirname(path);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });

--- a/packages/platform/src/orchestrator.ts
+++ b/packages/platform/src/orchestrator.ts
@@ -48,7 +48,7 @@ export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
     baseGatewayPort = 4001,
     baseShellPort = 3001,
     proxyUrl = 'http://proxy:8080',
-    memoryLimit = 256 * 1024 * 1024,
+    memoryLimit = 1024 * 1024 * 1024,
     cpuQuota = 50000,
     dataDir = '/data/users',
     platformSecret = '',


### PR DESCRIPTION
## Summary
- Increases default `memoryLimit` in orchestrator from 256MB to 1GB
- Fixes OOM kills: Claude Code (~170MB RSS) + Next.js (~135MB RSS) + esbuild workers (~38MB) exceeded the 256MB cgroup limit, causing the kernel to repeatedly SIGKILL the `claude` process whenever users tried to build apps
- Existing running containers were already live-updated via `docker update --memory 1G`

## Test plan
- [x] Verified all 19 running containers now show `1GiB` limit via `docker stats`
- [x] Confirmed no new OOM kills in `dmesg` after the update
- [ ] Monitor axel/groth containers to confirm Claude Code sessions complete without SIGKILL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin dashboard for real-time platform state monitoring with container and system metrics.

* **Improvements**
  * Enhanced audio handling for speech-to-text feature.
  * Increased default memory allocation for better performance.
  * Implemented idle-based container timeout and automatic resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->