### PR TITLE
fix(terminal): kill session on tab close + stop duplicate keystrokes

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1517,6 +1517,17 @@ export async function createGateway(config: GatewayConfig) {
                 handle = null;
               }
               break;
+            case "destroy":
+              if (handle) {
+                const sid = handle.sessionId;
+                handle.detach();
+                handle = null;
+                sessionRegistry.destroy(sid);
+                if (autoCreatedSessionId === sid) {
+                  autoCreatedSessionId = null;
+                }
+              }
+              break;
           }
         },
 

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -38,14 +38,18 @@ const DetachSchema = z.object({
   type: z.literal("detach"),
 });
 
+const DestroySchema = z.object({
+  type: z.literal("destroy"),
+});
+
 const PingSchema = z.object({
   type: z.literal("ping"),
 });
 
-export const ClientMessageSchema = z.union([AttachSchema, InputSchema, ResizeSchema, DetachSchema, PingSchema]);
+export const ClientMessageSchema = z.union([AttachSchema, InputSchema, ResizeSchema, DetachSchema, DestroySchema, PingSchema]);
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;
 
-export { AttachSchema, AttachNewSchema, AttachExistingSchema, InputSchema, ResizeSchema, DetachSchema, PingSchema, UUID_REGEX };
+export { AttachSchema, AttachNewSchema, AttachExistingSchema, InputSchema, ResizeSchema, DetachSchema, DestroySchema, PingSchema, UUID_REGEX };
 
 export interface SessionInfo {
   sessionId: string;

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useCallback, useState } from "react";
-import { getGatewayWs } from "@/lib/gateway";
+import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
 import type { Theme } from "@/hooks/useTheme";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { Terminal } from "@xterm/xterm";
@@ -56,7 +56,7 @@ function parseTerminalServerMessage(raw: string): TerminalServerMessage | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
+  } catch (_err: unknown) {
     return null;
   }
 
@@ -128,7 +128,7 @@ function extractTrustedClaudeAuthUrl(raw: string): string | null {
       return null;
     }
     return url.toString();
-  } catch {
+  } catch (_err: unknown) {
     return null;
   }
 }
@@ -451,7 +451,7 @@ export function TerminalPane({
                 heartbeatRef.current?.receivedPong();
                 return;
               }
-            } catch { /* fall through to normal parse */ }
+            } catch (_err: unknown) { /* fall through to normal parse */ }
           }
 
           const msg = parseTerminalServerMessage(raw);
@@ -631,14 +631,27 @@ export function TerminalPane({
         const shouldCache = !isClosingRef.current && (shouldCacheOnUnmountRef.current?.(paneId) ?? true);
 
         if (!shouldCache) {
-          // Pane is being closed — destroy the backend session so it doesn't leak
+          // Pane is being closed — destroy the backend session so it doesn't leak.
           const ws = wsRef.current;
-          if (ws) {
-            if (ws.readyState === WebSocket.OPEN) {
-              ws.send(JSON.stringify({ type: "destroy" }));
-            }
-            ws.close();
+          const sid = sessionIdRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: "destroy" }));
+          } else if (sid) {
+            // WS is CONNECTING/CLOSING/CLOSED so we can't send over it. Fall
+            // back to the REST endpoint so an existing session still gets
+            // killed (otherwise it'd leak until eviction).
+            void fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sid)}`, {
+              method: "DELETE",
+              keepalive: true,
+              signal: AbortSignal.timeout(5_000),
+            }).catch((err: unknown) => {
+              console.warn(
+                "Failed to destroy terminal session on close:",
+                err instanceof Error ? err.message : err,
+              );
+            });
           }
+          ws?.close();
           removeCached(paneId);
           term.dispose();
         } else if (wsRef.current) {
@@ -756,7 +769,7 @@ export function TerminalPane({
           </button>
           <button
             onClick={() => {
-              navigator.clipboard.writeText(authUrl).catch(() => {
+              navigator.clipboard.writeText(authUrl).catch((_err: unknown) => {
                 // Fallback for insecure contexts / iframe restrictions
                 const ta = document.createElement("textarea");
                 ta.value = authUrl;

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -174,6 +174,8 @@ export function TerminalPane({
   const shouldCacheOnUnmountRef = useRef(shouldCacheOnUnmount);
   const webglCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const webglContextLostHandlerRef = useRef<((event: Event) => void) | null>(null);
+  const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
+  const onResizeDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [authUrl, setAuthUrl] = useState<string | null>(null);
   const outputBufferRef = useRef("");
@@ -555,14 +557,16 @@ export function TerminalPane({
 
       document.addEventListener("visibilitychange", onVisibilityChange);
 
-      term.onData((data: string) => {
+      onDataDisposableRef.current?.dispose();
+      onDataDisposableRef.current = term.onData((data: string) => {
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: "input", data }));
         }
       });
 
-      term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
+      onResizeDisposableRef.current?.dispose();
+      onResizeDisposableRef.current = term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: "resize", cols, rows }));
@@ -620,14 +624,18 @@ export function TerminalPane({
         clearReconnectTimer();
         heartbeatRef.current?.stop();
         detachWebglContextLostHandler();
+        onDataDisposableRef.current?.dispose();
+        onDataDisposableRef.current = null;
+        onResizeDisposableRef.current?.dispose();
+        onResizeDisposableRef.current = null;
         const shouldCache = !isClosingRef.current && (shouldCacheOnUnmountRef.current?.(paneId) ?? true);
 
         if (!shouldCache) {
-          // Pane is being closed — clean up everything
+          // Pane is being closed — destroy the backend session so it doesn't leak
           const ws = wsRef.current;
           if (ws) {
             if (ws.readyState === WebSocket.OPEN) {
-              ws.send(JSON.stringify({ type: "detach" }));
+              ws.send(JSON.stringify({ type: "destroy" }));
             }
             ws.close();
           }


### PR DESCRIPTION
## Summary

- Closing a terminal tab/pane now actually kills the backend PTY session (previously it only detached the subscriber and leaked the process).
- Fixes 2–3× keystroke duplication after switching tabs — the cached xterm was stacking another `onData`/`onResize` subscription on every remount.

## Changes

- **packages/gateway/src/session-registry.ts** — new `DestroySchema` added to `ClientMessageSchema`.
- **packages/gateway/src/server.ts** — new `case "destroy"` in the `/ws/terminal` message switch calls `sessionRegistry.destroy(sessionId)`.
- **shell/src/components/terminal/TerminalPane.tsx** — capture xterm `onData`/`onResize` disposables in refs; dispose them on unmount (both cache and destroy paths). Send `destroy` instead of `detach` on the close path so the backend frees the PTY.

## Already deployed

These changes were rolled out to the VPS earlier in this session via rebuild + rolling restart of all user containers (image `matrixos-user:local` = `7bbd92cd2bf9`). Merging this PR just puts the source on `main`.

## Test plan

- [ ] Open two tabs, switch back and forth, type — no duplicate keystrokes on the previously-switched-away tab.
- [ ] Close a terminal tab while a PTY is active (e.g. Claude CLI running). Check the backend: `docker exec matrixos-<handle> curl -s http://localhost:4000/api/terminal/sessions` no longer lists that sessionId.
- [ ] Browser tab close + reopen still restores sessions (persistence is intentional and not affected).