### PR TITLE
fix(gateway/home-mirror): await chokidar ready before returning from start()

### DIFF
--- a/packages/gateway/src/sync/home-mirror.ts
+++ b/packages/gateway/src/sync/home-mirror.ts
@@ -924,28 +924,36 @@ export function createHomeMirror(config: HomeMirrorConfig): HomeMirror {
       // GitHub Actions runners), where the watches aren't installed yet.
       // Resolve on `close` too, so a concurrent stop() can't strand us
       // waiting for a `ready` event that will never fire on a closed watcher.
-      await new Promise<void>((resolve, reject) => {
-        const cleanup = () => {
-          watcher?.off("ready", onReady);
-          watcher?.off("error", onError);
-          watcher?.off("close", onClose);
-        };
-        const onReady = () => {
-          cleanup();
-          resolve();
-        };
-        const onError = (err: unknown) => {
-          cleanup();
-          reject(err instanceof Error ? err : new Error(String(err)));
-        };
-        const onClose = () => {
-          cleanup();
-          resolve();
-        };
-        watcher!.once("ready", onReady);
-        watcher!.once("error", onError);
-        watcher!.once("close", onClose);
-      });
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const cleanup = () => {
+            watcher?.off("ready", onReady);
+            watcher?.off("error", onError);
+            watcher?.off("close", onClose);
+          };
+          const onReady = () => {
+            cleanup();
+            resolve();
+          };
+          const onError = (err: unknown) => {
+            cleanup();
+            reject(err instanceof Error ? err : new Error(String(err)));
+          };
+          const onClose = () => {
+            cleanup();
+            resolve();
+          };
+          watcher!.once("ready", onReady);
+          watcher!.once("error", onError);
+          watcher!.once("close", onClose);
+        });
+      } catch (err: unknown) {
+        // Watcher errored before reaching ready -- close it (and any
+        // other resources start() acquired) so we don't leak inotify
+        // watches when start() throws.
+        await releaseResources();
+        throw err;
+      }
 
       if (stopRequested) {
         await releaseResources();

--- a/packages/gateway/src/sync/home-mirror.ts
+++ b/packages/gateway/src/sync/home-mirror.ts
@@ -922,8 +922,29 @@ export function createHomeMirror(config: HomeMirrorConfig): HomeMirror {
       // watches before returning. Otherwise a write that lands immediately
       // after start() resolves can be missed on slow filesystems (notably
       // GitHub Actions runners), where the watches aren't installed yet.
-      await new Promise<void>((resolve) => {
-        watcher!.once("ready", resolve);
+      // Resolve on `close` too, so a concurrent stop() can't strand us
+      // waiting for a `ready` event that will never fire on a closed watcher.
+      await new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          watcher?.off("ready", onReady);
+          watcher?.off("error", onError);
+          watcher?.off("close", onClose);
+        };
+        const onReady = () => {
+          cleanup();
+          resolve();
+        };
+        const onError = (err: unknown) => {
+          cleanup();
+          reject(err instanceof Error ? err : new Error(String(err)));
+        };
+        const onClose = () => {
+          cleanup();
+          resolve();
+        };
+        watcher!.once("ready", onReady);
+        watcher!.once("error", onError);
+        watcher!.once("close", onClose);
       });
 
       if (stopRequested) {

--- a/packages/gateway/src/sync/home-mirror.ts
+++ b/packages/gateway/src/sync/home-mirror.ts
@@ -918,6 +918,14 @@ export function createHomeMirror(config: HomeMirrorConfig): HomeMirror {
         log.error(`home mirror watcher error: ${errorMessage(err)}`);
       });
 
+      // Wait for chokidar to finish its initial scan and register inotify
+      // watches before returning. Otherwise a write that lands immediately
+      // after start() resolves can be missed on slow filesystems (notably
+      // GitHub Actions runners), where the watches aren't installed yet.
+      await new Promise<void>((resolve) => {
+        watcher!.once("ready", resolve);
+      });
+
       if (stopRequested) {
         await releaseResources();
         return;


### PR DESCRIPTION
## Summary
`createHomeMirror.start()` returned as soon as `watch()` was created, without awaiting chokidar's `ready` event. On slow filesystems (GitHub Actions runners), a write landing between `watch()` and `ready` is missed because inotify watches aren't registered yet. Local machines hid the race via faster I/O.

This was the root cause of the 7 `home-mirror.test.ts > subscribe-to-broadcasts` failures that have been blocking every CI run on `main` today, and every CLI release dispatch attempt (v0.2.2, v0.2.3, v0.2.4 all hit this).

## Why this is a production fix, not a test patch
Any caller that writes to `homeRoot` immediately after `await mirror.start()` resolves could lose the resulting broadcast on slow systems. The race was just easier to hit in tests because the test writes a file on the very next line.

## Verification
Ran `pnpm exec vitest run tests/gateway/sync/home-mirror.test.ts` on the VPS:

```
Test Files  1 passed (1)
     Tests  33 passed (33)
```

The 7 previously-failing tests now complete in 308–505ms each (previously: 15s timeout each).

## Test plan
- [ ] Merge.
- [ ] Re-dispatch `release.yml` with `version: 0.2.4` and confirm Test job is green.
- [ ] Confirm `@finnaai/matrix@0.2.4` lands on npm and the brew formula bumps.