### PR TITLE
feat(releases): add user release channel controls

### DIFF
--- a/distro/customer-vps/host-bin/matrix-update
+++ b/distro/customer-vps/host-bin/matrix-update
@@ -13,12 +13,12 @@ write_update_target() {
       printf '%s' "$target" > /opt/matrix/app/.update-channel
       rm -f /opt/matrix/app/.update-version
       ;;
-    v[0-9]*)
+    v[0-9]*|main-[A-Za-z0-9]*)
       printf '%s' "$target" > /opt/matrix/app/.update-version
       rm -f /opt/matrix/app/.update-channel
       ;;
     *)
-      echo "Usage: matrix-update [apply|rollback|stable|canary|beta|dev|<version>]" >&2
+      echo "Usage: matrix-update [apply|rollback|stable|canary|beta|dev|v<version>|main-<build>]" >&2
       exit 1
       ;;
   esac
@@ -36,13 +36,13 @@ case "${1:-apply}" in
     touch /opt/matrix/app/.rollback-now
     echo "Rollback triggered. Tailing sync-agent log (Ctrl-C to stop)..."
     ;;
-  stable|canary|beta|dev|v[0-9]*)
+  stable|canary|beta|dev|v[0-9]*|main-[A-Za-z0-9]*)
     write_update_target "$1"
     touch /opt/matrix/app/.update-now
     echo "Update to $1 triggered. Tailing sync-agent log (Ctrl-C to stop)..."
     ;;
   *)
-    echo "Usage: matrix-update [apply|rollback|stable|canary|beta|dev|<version>]" >&2
+    echo "Usage: matrix-update [apply|rollback|stable|canary|beta|dev|v<version>|main-<build>]" >&2
     exit 1
     ;;
 esac

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -116,7 +116,7 @@ Release metadata also records:
    matrix-update v0.X.0
    ```
 
-   The VPS sync agent asks the platform for DB-backed release metadata and downloads the bundle through a short-lived signed R2 URL.
+   Users can do the same from Matrix Settings -> System -> Updates: select `stable`, `canary`, `beta`, or `dev`, inspect the releases published for that channel, then install the latest release or any listed version for an upgrade or downgrade. The VPS sync agent asks the platform for DB-backed release metadata and downloads the bundle through a short-lived signed R2 URL.
 
 8. Grafana scrapes `/metrics`.
 
@@ -198,7 +198,7 @@ Or configure Vercel to deploy on tag push via GitHub webhook.
 matrix-update v0.X.0
 ```
 
-Channel rollback is a platform operation: promote `stable` back to a known-good version, then users on `stable` can update/downgrade to that release.
+Channel rollback can be platform-driven by promoting `stable` back to a known-good version, or user-driven from Matrix Settings by selecting a previous release in the current channel list.
 
 ## Tag Naming Examples
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -80,6 +80,8 @@ import { securityHeadersMiddleware } from "./security/headers.js";
 import { getSystemInfo } from "./system-info.js";
 import {
   checkForSystemUpdate,
+  listSystemReleases,
+  parseInternalUpgradeTarget,
   resolveSystemUpdateChannel,
   startSystemUpdate,
   writeInternalUpgradeTrigger,
@@ -3378,6 +3380,20 @@ export async function createGateway(config: GatewayConfig) {
     return c.json(result);
   });
 
