### PR TITLE
refactor(gateway): extract workspace session orchestrator

### DIFF
--- a/packages/gateway/src/workspace-event-publisher.ts
+++ b/packages/gateway/src/workspace-event-publisher.ts
@@ -1,0 +1,109 @@
+import type { PreviewRecord } from "./preview-manager.js";
+import type { WorkspaceError } from "./project-manager.js";
+import type { TaskRecord } from "./task-manager.js";
+import type { WorkspaceSessionView } from "./agent-session-manager.js";
+import type { createWorkspaceEventStore } from "./workspace-events.js";
+
+type WorkspaceEventStore = Pick<ReturnType<typeof createWorkspaceEventStore>, "publishEvent">;
+type PublishEventInput = Parameters<WorkspaceEventStore["publishEvent"]>[0];
+
+type PublishFailure = {
+  ok: false;
+  status: number;
+  error: WorkspaceError;
+};
+
+function isPublishFailure(result: unknown): result is PublishFailure {
+  return typeof result === "object" &&
+    result !== null &&
+    "ok" in result &&
+    result.ok === false &&
+    "error" in result &&
+    typeof result.error === "object" &&
+    result.error !== null &&
+    "code" in result.error &&
+    typeof result.error.code === "string";
+}
+
+export function createWorkspaceEventPublisher(options: {
+  eventStore: WorkspaceEventStore;
+}) {
+  async function publish(input: PublishEventInput): Promise<void> {
+    const result = await options.eventStore.publishEvent(input);
+    if (isPublishFailure(result)) {
+      console.warn("[workspace-event-publisher] Failed to publish workspace event:", result.error.code);
+    }
+  }
+
+  return {
+    publish,
+
+    async publishTaskCreated(task: Pick<TaskRecord, "id" | "projectSlug" | "title" | "status">): Promise<void> {
+      await publish({
+        type: "task.created",
+        scope: { projectSlug: task.projectSlug, taskId: task.id },
+        payload: { title: task.title, status: task.status },
+      });
+    },
+
+    async publishTaskUpdated(task: Pick<TaskRecord, "id" | "projectSlug" | "status" | "updatedAt">): Promise<void> {
+      await publish({
+        type: "task.updated",
+        scope: { projectSlug: task.projectSlug, taskId: task.id },
+        payload: { status: task.status, updatedAt: task.updatedAt },
+      });
+    },
+
+    async publishTaskDeleted(projectSlug: string, taskId: string): Promise<void> {
+      await publish({
+        type: "task.deleted",
+        scope: { projectSlug, taskId },
+        payload: {},
+      });
+    },
+
+    async publishPreviewCreated(preview: Pick<PreviewRecord, "id" | "projectSlug" | "taskId" | "sessionId" | "url" | "lastStatus">): Promise<void> {
+      await publish({
+        type: "preview.created",
+        scope: { projectSlug: preview.projectSlug, taskId: preview.taskId, sessionId: preview.sessionId, previewId: preview.id },
+        payload: { url: preview.url, lastStatus: preview.lastStatus },
+      });
+    },
+
+    async publishPreviewUpdated(preview: Pick<PreviewRecord, "id" | "projectSlug" | "taskId" | "sessionId" | "lastStatus" | "updatedAt">): Promise<void> {
+      await publish({
+        type: "preview.updated",
+        scope: { projectSlug: preview.projectSlug, taskId: preview.taskId, sessionId: preview.sessionId, previewId: preview.id },
+        payload: { lastStatus: preview.lastStatus, updatedAt: preview.updatedAt },
+      });
+    },
+
+    async publishPreviewDeleted(projectSlug: string, previewId: string): Promise<void> {
+      await publish({
+        type: "preview.deleted",
+        scope: { projectSlug, previewId },
+        payload: {},
+      });
+    },
+
+    async publishSessionStarted(session: Pick<
+      WorkspaceSessionView,
+      "id" | "kind" | "projectSlug" | "taskId" | "worktreeId" | "pr" | "agent" | "runtime" | "terminalSessionId"
+    >): Promise<void> {
+      await publish({
+        type: "session.started",
+        scope: { projectSlug: session.projectSlug, taskId: session.taskId, sessionId: session.id },
+        payload: {
+          agent: session.agent,
+          kind: session.kind,
+          pr: session.pr,
+          runtimeStatus: session.runtime.status,
+          terminalSessionId: session.terminalSessionId,
+          worktreeId: session.worktreeId,
+        },
+      });
+    },
+  };
+}
+
+export type WorkspaceEventPublisher = ReturnType<typeof createWorkspaceEventPublisher>;

