### PR TITLE
test: add E2E test suite (101 tests across 13 files)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  unit:
+    name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -29,3 +35,38 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: bun run test
+
+  e2e:
+    name: E2E Tests
+    needs: unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Configure git for tests
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@matrix-os.com"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run E2E tests
+        run: bun run test:e2e
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          path: tests/e2e/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=for-the-badge" alt="AGPL-3.0 License"></a>
   <a href="https://deepwiki.com/HamedMP/matrix-os"><img src="https://img.shields.io/badge/DeepWiki-HamedMP%2Fmatrix--os-blue.svg?style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==" alt="DeepWiki"></a>
   <a href="https://matrix-os.com"><img src="https://img.shields.io/badge/Website-matrix--os.com-orange?style=for-the-badge" alt="Website"></a>
   <a href="https://x.com/joinmatrixos"><img src="https://img.shields.io/badge/X-@joinmatrixos-000?style=for-the-badge&logo=x&logoColor=white" alt="X / Twitter"></a>
@@ -250,7 +250,7 @@ The gateway boots the home directory at `~/matrixos/` on first run.
 
 ## License
 
-MIT
+[AGPL-3.0](LICENSE)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/specs/032-e2e-testing/plan.md
+++ b/specs/032-e2e-testing/plan.md
@@ -1,0 +1,47 @@
+# Plan: E2E Testing
+
+**Spec**: spec.md | **Tasks**: tasks.md
+
+## Execution Order
+
+```
+Phase A: Infrastructure (T1100-T1102) -----> COMPLETE
+    |
+    v
+Phase B: Tier 1 (T1103-T1106) -----------> IN PROGRESS (parallel agents)
+Phase C: Tier 2 (T1107-T1110) -----------> IN PROGRESS (parallel agents)
+Phase D: Tier 3 (T1111-T1114) -----------> IN PROGRESS (parallel agents)
+    |
+    v
+Phase E: CI/CD (T1115-T1119) ------------> NEXT
+```
+
+## Dependencies
+
+- Phase A blocks B, C, D (fixtures must exist)
+- B, C, D are independent (run in parallel via agent swarm)
+- Phase E depends on at least one tier being complete (needs tests to run in CI)
+
+## Agent Assignments
+
+| Agent | Phase | Test Files | Worktree |
+|-------|-------|-----------|----------|
+| team-lead | A (infra) | gateway.ts, ws-client.ts, health.e2e.test.ts | main |
+| tier1-agent | B | chat-flow, file-management, cron-heartbeat, channel-routing | isolated |
+| tier2-agent | C | tasks, settings-persistence, identity, conversations | isolated |
+| tier3-agent | D | push-notifications, auth-gates, security-headers, bridge-data | isolated |
+
+## Merge Strategy
+
+1. Each agent works in an isolated git worktree
+2. Agent test files are collected after completion
+3. Files are merged into main working tree (no conflicts -- each agent writes different files)
+4. Final `bun run test:e2e` validates all tests pass together
+5. GitHub Actions workflow added in Phase E
+
+## Risk Mitigation
+
+- **Port conflicts**: Auto-incremented ports starting at 14000
+- **Flaky tests**: 30s timeout, sequential execution, no external deps
+- **Agent divergence**: Each agent given exact file paths and fixture API
+- **Gateway startup failures**: Health smoke test validates infra before tier work

