### PR TITLE
feat(shell): custom fullscreen mode for windows

### DIFF
--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
-import { useWindowManager, type LayoutWindow } from "@/hooks/useWindowManager";
+import { useWindowManager, type LayoutWindow, type AppWindow } from "@/hooks/useWindowManager";
 import { useCommandStore } from "@/stores/commands";
 import { useDesktopMode } from "@/stores/desktop-mode";
 import { useVocalStore } from "@/stores/vocal";
@@ -143,9 +143,11 @@ const MIN_HEIGHT = 200;
 function TrafficLights({
   onClose,
   onMinimize,
+  onFullscreen,
 }: {
   onClose: () => void;
   onMinimize: () => void;
+  onFullscreen?: () => void;
 }) {
   return (
     <div className="group/traffic flex items-center gap-1.5 mr-2">
@@ -174,8 +176,12 @@ function TrafficLights({
         </span>
       </button>
       <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onFullscreen?.();
+        }}
         className="size-3 rounded-full bg-[#28c840] flex items-center justify-center hover:brightness-90 transition-colors"
-        aria-label="Maximize"
+        aria-label="Fullscreen"
       />
     </div>
   );
@@ -426,6 +432,99 @@ function AoedeDockButton({
   );
 }
 
+function FullscreenOverlay({
+  win,
+  onExit,
+  chat,
+  onOpenApp,
+}: {
+  win: AppWindow | null;
+  onExit: () => void;
+  chat?: import("@/hooks/useChatState").ChatState;
+  onOpenApp: (name: string, path: string) => void;
+}) {
+  const [mounted, setMounted] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const prevWin = useRef<AppWindow | null>(null);
+  const exitingRef = useRef(false);
+
+  useEffect(() => {
+    if (win && !prevWin.current) {
+      exitingRef.current = false;
+      setMounted(true);
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => setVisible(true));
+      });
+    } else if (!win && prevWin.current) {
+      exitingRef.current = true;
+      setVisible(false);
+      const timer = setTimeout(() => {
+        setMounted(false);
+        exitingRef.current = false;
+      }, 350);
+      prevWin.current = win;
+      return () => clearTimeout(timer);
+    }
+    prevWin.current = win;
+  }, [win]);
+
+  if (!mounted) return null;
+
+  const target = win ?? prevWin.current;
+  if (!target) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] bg-background"
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: visible ? "scale(1)" : "scale(0.95)",
+        transition: "opacity 300ms cubic-bezier(0.22, 1, 0.36, 1), transform 300ms cubic-bezier(0.22, 1, 0.36, 1)",
+      }}
+    >
+      <div className="h-full w-full relative">
+        {target.path.startsWith("__terminal__") ? (
+          <TerminalApp />
+        ) : target.path === "__workspace__" ? (
+          <WorkspaceApp />
+        ) : target.path === "__file-browser__" ? (
+          <FileBrowser windowId={target.id} />
+        ) : target.path === "__chat__" ? (
+          <div className="h-full overflow-hidden">
+            {chat && (
+              <ChatApp
+                messages={chat.messages}
+                sessionId={chat.sessionId}
+                busy={chat.busy}
+                connected={chat.connected}
+                conversations={chat.conversations}
+                onNewChat={chat.newChat}
+                onSwitchConversation={chat.switchConversation}
+                onSubmit={chat.submitMessage}
+              />
+            )}
+          </div>
+        ) : (
+          <AppViewer path={target.path} onOpenApp={onOpenApp} />
+        )}
+      </div>
+      <div className="group/fsexit fixed top-0 left-0 z-[101] w-14 h-3 hover:h-10 transition-all duration-300">
+        <button
+          onClick={onExit}
+          className="ml-2.5 mt-0.5 group-hover/fsexit:mt-2 flex items-center gap-1.5 px-2 py-1 rounded-full bg-foreground/[0.03] group-hover/fsexit:bg-foreground/5 backdrop-blur-md border border-foreground/[0.04] group-hover/fsexit:border-foreground/[0.08] text-foreground/20 group-hover/fsexit:text-foreground/50 hover:!text-foreground/70 hover:!bg-foreground/10 transition-all duration-300 cursor-pointer"
+          aria-label="Exit fullscreen"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className="opacity-40 group-hover/fsexit:opacity-100 transition-opacity duration-300">
+            <path d="M1 5h3.5V1.5" />
+            <path d="M11 7H7.5v3.5" />
+          </svg>
+          <span className="text-[10px] font-medium tracking-wide opacity-0 group-hover/fsexit:opacity-100 transition-opacity duration-300">Exit</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
 interface DesktopProps {
   onOpenCommandPalette?: () => void;
   chat?: import("@/hooks/useChatState").ChatState;
@@ -446,6 +545,9 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
   const wmSetWindows = useWindowManager((s) => s.setWindows);
   const wmLoadLayout = useWindowManager((s) => s.loadLayout);
   const wmCascadeWindows = useWindowManager((s) => s.cascadeWindows);
+  const fullscreenWindowId = useWindowManager((s) => s.fullscreenWindowId);
+  const wmToggleFullscreen = useWindowManager((s) => s.toggleFullscreen);
+  const wmExitFullscreen = useWindowManager((s) => s.exitFullscreen);
 
   const [interacting, setInteracting] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -1193,8 +1295,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
         execute: () => {
           const focused = useWindowManager.getState().getFocusedWindow();
           if (!focused) return;
-          const el = document.querySelector(`[data-window-id="${focused.id}"]`) as HTMLElement | null;
-          if (el) el.requestFullscreen?.();
+          wmToggleFullscreen(focused.id);
         },
       },
     ]);
