### PR TITLE
feat(browser): expose gateway runtime APIs

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -8,6 +8,8 @@
     "./app-publish": "./src/app-publish.ts",
     "./app-fork": "./src/app-fork.ts",
     "./app-manifest": "./src/app-manifest.ts",
+    "./browser/routes": "./src/browser/routes.ts",
+    "./browser/ws": "./src/browser/ws.ts",
     "./sync/types": "./src/sync/types.ts"
   },
   "scripts": {

--- a/packages/gateway/src/app-db-kv.ts
+++ b/packages/gateway/src/app-db-kv.ts
@@ -28,7 +28,7 @@ export function createKvStore(kysely: Kysely<any>): KvStore {
       const result = await sql`
         DELETE FROM public._kv WHERE app = ${app} AND key = ${key}
       `.execute(kysely);
-      return (result.numAffectedRows ?? 0n) > 0n;
+      return (result.numAffectedRows ?? BigInt(0)) > BigInt(0);
     },
 
     async list(app) {

--- a/packages/gateway/src/app-runtime/build-cache.ts
+++ b/packages/gateway/src/app-runtime/build-cache.ts
@@ -1,4 +1,4 @@
-import { lstat, readFile, readdir, writeFile } from "node:fs/promises";
+import { lstat, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { join, relative } from "node:path";
 
@@ -75,6 +75,17 @@ async function listFiles(dir: string, prefix = "", recursive = true): Promise<st
       if (recursive) {
         files.push(...await listFiles(dir, rel, true));
       }
+    } else if (entry.isSymbolicLink()) {
+      try {
+        const target = await stat(join(dir, rel));
+        if (target.isDirectory()) {
+          if (recursive) files.push(...await listFiles(dir, rel, true));
+        } else if (target.isFile()) {
+          files.push(rel);
+        }
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      }
     } else {
       files.push(rel);
     }
@@ -88,12 +99,28 @@ function matchesGlob(path: string, pattern: string): boolean {
     const prefix = pattern.slice(0, -3);
     return path === prefix || path.startsWith(`${prefix}/`);
   }
-  const escaped = pattern
-    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-    .replaceAll("**", "\0")
-    .replaceAll("*", "[^/]*")
-    .replaceAll("\0", ".*");
-  return new RegExp(`^${escaped}$`).test(path);
+  let regex = "^";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const char = pattern[i];
+    const next = pattern[i + 1];
+    if (char === "*" && next === "*") {
+      if (pattern[i + 2] === "/") {
+        regex += "(?:.*/)?";
+        i += 2;
+      } else {
+        regex += ".*";
+        i += 1;
+      }
+    } else if (char === "*") {
+      regex += "[^/]*";
+    } else if (char === "?") {
+      regex += "[^/]";
+    } else {
+      regex += char && /[.+^${}()|[\]\\]/.test(char) ? `\\${char}` : char;
+    }
+  }
+  regex += "$";
+  return new RegExp(regex).test(path);
 }
 
 export async function hashLockfile(appDir: string): Promise<string> {

--- a/packages/gateway/src/app-runtime/build-cache.ts
+++ b/packages/gateway/src/app-runtime/build-cache.ts
@@ -1,4 +1,4 @@
-import { lstat, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { lstat, readFile, readdir, realpath, stat, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { join, relative } from "node:path";
 
@@ -65,10 +65,20 @@ async function listFilesForPattern(appDir: string, pattern: string): Promise<str
   return listFiles(appDir, root, pattern.includes("**"));
 }
 
-async function listFiles(dir: string, prefix = "", recursive = true): Promise<string[]> {
+async function listFiles(dir: string, prefix = "", recursive = true, visited = new Set<string>()): Promise<string[]> {
+  const currentDir = join(dir, prefix);
+  let currentRealPath: string;
+  try {
+    currentRealPath = await realpath(currentDir);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+  if (visited.has(currentRealPath)) return [];
+  visited.add(currentRealPath);
   let entries;
   try {
-    entries = await readdir(join(dir, prefix), { withFileTypes: true, encoding: "utf8" });
+    entries = await readdir(currentDir, { withFileTypes: true, encoding: "utf8" });
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
     throw err;
@@ -78,13 +88,13 @@ async function listFiles(dir: string, prefix = "", recursive = true): Promise<st
     const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
     if (entry.isDirectory()) {
       if (recursive) {
-        files.push(...await listFiles(dir, rel, true));
+        files.push(...await listFiles(dir, rel, true, visited));
       }
     } else if (entry.isSymbolicLink()) {
       try {
         const target = await stat(join(dir, rel));
         if (target.isDirectory()) {
-          if (recursive) files.push(...await listFiles(dir, rel, true));
+          if (recursive) files.push(...await listFiles(dir, rel, true, visited));
         } else if (target.isFile()) {
           files.push(rel);
         }

--- a/packages/gateway/src/app-runtime/build-cache.ts
+++ b/packages/gateway/src/app-runtime/build-cache.ts
@@ -54,7 +54,7 @@ async function listFilesForPattern(appDir: string, pattern: string): Promise<str
   const staticPrefix = pattern.slice(0, wildcardIndex);
   const slashIndex = staticPrefix.lastIndexOf("/");
   if (slashIndex === -1) {
-    return listFiles(appDir, "", false);
+    return listFiles(appDir, "", pattern.includes("**"));
   }
   const root = staticPrefix.slice(0, slashIndex);
   return listFiles(appDir, root, pattern.includes("**"));

--- a/packages/gateway/src/app-runtime/build-cache.ts
+++ b/packages/gateway/src/app-runtime/build-cache.ts
@@ -13,8 +13,8 @@ const STAMP_FILE = ".build-stamp";
 
 export async function hashSources(appDir: string, globs: string[]): Promise<string> {
   const files = new Set<string>();
-  const candidates = await listFiles(appDir);
   for (const pattern of globs) {
+    const candidates = await listFilesForPattern(appDir, pattern);
     for (const match of candidates) {
       if (!matchesGlob(match, pattern)) continue;
       const abs = join(appDir, match);
@@ -43,7 +43,24 @@ export async function hashSources(appDir: string, globs: string[]): Promise<stri
   return hash.digest("hex");
 }
 
-async function listFiles(dir: string, prefix = ""): Promise<string[]> {
+async function listFilesForPattern(appDir: string, pattern: string): Promise<string[]> {
+  if (pattern === "**/*" || pattern === "**") {
+    return listFiles(appDir, "", true);
+  }
+  const wildcardIndex = pattern.search(/[*?]/);
+  if (wildcardIndex === -1) {
+    return [pattern];
+  }
+  const staticPrefix = pattern.slice(0, wildcardIndex);
+  const slashIndex = staticPrefix.lastIndexOf("/");
+  if (slashIndex === -1) {
+    return listFiles(appDir, "", false);
+  }
+  const root = staticPrefix.slice(0, slashIndex);
+  return listFiles(appDir, root, pattern.includes("**"));
+}
+
+async function listFiles(dir: string, prefix = "", recursive = true): Promise<string[]> {
   let entries;
   try {
     entries = await readdir(join(dir, prefix), { withFileTypes: true, encoding: "utf8" });
@@ -55,7 +72,9 @@ async function listFiles(dir: string, prefix = ""): Promise<string[]> {
   for (const entry of entries) {
     const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
     if (entry.isDirectory()) {
-      files.push(...await listFiles(dir, rel));
+      if (recursive) {
+        files.push(...await listFiles(dir, rel, true));
+      }
     } else {
       files.push(rel);
     }

--- a/packages/gateway/src/app-runtime/build-cache.ts
+++ b/packages/gateway/src/app-runtime/build-cache.ts
@@ -20,7 +20,12 @@ export async function hashSources(appDir: string, globs: string[]): Promise<stri
       const abs = join(appDir, match);
       try {
         const st = await lstat(abs);
-        if (st.isFile()) files.add(abs);
+        if (st.isFile()) {
+          files.add(abs);
+        } else if (st.isSymbolicLink()) {
+          const target = await stat(abs);
+          if (target.isFile()) files.add(abs);
+        }
       } catch (err: unknown) {
         // ENOENT is expected for symlink-to-missing; rethrow anything else
         // (EACCES, EIO, EMFILE) so the build surfaces real filesystem errors

--- a/packages/gateway/src/app-runtime/build-cache.ts
+++ b/packages/gateway/src/app-runtime/build-cache.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, glob, stat } from "node:fs/promises";
+import { lstat, readFile, readdir, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { join, relative } from "node:path";
 
@@ -12,13 +12,15 @@ export interface BuildStamp {
 const STAMP_FILE = ".build-stamp";
 
 export async function hashSources(appDir: string, globs: string[]): Promise<string> {
-  const files: string[] = [];
+  const files = new Set<string>();
+  const candidates = await listFiles(appDir);
   for (const pattern of globs) {
-    for await (const match of glob(pattern, { cwd: appDir })) {
+    for (const match of candidates) {
+      if (!matchesGlob(match, pattern)) continue;
       const abs = join(appDir, match);
       try {
-        const st = await stat(abs);
-        if (st.isFile()) files.push(abs);
+        const st = await lstat(abs);
+        if (st.isFile()) files.add(abs);
       } catch (err: unknown) {
         // ENOENT is expected for symlink-to-missing; rethrow anything else
         // (EACCES, EIO, EMFILE) so the build surfaces real filesystem errors
@@ -29,16 +31,50 @@ export async function hashSources(appDir: string, globs: string[]): Promise<stri
   }
 
   // Sort by relative path for determinism regardless of filesystem order
-  files.sort((a, b) => relative(appDir, a).localeCompare(relative(appDir, b)));
+  const sortedFiles = [...files].sort((a, b) => relative(appDir, a).localeCompare(relative(appDir, b)));
 
   const hash = createHash("sha256");
-  for (const file of files) {
+  for (const file of sortedFiles) {
     const relPath = relative(appDir, file);
     hash.update(relPath);
     const content = await readFile(file);
     hash.update(content);
   }
   return hash.digest("hex");
+}
+
+async function listFiles(dir: string, prefix = ""): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(join(dir, prefix), { withFileTypes: true, encoding: "utf8" });
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...await listFiles(dir, rel));
+    } else {
+      files.push(rel);
+    }
+  }
+  return files;
+}
+
+function matchesGlob(path: string, pattern: string): boolean {
+  if (pattern === "**/*" || pattern === "**") return true;
+  if (pattern.endsWith("/**")) {
+    const prefix = pattern.slice(0, -3);
+    return path === prefix || path.startsWith(`${prefix}/`);
+  }
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replaceAll("**", "\0")
+    .replaceAll("*", "[^/]*")
+    .replaceAll("\0", ".*");
+  return new RegExp(`^${escaped}$`).test(path);
 }
 
 export async function hashLockfile(appDir: string): Promise<string> {

--- a/packages/gateway/src/app-runtime/safe-env.ts
+++ b/packages/gateway/src/app-runtime/safe-env.ts
@@ -32,10 +32,10 @@ function buildMinimalPath(): string {
 
 const MINIMAL_PATH = buildMinimalPath();
 
-export function safeEnv(opts: SafeEnvOptions): Record<string, string> {
+export function safeEnv(opts: SafeEnvOptions): NodeJS.ProcessEnv {
   const { slug, port, homeDir, databaseUrl } = opts;
 
-  const env: Record<string, string> = {
+  const env: NodeJS.ProcessEnv = {
     PORT: String(port),
     NODE_ENV: "production",
     HOME: join(homeDir, "apps", slug),
@@ -73,15 +73,15 @@ const SECRET_SUFFIX_RE = /(^|_)(SECRET|TOKEN|PASSWORD|PRIVATE_KEY|API_KEY|SECRET
 // Denylist (not allowlist like safeEnv): builds need the surrounding tool
 // ecosystem — XDG dirs, npm_config_*, TMPDIR, locale, proxy config — so we
 // start from process.env and strip known-sensitive keys.
-export function safeBuildEnv(opts: SafeBuildEnvOptions = {}): Record<string, string> {
-  const env: Record<string, string> = {};
+export function safeBuildEnv(opts: SafeBuildEnvOptions = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { NODE_ENV: "production" };
   for (const [k, v] of Object.entries(process.env)) {
     if (v === undefined) continue;
+    if (k === "NODE_ENV") continue;
     if (EXPLICIT_BUILD_DENY.has(k)) continue;
     if (SECRET_SUFFIX_RE.test(k)) continue;
     env[k] = v;
   }
-  env.NODE_ENV = "production";
   if (opts.storeDir) {
     env.npm_config_store_dir = opts.storeDir;
   }

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -201,6 +201,10 @@ export function authMiddleware(
 
     const authHeader = c.req.header("Authorization");
     if (BROWSER_WS_QUERY_TOKEN_PATTERN.test(normalizedPath)) {
+      const ip = getClientIp(c);
+      if (!rateLimiter.check(ip)) {
+        return tooManyRequests(c);
+      }
       return nextWithReady(c, next);
     }
     if (

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -203,7 +203,11 @@ export function authMiddleware(
     if (BROWSER_WS_QUERY_TOKEN_PATTERN.test(normalizedPath)) {
       return nextWithReady(c, next);
     }
-    if (BROWSER_HANDOFF_REST_PATHS.includes(normalizedPath)) {
+    if (
+      c.req.method === "POST" &&
+      BROWSER_HANDOFF_REST_PATHS.includes(normalizedPath) &&
+      c.req.header("x-browser-handoff") === "1"
+    ) {
       return nextWithReady(c, next);
     }
 

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -85,7 +85,8 @@ const HMAC_WEBHOOK_PREFIXES = [
   "/api/integrations/webhook/",
 ];
 const WS_QUERY_TOKEN_PATHS = ["/ws", "/ws/voice", "/ws/terminal", "/ws/onboarding", "/ws/vocal"];
-const WS_QUERY_TOKEN_PATH_PATTERNS = [/^\/api\/canvases\/[^/]+\/ws$/];
+const BROWSER_WS_QUERY_TOKEN_PATTERN = /^\/api\/browser\/sessions\/[^/]+\/ws$/;
+const WS_QUERY_TOKEN_PATH_PATTERNS = [/^\/api\/canvases\/[^/]+\/ws$/, BROWSER_WS_QUERY_TOKEN_PATTERN];
 
 // Constant-time string compare. Previously, the length-mismatch branch ran
 // timingSafeEqual(bufB, bufB) as a dummy call -- but the work done in
@@ -198,6 +199,10 @@ export function authMiddleware(
     }
 
     const authHeader = c.req.header("Authorization");
+    if (BROWSER_WS_QUERY_TOKEN_PATTERN.test(normalizedPath)) {
+      return nextWithReady(c, next);
+    }
+
     const isWsUpgrade =
       WS_QUERY_TOKEN_PATHS.some((p) => normalizedPath === p) ||
       WS_QUERY_TOKEN_PATH_PATTERNS.some((pattern) => pattern.test(normalizedPath));

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -87,6 +87,7 @@ const HMAC_WEBHOOK_PREFIXES = [
 const WS_QUERY_TOKEN_PATHS = ["/ws", "/ws/voice", "/ws/terminal", "/ws/onboarding", "/ws/vocal"];
 const BROWSER_WS_QUERY_TOKEN_PATTERN = /^\/api\/browser\/sessions\/[^/]+\/ws$/;
 const WS_QUERY_TOKEN_PATH_PATTERNS = [/^\/api\/canvases\/[^/]+\/ws$/, BROWSER_WS_QUERY_TOKEN_PATTERN];
+const BROWSER_HANDOFF_REST_PATHS = ["/api/browser/sessions"];
 
 // Constant-time string compare. Previously, the length-mismatch branch ran
 // timingSafeEqual(bufB, bufB) as a dummy call -- but the work done in
@@ -200,6 +201,9 @@ export function authMiddleware(
 
     const authHeader = c.req.header("Authorization");
     if (BROWSER_WS_QUERY_TOKEN_PATTERN.test(normalizedPath)) {
+      return nextWithReady(c, next);
+    }
+    if (BROWSER_HANDOFF_REST_PATHS.includes(normalizedPath)) {
       return nextWithReady(c, next);
     }
 

--- a/packages/gateway/src/browser/repository.ts
+++ b/packages/gateway/src/browser/repository.ts
@@ -902,22 +902,33 @@ export class KyselyBrowserRepository implements BrowserRepository {
   }): Promise<BrowserProfileClearResult> {
     return this.kysely.transaction().execute(async (trx) => {
       const profile = await this.upsertProfileIn(trx, opts.ownerId, opts.profileName, opts.now);
-      await trx
+      const timestamp = iso(opts.now);
+      const closedSessions = await trx
         .updateTable("browser_sessions")
         .set({
           state: "closed",
-          updated_at: iso(opts.now),
-          last_activity_at: iso(opts.now),
+          updated_at: timestamp,
+          last_activity_at: timestamp,
         })
         .where("owner_id", "=", opts.ownerId)
         .where("profile_id", "=", profile.id)
         .where("state", "=", "active")
+        .returning(["id"])
         .execute();
+      for (const session of closedSessions) {
+        await this.addAuditEventIn(trx, {
+          id: id("audit"),
+          ownerId: opts.ownerId,
+          eventType: "session.closed",
+          createdAt: timestamp,
+          metadata: { sessionId: session.id },
+        });
+      }
       const updated = await trx
         .updateTable("browser_profiles")
         .set({
           cleared_scopes: jsonb(opts.scopes),
-          updated_at: iso(opts.now),
+          updated_at: timestamp,
         })
         .where("id", "=", profile.id)
         .returningAll()
@@ -926,7 +937,7 @@ export class KyselyBrowserRepository implements BrowserRepository {
         id: id("audit"),
         ownerId: opts.ownerId,
         eventType: "profile.cleared",
-        createdAt: iso(opts.now),
+        createdAt: timestamp,
         metadata: {
           profileName: opts.profileName,
           scopes: [...opts.scopes],

--- a/packages/gateway/src/browser/routes.ts
+++ b/packages/gateway/src/browser/routes.ts
@@ -101,21 +101,31 @@ export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
 
   app.post("/sessions", bodyLimit({ maxSize: 16 * 1024 }), async (c) => {
     try {
-      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
       const input = sessionCreateSchema.parse(await c.req.json());
+      let ownerId = "local-owner";
       let targetUrl = input.targetUrl;
       if (input.handoffToken) {
         const publicKey = opts.handoffPublicKey ?? process.env.BROWSER_HANDOFF_PUBLIC_KEY;
         if (!publicKey) {
           return c.json({ error: { code: "handoff_unavailable", message: "Browser request is invalid." } }, 400);
         }
+        let expectedOwnerId: string | undefined;
+        try {
+          expectedOwnerId = opts.getOwnerId?.(c);
+        } catch (error: unknown) {
+          console.warn("[browser/routes] Handoff bootstrap proceeding without Matrix principal:", error instanceof Error ? error.message : String(error));
+          expectedOwnerId = undefined;
+        }
         const claims = await verifyBrowserHandoffToken({
           token: input.handoffToken,
           publicKey,
-          expectedOwnerId: ownerId,
+          ...(expectedOwnerId ? { expectedOwnerId } : {}),
           replayStore: handoffReplayStore,
         });
+        ownerId = claims.ownerId;
         targetUrl = claims.target;
+      } else {
+        ownerId = opts.getOwnerId?.(c) ?? "local-owner";
       }
       return c.json(await service.createSession({ ownerId, ...input, targetUrl }));
     } catch (error) {
@@ -190,8 +200,15 @@ export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
       const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
       const profileName = profileNameSchema.parse(c.req.param("profileName"));
       const input = profileClearSchema.parse(await c.req.json());
+      const activeSessions = (await service.listSessions({ ownerId }))
+        .filter((session) => session.profileName === profileName && session.state === "active")
+        .map((session) => session.id);
+      const profile = await service.clearProfile({ ownerId, profileName, scopes: input.scopes });
+      for (const sessionId of activeSessions) {
+        opts.streamHub?.notifySessionClosed(sessionId, "closed");
+      }
       return c.json({
-        profile: await service.clearProfile({ ownerId, profileName, scopes: input.scopes }),
+        profile,
       });
     } catch (error) {
       const safe = toBrowserSafeError(error);

--- a/packages/gateway/src/browser/routes.ts
+++ b/packages/gateway/src/browser/routes.ts
@@ -104,6 +104,9 @@ export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
       const input = sessionCreateSchema.parse(await c.req.json());
       let ownerId = "local-owner";
       let targetUrl = input.targetUrl;
+      if (c.req.header("x-browser-handoff") === "1" && !input.handoffToken) {
+        return c.json({ error: { code: "invalid_handoff", message: "Browser request is invalid." } }, 401);
+      }
       if (input.handoffToken) {
         const publicKey = opts.handoffPublicKey ?? process.env.BROWSER_HANDOFF_PUBLIC_KEY;
         if (!publicKey) {
@@ -200,11 +203,8 @@ export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
       const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
       const profileName = profileNameSchema.parse(c.req.param("profileName"));
       const input = profileClearSchema.parse(await c.req.json());
-      const activeSessions = (await service.listSessions({ ownerId }))
-        .filter((session) => session.profileName === profileName && session.state === "active")
-        .map((session) => session.id);
-      const profile = await service.clearProfile({ ownerId, profileName, scopes: input.scopes });
-      for (const sessionId of activeSessions) {
+      const { profile, closedSessionIds } = await service.clearProfileWithClosedSessions({ ownerId, profileName, scopes: input.scopes });
+      for (const sessionId of closedSessionIds) {
         opts.streamHub?.notifySessionClosed(sessionId, "closed");
       }
       return c.json({

--- a/packages/gateway/src/browser/routes.ts
+++ b/packages/gateway/src/browser/routes.ts
@@ -5,6 +5,7 @@ import { bodyLimit } from "hono/body-limit";
 import { BrowserService, toBrowserSafeError } from "./service.js";
 import { InMemoryBrowserRepository, type BrowserAuditEventType } from "./repository.js";
 import { BrowserHandoffReplayStore, verifyBrowserHandoffToken } from "../handoff-token.js";
+import type { BrowserStreamHub } from "./ws.js";
 
 const profileNameSchema = z.string().regex(/^[a-z][a-z0-9_-]{0,62}$/);
 
@@ -77,6 +78,7 @@ export interface BrowserRoutesOptions {
   service?: BrowserService;
   handoffPublicKey?: string;
   handoffReplayStore?: BrowserHandoffReplayStore;
+  streamHub?: BrowserStreamHub;
 }
 
 export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
@@ -137,7 +139,9 @@ export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
       const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
       const sessionId = z.string().min(1).max(128).parse(c.req.param("sessionId"));
       const input = takeoverSessionSchema.parse(await c.req.json());
-      return c.json(await service.takeoverSession({ ownerId, sessionId, deviceId: input.deviceId }));
+      const result = await service.takeoverSession({ ownerId, sessionId, deviceId: input.deviceId });
+      opts.streamHub?.notifySessionTakenOver(sessionId);
+      return c.json(result);
     } catch (error) {
       const safe = toBrowserSafeError(error);
       return c.json({ error: { code: safe.code, message: safe.message } }, safe.code === "payload_too_large" ? 413 : 400);

--- a/packages/gateway/src/browser/routes.ts
+++ b/packages/gateway/src/browser/routes.ts
@@ -127,7 +127,9 @@ export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
       const sessionId = z.string().min(1).max(128).parse(c.req.param("sessionId"));
       const input = closeSessionSchema.parse(await c.req.json());
       const state = input.reason === "idle" ? "hibernated" : input.reason === "recoverable" ? "recoverable" : "closed";
-      return c.json({ session: await service.closeSession({ ownerId, sessionId, state }) });
+      const session = await service.closeSession({ ownerId, sessionId, state });
+      if (session) opts.streamHub?.notifySessionClosed(sessionId, state);
+      return c.json({ session });
     } catch (error) {
       const safe = toBrowserSafeError(error);
       return c.json({ error: { code: safe.code, message: safe.message } }, safe.code === "payload_too_large" ? 413 : 400);

--- a/packages/gateway/src/browser/routes.ts
+++ b/packages/gateway/src/browser/routes.ts
@@ -66,11 +66,17 @@ const auditQuerySchema = z.object({
     "download.started",
     "download.completed",
     "download.failed",
+    "download.deleted",
     "profile.cleared",
     "permission.granted",
     "permission.revoked",
     "agent.access",
   ]).optional(),
+});
+
+const downloadsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  cursor: z.string().regex(/^\d+$/).transform((value) => Number.parseInt(value, 10)).optional(),
 });
 
 export interface BrowserRoutesOptions {
@@ -194,8 +200,24 @@ export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
   });
 
   app.get("/downloads", async (c) => {
-    const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
-    return c.json({ downloads: await service.listDownloads({ ownerId }) });
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const input = downloadsQuerySchema.parse({
+        limit: c.req.query("limit"),
+        cursor: c.req.query("cursor"),
+      });
+      const start = input.cursor ?? 0;
+      const downloads = await service.listDownloads({ ownerId });
+      const page = downloads.slice(start, start + input.limit);
+      const nextOffset = start + input.limit;
+      return c.json({
+        downloads: page,
+        nextCursor: nextOffset < downloads.length ? String(nextOffset) : null,
+      });
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, 400);
+    }
   });
 
   app.delete("/downloads/:downloadId", bodyLimit({ maxSize: 1024 }), async (c) => {

--- a/packages/gateway/src/browser/routes.ts
+++ b/packages/gateway/src/browser/routes.ts
@@ -1,0 +1,258 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { z } from "zod/v4";
+import { bodyLimit } from "hono/body-limit";
+import { BrowserService, toBrowserSafeError } from "./service.js";
+import { InMemoryBrowserRepository, type BrowserAuditEventType } from "./repository.js";
+import { BrowserHandoffReplayStore, verifyBrowserHandoffToken } from "../handoff-token.js";
+
+const profileNameSchema = z.string().regex(/^[a-z][a-z0-9_-]{0,62}$/);
+
+const sessionCreateSchema = z.object({
+  profileName: profileNameSchema.default("default"),
+  targetUrl: z.string().max(2048).optional(),
+  handoffToken: z.string().max(4096).optional(),
+  surface: z.enum(["canvas", "standalone"]),
+  deviceId: z.string().min(1).max(128),
+});
+
+const profileClearSchema = z.object({
+  scopes: z.array(z.enum([
+    "cookies",
+    "localStorage",
+    "sessionStorage",
+    "indexedDb",
+    "cache",
+    "serviceWorkers",
+    "sitePermissions",
+    "savedFormData",
+    "savedPasswords",
+    "history",
+    "downloads",
+  ])).min(1).max(16),
+});
+
+const grantCreateSchema = z.object({
+  sessionId: z.string().min(1).max(128),
+  scopes: z.array(z.enum(["read_dom", "screenshot", "navigate", "download", "automate_input"])).min(1).max(8),
+  domains: z.array(z.string().min(1).max(253)).min(1).max(32),
+  expiresAt: z.string().datetime().optional(),
+});
+
+const closeSessionSchema = z.object({
+  reason: z.enum(["user", "idle", "recoverable"]).default("user"),
+});
+
+const takeoverSessionSchema = z.object({
+  deviceId: z.string().min(1).max(128),
+  confirm: z.literal(true),
+});
+
+const tabCreateSchema = z.object({
+  targetUrl: z.string().min(1).max(2048),
+});
+
+const auditQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  cursor: z.string().min(1).max(256).optional(),
+  type: z.enum([
+    "session.created",
+    "session.closed",
+    "session.idle_hibernated",
+    "session.taken_over",
+    "navigation.attempted",
+    "navigation.blocked",
+    "download.started",
+    "download.completed",
+    "download.failed",
+    "profile.cleared",
+    "permission.granted",
+    "permission.revoked",
+    "agent.access",
+  ]).optional(),
+});
+
+export interface BrowserRoutesOptions {
+  getOwnerId?: (c: Context) => string;
+  service?: BrowserService;
+  handoffPublicKey?: string;
+  handoffReplayStore?: BrowserHandoffReplayStore;
+}
+
+export function createBrowserRoutes(opts: BrowserRoutesOptions = {}) {
+  const app = new Hono();
+  const service = opts.service ?? new BrowserService({ repo: new InMemoryBrowserRepository() });
+  const handoffReplayStore = opts.handoffReplayStore ?? new BrowserHandoffReplayStore();
+
+  app.get("/capability", (c) => c.json(service.capability()));
+
+  app.get("/sessions", async (c) => {
+    const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+    return c.json({ sessions: await service.listSessions({ ownerId }) });
+  });
+
+  app.post("/sessions", bodyLimit({ maxSize: 16 * 1024 }), async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const input = sessionCreateSchema.parse(await c.req.json());
+      let targetUrl = input.targetUrl;
+      if (input.handoffToken) {
+        const publicKey = opts.handoffPublicKey ?? process.env.BROWSER_HANDOFF_PUBLIC_KEY;
+        if (!publicKey) {
+          return c.json({ error: { code: "handoff_unavailable", message: "Browser request is invalid." } }, 400);
+        }
+        const claims = await verifyBrowserHandoffToken({
+          token: input.handoffToken,
+          publicKey,
+          expectedOwnerId: ownerId,
+          replayStore: handoffReplayStore,
+        });
+        targetUrl = claims.target;
+      }
+      return c.json(await service.createSession({ ownerId, ...input, targetUrl }));
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json(
+        { error: { code: safe.code, message: safe.message } },
+        safe.code === "payload_too_large" ? 413 : 400,
+      );
+    }
+  });
+
+  app.post("/sessions/:sessionId/close", bodyLimit({ maxSize: 4 * 1024 }), async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const sessionId = z.string().min(1).max(128).parse(c.req.param("sessionId"));
+      const input = closeSessionSchema.parse(await c.req.json());
+      const state = input.reason === "idle" ? "hibernated" : input.reason === "recoverable" ? "recoverable" : "closed";
+      return c.json({ session: await service.closeSession({ ownerId, sessionId, state }) });
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, safe.code === "payload_too_large" ? 413 : 400);
+    }
+  });
+
+  app.post("/sessions/:sessionId/takeover", bodyLimit({ maxSize: 4 * 1024 }), async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const sessionId = z.string().min(1).max(128).parse(c.req.param("sessionId"));
+      const input = takeoverSessionSchema.parse(await c.req.json());
+      return c.json(await service.takeoverSession({ ownerId, sessionId, deviceId: input.deviceId }));
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, safe.code === "payload_too_large" ? 413 : 400);
+    }
+  });
+
+  app.get("/sessions/:sessionId/tabs", async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const sessionId = z.string().min(1).max(128).parse(c.req.param("sessionId"));
+      return c.json({ tabs: await service.listTabs({ ownerId, sessionId }) });
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, 400);
+    }
+  });
+
+  app.post("/sessions/:sessionId/tabs", bodyLimit({ maxSize: 16 * 1024 }), async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const sessionId = z.string().min(1).max(128).parse(c.req.param("sessionId"));
+      const input = tabCreateSchema.parse(await c.req.json());
+      return c.json({
+        tab: await service.upsertTab({
+          ownerId,
+          sessionId,
+          url: input.targetUrl,
+        }),
+      });
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, safe.code === "payload_too_large" ? 413 : 400);
+    }
+  });
+
+  app.post("/profiles/:profileName/clear", bodyLimit({ maxSize: 16 * 1024 }), async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const profileName = profileNameSchema.parse(c.req.param("profileName"));
+      const input = profileClearSchema.parse(await c.req.json());
+      return c.json({
+        profile: await service.clearProfile({ ownerId, profileName, scopes: input.scopes }),
+      });
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, 400);
+    }
+  });
+
+  app.get("/downloads", async (c) => {
+    const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+    return c.json({ downloads: await service.listDownloads({ ownerId }) });
+  });
+
+  app.delete("/downloads/:downloadId", bodyLimit({ maxSize: 1024 }), async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const downloadId = z.string().min(1).max(128).parse(c.req.param("downloadId"));
+      const download = await service.deleteDownload({ ownerId, downloadId });
+      return c.json({ download });
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, 400);
+    }
+  });
+
+  app.get("/audit", async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const input = auditQuerySchema.parse({
+        limit: c.req.query("limit"),
+        cursor: c.req.query("cursor"),
+        type: c.req.query("type"),
+      });
+      return c.json(await service.listAudit({
+        ownerId,
+        limit: input.limit,
+        cursor: input.cursor,
+        eventType: input.type as BrowserAuditEventType | undefined,
+      }));
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, 400);
+    }
+  });
+
+  app.get("/grants", async (c) => {
+    const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+    return c.json({ grants: await service.listActiveGrants({ ownerId }) });
+  });
+
+  app.post("/grants", bodyLimit({ maxSize: 16 * 1024 }), async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const input = grantCreateSchema.parse(await c.req.json());
+      return c.json({
+        grant: await service.createGrant({ ownerId, ...input }),
+      });
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, 400);
+    }
+  });
+
+  app.delete("/grants/:grantId", bodyLimit({ maxSize: 1024 }), async (c) => {
+    try {
+      const ownerId = opts.getOwnerId?.(c) ?? "local-owner";
+      const grantId = z.string().min(1).max(128).parse(c.req.param("grantId"));
+      const grant = await service.revokeGrant({ ownerId, grantId });
+      return c.json({ grant });
+    } catch (error) {
+      const safe = toBrowserSafeError(error);
+      return c.json({ error: { code: safe.code, message: safe.message } }, 400);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/browser/ws.ts
+++ b/packages/gateway/src/browser/ws.ts
@@ -153,6 +153,31 @@ export class BrowserStreamHub {
     return delivered;
   }
 
+  notifySessionClosed(sessionId: string, state = "closed"): number {
+    const message: BrowserServerMessage = {
+      type: "stream.error",
+      payload: {
+        code: state === "hibernated" ? "idle_hibernated" : "session_closed",
+        message: "Browser session closed.",
+      },
+    };
+    const payload = JSON.stringify(message);
+    let delivered = 0;
+    for (const [id, connection] of this.connections.entries()) {
+      if (connection.sessionId !== sessionId) continue;
+      try {
+        connection.sender.send(payload);
+        delivered += 1;
+      } catch (error: unknown) {
+        console.warn("[browser/ws] Close notification failed:", error instanceof Error ? error.message : String(error));
+      } finally {
+        this.closeConnection(connection);
+        this.connections.delete(id);
+      }
+    }
+    return delivered;
+  }
+
   closeAll(message: BrowserServerMessage | ReturnType<typeof browserTakenOverMessage> = {
     type: "stream.error",
     payload: {

--- a/packages/gateway/src/browser/ws.ts
+++ b/packages/gateway/src/browser/ws.ts
@@ -1,0 +1,265 @@
+import {
+  BROWSER_STREAM_PROTOCOL_VERSION,
+  assertBrowserMessageSize,
+  parseBrowserClientMessage,
+  type BrowserClientMessage,
+} from "@matrix-os/mcp-browser/stream-protocol";
+import {
+  assertRelayIceCandidate,
+  createBrowserMediaOffer,
+  createEphemeralTurnCredential,
+  DEFAULT_BROWSER_MEDIA_BUDGET,
+  type BrowserMediaOffer,
+} from "@matrix-os/mcp-browser/media-service";
+
+export function parseBrowserWsMessage(raw: string | Buffer): BrowserClientMessage {
+  assertBrowserMessageSize(raw);
+  const value = JSON.parse(raw.toString());
+  return parseBrowserClientMessage(value);
+}
+
+export function browserTakenOverMessage() {
+  return {
+    type: "stream.taken_over",
+    payload: {
+      message: "Browser was opened on another device.",
+    },
+  } as const;
+}
+
+export type BrowserServerMessage =
+  | {
+    type: "stream.ready";
+    payload: {
+      protocolVersion: number;
+      ownerId: string;
+      sessionId: string;
+      mediaMode: "webrtc";
+      audio: { muted: boolean };
+      budgets: { maxWidth: number; maxHeight: number; maxFrameRate: number; maxBitrateKbps: number };
+    };
+  }
+  | BrowserMediaOffer
+  | { type: "media.ready"; payload: { sessionId: string } }
+  | { type: "media.ice.accepted"; payload: { candidate: string } }
+  | { type: "surface.focused"; payload: { surfaceId: string } }
+  | { type: "stream.error"; payload: { code: string; message: string } };
+
+export interface BrowserStreamSender {
+  send(message: string): void;
+  close?(): void;
+}
+
+export interface BrowserStreamConnection {
+  id: string;
+  ownerId: string;
+  sessionId: string;
+  surfaceId?: string;
+  sender: BrowserStreamSender;
+  lastTouchedAt: number;
+}
+
+export class BrowserStreamHub {
+  private readonly connections = new Map<string, BrowserStreamConnection>();
+
+  constructor(private readonly opts: {
+    maxConnections?: number;
+    staleMs?: number;
+    now?: () => number;
+  } = {}) {}
+
+  register(input: {
+    id: string;
+    ownerId: string;
+    sessionId: string;
+    sender: BrowserStreamSender;
+    surfaceId?: string;
+  }): void {
+    this.sweepStale();
+    const now = this.now();
+    this.connections.set(input.id, {
+      ...input,
+      lastTouchedAt: now,
+    });
+    this.evictOverflow();
+  }
+
+  touch(id: string, surfaceId?: string): void {
+    const connection = this.connections.get(id);
+    if (!connection) return;
+    connection.lastTouchedAt = this.now();
+    if (surfaceId) {
+      connection.surfaceId = surfaceId;
+    }
+  }
+
+  unregister(id: string): void {
+    this.connections.delete(id);
+  }
+
+  size(): number {
+    return this.connections.size;
+  }
+
+  sweepStale(): number {
+    const cutoff = this.now() - (this.opts.staleMs ?? 30_000);
+    let removed = 0;
+    for (const [id, connection] of this.connections.entries()) {
+      if (connection.lastTouchedAt <= cutoff) {
+        this.closeConnection(connection);
+        this.connections.delete(id);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  broadcastSession(sessionId: string, message: BrowserServerMessage | ReturnType<typeof browserTakenOverMessage>): number {
+    let delivered = 0;
+    const payload = JSON.stringify(message);
+    const dead: string[] = [];
+    for (const [id, connection] of this.connections.entries()) {
+      if (connection.sessionId !== sessionId) continue;
+      try {
+        connection.sender.send(payload);
+        delivered += 1;
+      } catch (error: unknown) {
+        console.warn("[browser/ws] Broadcast send failed:", error instanceof Error ? error.message : String(error));
+        dead.push(id);
+      }
+    }
+    for (const id of dead) {
+      this.closeConnection(this.connections.get(id));
+      this.connections.delete(id);
+    }
+    return delivered;
+  }
+
+  closeAll(message: BrowserServerMessage | ReturnType<typeof browserTakenOverMessage> = {
+    type: "stream.error",
+    payload: {
+      code: "shutdown",
+      message: "Browser stream is shutting down.",
+    },
+  }): void {
+    const payload = JSON.stringify(message);
+    for (const connection of this.connections.values()) {
+      try {
+        connection.sender.send(payload);
+      } catch (error: unknown) {
+        console.warn("[browser/ws] Shutdown notification failed:", error instanceof Error ? error.message : String(error));
+      } finally {
+        this.closeConnection(connection);
+      }
+    }
+    this.connections.clear();
+  }
+
+  private evictOverflow(): void {
+    const maxConnections = this.opts.maxConnections ?? 128;
+    while (this.connections.size > maxConnections) {
+      const oldest = [...this.connections.values()].sort((a, b) => a.lastTouchedAt - b.lastTouchedAt)[0];
+      if (!oldest) return;
+      this.closeConnection(oldest);
+      this.connections.delete(oldest.id);
+    }
+  }
+
+  private now(): number {
+    return this.opts.now?.() ?? Date.now();
+  }
+
+  private closeConnection(connection: BrowserStreamConnection | undefined): void {
+    try {
+      connection?.sender.close?.();
+    } catch (error: unknown) {
+      console.warn("[browser/ws] Close failed:", error instanceof Error ? error.message : String(error));
+    }
+  }
+}
+
+export class BrowserStreamController {
+  private focusedSurfaceId: string | undefined;
+
+  constructor(private readonly opts: {
+    ownerId: string;
+    sessionId: string;
+    turnUrls?: string[];
+    turnSecret?: string;
+    createOfferSdp?: () => string;
+  }) {}
+
+  handleClientMessage(raw: string | Buffer, context: { surfaceId?: string } = {}): BrowserServerMessage[] {
+    const message = parseBrowserWsMessage(raw);
+    if (message.type === "stream.hello") {
+      this.focusedSurfaceId ??= message.payload.surfaceId;
+      const messages: BrowserServerMessage[] = [
+        {
+          type: "stream.ready",
+          payload: {
+            protocolVersion: BROWSER_STREAM_PROTOCOL_VERSION,
+            ownerId: this.opts.ownerId,
+            sessionId: this.opts.sessionId,
+            mediaMode: "webrtc",
+            audio: { muted: DEFAULT_BROWSER_MEDIA_BUDGET.muted },
+            budgets: {
+              maxWidth: DEFAULT_BROWSER_MEDIA_BUDGET.maxWidth,
+              maxHeight: DEFAULT_BROWSER_MEDIA_BUDGET.maxHeight,
+              maxFrameRate: DEFAULT_BROWSER_MEDIA_BUDGET.maxFrameRate,
+              maxBitrateKbps: DEFAULT_BROWSER_MEDIA_BUDGET.maxBitrateKbps,
+            },
+          },
+        },
+      ];
+      if (this.opts.turnUrls && this.opts.turnUrls.length > 0) {
+        messages.push(createBrowserMediaOffer({
+          sdp: this.opts.createOfferSdp?.() ?? "v=0\r\ns=Matrix Browser\r\nt=0 0\r\n",
+          turn: createEphemeralTurnCredential({
+            ownerId: this.opts.ownerId,
+            sessionId: this.opts.sessionId,
+            urls: this.opts.turnUrls,
+            secret: this.opts.turnSecret,
+          }),
+        }));
+      }
+      messages.push({
+        type: "surface.focused",
+        payload: { surfaceId: this.focusedSurfaceId },
+      });
+      return messages;
+    }
+
+    if (message.type === "media.answer") {
+      return [{ type: "media.ready", payload: { sessionId: this.opts.sessionId } }];
+    }
+
+    if (message.type === "media.ice") {
+      assertRelayIceCandidate(message.payload.candidate);
+      return [{ type: "media.ice.accepted", payload: { candidate: message.payload.candidate } }];
+    }
+
+    if (message.type === "surface.focus") {
+      this.focusedSurfaceId = message.payload.surfaceId;
+      return [{ type: "surface.focused", payload: { surfaceId: message.payload.surfaceId } }];
+    }
+
+    if (isInputMessage(message) && context.surfaceId && this.focusedSurfaceId !== context.surfaceId) {
+      return [{
+        type: "stream.error",
+        payload: {
+          code: "stale_focus",
+          message: "Browser input came from a background surface.",
+        },
+      }];
+    }
+
+    return [];
+  }
+}
+
+function isInputMessage(message: BrowserClientMessage): boolean {
+  return message.type === "input.pointer" ||
+    message.type === "input.keyboard" ||
+    message.type === "input.ime" ||
+    message.type === "input.paste";
+}

--- a/packages/gateway/src/browser/ws.ts
+++ b/packages/gateway/src/browser/ws.ts
@@ -37,6 +37,7 @@ export type BrowserServerMessage =
       mediaMode: "webrtc";
       audio: { muted: boolean };
       budgets: { maxWidth: number; maxHeight: number; maxFrameRate: number; maxBitrateKbps: number };
+      turnCredentialExpiresAt?: string;
     };
   }
   | BrowserMediaOffer
@@ -236,6 +237,20 @@ export class BrowserStreamController {
     const message = parseBrowserWsMessage(raw);
     if (message.type === "stream.hello") {
       this.focusedSurfaceId ??= message.payload.surfaceId;
+      if (this.opts.turnUrls && this.opts.turnUrls.length > 0 && !this.opts.turnSecret) {
+        return [{
+          type: "stream.error",
+          payload: { code: "media_policy", message: "Browser media relay is unavailable." },
+        }];
+      }
+      const turnCredential = this.opts.turnUrls && this.opts.turnUrls.length > 0
+        ? createEphemeralTurnCredential({
+          ownerId: this.opts.ownerId,
+          sessionId: this.opts.sessionId,
+          urls: this.opts.turnUrls,
+          secret: this.opts.turnSecret as string,
+        })
+        : undefined;
       const messages: BrowserServerMessage[] = [
         {
           type: "stream.ready",
@@ -251,18 +266,14 @@ export class BrowserStreamController {
               maxFrameRate: DEFAULT_BROWSER_MEDIA_BUDGET.maxFrameRate,
               maxBitrateKbps: DEFAULT_BROWSER_MEDIA_BUDGET.maxBitrateKbps,
             },
+            ...(turnCredential ? { turnCredentialExpiresAt: turnCredential.expiresAt } : {}),
           },
         },
       ];
-      if (this.opts.turnUrls && this.opts.turnUrls.length > 0) {
+      if (turnCredential) {
         messages.push(createBrowserMediaOffer({
           sdp: this.opts.createOfferSdp?.() ?? "v=0\r\ns=Matrix Browser\r\nt=0 0\r\n",
-          turn: createEphemeralTurnCredential({
-            ownerId: this.opts.ownerId,
-            sessionId: this.opts.sessionId,
-            urls: this.opts.turnUrls,
-            secret: this.opts.turnSecret,
-          }),
+          turn: turnCredential,
         }));
       }
       messages.push({

--- a/packages/gateway/src/browser/ws.ts
+++ b/packages/gateway/src/browser/ws.ts
@@ -43,6 +43,7 @@ export type BrowserServerMessage =
   | BrowserMediaOffer
   | { type: "media.ready"; payload: { sessionId: string } }
   | { type: "media.ice.accepted"; payload: { candidate: string } }
+  | { type: "navigation.committed"; payload: { url: string } }
   | { type: "surface.focused"; payload: { surfaceId: string } }
   | { type: "stream.error"; payload: { code: string; message: string } };
 

--- a/packages/gateway/src/browser/ws.ts
+++ b/packages/gateway/src/browser/ws.ts
@@ -135,6 +135,24 @@ export class BrowserStreamHub {
     return delivered;
   }
 
+  notifySessionTakenOver(sessionId: string): number {
+    let delivered = 0;
+    const payload = JSON.stringify(browserTakenOverMessage());
+    for (const [id, connection] of this.connections.entries()) {
+      if (connection.sessionId !== sessionId) continue;
+      try {
+        connection.sender.send(payload);
+        delivered += 1;
+      } catch (error: unknown) {
+        console.warn("[browser/ws] Takeover notification failed:", error instanceof Error ? error.message : String(error));
+      } finally {
+        this.closeConnection(connection);
+        this.connections.delete(id);
+      }
+    }
+    return delivered;
+  }
+
   closeAll(message: BrowserServerMessage | ReturnType<typeof browserTakenOverMessage> = {
     type: "stream.error",
     payload: {

--- a/packages/gateway/src/cron/service.ts
+++ b/packages/gateway/src/cron/service.ts
@@ -1,4 +1,5 @@
 import cron from "node-cron";
+import type { ScheduledTask } from "node-cron";
 import type { CronJob } from "./types.js";
 import type { CronStore } from "./store.js";
 
@@ -18,7 +19,7 @@ export interface CronService {
 export function createCronService(config: CronServiceConfig): CronService {
   const { store, onTrigger } = config;
   const timers = new Map<string, ReturnType<typeof setInterval> | ReturnType<typeof setTimeout>>();
-  const cronTasks = new Map<string, cron.ScheduledTask>();
+  const cronTasks = new Map<string, ScheduledTask>();
   let started = false;
 
   function scheduleJob(job: CronJob): void {

--- a/packages/gateway/src/request-principal.ts
+++ b/packages/gateway/src/request-principal.ts
@@ -66,7 +66,7 @@ function readClaims(c: PrincipalContextReader): SyncJwtClaims | undefined {
 }
 
 function isLocalDevelopmentEnv(env: NodeJS.ProcessEnv): boolean {
-  const nodeEnv = env.NODE_ENV;
+  const nodeEnv = env.NODE_ENV as string | undefined;
   return nodeEnv === undefined || nodeEnv === "" || nodeEnv === "development" || nodeEnv === "test" || nodeEnv === "local";
 }
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -397,7 +397,10 @@ export async function createGateway(config: GatewayConfig) {
   let canvasSubscriptionHub: CanvasSubscriptionHub | null = null;
   let canvasCleanupTimer: ReturnType<typeof setInterval> | null = null;
   let browserRepository: BrowserRepository = new InMemoryBrowserRepository();
-  let browserService = new BrowserService({ repo: browserRepository });
+  let browserService = new BrowserService({
+    repo: browserRepository,
+    runtimeBaseUrl: process.env.BROWSER_RUNTIME_URL,
+  });
   const browserStreamHub = new BrowserStreamHub({ maxConnections: 256, staleMs: 60_000 });
 
   if (databaseUrl) {
@@ -413,7 +416,10 @@ export async function createGateway(config: GatewayConfig) {
       await canvasRepository.bootstrap();
       browserRepository = new KyselyBrowserRepository(kysely as unknown as Kysely<BrowserDatabase>);
       await browserRepository.bootstrap?.();
-      browserService = new BrowserService({ repo: browserRepository });
+      browserService = new BrowserService({
+        repo: browserRepository,
+        runtimeBaseUrl: process.env.BROWSER_RUNTIME_URL,
+      });
       canvasService = new CanvasService(canvasRepository, { terminalRegistry: sessionRegistry, homePath });
       canvasSubscriptionHub = new CanvasSubscriptionHub({
         authorize: async (subscriber) => {
@@ -3419,6 +3425,7 @@ export async function createGateway(config: GatewayConfig) {
   app.route("/api/browser", createBrowserRoutes({
     service: browserService,
     getOwnerId: (c) => requireRequestPrincipal(c).userId,
+    streamHub: browserStreamHub,
   }));
   app.get(
     "/api/browser/sessions/:sessionId/ws",

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -140,6 +140,14 @@ import { createCanvasRoutes } from "./canvas/routes.js";
 import { CanvasSubscriptionHub } from "./canvas/subscriptions.js";
 import { CanvasIdSchema } from "./canvas/contracts.js";
 import { cleanupCanvasTempFiles } from "./canvas/recovery.js";
+import { createBrowserRoutes } from "./browser/routes.js";
+import {
+  InMemoryBrowserRepository,
+  KyselyBrowserRepository,
+  type BrowserDatabase,
+  type BrowserRepository,
+} from "./browser/repository.js";
+import { BrowserService } from "./browser/service.js";
 import type { WSContext } from "hono/ws";
 import {
   MainWsClientMessageSchema,
@@ -161,6 +169,7 @@ import {
   createZellijAdapter,
   ShellRegistry as ZellijShellRegistry,
 } from "./shell/index.js";
+import { BrowserStreamController, BrowserStreamHub } from "./browser/ws.js";
 
 // Mirrors CallBodySchema in integrations/routes.ts so the dev-only
 // /api/bridge/service POST validates its body the same way the public
@@ -387,6 +396,9 @@ export async function createGateway(config: GatewayConfig) {
   let canvasService: CanvasService | null = null;
   let canvasSubscriptionHub: CanvasSubscriptionHub | null = null;
   let canvasCleanupTimer: ReturnType<typeof setInterval> | null = null;
+  let browserRepository: BrowserRepository = new InMemoryBrowserRepository();
+  let browserService = new BrowserService({ repo: browserRepository });
+  const browserStreamHub = new BrowserStreamHub({ maxConnections: 256, staleMs: 60_000 });
 
   if (databaseUrl) {
     try {
@@ -399,6 +411,9 @@ export async function createGateway(config: GatewayConfig) {
       appRegistry = createAppRegistry(appDb, kysely);
       canvasRepository = new CanvasRepository(kysely as Kysely<any>);
       await canvasRepository.bootstrap();
+      browserRepository = new KyselyBrowserRepository(kysely as unknown as Kysely<BrowserDatabase>);
+      await browserRepository.bootstrap?.();
+      browserService = new BrowserService({ repo: browserRepository });
       canvasService = new CanvasService(canvasRepository, { terminalRegistry: sessionRegistry, homePath });
       canvasSubscriptionHub = new CanvasSubscriptionHub({
         authorize: async (subscriber) => {
@@ -3401,6 +3416,80 @@ export async function createGateway(config: GatewayConfig) {
   // T978-T979: Settings API routes
   const settingsRoutes = createSettingsRoutes({ homePath, channelManager });
   app.route("/api/settings", settingsRoutes);
+  app.route("/api/browser", createBrowserRoutes({
+    service: browserService,
+    getOwnerId: (c) => requireRequestPrincipal(c).userId,
+  }));
+  app.get(
+    "/api/browser/sessions/:sessionId/ws",
+    upgradeWebSocket((c) => {
+      let ownerId: string;
+      let sessionId: string;
+      try {
+        sessionId = z.string().min(1).max(128).parse(c.req.param("sessionId"));
+        const token = extractBrowserStreamToken(c);
+        ownerId = browserService.verifyStreamToken({ token, sessionId }).ownerId;
+      } catch (err: unknown) {
+        console.error("[browser/ws] Upgrade rejected:", err instanceof Error ? err.message : String(err));
+        return {
+          onOpen(_evt, ws) {
+            ws.send(JSON.stringify({ type: "stream.error", payload: { code: "unauthorized" } }));
+            ws.close();
+          },
+        };
+      }
+
+      const connectionId = `browser_${randomBytes(12).toString("hex")}`;
+      let surfaceId: string | undefined;
+      const turnUrls = (process.env.BROWSER_TURN_URLS ?? "")
+        .split(",")
+        .map((url) => url.trim())
+        .filter(Boolean);
+      const controller = new BrowserStreamController({
+        ownerId,
+        sessionId,
+        turnUrls,
+        turnSecret: process.env.BROWSER_TURN_SECRET,
+      });
+      return {
+        onOpen(_evt, ws) {
+          browserStreamHub.register({
+            id: connectionId,
+            ownerId,
+            sessionId,
+            sender: ws,
+          });
+          ws.send(JSON.stringify({ type: "stream.accepted", payload: { sessionId } }));
+        },
+        onMessage(evt, ws) {
+          try {
+            browserStreamHub.touch(connectionId, surfaceId);
+            const messages = controller.handleClientMessage(
+              typeof evt.data === "string" ? evt.data : Buffer.from(evt.data as ArrayBuffer),
+              { surfaceId },
+            );
+            for (const message of messages) {
+              if (message.type === "surface.focused") {
+                surfaceId = message.payload.surfaceId;
+                browserStreamHub.touch(connectionId, surfaceId);
+              }
+              ws.send(JSON.stringify(message));
+            }
+          } catch (err: unknown) {
+            ws.send(JSON.stringify({
+              type: "stream.error",
+              payload: {
+                code: err instanceof Error && err.message === "upgrade_required" ? "upgrade_required" : "invalid_message",
+              },
+            }));
+          }
+        },
+        onClose() {
+          browserStreamHub.unregister(connectionId);
+        },
+      };
+    }),
+  );
 
   if (canvasService) {
     // Global authMiddleware is mounted before route registration; routes still resolve user IDs defensively.
@@ -3670,6 +3759,7 @@ export async function createGateway(config: GatewayConfig) {
       cronService.stop();
       if (canvasCleanupTimer) clearInterval(canvasCleanupTimer);
       canvasSubscriptionHub?.close();
+      browserStreamHub.closeAll();
       await channelManager.stop();
       await processManager.shutdownAll();
       await symphonyRunner.stop();
@@ -3680,6 +3770,7 @@ export async function createGateway(config: GatewayConfig) {
         logBestEffortFailure("Home mirror startup failed during shutdown", err);
       });
       syncR2?.destroy();
+      await browserRepository.destroy?.();
       await canvasRepository?.destroy();
       await socialRoutes?.shutdownPostHog();
       await appDb?.destroy();
@@ -3687,4 +3778,15 @@ export async function createGateway(config: GatewayConfig) {
       server.close();
     },
   };
+}
+
+function extractBrowserStreamToken(c: Context): string | null {
+  const protocolHeader = c.req.header("sec-websocket-protocol");
+  const protocolToken = protocolHeader
+    ?.split(",")
+    .map((value) => value.trim())
+    .find((value) => value.startsWith("browser-stream."))
+    ?.slice("browser-stream.".length);
+  if (protocolToken) return protocolToken;
+  return new URL(c.req.url).searchParams.get("token");
 }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -3459,7 +3459,20 @@ export async function createGateway(config: GatewayConfig) {
         turnSecret: process.env.BROWSER_TURN_SECRET,
       });
       return {
-        onOpen(_evt, ws) {
+        async onOpen(_evt, ws) {
+          try {
+            const session = await browserService.getSession({ ownerId, sessionId });
+            if (!session || session.state !== "active") {
+              ws.send(JSON.stringify({ type: "stream.error", payload: { code: "session_closed" } }));
+              ws.close();
+              return;
+            }
+          } catch (err: unknown) {
+            console.error("[browser/ws] Session state check failed:", err instanceof Error ? err.message : String(err));
+            ws.send(JSON.stringify({ type: "stream.error", payload: { code: "unauthorized" } }));
+            ws.close();
+            return;
+          }
           ws.send(JSON.stringify({ type: "stream.accepted", payload: { sessionId } }));
           browserStreamHub.register({
             id: connectionId,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -3460,13 +3460,13 @@ export async function createGateway(config: GatewayConfig) {
       });
       return {
         onOpen(_evt, ws) {
+          ws.send(JSON.stringify({ type: "stream.accepted", payload: { sessionId } }));
           browserStreamHub.register({
             id: connectionId,
             ownerId,
             sessionId,
             sender: ws,
           });
-          ws.send(JSON.stringify({ type: "stream.accepted", payload: { sessionId } }));
         },
         onMessage(evt, ws) {
           try {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -3434,6 +3434,9 @@ export async function createGateway(config: GatewayConfig) {
       let sessionId: string;
       try {
         sessionId = z.string().min(1).max(128).parse(c.req.param("sessionId"));
+        if (c.req.header("upgrade")?.toLowerCase() !== "websocket") {
+          throw new Error("not_websocket_upgrade");
+        }
         const token = extractBrowserStreamToken(c);
         ownerId = browserService.verifyStreamToken({ token, sessionId }).ownerId;
       } catch (err: unknown) {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -169,7 +169,7 @@ import {
   createZellijAdapter,
   ShellRegistry as ZellijShellRegistry,
 } from "./shell/index.js";
-import { BrowserStreamController, BrowserStreamHub } from "./browser/ws.js";
+import { BrowserStreamController, BrowserStreamHub, parseBrowserWsMessage } from "./browser/ws.js";
 
 // Mirrors CallBodySchema in integrations/routes.ts so the dev-only
 // /api/bridge/service POST validates its body the same way the public
@@ -3481,11 +3481,26 @@ export async function createGateway(config: GatewayConfig) {
             sender: ws,
           });
         },
-        onMessage(evt, ws) {
+        async onMessage(evt, ws) {
           try {
+            const raw = typeof evt.data === "string" ? evt.data : Buffer.from(evt.data as ArrayBuffer);
+            const parsed = parseBrowserWsMessage(raw);
+            if (parsed.type === "browser.navigate") {
+              await browserService.navigateSession({
+                ownerId,
+                sessionId,
+                targetUrl: parsed.payload.targetUrl,
+                surface: parsed.payload.surface,
+              });
+              ws.send(JSON.stringify({
+                type: "navigation.committed",
+                payload: { url: parsed.payload.targetUrl },
+              }));
+              return;
+            }
             browserStreamHub.touch(connectionId, surfaceId);
             const messages = controller.handleClientMessage(
-              typeof evt.data === "string" ? evt.data : Buffer.from(evt.data as ArrayBuffer),
+              raw,
               { surfaceId },
             );
             for (const message of messages) {

--- a/packages/gateway/src/symphony-runner.ts
+++ b/packages/gateway/src/symphony-runner.ts
@@ -588,7 +588,7 @@ async function firstUnavailablePath(
 }
 
 function buildSymphonyEnv(baseEnv: NodeJS.ProcessEnv, homePath: string, runId: string): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
+  const env: NodeJS.ProcessEnv = { NODE_ENV: baseEnv.NODE_ENV ?? "production" };
   for (const key of SYMPHONY_ENV_ALLOWLIST) {
     if (baseEnv[key] !== undefined) env[key] = baseEnv[key];
   }

--- a/packages/gateway/src/sync/home-mirror.ts
+++ b/packages/gateway/src/sync/home-mirror.ts
@@ -956,10 +956,14 @@ export function createHomeMirror(config: HomeMirrorConfig): HomeMirror {
       // waiting for a `ready` event that will never fire on a closed watcher.
       try {
         await new Promise<void>((resolve, reject) => {
+          const closeAwareWatcher = watcher as typeof watcher & {
+            off(event: "close", listener: () => void): typeof watcher;
+            once(event: "close", listener: () => void): typeof watcher;
+          };
           const cleanup = () => {
             watcher?.off("ready", onReady);
             watcher?.off("error", onError);
-            watcher?.off("close", onClose);
+            closeAwareWatcher?.off("close", onClose);
           };
           const onReady = () => {
             cleanup();
@@ -975,7 +979,7 @@ export function createHomeMirror(config: HomeMirrorConfig): HomeMirror {
           };
           watcher!.once("ready", onReady);
           watcher!.once("error", onError);
-          watcher!.once("close", onClose);
+          closeAwareWatcher!.once("close", onClose);
         });
       } catch (err: unknown) {
         // Watcher errored before reaching ready -- close it (and any

--- a/packages/gateway/src/sync/manifest.ts
+++ b/packages/gateway/src/sync/manifest.ts
@@ -109,7 +109,7 @@ function liveManifestStats(manifest: Manifest): { fileCount: number; totalSize: 
   const liveFiles = Object.values(manifest.files).filter((e) => !e.deleted);
   return {
     fileCount: liveFiles.length,
-    totalSize: liveFiles.reduce((sum, e) => sum + BigInt(e.size), 0n),
+    totalSize: liveFiles.reduce((sum, e) => sum + BigInt(e.size), BigInt(0)),
   };
 }
 

--- a/packages/gateway/src/sync/routes.ts
+++ b/packages/gateway/src/sync/routes.ts
@@ -216,7 +216,7 @@ export function createSyncRoutes(deps: SyncRouteDeps): Hono {
 
     syncConnectedPeers.set(deps.peerRegistry.getTotalPeerCount());
     syncManifestEntries.set(aggregate?.fileCount ?? 0);
-    syncManifestBytes.set(Number(aggregate?.totalSize ?? 0n));
+    syncManifestBytes.set(Number(aggregate?.totalSize ?? BigInt(0)));
 
     return c.json({
       connectedPeers: peers.map((p) => ({

--- a/tests/browser/focus-lease.test.ts
+++ b/tests/browser/focus-lease.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryBrowserRepository } from "../../packages/gateway/src/browser/repository.js";
+import { createTakeoverAuditEvent, recordTakeover } from "../../packages/gateway/src/browser/service.js";
+import { browserTakenOverMessage } from "../../packages/gateway/src/browser/ws.js";
+import { SessionManager } from "../../packages/mcp-browser/src/session-manager.js";
+import type { BrowserLike, PageLike } from "../../packages/mcp-browser/src/session-manager.js";
+
+function fakePage(): PageLike {
+  return {
+    async goto() { return null; },
+    async title() { return ""; },
+    url() { return "about:blank"; },
+    async screenshot() { return Buffer.from(""); },
+    async pdf() { return Buffer.from(""); },
+    async content() { return ""; },
+    async evaluate() { return undefined; },
+    async click() {},
+    async fill() {},
+    async selectOption() {},
+    getByRole() { return { async click() {} }; },
+    async waitForSelector() {},
+    async waitForNavigation() {},
+    async waitForLoadState() {},
+    setDefaultTimeout() {},
+    async close() {},
+    mouse: { async wheel() {} },
+    accessibility: { async snapshot() { return null; } },
+    on() {},
+    context() { return { pages: () => [this], async newPage() { return fakePage(); }, async close() {} }; },
+  };
+}
+
+function fakeBrowser(): BrowserLike {
+  const page = fakePage();
+  return {
+    async newPage() { return page; },
+    async close() {},
+    contexts() {
+      return [{ pages: () => [page], async newPage() { return page; }, async close() {} }];
+    },
+  };
+}
+
+describe("Browser focus lease and takeover audit", () => {
+  it("records explicit session takeover audit events", () => {
+    expect(createTakeoverAuditEvent({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      deviceId: "device_1",
+      now: 1_000,
+    })).toMatchObject({
+      ownerId: "owner_1",
+      eventType: "session.taken_over",
+      createdAt: new Date(1_000).toISOString(),
+      metadata: { sessionId: "session_1", deviceId: "device_1" },
+    });
+  });
+
+  it("releases focus surfaces on second-device takeover and exposes the stream takeover message", async () => {
+    const manager = new SessionManager({ launcher: async () => fakeBrowser() });
+    const session = await manager.launch({ profile: "default", deviceId: "device_1" });
+    manager.attachSurface({ sessionId: session.id, surfaceId: "canvas", deviceId: "device_1", kind: "canvas" });
+    manager.focusSurface("canvas");
+
+    manager.takeover({ deviceId: "device_2" });
+
+    expect(manager.getActive()?.lockDeviceId).toBe("device_2");
+    expect(manager.getActive()?.focusSurfaceId).toBeUndefined();
+    expect(manager.getActive()?.surfaces?.size).toBe(0);
+    expect(browserTakenOverMessage()).toEqual({
+      type: "stream.taken_over",
+      payload: { message: "Browser was opened on another device." },
+    });
+  });
+
+  it("keeps audit retention bounded to 180 days by default", async () => {
+    const repo = new InMemoryBrowserRepository();
+    await recordTakeover(repo, { ownerId: "owner_1", sessionId: "old", deviceId: "device_1", now: 1_000 });
+    await recordTakeover(repo, { ownerId: "owner_1", sessionId: "fresh", deviceId: "device_1", now: 200 * 24 * 60 * 60 * 1000 });
+
+    expect(repo.pruneAuditEvents({ ownerId: "owner_1", now: 200 * 24 * 60 * 60 * 1000 })).toBe(1);
+    expect(repo.listAuditEvents("owner_1")).toHaveLength(1);
+  });
+
+  it("redacts sensitive audit metadata", () => {
+    const repo = new InMemoryBrowserRepository();
+    repo.addAuditEvent({
+      id: "audit_1",
+      ownerId: "owner_1",
+      eventType: "agent.access",
+      createdAt: new Date(1_000).toISOString(),
+      metadata: {
+        url: "https://example.com/",
+        cookie: "secret",
+        screenshotPath: "/home/owner/file.png",
+        html: "<form>secret</form>",
+      },
+    });
+
+    expect(repo.listAuditEvents("owner_1")[0]?.metadata).toEqual({ url: "https://example.com/" });
+  });
+
+  it("serializes agent automate_input without taking the UI focus lease", async () => {
+    const manager = new SessionManager({ launcher: async () => fakeBrowser() });
+    await manager.launch({ profile: "default", deviceId: "device_1" });
+    manager.attachSurface({ sessionId: manager.getActive()!.id, surfaceId: "canvas", deviceId: "device_1", kind: "canvas" });
+    manager.focusSurface("canvas");
+
+    const result = await manager.enqueueAction(async () => "automated", { agent: true });
+
+    expect(result).toBe("automated");
+    expect(manager.getActive()?.focusSurfaceId).toBe("canvas");
+  });
+});

--- a/tests/browser/routes.test.ts
+++ b/tests/browser/routes.test.ts
@@ -1,0 +1,515 @@
+import { describe, expect, it } from "vitest";
+import { generateKeyPair } from "node:crypto";
+import { promisify } from "node:util";
+import { InMemoryBrowserRepository } from "../../packages/gateway/src/browser/repository.js";
+import { createBrowserRoutes } from "../../packages/gateway/src/browser/routes.js";
+import { BrowserService } from "../../packages/gateway/src/browser/service.js";
+import { signBrowserHandoffToken } from "../../packages/gateway/src/handoff-token.js";
+
+const generateRsa = promisify(generateKeyPair);
+
+describe("Browser gateway routes", () => {
+  it("returns coarse Browser capability data only", async () => {
+    const app = createBrowserRoutes();
+    const res = await app.request("/capability");
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      available: true,
+      capacityState: "ok",
+      activeSessionCount: 0,
+      limits: { maxSessions: 1, maxTabs: 12, maxStreams: 3 },
+    });
+  });
+
+  it("validates session payloads at the route boundary with safe errors", async () => {
+    const app = createBrowserRoutes();
+    const res = await app.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ profileName: "../bad", surface: "canvas", deviceId: "" }),
+    });
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error: { code: "validation_error", message: "Browser request is invalid." } });
+  });
+
+  it("binds created sessions to the authenticated owner scope", async () => {
+    const service = new BrowserService({
+      repo: new InMemoryBrowserRepository(),
+      streamTokenSecret: "test-stream-secret",
+    });
+    const app = createBrowserRoutes({ getOwnerId: () => "owner_1", service });
+    const res = await app.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ profileName: "default", surface: "canvas", deviceId: "device_1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { session: { id: string; ownerId: string; profileId: string }; streamToken: string };
+    expect(body).toMatchObject({
+      session: {
+        ownerId: "owner_1",
+        id: expect.stringMatching(/^browser_session_/),
+        profileId: expect.stringMatching(/^browser_profile_/),
+      },
+    });
+    expect(service.verifyStreamToken({
+      token: body.streamToken,
+      sessionId: body.session.id,
+    })).toMatchObject({
+      ownerId: "owner_1",
+      sessionId: body.session.id,
+    });
+    expect(() => service.verifyStreamToken({
+      token: body.streamToken,
+      sessionId: "other_session",
+    })).toThrow("invalid_browser_stream_token");
+  });
+
+  it("applies body limits before mutating session routes", async () => {
+    const app = createBrowserRoutes();
+    const body = JSON.stringify({ profileName: "x".repeat(20_000), surface: "canvas", deviceId: "device" });
+    const res = await app.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": String(Buffer.byteLength(body)) },
+      body,
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it("persists sessions through an owner-scoped repository", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo });
+    const first = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      targetUrl: "https://example.com/",
+    });
+    const resumed = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      targetUrl: "https://example.com/next",
+    });
+
+    expect(resumed.session.id).toBe(first.session.id);
+    expect(await repo.listSessions("owner_1")).toHaveLength(1);
+    expect(await repo.listSessions("owner_2")).toHaveLength(0);
+  });
+
+  it("requires takeover for another device on the same owner profile", async () => {
+    const service = new BrowserService({ repo: new InMemoryBrowserRepository() });
+    await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+    });
+
+    const second = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_2",
+      surface: "standalone",
+    });
+
+    expect(second.session.takeoverRequired).toBe(true);
+    expect(second.session.lockDeviceId).toBe("device_1");
+  });
+
+  it("takes over a locked session, marks the old session recoverable, and audits", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo, streamTokenSecret: "test-stream-secret" });
+    const app = createBrowserRoutes({
+      getOwnerId: () => "owner_1",
+      service,
+    });
+    const first = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      now: 1_000,
+    });
+
+    const takeover = await app.request(`/sessions/${first.session.id}/takeover`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ deviceId: "device_2", confirm: true }),
+    });
+
+    expect(takeover.status).toBe(200);
+    const body = await takeover.json() as { session: { id: string; lockDeviceId: string }; streamToken: string };
+    expect(body.session.id).not.toBe(first.session.id);
+    expect(body.session.lockDeviceId).toBe("device_2");
+    expect(service.verifyStreamToken({ token: body.streamToken, sessionId: body.session.id })).toMatchObject({
+      ownerId: "owner_1",
+      sessionId: body.session.id,
+    });
+    expect(await repo.getSession("owner_1", first.session.id)).toMatchObject({ state: "recoverable" });
+    expect((await repo.listAuditEvents("owner_1")).map((event) => event.eventType)).toEqual([
+      "session.created",
+      "session.closed",
+      "session.taken_over",
+      "session.created",
+    ]);
+  });
+
+  it("clears explicit profile scopes and audits without leaking sensitive metadata", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo });
+    await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+    });
+
+    const profile = await service.clearProfile({
+      ownerId: "owner_1",
+      profileName: "default",
+      scopes: ["cookies", "savedPasswords", "downloads"],
+    });
+
+    expect(profile.clearedScopes).toEqual(["cookies", "savedPasswords", "downloads"]);
+    expect(await repo.listAuditEvents("owner_1")).toEqual([
+      expect.objectContaining({
+        eventType: "session.created",
+      }),
+      expect.objectContaining({
+        eventType: "session.closed",
+      }),
+      expect.objectContaining({
+        eventType: "profile.cleared",
+        metadata: { profileName: "default", scopes: ["cookies", "savedPasswords", "downloads"] },
+      }),
+    ]);
+    expect((await repo.listSessions("owner_1"))[0]?.state).toBe("closed");
+  });
+
+  it("accepts every profile clear scope including browser stores and saved passwords", async () => {
+    const service = new BrowserService({ repo: new InMemoryBrowserRepository() });
+    const scopes = [
+      "cookies",
+      "localStorage",
+      "sessionStorage",
+      "indexedDb",
+      "cache",
+      "serviceWorkers",
+      "sitePermissions",
+      "savedFormData",
+      "savedPasswords",
+      "history",
+      "downloads",
+    ] as const;
+
+    const profile = await service.clearProfile({
+      ownerId: "owner_1",
+      profileName: "default",
+      scopes: [...scopes],
+    });
+
+    expect(profile.clearedScopes).toEqual(scopes);
+  });
+
+  it("creates, lists, expires, and revokes browser permission grants", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo });
+    const now = 1_000;
+    const grant = await service.createGrant({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      scopes: ["read_dom", "automate_input"],
+      domains: ["example.com"],
+      now,
+    });
+
+    expect(grant.expiresAt).toBe(new Date(now + 8 * 60 * 60 * 1000).toISOString());
+    expect(await service.listActiveGrants({ ownerId: "owner_1", now: now + 1_000 })).toHaveLength(1);
+    expect(await service.listActiveGrants({ ownerId: "owner_2", now: now + 1_000 })).toHaveLength(0);
+    await service.revokeGrant({ ownerId: "owner_1", grantId: grant.id, now: now + 2_000 });
+    expect(await service.listActiveGrants({ ownerId: "owner_1", now: now + 3_000 })).toEqual([]);
+  });
+
+  it("rejects grant domains that are not hostnames", async () => {
+    const service = new BrowserService({ repo: new InMemoryBrowserRepository() });
+    await expect(service.createGrant({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      scopes: ["read_dom"],
+      domains: ["https://example.com/secret"],
+      now: 1_000,
+    })).rejects.toThrow("invalid_grant_domain");
+  });
+
+  it("enforces agent action grants by scope and domain", async () => {
+    const service = new BrowserService({ repo: new InMemoryBrowserRepository() });
+    await service.createGrant({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      scopes: ["navigate"],
+      domains: ["example.com"],
+      now: 1_000,
+    });
+
+    await expect(service.authorizeAgentAction({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      action: "navigate",
+      url: "https://example.com/page",
+      now: 2_000,
+    })).resolves.toBeDefined();
+    await expect(service.authorizeAgentAction({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      action: "read_dom",
+      url: "https://example.com/page",
+      now: 2_000,
+    })).rejects.toThrow("Browser permission is required");
+    await expect(service.authorizeAgentAction({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      action: "navigate",
+      url: "https://evil.example.net/",
+      now: 2_000,
+    })).rejects.toThrow("Browser permission is required");
+  });
+
+  it("enforces every agent browser grant scope and emits redacted access audit", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo });
+    const scopes = ["read_dom", "screenshot", "navigate", "download", "automate_input"] as const;
+    await service.createGrant({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      scopes: [...scopes],
+      domains: ["*.example.com"],
+      now: 1_000,
+    });
+
+    for (const action of scopes) {
+      await expect(service.authorizeAgentAction({
+        ownerId: "owner_1",
+        sessionId: "session_1",
+        action,
+        url: "https://docs.example.com/page?token=secret",
+        now: 2_000,
+      })).resolves.toBeDefined();
+    }
+
+    await expect(service.authorizeAgentAction({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      action: "screenshot",
+      url: "https://example.net/",
+      now: 2_000,
+    })).rejects.toThrow("Browser permission is required");
+    expect((await repo.listAuditEvents("owner_1")).filter((event) => event.eventType === "agent.access")).toEqual([
+      expect.objectContaining({ metadata: { sessionId: "session_1", action: "read_dom", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: "session_1", action: "screenshot", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: "session_1", action: "navigate", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: "session_1", action: "download", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: "session_1", action: "automate_input", host: "docs.example.com" } }),
+    ]);
+  });
+
+  it("exposes profile clear and grant routes with owner isolation", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const app = createBrowserRoutes({
+      getOwnerId: () => "owner_1",
+      service: new BrowserService({ repo }),
+    });
+
+    const clear = await app.request("/profiles/default/clear", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scopes: ["cookies", "savedPasswords"] }),
+    });
+    expect(clear.status).toBe(200);
+    await expect(clear.json()).resolves.toEqual({
+      profile: expect.objectContaining({
+        ownerId: "owner_1",
+        name: "default",
+        clearedScopes: ["cookies", "savedPasswords"],
+      }),
+    });
+
+    const grantRes = await app.request("/grants", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessionId: "session_1",
+        scopes: ["read_dom"],
+        domains: ["example.com"],
+      }),
+    });
+    expect(grantRes.status).toBe(200);
+    const grantBody = await grantRes.json() as { grant: { id: string } };
+
+    const list = await app.request("/grants");
+    await expect(list.json()).resolves.toEqual({
+      grants: [expect.objectContaining({ ownerId: "owner_1", domains: ["example.com"] })],
+    });
+
+    const revoke = await app.request(`/grants/${grantBody.grant.id}`, { method: "DELETE" });
+    expect(revoke.status).toBe(200);
+    await expect((await app.request("/grants")).json()).resolves.toEqual({ grants: [] });
+  });
+
+  it("stores tabs, downloads, and audit pages with owner filters", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo });
+    const app = createBrowserRoutes({
+      getOwnerId: () => "owner_1",
+      service,
+    });
+    const session = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      now: 1_000,
+    });
+    await service.createSession({
+      ownerId: "owner_2",
+      profileName: "default",
+      deviceId: "device_2",
+      surface: "canvas",
+      now: 1_000,
+    });
+
+    const tabCreate = await app.request(`/sessions/${session.session.id}/tabs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ targetUrl: "https://example.com/" }),
+    });
+    expect(tabCreate.status).toBe(200);
+    await expect((await app.request(`/sessions/${session.session.id}/tabs`)).json()).resolves.toEqual({
+      tabs: [expect.objectContaining({
+        ownerId: "owner_1",
+        sessionId: session.session.id,
+        url: "https://example.com/",
+      })],
+    });
+
+    const download = await service.createDownload({
+      ownerId: "owner_1",
+      sessionId: session.session.id,
+      filename: "report.pdf",
+      stagedPath: "/safe/staged/report.pdf",
+      now: 2_000,
+    });
+    await service.completeDownload({
+      ownerId: "owner_1",
+      downloadId: download.id,
+      completedPath: "/safe/downloads/report.pdf",
+      now: 3_000,
+    });
+    await service.createDownload({
+      ownerId: "owner_2",
+      sessionId: "session_other",
+      filename: "other.pdf",
+      now: 2_000,
+    });
+
+    await expect((await app.request("/downloads")).json()).resolves.toEqual({
+      downloads: [expect.objectContaining({
+        id: download.id,
+        ownerId: "owner_1",
+        state: "complete",
+        filename: "report.pdf",
+      })],
+    });
+
+    const audit = await app.request("/audit?limit=2");
+    const auditBody = await audit.json() as { events: Array<{ eventType: string; ownerId: string }>; nextCursor: string | null };
+    expect(auditBody.events).toHaveLength(2);
+    expect(auditBody.events.every((event) => event.ownerId === "owner_1")).toBe(true);
+    expect(auditBody.events.map((event) => event.eventType)).toContain("download.completed");
+    expect(auditBody.nextCursor).toEqual(expect.any(String));
+  });
+
+  it("closes sessions and deletes downloads through bounded mutating routes", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo });
+    const app = createBrowserRoutes({
+      getOwnerId: () => "owner_1",
+      service,
+    });
+    const session = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      now: 1_000,
+    });
+    const download = await service.createDownload({
+      ownerId: "owner_1",
+      sessionId: session.session.id,
+      filename: "report.pdf",
+      now: 2_000,
+    });
+
+    const close = await app.request(`/sessions/${session.session.id}/close`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ reason: "idle" }),
+    });
+    expect(close.status).toBe(200);
+    await expect(close.json()).resolves.toEqual({
+      session: expect.objectContaining({ state: "hibernated" }),
+    });
+
+    const deleted = await app.request(`/downloads/${download.id}`, { method: "DELETE" });
+    expect(deleted.status).toBe(200);
+    await expect((await app.request("/downloads")).json()).resolves.toEqual({ downloads: [] });
+  });
+
+  it("verifies owner VPS handoff tokens before bootstrapping sessions", async () => {
+    const { privateKey, publicKey } = await generateRsa("rsa", { modulusLength: 2048 });
+    const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+    const token = await signBrowserHandoffToken({
+      privateKey,
+      keyId: "browser-key-1",
+      ownerId: "owner_1",
+      deviceId: "device_1",
+      target: "https://example.com/from-handoff",
+      nonce: "nonce_route",
+      now: Date.now(),
+    });
+    const repo = new InMemoryBrowserRepository();
+    const app = createBrowserRoutes({
+      getOwnerId: () => "owner_1",
+      handoffPublicKey: publicKeyPem,
+      service: new BrowserService({ repo }),
+    });
+
+    const res = await app.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        profileName: "default",
+        targetUrl: "https://ignored.example/",
+        handoffToken: token,
+        surface: "standalone",
+        deviceId: "device_1",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      session: { ownerId: "owner_1" },
+    });
+    expect(await repo.listAuditEvents("owner_1")).toEqual([
+      expect.objectContaining({ eventType: "session.created" }),
+      expect.objectContaining({
+        eventType: "navigation.attempted",
+        metadata: expect.objectContaining({ url: "https://example.com/from-handoff" }),
+      }),
+    ]);
+  });
+});

--- a/tests/browser/routes.test.ts
+++ b/tests/browser/routes.test.ts
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import { InMemoryBrowserRepository } from "../../packages/gateway/src/browser/repository.js";
 import { createBrowserRoutes } from "../../packages/gateway/src/browser/routes.js";
 import { BrowserService } from "../../packages/gateway/src/browser/service.js";
+import { BrowserStreamHub, browserTakenOverMessage } from "../../packages/gateway/src/browser/ws.js";
 import { signBrowserHandoffToken } from "../../packages/gateway/src/handoff-token.js";
 
 const generateRsa = promisify(generateKeyPair);
@@ -119,14 +120,20 @@ describe("Browser gateway routes", () => {
 
     expect(second.session.takeoverRequired).toBe(true);
     expect(second.session.lockDeviceId).toBe("device_1");
+    expect(second.streamToken).toBeNull();
+    expect(second.wsUrl).toBeNull();
   });
 
   it("takes over a locked session, marks the old session recoverable, and audits", async () => {
     const repo = new InMemoryBrowserRepository();
     const service = new BrowserService({ repo, streamTokenSecret: "test-stream-secret" });
+    const delivered: string[] = [];
+    const closed: string[] = [];
+    const streamHub = new BrowserStreamHub();
     const app = createBrowserRoutes({
       getOwnerId: () => "owner_1",
       service,
+      streamHub,
     });
     const first = await service.createSession({
       ownerId: "owner_1",
@@ -134,6 +141,19 @@ describe("Browser gateway routes", () => {
       deviceId: "device_1",
       surface: "canvas",
       now: 1_000,
+    });
+    streamHub.register({
+      id: "old_stream",
+      ownerId: "owner_1",
+      sessionId: first.session.id,
+      sender: {
+        send(message) {
+          delivered.push(message);
+        },
+        close() {
+          closed.push("old_stream");
+        },
+      },
     });
 
     const takeover = await app.request(`/sessions/${first.session.id}/takeover`, {
@@ -150,6 +170,9 @@ describe("Browser gateway routes", () => {
       ownerId: "owner_1",
       sessionId: body.session.id,
     });
+    expect(streamHub.size()).toBe(0);
+    expect(closed).toEqual(["old_stream"]);
+    expect(JSON.parse(delivered[0] ?? "{}")).toEqual(browserTakenOverMessage());
     expect(await repo.getSession("owner_1", first.session.id)).toMatchObject({ state: "recoverable" });
     expect((await repo.listAuditEvents("owner_1")).map((event) => event.eventType)).toEqual([
       "session.created",

--- a/tests/browser/routes.test.ts
+++ b/tests/browser/routes.test.ts
@@ -446,6 +446,12 @@ describe("Browser gateway routes", () => {
         state: "complete",
         filename: "report.pdf",
       })],
+      nextCursor: null,
+    });
+
+    await expect((await app.request("/downloads?limit=1&cursor=0")).json()).resolves.toEqual({
+      downloads: [expect.objectContaining({ id: download.id })],
+      nextCursor: null,
     });
 
     const audit = await app.request("/audit?limit=2");
@@ -489,7 +495,8 @@ describe("Browser gateway routes", () => {
 
     const deleted = await app.request(`/downloads/${download.id}`, { method: "DELETE" });
     expect(deleted.status).toBe(200);
-    await expect((await app.request("/downloads")).json()).resolves.toEqual({ downloads: [] });
+    await expect((await app.request("/downloads")).json()).resolves.toEqual({ downloads: [], nextCursor: null });
+    expect((await repo.listAuditEvents("owner_1")).map((event) => event.eventType)).toContain("download.deleted");
   });
 
   it("verifies owner VPS handoff tokens before bootstrapping sessions", async () => {

--- a/tests/browser/routes.test.ts
+++ b/tests/browser/routes.test.ts
@@ -214,6 +214,48 @@ describe("Browser gateway routes", () => {
     expect((await repo.listSessions("owner_1"))[0]?.state).toBe("closed");
   });
 
+  it("notifies active streams when profile clear closes sessions", async () => {
+    const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo });
+    const streamHub = new BrowserStreamHub();
+    const closed: string[] = [];
+    const sent: string[] = [];
+    const app = createBrowserRoutes({
+      getOwnerId: () => "owner_1",
+      service,
+      streamHub,
+    });
+    const session = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+    });
+    streamHub.register({
+      id: "stream_1",
+      ownerId: "owner_1",
+      sessionId: session.session.id,
+      sender: {
+        send(message) { sent.push(message); },
+        close() { closed.push("stream_1"); },
+      },
+    });
+
+    const clear = await app.request("/profiles/default/clear", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scopes: ["cookies"] }),
+    });
+
+    expect(clear.status).toBe(200);
+    expect(streamHub.size()).toBe(0);
+    expect(closed).toEqual(["stream_1"]);
+    expect(JSON.parse(sent[0] ?? "{}")).toMatchObject({
+      type: "stream.error",
+      payload: { code: "session_closed" },
+    });
+  });
+
   it("accepts every profile clear scope including browser stores and saved passwords", async () => {
     const service = new BrowserService({ repo: new InMemoryBrowserRepository() });
     const scopes = [
@@ -513,7 +555,6 @@ describe("Browser gateway routes", () => {
     });
     const repo = new InMemoryBrowserRepository();
     const app = createBrowserRoutes({
-      getOwnerId: () => "owner_1",
       handoffPublicKey: publicKeyPem,
       service: new BrowserService({ repo }),
     });

--- a/tests/browser/routes.test.ts
+++ b/tests/browser/routes.test.ts
@@ -68,6 +68,20 @@ describe("Browser gateway routes", () => {
     })).toThrow("invalid_browser_stream_token");
   });
 
+  it("rejects handoff-marked session bootstrap without a handoff token", async () => {
+    const app = createBrowserRoutes({ getOwnerId: () => "owner_1" });
+    const res = await app.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-browser-handoff": "1" },
+      body: JSON.stringify({ profileName: "default", surface: "standalone", deviceId: "device_1" }),
+    });
+
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "invalid_handoff", message: "Browser request is invalid." },
+    });
+    expect(res.status).toBe(401);
+  });
+
   it("applies body limits before mutating session routes", async () => {
     const app = createBrowserRoutes();
     const body = JSON.stringify({ profileName: "x".repeat(20_000), surface: "canvas", deviceId: "device" });
@@ -285,9 +299,16 @@ describe("Browser gateway routes", () => {
     const repo = new InMemoryBrowserRepository();
     const service = new BrowserService({ repo });
     const now = 1_000;
+    const session = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      now,
+    });
     const grant = await service.createGrant({
       ownerId: "owner_1",
-      sessionId: "session_1",
+      sessionId: session.session.id,
       scopes: ["read_dom", "automate_input"],
       domains: ["example.com"],
       now,
@@ -311,11 +332,38 @@ describe("Browser gateway routes", () => {
     })).rejects.toThrow("invalid_grant_domain");
   });
 
+  it("rejects grant expiry beyond the session-bound maximum", async () => {
+    const service = new BrowserService({ repo: new InMemoryBrowserRepository() });
+    const session = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      now: 1_000,
+    });
+
+    await expect(service.createGrant({
+      ownerId: "owner_1",
+      sessionId: session.session.id,
+      scopes: ["read_dom"],
+      domains: ["example.com"],
+      now: 1_000,
+      expiresAt: new Date(1_000 + 8 * 60 * 60 * 1000 + 1).toISOString(),
+    })).rejects.toThrow("invalid_grant_expiry");
+  });
+
   it("enforces agent action grants by scope and domain", async () => {
     const service = new BrowserService({ repo: new InMemoryBrowserRepository() });
+    const session = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      now: 1_000,
+    });
     await service.createGrant({
       ownerId: "owner_1",
-      sessionId: "session_1",
+      sessionId: session.session.id,
       scopes: ["navigate"],
       domains: ["example.com"],
       now: 1_000,
@@ -323,34 +371,49 @@ describe("Browser gateway routes", () => {
 
     await expect(service.authorizeAgentAction({
       ownerId: "owner_1",
-      sessionId: "session_1",
+      sessionId: session.session.id,
       action: "navigate",
       url: "https://example.com/page",
       now: 2_000,
     })).resolves.toBeDefined();
     await expect(service.authorizeAgentAction({
       ownerId: "owner_1",
-      sessionId: "session_1",
+      sessionId: session.session.id,
       action: "read_dom",
       url: "https://example.com/page",
       now: 2_000,
     })).rejects.toThrow("Browser permission is required");
     await expect(service.authorizeAgentAction({
       ownerId: "owner_1",
-      sessionId: "session_1",
+      sessionId: session.session.id,
       action: "navigate",
       url: "https://evil.example.net/",
       now: 2_000,
     })).rejects.toThrow("Browser permission is required");
+    await service.closeSession({ ownerId: "owner_1", sessionId: session.session.id, state: "closed", now: 3_000 });
+    await expect(service.authorizeAgentAction({
+      ownerId: "owner_1",
+      sessionId: session.session.id,
+      action: "navigate",
+      url: "https://example.com/page",
+      now: 4_000,
+    })).rejects.toThrow("Browser session was not found");
   });
 
   it("enforces every agent browser grant scope and emits redacted access audit", async () => {
     const repo = new InMemoryBrowserRepository();
     const service = new BrowserService({ repo });
     const scopes = ["read_dom", "screenshot", "navigate", "download", "automate_input"] as const;
+    const session = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+      now: 1_000,
+    });
     await service.createGrant({
       ownerId: "owner_1",
-      sessionId: "session_1",
+      sessionId: session.session.id,
       scopes: [...scopes],
       domains: ["*.example.com"],
       now: 1_000,
@@ -359,7 +422,7 @@ describe("Browser gateway routes", () => {
     for (const action of scopes) {
       await expect(service.authorizeAgentAction({
         ownerId: "owner_1",
-        sessionId: "session_1",
+        sessionId: session.session.id,
         action,
         url: "https://docs.example.com/page?token=secret",
         now: 2_000,
@@ -368,25 +431,32 @@ describe("Browser gateway routes", () => {
 
     await expect(service.authorizeAgentAction({
       ownerId: "owner_1",
-      sessionId: "session_1",
+      sessionId: session.session.id,
       action: "screenshot",
       url: "https://example.net/",
       now: 2_000,
     })).rejects.toThrow("Browser permission is required");
     expect((await repo.listAuditEvents("owner_1")).filter((event) => event.eventType === "agent.access")).toEqual([
-      expect.objectContaining({ metadata: { sessionId: "session_1", action: "read_dom", host: "docs.example.com" } }),
-      expect.objectContaining({ metadata: { sessionId: "session_1", action: "screenshot", host: "docs.example.com" } }),
-      expect.objectContaining({ metadata: { sessionId: "session_1", action: "navigate", host: "docs.example.com" } }),
-      expect.objectContaining({ metadata: { sessionId: "session_1", action: "download", host: "docs.example.com" } }),
-      expect.objectContaining({ metadata: { sessionId: "session_1", action: "automate_input", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: session.session.id, action: "read_dom", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: session.session.id, action: "screenshot", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: session.session.id, action: "navigate", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: session.session.id, action: "download", host: "docs.example.com" } }),
+      expect.objectContaining({ metadata: { sessionId: session.session.id, action: "automate_input", host: "docs.example.com" } }),
     ]);
   });
 
   it("exposes profile clear and grant routes with owner isolation", async () => {
     const repo = new InMemoryBrowserRepository();
+    const service = new BrowserService({ repo });
     const app = createBrowserRoutes({
       getOwnerId: () => "owner_1",
-      service: new BrowserService({ repo }),
+      service,
+    });
+    await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
     });
 
     const clear = await app.request("/profiles/default/clear", {
@@ -402,12 +472,18 @@ describe("Browser gateway routes", () => {
         clearedScopes: ["cookies", "savedPasswords"],
       }),
     });
+    const session = await service.createSession({
+      ownerId: "owner_1",
+      profileName: "default",
+      deviceId: "device_1",
+      surface: "canvas",
+    });
 
     const grantRes = await app.request("/grants", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        sessionId: "session_1",
+        sessionId: session.session.id,
         scopes: ["read_dom"],
         domains: ["example.com"],
       }),

--- a/tests/browser/ws.test.ts
+++ b/tests/browser/ws.test.ts
@@ -180,6 +180,30 @@ describe("Browser stream protocol", () => {
     expect(JSON.parse(delivered[0] ?? "{}")).toEqual(browserTakenOverMessage());
   });
 
+  it("notifies and closes old streams after takeover", () => {
+    const delivered: string[] = [];
+    const closed: string[] = [];
+    const hub = new BrowserStreamHub();
+    hub.register({
+      id: "old",
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      sender: {
+        send(message) {
+          delivered.push(message);
+        },
+        close() {
+          closed.push("old");
+        },
+      },
+    });
+
+    expect(hub.notifySessionTakenOver("session_1")).toBe(1);
+    expect(hub.size()).toBe(0);
+    expect(closed).toEqual(["old"]);
+    expect(JSON.parse(delivered[0] ?? "{}")).toEqual(browserTakenOverMessage());
+  });
+
   it("drains all browser streams on shutdown", () => {
     const sent: string[] = [];
     const closed: string[] = [];

--- a/tests/browser/ws.test.ts
+++ b/tests/browser/ws.test.ts
@@ -73,6 +73,7 @@ describe("Browser stream protocol", () => {
           protocolVersion: BROWSER_STREAM_PROTOCOL_VERSION,
           sessionId: "session_1",
           mediaMode: "webrtc",
+          turnCredentialExpiresAt: expect.any(String),
         }),
       },
       {
@@ -91,6 +92,20 @@ describe("Browser stream protocol", () => {
       {
         type: "surface.focused",
         payload: { surfaceId: "surface_1" },
+      },
+    ]);
+  });
+
+  it("rejects TURN configuration without a relay secret", () => {
+    const controller = new BrowserStreamController({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      turnUrls: ["turn:turn.matrix.test:3478?transport=udp"],
+    });
+    expect(controller.handleClientMessage(JSON.stringify(hello))).toEqual([
+      {
+        type: "stream.error",
+        payload: { code: "media_policy", message: "Browser media relay is unavailable." },
       },
     ]);
   });

--- a/tests/browser/ws.test.ts
+++ b/tests/browser/ws.test.ts
@@ -47,6 +47,16 @@ describe("Browser stream protocol", () => {
     }))).toThrow();
   });
 
+  it("accepts bounded browser navigation commands on the authenticated stream", () => {
+    expect(parseBrowserClientMessage({
+      type: "browser.navigate",
+      payload: { targetUrl: "https://example.com/docs", surface: "standalone" },
+    })).toEqual({
+      type: "browser.navigate",
+      payload: { targetUrl: "https://example.com/docs", surface: "standalone" },
+    });
+  });
+
   it("documents the bounded fallback-frame queue contract", () => {
     expect(MAX_FALLBACK_FRAME_QUEUE).toBe(3);
   });
@@ -115,11 +125,11 @@ describe("Browser stream protocol", () => {
     const controller = new BrowserStreamController({ ownerId: "owner_1", sessionId: "session_1" });
     expect(controller.handleClientMessage(JSON.stringify({
       type: "media.ice",
-      payload: { candidate: "candidate:1 1 udp 1 203.0.113.10 5000 typ relay" },
+      payload: { candidate: "candidate:1 1 udp 1 93.184.216.34 5000 typ relay" },
     }))).toEqual([
       {
         type: "media.ice.accepted",
-        payload: { candidate: "candidate:1 1 udp 1 203.0.113.10 5000 typ relay" },
+        payload: { candidate: "candidate:1 1 udp 1 93.184.216.34 5000 typ relay" },
       },
     ]);
     expect(() => controller.handleClientMessage(JSON.stringify({

--- a/tests/browser/ws.test.ts
+++ b/tests/browser/ws.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSER_STREAM_PROTOCOL_VERSION,
+  MAX_FALLBACK_FRAME_QUEUE,
+  MAX_STREAM_MESSAGE_BYTES,
+  parseBrowserClientMessage,
+} from "../../packages/mcp-browser/src/stream-protocol.js";
+import { BrowserStreamController, BrowserStreamHub, browserTakenOverMessage, parseBrowserWsMessage } from "../../packages/gateway/src/browser/ws.js";
+
+const hello = {
+  type: "stream.hello",
+  payload: {
+    protocolVersion: BROWSER_STREAM_PROTOCOL_VERSION,
+    surfaceId: "surface_1",
+    surface: "canvas",
+    deviceId: "device_1",
+    viewport: { width: 1280, height: 720, deviceScaleFactor: 1 },
+    media: {
+      preferredMode: "webrtc",
+      audio: true,
+      fallbackFrames: true,
+      iceTransportPolicy: "relay",
+    },
+  },
+} as const;
+
+describe("Browser stream protocol", () => {
+  it("accepts the current stream protocol version", () => {
+    expect(parseBrowserClientMessage(hello)).toEqual(hello);
+  });
+
+  it("rejects unsupported protocol versions with upgrade_required", () => {
+    expect(() => parseBrowserClientMessage({
+      ...hello,
+      payload: { ...hello.payload, protocolVersion: BROWSER_STREAM_PROTOCOL_VERSION + 1 },
+    })).toThrow("upgrade_required");
+  });
+
+  it("rejects oversize WebSocket frames before parsing", () => {
+    expect(() => parseBrowserWsMessage(Buffer.alloc(MAX_STREAM_MESSAGE_BYTES + 1))).toThrow("message_too_large");
+  });
+
+  it("validates frame payloads through bounded Zod schemas", () => {
+    expect(() => parseBrowserWsMessage(JSON.stringify({
+      type: "input.paste",
+      payload: { text: "x".repeat(16 * 1024 + 1) },
+    }))).toThrow();
+  });
+
+  it("documents the bounded fallback-frame queue contract", () => {
+    expect(MAX_FALLBACK_FRAME_QUEUE).toBe(3);
+  });
+
+  it("has an explicit takeover server message", () => {
+    expect(browserTakenOverMessage()).toEqual({
+      type: "stream.taken_over",
+      payload: { message: "Browser was opened on another device." },
+    });
+  });
+
+  it("negotiates stream ready, server media offer, and focused surface messages", () => {
+    const controller = new BrowserStreamController({
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      turnUrls: ["turn:turn.matrix.test:3478?transport=udp"],
+      turnSecret: "turn-secret",
+      createOfferSdp: () => "v=0\r\ns=browser\r\nt=0 0\r\n",
+    });
+    expect(controller.handleClientMessage(JSON.stringify(hello))).toEqual([
+      {
+        type: "stream.ready",
+        payload: expect.objectContaining({
+          protocolVersion: BROWSER_STREAM_PROTOCOL_VERSION,
+          sessionId: "session_1",
+          mediaMode: "webrtc",
+        }),
+      },
+      {
+        type: "media.offer",
+        payload: expect.objectContaining({
+          sdp: "v=0\r\ns=browser\r\nt=0 0\r\n",
+          iceTransportPolicy: "relay",
+          iceServers: [
+            expect.objectContaining({
+              urls: ["turn:turn.matrix.test:3478?transport=udp"],
+              credential: "turn-secret",
+            }),
+          ],
+        }),
+      },
+      {
+        type: "surface.focused",
+        payload: { surfaceId: "surface_1" },
+      },
+    ]);
+  });
+
+  it("accepts only relay ICE candidates from clients", () => {
+    const controller = new BrowserStreamController({ ownerId: "owner_1", sessionId: "session_1" });
+    expect(controller.handleClientMessage(JSON.stringify({
+      type: "media.ice",
+      payload: { candidate: "candidate:1 1 udp 1 203.0.113.10 5000 typ relay" },
+    }))).toEqual([
+      {
+        type: "media.ice.accepted",
+        payload: { candidate: "candidate:1 1 udp 1 203.0.113.10 5000 typ relay" },
+      },
+    ]);
+    expect(() => controller.handleClientMessage(JSON.stringify({
+      type: "media.ice",
+      payload: { candidate: "candidate:1 1 udp 1 10.0.0.2 5000 typ host" },
+    }))).toThrow("media_policy");
+  });
+
+  it("rejects input from stale focus surfaces", () => {
+    const controller = new BrowserStreamController({ ownerId: "owner_1", sessionId: "session_1" });
+    controller.handleClientMessage(JSON.stringify(hello));
+    controller.handleClientMessage(JSON.stringify({
+      type: "surface.focus",
+      payload: { surfaceId: "surface_2", reason: "programmatic" },
+    }), { surfaceId: "surface_2" });
+
+    expect(controller.handleClientMessage(JSON.stringify({
+      type: "input.pointer",
+      payload: { kind: "down", x: 1, y: 1, button: "left", modifiers: [] },
+    }), { surfaceId: "surface_1" })).toEqual([
+      {
+        type: "stream.error",
+        payload: { code: "stale_focus", message: "Browser input came from a background surface." },
+      },
+    ]);
+  });
+
+  it("evicts stale streams and closes them", () => {
+    let now = 1_000;
+    const closed: string[] = [];
+    const hub = new BrowserStreamHub({ staleMs: 100, now: () => now });
+    hub.register({
+      id: "conn_1",
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      sender: {
+        send() {},
+        close: () => closed.push("conn_1"),
+      },
+    });
+
+    now = 1_101;
+    expect(hub.sweepStale()).toBe(1);
+    expect(hub.size()).toBe(0);
+    expect(closed).toEqual(["conn_1"]);
+  });
+
+  it("evicts failed broadcast senders while continuing delivery", () => {
+    const delivered: string[] = [];
+    const hub = new BrowserStreamHub();
+    hub.register({
+      id: "bad",
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      sender: {
+        send() {
+          throw new Error("closed");
+        },
+      },
+    });
+    hub.register({
+      id: "good",
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      sender: {
+        send(message) {
+          delivered.push(message);
+        },
+      },
+    });
+
+    expect(hub.broadcastSession("session_1", browserTakenOverMessage())).toBe(1);
+    expect(hub.size()).toBe(1);
+    expect(JSON.parse(delivered[0] ?? "{}")).toEqual(browserTakenOverMessage());
+  });
+
+  it("drains all browser streams on shutdown", () => {
+    const sent: string[] = [];
+    const closed: string[] = [];
+    const hub = new BrowserStreamHub();
+    hub.register({
+      id: "conn_1",
+      ownerId: "owner_1",
+      sessionId: "session_1",
+      sender: {
+        send(message) {
+          sent.push(message);
+        },
+        close() {
+          closed.push("conn_1");
+        },
+      },
+    });
+
+    hub.closeAll();
+    expect(hub.size()).toBe(0);
+    expect(closed).toEqual(["conn_1"]);
+    expect(JSON.parse(sent[0] ?? "{}")).toMatchObject({
+      type: "stream.error",
+      payload: { code: "shutdown" },
+    });
+  });
+});

--- a/tests/browser/ws.test.ts
+++ b/tests/browser/ws.test.ts
@@ -84,7 +84,8 @@ describe("Browser stream protocol", () => {
           iceServers: [
             expect.objectContaining({
               urls: ["turn:turn.matrix.test:3478?transport=udp"],
-              credential: "turn-secret",
+              username: expect.stringContaining(":owner_1:session_1:"),
+              credential: expect.not.stringMatching(/^turn-secret$/),
             }),
           ],
         }),

--- a/tests/gateway/app-runtime/build-cache.test.ts
+++ b/tests/gateway/app-runtime/build-cache.test.ts
@@ -91,6 +91,16 @@ describe("build-cache", () => {
       expect(after).not.toBe(before);
     });
 
+    it("does not recurse forever through symlinked source directory cycles", async () => {
+      await mkdir(join(tmpDir, "src"), { recursive: true });
+      await writeFile(join(tmpDir, "src", "index.ts"), "export const value = 1;");
+      await symlink(tmpDir, join(tmpDir, "src", "loop"));
+
+      const hash = await hashSources(tmpDir, ["src/**/*.ts"]);
+
+      expect(hash.length).toBeGreaterThan(0);
+    });
+
     it("hashes symlinked source files matched by app source globs", async () => {
       await mkdir(join(tmpDir, "src"), { recursive: true });
       await writeFile(join(tmpDir, "shared.ts"), "export const value = 1;");

--- a/tests/gateway/app-runtime/build-cache.test.ts
+++ b/tests/gateway/app-runtime/build-cache.test.ts
@@ -91,6 +91,16 @@ describe("build-cache", () => {
       expect(after).not.toBe(before);
     });
 
+    it("hashes symlinked source files matched by app source globs", async () => {
+      await mkdir(join(tmpDir, "src"), { recursive: true });
+      await writeFile(join(tmpDir, "shared.ts"), "export const value = 1;");
+      await symlink(join(tmpDir, "shared.ts"), join(tmpDir, "src", "linked.ts"));
+      const before = await hashSources(tmpDir, ["src/**/*.ts"]);
+      await writeFile(join(tmpDir, "shared.ts"), "export const value = 2;");
+      const after = await hashSources(tmpDir, ["src/**/*.ts"]);
+      expect(after).not.toBe(before);
+    });
+
     it("ignores dependency and output trees outside source glob roots", async () => {
       await mkdir(join(tmpDir, "src"), { recursive: true });
       await mkdir(join(tmpDir, "node_modules", "pkg"), { recursive: true });

--- a/tests/gateway/app-runtime/build-cache.test.ts
+++ b/tests/gateway/app-runtime/build-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -60,6 +60,26 @@ describe("build-cache", () => {
       await writeFile(join(tmpDir, "src", "index.ts"), "export {};");
       const h = await hashSources(tmpDir, ["src/**"]);
       expect(h.length).toBeGreaterThan(0);
+    });
+
+    it("matches top-level files for double-star globs and question wildcards", async () => {
+      await mkdir(join(tmpDir, "src"), { recursive: true });
+      await writeFile(join(tmpDir, "src", "index.ts"), "export const value = 1;");
+      await writeFile(join(tmpDir, "src", "page1.ts"), "export const page = 1;");
+      const before = await hashSources(tmpDir, ["src/**/*.ts", "src/page?.ts"]);
+      await writeFile(join(tmpDir, "src", "index.ts"), "export const value = 2;");
+      const after = await hashSources(tmpDir, ["src/**/*.ts", "src/page?.ts"]);
+      expect(after).not.toBe(before);
+    });
+
+    it("follows symlinked source directories", async () => {
+      await mkdir(join(tmpDir, "real-src"), { recursive: true });
+      await writeFile(join(tmpDir, "real-src", "index.ts"), "export const value = 1;");
+      await symlink(join(tmpDir, "real-src"), join(tmpDir, "src"));
+      const before = await hashSources(tmpDir, ["src/**"]);
+      await writeFile(join(tmpDir, "real-src", "index.ts"), "export const value = 2;");
+      const after = await hashSources(tmpDir, ["src/**"]);
+      expect(after).not.toBe(before);
     });
 
     it("ignores dependency and output trees outside source glob roots", async () => {

--- a/tests/gateway/app-runtime/build-cache.test.ts
+++ b/tests/gateway/app-runtime/build-cache.test.ts
@@ -72,6 +72,15 @@ describe("build-cache", () => {
       expect(after).not.toBe(before);
     });
 
+    it("recurses root-relative double-star globs", async () => {
+      await mkdir(join(tmpDir, "pages"), { recursive: true });
+      await writeFile(join(tmpDir, "pages", "index.ts"), "export const page = 1;");
+      const before = await hashSources(tmpDir, ["**/*.ts"]);
+      await writeFile(join(tmpDir, "pages", "index.ts"), "export const page = 2;");
+      const after = await hashSources(tmpDir, ["**/*.ts"]);
+      expect(after).not.toBe(before);
+    });
+
     it("follows symlinked source directories", async () => {
       await mkdir(join(tmpDir, "real-src"), { recursive: true });
       await writeFile(join(tmpDir, "real-src", "index.ts"), "export const value = 1;");

--- a/tests/gateway/app-runtime/build-cache.test.ts
+++ b/tests/gateway/app-runtime/build-cache.test.ts
@@ -62,6 +62,21 @@ describe("build-cache", () => {
       expect(h.length).toBeGreaterThan(0);
     });
 
+    it("ignores dependency and output trees outside source glob roots", async () => {
+      await mkdir(join(tmpDir, "src"), { recursive: true });
+      await mkdir(join(tmpDir, "node_modules", "pkg"), { recursive: true });
+      await mkdir(join(tmpDir, "dist"), { recursive: true });
+      await writeFile(join(tmpDir, "src", "index.ts"), "export const value = 1;");
+      await writeFile(join(tmpDir, "node_modules", "pkg", "index.ts"), "ignored");
+      await writeFile(join(tmpDir, "dist", "bundle.js"), "ignored");
+
+      const before = await hashSources(tmpDir, ["src/**", "public/**", "*.config.*", "index.html", "matrix.json"]);
+      await writeFile(join(tmpDir, "node_modules", "pkg", "index.ts"), "ignored changed");
+      await writeFile(join(tmpDir, "dist", "bundle.js"), "ignored changed");
+
+      expect(await hashSources(tmpDir, ["src/**", "public/**", "*.config.*", "index.html", "matrix.json"])).toBe(before);
+    });
+
     it("returns empty hash when no files match", async () => {
       const h = await hashSources(tmpDir, ["*.nonexistent"]);
       expect(typeof h).toBe("string");

--- a/tests/gateway/auth.test.ts
+++ b/tests/gateway/auth.test.ts
@@ -6,16 +6,26 @@ import { mapRequestPrincipalError, requireRequestPrincipal, isRequestPrincipalEr
 const WEBHOOK_PROVIDERS = new Set(["twilio", "mock"]);
 const TEST_TOKEN = "test-bearer-token-for-auth-tests";
 
-function mockContext(path: string, authHeader?: string, queryToken?: string, ip?: string) {
+function mockContext(
+  path: string,
+  authHeader?: string,
+  queryToken?: string,
+  ip?: string,
+  opts: { method?: string; headers?: Record<string, string> } = {},
+) {
   const url = queryToken
     ? `http://localhost:4000${path}?token=${queryToken}`
     : `http://localhost:4000${path}`;
+  const headers = new Map(Object.entries(opts.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value]));
   return {
     req: {
       path,
       url,
+      method: opts.method ?? "GET",
       header: (name: string) => {
         const lower = name.toLowerCase();
+        const custom = headers.get(lower);
+        if (custom) return custom;
         if (name === "Authorization") return authHeader;
         if ((name === "X-Forwarded-For" || lower === "x-forwarded-for") && ip) return ip;
         return undefined;
@@ -192,10 +202,38 @@ describe("T133: Auth token middleware", () => {
     const mw = authMiddleware("secret-token");
     let nextCalled = false;
     await mw(
-      mockContext("/api/browser/sessions", undefined, undefined, "10.0.0.4"),
+      mockContext("/api/browser/sessions", undefined, undefined, "10.0.0.4", {
+        method: "POST",
+        headers: { "x-browser-handoff": "1" },
+      }),
       async () => { nextCalled = true; },
     );
     expect(nextCalled).toBe(true);
+  });
+
+  it("rejects non-POST browser handoff bootstrap without bearer auth", async () => {
+    const mw = authMiddleware("secret-token");
+    let nextCalled = false;
+    const result = await mw(
+      mockContext("/api/browser/sessions", undefined, undefined, "10.0.0.5", {
+        method: "GET",
+        headers: { "x-browser-handoff": "1" },
+      }),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(false);
+    expect(result?.status).toBe(401);
+  });
+
+  it("rejects browser session POST bootstrap without the handoff marker", async () => {
+    const mw = authMiddleware("secret-token");
+    let nextCalled = false;
+    const result = await mw(
+      mockContext("/api/browser/sessions", undefined, undefined, "10.0.0.6", { method: "POST" }),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(false);
+    expect(result?.status).toBe(401);
   });
 
   it("rejects REST endpoint with query token (only WS allowed)", async () => {

--- a/tests/gateway/auth.test.ts
+++ b/tests/gateway/auth.test.ts
@@ -188,6 +188,16 @@ describe("T133: Auth token middleware", () => {
     expect(nextCalled).toBe(true);
   });
 
+  it("lets browser session bootstrap reach route-level handoff token verification", async () => {
+    const mw = authMiddleware("secret-token");
+    let nextCalled = false;
+    await mw(
+      mockContext("/api/browser/sessions", undefined, undefined, "10.0.0.4"),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
   it("rejects REST endpoint with query token (only WS allowed)", async () => {
     const mw = authMiddleware("secret-token");
     let nextCalled = false;

--- a/tests/gateway/auth.test.ts
+++ b/tests/gateway/auth.test.ts
@@ -168,6 +168,26 @@ describe("T133: Auth token middleware", () => {
     expect(nextCalled).toBe(true);
   });
 
+  it("lets browser WebSocket paths reach route-level signed stream-token verification", async () => {
+    const mw = authMiddleware("secret-token");
+    let nextCalled = false;
+    await mw(
+      mockContext("/api/browser/sessions/browser_session_1/ws", undefined, "not-the-global-token", "10.0.0.4"),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
+  it("does not require the global query token for browser WebSocket subprotocol auth", async () => {
+    const mw = authMiddleware("secret-token");
+    let nextCalled = false;
+    await mw(
+      mockContext("/api/browser/sessions/browser_session_1/ws", undefined, undefined, "10.0.0.4"),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
   it("rejects REST endpoint with query token (only WS allowed)", async () => {
     const mw = authMiddleware("secret-token");
     let nextCalled = false;

--- a/tests/mcp-browser/browser-tool.test.ts
+++ b/tests/mcp-browser/browser-tool.test.ts
@@ -363,6 +363,51 @@ describe("Browser Tool (composite action dispatch)", () => {
     });
   });
 
+  describe("grant authorization", () => {
+    it("authorizes navigation and input actions before mutating the shared runtime", async () => {
+      const authorizeAgentAction = vi.fn().mockResolvedValue(undefined);
+      const tool = createBrowserTool({
+        homePath,
+        launcher: launcher as never,
+        idleTimeoutMs: 300_000,
+        resolveHostname: async () => ["93.184.216.34"],
+        authorizeAgentAction,
+      });
+
+      await expect(tool.execute({ action: "navigate", url: "https://example.com" })).resolves.toMatchObject({ success: true });
+      await expect(tool.execute({ action: "click", selector: "#go" })).resolves.toMatchObject({ success: true });
+
+      expect(authorizeAgentAction).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        action: "navigate",
+        scope: "navigate",
+        profile: "default",
+        url: "https://example.com/",
+        sessionId: expect.stringMatching(/^session_/),
+      }));
+      expect(authorizeAgentAction).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        action: "click",
+        scope: "automate_input",
+        url: "https://example.com",
+      }));
+      expect(mockPage.click).toHaveBeenCalledWith("#go");
+    });
+
+    it("blocks action side effects when the grant authorizer rejects", async () => {
+      const tool = createBrowserTool({
+        homePath,
+        launcher: launcher as never,
+        idleTimeoutMs: 300_000,
+        resolveHostname: async () => ["93.184.216.34"],
+        authorizeAgentAction: vi.fn().mockRejectedValue(new Error("grant required")),
+      });
+
+      const result = await tool.execute({ action: "navigate", url: "https://example.com" });
+
+      expect(result).toMatchObject({ success: false, error: "Browser action failed" });
+      expect(mockPage.goto).not.toHaveBeenCalled();
+    });
+  });
+
   describe("snapshot", () => {
     it("returns accessibility tree", async () => {
       await execute({ action: "launch" });

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isPublicShellPath } from "../../shell/src/lib/proxy-routes";
+import { isGatewayProxyPath, isPublicShellPath } from "../../shell/src/lib/proxy-routes";
 
 /**
  * Unit tests for the proxy.ts auth logic.
@@ -83,6 +83,8 @@ describe("proxy auth: route classification", () => {
     expect(isGatewayProxy("/")).toBe(false);
     expect(isGatewayProxy("/settings")).toBe(false);
     expect(isGatewayProxy("/health")).toBe(false);
+    expect(isGatewayProxyPath("/browser/google.com")).toBe(false);
+    expect(isGatewayProxyPath("/browser/https://example.com")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add Browser REST routes, stream WebSocket controller, stream auth handling, route registration, shutdown drains, and gateway export surfaces.
- Preserve current mainline server behavior while applying the Browser-specific route and typecheck changes.

## Tests
- bun run test -- tests/browser/focus-lease.test.ts tests/browser/routes.test.ts tests/browser/ws.test.ts tests/gateway/auth.test.ts tests/gateway/app-runtime/build-cache.test.ts tests/mcp-browser/browser-tool.test.ts tests/shell/proxy-auth.test.ts
- bun run typecheck
- bun run check:patterns

## Invariants
- Source of truth: Browser REST/WS routes delegate persistence to the owner-scoped Browser service/repository from the prior slice.
- Lock/transaction scope: HTTP handlers validate and authorize before service calls; WebSocket connections register in a bounded hub and are drained on shutdown.
- Acceptable orphan states: dropped WebSocket subscribers are evicted on failed send or stale sweeps; client stream errors are coarse and do not leak runtime internals.
- Auth source of truth: REST uses the Matrix request principal; Browser WebSockets verify signed stream tokens via the browser-stream subprotocol or explicit query-token path.
- Deferred scope: first-party Browser UI, standalone shell route, platform redirect route, and VPS packaging are in the next PR.