### PR TITLE
fix(platform): proxy generated assets and voice providers

### DIFF
--- a/packages/gateway/src/default-icons.ts
+++ b/packages/gateway/src/default-icons.ts
@@ -1,0 +1,90 @@
+import { lstat, readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const SAFE_ICON_FILE = /^([a-zA-Z0-9_-]+)\.(png|svg)$/;
+const SKIP_APP_DIRS = new Set(["node_modules"]);
+
+export async function resolveSystemIconUrl(homePath: string, requestedFile: string): Promise<string | null> {
+  const match = requestedFile.match(SAFE_ICON_FILE);
+  if (!match) return null;
+  const [, stem, requestedExt] = match;
+  const candidates = [
+    `${stem}.${requestedExt}`,
+    `${stem}.png`,
+    `${stem}.svg`,
+    "game-center.png",
+    "game.svg",
+  ];
+  for (const candidate of candidates) {
+    try {
+      const iconStat = await lstat(join(homePath, "system/icons", candidate));
+      if (iconStat.isFile()) return `/files/system/icons/${candidate}`;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.warn("[icons] failed to stat system icon:", err instanceof Error ? err.message : String(err));
+      }
+    }
+  }
+  return null;
+}
+
+export async function resolveDefaultAppIconUrl(homePath: string, slug: string): Promise<string | null> {
+  if (!/^[a-zA-Z0-9_-]+$/.test(slug)) return null;
+  return findDefaultAppIcon(homePath, join(homePath, "apps"), slug);
+}
+
+async function findDefaultAppIcon(homePath: string, dir: string, slug: string): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn("[icons] failed to scan app icons:", err instanceof Error ? err.message : String(err));
+    }
+    return null;
+  }
+
+  for (const entry of entries) {
+    if (SKIP_APP_DIRS.has(entry) || entry.startsWith("_template-")) continue;
+    const child = join(dir, entry);
+    let childStat;
+    try {
+      childStat = await lstat(child);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.warn("[icons] failed to inspect app icon directory:", err instanceof Error ? err.message : String(err));
+      }
+      continue;
+    }
+    if (!childStat.isDirectory()) continue;
+
+    const manifestIcon = await readManifestIcon(child, slug);
+    if (manifestIcon) {
+      const resolved = await resolveSystemIconUrl(homePath, `${manifestIcon}.png`);
+      if (resolved) return resolved;
+    }
+
+    const nested = await findDefaultAppIcon(homePath, child, slug);
+    if (nested) return nested;
+  }
+
+  return null;
+}
+
+async function readManifestIcon(appDir: string, slug: string): Promise<string | null> {
+  try {
+    const manifest = JSON.parse(await readFile(join(appDir, "matrix.json"), "utf8")) as {
+      slug?: unknown;
+      icon?: unknown;
+    };
+    if (manifest.slug !== slug) return null;
+    return typeof manifest.icon === "string" && /^[a-zA-Z0-9_-]+$/.test(manifest.icon)
+      ? manifest.icon
+      : slug;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn("[icons] failed to read app icon manifest:", err instanceof Error ? err.message : String(err));
+    }
+    return null;
+  }
+}

