### PR TITLE
ci(release): install ripgrep before pattern scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Unit tests
         run: bun run test
 
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
+
       - name: Pattern scan
         run: ./scripts/review/check-patterns.sh
 


### PR DESCRIPTION
## Summary
`release.yml`'s `Pattern scan` step calls `./scripts/review/check-patterns.sh`, which hard-requires `rg`. `ubuntu-latest` runners don't have it, so every CLI release dispatch was failing the test job at this step with the misleading hint `Install via: brew install ripgrep`.

`ci.yml` already installs ripgrep at lines 47-48 — this PR copies the same step into `release.yml` so dispatches actually reach the publish/release/homebrew jobs.

## Context
v0.2.4 release dispatch (run 24800019483) confirmed the chokidar fix from #46 — Unit tests went green (33/33 home-mirror passes in 4.6s). The release then died at Pattern scan due to the missing rg. This is the last gate.

## Test plan
- [ ] Merge.
- [ ] `gh workflow run release.yml --ref main -f version=0.2.4` and confirm the Test job's Pattern scan step passes.
- [ ] Confirm publish-npm + homebrew jobs run end-to-end and `@finnaai/matrix@0.2.4` lands on npm.