### PR TITLE
ci: add structured review pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── Gate 1: Mechanical checks ──
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # TODO: remove continue-on-error once baseline type errors in kernel are fixed
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Type check all packages
+        run: bun run typecheck
+
+  patterns:
+    name: Pattern Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
+
+      - name: Run CLAUDE.md pattern scanner on changed files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            ./scripts/review/check-patterns.sh --diff origin/${{ github.base_ref }}
+          else
+            ./scripts/review/check-patterns.sh
+          fi
+
+  # ── Gate 2: Tests ──
   unit:
     name: Unit Tests
+    needs: [typecheck, patterns]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -50,7 +96,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Configure git for tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     name: Unit Tests
     needs: [typecheck, patterns]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,18 +27,103 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            You are reviewing a PR for Matrix OS. Read CLAUDE.md first for project conventions.
 
-            Review this PR. Focus on:
-            1. Bugs, logic errors, and potential runtime failures
-            2. Security vulnerabilities (XSS, injection, auth issues)
-            3. Performance problems (memory leaks, unnecessary re-renders, N+1 queries)
-            4. Code quality and adherence to project conventions in CLAUDE.md
+            ## PR Size Gate
 
-            Be concise. Only flag real issues, not style nitpicks.
-            Use the gh CLI to read the PR diff and post inline comments on specific lines.
+            Check the PR stats. If additions > 3000 or changed files > 50, post a
+            top-level comment recommending the PR be split, with suggested groupings.
+            Still review, but note the size makes thorough review unreliable.
+
+            ## Review Structure: Three Passes
+
+            Do NOT review line-by-line. Instead, make three structured passes over the
+            changed files. Each pass catches a distinct class of issue. Do not repeat
+            findings across passes.
+
+            ### Pass 1: Mechanical CLAUDE.md Sweep
+
+            Run these searches on changed files and flag violations:
+
+            1. **Bare/empty catch blocks**: `catch {}`, `.catch(() => {})`, `.catch(() => undefined)`
+               Rule: every catch must check error type and at minimum log
+            2. **fetch() without signal**: any `fetch(` call missing `signal: AbortSignal.timeout()`
+               Rule: 10s for APIs, 30s for downloads
+            3. **Body consumption without bodyLimit**: `c.req.json()`, `.text()`, `.blob()`, `.arrayBuffer()`
+               Rule: Hono bodyLimit middleware required on every mutating endpoint
+            4. **Unbounded Map/Set**: `new Map()`, `new Set()` without size cap nearby
+               Rule: must have cap + eviction (LRU via delete-then-set, or TTL)
+            5. **Sync file I/O**: `writeFileSync`, `appendFileSync` in non-test code
+               Rule: banned in request handlers, use fs/promises
+            6. **Non-atomic file writes**: `writeFile(finalPath, ...)` without temp+rename
+               Rule: write to temp, then rename atomically
+
+            Report only confirmed violations with file:line. Skip if CI pattern scanner
+            already catches it (note that in the summary).
+
+            ### Pass 2: Trust-Boundary Sweep
+
+            For each changed file, identify where external input enters and trace it:
+
+            **Route handler files** (files with `app.get/post/put/delete/patch`):
+            - [ ] Every path/query/header param validated before use
+            - [ ] Error responses don't leak internals (no raw err.message, no Zod .issues)
+            - [ ] Auth middleware applied (check mounting order in parent file)
+
+            **Filesystem operation files** (files using join/resolve/readFile/writeFile/unlink):
+            - [ ] All paths validated via resolveWithinPrefix or equivalent
+            - [ ] Symlink checks before write/delete operations
+            - [ ] No path.join() on unvalidated external input
+
+            **Database operation files** (files with Drizzle/Kysely queries):
+            - [ ] 2+ related writes wrapped in transaction
+            - [ ] No TOCTOU (read-check-write without lock)
+            - [ ] ON CONFLICT for upserts instead of check-then-insert
+
+            **WebSocket/IPC handlers** (files processing ws.on('message') or IPC):
+            - [ ] Incoming messages validated with Zod schema before use
+            - [ ] No unchecked `as` casts on external data
+            - [ ] Buffer/message size caps
+
+            ### Pass 3: Atomicity and Failure-Mode Review
+
+            For each subsystem touched by the PR, ask these questions:
+
+            1. **What is the source of truth?** (DB? R2? filesystem?)
+               If there are two stores, what reconciles them on divergence?
+            2. **What is inside the lock/transaction?**
+               Are network calls (R2, external APIs) inside the critical section?
+               Could they be moved outside?
+            3. **What happens on partial failure?**
+               If step N succeeds and step N+1 fails, is there orphaned state?
+               Is there compensation/cleanup?
+            4. **What happens on shutdown/restart?**
+               Are watchers/intervals/connections cleaned up?
+               Is in-flight work drained or abandoned?
+            5. **What is explicitly deferred?**
+               If auth, validation, or cleanup is "not in scope", is that stated?
+
+            ## Output Format
+
+            Post ONE review comment with this structure:
+
+            ### PR Size Assessment
+            [additions/files count, split recommendation if needed]
+
+            ### Findings
+            [Grouped by pass. Each finding: severity (CRITICAL/HIGH/MEDIUM/LOW),
+            file:line, one-sentence description, one-sentence fix suggestion.
+            No duplicates across passes.]
+
+            ### What Looked Good
+            [2-3 bullet points on things done well — important for calibration]
+
+            Then post INLINE comments only for CRITICAL and HIGH findings on specific lines.
+            Do not post inline comments for MEDIUM/LOW — those go in the summary only.
+
+            Maximum 20 inline comments. If you find more than 20 HIGH+ issues, the PR
+            should probably be split.
           claude_args: |
             --model claude-opus-4-6