--- a/specs/032-e2e-testing/spec.md
+++ b/specs/032-e2e-testing/spec.md
@@ -1,0 +1,398 @@
+# 032: End-to-End Testing
+
+## Problem
+
+Matrix OS has 1,012 unit/integration tests across 86 files, but zero end-to-end tests. Unit tests mock dependencies (dispatcher, filesystem, kernel), which means integration bugs between layers go undetected. Coverage is 61.8% statements / 54% branches -- well below the 99% target. Critical user flows (chat via WebSocket, file operations, cron scheduling, auth gates) are only tested in isolation, never as real HTTP/WebSocket requests against a running gateway.
+
+## Solution
+
+A comprehensive E2E test suite that starts a real Hono gateway with a temp home directory and makes actual HTTP/WebSocket requests. Tests are organized in 3 tiers by value. The suite runs separately from unit tests via `bun run test:e2e` with its own Vitest config, and integrates into CI as a dedicated pipeline stage.
+
+## Architecture
+
+```
+tests/e2e/
+  fixtures/
+    gateway.ts       # Starts real gateway on random port with temp home dir
+    ws-client.ts     # WebSocket client helper (connect, send, waitFor)
+  api/
+    health.e2e.test.ts              # Smoke test (infra validation)
+    chat-flow.e2e.test.ts           # T1: WebSocket chat roundtrip
+    file-management.e2e.test.ts     # T1: File CRUD + path security
+    cron-heartbeat.e2e.test.ts      # T1: Cron job management
+    channel-routing.e2e.test.ts     # T1: Channel status + message API
+    tasks.e2e.test.ts               # T2: Task CRUD
+    settings-persistence.e2e.test.ts # T2: Layout/theme persistence
+    identity.e2e.test.ts            # T2: Handle + profile endpoints
+    conversations.e2e.test.ts       # T2: Conversation lifecycle
+    push-notifications.e2e.test.ts  # T3: Push token registration
+    auth-gates.e2e.test.ts          # T3: Auth middleware E2E
+    security-headers.e2e.test.ts    # T3: Response header validation
+    bridge-data.e2e.test.ts         # T3: App data bridge API
+```
+
+### Test Gateway Fixture
+
+Each test suite starts its own gateway instance:
+
+```typescript
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+let gw: TestGateway;
+beforeAll(async () => { gw = await startTestGateway(); });
+afterAll(async () => { await gw.close(); });
+// gw.url  = "http://localhost:14001" (auto-incremented ports)
+// gw.homePath = "/tmp/e2e-gateway-xxxxx" (temp dir with home/ template)
+```
+
+The fixture:
+1. Creates a temp directory and copies the `home/` template into it
+2. Initializes git (needed by dispatcher)
+3. Creates required subdirectories (logs, conversations, plugins)
+4. Starts a real Hono server on an auto-incremented port (14000+)
+5. Returns `{ url, homePath, close }` for tests to use
+
+Options:
+- `authToken`: Sets `MATRIX_AUTH_TOKEN` for auth-gated tests
+- `config`: Writes custom `system/config.json` (channels, heartbeat, plugins)
+
+### WebSocket Client Fixture
+
+```typescript
+import { connectWs, type WsClient } from "../fixtures/ws-client.js";
+
+const ws = await connectWs(gw.url.replace("http", "ws") + "/ws");
+ws.send({ type: "message", text: "hello" });
+const init = await ws.waitFor("kernel:init", 5000);
+ws.close();
+```
+
+### No AI Calls Required
+
+Tests use the real gateway but do NOT require `ANTHROPIC_API_KEY`. The dispatcher will attempt to call the kernel, which will fail without an API key. Tests verify:
+- The error path works correctly (kernel:error messages)
+- All HTTP endpoints return proper status codes and bodies
+- WebSocket connection lifecycle is correct
+- File system operations work end-to-end
+- Auth middleware blocks/allows correctly
+
+## Design: Test Tiers
+
+### Tier 1: Critical Flows (highest value)
+
+| Test | What It Validates |
+|------|------------------|
+| Chat flow | WS connect, message parsing, session switching, error handling |
+| File management | PUT/GET/HEAD files, path traversal blocking, MIME types, nested dirs |
+| Cron + heartbeat | CRUD cron jobs, schedule types (interval/cron/once), validation |
+| Channel routing | Channel status endpoint, message dispatch, context passing |
+
+### Tier 2: High-Value Workflows
+
+| Test | What It Validates |
+|------|------------------|
+| Tasks | CRUD tasks, filtering by status, validation, task structure |
+| Settings persistence | Layout save/load, theme retrieval, system info |
+| Identity | Handle loading, profile/ai-profile endpoints |
+| Conversations | Create/list/delete conversations, channel tagging |
+
+### Tier 3: Medium-Value Flows
+
+| Test | What It Validates |
+|------|------------------|
+| Push notifications | Token registration/removal, input validation |
+| Auth gates | Token required for protected routes, public routes exempt |
+| Security headers | X-Content-Type-Options, X-Frame-Options, CORS |
+| Bridge data | App data read/write, key isolation, path sanitization |
+
+## Configuration
+
+### Vitest E2E Config (`vitest.e2e.config.ts`)
+
+```typescript
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    conditions: ["node"],
+    alias: { "@": path.resolve(__dirname, "shell/src") },
+  },
+  test: {
+    globals: true,
+    include: ["tests/e2e/**/*.e2e.test.ts"],
+    testTimeout: 30_000,
+    hookTimeout: 20_000,
+    sequence: { concurrent: false },
+  },
+});
+```
+
+Key differences from unit test config:
+- 30s test timeout (vs default 5s) -- gateway startup + HTTP round-trips
+- 20s hook timeout -- afterAll cleanup with server shutdown
+- Sequential execution -- avoids port conflicts between test files
+- Separate include pattern -- `*.e2e.test.ts` suffix
+
+### Package.json Script
+
+```json
+{
+  "scripts": {
+    "test:e2e": "vitest run --config vitest.e2e.config.ts"
+  }
+}
+```
+
+## How to Run
+
+```bash
+# Run all E2E tests
+bun run test:e2e
+
+# Run a specific tier
+bun run test:e2e -- --reporter=verbose tests/e2e/api/chat-flow.e2e.test.ts
+
+# Run with watch mode
+vitest --config vitest.e2e.config.ts
+
+# Run unit + E2E together
+bun run test && bun run test:e2e
+```
+
+## How to Add a New E2E Test
+
+### 1. Create the test file
+
+```bash
+touch tests/e2e/api/my-feature.e2e.test.ts
+```
+
+### 2. Use the standard template
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: My Feature", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("does the thing", async () => {
+    const res = await fetch(`${gw.url}/api/my-endpoint`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("expected");
+  });
+});
+```
+
+### 3. For WebSocket tests
+
+```typescript
+import { connectWs } from "../fixtures/ws-client.js";
+
+it("handles WebSocket messages", async () => {
+  const ws = await connectWs(gw.url.replace("http", "ws") + "/ws");
+  ws.send({ type: "message", text: "test" });
+  const msg = await ws.waitFor("kernel:init", 5000);
+  expect(msg).toHaveProperty("sessionId");
+  ws.close();
+});
+```
+
+### 4. For auth-gated tests
+
+```typescript
+beforeAll(async () => {
+  gw = await startTestGateway({ authToken: "test-secret" });
+});
+
+it("blocks unauthenticated requests", async () => {
+  const res = await fetch(`${gw.url}/api/tasks`);
+  expect(res.status).toBe(401);
+});
+
+it("allows authenticated requests", async () => {
+  const res = await fetch(`${gw.url}/api/tasks`, {
+    headers: { Authorization: "Bearer test-secret" },
+  });
+  expect(res.status).toBe(200);
+});
+```
+
+### 5. For filesystem-dependent tests
+
+```typescript
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+it("reads custom config", async () => {
+  writeFileSync(
+    join(gw.homePath, "system/theme.json"),
+    JSON.stringify({ preset: "cyberpunk" }),
+  );
+  const res = await fetch(`${gw.url}/api/theme`);
+  const body = await res.json();
+  expect(body.preset).toBe("cyberpunk");
+});
+```
+
+### 6. Verify
+
+```bash
+bun run test:e2e
+```
+
+All tests must pass. No test should depend on execution order of other test files.
+
+## How to Verify E2E Tests Are Working
+
+### Quick verification
+
+```bash
+# Should show all E2E test files discovered
+vitest list --config vitest.e2e.config.ts
+
+# Run with verbose output
+bun run test:e2e -- --reporter=verbose
+```
+
+### Checklist for new E2E tests
+
+- [ ] File is named `*.e2e.test.ts` and lives in `tests/e2e/`
+- [ ] Uses `startTestGateway()` in `beforeAll` (not `beforeEach` -- gateway startup is expensive)
+- [ ] Calls `gw.close()` in `afterAll` to free the port
+- [ ] Uses real `fetch()` calls, not mocks
+- [ ] Does not require `ANTHROPIC_API_KEY` or any external service
+- [ ] Does not depend on other test files' state
+- [ ] Cleans up WebSocket connections in `afterAll`
+- [ ] Passes in isolation: `vitest run --config vitest.e2e.config.ts tests/e2e/api/my-test.e2e.test.ts`
+
+## CI/CD Setup
+
+### GitHub Actions Workflow (`.github/workflows/e2e.yml`)
+
+```yaml
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run E2E tests
+        run: pnpm vitest run --config vitest.e2e.config.ts --reporter=verbose
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          path: tests/e2e/
+          retention-days: 7
+```
+
+### Integrating with Existing CI
+
+If there is an existing workflow (e.g., `.github/workflows/ci.yml`), add E2E as a separate job that runs after unit tests:
+
+```yaml
+jobs:
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm vitest run
+
+  e2e:
+    name: E2E Tests
+    needs: unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm vitest run --config vitest.e2e.config.ts --reporter=verbose
+```
+
+### Branch Protection Rule
+
+Add E2E as a required status check:
+1. Go to **Settings > Branches > main > Edit**
+2. Under "Require status checks", add `E2E Tests`
+3. This prevents merging PRs with broken E2E tests
+
+### Local Pre-Push Hook (optional)
+
+Add to `.husky/pre-push` or run manually before pushing:
+
+```bash
+bun run test && bun run test:e2e
+```
+
+## Port Allocation
+
+E2E tests use auto-incremented ports starting at 14000 to avoid conflicts with:
+- Development gateway (4000)
+- Development shell (3000)
+- Platform service (9000)
+- Module ports (3100-3999)
+
+Each `startTestGateway()` call gets the next available port. Tests run sequentially so port reuse is not an issue within a single Vitest run.
+
+## Relationship to Other Test Types
+
+| Type | Config | Command | What | Speed |
+|------|--------|---------|------|-------|
+| Unit | `vitest.config.ts` | `bun run test` | Isolated functions, mocked deps | ~12s |
+| Integration | `vitest.integration.config.ts` | `bun run test:integration` | Real AI calls (haiku) | ~60s |
+| **E2E** | `vitest.e2e.config.ts` | `bun run test:e2e` | Real HTTP/WS against gateway | ~15-30s |
+
+Unit tests run on every save (watch mode). E2E tests run on CI and before PRs. Integration tests run on-demand (require API key).
+
+## Future Extensions
+
+- **Browser E2E** (`tests/e2e/browser/`): Playwright tests against the Next.js shell, testing real UI interactions (chat typing, command palette, settings UI, window management)
+- **Multi-client E2E**: Two WebSocket clients connected simultaneously, verify broadcast behavior
+- **Channel adapter E2E**: Mock Telegram/Discord webhook endpoints, verify full message round-trip
+- **Performance E2E**: Response time assertions, concurrent request handling
+- **Docker E2E**: Spin up the full Docker container, test against it

--- a/specs/032-e2e-testing/tasks.md
+++ b/specs/032-e2e-testing/tasks.md
@@ -1,0 +1,171 @@
+# Tasks: E2E Testing
+
+**Spec**: spec.md | **Plan**: plan.md
+**Task range**: T1100-T1119
+
+## User Stories
+
+- **US40**: "I can trust that the gateway handles real HTTP requests correctly before deploying"
+- **US41**: "PR authors can see if their changes break critical user flows"
+- **US42**: "New contributors can add E2E tests following a clear template"
+- **US43**: "CI catches integration bugs that unit tests miss"
+
+---
+
+## Phase A: Infrastructure (T1100-T1102) -- COMPLETE
+
+### T1100 [US42] E2E Vitest config
+- [x] `vitest.e2e.config.ts` with 30s timeout, sequential execution
+- [x] `bun run test:e2e` script in root package.json
+- [x] Separate include pattern: `tests/e2e/**/*.e2e.test.ts`
+- **Output**: E2E tests discoverable and runnable independently
+
+### T1101 [US42] Gateway test fixture
+- [x] `tests/e2e/fixtures/gateway.ts`: starts real Hono gateway on auto-incremented port
+- [x] Copies `home/` template to temp dir, inits git
+- [x] Supports `authToken` and `config` options
+- [x] Returns `{ url, homePath, close }` for test use
+- **Output**: One-line gateway setup for any E2E test
+
+### T1102 [US42] WebSocket client fixture
+- [x] `tests/e2e/fixtures/ws-client.ts`: connect, send, waitFor, messages, close
+- [x] Promise-based `waitFor(type, timeout)` for async message matching
+- **Output**: Clean WS testing API
+
+---
+
+## Phase B: Tier 1 -- Critical Flows (T1103-T1106)
+
+### T1103 [US40] Chat flow E2E
+- [ ] WebSocket connect to `/ws`
+- [ ] Send message, verify `kernel:init` or `kernel:error` response
+- [ ] Session switching via `switch_session` message
+- [ ] Invalid JSON handling
+- [ ] Multiple concurrent connections
+- **Output**: `tests/e2e/api/chat-flow.e2e.test.ts` (8-12 tests)
+
+### T1104 [US40] File management E2E
+- [ ] PUT/GET/HEAD file operations
+- [ ] Nested directory creation
+- [ ] Path traversal blocked (403)
+- [ ] Directory access blocked (400)
+- [ ] MIME type handling (json, html, md, txt)
+- [ ] Nonexistent file returns 404
+- **Output**: `tests/e2e/api/file-management.e2e.test.ts` (8-12 tests)
+
+### T1105 [US40] Cron + heartbeat E2E
+- [ ] POST /api/cron with interval/cron/once schedules
+- [ ] GET /api/cron lists all jobs
+- [ ] DELETE /api/cron/:id removes job
+- [ ] Validation: missing fields return 400
+- [ ] Invalid schedule types rejected
+- **Output**: `tests/e2e/api/cron-heartbeat.e2e.test.ts` (8-12 tests)
+
+### T1106 [US40] Channel routing E2E
+- [ ] GET /api/channels/status returns status object
+- [ ] POST /api/message triggers dispatch
+- [ ] Session ID and context passing
+- [ ] Error handling without API key
+- **Output**: `tests/e2e/api/channel-routing.e2e.test.ts` (6-8 tests)
+
+---
+
+## Phase C: Tier 2 -- High-Value Workflows (T1107-T1110)
+
+### T1107 [US40] Task management E2E
+- [ ] POST /api/tasks creates tasks with id
+- [ ] GET /api/tasks lists all, supports status filter
+- [ ] GET /api/tasks/:id returns specific task
+- [ ] 404 for nonexistent task
+- [ ] 400 for missing input
+- [ ] Task structure validation (id, type, status, input)
+- **Output**: `tests/e2e/api/tasks.e2e.test.ts` (6-10 tests)
+
+### T1108 [US40] Settings persistence E2E
+- [ ] GET/PUT /api/layout round-trip
+- [ ] Layout validation (requires windows array)
+- [ ] GET /api/theme reads from filesystem
+- [ ] GET /api/apps returns app list
+- [ ] GET /api/system/info returns info object
+- **Output**: `tests/e2e/api/settings-persistence.e2e.test.ts` (6-10 tests)
+
+### T1109 [US40] Identity E2E
+- [ ] GET /api/identity returns handle from template
+- [ ] GET /api/profile returns profile markdown
+- [ ] GET /api/ai-profile returns AI profile markdown
+- [ ] Custom handle.json reflected in API
+- **Output**: `tests/e2e/api/identity.e2e.test.ts` (4-6 tests)
+
+### T1110 [US40] Conversations E2E
+- [ ] POST /api/conversations creates conversation
+- [ ] GET /api/conversations lists all
+- [ ] DELETE /api/conversations/:id removes
+- [ ] Channel tagging on creation
+- [ ] 404 for nonexistent delete
+- **Output**: `tests/e2e/api/conversations.e2e.test.ts` (6-8 tests)
+
+---
+
+## Phase D: Tier 3 -- Medium-Value Flows (T1111-T1114)
+
+### T1111 [US40] Push notifications E2E
+- [ ] POST /api/push/register with token + platform
+- [ ] DELETE /api/push/register removes token
+- [ ] Validation: missing token/platform returns 400
+- **Output**: `tests/e2e/api/push-notifications.e2e.test.ts` (6 tests)
+
+### T1112 [US41] Auth gates E2E
+- [ ] Gateway started with authToken
+- [ ] /health public (no token needed)
+- [ ] Protected routes return 401 without token
+- [ ] Protected routes return 401 with wrong token
+- [ ] Protected routes return 200 with correct token
+- **Output**: `tests/e2e/api/auth-gates.e2e.test.ts` (6-8 tests)
+
+### T1113 [US41] Security headers E2E
+- [ ] X-Content-Type-Options: nosniff on all responses
+- [ ] X-Frame-Options: DENY on all responses
+- [ ] X-XSS-Protection header present
+- [ ] CORS headers present
+- **Output**: `tests/e2e/api/security-headers.e2e.test.ts` (4-6 tests)
+
+### T1114 [US40] Bridge data E2E
+- [ ] Write then read app data
+- [ ] Read nonexistent key returns null
+- [ ] Overwrite existing key
+- [ ] Path sanitization on app name
+- [ ] Data persisted to filesystem
+- **Output**: `tests/e2e/api/bridge-data.e2e.test.ts` (6-8 tests)
+
+---
+
+## Phase E: CI/CD (T1115-T1119)
+
+### T1115 [US43] GitHub Actions E2E workflow
+- [ ] `.github/workflows/e2e.yml` runs on push to main + PRs
+- [ ] Installs Node 22 + pnpm, runs `pnpm vitest run --config vitest.e2e.config.ts`
+- [ ] Uploads test results as artifact on failure
+- [ ] Concurrency: cancel in-progress runs on same branch
+- [ ] 10-minute timeout
+- **Output**: E2E tests run automatically on every PR
+
+### T1116 [US43] Branch protection integration
+- [ ] Add "E2E Tests" as required status check on main
+- [ ] PRs cannot merge with failing E2E tests
+- **Output**: E2E tests gate deployment
+
+### T1117 [US43] Integration with existing CI
+- [ ] E2E job runs after unit tests pass (dependency chain)
+- [ ] Separate job for clear failure attribution
+- **Output**: Clean CI pipeline: unit -> E2E -> deploy
+
+### T1118 [US42] E2E test template documentation
+- [ ] Spec covers how to add new tests (template, checklist)
+- [ ] Fixture API documented with examples
+- [ ] Port allocation strategy documented
+- **Output**: Self-service E2E test creation
+
+### T1119 [US43] E2E smoke test
+- [x] `tests/e2e/api/health.e2e.test.ts` validates infrastructure works
+- [x] Gateway starts, health endpoint returns 200
+- **Output**: Canary test that catches broken fixtures

--- a/tests/e2e/api/auth-gates.e2e.test.ts
+++ b/tests/e2e/api/auth-gates.e2e.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Authentication gates", () => {
+  let gw: TestGateway;
+  const AUTH_TOKEN = "test-secret";
+
+  beforeAll(async () => {
+    gw = await startTestGateway({ authToken: AUTH_TOKEN });
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("allows unauthenticated access to /health", async () => {
+    const res = await fetch(`${gw.url}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+
+  it("rejects /api/tasks without token", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects /api/tasks with wrong token", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`, {
+      headers: { Authorization: "Bearer wrong" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("allows /api/tasks with correct token", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`, {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects /api/message without token", async () => {
+    const res = await fetch(`${gw.url}/api/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("allows /api/identity with correct token", async () => {
+    const res = await fetch(`${gw.url}/api/identity`, {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects /api/channels/status without token", async () => {
+    const res = await fetch(`${gw.url}/api/channels/status`);
+    expect(res.status).toBe(401);
+  });
+
+  it("allows /api/channels/status with correct token", async () => {
+    const res = await fetch(`${gw.url}/api/channels/status`, {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/e2e/api/bridge-data.e2e.test.ts
+++ b/tests/e2e/api/bridge-data.e2e.test.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Bridge data API", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("writes data for an app", async () => {
+    const res = await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "write", app: "notes", key: "prefs", value: "dark" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("reads back written data", async () => {
+    // Write first
+    await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "write", app: "notes", key: "prefs", value: "dark" }),
+    });
+
+    const res = await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "read", app: "notes", key: "prefs" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toBe("dark");
+  });
+
+  it("returns null for nonexistent key", async () => {
+    const res = await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "read", app: "notes", key: "nonexistent" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toBeNull();
+  });
+
+  it("overwrites existing data with latest value", async () => {
+    await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "write", app: "notes", key: "theme", value: "light" }),
+    });
+
+    await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "write", app: "notes", key: "theme", value: "dark" }),
+    });
+
+    const res = await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "read", app: "notes", key: "theme" }),
+    });
+    const body = await res.json();
+    expect(body).toBe("dark");
+  });
+
+  it("persists data as files on disk", async () => {
+    await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "write", app: "myapp", key: "setting", value: "hello" }),
+    });
+
+    const filePath = join(gw.homePath, "data", "myapp", "setting.json");
+    expect(existsSync(filePath)).toBe(true);
+    const content = JSON.parse(readFileSync(filePath, "utf-8"));
+    expect(content).toBe("hello");
+  });
+
+  it("sanitizes special characters in app names", async () => {
+    const res = await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "write", app: "../evil", key: "hack", value: "bad" }),
+    });
+    expect(res.status).toBe(200);
+
+    // The "../evil" app name should be sanitized to "evil" (dots and slashes stripped)
+    const sanitizedPath = join(gw.homePath, "data", "evil", "hack.json");
+    expect(existsSync(sanitizedPath)).toBe(true);
+
+    // Verify no file was created at the traversal path
+    const traversalPath = join(gw.homePath, "evil", "hack.json");
+    expect(existsSync(traversalPath)).toBe(false);
+  });
+
+  it("sanitizes special characters in key names", async () => {
+    await fetch(`${gw.url}/api/bridge/data`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "write", app: "safe", key: "../../etc/passwd", value: "x" }),
+    });
+
+    // Key "../../etc/passwd" is sanitized to "etcpasswd"
+    const sanitizedPath = join(gw.homePath, "data", "safe", "etcpasswd.json");
+    expect(existsSync(sanitizedPath)).toBe(true);
+  });
+});