@@ -1230,6 +1331,19 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
     if (appCommands.length > 0) register(appCommands);
     return () => unregister(apps.map((a) => `app:${a.path}`));
   }, [apps, register, unregister]);
+
+  useEffect(() => {
+    if (!fullscreenWindowId) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") wmExitFullscreen();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [fullscreenWindowId, wmExitFullscreen]);
+
+  const fullscreenWindow = fullscreenWindowId
+    ? windows.find((w) => w.id === fullscreenWindowId)
+    : null;
 
   return (
     <TooltipProvider delayDuration={300}>
@@ -1731,6 +1845,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                   <TrafficLights
                     onClose={() => wmCloseWindow(win.id)}
                     onMinimize={() => animateMinimize(win.id)}
+                    onFullscreen={() => wmToggleFullscreen(win.id)}
                   />
                   <CardTitle className="text-xs font-medium truncate flex-1 text-center">
                     {win.title}
@@ -1825,6 +1940,13 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
           buttons. Lives outside both dock-orientation branches so it
           isn't unmounted when the viewport flips. */}
       <ChatPopover open={chatOpen} onOpenChange={setChatOpen} />
+
+      <FullscreenOverlay
+        win={fullscreenWindow ?? null}
+        onExit={wmExitFullscreen}
+        chat={chat}
+        onOpenApp={openWindow}
+      />
     </TooltipProvider>
   );
 }

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1873,6 +1873,41 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
           isn't unmounted when the viewport flips. */}
       <ChatPopover open={chatOpen} onOpenChange={setChatOpen} />
 
+      {fullscreenWindowId && desktopMode === "canvas" && (() => {
+        const fsWin = windows.find((w) => w.id === fullscreenWindowId);
+        if (!fsWin) return null;
+        return (
+          <div className="fixed inset-0 z-[100] bg-background overflow-hidden">
+            {fsWin.path.startsWith("__terminal__") ? (
+              <TerminalApp />
+            ) : fsWin.path === "__workspace__" ? (
+              <WorkspaceApp />
+            ) : fsWin.path === "__file-browser__" ? (
+              <FileBrowser windowId={fsWin.id} />
+            ) : fsWin.path === "__preview-window__" ? (
+              <PreviewWindow />
+            ) : fsWin.path === "__chat__" ? (
+              <div className="h-full overflow-hidden">
+                {chat && (
+                  <ChatApp
+                    messages={chat.messages}
+                    sessionId={chat.sessionId}
+                    busy={chat.busy}
+                    connected={chat.connected}
+                    conversations={chat.conversations}
+                    onNewChat={chat.newChat}
+                    onSwitchConversation={chat.switchConversation}
+                    onSubmit={chat.submitMessage}
+                  />
+                )}
+              </div>
+            ) : (
+              <AppViewer path={fsWin.path} onOpenApp={openWindow} />
+            )}
+          </div>
+        );
+      })()}
+
       {fullscreenWindowId && (
         <FullscreenExitPill onExit={wmExitFullscreen} />
       )}

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1260,7 +1260,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
   useEffect(() => {
     if (!fullscreenWindowId) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") wmExitFullscreen();
+      if (e.key === "Escape" && !e.defaultPrevented) wmExitFullscreen();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -446,21 +446,19 @@ function FullscreenOverlay({
   const [mounted, setMounted] = useState(false);
   const [visible, setVisible] = useState(false);
   const prevWin = useRef<AppWindow | null>(null);
-  const exitingRef = useRef(false);
 
   useEffect(() => {
     if (win && !prevWin.current) {
-      exitingRef.current = false;
       setMounted(true);
       requestAnimationFrame(() => {
         requestAnimationFrame(() => setVisible(true));
       });
+    } else if (win && prevWin.current && win.id !== prevWin.current.id) {
+      setVisible(true);
     } else if (!win && prevWin.current) {
-      exitingRef.current = true;
       setVisible(false);
       const timer = setTimeout(() => {
         setMounted(false);
-        exitingRef.current = false;
       }, 350);
       prevWin.current = win;
       return () => clearTimeout(timer);
@@ -489,6 +487,8 @@ function FullscreenOverlay({
           <WorkspaceApp />
         ) : target.path === "__file-browser__" ? (
           <FileBrowser windowId={target.id} />
+        ) : target.path === "__preview-window__" ? (
+          <PreviewWindow />
         ) : target.path === "__chat__" ? (
           <div className="h-full overflow-hidden">
             {chat && (

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1734,7 +1734,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                 key={win.id}
                 data-window-id={win.id}
                 className={isFullscreen
-                  ? "app-window fixed inset-0 gap-0 rounded-none p-0 overflow-hidden border-0"
+                  ? "fixed inset-0 gap-0 rounded-none p-0 overflow-hidden border-0 bg-background"
                   : "app-window absolute gap-0 rounded-none md:rounded-lg p-0 overflow-hidden shadow-2xl"
                 }
                 style={isFullscreen ? {

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
-import { useWindowManager, type LayoutWindow, type AppWindow } from "@/hooks/useWindowManager";
+import { useWindowManager, type LayoutWindow } from "@/hooks/useWindowManager";
 import { useCommandStore } from "@/stores/commands";
 import { useDesktopMode } from "@/stores/desktop-mode";
 import { useVocalStore } from "@/stores/vocal";
@@ -432,95 +432,20 @@ function AoedeDockButton({
   );
 }
 
-function FullscreenOverlay({
-  win,
-  onExit,
-  chat,
-  onOpenApp,
-}: {
-  win: AppWindow | null;
-  onExit: () => void;
-  chat?: import("@/hooks/useChatState").ChatState;
-  onOpenApp: (name: string, path: string) => void;
-}) {
-  const [mounted, setMounted] = useState(false);
-  const [visible, setVisible] = useState(false);
-  const prevWin = useRef<AppWindow | null>(null);
-
-  useEffect(() => {
-    if (win && !prevWin.current) {
-      setMounted(true);
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => setVisible(true));
-      });
-    } else if (win && prevWin.current && win.id !== prevWin.current.id) {
-      setVisible(true);
-    } else if (!win && prevWin.current) {
-      setVisible(false);
-      const timer = setTimeout(() => {
-        setMounted(false);
-      }, 350);
-      prevWin.current = win;
-      return () => clearTimeout(timer);
-    }
-    prevWin.current = win;
-  }, [win]);
-
-  if (!mounted) return null;
-
-  const target = win ?? prevWin.current;
-  if (!target) return null;
-
+function FullscreenExitPill({ onExit }: { onExit: () => void }) {
   return (
-    <div
-      className="fixed inset-0 z-[100] bg-background"
-      style={{
-        opacity: visible ? 1 : 0,
-        transform: visible ? "scale(1)" : "scale(0.95)",
-        transition: "opacity 300ms cubic-bezier(0.22, 1, 0.36, 1), transform 300ms cubic-bezier(0.22, 1, 0.36, 1)",
-      }}
-    >
-      <div className="h-full w-full relative">
-        {target.path.startsWith("__terminal__") ? (
-          <TerminalApp />
-        ) : target.path === "__workspace__" ? (
-          <WorkspaceApp />
-        ) : target.path === "__file-browser__" ? (
-          <FileBrowser windowId={target.id} />
-        ) : target.path === "__preview-window__" ? (
-          <PreviewWindow />
-        ) : target.path === "__chat__" ? (
-          <div className="h-full overflow-hidden">
-            {chat && (
-              <ChatApp
-                messages={chat.messages}
-                sessionId={chat.sessionId}
-                busy={chat.busy}
-                connected={chat.connected}
-                conversations={chat.conversations}
-                onNewChat={chat.newChat}
-                onSwitchConversation={chat.switchConversation}
-                onSubmit={chat.submitMessage}
-              />
-            )}
-          </div>
-        ) : (
-          <AppViewer path={target.path} onOpenApp={onOpenApp} />
-        )}
-      </div>
-      <div className="group/fsexit fixed top-0 left-0 z-[101] w-14 h-3 hover:h-10 transition-all duration-300">
-        <button
-          onClick={onExit}
-          className="ml-2.5 mt-0.5 group-hover/fsexit:mt-2 flex items-center gap-1.5 px-2 py-1 rounded-full bg-foreground/[0.03] group-hover/fsexit:bg-foreground/5 backdrop-blur-md border border-foreground/[0.04] group-hover/fsexit:border-foreground/[0.08] text-foreground/20 group-hover/fsexit:text-foreground/50 hover:!text-foreground/70 hover:!bg-foreground/10 transition-all duration-300 cursor-pointer"
-          aria-label="Exit fullscreen"
-        >
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className="opacity-40 group-hover/fsexit:opacity-100 transition-opacity duration-300">
-            <path d="M1 5h3.5V1.5" />
-            <path d="M11 7H7.5v3.5" />
-          </svg>
-          <span className="text-[10px] font-medium tracking-wide opacity-0 group-hover/fsexit:opacity-100 transition-opacity duration-300">Exit</span>
-        </button>
-      </div>
+    <div className="group/fsexit fixed top-0 left-0 z-[101] w-14 h-3 hover:h-10 transition-all duration-300">
+      <button
+        onClick={onExit}
+        className="ml-2.5 mt-0.5 group-hover/fsexit:mt-2 flex items-center gap-1.5 px-2 py-1 rounded-full bg-foreground/[0.03] group-hover/fsexit:bg-foreground/5 backdrop-blur-md border border-foreground/[0.04] group-hover/fsexit:border-foreground/[0.08] text-foreground/20 group-hover/fsexit:text-foreground/50 hover:!text-foreground/70 hover:!bg-foreground/10 transition-all duration-300 cursor-pointer"
+        aria-label="Exit fullscreen"
+      >
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className="opacity-40 group-hover/fsexit:opacity-100 transition-opacity duration-300">
+          <path d="M1 5h3.5V1.5" />
+          <path d="M11 7H7.5v3.5" />
+        </svg>
+        <span className="text-[10px] font-medium tracking-wide opacity-0 group-hover/fsexit:opacity-100 transition-opacity duration-300">Exit</span>
+      </button>
     </div>
   );
 }
@@ -1341,10 +1266,6 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
     return () => window.removeEventListener("keydown", onKey);
   }, [fullscreenWindowId, wmExitFullscreen]);
 
-  const fullscreenWindow = fullscreenWindowId
-    ? windows.find((w) => w.id === fullscreenWindowId)
-    : null;
-
   return (
     <TooltipProvider delayDuration={300}>
       {!showSetup && (
@@ -1786,8 +1707,9 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
               We render minimized windows too (display:none) so iframe state,
               terminal sockets, and React state survive minimize -> restore. */}
           {modeConfig.showWindows && desktopMode !== "canvas" && windows.map((win) => {
+            const isFullscreen = win.id === fullscreenWindowId;
             const isMinimizing = minimizingIds.has(win.id);
-            const isHidden = win.minimized && !isMinimizing;
+            const isHidden = win.minimized && !isMinimizing && !isFullscreen;
 
             // Compute dock target for suck animation
             let dockTargetX = 0;
@@ -1811,8 +1733,14 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
               <Card
                 key={win.id}
                 data-window-id={win.id}
-                className="app-window absolute gap-0 rounded-none md:rounded-lg p-0 overflow-hidden shadow-2xl"
-                style={{
+                className={isFullscreen
+                  ? "app-window fixed inset-0 gap-0 rounded-none p-0 overflow-hidden border-0"
+                  : "app-window absolute gap-0 rounded-none md:rounded-lg p-0 overflow-hidden shadow-2xl"
+                }
+                style={isFullscreen ? {
+                  zIndex: 100,
+                  transition: "all 300ms cubic-bezier(0.22, 1, 0.36, 1)",
+                } : {
                   "--win-x": `${win.x}px`,
                   "--win-y": `${win.y}px`,
                   "--win-w": `${win.width}px`,
@@ -1834,8 +1762,9 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                   pointerEvents: isMinimizing ? "none" : undefined,
                   display: isHidden ? "none" : undefined,
                 } as React.CSSProperties}
-                onMouseDown={() => wmFocusWindow(win.id)}
+                onMouseDown={() => !isFullscreen && wmFocusWindow(win.id)}
               >
+                {!isFullscreen && (
                 <CardHeader
                   className="flex flex-row items-center gap-0 px-3 py-2 border-b border-border md:cursor-grab md:active:cursor-grabbing select-none space-y-0"
                   onPointerDown={(e) => onDragStart(win.id, e)}
@@ -1872,6 +1801,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                     />
                   </div>
                 </CardHeader>
+                )}
 
                 <CardContent className="relative flex-1 p-0 min-h-0">
                   {win.path.startsWith("__terminal__") ? (
@@ -1905,6 +1835,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                   )}
                 </CardContent>
 
+                {!isFullscreen && (
                 <div
                   className="hidden md:block absolute bottom-0 right-0 size-4 cursor-se-resize touch-none z-20"
                   onPointerDown={(e) => onResizeStart(win.id, e)}
@@ -1929,6 +1860,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                     />
                   </svg>
                 </div>
+                )}
               </Card>
             );
           })}
@@ -1941,12 +1873,9 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
           isn't unmounted when the viewport flips. */}
       <ChatPopover open={chatOpen} onOpenChange={setChatOpen} />
 
-      <FullscreenOverlay
-        win={fullscreenWindow ?? null}
-        onExit={wmExitFullscreen}
-        chat={chat}
-        onOpenApp={openWindow}
-      />
+      {fullscreenWindowId && (
+        <FullscreenExitPill onExit={wmExitFullscreen} />
+      )}
     </TooltipProvider>
   );
 }

--- a/shell/src/components/MenuBar.tsx
+++ b/shell/src/components/MenuBar.tsx
@@ -224,8 +224,7 @@ export function MenuBar({ onOpenCommandPalette, onNewWindow, onMinimizeWindow, c
     { separator: true },
     { label: "Enter Full Screen", shortcut: "⌃⌘F", action: () => {
       if (!focusedWindow) return;
-      const el = document.querySelector(`[data-window-id="${focusedWindow.id}"]`) as HTMLElement | null;
-      if (el) el.requestFullscreen?.();
+      useWindowManager.getState().toggleFullscreen(focusedWindow.id);
     }},
     { separator: true },
     { label: "Command Palette", shortcut: "⌘K", action: onOpenCommandPalette },

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { useCanvasTransform, INTERACTION_THRESHOLD } from "@/hooks/useCanvasTransform";
 import { useWindowManager, type AppWindow } from "@/hooks/useWindowManager";
 import { useCanvasSettings } from "@/stores/canvas-settings";
@@ -50,7 +49,6 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
   const resizeWindow = useWindowManager((s) => s.resizeWindow);
   const focusedWindowId = useWindowManager((s) => s.focusedWindowId);
   const fullscreenWindowId = useWindowManager((s) => s.fullscreenWindowId);
-  const wmExitFullscreen = useWindowManager((s) => s.exitFullscreen);
   const iconUrl = useWindowManager((s) => s.apps.find((a) => a.path === win.path)?.iconUrl);
   const isFocused = focusedWindowId === win.id;
   const isFullscreen = fullscreenWindowId === win.id;
@@ -397,56 +395,6 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
       {titleBarInner}
     </div>
   );
-
-  if (isFullscreen) {
-    return createPortal(
-      <div
-        className="fixed inset-0 z-[100] bg-background overflow-hidden"
-        style={{ transition: "all 300ms cubic-bezier(0.22, 1, 0.36, 1)" }}
-      >
-        {win.path.startsWith("__terminal__") ? (
-          <TerminalApp />
-        ) : win.path === "__workspace__" ? (
-          <WorkspaceApp />
-        ) : win.path === "__file-browser__" ? (
-          <FileBrowser windowId={win.id} />
-        ) : win.path === "__preview-window__" ? (
-          <PreviewWindow />
-        ) : win.path === "__chat__" ? (
-          <div className="h-full overflow-hidden">
-            {chatState && (
-              <ChatApp
-                messages={chatState.messages}
-                sessionId={chatState.sessionId}
-                busy={chatState.busy}
-                connected={chatState.connected}
-                conversations={chatState.conversations}
-                onNewChat={chatState.newChat}
-                onSwitchConversation={chatState.switchConversation}
-                onSubmit={chatState.submitMessage}
-              />
-            )}
-          </div>
-        ) : (
-          <AppViewer path={win.path} />
-        )}
-        <div className="group/fsexit fixed top-0 left-0 z-[101] w-14 h-3 hover:h-10 transition-all duration-300">
-          <button
-            onClick={wmExitFullscreen}
-            className="ml-2.5 mt-0.5 group-hover/fsexit:mt-2 flex items-center gap-1.5 px-2 py-1 rounded-full bg-foreground/[0.03] group-hover/fsexit:bg-foreground/5 backdrop-blur-md border border-foreground/[0.04] group-hover/fsexit:border-foreground/[0.08] text-foreground/20 group-hover/fsexit:text-foreground/50 hover:!text-foreground/70 hover:!bg-foreground/10 transition-all duration-300 cursor-pointer"
-            aria-label="Exit fullscreen"
-          >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className="opacity-40 group-hover/fsexit:opacity-100 transition-opacity duration-300">
-              <path d="M1 5h3.5V1.5" />
-              <path d="M11 7H7.5v3.5" />
-            </svg>
-            <span className="text-[10px] font-medium tracking-wide opacity-0 group-hover/fsexit:opacity-100 transition-opacity duration-300">Exit</span>
-          </button>
-        </div>
-      </div>,
-      document.body,
-    );
-  }
 
   // Zoomed-out preview: icon card with title bar above
   if (!isInteractive) {

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -357,8 +357,8 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
               fontSize: "10px",
               lineHeight: 1,
             }}
-            onClick={(e) => { e.stopPropagation(); fitWindow(); }}
-            aria-label="Maximize"
+            onClick={(e) => { e.stopPropagation(); useWindowManager.getState().toggleFullscreen(win.id); }}
+            aria-label="Fullscreen"
           >
             <Maximize2 className="size-2.5" />
           </button>

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -241,8 +241,8 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
           </button>
           <button
             className="size-3 rounded-full bg-[#28c840] flex items-center justify-center hover:brightness-90 transition-colors"
-            onClick={(e) => { e.stopPropagation(); fitWindow(); }}
-            aria-label="Maximize"
+            onClick={(e) => { e.stopPropagation(); useWindowManager.getState().toggleFullscreen(win.id); }}
+            aria-label="Fullscreen"
           >
             <Maximize2 className="size-1.5 text-black/0 group-hover/traffic:text-black/60 transition-colors" />
           </button>

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -48,8 +48,11 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
   const moveWindow = useWindowManager((s) => s.moveWindow);
   const resizeWindow = useWindowManager((s) => s.resizeWindow);
   const focusedWindowId = useWindowManager((s) => s.focusedWindowId);
+  const fullscreenWindowId = useWindowManager((s) => s.fullscreenWindowId);
+  const wmExitFullscreen = useWindowManager((s) => s.exitFullscreen);
   const iconUrl = useWindowManager((s) => s.apps.find((a) => a.path === win.path)?.iconUrl);
   const isFocused = focusedWindowId === win.id;
+  const isFullscreen = fullscreenWindowId === win.id;
   const showTitles = useCanvasSettings((s) => s.showTitles);
   const themeStyle = useThemeStyle();
   const isNeumorphic = themeStyle === "neumorphic";
@@ -393,6 +396,55 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
       {titleBarInner}
     </div>
   );
+
+  if (isFullscreen) {
+    return (
+      <div
+        className="fixed inset-0 z-[100] bg-background overflow-hidden"
+        style={{ transition: "all 300ms cubic-bezier(0.22, 1, 0.36, 1)" }}
+      >
+        {win.path.startsWith("__terminal__") ? (
+          <TerminalApp />
+        ) : win.path === "__workspace__" ? (
+          <WorkspaceApp />
+        ) : win.path === "__file-browser__" ? (
+          <FileBrowser windowId={win.id} />
+        ) : win.path === "__preview-window__" ? (
+          <PreviewWindow />
+        ) : win.path === "__chat__" ? (
+          <div className="h-full overflow-hidden">
+            {chatState && (
+              <ChatApp
+                messages={chatState.messages}
+                sessionId={chatState.sessionId}
+                busy={chatState.busy}
+                connected={chatState.connected}
+                conversations={chatState.conversations}
+                onNewChat={chatState.newChat}
+                onSwitchConversation={chatState.switchConversation}
+                onSubmit={chatState.submitMessage}
+              />
+            )}
+          </div>
+        ) : (
+          <AppViewer path={win.path} />
+        )}
+        <div className="group/fsexit fixed top-0 left-0 z-[101] w-14 h-3 hover:h-10 transition-all duration-300">
+          <button
+            onClick={wmExitFullscreen}
+            className="ml-2.5 mt-0.5 group-hover/fsexit:mt-2 flex items-center gap-1.5 px-2 py-1 rounded-full bg-foreground/[0.03] group-hover/fsexit:bg-foreground/5 backdrop-blur-md border border-foreground/[0.04] group-hover/fsexit:border-foreground/[0.08] text-foreground/20 group-hover/fsexit:text-foreground/50 hover:!text-foreground/70 hover:!bg-foreground/10 transition-all duration-300 cursor-pointer"
+            aria-label="Exit fullscreen"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" className="opacity-40 group-hover/fsexit:opacity-100 transition-opacity duration-300">
+              <path d="M1 5h3.5V1.5" />
+              <path d="M11 7H7.5v3.5" />
+            </svg>
+            <span className="text-[10px] font-medium tracking-wide opacity-0 group-hover/fsexit:opacity-100 transition-opacity duration-300">Exit</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   // Zoomed-out preview: icon card with title bar above
   if (!isInteractive) {

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useCanvasTransform, INTERACTION_THRESHOLD } from "@/hooks/useCanvasTransform";
 import { useWindowManager, type AppWindow } from "@/hooks/useWindowManager";
 import { useCanvasSettings } from "@/stores/canvas-settings";
@@ -398,7 +399,7 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
   );
 
   if (isFullscreen) {
-    return (
+    return createPortal(
       <div
         className="fixed inset-0 z-[100] bg-background overflow-hidden"
         style={{ transition: "all 300ms cubic-bezier(0.22, 1, 0.36, 1)" }}
@@ -442,7 +443,8 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
             <span className="text-[10px] font-medium tracking-wide opacity-0 group-hover/fsexit:opacity-100 transition-opacity duration-300">Exit</span>
           </button>
         </div>
-      </div>
+      </div>,
+      document.body,
     );
   }
 

--- a/shell/src/hooks/useWindowManager.ts
+++ b/shell/src/hooks/useWindowManager.ts
@@ -246,6 +246,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
           closedPaths: newClosed,
           closedLayouts: newLayouts,
           focusedWindowId: state.focusedWindowId === id ? null : state.focusedWindowId,
+          fullscreenWindowId: state.fullscreenWindowId === id ? null : state.fullscreenWindowId,
         };
       });
     },

--- a/shell/src/hooks/useWindowManager.ts
+++ b/shell/src/hooks/useWindowManager.ts
@@ -53,6 +53,7 @@ interface WindowManagerState {
       default sort when the user hasn't manually reordered. In-memory only
       for now -- survives navigation but not full reload. */
   appLaunchTimes: Record<string, number>;
+  fullscreenWindowId: string | null;
 }
 
 interface WindowManagerActions {
@@ -72,6 +73,8 @@ interface WindowManagerActions {
   setWindows: (updater: AppWindow[] | ((prev: AppWindow[]) => AppWindow[])) => void;
   setApps: (updater: AppEntry[] | ((prev: AppEntry[]) => AppEntry[])) => void;
   cascadeWindows: (startX: number, startY: number, gap: number) => void;
+  toggleFullscreen: (id: string) => void;
+  exitFullscreen: () => void;
 }
 
 let saveTimer: ReturnType<typeof setTimeout> | undefined;
@@ -151,6 +154,7 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
     apps: [],
     focusedWindowId: null,
     appLaunchTimes: {},
+    fullscreenWindowId: null,
 
     openWindow: (name, path, dockXOffset) => {
       set((state) => {
@@ -387,6 +391,17 @@ export const useWindowManager = create<WindowManagerState & WindowManagerActions
           y: startY + i * gap,
         })),
       }));
+    },
+
+    toggleFullscreen: (id) => {
+      set((state) => ({
+        fullscreenWindowId: state.fullscreenWindowId === id ? null : id,
+        focusedWindowId: id,
+      }));
+    },
+
+    exitFullscreen: () => {
+      set({ fullscreenWindowId: null });
     },
   })),
 );


### PR DESCRIPTION
## Summary
- Adds a custom in-app fullscreen overlay triggered by the green traffic light button (replaces the browser-native `requestFullscreen` approach)
- Smooth scale+fade animation (300ms cubic-bezier) on enter/exit
- Top-left hover pill exit button with shrink icon and "Exit" label on hover
- Escape key exits fullscreen
- Works from desktop windows, canvas windows, and the command palette "Enter Full Screen" action

## Changes
- `useWindowManager.ts` — adds `fullscreenWindowId` state, `toggleFullscreen(id)`, and `exitFullscreen()` methods
- `Desktop.tsx` — adds `FullscreenOverlay` component, wires `TrafficLights` green button to fullscreen, adds Escape key handler
- `CanvasWindow.tsx` — wires green traffic light to `toggleFullscreen` instead of `fitWindow`

## Test plan
- [ ] Click green traffic light on a desktop window — enters fullscreen overlay
- [ ] Hover top-left corner — exit pill appears with "Exit" label
- [ ] Click exit pill — smoothly exits fullscreen
- [ ] Press Escape while in fullscreen — exits
- [ ] Command palette "Enter Full Screen" on a focused window — enters fullscreen
- [ ] Canvas mode: green traffic light enters fullscreen
- [ ] Verify all app types render correctly in fullscreen (terminal, workspace, file browser, chat, custom apps)