### PR TITLE
fix(cli/package.json): drop ./ prefix from bin paths

### DIFF
--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -24,9 +24,9 @@
     "node": ">=24"
   },
   "bin": {
-    "matrix": "./bin/matrix.mjs",
-    "matrixos": "./bin/matrix.mjs",
-    "mos": "./bin/matrix.mjs"
+    "matrix": "bin/matrix.mjs",
+    "matrixos": "bin/matrix.mjs",
+    "mos": "bin/matrix.mjs"
   },
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## Summary
`packages/sync-client/package.json` had bin paths prefixed with `./`:

```json
"bin": {
  "matrix": "./bin/matrix.mjs",
  "matrixos": "./bin/matrix.mjs",
  "mos": "./bin/matrix.mjs"
}
```

npm 11 (running on the CI runner with setup-node@v4 + node 24) treats this as invalid and **silently removes the bin entry** on publish. npm 10 cleans the path quietly, which hid the issue from local `npm pack --dry-run`. The v0.2.4 publish surfaced this with three warnings:

```
npm warn publish "bin[matrix]" script name bin/matrix.mjs was invalid and removed
npm warn publish "bin[matrixos]" script name bin/matrix.mjs was invalid and removed
npm warn publish "bin[mos]" script name bin/matrix.mjs was invalid and removed
```

The package would have shipped with no executable `matrix` / `matrixos` / `mos` commands -- effectively unusable -- if 2FA hadn't blocked the publish at the same step.

This is what `npm pkg fix` produces: drop the `./` prefix.

## Verification
`npm publish --dry-run` on the fixed branch (with deploy user's npm 10) no longer shows any bin warnings.

## Test plan
- [ ] Merge.
- [ ] Resolve the separate npm 2FA issue (see release run 24800958096 / EOTP error). Options: regenerate `NPM_TOKEN` as a Granular Access Token with 2FA bypass, OR set up OIDC trusted publishing on npmjs.com (best long-term — workflow already has `id-token: write` + `--provenance`).
- [ ] Re-dispatch `release.yml` with `version: 0.2.4` and confirm publish + GitHub release + brew formula bump all run, and the published package's `bin` field contains all three commands.