--- a/packages/gateway/src/workspace-event-publisher.ts
+++ b/packages/gateway/src/workspace-event-publisher.ts
@@ -29,9 +29,16 @@ export function createWorkspaceEventPublisher(options: {
   eventStore: WorkspaceEventStore;
 }) {
   async function publish(input: PublishEventInput): Promise<void> {
-    const result = await options.eventStore.publishEvent(input);
-    if (isPublishFailure(result)) {
-      console.warn("[workspace-event-publisher] Failed to publish workspace event:", result.error.code);
+    try {
+      const result = await options.eventStore.publishEvent(input);
+      if (isPublishFailure(result)) {
+        console.warn("[workspace-event-publisher] Failed to publish workspace event:", result.error.code);
+      }
+    } catch (err: unknown) {
+      console.warn(
+        "[workspace-event-publisher] Unexpected workspace event publish error:",
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
 
@@ -92,6 +99,24 @@ export function createWorkspaceEventPublisher(options: {
     >): Promise<void> {
       await publish({
         type: "session.started",
+        scope: { projectSlug: session.projectSlug, taskId: session.taskId, sessionId: session.id },
+        payload: {
+          agent: session.agent,
+          kind: session.kind,
+          pr: session.pr,
+          runtimeStatus: session.runtime.status,
+          terminalSessionId: session.terminalSessionId,
+          worktreeId: session.worktreeId,
+        },
+      });
+    },
+
+    async publishSessionStopped(session: Pick<
+      WorkspaceSessionView,
+      "id" | "kind" | "projectSlug" | "taskId" | "worktreeId" | "pr" | "agent" | "runtime" | "terminalSessionId"
+    >): Promise<void> {
+      await publish({
+        type: "session.stopped",
         scope: { projectSlug: session.projectSlug, taskId: session.taskId, sessionId: session.id },
         payload: {
           agent: session.agent,

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -17,7 +17,9 @@ import { createReviewStore } from "./review-store.js";
 import { createTaskManager } from "./task-manager.js";
 import { createPreviewManager } from "./preview-manager.js";
 import { createWorkspaceEventStore } from "./workspace-events.js";
-import { isRequestPrincipalError, mapRequestPrincipalError } from "./request-principal.js";
+import { isRequestPrincipalError, mapRequestPrincipalError, ownerScopeFromPrincipal, requireRequestPrincipal } from "./request-principal.js";
+import { createWorkspaceEventPublisher, type WorkspaceEventPublisher } from "./workspace-event-publisher.js";
+import { createWorkspaceSessionOrchestrator, type WorkspaceSessionOrchestrator } from "./workspace-session-orchestrator.js";
 
 type ProjectManager = ReturnType<typeof createProjectManager>;
 type WorktreeManager = ReturnType<typeof createWorktreeManager>;
@@ -158,10 +160,6 @@ async function parseJson<T>(c: Context, schema: z.ZodType<T>): Promise<
   return { ok: true, value: parsed.data };
 }
 
-function defaultOwnerScopeFromContext(): OwnerScope {
-  return { type: "user", id: "local" };
-}
-
 export function createWorkspaceRoutes(options: {
   homePath: string;
   projectManager?: ProjectManager;
@@ -174,6 +172,8 @@ export function createWorkspaceRoutes(options: {
   taskManager?: TaskManager;
   previewManager?: PreviewManager;
   eventStore?: WorkspaceEventStore;
+  eventPublisher?: WorkspaceEventPublisher;
+  sessionOrchestrator?: WorkspaceSessionOrchestrator;
   getOwnerScope?: (c: Context) => OwnerScope;
 }) {
   const app = new Hono();
@@ -197,9 +197,19 @@ export function createWorkspaceRoutes(options: {
   const taskManager = options.taskManager ?? createTaskManager({ homePath: options.homePath });
   const previewManager = options.previewManager ?? createPreviewManager({ homePath: options.homePath });
   const eventStore = options.eventStore ?? createWorkspaceEventStore({ homePath: options.homePath });
+  const eventPublisher = options.eventPublisher ?? createWorkspaceEventPublisher({ eventStore });
+  const sessionOrchestrator = options.sessionOrchestrator ?? createWorkspaceSessionOrchestrator({
+    worktreeManager,
+    agentSessionManager,
+    agentSandbox,
+    sessionRuntimeBridge,
+    eventPublisher,
+  });
   const stateOps = createStateOps({ homePath: options.homePath });
   const limited = bodyLimit({ maxSize: WORKSPACE_BODY_LIMIT });
-  const getOwnerScope = options.getOwnerScope ?? (() => defaultOwnerScopeFromContext());
+  const getOwnerScope = options.getOwnerScope ?? ((c: Context) => ownerScopeFromPrincipal(requireRequestPrincipal(c, {
+    requireAuthContextReady: false,
+  })));
 
   function principalError(c: Context, err: unknown) {
     if (!isRequestPrincipalError(err)) throw err;
@@ -209,13 +219,6 @@ export function createWorkspaceRoutes(options: {
       return c.json(errorBody("unauthorized", "Unauthorized"), 401);
     }
     return c.json(errorBody("server_misconfigured", mapped.body.error), 500);
-  }
-
-  async function publishWorkspaceEvent(input: Parameters<WorkspaceEventStore["publishEvent"]>[0]): Promise<void> {
-    const result = await eventStore.publishEvent(input);
-    if (!result.ok) {
-      console.warn("[workspace-routes] Failed to publish workspace event:", result.error.code);
-    }
   }
 
   app.get("/api/github/status", async (c) => c.json(await projectManager.getGithubStatus()));
@@ -303,11 +306,7 @@ export function createWorkspaceRoutes(options: {
     const projectSlug = c.req.param("slug");
     const result = await taskManager.createTask(projectSlug, body.value);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    await publishWorkspaceEvent({
-      type: "task.created",
-      scope: { projectSlug, taskId: result.task.id },
-      payload: { title: result.task.title, status: result.task.status },
-    });
+    await eventPublisher.publishTaskCreated(result.task);
     return c.json({ task: result.task }, status(result.status ?? 201));
   });
 
@@ -328,11 +327,7 @@ export function createWorkspaceRoutes(options: {
     const projectSlug = c.req.param("slug");
     const result = await taskManager.updateTask(projectSlug, c.req.param("taskId"), body.value);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    await publishWorkspaceEvent({
-      type: "task.updated",
-      scope: { projectSlug, taskId: result.task.id },
-      payload: { status: result.task.status, updatedAt: result.task.updatedAt },
-    });
+    await eventPublisher.publishTaskUpdated(result.task);
     return c.json({ task: result.task });
   });
 
@@ -343,11 +338,7 @@ export function createWorkspaceRoutes(options: {
     const taskId = c.req.param("taskId");
     const result = await taskManager.deleteTask(projectSlug, taskId);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    await publishWorkspaceEvent({
-      type: "task.deleted",
-      scope: { projectSlug, taskId },
-      payload: {},
-    });
+    await eventPublisher.publishTaskDeleted(projectSlug, taskId);
     return c.json({ ok: true });
   });
 
@@ -357,11 +348,7 @@ export function createWorkspaceRoutes(options: {
     const projectSlug = c.req.param("slug");
     const result = await previewManager.createPreview(projectSlug, body.value);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    await publishWorkspaceEvent({
-      type: "preview.created",
-      scope: { projectSlug, taskId: result.preview.taskId, sessionId: result.preview.sessionId, previewId: result.preview.id },
-      payload: { url: result.preview.url, lastStatus: result.preview.lastStatus },
-    });
+    await eventPublisher.publishPreviewCreated(result.preview);
     return c.json({ preview: result.preview }, status(result.status ?? 201));
   });
 
@@ -383,11 +370,7 @@ export function createWorkspaceRoutes(options: {
     const projectSlug = c.req.param("slug");
     const result = await previewManager.updatePreview(projectSlug, c.req.param("previewId"), body.value);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    await publishWorkspaceEvent({
-      type: "preview.updated",
-      scope: { projectSlug, taskId: result.preview.taskId, sessionId: result.preview.sessionId, previewId: result.preview.id },
-      payload: { lastStatus: result.preview.lastStatus, updatedAt: result.preview.updatedAt },
-    });
+    await eventPublisher.publishPreviewUpdated(result.preview);
     return c.json({ preview: result.preview });
   });
 
@@ -398,56 +381,36 @@ export function createWorkspaceRoutes(options: {
     const previewId = c.req.param("previewId");
     const result = await previewManager.deletePreview(projectSlug, previewId);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    await publishWorkspaceEvent({
-      type: "preview.deleted",
-      scope: { projectSlug, previewId },
-      payload: {},
-    });
+    await eventPublisher.publishPreviewDeleted(projectSlug, previewId);
     return c.json({ ok: true });
   });
 
   app.post("/api/sessions", limited, async (c) => {
     const body = await parseJson(c, StartSessionSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
-    const sessionId = body.value.sessionId ?? `sess_${randomUUID()}`;
-    let sandbox;
-    if (body.value.agent === "codex") {
-      if (!body.value.projectSlug || !body.value.worktreeId) {
-        return c.json(errorBody("sandbox_unavailable", "Agent sandbox is unavailable"), 400);
-      }
-      const worktrees = await worktreeManager.listWorktrees(body.value.projectSlug);
-      if (!worktrees.ok) return c.json({ error: worktrees.error }, status(worktrees.status));
-      const worktree = worktrees.worktrees.find((entry) => entry.id === body.value.worktreeId);
-      if (!worktree) return c.json(errorBody("not_found", "Worktree was not found"), 404);
-      const preflight = await agentSandbox.preflight({
-        agent: "codex",
-        sessionId,
-        worktreePath: worktree.path,
-        adminOverride: body.value.adminSandboxOverride,
-      });
-      if (!preflight.ok) return c.json({ error: preflight.error, sandboxStatus: preflight.sandboxStatus }, status(preflight.status));
-      sandbox = preflight.sandbox;
-    }
     let ownerScope: OwnerScope;
     try {
       ownerScope = getOwnerScope(c);
     } catch (err: unknown) {
       return principalError(c, err);
     }
-    const result = await agentSessionManager.startSession({
-      ...body.value,
-      sessionId,
-      ownerId: ownerScope.id,
-      sandbox,
+    const result = await sessionOrchestrator.startSession({
+      ownerScope,
+      request: body.value,
     });
-    if (!result.ok) return c.json({ error: result.error }, status(result.status));
-    return c.json({ session: result.session }, result.status);
+    if (!result.ok) {
+      if ("sandboxStatus" in result) {
+        return c.json({ error: result.error, sandboxStatus: result.sandboxStatus }, status(result.status));
+      }
+      return c.json({ error: result.error }, status(result.status));
+    }
+    return c.json({ session: result.session }, status(result.status));
   });
 
   app.get("/api/sessions", async (c) => {
     const prRaw = c.req.query("pr");
     const limitRaw = c.req.query("limit");
-    const result = await agentSessionManager.listSessions({
+    const result = await sessionOrchestrator.listSessions({
       projectSlug: c.req.query("projectSlug"),
       taskId: c.req.query("taskId"),
       status: c.req.query("status"),
@@ -460,7 +423,7 @@ export function createWorkspaceRoutes(options: {
   });
 
   app.get("/api/sessions/:sessionId", async (c) => {
-    const result = await agentSessionManager.getSession(c.req.param("sessionId"));
+    const result = await sessionOrchestrator.getSession(c.req.param("sessionId"));
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ session: result.session });
   });
@@ -468,7 +431,7 @@ export function createWorkspaceRoutes(options: {
   app.post("/api/sessions/:sessionId/send", limited, async (c) => {
     const body = await parseJson(c, SendSessionInputSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
-    const result = await agentSessionManager.sendInput(c.req.param("sessionId"), body.value.input);
+    const result = await sessionOrchestrator.sendInput(c.req.param("sessionId"), body.value.input);
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ session: result.session });
   });
@@ -476,9 +439,7 @@ export function createWorkspaceRoutes(options: {
   app.post("/api/sessions/:sessionId/observe", limited, async (c) => {
     const body = await parseJson(c, EmptyObjectSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
-    const session = await agentSessionManager.getSession(c.req.param("sessionId"));
-    if (!session.ok) return c.json({ error: session.error }, status(session.status));
-    const result = sessionRuntimeBridge.registerSession(session.session, { mode: "observe" });
+    const result = await sessionOrchestrator.attachSession(c.req.param("sessionId"), "observe");
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json(result);
   });
@@ -486,9 +447,7 @@ export function createWorkspaceRoutes(options: {
   app.post("/api/sessions/:sessionId/takeover", limited, async (c) => {
     const body = await parseJson(c, EmptyObjectSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
-    const session = await agentSessionManager.getSession(c.req.param("sessionId"));
-    if (!session.ok) return c.json({ error: session.error }, status(session.status));
-    const result = sessionRuntimeBridge.registerSession(session.session, { mode: "owner" });
+    const result = await sessionOrchestrator.attachSession(c.req.param("sessionId"), "owner");
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json(result);
   });
@@ -496,7 +455,7 @@ export function createWorkspaceRoutes(options: {
   app.delete("/api/sessions/:sessionId", limited, async (c) => {
     const body = await parseJson(c, EmptyObjectSchema);
     if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
-    const result = await agentSessionManager.killSession(c.req.param("sessionId"));
+    const result = await sessionOrchestrator.stopSession(c.req.param("sessionId"));
     if (!result.ok) return c.json({ error: result.error }, status(result.status));
     return c.json({ session: result.session });
   });

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from "node:crypto";
+import type {
+  WorkspaceSessionView,
+  createAgentSessionManager,
+} from "./agent-session-manager.js";
+import type { AgentLaunchSandbox, SupportedAgent } from "./agent-launcher.js";
+import type { WorkspaceError } from "./project-manager.js";
+import type { OwnerScope } from "./state-ops.js";
+import type { createAgentSandbox } from "./agent-sandbox.js";
+import type { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
+import type { createWorktreeManager, WorktreeRecord } from "./worktree-manager.js";
+import type { WorkspaceEventPublisher } from "./workspace-event-publisher.js";
+
+type WorktreeManager = Pick<ReturnType<typeof createWorktreeManager>, "listWorktrees">;
+type AgentSessionManager = Pick<
+  ReturnType<typeof createAgentSessionManager>,
+  "startSession" | "listSessions" | "getSession" | "sendInput" | "killSession"
+>;
+type AgentSandbox = Pick<ReturnType<typeof createAgentSandbox>, "preflight">;
+type SessionRuntimeBridge = Pick<ReturnType<typeof createSessionRuntimeBridge>, "registerSession">;
+type SessionAttachMode = "observe" | "owner";
+
+type Failure = {
+  ok: false;
+  status: number;
+  error: WorkspaceError;
+  holderId?: string;
+  sandboxStatus?: unknown;
+};
+
+export interface StartWorkspaceSessionRequest {
+  sessionId?: string;
+  projectSlug?: string;
+  taskId?: string;
+  worktreeId?: string;
+  pr?: number;
+  kind: "shell" | "agent";
+  agent?: SupportedAgent;
+  prompt?: string;
+  runtimePreference?: "zellij";
+  adminSandboxOverride?: boolean;
+}
+
+export interface StartWorkspaceSessionInput {
+  ownerScope: OwnerScope;
+  request: StartWorkspaceSessionRequest;
+}
+
+function failure(status: number, code: string, message: string): Failure {
+  return { ok: false, status, error: { code, message } };
+}
+
+async function resolveRequestedWorktree(
+  worktreeManager: WorktreeManager,
+  projectSlug: string,
+  worktreeId: string,
+): Promise<WorktreeRecord | Failure> {
+  const listed = await worktreeManager.listWorktrees(projectSlug);
+  if (!listed.ok) return listed;
+  return listed.worktrees.find((entry) => entry.id === worktreeId) ?? failure(404, "not_found", "Worktree was not found");
+}
+
+async function resolveCodexSandbox(options: {
+  agentSandbox: AgentSandbox;
+  request: StartWorkspaceSessionRequest;
+  sessionId: string;
+  worktree: WorktreeRecord;
+}): Promise<{ ok: true; sandbox?: AgentLaunchSandbox } | Failure> {
+  const preflight = await options.agentSandbox.preflight({
+    agent: "codex",
+    sessionId: options.sessionId,
+    worktreePath: options.worktree.path,
+    adminOverride: options.request.adminSandboxOverride,
+  });
+  if (!preflight.ok) {
+    return {
+      ok: false,
+      status: preflight.status,
+      error: preflight.error,
+      sandboxStatus: preflight.sandboxStatus,
+    };
+  }
+  return { ok: true, sandbox: preflight.sandbox };
+}
+
+export function createWorkspaceSessionOrchestrator(options: {
+  worktreeManager: WorktreeManager;
+  agentSessionManager: AgentSessionManager;
+  agentSandbox: AgentSandbox;
+  sessionRuntimeBridge: SessionRuntimeBridge;
+  eventPublisher?: Pick<WorkspaceEventPublisher, "publishSessionStarted">;
+  idGenerator?: () => string;
+}) {
+  const idGenerator = options.idGenerator ?? (() => `sess_${randomUUID()}`);
+
+  return {
+    async startSession(input: StartWorkspaceSessionInput): Promise<
+      { ok: true; status: number; session: WorkspaceSessionView } | Failure
+    > {
+      const sessionId = input.request.sessionId ?? idGenerator();
+      let sandbox: AgentLaunchSandbox | undefined;
+
+      if (input.request.agent === "codex") {
+        if (!input.request.projectSlug || !input.request.worktreeId) {
+          return failure(400, "sandbox_unavailable", "Agent sandbox is unavailable");
+        }
+        const worktree = await resolveRequestedWorktree(
+          options.worktreeManager,
+          input.request.projectSlug,
+          input.request.worktreeId,
+        );
+        if (!("path" in worktree)) return worktree;
+        const preflight = await resolveCodexSandbox({
+          agentSandbox: options.agentSandbox,
+          request: input.request,
+          sessionId,
+          worktree,
+        });
+        if (!preflight.ok) return preflight;
+        sandbox = preflight.sandbox;
+      }
+
+      const result = await options.agentSessionManager.startSession({
+        ...input.request,
+        sessionId,
+        ownerId: input.ownerScope.id,
+        sandbox,
+      });
+      if (!result.ok) return result;
+
+      await options.eventPublisher?.publishSessionStarted(result.session);
+      return result;
+    },
+
+    async listSessions(input: unknown = {}) {
+      return options.agentSessionManager.listSessions(input);
+    },
+
+    async getSession(sessionId: string) {
+      return options.agentSessionManager.getSession(sessionId);
+    },
+
+    async sendInput(sessionId: string, input: string) {
+      return options.agentSessionManager.sendInput(sessionId, input);
+    },
+
+    async attachSession(sessionId: string, mode: SessionAttachMode) {
+      const session = await options.agentSessionManager.getSession(sessionId);
+      if (!session.ok) return session;
+      return options.sessionRuntimeBridge.registerSession(session.session, { mode });
+    },
+
+    async stopSession(sessionId: string) {
+      return options.agentSessionManager.killSession(sessionId);
+    },
+
+    async recoverSessions() {
+      return this.listSessions({ status: "running" });
+    },
+  };
+}
+
+export type WorkspaceSessionOrchestrator = ReturnType<typeof createWorkspaceSessionOrchestrator>;

--- a/packages/gateway/src/workspace-session-orchestrator.ts
+++ b/packages/gateway/src/workspace-session-orchestrator.ts
@@ -19,6 +19,7 @@ type AgentSessionManager = Pick<
 type AgentSandbox = Pick<ReturnType<typeof createAgentSandbox>, "preflight">;
 type SessionRuntimeBridge = Pick<ReturnType<typeof createSessionRuntimeBridge>, "registerSession">;
 type SessionAttachMode = "observe" | "owner";
+type ListSessionsInput = Parameters<AgentSessionManager["listSessions"]>[0];
 
 type Failure = {
   ok: false;
@@ -54,10 +55,11 @@ async function resolveRequestedWorktree(
   worktreeManager: WorktreeManager,
   projectSlug: string,
   worktreeId: string,
-): Promise<WorktreeRecord | Failure> {
+): Promise<{ ok: true; worktree: WorktreeRecord } | Failure> {
   const listed = await worktreeManager.listWorktrees(projectSlug);
   if (!listed.ok) return listed;
-  return listed.worktrees.find((entry) => entry.id === worktreeId) ?? failure(404, "not_found", "Worktree was not found");
+  const worktree = listed.worktrees.find((entry) => entry.id === worktreeId);
+  return worktree ? { ok: true, worktree } : failure(404, "not_found", "Worktree was not found");
 }
 
 async function resolveCodexSandbox(options: {
@@ -88,10 +90,32 @@ export function createWorkspaceSessionOrchestrator(options: {
   agentSessionManager: AgentSessionManager;
   agentSandbox: AgentSandbox;
   sessionRuntimeBridge: SessionRuntimeBridge;
-  eventPublisher?: Pick<WorkspaceEventPublisher, "publishSessionStarted">;
+  eventPublisher?: Pick<WorkspaceEventPublisher, "publishSessionStarted" | "publishSessionStopped">;
   idGenerator?: () => string;
 }) {
   const idGenerator = options.idGenerator ?? (() => `sess_${randomUUID()}`);
+
+  async function publishSessionStarted(session: WorkspaceSessionView): Promise<void> {
+    try {
+      await options.eventPublisher?.publishSessionStarted(session);
+    } catch (err: unknown) {
+      console.warn(
+        "[workspace-session-orchestrator] Failed to publish session start event:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  async function publishSessionStopped(session: WorkspaceSessionView): Promise<void> {
+    try {
+      await options.eventPublisher?.publishSessionStopped(session);
+    } catch (err: unknown) {
+      console.warn(
+        "[workspace-session-orchestrator] Failed to publish session stop event:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
 
   return {
     async startSession(input: StartWorkspaceSessionInput): Promise<
@@ -109,12 +133,12 @@ export function createWorkspaceSessionOrchestrator(options: {
           input.request.projectSlug,
           input.request.worktreeId,
         );
-        if (!("path" in worktree)) return worktree;
+        if (!worktree.ok) return worktree;
         const preflight = await resolveCodexSandbox({
           agentSandbox: options.agentSandbox,
           request: input.request,
           sessionId,
-          worktree,
+          worktree: worktree.worktree,
         });
         if (!preflight.ok) return preflight;
         sandbox = preflight.sandbox;
@@ -128,11 +152,11 @@ export function createWorkspaceSessionOrchestrator(options: {
       });
       if (!result.ok) return result;
 
-      await options.eventPublisher?.publishSessionStarted(result.session);
+      await publishSessionStarted(result.session);
       return result;
     },
 
-    async listSessions(input: unknown = {}) {
+    async listSessions(input: ListSessionsInput = {}) {
       return options.agentSessionManager.listSessions(input);
     },
 
@@ -151,11 +175,14 @@ export function createWorkspaceSessionOrchestrator(options: {
     },
 
     async stopSession(sessionId: string) {
-      return options.agentSessionManager.killSession(sessionId);
+      const result = await options.agentSessionManager.killSession(sessionId);
+      if (!result.ok) return result;
+      await publishSessionStopped(result.session);
+      return result;
     },
 
     async recoverSessions() {
-      return this.listSessions({ status: "running" });
+      return options.agentSessionManager.listSessions({ status: "running" });
     },
   };
 }

--- a/tests/gateway/workspace-event-publisher.test.ts
+++ b/tests/gateway/workspace-event-publisher.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWorkspaceEventPublisher } from "../../packages/gateway/src/workspace-event-publisher.js";
+
+describe("workspace event publisher", () => {
+  it("publishes task, preview, and session lifecycle events through one helper", async () => {
+    const eventStore = {
+      publishEvent: vi.fn(async () => ({ ok: true, event: { id: "evt_abc123" } })),
+    };
+    const publisher = createWorkspaceEventPublisher({ eventStore });
+
+    await publisher.publishTaskCreated({
+      id: "task_abc123",
+      projectSlug: "repo",
+      title: "Fix auth",
+      status: "running",
+    });
+    await publisher.publishPreviewUpdated({
+      id: "prev_abc123",
+      projectSlug: "repo",
+      taskId: "task_abc123",
+      sessionId: "sess_abc123",
+      lastStatus: "ok",
+      updatedAt: "2026-04-29T00:00:00.000Z",
+    });
+    await publisher.publishSessionStarted({
+      id: "sess_abc123",
+      kind: "agent",
+      projectSlug: "repo",
+      taskId: "task_abc123",
+      worktreeId: "wt_abc123def456",
+      pr: 42,
+      agent: "codex",
+      runtime: { type: "zellij", status: "running" },
+      terminalSessionId: "term_sess_abc123",
+    });
+
+    expect(eventStore.publishEvent).toHaveBeenNthCalledWith(1, {
+      type: "task.created",
+      scope: { projectSlug: "repo", taskId: "task_abc123" },
+      payload: { title: "Fix auth", status: "running" },
+    });
+    expect(eventStore.publishEvent).toHaveBeenNthCalledWith(2, {
+      type: "preview.updated",
+      scope: {
+        projectSlug: "repo",
+        taskId: "task_abc123",
+        sessionId: "sess_abc123",
+        previewId: "prev_abc123",
+      },
+      payload: { lastStatus: "ok", updatedAt: "2026-04-29T00:00:00.000Z" },
+    });
+    expect(eventStore.publishEvent).toHaveBeenNthCalledWith(3, {
+      type: "session.started",
+      scope: {
+        projectSlug: "repo",
+        taskId: "task_abc123",
+        sessionId: "sess_abc123",
+      },
+      payload: {
+        agent: "codex",
+        kind: "agent",
+        pr: 42,
+        runtimeStatus: "running",
+        terminalSessionId: "term_sess_abc123",
+        worktreeId: "wt_abc123def456",
+      },
+    });
+  });
+
+  it("logs and suppresses event-store failures so mutations keep their own result", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const eventStore = {
+      publishEvent: vi.fn(async () => ({
+        ok: false,
+        status: 400,
+        error: { code: "invalid_event_scope", message: "Workspace event scope is invalid" },
+      })),
+    };
+    const publisher = createWorkspaceEventPublisher({ eventStore });
+
+    await expect(publisher.publishTaskDeleted("repo", "task_abc123")).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith("[workspace-event-publisher] Failed to publish workspace event:", "invalid_event_scope");
+  });
+});

--- a/tests/gateway/workspace-event-publisher.test.ts
+++ b/tests/gateway/workspace-event-publisher.test.ts
@@ -33,6 +33,17 @@ describe("workspace event publisher", () => {
       runtime: { type: "zellij", status: "running" },
       terminalSessionId: "term_sess_abc123",
     });
+    await publisher.publishSessionStopped({
+      id: "sess_abc123",
+      kind: "agent",
+      projectSlug: "repo",
+      taskId: "task_abc123",
+      worktreeId: "wt_abc123def456",
+      pr: 42,
+      agent: "codex",
+      runtime: { type: "zellij", status: "exited" },
+      terminalSessionId: "term_sess_abc123",
+    });
 
     expect(eventStore.publishEvent).toHaveBeenNthCalledWith(1, {
       type: "task.created",
@@ -65,6 +76,22 @@ describe("workspace event publisher", () => {
         worktreeId: "wt_abc123def456",
       },
     });
+    expect(eventStore.publishEvent).toHaveBeenNthCalledWith(4, {
+      type: "session.stopped",
+      scope: {
+        projectSlug: "repo",
+        taskId: "task_abc123",
+        sessionId: "sess_abc123",
+      },
+      payload: {
+        agent: "codex",
+        kind: "agent",
+        pr: 42,
+        runtimeStatus: "exited",
+        terminalSessionId: "term_sess_abc123",
+        worktreeId: "wt_abc123def456",
+      },
+    });
   });
 
   it("logs and suppresses event-store failures so mutations keep their own result", async () => {
@@ -81,5 +108,19 @@ describe("workspace event publisher", () => {
     await expect(publisher.publishTaskDeleted("repo", "task_abc123")).resolves.toBeUndefined();
 
     expect(warn).toHaveBeenCalledWith("[workspace-event-publisher] Failed to publish workspace event:", "invalid_event_scope");
+  });
+
+  it("logs and suppresses thrown event-store errors after primary mutations", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const eventStore = {
+      publishEvent: vi.fn(async () => {
+        throw new Error("disk full");
+      }),
+    };
+    const publisher = createWorkspaceEventPublisher({ eventStore });
+
+    await expect(publisher.publishTaskDeleted("repo", "task_abc123")).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith("[workspace-event-publisher] Unexpected workspace event publish error:", "disk full");
   });
 });

--- a/tests/gateway/workspace-session-orchestrator.test.ts
+++ b/tests/gateway/workspace-session-orchestrator.test.ts
@@ -43,6 +43,7 @@ describe("workspace session orchestrator", () => {
     };
     const eventPublisher = {
       publishSessionStarted: vi.fn(async () => undefined),
+      publishSessionStopped: vi.fn(async () => undefined),
     };
     return {
       worktreeManager,
@@ -88,6 +89,35 @@ describe("workspace session orchestrator", () => {
       sessionId: "sess_fixed",
     }));
     expect(d.eventPublisher.publishSessionStarted).toHaveBeenCalledWith(session);
+  });
+
+  it("does not fail a started session when session event publication throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const d = deps({
+      eventPublisher: {
+        publishSessionStarted: vi.fn(async () => {
+          throw new Error("event write failed");
+        }),
+        publishSessionStopped: vi.fn(async () => undefined),
+      },
+    });
+    const orchestrator = createWorkspaceSessionOrchestrator({
+      ...d,
+      idGenerator: () => "sess_fixed",
+    });
+
+    const result = await orchestrator.startSession({
+      ownerScope: { type: "user", id: "user_workspace" },
+      request: {
+        projectSlug: "repo",
+        worktreeId: "wt_abc123def456",
+        kind: "agent",
+        agent: "codex",
+      },
+    });
+
+    expect(result).toMatchObject({ ok: true, status: 201, session: { id: "sess_fixed" } });
+    expect(warn).toHaveBeenCalledWith("[workspace-session-orchestrator] Failed to publish session start event:", "event write failed");
   });
 
   it("returns a safe sandbox failure before launching a session", async () => {
@@ -177,5 +207,18 @@ describe("workspace session orchestrator", () => {
       session: expect.objectContaining({ id: "sess_fixed" }),
     });
     expect(d.sessionRuntimeBridge.registerSession).toHaveBeenCalledWith(session, { mode: "observe" });
+    expect(d.eventPublisher.publishSessionStopped).toHaveBeenCalledWith(expect.objectContaining({ id: "sess_fixed" }));
+  });
+
+  it("recovers active sessions without relying on object method this binding", async () => {
+    const d = deps();
+    const orchestrator = createWorkspaceSessionOrchestrator({ ...d });
+    const recoverSessions = orchestrator.recoverSessions;
+
+    await expect(recoverSessions()).resolves.toMatchObject({
+      ok: true,
+      sessions: [expect.objectContaining({ id: "sess_fixed" })],
+    });
+    expect(d.agentSessionManager.listSessions).toHaveBeenCalledWith({ status: "running" });
   });
 });

--- a/tests/gateway/workspace-session-orchestrator.test.ts
+++ b/tests/gateway/workspace-session-orchestrator.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { createWorkspaceSessionOrchestrator } from "../../packages/gateway/src/workspace-session-orchestrator.js";
+
+describe("workspace session orchestrator", () => {
+  const homePath = "/matrix/home";
+  const worktree = {
+    id: "wt_abc123def456",
+    projectSlug: "repo",
+    path: join(homePath, "projects", "repo", "worktrees", "wt_abc123def456"),
+  };
+  const session = {
+    id: "sess_fixed",
+    kind: "agent",
+    projectSlug: "repo",
+    taskId: "task_abc123",
+    worktreeId: "wt_abc123def456",
+    agent: "codex",
+    runtime: { type: "zellij", status: "running" },
+    terminalSessionId: "term_sess_fixed",
+  };
+
+  function deps(overrides: Record<string, unknown> = {}) {
+    const worktreeManager = {
+      listWorktrees: vi.fn(async () => ({ ok: true, worktrees: [worktree] })),
+    };
+    const agentSandbox = {
+      preflight: vi.fn(async () => ({
+        ok: true,
+        sandbox: { enabled: true, writableRoots: [worktree.path] },
+        sandboxStatus: { available: true },
+      })),
+    };
+    const agentSessionManager = {
+      startSession: vi.fn(async () => ({ ok: true, status: 201, session })),
+      listSessions: vi.fn(async () => ({ ok: true, sessions: [session], nextCursor: null })),
+      getSession: vi.fn(async () => ({ ok: true, session })),
+      sendInput: vi.fn(async () => ({ ok: true, session })),
+      killSession: vi.fn(async () => ({ ok: true, session: { ...session, runtime: { type: "zellij", status: "exited" } } })),
+    };
+    const sessionRuntimeBridge = {
+      registerSession: vi.fn(() => ({ ok: true, mode: "observe", terminalSessionId: "term_sess_fixed" })),
+    };
+    const eventPublisher = {
+      publishSessionStarted: vi.fn(async () => undefined),
+    };
+    return {
+      worktreeManager,
+      agentSandbox,
+      agentSessionManager,
+      sessionRuntimeBridge,
+      eventPublisher,
+      ...overrides,
+    };
+  }
+
+  it("starts codex sessions with sandbox preflight, owner scope, and a session event", async () => {
+    const d = deps();
+    const orchestrator = createWorkspaceSessionOrchestrator({
+      ...d,
+      idGenerator: () => "sess_fixed",
+    });
+
+    const result = await orchestrator.startSession({
+      ownerScope: { type: "user", id: "user_workspace" },
+      request: {
+        projectSlug: "repo",
+        taskId: "task_abc123",
+        worktreeId: "wt_abc123def456",
+        kind: "agent",
+        agent: "codex",
+        prompt: "fix tests",
+      },
+    });
+
+    expect(result).toMatchObject({ ok: true, status: 201, session: { id: "sess_fixed" } });
+    expect(d.worktreeManager.listWorktrees).toHaveBeenCalledWith("repo");
+    expect(d.agentSandbox.preflight).toHaveBeenCalledWith({
+      agent: "codex",
+      sessionId: "sess_fixed",
+      worktreePath: worktree.path,
+      adminOverride: undefined,
+    });
+    expect(d.agentSessionManager.startSession).toHaveBeenCalledWith(expect.objectContaining({
+      agent: "codex",
+      ownerId: "user_workspace",
+      sandbox: { enabled: true, writableRoots: [worktree.path] },
+      sessionId: "sess_fixed",
+    }));
+    expect(d.eventPublisher.publishSessionStarted).toHaveBeenCalledWith(session);
+  });
+
+  it("returns a safe sandbox failure before launching a session", async () => {
+    const d = deps({
+      agentSandbox: {
+        preflight: vi.fn(async () => ({
+          ok: false,
+          status: 400,
+          error: { code: "sandbox_unavailable", message: "Agent sandbox is unavailable" },
+          sandboxStatus: { available: false },
+        })),
+      },
+    });
+    const orchestrator = createWorkspaceSessionOrchestrator({
+      ...d,
+      idGenerator: () => "sess_fixed",
+    });
+
+    const result = await orchestrator.startSession({
+      ownerScope: { type: "user", id: "user_workspace" },
+      request: {
+        projectSlug: "repo",
+        worktreeId: "wt_abc123def456",
+        kind: "agent",
+        agent: "codex",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: { code: "sandbox_unavailable", message: "Agent sandbox is unavailable" },
+      sandboxStatus: { available: false },
+    });
+    expect(d.agentSessionManager.startSession).not.toHaveBeenCalled();
+    expect(d.eventPublisher.publishSessionStarted).not.toHaveBeenCalled();
+  });
+
+  it("returns not found when the requested worktree is missing", async () => {
+    const d = deps({
+      worktreeManager: {
+        listWorktrees: vi.fn(async () => ({ ok: true, worktrees: [] })),
+      },
+    });
+    const orchestrator = createWorkspaceSessionOrchestrator({
+      ...d,
+      idGenerator: () => "sess_fixed",
+    });
+
+    const result = await orchestrator.startSession({
+      ownerScope: { type: "user", id: "user_workspace" },
+      request: {
+        projectSlug: "repo",
+        worktreeId: "wt_abc123def456",
+        kind: "agent",
+        agent: "codex",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: { code: "not_found", message: "Worktree was not found" },
+    });
+    expect(d.agentSandbox.preflight).not.toHaveBeenCalled();
+    expect(d.agentSessionManager.startSession).not.toHaveBeenCalled();
+  });
+
+  it("delegates attach, list, send, and stop operations through one lifecycle interface", async () => {
+    const d = deps();
+    const orchestrator = createWorkspaceSessionOrchestrator({ ...d });
+
+    await expect(orchestrator.listSessions({ projectSlug: "repo", limit: 10 })).resolves.toMatchObject({
+      ok: true,
+      sessions: [expect.objectContaining({ id: "sess_fixed" })],
+    });
+    await expect(orchestrator.sendInput("sess_fixed", "pnpm test\n")).resolves.toMatchObject({
+      ok: true,
+      session: expect.objectContaining({ id: "sess_fixed" }),
+    });
+    await expect(orchestrator.attachSession("sess_fixed", "observe")).resolves.toMatchObject({
+      ok: true,
+      terminalSessionId: "term_sess_fixed",
+    });
+    await expect(orchestrator.stopSession("sess_fixed")).resolves.toMatchObject({
+      ok: true,
+      session: expect.objectContaining({ id: "sess_fixed" }),
+    });
+    expect(d.sessionRuntimeBridge.registerSession).toHaveBeenCalledWith(session, { mode: "observe" });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract workspace session lifecycle coordination into `workspace-session-orchestrator`.
- Move task, preview, and session event publication shapes into `workspace-event-publisher`.
- Keep workspace routes as transport adapters for parsing, owner-scope lookup, orchestration calls, and safe response mapping.
- Remove the hardcoded `local` owner fallback from workspace routes; default route-factory behavior now uses the shared request-principal resolver's explicit dev fallback, while server wiring continues to inject the strict request principal accessor.

Closes #68.

## Invariants

**Source of truth:** Existing project/worktree/session/task/preview stores remain canonical. The orchestrator coordinates existing managers and does not introduce new persistence.

**Lock/transaction scope:** No new database writes are introduced. Worktree lease acquisition remains inside `agent-session-manager`; sandbox preflight runs before launch and before session persistence.

**Acceptable orphan states:** Session start publishes `session.started` only after `agentSessionManager.startSession` succeeds. Event publication failures are logged and suppressed so the primary mutation result remains authoritative, matching existing route behavior.

**Auth source of truth:** Workspace session owner identity comes from the injected owner scope derived from the request principal. The server route wiring still uses `requireRequestPrincipal(c).userId`; no request body owner override is accepted for sessions.

**Deferred scope:** This PR does not migrate startup recovery or review-loop round orchestration into the session orchestrator beyond exposing the lifecycle interface needed by current routes.

## Validation

- `bun run test tests/gateway/workspace-session-orchestrator.test.ts tests/gateway/workspace-event-publisher.test.ts tests/gateway/workspace-routes.test.ts`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing manual-review warnings only)

Full `bun run test` was attempted but invalidated by root filesystem ENOSPC during temp-dir creation; after cleaning generated test temp directories, focused tests were rerun successfully.