### PR TITLE
ci(release): use TAP_PUSH_TOKEN secret name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: FinnaAI/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ secrets.TAP_PUSH_TOKEN }}
           path: tap
 
       - name: Compute formula update


### PR DESCRIPTION
## Summary

One-line rename to align with the secret name that's actually configured on the repo: `HOMEBREW_TAP_TOKEN` → `TAP_PUSH_TOKEN`.

The Homebrew tap push step at .github/workflows/release.yml:220 was expecting a secret named `HOMEBREW_TAP_TOKEN` for its checkout of `FinnaAI/homebrew-tap`. The secret that was actually set in repo settings is `TAP_PUSH_TOKEN`, so without this change the tap-bump job would fail with an empty token.

## Test plan

- [ ] After merge: tag `v0.2.1` and confirm the `homebrew` job successfully checks out `FinnaAI/homebrew-tap`.