### PR TITLE
fix: preserve terminal sessions across tab switches

### DIFF
--- a/packages/gateway/src/git-env.ts
+++ b/packages/gateway/src/git-env.ts
@@ -1,0 +1,8 @@
+// Ensure git has a committer identity even when the host lacks global config
+// (e.g. ephemeral CI runners, fresh containers). Overridable via env.
+export const GIT_ENV = {
+  GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Matrix OS",
+  GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "matrix-os@users.noreply.github.com",
+  GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Matrix OS",
+  GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "matrix-os@users.noreply.github.com",
+};

--- a/packages/gateway/src/git-sync.ts
+++ b/packages/gateway/src/git-sync.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { GIT_ENV } from "./git-env.js";
 
 const execAsync = promisify(execFile);
 
@@ -76,15 +77,6 @@ export function createAutoSync(sync: GitSync, options: AutoSyncOptions = {}): Au
     },
   };
 }
-
-// Ensure git has a committer identity even when the host lacks global config
-// (e.g. ephemeral CI runners, fresh containers). Overridable via env.
-const GIT_ENV = {
-  GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Matrix OS",
-  GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "matrix-os@users.noreply.github.com",
-  GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Matrix OS",
-  GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "matrix-os@users.noreply.github.com",
-};
 
 export function createGitSync(homePath: string): GitSync {
   async function git(...args: string[]): Promise<string> {

--- a/packages/gateway/src/git-sync.ts
+++ b/packages/gateway/src/git-sync.ts
@@ -95,7 +95,12 @@ export function createGitSync(homePath: string): GitSync {
       let branch = "main";
       try {
         branch = await git("rev-parse", "--abbrev-ref", "HEAD");
-      } catch {}
+      } catch (err) {
+        console.warn(
+          "[git-sync] Failed to resolve current branch, defaulting to main:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
 
       let ahead = 0;
       let behind = 0;
@@ -114,7 +119,12 @@ export function createGitSync(homePath: string): GitSync {
             ahead = a;
           }
         }
-      } catch {}
+      } catch (err) {
+        console.warn(
+          "[git-sync] Failed to resolve remote tracking status:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
 
       return { clean, ahead, behind, branch, hasRemote };
     },

--- a/packages/gateway/src/git-versioning.ts
+++ b/packages/gateway/src/git-versioning.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { writeFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { GIT_ENV } from "./git-env.js";
 
@@ -102,7 +102,12 @@ export function createGitAutoCommit(config: GitAutoCommitConfig): GitAutoCommit 
   return {
     start() {
       timer = setInterval(() => {
-        commitIfChanged().catch(() => {});
+        commitIfChanged().catch((err) => {
+          console.warn(
+            "[git-versioning] Auto-commit failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        });
       }, intervalMs);
     },
     stop() {
@@ -143,7 +148,11 @@ export function createSnapshotManager(homePath: string): SnapshotManager {
           "snapshot/*",
           "--format=%(refname:short)|%(objectname:short)|%(*objectname:short)|%(creatordate:iso-strict)",
         );
-      } catch {
+      } catch (err) {
+        console.warn(
+          "[git-versioning] Failed to list snapshots:",
+          err instanceof Error ? err.message : String(err),
+        );
         return [];
       }
 
@@ -193,7 +202,7 @@ export function createFileHistory(homePath: string): FileHistory {
       try {
         const content = await git(homePath, "show", `${commit}:${path}`);
         const fullPath = join(homePath, path);
-        writeFileSync(fullPath, content, "utf-8");
+        await writeFile(fullPath, content, "utf-8");
 
         await git(homePath, "add", path);
         await git(

--- a/packages/gateway/src/git-versioning.ts
+++ b/packages/gateway/src/git-versioning.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { GIT_ENV } from "./git-env.js";
 
 const execAsync = promisify(execFile);
 
@@ -62,15 +63,6 @@ export interface FileHistory {
   diff(path: string, commit: string): Promise<string>;
   restore(path: string, commit: string): Promise<RestoreResult>;
 }
-
-// Ensure git has a committer identity even when the host lacks global config
-// (e.g. ephemeral CI runners, fresh containers). Overridable via env.
-const GIT_ENV = {
-  GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Matrix OS",
-  GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "matrix-os@users.noreply.github.com",
-  GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Matrix OS",
-  GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "matrix-os@users.noreply.github.com",
-};
 
 async function git(homePath: string, ...args: string[]): Promise<string> {
   const { stdout } = await execAsync("git", args, {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -122,6 +122,15 @@ const BridgeCallBodySchema = z.object({
   params: z.record(z.string(), z.unknown()).optional(),
 });
 
+const TERMINAL_DEBUG_ENABLED = process.env.TERMINAL_DEBUG !== "0";
+
+function logTerminalDebug(event: string, details: Record<string, unknown> = {}): void {
+  if (!TERMINAL_DEBUG_ENABLED) {
+    return;
+  }
+  console.info("[terminal-debug][gateway]", event, details);
+}
+
 const INTEGRATION_PROXY_BODY_LIMIT = 64 * 1024;
 
 export interface GatewayConfig {
@@ -1356,15 +1365,20 @@ export async function createGateway(config: GatewayConfig) {
       let autoCreateTimer: ReturnType<typeof setTimeout> | null = null;
       let autoCreatedSessionId: string | null = null;
 
-      const cleanupAutoCreatedSession = () => {
+      const cleanupAutoCreatedSession = (destroyAutoCreated = true) => {
+        logTerminalDebug("ws-cleanup", {
+          destroyAutoCreated,
+          handleSessionId: handle?.sessionId ?? null,
+          autoCreatedSessionId,
+        });
         if (handle) {
           const shouldDestroyAutoCreated = autoCreatedSessionId === handle.sessionId;
           handle.detach();
           handle = null;
-          if (shouldDestroyAutoCreated && autoCreatedSessionId) {
+          if (destroyAutoCreated && shouldDestroyAutoCreated && autoCreatedSessionId) {
             sessionRegistry.destroy(autoCreatedSessionId);
           }
-        } else if (autoCreatedSessionId) {
+        } else if (destroyAutoCreated && autoCreatedSessionId) {
           sessionRegistry.destroy(autoCreatedSessionId);
         }
         autoCreatedSessionId = null;
@@ -1372,6 +1386,9 @@ export async function createGateway(config: GatewayConfig) {
 
       return {
         onOpen(_evt, ws) {
+          logTerminalDebug("ws-open", {
+            cwdParam: cwdParam ?? null,
+          });
           const sendJson = (msg: PtyServerMessage) => {
             try {
               ws.send(JSON.stringify(msg));
@@ -1388,6 +1405,7 @@ export async function createGateway(config: GatewayConfig) {
               let sessionId: string | null = null;
               try {
                 sessionId = sessionRegistry.create(cwdParam);
+                logTerminalDebug("auto-create-session", { cwd: cwdParam, sessionId });
                 autoCreatedSessionId = sessionId;
                 handle = sessionRegistry.attach(sessionId);
                 if (handle) {
@@ -1445,6 +1463,12 @@ export async function createGateway(config: GatewayConfig) {
               ws.send(JSON.stringify({ type: "pong" }));
               break;
             case "attach": {
+              logTerminalDebug("ws-attach-request", {
+                mode: "cwd" in msg ? "create" : "reattach",
+                cwd: "cwd" in msg ? msg.cwd : null,
+                sessionId: "sessionId" in msg ? msg.sessionId : null,
+                fromSeq: "fromSeq" in msg ? (msg.fromSeq ?? 0) : null,
+              });
               if (autoCreateTimer) {
                 clearTimeout(autoCreateTimer);
                 autoCreateTimer = null;
@@ -1457,6 +1481,11 @@ export async function createGateway(config: GatewayConfig) {
                 let sessionId: string | null = null;
                 try {
                   sessionId = sessionRegistry.create(msg.cwd, msg.shell);
+                  logTerminalDebug("create-session", {
+                    cwd: msg.cwd,
+                    shell: msg.shell ?? null,
+                    sessionId,
+                  });
                   autoCreatedSessionId = null;
                   handle = sessionRegistry.attach(sessionId);
                   if (handle) {
@@ -1481,6 +1510,7 @@ export async function createGateway(config: GatewayConfig) {
                 try {
                   handle = sessionRegistry.attach(msg.sessionId);
                   if (handle) {
+                    logTerminalDebug("attach-existing-success", { sessionId: msg.sessionId });
                     const info = sessionRegistry.getSession(msg.sessionId);
                     autoCreatedSessionId = null;
                     handle.subscribe(sendJson);
@@ -1492,6 +1522,7 @@ export async function createGateway(config: GatewayConfig) {
                     });
                     handle.replay(msg.fromSeq ?? 0);
                   } else {
+                    logTerminalDebug("attach-existing-miss", { sessionId: msg.sessionId });
                     sendJson({ type: "error", message: "Session not found" });
                   }
                 } catch (err: unknown) {
@@ -1513,17 +1544,19 @@ export async function createGateway(config: GatewayConfig) {
               break;
             case "detach":
               if (handle) {
+                logTerminalDebug("ws-detach", { sessionId: handle.sessionId });
                 handle.detach();
                 handle = null;
               }
               break;
             case "destroy":
               if (handle) {
-                const sid = handle.sessionId;
+                const sessionId = handle.sessionId;
+                logTerminalDebug("ws-destroy", { sessionId });
                 handle.detach();
                 handle = null;
-                sessionRegistry.destroy(sid);
-                if (autoCreatedSessionId === sid) {
+                sessionRegistry.destroy(sessionId);
+                if (autoCreatedSessionId === sessionId) {
                   autoCreatedSessionId = null;
                 }
               }
@@ -1532,11 +1565,15 @@ export async function createGateway(config: GatewayConfig) {
         },
 
         onClose() {
+          logTerminalDebug("ws-close", {
+            handleSessionId: handle?.sessionId ?? null,
+            autoCreatedSessionId,
+          });
           if (autoCreateTimer) {
             clearTimeout(autoCreateTimer);
             autoCreateTimer = null;
           }
-          cleanupAutoCreatedSession();
+          cleanupAutoCreatedSession(false);
         },
       };
     }),
@@ -1727,6 +1764,7 @@ export async function createGateway(config: GatewayConfig) {
 
   app.delete("/api/terminal/sessions/:id", (c) => {
     const id = c.req.param("id");
+    logTerminalDebug("rest-destroy-request", { sessionId: id });
     if (!UUID_REGEX.test(id)) return c.json({ error: "Invalid session ID" }, 400);
     const session = sessionRegistry.getSession(id);
     if (!session) return c.json({ error: "Session not found" }, 404);
@@ -1753,9 +1791,33 @@ export async function createGateway(config: GatewayConfig) {
     return c.json({ events });
   });
 
+  function resolveServedFilePath(filePath: string): string | null {
+    const fullPath = resolveWithinHome(homePath, filePath);
+    if (!fullPath) {
+      return null;
+    }
+    if (existsSync(fullPath)) {
+      return fullPath;
+    }
+
+    if (!filePath.endsWith("/manifest.json")) {
+      return fullPath;
+    }
+
+    const dirPath = dirname(fullPath);
+    const fallbackCandidates = [join(dirPath, "module.json"), join(dirPath, "matrix.json")];
+    for (const candidate of fallbackCandidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    return fullPath;
+  }
+
   app.on("HEAD", "/files/*", (c) => {
     const filePath = c.req.path.replace("/files/", "");
-    const fullPath = resolveWithinHome(homePath, filePath);
+    const fullPath = resolveServedFilePath(filePath);
     if (!fullPath) return c.text("Forbidden", 403);
     if (!existsSync(fullPath)) return c.text("Not found", 404);
     if (statSync(fullPath).isDirectory()) return c.text("Is a directory", 400);
@@ -1764,7 +1826,7 @@ export async function createGateway(config: GatewayConfig) {
 
   app.get("/files/*", (c) => {
     const filePath = c.req.path.replace("/files/", "");
-    const fullPath = resolveWithinHome(homePath, filePath);
+    const fullPath = resolveServedFilePath(filePath);
 
     if (!fullPath) {
       return c.text("Forbidden", 403);

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -8,6 +8,14 @@ import { RingBuffer } from "./ring-buffer.js";
 import { resolveWithinHome } from "./path-security.js";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const TERMINAL_DEBUG_ENABLED = process.env.TERMINAL_DEBUG !== "0";
+
+function logTerminalDebug(event: string, details: Record<string, unknown> = {}): void {
+  if (!TERMINAL_DEBUG_ENABLED) {
+    return;
+  }
+  console.info("[terminal-debug][registry]", event, details);
+}
 
 const AttachNewSchema = z.object({
   type: z.literal("attach"),
@@ -349,13 +357,28 @@ export class SessionRegistry {
     const session = new PtySession(sessionId, ptyProcess, buffer, targetCwd, resolvedShell);
     this.sessions.set(sessionId, session);
     this.schedulePersist();
+    logTerminalDebug("create", {
+      sessionId,
+      cwd: targetCwd,
+      shell: resolvedShell,
+      totalSessions: this.sessions.size,
+    });
 
     return sessionId;
   }
 
   attach(sessionId: string): SessionHandle | null {
     const session = this.sessions.get(sessionId);
-    if (!session) return null;
+    if (!session) {
+      logTerminalDebug("attach-miss", { sessionId, totalSessions: this.sessions.size });
+      return null;
+    }
+
+    logTerminalDebug("attach", {
+      sessionId,
+      attachedClients: session.attachedClients,
+      state: session.state,
+    });
 
     let subscriberFn: SubscriberFn | null = null;
     let detached = false;
@@ -410,6 +433,11 @@ export class SessionRegistry {
       detach() {
         if (detached) return;
         detached = true;
+        logTerminalDebug("detach", {
+          sessionId,
+          hadSubscriber: !!subscriberFn,
+          attachedClientsBefore: session.attachedClients,
+        });
         if (subscriberFn) {
           session.removeSubscriber(subscriberFn);
           session.decrementClients();
@@ -424,6 +452,12 @@ export class SessionRegistry {
   destroy(sessionId: string): void {
     const session = this.sessions.get(sessionId);
     if (!session) return;
+    logTerminalDebug("destroy", {
+      sessionId,
+      attachedClients: session.attachedClients,
+      state: session.state,
+      totalSessionsBefore: this.sessions.size,
+    });
 
     try {
       session.kill();
@@ -473,6 +507,11 @@ export class SessionRegistry {
     }
 
     if (candidate) {
+      logTerminalDebug("evict", {
+        sessionId: candidate.sessionId,
+        state: candidate.state,
+        attachedClients: candidate.attachedClients,
+      });
       this.destroy(candidate.sessionId);
     }
   }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -27,6 +27,7 @@ import { issueSyncJwt, verifySyncJwt } from './sync-jwt.js';
 import {
   getWebSocketUpgradeHost,
   getWebSocketUpgradeToken,
+  isAppDomainHost,
   isSafeWebSocketUpgradePath,
   stripWebSocketUpgradeToken,
 } from './ws-upgrade.js';
@@ -239,11 +240,6 @@ function describeError(err: unknown): string {
   }
   return String(err);
 }
-
-function isAppDomainHost(host: string): boolean {
-  return /^app\.matrix-os\.com(?::\d+)?$/i.test(host) || /^app\.localhost(?::\d+)?$/i.test(host);
-}
-
 function isSyncJwtAuthError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return (

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -23,8 +23,13 @@ import { createSocialFeedApi } from './social-api.js';
 import { createClerkAuth, type ClerkAuth } from './clerk-auth.js';
 import type { MatrixProvisioner } from './matrix-provisioning.js';
 import { createAuthRoutes } from './auth-routes.js';
-import { verifySyncJwt } from './sync-jwt.js';
-import { isSafeWebSocketUpgradePath } from './ws-upgrade.js';
+import { issueSyncJwt, verifySyncJwt } from './sync-jwt.js';
+import {
+  getWebSocketUpgradeHost,
+  getWebSocketUpgradeToken,
+  isSafeWebSocketUpgradePath,
+  stripWebSocketUpgradeToken,
+} from './ws-upgrade.js';
 import {
   buildPlatformVerificationToken,
   timingSafeTokenEquals,
@@ -49,6 +54,7 @@ const containerProxyDispatcher = new Agent({
   keepAliveMaxTimeout: 1,
   connections: 64,
 });
+const WS_TOKEN_EXPIRES_IN_SEC = 5 * 60;
 
 const ProvisionBodySchema = z.object({
   handle: z.string().regex(HANDLE_PATTERN),
@@ -234,6 +240,10 @@ function describeError(err: unknown): string {
   return String(err);
 }
 
+function isAppDomainHost(host: string): boolean {
+  return /^app\.matrix-os\.com(?::\d+)?$/i.test(host) || /^app\.localhost(?::\d+)?$/i.test(host);
+}
+
 function isSyncJwtAuthError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return (
@@ -250,10 +260,12 @@ async function resolveAppDomainIdentity(opts: {
   clerkAuth?: ClerkAuth;
   db: PlatformDB;
   platformJwtSecret: string;
+  wsToken?: string | null;
 }): Promise<AppDomainIdentity | null> {
-  const bearerToken = opts.authHeader?.startsWith('Bearer ')
-    ? opts.authHeader.slice(7)
-    : null;
+  const bearerToken =
+    opts.authHeader?.startsWith('Bearer ')
+      ? opts.authHeader.slice(7)
+      : opts.wsToken ?? null;
 
   if (bearerToken && opts.platformJwtSecret) {
     try {
@@ -297,6 +309,15 @@ async function resolveAppDomainIdentity(opts: {
     handle: record.handle,
     userId: result.userId,
   };
+}
+
+function getGatewayUrlForHandle(handle: string): string {
+  const safeHandle = requireValidHandle(handle);
+  const tmpl = process.env.GATEWAY_URL_TEMPLATE;
+  if (tmpl) {
+    return tmpl.replace('{handle}', safeHandle);
+  }
+  return 'https://app.matrix-os.com';
 }
 
 function getAuthPage(
@@ -514,17 +535,7 @@ export function createApp(deps: {
         clerkAuth,
         jwtSecret: platformJwtSecret,
         platformUrl: platformPublicUrl,
-        gatewayUrlForHandle: (handle) => {
-          // Single-domain production: every handle hits https://app.matrix-os.com,
-          // where the platform middleware resolves the Clerk session and proxies
-          // to the right container. Per-handle subdomains are deprecated.
-          // Dev override via GATEWAY_URL_TEMPLATE='http://localhost:4000' (single-tenant)
-          // or 'http://matrixos-{handle}:4000' for in-cluster Docker routing.
-          const safeHandle = requireValidHandle(handle);
-          const tmpl = process.env.GATEWAY_URL_TEMPLATE;
-          if (tmpl) return tmpl.replace('{handle}', safeHandle);
-          return 'https://app.matrix-os.com';
-        },
+        gatewayUrlForHandle: getGatewayUrlForHandle,
       }),
     );
   }
@@ -532,7 +543,7 @@ export function createApp(deps: {
   // Session-based routing: app.matrix-os.com -> Clerk session -> container
   app.use('*', async (c, next) => {
     const host = c.req.header('host') ?? '';
-    const isAppDomain = /^app\.matrix-os\.com$/i.test(host) || /^app\.localhost/i.test(host);
+    const isAppDomain = isAppDomainHost(host);
     if (!isAppDomain) return next();
 
     // Device-flow paths are served directly by the platform's auth-routes.ts
@@ -601,6 +612,23 @@ export function createApp(deps: {
       c.set('platformUserId', identity.userId);
       c.set('platformHandle', record.handle);
       return next();
+    }
+
+    if (path === '/api/auth/ws-token') {
+      if (!platformJwtSecret) {
+        return c.json({ error: 'WebSocket auth unavailable' }, 503);
+      }
+      const issued = await issueSyncJwt({
+        secret: platformJwtSecret,
+        clerkUserId: identity.userId,
+        handle: record.handle,
+        gatewayUrl: getGatewayUrlForHandle(record.handle),
+        expiresInSec: WS_TOKEN_EXPIRES_IN_SEC,
+      });
+      return c.json({
+        token: issued.token,
+        expiresAt: issued.expiresAt,
+      });
     }
 
     if (record.status === 'stopped') {
@@ -1247,93 +1275,91 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
 
   // WebSocket upgrade handler
   (server as import('node:http').Server).on('upgrade', async (req: IncomingMessage, socket, head) => {
-    const host = req.headers.host ?? '';
-
-    // Session-based WebSocket routing for app.matrix-os.com
-    const isAppDomain = /^app\.matrix-os\.com$/i.test(host) || /^app\.localhost/i.test(host);
-    if (isAppDomain) {
-      const identity = await resolveAppDomainIdentity({
-        authHeader: req.headers.authorization as string | undefined,
-        cookieHeader: req.headers.cookie,
-        clerkAuth,
-        db,
-        platformJwtSecret: PLATFORM_JWT_SECRET,
-      });
-      if (!identity) { socket.destroy(); return; }
-
-      const record = getContainer(db, identity.handle);
-      if (!record) { socket.destroy(); return; }
-      const path = req.url ?? '/';
-      let activeUpstream: ReturnType<typeof createConnection> | null = null;
-      const onSocketError = () => activeUpstream?.destroy();
-      socket.on('error', onSocketError);
-
-      const connectUpstream = async (attempt: number): Promise<void> => {
-        const endpoint = await resolveContainerEndpoint(docker, db, record.handle, record.containerId);
-        if (!endpoint) {
-          console.warn(
-            `[platform] websocket upstream unresolved handle=${record.handle} attempt=${attempt + 1} path=${path}`,
-          );
-          socket.destroy();
-          return;
-        }
-
-        let connected = false;
-        const upstream = createConnection({ host: endpoint.host, port: 4000 }, () => {
-          connected = true;
-          activeUpstream = upstream;
-          if (!isSafeWebSocketUpgradePath(path)) {
-            socket.destroy();
-            upstream.destroy();
-            return;
-          }
-          const headers = Object.entries(req.headers)
-            .filter(([k]) => k !== 'host' && k !== 'authorization' && k !== 'cookie')
-            .map(([k, v]) => `${k}: ${v}`)
-            .concat(
-              PLATFORM_SECRET
-                ? [
-                    `authorization: Bearer ${buildPlatformVerificationToken(record.handle, PLATFORM_SECRET)}`,
-                    `x-platform-verified: ${buildPlatformUserProof(record.handle, identity.userId, PLATFORM_SECRET)}`,
-                    `x-platform-user-id: ${identity.userId}`,
-                  ]
-                : [],
-            )
-            .join('\r\n');
-
-          upstream.write(
-            `${req.method} ${path} HTTP/1.1\r\nHost: ${endpoint.host}:4000\r\n${headers}\r\n\r\n`
-          );
-          if (head.length > 0) upstream.write(head);
-
-          upstream.pipe(socket);
-          socket.pipe(upstream);
-        });
-
-        upstream.on('error', (err) => {
-          console.warn(
-            `[platform] websocket upstream failed handle=${record.handle} attempt=${attempt + 1} host=${endpoint.host} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
-          );
-          if (!connected && attempt === 0 && !socket.destroyed) {
-            void connectUpstream(attempt + 1).catch((retryErr) => {
-              console.error('[platform] websocket upstream retry fatal error:', describeError(retryErr));
-              socket.destroy();
-            });
-            return;
-          }
-          socket.destroy();
-        });
-      };
-
-      void connectUpstream(0).catch((err) => {
-        console.error('[platform] websocket upstream fatal error:', describeError(err));
-        socket.destroy();
-      });
+    const host = getWebSocketUpgradeHost(req.headers.host, req.headers['x-forwarded-host']);
+    if (!isAppDomainHost(host)) {
+      socket.destroy();
       return;
     }
 
-    // Unknown host -- legacy {handle}.matrix-os.com subdomain routing retired;
-    // only app.matrix-os.com is supported for WebSocket upgrades.
-    socket.destroy();
+    const path = req.url ?? '/';
+    const wsToken = getWebSocketUpgradeToken(path);
+    const identity = await resolveAppDomainIdentity({
+      authHeader: req.headers.authorization as string | undefined,
+      cookieHeader: req.headers.cookie,
+      clerkAuth,
+      db,
+      platformJwtSecret: PLATFORM_JWT_SECRET,
+      wsToken,
+    });
+    if (!identity) { socket.destroy(); return; }
+
+    const record = getContainer(db, identity.handle);
+    if (!record) { socket.destroy(); return; }
+    let activeUpstream: ReturnType<typeof createConnection> | null = null;
+    const onSocketError = () => activeUpstream?.destroy();
+    socket.on('error', onSocketError);
+
+    const connectUpstream = async (attempt: number): Promise<void> => {
+      const endpoint = await resolveContainerEndpoint(docker, db, record.handle, record.containerId);
+      if (!endpoint) {
+        console.warn(
+          `[platform] websocket upstream unresolved handle=${record.handle} attempt=${attempt + 1} path=${path}`,
+        );
+        socket.destroy();
+        return;
+      }
+
+      let connected = false;
+      const upstream = createConnection({ host: endpoint.host, port: 4000 }, () => {
+        connected = true;
+        activeUpstream = upstream;
+        if (!isSafeWebSocketUpgradePath(path)) {
+          socket.destroy();
+          upstream.destroy();
+          return;
+        }
+        const upstreamPath = stripWebSocketUpgradeToken(path);
+        const headers = Object.entries(req.headers)
+          .filter(([k]) => k !== 'host' && k !== 'authorization' && k !== 'cookie')
+          .map(([k, v]) => `${k}: ${v}`)
+          .concat(
+            PLATFORM_SECRET
+              ? [
+                  `authorization: Bearer ${buildPlatformVerificationToken(record.handle, PLATFORM_SECRET)}`,
+                  `x-platform-verified: ${buildPlatformUserProof(record.handle, identity.userId, PLATFORM_SECRET)}`,
+                  `x-platform-user-id: ${identity.userId}`,
+                ]
+              : [],
+          )
+          .join('\r\n');
+
+        upstream.write(
+          `${req.method} ${upstreamPath} HTTP/1.1\r\nHost: ${endpoint.host}:4000\r\n${headers}\r\n\r\n`
+        );
+        if (head.length > 0) upstream.write(head);
+
+        upstream.pipe(socket);
+        socket.pipe(upstream);
+      });
+
+      upstream.on('error', (err) => {
+        console.warn(
+          `[platform] websocket upstream failed handle=${record.handle} attempt=${attempt + 1} host=${endpoint.host} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
+        );
+        if (!connected && attempt === 0 && !socket.destroyed) {
+          void connectUpstream(attempt + 1).catch((retryErr) => {
+            console.error('[platform] websocket upstream retry fatal error:', describeError(retryErr));
+            socket.destroy();
+          });
+          return;
+        }
+        socket.destroy();
+      });
+    };
+
+    void connectUpstream(0).catch((err) => {
+      console.error('[platform] websocket upstream fatal error:', describeError(err));
+      socket.destroy();
+    });
   });
 }

--- a/packages/platform/src/ws-upgrade.ts
+++ b/packages/platform/src/ws-upgrade.ts
@@ -13,6 +13,8 @@ export function getWebSocketUpgradeHost(
   hostHeader: string | string[] | undefined,
   forwardedHostHeader: string | string[] | undefined,
 ): string {
+  // The platform is expected to sit behind Cloudflare/nginx-style proxies that
+  // set x-forwarded-host to the externally requested host.
   const forwarded = normalizeHeaderValue(forwardedHostHeader)
     .split(",")
     .map((part) => part.trim())

--- a/packages/platform/src/ws-upgrade.ts
+++ b/packages/platform/src/ws-upgrade.ts
@@ -25,6 +25,10 @@ export function getWebSocketUpgradeHost(
   return normalizeHeaderValue(hostHeader).trim();
 }
 
+export function isAppDomainHost(host: string): boolean {
+  return /^app\.matrix-os\.com(?::\d+)?$/i.test(host) || /^app\.localhost(?::\d+)?$/i.test(host);
+}
+
 function parseWebSocketUpgradeUrl(path: string): URL | null {
   try {
     return new URL(path, "http://platform.invalid");

--- a/packages/platform/src/ws-upgrade.ts
+++ b/packages/platform/src/ws-upgrade.ts
@@ -1,3 +1,52 @@
 export function isSafeWebSocketUpgradePath(path: string): boolean {
   return !/[\r\n]/.test(path);
 }
+
+function normalizeHeaderValue(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+  return value ?? "";
+}
+
+export function getWebSocketUpgradeHost(
+  hostHeader: string | string[] | undefined,
+  forwardedHostHeader: string | string[] | undefined,
+): string {
+  const forwarded = normalizeHeaderValue(forwardedHostHeader)
+    .split(",")
+    .map((part) => part.trim())
+    .find((part) => part.length > 0);
+
+  if (forwarded) {
+    return forwarded;
+  }
+
+  return normalizeHeaderValue(hostHeader).trim();
+}
+
+function parseWebSocketUpgradeUrl(path: string): URL | null {
+  try {
+    return new URL(path, "http://platform.invalid");
+  } catch (err: unknown) {
+    if (err instanceof TypeError) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export function getWebSocketUpgradeToken(path: string): string | null {
+  const parsed = parseWebSocketUpgradeUrl(path);
+  return parsed?.searchParams.get("token") ?? null;
+}
+
+export function stripWebSocketUpgradeToken(path: string): string {
+  const parsed = parseWebSocketUpgradeUrl(path);
+  if (!parsed) {
+    return path;
+  }
+  parsed.searchParams.delete("token");
+  const search = parsed.searchParams.toString();
+  return `${parsed.pathname}${search ? `?${search}` : ""}`;
+}

--- a/shell/src/components/Terminal.tsx
+++ b/shell/src/components/Terminal.tsx
@@ -41,7 +41,13 @@ export function Terminal() {
       termRef.current = term;
 
       const wsUrl = await buildAuthenticatedWebSocketUrl("/ws/terminal")
-        .catch(() => getGatewayWs().replace("/ws", "/ws/terminal"));
+        .catch((err: unknown) => {
+          console.warn(
+            "[Terminal] Falling back to unauthenticated terminal websocket URL:",
+            err instanceof Error ? err.message : err,
+          );
+          return getGatewayWs().replace("/ws", "/ws/terminal");
+        });
       if (disposed) {
         term.dispose();
         return;

--- a/shell/src/components/Terminal.tsx
+++ b/shell/src/components/Terminal.tsx
@@ -4,8 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { getGatewayWs } from "@/lib/gateway";
-
-const TERMINAL_WS = getGatewayWs().replace("/ws", "/ws/terminal");
+import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 
 export function Terminal() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -41,7 +40,14 @@ export function Terminal() {
 
       termRef.current = term;
 
-      const ws = new WebSocket(TERMINAL_WS);
+      const wsUrl = await buildAuthenticatedWebSocketUrl("/ws/terminal")
+        .catch(() => getGatewayWs().replace("/ws", "/ws/terminal"));
+      if (disposed) {
+        term.dispose();
+        return;
+      }
+
+      const ws = new WebSocket(wsUrl);
       wsRef.current = ws;
 
       ws.onopen = () => {
@@ -63,7 +69,7 @@ export function Terminal() {
           } else if (msg.type === "exit") {
             term.write("\r\n[Process exited]\r\n");
           }
-        } catch {
+        } catch (_err: unknown) {
           // ignore malformed
         }
       };

--- a/shell/src/components/settings/sections/IntegrationsSection.tsx
+++ b/shell/src/components/settings/sections/IntegrationsSection.tsx
@@ -210,9 +210,13 @@ export function IntegrationsSection() {
   // WebSocket listener for real-time connection updates
   useEffect(() => {
     let ws: WebSocket | null = null;
+    let disposed = false;
     void buildAuthenticatedWebSocketUrl("/ws")
       .catch(() => getGatewayWs())
       .then((wsUrl) => {
+        if (disposed) {
+          return;
+        }
         try {
           ws = new WebSocket(wsUrl);
           ws.onmessage = (event) => {
@@ -233,6 +237,7 @@ export function IntegrationsSection() {
         }
       });
     return () => {
+      disposed = true;
       ws?.close();
     };
   }, [loadData]);

--- a/shell/src/components/settings/sections/IntegrationsSection.tsx
+++ b/shell/src/components/settings/sections/IntegrationsSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
+import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 
 const GATEWAY = getGatewayUrl();
 
@@ -84,7 +85,7 @@ function formatDate(iso: string): string {
       month: "short",
       day: "numeric",
     });
-  } catch {
+  } catch (_err: unknown) {
     return iso;
   }
 }
@@ -209,24 +210,28 @@ export function IntegrationsSection() {
   // WebSocket listener for real-time connection updates
   useEffect(() => {
     let ws: WebSocket | null = null;
-    try {
-      ws = new WebSocket(getGatewayWs());
-      ws.onmessage = (event) => {
+    void buildAuthenticatedWebSocketUrl("/ws")
+      .catch(() => getGatewayWs())
+      .then((wsUrl) => {
         try {
-          const msg = JSON.parse(event.data);
-          if (msg.type === "integration:connected" || msg.type === "integration:disconnected") {
-            loadData();
-          }
-        } catch {
-          // not JSON, ignore
+          ws = new WebSocket(wsUrl);
+          ws.onmessage = (event) => {
+            try {
+              const msg = JSON.parse(event.data);
+              if (msg.type === "integration:connected" || msg.type === "integration:disconnected") {
+                loadData();
+              }
+            } catch (_err: unknown) {
+              // not JSON, ignore
+            }
+          };
+          ws.onerror = () => {
+            // WebSocket errors are non-fatal; polling fallback handles it
+          };
+        } catch (_err: unknown) {
+          // WebSocket not available, rely on polling during connect
         }
-      };
-      ws.onerror = () => {
-        // WebSocket errors are non-fatal; polling fallback handles it
-      };
-    } catch {
-      // WebSocket not available, rely on polling during connect
-    }
+      });
     return () => {
       ws?.close();
     };

--- a/shell/src/components/settings/sections/IntegrationsSection.tsx
+++ b/shell/src/components/settings/sections/IntegrationsSection.tsx
@@ -212,7 +212,13 @@ export function IntegrationsSection() {
     let ws: WebSocket | null = null;
     let disposed = false;
     void buildAuthenticatedWebSocketUrl("/ws")
-      .catch(() => getGatewayWs())
+      .catch((err: unknown) => {
+        console.warn(
+          "[integrations] Falling back to unauthenticated websocket URL:",
+          err instanceof Error ? err.message : err,
+        );
+        return getGatewayWs();
+      })
       .then((wsUrl) => {
         if (disposed) {
           return;

--- a/shell/src/components/terminal/PaneGrid.tsx
+++ b/shell/src/components/terminal/PaneGrid.tsx
@@ -12,9 +12,10 @@ interface PaneGridProps {
   onFocusPane?: (paneId: string) => void;
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
+  shouldDestroyPane?: (paneId: string) => boolean;
 }
 
-export function PaneGrid({ paneTree, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane }: PaneGridProps) {
+export function PaneGrid({ paneTree, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane }: PaneGridProps) {
   return (
     <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
       <PaneNodeRenderer
@@ -24,6 +25,7 @@ export function PaneGrid({ paneTree, theme, focusedPaneId, onFocusPane, onSessio
         onFocusPane={onFocusPane}
         onSessionAttached={onSessionAttached}
         shouldCachePane={shouldCachePane}
+        shouldDestroyPane={shouldDestroyPane}
       />
     </div>
   );
@@ -36,13 +38,15 @@ interface PaneNodeRendererProps {
   onFocusPane?: (paneId: string) => void;
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
+  shouldDestroyPane?: (paneId: string) => boolean;
 }
 
-function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane }: PaneNodeRendererProps) {
+function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane }: PaneNodeRendererProps) {
   if (node.type === "pane") {
     return (
-      <div className="h-full w-full min-h-0 min-w-0">
+      <div key={node.id} className="h-full w-full min-h-0 min-w-0">
         <TerminalPane
+          key={node.id}
           paneId={node.id}
           cwd={node.cwd}
           theme={theme}
@@ -52,6 +56,7 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAt
           onFocus={onFocusPane}
           onSessionAttached={onSessionAttached}
           shouldCacheOnUnmount={shouldCachePane}
+          shouldDestroyOnUnmount={shouldDestroyPane}
         />
       </div>
     );
@@ -68,6 +73,7 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAt
       onFocusPane={onFocusPane}
       onSessionAttached={onSessionAttached}
       shouldCachePane={shouldCachePane}
+      shouldDestroyPane={shouldDestroyPane}
     />
   );
 }
@@ -82,9 +88,10 @@ interface SplitContainerProps {
   onFocusPane?: (paneId: string) => void;
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
+  shouldDestroyPane?: (paneId: string) => boolean;
 }
 
-function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane }: SplitContainerProps) {
+function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane }: SplitContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentRatio, setCurrentRatio] = useState(ratio);
 
@@ -137,6 +144,7 @@ function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, o
           onFocusPane={onFocusPane}
           onSessionAttached={onSessionAttached}
           shouldCachePane={shouldCachePane}
+          shouldDestroyPane={shouldDestroyPane}
         />
       </div>
       <div
@@ -152,6 +160,7 @@ function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, o
           onFocusPane={onFocusPane}
           onSessionAttached={onSessionAttached}
           shouldCachePane={shouldCachePane}
+          shouldDestroyPane={shouldDestroyPane}
         />
       </div>
     </div>

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -74,6 +74,47 @@ function hasPaneId(node: PaneNode, paneId: string): boolean {
   return hasPaneId(node.children[0], paneId) || hasPaneId(node.children[1], paneId);
 }
 
+function getPaneSessionId(node: PaneNode, paneId: string): string | null {
+  if (node.type === "pane") {
+    return node.id === paneId ? node.sessionId ?? null : null;
+  }
+  return getPaneSessionId(node.children[0], paneId) ?? getPaneSessionId(node.children[1], paneId);
+}
+
+function getSessionIds(node: PaneNode): string[] {
+  if (node.type === "pane") {
+    return node.sessionId ? [node.sessionId] : [];
+  }
+  return [...getSessionIds(node.children[0]), ...getSessionIds(node.children[1])];
+}
+
+function isTerminalDebugEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    if (window.localStorage.getItem("matrix-terminal-debug") === "1") {
+      return true;
+    }
+  } catch (_err: unknown) {
+    // Ignore storage access failures.
+  }
+
+  try {
+    return new URLSearchParams(window.location.search).get("terminalDebug") === "1";
+  } catch (_err: unknown) {
+    return false;
+  }
+}
+
+function terminalAppDebug(event: string, details: Record<string, unknown>): void {
+  if (!isTerminalDebugEnabled()) {
+    return;
+  }
+  console.info("[terminal-debug][app]", event, details);
+}
+
 const countPanes = countPanesFromStore;
 
 interface TerminalAppProps {
@@ -97,7 +138,17 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
   activeTabIdRef.current = activeTabId;
   const sidebarOpenRef = useRef(sidebarOpen);
   sidebarOpenRef.current = sidebarOpen;
+  const pendingPaneSessionsRef = useRef<Map<string, string>>(new Map());
+  const closingPaneIdsRef = useRef<Set<string>>(new Set());
   const layoutSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const log = useCallback((event: string, details: Record<string, unknown> = {}) => {
+    terminalAppDebug(event, {
+      activeTabId: activeTabIdRef.current,
+      focusedPaneId,
+      tabIds: tabsRef.current.map((tab) => tab.id),
+      ...details,
+    });
+  }, [focusedPaneId]);
 
   const persistLayoutNow = useCallback(() => {
     const layout: TerminalLayout = {
@@ -115,6 +166,44 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
     }).catch((err: unknown) => {
       console.warn("Failed to save terminal layout:", err instanceof Error ? err.message : err);
     });
+  }, []);
+
+  const destroyTerminalSessions = useCallback((sessionIds: string[]) => {
+    const uniqueIds = Array.from(new Set(sessionIds.filter((sessionId) => sessionId.length > 0)));
+    for (const sessionId of uniqueIds) {
+      void fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sessionId)}`, {
+        method: "DELETE",
+        keepalive: true,
+        signal: AbortSignal.timeout(5_000),
+      }).catch((err: unknown) => {
+        console.warn(
+          `Failed to destroy terminal session "${sessionId}" on explicit close:`,
+          err instanceof Error ? err.message : err,
+        );
+      });
+    }
+  }, []);
+
+  const getPendingSessionIds = useCallback((paneIds: string[]) => {
+    const seen = new Set<string>();
+    for (const paneId of paneIds) {
+      const sessionId = pendingPaneSessionsRef.current.get(paneId);
+      if (sessionId) {
+        seen.add(sessionId);
+      }
+    }
+    return Array.from(seen);
+  }, []);
+
+  const markPanesClosing = useCallback((paneIds: string[]) => {
+    for (const paneId of paneIds) {
+      closingPaneIdsRef.current.add(paneId);
+    }
+    setTimeout(() => {
+      for (const paneId of paneIds) {
+        closingPaneIdsRef.current.delete(paneId);
+      }
+    }, 0);
   }, []);
 
   const addTab = useCallback((cwd: string, label?: string, claude?: boolean) => {
@@ -226,6 +315,19 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
   }, [sidebarOpen]);
 
   const closeTab = useCallback((tabId: string) => {
+    const closingTab = tabsRef.current.find((tab) => tab.id === tabId);
+    if (closingTab) {
+      const paneIds = getAllPaneIds(closingTab.paneTree);
+      destroyTerminalSessions([
+        ...getSessionIds(closingTab.paneTree),
+        ...getPendingSessionIds(paneIds),
+      ]);
+      markPanesClosing(paneIds);
+    }
+    log("close-tab", {
+      tabId,
+      paneIds: tabsRef.current.find((tab) => tab.id === tabId)?.paneTree ? getAllPaneIds(tabsRef.current.find((tab) => tab.id === tabId)!.paneTree) : [],
+    });
     setTabs(prev => {
       const next = prev.filter(t => t.id !== tabId);
       setActiveTabId(curr => {
@@ -235,7 +337,7 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
       });
       return next;
     });
-  }, []);
+  }, [destroyTerminalSessions, getPendingSessionIds, log, markPanesClosing]);
 
   const splitPane = useCallback((paneId: string, dir: "horizontal" | "vertical") => {
     setTabs(prev => prev.map(t => {
@@ -245,6 +347,15 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
   }, [activeTabId]);
 
   const closePane = useCallback((paneId: string) => {
+    const activeTabRecord = tabsRef.current.find((tab) => tab.id === activeTabId);
+    const closingSessionIds = new Set<string>();
+    const closingSessionId = activeTabRecord ? getPaneSessionId(activeTabRecord.paneTree, paneId) : null;
+    if (closingSessionId) closingSessionIds.add(closingSessionId);
+    const pendingSessionId = pendingPaneSessionsRef.current.get(paneId);
+    if (pendingSessionId) closingSessionIds.add(pendingSessionId);
+    destroyTerminalSessions(Array.from(closingSessionIds));
+    markPanesClosing([paneId]);
+    log("close-pane", { paneId });
     setTabs(prev => {
       const tab = prev.find(t => t.id === activeTabId);
       if (!tab) return prev;
@@ -258,7 +369,7 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
       setFocusedPaneId(getFirstPaneId(newTree));
       return prev.map(t => t.id === activeTabId ? { ...t, paneTree: newTree } : t);
     });
-  }, [activeTabId]);
+  }, [activeTabId, destroyTerminalSessions, log, markPanesClosing]);
 
   const renameTab = useCallback((tabId: string, label: string) => {
     setTabs(prev => prev.map(t => t.id === tabId ? { ...t, label } : t));
@@ -276,6 +387,8 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
   const getCwd = useCallback(() => sidebarSelectedPath ?? DEFAULT_CWD, [sidebarSelectedPath]);
 
   const handleSessionAttached = useCallback((paneId: string, sessionId: string) => {
+    log("session-attached", { paneId, sessionId });
+    pendingPaneSessionsRef.current.set(paneId, sessionId);
     setTabs((prev) => {
       const nextTabs = prev.map((tab) => {
         const nextTree = setPaneSessionId(tab.paneTree, paneId, sessionId);
@@ -284,11 +397,45 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
       tabsRef.current = nextTabs;
       return nextTabs;
     });
-  }, []);
+  }, [log]);
 
   const shouldCachePane = useCallback((paneId: string) => {
-    return tabsRef.current.some((tab) => hasPaneId(tab.paneTree, paneId));
+    const keep = !closingPaneIdsRef.current.has(paneId) && tabsRef.current.some((tab) => hasPaneId(tab.paneTree, paneId));
+    log("should-cache-pane", {
+      paneId,
+      keep,
+      tabs: tabsRef.current.map((tab) => ({
+        tabId: tab.id,
+        paneIds: getAllPaneIds(tab.paneTree),
+      })),
+    });
+    return keep;
+  }, [log]);
+
+  const shouldDestroyPane = useCallback((paneId: string) => {
+    return closingPaneIdsRef.current.has(paneId);
   }, []);
+
+  useEffect(() => {
+    const livePaneIds = new Set<string>();
+    for (const tab of tabs) {
+      for (const paneId of getAllPaneIds(tab.paneTree)) {
+        livePaneIds.add(paneId);
+      }
+    }
+    for (const paneId of Array.from(pendingPaneSessionsRef.current.keys())) {
+      if (!livePaneIds.has(paneId)) {
+        pendingPaneSessionsRef.current.delete(paneId);
+      }
+    }
+
+    log("tabs-changed", {
+      tabs: tabs.map((tab) => ({
+        tabId: tab.id,
+        paneIds: getAllPaneIds(tab.paneTree),
+      })),
+    });
+  }, [log, tabs]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (!e.ctrlKey || !e.shiftKey) return;
@@ -331,6 +478,7 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
               onFocusPane={setFocusedPaneId}
               onSessionAttached={handleSessionAttached}
               shouldCachePane={shouldCachePane}
+              shouldDestroyPane={shouldDestroyPane}
             />
           ) : !initialized ? (
             <div className="flex-1" style={{ background: "var(--background)" }} />

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -5,6 +5,7 @@ import { type PaneNode, countPanes as countPanesFromStore, getAllPaneIds } from 
 import { PaneGrid } from "./PaneGrid";
 import { useTheme } from "@/hooks/useTheme";
 import { getGatewayUrl } from "@/lib/gateway";
+import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 
 const DEFAULT_CWD = "projects";
 
@@ -86,26 +87,6 @@ function getSessionIds(node: PaneNode): string[] {
     return node.sessionId ? [node.sessionId] : [];
   }
   return [...getSessionIds(node.children[0]), ...getSessionIds(node.children[1])];
-}
-
-function isTerminalDebugEnabled(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  try {
-    if (window.localStorage.getItem("matrix-terminal-debug") === "1") {
-      return true;
-    }
-  } catch (_err: unknown) {
-    // Ignore storage access failures.
-  }
-
-  try {
-    return new URLSearchParams(window.location.search).get("terminalDebug") === "1";
-  } catch (_err: unknown) {
-    return false;
-  }
 }
 
 function terminalAppDebug(event: string, details: Record<string, unknown>): void {

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -609,7 +609,11 @@ export function TerminalPane({
         void buildAuthenticatedWebSocketUrl("/ws/terminal", {
           cwd: query?.cwd,
         })
-          .catch(() => {
+          .catch((err: unknown) => {
+            console.warn(
+              "[terminal] Falling back to unauthenticated terminal websocket URL:",
+              err instanceof Error ? err.message : err,
+            );
             const baseWs = getGatewayWs().replace("/ws", "/ws/terminal");
             return query?.cwd ? `${baseWs}?cwd=${encodeURIComponent(query.cwd)}` : baseWs;
           })

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
+import { createSocketHealth } from "@/lib/socket-health";
+import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
+import { useTerminalSettings } from "@/stores/terminal-settings";
 import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 import type { Theme } from "@/hooks/useTheme";
 import type { FitAddon } from "@xterm/addon-fit";
@@ -10,9 +13,7 @@ import { getAnsiPalette, getTerminalThemePreset } from "./terminal-themes";
 import { TerminalSearchBar } from "./TerminalSearchBar";
 import { WebLinkProvider } from "./web-link-provider";
 import { cacheTerminal, getCached, removeCached, type CachedTerminal } from "./terminal-cache";
-import { getCachedTerminalRestorePlan } from "./terminal-restore";
-import { createSocketHealth } from "@/lib/socket-health";
-import { useTerminalSettings } from "@/stores/terminal-settings";
+import { closeStaleCachedSocket, getCachedTerminalRestorePlan } from "./terminal-restore";
 
 function buildXtermTheme(theme: Theme, terminalThemeId: import("@/stores/terminal-settings").TerminalThemeId) {
   if (terminalThemeId !== "system") {
@@ -132,26 +133,6 @@ function extractTrustedClaudeAuthUrl(raw: string): string | null {
     return url.toString();
   } catch (_err: unknown) {
     return null;
-  }
-}
-
-function isTerminalDebugEnabled(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  try {
-    if (window.localStorage.getItem("matrix-terminal-debug") === "1") {
-      return true;
-    }
-  } catch (_err: unknown) {
-    // Ignore storage access failures.
-  }
-
-  try {
-    return new URLSearchParams(window.location.search).get("terminalDebug") === "1";
-  } catch (_err: unknown) {
-    return false;
   }
 }
 
@@ -649,6 +630,7 @@ export function TerminalPane({
       if (cached && canReuseCachedSocket) {
         bindWs(cached.ws, cached.ws.readyState === WebSocket.CONNECTING);
       } else {
+        closeStaleCachedSocket(cached);
         connectWs();
       }
 

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
+import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 import type { Theme } from "@/hooks/useTheme";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { Terminal } from "@xterm/xterm";
@@ -9,6 +10,7 @@ import { getAnsiPalette, getTerminalThemePreset } from "./terminal-themes";
 import { TerminalSearchBar } from "./TerminalSearchBar";
 import { WebLinkProvider } from "./web-link-provider";
 import { cacheTerminal, getCached, removeCached, type CachedTerminal } from "./terminal-cache";
+import { getCachedTerminalRestorePlan } from "./terminal-restore";
 import { createSocketHealth } from "@/lib/socket-health";
 import { useTerminalSettings } from "@/stores/terminal-settings";
 
@@ -133,6 +135,52 @@ function extractTrustedClaudeAuthUrl(raw: string): string | null {
   }
 }
 
+function isTerminalDebugEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    if (window.localStorage.getItem("matrix-terminal-debug") === "1") {
+      return true;
+    }
+  } catch (_err: unknown) {
+    // Ignore storage access failures.
+  }
+
+  try {
+    return new URLSearchParams(window.location.search).get("terminalDebug") === "1";
+  } catch (_err: unknown) {
+    return false;
+  }
+}
+
+function terminalDebug(event: string, details: Record<string, unknown>): void {
+  if (!isTerminalDebugEnabled()) {
+    return;
+  }
+  console.info("[terminal-debug][pane]", event, details);
+}
+
+function describeReadyState(ws: WebSocket | null): string {
+  if (!ws) {
+    return "null";
+  }
+
+  switch (ws.readyState) {
+    case WebSocket.CONNECTING:
+      return "CONNECTING";
+    case WebSocket.OPEN:
+      return "OPEN";
+    case WebSocket.CLOSING:
+      return "CLOSING";
+    case WebSocket.CLOSED:
+      return "CLOSED";
+    default:
+      return `UNKNOWN(${String((ws as { readyState?: unknown }).readyState)})`;
+  }
+}
+
 interface TerminalPaneProps {
   paneId: string;
   cwd: string;
@@ -144,6 +192,7 @@ interface TerminalPaneProps {
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   isClosing?: boolean;
   shouldCacheOnUnmount?: (paneId: string) => boolean;
+  shouldDestroyOnUnmount?: (paneId: string) => boolean;
 }
 
 export function TerminalPane({
@@ -157,6 +206,7 @@ export function TerminalPane({
   onSessionAttached,
   isClosing,
   shouldCacheOnUnmount,
+  shouldDestroyOnUnmount,
 }: TerminalPaneProps) {
   const terminalThemeId = useTerminalSettings((s) => s.themeId);
   const terminalFontSize = useTerminalSettings((s) => s.fontSize);
@@ -172,6 +222,7 @@ export function TerminalPane({
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onSessionAttachedRef = useRef(onSessionAttached);
   const shouldCacheOnUnmountRef = useRef(shouldCacheOnUnmount);
+  const shouldDestroyOnUnmountRef = useRef(shouldDestroyOnUnmount);
   const webglCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const webglContextLostHandlerRef = useRef<((event: Event) => void) | null>(null);
   const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
@@ -185,6 +236,7 @@ export function TerminalPane({
 
   onSessionAttachedRef.current = onSessionAttached;
   shouldCacheOnUnmountRef.current = shouldCacheOnUnmount;
+  shouldDestroyOnUnmountRef.current = shouldDestroyOnUnmount;
 
   const handleFocus = useCallback(() => {
     onFocus?.(paneId);
@@ -204,6 +256,17 @@ export function TerminalPane({
     let disposed = false;
 
     async function init() {
+      const log = (event: string, details: Record<string, unknown> = {}) => {
+        terminalDebug(event, {
+          paneId,
+          cwd,
+          sessionId: sessionIdRef.current,
+          lastSeq: lastSeqRef.current,
+          wsState: describeReadyState(wsRef.current),
+          ...details,
+        });
+      };
+
       const clearAuthDetectTimer = () => {
         if (authDetectTimerRef.current) {
           clearTimeout(authDetectTimerRef.current);
@@ -232,11 +295,17 @@ export function TerminalPane({
       }
 
       // Check cache first — instant tab switch
-      const cached = getCached(paneId);
-      const canReuseCached = Boolean(
-        cached &&
-        (cached.ws.readyState === WebSocket.OPEN || cached.ws.readyState === WebSocket.CONNECTING),
-      );
+      const cachedRestore = getCachedTerminalRestorePlan(getCached(paneId));
+      const cached = cachedRestore.cached;
+      const canReuseCachedTerminal = cachedRestore.reuseTerminal;
+      const canReuseCachedSocket = cachedRestore.reuseSocket;
+      log("init", {
+        cached: !!cached,
+        reuseTerminal: canReuseCachedTerminal,
+        reuseSocket: canReuseCachedSocket,
+        cachedSessionId: cachedRestore.sessionId,
+        cachedLastSeq: cachedRestore.lastSeq,
+      });
 
       let term: Terminal;
       let fitAddon: FitAddon;
@@ -279,7 +348,7 @@ export function TerminalPane({
         canvas.addEventListener("webglcontextlost", onWebglContextLost);
       };
 
-      if (canReuseCached && cached) {
+      if (canReuseCachedTerminal && cached) {
         const termElement = (cached.terminal as { element?: HTMLElement }).element;
         if (termElement) {
           container.appendChild(termElement);
@@ -293,18 +362,9 @@ export function TerminalPane({
         fitAddonRef.current = cached.fitAddon;
         searchAddonRef.current = cached.searchAddon;
         wsRef.current = cached.ws;
-        sessionIdRef.current = cached.sessionId;
-        lastSeqRef.current = cached.lastSeq;
+        sessionIdRef.current = cachedRestore.sessionId;
+        lastSeqRef.current = cachedRestore.lastSeq;
       } else {
-        if (cached) {
-          removeCached(paneId);
-          try {
-            cached.terminal.dispose();
-          } catch (err: unknown) {
-            console.warn("Failed to dispose stale terminal cache:", err instanceof Error ? err.message : err);
-          }
-        }
-
         // Cache miss — create fresh terminal
         const { Terminal: XTerm } = await import("@xterm/xterm");
         const { FitAddon } = await import("@xterm/addon-fit");
@@ -367,8 +427,18 @@ export function TerminalPane({
 
       function bindWs(ws: WebSocket, attachOnOpen: boolean) {
         wsRef.current = ws;
+        log("bind-ws", {
+          attachOnOpen,
+          boundWsState: describeReadyState(ws),
+        });
 
         const sendAttach = () => {
+          const attachMode = sessionIdRef.current ? "reattach" : "create";
+          log("send-attach", {
+            attachMode,
+            attachSessionId: sessionIdRef.current,
+            fromSeq: lastSeqRef.current,
+          });
           if (sessionIdRef.current) {
             ws.send(JSON.stringify({
               type: "attach",
@@ -393,6 +463,7 @@ export function TerminalPane({
         ws.onopen = () => {
           reconnectAttemptRef.current = 0;
           clearReconnectTimer();
+          log("ws-open", { attachOnOpen });
 
           // Start heartbeat
           if (heartbeatRef.current) heartbeatRef.current.stop();
@@ -414,6 +485,7 @@ export function TerminalPane({
         };
 
         ws.onerror = () => {
+          log("ws-error");
           if (!sessionIdRef.current) {
             term.write("\r\n\x1b[31mConnection error. Is the gateway running?\x1b[0m\r\n");
           }
@@ -421,6 +493,11 @@ export function TerminalPane({
 
         ws.onclose = () => {
           heartbeatRef.current?.stop();
+          log("ws-close", {
+            disposed,
+            isClosing: isClosingRef.current,
+            reconnectAttempt: reconnectAttemptRef.current,
+          });
           if (disposed || isClosingRef.current) return;
 
           // Attempt reconnection with exponential backoff
@@ -429,10 +506,12 @@ export function TerminalPane({
             clearReconnectTimer();
             const delay = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s
             reconnectAttemptRef.current = attempt + 1;
+            log("schedule-reconnect", { delayMs: delay, nextAttempt: reconnectAttemptRef.current });
             term.write(`\r\n\x1b[33m[Reconnecting in ${delay / 1000}s...]\x1b[0m\r\n`);
             reconnectTimerRef.current = setTimeout(() => {
               reconnectTimerRef.current = null;
               if (!disposed && !isClosingRef.current) {
+                log("run-reconnect");
                 connectWs();
               }
             }, delay);
@@ -461,6 +540,11 @@ export function TerminalPane({
 
           switch (msg.type) {
             case "attached":
+              log("attached", {
+                attachedSessionId: msg.sessionId,
+                state: msg.state,
+                exitCode: msg.exitCode ?? null,
+              });
               sessionIdRef.current = msg.sessionId;
               onSessionAttachedRef.current?.(paneId, msg.sessionId);
               if (msg.state === "exited") {
@@ -510,10 +594,13 @@ export function TerminalPane({
 
             case "error": {
               const safeMsg = stripTerminalControls(msg.message);
+              log("server-error", { message: safeMsg });
               if (safeMsg === "Session not found" && sessionIdRef.current) {
+                log("session-not-found-reset");
                 sessionIdRef.current = null;
                 lastSeqRef.current = 0;
                 term.write("\r\n\x1b[33m[Session expired, starting new session...]\x1b[0m\r\n");
+                log("fallback-create-after-session-not-found");
                 ws.send(JSON.stringify({ type: "attach", cwd }));
               } else {
                 term.write(`\r\n\x1b[31m[Error: ${safeMsg}]\x1b[0m\r\n`);
@@ -529,27 +616,54 @@ export function TerminalPane({
       }
 
       function connectWs() {
-        const baseWs = getGatewayWs().replace("/ws", "/ws/terminal");
-        const wsUrl = cwd ? `${baseWs}?cwd=${encodeURIComponent(cwd)}` : baseWs;
-        const ws = new WebSocket(wsUrl);
-        bindWs(ws, true);
+        const query =
+          sessionIdRef.current || !cwd
+            ? undefined
+            : { cwd };
+        log("connect-ws", {
+          queryCwd: query?.cwd ?? null,
+          reconnectAttempt: reconnectAttemptRef.current,
+        });
+
+        void buildAuthenticatedWebSocketUrl("/ws/terminal", {
+          cwd: query?.cwd,
+        })
+          .catch(() => {
+            const baseWs = getGatewayWs().replace("/ws", "/ws/terminal");
+            return query?.cwd ? `${baseWs}?cwd=${encodeURIComponent(query.cwd)}` : baseWs;
+          })
+          .then((wsUrl) => {
+            if (disposed || isClosingRef.current) {
+              log("connect-ws-abort", { reason: disposed ? "disposed" : "closing" });
+              return;
+            }
+            log("connect-ws-url", {
+              urlIncludesCwd: wsUrl.includes("cwd="),
+              urlIncludesToken: wsUrl.includes("token="),
+            });
+            const ws = new WebSocket(wsUrl);
+            bindWs(ws, true);
+          });
       }
 
-      if (canReuseCached && cached) {
+      if (cached && canReuseCachedSocket) {
         bindWs(cached.ws, cached.ws.readyState === WebSocket.CONNECTING);
       } else {
         connectWs();
       }
 
       const onVisibilityChange = () => {
+        log("visibilitychange", { visibilityState: document.visibilityState });
         if (document.visibilityState === "visible") {
           const ws = wsRef.current;
           if (ws?.readyState === WebSocket.OPEN) {
+            log("visibility-ping-now");
             heartbeatRef.current?.pingNow();
           } else if (!disposed && !isClosingRef.current && sessionIdRef.current) {
             // Disconnected while hidden, reconnect now
             reconnectAttemptRef.current = 0;
             clearReconnectTimer();
+            log("visibility-reconnect-now");
             connectWs();
           }
         }
@@ -629,33 +743,34 @@ export function TerminalPane({
         onResizeDisposableRef.current?.dispose();
         onResizeDisposableRef.current = null;
         const shouldCache = !isClosingRef.current && (shouldCacheOnUnmountRef.current?.(paneId) ?? true);
+        const shouldDestroy = shouldDestroyOnUnmountRef.current?.(paneId) ?? false;
+        log("cleanup", {
+          shouldCache,
+          shouldDestroy,
+          isClosing: isClosingRef.current,
+          paneStillInTree: shouldCacheOnUnmountRef.current?.(paneId) ?? true,
+        });
 
         if (!shouldCache) {
-          // Pane is being closed — destroy the backend session so it doesn't leak.
+          // Plain unmounts should not destroy the session. Explicit pane/tab close
+          // may still need to destroy a just-created session before layout state
+          // has been updated with its session id.
           const ws = wsRef.current;
-          const sid = sessionIdRef.current;
           if (ws && ws.readyState === WebSocket.OPEN) {
-            ws.send(JSON.stringify({ type: "destroy" }));
-          } else if (sid) {
-            // WS is CONNECTING/CLOSING/CLOSED so we can't send over it. Fall
-            // back to the REST endpoint so an existing session still gets
-            // killed (otherwise it'd leak until eviction).
-            void fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sid)}`, {
-              method: "DELETE",
-              keepalive: true,
-              signal: AbortSignal.timeout(5_000),
-            }).catch((err: unknown) => {
-              console.warn(
-                "Failed to destroy terminal session on close:",
-                err instanceof Error ? err.message : err,
-              );
-            });
+            if (shouldDestroy) {
+              log("cleanup-destroy-via-ws");
+              ws.send(JSON.stringify({ type: "destroy" }));
+            } else {
+              log("cleanup-detach-via-ws");
+              ws.send(JSON.stringify({ type: "detach" }));
+            }
           }
           ws?.close();
           removeCached(paneId);
           term.dispose();
         } else if (wsRef.current) {
           // Tab switch — cache the terminal for instant restore
+          log("cleanup-cache-terminal");
           const termElement = (term as { element?: HTMLElement }).element;
           if (termElement?.parentNode) {
             termElement.parentNode.removeChild(termElement);
@@ -672,6 +787,7 @@ export function TerminalPane({
           });
         } else {
           // WS never established — dispose, don't cache
+          log("cleanup-dispose-no-ws");
           term.dispose();
         }
       };

--- a/shell/src/components/terminal/terminal-cache.ts
+++ b/shell/src/components/terminal/terminal-cache.ts
@@ -14,13 +14,50 @@ export interface CachedTerminal {
 const MAX_CACHED = 20;
 const cache = new Map<string, CachedTerminal>();
 
+function isTerminalDebugEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    if (window.localStorage.getItem("matrix-terminal-debug") === "1") {
+      return true;
+    }
+  } catch (_err: unknown) {
+    // Ignore storage access failures.
+  }
+
+  try {
+    return new URLSearchParams(window.location.search).get("terminalDebug") === "1";
+  } catch (_err: unknown) {
+    return false;
+  }
+}
+
+function terminalCacheDebug(event: string, details: Record<string, unknown>): void {
+  if (!isTerminalDebugEnabled()) {
+    return;
+  }
+  console.info("[terminal-debug][cache]", event, details);
+}
+
 export function cacheTerminal(paneId: string, entry: CachedTerminal): void {
+  terminalCacheDebug("cache-put", {
+    paneId,
+    sessionId: entry.sessionId,
+    lastSeq: entry.lastSeq,
+    cacheSizeBefore: cache.size,
+  });
   cache.delete(paneId);
   while (cache.size >= MAX_CACHED) {
     const oldest = cache.keys().next().value!;
     const evicted = cache.get(oldest);
     cache.delete(oldest);
     if (evicted) {
+      terminalCacheDebug("cache-evict", {
+        paneId: oldest,
+        sessionId: evicted.sessionId,
+      });
       try { evicted.ws.send(JSON.stringify({ type: "detach" })); } catch (e: unknown) { console.warn("Cache eviction detach:", e instanceof Error ? e.message : e); }
       try { evicted.ws.close(); } catch (e: unknown) { console.warn("Cache eviction ws.close:", e instanceof Error ? e.message : e); }
       try { evicted.terminal.dispose(); } catch (e: unknown) { console.warn("Cache eviction dispose:", e instanceof Error ? e.message : e); }
@@ -31,6 +68,11 @@ export function cacheTerminal(paneId: string, entry: CachedTerminal): void {
 
 export function getCached(paneId: string): CachedTerminal | null {
   const entry = cache.get(paneId);
+  terminalCacheDebug("cache-get", {
+    paneId,
+    hit: !!entry,
+    sessionId: entry?.sessionId ?? null,
+  });
   if (entry) {
     cache.delete(paneId);
     cache.set(paneId, entry);
@@ -39,6 +81,7 @@ export function getCached(paneId: string): CachedTerminal | null {
 }
 
 export function removeCached(paneId: string): void {
+  terminalCacheDebug("cache-remove", { paneId, hadEntry: cache.has(paneId) });
   cache.delete(paneId);
 }
 

--- a/shell/src/components/terminal/terminal-cache.ts
+++ b/shell/src/components/terminal/terminal-cache.ts
@@ -1,5 +1,6 @@
 import type { Terminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
+import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 
 export interface CachedTerminal {
   terminal: Terminal;
@@ -13,26 +14,6 @@ export interface CachedTerminal {
 
 const MAX_CACHED = 20;
 const cache = new Map<string, CachedTerminal>();
-
-function isTerminalDebugEnabled(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  try {
-    if (window.localStorage.getItem("matrix-terminal-debug") === "1") {
-      return true;
-    }
-  } catch (_err: unknown) {
-    // Ignore storage access failures.
-  }
-
-  try {
-    return new URLSearchParams(window.location.search).get("terminalDebug") === "1";
-  } catch (_err: unknown) {
-    return false;
-  }
-}
 
 function terminalCacheDebug(event: string, details: Record<string, unknown>): void {
   if (!isTerminalDebugEnabled()) {

--- a/shell/src/components/terminal/terminal-restore.ts
+++ b/shell/src/components/terminal/terminal-restore.ts
@@ -29,3 +29,11 @@ export function getCachedTerminalRestorePlan(cached: CachedTerminal | null): Cac
     lastSeq: cached.lastSeq,
   };
 }
+
+export function closeStaleCachedSocket(cached: CachedTerminal | null): void {
+  if (!cached || cached.ws.readyState === WebSocket.CLOSED) {
+    return;
+  }
+
+  cached.ws.close();
+}

--- a/shell/src/components/terminal/terminal-restore.ts
+++ b/shell/src/components/terminal/terminal-restore.ts
@@ -1,0 +1,31 @@
+import type { CachedTerminal } from "./terminal-cache";
+
+export interface CachedTerminalRestorePlan {
+  cached: CachedTerminal | null;
+  reuseTerminal: boolean;
+  reuseSocket: boolean;
+  sessionId: string | null;
+  lastSeq: number;
+}
+
+export function getCachedTerminalRestorePlan(cached: CachedTerminal | null): CachedTerminalRestorePlan {
+  if (!cached) {
+    return {
+      cached: null,
+      reuseTerminal: false,
+      reuseSocket: false,
+      sessionId: null,
+      lastSeq: 0,
+    };
+  }
+
+  const reuseSocket = cached.ws.readyState === WebSocket.OPEN || cached.ws.readyState === WebSocket.CONNECTING;
+
+  return {
+    cached,
+    reuseTerminal: true,
+    reuseSocket,
+    sessionId: cached.sessionId || null,
+    lastSeq: cached.lastSeq,
+  };
+}

--- a/shell/src/hooks/useSocket.ts
+++ b/shell/src/hooks/useSocket.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { getGatewayWs } from "@/lib/gateway";
+import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 import { createSocketHealth, MessageQueue, reconnectDelay } from "@/lib/socket-health";
 import { useConnectionHealth } from "./useConnectionHealth";
 
@@ -24,7 +25,6 @@ export type ServerMessage =
 
 type MessageHandler = (msg: ServerMessage) => void;
 
-const GATEWAY_WS = getGatewayWs();
 const PING_INTERVAL = 30_000;
 const PONG_TIMEOUT = 5_000;
 const MAX_RECONNECT_ATTEMPTS = 60;
@@ -71,45 +71,53 @@ function connect() {
   if (globalSocket?.readyState === WebSocket.CONNECTING) return;
 
   setConnectionState("reconnecting");
-  globalSocket = new WebSocket(GATEWAY_WS);
-
-  globalSocket.onopen = () => {
-    reconnectAttempt = 0;
-    setConnectionState("connected");
-    heartbeat.start();
-    drainQueue();
-  };
-
-  globalSocket.onmessage = (evt) => {
-    try {
-      const msg = JSON.parse(evt.data) as ServerMessage;
-      if (msg.type === "pong") {
-        heartbeat.receivedPong();
+  void buildAuthenticatedWebSocketUrl("/ws")
+    .catch(() => null)
+    .then((wsUrl) => {
+      if (globalSocket?.readyState === WebSocket.OPEN || globalSocket?.readyState === WebSocket.CONNECTING) {
         return;
       }
-      for (const handler of handlers) {
-        handler(msg);
-      }
-    } catch {
-      // ignore malformed messages
-    }
-  };
 
-  globalSocket.onclose = () => {
-    heartbeat.stop();
-    if (reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
-      setConnectionState("disconnected");
-      return;
-    }
-    setConnectionState("reconnecting");
-    const delay = reconnectDelay(reconnectAttempt);
-    reconnectAttempt++;
-    reconnectTimer = setTimeout(connect, delay);
-  };
+      globalSocket = new WebSocket(wsUrl ?? getGatewayWs());
 
-  globalSocket.onerror = () => {
-    globalSocket?.close();
-  };
+      globalSocket.onopen = () => {
+        reconnectAttempt = 0;
+        setConnectionState("connected");
+        heartbeat.start();
+        drainQueue();
+      };
+
+      globalSocket.onmessage = (evt) => {
+        try {
+          const msg = JSON.parse(evt.data) as ServerMessage;
+          if (msg.type === "pong") {
+            heartbeat.receivedPong();
+            return;
+          }
+          for (const handler of handlers) {
+            handler(msg);
+          }
+        } catch (_err: unknown) {
+          // ignore malformed messages
+        }
+      };
+
+      globalSocket.onclose = () => {
+        heartbeat.stop();
+        if (reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
+          setConnectionState("disconnected");
+          return;
+        }
+        setConnectionState("reconnecting");
+        const delay = reconnectDelay(reconnectAttempt);
+        reconnectAttempt++;
+        reconnectTimer = setTimeout(connect, delay);
+      };
+
+      globalSocket.onerror = () => {
+        globalSocket?.close();
+      };
+    });
 }
 
 export function ensureConnected() {

--- a/shell/src/hooks/useSocket.ts
+++ b/shell/src/hooks/useSocket.ts
@@ -72,7 +72,13 @@ function connect() {
 
   setConnectionState("reconnecting");
   void buildAuthenticatedWebSocketUrl("/ws")
-    .catch(() => null)
+    .catch((err: unknown) => {
+      console.warn(
+        "[useSocket] Falling back to unauthenticated websocket URL:",
+        err instanceof Error ? err.message : err,
+      );
+      return null;
+    })
     .then((wsUrl) => {
       if (globalSocket?.readyState === WebSocket.OPEN || globalSocket?.readyState === WebSocket.CONNECTING) {
         return;

--- a/shell/src/hooks/useVoice.ts
+++ b/shell/src/hooks/useVoice.ts
@@ -40,7 +40,13 @@ export function useVoice(opts?: UseVoiceOptions): UseVoiceReturn {
   const getWsUrl = useCallback(async () => {
     if (opts?.wsUrl) return opts.wsUrl;
     return buildAuthenticatedWebSocketUrl("/ws/voice")
-      .catch(() => getGatewayWs().replace(/\/ws$/, "/ws/voice"));
+      .catch((err: unknown) => {
+        console.warn(
+          "[useVoice] Falling back to unauthenticated voice websocket URL:",
+          err instanceof Error ? err.message : err,
+        );
+        return getGatewayWs().replace(/\/ws$/, "/ws/voice");
+      });
   }, [opts?.wsUrl]);
 
   const connectWs = useCallback(async () => {
@@ -69,7 +75,12 @@ export function useVoice(opts?: UseVoiceOptions): UseVoiceReturn {
             setIsTranscribing(false);
             opts?.onError?.(msg.message);
           }
-        } catch (_err: unknown) {}
+        } catch (_err: unknown) {
+          console.warn(
+            "[useVoice] malformed ws message:",
+            _err instanceof Error ? _err.message : _err,
+          );
+        }
       } else if (event.data instanceof Blob) {
         event.data.arrayBuffer().then((buffer) => playAudio(buffer));
       }
@@ -170,7 +181,12 @@ export function useVoice(opts?: UseVoiceOptions): UseVoiceReturn {
         mediaRecorderRef.current.stop();
       }
       if (audioContextRef.current) {
-        audioContextRef.current.close().catch((_err: unknown) => {});
+        audioContextRef.current.close().catch((_err: unknown) => {
+          console.warn(
+            "[useVoice] AudioContext close failed:",
+            _err instanceof Error ? _err.message : _err,
+          );
+        });
         audioContextRef.current = null;
       }
     };

--- a/shell/src/hooks/useVoice.ts
+++ b/shell/src/hooks/useVoice.ts
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { getGatewayWs } from "../lib/gateway";
+import { buildAuthenticatedWebSocketUrl } from "../lib/websocket-auth";
 
 interface UseVoiceOptions {
   wsUrl?: string;
@@ -36,15 +37,16 @@ export function useVoice(opts?: UseVoiceOptions): UseVoiceReturn {
   const wsRef = useRef<WebSocket | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
 
-  const getWsUrl = useCallback(() => {
+  const getWsUrl = useCallback(async () => {
     if (opts?.wsUrl) return opts.wsUrl;
-    return getGatewayWs().replace(/\/ws$/, "/ws/voice");
+    return buildAuthenticatedWebSocketUrl("/ws/voice")
+      .catch(() => getGatewayWs().replace(/\/ws$/, "/ws/voice"));
   }, [opts?.wsUrl]);
 
-  const connectWs = useCallback(() => {
+  const connectWs = useCallback(async () => {
     if (wsRef.current?.readyState === WebSocket.OPEN) return wsRef.current;
 
-    const ws = new WebSocket(getWsUrl());
+    const ws = new WebSocket(await getWsUrl());
     wsRef.current = ws;
 
     ws.onmessage = (event) => {
@@ -56,20 +58,18 @@ export function useVoice(opts?: UseVoiceOptions): UseVoiceReturn {
             opts.onTranscription(msg.text);
           }
           if (msg.type === "voice_audio" && msg.audio) {
-            const MIME_MAP: Record<string, string> = { mp3: "audio/mpeg", wav: "audio/wav", ogg: "audio/ogg", opus: "audio/opus", webm: "audio/webm", flac: "audio/flac" };
-            const mime = MIME_MAP[msg.format] ?? "audio/mpeg";
             try {
               const binary = atob(msg.audio);
               const bytes = new Uint8Array(binary.length);
               for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
               playAudio(bytes.buffer);
-            } catch { /* decode error */ }
+            } catch (_err: unknown) { /* decode error */ }
           }
           if (msg.type === "voice_error") {
             setIsTranscribing(false);
             opts?.onError?.(msg.message);
           }
-        } catch {}
+        } catch (_err: unknown) {}
       } else if (event.data instanceof Blob) {
         event.data.arrayBuffer().then((buffer) => playAudio(buffer));
       }
@@ -107,20 +107,24 @@ export function useVoice(opts?: UseVoiceOptions): UseVoiceReturn {
 
         setIsTranscribing(true);
 
-        const ws = connectWs();
-        const sendAudio = () => {
-          ws.send(JSON.stringify({ type: "audio_start" }));
-          blob.arrayBuffer().then((buffer) => {
-            ws.send(buffer);
-            ws.send(JSON.stringify({ type: "audio_end" }));
-          });
-        };
+        void connectWs().then((ws) => {
+          const sendAudio = () => {
+            ws.send(JSON.stringify({ type: "audio_start" }));
+            blob.arrayBuffer().then((buffer) => {
+              ws.send(buffer);
+              ws.send(JSON.stringify({ type: "audio_end" }));
+            });
+          };
 
-        if (ws.readyState === WebSocket.OPEN) {
-          sendAudio();
-        } else {
-          ws.addEventListener("open", sendAudio, { once: true });
-        }
+          if (ws.readyState === WebSocket.OPEN) {
+            sendAudio();
+          } else {
+            ws.addEventListener("open", sendAudio, { once: true });
+          }
+        }).catch(() => {
+          setIsTranscribing(false);
+          opts?.onError?.("Voice WebSocket connection failed");
+        });
       };
 
       mediaRecorderRef.current = recorder;
@@ -166,7 +170,7 @@ export function useVoice(opts?: UseVoiceOptions): UseVoiceReturn {
         mediaRecorderRef.current.stop();
       }
       if (audioContextRef.current) {
-        audioContextRef.current.close().catch(() => {});
+        audioContextRef.current.close().catch((_err: unknown) => {});
         audioContextRef.current = null;
       }
     };

--- a/shell/src/lib/terminal-debug.ts
+++ b/shell/src/lib/terminal-debug.ts
@@ -1,0 +1,19 @@
+export function isTerminalDebugEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    if (window.localStorage.getItem("matrix-terminal-debug") === "1") {
+      return true;
+    }
+  } catch (_err: unknown) {
+    // Ignore storage access failures.
+  }
+
+  try {
+    return new URLSearchParams(window.location.search).get("terminalDebug") === "1";
+  } catch (_err: unknown) {
+    return false;
+  }
+}

--- a/shell/src/lib/websocket-auth.ts
+++ b/shell/src/lib/websocket-auth.ts
@@ -1,0 +1,83 @@
+import { getGatewayUrl, getGatewayWs } from "./gateway";
+
+const WS_AUTH_PATH = "/api/auth/ws-token";
+const WS_TOKEN_REFRESH_SKEW_MS = 30_000;
+
+let cachedToken: string | null = null;
+let cachedExpiresAt = 0;
+let inflightTokenRequest: Promise<string | null> | null = null;
+
+interface WsTokenResponse {
+  token?: unknown;
+  expiresAt?: unknown;
+}
+
+function getCachedToken(now = Date.now()): string | null {
+  if (!cachedToken) {
+    return null;
+  }
+  if (cachedExpiresAt - WS_TOKEN_REFRESH_SKEW_MS <= now) {
+    cachedToken = null;
+    cachedExpiresAt = 0;
+    return null;
+  }
+  return cachedToken;
+}
+
+async function fetchWebSocketToken(): Promise<string | null> {
+  const res = await fetch(`${getGatewayUrl()}${WS_AUTH_PATH}`, {
+    credentials: "same-origin",
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    return null;
+  }
+  const body = await res.json() as WsTokenResponse;
+  if (typeof body.token !== "string" || typeof body.expiresAt !== "number") {
+    return null;
+  }
+  cachedToken = body.token;
+  cachedExpiresAt = body.expiresAt;
+  return body.token;
+}
+
+export async function getWebSocketAuthToken(): Promise<string | null> {
+  const cached = getCachedToken();
+  if (cached) {
+    return cached;
+  }
+  if (!inflightTokenRequest) {
+    inflightTokenRequest = fetchWebSocketToken().finally(() => {
+      inflightTokenRequest = null;
+    });
+  }
+  return inflightTokenRequest;
+}
+
+export async function buildAuthenticatedWebSocketUrl(
+  path: string,
+  query?: Record<string, string | undefined>,
+): Promise<string> {
+  const gatewayUrl = new URL(getGatewayWs());
+  gatewayUrl.pathname = path;
+  gatewayUrl.search = "";
+
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (typeof value === "string" && value.length > 0) {
+      gatewayUrl.searchParams.set(key, value);
+    }
+  }
+
+  const token = await getWebSocketAuthToken();
+  if (token) {
+    gatewayUrl.searchParams.set("token", token);
+  }
+
+  return gatewayUrl.toString();
+}
+
+export function resetWebSocketAuthTokenCacheForTests(): void {
+  cachedToken = null;
+  cachedExpiresAt = 0;
+  inflightTokenRequest = null;
+}

--- a/tests/gateway/auth-jwt.test.ts
+++ b/tests/gateway/auth-jwt.test.ts
@@ -33,12 +33,12 @@ function signHs256Jwt(
   return `${signingInput}.${base64UrlEncode(signature)}`;
 }
 
-function mockContext(path: string, authHeader?: string, ip?: string) {
+function mockContext(path: string, authHeader?: string, ip?: string, url?: string) {
   const store = new Map<string, unknown>();
   return {
     req: {
       path,
-      url: `http://localhost:4000${path}`,
+      url: url ?? `http://localhost:4000${path}`,
       header: (name: string) => {
         if (name === "Authorization") return authHeader;
         if (name === "X-Forwarded-For" && ip) return ip;
@@ -184,6 +184,30 @@ describe("authMiddleware: hybrid bearer + JWT acceptance", () => {
     let nextCalled = false;
     await mw(
       mockContext("/api/message", `Bearer ${issued.token}`),
+      async () => {
+        nextCalled = true;
+      },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
+  it("accepts a valid sync JWT in the websocket query string", async () => {
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: HANDLE,
+      gatewayUrl: "https://app.matrix-os.com",
+    });
+
+    const mw = authMiddleware("legacy-shared-secret");
+    let nextCalled = false;
+    await mw(
+      mockContext(
+        "/ws/terminal",
+        undefined,
+        undefined,
+        `http://localhost:4000/ws/terminal?token=${encodeURIComponent(issued.token)}&cwd=projects`,
+      ),
       async () => {
         nextCalled = true;
       },

--- a/tests/platform/ws-upgrade.test.ts
+++ b/tests/platform/ws-upgrade.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getWebSocketUpgradeHost,
   getWebSocketUpgradeToken,
+  isAppDomainHost,
   isSafeWebSocketUpgradePath,
   stripWebSocketUpgradeToken,
 } from "../../packages/platform/src/ws-upgrade.js";
@@ -34,5 +35,12 @@ describe("isSafeWebSocketUpgradePath", () => {
 
   it("falls back to host when x-forwarded-host is absent", () => {
     expect(getWebSocketUpgradeHost("app.matrix-os.com", undefined)).toBe("app.matrix-os.com");
+  });
+
+  it("accepts only app-domain websocket hosts", () => {
+    expect(isAppDomainHost("app.matrix-os.com")).toBe(true);
+    expect(isAppDomainHost("app.localhost:3000")).toBe(true);
+    expect(isAppDomainHost("legacy.matrix-os.com")).toBe(false);
+    expect(isAppDomainHost("malicious.example.com")).toBe(false);
   });
 });

--- a/tests/platform/ws-upgrade.test.ts
+++ b/tests/platform/ws-upgrade.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isSafeWebSocketUpgradePath } from "../../packages/platform/src/ws-upgrade.js";
+import {
+  getWebSocketUpgradeHost,
+  getWebSocketUpgradeToken,
+  isSafeWebSocketUpgradePath,
+  stripWebSocketUpgradeToken,
+} from "../../packages/platform/src/ws-upgrade.js";
 
 describe("isSafeWebSocketUpgradePath", () => {
   it("accepts normal websocket paths", () => {
@@ -10,5 +15,24 @@ describe("isSafeWebSocketUpgradePath", () => {
   it("rejects CRLF injection in the request target", () => {
     expect(isSafeWebSocketUpgradePath("/ws\r\nX-Evil: yes")).toBe(false);
     expect(isSafeWebSocketUpgradePath("/ws\nGET /admin HTTP/1.1")).toBe(false);
+  });
+
+  it("extracts the websocket query token", () => {
+    expect(getWebSocketUpgradeToken("/ws?token=abc123&cwd=projects")).toBe("abc123");
+    expect(getWebSocketUpgradeToken("/ws?cwd=projects")).toBeNull();
+  });
+
+  it("strips the websocket query token before proxying upstream", () => {
+    expect(stripWebSocketUpgradeToken("/ws?token=abc123&cwd=projects")).toBe("/ws?cwd=projects");
+    expect(stripWebSocketUpgradeToken("/ws/terminal?token=abc123")).toBe("/ws/terminal");
+  });
+
+  it("prefers x-forwarded-host for websocket host resolution", () => {
+    expect(getWebSocketUpgradeHost("platform:9000", "app.matrix-os.com")).toBe("app.matrix-os.com");
+    expect(getWebSocketUpgradeHost("platform:9000", "app.matrix-os.com, platform:9000")).toBe("app.matrix-os.com");
+  });
+
+  it("falls back to host when x-forwarded-host is absent", () => {
+    expect(getWebSocketUpgradeHost("app.matrix-os.com", undefined)).toBe("app.matrix-os.com");
   });
 });

--- a/tests/shell/integrations-section-component.test.tsx
+++ b/tests/shell/integrations-section-component.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { buildAuthenticatedWebSocketUrl } = vi.hoisted(() => ({
+  buildAuthenticatedWebSocketUrl: vi.fn<() => Promise<string>>(),
+}));
+
+vi.mock("@/lib/websocket-auth", () => ({
+  buildAuthenticatedWebSocketUrl,
+}));
+
+vi.mock("@/lib/gateway", () => ({
+  getGatewayUrl: () => "http://gateway.test",
+  getGatewayWs: () => "ws://gateway.test/ws",
+}));
+
+import { IntegrationsSection } from "../../shell/src/components/settings/sections/IntegrationsSection.js";
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("IntegrationsSection websocket lifecycle", () => {
+  const fetchMock = vi.fn((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/integrations/available")) {
+      return Promise.resolve({ ok: true, json: async () => ({ services: [] }) });
+    }
+    if (url.includes("/api/integrations")) {
+      return Promise.resolve({ ok: true, json: async () => ({ connections: [] }) });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+
+  beforeEach(() => {
+    fetchMock.mockClear();
+    buildAuthenticatedWebSocketUrl.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not open a websocket after unmount when the authenticated URL resolves late", async () => {
+    const deferred = createDeferred<string>();
+    const webSocketCtor = vi.fn(function WebSocketMock(this: { close: ReturnType<typeof vi.fn> }) {
+      this.close = vi.fn();
+    });
+    buildAuthenticatedWebSocketUrl.mockReturnValueOnce(deferred.promise);
+    vi.stubGlobal("WebSocket", webSocketCtor as unknown as typeof WebSocket);
+
+    const { unmount } = render(<IntegrationsSection />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    unmount();
+
+    await act(async () => {
+      deferred.resolve("ws://gateway.test/ws?token=late");
+      await deferred.promise;
+      await Promise.resolve();
+    });
+
+    expect(webSocketCtor).not.toHaveBeenCalled();
+  });
+});

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { act, render } from "@testing-library/react";
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
 
 const paneGridSpy = vi.fn();
@@ -141,5 +142,32 @@ describe("TerminalApp", () => {
         },
       ],
     });
+  });
+
+  it("destroys a just-attached session when the tab closes before layout state catches up", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const props = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { type: "pane"; id: string };
+      onSessionAttached: (paneId: string, sessionId: string) => void;
+    };
+
+    act(() => {
+      props.onSessionAttached(props.paneTree.id, "session-pending-close");
+    });
+
+    fireEvent.click(screen.getByText("x"));
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const deleteCalls = fetchMock.mock.calls.filter(([input, init]) => (
+      String(input).includes("/api/terminal/sessions/session-pending-close") && init?.method === "DELETE"
+    ));
+
+    expect(deleteCalls.length).toBe(1);
   });
 });

--- a/tests/shell/terminal-debug.test.ts
+++ b/tests/shell/terminal-debug.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isTerminalDebugEnabled } from "../../shell/src/lib/terminal-debug.js";
+
+describe("isTerminalDebugEnabled", () => {
+  let storage: { getItem: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    storage = {
+      getItem: vi.fn(() => null),
+    };
+    Object.defineProperty(window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("enables terminal debug via localStorage", () => {
+    storage.getItem.mockImplementation((key: string) => (
+      key === "matrix-terminal-debug" ? "1" : null
+    ));
+
+    expect(isTerminalDebugEnabled()).toBe(true);
+  });
+
+  it("enables terminal debug via query string", () => {
+    window.history.replaceState({}, "", "/?terminalDebug=1");
+
+    expect(isTerminalDebugEnabled()).toBe(true);
+  });
+
+  it("stays disabled when neither flag is present", () => {
+    expect(isTerminalDebugEnabled()).toBe(false);
+  });
+});

--- a/tests/shell/terminal-pane.test.tsx
+++ b/tests/shell/terminal-pane.test.tsx
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { getCachedTerminalRestorePlan } from "../../shell/src/components/terminal/terminal-restore.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  closeStaleCachedSocket,
+  getCachedTerminalRestorePlan,
+} from "../../shell/src/components/terminal/terminal-restore.js";
 import type { CachedTerminal } from "../../shell/src/components/terminal/terminal-cache.js";
 
 describe("getCachedTerminalRestorePlan", () => {
@@ -20,5 +23,45 @@ describe("getCachedTerminalRestorePlan", () => {
     expect(plan.reuseSocket).toBe(false);
     expect(plan.sessionId).toBe("session-123");
     expect(plan.lastSeq).toBe(42);
+  });
+
+  it("closes a stale cached socket before reconnecting", () => {
+    const close = vi.fn();
+    const cached = {
+      terminal: {} as CachedTerminal["terminal"],
+      fitAddon: {} as CachedTerminal["fitAddon"],
+      webglAddon: null,
+      searchAddon: null,
+      ws: {
+        readyState: WebSocket.CLOSING,
+        close,
+      } as unknown as WebSocket,
+      lastSeq: 7,
+      sessionId: "session-456",
+    } satisfies CachedTerminal;
+
+    closeStaleCachedSocket(cached);
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("does not re-close an already closed cached socket", () => {
+    const close = vi.fn();
+    const cached = {
+      terminal: {} as CachedTerminal["terminal"],
+      fitAddon: {} as CachedTerminal["fitAddon"],
+      webglAddon: null,
+      searchAddon: null,
+      ws: {
+        readyState: WebSocket.CLOSED,
+        close,
+      } as unknown as WebSocket,
+      lastSeq: 7,
+      sessionId: "session-456",
+    } satisfies CachedTerminal;
+
+    closeStaleCachedSocket(cached);
+
+    expect(close).not.toHaveBeenCalled();
   });
 });

--- a/tests/shell/terminal-pane.test.tsx
+++ b/tests/shell/terminal-pane.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getCachedTerminalRestorePlan } from "../../shell/src/components/terminal/terminal-restore.js";
+import type { CachedTerminal } from "../../shell/src/components/terminal/terminal-cache.js";
+
+describe("getCachedTerminalRestorePlan", () => {
+  it("preserves cached session state even when the cached socket can no longer be reused", () => {
+    const cached = {
+      terminal: {} as CachedTerminal["terminal"],
+      fitAddon: {} as CachedTerminal["fitAddon"],
+      webglAddon: null,
+      searchAddon: null,
+      ws: { readyState: 3 } as WebSocket,
+      lastSeq: 42,
+      sessionId: "session-123",
+    } satisfies CachedTerminal;
+
+    const plan = getCachedTerminalRestorePlan(cached);
+
+    expect(plan.reuseTerminal).toBe(true);
+    expect(plan.reuseSocket).toBe(false);
+    expect(plan.sessionId).toBe("session-123");
+    expect(plan.lastSeq).toBe(42);
+  });
+});

--- a/tests/shell/useSocket.test.ts
+++ b/tests/shell/useSocket.test.ts
@@ -160,7 +160,7 @@ describe("useSocket message protocol", () => {
     ws.onmessage = (evt) => {
       try {
         received.push(JSON.parse(evt.data));
-      } catch {
+      } catch (_err: unknown) {
         // Ignored, matching hook behavior
       }
     };
@@ -174,10 +174,18 @@ describe("useSocket heartbeat and resilience", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     MockWebSocket.instances = [];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      token: "ws-token",
+      expiresAt: Date.now() + 60_000,
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })));
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   it("sends ping every 30 seconds when connected", async () => {
@@ -192,6 +200,7 @@ describe("useSocket heartbeat and resilience", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     const ws = MockWebSocket.instances[0];
+    expect(ws.url).toContain("token=ws-token");
 
     // Advance 30s for first ping
     vi.advanceTimersByTime(30_000);


### PR DESCRIPTION
## Summary
- preserve terminal sessions across websocket reconnects and tab switches instead of treating ordinary unmounts as terminal destruction
- add short-lived authenticated websocket tokens for browser sockets so `/ws`, `/ws/terminal`, `/ws/voice`, and integrations sockets reconnect through the app domain reliably
- fix pane identity leakage during terminal tab switches by giving terminal panes stable React keys and by separating cached terminal reuse from cached websocket reuse
- add focused regression coverage for gateway JWT auth, platform websocket upgrades, terminal pane restore, terminal app behavior, and browser socket auth

## Root Cause
Two client-side issues were combining into the terminal failure:
- terminal panes could be remounted across different tabs without a stable React identity, which leaked session refs between panes
- plain pane unmounts could behave too much like terminal closure, so session ownership was lost during in-app tab switches

The server-side reattach path was already working, so this PR hardens the browser/gateway path that sits on top of it.

## Validation
- `pnpm exec vitest run tests/gateway/auth-jwt.test.ts tests/platform/ws-upgrade.test.ts tests/shell/terminal-app-component.test.tsx tests/shell/terminal-pane.test.tsx tests/shell/useSocket.test.ts`
- live verification on the `hamedmp` container showed the terminal surviving in-app tab switches after deploy

## Notes
This PR intentionally does not include the broader platform-origin / cloudflared stability work. That is being handled separately because it is a distinct reliability issue from the terminal tab-switch bug.