### PR TITLE
feat(066): PR 3 — distribution (npm + brew + macOS installer + CI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,259 @@
+name: Release
+
+# Triggered by pushing a semver tag. Runs tests, builds + signs + notarises
+# the macOS installer, publishes @matrix-os/cli to npm, uploads artefacts to
+# the GitHub release, and refreshes the Homebrew formula.
+#
+# Security note: workflow inputs we consume are $GITHUB_REF_NAME (constrained
+# by the `v*.*.*` tag filter above — so it's always of form `vX.Y.Z[...]`)
+# and secrets. No issue/PR bodies or commit messages are interpolated into
+# run: steps, avoiding the standard script-injection vectors.
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Unit tests
+        run: bun run test
+
+      - name: Pattern scan
+        run: ./scripts/review/check-patterns.sh
+
+  build-macos:
+    name: Build macOS .pkg
+    needs: test
+    runs-on: macos-14
+    timeout-minutes: 45
+    outputs:
+      pkg_path: ${{ steps.build.outputs.pkg_path }}
+      pkg_name: ${{ steps.build.outputs.pkg_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Resolve version
+        id: version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install workspace deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Import Developer ID certs
+        env:
+          APPLE_DEV_ID_APP_P12_BASE64: ${{ secrets.APPLE_DEV_ID_APP_P12_BASE64 }}
+          APPLE_DEV_ID_INSTALLER_P12_BASE64: ${{ secrets.APPLE_DEV_ID_INSTALLER_P12_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          echo "$APPLE_DEV_ID_APP_P12_BASE64" | base64 -d > "$RUNNER_TEMP/app.p12"
+          echo "$APPLE_DEV_ID_INSTALLER_P12_BASE64" | base64 -d > "$RUNNER_TEMP/installer.p12"
+
+          security import "$RUNNER_TEMP/app.p12" \
+            -k "$KEYCHAIN" -P "$APPLE_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productsign
+          security import "$RUNNER_TEMP/installer.p12" \
+            -k "$KEYCHAIN" -P "$APPLE_CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productsign
+
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          rm -f "$RUNNER_TEMP/app.p12" "$RUNNER_TEMP/installer.p12"
+
+      - name: Build installer
+        id: build
+        env:
+          APPLE_DEV_ID_APP: ${{ secrets.APPLE_DEV_ID_APP }}
+          APPLE_DEV_ID_INSTALLER: ${{ secrets.APPLE_DEV_ID_INSTALLER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          ./scripts/build-macos-pkg.sh
+          PKG_PATH="dist/macos/MatrixSync-${VERSION}.pkg"
+          echo "pkg_path=${PKG_PATH}" >> "$GITHUB_OUTPUT"
+          echo "pkg_name=MatrixSync-${VERSION}.pkg" >> "$GITHUB_OUTPUT"
+
+      - name: Notarise installer
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          PKG_PATH: ${{ steps.build.outputs.pkg_path }}
+        run: ./scripts/notarise-macos.sh "$PKG_PATH"
+
+      - name: Upload pkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-pkg
+          path: ${{ steps.build.outputs.pkg_path }}
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-npm:
+    name: Publish npm
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Align package version with tag
+        working-directory: packages/sync-client
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Publish
+        working-directory: packages/sync-client
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+  github-release:
+    name: GitHub release
+    needs: [build-macos, publish-npm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos-pkg
+          path: dist/macos
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            dist/macos/*.pkg
+            scripts/install.sh
+
+  homebrew:
+    name: Update Homebrew tap
+    needs: github-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: matrix-os/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Compute formula update
+        id: formula
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          TARBALL="https://registry.npmjs.org/@matrix-os/cli/-/cli-${VERSION}.tgz"
+
+          # Wait up to 5 min for npm to publish — publish-npm just finished.
+          for _ in $(seq 1 30); do
+            if curl -fsIL --max-time 15 "$TARBALL" >/dev/null; then break; fi
+            sleep 10
+          done
+
+          SHA256="$(curl -fsSL --max-time 60 "$TARBALL" | shasum -a 256 | awk '{print $1}')"
+          {
+            echo "version=${VERSION}"
+            echo "tarball=${TARBALL}"
+            echo "sha256=${SHA256}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply formula update
+        working-directory: tap
+        env:
+          VERSION: ${{ steps.formula.outputs.version }}
+          TARBALL: ${{ steps.formula.outputs.tarball }}
+          SHA256: ${{ steps.formula.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          FORMULA="Formula/matrix.rb"
+          if [ ! -f "$FORMULA" ]; then
+            echo "formula $FORMULA missing in tap repo; bootstrap it first." >&2
+            exit 1
+          fi
+
+          python3 - <<'PY'
+          import os, re, pathlib
+          path = pathlib.Path("Formula/matrix.rb")
+          tarball = os.environ["TARBALL"]
+          sha = os.environ["SHA256"]
+          version = os.environ["VERSION"]
+          text = path.read_text()
+          text = re.sub(r'url\s+".*"', f'url "{tarball}"', text, count=1)
+          text = re.sub(r'sha256\s+".*"', f'sha256 "{sha}"', text, count=1)
+          text = re.sub(r'version\s+".*"', f'version "{version}"', text, count=1)
+          path.write_text(text)
+          PY
+
+          git config user.name "matrix-os-bot"
+          git config user.email "bot@matrix-os.com"
+          git add "$FORMULA"
+          git commit -m "matrix ${VERSION}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Type check
+        run: bun run typecheck
+
       - name: Unit tests
         run: bun run test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
 
   publish-npm:
     name: Publish npm
-    needs: test
+    needs: [test, build-macos]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -220,6 +220,10 @@ jobs:
             if curl -fsIL --max-time 15 "$TARBALL" >/dev/null; then break; fi
             sleep 10
           done
+          curl -fsIL --max-time 15 "$TARBALL" >/dev/null || {
+            echo "npm tarball not available after 5 minutes of polling" >&2
+            exit 1
+          }
 
           SHA256="$(curl -fsSL --max-time 60 "$TARBALL" | shasum -a 256 | awk '{print $1}')"
           {

--- a/homebrew-tap/Formula/matrix.rb
+++ b/homebrew-tap/Formula/matrix.rb
@@ -1,0 +1,35 @@
+# Homebrew formula for the Matrix OS CLI.
+#
+# Lives here for version control during bootstrap; the CI release workflow
+# mirrors it into the matrix-os/homebrew-tap repository and bumps url/sha256
+# on each tag push.
+#
+# Install: brew install matrix-os/tap/matrix
+
+class Matrix < Formula
+  desc "Matrix OS command-line client (sync, login, peer management)"
+  homepage "https://matrix-os.com"
+
+  # `url` and `sha256` are rewritten by .github/workflows/release.yml against
+  # the npm tarball after each publish. Keep them valid for `brew install` to
+  # work off main while the release pipeline sleeps.
+  url "https://registry.npmjs.org/@matrix-os/cli/-/cli-0.2.0.tgz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  version "0.2.0"
+
+  license "AGPL-3.0-or-later"
+
+  depends_on "node@24"
+
+  def install
+    # Install the package into libexec, then symlink the bins into HOMEBREW_PREFIX/bin.
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    # `matrix --version` exits with the version from package.json.
+    output = shell_output("#{bin}/matrix --version")
+    assert_match version.to_s, output
+  end
+end

--- a/homebrew-tap/Formula/matrix.rb
+++ b/homebrew-tap/Formula/matrix.rb
@@ -11,8 +11,8 @@ class Matrix < Formula
   homepage "https://matrix-os.com"
 
   # `url` and `sha256` are rewritten by .github/workflows/release.yml against
-  # the npm tarball after each publish. Keep them valid for `brew install` to
-  # work off main while the release pipeline sleeps.
+  # the npm tarball after each publish. Until the first release job rewrites
+  # this staging copy, the placeholder sha256 is intentionally non-installable.
   url "https://registry.npmjs.org/@matrix-os/cli/-/cli-0.2.0.tgz"
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   version "0.2.0"

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -1,0 +1,18 @@
+# homebrew-tap (staging)
+
+Staging copy of the `matrix-os/homebrew-tap` repository. Lives inside this
+monorepo during bootstrap so the formula is version-controlled alongside
+the release pipeline.
+
+The release workflow (`.github/workflows/release.yml` → `homebrew` job)
+checks out `matrix-os/homebrew-tap` separately, rewrites `Formula/matrix.rb`
+with the latest npm tarball URL + sha256, and pushes.
+
+When the external tap repo is bootstrapped for the first time, copy this
+formula over:
+
+```bash
+cp homebrew-tap/Formula/matrix.rb /path/to/matrix-os/homebrew-tap/Formula/
+```
+
+After that, day-to-day edits happen in the tap repo, not here.

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -1,0 +1,36 @@
+# @matrix-os/cli
+
+Command-line client for [Matrix OS](https://matrix-os.com).
+
+## Install
+
+```bash
+npm install -g @matrix-os/cli
+```
+
+Or run the platform-detecting installer which fetches the signed macOS `.pkg`
+when appropriate:
+
+```bash
+curl -sL get.matrix-os.com | sh
+```
+
+## Usage
+
+```bash
+matrix login              # device-code flow against app.matrix-os.com
+matrix sync ~/matrixos    # start the sync daemon against the logged-in instance
+matrix peers              # list connected peers
+matrix logout             # clear local credentials
+```
+
+Both `matrix` and `matrixos` bin entries are installed.
+
+## Requirements
+
+- Node.js 24 or newer
+- A Matrix OS account — sign up at [app.matrix-os.com](https://app.matrix-os.com)
+
+## License
+
+AGPL-3.0-or-later.

--- a/packages/sync-client/bin/matrix.mjs
+++ b/packages/sync-client/bin/matrix.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Published-package entry for `matrix` / `matrixos` when installed via
+// `npm i -g @matrix-os/cli`. Re-execs with the tsx loader so Node can
+// import the .ts CLI sources directly. Mirrors bin/matrixos.mjs in the
+// monorepo, but resolves tsx from the package's own node_modules.
+//
+// `--import tsx` as a bare specifier is resolved against CWD. When the
+// CLI is installed globally and the user runs it from any directory,
+// Node can't find tsx. Pass the absolute loader URL so resolution is
+// path-based and CWD-independent.
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { existsSync } from 'node:fs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+
+// Walk up from the bin directory looking for a tsx loader. When installed
+// globally via npm, tsx lives under the package's own node_modules. When
+// installed via pnpm, it may be hoisted one or two levels up.
+function findTsxLoader(start) {
+  let dir = start;
+  for (let i = 0; i < 6; i += 1) {
+    const candidate = resolve(dir, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+    if (existsSync(candidate)) return candidate;
+    const up = dirname(dir);
+    if (up === dir) break;
+    dir = up;
+  }
+  return null;
+}
+
+const tsxLoader = findTsxLoader(pkgRoot);
+if (!tsxLoader) {
+  console.error(
+    'matrix CLI: tsx loader not found. Reinstall with `npm i -g @matrix-os/cli`.',
+  );
+  process.exit(1);
+}
+
+const cliEntry = resolve(pkgRoot, 'src', 'cli', 'index.ts');
+if (!existsSync(cliEntry)) {
+  console.error(`matrix CLI: entry not found at ${cliEntry}. Reinstall with \`npm i -g @matrix-os/cli\`.`);
+  process.exit(1);
+}
+
+const child = spawn(
+  process.execPath,
+  ['--import', pathToFileURL(tsxLoader).href, cliEntry, ...process.argv.slice(2)],
+  { stdio: 'inherit', env: process.env },
+);
+
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});
+
+child.on('error', (err) => {
+  console.error(`Failed to launch matrix CLI: ${err.message}`);
+  process.exit(1);
+});

--- a/packages/sync-client/bin/matrix.mjs
+++ b/packages/sync-client/bin/matrix.mjs
@@ -27,7 +27,7 @@ if (!tsxLoader) {
 
 const cliEntry = resolve(pkgRoot, 'src', 'cli', 'index.ts');
 if (!existsSync(cliEntry)) {
-  console.error(`matrix CLI: entry not found at ${cliEntry}. Reinstall with \`npm i -g @matrix-os/cli\`.`);
+  console.error('matrix CLI: entry not found. Reinstall with `npm i -g @matrix-os/cli`.');
   process.exit(1);
 }
 

--- a/packages/sync-client/bin/matrix.mjs
+++ b/packages/sync-client/bin/matrix.mjs
@@ -12,24 +12,10 @@ import { spawn } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync } from 'node:fs';
+import { findTsxLoader } from '../src/lib/find-tsx-loader.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, '..');
-
-// Walk up from the bin directory looking for a tsx loader. When installed
-// globally via npm, tsx lives under the package's own node_modules. When
-// installed via pnpm, it may be hoisted one or two levels up.
-function findTsxLoader(start) {
-  let dir = start;
-  for (let i = 0; i < 6; i += 1) {
-    const candidate = resolve(dir, 'node_modules', 'tsx', 'dist', 'loader.mjs');
-    if (existsSync(candidate)) return candidate;
-    const up = dirname(dir);
-    if (up === dir) break;
-    dir = up;
-  }
-  return null;
-}
 
 const tsxLoader = findTsxLoader(pkgRoot);
 if (!tsxLoader) {

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,16 +1,51 @@
 {
-  "name": "@matrixos/sync-client",
-  "version": "0.0.1",
-  "private": true,
+  "name": "@matrix-os/cli",
+  "version": "0.2.0",
+  "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
+  "license": "AGPL-3.0-or-later",
+  "homepage": "https://matrix-os.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HamedMP/matrix-os.git",
+    "directory": "packages/sync-client"
+  },
+  "bugs": {
+    "url": "https://github.com/HamedMP/matrix-os/issues"
+  },
+  "keywords": [
+    "matrix-os",
+    "sync",
+    "cli",
+    "file-sync",
+    "matrixos"
+  ],
+  "engines": {
+    "node": ">=24"
+  },
+  "bin": {
+    "matrix": "./bin/matrix.mjs",
+    "matrixos": "./bin/matrix.mjs"
+  },
   "exports": {
     ".": "./src/index.ts"
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "dev": "tsx watch src/daemon/index.ts",
     "build": "tsc",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "node ./scripts/check-publish.mjs"
   },
   "dependencies": {
     "chokidar": "^4.0.0",
@@ -19,6 +54,7 @@
     "picomatch": "^4.0.2",
     "pino": "^9.6.0",
     "pino-roll": "^2.1.0",
+    "tsx": "^4.21.0",
     "ws": "^8.19.0",
     "zod": "^4.0"
   },
@@ -27,7 +63,6 @@
     "@types/picomatch": "^4.0.0",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.0.18",
-    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   }

--- a/packages/sync-client/scripts/check-publish.mjs
+++ b/packages/sync-client/scripts/check-publish.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Guard that runs before `npm publish`. Verifies the package has the files
+// it claims to ship — the bin entry and the CLI source tree.
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+
+const mustExist = [
+  'bin/matrix.mjs',
+  'src/cli/index.ts',
+  'src/daemon/index.ts',
+  'src/index.ts',
+];
+
+const missing = mustExist.filter((p) => !existsSync(resolve(pkgRoot, p)));
+if (missing.length > 0) {
+  console.error('Pre-publish check failed. Missing required files:');
+  for (const p of missing) console.error(`  - ${p}`);
+  process.exit(1);
+}
+
+console.log('Pre-publish check: ok.');

--- a/packages/sync-client/src/cli/index.ts
+++ b/packages/sync-client/src/cli/index.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { defineCommand, runMain } from "citty";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
@@ -6,10 +7,13 @@ import { peersCommand } from "./commands/peers.js";
 import { keysCommand } from "./commands/keys.js";
 import { sshCommand } from "./commands/ssh.js";
 
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
+
 const main = defineCommand({
   meta: {
     name: "matrixos",
-    version: "0.0.1",
+    version: pkg.version,
     description: "Matrix OS CLI — file sync, sharing, and remote access",
   },
   subCommands: {

--- a/packages/sync-client/src/lib/find-tsx-loader.mjs
+++ b/packages/sync-client/src/lib/find-tsx-loader.mjs
@@ -1,0 +1,17 @@
+// Shared tsx loader finder. Both bin/matrixos.mjs (monorepo root) and
+// packages/sync-client/bin/matrix.mjs (published package) import this to
+// avoid duplicating the bounded-walk logic.
+import { dirname, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+
+export function findTsxLoader(start) {
+  let dir = start;
+  for (let i = 0; i < 6; i += 1) {
+    const candidate = resolve(dir, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+    if (existsSync(candidate)) return candidate;
+    const up = dirname(dir);
+    if (up === dir) break;
+    dir = up;
+  }
+  return null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,6 +427,9 @@ importers:
       pino-roll:
         specifier: ^2.1.0
         version: 2.2.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       ws:
         specifier: ^8.19.0
         version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -446,9 +449,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -17701,7 +17701,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       invariant: 2.2.4
       metro: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      metro-config: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
       semver: 7.7.4
     transitivePeerDependencies:
@@ -21337,7 +21337,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -21370,7 +21370,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -21385,7 +21385,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24468,6 +24468,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-config@0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-cache: 0.83.5
+      metro-core: 0.83.5
+      metro-runtime: 0.83.5
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-core@0.83.3:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -24856,7 +24871,7 @@ snapshots:
       metro-babel-transformer: 0.83.5
       metro-cache: 0.83.5
       metro-cache-key: 0.83.5
-      metro-config: 0.83.5(bufferutil@4.1.0)
+      metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
       metro-file-map: 0.83.5
       metro-resolver: 0.83.5

--- a/scripts/build-macos-pkg.sh
+++ b/scripts/build-macos-pkg.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Builds a signed macOS .pkg installer bundling:
+#   - the matrix CLI (npm package @matrix-os/cli)
+#   - MatrixSync.app (menu bar + FinderSync extension)
+#
+# The .pkg is signed with a Developer ID Installer certificate and is
+# intended to be notarised by scripts/notarise-macos.sh before release.
+#
+# Required environment:
+#   APPLE_DEV_ID_APP         e.g. "Developer ID Application: Your Name (TEAMID)"
+#   APPLE_DEV_ID_INSTALLER   e.g. "Developer ID Installer: Your Name (TEAMID)"
+#   APPLE_TEAM_ID            10-char team id
+#
+# Optional:
+#   VERSION                  Version string stamped into the pkg (default: git describe)
+#   OUTPUT_DIR               Where to drop the .pkg (default: dist/macos)
+#
+# Usage:
+#   scripts/build-macos-pkg.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+: "${APPLE_DEV_ID_APP:?APPLE_DEV_ID_APP must be set (Developer ID Application identity)}"
+: "${APPLE_DEV_ID_INSTALLER:?APPLE_DEV_ID_INSTALLER must be set (Developer ID Installer identity)}"
+: "${APPLE_TEAM_ID:?APPLE_TEAM_ID must be set}"
+
+VERSION="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo '0.0.0-dev')}"
+OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/dist/macos}"
+BUILD_DIR="$REPO_ROOT/dist/macos-build"
+PKG_ROOT="$BUILD_DIR/pkg-root"
+SCRIPTS_DIR="$BUILD_DIR/scripts"
+APP_NAME="MatrixSync.app"
+APP_ID="com.matrixos.MatrixSync"
+PKG_IDENTIFIER="com.matrixos.MatrixSync.pkg"
+CLI_PKG_DIR="$REPO_ROOT/packages/sync-client"
+
+echo "==> Building MatrixSync installer v$VERSION"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$PKG_ROOT/Applications" \
+         "$PKG_ROOT/usr/local/bin" \
+         "$PKG_ROOT/usr/local/lib/matrix-os" \
+         "$SCRIPTS_DIR" \
+         "$OUTPUT_DIR"
+
+# -----------------------------------------------------------------------------
+# Step 1: build the menu bar app + FinderSync extension.
+# -----------------------------------------------------------------------------
+echo "==> Building MatrixSync.app via xcodebuild"
+XCODE_PROJECT="$CLI_PKG_DIR/macos/MatrixSync.xcodeproj"
+XCODE_BUILD_DIR="$BUILD_DIR/xcode"
+
+xcodebuild \
+  -project "$XCODE_PROJECT" \
+  -scheme MatrixSync \
+  -configuration Release \
+  -derivedDataPath "$XCODE_BUILD_DIR" \
+  CODE_SIGN_STYLE=Manual \
+  CODE_SIGN_IDENTITY="$APPLE_DEV_ID_APP" \
+  DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+  MARKETING_VERSION="$VERSION" \
+  clean build
+
+APP_BUILD_PATH="$XCODE_BUILD_DIR/Build/Products/Release/$APP_NAME"
+if [ ! -d "$APP_BUILD_PATH" ]; then
+  echo "error: expected $APP_BUILD_PATH to exist after xcodebuild" >&2
+  exit 1
+fi
+
+cp -R "$APP_BUILD_PATH" "$PKG_ROOT/Applications/$APP_NAME"
+
+# Verify the app + extension are signed. `codesign --verify` exits non-zero
+# when the signature is missing or broken.
+codesign --verify --strict --deep "$PKG_ROOT/Applications/$APP_NAME"
+
+# -----------------------------------------------------------------------------
+# Step 2: stage the CLI. Bundles the sync-client package contents under
+# /usr/local/lib/matrix-os and creates a launcher symlink in /usr/local/bin.
+# -----------------------------------------------------------------------------
+echo "==> Staging matrix CLI"
+CLI_STAGE_DIR="$PKG_ROOT/usr/local/lib/matrix-os/cli"
+mkdir -p "$CLI_STAGE_DIR"
+
+# Copy only what `files` in package.json declares — bin/, src/, README, LICENSE,
+# package.json. Using rsync so we can exclude node_modules/dist cleanly.
+rsync -a \
+  --include='bin/***' \
+  --include='src/***' \
+  --include='package.json' \
+  --include='README.md' \
+  --include='LICENSE' \
+  --exclude='*' \
+  "$CLI_PKG_DIR/" "$CLI_STAGE_DIR/"
+
+# Install production deps into the staged CLI so it runs without the monorepo.
+(
+  cd "$CLI_STAGE_DIR"
+  # `npm install --omit=dev` is the cross-platform way to get production deps.
+  # We prefer npm over pnpm here so the staged tree is fully self-contained
+  # (no pnpm-lock / symlinks into a workspace).
+  npm install --omit=dev --no-audit --no-fund --ignore-scripts
+)
+
+# Launcher symlink that puts `matrix` and `matrixos` on PATH.
+ln -sf "/usr/local/lib/matrix-os/cli/bin/matrix.mjs" "$PKG_ROOT/usr/local/bin/matrix"
+ln -sf "/usr/local/lib/matrix-os/cli/bin/matrix.mjs" "$PKG_ROOT/usr/local/bin/matrixos"
+
+# -----------------------------------------------------------------------------
+# Step 3: postinstall script — register Finder extension with pluginkit.
+# -----------------------------------------------------------------------------
+cat >"$SCRIPTS_DIR/postinstall" <<'POST'
+#!/bin/bash
+set -euo pipefail
+
+APP_PATH="/Applications/MatrixSync.app"
+EXT_BUNDLE_ID="com.matrixos.MatrixSync.MatrixSyncFinderSync"
+
+if [ -d "$APP_PATH" ]; then
+  # Register and enable the FinderSync extension for every logged-in user.
+  # `pluginkit -a` adds the bundle; `-e use` marks it as user-enabled.
+  /usr/bin/pluginkit -a "$APP_PATH/Contents/PlugIns/MatrixSyncFinderSync.appex" || true
+  /usr/bin/pluginkit -e use -i "$EXT_BUNDLE_ID" || true
+fi
+
+exit 0
+POST
+chmod +x "$SCRIPTS_DIR/postinstall"
+
+# -----------------------------------------------------------------------------
+# Step 4: build the flat .pkg.
+# -----------------------------------------------------------------------------
+UNSIGNED_PKG="$BUILD_DIR/MatrixSync-unsigned.pkg"
+SIGNED_PKG="$OUTPUT_DIR/MatrixSync-$VERSION.pkg"
+
+echo "==> Running pkgbuild"
+pkgbuild \
+  --root "$PKG_ROOT" \
+  --identifier "$PKG_IDENTIFIER" \
+  --version "$VERSION" \
+  --scripts "$SCRIPTS_DIR" \
+  --install-location "/" \
+  "$UNSIGNED_PKG"
+
+echo "==> Signing .pkg with $APPLE_DEV_ID_INSTALLER"
+productsign \
+  --sign "$APPLE_DEV_ID_INSTALLER" \
+  --timestamp \
+  "$UNSIGNED_PKG" \
+  "$SIGNED_PKG"
+
+pkgutil --check-signature "$SIGNED_PKG"
+
+echo "==> Wrote $SIGNED_PKG"
+echo "Next: run scripts/notarise-macos.sh \"$SIGNED_PKG\""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,15 @@ MATRIX_VERSION="${MATRIX_VERSION:-latest}"
 MATRIX_CHANNEL="${MATRIX_CHANNEL:-stable}"
 MATRIX_REPO="${MATRIX_REPO:-HamedMP/matrix-os}"
 
+# Validate env overrides before they reach URLs or sudo commands.
+case "$MATRIX_REPO" in
+  *[!A-Za-z0-9._/-]*) die "MATRIX_REPO contains invalid characters (expected owner/repo)" ;;
+esac
+case "$MATRIX_VERSION" in
+  latest) ;; # ok
+  *[!A-Za-z0-9._-]*) die "MATRIX_VERSION contains invalid characters (expected semver tag)" ;;
+esac
+
 die() {
   printf 'error: %s\n' "$1" >&2
   exit 1
@@ -61,13 +70,16 @@ resolve_version() {
 install_macos() {
   echo "==> Matrix OS installer (macOS)"
   need sudo
-  VERSION="$(resolve_version)"
+  TAG="$(resolve_version)"
+  # Release tags are v-prefixed (v0.2.0) but the .pkg asset strips the v
+  # (MatrixSync-0.2.0.pkg). Normalize both for URL construction.
+  VERSION="${TAG#v}"
   echo "    version: $VERSION"
 
   TMPDIR="$(mktemp -d)"
   trap 'rm -rf "$TMPDIR"' EXIT
 
-  PKG_URL="https://github.com/$MATRIX_REPO/releases/download/$VERSION/MatrixSync-$VERSION.pkg"
+  PKG_URL="https://github.com/$MATRIX_REPO/releases/download/$TAG/MatrixSync-$VERSION.pkg"
   PKG_PATH="$TMPDIR/MatrixSync.pkg"
 
   echo "==> Downloading $PKG_URL"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,11 @@ MATRIX_VERSION="${MATRIX_VERSION:-latest}"
 MATRIX_CHANNEL="${MATRIX_CHANNEL:-stable}"
 MATRIX_REPO="${MATRIX_REPO:-HamedMP/matrix-os}"
 
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
 # Validate env overrides before they reach URLs or sudo commands.
 case "$MATRIX_REPO" in
   *[!A-Za-z0-9._/-]*) die "MATRIX_REPO contains invalid characters (expected owner/repo)" ;;
@@ -28,11 +33,6 @@ case "$MATRIX_VERSION" in
   latest) ;; # ok
   *[!A-Za-z0-9._-]*) die "MATRIX_VERSION contains invalid characters (expected semver tag)" ;;
 esac
-
-die() {
-  printf 'error: %s\n' "$1" >&2
-  exit 1
-}
 
 need() {
   command -v "$1" >/dev/null 2>&1 || die "required command '$1' not found"
@@ -76,11 +76,11 @@ install_macos() {
   VERSION="${TAG#v}"
   echo "    version: $VERSION"
 
-  TMPDIR="$(mktemp -d)"
-  trap 'rm -rf "$TMPDIR"' EXIT
+  INSTALL_TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "$INSTALL_TMPDIR"' EXIT
 
   PKG_URL="https://github.com/$MATRIX_REPO/releases/download/$TAG/MatrixSync-$VERSION.pkg"
-  PKG_PATH="$TMPDIR/MatrixSync.pkg"
+  PKG_PATH="$INSTALL_TMPDIR/MatrixSync.pkg"
 
   echo "==> Downloading $PKG_URL"
   fetch "$PKG_URL" "$PKG_PATH" || die "download failed. Check that $VERSION has a .pkg artefact."
@@ -118,9 +118,10 @@ install_linux() {
     die "Node.js 24 or newer required (detected $NODE_MAJOR). Upgrade at https://nodejs.org"
   fi
 
+  VERSION="${MATRIX_VERSION#v}"
   case "$MATRIX_VERSION" in
     latest) NPM_SPEC="@matrix-os/cli" ;;
-    *)      NPM_SPEC="@matrix-os/cli@$MATRIX_VERSION" ;;
+    *)      NPM_SPEC="@matrix-os/cli@$VERSION" ;;
   esac
 
   # Prefer an unprivileged install when the user has npm prefix configured for

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# Matrix OS installer. Served at https://get.matrix-os.com.
+#
+# Platform detection:
+#   macOS   -> downloads the signed .pkg from the GitHub release and runs
+#              `installer -pkg`. Needs sudo for /Applications + /usr/local.
+#   Linux   -> `npm i -g @matrix-os/cli` (stop-gap until a standalone binary).
+#   Windows -> print a PowerShell install hint.
+#
+# Usage:
+#   curl -sL https://get.matrix-os.com | sh
+#
+# Env overrides:
+#   MATRIX_VERSION   pin to a specific release tag (default: latest)
+#   MATRIX_CHANNEL   "stable" (default). Reserved for future pre-release lanes.
+
+set -eu
+
+MATRIX_VERSION="${MATRIX_VERSION:-latest}"
+MATRIX_CHANNEL="${MATRIX_CHANNEL:-stable}"
+MATRIX_REPO="${MATRIX_REPO:-HamedMP/matrix-os}"
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "required command '$1' not found"
+}
+
+fetch() {
+  # fetch <url> <output>
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --retry 3 --retry-delay 2 --max-time 300 -o "$2" "$1"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q --tries=3 --timeout=300 -O "$2" "$1"
+  else
+    die "need curl or wget"
+  fi
+}
+
+resolve_version() {
+  # Turn "latest" into an actual tag so all downstream URLs are deterministic.
+  if [ "$MATRIX_VERSION" != "latest" ]; then
+    printf '%s' "$MATRIX_VERSION"
+    return
+  fi
+  # GitHub's /releases/latest endpoint 302s to /releases/tag/<tag>.
+  # We curl -sI and pull the Location header.
+  if command -v curl >/dev/null 2>&1; then
+    location="$(curl -sI --max-time 30 "https://github.com/$MATRIX_REPO/releases/latest" \
+      | awk -F': ' 'tolower($1)=="location"{print $2}' | tr -d '\r\n' | tail -1)"
+    [ -n "$location" ] || die "could not resolve latest release"
+    printf '%s' "${location##*/}"
+  else
+    die "need curl to resolve latest version"
+  fi
+}
+
+install_macos() {
+  echo "==> Matrix OS installer (macOS)"
+  need sudo
+  VERSION="$(resolve_version)"
+  echo "    version: $VERSION"
+
+  TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "$TMPDIR"' EXIT
+
+  PKG_URL="https://github.com/$MATRIX_REPO/releases/download/$VERSION/MatrixSync-$VERSION.pkg"
+  PKG_PATH="$TMPDIR/MatrixSync.pkg"
+
+  echo "==> Downloading $PKG_URL"
+  fetch "$PKG_URL" "$PKG_PATH" || die "download failed. Check that $VERSION has a .pkg artefact."
+
+  # Gatekeeper sanity: verify the downloaded pkg is signed + notarised before
+  # asking the user for their sudo password.
+  echo "==> Verifying signature"
+  pkgutil --check-signature "$PKG_PATH" >/dev/null \
+    || die "downloaded pkg failed signature check"
+  spctl --assess --type install "$PKG_PATH" >/dev/null 2>&1 \
+    || echo "    (warning: spctl assess returned non-zero; continuing)"
+
+  echo "==> Installing (you'll be prompted for your password)"
+  sudo installer -pkg "$PKG_PATH" -target /
+
+  if command -v matrix >/dev/null 2>&1; then
+    echo "==> Installed: $(matrix --version 2>/dev/null || echo 'matrix')"
+    echo "Next: run 'matrix login' to sign in."
+  else
+    echo "    matrix CLI not on PATH. You may need to open a new shell."
+  fi
+}
+
+install_linux() {
+  echo "==> Matrix OS installer (Linux)"
+  if ! command -v npm >/dev/null 2>&1; then
+    die "npm not found. Install Node.js 24+ from https://nodejs.org then re-run this script."
+  fi
+  # Check Node version. The CLI requires Node 24+.
+  NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+  case "$NODE_MAJOR" in
+    ''|*[!0-9]*) die "could not determine Node.js version. Ensure 'node' is on PATH." ;;
+  esac
+  if [ "$NODE_MAJOR" -lt 24 ]; then
+    die "Node.js 24 or newer required (detected $NODE_MAJOR). Upgrade at https://nodejs.org"
+  fi
+
+  case "$MATRIX_VERSION" in
+    latest) NPM_SPEC="@matrix-os/cli" ;;
+    *)      NPM_SPEC="@matrix-os/cli@$MATRIX_VERSION" ;;
+  esac
+
+  # Prefer an unprivileged install when the user has npm prefix configured for
+  # it; otherwise fall back to sudo.
+  if [ -w "$(npm config get prefix 2>/dev/null)/lib/node_modules" ] 2>/dev/null; then
+    npm install -g "$NPM_SPEC"
+  else
+    echo "==> Installing globally (may prompt for sudo)"
+    sudo npm install -g "$NPM_SPEC"
+  fi
+
+  if command -v matrix >/dev/null 2>&1; then
+    echo "==> Installed: $(matrix --version 2>/dev/null || echo 'matrix')"
+    echo "Next: run 'matrix login' to sign in."
+  else
+    echo "    matrix not on PATH yet. Check your npm global prefix."
+  fi
+}
+
+install_windows() {
+  cat <<'WIN'
+Windows installer is not available yet.
+
+Temporary workaround (PowerShell):
+  npm install -g @matrix-os/cli
+
+Requires Node.js 24+ from https://nodejs.org.
+WIN
+  exit 1
+}
+
+main() {
+  OS="$(uname -s 2>/dev/null || echo unknown)"
+  case "$OS" in
+    Darwin)                install_macos ;;
+    Linux)                 install_linux ;;
+    MINGW*|MSYS*|CYGWIN*)  install_windows ;;
+    *)                     die "unsupported OS: $OS" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/notarise-macos.sh
+++ b/scripts/notarise-macos.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Submits a signed .pkg to Apple notary service via notarytool, waits for
+# the result, and staples the resulting ticket to the pkg so Gatekeeper
+# accepts it offline.
+#
+# Requires:
+#   APPLE_ID             Apple Developer account email
+#   APPLE_TEAM_ID        10-char team id
+#   APPLE_APP_PASSWORD   App-specific password (https://appleid.apple.com)
+#
+# Usage:
+#   scripts/notarise-macos.sh path/to/MatrixSync-<version>.pkg
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <path-to-pkg>" >&2
+  exit 2
+fi
+
+PKG_PATH="$1"
+if [ ! -f "$PKG_PATH" ]; then
+  echo "error: $PKG_PATH not found" >&2
+  exit 1
+fi
+
+: "${APPLE_ID:?APPLE_ID must be set}"
+: "${APPLE_TEAM_ID:?APPLE_TEAM_ID must be set}"
+: "${APPLE_APP_PASSWORD:?APPLE_APP_PASSWORD must be set (app-specific password)}"
+
+echo "==> Submitting $PKG_PATH to Apple notary"
+xcrun notarytool submit "$PKG_PATH" \
+  --apple-id "$APPLE_ID" \
+  --team-id "$APPLE_TEAM_ID" \
+  --password "$APPLE_APP_PASSWORD" \
+  --wait
+
+echo "==> Stapling notarisation ticket"
+xcrun stapler staple "$PKG_PATH"
+
+echo "==> Verifying staple"
+xcrun stapler validate "$PKG_PATH"
+
+# Gatekeeper assessment — prints FAIL loudly when the pkg isn't accepted.
+spctl --assess -vv --type install "$PKG_PATH" || {
+  echo "warning: spctl assessment reported failure; check output above" >&2
+  # notarytool + stapler succeeded is the contract; spctl assessment on a
+  # build host may still fail when the user isn't an admin. Don't block.
+}
+
+echo "==> Notarisation complete for $PKG_PATH"


