### PR TITLE
feat(cli): retarget distribution to @finnaai/matrix + FinnaAI tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
-# Triggered by pushing a semver tag. Runs tests, builds + signs + notarises
-# the macOS installer, publishes @matrix-os/cli to npm, uploads artefacts to
-# the GitHub release, and refreshes the Homebrew formula.
+# Triggered by pushing a semver tag. Runs tests, publishes @finnaai/matrix
+# to npm, builds + signs + notarises the macOS installer (when enabled via
+# ENABLE_MACOS_PKG), uploads artefacts to the GitHub release, and refreshes
+# the Homebrew formula in FinnaAI/homebrew-tap.
 #
 # Security note: workflow inputs we consume are $GITHUB_REF_NAME (constrained
 # by the `v*.*.*` tag filter above — so it's always of form `vX.Y.Z[...]`)
@@ -52,6 +53,10 @@ jobs:
   build-macos:
     name: Build macOS .pkg
     needs: test
+    # Only runs when Apple Developer ID certs are configured. Until those
+    # secrets are set, the macOS job skips and the npm/homebrew release
+    # pipeline continues unblocked.
+    if: ${{ vars.ENABLE_MACOS_PKG == 'true' }}
     runs-on: macos-14
     timeout-minutes: 45
     outputs:
@@ -141,6 +146,10 @@ jobs:
   publish-npm:
     name: Publish npm
     needs: [test, build-macos]
