### PR TITLE
fix: harden platform proxy container resolution

### DIFF
--- a/packages/gateway/src/git-sync.ts
+++ b/packages/gateway/src/git-sync.ts
@@ -77,9 +77,21 @@ export function createAutoSync(sync: GitSync, options: AutoSyncOptions = {}): Au
   };
 }
 
+// Ensure git has a committer identity even when the host lacks global config
+// (e.g. ephemeral CI runners, fresh containers). Overridable via env.
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Matrix OS",
+  GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "matrix-os@users.noreply.github.com",
+  GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Matrix OS",
+  GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "matrix-os@users.noreply.github.com",
+};
+
 export function createGitSync(homePath: string): GitSync {
   async function git(...args: string[]): Promise<string> {
-    const { stdout } = await execAsync("git", args, { cwd: homePath });
+    const { stdout } = await execAsync("git", args, {
+      cwd: homePath,
+      env: { ...process.env, ...GIT_ENV },
+    });
     return stdout.trim();
   }
 

--- a/packages/gateway/src/git-versioning.ts
+++ b/packages/gateway/src/git-versioning.ts
@@ -63,8 +63,20 @@ export interface FileHistory {
   restore(path: string, commit: string): Promise<RestoreResult>;
 }
 
+// Ensure git has a committer identity even when the host lacks global config
+// (e.g. ephemeral CI runners, fresh containers). Overridable via env.
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? "Matrix OS",
+  GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL ?? "matrix-os@users.noreply.github.com",
+  GIT_COMMITTER_NAME: process.env.GIT_COMMITTER_NAME ?? "Matrix OS",
+  GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? "matrix-os@users.noreply.github.com",
+};
+
 async function git(homePath: string, ...args: string[]): Promise<string> {
-  const { stdout } = await execAsync("git", args, { cwd: homePath });
+  const { stdout } = await execAsync("git", args, {
+    cwd: homePath,
+    env: { ...process.env, ...GIT_ENV },
+  });
   return stdout.trim();
 }
 

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1322,7 +1322,10 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
         });
       };
 
