### PR TITLE
fix(sync-client): recover from stale manifest cache instead of crashing

### DIFF
--- a/packages/sync-client/src/daemon/manifest-cache.ts
+++ b/packages/sync-client/src/daemon/manifest-cache.ts
@@ -79,6 +79,9 @@ async function backupCorruptState(
   try {
     await pruneOldCorruptBackups(filePath, MAX_CORRUPT_BACKUPS - 1);
     await writeUtf8FileAtomic(backupPath, raw, 0o600);
+    // Remove the original so a restart before the next saveSyncState does
+    // not produce another backup of identical bytes.
+    await unlink(filePath).catch(() => undefined);
     console.warn(
       `[manifest-cache] ${reason}: backed up ${filePath} to ${backupPath} and reset state. Cause: ${causeMessage}`,
     );

--- a/packages/sync-client/src/daemon/manifest-cache.ts
+++ b/packages/sync-client/src/daemon/manifest-cache.ts
@@ -46,8 +46,48 @@ export async function loadSyncState(filePath: string): Promise<SyncState> {
     throw err;
   }
 
-  const parsed: unknown = JSON.parse(raw);
-  return SyncStateSchema.parse(parsed);
+  // The cache is a derivable accelerator, not a source of truth: any cached
+  // state is worth losing if it would otherwise crash the daemon. A schema
+  // tightening shipped in a CLI upgrade (e.g. mtime number -> int) would
+  // otherwise brick every existing install until the user manually deleted
+  // sync-state.json. Back the bad file up so it stays inspectable and rebuild
+  // from the server manifest on next sync.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    await backupCorruptState(filePath, raw, "malformed-json", err);
+    return { ...DEFAULT_STATE, files: {} };
+  }
+
+  const result = SyncStateSchema.safeParse(parsed);
+  if (!result.success) {
+    await backupCorruptState(filePath, raw, "schema-mismatch", result.error);
+    return { ...DEFAULT_STATE, files: {} };
+  }
+  return result.data;
+}
+
+async function backupCorruptState(
+  filePath: string,
+  raw: string,
+  reason: "malformed-json" | "schema-mismatch",
+  cause: unknown,
+): Promise<void> {
+  const backupPath = `${filePath}.corrupt-${Date.now()}`;
+  const causeMessage = cause instanceof Error ? cause.message : String(cause);
+  try {
+    await writeUtf8FileAtomic(backupPath, raw, 0o600);
+    console.warn(
+      `[manifest-cache] ${reason}: backed up ${filePath} to ${backupPath} and reset state. Cause: ${causeMessage}`,
+    );
+  } catch (backupErr) {
+    const backupMessage =
+      backupErr instanceof Error ? backupErr.message : String(backupErr);
+    console.warn(
+      `[manifest-cache] ${reason}: could not back up ${filePath} (${backupMessage}); resetting state anyway. Cause: ${causeMessage}`,
+    );
+  }
 }
 
 export async function saveSyncState(

--- a/packages/sync-client/src/daemon/manifest-cache.ts
+++ b/packages/sync-client/src/daemon/manifest-cache.ts
@@ -1,8 +1,11 @@
-import { readFile, mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { readFile, mkdir, readdir, unlink } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { basename, dirname, join } from "node:path";
 import { SyncStateSchema } from "./types.js";
 import type { SyncState, Manifest, ManifestEntry } from "./types.js";
 import { writeUtf8FileAtomic } from "../lib/atomic-write.js";
+
+const MAX_CORRUPT_BACKUPS = 3;
 
 export type { SyncState };
 
@@ -46,12 +49,8 @@ export async function loadSyncState(filePath: string): Promise<SyncState> {
     throw err;
   }
 
-  // The cache is a derivable accelerator, not a source of truth: any cached
-  // state is worth losing if it would otherwise crash the daemon. A schema
-  // tightening shipped in a CLI upgrade (e.g. mtime number -> int) would
-  // otherwise brick every existing install until the user manually deleted
-  // sync-state.json. Back the bad file up so it stays inspectable and rebuild
-  // from the server manifest on next sync.
+  // Cache is expendable: bad bytes get backed up and reset rather than
+  // crash-loop the daemon (a 0.2.4 schema tightening bricked installs).
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -74,9 +73,11 @@ async function backupCorruptState(
   reason: "malformed-json" | "schema-mismatch",
   cause: unknown,
 ): Promise<void> {
-  const backupPath = `${filePath}.corrupt-${Date.now()}`;
+  // Suffix with a uuid so two recoveries within the same ms don't collide.
+  const backupPath = `${filePath}.corrupt-${Date.now()}-${randomUUID().slice(0, 8)}`;
   const causeMessage = cause instanceof Error ? cause.message : String(cause);
   try {
+    await pruneOldCorruptBackups(filePath, MAX_CORRUPT_BACKUPS - 1);
     await writeUtf8FileAtomic(backupPath, raw, 0o600);
     console.warn(
       `[manifest-cache] ${reason}: backed up ${filePath} to ${backupPath} and reset state. Cause: ${causeMessage}`,
@@ -88,6 +89,28 @@ async function backupCorruptState(
       `[manifest-cache] ${reason}: could not back up ${filePath} (${backupMessage}); resetting state anyway. Cause: ${causeMessage}`,
     );
   }
+}
+
+async function pruneOldCorruptBackups(
+  filePath: string,
+  keep: number,
+): Promise<void> {
+  const dir = dirname(filePath);
+  const prefix = `${basename(filePath)}.corrupt-`;
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return;
+  }
+  const backups = entries.filter((e) => e.startsWith(prefix)).sort();
+  const removeCount = Math.max(0, backups.length - keep);
+  if (removeCount === 0) return;
+  await Promise.all(
+    backups
+      .slice(0, removeCount)
+      .map((name) => unlink(join(dir, name)).catch(() => undefined)),
+  );
 }
 
 export async function saveSyncState(

--- a/packages/sync-client/src/daemon/manifest-cache.ts
+++ b/packages/sync-client/src/daemon/manifest-cache.ts
@@ -81,7 +81,12 @@ async function backupCorruptState(
     await writeUtf8FileAtomic(backupPath, raw, 0o600);
     // Remove the original so a restart before the next saveSyncState does
     // not produce another backup of identical bytes.
-    await unlink(filePath).catch(() => undefined);
+    await unlink(filePath).catch((err: unknown) => {
+      if (isENOENT(err)) return;
+      console.warn(
+        `[manifest-cache] could not remove corrupt ${filePath} after backup: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
     console.warn(
       `[manifest-cache] ${reason}: backed up ${filePath} to ${backupPath} and reset state. Cause: ${causeMessage}`,
     );
@@ -103,16 +108,33 @@ async function pruneOldCorruptBackups(
   let entries: string[];
   try {
     entries = await readdir(dir);
-  } catch {
+  } catch (err: unknown) {
+    if (isENOENT(err)) return;
+    console.warn(
+      `[manifest-cache] could not list ${dir} for backup pruning: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return;
   }
   const backups = entries.filter((e) => e.startsWith(prefix)).sort();
   const removeCount = Math.max(0, backups.length - keep);
   if (removeCount === 0) return;
   await Promise.all(
-    backups
-      .slice(0, removeCount)
-      .map((name) => unlink(join(dir, name)).catch(() => undefined)),
+    backups.slice(0, removeCount).map((name) =>
+      unlink(join(dir, name)).catch((err: unknown) => {
+        if (isENOENT(err)) return;
+        console.warn(
+          `[manifest-cache] could not prune old backup ${name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }),
+    ),
+  );
+}
+
+function isENOENT(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === "ENOENT"
   );
 }
 

--- a/packages/sync-client/tests/unit/manifest-cache.test.ts
+++ b/packages/sync-client/tests/unit/manifest-cache.test.ts
@@ -18,6 +18,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await rm(TEST_DIR, { recursive: true, force: true });
 });
 
@@ -68,7 +69,6 @@ describe("loadSyncState", () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("malformed-json"),
     );
-    warn.mockRestore();
   });
 
   it("recovers from schema mismatch by backing it up and returning default state", async () => {
@@ -88,7 +88,6 @@ describe("loadSyncState", () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("schema-mismatch"),
     );
-    warn.mockRestore();
   });
 
   it("still resets state when the backup write itself fails", async () => {
@@ -115,11 +114,10 @@ describe("loadSyncState", () => {
     } finally {
       await chmod(TEST_DIR, 0o700);
     }
-    warn.mockRestore();
   });
 
   it("caps .corrupt-* backups so they cannot accumulate unbounded", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
     for (let i = 0; i < 5; i++) {
       await writeFile(STATE_PATH, `bad-${i} {{{`);
@@ -130,7 +128,6 @@ describe("loadSyncState", () => {
     const backups = entries.filter((e) => e.startsWith("sync-state.json.corrupt-"));
     expect(backups.length).toBeLessThanOrEqual(3);
     expect(backups.length).toBeGreaterThan(0);
-    warn.mockRestore();
   });
 
   // Regression: a daemon shipped before mtime was tightened from z.number()
@@ -151,7 +148,7 @@ describe("loadSyncState", () => {
       },
     });
     await writeFile(STATE_PATH, corrupt);
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const state = await loadSyncState(STATE_PATH);
 
@@ -160,7 +157,6 @@ describe("loadSyncState", () => {
 
     const entries = await readdir(TEST_DIR);
     expect(entries.some((e) => e.startsWith("sync-state.json.corrupt-"))).toBe(true);
-    warn.mockRestore();
   });
 });
 

--- a/packages/sync-client/tests/unit/manifest-cache.test.ts
+++ b/packages/sync-client/tests/unit/manifest-cache.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { writeFile, mkdir, rm, readFile, stat } from "node:fs/promises";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { writeFile, mkdir, rm, readFile, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 import {
   loadSyncState,
@@ -51,16 +51,74 @@ describe("loadSyncState", () => {
     expect(state.files["src/index.ts"]?.hash).toBe(data.files["src/index.ts"]!.hash);
   });
 
-  it("throws on malformed JSON", async () => {
-    await writeFile(STATE_PATH, "not valid json {{{");
+  it("recovers from malformed JSON by backing it up and returning default state", async () => {
+    const corrupt = "not valid json {{{";
+    await writeFile(STATE_PATH, corrupt);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    await expect(loadSyncState(STATE_PATH)).rejects.toThrow();
+    const state = await loadSyncState(STATE_PATH);
+
+    expect(state.manifestVersion).toBe(0);
+    expect(Object.keys(state.files)).toHaveLength(0);
+
+    const entries = await readdir(TEST_DIR);
+    const backups = entries.filter((e) => e.startsWith("sync-state.json.corrupt-"));
+    expect(backups).toHaveLength(1);
+    expect(await readFile(join(TEST_DIR, backups[0]!), "utf-8")).toBe(corrupt);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("malformed-json"),
+    );
+    warn.mockRestore();
   });
 
-  it("throws on invalid schema (missing required fields)", async () => {
-    await writeFile(STATE_PATH, JSON.stringify({ manifestVersion: "not-a-number" }));
+  it("recovers from schema mismatch by backing it up and returning default state", async () => {
+    const corrupt = JSON.stringify({ manifestVersion: "not-a-number" });
+    await writeFile(STATE_PATH, corrupt);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    await expect(loadSyncState(STATE_PATH)).rejects.toThrow();
+    const state = await loadSyncState(STATE_PATH);
+
+    expect(state.manifestVersion).toBe(0);
+    expect(Object.keys(state.files)).toHaveLength(0);
+
+    const entries = await readdir(TEST_DIR);
+    const backups = entries.filter((e) => e.startsWith("sync-state.json.corrupt-"));
+    expect(backups).toHaveLength(1);
+    expect(await readFile(join(TEST_DIR, backups[0]!), "utf-8")).toBe(corrupt);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("schema-mismatch"),
+    );
+    warn.mockRestore();
+  });
+
+  // Regression: a daemon shipped before mtime was tightened from z.number()
+  // to z.int() wrote floating-point millisecond timestamps into sync-state.json.
+  // The 0.2.4 schema rejected them and the daemon crash-looped on every
+  // existing install. This test pins the recovery behavior so a future schema
+  // tightening can't reproduce the same outage.
+  it("recovers when an old daemon wrote a non-integer mtime", async () => {
+    const corrupt = JSON.stringify({
+      manifestVersion: 5,
+      lastSyncAt: 1700000000000,
+      files: {
+        "system/icons/folder.svg": {
+          hash: "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+          mtime: 1700000000000.123,
+          size: 1024,
+        },
+      },
+    });
+    await writeFile(STATE_PATH, corrupt);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const state = await loadSyncState(STATE_PATH);
+
+    expect(state.manifestVersion).toBe(0);
+    expect(Object.keys(state.files)).toHaveLength(0);
+
+    const entries = await readdir(TEST_DIR);
+    expect(entries.some((e) => e.startsWith("sync-state.json.corrupt-"))).toBe(true);
+    warn.mockRestore();
   });
 });
 

--- a/packages/sync-client/tests/unit/manifest-cache.test.ts
+++ b/packages/sync-client/tests/unit/manifest-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { writeFile, mkdir, rm, readFile, readdir, stat } from "node:fs/promises";
+import { writeFile, mkdir, rm, readFile, readdir, stat, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import {
   loadSyncState,
@@ -88,6 +88,48 @@ describe("loadSyncState", () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining("schema-mismatch"),
     );
+    warn.mockRestore();
+  });
+
+  it("still resets state when the backup write itself fails", async () => {
+    if (process.getuid?.() === 0) {
+      // root bypasses chmod-enforced perms, so this scenario can't be
+      // simulated without module mocking. Skip rather than silently pass.
+      return;
+    }
+    const corrupt = "not valid json {{{";
+    await writeFile(STATE_PATH, corrupt);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Make the directory read-only so writeUtf8FileAtomic's tmp-file
+    // creation fails. Restore in finally so afterEach can clean up.
+    await chmod(TEST_DIR, 0o500);
+    try {
+      const state = await loadSyncState(STATE_PATH);
+
+      expect(state.manifestVersion).toBe(0);
+      expect(Object.keys(state.files)).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("could not back up"),
+      );
+    } finally {
+      await chmod(TEST_DIR, 0o700);
+    }
+    warn.mockRestore();
+  });
+
+  it("caps .corrupt-* backups so they cannot accumulate unbounded", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    for (let i = 0; i < 5; i++) {
+      await writeFile(STATE_PATH, `bad-${i} {{{`);
+      await loadSyncState(STATE_PATH);
+    }
+
+    const entries = await readdir(TEST_DIR);
+    const backups = entries.filter((e) => e.startsWith("sync-state.json.corrupt-"));
+    expect(backups.length).toBeLessThanOrEqual(3);
+    expect(backups.length).toBeGreaterThan(0);
     warn.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

- The 0.2.4 schema tightening of `mtime` from `z.number()` to `z.int()` made `loadSyncState` reject every `sync-state.json` written by an earlier daemon, crash-looping the daemon on existing installs (encountered by an end user today).
- Treat the cache as a derivable accelerator: on JSON parse error or schema mismatch, back the file up to `sync-state.json.corrupt-<timestamp>` and return `DEFAULT_STATE`. The daemon rebuilds from the server manifest on next sync.
- Adds a regression test pinned on the exact float-mtime payload that reproduced the outage, plus an "if backup write fails, still reset" graceful path.

## Why now

The crash log a real user hit:
```
Invalid input: expected int, received number
  path: [files, system/icons/folder.svg, mtime]
  ...
at loadSyncState (.../manifest-cache.ts:50:26)
at startDaemon  (.../daemon/index.ts:401:19)
```

Their only recovery was `rm ~/.matrixos/sync-state.json`, after locating the log themselves. Future schema changes should not require that.

## Test plan

- [x] `pnpm exec vitest run packages/sync-client/tests/unit/manifest-cache.test.ts` — 18/18 pass (15 existing + 3 new recovery cases)
- [ ] Reviewer: confirm the corrupt-file naming convention works on Windows (the timestamp is just `Date.now()`, no `:` characters, so it should be safe; explicit confirmation welcome)
- [ ] Reviewer: confirm there's no caller that *relies* on `loadSyncState` throwing (none in `packages/sync-client/src/`; checked via grep — only callers are `daemon/index.ts` which already treats it as a populate-or-empty)