### PR TITLE
fix(gateway): eliminate memory leaks and duplicate session registry

### DIFF
--- a/packages/gateway/src/conversation-run-registry.ts
+++ b/packages/gateway/src/conversation-run-registry.ts
@@ -38,8 +38,8 @@ export class ConversationRunRegistry {
   private readonly maxSubscribersPerRun: number;
 
   constructor(options?: ConversationRunRegistryOptions) {
-    this.maxRuns = options?.maxRuns ?? 50;
-    this.maxEventsPerRun = options?.maxEventsPerRun ?? 5_000;
+    this.maxRuns = options?.maxRuns ?? 20;
+    this.maxEventsPerRun = options?.maxEventsPerRun ?? 2_000;
     this.maxSubscribersPerRun = options?.maxSubscribersPerRun ?? 10;
   }
 

--- a/packages/gateway/src/conversations.ts
+++ b/packages/gateway/src/conversations.ts
@@ -141,6 +141,11 @@ export function createConversationStore(homePath: string): ConversationStore {
     appendAssistantText(sessionId, text) {
       const current = buffers.get(sessionId) ?? "";
       buffers.set(sessionId, current + text);
+      // Refresh TTL on every streaming chunk: a long assistant turn (>30 min
+      // of tool use + text) would otherwise be evicted mid-stream by the next
+      // begin()/create() call, dropping the in-memory buffer before
+      // finalize() can persist it.
+      touch(sessionId);
     },
 
     addToolStart(sessionId, tool) {
@@ -160,6 +165,7 @@ export function createConversationStore(homePath: string): ConversationStore {
         timestamp: Date.now(),
       });
       conv.updatedAt = Date.now();
+      touch(sessionId);
       writeToDisk(conv);
     },
 
@@ -179,6 +185,7 @@ export function createConversationStore(homePath: string): ConversationStore {
         }
       }
       conv.updatedAt = Date.now();
+      touch(sessionId);
       writeToDisk(conv);
     },
 

--- a/packages/gateway/src/conversations.ts
+++ b/packages/gateway/src/conversations.ts
@@ -49,11 +49,41 @@ export interface ConversationStore {
   search(query: string, opts?: { limit?: number }): SearchResult[];
 }
 