-      void connectUpstream(0);
+      void connectUpstream(0).catch((err) => {
+        console.error('[platform] websocket upstream fatal error:', describeError(err));
+        socket.destroy();
+      });
       return;
     }
 

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1315,7 +1315,10 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
             `[platform] websocket upstream failed handle=${record.handle} attempt=${attempt + 1} host=${endpoint.host} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
           );
           if (!connected && attempt === 0 && !socket.destroyed) {
-            void connectUpstream(attempt + 1);
+            void connectUpstream(attempt + 1).catch((retryErr) => {
+              console.error('[platform] websocket upstream retry fatal error:', describeError(retryErr));
+              socket.destroy();
+            });
             return;
           }
           socket.destroy();

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -5,6 +5,7 @@ import { serve } from '@hono/node-server';
 import { createConnection } from 'node:net';
 import type { IncomingMessage } from 'node:http';
 import Dockerode from 'dockerode';
+import { Agent } from 'undici';
 import { z } from 'zod/v4';
 import {
   createPlatformDb,
@@ -12,17 +13,15 @@ import {
   getContainer,
   getContainerByClerkId,
   updateLastActive,
+  updateContainerStatus,
   listContainers,
 } from './db.js';
-import { createOrchestrator, type Orchestrator } from './orchestrator.js';
-import { createLifecycleManager, type LifecycleManager } from './lifecycle.js';
+import type { Orchestrator } from './orchestrator.js';
 import { createSocialApi } from './social.js';
 import { createStoreApi } from './store-api.js';
 import { createSocialFeedApi } from './social-api.js';
 import { createClerkAuth, type ClerkAuth } from './clerk-auth.js';
-import { createMatrixProvisioner, type MatrixProvisioner } from './matrix-provisioning.js';
-import { metricsRegistry } from './metrics.js';
-import { createStatsCollector } from './stats-collector.js';
+import type { MatrixProvisioner } from './matrix-provisioning.js';
 import { createAuthRoutes } from './auth-routes.js';
 import { verifySyncJwt } from './sync-jwt.js';
 import { isSafeWebSocketUpgradePath } from './ws-upgrade.js';
@@ -40,6 +39,16 @@ const DEV_PLATFORM_JWT_SECRET = 'dev-platform-jwt-secret-please-change-32';
 const HANDLE_PATTERN = /^[a-z][a-z0-9-]{2,30}$/;
 const ADMIN_BODY_LIMIT = 64 * 1024;
 const CLERK_SCRIPT_ORIGIN = 'https://clerk.matrix-os.com';
+const PROXY_TIMEOUT_MS = 30_000;
+
+// User containers churn frequently, so keep proxy connections short-lived
+// instead of letting long-lived pooled upstream state go stale.
+const containerProxyDispatcher = new Agent({
+  pipelining: 0,
+  keepAliveTimeout: 1,
+  keepAliveMaxTimeout: 1,
+  connections: 64,
+});
 
 const ProvisionBodySchema = z.object({
   handle: z.string().regex(HANDLE_PATTERN),
@@ -135,6 +144,94 @@ export function checkUnsafeDefaultSecrets(
 interface AppDomainIdentity {
   handle: string;
   userId: string;
+}
+
+interface ResolvedContainerEndpoint {
+  containerId: string | null;
+  host: string;
+  source: 'record' | 'docker-id' | 'docker-name';
+}
+
+function isDockerNotFoundError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes('No such container') || message.includes('404');
+}
+
+async function inspectLiveContainer(
+  docker: Dockerode,
+  handle: string,
+  containerId?: string | null,
+): Promise<{ info: Dockerode.ContainerInspectInfo; source: 'docker-id' | 'docker-name' } | null> {
+  const candidates: Array<{ target: string; source: 'docker-id' | 'docker-name' }> = [];
+  if (containerId) {
+    candidates.push({ target: containerId, source: 'docker-id' });
+  }
+  candidates.push({ target: `matrixos-${handle}`, source: 'docker-name' });
+
+  for (const candidate of candidates) {
+    try {
+      const info = await docker.getContainer(candidate.target).inspect();
+      return { info, source: candidate.source };
+    } catch (err: unknown) {
+      if (!isDockerNotFoundError(err)) {
+        throw err;
+      }
+    }
+  }
+
+  return null;
+}
+
+function getContainerHostFromInspect(
+  info: Dockerode.ContainerInspectInfo,
+  handle: string,
+): string {
+  const networks = info.NetworkSettings?.Networks
+    ? Object.values(info.NetworkSettings.Networks)
+    : [];
+  const ip = networks.find(
+    (network) => typeof network?.IPAddress === 'string' && network.IPAddress.length > 0,
+  )?.IPAddress;
+  return ip || `matrixos-${handle}`;
+}
+
+async function resolveContainerEndpoint(
+  docker: Dockerode | undefined,
+  db: PlatformDB,
+  handle: string,
+  containerId?: string | null,
+): Promise<ResolvedContainerEndpoint | null> {
+  if (!docker) {
+    return {
+      containerId: containerId ?? null,
+      host: `matrixos-${handle}`,
+      source: 'record',
+    };
+  }
+
+  const inspected = await inspectLiveContainer(docker, handle, containerId);
+  if (!inspected) {
+    return null;
+  }
+
+  const { info, source } = inspected;
+  if (info.Id && info.Id !== containerId) {
+    updateContainerStatus(db, handle, info.State?.Running ? 'running' : 'stopped', info.Id);
+  }
+
+  return {
+    containerId: info.Id ?? containerId ?? null,
+    host: getContainerHostFromInspect(info, handle),
+    source,
+  };
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) {
+    const code = (err as Error & { code?: string }).code;
+    return code ? `${code}: ${err.message}` : err.message;
+  }
+  return String(err);
 }
 
 function isSyncJwtAuthError(err: unknown): boolean {
@@ -360,6 +457,7 @@ export function checkHomeMirrorS3Env(
 
 export function createApp(deps: {
   db: PlatformDB;
+  docker?: Dockerode;
   orchestrator: Orchestrator;
   clerkAuth?: ClerkAuth;
   matrixProvisioner?: MatrixProvisioner;
@@ -368,7 +466,7 @@ export function createApp(deps: {
   internalIntegrationRoutes?: Hono<any>;
   internalSyncRoutes?: Hono<any>;
 }) {
-  const { db, orchestrator, clerkAuth, matrixProvisioner } = deps;
+  const { db, docker, orchestrator, clerkAuth, matrixProvisioner } = deps;
   const platformSecret = deps.platformSecret ?? process.env.PLATFORM_SECRET ?? '';
   const app = new Hono<{
     Variables: {
@@ -395,6 +493,7 @@ export function createApp(deps: {
 
   // Prometheus metrics (unauthenticated for scraping)
   app.get('/metrics', async (c) => {
+    const { metricsRegistry } = await import('./metrics.js');
     const metrics = await metricsRegistry.metrics();
     return c.text(metrics, 200, {
       'Content-Type': metricsRegistry.contentType,
@@ -517,39 +616,57 @@ export function createApp(deps: {
 
     const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
     const targetPort = isGatewayPath ? 4000 : 3000;
-    const targetUrl = `http://matrixos-${record.handle}:${targetPort}${path}${qs}`;
-
-    try {
-      const headers = new Headers();
-      for (const [key, value] of Object.entries(c.req.header())) {
-        if (key !== 'host' && key !== 'cookie' && key !== 'authorization' && value) {
-          headers.set(key, value);
-        }
+    const body = ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob();
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(c.req.header())) {
+      if (key !== 'host' && key !== 'cookie' && key !== 'authorization' && value) {
+        headers.set(key, value);
       }
-      headers.set('x-forwarded-host', host);
-      headers.set('x-forwarded-proto', 'https');
-      if (platformSecret) {
-        headers.set('authorization', `Bearer ${buildPlatformVerificationToken(record.handle, platformSecret)}`);
-        headers.set('x-platform-verified', buildPlatformUserProof(record.handle, identity.userId, platformSecret));
-      }
-      headers.set('x-platform-user-id', identity.userId);
-
-      const upstream = await fetch(targetUrl, {
-        method: c.req.method,
-        headers,
-        redirect: 'manual',
-        signal: AbortSignal.timeout(30_000),
-        body: ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob(),
-      });
-
-      return new Response(upstream.body, {
-        status: upstream.status,
-        headers: upstream.headers,
-      });
-    } catch (err: unknown) {
-      logPlatformRouteError('app-domain proxy', err);
-      return c.json({ error: 'Container unreachable' }, 502);
     }
+    headers.set('x-forwarded-host', host);
+    headers.set('x-forwarded-proto', 'https');
+    headers.set('connection', 'close');
+    if (platformSecret) {
+      headers.set('authorization', `Bearer ${buildPlatformVerificationToken(record.handle, platformSecret)}`);
+      headers.set('x-platform-verified', buildPlatformUserProof(record.handle, identity.userId, platformSecret));
+    }
+    headers.set('x-platform-user-id', identity.userId);
+
+    let lastErr: unknown = null;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const endpoint = await resolveContainerEndpoint(docker, db, record.handle, record.containerId);
+      if (!endpoint) {
+        console.warn(
+          `[platform] app-domain proxy unresolved handle=${record.handle} attempt=${attempt + 1} path=${path} targetPort=${targetPort}`,
+        );
+        return c.json({ error: 'Container unreachable' }, 502);
+      }
+
+      const targetUrl = `http://${endpoint.host}:${targetPort}${path}${qs}`;
+      try {
+        const upstream = await fetch(targetUrl, {
+          method: c.req.method,
+          headers,
+          redirect: 'manual',
+          signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
+          body,
+          dispatcher: containerProxyDispatcher,
+        } as RequestInit & { dispatcher: Agent });
+
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: upstream.headers,
+        });
+      } catch (err: unknown) {
+        lastErr = err;
+        console.warn(
+          `[platform] app-domain proxy retry attempt=${attempt + 1} handle=${record.handle} target=${targetUrl} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
+        );
+      }
+    }
+
+    logPlatformRouteError('app-domain proxy', lastErr);
+    return c.json({ error: 'Container unreachable' }, 502);
   });
 
   if (deps.integrationRoutes) {
@@ -977,6 +1094,10 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
 
   checkHomeMirrorS3Env();
 
+  const [{ createOrchestrator }, { createLifecycleManager }] = await Promise.all([
+    import('./orchestrator.js'),
+    import('./lifecycle.js'),
+  ]);
   const orchestrator = createOrchestrator({
     db,
     docker,
@@ -991,9 +1112,13 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
   const lifecycle = createLifecycleManager({ db, orchestrator, maxRunning });
   lifecycle.start();
 
+  const { createStatsCollector } = await import('./stats-collector.js');
   const statsCollector = createStatsCollector({
     docker,
     listRunning: () => listContainers(db, 'running'),
+    onResolvedContainerId: (handle, containerId) => {
+      updateContainerStatus(db, handle, 'running', containerId);
+    },
   });
   statsCollector.start();
 
@@ -1018,6 +1143,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     process.exit(1);
   }
   if (conduitUrl) {
+    const { createMatrixProvisioner } = await import('./matrix-provisioning.js');
     matrixProvisioner = createMatrixProvisioner({
       db,
       homeserverUrl: conduitUrl,
@@ -1106,6 +1232,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
 
   const app = createApp({
     db,
+    docker,
     orchestrator,
     clerkAuth,
     matrixProvisioner,
@@ -1136,39 +1263,66 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
 
       const record = getContainer(db, identity.handle);
       if (!record) { socket.destroy(); return; }
+      const path = req.url ?? '/';
+      let activeUpstream: ReturnType<typeof createConnection> | null = null;
+      const onSocketError = () => activeUpstream?.destroy();
+      socket.on('error', onSocketError);
 
-      const upstream = createConnection({ host: `matrixos-${record.handle}`, port: 4000 }, () => {
-        const path = req.url ?? '/';
-        if (!isSafeWebSocketUpgradePath(path)) {
+      const connectUpstream = async (attempt: number): Promise<void> => {
+        const endpoint = await resolveContainerEndpoint(docker, db, record.handle, record.containerId);
+        if (!endpoint) {
+          console.warn(
+            `[platform] websocket upstream unresolved handle=${record.handle} attempt=${attempt + 1} path=${path}`,
+          );
           socket.destroy();
-          upstream.destroy();
           return;
         }
-        const headers = Object.entries(req.headers)
-          .filter(([k]) => k !== 'host' && k !== 'authorization' && k !== 'cookie')
-          .map(([k, v]) => `${k}: ${v}`)
-          .concat(
-            PLATFORM_SECRET
-              ? [
-                  `authorization: Bearer ${buildPlatformVerificationToken(record.handle, PLATFORM_SECRET)}`,
-                  `x-platform-verified: ${buildPlatformUserProof(record.handle, identity.userId, PLATFORM_SECRET)}`,
-                  `x-platform-user-id: ${identity.userId}`,
-                ]
-              : [],
-          )
-          .join('\r\n');
 
-        upstream.write(
-          `${req.method} ${path} HTTP/1.1\r\nHost: matrixos-${record.handle}:4000\r\n${headers}\r\n\r\n`
-        );
-        if (head.length > 0) upstream.write(head);
+        let connected = false;
+        const upstream = createConnection({ host: endpoint.host, port: 4000 }, () => {
+          connected = true;
+          activeUpstream = upstream;
+          if (!isSafeWebSocketUpgradePath(path)) {
+            socket.destroy();
+            upstream.destroy();
+            return;
+          }
+          const headers = Object.entries(req.headers)
+            .filter(([k]) => k !== 'host' && k !== 'authorization' && k !== 'cookie')
+            .map(([k, v]) => `${k}: ${v}`)
+            .concat(
+              PLATFORM_SECRET
+                ? [
+                    `authorization: Bearer ${buildPlatformVerificationToken(record.handle, PLATFORM_SECRET)}`,
+                    `x-platform-verified: ${buildPlatformUserProof(record.handle, identity.userId, PLATFORM_SECRET)}`,
+                    `x-platform-user-id: ${identity.userId}`,
+                  ]
+                : [],
+            )
+            .join('\r\n');
 
-        upstream.pipe(socket);
-        socket.pipe(upstream);
-      });
+          upstream.write(
+            `${req.method} ${path} HTTP/1.1\r\nHost: ${endpoint.host}:4000\r\n${headers}\r\n\r\n`
+          );
+          if (head.length > 0) upstream.write(head);
 
-      upstream.on('error', () => socket.destroy());
-      socket.on('error', () => upstream.destroy());
+          upstream.pipe(socket);
+          socket.pipe(upstream);
+        });
+
+        upstream.on('error', (err) => {
+          console.warn(
+            `[platform] websocket upstream failed handle=${record.handle} attempt=${attempt + 1} host=${endpoint.host} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
+          );
+          if (!connected && attempt === 0 && !socket.destroyed) {
+            void connectUpstream(attempt + 1);
+            return;
+          }
+          socket.destroy();
+        });
+      };
+
+      void connectUpstream(0);
       return;
     }
 

