### PR TITLE
feat: terminal app redesign + zellij/pi/ssh + staging hot-reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ FROM node:24-alpine AS runtime
 
 # Runtime: git (home dir init + self-healing), build tools (node-pty native addon),
 # bubblewrap (bwrap) for codex's per-command sandbox
-RUN apk add --no-cache git python3 make g++ linux-headers bash su-exec bubblewrap
+RUN apk add --no-cache git python3 make g++ linux-headers bash su-exec bubblewrap openssh-client
 
 RUN corepack enable && corepack prepare pnpm@10.6.2 --activate
 
@@ -55,7 +55,8 @@ RUN corepack enable && corepack prepare pnpm@10.6.2 --activate
 RUN npm install -g \
     @anthropic-ai/claude-code@2.1.91 \
     @openai/codex@0.118.0 \
-    opencode-ai@1.3.13
+    opencode-ai@1.14.25 \
+    @mariozechner/pi-coding-agent@0.70.2
 
 # GitHub CLI (release binary; alpine's github-cli package trails a few versions).
 # GH_SHA256 must match the upstream gh_${GH_VERSION}_checksums.txt entry for
@@ -68,6 +69,19 @@ RUN set -eux; \
     tar -xzf /tmp/gh.tgz -C /tmp; \
     mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh; \
     rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_amd64"
+
+# Zellij terminal multiplexer (static musl binary).
+# ZELLIJ_SHA256 must be the SHA-256 of the published .tar.gz (compute with
+# `curl -sL <url> | sha256sum`). The upstream `.sha256sum` file in the
+# release assets refers to the *binary*, not the archive.
+ARG ZELLIJ_VERSION=0.44.1
+ARG ZELLIJ_SHA256=669825021d529fca5d939888263c9d2a90762145191fa07581a15250e8af2b49
+RUN set -eux; \
+    wget -qO /tmp/zellij.tgz "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-x86_64-unknown-linux-musl.tar.gz"; \
+    echo "${ZELLIJ_SHA256}  /tmp/zellij.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/zellij.tgz -C /usr/local/bin zellij; \
+    chmod +x /usr/local/bin/zellij; \
+    rm /tmp/zellij.tgz
 
 # Non-root user (Claude CLI refuses --dangerously-skip-permissions as root)
 RUN adduser -D -u 1001 -h /home/matrixos matrixos && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ FROM node:24-alpine AS runtime
 
 # Runtime: git (home dir init + self-healing), build tools (node-pty native addon),
 # bubblewrap (bwrap) for codex's per-command sandbox
-RUN apk add --no-cache git python3 make g++ linux-headers bash su-exec bubblewrap openssh-client
+RUN apk add --no-cache git python3 make g++ linux-headers bash su-exec bubblewrap openssh-client curl
 
 RUN corepack enable && corepack prepare pnpm@10.6.2 --activate
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,7 @@ FROM node:24-alpine
 # System deps for native addons (node-pty, better-sqlite3, sqlite-vec) and
 # bubblewrap (bwrap) for codex's per-command sandbox
 RUN apk add --no-cache git python3 make g++ linux-headers bash su-exec cmake \
-    zsh curl shadow bubblewrap
+    zsh curl shadow bubblewrap openssh-client
 
 # pnpm via corepack (Agent SDK bundles its own claude runtime)
 RUN corepack enable && corepack prepare pnpm@10.6.2 --activate
@@ -16,7 +16,8 @@ RUN corepack enable && corepack prepare pnpm@10.6.2 --activate
 RUN npm install -g \
     @anthropic-ai/claude-code@2.1.91 \
     @openai/codex@0.118.0 \
-    opencode-ai@1.3.13
+    opencode-ai@1.14.25 \
+    @mariozechner/pi-coding-agent@0.70.2
 
 # QMD semantic search (BM25 + optional vector search)
 RUN npm install -g @tobilu/qmd
@@ -32,6 +33,17 @@ RUN set -eux; \
     tar -xzf /tmp/gh.tgz -C /tmp; \
     mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh; \
     rm -rf /tmp/gh.tgz "/tmp/gh_${GH_VERSION}_linux_amd64"
+
+# Zellij terminal multiplexer (static musl binary).
+# ZELLIJ_SHA256 must be the SHA-256 of the published .tar.gz.
+ARG ZELLIJ_VERSION=0.44.1
+ARG ZELLIJ_SHA256=669825021d529fca5d939888263c9d2a90762145191fa07581a15250e8af2b49
+RUN set -eux; \
+    wget -qO /tmp/zellij.tgz "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-x86_64-unknown-linux-musl.tar.gz"; \
+    echo "${ZELLIJ_SHA256}  /tmp/zellij.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/zellij.tgz -C /usr/local/bin zellij; \
+    chmod +x /usr/local/bin/zellij; \
+    rm /tmp/zellij.tgz
 
 # Non-root user (Agent SDK refuses bypassPermissions as root)
 RUN addgroup -S matrixos && adduser -S matrixos -G matrixos -h /home/matrixos -s /bin/zsh

--- a/distro/cloudflared.yml
+++ b/distro/cloudflared.yml
@@ -4,6 +4,12 @@ credentials-file: /etc/cloudflared/credentials.json
 ingress:
   - hostname: grafana.matrix-os.com
     service: http://grafana:3000
+  # Staging dev container (HMR shell). MUST come before the *.matrix-os.com
+  # wildcard or it would be swallowed by the platform router.
+  - hostname: staging.matrix-os.com
+    service: http://matrixos-staging:3000
+  - hostname: api-staging.matrix-os.com
+    service: http://matrixos-staging:4000
   - hostname: api.matrix-os.com
     service: http://platform:9000
   - hostname: "*.matrix-os.com"

--- a/distro/docker-dev-entrypoint.sh
+++ b/distro/docker-dev-entrypoint.sh
@@ -47,18 +47,40 @@ for tool in .claude .codex; do
 done
 
 # Expose Matrix OS skills to Claude Code and Codex
-# Clean stale copies from previous runs, then create fresh ones.
+# Clean Matrix-managed copies from previous runs, then create fresh ones.
 # Both tools discover skills in project-level and user-level directories.
-rm -rf "$MATRIX_HOME/.claude/skills" "$MATRIX_HOME/.codex/skills" \
-       "/home/matrixos/.claude/skills" "/home/matrixos/.codex/skills"
+cleanup_matrix_skills() {
+  skills_root="$1"
+  mkdir -p "$skills_root"
+  for generated in "$skills_root"/matrix-*; do
+    [ -e "$generated" ] || continue
+    [ -f "$generated/.matrix-os-managed" ] && rm -rf "$generated"
+  done
+  for skill in "$MATRIX_HOME/agents/skills/"*.md; do
+    [ -f "$skill" ] || continue
+    name=$(basename "$skill" .md)
+    legacy="$skills_root/$name"
+    if [ -f "$legacy/SKILL.md" ] && grep -q "^name: matrix-$name\$" "$legacy/SKILL.md"; then
+      rm -rf "$legacy"
+    elif [ -f "$legacy/agents/openai.yaml" ] && grep -q 'display_name: "Matrix:' "$legacy/agents/openai.yaml"; then
+      rm -rf "$legacy"
+    fi
+  done
+}
+for skills_root in "/home/matrixos/.claude/skills" "/home/matrixos/.codex/skills" \
+                   "$MATRIX_HOME/.claude/skills" "$MATRIX_HOME/.codex/skills"; do
+  cleanup_matrix_skills "$skills_root"
+done
 
 for skills_root in "/home/matrixos/.claude/skills" "$MATRIX_HOME/.claude/skills"; do
   mkdir -p "$skills_root"
   for skill in "$MATRIX_HOME/agents/skills/"*.md; do
     [ -f "$skill" ] || continue
     name=$(basename "$skill" .md)
-    mkdir -p "$skills_root/$name"
-    sed "s/^name: .*/name: matrix-$name/" "$skill" > "$skills_root/$name/SKILL.md"
+    out="$skills_root/matrix-$name"
+    mkdir -p "$out"
+    sed "s/^name: .*/name: matrix-$name/" "$skill" > "$out/SKILL.md"
+    touch "$out/.matrix-os-managed"
   done
 done
 
@@ -68,17 +90,19 @@ for skills_root in "/home/matrixos/.codex/skills" "$MATRIX_HOME/.codex/skills"; 
   for skill in "$MATRIX_HOME/agents/skills/"*.md; do
     [ -f "$skill" ] || continue
     name=$(basename "$skill" .md)
