### PR TITLE
fix(gateway,tests): committer identity in git helpers + stabilize home-mirror tests

### DIFF
--- a/packages/gateway/src/git-sync.ts
+++ b/packages/gateway/src/git-sync.ts
@@ -77,9 +77,21 @@ export function createAutoSync(sync: GitSync, options: AutoSyncOptions = {}): Au
   };
 }
 
+// Ensure git has a committer identity even when the host lacks global config
+// (e.g. ephemeral CI runners, fresh containers). Overridable via env.
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Matrix OS",
+  GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "matrix-os@users.noreply.github.com",
+  GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Matrix OS",
+  GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "matrix-os@users.noreply.github.com",
+};
+
 export function createGitSync(homePath: string): GitSync {
   async function git(...args: string[]): Promise<string> {
-    const { stdout } = await execAsync("git", args, { cwd: homePath });
+    const { stdout } = await execAsync("git", args, {
+      cwd: homePath,
+      env: { ...process.env, ...GIT_ENV },
+    });
     return stdout.trim();
   }
 

--- a/packages/gateway/src/git-versioning.ts
+++ b/packages/gateway/src/git-versioning.ts
@@ -63,8 +63,20 @@ export interface FileHistory {
   restore(path: string, commit: string): Promise<RestoreResult>;
 }
 
+// Ensure git has a committer identity even when the host lacks global config
+// (e.g. ephemeral CI runners, fresh containers). Overridable via env.
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Matrix OS",
+  GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "matrix-os@users.noreply.github.com",
+  GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Matrix OS",
+  GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "matrix-os@users.noreply.github.com",
+};
+
 async function git(homePath: string, ...args: string[]): Promise<string> {
-  const { stdout } = await execAsync("git", args, { cwd: homePath });
+  const { stdout } = await execAsync("git", args, {
+    cwd: homePath,
+    env: { ...process.env, ...GIT_ENV },
+  });
   return stdout.trim();
 }
 

--- a/tests/gateway/sync/home-mirror.test.ts
+++ b/tests/gateway/sync/home-mirror.test.ts
@@ -736,10 +736,13 @@ describe("createHomeMirror", () => {
       await mirror.start();
 
       // Drop a file in the container's home -- mirror should upload AND
-      // broadcast. Chokidar + awaitWriteFinish (250ms) + macOS fsevents
-      // startup latency needs ~1.5s in CI.
+      // broadcast. Chokidar + awaitWriteFinish (250ms) + fsevents startup
+      // latency is ~1.5s locally but variable on CI, so poll rather than
+      // sleep a fixed interval.
       await writeFile(join(tmpRoot, "new.md"), "container wrote this");
-      await settle(1500);
+      await waitFor(() =>
+        laptopSends.some((s) => s.includes('"sync:change"') && s.includes("new.md")),
+      );
 
       const syncChanges = laptopSends.filter((s) => s.includes('"sync:change"'));
       expect(syncChanges.length).toBeGreaterThan(0);

--- a/tests/gateway/sync/home-mirror.test.ts
+++ b/tests/gateway/sync/home-mirror.test.ts
@@ -74,7 +74,7 @@ async function settle(ms = 30) {
   await new Promise((r) => setTimeout(r, ms));
 }
 
-async function waitFor(check: () => boolean, timeoutMs = 3_000): Promise<void> {
+async function waitFor(check: () => boolean, timeoutMs = 15_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (check()) return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    // CI runners are sometimes slow under load; tests that rely on async
+    // waitFor polling can exceed the 5s vitest default.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     exclude: ["tests/**/*.integration.ts", "node_modules", "dist", ".next"],
     coverage: {


### PR DESCRIPTION
## Summary
Three commits, all aimed at unblocking the CI Test job that has been failing every CLI release dispatch.

1. **`fix(gateway): set git committer identity via env for commits in git helpers`** — `packages/gateway/src/git-sync.ts` and `git-versioning.ts` now seed `GIT_AUTHOR_*` / `GIT_COMMITTER_*` from env vars (with sane fallbacks) before invoking git. Without this, `git commit` from gateway helpers fails on machines that have no global `user.email` set — exactly the failure mode that produced `tests/gateway/git-versioning.test.ts` errors like "expected 'Restored' but got '<initial sha> init'" (the auto-commit / restore commits weren't being created at all).

2. **`fix(tests): bump home-mirror waitFor timeout 3s -> 15s (CI flake)`** — addresses the seven `tests/gateway/sync/home-mirror.test.ts` timeouts in the `subscribe-to-broadcasts` block (lines 745, 850, 998, 1034, 1095, 1138, 1207). The work happens but slow CI runners blow past 3 s.

3. **`fix(tests): bump vitest testTimeout and convert fixed sleep to waitFor`** — bumps `testTimeout`/`hookTimeout` to 20 s in `vitest.config.ts` (was the 5 s default) and replaces a fixed `sleep(1500)` settle in `home-mirror.test.ts:741` with a polling `waitFor` on the actual broadcast contents.

## Why this PR (and not just merging `fix/lib-git-identity`)
The `fix/lib-git-identity` branch was forked before PR #44 landed, so its tip would revert the manual-dispatch `release.yml`. This branch is the same three commits rebased onto current `main`. The original `fix/lib-git-identity` branch can be deleted after this merges.

## Test plan
- [ ] Merge.
- [ ] `gh workflow run release.yml --ref main -f version=0.2.4` and confirm Test job passes (specifically: zero failures in `home-mirror.test.ts` and `git-versioning.test.ts`).
- [ ] Confirm the publish-npm + homebrew jobs run end-to-end and `@finnaai/matrix@0.2.4` lands on the registry.