+    # Skipped jobs report as "skipped" in needs.build-macos.result; we want
+    # npm publish to continue even when the macOS pkg is disabled, but fail
+    # fast if it actually failed.
+    if: ${{ !cancelled() && needs.test.result == 'success' && (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -174,12 +183,15 @@ jobs:
   github-release:
     name: GitHub release
     needs: [build-macos, publish-npm]
+    if: ${{ !cancelled() && needs.publish-npm.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - name: Download macOS pkg (if built)
+        if: ${{ needs.build-macos.result == 'success' }}
+        uses: actions/download-artifact@v4
         with:
           name: macos-pkg
           path: dist/macos
@@ -193,16 +205,18 @@ jobs:
           files: |
             dist/macos/*.pkg
             scripts/install.sh
+          fail_on_unmatched_files: false
 
   homebrew:
     name: Update Homebrew tap
     needs: github-release
+    if: ${{ !cancelled() && needs.github-release.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: matrix-os/homebrew-tap
+          repository: FinnaAI/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
 
@@ -213,7 +227,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
-          TARBALL="https://registry.npmjs.org/@matrix-os/cli/-/cli-${VERSION}.tgz"
+          TARBALL="https://registry.npmjs.org/@finnaai/matrix/-/matrix-${VERSION}.tgz"
 
           # Wait up to 5 min for npm to publish — publish-npm just finished.
           for _ in $(seq 1 30); do

--- a/homebrew-tap/Formula/matrix.rb
+++ b/homebrew-tap/Formula/matrix.rb
@@ -1,10 +1,10 @@
 # Homebrew formula for the Matrix OS CLI.
 #
 # Lives here for version control during bootstrap; the CI release workflow
-# mirrors it into the matrix-os/homebrew-tap repository and bumps url/sha256
+# mirrors it into the FinnaAI/homebrew-tap repository and bumps url/sha256
 # on each tag push.
 #
-# Install: brew install matrix-os/tap/matrix
+# Install: brew install finnaai/tap/matrix
 
 class Matrix < Formula
   desc "Matrix OS command-line client (sync, login, peer management)"
@@ -13,7 +13,7 @@ class Matrix < Formula
   # `url` and `sha256` are rewritten by .github/workflows/release.yml against
   # the npm tarball after each publish. Until the first release job rewrites
   # this staging copy, the placeholder sha256 is intentionally non-installable.
-  url "https://registry.npmjs.org/@matrix-os/cli/-/cli-0.2.0.tgz"
+  url "https://registry.npmjs.org/@finnaai/matrix/-/matrix-0.2.0.tgz"
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   version "0.2.0"
 

--- a/homebrew-tap/README.md
+++ b/homebrew-tap/README.md
@@ -1,18 +1,18 @@
 # homebrew-tap (staging)
 
-Staging copy of the `matrix-os/homebrew-tap` repository. Lives inside this
+Staging copy of the `FinnaAI/homebrew-tap` repository. Lives inside this
 monorepo during bootstrap so the formula is version-controlled alongside
 the release pipeline.
 
 The release workflow (`.github/workflows/release.yml` → `homebrew` job)
-checks out `matrix-os/homebrew-tap` separately, rewrites `Formula/matrix.rb`
+checks out `FinnaAI/homebrew-tap` separately, rewrites `Formula/matrix.rb`
 with the latest npm tarball URL + sha256, and pushes.
 
 When the external tap repo is bootstrapped for the first time, copy this
 formula over:
 
 ```bash
-cp homebrew-tap/Formula/matrix.rb /path/to/matrix-os/homebrew-tap/Formula/
+cp homebrew-tap/Formula/matrix.rb /path/to/FinnaAI/homebrew-tap/Formula/
 ```
 
 After that, day-to-day edits happen in the tap repo, not here.

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -1,17 +1,17 @@
-# @matrix-os/cli
+# @finnaai/matrix
 
 Command-line client for [Matrix OS](https://matrix-os.com).
 
 ## Install
 
 ```bash
-npm install -g @matrix-os/cli
-```
+# Homebrew (macOS/Linux)
+brew install finnaai/tap/matrix
 
-Or run the platform-detecting installer which fetches the signed macOS `.pkg`
-when appropriate:
+# npm
+npm install -g @finnaai/matrix
 
-```bash
+# curl (auto-detects platform)
 curl -sL get.matrix-os.com | sh
 ```
 
@@ -24,7 +24,7 @@ matrix peers              # list connected peers
 matrix logout             # clear local credentials
 ```
 
-Both `matrix` and `matrixos` bin entries are installed.
+All three bin entries are installed: `matrix`, `matrixos`, `mos`.
 
 ## Requirements
 

--- a/packages/sync-client/bin/matrix.mjs
+++ b/packages/sync-client/bin/matrix.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Published-package entry for `matrix` / `matrixos` when installed via
-// `npm i -g @matrix-os/cli`. Re-execs with the tsx loader so Node can
+// `npm i -g @finnaai/matrix`. Re-execs with the tsx loader so Node can
 // import the .ts CLI sources directly. Mirrors bin/matrixos.mjs in the
 // monorepo, but resolves tsx from the package's own node_modules.
 //
@@ -20,14 +20,14 @@ const pkgRoot = resolve(here, '..');
 const tsxLoader = findTsxLoader(pkgRoot);
 if (!tsxLoader) {
   console.error(
-    'matrix CLI: tsx loader not found. Reinstall with `npm i -g @matrix-os/cli`.',
+    'matrix CLI: tsx loader not found. Reinstall with `npm i -g @finnaai/matrix`.',
   );
   process.exit(1);
 }
 
 const cliEntry = resolve(pkgRoot, 'src', 'cli', 'index.ts');
 if (!existsSync(cliEntry)) {
-  console.error('matrix CLI: entry not found. Reinstall with `npm i -g @matrix-os/cli`.');
+  console.error('matrix CLI: entry not found. Reinstall with `npm i -g @finnaai/matrix`.');
   process.exit(1);
 }
 

--- a/packages/sync-client/bin/matrix.mjs
+++ b/packages/sync-client/bin/matrix.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Published-package entry for `matrix` / `matrixos` when installed via
+// Published-package entry for `matrix` / `matrixos` / `mos` when installed via
 // `npm i -g @finnaai/matrix`. Re-execs with the tsx loader so Node can
 // import the .ts CLI sources directly. Mirrors bin/matrixos.mjs in the
 // monorepo, but resolves tsx from the package's own node_modules.

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@matrix-os/cli",
+  "name": "@finnaai/matrix",
   "version": "0.2.0",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
@@ -25,7 +25,8 @@
   },
   "bin": {
     "matrix": "./bin/matrix.mjs",
-    "matrixos": "./bin/matrix.mjs"
+    "matrixos": "./bin/matrix.mjs",
+    "mos": "./bin/matrix.mjs"
   },
   "exports": {
     ".": "./src/index.ts"

--- a/scripts/build-macos-pkg.sh
+++ b/scripts/build-macos-pkg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Builds a signed macOS .pkg installer bundling:
-#   - the matrix CLI (npm package @matrix-os/cli)
+#   - the matrix CLI (npm package @finnaai/matrix)
 #   - MatrixSync.app (menu bar + FinderSync extension)
 #
 # The .pkg is signed with a Developer ID Installer certificate and is

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@
 # Platform detection:
 #   macOS   -> downloads the signed .pkg from the GitHub release and runs
 #              `installer -pkg`. Needs sudo for /Applications + /usr/local.
-#   Linux   -> `npm i -g @matrix-os/cli` (stop-gap until a standalone binary).
+#   Linux   -> `npm i -g @finnaai/matrix` (stop-gap until a standalone binary).
 #   Windows -> print a PowerShell install hint.
 #
 # Usage:
@@ -120,8 +120,8 @@ install_linux() {
 
   VERSION="${MATRIX_VERSION#v}"
   case "$MATRIX_VERSION" in
-    latest) NPM_SPEC="@matrix-os/cli" ;;
-    *)      NPM_SPEC="@matrix-os/cli@$VERSION" ;;
+    latest) NPM_SPEC="@finnaai/matrix" ;;
+    *)      NPM_SPEC="@finnaai/matrix@$VERSION" ;;
   esac
 
   # Prefer an unprivileged install when the user has npm prefix configured for
@@ -146,7 +146,7 @@ install_windows() {
 Windows installer is not available yet.
 
 Temporary workaround (PowerShell):
-  npm install -g @matrix-os/cli
+  npm install -g @finnaai/matrix
 
 Requires Node.js 24+ from https://nodejs.org.
 WIN


### PR DESCRIPTION
## Summary

Adjusts the CLI distribution landed by spec 066/067 to the naming you picked this session:

| | Before (on main) | After |
|---|---|---|
| npm package | `@matrix-os/cli` | `@finnaai/matrix` |
| Brew tap | `matrix-os/tap/matrix` | `finnaai/tap/matrix` |
| Tap repo | `matrix-os/homebrew-tap` (not created) | `FinnaAI/homebrew-tap` (**already exists, formula seeded**) |
| Bin aliases | `matrix`, `matrixos` | `matrix`, `matrixos`, `mos` |
| macOS .pkg | runs unconditionally (needs Apple certs) | gated on repo var `ENABLE_MACOS_PKG` |

## Q: npm vs our JS blob — decision

Went with npm for the primary distribution channel:

- `npm i -g @finnaai/matrix` is one command any JS dev recognizes.
- Windows support for free.
- Brew formula is trivial — it just `npm install`s into libexec.
- npm handles tarball hosting and version history, no extra infra.
- `@finnaai` scope is available on the registry.

The JS blob I built locally is dropped; npm covers it.

## Files changed

- **packages/sync-client/package.json** — name, bin entries
- **packages/sync-client/bin/matrix.mjs** — error messages
- **packages/sync-client/README.md** — install instructions for all three channels
- **scripts/install.sh** — `@finnaai/matrix` as npm spec
- **scripts/build-macos-pkg.sh** — header comment only
- **homebrew-tap/Formula/matrix.rb** — staging formula URL
- **homebrew-tap/README.md** — tap repo path
- **.github/workflows/release.yml**
  - `build-macos` job gated on `vars.ENABLE_MACOS_PKG == 'true'`
  - `publish-npm` + `github-release` + `homebrew` all handle macOS being skipped
  - Homebrew job checks out `FinnaAI/homebrew-tap` instead of `matrix-os/homebrew-tap`
  - Tarball URL path rewritten for the new npm scope

## Setup required (one-time)

- [ ] **NPM_TOKEN** secret on `HamedMP/matrix-os` — classic token with publish rights on `@finnaai` scope. First publish will create the scope automatically if your npm username is `finnaai`; otherwise `npm org create finnaai` then add members.
- [ ] **HOMEBREW_TAP_TOKEN** secret — fine-grained PAT with `contents: write` on `FinnaAI/homebrew-tap`.
- [ ] (Later) **ENABLE_MACOS_PKG** repo variable — set to `true` when Apple Developer ID certs are ready.

## How releases work after merge

1. `git tag v0.2.1 && git push --tags` triggers `release.yml`.
2. `test` → `publish-npm` → `github-release` → `homebrew` (skipping `build-macos` until the repo var is set).
3. `brew install finnaai/tap/matrix`, `npm i -g @finnaai/matrix`, and `curl -sL get.matrix-os.com | sh` all resolve to the same artefact.

## Test plan

- [ ] CI green on this PR (no publish is triggered — only on tag push).
- [ ] After merge: tag `v0.2.1`, watch workflow, confirm:
  - [ ] npm shows `@finnaai/matrix@0.2.1`
  - [ ] `FinnaAI/homebrew-tap` main branch updated with fresh `url`/`sha256`
  - [ ] GitHub release `v0.2.1` has `install.sh` attached (no .pkg yet)
- [ ] On a Mac: `brew tap finnaai/tap && brew install finnaai/tap/matrix && matrix --version`
- [ ] On Linux: `npm i -g @finnaai/matrix && matrix --version`