+  app.get("/api/system/releases", async (c) => {
+    const info = getSystemInfo(homePath);
+    const channel = resolveSystemUpdateChannel(c.req.query("channel"), {
+      envChannel: process.env.MATRIX_UPDATE_CHANNEL,
+      installedChannel: info.release?.channel,
+    });
+    if (!channel) return c.json({ error: "Invalid update channel" }, 400);
+    const result = await listSystemReleases({
+      platformUrl: process.env.MATRIX_UPDATE_MANIFEST_BASE_URL ?? process.env.PLATFORM_INTERNAL_URL,
+      channel,
+    });
+    return c.json(result);
+  });
+
   app.post("/system/backup", bodyLimit({ maxSize: 1024 }), (c) => {
     const token = process.env.MATRIX_SYSTEM_BACKUP_TOKEN;
     if (!token) {
@@ -3400,30 +3416,40 @@ export async function createGateway(config: GatewayConfig) {
         console.warn("[system-update] Failed to parse update request:", err);
       }
     }
-    const requestedChannel =
-      body && typeof body === "object" && "channel" in body ? (body as { channel?: unknown }).channel : undefined;
     const info = getSystemInfo(homePath);
-    const channel = resolveSystemUpdateChannel(requestedChannel, {
-      envChannel: process.env.MATRIX_UPDATE_CHANNEL,
-      installedChannel: info.release?.channel,
-    });
-    if (!channel) return c.json({ error: "Invalid update channel" }, 400);
+    const parsedTarget = parseInternalUpgradeTarget(body);
+    if (!parsedTarget.ok) return c.json({ error: parsedTarget.error }, 400);
+    const target = parsedTarget.target ?? (() => {
+      const channel = resolveSystemUpdateChannel(undefined, {
+        envChannel: process.env.MATRIX_UPDATE_CHANNEL,
+        installedChannel: info.release?.channel,
+      });
+      return channel ? { type: "channel" as const, value: channel } : null;
+    })();
+    if (!target) return c.json({ error: "Invalid update channel" }, 400);
 
-    const result = await startSystemUpdate({ channel });
+    const result = await startSystemUpdate({ target });
     if (!result.ok) {
       return c.json({ error: "Update not configured" }, 503);
     }
     void posthogErrorTracker.captureEvent("matrix_system_update_requested", {
       distinctId: process.env.MATRIX_HANDLE ?? "matrix-gateway",
       properties: {
-        channel,
+        targetType: target.type,
+        targetValue: target.value,
+        channel: target.type === "channel" ? target.value : undefined,
         handle: process.env.MATRIX_HANDLE,
       },
     }).catch((err: unknown) => {
       const kind = err instanceof Error ? err.name : typeof err;
       console.warn(`[posthog] Failed to queue system update event: ${kind}`);
     });
-    return c.json({ ok: true, status: result.status, channel }, 202);
+    return c.json({
+      ok: true,
+      status: result.status,
+      target,
+      ...(target.type === "channel" ? { channel: target.value } : { version: target.value }),
+    }, 202);
   }
 
   app.post("/api/system/update", upgradeBodyLimit, startUpdateFromRequest);

--- a/packages/gateway/src/system-update.ts
+++ b/packages/gateway/src/system-update.ts
@@ -22,6 +22,7 @@ export interface HostBundleRelease {
   size?: number;
   bundleSha256?: string;
   installedAt?: string;
+  createdAt?: string;
   severity?: UpdateSeverity;
   changelog?: string;
   updateType?: UpdateType;
@@ -49,6 +50,13 @@ export interface SystemUpdateCheck {
   latest: HostBundleRelease | null;
   updateAvailable: boolean;
   checkedAt: string;
+  error?: string;
+}
+
+export interface SystemReleaseList {
+  channel: UpdateChannel;
+  releases: HostBundleRelease[];
+  generatedAt: string;
   error?: string;
 }
 
@@ -249,11 +257,68 @@ export async function checkForSystemUpdate(options: {
   }
 }
 
-export async function startSystemUpdate(options: {
+export async function listSystemReleases(options: {
+  platformUrl?: string;
   channel: UpdateChannel;
+  fetchImpl?: typeof fetch;
+  now?: Date;
+}): Promise<SystemReleaseList> {
+  const generatedAt = (options.now ?? new Date()).toISOString();
+  if (!options.platformUrl) {
+    return {
+      channel: options.channel,
+      releases: [],
+      generatedAt,
+      error: "Release list not configured",
+    };
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = new URL("/system-bundles/releases", options.platformUrl);
+  url.searchParams.set("channel", options.channel);
+  try {
+    const res = await fetchImpl(url.toString(), {
+      signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`release list unavailable: ${res.status}`);
+    }
+    const data = await res.json() as { releases?: unknown; generatedAt?: unknown };
+    const releases = Array.isArray(data.releases)
+      ? data.releases.filter((release): release is HostBundleRelease => (
+          release !== null &&
+          typeof release === "object" &&
+          typeof (release as { version?: unknown }).version === "string"
+        ))
+      : [];
+    return {
+      channel: options.channel,
+      releases,
+      generatedAt: typeof data.generatedAt === "string" ? data.generatedAt : generatedAt,
+    };
+  } catch (err: unknown) {
+    console.warn(
+      "[system-update] Failed to list host bundle releases:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return {
+      channel: options.channel,
+      releases: [],
+      generatedAt,
+      error: "Release list unavailable",
+    };
+  }
+}
+
+export async function startSystemUpdate(options: {
+  channel?: UpdateChannel;
+  target?: InternalUpgradeTarget;
   updateCommand?: string;
   spawnImpl?: typeof spawn;
 }): Promise<{ ok: true; status: "started" } | { ok: false; status: "not_configured" }> {
+  const target = options.target ?? (options.channel ? { type: "channel" as const, value: options.channel } : null);
+  if (!target) return { ok: false, status: "not_configured" };
+
   const updateCommand = options.updateCommand ?? process.env.MATRIX_UPDATE_COMMAND ?? "/opt/matrix/bin/matrix-update";
   try {
     await access(updateCommand, constants.X_OK);
@@ -268,7 +333,7 @@ export async function startSystemUpdate(options: {
   }
 
   const spawnImpl = options.spawnImpl ?? spawn;
-  const child = spawnImpl("sudo", ["-n", updateCommand, options.channel], {
+  const child = spawnImpl("sudo", ["-n", updateCommand, target.value], {
     detached: true,
     stdio: "ignore",
     env: process.env,

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -38,6 +38,7 @@ interface UserMachinesTable {
 
 interface HostBundleReleasesTable {
   version: string;
+  channel: string | null;
   git_commit: string;
   git_ref: string | null;
   build_time: string;
@@ -55,6 +56,12 @@ interface HostBundleChannelsTable {
   channel: string;
   version: string;
   updated_at: string;
+}
+
+interface HostBundleReleaseChannelsTable {
+  channel: string;
+  version: string;
+  promoted_at: string;
 }
 
 interface ProviderDeletionQueueTable {
@@ -166,6 +173,7 @@ export interface PlatformDatabase {
   user_machines: UserMachinesTable;
   host_bundle_releases: HostBundleReleasesTable;
   host_bundle_channels: HostBundleChannelsTable;
+  host_bundle_release_channels: HostBundleReleaseChannelsTable;
   provider_deletion_queue: ProviderDeletionQueueTable;
   port_assignments: PortAssignmentsTable;
   device_codes: DeviceCodesTable;
@@ -229,6 +237,7 @@ export interface UserMachineRecord {
 
 export interface HostBundleReleaseRecord {
   version: string;
+  channel: string | null;
   gitCommit: string;
   gitRef: string | null;
   buildTime: string;
@@ -244,6 +253,7 @@ export interface HostBundleReleaseRecord {
 
 export interface NewHostBundleRelease {
   version: string;
+  channel?: string | null;
   gitCommit: string;
   gitRef?: string | null;
   buildTime: string;
@@ -382,6 +392,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   await sql`
     CREATE TABLE IF NOT EXISTS host_bundle_releases (
       version TEXT PRIMARY KEY,
+      channel TEXT,
       git_commit TEXT NOT NULL,
       git_ref TEXT,
       build_time TEXT NOT NULL,
@@ -395,6 +406,8 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       created_at TEXT NOT NULL
     )
   `.execute(db);
+  await sql`ALTER TABLE host_bundle_releases ADD COLUMN IF NOT EXISTS channel TEXT`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_host_bundle_releases_channel ON host_bundle_releases(channel)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_host_bundle_releases_created_at ON host_bundle_releases(created_at)`.execute(db);
 
   await sql`
@@ -405,6 +418,29 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     )
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_host_bundle_channels_version ON host_bundle_channels(version)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS host_bundle_release_channels (
+      channel TEXT NOT NULL,
+      version TEXT NOT NULL REFERENCES host_bundle_releases(version),
+      promoted_at TEXT NOT NULL,
+      PRIMARY KEY (channel, version)
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_host_bundle_release_channels_version ON host_bundle_release_channels(version)`.execute(db);
+  await sql`
+    INSERT INTO host_bundle_release_channels(channel, version, promoted_at)
+    SELECT channel, version, created_at
+    FROM host_bundle_releases
+    WHERE channel IS NOT NULL
+    ON CONFLICT (channel, version) DO NOTHING
+  `.execute(db);
+  await sql`
+    INSERT INTO host_bundle_release_channels(channel, version, promoted_at)
+    SELECT channel, version, updated_at
+    FROM host_bundle_channels
+    ON CONFLICT (channel, version) DO UPDATE SET promoted_at = EXCLUDED.promoted_at
+  `.execute(db);
 
   await sql`
     CREATE TABLE IF NOT EXISTS provider_deletion_queue (
@@ -693,6 +729,7 @@ function toUserMachineUpdate(values: Partial<NewUserMachine>): Partial<UserMachi
 function mapHostBundleRelease(row: HostBundleReleasesTable): HostBundleReleaseRecord {
   return {
     version: row.version,
+    channel: row.channel,
     gitCommit: row.git_commit,
     gitRef: row.git_ref,
     buildTime: row.build_time,
@@ -711,6 +748,7 @@ function toHostBundleReleaseRow(record: NewHostBundleRelease): HostBundleRelease
   const now = new Date().toISOString();
   return {
     version: record.version,
+    channel: record.channel ?? null,
     git_commit: record.gitCommit,
     git_ref: record.gitRef ?? null,
     build_time: record.buildTime,
@@ -1054,29 +1092,31 @@ export async function upsertHostBundleRelease(
 ): Promise<HostBundleReleaseRecord> {
   await db.ready;
   const row = toHostBundleReleaseRow(record);
-  const saved = await db.executor
-    .insertInto('host_bundle_releases')
-    .values(row)
-    .onConflict((oc) =>
-      oc.column('version').doUpdateSet({
-        git_commit: row.git_commit,
-        git_ref: row.git_ref,
-        build_time: row.build_time,
-        severity: row.severity,
-        update_type: row.update_type,
-        changelog: row.changelog,
-      })
-        .where(sql<boolean>`host_bundle_releases.bundle_key = ${row.bundle_key}`)
-        .where(sql<boolean>`host_bundle_releases.checksum_key IS NOT DISTINCT FROM ${row.checksum_key}`)
-        .where(sql<boolean>`host_bundle_releases.sha256 = ${row.sha256}`)
-        .where(sql<boolean>`host_bundle_releases.size = ${row.size}`),
-    )
-    .returningAll()
-    .executeTakeFirst();
-  if (!saved) {
-    throw new HostBundleReleaseConflictError(row.version);
-  }
-  return mapHostBundleRelease(saved);
+  return db.executor.transaction().execute(async (trx) => {
+    const saved = await trx
+      .insertInto('host_bundle_releases')
+      .values(row)
+      .onConflict((oc) =>
+        oc.column('version').doUpdateSet({
+          git_commit: row.git_commit,
+          git_ref: row.git_ref,
+          build_time: row.build_time,
+          severity: row.severity,
+          update_type: row.update_type,
+          changelog: row.changelog,
+        })
+          .where(sql<boolean>`host_bundle_releases.bundle_key = ${row.bundle_key}`)
+          .where(sql<boolean>`host_bundle_releases.checksum_key IS NOT DISTINCT FROM ${row.checksum_key}`)
+          .where(sql<boolean>`host_bundle_releases.sha256 = ${row.sha256}`)
+          .where(sql<boolean>`host_bundle_releases.size = ${row.size}`),
+      )
+      .returningAll()
+      .executeTakeFirst();
+    if (!saved) {
+      throw new HostBundleReleaseConflictError(row.version);
+    }
+    return mapHostBundleRelease(saved);
+  });
 }
 
 export async function getHostBundleRelease(
@@ -1095,8 +1135,20 @@ export async function getHostBundleRelease(
 export async function listHostBundleReleases(
   db: PlatformDB,
   limit = 50,
+  channel?: string,
 ): Promise<HostBundleReleaseRecord[]> {
   await db.ready;
+  if (channel) {
+    const rows = await db.executor
+      .selectFrom('host_bundle_release_channels')
+      .innerJoin('host_bundle_releases', 'host_bundle_releases.version', 'host_bundle_release_channels.version')
+      .selectAll('host_bundle_releases')
+      .where('host_bundle_release_channels.channel', '=', channel)
+      .orderBy('host_bundle_releases.created_at', 'desc')
+      .limit(limit)
+      .execute();
+    return rows.map(mapHostBundleRelease);
+  }
   const rows = await db.executor
     .selectFrom('host_bundle_releases')
     .selectAll()
@@ -1113,22 +1165,35 @@ export async function promoteHostBundleChannel(
   updatedAt = new Date().toISOString(),
 ): Promise<HostBundleChannelRecord> {
   await db.ready;
-  const release = await getHostBundleRelease(db, version);
-  if (!release) {
-    throw new Error('Cannot promote unknown host bundle release');
-  }
-  const row = await db.executor
-    .insertInto('host_bundle_channels')
-    .values({ channel, version, updated_at: updatedAt })
-    .onConflict((oc) =>
-      oc.column('channel').doUpdateSet({
-        version,
-        updated_at: updatedAt,
-      }),
-    )
-    .returningAll()
-    .executeTakeFirstOrThrow();
-  return mapHostBundleChannel(row);
+  return db.executor.transaction().execute(async (trx) => {
+    const release = await trx
+      .selectFrom('host_bundle_releases')
+      .selectAll()
+      .where('version', '=', version)
+      .executeTakeFirst();
+    if (!release) {
+      throw new Error('Cannot promote unknown host bundle release');
+    }
+    const row = await trx
+      .insertInto('host_bundle_channels')
+      .values({ channel, version, updated_at: updatedAt })
+      .onConflict((oc) =>
+        oc.column('channel').doUpdateSet({
+          version,
+          updated_at: updatedAt,
+        }),
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await trx
+      .insertInto('host_bundle_release_channels')
+      .values({ channel, version, promoted_at: updatedAt })
+      .onConflict((oc) => oc.columns(['channel', 'version']).doUpdateSet({
+        promoted_at: updatedAt,
+      }))
+      .executeTakeFirst();
+    return mapHostBundleChannel(row);
+  });
 }
 
 export async function getHostBundleChannel(

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -272,9 +272,11 @@ function isObjectNotFoundError(err: unknown): boolean {
 function hostBundleReleaseResponse(
   release: HostBundleReleaseRecord,
   url?: string,
+  channel?: string,
 ): Record<string, unknown> {
   return {
     version: release.version,
+    channel: channel ?? release.channel,
     gitCommit: release.gitCommit,
     gitRef: release.gitRef,
     buildTime: release.buildTime,
@@ -1047,9 +1049,16 @@ export function createApp(deps: {
   }
 
   app.get('/system-bundles/releases', async (c) => {
+    const channel = c.req.query('channel');
+    if (channel !== undefined && !HOST_BUNDLE_CHANNEL_PATTERN.test(channel)) {
+      return c.json({ error: 'Invalid request' }, 400);
+    }
     try {
-      const releases = await listHostBundleReleases(db, 100);
-      return c.json({ releases: releases.map((release) => hostBundleReleaseResponse(release)) });
+      const releases = await listHostBundleReleases(db, 100, channel);
+      return c.json({
+        generatedAt: new Date().toISOString(),
+        releases: releases.map((release) => hostBundleReleaseResponse(release)),
+      });
     } catch (err: unknown) {
       logPlatformRouteError('/system-bundles/releases', err);
       return c.json({ error: 'Host bundle unavailable' }, 502);
@@ -1175,7 +1184,7 @@ export function createApp(deps: {
           return c.json({ error: 'Not found' }, 404);
         }
         const url = await getSignedBundleUrl(release);
-        return c.json(hostBundleReleaseResponse(release, url), 200, {
+        return c.json(hostBundleReleaseResponse(release, url, channel), 200, {
           'cache-control': 'private, max-age=30',
         });
       } catch (err: unknown) {
@@ -1236,7 +1245,7 @@ export function createApp(deps: {
     if (file.endsWith('.json')) {
       try {
         const url = await getSignedBundleUrl(release);
-        return c.json(hostBundleReleaseResponse(release, url), 200, {
+        return c.json(hostBundleReleaseResponse(release, url, isChannelAlias ? imageVersion : undefined), 200, {
           'cache-control': 'private, max-age=30',
         });
       } catch (err: unknown) {
@@ -1293,7 +1302,7 @@ export function createApp(deps: {
         return c.json({ error: 'Not found' }, 404);
       }
       const url = await getSignedBundleUrl(release);
-      return c.json(hostBundleReleaseResponse(release, url), 200, {
+      return c.json(hostBundleReleaseResponse(release, url, channel), 200, {
         'cache-control': 'private, max-age=30',
       });
     } catch (err: unknown) {

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
@@ -59,25 +59,97 @@ interface SystemUpdateStatus {
   error?: string;
 }
 
+interface SystemRelease {
+  version?: string;
+  channel?: string;
+  gitCommit?: string;
+  gitRef?: string;
+  buildTime?: string;
+  bundleSha256?: string;
+  severity?: string;
+  changelog?: string;
+  updateType?: string;
+  createdAt?: string;
+}
+
+interface SystemReleaseList {
+  channel?: string;
+  releases?: SystemRelease[];
+  generatedAt?: string;
+  error?: string;
+}
+
 import {
   normalizeMatrixReleaseTag,
   isNewer,
+  releaseActionLabel,
   severityBadgeStyle,
   resolveSystemUpdateState,
 } from "./system-update-state";
-export { normalizeMatrixReleaseTag, isNewer, severityBadgeStyle, resolveSystemUpdateState };
+export { normalizeMatrixReleaseTag, isNewer, releaseActionLabel, severityBadgeStyle, resolveSystemUpdateState };
+
+const RELEASE_CHANNELS = ["stable", "canary", "beta", "dev"] as const;
+type ReleaseChannel = typeof RELEASE_CHANNELS[number];
+
+function coerceReleaseChannel(value: unknown): ReleaseChannel {
+  return RELEASE_CHANNELS.includes(value as ReleaseChannel) ? value as ReleaseChannel : "stable";
+}
 
 export function SystemSection() {
   const [info, setInfo] = useState<SystemInfo>({});
   const [health, setHealth] = useState<HealthStatus | null>(null);
   const [updateStatus, setUpdateStatus] = useState<SystemUpdateStatus | null>(null);
+  const [selectedChannel, setSelectedChannel] = useState<ReleaseChannel>("stable");
+  const [releaseList, setReleaseList] = useState<SystemReleaseList | null>(null);
+  const [releaseLoading, setReleaseLoading] = useState(false);
+  const [upgrading, setUpgrading] = useState(false);
+  const [installingTarget, setInstallingTarget] = useState<string | null>(null);
+  const [upgradeError, setUpgradeError] = useState<string | null>(null);
+  const releaseRequestIdRef = useRef(0);
+
+  const refreshReleaseData = useCallback(async (channel: ReleaseChannel) => {
+    const requestId = releaseRequestIdRef.current + 1;
+    releaseRequestIdRef.current = requestId;
+    setReleaseLoading(true);
+    setUpgradeError(null);
+    try {
+      const [updateRes, releasesRes] = await Promise.all([
+        fetch(`${GATEWAY}/api/system/update?channel=${channel}`, { signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS) }),
+        fetch(`${GATEWAY}/api/system/releases?channel=${channel}`, { signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS) }),
+      ]);
+      const nextUpdateStatus = updateRes.ok ? await updateRes.json() : null;
+      const nextReleaseList = releasesRes.ok ? await releasesRes.json() : {
+        channel,
+        releases: [],
+        error: "Release list unavailable",
+      };
+      if (releaseRequestIdRef.current !== requestId) return;
+      setUpdateStatus(nextUpdateStatus);
+      setReleaseList(nextReleaseList);
+    } catch (err: unknown) {
+      if (releaseRequestIdRef.current !== requestId) return;
+      console.warn("[system-settings] failed to load release metadata:", err instanceof Error ? err.message : String(err));
+      setUpdateStatus(null);
+      setReleaseList({ channel, releases: [], error: "Release metadata unavailable" });
+    } finally {
+      if (releaseRequestIdRef.current === requestId) {
+        setReleaseLoading(false);
+      }
+    }
+  }, []);
 
   useEffect(() => {
     fetch(`${GATEWAY}/api/system/info`, { signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS) })
       .then((r) => r.ok ? r.json() : {})
-      .then(setInfo)
+      .then((data: SystemInfo) => {
+        setInfo(data);
+        const channel = coerceReleaseChannel(data.release?.channel);
+        setSelectedChannel(channel);
+        void refreshReleaseData(channel);
+      })
       .catch((err: unknown) => {
         console.warn("[system-settings] failed to load system info:", err instanceof Error ? err.message : String(err));
+        void refreshReleaseData("stable");
       });
 
     fetch(`${GATEWAY}/health`, { signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS) })
@@ -87,26 +159,19 @@ export function SystemSection() {
         console.warn("[system-settings] failed to load health:", err instanceof Error ? err.message : String(err));
       });
 
-    fetch(`${GATEWAY}/api/system/update`, { signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS) })
-      .then((r) => r.ok ? r.json() : null)
-      .then(setUpdateStatus)
-      .catch((err: unknown) => {
-        console.warn("[system-settings] failed to load update metadata:", err instanceof Error ? err.message : String(err));
-      });
-  }, []);
+  }, [refreshReleaseData]);
 
-  const [upgrading, setUpgrading] = useState(false);
-  const [upgradeError, setUpgradeError] = useState<string | null>(null);
-
-  const handleUpgrade = useCallback(async () => {
+  const startUpdate = useCallback(async (target: { channel?: ReleaseChannel; version?: string }) => {
+    const targetKey = target.version ?? target.channel ?? "stable";
     setUpgrading(true);
+    setInstallingTarget(targetKey);
     setUpgradeError(null);
 
     try {
       const res = await fetch(`${GATEWAY}/api/system/update`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ channel: updateStatus?.channel ?? info.release?.channel ?? "stable" }),
+        body: JSON.stringify(target),
         signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS),
       });
       if (!res.ok) {
@@ -122,6 +187,7 @@ export function SystemSection() {
         }
         setUpgradeError(message);
         setUpgrading(false);
+        setInstallingTarget(null);
         return;
       }
     } catch (err: unknown) {
@@ -131,7 +197,17 @@ export function SystemSection() {
 
     // Container will restart; reload after 15s
     setTimeout(() => window.location.reload(), 15000);
-  }, [info.release?.channel, updateStatus?.channel]);
+  }, []);
+
+  const handleChannelChange = useCallback((value: string) => {
+    const channel = coerceReleaseChannel(value);
+    setSelectedChannel(channel);
+    void refreshReleaseData(channel);
+  }, [refreshReleaseData]);
+
+  const handleUpgrade = useCallback(async () => {
+    await startUpdate({ channel: selectedChannel });
+  }, [selectedChannel, startUpdate]);
 
   const resolvedUpdate = resolveSystemUpdateState({
     installedVersion: info.release?.version ?? info.version,
@@ -144,6 +220,9 @@ export function SystemSection() {
   const currentVersion = resolvedUpdate.currentVersion;
   const latestVersion = resolvedUpdate.latestVersion;
   const updateAvailable = resolvedUpdate.updateAvailable;
+  const installedChannel = coerceReleaseChannel(info.release?.channel);
+  const releaseRows = releaseList?.releases ?? [];
+  const canInstallSelectedChannel = Boolean(latestVersion && (updateAvailable || selectedChannel !== installedChannel));
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
@@ -206,26 +285,59 @@ export function SystemSection() {
             Updates
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-muted-foreground">Current version</span>
-            <span className="font-mono text-xs">{currentVersion}</span>
-          </div>
-          {latestVersion && (
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">Latest {updateStatus?.channel ?? "stable"} release</span>
-              <div className="flex items-center gap-2">
-                <span className="font-mono text-xs">{latestVersion}</span>
-                {updateAvailable && (
-                  <Badge variant="outline" className={`text-xs ${severityBadgeStyle(resolvedUpdate.severity)}`}>
-                    {resolvedUpdate.severity === "security" ? "Security update" : "Update available"}
-                  </Badge>
-                )}
-              </div>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+            <div className="space-y-1.5">
+              <label htmlFor="release-channel" className="text-xs font-medium text-muted-foreground">
+                Release channel
+              </label>
+              <select
+                id="release-channel"
+                value={selectedChannel}
+                onChange={(event) => handleChannelChange(event.target.value)}
+                disabled={releaseLoading || upgrading}
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+              >
+                {RELEASE_CHANNELS.map((channel) => (
+                  <option key={channel} value={channel}>{channel}</option>
+                ))}
+              </select>
             </div>
-          )}
-          {updateStatus?.error && (
-            <p className="text-xs text-muted-foreground">{updateStatus.error}</p>
+            <button
+              onClick={() => void refreshReleaseData(selectedChannel)}
+              disabled={releaseLoading || upgrading}
+              className="inline-flex h-9 items-center justify-center rounded-md border border-border px-3 text-sm font-medium hover:bg-muted transition-colors disabled:opacity-50"
+            >
+              {releaseLoading ? "Checking..." : "Check"}
+            </button>
+          </div>
+
+          <div className="grid gap-2 text-sm">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-muted-foreground">Current version</span>
+              <span className="font-mono text-xs text-right">{currentVersion}</span>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-muted-foreground">Installed channel</span>
+              <Badge variant="outline" className="text-xs">{installedChannel}</Badge>
+            </div>
+            {latestVersion && (
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Latest {selectedChannel} release</span>
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-xs">{latestVersion}</span>
+                  {updateAvailable && (
+                    <Badge variant="outline" className={`text-xs ${severityBadgeStyle(resolvedUpdate.severity)}`}>
+                      {resolvedUpdate.severity === "security" ? "Security update" : "Update available"}
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {(updateStatus?.error || releaseList?.error) && (
+            <p className="text-xs text-muted-foreground">{updateStatus?.error ?? releaseList?.error}</p>
           )}
           {resolvedUpdate.changelog && updateAvailable && (
             <p className="text-xs text-muted-foreground whitespace-pre-line">{resolvedUpdate.changelog}</p>
@@ -235,25 +347,82 @@ export function SystemSection() {
               This is a security update scheduled for automatic installation. Use the button below if it hasn't taken effect.
             </p>
           )}
-          {updateAvailable && (
+          {canInstallSelectedChannel && (
             <div className="pt-1 space-y-2">
               <button
                 onClick={handleUpgrade}
                 disabled={upgrading}
-                className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors disabled:opacity-50"
+                className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors disabled:opacity-50"
               >
-                {upgrading ? "Upgrading... reloading in 15s" : resolvedUpdate.autoApplying ? "Retry Update" : "Upgrade Now"}
+                {upgrading
+                  ? "Installing... reloading in 15s"
+                  : selectedChannel !== installedChannel
+                    ? `Switch to ${selectedChannel}`
+                    : resolvedUpdate.autoApplying ? "Retry Update" : "Upgrade Now"}
               </button>
               {upgradeError && (
                 <p className="text-xs text-red-500">{upgradeError}</p>
               )}
             </div>
           )}
-          {latestVersion && !updateAvailable && (
+          {latestVersion && !canInstallSelectedChannel && (
             <p className="text-xs text-muted-foreground pt-1">
-              You are running the latest version.
+              You are running the latest release for this channel.
             </p>
           )}
+
+          <Separator />
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-medium text-muted-foreground">Available {selectedChannel} releases</p>
+              {releaseList?.generatedAt && (
+                <span className="text-[11px] text-muted-foreground">
+                  {new Date(releaseList.generatedAt).toLocaleString()}
+                </span>
+              )}
+            </div>
+            {releaseRows.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                {releaseLoading ? "Loading releases..." : "No releases found for this channel."}
+              </p>
+            )}
+            <div className="space-y-2">
+              {releaseRows.slice(0, 12).map((release) => {
+                const action = releaseActionLabel({
+                  candidateVersion: release.version,
+                  currentVersion,
+                  candidateBuildTime: release.buildTime,
+                  currentBuildTime: info.release?.buildTime ?? info.build?.date,
+                });
+                const canInstallRelease = action !== "Installed" && Boolean(release.version);
+                return (
+                  <div key={release.version ?? release.gitCommit} className="flex items-center justify-between gap-3 rounded-md border border-border p-3">
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-xs">{release.version ?? "unknown"}</span>
+                        {release.severity && release.severity !== "normal" && (
+                          <Badge variant="outline" className={`text-[11px] ${severityBadgeStyle(release.severity)}`}>
+                            {release.severity}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {[release.gitCommit?.slice(0, 12), release.buildTime].filter(Boolean).join(" · ")}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => release.version && void startUpdate({ version: release.version })}
+                      disabled={!canInstallRelease || upgrading}
+                      className="shrink-0 rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors disabled:opacity-50"
+                    >
+                      {installingTarget === release.version ? "Installing" : action}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </CardContent>
       </Card>
 

--- a/shell/src/components/settings/sections/system-update-state.ts
+++ b/shell/src/components/settings/sections/system-update-state.ts
@@ -23,6 +23,61 @@ export function isNewer(latest: string, current: string): boolean {
   return false;
 }
 
+function parseHostBundleVersion(value: string | undefined): number[] | null {
+  if (!value) return null;
+  const mainBuild = value.match(/^main-[A-Za-z0-9]+-(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/);
+  if (mainBuild) {
+    return [
+      Number(mainBuild[1]),
+      Number(mainBuild[2]),
+      Number(mainBuild[3]),
+      Number(mainBuild[4]),
+      Number(mainBuild[5]),
+      Number(mainBuild[6]),
+    ];
+  }
+  // Keep this date-release parser aligned with packages/gateway/src/system-update.ts parseReleaseNumber.
+  const match = value.match(/^v?(\d{4})\.(\d{2})\.(\d{2})(?:[-.](\d+))?/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3]), Number(match[4] ?? 0)];
+}
+
+export function compareHostBundleReleaseVersions(candidate: string | undefined, current: string | undefined): number {
+  if (!candidate || !current) return 0;
+  if (candidate === current) return 0;
+  const a = parseHostBundleVersion(candidate);
+  const b = parseHostBundleVersion(current);
+  if (!a || !b) return 0;
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av > bv) return 1;
+    if (av < bv) return -1;
+  }
+  return 0;
+}
+
+export function releaseActionLabel(input: {
+  candidateVersion?: string;
+  currentVersion?: string;
+  candidateBuildTime?: string;
+  currentBuildTime?: string;
+}): "Installed" | "Upgrade" | "Downgrade" | "Install" {
+  if (input.candidateVersion && input.candidateVersion === input.currentVersion) return "Installed";
+  const versionComparison = compareHostBundleReleaseVersions(input.candidateVersion, input.currentVersion);
+  if (versionComparison > 0) return "Upgrade";
+  if (versionComparison < 0) return "Downgrade";
+  if (input.candidateBuildTime && input.currentBuildTime) {
+    const candidateTime = Date.parse(input.candidateBuildTime);
+    const currentTime = Date.parse(input.currentBuildTime);
+    if (Number.isFinite(candidateTime) && Number.isFinite(currentTime)) {
+      if (candidateTime > currentTime) return "Upgrade";
+      if (candidateTime < currentTime) return "Downgrade";
+    }
+  }
+  return "Install";
+}
+
 export function severityBadgeStyle(severity?: string): string {
   switch (severity) {
     case "security": return "bg-red-500/10 text-red-600";

--- a/tests/gateway/system-update.test.ts
+++ b/tests/gateway/system-update.test.ts
@@ -6,6 +6,7 @@ import {
   checkForSystemUpdate,
   compareHostBundleVersions,
   isAutoApplyUpdate,
+  listSystemReleases,
   parseUpdateChannel,
   parseInternalUpgradeTarget,
   parseUpdateVersion,
@@ -154,6 +155,28 @@ describe("system update checks", () => {
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
+
+  it("lists releases for the selected channel from the platform", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      generatedAt: "2026-05-14T00:00:00.000Z",
+      releases: [
+        { version: "main-new", channel: "dev", gitCommit: "new-sha" },
+        { version: "main-old", channel: "dev", gitCommit: "old-sha" },
+      ],
+    })));
+
+    const result = await listSystemReleases({
+      platformUrl: "https://app.matrix-os.com",
+      channel: "dev",
+      fetchImpl,
+    });
+
+    expect(result.releases.map((release) => release.version)).toEqual(["main-new", "main-old"]);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/system-bundles/releases?channel=dev",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
 });
 
 describe("two-lane update severity", () => {
@@ -237,6 +260,30 @@ describe("system update start", () => {
       expect(spawnImpl).toHaveBeenCalledWith(
         "sudo",
         ["-n", updateCommand, "stable"],
+        expect.objectContaining({ detached: true, stdio: "ignore" }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("starts the local VPS updater with an explicit version for downgrades", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "matrix-update-"));
+    const updateCommand = join(dir, "matrix-update");
+    writeFileSync(updateCommand, "#!/bin/sh\n", { mode: 0o755 });
+    const spawnImpl = vi.fn().mockReturnValue({ unref: vi.fn() });
+
+    try {
+      const result = await startSystemUpdate({
+        target: { type: "version", value: "v2026.05.12-1" },
+        updateCommand,
+        spawnImpl,
+      });
+
+      expect(result).toEqual({ ok: true, status: "started" });
+      expect(spawnImpl).toHaveBeenCalledWith(
+        "sudo",
+        ["-n", updateCommand, "v2026.05.12-1"],
         expect.objectContaining({ detached: true, stdio: "ignore" }),
       );
     } finally {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -98,9 +98,9 @@ describe('customer VPS host bundle', () => {
     expect(updater).toContain('/opt/matrix/app/.update-version');
     expect(updater).toContain('touch /opt/matrix/app/.update-now');
     expect(updater).toContain('touch /opt/matrix/app/.rollback-now');
-    expect(updater).toContain('stable|canary|beta|dev|v[0-9]*');
+    expect(updater).toContain('stable|canary|beta|dev|v[0-9]*|main-[A-Za-z0-9]*');
     expect(updater).toContain('journalctl -u matrix-sync-agent -f --no-pager -n 20');
-    expect(updater).toContain('Usage: matrix-update [apply|rollback|stable|canary|beta|dev|<version>]');
+    expect(updater).toContain('Usage: matrix-update [apply|rollback|stable|canary|beta|dev|v<version>|main-<build>]');
   });
 
   it('sync agent replaces the app tree with root permissions', () => {

--- a/tests/platform/host-bundle-route.test.ts
+++ b/tests/platform/host-bundle-route.test.ts
@@ -3,6 +3,7 @@ import { createApp } from '../../packages/platform/src/main.js';
 import type { CustomerVpsObjectStore } from '../../packages/platform/src/customer-vps-r2.js';
 import {
   getHostBundleRelease,
+  listHostBundleReleases,
   promoteHostBundleChannel,
   type PlatformDB,
   upsertHostBundleRelease,
@@ -154,6 +155,7 @@ describe('platform host bundle route', () => {
     expect(res.headers.get('content-type')).toContain('application/json');
     await expect(res.json()).resolves.toMatchObject({
       version: 'v2026.05.12-1',
+      channel: 'stable',
       gitCommit: 'c1598218',
       sha256: 'a'.repeat(64),
       url: 'https://r2.example/signed-host-bundle',
@@ -163,6 +165,52 @@ describe('platform host bundle route', () => {
       'system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz',
       3600,
     );
+  });
+
+  it('serializes the requested channel for promoted channel aliases', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-7',
+      gitCommit: 'c1598218',
+      gitRef: 'refs/tags/v2026.05.12-7',
+      buildTime: '2026-05-12T04:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-7/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-7/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'e'.repeat(64),
+      size: 7890,
+      channel: 'canary',
+    });
+    await promoteHostBundleChannel(db, 'stable', 'v2026.05.12-7');
+    const getPresignedGetUrl = vi.fn().mockResolvedValue('https://r2.example/promoted-host-bundle');
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const channelManifestRes = await app.request('/system-bundles/channels/stable.json');
+    expect(channelManifestRes.status).toBe(200);
+    await expect(channelManifestRes.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-7',
+      channel: 'stable',
+    });
+
+    const aliasReleaseRes = await app.request('/system-bundles/stable/release.json');
+    expect(aliasReleaseRes.status).toBe(200);
+    await expect(aliasReleaseRes.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-7',
+      channel: 'stable',
+    });
+
+    const immutableReleaseRes = await app.request('/system-bundles/releases/v2026.05.12-7.json');
+    expect(immutableReleaseRes.status).toBe(200);
+    await expect(immutableReleaseRes.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-7',
+      channel: 'canary',
+    });
   });
 
   it('resolves channel aliases to DB releases for cloud-init bundle downloads', async () => {
@@ -244,6 +292,7 @@ describe('platform host bundle route', () => {
     await expect(res.json()).resolves.toMatchObject({
       release: {
         version: 'v2026.05.12-2',
+        channel: 'canary',
         gitCommit: 'c15982181234567890',
       },
       channel: {
@@ -257,10 +306,89 @@ describe('platform host bundle route', () => {
       releases: [
         {
           version: 'v2026.05.12-2',
+          channel: 'canary',
           bundleKey: 'system-bundles/v2026.05.12-2/matrix-host-bundle.tar.gz',
         },
       ],
     });
+
+    const channelReleasesRes = await app.request('/system-bundles/releases?channel=canary');
+    await expect(channelReleasesRes.json()).resolves.toMatchObject({
+      releases: [{ version: 'v2026.05.12-2', channel: 'canary' }],
+    });
+
+    const stableReleasesRes = await app.request('/system-bundles/releases?channel=stable');
+    await expect(stableReleasesRes.json()).resolves.toMatchObject({ releases: [] });
+
+    const emptyChannelRes = await app.request('/system-bundles/releases?channel=');
+    expect(emptyChannelRes.status).toBe(400);
+
+    const promoteRes = await app.request('/system-bundles/channels/stable', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer secret',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ version: 'v2026.05.12-2' }),
+    });
+    expect(promoteRes.status).toBe(200);
+
+    const promotedStableRes = await app.request('/system-bundles/releases?channel=stable');
+    await expect(promotedStableRes.json()).resolves.toMatchObject({
+      releases: [{ version: 'v2026.05.12-2', channel: 'canary' }],
+    });
+
+    const canaryAfterPromotionRes = await app.request('/system-bundles/releases?channel=canary');
+    await expect(canaryAfterPromotionRes.json()).resolves.toMatchObject({
+      releases: [{ version: 'v2026.05.12-2', channel: 'canary' }],
+    });
+
+    const reRegisterRes = await app.request('/system-bundles/releases', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer secret',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        version: 'v2026.05.12-2',
+        gitCommit: 'c15982181234567890',
+        gitRef: 'refs/tags/v2026.05.12-2',
+        buildTime: '2026-05-12T01:00:00.000Z',
+        bundleKey: 'system-bundles/v2026.05.12-2/matrix-host-bundle.tar.gz',
+        checksumKey: 'system-bundles/v2026.05.12-2/matrix-host-bundle.tar.gz.sha256',
+        sha256: 'b'.repeat(64),
+        size: 5678,
+        channel: 'stable',
+      }),
+    });
+    expect(reRegisterRes.status).toBe(200);
+
+    const canaryAfterReRegisterRes = await app.request('/system-bundles/releases?channel=canary');
+    await expect(canaryAfterReRegisterRes.json()).resolves.toMatchObject({
+      releases: [{ version: 'v2026.05.12-2', channel: 'canary' }],
+    });
+  });
+
+  it('only adds release channel history when channel promotion succeeds', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.12-6',
+      gitCommit: 'c15982181234567890',
+      gitRef: 'refs/tags/v2026.05.12-6',
+      buildTime: '2026-05-12T03:00:00.000Z',
+      bundleKey: 'system-bundles/v2026.05.12-6/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.12-6/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'd'.repeat(64),
+      size: 4321,
+      channel: 'dev',
+    });
+
+    await expect(listHostBundleReleases(db, 10, 'dev')).resolves.toEqual([]);
+
+    await promoteHostBundleChannel(db, 'dev', 'v2026.05.12-6');
+
+    await expect(listHostBundleReleases(db, 10, 'dev')).resolves.toMatchObject([
+      { version: 'v2026.05.12-6', channel: 'dev' },
+    ]);
   });
 
   it('rejects release re-registration when immutable artifact fields differ', async () => {

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/gateway", () => ({
+  getGatewayUrl: () => "http://gateway.test",
+}));
+
+import { SystemSection } from "../../shell/src/components/settings/sections/SystemSection.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    json: async () => body,
+  } as Response;
+}
+
+describe("SystemSection release refresh", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ignores stale release metadata when the selected channel changes", async () => {
+    const stableUpdate = deferred<Response>();
+    const stableReleases = deferred<Response>();
+    const devUpdate = deferred<Response>();
+    const devReleases = deferred<Response>();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        return Promise.resolve(jsonResponse({
+          version: "v2026.05.14-1",
+          release: {
+            version: "v2026.05.14-1",
+            channel: "stable",
+            buildTime: "2026-05-14T11:00:00.000Z",
+          },
+        }));
+      }
+      if (url.endsWith("/health")) {
+        return Promise.resolve(jsonResponse({ status: "ok", cronJobs: 0, channels: {} }));
+      }
+      if (url.endsWith("/api/system/update?channel=stable")) return stableUpdate.promise;
+      if (url.endsWith("/api/system/releases?channel=stable")) return stableReleases.promise;
+      if (url.endsWith("/api/system/update?channel=dev")) return devUpdate.promise;
+      if (url.endsWith("/api/system/releases?channel=dev")) return devReleases.promise;
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SystemSection />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://gateway.test/api/system/update?channel=stable",
+        expect.any(Object),
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText("Release channel"), {
+      target: { value: "dev" },
+    });
+
+    await act(async () => {
+      devUpdate.resolve(jsonResponse({
+        channel: "dev",
+        latest: {
+          version: "main-abc1234-20260514130000",
+          buildTime: "2026-05-14T13:00:00.000Z",
+        },
+        updateAvailable: true,
+      }));
+      devReleases.resolve(jsonResponse({
+        channel: "dev",
+        releases: [{
+          version: "main-abc1234-20260514130000",
+          buildTime: "2026-05-14T13:00:00.000Z",
+        }],
+      }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Latest dev release")).toBeTruthy();
+      expect(screen.getAllByText("main-abc1234-20260514130000").length).toBeGreaterThan(0);
+    });
+
+    await act(async () => {
+      stableUpdate.resolve(jsonResponse({
+        channel: "stable",
+        latest: {
+          version: "v2026.05.14-2",
+          buildTime: "2026-05-14T12:00:00.000Z",
+        },
+        updateAvailable: true,
+      }));
+      stableReleases.resolve(jsonResponse({
+        channel: "stable",
+        releases: [{
+          version: "v2026.05.14-2",
+          buildTime: "2026-05-14T12:00:00.000Z",
+        }],
+      }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Latest dev release")).toBeTruthy();
+    });
+    expect(screen.queryByText("Latest stable release")).toBeNull();
+    expect(screen.queryByText("v2026.05.14-2")).toBeNull();
+  });
+});

--- a/tests/shell/system-section-version.test.ts
+++ b/tests/shell/system-section-version.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  compareHostBundleReleaseVersions,
   isNewer,
   normalizeMatrixReleaseTag,
+  releaseActionLabel,
   resolveSystemUpdateState,
   severityBadgeStyle,
 } from "../../shell/src/components/settings/sections/system-update-state.js";
@@ -20,6 +22,43 @@ describe("SystemSection version helpers", () => {
     expect(isNewer("0.2.4", "0.2.3")).toBe(true);
     expect(isNewer("0.2.4", "0.2.4")).toBe(false);
     expect(isNewer("0.2.3", "0.2.4")).toBe(false);
+  });
+
+  it("compares host bundle releases for downgrade actions", () => {
+    expect(compareHostBundleReleaseVersions("v2026.05.14-2", "v2026.05.14-1")).toBe(1);
+    expect(compareHostBundleReleaseVersions("v2026.05.13-1", "v2026.05.14-1")).toBe(-1);
+    expect(compareHostBundleReleaseVersions("v2026.05.14-1", "v2026.05.14-1")).toBe(0);
+    expect(compareHostBundleReleaseVersions(
+      "main-abc1234-20260514121530",
+      "main-abc1234-20260514111530",
+    )).toBe(1);
+    expect(compareHostBundleReleaseVersions(
+      "main-abc1234-20260513121530",
+      "main-abc1234-20260514111530",
+    )).toBe(-1);
+    expect(compareHostBundleReleaseVersions(
+      "main-abc1234-20260514121530",
+      "v2026.05.14-1",
+    )).toBe(1);
+    expect(compareHostBundleReleaseVersions(
+      "v2026.05.14-1",
+      "main-abc1234-20260514121530",
+    )).toBe(-1);
+  });
+
+  it("labels explicit release installs as upgrade or downgrade", () => {
+    expect(releaseActionLabel({
+      candidateVersion: "v2026.05.14-2",
+      currentVersion: "v2026.05.14-1",
+    })).toBe("Upgrade");
+    expect(releaseActionLabel({
+      candidateVersion: "v2026.05.13-1",
+      currentVersion: "v2026.05.14-1",
+    })).toBe("Downgrade");
+    expect(releaseActionLabel({
+      candidateVersion: "v2026.05.14-1",
+      currentVersion: "v2026.05.14-1",
+    })).toBe("Installed");
   });
 
   it("uses VPS host-bundle update metadata before GitHub release tags", () => {


### PR DESCRIPTION
## Summary
- Add Matrix Settings release controls for selecting `stable`, `canary`, `beta`, or `dev`, checking that channel, and installing the latest release.
- Add channel-scoped release history in Settings so users can install an explicit previous or newer version for downgrade/upgrade.
- Extend gateway and platform release APIs to list releases by channel and to trigger validated version targets, including `main-*` dev builds.
- Persist release channel history separately from current channel pointers and document user-driven channel/version updates.

## Tests
- `bun run test tests/shell/system-section-refresh.test.tsx tests/platform/host-bundle-route.test.ts tests/shell/system-section-version.test.ts tests/gateway/system-update.test.ts tests/platform/customer-vps-host-bundle.test.ts`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run test` was started locally but stayed silent for 5+ minutes, so I stopped it and left full-suite coverage to CI.

## Invariants
- **Source of truth**: Platform Postgres `host_bundle_releases`, `host_bundle_channels`, and `host_bundle_release_channels` are canonical for published host bundles, current channel pointers, and channel history. Customer VPS release state remains `/opt/matrix/release.json` plus the sync-agent update trigger files under `/opt/matrix/app`.
- **Lock/transaction scope**: Release registration is artifact-metadata only. Channel pointer updates and channel-history writes happen together in `promoteHostBundleChannel` so a failed promotion cannot expose unpromoted releases in channel history. User-triggered installs only validate a channel/version and spawn the local `matrix-update` command; network bundle fetch/apply remains inside the VPS sync-agent updater path.
- **Acceptable orphan states**: If Settings triggers an update and the connection drops, the UI assumes the VPS is restarting and reloads. If release-channel metadata refreshes race, Settings commits only the latest request id so stale channel responses cannot replace the selected channel state. Channel-alias manifests serialize the requested channel so a promoted bundle installed through `stable` remains on `stable` after restart. If the updater command is missing, the gateway returns a generic 503 and does not write partial release state.
- **Auth source of truth**: Settings calls are served by the authenticated user VPS gateway. Platform release registration and promotion remain protected by `PLATFORM_SECRET`; public release listing exposes metadata only, not signed bundle URLs.
- **Deferred scope**: This PR does not add scheduled auto-update policy controls, fleet-wide operator rollout controls, or rich release notes rendering beyond the existing changelog text.