-    mkdir -p "$skills_root/$name/agents"
-    cp -f "$skill" "$skills_root/$name/SKILL.md"
+    out="$skills_root/matrix-$name"
+    mkdir -p "$out/agents"
+    sed "s/^name: .*/name: matrix-$name/" "$skill" > "$out/SKILL.md"
+    touch "$out/.matrix-os-managed"
     display=$(echo "$name" | tr '-' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1')
     desc=$(sed -n 's/^description: *//p' "$skill" | head -1)
     short_desc=$(printf '%s' "${desc:-$display skill}" | sed 's/\\/\\\\/g; s/"/\\"/g')
     prompt_desc=$(printf '%s' "${desc:-this task}" | sed 's/\\/\\\\/g; s/"/\\"/g')
-    cat > "$skills_root/$name/agents/openai.yaml" <<EOYAML
+    cat > "$out/agents/openai.yaml" <<EOYAML
 interface:
   display_name: "Matrix: $display"
   short_description: "$short_desc"
-  default_prompt: "Use \$$name for $prompt_desc."
+  default_prompt: "Use \$matrix-$name for $prompt_desc."
 EOYAML
   done
 done

--- a/distro/docker-entrypoint.sh
+++ b/distro/docker-entrypoint.sh
@@ -39,16 +39,38 @@ ln -sfn "$MATRIX_HOME/.ssh" /home/matrixos/.ssh
 # the user sees "No skills found" inside Claude Code even though skills
 # live at $MATRIX_HOME/agents/skills/. Re-runs every boot so deletions and
 # updates flow through.
-echo "Syncing skills into ~/.claude/skills and ~/.codex/skills..."
-rm -rf /home/matrixos/.claude/skills /home/matrixos/.codex/skills \
-       "$MATRIX_HOME/.claude/skills" "$MATRIX_HOME/.codex/skills"
+echo "Syncing Matrix skills into ~/.claude/skills and ~/.codex/skills..."
+cleanup_matrix_skills() {
+  skills_root="$1"
+  mkdir -p "$skills_root"
+  for generated in "$skills_root"/matrix-*; do
+    [ -e "$generated" ] || continue
+    [ -f "$generated/.matrix-os-managed" ] && rm -rf "$generated"
+  done
+  for skill in "$MATRIX_HOME/agents/skills/"*.md; do
+    [ -f "$skill" ] || continue
+    name=$(basename "$skill" .md)
+    legacy="$skills_root/$name"
+    if [ -f "$legacy/SKILL.md" ] && grep -q "^name: matrix-$name\$" "$legacy/SKILL.md"; then
+      rm -rf "$legacy"
+    elif [ -f "$legacy/agents/openai.yaml" ] && grep -q 'display_name: "Matrix:' "$legacy/agents/openai.yaml"; then
+      rm -rf "$legacy"
+    fi
+  done
+}
+for skills_root in "/home/matrixos/.claude/skills" "/home/matrixos/.codex/skills" \
+                   "$MATRIX_HOME/.claude/skills" "$MATRIX_HOME/.codex/skills"; do
+  cleanup_matrix_skills "$skills_root"
+done
 for skills_root in "/home/matrixos/.claude/skills" "$MATRIX_HOME/.claude/skills"; do
   mkdir -p "$skills_root"
   for skill in "$MATRIX_HOME/agents/skills/"*.md; do
     [ -f "$skill" ] || continue
     name=$(basename "$skill" .md)
-    mkdir -p "$skills_root/$name"
-    sed "s/^name: .*/name: matrix-$name/" "$skill" > "$skills_root/$name/SKILL.md"
+    out="$skills_root/matrix-$name"
+    mkdir -p "$out"
+    sed "s/^name: .*/name: matrix-$name/" "$skill" > "$out/SKILL.md"
+    touch "$out/.matrix-os-managed"
   done
 done
 for skills_root in "/home/matrixos/.codex/skills" "$MATRIX_HOME/.codex/skills"; do
@@ -56,17 +78,19 @@ for skills_root in "/home/matrixos/.codex/skills" "$MATRIX_HOME/.codex/skills"; 
   for skill in "$MATRIX_HOME/agents/skills/"*.md; do
     [ -f "$skill" ] || continue
     name=$(basename "$skill" .md)
-    mkdir -p "$skills_root/$name/agents"
-    cp -f "$skill" "$skills_root/$name/SKILL.md"
+    out="$skills_root/matrix-$name"
+    mkdir -p "$out/agents"
+    sed "s/^name: .*/name: matrix-$name/" "$skill" > "$out/SKILL.md"
+    touch "$out/.matrix-os-managed"
     display=$(echo "$name" | tr '-' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1')
     desc=$(sed -n 's/^description: *//p' "$skill" | head -1)
     short_desc=$(printf '%s' "${desc:-$display skill}" | sed 's/\\/\\\\/g; s/"/\\"/g')
     prompt_desc=$(printf '%s' "${desc:-this task}" | sed 's/\\/\\\\/g; s/"/\\"/g')
-    cat > "$skills_root/$name/agents/openai.yaml" <<EOYAML
+    cat > "$out/agents/openai.yaml" <<EOYAML
 interface:
   display_name: "Matrix: $display"
   short_description: "$short_desc"
-  default_prompt: "Use \$$name for $prompt_desc."
+  default_prompt: "Use \$matrix-$name for $prompt_desc."
 EOYAML
   done
 done

--- a/distro/docker-entrypoint.sh
+++ b/distro/docker-entrypoint.sh
@@ -19,6 +19,59 @@ if [ -d "$MATRIX_HOME" ] && [ ! -d "$MATRIX_HOME/system" ]; then
   cd /app
 fi
 
+# Unify SSH config: terminal panes run with HOME=$MATRIX_HOME, so `ssh-keygen`
+# / `gh auth login` write into $MATRIX_HOME/.ssh, but `ssh` itself uses the
+# passwd-derived $HOME (/home/matrixos), so it never finds the key. Symlink
+# the canonical $MATRIX_HOME/.ssh into the user home — same pattern the dev
+# entrypoint uses for .claude and .codex.
+mkdir -p "$MATRIX_HOME/.ssh"
+chown matrixos:matrixos "$MATRIX_HOME/.ssh"
+chmod 700 "$MATRIX_HOME/.ssh"
+if [ -d /home/matrixos/.ssh ] && [ ! -L /home/matrixos/.ssh ]; then
+  # Migrate any pre-existing keys/known_hosts (no-clobber) before replacing.
+  cp -an /home/matrixos/.ssh/. "$MATRIX_HOME/.ssh/" 2>/dev/null || true
+  rm -rf /home/matrixos/.ssh
+fi
+ln -sfn "$MATRIX_HOME/.ssh" /home/matrixos/.ssh
+
+# Expose Matrix OS skills to Claude Code (and Codex). Both tools discover
+# skills in $HOME/.claude/skills and $HOME/.codex/skills. Without this sync
+# the user sees "No skills found" inside Claude Code even though skills
+# live at $MATRIX_HOME/agents/skills/. Re-runs every boot so deletions and
+# updates flow through.
+echo "Syncing skills into ~/.claude/skills and ~/.codex/skills..."
+rm -rf /home/matrixos/.claude/skills /home/matrixos/.codex/skills \
+       "$MATRIX_HOME/.claude/skills" "$MATRIX_HOME/.codex/skills"
+for skills_root in "/home/matrixos/.claude/skills" "$MATRIX_HOME/.claude/skills"; do
+  mkdir -p "$skills_root"
+  for skill in "$MATRIX_HOME/agents/skills/"*.md; do
+    [ -f "$skill" ] || continue
+    name=$(basename "$skill" .md)
+    mkdir -p "$skills_root/$name"
+    sed "s/^name: .*/name: matrix-$name/" "$skill" > "$skills_root/$name/SKILL.md"
+  done
+done
+for skills_root in "/home/matrixos/.codex/skills" "$MATRIX_HOME/.codex/skills"; do
+  mkdir -p "$skills_root"
+  for skill in "$MATRIX_HOME/agents/skills/"*.md; do
+    [ -f "$skill" ] || continue
+    name=$(basename "$skill" .md)
+    mkdir -p "$skills_root/$name/agents"
+    cp -f "$skill" "$skills_root/$name/SKILL.md"
+    display=$(echo "$name" | tr '-' ' ' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1')
+    desc=$(sed -n 's/^description: *//p' "$skill" | head -1)
+    short_desc=$(printf '%s' "${desc:-$display skill}" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    prompt_desc=$(printf '%s' "${desc:-this task}" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    cat > "$skills_root/$name/agents/openai.yaml" <<EOYAML
+interface:
+  display_name: "Matrix: $display"
+  short_description: "$short_desc"
+  default_prompt: "Use \$$name for $prompt_desc."
+EOYAML
+  done
+done
+chown -R matrixos:matrixos /home/matrixos/.claude /home/matrixos/.codex 2>/dev/null || true
+
 # Start Next.js shell in background as non-root user
 cd /app/shell
 su-exec matrixos node ../node_modules/next/dist/bin/next start -p 3000 &

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -4,17 +4,14 @@
 # existing cloudflared tunnel. Source is bind-mounted from ~/matrix-os
 # so edits on disk hit `next dev` (Turbopack HMR) and `tsx watch` for
 # the gateway. Joins the platform's matrixos-net so cloudflared can
-# reach it as `staging-dev:3000` / `staging-dev:4000`.
+# reach it as `matrixos-staging:3000` / `matrixos-staging:4000`.
 #
 # Usage:
 #   docker compose -f docker-compose.staging.yml up -d --build
 #   docker compose -f docker-compose.staging.yml logs -f
 #   docker compose -f docker-compose.staging.yml down
 #
-# Reuses the platform's postgres (distro-postgres-1) on matrixos-net,
-# database `matrixos_staging` (created on first connect by the staging
-# pg superuser; if your auth is locked down, swap to the main `matrixos`
-# DB).
+# Reuses the platform's postgres (distro-postgres-1) on matrixos-net.
 
 services:
   staging-dev:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -46,8 +46,8 @@ services:
       - NEXT_PUBLIC_GATEWAY_URL=https://api-staging.matrix-os.com
       - GATEWAY_URL=http://localhost:4000
       # Reuse platform postgres on matrixos-net.
-      - DATABASE_URL=postgresql://matrixos:matrixos@postgres:5432/matrixos
-      - PLATFORM_DATABASE_URL=postgresql://matrixos:matrixos@postgres:5432/matrixos
+      - DATABASE_URL=${STAGING_DATABASE_URL:-postgresql://matrixos:matrixos@postgres:5432/matrixos}
+      - PLATFORM_DATABASE_URL=${STAGING_PLATFORM_DATABASE_URL:-postgresql://matrixos:matrixos@postgres:5432/matrixos}
     networks:
       - matrixos-net
     restart: unless-stopped

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,70 @@
+# Matrix OS -- Staging on this VPS
+#
+# Hot-reloading dev container exposed at staging.matrix-os.com via the
+# existing cloudflared tunnel. Source is bind-mounted from ~/matrix-os
+# so edits on disk hit `next dev` (Turbopack HMR) and `tsx watch` for
+# the gateway. Joins the platform's matrixos-net so cloudflared can
+# reach it as `staging-dev:3000` / `staging-dev:4000`.
+#
+# Usage:
+#   docker compose -f docker-compose.staging.yml up -d --build
+#   docker compose -f docker-compose.staging.yml logs -f
+#   docker compose -f docker-compose.staging.yml down
+#
+# Reuses the platform's postgres (distro-postgres-1) on matrixos-net,
+# database `matrixos_staging` (created on first connect by the staging
+# pg superuser; if your auth is locked down, swap to the main `matrixos`
+# DB).
+
+services:
+  staging-dev:
+    container_name: matrixos-staging
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./packages:/app/packages
+      - ./shell:/app/shell
+      - ./home:/app/home
+      - ./tests:/app/tests
+      - ./specs:/app/specs
+      - ./docs:/app/docs
+      - ./distro:/app/distro
+      - ./scripts:/app/scripts
+      - ./package.json:/app/package.json
+      - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
+      - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./tsconfig.json:/app/tsconfig.json
+      - ./vitest.config.ts:/app/vitest.config.ts
+      - staging-node-modules:/app/node_modules
+      - staging-home:/home/matrixos/home
+    environment:
+      - NODE_ENV=development
+      - MATRIX_HOME=/home/matrixos/home
+      - MATRIX_HANDLE=staging
+      - MATRIX_DISPLAY_NAME=Staging
+      - PORT=4000
+      # Public URLs the browser will see. Cloudflared terminates TLS.
+      - NEXT_PUBLIC_GATEWAY_WS=wss://api-staging.matrix-os.com/ws
+      - NEXT_PUBLIC_GATEWAY_URL=https://api-staging.matrix-os.com
+      - GATEWAY_URL=http://localhost:4000
+      # Reuse platform postgres on matrixos-net.
+      - DATABASE_URL=postgresql://matrixos:matrixos@postgres:5432/matrixos
+      - PLATFORM_DATABASE_URL=postgresql://matrixos:matrixos@postgres:5432/matrixos
+    networks:
+      - matrixos-net
+    restart: unless-stopped
+    healthcheck:
+      test: wget -qO- http://localhost:4000/health || exit 1
+      interval: 15s
+      timeout: 5s
+      start_period: 60s
+
+volumes:
+  staging-node-modules:
+  staging-home:
+
+networks:
+  matrixos-net:
+    external: true
+    name: matrixos-net

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -45,9 +45,10 @@ services:
       - NEXT_PUBLIC_GATEWAY_WS=wss://api-staging.matrix-os.com/ws
       - NEXT_PUBLIC_GATEWAY_URL=https://api-staging.matrix-os.com
       - GATEWAY_URL=http://localhost:4000
-      # Reuse platform postgres on matrixos-net.
-      - DATABASE_URL=${STAGING_DATABASE_URL:-postgresql://matrixos:matrixos@postgres:5432/matrixos}
-      - PLATFORM_DATABASE_URL=${STAGING_PLATFORM_DATABASE_URL:-postgresql://matrixos:matrixos@postgres:5432/matrixos}
+      # Reuse platform postgres on matrixos-net. Keep the password in a local
+      # .env file, not in git.
+      - DATABASE_URL=${STAGING_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/${STAGING_DB_NAME:-matrixos_staging}}
+      - PLATFORM_DATABASE_URL=${STAGING_PLATFORM_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/${STAGING_DB_NAME:-matrixos_staging}}
     networks:
       - matrixos-net
     restart: unless-stopped

--- a/packages/gateway/src/projects.ts
+++ b/packages/gateway/src/projects.ts
@@ -1,0 +1,165 @@
+import { execFile } from "node:child_process";
+import type { Dirent } from "node:fs";
+import { lstat, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { resolveWithinHome } from "./path-security.js";
+
+export interface ProjectInfo {
+  name: string;
+  path: string;
+  isGit: boolean;
+  branch: string | null;
+  dirtyCount: number;
+  modified: string | null;
+}
+
+type GitExec = (
+  args: string[],
+  options: { cwd: string; timeout: number },
+) => Promise<{ stdout: string }>;
+
+const execGit: GitExec = async (args, options) => {
+  const exec = promisify(execFile);
+  const { stdout } = await exec("git", args, {
+    cwd: options.cwd,
+    encoding: "utf-8",
+    timeout: options.timeout,
+  });
+  return { stdout };
+};
+
+function isIgnoredFsError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code !== undefined &&
+    ["ENOENT", "ENOTDIR"].includes((err as NodeJS.ErrnoException).code!)
+  );
+}
+
+function logUnexpectedProjectError(context: string, err: unknown): void {
+  if (isIgnoredFsError(err)) {
+    return;
+  }
+  console.warn(`[projects] ${context}:`, err instanceof Error ? err.message : err);
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(values[index]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+async function inspectProject(
+  entry: Dirent,
+  resolvedRoot: string,
+  rootParam: string,
+  runGit: GitExec,
+): Promise<ProjectInfo | null> {
+  const fullPath = join(resolvedRoot, entry.name);
+  const relPath = rootParam === "." ? entry.name : `${rootParam.replace(/\/+$/, "")}/${entry.name}`;
+  let branch: string | null = null;
+  let dirtyCount = 0;
+  let isGit = false;
+  let modified: string | null = null;
+
+  try {
+    const linkStat = await lstat(fullPath);
+    if (linkStat.isSymbolicLink()) {
+      return null;
+    }
+    if (!linkStat.isDirectory()) {
+      return null;
+    }
+    modified = new Date(linkStat.mtimeMs).toISOString();
+  } catch (err: unknown) {
+    logUnexpectedProjectError(`Failed to inspect ${relPath}`, err);
+    return null;
+  }
+
+  try {
+    await stat(join(fullPath, ".git"));
+    const { stdout } = await runGit(["rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd: fullPath,
+      timeout: 2000,
+    });
+    branch = stdout.trim();
+    isGit = true;
+  } catch (err: unknown) {
+    logUnexpectedProjectError(`Failed to read git branch for ${relPath}`, err);
+    isGit = false;
+  }
+
+  if (isGit) {
+    try {
+      const { stdout } = await runGit(["status", "--porcelain"], {
+        cwd: fullPath,
+        timeout: 2000,
+      });
+      dirtyCount = stdout.split("\n").filter((line) => line.trim().length > 0).length;
+    } catch (err: unknown) {
+      logUnexpectedProjectError(`Failed to read git status for ${relPath}`, err);
+    }
+  }
+
+  return {
+    name: entry.name,
+    path: relPath,
+    isGit,
+    branch,
+    dirtyCount,
+    modified,
+  };
+}
+
+export async function listProjects(
+  homePath: string,
+  rootParam: string,
+  options: { runGit?: GitExec; concurrency?: number } = {},
+): Promise<{ ok: true; root: string; projects: ProjectInfo[] } | { ok: false; status: number; error: string }> {
+  const normalizedRoot = rootParam.trim();
+  if (normalizedRoot.length === 0 || normalizedRoot.length > 1024) {
+    return { ok: false, status: 400, error: "Invalid root" };
+  }
+
+  const resolved = resolveWithinHome(homePath, normalizedRoot);
+  if (!resolved) {
+    return { ok: false, status: 400, error: "Invalid root" };
+  }
+
+  let entries: Dirent[];
+  try {
+    entries = await readdir(resolved, { withFileTypes: true, encoding: "utf8" });
+  } catch (err: unknown) {
+    logUnexpectedProjectError(`Failed to read root ${normalizedRoot}`, err);
+    return { ok: true, root: normalizedRoot, projects: [] };
+  }
+
+  const dirs = entries.filter((entry) => entry.isDirectory() && !entry.name.startsWith("."));
+  const inspected = await mapWithConcurrency(
+    dirs,
+    options.concurrency ?? 8,
+    (entry) => inspectProject(entry, resolved, normalizedRoot, options.runGit ?? execGit),
+  );
+  const projects = inspected.filter((project): project is ProjectInfo => project !== null);
+
+  projects.sort((a, b) => {
+    if (!a.modified || !b.modified) return a.name.localeCompare(b.name);
+    return b.modified.localeCompare(a.modified);
+  });
+
+  return { ok: true, root: normalizedRoot, projects };
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2056,7 +2056,7 @@ export async function createGateway(config: GatewayConfig) {
     }
     const resolved = resolveWithinHome(homePath, rootParam);
     if (!resolved) return c.json({ error: "Invalid root" }, 400);
-    let entries;
+    let entries: import("node:fs").Dirent[];
     try {
       const { readdir } = await import("node:fs/promises");
       entries = await readdir(resolved, { withFileTypes: true, encoding: "utf8" });
@@ -2070,49 +2070,66 @@ export async function createGateway(config: GatewayConfig) {
     const { promisify } = await import("node:util");
     const { stat } = await import("node:fs/promises");
     const exec = promisify(execFile);
+    const mapWithConcurrency = async <T, R>(
+      values: T[],
+      concurrency: number,
+      mapper: (value: T) => Promise<R>,
+    ): Promise<R[]> => {
+      const results = new Array<R>(values.length);
+      let nextIndex = 0;
+      const workers = Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+        while (nextIndex < values.length) {
+          const index = nextIndex;
+          nextIndex += 1;
+          results[index] = await mapper(values[index]);
+        }
+      });
+      await Promise.all(workers);
+      return results;
+    };
 
-    const projects = await Promise.all(
-      dirs.map(async (entry) => {
-        const fullPath = `${resolved}/${entry.name}`;
-        const relPath = `${rootParam}/${entry.name}`;
-        let branch: string | null = null;
-        let dirtyCount = 0;
-        let isGit = false;
-        let modified: string | null = null;
+    const projects = await mapWithConcurrency(dirs, 8, async (entry) => {
+      const fullPath = join(resolved, entry.name);
+      const relPath = rootParam === "." ? entry.name : `${rootParam.replace(/\/+$/, "")}/${entry.name}`;
+      let branch: string | null = null;
+      let dirtyCount = 0;
+      let isGit = false;
+      let modified: string | null = null;
+      try {
+        const s = await stat(fullPath);
+        modified = new Date(s.mtimeMs).toISOString();
+      } catch (_err: unknown) { /* skip mtime */ }
+      try {
+        await stat(join(fullPath, ".git"));
+        const { stdout } = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+          cwd: fullPath,
+          encoding: "utf-8",
+          timeout: 2000,
+        });
+        branch = stdout.trim();
+        isGit = true;
+      } catch (_err: unknown) {
+        isGit = false;
+      }
+      if (isGit) {
         try {
-          const s = await stat(fullPath);
-          modified = new Date(s.mtimeMs).toISOString();
-        } catch (_err: unknown) { /* skip mtime */ }
-        try {
-          const { stdout } = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+          const { stdout } = await exec("git", ["status", "--porcelain"], {
             cwd: fullPath,
             encoding: "utf-8",
             timeout: 2000,
           });
-          branch = stdout.trim();
-          isGit = true;
-        } catch (_err: unknown) {
-          isGit = false;
-        }
-        if (isGit) {
-          try {
-            const { stdout } = await exec("git", ["status", "--porcelain"], {
-              cwd: fullPath,
-              encoding: "utf-8",
-              timeout: 2000,
-            });
-            dirtyCount = stdout.split("\n").filter((l) => l.trim().length > 0).length;
-          } catch (_err: unknown) { /* leave 0 */ }
-        }
-        return {
-          name: entry.name,
-          path: relPath,
-          isGit,
-          branch,
-          dirtyCount,
-          modified,
-        };
-      }),
+          dirtyCount = stdout.split("\n").filter((l) => l.trim().length > 0).length;
+        } catch (_err: unknown) { /* leave 0 */ }
+      }
+      return {
+        name: entry.name,
+        path: relPath,
+        isGit,
+        branch,
+        dirtyCount,
+        modified,
+      };
+    },
     );
 
     projects.sort((a, b) => {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2049,6 +2049,80 @@ export async function createGateway(config: GatewayConfig) {
     return c.json(result);
   });
 
+  app.get("/api/projects", async (c) => {
+    const rootParam = (c.req.query("root") ?? "projects").trim();
+    if (rootParam.length === 0 || rootParam.length > 1024) {
+      return c.json({ error: "Invalid root" }, 400);
+    }
+    const resolved = resolveWithinHome(homePath, rootParam);
+    if (!resolved) return c.json({ error: "Invalid root" }, 400);
+    let entries;
+    try {
+      const { readdir } = await import("node:fs/promises");
+      entries = await readdir(resolved, { withFileTypes: true, encoding: "utf8" });
+    } catch (err: unknown) {
+      console.warn("[projects] Failed to read root:", err instanceof Error ? err.message : err);
+      return c.json({ projects: [] });
+    }
+    const dirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith("."));
+
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const { stat } = await import("node:fs/promises");
+    const exec = promisify(execFile);
+
+    const projects = await Promise.all(
+      dirs.map(async (entry) => {
+        const fullPath = `${resolved}/${entry.name}`;
+        const relPath = `${rootParam}/${entry.name}`;
+        let branch: string | null = null;
+        let dirtyCount = 0;
+        let isGit = false;
+        let modified: string | null = null;
+        try {
+          const s = await stat(fullPath);
+          modified = new Date(s.mtimeMs).toISOString();
+        } catch (_err: unknown) { /* skip mtime */ }
+        try {
+          const { stdout } = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+            cwd: fullPath,
+            encoding: "utf-8",
+            timeout: 2000,
+          });
+          branch = stdout.trim();
+          isGit = true;
+        } catch (_err: unknown) {
+          isGit = false;
+        }
+        if (isGit) {
+          try {
+            const { stdout } = await exec("git", ["status", "--porcelain"], {
+              cwd: fullPath,
+              encoding: "utf-8",
+              timeout: 2000,
+            });
+            dirtyCount = stdout.split("\n").filter((l) => l.trim().length > 0).length;
+          } catch (_err: unknown) { /* leave 0 */ }
+        }
+        return {
+          name: entry.name,
+          path: relPath,
+          isGit,
+          branch,
+          dirtyCount,
+          modified,
+        };
+      }),
+    );
+
+    projects.sort((a, b) => {
+      if (!a.modified || !b.modified) return a.name.localeCompare(b.name);
+      return b.modified.localeCompare(a.modified);
+    });
+
+    return c.json({ root: rootParam, projects });
+  });
+
   app.get("/api/terminal/layout", async (c) => {
     const layoutPath = join(homePath, "system", "terminal-layout.json");
     try {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -21,6 +21,7 @@ import { listDirectory } from "./files-tree.js";
 import { fileStat, fileMkdir, fileTouch, fileRename, fileCopy, fileDuplicate } from "./file-ops.js";
 import { fileSearch } from "./file-search.js";
 import { fileDelete, trashList, trashRestore, trashEmpty } from "./trash.js";
+import { listProjects } from "./projects.js";
 import { createChannelManager, type ChannelManager } from "./channels/manager.js";
 import { createOutboundQueue } from "./security/outbound-queue.js";
 import { createTelegramAdapter, type TelegramAdapter } from "./channels/telegram.js";
@@ -2051,93 +2052,9 @@ export async function createGateway(config: GatewayConfig) {
 
   app.get("/api/projects", async (c) => {
     const rootParam = (c.req.query("root") ?? "projects").trim();
-    if (rootParam.length === 0 || rootParam.length > 1024) {
-      return c.json({ error: "Invalid root" }, 400);
-    }
-    const resolved = resolveWithinHome(homePath, rootParam);
-    if (!resolved) return c.json({ error: "Invalid root" }, 400);
-    let entries: import("node:fs").Dirent[];
-    try {
-      const { readdir } = await import("node:fs/promises");
-      entries = await readdir(resolved, { withFileTypes: true, encoding: "utf8" });
-    } catch (err: unknown) {
-      console.warn("[projects] Failed to read root:", err instanceof Error ? err.message : err);
-      return c.json({ projects: [] });
-    }
-    const dirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith("."));
-
-    const { execFile } = await import("node:child_process");
-    const { promisify } = await import("node:util");
-    const { stat } = await import("node:fs/promises");
-    const exec = promisify(execFile);
-    const mapWithConcurrency = async <T, R>(
-      values: T[],
-      concurrency: number,
-      mapper: (value: T) => Promise<R>,
-    ): Promise<R[]> => {
-      const results = new Array<R>(values.length);
-      let nextIndex = 0;
-      const workers = Array.from({ length: Math.min(concurrency, values.length) }, async () => {
-        while (nextIndex < values.length) {
-          const index = nextIndex;
-          nextIndex += 1;
-          results[index] = await mapper(values[index]);
-        }
-      });
-      await Promise.all(workers);
-      return results;
-    };
-
-    const projects = await mapWithConcurrency(dirs, 8, async (entry) => {
-      const fullPath = join(resolved, entry.name);
-      const relPath = rootParam === "." ? entry.name : `${rootParam.replace(/\/+$/, "")}/${entry.name}`;
-      let branch: string | null = null;
-      let dirtyCount = 0;
-      let isGit = false;
-      let modified: string | null = null;
-      try {
-        const s = await stat(fullPath);
-        modified = new Date(s.mtimeMs).toISOString();
-      } catch (_err: unknown) { /* skip mtime */ }
-      try {
-        await stat(join(fullPath, ".git"));
-        const { stdout } = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
-          cwd: fullPath,
-          encoding: "utf-8",
-          timeout: 2000,
-        });
-        branch = stdout.trim();
-        isGit = true;
-      } catch (_err: unknown) {
-        isGit = false;
-      }
-      if (isGit) {
-        try {
-          const { stdout } = await exec("git", ["status", "--porcelain"], {
-            cwd: fullPath,
-            encoding: "utf-8",
-            timeout: 2000,
-          });
-          dirtyCount = stdout.split("\n").filter((l) => l.trim().length > 0).length;
-        } catch (_err: unknown) { /* leave 0 */ }
-      }
-      return {
-        name: entry.name,
-        path: relPath,
-        isGit,
-        branch,
-        dirtyCount,
-        modified,
-      };
-    },
-    );
-
-    projects.sort((a, b) => {
-      if (!a.modified || !b.modified) return a.name.localeCompare(b.name);
-      return b.modified.localeCompare(a.modified);
-    });
-
-    return c.json({ root: rootParam, projects });
+    const result = await listProjects(homePath, rootParam);
+    if (!result.ok) return c.json({ error: result.error }, result.status as ContentfulStatusCode);
+    return c.json({ root: result.root, projects: result.projects });
   });
 
   app.get("/api/terminal/layout", async (c) => {

--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -10,7 +10,6 @@ const nextConfig: NextConfig = {
   // resources on cross-origin hostnames by default.
   allowedDevOrigins: [
     "staging.matrix-os.com",
-    "*.matrix-os.com",
     "localhost",
     "127.0.0.1",
   ],

--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -5,6 +5,15 @@ const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  // Allow HMR websockets when the dev shell is reached through a tunnel
+  // (staging.matrix-os.com) rather than localhost. Next 16 blocks dev
+  // resources on cross-origin hostnames by default.
+  allowedDevOrigins: [
+    "staging.matrix-os.com",
+    "*.matrix-os.com",
+    "localhost",
+    "127.0.0.1",
+  ],
   // Next's default trailing-slash 308 redirect breaks spec 063 app-runtime:
   // the iframe navigates to /apps/{slug}/ (trailing slash), Next 308s to
   // /apps/{slug} (no slash), and the browser drops the cookie because its

--- a/shell/src/components/terminal/PaneGrid.tsx
+++ b/shell/src/components/terminal/PaneGrid.tsx
@@ -53,6 +53,7 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAt
           isFocused={focusedPaneId === node.id}
           sessionId={node.sessionId}
           claudeMode={node.claudeMode === true}
+          startupCommand={node.startupCommand}
           onFocus={onFocusPane}
           onSessionAttached={onSessionAttached}
           shouldCacheOnUnmount={shouldCachePane}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useCallback, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useCallback, useState } from "react";
 import { type PaneNode, countPanes as countPanesFromStore, getAllPaneIds } from "@/stores/terminal-store";
 import { PaneGrid } from "./PaneGrid";
 import { useTheme } from "@/hooks/useTheme";
@@ -23,18 +23,13 @@ const ZELLIJ_THEME_BY_TERMINAL: Record<string, string> = {
   "github-light": "default",
 };
 
-// Build a one-shot shell command that writes a minimal zellij config
-// honoring the user's terminal theme, then launches zellij. This keeps
-// zellij in sync with the xterm theme without requiring the user to
-// hand-edit ~/.config/zellij/config.kdl.
+// Build a one-shot shell command that writes a Matrix-owned zellij config
+// honoring the user's terminal theme, then launches zellij with that config.
 function zellijLaunchCommand(themeId: TerminalThemeId, isLight: boolean): string {
   const mapped = themeId !== "system" ? ZELLIJ_THEME_BY_TERMINAL[themeId] : undefined;
   const fallback = isLight ? "one-half-light" : "default";
   const theme = mapped ?? fallback;
-  // Single line: idempotent config write, then exec zellij. Quoting note:
-  // the literal `theme "X"` line needs to land in the file, so we wrap the
-  // outer string in single quotes and embed `\"` escapes.
-  return `mkdir -p ~/.config/zellij && printf 'theme "${theme}"\\n' > ~/.config/zellij/config.kdl && zellij`;
+  return `mkdir -p ~/.config/matrix-os && printf 'theme "${theme}"\\n' > ~/.config/matrix-os/zellij.kdl && exec zellij --config ~/.config/matrix-os/zellij.kdl`;
 }
 
 const DEFAULT_CWD = "projects";
@@ -550,8 +545,6 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
 }
 
 // ---- Context for local state ----
-
-import { createContext, useContext } from "react";
 
 interface TerminalAppContextType {
   tabs: Tab[];

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -32,6 +32,15 @@ function zellijLaunchCommand(themeId: TerminalThemeId, isLight: boolean): string
   return `mkdir -p ~/.config/matrix-os && printf 'theme "${theme}"\\n' > ~/.config/matrix-os/zellij.kdl && exec zellij --config ~/.config/matrix-os/zellij.kdl`;
 }
 
+function isLightTerminalTheme(themeId: TerminalThemeId, desktopThemeSlug?: string): boolean {
+  return (
+    themeId === "one-light" ||
+    themeId === "solarized-light" ||
+    themeId === "github-light" ||
+    (themeId === "system" && /light|day/i.test(desktopThemeSlug ?? ""))
+  );
+}
+
 const DEFAULT_CWD = "projects";
 
 interface Tab {
@@ -131,11 +140,7 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
   const theme = useTheme();
   const themeId = useTerminalSettings((s) => s.themeId);
   const setTerminalThemeId = useTerminalSettings((s) => s.setThemeId);
-  const isLightTheme =
-    themeId === "one-light" ||
-    themeId === "solarized-light" ||
-    themeId === "github-light" ||
-    (themeId === "system" && /light|day/i.test(((theme as { slug?: string }).slug ?? "")));
+  const isLightTheme = isLightTerminalTheme(themeId, (theme as { slug?: string }).slug);
 
   // Match the padding around the xterm to the active terminal theme so the
   // user never sees a colored seam between the OS theme bg and the xterm
@@ -866,9 +871,9 @@ type SidebarTab = "projects" | "files";
 
 function LocalTerminalSidebar() {
   const ctx = useTerminalAppContext();
+  const theme = useTheme();
   const themeId = useTerminalSettings((s) => s.themeId);
-  const isLightSidebar =
-    themeId === "one-light" || themeId === "solarized-light" || themeId === "github-light";
+  const isLightSidebar = isLightTerminalTheme(themeId, (theme as { slug?: string }).slug);
   const [tab, setTab] = useState<SidebarTab>("projects");
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [projectsLoading, setProjectsLoading] = useState(true);

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -6,6 +6,36 @@ import { PaneGrid } from "./PaneGrid";
 import { useTheme } from "@/hooks/useTheme";
 import { getGatewayUrl } from "@/lib/gateway";
 import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
+import { useTerminalSettings, type TerminalThemeId } from "@/stores/terminal-settings";
+import { TERMINAL_THEME_OPTIONS, getTerminalThemePreset } from "./terminal-themes";
+
+// Map xterm theme ids onto zellij's built-in theme names. Zellij ships with
+// these themes in 0.44, so referencing them by name "just works".
+const ZELLIJ_THEME_BY_TERMINAL: Record<string, string> = {
+  "one-dark": "one-half-dark",
+  "one-light": "one-half-light",
+  "catppuccin-mocha": "catppuccin-mocha",
+  "dracula": "dracula",
+  "nord": "nord",
+  "solarized-dark": "solarized-dark",
+  "solarized-light": "solarized-light",
+  "github-dark": "default",
+  "github-light": "default",
+};
+
+// Build a one-shot shell command that writes a minimal zellij config
+// honoring the user's terminal theme, then launches zellij. This keeps
+// zellij in sync with the xterm theme without requiring the user to
+// hand-edit ~/.config/zellij/config.kdl.
+function zellijLaunchCommand(themeId: TerminalThemeId, isLight: boolean): string {
+  const mapped = themeId !== "system" ? ZELLIJ_THEME_BY_TERMINAL[themeId] : undefined;
+  const fallback = isLight ? "one-half-light" : "default";
+  const theme = mapped ?? fallback;
+  // Single line: idempotent config write, then exec zellij. Quoting note:
+  // the literal `theme "X"` line needs to land in the file, so we wrap the
+  // outer string in single quotes and embed `\"` escapes.
+  return `mkdir -p ~/.config/zellij && printf 'theme "${theme}"\\n' > ~/.config/zellij/config.kdl && zellij`;
+}
 
 const DEFAULT_CWD = "projects";
 
@@ -104,6 +134,21 @@ interface TerminalAppProps {
 
 export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
   const theme = useTheme();
+  const themeId = useTerminalSettings((s) => s.themeId);
+  const setTerminalThemeId = useTerminalSettings((s) => s.setThemeId);
+  const isLightTheme =
+    themeId === "one-light" ||
+    themeId === "solarized-light" ||
+    themeId === "github-light" ||
+    (themeId === "system" && /light|day/i.test(((theme as { slug?: string }).slug ?? "")));
+
+  // Match the padding around the xterm to the active terminal theme so the
+  // user never sees a colored seam between the OS theme bg and the xterm
+  // bg. Falls back to the desktop theme bg when "Match OS" is selected.
+  const terminalBackground =
+    themeId === "system"
+      ? (theme.colors.background || "var(--background)")
+      : getTerminalThemePreset(themeId).background;
 
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [activeTabId, setActiveTabId] = useState("");
@@ -117,6 +162,8 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
   tabsRef.current = tabs;
   const activeTabIdRef = useRef(activeTabId);
   activeTabIdRef.current = activeTabId;
+  const themeIdRef = useRef(themeId);
+  themeIdRef.current = themeId;
   const sidebarOpenRef = useRef(sidebarOpen);
   sidebarOpenRef.current = sidebarOpen;
   const pendingPaneSessionsRef = useRef<Map<string, string>>(new Map());
@@ -187,16 +234,29 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
     }, 0);
   }, []);
 
-  const addTab = useCallback((cwd: string, label?: string, claude?: boolean) => {
-    const id = genId();
-    const paneId = genId();
-    const basename = cwd.split("/").filter(Boolean).pop() ?? "~";
-    const tab: Tab = { id, label: label ?? basename, paneTree: { type: "pane", id: paneId, cwd, claudeMode: claude } };
-    setTabs(prev => [...prev, tab]);
-    setActiveTabId(id);
-    setFocusedPaneId(paneId);
-    return id;
-  }, []);
+  const addTab = useCallback(
+    (cwd: string, label?: string, claude?: boolean, startupCommand?: string) => {
+      const id = genId();
+      const paneId = genId();
+      const basename = cwd.split("/").filter(Boolean).pop() ?? "~";
+      const tab: Tab = {
+        id,
+        label: label ?? basename,
+        paneTree: {
+          type: "pane",
+          id: paneId,
+          cwd,
+          claudeMode: claude,
+          startupCommand,
+        },
+      };
+      setTabs((prev) => [...prev, tab]);
+      setActiveTabId(id);
+      setFocusedPaneId(paneId);
+      return id;
+    },
+    [],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -427,8 +487,9 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
       case "E": e.preventDefault(); if (focusedPaneId) splitPane(focusedPaneId, "vertical"); break;
       case "B": e.preventDefault(); setSidebarOpen(o => !o); break;
       case "C": e.preventDefault(); addTab(getCwd(), "Claude Code", true); break;
+      case "Z": e.preventDefault(); addTab(getCwd(), "Zellij", false, zellijLaunchCommand(themeIdRef.current, isLightTheme)); break;
     }
-  }, [addTab, closePane, splitPane, focusedPaneId, getCwd]);
+  }, [addTab, closePane, splitPane, focusedPaneId, getCwd, isLightTheme]);
 
   const activeTab = tabs.find(t => t.id === activeTabId);
 
@@ -448,19 +509,24 @@ export function TerminalApp({ initialCommand }: TerminalAppProps = {}) {
       onKeyDown={handleKeyDown}
     >
       <TerminalAppContext.Provider value={storeApi}>
-        <LocalTerminalTabBar defaultCwd={DEFAULT_CWD} />
+        <LocalTerminalTabBar defaultCwd={DEFAULT_CWD} isLightTheme={isLightTheme} />
         <div className="flex flex-1 min-h-0">
           <LocalTerminalSidebar />
           {activeTab ? (
-            <PaneGrid
-              paneTree={activeTab.paneTree}
-              theme={theme}
-              focusedPaneId={focusedPaneId}
-              onFocusPane={setFocusedPaneId}
-              onSessionAttached={handleSessionAttached}
-              shouldCachePane={shouldCachePane}
-              shouldDestroyPane={shouldDestroyPane}
-            />
+            <div
+              className="flex-1 min-w-0 min-h-0 flex"
+              style={{ padding: "8px 10px 8px 12px", background: terminalBackground }}
+            >
+              <PaneGrid
+                paneTree={activeTab.paneTree}
+                theme={theme}
+                focusedPaneId={focusedPaneId}
+                onFocusPane={setFocusedPaneId}
+                onSessionAttached={handleSessionAttached}
+                shouldCachePane={shouldCachePane}
+                shouldDestroyPane={shouldDestroyPane}
+              />
+            </div>
           ) : !initialized ? (
             <div className="flex-1" style={{ background: "var(--background)" }} />
           ) : (
@@ -493,7 +559,7 @@ interface TerminalAppContextType {
   sidebarOpen: boolean;
   sidebarSelectedPath: string | null;
   focusedPaneId: string | null;
-  addTab: (cwd: string, label?: string, claude?: boolean) => string;
+  addTab: (cwd: string, label?: string, claude?: boolean, startupCommand?: string) => string;
   closeTab: (tabId: string) => void;
   setActiveTab: (tabId: string) => void;
   renameTab: (tabId: string, label: string) => void;
@@ -515,51 +581,336 @@ function useTerminalAppContext() {
 
 // ---- Local versions of TabBar and Sidebar that use context instead of global store ----
 
-function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
+const ICON_SIZE = 16;
+
+function IconPlus() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round">
+      <line x1="8" y1="3" x2="8" y2="13" />
+      <line x1="3" y1="8" x2="13" y2="8" />
+    </svg>
+  );
+}
+function IconSplitH() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+      <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" />
+      <line x1="8" y1="3" x2="8" y2="13" />
+    </svg>
+  );
+}
+function IconSplitV() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+      <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" />
+      <line x1="3" y1="8" x2="13" y2="8" />
+    </svg>
+  );
+}
+function IconClose() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+      <line x1="3" y1="3" x2="9" y2="9" />
+      <line x1="9" y1="3" x2="3" y2="9" />
+    </svg>
+  );
+}
+function IconPalette() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+      <path d="M8 2c-3.3 0-6 2.4-6 5.5 0 1.7 1.3 3 3 3h1c.6 0 1 .4 1 1v.5c0 1.1.9 2 2 2h.2c2.7 0 4.8-2.2 4.8-4.9V7.5C14 4.4 11.3 2 8 2z" />
+      <circle cx="5" cy="6" r="0.7" fill="currentColor" stroke="none" />
+      <circle cx="8" cy="4.5" r="0.7" fill="currentColor" stroke="none" />
+      <circle cx="11" cy="6" r="0.7" fill="currentColor" stroke="none" />
+      <circle cx="11.5" cy="9" r="0.7" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+interface ToolbarBtnProps {
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+  variant?: "default" | "primary" | "success";
+}
+function ToolbarBtn({ onClick, title, children, variant = "default" }: ToolbarBtnProps) {
+  const colors =
+    variant === "success"
+      ? { bg: "var(--success)", color: "white", border: "transparent" }
+      : variant === "primary"
+        ? { bg: "var(--primary)", color: "white", border: "transparent" }
+        : { bg: "transparent", color: "var(--muted-foreground)", border: "transparent" };
+  return (
+    <button
+      className="cursor-pointer transition-colors flex items-center justify-center gap-1.5"
+      style={{
+        height: 28,
+        minWidth: 28,
+        padding: variant === "default" ? "0 6px" : "0 10px",
+        fontSize: 12,
+        fontWeight: variant === "default" ? 400 : 500,
+        borderRadius: 6,
+        background: colors.bg,
+        color: colors.color,
+        border: `1px solid ${colors.border}`,
+      }}
+      onMouseEnter={(e) => {
+        if (variant === "default") {
+          e.currentTarget.style.background = "var(--accent)";
+          e.currentTarget.style.color = "var(--foreground)";
+        } else {
+          e.currentTarget.style.opacity = "0.85";
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (variant === "default") {
+          e.currentTarget.style.background = "transparent";
+          e.currentTarget.style.color = "var(--muted-foreground)";
+        } else {
+          e.currentTarget.style.opacity = "1";
+        }
+      }}
+      onClick={onClick}
+      title={title}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ThemePickerButton() {
+  const themeId = useTerminalSettings((s) => s.themeId);
+  const setThemeId = useTerminalSettings((s) => s.setThemeId);
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const current = TERMINAL_THEME_OPTIONS.find((o) => o.id === themeId) ?? TERMINAL_THEME_OPTIONS[0];
+
+  return (
+    <div ref={wrapRef} style={{ position: "relative" }}>
+      <ToolbarBtn onClick={() => setOpen((o) => !o)} title={`Terminal theme: ${current.label}`}>
+        <IconPalette />
+      </ToolbarBtn>
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: 32,
+            right: 0,
+            zIndex: 50,
+            background: "var(--card)",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+            padding: 4,
+            minWidth: 180,
+          }}
+        >
+          <div style={{ padding: "6px 10px", fontSize: 10, color: "var(--muted-foreground)", textTransform: "uppercase", letterSpacing: 0.5 }}>
+            Terminal Theme
+          </div>
+          {TERMINAL_THEME_OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              onClick={() => { setThemeId(opt.id); setOpen(false); }}
+              className="w-full flex items-center gap-2 cursor-pointer transition-colors"
+              style={{
+                padding: "6px 10px",
+                fontSize: 12,
+                background: opt.id === themeId ? "var(--accent)" : "transparent",
+                color: "var(--foreground)",
+                border: "none",
+                textAlign: "left",
+                borderRadius: 4,
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "var(--accent)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = opt.id === themeId ? "var(--accent)" : "transparent"; }}
+            >
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: opt.id === themeId ? "var(--primary)" : "var(--border)" }} />
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LocalTerminalTabBar({ defaultCwd, isLightTheme }: { defaultCwd: string; isLightTheme: boolean }) {
   const ctx = useTerminalAppContext();
+  const themeId = useTerminalSettings((s) => s.themeId);
   const dragIndexRef = useRef<number | null>(null);
 
   const getCwd = () => ctx.sidebarSelectedPath ?? defaultCwd;
 
   return (
-    <div className="flex items-stretch border-b shrink-0 select-none" style={{ background: "var(--card)", borderColor: "var(--border)", height: 34 }}>
-      <div className="flex items-stretch overflow-x-auto flex-1 min-w-0">
-        {ctx.tabs.map((tab, i) => (
-          <div
-            key={tab.id}
-            className="flex items-center gap-1.5 px-3 text-xs cursor-pointer whitespace-nowrap"
-            style={{
-              background: tab.id === ctx.activeTabId ? "var(--background)" : "transparent",
-              borderRight: "1px solid var(--border)",
-              borderTop: tab.id === ctx.activeTabId ? "2px solid var(--primary)" : "2px solid transparent",
-              color: tab.id === ctx.activeTabId ? "var(--foreground)" : "var(--muted-foreground)",
-            }}
-            draggable
-            onClick={() => ctx.setActiveTab(tab.id)}
-            onDragStart={() => { dragIndexRef.current = i; }}
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={(e) => { e.preventDefault(); if (dragIndexRef.current !== null && dragIndexRef.current !== i) ctx.reorderTabs(dragIndexRef.current, i); dragIndexRef.current = null; }}
-          >
-            <span className="size-1.5 rounded-full" style={{ background: "var(--success)" }} />
-            <span>{tab.label}</span>
-            <button className="ml-1 opacity-40 hover:opacity-100" onClick={(e) => { e.stopPropagation(); ctx.closeTab(tab.id); }} style={{ color: "var(--muted-foreground)" }}>x</button>
-          </div>
-        ))}
+    <div
+      className="flex items-stretch border-b shrink-0 select-none"
+      style={{
+        background: "var(--card)",
+        borderColor: "var(--border)",
+        height: 40,
+        padding: "4px 6px",
+        gap: 4,
+      }}
+    >
+      <div className="flex items-stretch overflow-x-auto flex-1 min-w-0" style={{ gap: 2 }}>
+        {ctx.tabs.map((tab, i) => {
+          const active = tab.id === ctx.activeTabId;
+          return (
+            <div
+              key={tab.id}
+              className="flex items-center gap-1.5 cursor-pointer whitespace-nowrap transition-colors"
+              style={{
+                background: active ? "var(--background)" : "transparent",
+                color: active ? "var(--foreground)" : "var(--muted-foreground)",
+                border: `1px solid ${active ? "var(--border)" : "transparent"}`,
+                borderRadius: 6,
+                padding: "0 10px",
+                fontSize: 12,
+                height: 30,
+                fontWeight: active ? 500 : 400,
+              }}
+              draggable
+              onClick={() => ctx.setActiveTab(tab.id)}
+              onDragStart={() => { dragIndexRef.current = i; }}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => { e.preventDefault(); if (dragIndexRef.current !== null && dragIndexRef.current !== i) ctx.reorderTabs(dragIndexRef.current, i); dragIndexRef.current = null; }}
+            >
+              <span
+                style={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: "50%",
+                  background: active ? "var(--success)" : "var(--muted-foreground)",
+                  opacity: active ? 1 : 0.5,
+                }}
+              />
+              <span style={{ maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis" }}>{tab.label}</span>
+              <button
+                className="cursor-pointer flex items-center justify-center transition-colors"
+                onClick={(e) => { e.stopPropagation(); ctx.closeTab(tab.id); }}
+                style={{
+                  width: 16,
+                  height: 16,
+                  borderRadius: 3,
+                  border: "none",
+                  background: "transparent",
+                  color: "var(--muted-foreground)",
+                  opacity: 0.5,
+                  marginLeft: 2,
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.opacity = "1"; e.currentTarget.style.background = "var(--accent)"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.opacity = "0.5"; e.currentTarget.style.background = "transparent"; }}
+                title="Close tab"
+              >
+                <IconClose />
+              </button>
+            </div>
+          );
+        })}
       </div>
-      <div className="flex items-center gap-1 px-2 shrink-0">
-        <button className="text-xs cursor-pointer hover:opacity-80" style={{ background: "var(--success)", color: "white", borderRadius: 4, padding: "2px 8px" }} onClick={() => ctx.addTab(getCwd(), "Claude Code", true)} title="Launch Claude Code">Claude Code</button>
-        <button className="text-xs cursor-pointer hover:opacity-80" style={{ color: "var(--muted-foreground)" }} onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "horizontal"); }} title="Split horizontal">&#8862;</button>
-        <button className="text-xs cursor-pointer hover:opacity-80" style={{ color: "var(--muted-foreground)" }} onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "vertical"); }} title="Split vertical">&#8863;</button>
-        <button className="text-xs cursor-pointer hover:opacity-80" style={{ color: "var(--muted-foreground)" }} onClick={() => ctx.addTab(getCwd())} title="New tab">+</button>
+      <div className="flex items-center shrink-0" style={{ gap: 4, paddingLeft: 8, borderLeft: "1px solid var(--border)" }}>
+        <ToolbarBtn
+          onClick={() => ctx.addTab(getCwd(), "Claude Code", true)}
+          title="Launch Claude Code (Ctrl+Shift+C)"
+          variant="success"
+        >
+          Claude
+        </ToolbarBtn>
+        <ToolbarBtn
+          onClick={() => ctx.addTab(getCwd(), "Zellij", false, zellijLaunchCommand(themeId, isLightTheme))}
+          title="Launch Zellij (Ctrl+Shift+Z)"
+          variant="primary"
+        >
+          Zellij
+        </ToolbarBtn>
+        <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
+        <ToolbarBtn
+          onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "horizontal"); }}
+          title="Split horizontally (Ctrl+Shift+D)"
+        >
+          <IconSplitH />
+        </ToolbarBtn>
+        <ToolbarBtn
+          onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "vertical"); }}
+          title="Split vertically (Ctrl+Shift+E)"
+        >
+          <IconSplitV />
+        </ToolbarBtn>
+        <ToolbarBtn
+          onClick={() => ctx.addTab(getCwd())}
+          title="New tab (Ctrl+Shift+T)"
+        >
+          <IconPlus />
+        </ToolbarBtn>
+        <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
+        <ThemePickerButton />
       </div>
     </div>
   );
 }
 