-            --max-turns 50
-            --allowedTools "Bash(gh pr:*),Bash(gh api:*),Bash(gh diff:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Read,Glob,Grep"
+            --max-turns 25
+            --allowedTools "Bash(gh pr:*),Bash(gh api:*),Bash(gh diff:*),Bash(cat:*),Bash(head:*),Bash(wc:*),Bash(rg:*),Read,Glob,Grep"

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -32,30 +32,73 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            Security-focused review for Matrix OS. Read CLAUDE.md first.
 
-            Perform a security-focused review of this PR. Check for:
+            ## Scope
 
-            ## OWASP Top 10
-            - SQL Injection (we use Drizzle ORM - check for raw queries)
-            - Cross-Site Scripting (XSS) in shell components
-            - Broken Authentication (auth middleware, MATRIX_AUTH_TOKEN)
-            - Sensitive Data Exposure (API keys, tokens in logs)
-            - Broken Access Control (file path traversal, IPC tool access)
-            - Server-Side Request Forgery (SSRF) in gateway proxy/fetch
-            - Security Misconfiguration (permissive CORS, missing headers)
+            Only review changed files. Focus exclusively on security — not code style,
+            performance, or conventions (the code review workflow handles those).
 
-            ## Project-Specific
-            - Agent SDK tool restrictions (bypassPermissions, allowedTools)
-            - File system access outside home directory
-            - Channel adapter input sanitization (Telegram, Discord, etc.)
-            - WebSocket message validation
-            - GitHub Actions workflow injection
+            ## Pass 1: Trust Boundary Audit
 
-            Rate findings as CRITICAL, HIGH, MEDIUM, or LOW.
-            Only report real issues, not theoretical concerns.
-            Use inline comments on the specific lines.
+            For every changed file, identify ALL trust boundaries — points where
+            untrusted data enters the system. Then verify each one:
+
+            **HTTP request data** (headers, params, body, query):
+            - Validated with Zod schema before any use?
+            - Path params checked against safe regex (SAFE_SLUG)?
+            - Headers (X-Forwarded-For, X-Peer-Id, etc.) validated for length/format?
+            - Error responses free of internal details (no raw errors, no stack traces)?
+
+            **Filesystem paths** (any join/resolve/readFile/writeFile/unlink):
+            - Passed through resolveWithinPrefix or equivalent containment check?
+            - Symlink-safe? (lstat check before write/delete)
+            - Intermediate dirs checked after mkdir? (symlink-race TOCTOU)
+
+            **WebSocket/IPC messages**:
+            - Parsed with Zod schema, not bare `as` cast?
+            - Size-capped before buffering?
+
+            **Inter-service calls** (platform-to-container, gateway-to-R2):
+            - Authenticated (HMAC, JWT, bearer)?
+            - Env vars not leaking secrets to user containers?
+
+            ## Pass 2: Auth Boundary Verification
+
+            Trace the auth middleware mounting order in every changed router file:
+            - Is auth middleware mounted BEFORE the routes it should protect?
+            - Are public/exempt routes explicitly listed (not implicit by mount order)?
+            - Rate limiters: applied before or after auth? (should be before)
+            - Rate limiter keying: uses trusted IP source? (cf-connecting-ip > x-real-ip > x-forwarded-for)
+
+            ## Pass 3: Atomicity Under Adversarial Conditions
+
+            For every multi-step operation in changed files:
+            - **Concurrent access**: What happens with 2 simultaneous requests?
+              Is there a lock/transaction? What does the lock actually cover?
+            - **Partial failure**: If step 2 of 3 fails, is there orphaned state?
+              (orphaned R2 blobs, DB records without corresponding files, etc.)
+            - **Timing attacks**: Any comparison that leaks information via timing?
+              (Must use timingSafeEqual with proper length padding)
+
+            ## Pass 4: Container/Platform Security
+
+            If orchestrator, Docker, or container env files are changed:
+            - No secrets forwarded to user containers (PLATFORM_SECRET, DB URLs)
+            - Container isolation: no shared credentials for per-user resources
+            - Docker socket not exposed to user containers
+
+            ## Output
+
+            Rate each finding: CRITICAL, HIGH, MEDIUM, LOW.
+
+            CRITICAL = exploitable now (path traversal, auth bypass, secret leak).
+            HIGH = exploitable with specific conditions.
+            MEDIUM = defense-in-depth gap.
+            LOW = theoretical or requires internal access.
+
+            Post ONE summary comment + inline comments for CRITICAL/HIGH only.
+            Maximum 15 inline comments.
           claude_args: |
             --model claude-opus-4-6
             --max-turns 25

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,29 +146,40 @@ Read `specs/ux-guide.md`. Key rules:
 
 Every spec with endpoints/WebSockets/IPC/file I/O must include: security architecture (auth matrix, input validation, error policy), integration wiring (startup sequence, cross-package comms), failure modes (timeouts, concurrent access, crash recovery), resource management (buffer limits, file cleanup). Full checklist: `specs/quality-gates.md`
 
