### PR TITLE
feat(container): install bubblewrap for codex sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,9 @@ RUN cd shell && node ../node_modules/next/dist/bin/next build
 # --------------------------------------------------
 FROM node:24-alpine AS runtime
 
-# Runtime: git (home dir init + self-healing), build tools (node-pty native addon)
-RUN apk add --no-cache git python3 make g++ linux-headers bash su-exec
+# Runtime: git (home dir init + self-healing), build tools (node-pty native addon),
+# bubblewrap (bwrap) for codex's per-command sandbox
+RUN apk add --no-cache git python3 make g++ linux-headers bash su-exec bubblewrap
 
 RUN corepack enable && corepack prepare pnpm@10.6.2 --activate
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,9 +4,10 @@
 
 FROM node:24-alpine
 
-# System deps for native addons (node-pty, better-sqlite3, sqlite-vec)
+# System deps for native addons (node-pty, better-sqlite3, sqlite-vec) and
+# bubblewrap (bwrap) for codex's per-command sandbox
 RUN apk add --no-cache git python3 make g++ linux-headers bash su-exec cmake \
-    zsh curl shadow
+    zsh curl shadow bubblewrap
 
 # pnpm via corepack (Agent SDK bundles its own claude runtime)
 RUN corepack enable && corepack prepare pnpm@10.6.2 --activate


### PR DESCRIPTION
## Summary
Install \`bubblewrap\` in both \`Dockerfile\` and \`Dockerfile.dev\` so \`codex\` finds \`bwrap\` on PATH and uses its per-command Linux sandbox instead of the bundled fallback helper (which wants unprivileged user namespaces and is less reliable across hosts).

Nested sandbox note: \`bwrap\` runs inside the Docker container. Alpine's \`bubblewrap\` package uses namespace creation that works with Docker's default seccomp + AppArmor profiles, so no extra \`--cap-add\` or \`--security-opt\` flags are needed on the container.

## Test plan
- [ ] Rebuild user image + upgrade one container.
- [ ] Inside the container as \`matrixos\`: \`which bwrap && bwrap --version\` should print a version.
- [ ] Run \`codex\` with default permissions and confirm no \"sandbox: no bwrap on PATH, falling back\" warning in its startup output.
- [ ] Quick sanity: \`codex exec \"echo hi\"\` still works.