--- a/packages/gateway/src/default-icons.ts
+++ b/packages/gateway/src/default-icons.ts
@@ -8,13 +8,15 @@ export async function resolveSystemIconUrl(homePath: string, requestedFile: stri
   const match = requestedFile.match(SAFE_ICON_FILE);
   if (!match) return null;
   const [, stem, requestedExt] = match;
-  const candidates = [
-    `${stem}.${requestedExt}`,
-    `${stem}.png`,
-    `${stem}.svg`,
-    "game-center.png",
-    "game.svg",
-  ];
+  const candidates = Array.from(
+    new Set([
+      `${stem}.${requestedExt}`,
+      `${stem}.png`,
+      `${stem}.svg`,
+      "game-center.png",
+      "game.svg",
+    ]),
+  );
   for (const candidate of candidates) {
     try {
       const iconStat = await lstat(join(homePath, "system/icons", candidate));

--- a/packages/gateway/src/onboarding/gemini-live.ts
+++ b/packages/gateway/src/onboarding/gemini-live.ts
@@ -82,6 +82,15 @@ HARD RULES:
 - Keep every response to 1-2 sentences. This is a conversation, not a monologue.`;
 
 const GEMINI_WS_URL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
+const INTERNAL_GEMINI_LIVE_PROXY_PATH = "/gemini-live";
+
+export interface GeminiLiveProxyConfig {
+  platformUrl: string;
+  handle: string;
+  token: string;
+}
+
+export type GeminiLiveConnection = string | { proxy: GeminiLiveProxyConfig };
 
 export interface GeminiSetupOverrides {
   systemInstruction?: string;
@@ -211,8 +220,36 @@ export interface GeminiLiveClient {
   readonly transcript: string;
 }
 
+export function hasGeminiLiveConnection(connection: GeminiLiveConnection | undefined): boolean {
+  if (!connection) return false;
+  if (typeof connection === "string") return connection.length > 0;
+  return Boolean(connection.proxy.platformUrl && connection.proxy.handle && connection.proxy.token);
+}
+
+export function buildGeminiLiveWebSocketTarget(connection: GeminiLiveConnection): {
+  url: string;
+  headers: Record<string, string>;
+} {
+  if (typeof connection === "string") {
+    return {
+      url: GEMINI_WS_URL,
+      headers: { "x-goog-api-key": connection },
+    };
+  }
+
+  const base = new URL(connection.proxy.platformUrl);
+  base.protocol = base.protocol === "https:" ? "wss:" : "ws:";
+  const root = base.pathname.endsWith("/") ? base.pathname.slice(0, -1) : base.pathname;
+  base.pathname = `${root}/internal/containers/${encodeURIComponent(connection.proxy.handle)}${INTERNAL_GEMINI_LIVE_PROXY_PATH}`;
+  base.search = "";
+  return {
+    url: base.toString(),
+    headers: { authorization: `Bearer ${connection.proxy.token}` },
+  };
+}
+
 export function createGeminiLiveClient(
-  apiKey: string,
+  connection: GeminiLiveConnection,
   model: string,
   overrides?: GeminiSetupOverrides,
 ): GeminiLiveClient {
@@ -222,12 +259,8 @@ export function createGeminiLiveClient(
 
   function connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      // Pass the API key via header rather than query string so it doesn't
-      // land in proxy access logs, gateway error traces, or stack dumps
-      // (Google's BidiGenerateContent endpoint accepts both forms).
-      ws = new WebSocket(GEMINI_WS_URL, {
-        headers: { "x-goog-api-key": apiKey },
-      });
+      const target = buildGeminiLiveWebSocketTarget(connection);
+      ws = new WebSocket(target.url, { headers: target.headers });
 
       const timeout = setTimeout(() => {
         ws?.close();

--- a/packages/gateway/src/onboarding/ws-handler.ts
+++ b/packages/gateway/src/onboarding/ws-handler.ts
@@ -2,7 +2,13 @@ import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createStateMachine, type StateMachineSnapshot } from "./state-machine.js";
-import { createGeminiLiveClient, type GeminiLiveClient, type GeminiEvent } from "./gemini-live.js";
+import {
+  createGeminiLiveClient,
+  hasGeminiLiveConnection,
+  type GeminiLiveClient,
+  type GeminiEvent,
+  type GeminiLiveConnection,
+} from "./gemini-live.js";
 import { validateApiKeyFormat, validateApiKeyLive, storeApiKey, hasApiKey } from "./api-key.js";
 import {
   MAX_AUDIO_SESSION_BYTES,
@@ -17,7 +23,8 @@ import { createProfileBuilder } from "./keyword-detector.js";
 
 export interface OnboardingDeps {
   homePath: string;
-  geminiApiKey: string;
+  geminiApiKey?: string;
+  geminiConnection?: GeminiLiveConnection;
   geminiModel: string;
 }
 
@@ -246,14 +253,16 @@ export function createOnboardingHandler(deps: OnboardingDeps) {
       });
     }
 
-    console.log("[onboarding] Sending stage:", sm.current, "audioMode:", audioMode, "hasKey:", !!deps.geminiApiKey);
+    const geminiConnection = deps.geminiConnection ?? deps.geminiApiKey ?? "";
+    const hasVoiceConnection = hasGeminiLiveConnection(geminiConnection);
+    console.log("[onboarding] Sending stage:", sm.current, "audioMode:", audioMode, "hasVoiceConnection:", hasVoiceConnection);
     send({ type: "stage", stage: sm.current, audioSource: audioMode ? "gemini_live" : undefined });
 
-    if (audioMode && deps.geminiApiKey) {
+    if (audioMode && hasVoiceConnection) {
       let client: GeminiLiveClient | null = null;
       try {
         console.log("[onboarding] Connecting to Gemini Live...");
-        client = createGeminiLiveClient(deps.geminiApiKey, deps.geminiModel);
+        client = createGeminiLiveClient(geminiConnection, deps.geminiModel);
         gemini = client;
         setupGeminiHandlers(client);
         await client.connect();
@@ -272,7 +281,7 @@ export function createOnboardingHandler(deps: OnboardingDeps) {
         audioMode = false;
       }
     } else {
-      console.log("[onboarding] No voice mode — geminiApiKey:", deps.geminiApiKey ? "set" : "MISSING");
+      console.log("[onboarding] No voice mode — Gemini Live connection:", hasVoiceConnection ? "set" : "MISSING");
       audioMode = false;
       send({ type: "mode_change", mode: "text" });
     }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -64,6 +64,8 @@ import {
 import { isRequestPrincipalError, mapRequestPrincipalError, requireRequestPrincipal } from "./request-principal.js";
 import { createOnboardingHandler } from "./onboarding/ws-handler.js";
 import { createVocalHandler } from "./vocal/ws-handler.js";
+import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
+import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
 import { securityHeadersMiddleware } from "./security/headers.js";
 import { getSystemInfo } from "./system-info.js";
 import {
@@ -511,6 +513,10 @@ export async function createGateway(config: GatewayConfig) {
   const internalPlatformUrl = process.env.PLATFORM_INTERNAL_URL;
   const internalPlatformToken = process.env.UPGRADE_TOKEN;
   const internalHandle = process.env.MATRIX_HANDLE;
+  const geminiLiveConnection: GeminiLiveConnection =
+    internalPlatformUrl && internalPlatformToken && internalHandle
+      ? { proxy: { platformUrl: internalPlatformUrl, token: internalPlatformToken, handle: internalHandle } }
+      : process.env.GEMINI_API_KEY ?? "";
 
   if (((s3AccessKey && s3SecretKey) || (internalPlatformUrl && internalPlatformToken && internalHandle)) && kyselyInstance) {
     try {
@@ -2124,7 +2130,7 @@ export async function createGateway(config: GatewayConfig) {
   // --- Onboarding WebSocket ---
   const onboardingHandler = createOnboardingHandler({
     homePath,
-    geminiApiKey: process.env.GEMINI_API_KEY ?? "",
+    geminiConnection: geminiLiveConnection,
     geminiModel: process.env.ONBOARDING_GEMINI_MODEL ?? "gemini-3.1-flash-live-preview",
   });
 
@@ -2197,7 +2203,7 @@ export async function createGateway(config: GatewayConfig) {
     upgradeWebSocket(() => {
       const vocalHandler = createVocalHandler({
         homePath,
-        geminiApiKey: process.env.GEMINI_API_KEY ?? "",
+        geminiConnection: geminiLiveConnection,
         // VOCAL_GEMINI_MODEL keeps Aoede independently configurable from
         // onboarding; fall back to ONBOARDING_GEMINI_MODEL so existing
         // deployments don't regress until operators set the vocal-specific
@@ -3093,29 +3099,10 @@ export async function createGateway(config: GatewayConfig) {
     return c.json(await listApps(homePath));
   });
 
-  function resolveSystemIconUrl(requestedFile: string): string | null {
-    const match = requestedFile.match(/^([a-zA-Z0-9_-]+)\.(png|svg)$/);
-    if (!match) return null;
-    const [, stem, requestedExt] = match;
-    const candidates = [
-      `${stem}.${requestedExt}`,
-      `${stem}.png`,
-      `${stem}.svg`,
-      "game-center.png",
-      "game.svg",
-    ];
-    for (const candidate of candidates) {
-      if (existsSync(join(homePath, "system/icons", candidate))) {
-        return `/files/system/icons/${candidate}`;
-      }
-    }
-    return null;
-  }
-
-  const redirectIconRequest = (c: Context) => {
+  const redirectIconRequest = async (c: Context) => {
     const file = c.req.param("file");
     if (!file) return c.text("Icon not found", 404);
-    const target = resolveSystemIconUrl(file);
+    const target = await resolveSystemIconUrl(homePath, file);
     if (!target) return c.text("Icon not found", 404);
     return c.redirect(target, 307);
   };
@@ -3149,10 +3136,18 @@ export async function createGateway(config: GatewayConfig) {
     if (!/^[a-zA-Z0-9_-]+$/.test(slug)) {
       return c.json({ error: "Invalid slug" }, 400);
     }
+    const shippedDefaultIcon = await resolveDefaultAppIconUrl(homePath, slug);
+    if (shippedDefaultIcon) {
+      return c.json({
+        iconUrl: shippedDefaultIcon,
+        generated: false,
+        shipped: true,
+      });
+    }
     const geminiKey = process.env.GEMINI_API_KEY ?? "";
     if (!geminiKey) {
       return c.json({
-        iconUrl: resolveSystemIconUrl(`${slug}.png`) ?? "/files/system/icons/game.svg",
+        iconUrl: (await resolveSystemIconUrl(homePath, `${slug}.png`)) ?? "/files/system/icons/game.svg",
         generated: false,
       });
     }
@@ -3205,52 +3200,9 @@ export async function createGateway(config: GatewayConfig) {
     }
   });
 
-  app.post("/api/icons/regenerate-all", async (c) => {
-    const geminiKey = process.env.GEMINI_API_KEY ?? "";
-    if (!geminiKey) {
-      return c.json({ regenerated: 0, failed: [], generated: false });
-    }
-
-    let iconStyle = "";
-    try {
-      const desktop = JSON.parse(readFileSync(join(homePath, "system/desktop.json"), "utf-8"));
-      iconStyle = desktop.iconStyle ?? "";
-    } catch (err: unknown) {
-      logBestEffortFailure("Failed to read desktop icon style", err);
-    }
-    if (!iconStyle) {
-      iconStyle = "macOS-style app icon filling the entire square canvas edge to edge with zero margin or padding, flat solid background color (not gradient) in a smooth muted tone unique to each app, a single white or light symbol centered that clearly represents what the app does (e.g. terminal shows a command prompt, calculator shows a calculator, notes shows a notepad, chess shows a chess piece), the symbol should be instantly recognizable and directly related to the app purpose, clean modern design with minimal depth, no text, no transparency, no rounded corners (UI handles rounding), background color must be a single solid color extending to all edges";
-    }
-
-    const iconsDir = join(homePath, "system/icons");
-    if (!existsSync(iconsDir)) {
-      return c.json({ regenerated: 0, failed: [] });
-    }
-
-    const pngFiles = readdirSync(iconsDir).filter((f: string) => f.endsWith(".png"));
-    const client = createImageClient(geminiKey);
-    let regenerated = 0;
-    const failed: string[] = [];
-
-    for (const file of pngFiles) {
-      const slug = file.replace(/\.png$/, "");
-      const name = slug.replace(/-/g, " ").replace(/_/g, " ");
-      const prompt = `App icon for '${name}': ${iconStyle}, no text, 1:1 square`;
-      try {
-        await client.generateImage(prompt, {
-          aspectRatio: "1:1",
-          imageDir: iconsDir,
-          saveAs: `${slug}.png`,
-        });
-        regenerated++;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : "Unknown error";
-        console.error(`Icon regeneration failed for "${slug}":`, msg);
-        failed.push(slug);
-      }
-    }
-
-    return c.json({ regenerated, failed });
+  app.post("/api/icons/regenerate-all", appIconBodyLimit, async (c) => {
+    void c;
+    return c.json({ regenerated: 0, failed: [], generated: false, reason: "default_icons_are_shipped" });
   });
 
   app.get("/api/cron", (c) => {

--- a/packages/gateway/src/vocal/ws-handler.ts
+++ b/packages/gateway/src/vocal/ws-handler.ts
@@ -1,4 +1,10 @@
-import { createGeminiLiveClient, type GeminiLiveClient, type GeminiEvent } from "../onboarding/gemini-live.js";
+import {
+  createGeminiLiveClient,
+  hasGeminiLiveConnection,
+  type GeminiLiveClient,
+  type GeminiEvent,
+  type GeminiLiveConnection,
+} from "../onboarding/gemini-live.js";
 import { VOCAL_SYSTEM_INSTRUCTION } from "./prompt.js";
 import { loadProfile, appendFact, renderProfileForPrompt } from "./profile.js";
 import { z } from "zod/v4";
@@ -69,7 +75,8 @@ interface DelegationSnapshot {
 
 export interface VocalDeps {
   homePath: string;
-  geminiApiKey: string;
+  geminiApiKey?: string;
+  geminiConnection?: GeminiLiveConnection;
   geminiModel: string;
 }
 
@@ -400,7 +407,8 @@ export function createVocalHandler(deps: VocalDeps) {
     audioMode = audioFormat === "pcm16";
     audioBytesReceived = 0;
 
-    if (!deps.geminiApiKey) {
+    const geminiConnection = deps.geminiConnection ?? deps.geminiApiKey ?? "";
+    if (!hasGeminiLiveConnection(geminiConnection)) {
       send({ type: "error", message: "Voice unavailable", retryable: false });
       return;
     }
@@ -418,7 +426,7 @@ export function createVocalHandler(deps: VocalDeps) {
     let client: GeminiLiveClient | null = null;
     try {
       closeGemini();
-      client = createGeminiLiveClient(deps.geminiApiKey, deps.geminiModel, {
+      client = createGeminiLiveClient(geminiConnection, deps.geminiModel, {
         systemInstruction,
         tools: VOCAL_TOOLS,
       });

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -13,6 +13,7 @@
     "@types/dockerode": "^3.3.38",
     "@types/node": "^25.2.3",
     "@types/pg": "^8.18.0",
+    "@types/ws": "^8.18.1",
     "kysely-pglite": "^0.6.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
@@ -25,6 +26,7 @@
     "jose": "^6.1.3",
     "kysely": "^0.28.13",
     "pg": "^8.20.0",
-    "prom-client": "^15.1.3"
+    "prom-client": "^15.1.3",
+    "ws": "^8.19.0"
   }
 }

--- a/packages/platform/src/gemini-live-proxy.ts
+++ b/packages/platform/src/gemini-live-proxy.ts
@@ -34,6 +34,7 @@ export async function handleInternalGeminiLiveProxyUpgrade(opts: {
   db: PlatformDB;
   platformSecret: string;
   geminiApiKey: string;
+  geminiWsUrl?: string;
 }): Promise<boolean> {
   const parsed = parseInternalGeminiLivePath(opts.req.url ?? "/");
   if (!parsed) return false;
@@ -62,12 +63,12 @@ export async function handleInternalGeminiLiveProxyUpgrade(opts: {
   }
 
   proxyServer.handleUpgrade(opts.req, opts.socket, opts.head, (client) => {
-    const provider = new WebSocket(GEMINI_WS_URL, {
+    const provider = new WebSocket(opts.geminiWsUrl ?? GEMINI_WS_URL, {
       headers: { "x-goog-api-key": opts.geminiApiKey },
       perMessageDeflate: false,
       maxPayload: MAX_GEMINI_LIVE_PAYLOAD_BYTES,
     });
-    const queued: Array<WebSocket.RawData> = [];
+    const queued: Array<{ data: WebSocket.RawData; isBinary: boolean }> = [];
     let providerOpen = false;
 
     const closeBoth = () => {
@@ -75,11 +76,11 @@ export async function handleInternalGeminiLiveProxyUpgrade(opts: {
       provider.close();
     };
 
-    client.on("message", (data) => {
+    client.on("message", (data, isBinary) => {
       if (provider.readyState === WebSocket.OPEN) {
-        provider.send(data);
+        provider.send(data, { binary: isBinary });
       } else if (!providerOpen && queued.length < 16) {
-        queued.push(data);
+        queued.push({ data, isBinary });
       } else {
         closeBoth();
       }
@@ -90,11 +91,12 @@ export async function handleInternalGeminiLiveProxyUpgrade(opts: {
     provider.on("open", () => {
       providerOpen = true;
       while (queued.length > 0 && provider.readyState === WebSocket.OPEN) {
-        provider.send(queued.shift()!);
+        const item = queued.shift()!;
+        provider.send(item.data, { binary: item.isBinary });
       }
     });
-    provider.on("message", (data) => {
-      if (client.readyState === WebSocket.OPEN) client.send(data);
+    provider.on("message", (data, isBinary) => {
+      if (client.readyState === WebSocket.OPEN) client.send(data, { binary: isBinary });
     });
     provider.on("close", () => client.close());
     provider.on("error", (err) => {

--- a/packages/platform/src/gemini-live-proxy.ts
+++ b/packages/platform/src/gemini-live-proxy.ts
@@ -1,0 +1,107 @@
+import type { IncomingMessage } from "node:http";
+import type { Socket } from "node:net";
+import { WebSocket, WebSocketServer } from "ws";
+import { getContainer, type PlatformDB } from "./db.js";
+import {
+  buildPlatformVerificationToken,
+  timingSafeTokenEquals,
+} from "./platform-token.js";
+
+const GEMINI_WS_URL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent";
+const INTERNAL_GEMINI_LIVE_PATH = /^\/internal\/containers\/([a-z][a-z0-9-]{2,30})\/gemini-live(?:\?.*)?$/;
+const MAX_GEMINI_LIVE_PAYLOAD_BYTES = 512 * 1024;
+
+const proxyServer = new WebSocketServer({
+  noServer: true,
+  maxPayload: MAX_GEMINI_LIVE_PAYLOAD_BYTES,
+  perMessageDeflate: false,
+});
+
+export function parseInternalGeminiLivePath(path: string): { handle: string } | null {
+  const match = path.match(INTERNAL_GEMINI_LIVE_PATH);
+  return match ? { handle: match[1] } : null;
+}
+
+function rejectUpgrade(socket: Socket, status: number, message: string): void {
+  socket.write(`HTTP/1.1 ${status} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`);
+  socket.destroy();
+}
+
+export async function handleInternalGeminiLiveProxyUpgrade(opts: {
+  req: IncomingMessage;
+  socket: Socket;
+  head: Buffer;
+  db: PlatformDB;
+  platformSecret: string;
+  geminiApiKey: string;
+}): Promise<boolean> {
+  const parsed = parseInternalGeminiLivePath(opts.req.url ?? "/");
+  if (!parsed) return false;
+
+  if (!opts.platformSecret) {
+    rejectUpgrade(opts.socket, 503, "Service Unavailable");
+    return true;
+  }
+  if (!opts.geminiApiKey) {
+    rejectUpgrade(opts.socket, 503, "Service Unavailable");
+    return true;
+  }
+
+  const auth = opts.req.headers.authorization;
+  const token = typeof auth === "string" && auth.startsWith("Bearer ") ? auth.slice(7) : undefined;
+  const expected = buildPlatformVerificationToken(parsed.handle, opts.platformSecret);
+  if (!timingSafeTokenEquals(token, expected)) {
+    rejectUpgrade(opts.socket, 401, "Unauthorized");
+    return true;
+  }
+
+  const record = await getContainer(opts.db, parsed.handle);
+  if (!record?.clerkUserId) {
+    rejectUpgrade(opts.socket, 404, "Not Found");
+    return true;
+  }
+
+  proxyServer.handleUpgrade(opts.req, opts.socket, opts.head, (client) => {
+    const provider = new WebSocket(GEMINI_WS_URL, {
+      headers: { "x-goog-api-key": opts.geminiApiKey },
+      perMessageDeflate: false,
+      maxPayload: MAX_GEMINI_LIVE_PAYLOAD_BYTES,
+    });
+    const queued: Array<WebSocket.RawData> = [];
+    let providerOpen = false;
+
+    const closeBoth = () => {
+      client.close();
+      provider.close();
+    };
+
+    client.on("message", (data) => {
+      if (provider.readyState === WebSocket.OPEN) {
+        provider.send(data);
+      } else if (!providerOpen && queued.length < 16) {
+        queued.push(data);
+      } else {
+        closeBoth();
+      }
+    });
+    client.on("close", () => provider.close());
+    client.on("error", () => provider.close());
+
+    provider.on("open", () => {
+      providerOpen = true;
+      while (queued.length > 0 && provider.readyState === WebSocket.OPEN) {
+        provider.send(queued.shift()!);
+      }
+    });
+    provider.on("message", (data) => {
+      if (client.readyState === WebSocket.OPEN) client.send(data);
+    });
+    provider.on("close", () => client.close());
+    provider.on("error", (err) => {
+      console.warn("[platform] Gemini Live proxy upstream error:", err instanceof Error ? err.message : String(err));
+      client.close();
+    });
+  });
+
+  return true;
+}

--- a/packages/platform/src/gemini-live-proxy.ts
+++ b/packages/platform/src/gemini-live-proxy.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from "node:http";
 import type { Socket } from "node:net";
 import { WebSocket, WebSocketServer } from "ws";
-import { getContainer, type PlatformDB } from "./db.js";
+import { getContainer, getRunningUserMachineByHandle, type PlatformDB } from "./db.js";
 import {
   buildPlatformVerificationToken,
   timingSafeTokenEquals,
@@ -56,8 +56,9 @@ export async function handleInternalGeminiLiveProxyUpgrade(opts: {
     return true;
   }
 
-  const record = await getContainer(opts.db, parsed.handle);
-  if (!record?.clerkUserId) {
+  const container = await getContainer(opts.db, parsed.handle);
+  const machine = container?.clerkUserId ? undefined : await getRunningUserMachineByHandle(opts.db, parsed.handle);
+  if (!container?.clerkUserId && !machine?.clerkUserId) {
     rejectUpgrade(opts.socket, 404, "Not Found");
     return true;
   }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -50,6 +50,7 @@ import { createCustomerVpsRoutes } from './customer-vps-routes.js';
 import { CustomerVpsError } from './customer-vps-errors.js';
 import { buildCustomerVpsProxyUrl } from './profile-routing.js';
 import type { CustomerVpsObjectStore } from './customer-vps-r2.js';
+import { handleInternalGeminiLiveProxyUpgrade } from './gemini-live-proxy.js';
 
 const PORT = Number(process.env.PLATFORM_PORT ?? 9000);
 const PLATFORM_SECRET = process.env.PLATFORM_SECRET ?? '';
@@ -2004,9 +2005,6 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
   if (process.env.CLERK_SECRET_KEY) {
     extraEnv.push(`CLERK_SECRET_KEY=${process.env.CLERK_SECRET_KEY}`);
   }
-  if (process.env.GEMINI_API_KEY) {
-    extraEnv.push(`GEMINI_API_KEY=${process.env.GEMINI_API_KEY}`);
-  }
   for (const key of [
     'MATRIX_HOME_MIRROR',
     'POSTHOG_TOKEN',
@@ -2324,6 +2322,22 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
 
   // WebSocket upgrade handler
   (server as import('node:http').Server).on('upgrade', async (req: IncomingMessage, socket, head) => {
+    try {
+      const handledInternalGeminiLive = await handleInternalGeminiLiveProxyUpgrade({
+        req,
+        socket: socket as Socket,
+        head,
+        db,
+        platformSecret: PLATFORM_SECRET,
+        geminiApiKey: process.env.GEMINI_API_KEY ?? '',
+      });
+      if (handledInternalGeminiLive) return;
+    } catch (err: unknown) {
+      console.warn('[platform] internal Gemini Live proxy failed:', describeError(err));
+      socket.destroy();
+      return;
+    }
+
     const host = getWebSocketUpgradeHost(req.headers.host, req.headers['x-forwarded-host']);
     if (!isSessionRoutedHost(host)) {
       socket.destroy();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     devDependencies:
       '@electric-sql/pglite':
         specifier: ^0.4.0
@@ -439,6 +442,9 @@ importers:
       '@types/pg':
         specifier: ^8.18.0
         version: 8.20.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       kysely-pglite:
         specifier: ^0.6.1
         version: 0.6.1(@electric-sql/pglite@0.4.1)(better-sqlite3@12.8.0)(kysely@0.28.14)(pg@8.20.0)

--- a/tests/gateway/default-icons.test.ts
+++ b/tests/gateway/default-icons.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "../../packages/gateway/src/default-icons.js";
+
+describe("default app icons", () => {
+  it("resolves shipped manifest icons for default apps", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-icons-"));
+    try {
+      await mkdir(join(homePath, "apps/notes"), { recursive: true });
+      await mkdir(join(homePath, "system/icons"), { recursive: true });
+      await writeFile(
+        join(homePath, "apps/notes/matrix.json"),
+        JSON.stringify({ name: "Notes", slug: "notes", icon: "notes" }),
+      );
+      await writeFile(join(homePath, "system/icons/notes.png"), "png");
+
+      await expect(resolveDefaultAppIconUrl(homePath, "notes")).resolves.toBe("/files/system/icons/notes.png");
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the shared game icon without generating a new asset", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-icons-"));
+    try {
+      await mkdir(join(homePath, "system/icons"), { recursive: true });
+      await writeFile(join(homePath, "system/icons/game-center.png"), "png");
+
+      await expect(resolveSystemIconUrl(homePath, "missing-game.png")).resolves.toBe("/files/system/icons/game-center.png");
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/onboarding/gemini-live.test.ts
+++ b/tests/gateway/onboarding/gemini-live.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGeminiLiveWebSocketTarget,
+  hasGeminiLiveConnection,
+} from "../../../packages/gateway/src/onboarding/gemini-live.js";
+
+describe("Gemini Live connection target", () => {
+  it("uses a provider header for direct platform-owned calls", () => {
+    const target = buildGeminiLiveWebSocketTarget("gemini-key");
+
+    expect(target.url).toBe("wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent");
+    expect(target.headers).toEqual({ "x-goog-api-key": "gemini-key" });
+  });
+
+  it("uses the platform internal proxy without exposing the provider key to customer gateways", () => {
+    const target = buildGeminiLiveWebSocketTarget({
+      proxy: {
+        platformUrl: "https://platform.internal/base?debug=true",
+        handle: "alice",
+        token: "container-token",
+      },
+    });
+
+    expect(target.url).toBe("wss://platform.internal/base/internal/containers/alice/gemini-live");
+    expect(target.headers).toEqual({ authorization: "Bearer container-token" });
+    expect(Object.keys(target.headers)).not.toContain("x-goog-api-key");
+  });
+
+  it("treats complete proxy config as a voice connection", () => {
+    expect(hasGeminiLiveConnection({ proxy: { platformUrl: "http://platform", handle: "alice", token: "tok" } })).toBe(true);
+    expect(hasGeminiLiveConnection({ proxy: { platformUrl: "http://platform", handle: "alice", token: "" } })).toBe(false);
+  });
+});

--- a/tests/gateway/onboarding/ws-handler.test.ts
+++ b/tests/gateway/onboarding/ws-handler.test.ts
@@ -22,6 +22,15 @@ const geminiMock = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../packages/gateway/src/onboarding/gemini-live.js", () => ({
+  hasGeminiLiveConnection: vi.fn((connection: unknown) => {
+    if (!connection) return false;
+    if (typeof connection === "string") return connection.length > 0;
+    if (typeof connection === "object" && "proxy" in connection) {
+      const proxy = (connection as { proxy?: { platformUrl?: string; handle?: string; token?: string } }).proxy;
+      return Boolean(proxy?.platformUrl && proxy.handle && proxy.token);
+    }
+    return false;
+  }),
   createGeminiLiveClient: vi.fn(() => {
     const client = {
       on: vi.fn(),

--- a/tests/gateway/vocal/ws-handler.test.ts
+++ b/tests/gateway/vocal/ws-handler.test.ts
@@ -20,6 +20,15 @@ const geminiMock = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../packages/gateway/src/onboarding/gemini-live.js", () => ({
+  hasGeminiLiveConnection: vi.fn((connection: unknown) => {
+    if (!connection) return false;
+    if (typeof connection === "string") return connection.length > 0;
+    if (typeof connection === "object" && "proxy" in connection) {
+      const proxy = (connection as { proxy?: { platformUrl?: string; handle?: string; token?: string } }).proxy;
+      return Boolean(proxy?.platformUrl && proxy.handle && proxy.token);
+    }
+    return false;
+  }),
   createGeminiLiveClient: vi.fn(() => {
     const events = new Map<string, (evt: unknown) => void>();
     const client = {

--- a/tests/platform/gemini-live-proxy.test.ts
+++ b/tests/platform/gemini-live-proxy.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { parseInternalGeminiLivePath } from "../../packages/platform/src/gemini-live-proxy.js";
+
+describe("platform Gemini Live proxy", () => {
+  it("accepts the internal per-container proxy path", () => {
+    expect(parseInternalGeminiLivePath("/internal/containers/alice/gemini-live")).toEqual({ handle: "alice" });
+  });
+
+  it("rejects unsafe or public proxy paths", () => {
+    expect(parseInternalGeminiLivePath("/api/gemini-live")).toBeNull();
+    expect(parseInternalGeminiLivePath("/internal/containers/../../gemini-live")).toBeNull();
+    expect(parseInternalGeminiLivePath("/internal/containers/a/gemini-live")).toBeNull();
+  });
+});

--- a/tests/platform/gemini-live-proxy.test.ts
+++ b/tests/platform/gemini-live-proxy.test.ts
@@ -1,5 +1,26 @@
-import { describe, expect, it } from "vitest";
-import { parseInternalGeminiLivePath } from "../../packages/platform/src/gemini-live-proxy.js";
+import { createServer } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import type { PlatformDB } from "../../packages/platform/src/db.js";
+import {
+  handleInternalGeminiLiveProxyUpgrade,
+  parseInternalGeminiLivePath,
+} from "../../packages/platform/src/gemini-live-proxy.js";
+import { buildPlatformVerificationToken } from "../../packages/platform/src/platform-token.js";
+
+const cleanup: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((close) => close()));
+});
+
+function closeServer(server: { close: (callback?: (err?: Error) => void) => void }): () => Promise<void> {
+  return () =>
+    new Promise<void>((resolve, reject) => {
+      server.close((err?: Error) => (err ? reject(err) : resolve()));
+    });
+}
 
 describe("platform Gemini Live proxy", () => {
   it("accepts the internal per-container proxy path", () => {
@@ -10,5 +31,75 @@ describe("platform Gemini Live proxy", () => {
     expect(parseInternalGeminiLivePath("/api/gemini-live")).toBeNull();
     expect(parseInternalGeminiLivePath("/internal/containers/../../gemini-live")).toBeNull();
     expect(parseInternalGeminiLivePath("/internal/containers/a/gemini-live")).toBeNull();
+  });
+
+  it("preserves text frames in both proxy directions", async () => {
+    const providerHttp = createServer();
+    const providerServer = new WebSocketServer({ server: providerHttp });
+    cleanup.push(closeServer(providerServer), closeServer(providerHttp));
+
+    const providerReceived = new Promise<{ text: string; isBinary: boolean }>((resolve) => {
+      providerServer.on("connection", (socket) => {
+        socket.on("message", (data, isBinary) => {
+          resolve({ text: data.toString(), isBinary });
+          socket.send(JSON.stringify({ ok: true }), { binary: false });
+        });
+      });
+    });
+    await new Promise<void>((resolve) => providerHttp.listen(0, "127.0.0.1", resolve));
+    const providerPort = (providerHttp.address() as AddressInfo).port;
+
+    const platformSecret = "platform-secret";
+    const proxyHttp = createServer();
+    proxyHttp.on("upgrade", (req, socket, head) => {
+      void handleInternalGeminiLiveProxyUpgrade({
+        req,
+        socket,
+        head,
+        db: {
+          ready: Promise.resolve(),
+          executor: {
+            selectFrom: () => ({
+              selectAll: () => ({
+                where: () => ({
+                  executeTakeFirst: async () => ({
+                    handle: "alice",
+                    clerk_user_id: "user_alice",
+                    container_id: "matrixos-alice",
+                    port: 3001,
+                    shell_port: 3101,
+                    status: "running",
+                    created_at: new Date().toISOString(),
+                    last_active: new Date().toISOString(),
+                  }),
+                }),
+              }),
+            }),
+          },
+        } as unknown as PlatformDB,
+        platformSecret,
+        geminiApiKey: "gemini-key",
+        geminiWsUrl: `ws://127.0.0.1:${providerPort}`,
+      });
+    });
+    cleanup.push(closeServer(proxyHttp));
+    await new Promise<void>((resolve) => proxyHttp.listen(0, "127.0.0.1", resolve));
+    const proxyPort = (proxyHttp.address() as AddressInfo).port;
+
+    const client = new WebSocket(`ws://127.0.0.1:${proxyPort}/internal/containers/alice/gemini-live`, {
+      headers: { authorization: `Bearer ${buildPlatformVerificationToken("alice", platformSecret)}` },
+    });
+    cleanup.push(async () => {
+      client.close();
+    });
+
+    const clientReceived = new Promise<{ text: string; isBinary: boolean }>((resolve) => {
+      client.on("message", (data, isBinary) => resolve({ text: data.toString(), isBinary }));
+    });
+    await new Promise<void>((resolve) => client.on("open", resolve));
+    client.send(JSON.stringify({ setup: true }), { binary: false });
+
+    await expect(providerReceived).resolves.toEqual({ text: JSON.stringify({ setup: true }), isBinary: false });
+    await expect(clientReceived).resolves.toEqual({ text: JSON.stringify({ ok: true }), isBinary: false });
   });
 });