-## Code Review Essentials
+## Code Review Pipeline
 
-Check failure modes, not just happy paths:
+Full guide: `docs/dev/review-pipeline.md`. Use three structured passes, not line-by-line review.
 
-- **Error handling**: typed catch blocks (not bare `catch { return null }`), async `.catch()`, no leaking internals
-- **Atomicity**: 3+ sequential DB writes need transactions, no TOCTOU races
-- **API contract**: response field names match frontend, no dead code paths
-- **Type safety**: no unchecked `as` casts, sync/async signature matches
+### Pre-PR Checklist (mandatory)
 
-### Review Sweeps
+```bash
+bun run typecheck           # tsc --noEmit for all packages
+bun run check:patterns      # CLAUDE.md pattern scanner (scripts/review/check-patterns.sh)
+bun run test                # unit tests
+```
 
-For every PR review, run these targeted sweeps on touched files:
+### Three Review Passes
 
-- **Fetch timeout sweep**: inspect every new `fetch(` call in backend, shell, injected bridge scripts, and tests/mocks that mirror production code. Real calls must include `signal: AbortSignal.timeout(...)`.
-- **Empty catch sweep**: grep for `catch {}`, `catch { return ... }`, and `.catch(() => {})`. Every catch must log or explicitly handle the failure mode.
-- **Parity sweep for mirrored routes**: if logic exists in both a public route and a bridge/dev/proxy route, verify they share one helper or match behavior exactly (validation, verb dispatch, fallback behavior, errors, timeouts).
-- **Bridge/API argument sweep**: when shell bridge helpers call backend routes, confirm they expose every backend disambiguator the feature depends on (`label`, IDs, paging, etc.), not just the "happy path" arguments.
-- **Review grep commands**: at minimum run `rg -n 'fetch\\(' packages shell` and `rg -n 'catch\\s*\\{|\\.catch\\(\\(\\) => \\{\\s*\\}\\)' packages shell tests` before finalizing a review.
+1. **Mechanical CLAUDE.md sweep**: Run `bun run check:patterns` and fix all violations. The scanner checks: bare catch, fetch without signal, sync file I/O, unbounded Map/Set. Warnings (bodyLimit, path ops, external headers) require manual verification.
+
+2. **Trust-boundary sweep**: For each changed file, classify it (route handler, filesystem, database, WS/IPC) and apply the matching checklist from `docs/dev/review-pipeline.md`. Trace external input from entry to use.
+
+3. **Atomicity/failure-mode review**: For each subsystem touched, answer: What is the source of truth? What is inside the lock/transaction? What happens on partial failure? What happens on shutdown? What is explicitly deferred?
+
+### PR Size Limits
+
+- **> 3000 additions or > 50 files**: split the PR
+- Split along: gateway, platform, sync-client, shell, docs/deploy
+
+### PR Body: Mandatory Invariants
+
+Every backend PR must document: source of truth, lock/transaction scope, acceptable orphan states, auth source of truth, and explicitly deferred scope.
 
 ## Reference Docs
 
 Read these on demand, not every session:
 
+- `docs/dev/review-pipeline.md` -- when reviewing or opening PRs (three-pass structure, checklists, CI gates)
 - `docs/dev/onboarding.md` -- developer setup, API keys, and getting started
 - `docs/dev/pr-review-analysis.md` -- when triaging review comments or understanding recurring defect patterns
 - `docs/dev/docker-development.md` -- when working on Docker setup or debugging container issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,19 +122,40 @@ Read `specs/ux-guide.md`. Key rules:
 
 Every spec with endpoints/WebSockets/IPC/file I/O must include: security architecture (auth matrix, input validation, error policy), integration wiring (startup sequence, cross-package comms), failure modes (timeouts, concurrent access, crash recovery), resource management (buffer limits, file cleanup). Full checklist: `specs/quality-gates.md`
 
-## Code Review Essentials
+## Code Review Pipeline
 
-Check failure modes, not just happy paths:
+Full guide: `docs/dev/review-pipeline.md`. Three-pass structure, not line-by-line.
 