--- a/packages/platform/src/stats-collector.ts
+++ b/packages/platform/src/stats-collector.ts
@@ -46,6 +46,24 @@ function parseCpuPercent(stats: any): number {
   return (cpuDelta / systemDelta) * numCpus * 100;
 }
 
+function buildAndRecordEntry(handle: string, raw: any): ContainerStats {
+  const cpuPercent = parseCpuPercent(raw);
+  const memoryUsage = raw.memory_stats?.usage ?? 0;
+  const memoryLimit = raw.memory_stats?.limit ?? 0;
+
+  containerCpuUsage.set({ handle }, cpuPercent);
+  containerMemoryUsage.set({ handle }, memoryUsage);
+  containerMemoryLimit.set({ handle }, memoryLimit);
+
+  return {
+    handle,
+    cpuPercent,
+    memoryUsage,
+    memoryLimit,
+    timestamp: Date.now(),
+  };
+}
+
 export function createStatsCollector(config: StatsCollectorConfig): StatsCollector {
   const { docker, listRunning, onResolvedContainerId, intervalMs = 15_000 } = config;
   let timer: ReturnType<typeof setInterval> | null = null;
@@ -60,24 +78,7 @@ export function createStatsCollector(config: StatsCollectorConfig): StatsCollect
       let container = docker.getContainer(row.containerId);
       try {
         const raw = await container.stats({ stream: false } as any) as any;
-
-        const cpuPercent = parseCpuPercent(raw);
-        const memUsage = raw.memory_stats?.usage ?? 0;
-        const memLimit = raw.memory_stats?.limit ?? 0;
-
-        const entry: ContainerStats = {
-          handle: row.handle,
-          cpuPercent,
-          memoryUsage: memUsage,
-          memoryLimit: memLimit,
-          timestamp: Date.now(),
-        };
-
-        containerCpuUsage.set({ handle: row.handle }, cpuPercent);
-        containerMemoryUsage.set({ handle: row.handle }, memUsage);
-        containerMemoryLimit.set({ handle: row.handle }, memLimit);
-
-        results.push(entry);
+        results.push(buildAndRecordEntry(row.handle, raw));
       } catch (err: unknown) {
         if (err instanceof Error && err.message.includes('No such container')) {
           try {
@@ -85,23 +86,7 @@ export function createStatsCollector(config: StatsCollectorConfig): StatsCollect
             const inspect = await container.inspect();
             onResolvedContainerId?.(row.handle, inspect.Id);
             const raw = await container.stats({ stream: false } as any) as any;
-
-            const cpuPercent = parseCpuPercent(raw);
-            const memUsage = raw.memory_stats?.usage ?? 0;
-            const memLimit = raw.memory_stats?.limit ?? 0;
-
-            const entry: ContainerStats = {
-              handle: row.handle,
-              cpuPercent,
-              memoryUsage: memUsage,
-              memoryLimit: memLimit,
-              timestamp: Date.now(),
-            };
-
-            containerCpuUsage.set({ handle: row.handle }, cpuPercent);
-            containerMemoryUsage.set({ handle: row.handle }, memUsage);
-            containerMemoryLimit.set({ handle: row.handle }, memLimit);
-            results.push(entry);
+            results.push(buildAndRecordEntry(row.handle, raw));
             continue;
           } catch (_fallbackErr: unknown) {
             // Fall through to the warning below.

--- a/packages/platform/src/stats-collector.ts
+++ b/packages/platform/src/stats-collector.ts
@@ -22,6 +22,7 @@ interface RunningContainer {
 export interface StatsCollectorConfig {
   docker: Dockerode;
   listRunning: () => RunningContainer[];
+  onResolvedContainerId?: (handle: string, containerId: string) => void;
   intervalMs?: number;
 }
 
@@ -46,7 +47,7 @@ function parseCpuPercent(stats: any): number {
 }
 
 export function createStatsCollector(config: StatsCollectorConfig): StatsCollector {
-  const { docker, listRunning, intervalMs = 15_000 } = config;
+  const { docker, listRunning, onResolvedContainerId, intervalMs = 15_000 } = config;
   let timer: ReturnType<typeof setInterval> | null = null;
 
   async function collectOnce(): Promise<ContainerStats[]> {
@@ -56,8 +57,8 @@ export function createStatsCollector(config: StatsCollectorConfig): StatsCollect
     for (const row of containers) {
       if (!row.containerId) continue;
 
+      let container = docker.getContainer(row.containerId);
       try {
-        const container = docker.getContainer(row.containerId);
         const raw = await container.stats({ stream: false } as any) as any;
 
         const cpuPercent = parseCpuPercent(raw);
@@ -78,6 +79,34 @@ export function createStatsCollector(config: StatsCollectorConfig): StatsCollect
 
         results.push(entry);
       } catch (err: unknown) {
+        if (err instanceof Error && err.message.includes('No such container')) {
+          try {
+            container = docker.getContainer(`matrixos-${row.handle}`);
+            const inspect = await container.inspect();
+            onResolvedContainerId?.(row.handle, inspect.Id);
+            const raw = await container.stats({ stream: false } as any) as any;
+
+            const cpuPercent = parseCpuPercent(raw);
+            const memUsage = raw.memory_stats?.usage ?? 0;
+            const memLimit = raw.memory_stats?.limit ?? 0;
+
+            const entry: ContainerStats = {
+              handle: row.handle,
+              cpuPercent,
+              memoryUsage: memUsage,
+              memoryLimit: memLimit,
+              timestamp: Date.now(),
+            };
+
+            containerCpuUsage.set({ handle: row.handle }, cpuPercent);
+            containerMemoryUsage.set({ handle: row.handle }, memUsage);
+            containerMemoryLimit.set({ handle: row.handle }, memLimit);
+            results.push(entry);
+            continue;
+          } catch (_fallbackErr: unknown) {
+            // Fall through to the warning below.
+          }
+        }
         console.warn(
           `[stats-collector] Failed to collect stats for ${row.handle}:`,
           err instanceof Error ? err.message : String(err),

--- a/tests/gateway/sync/home-mirror.test.ts
+++ b/tests/gateway/sync/home-mirror.test.ts
@@ -736,10 +736,13 @@ describe("createHomeMirror", () => {
       await mirror.start();
 
       // Drop a file in the container's home -- mirror should upload AND
-      // broadcast. Chokidar + awaitWriteFinish (250ms) + macOS fsevents
-      // startup latency needs ~1.5s in CI.
+      // broadcast. Chokidar + awaitWriteFinish (250ms) + fsevents startup
+      // latency is ~1.5s locally but variable on CI, so poll rather than
+      // sleep a fixed interval.
       await writeFile(join(tmpRoot, "new.md"), "container wrote this");
-      await settle(1500);
+      await waitFor(() =>
+        laptopSends.some((s) => s.includes('"sync:change"') && s.includes("new.md")),
+      );
 
       const syncChanges = laptopSends.filter((s) => s.includes('"sync:change"'));
       expect(syncChanges.length).toBeGreaterThan(0);

--- a/tests/gateway/sync/home-mirror.test.ts
+++ b/tests/gateway/sync/home-mirror.test.ts
@@ -74,7 +74,7 @@ async function settle(ms = 30) {
   await new Promise((r) => setTimeout(r, ms));
 }
 
-async function waitFor(check: () => boolean, timeoutMs = 3_000): Promise<void> {
+async function waitFor(check: () => boolean, timeoutMs = 15_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (check()) return;

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2,12 +2,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { join } from "node:path";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { createPlatformDb, type PlatformDB, insertContainer } from "../../packages/platform/src/db.js";
+import { createPlatformDb, type PlatformDB, getContainer, insertContainer } from "../../packages/platform/src/db.js";
 import { createApp } from "../../packages/platform/src/main.js";
 import type { Orchestrator } from "../../packages/platform/src/orchestrator.js";
 import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
 import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
 import * as syncJwt from "../../packages/platform/src/sync-jwt.js";
+import type Dockerode from "dockerode";
 
 const JWT_SECRET = "test-secret-at-least-32-characters-long";
 
@@ -31,6 +32,29 @@ function stubOrchestrator(): Orchestrator {
     listAll: vi.fn().mockReturnValue([]),
     syncStates: vi.fn(),
   };
+}
+
+function stubDocker(inspectInfo: { id?: string; ipAddress?: string; running?: boolean } = {}): Dockerode {
+  const {
+    id = "docker-ctr-1",
+    ipAddress = "172.18.0.14",
+    running = true,
+  } = inspectInfo;
+  return {
+    getContainer: vi.fn(() => ({
+      inspect: vi.fn().mockResolvedValue({
+        Id: id,
+        State: { Running: running },
+        NetworkSettings: {
+          Networks: {
+            "matrixos-net": {
+              IPAddress: ipAddress,
+            },
+          },
+        },
+      }),
+    })),
+  } as unknown as Dockerode;
 }
 
 describe("platform proxy routing", () => {
@@ -165,8 +189,11 @@ describe("platform proxy routing", () => {
   });
 
   it("logs and returns 502 when the app-domain container proxy fetch fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("upstream exploded"));
+    vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("upstream exploded"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"));
     const app = createApp({
       db,
       orchestrator: stubOrchestrator(),
@@ -185,6 +212,45 @@ describe("platform proxy routing", () => {
 
     expect(res.status).toBe(502);
     expect(await res.json()).toEqual({ error: "Container unreachable" });
-    expect(errorSpy).toHaveBeenCalledWith("[platform] app-domain proxy failed:", "upstream exploded");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[platform] app-domain proxy retry attempt=1 handle=alice"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[platform] app-domain proxy retry attempt=2 handle=alice"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith("[platform] app-domain proxy failed:", "fetch failed");
+  });
+
+  it("re-resolves the live container endpoint and retries the proxy request", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("socket hang up"))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const docker = stubDocker({ id: "docker-ctr-2", ipAddress: "172.18.0.55" });
+    const app = createApp({
+      db,
+      docker,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/api/ping", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://172.18.0.55:4000/api/ping");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://172.18.0.55:4000/api/ping");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[platform] app-domain proxy retry attempt=1 handle=alice"),
+    );
+    expect(getContainer(db, "alice")?.containerId).toBe("docker-ctr-2");
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    // CI runners are sometimes slow under load; tests that rely on async
+    // waitFor polling can exceed the 5s vitest default.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
     exclude: ["tests/**/*.integration.ts", "node_modules", "dist", ".next"],
     coverage: {


### PR DESCRIPTION
## Summary
- re-resolve live user-container endpoints for app-domain proxy requests instead of trusting stale container ids
- use short-lived upstream proxy connections and richer retry diagnostics to reduce stale platform origin state
- recover stats collection from stale stored container ids and add focused proxy routing regression coverage

## Root cause
After user-container upgrades/restarts, `platform` could keep using stale upstream connection/container state even when the replacement container was healthy and reachable. That produced recurring `502` responses on `app.matrix-os.com` until `platform` and sometimes `cloudflared` were restarted.

## Changes
- add live container endpoint resolution via Docker inspect with container-id and `matrixos-<handle>` fallback
- retry app-domain proxy requests after refreshing endpoint resolution
- log handle, target, resolution source, container id, and concrete failure reason on retries
- re-resolve websocket upstream targets before connect and retry once on failure
- let stats collection refresh stale stored container ids from the live container name
- add proxy-routing regression tests for stale endpoint recovery

## Validation
- `pnpm exec vitest run tests/platform/ws-upgrade.test.ts tests/platform/proxy-routing.test.ts`

## Notes
- This is intentionally separate from PR #49, which fixes terminal session/tab-switch behavior.