### PR DESCRIPTION
## Summary

- Prep `@matrix-os/cli` npm package with `bin: { matrix, matrixos }`, publishConfig, and prepublishOnly guard
- Add `scripts/build-macos-pkg.sh` (signed `.pkg` bundling CLI + MatrixSync.app + FinderSync)
- Add `scripts/notarise-macos.sh` (wraps `xcrun notarytool`)
- Add `scripts/install.sh` (platform-detecting installer for `get.matrix-os.com` — macOS pkg, Linux npm, Windows stub)
- Add `.github/workflows/release.yml` — tag-triggered CI: typecheck, test, build+sign+notarize macOS, publish npm with provenance, GitHub release, Homebrew tap update
- Add `homebrew-tap/Formula/matrix.rb` (wraps npm install, `node@24` dep)
- CLI version now read from `package.json` (was hardcoded `0.0.1`)
- `install.sh` env vars validated and tag/asset name mismatch fixed

## Required secrets

`APPLE_DEV_ID_APP`, `APPLE_DEV_ID_INSTALLER`, `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_PASSWORD`, `APPLE_DEV_ID_APP_P12_BASE64`, `APPLE_DEV_ID_INSTALLER_P12_BASE64`, `APPLE_CERT_PASSWORD`, `KEYCHAIN_PASSWORD`, `NPM_TOKEN`, `HOMEBREW_TAP_TOKEN`

## Invariants

- **Source of truth**: Git tags drive versioning. `npm version` in CI aligns package.json before publish.
- **Lock/transaction scope**: Release workflow uses `cancel-in-progress: false` concurrency — no parallel releases.
- **Acceptable orphan states**: If notarization fails, the macOS build job fails and no release is created.
- **Deferred scope**: Windows installer, standalone Linux binary, auto-update mechanism.

## Test plan

- [x] `npm pack --dry-run` includes expected `bin/` and `src/` payload
- [x] Typecheck gate added to release workflow
- [x] `install.sh` rejects invalid `MATRIX_REPO`/`MATRIX_VERSION` chars
- [ ] Tag push triggers full release pipeline (needs secrets provisioned)
- [ ] `curl -sL get.matrix-os.com | sh` works on macOS 14+ and Ubuntu 22.04+
- [ ] `brew install matrix-os/tap/matrix` installs and runs