### PR TITLE
Ship CLI via brew/curl + terminal session + input fixes

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,88 @@
+name: Release CLI
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.9.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build + pack CLI tarball
+        run: pnpm pack:cli
+
+      - name: Read version
+        id: meta
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tarball=dist/cli/matrix-cli-${version}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "sha=$(awk '{print $1}' dist/cli/matrix-cli-${version}.tar.gz.sha256)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          gh release upload "$tag" \
+            "${{ steps.meta.outputs.tarball }}" \
+            "${{ steps.meta.outputs.tarball }}.sha256" \
+            --clobber
+
+      - name: Bump Homebrew tap
+        if: ${{ secrets.TAP_PUSH_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PUSH_TOKEN }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          SHA256: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -eu
+          ver_v="v${VERSION}"
+          work="$(mktemp -d)"
+          gh repo clone finnaai/homebrew-tap "$work" -- --depth=1
+          cd "$work"
+          git config user.name "matrix-os-bot"
+          git config user.email "bot@matrix-os.com"
+          mkdir -p Formula
+          sed -e "s|^  url .*|  url \"https://github.com/hamedmp/matrix-os/releases/download/${ver_v}/matrix-cli-${VERSION}.tar.gz\"|" \
+              -e "s|^  sha256 .*|  sha256 \"${SHA256}\"|" \
+              -e "s|^  version .*|  version \"${VERSION}\"|" \
+              Formula/matrix.rb > Formula/matrix.rb.new || true
+          if [ ! -s Formula/matrix.rb.new ]; then
+            cp "${GITHUB_WORKSPACE}/distro/homebrew/matrix.rb" Formula/matrix.rb.new
+            sed -i \
+              -e "s|releases/download/v[0-9.]*/matrix-cli-[0-9.]*\\.tar\\.gz|releases/download/${ver_v}/matrix-cli-${VERSION}.tar.gz|" \
+              -e "s|sha256 \"[0-9a-f]*\"|sha256 \"${SHA256}\"|" \
+              -e "s|version \"[0-9.]*\"|version \"${VERSION}\"|" \
+              Formula/matrix.rb.new
+          fi
+          mv Formula/matrix.rb.new Formula/matrix.rb
+          git add Formula/matrix.rb
+          if git diff --cached --quiet; then
+            echo "no tap changes"
+            exit 0
+          fi
+          git commit -m "matrix ${VERSION}"
+          git push origin HEAD:main

--- a/distro/homebrew/matrix.rb
+++ b/distro/homebrew/matrix.rb
@@ -1,0 +1,29 @@
+# Homebrew formula for the Matrix OS CLI.
+#
+# This file lives in this repo as a template. The published copy belongs in
+# the tap repo at https://github.com/finnaai/homebrew-tap under `Formula/matrix.rb`.
+#
+# The release workflow (.github/workflows/release-cli.yml) auto-bumps the
+# `url` and `sha256` in the tap copy when a new `v*` tag is pushed.
+
+class Matrix < Formula
+  desc "Matrix OS CLI — file sync, sharing, and remote access"
+  homepage "https://matrix-os.com"
+  url "https://github.com/hamedmp/matrix-os/releases/download/v0.9.0/matrix-cli-0.9.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "AGPL-3.0-or-later"
+  version "0.9.0"
+
+  depends_on "node@20"
+
+  def install
+    libexec.install Dir["*"]
+    %w[matrix matrixos mos].each do |alias_name|
+      bin.install_symlink libexec/"bin/#{alias_name}"
+    end
+  end
+
+  test do
+    assert_match(/\d+\.\d+\.\d+/, shell_output("#{bin}/matrix --version"))
+  end
+end

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "docker:logs": "docker compose -f docker-compose.dev.yml logs -f dev",
     "docker:shell": "docker compose -f docker-compose.dev.yml exec -u matrixos dev sh",
     "docker:build": "docker compose -f docker-compose.dev.yml build --no-cache",
+    "build:cli": "node --import tsx scripts/build-cli.ts",
+    "pack:cli": "node --import tsx scripts/build-cli.ts --pack",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1517,6 +1517,17 @@ export async function createGateway(config: GatewayConfig) {
                 handle = null;
               }
               break;
+            case "destroy":
+              if (handle) {
+                const sid = handle.sessionId;
+                handle.detach();
+                handle = null;
+                sessionRegistry.destroy(sid);
+                if (autoCreatedSessionId === sid) {
+                  autoCreatedSessionId = null;
+                }
+              }
+              break;
           }
         },
 

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -38,14 +38,18 @@ const DetachSchema = z.object({
   type: z.literal("detach"),
 });
 
