### PR TITLE
fix(container,terminal): agent auto-updates, gh CLI, reconnect banner cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,21 @@ RUN npm install -g \
     @openai/codex@0.118.0 \
     opencode-ai@1.3.13
 
+# GitHub CLI (release binary; alpine's github-cli package trails a few versions)
+ARG GH_VERSION=2.86.0
+RUN wget -qO- "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /tmp && \
+    mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh && \
+    rm -rf "/tmp/gh_${GH_VERSION}_linux_amd64"
+
 # Non-root user (Claude CLI refuses --dangerously-skip-permissions as root)
 RUN adduser -D -u 1001 -h /home/matrixos matrixos && \
     su-exec matrixos git config --global user.name "Matrix OS" && \
     su-exec matrixos git config --global user.email "os@matrix-os.com"
+
+# Give matrixos write access to global npm so claude/codex/opencode
+# can auto-update themselves from inside the container.
+RUN chown -R matrixos:matrixos /usr/local/lib/node_modules /usr/local/bin
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,17 @@ RUN npm install -g \
     @openai/codex@0.118.0 \
     opencode-ai@1.3.13
 
-# GitHub CLI (release binary; alpine's github-cli package trails a few versions)
+# GitHub CLI (release binary; alpine's github-cli package trails a few versions).
+# GH_SHA256 must match the upstream gh_${GH_VERSION}_checksums.txt entry for
+# gh_${GH_VERSION}_linux_amd64.tar.gz -- bump both values together.
 ARG GH_VERSION=2.86.0
-RUN wget -qO- "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz -C /tmp && \
-    mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh && \
-    rm -rf "/tmp/gh_${GH_VERSION}_linux_amd64"
+ARG GH_SHA256=f3b08bd6a28420cc2229b0a1a687fa25f2b838d3f04b297414c1041ca68103c7
+RUN set -eux; \
+    wget -qO /tmp/gh.tgz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz"; \
+    echo "${GH_SHA256}  /tmp/gh.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tgz -C /tmp; \
+    mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_amd64"
 
 # Non-root user (Claude CLI refuses --dangerously-skip-permissions as root)
 RUN adduser -D -u 1001 -h /home/matrixos matrixos && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,8 +20,19 @@ RUN npm install -g \
 # QMD semantic search (BM25 + optional vector search)
 RUN npm install -g @tobilu/qmd
 
+# GitHub CLI (release binary; alpine's github-cli package trails a few versions)
+ARG GH_VERSION=2.86.0
+RUN wget -qO- "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /tmp && \
+    mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh && \
+    rm -rf "/tmp/gh_${GH_VERSION}_linux_amd64"
+
 # Non-root user (Agent SDK refuses bypassPermissions as root)
 RUN addgroup -S matrixos && adduser -S matrixos -G matrixos -h /home/matrixos -s /bin/zsh
+
+# Give matrixos write access to global npm so claude/codex/opencode
+# can auto-update themselves from inside the container.
+RUN chown -R matrixos:matrixos /usr/local/lib/node_modules /usr/local/bin
 
 # Powerlevel10k + pinned zsh plugins
 RUN mkdir -p /home/matrixos/.zsh/themes /home/matrixos/.zsh/plugins && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,12 +20,17 @@ RUN npm install -g \
 # QMD semantic search (BM25 + optional vector search)
 RUN npm install -g @tobilu/qmd
 
-# GitHub CLI (release binary; alpine's github-cli package trails a few versions)
+# GitHub CLI (release binary; alpine's github-cli package trails a few versions).
+# GH_SHA256 must match the upstream gh_${GH_VERSION}_checksums.txt entry for
+# gh_${GH_VERSION}_linux_amd64.tar.gz -- bump both values together.
 ARG GH_VERSION=2.86.0