+interface ProjectInfo {
+  name: string;
+  path: string;
+  isGit: boolean;
+  branch: string | null;
+  dirtyCount: number;
+  modified: string | null;
+}
+
+type SidebarTab = "projects" | "files";
+
 function LocalTerminalSidebar() {
   const ctx = useTerminalAppContext();
+  const themeId = useTerminalSettings((s) => s.themeId);
+  const isLightSidebar =
+    themeId === "one-light" || themeId === "solarized-light" || themeId === "github-light";
+  const [tab, setTab] = useState<SidebarTab>("projects");
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [projectsLoading, setProjectsLoading] = useState(true);
+  const [projectsError, setProjectsError] = useState<string | null>(null);
   const [rootPath, setRootPath] = useState("projects");
   const [tree, setTree] = useState<TreeNode[]>([]);
+  const [filter, setFilter] = useState("");
+
+  const fetchProjects = useCallback(async () => {
+    setProjectsLoading(true);
+    setProjectsError(null);
+    try {
+      const res = await fetch(`${getGatewayUrl()}/api/projects?root=projects`, {
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) {
+        setProjectsError("Failed to load projects");
+        setProjects([]);
+        return;
+      }
+      const data = (await res.json()) as { projects?: ProjectInfo[] };
+      setProjects(Array.isArray(data.projects) ? data.projects : []);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("Failed to load projects:", msg);
+      setProjectsError("Could not reach gateway");
+      setProjects([]);
+    } finally {
+      setProjectsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tab === "projects") void fetchProjects();
+  }, [tab, fetchProjects]);
 
   const fetchDir = useCallback(async (path: string) => {
     try {
@@ -575,8 +926,9 @@ function LocalTerminalSidebar() {
   }, []);
 
   useEffect(() => {
+    if (tab !== "files") return;
     fetchDir(rootPath).then((entries: TreeNode[]) => setTree(entries.map(e => ({ ...e, path: `${rootPath}/${e.name}` }))));
-  }, [rootPath, fetchDir]);
+  }, [rootPath, fetchDir, tab]);
 
   const toggleExpand = useCallback(async (node: TreeNode) => {
     if (node.type !== "directory") return;
@@ -587,32 +939,288 @@ function LocalTerminalSidebar() {
 
   if (!ctx.sidebarOpen) {
     return (
-      <div className="flex flex-col items-center py-2 gap-2 shrink-0" style={{ width: 36, background: "var(--card)", borderRight: "1px solid var(--border)" }}>
-        <button className="flex items-center justify-center rounded cursor-pointer hover:bg-[var(--accent)]" style={{ width: 24, height: 24, fontSize: 14 }} onClick={() => ctx.setSidebarOpen(true)} title="Files">&#128193;</button>
+      <div className="flex flex-col items-center py-2 gap-2 shrink-0" style={{ width: 40, background: "var(--card)", borderRight: "1px solid var(--border)" }}>
+        <button
+          className="flex items-center justify-center rounded cursor-pointer hover:bg-[var(--accent)] transition-colors"
+          style={{ width: 28, height: 28, fontSize: 14 }}
+          onClick={() => ctx.setSidebarOpen(true)}
+          title="Open sidebar (Ctrl+Shift+B)"
+        >
+          ☰
+        </button>
       </div>
     );
   }
 
   const isAtRoot = !rootPath || rootPath === ".";
+  const filteredProjects = filter
+    ? projects.filter((p) => p.name.toLowerCase().includes(filter.toLowerCase()))
+    : projects;
 
   return (
-    <div className="flex flex-col shrink-0 overflow-hidden" style={{ width: 200, background: "var(--card)", borderRight: "1px solid var(--border)" }}>
-      <div className="flex items-center gap-1 px-2 py-1.5 text-[10px] shrink-0" style={{ borderBottom: "1px solid var(--border)" }}>
-        <button className="flex items-center justify-center rounded cursor-pointer hover:bg-[var(--accent)]" style={{ width: 24, height: 24, fontSize: 14 }} onClick={() => ctx.setSidebarOpen(false)} title="Files">&#128193;</button>
-        {!isAtRoot && <button className="text-xs opacity-60 hover:opacity-100 cursor-pointer" onClick={() => { const p = rootPath.split("/").filter(Boolean); p.pop(); setRootPath(p.join("/") || ""); }} style={{ color: "var(--muted-foreground)" }}>..</button>}
-        <span className="text-[10px] truncate" style={{ color: "var(--muted-foreground)", textTransform: "uppercase", letterSpacing: "0.5px" }}>{rootPath || "~"}</span>
+    <div className="flex flex-col shrink-0 overflow-hidden" style={{ width: 240, background: "var(--card)", borderRight: "1px solid var(--border)", paddingLeft: 4 }}>
+      <div className="flex items-stretch shrink-0" style={{ borderBottom: "1px solid var(--border)" }}>
+        <button
+          className="flex-1 flex items-center justify-center gap-1.5 text-[11px] cursor-pointer transition-colors"
+          style={{
+            padding: "8px 6px",
+            background: tab === "projects" ? "var(--background)" : "transparent",
+            color: tab === "projects" ? "var(--foreground)" : "var(--muted-foreground)",
+            borderBottom: tab === "projects" ? "2px solid var(--primary)" : "2px solid transparent",
+            fontWeight: 500,
+            letterSpacing: "0.3px",
+          }}
+          onClick={() => setTab("projects")}
+        >
+          <span style={{ fontSize: 12 }}>◆</span> Projects
+        </button>
+        <button
+          className="flex-1 flex items-center justify-center gap-1.5 text-[11px] cursor-pointer transition-colors"
+          style={{
+            padding: "8px 6px",
+            background: tab === "files" ? "var(--background)" : "transparent",
+            color: tab === "files" ? "var(--foreground)" : "var(--muted-foreground)",
+            borderBottom: tab === "files" ? "2px solid var(--primary)" : "2px solid transparent",
+            fontWeight: 500,
+            letterSpacing: "0.3px",
+          }}
+          onClick={() => setTab("files")}
+        >
+          <span style={{ fontSize: 12 }}>▤</span> Files
+        </button>
+        <button
+          className="flex items-center justify-center cursor-pointer hover:bg-[var(--accent)] transition-colors"
+          style={{ width: 28, color: "var(--muted-foreground)", fontSize: 14 }}
+          onClick={() => ctx.setSidebarOpen(false)}
+          title="Hide sidebar (Ctrl+Shift+B)"
+        >
+          ‹
+        </button>
       </div>
-      <div className="flex-1 overflow-y-auto py-1 text-xs">
-        {tree.map(node => (
-          <TreeItem key={node.path} node={node} depth={0} selectedPath={ctx.sidebarSelectedPath}
-            onToggle={toggleExpand}
-            onSelect={(n) => { if (n.type === "directory") ctx.setSidebarSelectedPath(n.path); }}
-            onOpenTerminal={(path) => ctx.addTab(path)}
-          />
-        ))}
-        {tree.length === 0 && <div className="px-3 py-4 text-center" style={{ color: "var(--muted-foreground)" }}>Empty directory</div>}
+
+      {tab === "projects" ? (
+        <>
+          <div className="flex items-center gap-1.5 px-2 py-1.5 shrink-0" style={{ borderBottom: "1px solid var(--border)" }}>
+            <input
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter..."
+              className="flex-1 text-[11px] outline-none"
+              style={{
+                background: "var(--background)",
+                color: "var(--foreground)",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                padding: "3px 6px",
+              }}
+            />
+            <button
+              onClick={() => void fetchProjects()}
+              className="cursor-pointer hover:bg-[var(--accent)] rounded transition-colors"
+              style={{ color: "var(--muted-foreground)", fontSize: 12, padding: "2px 6px" }}
+              title="Refresh"
+            >
+              ↻
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto py-1">
+            {projectsLoading && (
+              <div className="px-3 py-6 text-center text-[11px]" style={{ color: "var(--muted-foreground)" }}>
+                Loading projects…
+              </div>
+            )}
+            {!projectsLoading && projectsError && (
+              <div className="px-3 py-6 text-center text-[11px]" style={{ color: "var(--destructive)" }}>
+                {projectsError}
+              </div>
+            )}
+            {!projectsLoading && !projectsError && filteredProjects.length === 0 && (
+              <div className="px-3 py-6 text-center text-[11px]" style={{ color: "var(--muted-foreground)" }}>
+                {filter ? "No matches" : (
+                  <>
+                    <div style={{ fontSize: 22, marginBottom: 6 }}>◇</div>
+                    <div style={{ marginBottom: 4 }}>No projects yet</div>
+                    <div style={{ opacity: 0.7 }}>Create or clone into <code>~/projects</code></div>
+                  </>
+                )}
+              </div>
+            )}
+            {!projectsLoading && filteredProjects.map((p) => (
+              <ProjectCard
+                key={p.path}
+                project={p}
+                onOpenShell={() => ctx.addTab(p.path, p.name)}
+                onOpenClaude={() => ctx.addTab(p.path, `${p.name} · claude`, true)}
+                onOpenZellij={() => ctx.addTab(p.path, `${p.name} · zellij`, false, zellijLaunchCommand(themeId, isLightSidebar))}
+                onSelect={() => ctx.setSidebarSelectedPath(p.path)}
+                isSelected={ctx.sidebarSelectedPath === p.path}
+              />
+            ))}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex items-center gap-1 px-2 py-1.5 text-[10px] shrink-0" style={{ borderBottom: "1px solid var(--border)" }}>
+            {!isAtRoot && (
+              <button
+                className="text-xs opacity-60 hover:opacity-100 cursor-pointer"
+                onClick={() => { const p = rootPath.split("/").filter(Boolean); p.pop(); setRootPath(p.join("/") || ""); }}
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                ←
+              </button>
+            )}
+            <span
+              className="text-[10px] truncate"
+              style={{ color: "var(--muted-foreground)", textTransform: "uppercase", letterSpacing: "0.5px" }}
+            >
+              {rootPath || "~"}
+            </span>
+          </div>
+          <div className="flex-1 overflow-y-auto py-1 text-xs">
+            {tree.map(node => (
+              <TreeItem
+                key={node.path}
+                node={node}
+                depth={0}
+                selectedPath={ctx.sidebarSelectedPath}
+                onToggle={toggleExpand}
+                onSelect={(n) => { if (n.type === "directory") ctx.setSidebarSelectedPath(n.path); }}
+                onOpenTerminal={(path) => ctx.addTab(path)}
+              />
+            ))}
+            {tree.length === 0 && (
+              <div className="px-3 py-4 text-center" style={{ color: "var(--muted-foreground)" }}>
+                Empty directory
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface ProjectCardProps {
+  project: ProjectInfo;
+  onOpenShell: () => void;
+  onOpenClaude: () => void;
+  onOpenZellij: () => void;
+  onSelect: () => void;
+  isSelected: boolean;
+}
+
+function ProjectCard({ project, onOpenShell, onOpenClaude, onOpenZellij, onSelect, isSelected }: ProjectCardProps) {
+  const [hover, setHover] = useState(false);
+  return (
+    <div
+      className="cursor-pointer transition-colors"
+      style={{
+        margin: "3px 8px",
+        padding: "8px 10px 6px",
+        borderRadius: 6,
+        background: isSelected ? "var(--accent)" : hover ? "var(--accent)" : "transparent",
+        border: `1px solid ${isSelected ? "var(--primary)" : "transparent"}`,
+      }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onClick={onSelect}
+      onDoubleClick={onOpenShell}
+      title={`${project.path}\nDouble-click to open terminal`}
+    >
+      <div className="flex items-center gap-1.5" style={{ marginBottom: 4 }}>
+        <span
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            background: project.dirtyCount > 0 ? "var(--warning)" : project.isGit ? "var(--success)" : "var(--muted-foreground)",
+            flexShrink: 0,
+          }}
+        />
+        <span
+          className="text-[12px] truncate flex-1"
+          style={{ color: "var(--foreground)", fontWeight: 500 }}
+        >
+          {project.name}
+        </span>
+      </div>
+      <div className="flex items-center gap-1.5 text-[10px]" style={{ color: "var(--muted-foreground)", paddingLeft: 12 }}>
+        {project.isGit && project.branch && (
+          <span
+            style={{
+              padding: "1px 5px",
+              borderRadius: 3,
+              background: "var(--background)",
+              border: "1px solid var(--border)",
+              fontFamily: "var(--font-mono, ui-monospace, monospace)",
+              maxWidth: 100,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {project.branch}
+          </span>
+        )}
+        {project.dirtyCount > 0 && (
+          <span
+            style={{
+              padding: "1px 5px",
+              borderRadius: 3,
+              background: "var(--warning)",
+              color: "var(--card)",
+              fontWeight: 600,
+            }}
+          >
+            {project.dirtyCount}
+          </span>
+        )}
+        {!project.isGit && <span style={{ opacity: 0.6 }}>folder</span>}
+      </div>
+      <div
+        className="flex items-center gap-1"
+        style={{
+          marginTop: 6,
+          paddingLeft: 12,
+          opacity: hover || isSelected ? 1 : 0,
+          maxHeight: hover || isSelected ? 22 : 0,
+          overflow: "hidden",
+          transition: "opacity 120ms, max-height 120ms",
+        }}
+      >
+        <ProjectActionBtn label="Shell" onClick={(e) => { e.stopPropagation(); onOpenShell(); }} />
+        <ProjectActionBtn label="Claude" onClick={(e) => { e.stopPropagation(); onOpenClaude(); }} accent="var(--success)" />
+        <ProjectActionBtn label="Zellij" onClick={(e) => { e.stopPropagation(); onOpenZellij(); }} accent="var(--primary)" />
       </div>
     </div>
+  );
+}
+
+function ProjectActionBtn({
+  label,
+  onClick,
+  accent,
+}: {
+  label: string;
+  onClick: (e: React.MouseEvent) => void;
+  accent?: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="text-[10px] cursor-pointer transition-colors"
+      style={{
+        padding: "2px 6px",
+        borderRadius: 3,
+        background: accent ?? "var(--background)",
+        color: accent ? "white" : "var(--foreground)",
+        border: accent ? "none" : "1px solid var(--border)",
+        opacity: 0.9,
+      }}
+    >
+      {label}
+    </button>
   );
 }
 

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -169,6 +169,7 @@ interface TerminalPaneProps {
   isFocused: boolean;
   sessionId?: string;
   claudeMode?: boolean;
+  startupCommand?: string;
   onFocus?: (paneId: string) => void;
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   isClosing?: boolean;
@@ -183,6 +184,7 @@ export function TerminalPane({
   isFocused,
   sessionId: initialSessionId,
   claudeMode,
+  startupCommand,
   onFocus,
   onSessionAttached,
   isClosing,
@@ -361,6 +363,12 @@ export function TerminalPane({
           fontSize: terminalFontSize,
           fontFamily: theme.fonts?.mono || "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace",
           theme: xtermTheme,
+          // Make ⌥ (Option) on macOS act as Meta — without this, Option+Left/Right
+          // never reaches the shell as ESC-b / ESC-f, so word-jump is broken.
+          macOptionIsMeta: true,
+          // Send a Unicode bullet for Option+key combos that fall through to the
+          // browser instead of producing accented characters.
+          macOptionClickForcesSelection: true,
         });
 
         const nextFitAddon = new FitAddon();
@@ -399,6 +407,53 @@ export function TerminalPane({
         // Link provider
         xterm.registerLinkProvider(new WebLinkProvider(xterm));
 
+        // OSC 52 clipboard handler — used by TUIs (Claude Code, tmux, neovim, ...)
+        // to copy text to the host clipboard. Format: "<Pc>;<Pd>" where Pc is the
+        // selection target ("c", "p", "s", "0"-"7") and Pd is base64 or "?".
+        try {
+          xterm.parser.registerOscHandler(52, (data: string) => {
+            const semi = data.indexOf(";");
+            if (semi < 0) return false;
+            const payload = data.slice(semi + 1);
+            if (payload === "" || payload === "?") {
+              // Query for current clipboard contents — we don't expose this.
+              return true;
+            }
+            let text: string;
+            try {
+              const bytes = Uint8Array.from(atob(payload), (ch) => ch.charCodeAt(0));
+              text = new TextDecoder().decode(bytes);
+            } catch (_err: unknown) {
+              return false;
+            }
+            const fallbackCopy = () => {
+              try {
+                const ta = document.createElement("textarea");
+                ta.value = text;
+                ta.style.position = "fixed";
+                ta.style.opacity = "0";
+                document.body.appendChild(ta);
+                ta.select();
+                document.execCommand("copy");
+                document.body.removeChild(ta);
+              } catch (err: unknown) {
+                console.warn("OSC 52 fallback copy failed:", err instanceof Error ? err.message : err);
+              }
+            };
+            if (typeof navigator !== "undefined" && navigator.clipboard) {
+              navigator.clipboard.writeText(text).catch((err: unknown) => {
+                console.warn("OSC 52 clipboard write failed, using fallback:", err instanceof Error ? err.message : err);
+                fallbackCopy();
+              });
+            } else {
+              fallbackCopy();
+            }
+            return true;
+          });
+        } catch (err: unknown) {
+          console.warn("Failed to register OSC 52 handler:", err instanceof Error ? err.message : err);
+        }
+
         if (disposed) {
           xterm.dispose();
           return;
@@ -433,10 +488,13 @@ export function TerminalPane({
 
           ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
 
-          if (claudeMode && !sessionIdRef.current) {
+          const startup = sessionIdRef.current
+            ? null
+            : startupCommand?.trim() || (claudeMode ? "claude" : null);
+          if (startup) {
             setTimeout(() => {
               if (ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify({ type: "input", data: "claude\r" }));
+                ws.send(JSON.stringify({ type: "input", data: `${startup}\r` }));
               }
             }, 100);
           }
@@ -690,6 +748,13 @@ export function TerminalPane({
       });
 
       // Keyboard shortcuts
+      const sendRaw = (data: string) => {
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "input", data }));
+        }
+      };
+
       term.attachCustomKeyEventHandler((ev: KeyboardEvent) => {
         if (ev.type !== "keydown") return true;
 
@@ -723,6 +788,30 @@ export function TerminalPane({
             console.warn("Clipboard paste failed:", err instanceof Error ? err.message : err);
           });
           return false;
+        }
+
+        // macOS-style line-editing shortcuts. The browser only delivers
+        // Cmd-arrow events to us when the focus is inside xterm; otherwise
+        // the OS swallows them. We map them to the readline-equivalent
+        // control sequences so bash/zsh, claude, pi, etc. all behave
+        // predictably regardless of OS keymap.
+        if (ev.metaKey && !ev.ctrlKey && !ev.altKey) {
+          if (ev.key === "ArrowLeft") {
+            sendRaw("\x01"); // Ctrl-A — beginning of line
+            return false;
+          }
+          if (ev.key === "ArrowRight") {
+            sendRaw("\x05"); // Ctrl-E — end of line
+            return false;
+          }
+          if (ev.key === "Backspace") {
+            sendRaw("\x15"); // Ctrl-U — kill to start of line
+            return false;
+          }
+          if (ev.key === "ArrowUp") {
+            sendRaw("\x1b[1;5H"); // scroll-to-top emulation: Home with Ctrl mod
+            return false;
+          }
         }
 
         return true;
@@ -801,7 +890,7 @@ export function TerminalPane({
       disposed = true;
       cleanup.then((fn) => fn?.());
     };
-  }, [claudeMode, cursorBlink, cwd, paneId, terminalFontSize, terminalThemeId, theme]);
+  }, [claudeMode, cursorBlink, cwd, paneId, startupCommand, terminalFontSize, terminalThemeId, theme]);
 
   useEffect(() => {
     if (termRef.current && fitAddonRef.current) {

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -38,6 +38,8 @@ const BRACKETED_PASTE_OPEN = "\x1b[200~";
 const BRACKETED_PASTE_CLOSE = "\x1b[201~";
 const BRACKETED_PASTE_OVERHEAD = BRACKETED_PASTE_OPEN.length + BRACKETED_PASTE_CLOSE.length;
 const MAX_TERMINAL_INPUT = 65_536;
+const MAX_OSC52_BASE64_LENGTH = 1_000_000;
+const OSC52_ALLOWED_TARGETS = new Set(["", "c", "p", "s", "0", "1", "2", "3", "4", "5", "6", "7"]);
 
 type TerminalServerMessage =
   | { type: "attached"; sessionId: string; state: "running" | "exited"; exitCode: number | null }
@@ -414,10 +416,15 @@ export function TerminalPane({
           xterm.parser.registerOscHandler(52, (data: string) => {
             const semi = data.indexOf(";");
             if (semi < 0) return false;
+            const target = data.slice(0, semi);
+            if (!OSC52_ALLOWED_TARGETS.has(target)) return false;
             const payload = data.slice(semi + 1);
             if (payload === "" || payload === "?") {
               // Query for current clipboard contents — we don't expose this.
               return true;
+            }
+            if (payload.length > MAX_OSC52_BASE64_LENGTH || !/^[A-Za-z0-9+/=]+$/.test(payload)) {
+              return false;
             }
             let text: string;
             try {
@@ -432,12 +439,14 @@ export function TerminalPane({
                 ta.value = text;
                 ta.style.position = "fixed";
                 ta.style.opacity = "0";
+                ta.setAttribute("data-osc52-fallback", "true");
                 document.body.appendChild(ta);
                 ta.select();
                 document.execCommand("copy");
-                document.body.removeChild(ta);
               } catch (err: unknown) {
                 console.warn("OSC 52 fallback copy failed:", err instanceof Error ? err.message : err);
+              } finally {
+                document.querySelectorAll("textarea[data-osc52-fallback='true']").forEach((node) => node.remove());
               }
             };
             if (typeof navigator !== "undefined" && navigator.clipboard) {

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -213,6 +213,7 @@ export function TerminalPane({
   const webglContextLostHandlerRef = useRef<((event: Event) => void) | null>(null);
   const onDataDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const onResizeDisposableRef = useRef<{ dispose: () => void } | null>(null);
+  const initialStartupCommandRef = useRef(startupCommand);
   const [searchOpen, setSearchOpen] = useState(false);
   const [authUrl, setAuthUrl] = useState<string | null>(null);
   const outputBufferRef = useRef("");
@@ -499,7 +500,7 @@ export function TerminalPane({
 
           const startup = sessionIdRef.current
             ? null
-            : startupCommand?.trim() || (claudeMode ? "claude" : null);
+            : initialStartupCommandRef.current?.trim() || (claudeMode ? "claude" : null);
           if (startup) {
             setTimeout(() => {
               if (ws.readyState === WebSocket.OPEN) {
@@ -899,7 +900,7 @@ export function TerminalPane({
       disposed = true;
       cleanup.then((fn) => fn?.());
     };
-  }, [claudeMode, cursorBlink, cwd, paneId, startupCommand, terminalFontSize, terminalThemeId, theme]);
+  }, [claudeMode, cursorBlink, cwd, paneId, terminalFontSize, terminalThemeId, theme]);
 
   useEffect(() => {
     if (termRef.current && fitAddonRef.current) {

--- a/shell/src/components/terminal/terminal-themes.ts
+++ b/shell/src/components/terminal/terminal-themes.ts
@@ -45,7 +45,9 @@ const palettes: Record<string, AnsiPalette> = {
     brightBlue: "#4078f2",
     brightMagenta: "#a626a4",
     brightCyan: "#0184bc",
-    brightWhite: "#fafafa",
+    // Was #fafafa which equals the background — bold/bright-white text
+    // disappeared. Use a very light neutral that still has contrast.
+    brightWhite: "#dcdcdc",
   },
   "catppuccin-mocha": {
     black: "#45475a",
@@ -63,7 +65,9 @@ const palettes: Record<string, AnsiPalette> = {
     brightBlue: "#89b4fa",
     brightMagenta: "#f5c2e7",
     brightCyan: "#94e2d5",
-    brightWhite: "#a6adc8",
+    // Catppuccin "text" — the brightest fg variant. Was previously subtext0
+    // which is *darker* than `white` and made bold text look dim.
+    brightWhite: "#cdd6f4",
   },
   "dracula": {
     black: "#21222c",
@@ -110,32 +114,38 @@ const palettes: Record<string, AnsiPalette> = {
     magenta: "#d33682",
     cyan: "#2aa198",
     white: "#eee8d5",
-    brightBlack: "#002b36",
+    // brightBlack used to equal the background (#002b36) which made dim
+    // text invisible. Use base01 instead — Solarized's intended "comment"
+    // color, slightly brighter than base02.
+    brightBlack: "#586e75",
     brightRed: "#cb4b16",
-    brightGreen: "#586e75",
-    brightYellow: "#657b83",
-    brightBlue: "#839496",
+    brightGreen: "#859900",
+    brightYellow: "#b58900",
+    brightBlue: "#268bd2",
     brightMagenta: "#6c71c4",
-    brightCyan: "#93a1a1",
+    brightCyan: "#2aa198",
     brightWhite: "#fdf6e3",
   },
   "solarized-light": {
-    black: "#eee8d5",
+    black: "#073642",
     red: "#dc322f",
     green: "#859900",
     yellow: "#b58900",
     blue: "#268bd2",
     magenta: "#d33682",
     cyan: "#2aa198",
-    white: "#073642",
-    brightBlack: "#fdf6e3",
+    white: "#eee8d5",
+    // For light mode, brightBlack should still be a dim grey on a light
+    // background — base1 (#93a1a1). The previous value (#fdf6e3) was the
+    // background itself, hiding all dim text.
+    brightBlack: "#93a1a1",
     brightRed: "#cb4b16",
-    brightGreen: "#93a1a1",
-    brightYellow: "#839496",
-    brightBlue: "#657b83",
+    brightGreen: "#859900",
+    brightYellow: "#b58900",
+    brightBlue: "#268bd2",
     brightMagenta: "#6c71c4",
-    brightCyan: "#586e75",
-    brightWhite: "#002b36",
+    brightCyan: "#2aa198",
+    brightWhite: "#fdf6e3",
   },
   "github-dark": {
     black: "#484f58",
@@ -144,7 +154,10 @@ const palettes: Record<string, AnsiPalette> = {
     yellow: "#d29922",
     blue: "#58a6ff",
     magenta: "#bc8cff",
-    cyan: "#39d353",
+    // GitHub's primer palette has no dedicated "cyan" — previously this
+    // was set to a green hex which collided with `green`/`brightGreen`
+    // and made cyan-output invisible on green backgrounds.
+    cyan: "#76e3ea",
     white: "#b1bac4",
     brightBlack: "#6e7681",
     brightRed: "#ffa198",
@@ -152,14 +165,14 @@ const palettes: Record<string, AnsiPalette> = {
     brightYellow: "#e3b341",
     brightBlue: "#79c0ff",
     brightMagenta: "#d2a8ff",
-    brightCyan: "#56d364",
+    brightCyan: "#a5f3fc",
     brightWhite: "#f0f6fc",
   },
   "github-light": {
     black: "#24292f",
     red: "#cf222e",
     green: "#116329",
-    yellow: "#4d2d00",
+    yellow: "#9a6700",
     blue: "#0969da",
     magenta: "#8250df",
     cyan: "#1b7c83",
@@ -167,11 +180,14 @@ const palettes: Record<string, AnsiPalette> = {
     brightBlack: "#57606a",
     brightRed: "#a40e26",
     brightGreen: "#1a7f37",
-    brightYellow: "#633c01",
+    // Was #633c01 (almost-black brown) which is unreadable as "yellow".
+    brightYellow: "#bf8700",
     brightBlue: "#218bff",
     brightMagenta: "#a475f9",
     brightCyan: "#3192aa",
-    brightWhite: "#8c959f",
+    // brightWhite must be lighter than `white` — was darker, swapping
+    // visual weight on bold text.
+    brightWhite: "#d0d7de",
   },
 };
 

--- a/shell/src/stores/terminal-store.ts
+++ b/shell/src/stores/terminal-store.ts
@@ -2,7 +2,14 @@ import { create } from "zustand";
 import { getGatewayUrl } from "@/lib/gateway";
 
 export type PaneNode =
-  | { type: "pane"; id: string; cwd: string; sessionId?: string; claudeMode?: boolean }
+  | {
+      type: "pane";
+      id: string;
+      cwd: string;
+      sessionId?: string;
+      claudeMode?: boolean;
+      startupCommand?: string;
+    }
   | { type: "split"; direction: "horizontal" | "vertical"; children: [PaneNode, PaneNode]; ratio: number };
 
 export interface TerminalTab {

--- a/tests/gateway/projects.test.ts
+++ b/tests/gateway/projects.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { listProjects } from "../../packages/gateway/src/projects.js";
+
+describe("listProjects", () => {
+  let homePath: string;
+
+  beforeEach(async () => {
+    homePath = await mkdtemp(join(tmpdir(), "matrix-projects-test-"));
+    mkdirSync(join(homePath, "projects"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(homePath, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("lists project directories with git branch and dirty count", async () => {
+    mkdirSync(join(homePath, "projects", "alpha", ".git"), { recursive: true });
+    mkdirSync(join(homePath, "projects", "beta"), { recursive: true });
+    writeFileSync(join(homePath, "projects", ".hidden"), "ignored");
+
+    const runGit = vi.fn(async (args: string[], { cwd }: { cwd: string }) => {
+      if (args[0] === "rev-parse") {
+        return { stdout: cwd.endsWith("alpha") ? "main\n" : "ignored\n" };
+      }
+      return { stdout: " M src/index.ts\n?? notes.md\n" };
+    });
+
+    const result = await listProjects(homePath, "projects", { runGit });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.projects).toHaveLength(2);
+    expect(result.projects.find((project) => project.name === "alpha")).toMatchObject({
+      path: "projects/alpha",
+      isGit: true,
+      branch: "main",
+      dirtyCount: 2,
+    });
+    expect(result.projects.find((project) => project.name === "beta")).toMatchObject({
+      path: "projects/beta",
+      isGit: false,
+      branch: null,
+      dirtyCount: 0,
+    });
+    expect(runGit).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects invalid roots", async () => {
+    await expect(listProjects(homePath, "../outside")).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: "Invalid root",
+    });
+    await expect(listProjects(homePath, "")).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: "Invalid root",
+    });
+  });
+
+  it("returns an empty project list for a missing root without leaking raw errors", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await listProjects(homePath, "missing");
+
+    expect(result).toEqual({ ok: true, root: "missing", projects: [] });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("skips symlinked project entries so external repos are not inspected", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "matrix-projects-outside-"));
+    mkdirSync(join(outside, ".git"), { recursive: true });
+    symlinkSync(outside, join(homePath, "projects", "external"));
+    const runGit = vi.fn(async () => ({ stdout: "main\n" }));
+
+    const result = await listProjects(homePath, "projects", { runGit });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.projects).toEqual([]);
+    }
+    expect(runGit).not.toHaveBeenCalled();
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("logs unexpected git probe failures and treats the entry as non-git", async () => {
+    mkdirSync(join(homePath, "projects", "broken", ".git"), { recursive: true });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const runGit = vi.fn(async () => {
+      throw Object.assign(new Error("git timed out"), { code: "ETIMEDOUT" });
+    });
+
+    const result = await listProjects(homePath, "projects", { runGit });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.projects[0]).toMatchObject({ name: "broken", isGit: false });
+    }
+    expect(warn).toHaveBeenCalledWith(
+      "[projects] Failed to read git branch for projects/broken:",
+      "git timed out",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Big-ish quality-of-life pass on the in-browser terminal plus a few infra wins.

### Terminal app
- New tab bar: pill-shaped tabs, proper SVG icons (split-h, split-v, plus, close), prominent Claude / Zellij launchers, palette dropdown to switch any of the 9 terminal themes inline.
- Projects pane: replaces the file-tree-only sidebar with a Projects/Files toggle. Projects view scans \`~/projects\`, lists git repos with branch chip + dirty-count badge + filter, hover reveals quick-launch buttons (Shell / Claude / Zellij). Backed by new \`GET /api/projects\` gateway endpoint.
- OSC 52 clipboard handler — fixes Claude Code's \`c\` shortcut on the OAuth login (and the same for tmux/neovim).
- Generic \`startupCommand?\` on \`PaneNode\` (\`claudeMode\` kept for backward compat). Zellij launcher writes a theme-matched \`~/.config/zellij/config.kdl\` so dark/light stays consistent with the xterm.
- macOS line-edit keys: \`macOptionIsMeta\` enables Option+Left/Right word-jump; Cmd+Left/Right/Backspace mapped to Ctrl-A/E/U.
- Theme palette fixes: solarized-{dark,light}.brightBlack used to equal the bg (invisible dim text); one-light.brightWhite same; catppuccin-mocha.brightWhite was darker than \`white\`; github-dark cyan was actually green; github-light brightYellow unreadable. All audited and fixed.
- Padding around the xterm now matches the active theme's bg — no more colored seam between desktop chrome and terminal.

### Container image
- \`@mariozechner/pi-coding-agent\` (\`pi\` binary) added next to claude-code / codex / opencode. Opencode bumped to 1.14.25.
- \`zellij 0.44.1\` (static musl binary, SHA256 pinned).
- \`openssh-client\` so \`git clone git@github.com:...\` works.

### Production entrypoint
- Skills sync: copies \`\$MATRIX_HOME/agents/skills/*.md\` into \`~/.claude/skills\` and \`~/.codex/skills\` on every boot. Fixes "No skills found" inside Claude Code when the user has skills in their home volume.
- SSH symlink: \`/home/matrixos/.ssh\` → \`\$MATRIX_HOME/.ssh\` so keys created by gh / ssh-keygen in a terminal pane (HOME=\$MATRIX_HOME) are visible to ssh (HOME=/home/matrixos). Same trick the dev entrypoint already does for .claude / .codex.

### Staging on the VPS
- New \`docker-compose.staging.yml\` runs a hot-reloading dev container joined to the platform's \`matrixos-net\`.
- \`distro/cloudflared.yml\` gains ingress for \`staging.matrix-os.com\` and \`api-staging.matrix-os.com\` (placed before the \`*.matrix-os.com\` wildcard so they don't get swallowed by the platform router).
- \`shell/next.config.ts\`: \`allowedDevOrigins\` covers the staging hostnames so Next 16 doesn't block HMR over the tunnel.

## Test plan
- [ ] Open the terminal app, verify the redesigned tab bar (split / new / theme picker) renders with crisp icons.
- [ ] Switch through all 9 themes and confirm dim/bold text is readable in each (the palette fixes were the main motivation).
- [ ] Click the projects sidebar — repos under \`~/projects\` should list with branch + dirty count.
- [ ] Hover a project card → press Claude / Zellij / Shell → tab opens in that cwd.
- [ ] Run \`claude\` → press \`c\` on the OAuth screen → URL ends up in host clipboard (OSC 52).
- [ ] In a shell pane: Option+Left/Right jumps by word; Cmd+Left/Right jumps to start/end of line.
- [ ] In the live container: \`pi --version\`, \`zellij --version\`, \`opencode --version\`, \`ssh -V\` all work.
- [ ] Claude Code's Skills picker lists the matrix skills.
- [ ] Generate an ssh key in a terminal pane, \`gh ssh-key add\`, \`git clone git@github.com:HamedMP/matrix-os.git\` succeeds.
- [ ] \`https://staging.matrix-os.com\` serves the dev shell with HMR over the tunnel.