-- **Error handling**: typed catch blocks (not bare `catch { return null }`), async `.catch()`, no leaking internals
-- **Atomicity**: 3+ sequential DB writes need transactions, no TOCTOU races
-- **API contract**: response field names match frontend, no dead code paths
-- **Type safety**: no unchecked `as` casts, sync/async signature matches
+### Pre-PR Checklist
+
+Before opening any PR, run:
+
+```bash
+bun run typecheck           # tsc --noEmit for all packages
+bun run check:patterns      # CLAUDE.md pattern scanner
+bun run test                # unit tests
+```
+
+### Three Review Passes
+
+1. **Mechanical CLAUDE.md sweep**: bare catch, fetch without signal, missing bodyLimit, unbounded Map/Set, sync file I/O. Mostly automated by `scripts/review/check-patterns.sh`.
+2. **Trust-boundary sweep**: trace external input through route handlers, filesystem ops, DB queries, WS/IPC handlers. Apply per-file-type checklists.
+3. **Atomicity/failure-mode review**: source of truth, lock scope, partial failure, shutdown cleanup, deferred scope.
+
+### PR Size Limits
+
+- **> 3000 additions or > 50 files**: split the PR
+- Split boundaries: gateway, platform, sync-client, shell, docs/deploy
+
+### PR Body: Mandatory Invariants
+
+Every backend PR must document: source of truth, lock/transaction scope, acceptable orphan states, auth source of truth, and explicitly deferred scope.
 
 ## Reference Docs
 
 Read these on demand, not every session:
 
+- `docs/dev/review-pipeline.md` -- when reviewing or opening PRs (three-pass structure, checklists, CI gates)
 - `docs/dev/pr-review-analysis.md` -- when triaging review comments or understanding recurring defect patterns
 - `docs/dev/docker-development.md` -- when working on Docker setup or debugging container issues
 - `docs/dev/vps-deployment.md` -- when deploying to production or managing the VPS

