### PR TITLE
feat(066): PR 2 — client UX + daemon IPC

### DIFF
--- a/bin/matrixos.mjs
+++ b/bin/matrixos.mjs
@@ -12,24 +12,9 @@ import { spawn } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync } from 'node:fs';
+import { findTsxLoader } from '../packages/sync-client/src/lib/find-tsx-loader.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
-
-// Walk up from this file looking for tsx. Works whether the launcher is
-// the repo-root `bin/matrixos.mjs` (tsx in `<repo>/node_modules`), invoked
-// via `pnpm link --global` from any cwd, or via a packaged install where
-// tsx may be hoisted one or two levels up.
-function findTsxLoader(start) {
-  let dir = start;
-  for (let i = 0; i < 6; i += 1) {
-    const candidate = resolve(dir, 'node_modules', 'tsx', 'dist', 'loader.mjs');
-    if (existsSync(candidate)) return candidate;
-    const up = dirname(dir);
-    if (up === dir) break;
-    dir = up;
-  }
-  return null;
-}
 
 const tsxLoader = findTsxLoader(here);
 if (!tsxLoader) {

--- a/bin/matrixos.mjs
+++ b/bin/matrixos.mjs
@@ -14,18 +14,40 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync } from 'node:fs';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const tsxLoader = resolve(here, '..', 'node_modules', 'tsx', 'dist', 'loader.mjs');
 