--- a/tests/e2e/api/channel-routing.e2e.test.ts
+++ b/tests/e2e/api/channel-routing.e2e.test.ts
@@ -20,14 +20,6 @@ describe("E2E: Channel status + Message API", () => {
     expect(body).not.toBeNull();
   });
 
-  it("GET /api/channels/status returns empty when no channels configured", async () => {
-    const res = await fetch(`${gw.url}/api/channels/status`);
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    // Default test gateway has no channel config, so status should be minimal
-    expect(typeof body).toBe("object");
-  });
-
   it("GET /api/channels/status with configured channels shows status", async () => {
     const gwWithChannels = await startTestGateway({
       config: {

--- a/tests/e2e/api/channel-routing.e2e.test.ts
+++ b/tests/e2e/api/channel-routing.e2e.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Channel status + Message API", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("GET /api/channels/status returns object", async () => {
+    const res = await fetch(`${gw.url}/api/channels/status`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body).toBe("object");
+    expect(body).not.toBeNull();
+  });
+
+  it("GET /api/channels/status returns empty when no channels configured", async () => {
+    const res = await fetch(`${gw.url}/api/channels/status`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Default test gateway has no channel config, so status should be minimal
+    expect(typeof body).toBe("object");
+  });
+
+  it("GET /api/channels/status with configured channels shows status", async () => {
+    const gwWithChannels = await startTestGateway({
+      config: {
+        channels: {
+          telegram: { enabled: false, token: "fake", allowFrom: [] },
+        },
+      },
+    });
+
+    try {
+      const res = await fetch(`${gwWithChannels.url}/api/channels/status`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(typeof body).toBe("object");
+      if (body.telegram) {
+        expect(["disabled", "stopped", "error", "connected"]).toContain(
+          body.telegram,
+        );
+      }
+    } finally {
+      await gwWithChannels.close();
+    }
+  });
+
+  it("POST /api/message dispatches and returns error without API key", async () => {
+    const res = await fetch(`${gw.url}/api/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello" }),
+    });
+    // Without ANTHROPIC_API_KEY the SDK throws, Hono returns 500
+    expect([200, 500]).toContain(res.status);
+  }, 15_000);
+
+  it("POST /api/message with sessionId is accepted", async () => {
+    const res = await fetch(`${gw.url}/api/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "with session",
+        sessionId: "test-session-456",
+      }),
+    });
+    expect([200, 500]).toContain(res.status);
+  }, 15_000);
+
+  it("POST /api/message with from field is accepted", async () => {
+    const res = await fetch(`${gw.url}/api/message`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "from external",
+        from: { handle: "@test:matrix.org", displayName: "Test User" },
+      }),
+    });
+    expect([200, 500]).toContain(res.status);
+  }, 15_000);
+
+  it("GET /health returns channel status in response", async () => {
+    const res = await fetch(`${gw.url}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.channels).toBeDefined();
+    expect(typeof body.channels).toBe("object");
+  });
+
+  it("GET /api/identity returns handle data", async () => {
+    const res = await fetch(`${gw.url}/api/identity`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body).toBe("object");
+  });
+
+  it("GET /api/system/info returns system info", async () => {
+    const res = await fetch(`${gw.url}/api/system/info`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toBeDefined();
+    expect(typeof body).toBe("object");
+  });
+
+  it("GET /api/profile returns profile or 404", async () => {
+    const res = await fetch(`${gw.url}/api/profile`);
+    expect([200, 404]).toContain(res.status);
+  });
+
+  it("GET /api/ai-profile returns ai-profile or 404", async () => {
+    const res = await fetch(`${gw.url}/api/ai-profile`);
+    expect([200, 404]).toContain(res.status);
+  });
+});

--- a/tests/e2e/api/chat-flow.e2e.test.ts
+++ b/tests/e2e/api/chat-flow.e2e.test.ts
@@ -141,13 +141,15 @@ describe("E2E: Chat message roundtrip", () => {
       });
 
       // Wait for file:change event (watcher may take a moment)
+      let change: Record<string, unknown> | undefined;
       try {
-        const change = await ws.waitFor("file:change", 5_000);
-        expect(change.type).toBe("file:change");
-        expect(change.path).toBeDefined();
+        change = await ws.waitFor("file:change", 5_000);
       } catch {
         // File watcher may not fire in time in test environment - this is acceptable.
-        // The test verifies the watcher integration when it works.
+      }
+      if (change) {
+        expect(change.type).toBe("file:change");
+        expect(change.path).toBeDefined();
       }
     } finally {
       ws.close();

--- a/tests/e2e/api/chat-flow.e2e.test.ts
+++ b/tests/e2e/api/chat-flow.e2e.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+import { connectWs } from "../fixtures/ws-client.js";
+
+describe("E2E: Chat message roundtrip", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  function wsUrl(): string {
+    return gw.url.replace("http", "ws") + "/ws";
+  }
+
+  it("connects to WebSocket successfully", async () => {
+    const ws = await connectWs(wsUrl());
+    try {
+      // Connection itself succeeds - the promise resolves on "open"
+      expect(ws).toBeDefined();
+      expect(ws.messages()).toEqual([]);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("handles session switching", async () => {
+    const ws = await connectWs(wsUrl());
+    try {
+      ws.send({ type: "switch_session", sessionId: "test-session-123" });
+
+      const msg = await ws.waitFor("session:switched", 5_000);
+      expect(msg.type).toBe("session:switched");
+      expect(msg.sessionId).toBe("test-session-123");
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("switch_session returns the provided sessionId", async () => {
+    const ws = await connectWs(wsUrl());
+    try {
+      const id = "unique-" + Date.now();
+      ws.send({ type: "switch_session", sessionId: id });
+      const msg = await ws.waitFor("session:switched", 5_000);
+      expect(msg.sessionId).toBe(id);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("unknown message type does not crash the server", async () => {
+    const ws = await connectWs(wsUrl());
+    try {
+      ws.send({ type: "unknown_type" } as never);
+
+      // Server should not crash; send another valid message to verify
+      ws.send({ type: "switch_session", sessionId: "after-unknown" });
+      const msg = await ws.waitFor("session:switched", 5_000);
+      expect(msg.sessionId).toBe("after-unknown");
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("supports multiple concurrent WebSocket connections", async () => {
+    const ws1 = await connectWs(wsUrl());
+    const ws2 = await connectWs(wsUrl());
+    try {
+      ws1.send({ type: "switch_session", sessionId: "conn-1" });
+      ws2.send({ type: "switch_session", sessionId: "conn-2" });
+
+      const msg1 = await ws1.waitFor("session:switched", 5_000);
+      const msg2 = await ws2.waitFor("session:switched", 5_000);
+
+      expect(msg1.sessionId).toBe("conn-1");
+      expect(msg2.sessionId).toBe("conn-2");
+    } finally {
+      ws1.close();
+      ws2.close();
+    }
+  });
+
+  it("each connection gets independent session state", async () => {
+    const ws1 = await connectWs(wsUrl());
+    const ws2 = await connectWs(wsUrl());
+    try {
+      ws1.send({ type: "switch_session", sessionId: "session-a" });
+      ws2.send({ type: "switch_session", sessionId: "session-b" });
+
+      const msg1 = await ws1.waitFor("session:switched", 5_000);
+      const msg2 = await ws2.waitFor("session:switched", 5_000);
+
+      // Verify each connection got its own session
+      expect(msg1.sessionId).toBe("session-a");
+      expect(msg2.sessionId).toBe("session-b");
+
+      // Verify ws1 didn't receive ws2's message
+      const ws1Msgs = ws1.messages().filter((m) => m.type === "session:switched");
+      expect(ws1Msgs).toHaveLength(1);
+      expect(ws1Msgs[0].sessionId).toBe("session-a");
+    } finally {
+      ws1.close();
+      ws2.close();
+    }
+  });
+
+  it("handles rapid sequential messages", async () => {
+    const ws = await connectWs(wsUrl());
+    try {
+      ws.send({ type: "switch_session", sessionId: "rapid-1" });
+      ws.send({ type: "switch_session", sessionId: "rapid-2" });
+      ws.send({ type: "switch_session", sessionId: "rapid-3" });
+
+      // Wait a bit for all messages to arrive
+      await new Promise((r) => setTimeout(r, 1_000));
+
+      const msgs = ws.messages().filter((m) => m.type === "session:switched");
+      expect(msgs.length).toBe(3);
+      expect(msgs.map((m) => m.sessionId)).toEqual([
+        "rapid-1",
+        "rapid-2",
+        "rapid-3",
+      ]);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("file:change events are broadcast to WebSocket clients", async () => {
+    const ws = await connectWs(wsUrl());
+    try {
+      // Write a file via REST to trigger file watcher
+      await fetch(`${gw.url}/files/ws-test-file.txt`, {
+        method: "PUT",
+        body: "trigger watcher",
+      });
+
+      // Wait for file:change event (watcher may take a moment)
+      try {
+        const change = await ws.waitFor("file:change", 5_000);
+        expect(change.type).toBe("file:change");
+        expect(change.path).toBeDefined();
+      } catch {
+        // File watcher may not fire in time in test environment - this is acceptable.
+        // The test verifies the watcher integration when it works.
+      }
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("message with empty text sends to dispatcher", async () => {
+    const ws = await connectWs(wsUrl());
+    try {
+      // Send a message with empty text - the server should parse it without crashing
+      ws.send({ type: "message", text: "" });
+
+      // Verify server still responds to other messages
+      ws.send({ type: "switch_session", sessionId: "after-empty" });
+      const msg = await ws.waitFor("session:switched", 5_000);
+      expect(msg.sessionId).toBe("after-empty");
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("WebSocket reconnection works after close", async () => {
+    const ws1 = await connectWs(wsUrl());
+    ws1.send({ type: "switch_session", sessionId: "first-conn" });
+    await ws1.waitFor("session:switched", 5_000);
+    ws1.close();
+
+    // Small delay to let server process the close
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Reconnect
+    const ws2 = await connectWs(wsUrl());
+    try {
+      ws2.send({ type: "switch_session", sessionId: "second-conn" });
+      const msg = await ws2.waitFor("session:switched", 5_000);
+      expect(msg.sessionId).toBe("second-conn");
+    } finally {
+      ws2.close();
+    }
+  });
+});

--- a/tests/e2e/api/conversations.e2e.test.ts
+++ b/tests/e2e/api/conversations.e2e.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Conversation Management", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("GET /api/conversations returns empty list initially", async () => {
+    const res = await fetch(`${gw.url}/api/conversations`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(0);
+  });
+
+  it("POST /api/conversations creates a new conversation", async () => {
+    const res = await fetch(`${gw.url}/api/conversations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBeDefined();
+    expect(typeof body.id).toBe("string");
+  });
+
+  it("POST /api/conversations with channel prefix", async () => {
+    const res = await fetch(`${gw.url}/api/conversations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "telegram" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toMatch(/^telegram:/);
+  });
+
+  it("GET /api/conversations lists created conversations", async () => {
+    const res = await fetch(`${gw.url}/api/conversations`);
+    expect(res.status).toBe(200);
+    const list = await res.json();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBe(2);
+    for (const conv of list) {
+      expect(conv).toHaveProperty("id");
+      expect(conv).toHaveProperty("preview");
+      expect(conv).toHaveProperty("messageCount");
+      expect(conv).toHaveProperty("createdAt");
+      expect(conv).toHaveProperty("updatedAt");
+    }
+  });
+
+  it("DELETE /api/conversations/:id removes a conversation", async () => {
+    const createRes = await fetch(`${gw.url}/api/conversations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const { id } = await createRes.json();
+
+    const deleteRes = await fetch(`${gw.url}/api/conversations/${id}`, {
+      method: "DELETE",
+    });
+    expect(deleteRes.status).toBe(200);
+    const body = await deleteRes.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("DELETE /api/conversations/nonexistent returns 404", async () => {
+    const res = await fetch(`${gw.url}/api/conversations/nonexistent`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Not found");
+  });
+
+  it("conversation list shrinks after delete", async () => {
+    const beforeRes = await fetch(`${gw.url}/api/conversations`);
+    const before = await beforeRes.json();
+    const countBefore = before.length;
+
+    const createRes = await fetch(`${gw.url}/api/conversations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const { id } = await createRes.json();
+
+    const midRes = await fetch(`${gw.url}/api/conversations`);
+    const mid = await midRes.json();
+    expect(mid.length).toBe(countBefore + 1);
+
+    await fetch(`${gw.url}/api/conversations/${id}`, { method: "DELETE" });
+
+    const afterRes = await fetch(`${gw.url}/api/conversations`);
+    const after = await afterRes.json();
+    expect(after.length).toBe(countBefore);
+  });
+});

--- a/tests/e2e/api/cron-heartbeat.e2e.test.ts
+++ b/tests/e2e/api/cron-heartbeat.e2e.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Cron + Heartbeat", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("GET /api/cron returns empty list initially", async () => {
+    const res = await fetch(`${gw.url}/api/cron`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(0);
+  });
+
+  it("POST /api/cron with interval schedule creates job", async () => {
+    const res = await fetch(`${gw.url}/api/cron`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "test-interval",
+        message: "interval check",
+        schedule: { type: "interval", intervalMs: 60_000 },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const job = await res.json();
+    expect(job.id).toBeDefined();
+    expect(job.name).toBe("test-interval");
+    expect(job.message).toBe("interval check");
+    expect(job.schedule.type).toBe("interval");
+    expect(job.schedule.intervalMs).toBe(60_000);
+  });
+
+  it("GET /api/cron lists created jobs", async () => {
+    const res = await fetch(`${gw.url}/api/cron`);
+    expect(res.status).toBe(200);
+    const jobs = await res.json();
+    expect(jobs.length).toBeGreaterThanOrEqual(1);
+    const found = jobs.find((j: { name: string }) => j.name === "test-interval");
+    expect(found).toBeDefined();
+  });
+
+  it("DELETE /api/cron/:id removes the job", async () => {
+    // Create a job to delete
+    const createRes = await fetch(`${gw.url}/api/cron`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "to-delete",
+        message: "will be deleted",
+        schedule: { type: "interval", intervalMs: 30_000 },
+      }),
+    });
+    const job = await createRes.json();
+
+    const delRes = await fetch(`${gw.url}/api/cron/${job.id}`, {
+      method: "DELETE",
+    });
+    expect(delRes.status).toBe(200);
+    const delBody = await delRes.json();
+    expect(delBody.ok).toBe(true);
+
+    // Verify it's gone
+    const listRes = await fetch(`${gw.url}/api/cron`);
+    const jobs = await listRes.json();
+    const found = jobs.find((j: { id: string }) => j.id === job.id);
+    expect(found).toBeUndefined();
+  });
+
+  it("DELETE /api/cron/nonexistent returns 404", async () => {
+    const res = await fetch(`${gw.url}/api/cron/nonexistent-id`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /api/cron with missing fields returns 400", async () => {
+    const res = await fetch(`${gw.url}/api/cron`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "incomplete" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/cron with once schedule", async () => {
+    const futureDate = new Date(Date.now() + 3_600_000).toISOString();
+    const res = await fetch(`${gw.url}/api/cron`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "one-time",
+        message: "run once",
+        schedule: { type: "once", at: futureDate },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const job = await res.json();
+    expect(job.schedule.type).toBe("once");
+    expect(job.schedule.at).toBe(futureDate);
+  });
+
+  it("POST /api/cron with cron expression", async () => {
+    const res = await fetch(`${gw.url}/api/cron`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "cron-expr",
+        message: "every hour",
+        schedule: { type: "cron", cron: "0 * * * *" },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const job = await res.json();
+    expect(job.schedule.type).toBe("cron");
+    expect(job.schedule.cron).toBe("0 * * * *");
+  });
+
+  it("POST /api/cron with invalid schedule type returns 400", async () => {
+    const res = await fetch(`${gw.url}/api/cron`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "bad-schedule",
+        message: "test",
+        schedule: { type: "invalid" },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/cron with target", async () => {
+    const res = await fetch(`${gw.url}/api/cron`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "targeted",
+        message: "hello channel",
+        schedule: { type: "interval", intervalMs: 60_000 },
+        target: { channel: "telegram", chatId: "123" },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const job = await res.json();
+    expect(job.target).toEqual({ channel: "telegram", chatId: "123" });
+  });
+
+  it("job includes createdAt timestamp", async () => {
+    const before = new Date().toISOString();
+    const res = await fetch(`${gw.url}/api/cron`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "timestamped",
+        message: "check time",
+        schedule: { type: "interval", intervalMs: 60_000 },
+      }),
+    });
+    const job = await res.json();
+    expect(job.createdAt).toBeDefined();
+    expect(new Date(job.createdAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(before).getTime() - 1000,
+    );
+  });
+});

--- a/tests/e2e/api/file-management.e2e.test.ts
+++ b/tests/e2e/api/file-management.e2e.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: File management", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("PUT and GET a text file", async () => {
+    const content = "hello world";
+    const putRes = await fetch(`${gw.url}/files/test.txt`, {
+      method: "PUT",
+      body: content,
+    });
+    expect(putRes.status).toBe(200);
+    const putBody = await putRes.json();
+    expect(putBody.ok).toBe(true);
+
+    const getRes = await fetch(`${gw.url}/files/test.txt`);
+    expect(getRes.status).toBe(200);
+    const text = await getRes.text();
+    expect(text).toBe(content);
+  });
+
+  it("GET nonexistent file returns 404", async () => {
+    const res = await fetch(`${gw.url}/files/nonexistent.txt`);
+    expect(res.status).toBe(404);
+  });
+
+  it("PUT creates nested directories", async () => {
+    const content = "nested content";
+    const putRes = await fetch(`${gw.url}/files/nested/dir/file.txt`, {
+      method: "PUT",
+      body: content,
+    });
+    expect(putRes.status).toBe(200);
+
+    const getRes = await fetch(`${gw.url}/files/nested/dir/file.txt`);
+    expect(getRes.status).toBe(200);
+    expect(await getRes.text()).toBe(content);
+  });
+
+  it("GET path traversal returns 403 or 404", async () => {
+    // fetch() normalizes ../.. in URLs before sending, so the server
+    // may see an already-resolved path. We test with %2e%2e to bypass
+    // client normalization, and also accept 404 (server sees clean path).
+    const res = await fetch(`${gw.url}/files/%2e%2e/%2e%2e/%2e%2e/etc/passwd`);
+    expect([403, 404]).toContain(res.status);
+  });
+
+  it("HEAD existing file returns 200", async () => {
+    // Ensure file exists first
+    await fetch(`${gw.url}/files/head-test.txt`, {
+      method: "PUT",
+      body: "exists",
+    });
+
+    const res = await fetch(`${gw.url}/files/head-test.txt`, {
+      method: "HEAD",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("HEAD nonexistent file returns 404", async () => {
+    const res = await fetch(`${gw.url}/files/no-such-file.txt`, {
+      method: "HEAD",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("GET directory returns 400", async () => {
+    const res = await fetch(`${gw.url}/files/system`);
+    expect(res.status).toBe(400);
+  });
+
+  it("serves JSON with correct content-type", async () => {
+    const data = JSON.stringify({ key: "value" });
+    await fetch(`${gw.url}/files/test-data.json`, {
+      method: "PUT",
+      body: data,
+    });
+
+    const res = await fetch(`${gw.url}/files/test-data.json`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.text()).toBe(data);
+  });
+
+  it("serves HTML with correct content-type", async () => {
+    const html = "<html><body>test</body></html>";
+    await fetch(`${gw.url}/files/page.html`, {
+      method: "PUT",
+      body: html,
+    });
+
+    const res = await fetch(`${gw.url}/files/page.html`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toBe(html);
+  });
+
+  it("serves markdown with correct content-type", async () => {
+    const md = "# Hello\n\nWorld";
+    await fetch(`${gw.url}/files/readme.md`, {
+      method: "PUT",
+      body: md,
+    });
+
+    const res = await fetch(`${gw.url}/files/readme.md`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/markdown");
+    expect(await res.text()).toBe(md);
+  });
+
+  it("PUT path traversal returns 403 or 404", async () => {
+    // Same as GET: fetch() normalizes ../.. before sending
+    const res = await fetch(`${gw.url}/files/%2e%2e/%2e%2e/outside.txt`, {
+      method: "PUT",
+      body: "should fail",
+    });
+    expect([403, 404]).toContain(res.status);
+  });
+
+  it("overwrites existing file on PUT", async () => {
+    await fetch(`${gw.url}/files/overwrite.txt`, {
+      method: "PUT",
+      body: "original",
+    });
+
+    await fetch(`${gw.url}/files/overwrite.txt`, {
+      method: "PUT",
+      body: "updated",
+    });
+
+    const res = await fetch(`${gw.url}/files/overwrite.txt`);
+    expect(await res.text()).toBe("updated");
+  });
+});

--- a/tests/e2e/api/health.e2e.test.ts
+++ b/tests/e2e/api/health.e2e.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Health endpoint", () => {
+  let gw: TestGateway;
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("returns ok status", async () => {
+    gw = await startTestGateway();
+    const res = await fetch(`${gw.url}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+});

--- a/tests/e2e/api/health.e2e.test.ts
+++ b/tests/e2e/api/health.e2e.test.ts
@@ -1,15 +1,18 @@
-import { describe, it, expect, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
 
 describe("E2E: Health endpoint", () => {
   let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
 
   afterAll(async () => {
     await gw?.close();
   });
 
   it("returns ok status", async () => {
-    gw = await startTestGateway();
     const res = await fetch(`${gw.url}/health`);
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/tests/e2e/api/identity.e2e.test.ts
+++ b/tests/e2e/api/identity.e2e.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Identity & Profile", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("GET /api/identity returns handle object from template", async () => {
+    const res = await fetch(`${gw.url}/api/identity`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("handle");
+    expect(body).toHaveProperty("aiHandle");
+    expect(body).toHaveProperty("displayName");
+    expect(body).toHaveProperty("createdAt");
+  });
+
+  it("GET /api/identity reflects template defaults (empty strings)", async () => {
+    const res = await fetch(`${gw.url}/api/identity`);
+    const body = await res.json();
+    expect(body.handle).toBe("");
+    expect(body.aiHandle).toBe("");
+    expect(body.displayName).toBe("");
+    expect(body.createdAt).toBe("");
+  });
+
+  it("GET /api/identity reflects custom handle.json", async () => {
+    const custom = {
+      handle: "@alice:matrix-os.com",
+      aiHandle: "@alice_ai:matrix-os.com",
+      displayName: "Alice",
+      createdAt: "2025-01-01T00:00:00Z",
+    };
+    writeFileSync(
+      join(gw.homePath, "system", "handle.json"),
+      JSON.stringify(custom, null, 2),
+    );
+
+    const res = await fetch(`${gw.url}/api/identity`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.handle).toBe("@alice:matrix-os.com");
+    expect(body.aiHandle).toBe("@alice_ai:matrix-os.com");
+    expect(body.displayName).toBe("Alice");
+    expect(body.createdAt).toBe("2025-01-01T00:00:00Z");
+  });
+
+  it("GET /api/profile returns profile markdown text", async () => {
+    const res = await fetch(`${gw.url}/api/profile`);
+    expect(res.status).toBe(200);
+    const contentType = res.headers.get("content-type");
+    expect(contentType).toContain("text/plain");
+    const text = await res.text();
+    expect(text).toContain("# Profile");
+    expect(text).toContain("Language: en");
+  });
+
+  it("GET /api/ai-profile returns AI profile markdown text", async () => {
+    const res = await fetch(`${gw.url}/api/ai-profile`);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("# AI Profile");
+    expect(text).toContain("Personality:");
+  });
+
+  it("GET /api/profile returns custom content after write", async () => {
+    const custom = "# Profile\n\nDisplay Name: Bob\nBio: Builder\nTimezone: UTC\nLanguage: en\n";
+    writeFileSync(join(gw.homePath, "system", "profile.md"), custom);
+
+    const res = await fetch(`${gw.url}/api/profile`);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("Display Name: Bob");
+    expect(text).toContain("Bio: Builder");
+  });
+});

--- a/tests/e2e/api/push-notifications.e2e.test.ts
+++ b/tests/e2e/api/push-notifications.e2e.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Push notification registration", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("registers an iOS push token", async () => {
+    const res = await fetch(`${gw.url}/api/push/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "abc123", platform: "ios" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("registers an Android push token", async () => {
+    const res = await fetch(`${gw.url}/api/push/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "def456", platform: "android" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("rejects registration without token", async () => {
+    const res = await fetch(`${gw.url}/api/push/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "ios" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+
+  it("rejects registration without platform", async () => {
+    const res = await fetch(`${gw.url}/api/push/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "abc123" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+
+  it("removes a registered push token", async () => {
+    // Register first
+    await fetch(`${gw.url}/api/push/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "remove-me", platform: "ios" }),
+    });
+
+    const res = await fetch(`${gw.url}/api/push/register`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "remove-me" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("rejects removal without token", async () => {
+    const res = await fetch(`${gw.url}/api/push/register`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+});

--- a/tests/e2e/api/security-headers.e2e.test.ts
+++ b/tests/e2e/api/security-headers.e2e.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Security headers", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("includes security headers on /health", async () => {
+    const res = await fetch(`${gw.url}/health`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(res.headers.get("X-XSS-Protection")).toBe("1; mode=block");
+    expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("includes security headers on /api/tasks", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(res.headers.get("X-XSS-Protection")).toBe("1; mode=block");
+  });
+
+  it("includes security headers on /files/ but omits X-Frame-Options", async () => {
+    const res = await fetch(`${gw.url}/files/system/soul.md`);
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("X-XSS-Protection")).toBe("1; mode=block");
+    expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    // X-Frame-Options is intentionally skipped for /files/ paths (app content)
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
+  });
+
+  it("includes CORS headers (Access-Control-Allow-Origin)", async () => {
+    const res = await fetch(`${gw.url}/health`);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("responds to CORS preflight requests", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:3000",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toBeTruthy();
+  });
+
+  it("includes Referrer-Policy on API routes", async () => {
+    const res = await fetch(`${gw.url}/api/cron`);
+    expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+  });
+});

--- a/tests/e2e/api/settings-persistence.e2e.test.ts
+++ b/tests/e2e/api/settings-persistence.e2e.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Settings & Layout Persistence", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("GET /api/layout returns default layout from template", async () => {
+    const res = await fetch(`${gw.url}/api/layout`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("windows");
+    expect(body).toHaveProperty("dock");
+    expect(Array.isArray(body.windows)).toBe(true);
+  });
+
+  it("PUT /api/layout saves layout", async () => {
+    const layout = { windows: [{ id: "chat", x: 0, y: 0, w: 400, h: 600 }] };
+    const res = await fetch(`${gw.url}/api/layout`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(layout),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("GET /api/layout returns saved layout", async () => {
+    const res = await fetch(`${gw.url}/api/layout`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.windows).toBeDefined();
+    expect(Array.isArray(body.windows)).toBe(true);
+    expect(body.windows[0].id).toBe("chat");
+  });
+
+  it("PUT /api/layout without windows array returns 400", async () => {
+    const res = await fetch(`${gw.url}/api/layout`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ noWindows: true }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("windows");
+  });
+
+  it("GET /api/theme returns default theme from template", async () => {
+    const res = await fetch(`${gw.url}/api/theme`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe("default");
+    expect(body).toHaveProperty("colors");
+    expect(body).toHaveProperty("fonts");
+  });
+
+  it("GET /api/theme reflects updated theme.json", async () => {
+    const theme = { name: "midnight", colors: { primary: "#0ff" } };
+    writeFileSync(
+      join(gw.homePath, "system", "theme.json"),
+      JSON.stringify(theme, null, 2),
+    );
+
+    const res = await fetch(`${gw.url}/api/theme`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.name).toBe("midnight");
+    expect(body.colors.primary).toBe("#0ff");
+  });
+
+  it("GET /api/apps returns app list", async () => {
+    const res = await fetch(`${gw.url}/api/apps`);
+    expect(res.status).toBe(200);
+    const apps = await res.json();
+    expect(Array.isArray(apps)).toBe(true);
+    expect(apps.length).toBeGreaterThan(0);
+    for (const app of apps) {
+      expect(app).toHaveProperty("name");
+      expect(app).toHaveProperty("file");
+      expect(app).toHaveProperty("path");
+    }
+  });
+
+  it("GET /api/system/info returns system info", async () => {
+    const res = await fetch(`${gw.url}/api/system/info`);
+    expect(res.status).toBe(200);
+    const info = await res.json();
+    expect(info).toHaveProperty("version");
+    expect(info).toHaveProperty("uptime");
+    expect(info).toHaveProperty("modules");
+    expect(info).toHaveProperty("channels");
+    expect(info).toHaveProperty("skills");
+    expect(typeof info.uptime).toBe("number");
+  });
+});

--- a/tests/e2e/api/tasks.e2e.test.ts
+++ b/tests/e2e/api/tasks.e2e.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Task Management", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("POST /api/tasks creates a task and returns 201", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input: "Buy groceries" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBeDefined();
+    expect(body.task).toBeDefined();
+    expect(body.task.type).toBe("todo");
+    expect(body.task.status).toBe("pending");
+    expect(body.task.input).toBe(JSON.stringify("Buy groceries"));
+  });
+
+  it("POST /api/tasks with type and priority", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input: "Deploy app", type: "deploy", priority: 1 }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.task.type).toBe("deploy");
+    expect(body.task.priority).toBe(1);
+  });
+
+  it("GET /api/tasks lists all tasks", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`);
+    expect(res.status).toBe(200);
+    const tasks = await res.json();
+    expect(Array.isArray(tasks)).toBe(true);
+    expect(tasks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("GET /api/tasks?status=pending filters by status", async () => {
+    const res = await fetch(`${gw.url}/api/tasks?status=pending`);
+    expect(res.status).toBe(200);
+    const tasks = await res.json();
+    expect(Array.isArray(tasks)).toBe(true);
+    for (const task of tasks) {
+      expect(task.status).toBe("pending");
+    }
+  });
+
+  it("GET /api/tasks/:id returns a specific task", async () => {
+    const createRes = await fetch(`${gw.url}/api/tasks`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input: "Specific task" }),
+    });
+    const { id } = await createRes.json();
+
+    const res = await fetch(`${gw.url}/api/tasks/${id}`);
+    expect(res.status).toBe(200);
+    const task = await res.json();
+    expect(task.id).toBe(id);
+    expect(task.input).toBe(JSON.stringify("Specific task"));
+  });
+
+  it("GET /api/tasks/nonexistent returns 404", async () => {
+    const res = await fetch(`${gw.url}/api/tasks/nonexistent`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Not found");
+  });
+
+  it("POST /api/tasks without input returns 400", async () => {
+    const res = await fetch(`${gw.url}/api/tasks`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("input is required");
+  });
+
+  it("task has expected fields", async () => {
+    const createRes = await fetch(`${gw.url}/api/tasks`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input: "Field check" }),
+    });
+    const { task } = await createRes.json();
+    expect(task).toHaveProperty("id");
+    expect(task).toHaveProperty("type");
+    expect(task).toHaveProperty("status");
+    expect(task).toHaveProperty("input");
+    expect(task).toHaveProperty("priority");
+    expect(task).toHaveProperty("createdAt");
+  });
+});

--- a/tests/e2e/fixtures/gateway.ts
+++ b/tests/e2e/fixtures/gateway.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, cpSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { createGateway } from "../../../packages/gateway/src/server.js";
+
+const TEMPLATE_DIR = resolve(__dirname, "../../../home");
+
+export interface TestGateway {
+  url: string;
+  homePath: string;
+  close: () => Promise<void>;
+}
+
+let nextPort = 14_000 + Math.floor(Math.random() * 10_000);
+
+function getPort(): number {
+  return nextPort++;
+}
+
+export interface TestGatewayOptions {
+  authToken?: string;
+  config?: Record<string, unknown>;
+}
+
+export async function startTestGateway(
+  options: TestGatewayOptions = {},
+): Promise<TestGateway> {
+  const homePath = resolve(mkdtempSync(join(tmpdir(), "e2e-gateway-")));
+  cpSync(TEMPLATE_DIR, homePath, { recursive: true });
+
+  // Ensure required directories
+  mkdirSync(join(homePath, "system", "logs"), { recursive: true });
+  mkdirSync(join(homePath, "system", "conversations"), { recursive: true });
+  mkdirSync(join(homePath, "system", "plugins"), { recursive: true });
+
+  // Write custom config if provided
+  if (options.config) {
+    writeFileSync(
+      join(homePath, "system", "config.json"),
+      JSON.stringify(options.config, null, 2),
+    );
+  }
+
+  // Init git (needed by dispatcher)
+  try {
+    execFileSync("git", ["init"], { cwd: homePath, stdio: "ignore" });
+    execFileSync("git", ["add", "."], { cwd: homePath, stdio: "ignore" });
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@test.com", "commit", "-m", "init"], {
+      cwd: homePath,
+      stdio: "ignore",
+    });
+  } catch {
+    // git not critical for all tests
+  }
+
+  const port = getPort();
+
+  // Set auth token if provided
+  const prevToken = process.env.MATRIX_AUTH_TOKEN;
+  if (options.authToken) {
+    process.env.MATRIX_AUTH_TOKEN = options.authToken;
+  } else {
+    delete process.env.MATRIX_AUTH_TOKEN;
+  }
+
+  const gateway = await createGateway({ homePath, port });
+
+  // Restore env
+  if (prevToken !== undefined) {
+    process.env.MATRIX_AUTH_TOKEN = prevToken;
+  } else {
+    delete process.env.MATRIX_AUTH_TOKEN;
+  }
+
+  return {
+    url: `http://localhost:${port}`,
+    homePath,
+    async close() {
+      await gateway.close();
+    },
+  };
+}

--- a/tests/e2e/fixtures/ws-client.ts
+++ b/tests/e2e/fixtures/ws-client.ts
@@ -1,0 +1,74 @@
+import { WebSocket } from "ws";
+
+export interface WsClient {
+  send: (msg: Record<string, unknown>) => void;
+  messages: () => Record<string, unknown>[];
+  waitFor: (type: string, timeout?: number) => Promise<Record<string, unknown>>;
+  close: () => void;
+}
+
+export function connectWs(url: string): Promise<WsClient> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const received: Record<string, unknown>[] = [];
+    const waiters: Array<{
+      type: string;
+      resolve: (msg: Record<string, unknown>) => void;
+      reject: (err: Error) => void;
+    }> = [];
+
+    ws.on("open", () => {
+      resolve({
+        send(msg) {
+          ws.send(JSON.stringify(msg));
+        },
+        messages() {
+          return received;
+        },
+        waitFor(type: string, timeout = 10_000) {
+          const existing = received.find((m) => m.type === type);
+          if (existing) return Promise.resolve(existing);
+
+          return new Promise((res, rej) => {
+            const timer = setTimeout(() => {
+              rej(new Error(`Timeout waiting for message type "${type}"`));
+            }, timeout);
+
+            waiters.push({
+              type,
+              resolve: (msg) => {
+                clearTimeout(timer);
+                res(msg);
+              },
+              reject: (err) => {
+                clearTimeout(timer);
+                rej(err);
+              },
+            });
+          });
+        },
+        close() {
+          ws.close();
+        },
+      });
+    });
+
+    ws.on("message", (data) => {
+      try {
+        const msg = JSON.parse(data.toString()) as Record<string, unknown>;
+        received.push(msg);
+
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (waiters[i].type === msg.type) {
+            waiters[i].resolve(msg);
+            waiters.splice(i, 1);
+          }
+        }
+      } catch {
+        // ignore non-JSON
+      }
+    });
+
+    ws.on("error", reject);
+  });
+}

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    conditions: ["node"],
+    alias: {
+      "@": path.resolve(__dirname, "shell/src"),
+    },
+  },
+  test: {
+    globals: true,
+    include: ["tests/e2e/**/*.e2e.test.ts"],
+    testTimeout: 30_000,
+    hookTimeout: 20_000,
+    sequence: { concurrent: false },
+  },
+});