-RUN wget -qO- "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz -C /tmp && \
-    mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh && \
-    rm -rf "/tmp/gh_${GH_VERSION}_linux_amd64"
+ARG GH_SHA256=f3b08bd6a28420cc2229b0a1a687fa25f2b838d3f04b297414c1041ca68103c7
+RUN set -eux; \
+    wget -qO /tmp/gh.tgz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz"; \
+    echo "${GH_SHA256}  /tmp/gh.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tgz -C /tmp; \
+    mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_amd64"
 
 # Non-root user (Agent SDK refuses bypassPermissions as root)
 RUN addgroup -S matrixos && adduser -S matrixos -G matrixos -h /home/matrixos -s /bin/zsh

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -448,8 +448,12 @@ export function TerminalPane({
           if (reconnectLinesWrittenRef.current > 0) {
             // Erase the "[Reconnecting in Ns...]" lines we appended while
             // disconnected so the scrollback stays clean after recovery.
+            // Each banner is `\r\n[text]\r\n` -- the leading \r\n moves onto
+            // a fresh line, so we only need to move up (lines - 1) to land
+            // on the first banner row without clobbering the content row
+            // that was there before the disconnect.
             const lines = reconnectLinesWrittenRef.current;
-            term.write(`\x1b[${lines}A\r\x1b[0J`);
+            term.write(`\x1b[${lines - 1}A\r\x1b[0J`);
             reconnectLinesWrittenRef.current = 0;
           }
           log("ws-open", { attachOnOpen });

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -201,6 +201,7 @@ export function TerminalPane({
   const lastSeqRef = useRef<number>(0);
   const reconnectAttemptRef = useRef<number>(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectLinesWrittenRef = useRef<number>(0);
   const onSessionAttachedRef = useRef(onSessionAttached);
   const shouldCacheOnUnmountRef = useRef(shouldCacheOnUnmount);
   const shouldDestroyOnUnmountRef = useRef(shouldDestroyOnUnmount);
@@ -444,6 +445,13 @@ export function TerminalPane({
         ws.onopen = () => {
           reconnectAttemptRef.current = 0;
           clearReconnectTimer();
+          if (reconnectLinesWrittenRef.current > 0) {
+            // Erase the "[Reconnecting in Ns...]" lines we appended while
+            // disconnected so the scrollback stays clean after recovery.
+            const lines = reconnectLinesWrittenRef.current;
+            term.write(`\x1b[${lines}A\r\x1b[0J`);
+            reconnectLinesWrittenRef.current = 0;
+          }
           log("ws-open", { attachOnOpen });
 
           // Start heartbeat
@@ -489,6 +497,7 @@ export function TerminalPane({
             reconnectAttemptRef.current = attempt + 1;
             log("schedule-reconnect", { delayMs: delay, nextAttempt: reconnectAttemptRef.current });
             term.write(`\r\n\x1b[33m[Reconnecting in ${delay / 1000}s...]\x1b[0m\r\n`);
+            reconnectLinesWrittenRef.current += 2;
             reconnectTimerRef.current = setTimeout(() => {
               reconnectTimerRef.current = null;
               if (!disposed && !isClosingRef.current) {
@@ -498,6 +507,9 @@ export function TerminalPane({
             }, delay);
           } else {
             term.write("\r\n\x1b[90m[Disconnected]\x1b[0m\r\n");
+            // Give up cleaning the "[Reconnecting...]" banners - leave them
+            // as context for why we disconnected.
+            reconnectLinesWrittenRef.current = 0;
           }
         };
 


### PR DESCRIPTION
## Summary
- **Agent auto-updates work inside user containers.** `/usr/local/lib/node_modules` and `/usr/local/bin` were root-owned, so `claude` (and `codex`/`opencode`) hit EACCES on self-update. Chowned both to `matrixos` in the Dockerfile so the auto-updater can write its package dir and rewire the `/usr/local/bin/claude` symlink.
- **`gh` CLI (v2.86.0) in every user container.** Installed from the official release tarball in both `Dockerfile` and `Dockerfile.dev`. Alpine's `github-cli` package trails upstream by a few versions, so we pull the binary directly.
- **Reconnect banner no longer litters the terminal.** `TerminalPane.tsx` counts the lines written by each `[Reconnecting in Ns...]` banner and erases them on the next successful `ws.onopen` via `\x1b[{N}A\r\x1b[0J`. Final `[Disconnected]` after 3 failed attempts is preserved on purpose.

## Test plan
- [ ] Rebuild user image: \`docker build -t matrixos-user:local -f Dockerfile .\` on the VPS with the existing \`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY\` build arg.
- [ ] \`curl -X POST http://localhost:9000/containers/rolling-restart -H \"Authorization: Bearer \$PLATFORM_SECRET\"\` and confirm the \`skipped\` array is what's expected.
- [ ] Inside a restarted container as \`matrixos\`:
  - [ ] \`claude doctor\` -> no EACCES, and \`npm i -g @anthropic-ai/claude-code@<new>\` succeeds without sudo.
  - [ ] \`which gh && gh --version\` -> \`2.86.0\`.
  - [ ] \`gh auth login\` flow works from inside the container (device flow).
- [ ] In the shell UI:
  - [ ] Force a disconnect (kill the gateway briefly or toggle network); wait for 1-3 reconnect attempts.
  - [ ] On successful reconnect, the \`[Reconnecting in Ns...]\` lines are gone from the scrollback.
  - [ ] Exhaust the 3 attempts: \`[Disconnected]\` banner stays visible.
  - [ ] Unrelated scrollback above the banners is unaffected.

## Notes
- Deliberate scope: didn't merge into the \`fix/lib-git-identity\` branch's in-progress TerminalPane refactor to keep these three hunks independently reviewable/revertable.
- Follow-up (not in this PR): add a \`pi\` agent alongside \`opencode-ai\` once the target package is confirmed; SSH/terminal-share docs also deferred.