### PR TITLE
fix(ci): use correct R2 secret names

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -125,9 +125,9 @@ jobs:
     timeout-minutes: 10
     env:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET: ${{ vars.R2_BUCKET || 'matrixos-sync' }}
       MATRIX_IMAGE_VERSION: matrix-os-host
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -107,9 +107,8 @@ jobs:
           MATRIX_BUILD_DATE: ${{ github.event.head_commit.timestamp }}
         run: |
           set -euo pipefail
-          BUNDLE_PATH="$(./scripts/build-host-bundle.sh)"
-          echo "bundle_path=$BUNDLE_PATH" >> "$GITHUB_OUTPUT"
-          echo "Built: $BUNDLE_PATH"
+          ./scripts/build-host-bundle.sh
+          echo "bundle_path=dist/host-bundle/matrix-host-bundle.tar.gz" >> "$GITHUB_OUTPUT"
 
       - name: Upload bundle artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Workflow used AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY but repo secrets are named R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY. Also defaults R2_BUCKET to 'matrixos-sync'.