+const DestroySchema = z.object({
+  type: z.literal("destroy"),
+});
+
 const PingSchema = z.object({
   type: z.literal("ping"),
 });
 
-export const ClientMessageSchema = z.union([AttachSchema, InputSchema, ResizeSchema, DetachSchema, PingSchema]);
+export const ClientMessageSchema = z.union([AttachSchema, InputSchema, ResizeSchema, DetachSchema, DestroySchema, PingSchema]);
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;
 
-export { AttachSchema, AttachNewSchema, AttachExistingSchema, InputSchema, ResizeSchema, DetachSchema, PingSchema, UUID_REGEX };
+export { AttachSchema, AttachNewSchema, AttachExistingSchema, InputSchema, ResizeSchema, DetachSchema, DestroySchema, PingSchema, UUID_REGEX };
 
 export interface SessionInfo {
   sessionId: string;

--- a/packages/sync-client/src/cli/index.ts
+++ b/packages/sync-client/src/cli/index.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import { defineCommand, runMain } from "citty";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
@@ -6,10 +7,23 @@ import { peersCommand } from "./commands/peers.js";
 import { keysCommand } from "./commands/keys.js";
 import { sshCommand } from "./commands/ssh.js";
 
+// Build-time constant replaced by esbuild's --define. Falls back to "dev"
+// when running from source (e.g. `pnpm tsx bin/...`).
+declare const __MATRIX_CLI_VERSION__: string;
+const version =
+  typeof __MATRIX_CLI_VERSION__ === "string" ? __MATRIX_CLI_VERSION__ : "dev";
+
+// Prefer the invoking alias (matrix/matrixos/mos) for help text. The POSIX
+// wrapper sets MATRIX_CLI_NAME; when running directly (tsx/source), fall
+// back to argv[1] stripped of its extension.
+const invokedAs =
+  process.env.MATRIX_CLI_NAME ??
+  basename(process.argv[1] ?? "matrix").replace(/\.js$/, "");
+
 const main = defineCommand({
   meta: {
-    name: "matrixos",
-    version: "0.0.1",
+    name: invokedAs || "matrix",
+    version,
     description: "Matrix OS CLI — file sync, sharing, and remote access",
   },
   subCommands: {

--- a/scripts/build-cli.ts
+++ b/scripts/build-cli.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Bundles the Matrix OS CLI into a single JS file and packs a tarball for release.
+// Output: dist/cli/matrix-cli-<version>.tar.gz
+//
+// Usage:
+//   node --import tsx scripts/build-cli.ts           # builds dist/cli/
+//   node --import tsx scripts/build-cli.ts --pack    # also produces the tarball
+//
+// Run via `pnpm build:cli` / `pnpm pack:cli`.
+
+import { mkdirSync, writeFileSync, rmSync, readFileSync, chmodSync, existsSync, statSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(here, "..");
+const outRoot = join(rootDir, "dist", "cli");
+const stageDir = join(outRoot, "stage");
+const binDir = join(stageDir, "bin");
+
+const rootPkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf-8"));
+const version: string = rootPkg.version ?? "0.0.0";
+const shouldPack = process.argv.includes("--pack");
+
+const entry = join(rootDir, "packages", "sync-client", "src", "cli", "index.ts");
+if (!existsSync(entry)) {
+  console.error(`missing entry: ${entry}`);
+  process.exit(1);
+}
+
+rmSync(outRoot, { recursive: true, force: true });
+mkdirSync(binDir, { recursive: true });
+
+const outFile = join(binDir, "matrix.js");
+const esbuild = join(rootDir, "node_modules", ".bin", "esbuild");
+if (!existsSync(esbuild)) {
+  console.error(`esbuild not found at ${esbuild}; run \`pnpm install\` first`);
+  process.exit(1);
+}
+
+const result = spawnSync(
+  esbuild,
+  [
+    entry,
+    "--bundle",
+    "--platform=node",
+    "--target=node20",
+    "--format=esm",
+    `--outfile=${outFile}`,
+    "--banner:js=#!/usr/bin/env node\nimport { createRequire } from 'node:module'; const require = createRequire(import.meta.url);",
+    "--legal-comments=none",
+    `--define:__MATRIX_CLI_VERSION__=${JSON.stringify(version)}`,
+  ],
+  { stdio: "inherit" },
+);
+if (result.status !== 0) process.exit(result.status ?? 1);
+
+chmodSync(outFile, 0o755);
+
+const wrapper = (target: string) => `#!/bin/sh
+MATRIX_CLI_NAME="$(basename "$0")" exec node "$(dirname "$0")/${target}" "$@"
+`;
+for (const name of ["matrix", "matrixos", "mos"]) {
+  const p = join(binDir, name);
+  writeFileSync(p, wrapper("matrix.js"));
+  chmodSync(p, 0o755);
+}
+
+const distPkg = {
+  name: "@finnaai/matrix",
+  version,
+  type: "module",
+  bin: {
+    matrix: "./bin/matrix",
+    matrixos: "./bin/matrixos",
+    mos: "./bin/mos",
+  },
+  engines: { node: ">=20" },
+  license: rootPkg.license ?? "AGPL-3.0-or-later",
+};
+writeFileSync(join(stageDir, "package.json"), JSON.stringify(distPkg, null, 2));
+
+writeFileSync(
+  join(stageDir, "README.md"),
+  `# Matrix OS CLI
+
+Installed via \`brew install finnaai/tap/matrix\` or \`curl -fsSL https://matrix-os.com/install | sh\`.
+
+Run \`matrix help\` for usage.
+`,
+);
+
+const sizeKB = (statSync(outFile).size / 1024).toFixed(1);
+console.log(`built: ${outFile} (${sizeKB} KB)`);
+
+if (shouldPack) {
+  const tarball = join(outRoot, `matrix-cli-${version}.tar.gz`);
+  const tar = spawnSync("tar", ["-czf", tarball, "-C", outRoot, "stage"], { stdio: "inherit" });
+  if (tar.status !== 0) process.exit(tar.status ?? 1);
+
+  let digest = "";
+  const sha = spawnSync("sha256sum", [tarball], { encoding: "utf-8" });
+  if (sha.status === 0) {
+    digest = (sha.stdout ?? "").split(/\s+/)[0];
+  } else {
+    const sha2 = spawnSync("shasum", ["-a", "256", tarball], { encoding: "utf-8" });
+    if (sha2.status === 0) digest = (sha2.stdout ?? "").split(/\s+/)[0];
+  }
+  if (digest) {
+    writeFileSync(`${tarball}.sha256`, `${digest}  matrix-cli-${version}.tar.gz\n`);
+  }
+  console.log(`packed: ${tarball}`);
+  if (digest) console.log(`sha256: ${digest}`);
+}

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -174,6 +174,8 @@ export function TerminalPane({
   const shouldCacheOnUnmountRef = useRef(shouldCacheOnUnmount);
   const webglCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const webglContextLostHandlerRef = useRef<((event: Event) => void) | null>(null);
+  const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
+  const onResizeDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [authUrl, setAuthUrl] = useState<string | null>(null);
   const outputBufferRef = useRef("");
@@ -555,14 +557,16 @@ export function TerminalPane({
 
       document.addEventListener("visibilitychange", onVisibilityChange);
 
-      term.onData((data: string) => {
+      onDataDisposableRef.current?.dispose();
+      onDataDisposableRef.current = term.onData((data: string) => {
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: "input", data }));
         }
       });
 
-      term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
+      onResizeDisposableRef.current?.dispose();
+      onResizeDisposableRef.current = term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: "resize", cols, rows }));
@@ -620,14 +624,18 @@ export function TerminalPane({
         clearReconnectTimer();
         heartbeatRef.current?.stop();
         detachWebglContextLostHandler();
+        onDataDisposableRef.current?.dispose();
+        onDataDisposableRef.current = null;
+        onResizeDisposableRef.current?.dispose();
+        onResizeDisposableRef.current = null;
         const shouldCache = !isClosingRef.current && (shouldCacheOnUnmountRef.current?.(paneId) ?? true);
 
         if (!shouldCache) {
-          // Pane is being closed — clean up everything
+          // Pane is being closed — destroy the backend session so it doesn't leak
           const ws = wsRef.current;
           if (ws) {
             if (ws.readyState === WebSocket.OPEN) {
-              ws.send(JSON.stringify({ type: "detach" }));
+              ws.send(JSON.stringify({ type: "destroy" }));
             }
             ws.close();
           }

--- a/www/public/install.sh
+++ b/www/public/install.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Matrix OS CLI installer.
+# Usage:
+#   curl -fsSL https://matrix-os.com/install | sh
+#   curl -fsSL https://matrix-os.com/install | VERSION=v0.9.0 sh
+#
+# Downloads the latest (or pinned) CLI release tarball from GitHub, extracts
+# it under $PREFIX, and symlinks `matrix`, `matrixos`, `mos` into $BIN_DIR.
+
+set -eu
+
+REPO="${REPO:-hamedmp/matrix-os}"
+PREFIX="${PREFIX:-$HOME/.finnaai/matrix}"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+VERSION="${VERSION:-latest}"
+
+RED="$(printf '\033[31m')"
+GREEN="$(printf '\033[32m')"
+YELLOW="$(printf '\033[33m')"
+DIM="$(printf '\033[2m')"
+RESET="$(printf '\033[0m')"
+
+log() { printf '%s\n' "$*"; }
+err() { printf '%s%s%s\n' "$RED" "$*" "$RESET" >&2; }
+warn() { printf '%s%s%s\n' "$YELLOW" "$*" "$RESET" >&2; }
+ok() { printf '%s%s%s\n' "$GREEN" "$*" "$RESET"; }
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || { err "missing required tool: $1"; exit 1; }
+}
+
+need curl
+need tar
+need uname
+
+if ! command -v node >/dev/null 2>&1; then
+  err "node is required (>= 20). Install from https://nodejs.org or via your package manager, then re-run."
+  exit 1
+fi
+
+node_major="$(node -p 'process.versions.node.split(".")[0]')"
+if [ "${node_major:-0}" -lt 20 ]; then
+  err "node >= 20 required; found $(node -v)"
+  exit 1
+fi
+
+api_base="https://api.github.com/repos/$REPO/releases"
+if [ "$VERSION" = "latest" ]; then
+  resolved="$(curl -fsSL "$api_base/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
+  if [ -z "${resolved:-}" ]; then
+    err "could not resolve latest release from $api_base/latest"
+    exit 1
+  fi
+  VERSION="$resolved"
+fi
+
+ver_no_v="${VERSION#v}"
+asset="matrix-cli-${ver_no_v}.tar.gz"
+url="https://github.com/$REPO/releases/download/$VERSION/$asset"
+
+log "Downloading $asset from $VERSION"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+if ! curl -fsSL "$url" -o "$tmp/$asset"; then
+  err "download failed: $url"
+  exit 1
+fi
+
+if curl -fsSL "$url.sha256" -o "$tmp/$asset.sha256" 2>/dev/null; then
+  expected="$(awk '{print $1}' "$tmp/$asset.sha256")"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+  else
+    actual=""
+  fi
+  if [ -n "$actual" ] && [ "$actual" != "$expected" ]; then
+    err "checksum mismatch: expected $expected, got $actual"
+    exit 1
+  fi
+fi
+
+mkdir -p "$PREFIX" "$BIN_DIR"
+rm -rf "$PREFIX"/stage "$PREFIX"/bin "$PREFIX"/package.json "$PREFIX"/README.md
+tar -xzf "$tmp/$asset" -C "$PREFIX"
+# Tarball has a `stage/` top dir. Flatten.
+if [ -d "$PREFIX/stage" ]; then
+  for f in "$PREFIX"/stage/* "$PREFIX"/stage/.[!.]*; do
+    [ -e "$f" ] || continue
+    mv "$f" "$PREFIX/"
+  done
+  rmdir "$PREFIX/stage"
+fi
+
+for name in matrix matrixos mos; do
+  ln -sf "$PREFIX/bin/$name" "$BIN_DIR/$name"
+done
+
+ok "Matrix OS CLI ${VERSION} installed."
+log "${DIM}Prefix: ${PREFIX}${RESET}"
+log "${DIM}Aliases: matrix, matrixos, mos → ${BIN_DIR}${RESET}"
+
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) warn "add $BIN_DIR to PATH: export PATH=\"$BIN_DIR:\$PATH\"" ;;
+esac
+
+log ""
+log "Try: matrix --help"

--- a/www/vercel.json
+++ b/www/vercel.json
@@ -3,7 +3,17 @@
   "framework": "nextjs",
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install --frozen-lockfile",
+  "rewrites": [
+    { "source": "/install", "destination": "/install.sh" }
+  ],
   "headers": [
+    {
+      "source": "/install(\\.sh)?",
+      "headers": [
+        { "key": "Content-Type", "value": "text/x-shellscript; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=300" }
+      ]
+    },
     {
       "source": "/(.*)",
       "headers": [


### PR DESCRIPTION
## Summary

- **fix(terminal)**: closing a tab/pane now kills the backend PTY session (previously leaked). Also fixes duplicate keystrokes after tab switches caused by stacked xterm `onData`/`onResize` listeners on cached terminals.
- **feat(cli)**: ship the sync-client CLI as a single bundled tarball under three aliases (`matrix`, `matrixos`, `mos`) via Homebrew tap `finnaai/tap/matrix` and curl-sh installer at `matrix-os.com/install`.

## Behavior

- New WS message `destroy` on `/ws/terminal` calls `sessionRegistry.destroy(sessionId)`.
- Shell sends `destroy` (not `detach`) on the pane-close path; disposes xterm event handlers on unmount so cached panes don't accumulate listeners.
- `pnpm build:cli` / `pnpm pack:cli` build a 656 KB self-contained CLI JS bundle.
- `.github/workflows/release-cli.yml` runs on tag `v*`: builds, packs tarball + sha256, attaches to the GitHub release, and (with `TAP_PUSH_TOKEN` secret) auto-bumps `FinnaAI/homebrew-tap`'s `Formula/matrix.rb`.
- `www/vercel.json` rewrites `/install` → `/install.sh` with shell-script content-type.

## Deployed to VPS already

The terminal fixes were deployed earlier in this session via rebuild + rolling restart of all user containers (`matrixos-user:local` → `7bbd92cd2bf9`). Merging this PR doesn't change the VPS state; it just puts the source on `main`.

## Still manual after merge

- Vercel will auto-deploy `www/` on the merge → `/install` endpoint goes live.
- Cut the release: `git tag v0.9.1 && git push --tags`.
- That triggers `release-cli.yml` → uploads tarball to the `v0.9.1` GitHub release → bumps the formula.
- After that: `brew install finnaai/tap/matrix` and `curl -fsSL https://matrix-os.com/install | sh` work end-to-end.

## Test plan

- [ ] Smoke test the bundled CLI locally on a Mac after tagging — `brew tap finnaai/tap && brew install finnaai/tap/matrix && matrix --version` → `0.9.1`
- [ ] `curl -fsSL https://matrix-os.com/install | sh` on Linux → `matrix --version`
- [ ] In the shell: open two tabs, switch back and forth, type — no duplicate keystrokes
- [ ] Close a terminal tab, then check that the PTY is gone from the gateway (`docker exec matrixos-<you> curl -s http://localhost:4000/api/terminal/sessions` should omit the old sessionId)