### PR TITLE
fix(www): add sitemap/robots.txt and fix SEO audit warnings

### DIFF
--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -27,12 +27,12 @@ const sourceSerif = Source_Serif_4({
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://matrix-os.com"),
-  title: "Matrix OS | The OS That Builds Itself",
+  title: "Matrix OS | AI-Native Operating System That Builds Itself",
   description:
-    "An AI-native operating system where software is generated in real time from conversation. Your OS, your messaging, your social network, your AI assistant, unified under one identity.",
+    "Matrix OS is an AI-native operating system that generates software from conversation. Describe what you need and watch it appear on your desktop.",
   openGraph: {
-    title: "Matrix OS",
-    description: "The OS that builds itself. Describe what you need. It writes it into existence.",
+    title: "Matrix OS | AI-Native Operating System",
+    description: "The AI-native operating system that builds itself. Describe what you need. It writes it into existence.",
     url: "https://matrix-os.com",
     siteName: "Matrix OS",
     type: "website",
@@ -40,16 +40,17 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Matrix OS",
-    description: "The OS that builds itself. Describe what you need. It writes it into existence.",
+    title: "Matrix OS | AI-Native Operating System",
+    description: "The AI-native operating system that builds itself. Describe what you need. It writes it into existence.",
     creator: "@HamedMP",
   },
   keywords: [
+    "AI-native operating system",
     "AI operating system",
     "Claude Agent SDK",
-    "AI-native OS",
     "self-building software",
     "Matrix OS",
+    "generative OS",
   ],
 };
 
@@ -61,6 +62,11 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="en" suppressHydrationWarning>
+        <head>
+          <link rel="dns-prefetch" href="https://clerk.matrix-os.com" />
+          <link rel="dns-prefetch" href="https://eu.i.posthog.com" />
+          <link rel="preconnect" href="https://clerk.matrix-os.com" crossOrigin="anonymous" />
+        </head>
         <body className={`${inter.variable} ${jetbrainsMono.variable} ${caveat.variable} ${sourceSerif.variable}`}>
           {children}
           <Analytics />

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -66,6 +66,7 @@ export default function RootLayout({
           <link rel="dns-prefetch" href="https://clerk.matrix-os.com" />
           <link rel="dns-prefetch" href="https://eu.i.posthog.com" />
           <link rel="preconnect" href="https://clerk.matrix-os.com" crossOrigin="anonymous" />
+          <link rel="preconnect" href="https://eu.i.posthog.com" crossOrigin="anonymous" />
         </head>
         <body className={`${inter.variable} ${jetbrainsMono.variable} ${caveat.variable} ${sourceSerif.variable}`}>
           {children}

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -149,9 +149,9 @@ function Hero() {
         {/* Text block */}
         <div className="text-center mb-16">
           <h1 className="animate-fade-up text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight mb-6 leading-[1.1]">
-            Your computer is stuck in 1984.
+            The AI-native operating system
             <br />
-            <span className="font-[family-name:var(--font-caveat)] text-primary text-[1.15em]">This one isn't.</span>
+            <span className="font-[family-name:var(--font-caveat)] text-primary text-[1.15em]">that builds itself.</span>
           </h1>
 
           <p className="animate-fade-up delay-100 text-base sm:text-lg text-muted-foreground max-w-xl mx-auto mb-10 leading-relaxed">
@@ -366,9 +366,15 @@ function Problem() {
           <br />
           Files scattered across services you don't control.
         </h2>
-        <p className="text-lg text-muted-foreground leading-relaxed max-w-xl mx-auto mb-10">
+        <p className="text-lg text-muted-foreground leading-relaxed max-w-xl mx-auto mb-6">
           What if your OS understood you? What if software wrote itself?
           What if every device you own was the same computer?
+        </p>
+        <p className="text-base text-muted-foreground leading-relaxed max-w-xl mx-auto mb-10">
+          Matrix OS is an AI-native operating system built on the Claude Agent SDK.
+          It replaces the traditional app-per-task model with a single AI kernel
+          that generates, manages, and evolves software from plain conversation.
+          Everything lives as files you own, synced across every device.
         </p>
         <SignedOut>
           <Button size="lg" className="h-11 px-7 text-sm rounded-xl" asChild>

--- a/www/src/app/robots.ts
+++ b/www/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/dashboard", "/admin", "/api/"],
+    },
+    sitemap: "https://matrix-os.com/sitemap.xml",
+  };
+}

--- a/www/src/app/sitemap.ts
+++ b/www/src/app/sitemap.ts
@@ -1,49 +1,29 @@
 import type { MetadataRoute } from "next";
+import { source } from "@/lib/source";
 
 const BASE_URL = "https://matrix-os.com";
-
-const docSlugs = [
-  "",
-  "guide",
-  "guide/getting-started",
-  "guide/agents",
-  "guide/channels",
-  "guide/apps",
-  "guide/file-system",
-  "guide/storage",
-  "guide/social",
-  "guide/app-store",
-  "guide/design-system",
-  "developer",
-  "developer/architecture",
-  "developer/contributing",
-  "developer/testing",
-  "developer/ipc-tools",
-  "developer/logging",
-  "developer/skills",
-];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
-      lastModified: new Date(),
+      lastModified: new Date("2026-03-23"),
       changeFrequency: "weekly",
       priority: 1,
     },
     {
       url: `${BASE_URL}/whitepaper`,
-      lastModified: new Date(),
+      lastModified: new Date("2026-03-23"),
       changeFrequency: "monthly",
       priority: 0.8,
     },
   ];
 
