### PR TITLE
ci: parallelize test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,14 @@ jobs:
 
   # ── Gate 2: Tests ──
   unit:
-    name: Unit Tests
+    name: Unit Tests (${{ matrix.shard }}/4)
     needs: [typecheck, patterns]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
 
@@ -90,7 +94,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: bun run test
+      - run: bun run test -- --shard=${{ matrix.shard }}/4
 
   e2e:
     name: E2E Tests

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -11,10 +11,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker-scenarios:
-    name: Docker Scenario Tests
+  docker-build:
+    name: Build Docker Test Image
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Populate dev image cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dev
+          cache-from: type=gha,scope=dev-image
+          cache-to: type=gha,mode=max,scope=dev-image
+
+  docker-scenarios:
+    name: Docker Scenario Tests (${{ matrix.scenario }})
+    needs: docker-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # multi-user and resource-limits remain excluded because they need
+        # dedicated profile/resource setup outside this parallel smoke matrix.
+        scenario:
+          - fresh-install
+          - upgrade
+          - customized-files
+          - channels
+          - recovery
 
     steps:
       - uses: actions/checkout@v4
@@ -22,46 +52,49 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
+      - name: Build dev image
+        uses: docker/build-push-action@v6
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile.dev', 'pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          context: .
+          file: Dockerfile.dev
+          load: true
+          tags: matrix-os-dev:ci
+          cache-from: type=gha,scope=dev-image
 
       - name: Create CI env file
         run: |
           echo "ANTHROPIC_API_KEY=test-not-used-in-docker-scenarios" > .env.docker
 
+      - name: Create CI compose override
+        run: |
+          cat > docker-compose.ci.yml <<'EOF'
+          services:
+            dev:
+              image: matrix-os-dev:ci
+              build: null
+          EOF
+
       - name: Create external volumes
         run: docker volume create matrixos-ai-auth
