### PR TITLE
fix(canvas): correct mouse position offset when scrolling and zooming

### DIFF
--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -705,7 +705,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
       requestAnimationFrame(() => {
         const win = useWindowManager.getState().windows.find((w) => w.path === actualPath);
         if (win) {
-          const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+          const cRect = useCanvasTransform.getState().containerRect;
           useCanvasTransform.getState().focusOnWindow(
             win,
             cRect?.width ?? window.innerWidth,
@@ -721,7 +721,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
     requestAnimationFrame(() => {
       const win = useWindowManager.getState().getWindow(winId);
       if (!win || win.minimized) return;
-      const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+      const cRect = useCanvasTransform.getState().containerRect;
       useCanvasTransform.getState().focusOnWindow(
         win,
         cRect?.width ?? window.innerWidth,

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -705,10 +705,11 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
       requestAnimationFrame(() => {
         const win = useWindowManager.getState().windows.find((w) => w.path === actualPath);
         if (win) {
+          const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
           useCanvasTransform.getState().focusOnWindow(
             win,
-            window.innerWidth,
-            window.innerHeight,
+            cRect?.width ?? window.innerWidth,
+            cRect?.height ?? window.innerHeight,
           );
         }
       });
@@ -720,10 +721,11 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
     requestAnimationFrame(() => {
       const win = useWindowManager.getState().getWindow(winId);
       if (!win || win.minimized) return;
+      const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
       useCanvasTransform.getState().focusOnWindow(
         win,
-        window.innerWidth,
-        window.innerHeight,
+        cRect?.width ?? window.innerWidth,
+        cRect?.height ?? window.innerHeight,
       );
     });
   }, []);

--- a/shell/src/components/canvas/CanvasGroup.tsx
+++ b/shell/src/components/canvas/CanvasGroup.tsx
@@ -53,7 +53,7 @@ export function CanvasGroupRect({ group }: CanvasGroupProps) {
   const onDoubleClick = useCallback(() => {
     const memberWindows = windows.filter((w) => group.windowIds.includes(w.id));
     if (memberWindows.length === 0) return;
-    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+    const cRect = useCanvasTransform.getState().containerRect;
     fitAll(
       memberWindows.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
       cRect?.width ?? window.innerWidth,

--- a/shell/src/components/canvas/CanvasGroup.tsx
+++ b/shell/src/components/canvas/CanvasGroup.tsx
@@ -53,10 +53,11 @@ export function CanvasGroupRect({ group }: CanvasGroupProps) {
   const onDoubleClick = useCallback(() => {
     const memberWindows = windows.filter((w) => group.windowIds.includes(w.id));
     if (memberWindows.length === 0) return;
+    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
     fitAll(
       memberWindows.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
-      window.innerWidth,
-      window.innerHeight,
+      cRect?.width ?? window.innerWidth,
+      cRect?.height ?? window.innerHeight,
     );
   }, [windows, group.windowIds, fitAll]);
 

--- a/shell/src/components/canvas/CanvasMinimap.tsx
+++ b/shell/src/components/canvas/CanvasMinimap.tsx
@@ -75,16 +75,15 @@ export function CanvasMinimap() {
     ctx.roundRect(0, 0, LG_W, LG_H, 8);
     ctx.fill();
 
-    const { zoom, panX, panY, screenToCanvas, containerEl } = useCanvasTransform.getState();
+    const { zoom, panX, panY, screenToCanvas, containerRect } = useCanvasTransform.getState();
     const windows = useWindowManager.getState().windows.filter((w) => !w.minimized);
     const groups = useCanvasGroups.getState().groups;
 
     // Viewport rect in canvas coords — use container bounds, not window bounds
-    const cRect = containerEl?.getBoundingClientRect();
-    const cLeft = cRect?.left ?? 0;
-    const cTop = cRect?.top ?? 0;
-    const cRight = cLeft + (cRect?.width ?? window.innerWidth);
-    const cBottom = cTop + (cRect?.height ?? window.innerHeight);
+    const cLeft = containerRect?.left ?? 0;
+    const cTop = containerRect?.top ?? 0;
+    const cRight = cLeft + (containerRect?.width ?? window.innerWidth);
+    const cBottom = cTop + (containerRect?.height ?? window.innerHeight);
     const topLeft = screenToCanvas(cLeft, cTop);
     const bottomRight = screenToCanvas(cRight, cBottom);
     const viewportRect = {
@@ -160,13 +159,12 @@ export function CanvasMinimap() {
       const mx = clientX - rect.left;
       const my = clientY - rect.top;
 
-      const { zoom, screenToCanvas, containerEl } = useCanvasTransform.getState();
+      const { zoom, screenToCanvas, containerRect } = useCanvasTransform.getState();
       const windows = useWindowManager.getState().windows.filter((w) => !w.minimized);
-      const cRect = containerEl?.getBoundingClientRect();
-      const cLeft = cRect?.left ?? 0;
-      const cTop = cRect?.top ?? 0;
-      const cW = cRect?.width ?? window.innerWidth;
-      const cH = cRect?.height ?? window.innerHeight;
+      const cLeft = containerRect?.left ?? 0;
+      const cTop = containerRect?.top ?? 0;
+      const cW = containerRect?.width ?? window.innerWidth;
+      const cH = containerRect?.height ?? window.innerHeight;
       const topLeft = screenToCanvas(cLeft, cTop);
       const bottomRight = screenToCanvas(cLeft + cW, cTop + cH);
       const viewportRect = {

--- a/shell/src/components/canvas/CanvasMinimap.tsx
+++ b/shell/src/components/canvas/CanvasMinimap.tsx
@@ -75,13 +75,18 @@ export function CanvasMinimap() {
     ctx.roundRect(0, 0, LG_W, LG_H, 8);
     ctx.fill();
 
-    const { zoom, panX, panY, screenToCanvas } = useCanvasTransform.getState();
+    const { zoom, panX, panY, screenToCanvas, containerEl } = useCanvasTransform.getState();
     const windows = useWindowManager.getState().windows.filter((w) => !w.minimized);
     const groups = useCanvasGroups.getState().groups;
 
-    // Viewport rect in canvas coords
-    const topLeft = screenToCanvas(0, 0);
-    const bottomRight = screenToCanvas(window.innerWidth, window.innerHeight);
+    // Viewport rect in canvas coords — use container bounds, not window bounds
+    const cRect = containerEl?.getBoundingClientRect();
+    const cLeft = cRect?.left ?? 0;
+    const cTop = cRect?.top ?? 0;
+    const cRight = cLeft + (cRect?.width ?? window.innerWidth);
+    const cBottom = cTop + (cRect?.height ?? window.innerHeight);
+    const topLeft = screenToCanvas(cLeft, cTop);
+    const bottomRight = screenToCanvas(cRight, cBottom);
     const viewportRect = {
       x: topLeft.x,
       y: topLeft.y,
@@ -155,10 +160,15 @@ export function CanvasMinimap() {
       const mx = clientX - rect.left;
       const my = clientY - rect.top;
 
-      const { zoom, screenToCanvas } = useCanvasTransform.getState();
+      const { zoom, screenToCanvas, containerEl } = useCanvasTransform.getState();
       const windows = useWindowManager.getState().windows.filter((w) => !w.minimized);
-      const topLeft = screenToCanvas(0, 0);
-      const bottomRight = screenToCanvas(window.innerWidth, window.innerHeight);
+      const cRect = containerEl?.getBoundingClientRect();
+      const cLeft = cRect?.left ?? 0;
+      const cTop = cRect?.top ?? 0;
+      const cW = cRect?.width ?? window.innerWidth;
+      const cH = cRect?.height ?? window.innerHeight;
+      const topLeft = screenToCanvas(cLeft, cTop);
+      const bottomRight = screenToCanvas(cLeft + cW, cTop + cH);
       const viewportRect = {
         x: topLeft.x,
         y: topLeft.y,
@@ -181,8 +191,8 @@ export function CanvasMinimap() {
       const canvasY = (my - offsetY) / scale + world.minY;
 
       // Center viewport on this point
-      const panX = window.innerWidth / (2 * zoom) - canvasX;
-      const panY = window.innerHeight / (2 * zoom) - canvasY;
+      const panX = cW / (2 * zoom) - canvasX;
+      const panY = cH / (2 * zoom) - canvasY;
       useCanvasTransform.getState().setPan(panX, panY);
     },
     [],

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -40,7 +40,7 @@ export function CanvasRenderer() {
         wm.moveWindow(wins[i].id, x, y);
       }
       const arranged = useWindowManager.getState().windows;
-      const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+      const cRect = useCanvasTransform.getState().containerRect;
       fitAll(
         arranged.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
         cRect?.width ?? window.innerWidth,
@@ -82,7 +82,7 @@ export function CanvasRenderer() {
 
   const handleFitAll = useCallback(() => {
     const wins = useWindowManager.getState().windows.filter((w) => !w.minimized);
-    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+    const cRect = useCanvasTransform.getState().containerRect;
     fitAll(
       wins.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
       cRect?.width ?? window.innerWidth,

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -40,10 +40,11 @@ export function CanvasRenderer() {
         wm.moveWindow(wins[i].id, x, y);
       }
       const arranged = useWindowManager.getState().windows;
+      const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
       fitAll(
         arranged.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
-        window.innerWidth,
-        window.innerHeight,
+        cRect?.width ?? window.innerWidth,
+        cRect?.height ?? window.innerHeight,
       );
     },
     [fitAll],
@@ -81,10 +82,11 @@ export function CanvasRenderer() {
 
   const handleFitAll = useCallback(() => {
     const wins = useWindowManager.getState().windows.filter((w) => !w.minimized);
+    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
     fitAll(
       wins.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
-      window.innerWidth,
-      window.innerHeight,
+      cRect?.width ?? window.innerWidth,
+      cRect?.height ?? window.innerHeight,
     );
   }, [fitAll]);
 

--- a/shell/src/components/canvas/CanvasToolbar.tsx
+++ b/shell/src/components/canvas/CanvasToolbar.tsx
@@ -46,10 +46,11 @@ export function autoArrangeWindows() {
   }
 
   const arranged = useWindowManager.getState().windows.filter((w) => !w.minimized);
+  const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
   useCanvasTransform.getState().fitAll(
     arranged.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
-    window.innerWidth,
-    window.innerHeight,
+    cRect?.width ?? window.innerWidth,
+    cRect?.height ?? window.innerHeight,
   );
 }
 
@@ -69,10 +70,11 @@ export function CanvasToolbar() {
 
   const onFitAll = useCallback(() => {
     const windows = useWindowManager.getState().windows.filter((w) => !w.minimized);
+    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
     fitAll(
       windows.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
-      window.innerWidth,
-      window.innerHeight,
+      cRect?.width ?? window.innerWidth,
+      cRect?.height ?? window.innerHeight,
     );
   }, [fitAll]);
 
@@ -80,7 +82,10 @@ export function CanvasToolbar() {
   const screenToCanvas = useCanvasTransform((s) => s.screenToCanvas);
 
   const onAddLabel = useCallback(() => {
-    const center = screenToCanvas(window.innerWidth / 2, window.innerHeight / 2);
+    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+    const cx = (cRect?.left ?? 0) + (cRect?.width ?? window.innerWidth) / 2;
+    const cy = (cRect?.top ?? 0) + (cRect?.height ?? window.innerHeight) / 2;
+    const center = screenToCanvas(cx, cy);
     createLabel("Label", center.x, center.y);
   }, [screenToCanvas, createLabel]);
 

--- a/shell/src/components/canvas/CanvasToolbar.tsx
+++ b/shell/src/components/canvas/CanvasToolbar.tsx
@@ -46,7 +46,7 @@ export function autoArrangeWindows() {
   }
 
   const arranged = useWindowManager.getState().windows.filter((w) => !w.minimized);
-  const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+  const cRect = useCanvasTransform.getState().containerRect;
   useCanvasTransform.getState().fitAll(
     arranged.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
     cRect?.width ?? window.innerWidth,
@@ -70,7 +70,7 @@ export function CanvasToolbar() {
 
   const onFitAll = useCallback(() => {
     const windows = useWindowManager.getState().windows.filter((w) => !w.minimized);
-    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+    const cRect = useCanvasTransform.getState().containerRect;
     fitAll(
       windows.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
       cRect?.width ?? window.innerWidth,
@@ -82,7 +82,7 @@ export function CanvasToolbar() {
   const screenToCanvas = useCanvasTransform((s) => s.screenToCanvas);
 
   const onAddLabel = useCallback(() => {
-    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+    const cRect = useCanvasTransform.getState().containerRect;
     const cx = (cRect?.left ?? 0) + (cRect?.width ?? window.innerWidth) / 2;
     const cy = (cRect?.top ?? 0) + (cRect?.height ?? window.innerHeight) / 2;
     const center = screenToCanvas(cx, cy);

--- a/shell/src/components/canvas/CanvasTransform.tsx
+++ b/shell/src/components/canvas/CanvasTransform.tsx
@@ -27,7 +27,7 @@ export function CanvasTransform({
   const panBy = useCanvasTransform((s) => s.panBy);
   const navMode = useCanvasSettings((s) => s.navMode);
 
-  const setContainerEl = useCanvasTransform((s) => s.setContainerEl);
+  const setContainerRect = useCanvasTransform((s) => s.setContainerRect);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const zoomOverlayRef = useRef<HTMLDivElement>(null);
@@ -39,9 +39,22 @@ export function CanvasTransform({
   const [grabCursor, setGrabCursor] = useState(false);
 
   useEffect(() => {
-    setContainerEl(containerRef.current);
-    return () => setContainerEl(null);
-  }, [setContainerEl]);
+    const el = containerRef.current;
+    if (!el) return;
+    const sync = () => {
+      const r = el.getBoundingClientRect();
+      setContainerRect({ left: r.left, top: r.top, width: r.width, height: r.height });
+    };
+    sync();
+    const ro = new ResizeObserver(sync);
+    ro.observe(el);
+    window.addEventListener("scroll", sync, true);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("scroll", sync, true);
+      setContainerRect(null);
+    };
+  }, [setContainerRect]);
 
   const isCanvasSurfaceEvent = useCallback((target: EventTarget | null) => {
     if (

--- a/shell/src/components/canvas/CanvasTransform.tsx
+++ b/shell/src/components/canvas/CanvasTransform.tsx
@@ -27,6 +27,8 @@ export function CanvasTransform({
   const panBy = useCanvasTransform((s) => s.panBy);
   const navMode = useCanvasSettings((s) => s.navMode);
 
+  const setContainerEl = useCanvasTransform((s) => s.setContainerEl);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const zoomOverlayRef = useRef<HTMLDivElement>(null);
   const transformRef = useRef<HTMLDivElement>(null);
@@ -35,6 +37,11 @@ export function CanvasTransform({
   const lastPointer = useRef({ x: 0, y: 0 });
   const spaceDown = useRef(false);
   const [grabCursor, setGrabCursor] = useState(false);
+
+  useEffect(() => {
+    setContainerEl(containerRef.current);
+    return () => setContainerEl(null);
+  }, [setContainerEl]);
 
   const isCanvasSurfaceEvent = useCallback((target: EventTarget | null) => {
     if (

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -57,7 +57,7 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
   const isNeumorphic = themeStyle === "neumorphic";
 
   const fitWindow = useCallback(() => {
-    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
+    const cRect = useCanvasTransform.getState().containerRect;
     fitAll(
       [{ x: win.x, y: win.y, width: win.width, height: win.height }],
       cRect?.width ?? window.innerWidth,

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -57,10 +57,11 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
   const isNeumorphic = themeStyle === "neumorphic";
 
   const fitWindow = useCallback(() => {
+    const cRect = useCanvasTransform.getState().containerEl?.getBoundingClientRect();
     fitAll(
       [{ x: win.x, y: win.y, width: win.width, height: win.height }],
-      window.innerWidth,
-      window.innerHeight,
+      cRect?.width ?? window.innerWidth,
+      cRect?.height ?? window.innerHeight,
     );
   }, [fitAll, win.x, win.y, win.width, win.height]);
 

--- a/shell/src/hooks/useCanvasTransform.ts
+++ b/shell/src/hooks/useCanvasTransform.ts
@@ -29,6 +29,7 @@ interface CanvasTransformState {
   isAnimating: boolean;
   /** True while the user is actively scrolling/wheeling the canvas. */
   isScrolling: boolean;
+  containerEl: HTMLElement | null;
 }
 
 interface CanvasTransformActions {
@@ -40,6 +41,7 @@ interface CanvasTransformActions {
   setPan: (x: number, y: number) => void;
   panBy: (dx: number, dy: number) => void;
   setIsScrolling: (v: boolean) => void;
+  setContainerEl: (el: HTMLElement | null) => void;
   screenToCanvas: (sx: number, sy: number) => { x: number; y: number };
   canvasToScreen: (cx: number, cy: number) => { x: number; y: number };
   fitAll: (windows: WindowRect[], viewportW: number, viewportH: number) => void;
@@ -54,6 +56,7 @@ export const useCanvasTransform = create<CanvasTransformState & CanvasTransformA
     panY: 0,
     isAnimating: false,
     isScrolling: false,
+    containerEl: null,
 
     setZoom: (zoom) => set({ zoom: clampZoom(zoom) }),
 
@@ -65,10 +68,13 @@ export const useCanvasTransform = create<CanvasTransformState & CanvasTransformA
 
     zoomAtPoint: (newZoom, cx, cy) => {
       const clamped = clampZoom(newZoom);
+      const rect = get().containerEl?.getBoundingClientRect();
+      const lx = cx - (rect?.left ?? 0);
+      const ly = cy - (rect?.top ?? 0);
       set((s) => ({
         zoom: clamped,
-        panX: s.panX + cx * (1 / clamped - 1 / s.zoom),
-        panY: s.panY + cy * (1 / clamped - 1 / s.zoom),
+        panX: s.panX + lx * (1 / clamped - 1 / s.zoom),
+        panY: s.panY + ly * (1 / clamped - 1 / s.zoom),
       }));
     },
 
@@ -81,19 +87,25 @@ export const useCanvasTransform = create<CanvasTransformState & CanvasTransformA
 
     setIsScrolling: (v) => { if (get().isScrolling !== v) set({ isScrolling: v }); },
 
+    setContainerEl: (el) => set({ containerEl: el }),
+
     screenToCanvas: (sx, sy) => {
-      const { zoom, panX, panY } = get();
+      const { zoom, panX, panY, containerEl } = get();
+      const rect = containerEl?.getBoundingClientRect();
+      const lx = sx - (rect?.left ?? 0);
+      const ly = sy - (rect?.top ?? 0);
       return {
-        x: (sx - panX * zoom) / zoom,
-        y: (sy - panY * zoom) / zoom,
+        x: lx / zoom - panX,
+        y: ly / zoom - panY,
       };
     },
 
     canvasToScreen: (cx, cy) => {
-      const { zoom, panX, panY } = get();
+      const { zoom, panX, panY, containerEl } = get();
+      const rect = containerEl?.getBoundingClientRect();
       return {
-        x: (cx + panX) * zoom,
-        y: (cy + panY) * zoom,
+        x: (cx + panX) * zoom + (rect?.left ?? 0),
+        y: (cy + panY) * zoom + (rect?.top ?? 0),
       };
     },
 

--- a/shell/src/hooks/useCanvasTransform.ts
+++ b/shell/src/hooks/useCanvasTransform.ts
@@ -22,6 +22,13 @@ interface WindowRect {
 /** Maximum pan distance from origin in canvas units. Prevents getting lost. */
 const PAN_LIMIT = 8000;
 
+interface ContainerRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 interface CanvasTransformState {
   zoom: number;
   panX: number;
@@ -29,7 +36,7 @@ interface CanvasTransformState {
   isAnimating: boolean;
   /** True while the user is actively scrolling/wheeling the canvas. */
   isScrolling: boolean;
-  containerEl: HTMLElement | null;
+  containerRect: ContainerRect | null;
 }
 
 interface CanvasTransformActions {
@@ -41,7 +48,7 @@ interface CanvasTransformActions {
   setPan: (x: number, y: number) => void;
   panBy: (dx: number, dy: number) => void;
   setIsScrolling: (v: boolean) => void;
-  setContainerEl: (el: HTMLElement | null) => void;
+  setContainerRect: (rect: ContainerRect | null) => void;
   screenToCanvas: (sx: number, sy: number) => { x: number; y: number };
   canvasToScreen: (cx: number, cy: number) => { x: number; y: number };
   fitAll: (windows: WindowRect[], viewportW: number, viewportH: number) => void;
@@ -56,7 +63,7 @@ export const useCanvasTransform = create<CanvasTransformState & CanvasTransformA
     panY: 0,
     isAnimating: false,
     isScrolling: false,
-    containerEl: null,
+    containerRect: null,
 
     setZoom: (zoom) => set({ zoom: clampZoom(zoom) }),
 
@@ -68,7 +75,7 @@ export const useCanvasTransform = create<CanvasTransformState & CanvasTransformA
 
     zoomAtPoint: (newZoom, cx, cy) => {
       const clamped = clampZoom(newZoom);
-      const rect = get().containerEl?.getBoundingClientRect();
+      const rect = get().containerRect;
       const lx = cx - (rect?.left ?? 0);
       const ly = cy - (rect?.top ?? 0);
       set((s) => ({
@@ -87,13 +94,12 @@ export const useCanvasTransform = create<CanvasTransformState & CanvasTransformA
 
     setIsScrolling: (v) => { if (get().isScrolling !== v) set({ isScrolling: v }); },
 
-    setContainerEl: (el) => set({ containerEl: el }),
+    setContainerRect: (rect) => set({ containerRect: rect }),
 
     screenToCanvas: (sx, sy) => {
-      const { zoom, panX, panY, containerEl } = get();
-      const rect = containerEl?.getBoundingClientRect();
-      const lx = sx - (rect?.left ?? 0);
-      const ly = sy - (rect?.top ?? 0);
+      const { zoom, panX, panY, containerRect } = get();
+      const lx = sx - (containerRect?.left ?? 0);
+      const ly = sy - (containerRect?.top ?? 0);
       return {
         x: lx / zoom - panX,
         y: ly / zoom - panY,
@@ -101,11 +107,10 @@ export const useCanvasTransform = create<CanvasTransformState & CanvasTransformA
     },
 
     canvasToScreen: (cx, cy) => {
-      const { zoom, panX, panY, containerEl } = get();
-      const rect = containerEl?.getBoundingClientRect();
+      const { zoom, panX, panY, containerRect } = get();
       return {
-        x: (cx + panX) * zoom + (rect?.left ?? 0),
-        y: (cy + panY) * zoom + (rect?.top ?? 0),
+        x: (cx + panX) * zoom + (containerRect?.left ?? 0),
+        y: (cy + panY) * zoom + (containerRect?.top ?? 0),
       };
     },
 

--- a/tests/shell/canvas-minimap.test.ts
+++ b/tests/shell/canvas-minimap.test.ts
@@ -43,6 +43,31 @@ describe("Canvas Minimap", () => {
       expect(bottomRight.x).toBe(350);
       expect(bottomRight.y).toBe(250);
     });
+
+    it("subtracts container offset when containerRect is set", () => {
+      useCanvasTransform.setState({ containerRect: { left: 60, top: 28, width: 740, height: 572 } });
+      const { screenToCanvas } = useCanvasTransform.getState();
+      const topLeft = screenToCanvas(60, 28);
+      const bottomRight = screenToCanvas(800, 600);
+      expect(topLeft.x).toBe(0);
+      expect(topLeft.y).toBe(0);
+      expect(bottomRight.x).toBe(740);
+      expect(bottomRight.y).toBe(572);
+      useCanvasTransform.setState({ containerRect: null });
+    });
+
+    it("subtracts container offset when zoomed and panned", () => {
+      useCanvasTransform.setState({ containerRect: { left: 60, top: 28, width: 740, height: 572 } });
+      useCanvasTransform.getState().setTransform(2, 50, 50);
+      const { screenToCanvas } = useCanvasTransform.getState();
+      const topLeft = screenToCanvas(60, 28);
+      const bottomRight = screenToCanvas(800, 600);
+      expect(topLeft.x).toBe(-50);
+      expect(topLeft.y).toBe(-50);
+      expect(bottomRight.x).toBe(320);
+      expect(bottomRight.y).toBe(236);
+      useCanvasTransform.setState({ containerRect: null });
+    });
   });
 
   describe("bounds computation", () => {

--- a/tests/shell/canvas-transform.test.ts
+++ b/tests/shell/canvas-transform.test.ts
@@ -201,32 +201,30 @@ describe("Canvas Transform Store", () => {
   });
 
   describe("container offset", () => {
-    function mockContainer(left: number, top: number, width = 800, height = 600) {
-      return {
-        getBoundingClientRect: () => ({ left, top, width, height, right: left + width, bottom: top + height, x: left, y: top, toJSON() {} }),
-      } as HTMLElement;
+    function rect(left: number, top: number, width = 800, height = 600) {
+      return { left, top, width, height };
     }
 
     afterEach(() => {
-      useCanvasTransform.setState({ containerEl: null });
+      useCanvasTransform.setState({ containerRect: null });
     });
 
     it("screenToCanvas subtracts container offset", () => {
-      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerEl: mockContainer(250, 28) });
+      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerRect: rect(250, 28) });
       const pt = useCanvasTransform.getState().screenToCanvas(500, 300);
       expect(pt.x).toBeCloseTo(250);
       expect(pt.y).toBeCloseTo(272);
     });
 
     it("canvasToScreen adds container offset", () => {
-      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerEl: mockContainer(250, 28) });
+      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerRect: rect(250, 28) });
       const pt = useCanvasTransform.getState().canvasToScreen(250, 272);
       expect(pt.x).toBeCloseTo(500);
       expect(pt.y).toBeCloseTo(300);
     });
 
     it("round-trip with container offset", () => {
-      useCanvasTransform.setState({ zoom: 1.5, panX: -200, panY: 100, containerEl: mockContainer(250, 28) });
+      useCanvasTransform.setState({ zoom: 1.5, panX: -200, panY: 100, containerRect: rect(250, 28) });
       const { screenToCanvas, canvasToScreen } = useCanvasTransform.getState();
       const canvas = screenToCanvas(600, 400);
       const screen = canvasToScreen(canvas.x, canvas.y);
@@ -235,7 +233,7 @@ describe("Canvas Transform Store", () => {
     });
 
     it("zoomAtPoint preserves focal point with container offset", () => {
-      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerEl: mockContainer(250, 28) });
+      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerRect: rect(250, 28) });
       const canvasBefore = useCanvasTransform.getState().screenToCanvas(500, 300);
 
       useCanvasTransform.getState().zoomAtPoint(2, 500, 300);
@@ -247,7 +245,7 @@ describe("Canvas Transform Store", () => {
     });
 
     it("zoomAtPoint preserves focal point with offset and existing pan", () => {
-      useCanvasTransform.setState({ zoom: 1.5, panX: -200, panY: 100, containerEl: mockContainer(100, 50) });
+      useCanvasTransform.setState({ zoom: 1.5, panX: -200, panY: 100, containerRect: rect(100, 50) });
       const canvasBefore = useCanvasTransform.getState().screenToCanvas(600, 400);
 
       useCanvasTransform.getState().zoomAtPoint(2.5, 600, 400);
@@ -258,7 +256,7 @@ describe("Canvas Transform Store", () => {
     });
 
     it("multiple zoom steps maintain focal point stability", () => {
-      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerEl: mockContainer(200, 40) });
+      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerRect: rect(200, 40) });
       const canvasBefore = useCanvasTransform.getState().screenToCanvas(500, 300);
 
       for (let z = 1.1; z <= 2.0; z += 0.1) {

--- a/tests/shell/canvas-transform.test.ts
+++ b/tests/shell/canvas-transform.test.ts
@@ -199,4 +199,75 @@ describe("Canvas Transform Store", () => {
       expect(useCanvasTransform.getState().isAnimating).toBe(true);
     });
   });
+
+  describe("container offset", () => {
+    function mockContainer(left: number, top: number, width = 800, height = 600) {
+      return {
+        getBoundingClientRect: () => ({ left, top, width, height, right: left + width, bottom: top + height, x: left, y: top, toJSON() {} }),
+      } as HTMLElement;
+    }
+
+    afterEach(() => {
+      useCanvasTransform.setState({ containerEl: null });
+    });
+
+    it("screenToCanvas subtracts container offset", () => {
+      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerEl: mockContainer(250, 28) });
+      const pt = useCanvasTransform.getState().screenToCanvas(500, 300);
+      expect(pt.x).toBeCloseTo(250);
+      expect(pt.y).toBeCloseTo(272);
+    });
+
+    it("canvasToScreen adds container offset", () => {
+      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerEl: mockContainer(250, 28) });
+      const pt = useCanvasTransform.getState().canvasToScreen(250, 272);
+      expect(pt.x).toBeCloseTo(500);
+      expect(pt.y).toBeCloseTo(300);
+    });
+
+    it("round-trip with container offset", () => {
+      useCanvasTransform.setState({ zoom: 1.5, panX: -200, panY: 100, containerEl: mockContainer(250, 28) });
+      const { screenToCanvas, canvasToScreen } = useCanvasTransform.getState();
+      const canvas = screenToCanvas(600, 400);
+      const screen = canvasToScreen(canvas.x, canvas.y);
+      expect(screen.x).toBeCloseTo(600);
+      expect(screen.y).toBeCloseTo(400);
+    });
+
+    it("zoomAtPoint preserves focal point with container offset", () => {
+      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerEl: mockContainer(250, 28) });
+      const canvasBefore = useCanvasTransform.getState().screenToCanvas(500, 300);
+
+      useCanvasTransform.getState().zoomAtPoint(2, 500, 300);
+      expect(useCanvasTransform.getState().zoom).toBe(2);
+
+      const screenAfter = useCanvasTransform.getState().canvasToScreen(canvasBefore.x, canvasBefore.y);
+      expect(screenAfter.x).toBeCloseTo(500);
+      expect(screenAfter.y).toBeCloseTo(300);
+    });
+
+    it("zoomAtPoint preserves focal point with offset and existing pan", () => {
+      useCanvasTransform.setState({ zoom: 1.5, panX: -200, panY: 100, containerEl: mockContainer(100, 50) });
+      const canvasBefore = useCanvasTransform.getState().screenToCanvas(600, 400);
+
+      useCanvasTransform.getState().zoomAtPoint(2.5, 600, 400);
+
+      const screenAfter = useCanvasTransform.getState().canvasToScreen(canvasBefore.x, canvasBefore.y);
+      expect(screenAfter.x).toBeCloseTo(600);
+      expect(screenAfter.y).toBeCloseTo(400);
+    });
+
+    it("multiple zoom steps maintain focal point stability", () => {
+      useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, containerEl: mockContainer(200, 40) });
+      const canvasBefore = useCanvasTransform.getState().screenToCanvas(500, 300);
+
+      for (let z = 1.1; z <= 2.0; z += 0.1) {
+        useCanvasTransform.getState().zoomAtPoint(z, 500, 300);
+      }
+
+      const screenAfter = useCanvasTransform.getState().canvasToScreen(canvasBefore.x, canvasBefore.y);
+      expect(screenAfter.x).toBeCloseTo(500, 0);
+      expect(screenAfter.y).toBeCloseTo(300, 0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: `screenToCanvas`, `canvasToScreen`, and `zoomAtPoint` all received raw viewport-relative `clientX`/`clientY` but assumed container-relative coordinates. When the canvas has layout offset (menu bar padding, etc.), the error compounds with each zoom step — the logical mouse drifts from the physical cursor.
- **Fix**: Cache the container's bounding rect in the zustand store (updated via `ResizeObserver` + scroll listener) and subtract the offset in all coordinate conversions. Falls back to (0,0) when no container is registered (backward-compatible).
- **Also fixed**: All `fitAll` and `focusOnWindow` callers now use container dimensions instead of `window.innerWidth`/`window.innerHeight`, so fit-to-view and focus centering respect the actual canvas area.
- **Performance**: Container rect is cached as plain data — no `getBoundingClientRect()` on hot-path `screenToCanvas`/`canvasToScreen` calls.

## Test plan

- [x] TypeScript compiles with no errors
- [x] All 27 canvas transform unit tests pass (21 existing + 6 new)
- [x] All 10 canvas minimap tests pass (8 existing + 2 new offset tests)
- [x] Playwright E2E: coordinate round-trips exact at all zoom levels, 0px drift
- [ ] Manual: scroll/pan the canvas, then zoom in — mouse should stay aligned with physical cursor
- [ ] Manual: text selection should track the physical cursor position after zoom