### PR TITLE
fix(tests): configure git identity in tmp repos so CI commits succeed

### DIFF
--- a/tests/gateway/git-sync.test.ts
+++ b/tests/gateway/git-sync.test.ts
@@ -103,7 +103,7 @@ describe("T220: GitSync", () => {
     execFileSync("git", ["clone", remote, clone], { stdio: "ignore" });
     writeFileSync(join(clone, "new-file.txt"), "from clone");
     execFileSync("git", ["add", "."], { cwd: clone, stdio: "ignore" });
-    execFileSync("git", ["commit", "-m", "remote change"], { cwd: clone, stdio: "ignore" });
+    execFileSync("git", [...GIT_ID, "commit", "-m", "remote change"], { cwd: clone, stdio: "ignore" });
     execFileSync("git", ["push"], { cwd: clone, stdio: "ignore" });
 
     // Pull into original

--- a/tests/gateway/git-sync.test.ts
+++ b/tests/gateway/git-sync.test.ts
@@ -5,13 +5,15 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { createGitSync, createAutoSync, type GitSync, type AutoSync } from "../../packages/gateway/src/git-sync.js";
 
+const GIT_ID = ["-c", "user.email=ci@matrix-os.test", "-c", "user.name=Test"];
+
 function tmpGitRepo(): string {
   const dir = resolve(mkdtempSync(join(tmpdir(), "git-sync-")));
   mkdirSync(join(dir, "system"), { recursive: true });
   writeFileSync(join(dir, "system", "state.md"), "initial");
   execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
   execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
-  execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
+  execFileSync("git", [...GIT_ID, "commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
   return dir;
 }
 

--- a/tests/gateway/git-versioning.test.ts
+++ b/tests/gateway/git-versioning.test.ts
@@ -12,6 +12,8 @@ import {
   type FileHistory,
 } from "../../packages/gateway/src/git-versioning.js";
 
+const GIT_ID = ["-c", "user.email=ci@matrix-os.test", "-c", "user.name=Test"];
+
 function tmpGitRepo(): string {
   const dir = resolve(mkdtempSync(join(tmpdir(), "git-ver-")));
   mkdirSync(join(dir, "system"), { recursive: true });
@@ -20,7 +22,7 @@ function tmpGitRepo(): string {
   writeFileSync(join(dir, ".gitignore"), "*.sqlite\nnode_modules/\n");
   execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
   execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
-  execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
+  execFileSync("git", [...GIT_ID, "commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
   return dir;
 }
 
@@ -184,11 +186,11 @@ describe("T1512: File history API", () => {
     // Make some commits modifying the file
     writeFileSync(join(homePath, "system", "state.md"), "v2");
     execFileSync("git", ["add", "."], { cwd: homePath, stdio: "ignore" });
-    execFileSync("git", ["commit", "-m", "update state to v2"], { cwd: homePath, stdio: "ignore" });
+    execFileSync("git", [...GIT_ID, "commit", "-m", "update state to v2"], { cwd: homePath, stdio: "ignore" });
 
     writeFileSync(join(homePath, "system", "state.md"), "v3");
     execFileSync("git", ["add", "."], { cwd: homePath, stdio: "ignore" });
-    execFileSync("git", ["commit", "-m", "update state to v3"], { cwd: homePath, stdio: "ignore" });
+    execFileSync("git", [...GIT_ID, "commit", "-m", "update state to v3"], { cwd: homePath, stdio: "ignore" });
 
     const entries = await history.log("system/state.md");
     expect(entries.length).toBeGreaterThanOrEqual(2);
@@ -201,7 +203,7 @@ describe("T1512: File history API", () => {
     for (let i = 0; i < 5; i++) {
       writeFileSync(join(homePath, "system", "state.md"), `v${i + 2}`);
       execFileSync("git", ["add", "."], { cwd: homePath, stdio: "ignore" });
-      execFileSync("git", ["commit", "-m", `commit ${i + 2}`], { cwd: homePath, stdio: "ignore" });
+      execFileSync("git", [...GIT_ID, "commit", "-m", `commit ${i + 2}`], { cwd: homePath, stdio: "ignore" });
     }
 
     const page1 = await history.log("system/state.md", { limit: 2, offset: 0 });
@@ -217,7 +219,7 @@ describe("T1512: File history API", () => {
   it("returns diff for a specific commit", async () => {
     writeFileSync(join(homePath, "system", "state.md"), "changed content");
     execFileSync("git", ["add", "."], { cwd: homePath, stdio: "ignore" });
-    execFileSync("git", ["commit", "-m", "change content"], { cwd: homePath, stdio: "ignore" });
+    execFileSync("git", [...GIT_ID, "commit", "-m", "change content"], { cwd: homePath, stdio: "ignore" });
 
     const entries = await history.log("system/state.md");
     const diff = await history.diff("system/state.md", entries[0].commit);
@@ -246,7 +248,7 @@ describe("T1513: File restore", () => {
     // Modify the file
     writeFileSync(join(homePath, "system", "state.md"), "new content");
     execFileSync("git", ["add", "."], { cwd: homePath, stdio: "ignore" });
-    execFileSync("git", ["commit", "-m", "modify state"], { cwd: homePath, stdio: "ignore" });
+    execFileSync("git", [...GIT_ID, "commit", "-m", "modify state"], { cwd: homePath, stdio: "ignore" });
 
     // Restore from initial commit
     const result = await history.restore("system/state.md", initialCommit);
@@ -262,7 +264,7 @@ describe("T1513: File restore", () => {
 
     writeFileSync(join(homePath, "system", "state.md"), "new content");
     execFileSync("git", ["add", "."], { cwd: homePath, stdio: "ignore" });
-    execFileSync("git", ["commit", "-m", "modify state"], { cwd: homePath, stdio: "ignore" });
+    execFileSync("git", [...GIT_ID, "commit", "-m", "modify state"], { cwd: homePath, stdio: "ignore" });
 
     await history.restore("system/state.md", initialCommit);
 


### PR DESCRIPTION
## Summary

The v0.2.0 release workflow's Test job failed with 37 failures in `tests/gateway/git-sync.test.ts` and `tests/gateway/git-versioning.test.ts` — all with `Error: Command failed: git commit -m init` (exit status 128).

**Root cause:** GitHub Actions runners have no global `user.name` / `user.email` set, so bare `git commit` refuses to commit. Local dev machines have these set globally, hiding the bug.

**Fix:** pass `-c user.email=ci@matrix-os.test -c user.name=Test` to every `git commit` call in those test setups, matching the pattern already in `tests/e2e/fixtures/gateway.ts:49`.

## Files

- `tests/gateway/git-sync.test.ts` — add `GIT_ID` const, use it on the `init` commit
- `tests/gateway/git-versioning.test.ts` — same pattern, applied to 7 `git commit` sites

The two `tests/kernel/*.test.ts` files with similar setups already call `git config user.email/user.name` explicitly — no changes needed there.

## After merge

The `v0.2.0` tag is already pushed and the release run (24795721680) failed. To unblock:
1. Merge this PR
2. Either re-push the tag (`git tag -d v0.2.0 && git push origin :refs/tags/v0.2.0 && git tag v0.2.0 <new-commit> && git push --tags`) or cut `v0.2.1` — whichever you prefer