-if (!existsSync(tsxLoader)) {
+// Walk up from this file looking for tsx. Works whether the launcher is
+// the repo-root `bin/matrixos.mjs` (tsx in `<repo>/node_modules`), invoked
+// via `pnpm link --global` from any cwd, or via a packaged install where
+// tsx may be hoisted one or two levels up.
+function findTsxLoader(start) {
+  let dir = start;
+  for (let i = 0; i < 6; i += 1) {
+    const candidate = resolve(dir, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+    if (existsSync(candidate)) return candidate;
+    const up = dirname(dir);
+    if (up === dir) break;
+    dir = up;
+  }
+  return null;
+}
+
+const tsxLoader = findTsxLoader(here);
+if (!tsxLoader) {
   console.error(
-    `tsx loader not found at ${tsxLoader}. Run \`pnpm install\` in the matrix-os repo before invoking the matrix CLI.`,
+    'matrix CLI: tsx loader not found. Run `pnpm install` in the matrix-os repo before invoking the matrix CLI.',
   );
+  process.exit(1);
+}
+
+const cliEntry = resolve(here, 'matrixos.ts');
+if (!existsSync(cliEntry)) {
+  console.error(`matrix CLI: entry not found at ${cliEntry}.`);
   process.exit(1);
 }
 
 const child = spawn(
   process.execPath,
-  ['--import', pathToFileURL(tsxLoader).href, resolve(here, 'matrixos.ts'), ...process.argv.slice(2)],
+  ['--import', pathToFileURL(tsxLoader).href, cliEntry, ...process.argv.slice(2)],
   {
     stdio: 'inherit',
     env: process.env,

--- a/packages/sync-client/src/cli/commands/login.ts
+++ b/packages/sync-client/src/cli/commands/login.ts
@@ -2,6 +2,7 @@ import { defineCommand } from "citty";
 import { login } from "../../auth/oauth.js";
 import { clearAuth, saveAuth } from "../../auth/token-store.js";
 import {
+  defaultGatewayUrl,
   defaultPlatformUrl,
   defaultSyncPath,
   generatePeerId,
@@ -21,7 +22,7 @@ export const loginCommand = defineCommand({
     },
     platform: {
       type: "string",
-      description: "Override platform URL (default: from config or platform.matrix-os.com)",
+      description: "Override platform URL (default: from config or app.matrix-os.com)",
     },
   },
   run: async (ctx) => {
@@ -125,7 +126,11 @@ export const loginCommand = defineCommand({
 
     const next: SyncConfig = {
       platformUrl,
-      gatewayUrl: gatewayUrl ?? existing?.gatewayUrl ?? platformUrl,
+      // Prefer the server-supplied gatewayUrl (PR 1 always returns
+      // app.matrix-os.com); fall back to the client's known default
+      // before ever reusing platformUrl, because a dev override of
+      // `--platform http://localhost:9000` must NOT become the gatewayUrl.
+      gatewayUrl: gatewayUrl ?? existing?.gatewayUrl ?? defaultGatewayUrl(),
       syncPath: existing?.syncPath ?? defaultSyncPath(),
       gatewayFolder: existing?.gatewayFolder ?? "",
       peerId: existing?.peerId ?? generatePeerId(),

--- a/packages/sync-client/src/cli/commands/login.ts
+++ b/packages/sync-client/src/cli/commands/login.ts
@@ -141,6 +141,6 @@ export const loginCommand = defineCommand({
     await saveConfig(next);
 
     console.log(`Logged in as @${auth.handle}`);
-    if (gatewayUrl) console.log(`Gateway: ${gatewayUrl}`);
+    console.log(`Gateway: ${next.gatewayUrl}${gatewayUrl ? "" : " (default)"}`);
   },
 });

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -1,13 +1,11 @@
 import { join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFile, writeFile, unlink, mkdir, stat } from "node:fs/promises";
+import { readFile, writeFile, unlink, stat } from "node:fs/promises";
 import pino from "pino";
 import {
   loadConfig,
   saveConfig,
   getConfigDir,
-  normalizeGatewayFolder,
-  resolveSyncPathWithinHome,
   type SyncConfig,
 } from "../lib/config.js";
 import { clearAuth, isExpired, loadAuth } from "../auth/token-store.js";
@@ -17,6 +15,7 @@ import { loadSyncState, saveSyncState } from "./manifest-cache.js";
 import { FileWatcher } from "./watcher.js";
 import { SyncWsClient } from "./ws-client.js";
 import { IpcServer } from "./ipc-server.js";
+import { createIpcHandler } from "./ipc-handler.js";
 import { createRemotePrefixMapper } from "./remote-prefix.js";
 import {
   requestPresignedUrls,
@@ -586,85 +585,16 @@ export async function startDaemon(): Promise<void> {
     onError: (err) => logger.error({ err }, "WebSocket error"),
   });
 
-  const ipcServer = new IpcServer({
-    socketPath,
-    handler: async (command, args) => {
-      switch (command) {
-        case "status":
-          return {
-            syncing: !config.pauseSync,
-            manifestVersion: syncState.manifestVersion,
-            lastSyncAt: syncState.lastSyncAt,
-            fileCount: Object.keys(syncState.files).length,
-            syncPath: config.syncPath,
-            gatewayFolder: config.gatewayFolder ?? "",
-            gatewayUrl: config.gatewayUrl,
-            platformUrl: config.platformUrl,
-            peerId: config.peerId,
-          };
-        case "pause":
-          await persistPauseState(config, true);
-          return { paused: true };
-        case "resume":
-          await persistPauseState(config, false);
-          return { paused: false };
-        case "getConfig":
-          // Exposes the full persisted config (without auth tokens) so the
-          // menu bar app can render a Settings view. Token lives in auth.json
-          // and is fetched separately via /me on the platform.
-          return {
-            syncPath: config.syncPath,
-            gatewayFolder: config.gatewayFolder ?? "",
-            gatewayUrl: config.gatewayUrl,
-            platformUrl: config.platformUrl,
-            peerId: config.peerId,
-            pauseSync: config.pauseSync,
-          };
-        case "setSyncPath": {
-          // Writes the new path to config.json and asks the caller to
-          // restart the daemon. Changing syncPath live would require tearing
-          // down the FileWatcher + restarting the initial-pull, which is
-          // exactly what a daemon restart does -- so we stop short of that
-          // here and let the client call `restart` next.
-          const raw = typeof args.syncPath === "string" ? args.syncPath : "";
-          const newPath = resolveSyncPathWithinHome(raw);
-          await mkdir(newPath, { recursive: true });
-          const updated = { ...config, syncPath: newPath };
-          await saveConfig(updated);
-          return { syncPath: newPath, restartRequired: true };
-        }
-        case "setGatewayFolder": {
-          // Same semantics as setSyncPath -- persist, caller restarts.
-          const folder = typeof args.gatewayFolder === "string" ? args.gatewayFolder : "";
-          const normalizedFolder = normalizeGatewayFolder(folder);
-          const updated = { ...config, gatewayFolder: normalizedFolder };
-          await saveConfig(updated);
-          return { gatewayFolder: normalizedFolder, restartRequired: true };
-        }
-        case "restart":
-          // Exit with a distinct code; launchd's KeepAlive will restart us.
-          // Schedule after the IPC response is flushed so the client sees
-          // "restarting" before the socket closes.
-          setTimeout(() => {
-            logger.info("Restart requested via IPC");
-            process.exit(3);
-          }, 50);
-          return { restarting: true };
-        case "logout":
-          // Wipe the auth token and exit. Next launch will fail the
-          // loadAuth() guard and the daemon stays down until the user runs
-          // `matrix login` again.
-          await clearAuth();
-          setTimeout(() => {
-            logger.info("Logout requested via IPC");
-            process.exit(0);
-          }, 50);
-          return { loggedOut: true };
-        default:
-          throw new Error(`Unknown command: ${command}`);
-      }
-    },
+  const ipcHandler = createIpcHandler({
+    config,
+    syncState,
+    logger: { info: (msg) => logger.info(msg) },
+    saveConfig: (next) => saveConfig(next),
+    persistPauseState,
+    clearAuth,
+    exit: (code) => process.exit(code),
   });
+  const ipcServer = new IpcServer({ socketPath, handler: ipcHandler });
 
   const shutdown = async () => {
     logger.info("Shutting down daemon");

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -108,10 +108,11 @@ export async function waitForManifest(
         opts.logger.warn(
           `Manifest poll attempt ${attempt} failed (unexpected non-Error talking to ${opts.gatewayUrl})`,
         );
+      } else {
+        opts.logger.warn(
+          `Manifest poll attempt ${attempt} failed (network error talking to ${opts.gatewayUrl})`,
+        );
       }
-      opts.logger.warn(
-        `Manifest poll attempt ${attempt} failed (network error talking to ${opts.gatewayUrl})`,
-      );
       await sleep(intervalMs);
       continue;
     }

--- a/packages/sync-client/src/daemon/ipc-handler.ts
+++ b/packages/sync-client/src/daemon/ipc-handler.ts
@@ -1,0 +1,118 @@
+// Pure, dependency-injected command router for the daemon's IPC socket.
+//
+// Extracted from `daemon/index.ts` so the command set can be unit-tested
+// without booting the watcher / WebSocket / filesystem state. The daemon
+// entry wires this into an `IpcServer`; tests can call `createIpcHandler`
+// directly with fakes for the pieces that touch the filesystem or process.
+import { mkdir } from "node:fs/promises";
+import {
+  normalizeGatewayFolder,
+  resolveSyncPathWithinHome,
+  type SyncConfig,
+} from "../lib/config.js";
+import type { SyncState } from "./types.js";
+
+export interface IpcHandlerLogger {
+  info: (msg: string) => void;
+}
+
+export interface IpcHandlerDeps {
+  config: SyncConfig;
+  syncState: SyncState;
+  logger: IpcHandlerLogger;
+  saveConfig: (config: SyncConfig) => Promise<void>;
+  persistPauseState: (
+    config: SyncConfig,
+    paused: boolean,
+  ) => Promise<void>;
+  clearAuth: () => Promise<void>;
+  exit: (code: number) => void;
+  ensureDir?: (path: string) => Promise<void>;
+  schedule?: (fn: () => void, ms: number) => void;
+}
+
+export type IpcHandler = (
+  command: string,
+  args: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+const DEFAULT_EXIT_DELAY_MS = 50;
+
+export function createIpcHandler(deps: IpcHandlerDeps): IpcHandler {
+  const ensureDir =
+    deps.ensureDir ?? ((path: string) => mkdir(path, { recursive: true }).then(() => undefined));
+  const schedule = deps.schedule ?? ((fn, ms) => setTimeout(fn, ms).unref());
+
+  return async (command, args) => {
+    switch (command) {
+      case "status":
+        return {
+          syncing: !deps.config.pauseSync,
+          manifestVersion: deps.syncState.manifestVersion,
+          lastSyncAt: deps.syncState.lastSyncAt,
+          fileCount: Object.keys(deps.syncState.files).length,
+          syncPath: deps.config.syncPath,
+          gatewayFolder: deps.config.gatewayFolder ?? "",
+          gatewayUrl: deps.config.gatewayUrl,
+          platformUrl: deps.config.platformUrl,
+          peerId: deps.config.peerId,
+        };
+      case "pause":
+        await deps.persistPauseState(deps.config, true);
+        return { paused: true };
+      case "resume":
+        await deps.persistPauseState(deps.config, false);
+        return { paused: false };
+      case "getConfig":
+        // Token-free projection of the daemon's persisted config. The menu
+        // bar app calls this to render a Settings view; auth.json is read
+        // separately.
+        return {
+          syncPath: deps.config.syncPath,
+          gatewayFolder: deps.config.gatewayFolder ?? "",
+          gatewayUrl: deps.config.gatewayUrl,
+          platformUrl: deps.config.platformUrl,
+          peerId: deps.config.peerId,
+          pauseSync: deps.config.pauseSync,
+        };
+      case "setSyncPath": {
+        // Validate + normalize within $HOME, persist, and signal the client
+        // that it must call `restart` before the change takes effect. We
+        // intentionally don't tear down the watcher live -- that's exactly
+        // what a daemon restart does.
+        const raw = typeof args.syncPath === "string" ? args.syncPath : "";
+        const newPath = resolveSyncPathWithinHome(raw);
+        await ensureDir(newPath);
+        deps.config.syncPath = newPath;
+        await deps.saveConfig(deps.config);
+        return { syncPath: newPath, restartRequired: true };
+      }
+      case "setGatewayFolder": {
+        const folder = typeof args.gatewayFolder === "string" ? args.gatewayFolder : "";
+        const normalizedFolder = normalizeGatewayFolder(folder);
+        deps.config.gatewayFolder = normalizedFolder;
+        await deps.saveConfig(deps.config);
+        return { gatewayFolder: normalizedFolder, restartRequired: true };
+      }
+      case "restart":
+        // Distinct exit code; launchd / systemd KeepAlive re-launches us.
+        // Delay so the IPC response is flushed before the socket closes.
+        schedule(() => {
+          deps.logger.info("Restart requested via IPC");
+          deps.exit(3);
+        }, DEFAULT_EXIT_DELAY_MS);
+        return { restarting: true };
+      case "logout":
+        // Wipe auth.json and exit 0. Next launch fails the loadAuth() guard
+        // and the daemon stays down until the user runs `matrix login`.
+        await deps.clearAuth();
+        schedule(() => {
+          deps.logger.info("Logout requested via IPC");
+          deps.exit(0);
+        }, DEFAULT_EXIT_DELAY_MS);
+        return { loggedOut: true };
+      default:
+        throw new Error(`Unknown command: ${command}`);
+    }
+  };
+}

--- a/packages/sync-client/src/daemon/ipc-handler.ts
+++ b/packages/sync-client/src/daemon/ipc-handler.ts
@@ -83,15 +83,17 @@ export function createIpcHandler(deps: IpcHandlerDeps): IpcHandler {
         const raw = typeof args.syncPath === "string" ? args.syncPath : "";
         const newPath = resolveSyncPathWithinHome(raw);
         await ensureDir(newPath);
+        const nextSyncPath = { ...deps.config, syncPath: newPath };
+        await deps.saveConfig(nextSyncPath);
         deps.config.syncPath = newPath;
-        await deps.saveConfig(deps.config);
         return { syncPath: newPath, restartRequired: true };
       }
       case "setGatewayFolder": {
         const folder = typeof args.gatewayFolder === "string" ? args.gatewayFolder : "";
         const normalizedFolder = normalizeGatewayFolder(folder);
+        const nextFolder = { ...deps.config, gatewayFolder: normalizedFolder };
+        await deps.saveConfig(nextFolder);
         deps.config.gatewayFolder = normalizedFolder;
-        await deps.saveConfig(deps.config);
         return { gatewayFolder: normalizedFolder, restartRequired: true };
       }
       case "restart":
@@ -112,7 +114,7 @@ export function createIpcHandler(deps: IpcHandlerDeps): IpcHandler {
         }, DEFAULT_EXIT_DELAY_MS);
         return { loggedOut: true };
       default:
-        throw new Error(`Unknown command: ${command}`);
+        throw new Error("Unknown IPC command");
     }
   };
 }

--- a/packages/sync-client/src/daemon/ipc-handler.ts
+++ b/packages/sync-client/src/daemon/ipc-handler.ts
@@ -14,6 +14,8 @@ import type { SyncState } from "./types.js";
 
 export interface IpcHandlerLogger {
   info: (msg: string) => void;
+  warn?: (msg: string) => void;
+  error?: (msg: string) => void;
 }
 
 export interface IpcHandlerDeps {

--- a/packages/sync-client/src/daemon/ipc-server.ts
+++ b/packages/sync-client/src/daemon/ipc-server.ts
@@ -2,10 +2,8 @@ import { createServer, type Server, type Socket } from "node:net";
 import { chmod, mkdir, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 
-export type IpcHandler = (
-  command: string,
-  args: Record<string, unknown>,
-) => Promise<Record<string, unknown>>;
+import type { IpcHandler } from "./ipc-handler.js";
+export type { IpcHandler };
 
 export interface IpcServerOptions {
   socketPath: string;

--- a/packages/sync-client/src/lib/config.ts
+++ b/packages/sync-client/src/lib/config.ts
@@ -8,8 +8,9 @@ import { writeUtf8FileAtomic } from "./atomic-write.js";
 export const SyncConfigSchema = z.object({
   // platformUrl owns identity: device-flow login, JWT issuance, /api/me.
   // gatewayUrl is the per-user data plane (sync API + WS). They differ in
-  // production (https://platform.matrix-os.com vs https://alice.matrix-os.com)
-  // and may be the same host in single-tenant dev.
+  // production (both terminate at https://app.matrix-os.com since spec 066
+  // PR 1; the platform dispatches HTTP + WS to the right per-user container
+  // based on the Clerk session) and may be the same host in single-tenant dev.
   platformUrl: z.url().optional(),
   gatewayUrl: z.url(),
   syncPath: z.string().min(1),
@@ -30,8 +31,19 @@ export type SyncConfig = z.infer<typeof SyncConfigSchema>;
 const MAX_GATEWAY_FOLDER_LENGTH = 1024;
 const DOUBLE_DOT_SEGMENT = /(?:^|\/)\.\.(?:\/|$)/;
 
+// Single rollout domain: all platform + gateway traffic terminates at
+// app.matrix-os.com. The legacy platform.matrix-os.com host was retired in
+// spec 066 PR 1 -- do not reintroduce it without updating the platform's
+// session-routing middleware at the same time.
+export const DEFAULT_PLATFORM_URL = "https://app.matrix-os.com";
+export const DEFAULT_GATEWAY_URL = "https://app.matrix-os.com";
+
 export function defaultPlatformUrl(): string {
-  return process.env.MATRIXOS_PLATFORM_URL ?? "https://platform.matrix-os.com";
+  return process.env.MATRIXOS_PLATFORM_URL ?? DEFAULT_PLATFORM_URL;
+}
+
+export function defaultGatewayUrl(): string {
+  return process.env.MATRIXOS_GATEWAY_URL ?? DEFAULT_GATEWAY_URL;
 }
 
 function configDir(): string {

--- a/packages/sync-client/src/lib/find-tsx-loader.mjs
+++ b/packages/sync-client/src/lib/find-tsx-loader.mjs
@@ -1,0 +1,17 @@
+// Shared tsx loader finder. Both bin/matrixos.mjs (monorepo root) and
+// packages/sync-client/bin/matrix.mjs (published package) import this to
+// avoid duplicating the bounded-walk logic.
+import { dirname, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+
+export function findTsxLoader(start) {
+  let dir = start;
+  for (let i = 0; i < 6; i += 1) {
+    const candidate = resolve(dir, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+    if (existsSync(candidate)) return candidate;
+    const up = dirname(dir);
+    if (up === dir) break;
+    dir = up;
+  }
+  return null;
+}

--- a/packages/sync-client/tests/unit/config.test.ts
+++ b/packages/sync-client/tests/unit/config.test.ts
@@ -1,8 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  DEFAULT_GATEWAY_URL,
+  DEFAULT_PLATFORM_URL,
+  defaultGatewayUrl,
+  defaultPlatformUrl,
   generatePeerId,
   normalizeGatewayFolder,
   resolveSyncPathWithinHome,
@@ -37,6 +41,38 @@ describe("saveConfig", () => {
     );
     expect((await stat(join(tempDir, "private"))).mode & 0o777).toBe(0o700);
     expect((await stat(configPath)).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("default URL constants and functions", () => {
+  afterEach(() => {
+    delete process.env.MATRIXOS_PLATFORM_URL;
+    delete process.env.MATRIXOS_GATEWAY_URL;
+  });
+
+  it("DEFAULT_PLATFORM_URL and DEFAULT_GATEWAY_URL are app.matrix-os.com", () => {
+    expect(DEFAULT_PLATFORM_URL).toBe("https://app.matrix-os.com");
+    expect(DEFAULT_GATEWAY_URL).toBe("https://app.matrix-os.com");
+  });
+
+  it("defaultPlatformUrl returns the constant when env is unset", () => {
+    delete process.env.MATRIXOS_PLATFORM_URL;
+    expect(defaultPlatformUrl()).toBe(DEFAULT_PLATFORM_URL);
+  });
+
+  it("defaultPlatformUrl returns the env override when set", () => {
+    process.env.MATRIXOS_PLATFORM_URL = "http://localhost:9000";
+    expect(defaultPlatformUrl()).toBe("http://localhost:9000");
+  });
+
+  it("defaultGatewayUrl returns the constant when env is unset", () => {
+    delete process.env.MATRIXOS_GATEWAY_URL;
+    expect(defaultGatewayUrl()).toBe(DEFAULT_GATEWAY_URL);
+  });
+
+  it("defaultGatewayUrl returns the env override when set", () => {
+    process.env.MATRIXOS_GATEWAY_URL = "http://localhost:4000";
+    expect(defaultGatewayUrl()).toBe("http://localhost:4000");
   });
 });
 

--- a/packages/sync-client/tests/unit/find-tsx-loader.test.ts
+++ b/packages/sync-client/tests/unit/find-tsx-loader.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { findTsxLoader } from "../../src/lib/find-tsx-loader.mjs";
+
+describe("findTsxLoader", () => {
+  let tempDir: string;
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("finds tsx at the immediate level", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "tsx-test-"));
+    const loaderPath = join(tempDir, "node_modules", "tsx", "dist", "loader.mjs");
+    await mkdir(join(tempDir, "node_modules", "tsx", "dist"), { recursive: true });
+    await writeFile(loaderPath, "// stub");
+
+    expect(findTsxLoader(tempDir)).toBe(loaderPath);
+  });
+
+  it("finds tsx 2 levels up (pnpm hoisting)", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "tsx-test-"));
+    const loaderPath = join(tempDir, "node_modules", "tsx", "dist", "loader.mjs");
+    await mkdir(join(tempDir, "node_modules", "tsx", "dist"), { recursive: true });
+    await writeFile(loaderPath, "// stub");
+
+    const nested = join(tempDir, "packages", "sync-client");
+    await mkdir(nested, { recursive: true });
+
+    expect(findTsxLoader(nested)).toBe(loaderPath);
+  });
+
+  it("returns null when tsx is not found within 6 levels", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "tsx-test-"));
+    const deep = join(tempDir, "a", "b", "c", "d", "e", "f", "g");
+    await mkdir(deep, { recursive: true });
+
+    expect(findTsxLoader(deep)).toBeNull();
+  });
+
+  it("handles root directory without infinite loop", () => {
+    expect(findTsxLoader("/")).toBeNull();
+  });
+});

--- a/packages/sync-client/tests/unit/ipc-handler.test.ts
+++ b/packages/sync-client/tests/unit/ipc-handler.test.ts
@@ -154,7 +154,9 @@ describe("createIpcHandler", () => {
 
       expect(res).toEqual({ syncPath: next, restartRequired: true });
       expect(deps.config.syncPath).toBe(next);
-      expect(saveConfig).toHaveBeenCalledWith(deps.config);
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ syncPath: next }),
+      );
       expect(ensureDir).toHaveBeenCalledWith(next);
     });
 
@@ -204,7 +206,9 @@ describe("createIpcHandler", () => {
 
       expect(res).toEqual({ gatewayFolder: "audit", restartRequired: true });
       expect(deps.config.gatewayFolder).toBe("audit");
-      expect(saveConfig).toHaveBeenCalledWith(deps.config);
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ gatewayFolder: "audit" }),
+      );
     });
 
     it("rejects folders that start with a leading slash", async () => {

--- a/packages/sync-client/tests/unit/ipc-handler.test.ts
+++ b/packages/sync-client/tests/unit/ipc-handler.test.ts
@@ -275,11 +275,12 @@ describe("createIpcHandler", () => {
   });
 
   describe("unknown command", () => {
-    it("rejects with a descriptive error", async () => {
+    it("rejects without exposing the command name", async () => {
       const { deps } = createDeps();
       const handler = createIpcHandler(deps);
 
-      await expect(handler("nope", {})).rejects.toThrow(/Unknown command/);
+      await expect(handler("nope", {})).rejects.toThrow(/Unknown IPC command/);
+      await expect(handler("nope", {})).rejects.not.toThrow(/nope/);
     });
   });
 
@@ -294,6 +295,31 @@ describe("createIpcHandler", () => {
       const res = await handler("getConfig", {});
 
       expect(res.gatewayFolder).toBe("notes");
+    });
+  });
+
+  describe("setSyncPath does not mutate config if saveConfig fails", () => {
+    it("preserves the original syncPath on persist failure", async () => {
+      const originalPath = join(homedir(), "matrixos");
+      const { deps, saveConfig } = createDeps();
+      saveConfig.mockRejectedValueOnce(new Error("disk full"));
+      const handler = createIpcHandler(deps);
+      const next = join(homedir(), "matrixos-new");
+
+      await expect(handler("setSyncPath", { syncPath: next })).rejects.toThrow("disk full");
+      expect(deps.config.syncPath).toBe(originalPath);
+    });
+  });
+
+  describe("setGatewayFolder does not mutate config if saveConfig fails", () => {
+    it("preserves the original folder on persist failure", async () => {
+      const { deps, saveConfig } = createDeps();
+      deps.config.gatewayFolder = "original";
+      saveConfig.mockRejectedValueOnce(new Error("disk full"));
+      const handler = createIpcHandler(deps);
+
+      await expect(handler("setGatewayFolder", { gatewayFolder: "new-folder" })).rejects.toThrow("disk full");
+      expect(deps.config.gatewayFolder).toBe("original");
     });
   });
 

--- a/packages/sync-client/tests/unit/ipc-handler.test.ts
+++ b/packages/sync-client/tests/unit/ipc-handler.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi } from "vitest";
+import { homedir } from "node:os";
+import { rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createIpcHandler } from "../../src/daemon/ipc-handler.js";
+import type { SyncConfig } from "../../src/lib/config.js";
+import type { SyncState } from "../../src/daemon/types.js";
+
+function baseConfig(): SyncConfig {
+  return {
+    platformUrl: "https://app.example.com",
+    gatewayUrl: "https://app.example.com",
+    syncPath: join(homedir(), "matrixos"),
+    gatewayFolder: "",
+    peerId: "host-abcd1234",
+    pauseSync: false,
+  };
+}
+
+function baseState(): SyncState {
+  return {
+    manifestVersion: 4,
+    lastSyncAt: 1234,
+    files: {
+      "a.md": { hash: "sha256:aa", mtime: 1, size: 1 },
+      "b.md": { hash: "sha256:bb", mtime: 2, size: 2 },
+    },
+  };
+}
+
+function createDeps(overrides: Partial<Parameters<typeof createIpcHandler>[0]> = {}) {
+  const saveConfig = vi.fn().mockResolvedValue(undefined);
+  const persistPauseState = vi.fn(async (cfg: SyncConfig, paused: boolean) => {
+    cfg.pauseSync = paused;
+  });
+  const clearAuth = vi.fn().mockResolvedValue(undefined);
+  const exit = vi.fn();
+  const ensureDir = vi.fn().mockResolvedValue(undefined);
+  const scheduled: Array<{ fn: () => void; ms: number }> = [];
+  const schedule = (fn: () => void, ms: number) => {
+    scheduled.push({ fn, ms });
+  };
+  const logger = { info: vi.fn() };
+
+  const deps = {
+    config: baseConfig(),
+    syncState: baseState(),
+    logger,
+    saveConfig,
+    persistPauseState,
+    clearAuth,
+    exit,
+    ensureDir,
+    schedule,
+    ...overrides,
+  };
+  return { deps, saveConfig, persistPauseState, clearAuth, exit, ensureDir, scheduled, logger };
+}
+
+describe("createIpcHandler", () => {
+  describe("status", () => {
+    it("returns a token-free snapshot of config + syncState", async () => {
+      const { deps } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("status", {});
+
+      expect(res).toEqual({
+        syncing: true,
+        manifestVersion: 4,
+        lastSyncAt: 1234,
+        fileCount: 2,
+        syncPath: deps.config.syncPath,
+        gatewayFolder: "",
+        gatewayUrl: deps.config.gatewayUrl,
+        platformUrl: deps.config.platformUrl,
+        peerId: deps.config.peerId,
+      });
+    });
+
+    it("reports syncing: false when pauseSync is true", async () => {
+      const { deps } = createDeps();
+      deps.config.pauseSync = true;
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("status", {});
+
+      expect(res.syncing).toBe(false);
+    });
+  });
+
+  describe("pause / resume", () => {
+    it("pause flips pauseSync and persists", async () => {
+      const { deps, persistPauseState } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("pause", {});
+
+      expect(res).toEqual({ paused: true });
+      expect(persistPauseState).toHaveBeenCalledWith(deps.config, true);
+    });
+
+    it("resume flips pauseSync back off", async () => {
+      const { deps, persistPauseState } = createDeps();
+      deps.config.pauseSync = true;
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("resume", {});
+
+      expect(res).toEqual({ paused: false });
+      expect(persistPauseState).toHaveBeenCalledWith(deps.config, false);
+    });
+  });
+
+  describe("getConfig", () => {
+    it("returns the current persisted config without tokens", async () => {
+      const { deps } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("getConfig", {});
+
+      expect(res).toEqual({
+        syncPath: deps.config.syncPath,
+        gatewayFolder: "",
+        gatewayUrl: deps.config.gatewayUrl,
+        platformUrl: deps.config.platformUrl,
+        peerId: deps.config.peerId,
+        pauseSync: false,
+      });
+      // Defensively assert no leakage of auth-shaped fields.
+      expect(res).not.toHaveProperty("accessToken");
+      expect(res).not.toHaveProperty("token");
+    });
+
+    it("normalizes a missing gatewayFolder to an empty string", async () => {
+      const { deps } = createDeps();
+      delete (deps.config as Partial<SyncConfig>).gatewayFolder;
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("getConfig", {});
+
+      expect(res.gatewayFolder).toBe("");
+    });
+  });
+
+  describe("setSyncPath", () => {
+    it("validates within $HOME, persists, and signals restart", async () => {
+      const { deps, saveConfig, ensureDir } = createDeps();
+      const handler = createIpcHandler(deps);
+      const next = join(homedir(), "matrixos-alt");
+
+      const res = await handler("setSyncPath", { syncPath: next });
+
+      expect(res).toEqual({ syncPath: next, restartRequired: true });
+      expect(deps.config.syncPath).toBe(next);
+      expect(saveConfig).toHaveBeenCalledWith(deps.config);
+      expect(ensureDir).toHaveBeenCalledWith(next);
+    });
+
+    it("rejects paths that escape $HOME", async () => {
+      const { deps, saveConfig } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      await expect(
+        handler("setSyncPath", { syncPath: "/etc/passwd" }),
+      ).rejects.toThrow(/home directory/i);
+      expect(saveConfig).not.toHaveBeenCalled();
+    });
+
+    it("rejects a missing / blank syncPath arg", async () => {
+      const { deps, saveConfig } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      await expect(handler("setSyncPath", {})).rejects.toThrow(/required/i);
+      await expect(
+        handler("setSyncPath", { syncPath: "   " }),
+      ).rejects.toThrow(/required/i);
+      expect(saveConfig).not.toHaveBeenCalled();
+    });
+
+    it("actually creates the directory on disk when no ensureDir override is passed", async () => {
+      const { deps, saveConfig } = createDeps({ ensureDir: undefined });
+      // Use a unique dir inside $HOME so resolveSyncPathWithinHome accepts it.
+      const inHome = join(homedir(), `.matrixos-ipc-test-${Date.now()}`);
+      const handler = createIpcHandler(deps);
+      try {
+        const res = await handler("setSyncPath", { syncPath: inHome });
+        expect(res.syncPath).toBe(inHome);
+        expect(existsSync(inHome)).toBe(true);
+        expect(saveConfig).toHaveBeenCalled();
+      } finally {
+        await rm(inHome, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("setGatewayFolder", () => {
+    it("normalizes and persists a new folder", async () => {
+      const { deps, saveConfig } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("setGatewayFolder", { gatewayFolder: "audit/" });
+
+      expect(res).toEqual({ gatewayFolder: "audit", restartRequired: true });
+      expect(deps.config.gatewayFolder).toBe("audit");
+      expect(saveConfig).toHaveBeenCalledWith(deps.config);
+    });
+
+    it("rejects folders that start with a leading slash", async () => {
+      const { deps, saveConfig } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      await expect(
+        handler("setGatewayFolder", { gatewayFolder: "/audit" }),
+      ).rejects.toThrow(/must not start with/i);
+      expect(saveConfig).not.toHaveBeenCalled();
+    });
+
+    it("accepts an empty folder (full-mirror mode)", async () => {
+      const { deps, saveConfig } = createDeps();
+      deps.config.gatewayFolder = "audit";
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("setGatewayFolder", { gatewayFolder: "" });
+
+      expect(res).toEqual({ gatewayFolder: "", restartRequired: true });
+      expect(deps.config.gatewayFolder).toBe("");
+      expect(saveConfig).toHaveBeenCalled();
+    });
+
+    it("rejects traversal via '..' segments", async () => {
+      const { deps, saveConfig } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      await expect(
+        handler("setGatewayFolder", { gatewayFolder: "../../etc" }),
+      ).rejects.toThrow(/\.\./);
+      expect(saveConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("restart", () => {
+    it("schedules exit(3) and returns immediately", async () => {
+      const { deps, exit, scheduled, logger } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("restart", {});
+
+      expect(res).toEqual({ restarting: true });
+      expect(exit).not.toHaveBeenCalled();
+      expect(scheduled).toHaveLength(1);
+
+      scheduled[0]!.fn();
+      expect(logger.info).toHaveBeenCalledWith("Restart requested via IPC");
+      expect(exit).toHaveBeenCalledWith(3);
+    });
+  });
+
+  describe("logout", () => {
+    it("clears auth, schedules exit(0), and returns immediately", async () => {
+      const { deps, clearAuth, exit, scheduled, logger } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      const res = await handler("logout", {});
+
+      expect(res).toEqual({ loggedOut: true });
+      expect(clearAuth).toHaveBeenCalledTimes(1);
+      expect(exit).not.toHaveBeenCalled();
+
+      scheduled[0]!.fn();
+      expect(logger.info).toHaveBeenCalledWith("Logout requested via IPC");
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe("unknown command", () => {
+    it("rejects with a descriptive error", async () => {
+      const { deps } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      await expect(handler("nope", {})).rejects.toThrow(/Unknown command/);
+    });
+  });
+
+  describe("getConfig after setGatewayFolder", () => {
+    it("reflects the updated folder in subsequent getConfig calls", async () => {
+      // Regression: the handler must update the same config object the
+      // daemon is holding a reference to; cloning it breaks this.
+      const { deps } = createDeps();
+      const handler = createIpcHandler(deps);
+
+      await handler("setGatewayFolder", { gatewayFolder: "notes" });
+      const res = await handler("getConfig", {});
+
+      expect(res.gatewayFolder).toBe("notes");
+    });
+  });
+
+  describe("getConfig after setSyncPath", () => {
+    it("reflects the updated path in subsequent getConfig / status calls", async () => {
+      const { deps } = createDeps();
+      const handler = createIpcHandler(deps);
+      const next = join(homedir(), `matrixos-new-${Date.now()}`);
+
+      await handler("setSyncPath", { syncPath: next });
+      const status = await handler("status", {});
+      const cfg = await handler("getConfig", {});
+
+      expect(status.syncPath).toBe(next);
+      expect(cfg.syncPath).toBe(next);
+    });
+  });
+});

--- a/packages/sync-client/tests/unit/login.test.ts
+++ b/packages/sync-client/tests/unit/login.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../src/auth/oauth.js", () => ({
 
 vi.mock("../../src/lib/config.js", () => ({
   defaultPlatformUrl: () => "https://platform.example",
+  defaultGatewayUrl: () => "https://gateway.example",
   defaultSyncPath: () => "/tmp/syncpath",
   generatePeerId: () => "peer-test",
   loadConfig: loadConfigMock,
@@ -108,6 +109,25 @@ describe("loginCommand /api/me handling", () => {
 
     expect(clearAuthMock).not.toHaveBeenCalled();
     expect(saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to defaultGatewayUrl when /api/me returns 200 without one", async () => {
+    // Regression: earlier impl fell back to `platformUrl`, which was wrong
+    // when --platform pointed at a dev override (`http://localhost:9000`).
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ userId: "user_test", handle: "alice" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runLogin();
+
+    expect(saveConfigMock).toHaveBeenCalledTimes(1);
+    const written = saveConfigMock.mock.calls[0]![0];
+    expect(written.gatewayUrl).toBe("https://gateway.example");
+    expect(written.platformUrl).toBe(PLATFORM_URL);
   });
 
   it("saves config with the server-supplied gatewayUrl on 200", async () => {


### PR DESCRIPTION
## Summary

- Extract daemon IPC command router as a testable unit (`ipc-handler.ts`) with full DI — 23 unit tests covering all 8 commands, path traversal rejection, config mutation semantics, and saveConfig failure safety
- Default `gatewayUrl` to `https://app.matrix-os.com` (single rollout domain), with env-var override for dev
- Fix `bin/matrixos.mjs` tsx loader to walk up directories (CWD-independent resolution after `pnpm link --global`)
- Extract `findTsxLoader` to shared `find-tsx-loader.mjs` (deduplicated from bin launchers)

## Invariants

- **Source of truth**: `~/.matrixos/config.json` is canonical. In-memory config is only mutated after `saveConfig()` succeeds (spread-then-assign pattern).
- **Lock/transaction scope**: IPC commands are serial (single Unix socket, one handler at a time). No concurrent mutation of config.
- **Acceptable orphan states**: If `setSyncPath` creates the directory but `saveConfig` throws, the empty directory is left behind (harmless).
- **Auth source of truth**: `~/.matrixos/auth.json` — `logout` IPC wipes it then exits.
- **Deferred scope**: Mac app Swift code (SettingsView, FinderSync) — requires Xcode, not in this PR.

## Test plan

- [x] `pnpm --filter sync-client exec tsc --noEmit` — clean
- [x] 41 unit tests pass (ipc-handler, config defaults, login fallback, find-tsx-loader)
- [x] Pre-existing `oauth.test.ts` failure unchanged (vi.mock hoisting, not touched)
- [ ] Manual: `matrix login` against prod writes `gatewayUrl: https://app.matrix-os.com`
- [ ] Manual: `matrix login --dev` writes localhost URLs