### PR TITLE
fix: tighten platform proxy follow-up handling

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -46,6 +46,7 @@ const HANDLE_PATTERN = /^[a-z][a-z0-9-]{2,30}$/;
 const ADMIN_BODY_LIMIT = 64 * 1024;
 const CLERK_SCRIPT_ORIGIN = 'https://clerk.matrix-os.com';
 const PROXY_TIMEOUT_MS = 30_000;
+const DOCKER_INSPECT_TIMEOUT_MS = 10_000;
 
 // User containers churn frequently, so keep proxy connections short-lived
 // instead of letting long-lived pooled upstream state go stale.
@@ -177,7 +178,12 @@ async function inspectLiveContainer(
 
   for (const candidate of candidates) {
     try {
-      const info = await docker.getContainer(candidate.target).inspect();
+      const info = await Promise.race([
+        docker.getContainer(candidate.target).inspect(),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error(`Docker inspect timeout after ${DOCKER_INSPECT_TIMEOUT_MS}ms`)), DOCKER_INSPECT_TIMEOUT_MS);
+        }),
+      ]);
       return { info, source: candidate.source };
     } catch (err: unknown) {
       if (!isDockerNotFoundError(err)) {
@@ -1339,6 +1345,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       });
 
       upstream.on('error', (err) => {
+        upstream.destroy();
         console.warn(
           `[platform] websocket upstream failed handle=${record.handle} attempt=${attempt + 1} host=${endpoint.host} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
         );

--- a/packages/platform/src/stats-collector.ts
+++ b/packages/platform/src/stats-collector.ts
@@ -88,8 +88,11 @@ export function createStatsCollector(config: StatsCollectorConfig): StatsCollect
             const raw = await container.stats({ stream: false } as any) as any;
             results.push(buildAndRecordEntry(row.handle, raw));
             continue;
-          } catch (_fallbackErr: unknown) {
-            // Fall through to the warning below.
+          } catch (fallbackErr: unknown) {
+            console.warn(
+              `[stats-collector] Name-based fallback also failed for ${row.handle}:`,
+              fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr),
+            );
           }
         }
         console.warn(

--- a/tests/platform/stats-collector.test.ts
+++ b/tests/platform/stats-collector.test.ts
@@ -135,10 +135,18 @@ describe('platform/stats-collector', () => {
   });
 
   it('handles disappeared container gracefully', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const docker = {
-      getContainer: vi.fn(() => ({
-        stats: vi.fn().mockRejectedValue(new Error('no such container')),
-      })),
+      getContainer: vi.fn((id: string) => {
+        if (id === 'gone-1') {
+          return {
+            stats: vi.fn().mockRejectedValue(new Error('No such container')),
+          };
+        }
+        return {
+          inspect: vi.fn().mockRejectedValue(new Error('fallback inspect failed')),
+        };
+      }),
     };
 
     const db = createMockDb([
@@ -152,6 +160,10 @@ describe('platform/stats-collector', () => {
 
     const results = await collector.collectOnce();
     expect(results).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[stats-collector] Name-based fallback also failed for ghost:',
+      'fallback inspect failed',
+    );
   });
 
   it('skips containers without containerId', async () => {


### PR DESCRIPTION
## Summary
- add a bounded timeout around Docker container inspection during endpoint resolution
- explicitly destroy failed websocket upstream sockets before retrying
- log name-based stats fallback failures and cover that path in the stats collector test

## Testing
- pnpm exec vitest run tests/platform/proxy-routing.test.ts tests/platform/ws-upgrade.test.ts

## Notes
- `tests/platform/stats-collector.test.ts` was updated for the new fallback logging path, but I did not run that file in this worktree because `prom-client` is not available in the local dependency set here.