### PR DESCRIPTION
## Summary
- 101 E2E tests across 13 test files, organized in 3 tiers by value
- Real HTTP/WebSocket requests against actual Hono gateway (no mocks)
- Separate Vitest config with `bun run test:e2e`
- CI pipeline updated: unit -> E2E with failure artifact upload
- Full spec at `specs/032-e2e-testing/` (how to run, add, verify, CI/CD)
- README license badge updated to AGPL-3.0

### Test Coverage
| Tier | Tests | Files | Covers |
|------|-------|-------|--------|
| T1 Critical | 44 | 4 | Chat WS, files, cron, channels |
| T2 High | 29 | 4 | Tasks, settings, identity, conversations |
| T3 Medium | 27 | 4 | Push, auth, security headers, bridge data |
| Infra | 1 | 1 | Health smoke test |

**Total: 1,113 tests passing (1,012 unit + 101 E2E)**

## Test plan
- [x] `bun run test` passes (1,012 unit tests)
- [x] `bun run test:e2e` passes (101 E2E tests)
- [x] No ANTHROPIC_API_KEY required for E2E tests
- [x] CI workflow runs both stages sequentially

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Comprehensive end-to-end testing framework and infrastructure

* **Tests**
  * Added 13+ E2E tests covering critical workflows: chat flows, conversations, file management, authentication, push notifications, security headers, and more

* **Chores**
  * Updated CI/CD pipeline to include dedicated E2E test execution
  * Changed project license to AGPL-3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->