--- a/tests/platform/gemini-live-proxy.test.ts
+++ b/tests/platform/gemini-live-proxy.test.ts
@@ -22,6 +22,22 @@ function closeServer(server: { close: (callback?: (err?: Error) => void) => void
     });
 }
 
+function mockPlatformDb(rows: { container?: unknown; machine?: unknown }): PlatformDB {
+  return {
+    ready: Promise.resolve(),
+    executor: {
+      selectFrom: (table: string) => {
+        const builder = {
+          selectAll: () => builder,
+          where: () => builder,
+          executeTakeFirst: async () => (table === "containers" ? rows.container : rows.machine),
+        };
+        return builder;
+      },
+    },
+  } as unknown as PlatformDB;
+}
+
 describe("platform Gemini Live proxy", () => {
   it("accepts the internal per-container proxy path", () => {
     expect(parseInternalGeminiLivePath("/internal/containers/alice/gemini-live")).toEqual({ handle: "alice" });
@@ -56,27 +72,25 @@ describe("platform Gemini Live proxy", () => {
         req,
         socket,
         head,
-        db: {
-          ready: Promise.resolve(),
-          executor: {
-            selectFrom: () => ({
-              selectAll: () => ({
-                where: () => ({
-                  executeTakeFirst: async () => ({
-                    handle: "alice",
-                    clerk_user_id: "user_alice",
-                    container_id: "matrixos-alice",
-                    port: 3001,
-                    shell_port: 3101,
-                    status: "running",
-                    created_at: new Date().toISOString(),
-                    last_active: new Date().toISOString(),
-                  }),
-                }),
-              }),
-            }),
+        db: mockPlatformDb({
+          machine: {
+            machine_id: "machine-alice",
+            clerk_user_id: "user_alice",
+            handle: "alice",
+            hetzner_server_id: 123,
+            public_ipv4: "203.0.113.10",
+            public_ipv6: null,
+            status: "running",
+            image_version: "v1",
+            registration_token_hash: null,
+            registration_token_expires_at: null,
+            provisioned_at: new Date().toISOString(),
+            last_seen_at: new Date().toISOString(),
+            deleted_at: null,
+            failure_code: null,
+            failure_at: null,
           },
-        } as unknown as PlatformDB,
+        }),
         platformSecret,
         geminiApiKey: "gemini-key",
         geminiWsUrl: `ws://127.0.0.1:${providerPort}`,


### PR DESCRIPTION
## Summary
- Resolve default app icons from shipped `home/system/icons` assets and disable default-app bulk icon regeneration.
- Route onboarding and vocal/Aeode Gemini Live sessions from customer gateways through a platform-owned internal WebSocket proxy.
- Keep provider keys on the platform by removing `GEMINI_API_KEY` injection into user/customer runtime envs.

## Validation
- `pnpm exec vitest run tests/gateway/default-icons.test.ts tests/gateway/onboarding/gemini-live.test.ts tests/platform/gemini-live-proxy.test.ts tests/gateway/onboarding/ws-handler.test.ts tests/gateway/vocal/ws-handler.test.ts`
- `bun run typecheck`
- `bun run check:patterns` (0 violations, 5 existing warnings)
- `bun run test -- --reporter=dot` (402 files passed, 3 skipped; 4490 tests passed, 20 skipped)

## Invariants
- **Source of truth**: Default app icons are the shipped files under `home/system/icons`; platform env owns the Gemini provider key; customer gateways only hold the internal platform URL, handle, and upgrade token.
- **Lock/transaction scope**: No database writes or transactions are introduced. The Gemini Live proxy validates the platform bearer token and container identity before opening provider WebSockets; no network calls run inside a DB transaction.
- **Acceptable orphan states**: Client and provider WebSockets can close independently; either side closing or erroring closes the other side. Default app icon lookup falls back to a shipped shared game icon instead of generating a new asset.
- **Auth source of truth**: The internal Gemini Live proxy uses the existing HMAC platform verification token derived from `UPGRADE_TOKEN`/`PLATFORM_SECRET`. Direct Gemini key usage remains only for non-customer local/dev gateways without platform internal env configured.
- **Deferred scope**: Legacy voice TTS/STT/telephony provider helpers are not changed here; this PR covers onboarding and vocal/Aeode Gemini Live routing plus default app icon generation behavior.
