### PR TITLE
fix(shell): use extensionless import for Turbopack

### DIFF
--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -64,7 +64,7 @@ import {
   isNewer,
   severityBadgeStyle,
   resolveSystemUpdateState,
-} from "./system-update-state.js";
+} from "./system-update-state";
 export { normalizeMatrixReleaseTag, isNewer, severityBadgeStyle, resolveSystemUpdateState };
 
 export function SystemSection() {


### PR DESCRIPTION
Turbopack can't resolve `./system-update-state.js` — needs extensionless import for .ts files. Fixes the Host Bundle Release build failure.