### PR TITLE
ci: enable sticky PR comments for Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

- Add `use_sticky_comment: true` to the Claude code review workflow

Without this flag, the review output only appears in the Actions job summary page, not as an actual comment on the PR. This is why reviews were running successfully but never commenting.

## Test plan
- [ ] Merge this PR first, then the canvas PR (#12) should get a review comment