-  const docPages: MetadataRoute.Sitemap = docSlugs.map((slug) => ({
-    url: slug ? `${BASE_URL}/docs/${slug}` : `${BASE_URL}/docs`,
-    lastModified: new Date(),
+  const docPages: MetadataRoute.Sitemap = source.getPages().map((page) => ({
+    url: `${BASE_URL}/docs/${page.slugs.join("/")}`,
+    lastModified: new Date("2026-03-23"),
     changeFrequency: "weekly" as const,
-    priority: slug === "" ? 0.9 : 0.7,
+    priority: 0.7,
   }));
 
   return [...staticPages, ...docPages];

--- a/www/src/app/sitemap.ts
+++ b/www/src/app/sitemap.ts
@@ -7,13 +7,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
-      lastModified: new Date("2026-03-23"),
+      lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
     },
     {
       url: `${BASE_URL}/whitepaper`,
-      lastModified: new Date("2026-03-23"),
+      lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.8,
     },
@@ -21,7 +21,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const docPages: MetadataRoute.Sitemap = source.getPages().map((page) => ({
     url: `${BASE_URL}/docs/${page.slugs.join("/")}`,
-    lastModified: new Date("2026-03-23"),
+    lastModified: page.data.lastModified ? new Date(page.data.lastModified) : new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.7,
   }));

--- a/www/src/app/sitemap.ts
+++ b/www/src/app/sitemap.ts
@@ -1,0 +1,50 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://matrix-os.com";
+
+const docSlugs = [
+  "",
+  "guide",
+  "guide/getting-started",
+  "guide/agents",
+  "guide/channels",
+  "guide/apps",
+  "guide/file-system",
+  "guide/storage",
+  "guide/social",
+  "guide/app-store",
+  "guide/design-system",
+  "developer",
+  "developer/architecture",
+  "developer/contributing",
+  "developer/testing",
+  "developer/ipc-tools",
+  "developer/logging",
+  "developer/skills",
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/whitepaper`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+
+  const docPages: MetadataRoute.Sitemap = docSlugs.map((slug) => ({
+    url: slug ? `${BASE_URL}/docs/${slug}` : `${BASE_URL}/docs`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: slug === "" ? 0.9 : 0.7,
+  }));
+
+  return [...staticPages, ...docPages];
+}


### PR DESCRIPTION
## Summary
- Add `sitemap.ts` generating `/sitemap.xml` with 20 URLs (homepage, whitepaper, all doc pages)
- Add `robots.ts` generating `/robots.txt` (blocks `/dashboard`, `/admin`, `/api/`, points to sitemap)
- Shorten meta description from 175 to 145 chars (under 155 recommended max)
- Add target keyword "AI-native operating system" to title, H1, OG tags, Twitter tags, keywords, and body copy
- Add `dns-prefetch`/`preconnect` hints for Clerk and PostHog to reduce render-blocking
- Add descriptive paragraph to Problem section improving content-to-code ratio

## Test plan
- [ ] Verify `/sitemap.xml` returns valid XML with all expected URLs
- [ ] Verify `/robots.txt` returns correct rules and sitemap pointer
- [ ] Run SEO audit tool and confirm all 4 warnings are resolved
- [ ] Check meta description length stays under 155 chars
- [ ] Verify H1 contains "AI-native operating system" keyword
- [ ] Visual check that the landing page hero section still looks good with the new headline