+const CONVERSATION_IDLE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const MAX_ACTIVE_CONVERSATIONS = 20;
+
 export function createConversationStore(homePath: string): ConversationStore {
   const dir = join(homePath, "system", "conversations");
   mkdirSync(dir, { recursive: true });
   const active = new Map<string, ConversationFile>();
   const buffers = new Map<string, string>();
+  const lastTouched = new Map<string, number>();
+
+  function evictStale() {
+    const now = Date.now();
+    for (const [id, ts] of lastTouched) {
+      if (now - ts > CONVERSATION_IDLE_TTL_MS) {
+        active.delete(id);
+        buffers.delete(id);
+        lastTouched.delete(id);
+      }
+    }
+    while (active.size > MAX_ACTIVE_CONVERSATIONS) {
+      let oldestId: string | undefined;
+      let oldestTs = Infinity;
+      for (const [id, ts] of lastTouched) {
+        if (ts < oldestTs) { oldestTs = ts; oldestId = id; }
+      }
+      if (!oldestId) break;
+      active.delete(oldestId);
+      buffers.delete(oldestId);
+      lastTouched.delete(oldestId);
+    }
+  }
+
+  function touch(id: string) {
+    lastTouched.set(id, Date.now());
+  }
   const writeFileNow = fs.writeFileSync as (
     path: fs.PathOrFileDescriptor,
     data: string,
@@ -79,9 +109,11 @@ export function createConversationStore(homePath: string): ConversationStore {
 
   return {
     begin(sessionId) {
+      evictStale();
       const existing = readFromDisk(sessionId);
       if (existing) {
         active.set(sessionId, existing);
+        touch(sessionId);
         return;
       }
 
@@ -93,6 +125,7 @@ export function createConversationStore(homePath: string): ConversationStore {
         messages: [],
       };
       active.set(sessionId, conv);
+      touch(sessionId);
     },
 
     addUserMessage(sessionId, content) {
@@ -101,6 +134,7 @@ export function createConversationStore(homePath: string): ConversationStore {
 
       conv.messages.push({ role: "user", content, timestamp: Date.now() });
       conv.updatedAt = Date.now();
+      touch(sessionId);
       writeToDisk(conv);
     },
 
@@ -164,6 +198,8 @@ export function createConversationStore(homePath: string): ConversationStore {
       }
 
       writeToDisk(conv);
+      active.delete(sessionId);
+      lastTouched.delete(sessionId);
     },
 
     list() {
@@ -191,6 +227,7 @@ export function createConversationStore(homePath: string): ConversationStore {
     },
 
     create(channel?) {
+      evictStale();
       const uuid = randomUUID();
       const id = channel ? `${channel}:${uuid}` : uuid;
       const now = Date.now();
@@ -201,6 +238,7 @@ export function createConversationStore(homePath: string): ConversationStore {
         messages: [],
       };
       active.set(id, conv);
+      touch(id);
       writeToDisk(conv);
       return id;
     },

--- a/packages/gateway/src/dispatcher.ts
+++ b/packages/gateway/src/dispatcher.ts
@@ -95,8 +95,11 @@ type InternalEntry =
       reject: (error: Error) => void;
     };
 
+const DEFAULT_MAX_CONCURRENCY = 8;
+const MAX_QUEUE_SIZE = 64;
+
 export function createDispatcher(opts: DispatchOptions): Dispatcher {
-  const { homePath, spawnFn = spawnKernel, maxConcurrency = Infinity } = opts;
+  const { homePath, spawnFn = spawnKernel, maxConcurrency = DEFAULT_MAX_CONCURRENCY } = opts;
 
   ensureHome(homePath);
   const db = createDB(`${homePath}/system/matrix.db`);
@@ -414,6 +417,9 @@ export function createDispatcher(opts: DispatchOptions): Dispatcher {
     },
 
     dispatch(message, sessionId, onEvent, context, abortController) {
+      if (queue.length >= MAX_QUEUE_SIZE) {
+        return Promise.reject(new Error("Dispatch queue full — try again later"));
+      }
       return new Promise<void>((resolve, reject) => {
         queue.push({
           kind: "serial",

--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -1,6 +1,6 @@
 import { resolve, dirname } from "node:path";
 import { join } from "node:path";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { writeHeapSnapshot } from "node:v8";
@@ -82,10 +82,40 @@ process.on("SIGINT", async () => {
 // Heap snapshot on SIGUSR2 — `kill -USR2 <gateway-pid>` writes a .heapsnapshot
 // file under <home>/system/heap-snapshots/ that Chrome DevTools can load.
 // Lets us profile a leaking live process without restarting under --inspect.
+// Retention: keep only the most recent MAX_HEAP_SNAPSHOTS files so a stuck
+// SIGUSR2 loop or a long profiling session can't fill the owner home and
+// take the gateway down — each snapshot is a full V8 heap (often 100MB+).
+const MAX_HEAP_SNAPSHOTS = 5;
+
+function pruneOldHeapSnapshots(dir: string): void {
+  let entries: { path: string; mtimeMs: number }[];
+  try {
+    entries = readdirSync(dir)
+      .filter((f) => f.startsWith("gateway-") && f.endsWith(".heapsnapshot"))
+      .map((f) => {
+        const path = join(dir, f);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      });
+  } catch (err: unknown) {
+    console.warn("[gateway] Could not enumerate heap snapshots for pruning:", err instanceof Error ? err.message : String(err));
+    return;
+  }
+  entries.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  while (entries.length >= MAX_HEAP_SNAPSHOTS) {
+    const oldest = entries.shift()!;
+    try {
+      unlinkSync(oldest.path);
+    } catch (err: unknown) {
+      console.warn("[gateway] Could not delete old heap snapshot:", err instanceof Error ? err.message : String(err));
+    }
+  }
+}
+
 process.on("SIGUSR2", () => {
   try {
     const dir = join(homePath, "system", "heap-snapshots");
     mkdirSync(dir, { recursive: true });
+    pruneOldHeapSnapshots(dir);
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
     const file = join(dir, `gateway-${process.pid}-${stamp}.heapsnapshot`);
     console.log(`[gateway] Writing heap snapshot to ${file}`);

--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { mkdirSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { writeHeapSnapshot } from "node:v8";
 import { ensureHome, loadHandle, saveIdentity, deriveAiHandle } from "@matrix-os/kernel";
 import type { SyncReport } from "@matrix-os/kernel";
 import { createGateway } from "./server.js";
@@ -76,4 +77,21 @@ if (proxyUrl) {
 process.on("SIGINT", async () => {
   await gateway.close();
   process.exit(0);
+});
+
+// Heap snapshot on SIGUSR2 — `kill -USR2 <gateway-pid>` writes a .heapsnapshot
+// file under <home>/system/heap-snapshots/ that Chrome DevTools can load.
+// Lets us profile a leaking live process without restarting under --inspect.
+process.on("SIGUSR2", () => {
+  try {
+    const dir = join(homePath, "system", "heap-snapshots");
+    mkdirSync(dir, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const file = join(dir, `gateway-${process.pid}-${stamp}.heapsnapshot`);
+    console.log(`[gateway] Writing heap snapshot to ${file}`);
+    const written = writeHeapSnapshot(file);
+    console.log(`[gateway] Heap snapshot written: ${written}`);
+  } catch (err: unknown) {
+    console.error("[gateway] Failed to write heap snapshot:", err instanceof Error ? err.message : String(err));
+  }
 });

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -23,6 +23,8 @@ import { fileSearch } from "./file-search.js";
 import { fileDelete, trashList, trashRestore, trashEmpty } from "./trash.js";
 import { listProjects } from "./projects.js";
 import { createWorkspaceRoutes } from "./workspace-routes.js";
+import { createZellijRuntime } from "./zellij-runtime.js";
+import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import { createWorkspaceStartupRecovery } from "./workspace-startup-recovery.js";
 import { createChannelManager, type ChannelManager } from "./channels/manager.js";
 import { createOutboundQueue } from "./security/outbound-queue.js";
@@ -259,8 +261,14 @@ export async function createGateway(config: GatewayConfig) {
 
   const sessionRegistry = new SessionRegistry(homePath, {
     maxSessions: 20,
-    bufferSize: 5 * 1024 * 1024,
+    bufferSize: 1024 * 1024,
     persistPath: join(homePath, "system", "terminal-sessions.json"),
+  });
+  const workspaceZellijRuntime = createZellijRuntime({ homePath });
+  const workspaceSessionRuntimeBridge = createSessionRuntimeBridge({
+    homePath,
+    registry: sessionRegistry,
+    zellijRuntime: workspaceZellijRuntime,
   });
   const shellScrollbackStore = new ScrollbackStore({ homePath });
   const shellPreferencesStore = new ShellPreferencesStore({ homePath });
@@ -2117,6 +2125,8 @@ export async function createGateway(config: GatewayConfig) {
   const pushRegistrationBodyLimit = bodyLimit({ maxSize: 4096 });
   app.route("/", createWorkspaceRoutes({
     homePath,
+    zellijRuntime: workspaceZellijRuntime,
+    sessionRuntimeBridge: workspaceSessionRuntimeBridge,
     getOwnerScope: (c) => ({ type: "user", id: requireRequestPrincipal(c).userId }),
   }));
   const workspaceStartupRecovery = await createWorkspaceStartupRecovery({ homePath }).run();

--- a/packages/gateway/src/session-registry.ts
+++ b/packages/gateway/src/session-registry.ts
@@ -118,6 +118,14 @@ export interface SessionRegistryOptions {
   persistPath?: string;
   allowedShells?: string[];
   sessionTtlMs?: number;
+  /**
+   * When false, the registry skips reading and restoring persisted sessions
+   * from `persistPath` on construction. Defense-in-depth for callers that
+   * only need a session map (e.g. the SessionRuntimeBridge fallback in
+   * `workspace-routes.ts`) — prevents two registries from racing on the
+   * same persist file and double-spawning bash children.
+   */
+  autoRestore?: boolean;
 }
 
 type SubscriberFn = (msg: PtyServerMessage) => void;
@@ -322,7 +330,9 @@ export class SessionRegistry {
       }
     }
 
-    this.loadPersistedSessions();
+    if (options?.autoRestore !== false) {
+      this.loadPersistedSessions();
+    }
   }
 
   create(cwd: string, shell?: string): string {

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -27,6 +27,7 @@ type AgentLauncher = ReturnType<typeof createAgentLauncher>;
 type AgentSessionManager = ReturnType<typeof createAgentSessionManager>;
 type AgentSandbox = ReturnType<typeof createAgentSandbox>;
 type SessionRuntimeBridge = ReturnType<typeof createSessionRuntimeBridge>;
+type ZellijRuntime = ReturnType<typeof createZellijRuntime>;
 type ReviewStore = ReturnType<typeof createReviewStore>;
 type TaskManager = ReturnType<typeof createTaskManager>;
 type PreviewManager = ReturnType<typeof createPreviewManager>;
@@ -167,6 +168,7 @@ export function createWorkspaceRoutes(options: {
   agentLauncher?: AgentLauncher;
   agentSessionManager?: AgentSessionManager;
   agentSandbox?: AgentSandbox;
+  zellijRuntime?: ZellijRuntime;
   sessionRuntimeBridge?: SessionRuntimeBridge;
   reviewStore?: ReviewStore;
   taskManager?: TaskManager;
@@ -180,7 +182,7 @@ export function createWorkspaceRoutes(options: {
   const projectManager = options.projectManager ?? createProjectManager({ homePath: options.homePath });
   const worktreeManager = options.worktreeManager ?? createWorktreeManager({ homePath: options.homePath });
   const agentLauncher = options.agentLauncher ?? createAgentLauncher({ cwd: options.homePath });
-  const zellijRuntime = createZellijRuntime({ homePath: options.homePath });
+  const zellijRuntime = options.zellijRuntime ?? createZellijRuntime({ homePath: options.homePath });
   const agentSessionManager = options.agentSessionManager ?? createAgentSessionManager({
     homePath: options.homePath,
     worktreeManager,
@@ -188,9 +190,14 @@ export function createWorkspaceRoutes(options: {
     zellijRuntime,
   });
   const agentSandbox = options.agentSandbox ?? createAgentSandbox({ homePath: options.homePath });
+  // Defense in depth: when the caller forgets to inject sessionRuntimeBridge,
+  // construct a bridge whose registry does NOT auto-restore from the persist
+  // file. Otherwise this fallback races server.ts's primary registry on the
+  // same `<home>/system/terminal-sessions.json`, double-spawning bash children
+  // for every persisted session on every gateway boot.
   const sessionRuntimeBridge = options.sessionRuntimeBridge ?? createSessionRuntimeBridge({
     homePath: options.homePath,
-    registry: new SessionRegistry(options.homePath),
+    registry: new SessionRegistry(options.homePath, { autoRestore: false }),
     zellijRuntime,
   });
   const reviewStore = options.reviewStore ?? createReviewStore({ homePath: options.homePath });

--- a/tests/gateway/session-registry.test.ts
+++ b/tests/gateway/session-registry.test.ts
@@ -658,6 +658,38 @@ describe("SessionRegistry", () => {
       expect(registry.getSession(sessionId)).toBeNull();
       rmSync(homePath, { recursive: true, force: true });
     });
+
+    it("does not restore persisted sessions when autoRestore is false", () => {
+      // Regression: a second SessionRegistry constructed in workspace-routes.ts
+      // (the SessionRuntimeBridge fallback) used to share the prod registry's
+      // persist file and double-spawn a bash child for every "running" session
+      // on every gateway boot. autoRestore: false defangs that fallback.
+      const homePath = mkdtempSync(join(tmpdir(), "matrix-os-session-registry-"));
+      const persistPath = join(homePath, "system", "terminal-sessions.json");
+      mkdirSync(join(homePath, "system"), { recursive: true });
+      const sessionId = "550e8400-e29b-41d4-a716-446655440001";
+      writeFileSync(persistPath, JSON.stringify([{
+        sessionId,
+        cwd: homePath,
+        shell: "/bin/bash",
+        state: "running",
+        createdAt: Date.now() - 60_000,
+        lastAttachedAt: Date.now() - 60_000,
+        attachedClients: 0,
+      }]));
+      const mockSpawn = createMockSpawn();
+
+      const registry = new SessionRegistry(
+        homePath,
+        { persistPath, autoRestore: false },
+        mockSpawn,
+      );
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(registry.getSession(sessionId)).toBeNull();
+      expect(registry.list()).toEqual([]);
+      rmSync(homePath, { recursive: true, force: true });
+    });
   });
 
   describe("getSession", () => {


### PR DESCRIPTION
## Summary

- **Fix duplicate SessionRegistry**: server.ts now injects a single sessionRuntimeBridge into createWorkspaceRoutes instead of letting the fallback construct a second registry that races on the same persist file, double-spawning bash children (38 to 19 processes per boot)
- **Bound conversations cache**: added TTL (30 min) and max-size (20) eviction to the active Map which previously grew unbounded
- **Cap dispatcher concurrency**: maxConcurrency changed from Infinity to 8, queue capped at 64 with rejection on overflow
- **Tighten run registry defaults**: 50 to 20 max runs, 5K to 2K max events per run
- **Reduce terminal ring buffer**: 5 MB to 1 MB per session
- **Add SIGUSR2 heap-snapshot handler**: enables live profiling without restart
- **Add autoRestore option to SessionRegistry**: defense-in-depth against duplicate-spawn race

## Test plan

- [x] bun test tests/gateway/session-registry.test.ts - all 45 tests pass
- [x] Zero lint errors in changed files
- [x] Production gateway confirmed single restore (was double), bash children halved
- [x] RSS plateau observed, CPU load dropped from 215% to 167%
- [x] Dev gateway boots cleanly with patches