-
-      - name: Build dev image
-        run: |
-          docker compose -f docker-compose.dev.yml build dev
-        env:
-          DOCKER_BUILDKIT: 1
 
       - name: Run scenario tests
         run: |
           chmod +x scripts/docker-test/*.sh
-          ./scripts/docker-test/run-all.sh
+          ./scripts/docker-test/${{ matrix.scenario }}.sh
         env:
-          # Skip multi-user and resource-limits in CI to save time
-          SKIP_SCENARIOS: "multi-user resource-limits"
+          COMPOSE_OVERRIDE_FILE: ${{ github.workspace }}/docker-compose.ci.yml
 
       - name: Collect container logs on failure
         if: failure()
         run: |
           mkdir -p /tmp/docker-test-logs
-          docker compose -f docker-compose.dev.yml logs --tail 100 > /tmp/docker-test-logs/compose.log 2>&1 || true
-          docker compose -f docker-compose.dev.yml ps -a > /tmp/docker-test-logs/containers.log 2>&1 || true
+          docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml logs --tail 100 > /tmp/docker-test-logs/compose.log 2>&1 || true
+          docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml ps -a > /tmp/docker-test-logs/containers.log 2>&1 || true
 
       - name: Upload test logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: docker-test-logs
+          name: docker-test-logs-${{ matrix.scenario }}
           path: /tmp/docker-test-logs/
           retention-days: 7

--- a/scripts/docker-test/channels.sh
+++ b/scripts/docker-test/channels.sh
@@ -14,7 +14,7 @@ begin_test "Channel Adapter Lifecycle"
 # Clean slate and start
 echo -e "${YELLOW}[SETUP]${NC} Starting fresh container..."
 $COMPOSE down -v --timeout 5 2>/dev/null || true
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 
@@ -37,7 +37,7 @@ INNEREOF'
 # Restart to pick up channel config
 echo -e "${YELLOW}[SETUP]${NC} Restarting to load channel config..."
 $COMPOSE stop dev
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 

--- a/scripts/docker-test/customized-files.sh
+++ b/scripts/docker-test/customized-files.sh
@@ -14,7 +14,7 @@ begin_test "Customized Files Survive Sync"
 # Clean slate and start
 echo -e "${YELLOW}[SETUP]${NC} Starting fresh container..."
 $COMPOSE down -v --timeout 5 2>/dev/null || true
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 
@@ -41,7 +41,7 @@ $COMPOSE exec -T dev rm -f /home/matrixos/home/system/logs/template-sync.log
 # Restart container (triggers template sync)
 echo -e "${YELLOW}[SETUP]${NC} Restarting container to trigger sync..."
 $COMPOSE stop dev
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 

--- a/scripts/docker-test/fresh-install.sh
+++ b/scripts/docker-test/fresh-install.sh
@@ -17,7 +17,7 @@ $COMPOSE down -v --timeout 5 2>/dev/null || true
 
 # Start fresh
 echo -e "${YELLOW}[SETUP]${NC} Starting dev container..."
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 

--- a/scripts/docker-test/lib.sh
+++ b/scripts/docker-test/lib.sh
@@ -19,7 +19,13 @@ TEST_NAME=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.dev.yml"
-COMPOSE="docker compose -f $COMPOSE_FILE"
+if [ -n "${COMPOSE_OVERRIDE_FILE:-}" ]; then
+  COMPOSE="docker compose -f $COMPOSE_FILE -f $COMPOSE_OVERRIDE_FILE"
+  COMPOSE_UP_FLAGS="--no-build"
+else
+  COMPOSE="docker compose -f $COMPOSE_FILE"
+  COMPOSE_UP_FLAGS=""
+fi
 
 # Gateway base URL for the default dev container
 GATEWAY_URL="${GATEWAY_URL:-http://localhost:4000}"

--- a/scripts/docker-test/multi-user.sh
+++ b/scripts/docker-test/multi-user.sh
@@ -22,7 +22,7 @@ begin_test "Multi-User (Alice + Bob)"
 # Clean slate
 echo -e "${YELLOW}[SETUP]${NC} Starting multi-user containers..."
 $COMPOSE --profile multi --profile full down -v --timeout 5 2>/dev/null || true
-$COMPOSE --profile multi --profile full up -d alice bob
+$COMPOSE --profile multi --profile full up $COMPOSE_UP_FLAGS -d alice bob
 
 # Wait for both instances
 wait_for_url "$ALICE_URL/health" 90

--- a/scripts/docker-test/recovery.sh
+++ b/scripts/docker-test/recovery.sh
@@ -14,7 +14,7 @@ begin_test "Crash Recovery"
 # Clean slate and start
 echo -e "${YELLOW}[SETUP]${NC} Starting fresh container..."
 $COMPOSE down -v --timeout 5 2>/dev/null || true
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 
@@ -54,7 +54,7 @@ sleep 2
 
 # Restart
 echo -e "${YELLOW}[ACTION]${NC} Restarting container..."
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 

--- a/scripts/docker-test/upgrade.sh
+++ b/scripts/docker-test/upgrade.sh
@@ -14,7 +14,7 @@ begin_test "Upgrade (Template Sync)"
 # Clean slate and start
 echo -e "${YELLOW}[SETUP]${NC} Starting fresh container..."
 $COMPOSE down -v --timeout 5 2>/dev/null || true
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 
@@ -31,7 +31,7 @@ $COMPOSE exec -T dev rm -f /home/matrixos/home/system/logs/template-sync.log
 # Stop container (preserves volume)
 echo -e "${YELLOW}[SETUP]${NC} Restarting container to trigger sync..."
 $COMPOSE stop dev
-$COMPOSE up -d dev
+$COMPOSE up $COMPOSE_UP_FLAGS -d dev
 
 wait_for_healthy "dev" 90
 


### PR DESCRIPTION
## What changed

- Shards the Unit Tests workflow into four Vitest shards so the suite runs in parallel instead of one long `bun run test` job.
- Splits Docker scenario CI into a scenario matrix for the PR-required scenarios: `fresh-install`, `upgrade`, `customized-files`, `channels`, and `recovery`.
- Replaces the unused `/tmp/.buildx-cache` restore with `docker/build-push-action` using GitHub Actions cache and a loaded `matrix-os-dev:ci` image.
- Adds `COMPOSE_OVERRIDE_FILE` support to the Docker test harness so CI can run scenarios against the prebuilt image without changing local developer compose behavior.

## Why

The unit suite was passing but running close to the old timeout. Docker scenarios were also serialized behind one image build and one `run-all.sh` invocation. This keeps the same checks but reduces wall-clock time by letting GitHub Actions schedule independent shards/scenarios concurrently.

## Validation

- `bash -n scripts/docker-test/lib.sh scripts/docker-test/run-all.sh scripts/docker-test/fresh-install.sh scripts/docker-test/upgrade.sh scripts/docker-test/customized-files.sh scripts/docker-test/channels.sh scripts/docker-test/recovery.sh`
- `git diff --check`

Note: local YAML validation tooling (`actionlint`, Ruby YAML parser) is not installed in this VPS shell, so GitHub Actions will be the authoritative workflow syntax check on this draft PR.