--- a/docs/dev/review-pipeline.md
+++ b/docs/dev/review-pipeline.md
@@ -1,0 +1,230 @@
+# Review Pipeline
+
+How code gets reviewed in Matrix OS. Derived from the PR #30 post-mortem (154 inline comments, ~12 root-cause classes).
+
+## The Problem This Solves
+
+PR #30 received 167 review submissions that found overlapping subsets of the same ~12 root-cause classes. More reviews didn't help — structured passes do.
+
+The fix is not "review harder." It's: **review a frozen, smaller PR with three explicit passes: mechanical gates, trust-boundary sweep, and atomicity/failure-mode review.**
+
+## Pipeline Stages
+
+```
+PR opens
+  |
+  +-- CI Gate 1: typecheck + pattern scan    --> catches build errors, CLAUDE.md violations
+  |
+  +-- CI Gate 2: unit tests + e2e            --> catches correctness regressions
+  |
+  +-- AI Review: three-pass structured review --> catches trust-boundary + atomicity issues
+  |
+  +-- AI Security Review: focused security    --> catches auth/traversal/container issues
+  |
+  +-- Human Review (if needed)                --> architecture, design, product decisions
+```
+
+### What Each Stage Catches
+
+| Stage | Category | Example from PR #30 |
+|-------|----------|---------------------|
+| **typecheck** | Missing imports, type mismatches, missing fields | Missing `stat` import, `R2ClientConfig` wrong fields, presign `size` field. *Note: runs as warning (`continue-on-error`) until baseline type errors are fixed.* |
+| **pattern scan** | CLAUDE.md mechanical violations | Bare catch blocks, fetch without signal, writeFileSync, unbounded Maps |
+| **unit tests** | Correctness regressions | Deleted files resurrected, schema inconsistencies |
+| **AI review pass 1** | Remaining mechanical issues the scanner can't catch | Non-atomic file writes, bodyLimit gaps, shutdown cleanup |
+| **AI review pass 2** | Trust-boundary violations | Path traversal, unvalidated headers, error leaking, share authz gaps |
+| **AI review pass 3** | Atomicity and failure modes | Advisory lock bugs, DB/R2 split-brain, partial failure orphans |
+| **AI security review** | Auth boundaries, container isolation | Internal routes without auth, secret forwarding, timing leaks |
+
+## Running Locally
+
+Before opening a PR:
+
+```bash
+# Gate 1: mechanical checks
+bun run typecheck                     # tsc --noEmit for all packages
+bun run check:patterns:diff           # CLAUDE.md pattern scanner (changed files only)
+
+# Gate 2: tests
+bun run test                          # unit tests
+bun run test:e2e                      # e2e tests
+
+# Full scan (useful for baseline audits, noisy on large codebases)
+bun run check:patterns                # all files in packages/ and shell/
+```
+
+## PR Size Guidelines
+
+| Additions | Files | Recommendation |
+|-----------|-------|----------------|
+| < 1000 | < 20 | Single PR, standard review |
+| 1000-3000 | 20-50 | Single PR, request structured review |
+| > 3000 | > 50 | **Split the PR** |
+
+Suggested split boundaries for Matrix OS:
+- **gateway** routes + middleware (one PR)
+- **platform** auth + orchestrator (one PR)
+- **sync-client** daemon + CLI (one PR)
+- **shell** frontend changes (one PR)
+- **docs + deploy** configuration (one PR)
+
+## PR Body: Mandatory Invariants Section
+
+Every PR touching backend code must include an invariants section:
+
+```markdown
+## Invariants
+
+### Source of truth
+- [What is the canonical data store for each entity?]
+- [If two stores exist, what reconciles divergence?]
+
+### Lock/transaction scope
+- [What operations are inside the critical section?]
+- [Are network calls (R2, external APIs) inside or outside the lock?]
+
+### Acceptable orphan states
+- [If step N fails after step N-1 succeeds, what is the resulting state?]
+- [Is there cleanup/GC for orphaned objects?]
+
+### Auth source of truth
+- [Which auth mechanism is primary? (JWT, bearer, HMAC)]
+- [What is the fallback behavior on auth failure?]
+
+### Deferred scope
+- [What is explicitly NOT in scope? (e.g., "share authz not wired yet")]
+```
+
+## Branch Freeze Rule
+
+No deep review until the author either:
+1. Declares a **review commit range** that won't move (e.g., "review `abc123..def456`"), or
+2. Marks the PR as **ready for review** and stops pushing.
+
+Reviewing a moving target guarantees second-order regressions — the PR #30 post-mortem showed later fix-wave commits introducing new issues that weren't in the original diff.
+
+## The Review Passes
+
+### Pass 1: Mechanical CLAUDE.md Sweep
+
+Run these `rg` commands on changed files. Each maps to a mandatory pattern:
+
+```bash
+# Error handling: bare/empty catch
+rg -n 'catch\s*\{' packages --glob '*.ts' --glob '!*.test.ts'
+rg -n '\.catch\(\s*\(\s*\)\s*=>' packages --glob '*.ts' --glob '!*.test.ts'
+
+# External calls: fetch without timeout
+rg -n 'fetch\(' packages shell --glob '*.ts' --glob '!*.test.ts'
+
+# Input validation: body consumption (verify bodyLimit present)
+rg -n 'c\.req\.(json|text|blob|arrayBuffer)\(' packages --glob '*.ts'
+
+# Resource management: unbounded structures
+rg -n 'new Map|new Set|buffer +=' packages --glob '*.ts' --glob '!*.test.ts'
+
+# Trust boundaries: path operations + external identifiers
+rg -n 'join\(|resolve\(|realpath\(|rename\(|unlink\(' packages --glob '*.ts' --glob '!*.test.ts'
+rg -n 'X-Forwarded-For|X-Peer-Id|peerId' packages --glob '*.ts' -i
+```
+
+The CI pattern scanner (`scripts/review/check-patterns.sh`) automates these. Reviewers only need to verify the scanner's warnings manually.
+
+### Pass 2: Trust-Boundary Sweep
+
+For each changed file, classify it and apply the matching checklist:
+
+**Route handler files** (`routes.ts`, `server.ts`, `auth-routes.ts`):
+- [ ] Every path/query/header param validated before use
+- [ ] Error responses don't leak internals (no `err.message`, no Zod `.issues`)
+- [ ] Auth middleware applied — check mounting order in parent
+- [ ] bodyLimit on every mutating endpoint
+- [ ] Rate limiter keyed on trusted IP source
+
+**Filesystem files** (`home-mirror.ts`, `settings.ts`, file ops):
+- [ ] All paths through `resolveWithinPrefix` or equivalent
+- [ ] Symlink checks (`lstat` + `isSymbolicLink()`) before write/delete
+- [ ] No `path.join()` on unvalidated external input
+- [ ] Atomic writes (temp file + rename) for all non-test code
+- [ ] File size checks before buffering into memory
+
+**Database files** (`db-impl.ts`, `sharing.ts`, `device-flow.ts`):
+- [ ] 2+ related writes in a transaction
+- [ ] No TOCTOU (read → check → write without lock)
+- [ ] `ON CONFLICT` for idempotent upserts
+- [ ] Advisory lock scope matches the operations it protects
+
+**WebSocket/IPC files** (`ws-events.ts`, `ws-client.ts`, `ipc-server.ts`):
+- [ ] Incoming messages validated with Zod (not bare `as` cast)
+- [ ] Buffer/message size caps
+- [ ] Peer cleanup on disconnect (removePeer in onClose)
+- [ ] Connection/handshake timeouts
+
+### Pass 3: Atomicity and Failure-Mode Review
+
+For each subsystem the PR touches, answer these questions:
+
+1. **Source of truth**: What is it? If there are two stores (e.g., DB version counter + R2 manifest JSON), what reconciles them? What if they diverge?
+
+2. **Lock scope**: What's inside the lock/transaction? Are network calls (R2 putObject, external APIs) holding the lock? Could they be moved outside? (Content-addressed uploads can always happen outside the lock.)
+
+3. **Partial failure**: If step N succeeds and step N+1 fails, what state does the system end up in? Is there orphaned data? Is there compensation/cleanup/GC?
+
+4. **Shutdown/restart**: Are watchers, intervals, WebSocket connections, and serial queues cleaned up? Does hot-reload stack up duplicate watchers?
+
+5. **Deferred scope**: If auth, validation, or cleanup is "not in scope yet," is that explicitly stated? Dead authz code (defined but never called) is a trap for future developers.
+
+### Pass 4: Runtime Contract Review (platform/container PRs only)
+
+Many PR #30 misses were not code-local — they were wiring issues visible only when tracing the platform-to-container-to-gateway flow at runtime. For any PR touching `packages/platform/`, `docker-compose*.yml`, or orchestrator code:
+
+1. **Env propagation**: Which env vars does the platform inject into user containers? Are any secrets (PLATFORM_SECRET, DATABASE_URL, S3 credentials) leaking? Trace `buildEnv()` in `orchestrator.ts`.
+
+2. **Internal route auth**: Are internal routes (platform ↔ container) authenticated? Check HMAC/bearer middleware mounting order. Port exposure in docker-compose.
+
+3. **Service contract**: Does the gateway expect headers/env vars the platform actually provides? (e.g., `x-platform-user-id` set but never read, `MATRIX_USER_ID` injected vs header-based identity).
+
+4. **Presigned URL split-horizon**: If presigned URLs are generated, do they use the correct endpoint for the consumer? (Internal services use `minio:9000`, external clients use `localhost:9100` or the public URL.)
+
+5. **Startup/shutdown ordering**: Does the compose dependency graph match the actual readiness requirements? Health checks present and meaningful?
+
+This pass cannot be done from code alone — it requires mentally (or actually) running the flow end-to-end.
+
+## Adversarial Test Requirements
+
+PRs touching these areas must include adversarial tests, not just happy-path:
+
+| Area | Required tests |
+|------|---------------|
+| Auth/device flow | Concurrent approval/poll |
+| File sync | Path traversal attempts (`../`), symlink targets |
+| WebSocket handlers | Malformed payloads, oversized messages |
+| File operations | Crash-safe temp files (verify temp cleanup) |
+| Container env | Verify secrets not forwarded to user containers |
+| Shutdown | Cleanup verification (no leaked watchers/connections) |
+
+## For AI Agents
+
+If you are an AI agent (Claude, Copilot, etc.) writing or reviewing code for Matrix OS:
+
+1. **Before writing code**: Run `bun run check:patterns` to see current violations. Don't add new ones.
+
+2. **Before opening a PR**: Run `bun run typecheck && bun run check:patterns && bun run test`. All must pass.
+
+3. **When reviewing a PR**: Use the three-pass structure above. Do NOT review line-by-line. Post ONE structured summary + inline comments only for CRITICAL/HIGH.
+
+4. **Max 20 inline comments per review**. If you find more than 20 HIGH+ issues, the PR is too large — recommend splitting.
+
+5. **Never repeat findings across passes**. Each finding belongs to exactly one pass.
+
+6. **Include "What Looked Good"** in every review. Calibration matters — silent approval of good patterns reinforces them.
+
+## CI Workflow Reference
+
+| Workflow | Trigger | What it does |
+|----------|---------|-------------|
+| `ci.yml` | push/PR to main | typecheck → pattern scan → unit tests → e2e |
+| `claude-code-review.yml` | PR opened/sync | Three-pass AI review (code quality) |
+| `security-review.yml` | PR touching packages/gateway,kernel,platform | Four-pass AI security review |
+| `screenshots.yml` | PR touching shell/** | Playwright visual regression |
+| `docker-test.yml` | push/PR to main | Docker scenario tests |

--- a/package.json
+++ b/package.json
@@ -33,7 +33,11 @@
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:coverage": "vitest run --coverage",
-    "test:e2e": "vitest run --config vitest.e2e.config.ts"
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "typecheck": "bun run --filter '@matrix-os/kernel' build && bun run --filter '@matrix-os/gateway' build && bun run --filter '@matrix-os/platform' build && bun run --filter '@matrix-os/proxy' build",
+    "check:patterns": "./scripts/review/check-patterns.sh",
+    "check:patterns:diff": "./scripts/review/check-patterns.sh --diff main",
+    "lint": "bun run --filter './shell' lint"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/scripts/review/check-patterns.sh
+++ b/scripts/review/check-patterns.sh
@@ -48,7 +48,11 @@ fi
 
 # Build file list
 if [[ -n "$DIFF_BASE" ]]; then
-  FILES=$(git diff --name-only --diff-filter=ACMR "$DIFF_BASE"...HEAD -- $SCAN_PATHS 2>/dev/null | grep -E '\.(ts|tsx)$' || true)
+  if ! git rev-parse --verify "$DIFF_BASE" &>/dev/null; then
+    echo "Error: diff base '$DIFF_BASE' not found. Run 'git fetch' first." >&2
+    exit 2
+  fi
+  FILES=$(git diff --name-only --diff-filter=ACMR "$DIFF_BASE"...HEAD -- $SCAN_PATHS | grep -E '\.(ts|tsx)$' || true)
   if [[ -z "$FILES" ]]; then
     echo "No TypeScript files changed vs $DIFF_BASE."
     exit 0

--- a/scripts/review/check-patterns.sh
+++ b/scripts/review/check-patterns.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# CLAUDE.md Mandatory Pattern Scanner
+#
+# Runs mechanical sweeps against source files to catch recurring defect
+# patterns documented in CLAUDE.md § Mandatory Code Patterns.
+#
+# Exit codes:
+#   0 — no violations found
+#   1 — violations found (details on stdout)
+#   2 — script error
+#
+# Usage:
+#   ./scripts/review/check-patterns.sh              # scan all packages
+#   ./scripts/review/check-patterns.sh --diff main   # scan only files changed vs main
+#   ./scripts/review/check-patterns.sh --strict       # treat warnings as errors
+
+set -euo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+SCAN_PATHS="packages shell"
+DIFF_BASE=""
+STRICT=false
+VIOLATIONS=0
+WARNINGS=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --diff)  DIFF_BASE="$2"; shift 2 ;;
+    --strict) STRICT=true; shift ;;
+    --help)
+      echo "Usage: $0 [--diff <base-branch>] [--strict]"
+      echo "  --diff <branch>  Only scan files changed vs <branch>"
+      echo "  --strict         Treat warnings as errors"
+      exit 0 ;;
+    *) echo "Unknown option: $1"; exit 2 ;;
+  esac
+done
+
+if ! command -v rg &>/dev/null; then
+  echo "Error: ripgrep (rg) is required. Install via: brew install ripgrep" >&2
+  exit 2
+fi
+
+# Build file list
+if [[ -n "$DIFF_BASE" ]]; then
+  FILES=$(git diff --name-only --diff-filter=ACMR "$DIFF_BASE"...HEAD -- $SCAN_PATHS 2>/dev/null | grep -E '\.(ts|tsx)$' || true)
+  if [[ -z "$FILES" ]]; then
+    echo "No TypeScript files changed vs $DIFF_BASE."
+    exit 0
+  fi
+  FILE_ARGS="$FILES"
+  SCAN_MODE="changed files vs $DIFF_BASE"
+else
+  FILE_ARGS=""
+  SCAN_MODE="all files in: $SCAN_PATHS"
+fi
+
+header() {
+  echo ""
+  echo -e "${BOLD}${CYAN}── $1 ──${RESET}"
+}
+
+violation() {
+  echo -e "  ${RED}VIOLATION${RESET} $1"
+  VIOLATIONS=$((VIOLATIONS + 1))
+}
+
+warning() {
+  echo -e "  ${YELLOW}WARNING${RESET} $1"
+  WARNINGS=$((WARNINGS + 1))
+}
+
+rg_scan() {
+  local pattern="$1"
+  shift
+  if [[ -n "$FILE_ARGS" ]]; then
+    echo "$FILE_ARGS" | xargs rg -n "$pattern" "$@" 2>/dev/null || true
+  else
+    rg -n "$pattern" "$@" $SCAN_PATHS 2>/dev/null || true
+  fi
+}
+
+echo -e "${BOLD}CLAUDE.md Pattern Scanner${RESET}"
+echo "Scanning: $SCAN_MODE"
+echo ""
+
+# ═══════════════════════════════════════════════════════════════
+# PASS 1: Mechanical CLAUDE.md sweeps (Category 3 from review)
+# ═══════════════════════════════════════════════════════════════
+
+header "1. Error Handling — bare/empty catch blocks"
+
+MATCHES=$(rg_scan 'catch\s*\{' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  violation "Bare catch {} blocks (CLAUDE.md: every catch must check error type)"
+  echo "$MATCHES" | head -20
+fi
+
+MATCHES=$(rg_scan '\.catch\(\s*\(\s*\)\s*=>' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  violation "Empty .catch(() => ...) — error param ignored (CLAUDE.md: no bare catch)"
+  echo "$MATCHES" | head -20
+fi
+
+MATCHES=$(rg_scan '\.catch\(\s*\(\s*_\w*\s*\)\s*=>' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  warning "Catch with explicitly unused param (_err) — verify error is logged"
+  echo "$MATCHES" | head -10
+fi
+
+header "2. External Calls — fetch() without AbortSignal.timeout"
+
+MATCHES=$(rg_scan 'fetch\(' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  # Check each fetch call for a signal
+  MISSING_SIGNAL=""
+  while IFS= read -r line; do
+    file_line=$(echo "$line" | cut -d: -f1-2)
+    if ! echo "$line" | grep -q 'signal'; then
+      MISSING_SIGNAL+="$line"$'\n'
+    fi
+  done <<< "$MATCHES"
+  if [[ -n "$MISSING_SIGNAL" ]]; then
+    violation "fetch() without signal: (CLAUDE.md: every fetch MUST have AbortSignal.timeout)"
+    echo "$MISSING_SIGNAL" | head -20
+  fi
+fi
+
+header "3. Input Validation — missing bodyLimit on mutating endpoints"
+
+MATCHES=$(rg_scan 'c\.req\.(json|text|blob|arrayBuffer)\(' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  warning "Body consumption calls — verify bodyLimit middleware is applied to each route"
+  echo "$MATCHES" | head -20
+fi
+
+header "4. Resource Management — unbounded in-memory structures"
+
+MATCHES=$(rg_scan 'new (Map|Set)\(' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  warning "Map/Set creation — verify each has a size cap and eviction policy"
+  echo "$MATCHES" | head -20
+fi
+
+MATCHES=$(rg_scan 'buffer \+=' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  warning "Buffer concatenation — verify bounded with a size cap"
+  echo "$MATCHES" | head -10
+fi
+
+header "5. Resource Management — writeFileSync/appendFileSync in handlers"
+
+MATCHES=$(rg_scan '(writeFileSync|appendFileSync)' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  violation "Sync file I/O (CLAUDE.md: banned in request handlers, use fs/promises)"
+  echo "$MATCHES" | head -10
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# PASS 2: Trust-boundary sweep (Category 2 from review)
+# ═══════════════════════════════════════════════════════════════
+
+header "6. Trust Boundaries — path operations on external input"
+
+MATCHES=$(rg_scan '(join|resolve|realpath|rename|unlink)\(' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**')
+if [[ -n "$MATCHES" ]]; then
+  warning "Path operations — verify input is validated via resolveWithinPrefix or equivalent"
+  echo "$MATCHES" | head -30
+fi
+
+header "7. Trust Boundaries — headers and identifiers from external sources"
+
+MATCHES=$(rg_scan '(X-Forwarded-For|X-Peer-Id|X-Real-Ip|peerId|userId)' --glob '*.ts' --glob '!*.test.ts' --glob '!*.spec.ts' --glob '!**/node_modules/**' --glob '!**/dist/**' -i)
+if [[ -n "$MATCHES" ]]; then
+  warning "External headers/identifiers — verify validated before use in keys, paths, or SQL"
+  echo "$MATCHES" | head -20
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# Summary
+# ═══════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}════════════════════════════════════════${RESET}"
+if [[ $VIOLATIONS -gt 0 ]]; then
+  echo -e "${RED}${BOLD}FAIL${RESET}: $VIOLATIONS violation(s), $WARNINGS warning(s)"
+  if $STRICT; then
+    exit 1
+  else
+    exit 1
+  fi
+elif [[ $WARNINGS -gt 0 ]]; then
+  echo -e "${YELLOW}${BOLD}WARN${RESET}: $WARNINGS warning(s), 0 violations"
+  if $STRICT; then
+    echo "(--strict mode: treating warnings as errors)"
+    exit 1
+  fi
+  exit 0
+else
+  echo -e "${CYAN}${BOLD}PASS${RESET}: no violations or warnings"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Adds automated CLAUDE.md pattern scanner (`scripts/review/check-patterns.sh`)
- Adds typecheck + pattern scan as CI gates before unit tests
- Replaces vague AI review prompts with structured three-pass model
- Adds `docs/dev/review-pipeline.md` — comprehensive guide for humans and AI agents
- Updates CLAUDE.md and AGENTS.md with pre-PR checklist, PR size limits, and mandatory invariants

Derived from the PR #30 post-mortem: 154 inline comments → ~12 root-cause classes → 5 categories → 3 structured passes.

## Invariants

### Source of truth
CI workflows (`.github/workflows/`) define what gates run. CLAUDE.md/AGENTS.md define what agents should check. `docs/dev/review-pipeline.md` is the canonical reference.

### Deferred scope
- Typecheck gate runs as `continue-on-error: true` until baseline type errors in kernel are fixed
- Pattern scanner has known violations on existing code — CI scans changed files only (via `--diff`) so existing debt doesn't block new PRs
- No pre-commit hooks yet (husky/lint-staged) — CI-only enforcement for now
- No branch protection rules — those need to be configured in GitHub settings manually

## Test plan

- [ ] Pattern scanner runs locally: `./scripts/review/check-patterns.sh`
- [ ] Pattern scanner diff mode works: `./scripts/review/check-patterns.sh --diff main`
- [ ] Typecheck script runs: `bun run typecheck` (expected to show existing kernel errors)
- [ ] CI workflow parses: review YAML syntax in GitHub Actions tab
- [ ] Review workflow triggers on next PR and produces structured three-pass output