### PR TITLE
feat(mobile): add launcher-first mobile shell

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/078-matrix-symphony"
+  "feature_directory": "specs/075-mobile-shell"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,8 @@ Read these on demand, not every session:
 - Files under the owner-controlled Matrix home (`~/system/shell-sessions.json`, `~/system/layouts/*.kdl`) plus local CLI files under `~/.matrixos/profiles.json` and `~/.matrixos/profiles/<name>/` (068-zellij-cli)
 - TypeScript 5.5+ strict, ES modules, Node.js 24+ + Hono gateway, Hono WebSocket support, Zod 4 via `zod/v4`, existing `jose` JWT validation, Vitest (072-request-principal)
 - No new persistence; request principal is request-scoped. Existing consumers continue to use owner-controlled PostgreSQL/Kysely and sync R2/object storage through existing repositories. (072-request-principal)
+- TypeScript strict, ES modules, Node.js 24+ for gateway; React 19, React Native 0.83, Expo Router 55 for mobile shell + Hono gateway, Zod 4 via `zod/v4`, existing terminal stack (`node-pty`, `@xterm/xterm` on web), Expo Router, React Native WebView, Clerk Expo, AsyncStorage/SecureStore (075-mobile-shell)
+- Owner-controlled Matrix home files for shell/terminal session metadata (`~/system/terminal-sessions.json`, terminal layout files) plus existing owner Postgres where current workspace/app data already lives. No new embedded database or ORM. (075-mobile-shell)
 
 - TypeScript 5.5+ strict, ES modules + node-pty (backend), @xterm/xterm + addon-webgl + addon-search + addon-serialize + addon-fit (frontend), Hono WebSocket (gateway), Zod 4 (validation) (056-terminal-upgrade)
 - Files — `~/system/terminal-sessions.json` (session metadata), `~/system/terminal-layout.json` (layout with sessionId) (056-terminal-upgrade)
@@ -338,5 +340,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/078-matrix-symphony/plan.md`.
+Current Spec Kit plan: `specs/075-mobile-shell/plan.md`.
 <!-- SPECKIT END -->

--- a/apps/mobile/__tests__/TerminalControlBar.test.tsx
+++ b/apps/mobile/__tests__/TerminalControlBar.test.tsx
@@ -1,0 +1,36 @@
+import * as Clipboard from "expo-clipboard";
+import {
+  TERMINAL_CONTROL_KEYS,
+  sendTerminalClipboardPaste,
+} from "../components/TerminalControlBar";
+import { buildTerminalControlSequence } from "../lib/terminal-state";
+
+describe("TerminalControlBar", () => {
+  it("exposes the expected mobile terminal control keys", () => {
+    expect(TERMINAL_CONTROL_KEYS.map((entry) => entry.label)).toEqual([
+      "Esc",
+      "Tab",
+      "Enter",
+      "Ctrl-C",
+      "Ctrl-D",
+      "Ctrl-L",
+    ]);
+    expect(TERMINAL_CONTROL_KEYS.map((entry) => buildTerminalControlSequence(entry.key))).toEqual([
+      "\x1b",
+      "\t",
+      "\r",
+      "\x03",
+      "\x04",
+      "\x0c",
+    ]);
+  });
+
+  it("sends clipboard text through the terminal paste action", async () => {
+    const onSend = jest.fn();
+    jest.spyOn(Clipboard, "getStringAsync").mockResolvedValueOnce("copied text");
+
+    await sendTerminalClipboardPaste(onSend);
+
+    expect(onSend).toHaveBeenCalledWith("copied text");
+  });
+});

--- a/apps/mobile/__tests__/apps-screen.test.tsx
+++ b/apps/mobile/__tests__/apps-screen.test.tsx
@@ -1,27 +1,33 @@
-import React from "react";
-import { render, waitFor } from "@testing-library/react-native";
-import AppsScreen from "../app/(tabs)/apps";
-import { useGateway } from "../app/_layout";
-import { GatewayClient } from "../lib/gateway-client";
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
 
 jest.mock("../app/_layout", () => ({
   useGateway: jest.fn(),
 }));
 
-jest.mock("expo-router", () => {
-  const React = require("react");
+jest.mock("expo-router", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock("expo-image", () => {
+  const { View } = require("react-native");
   return {
-    Link: ({ children }: { children: React.ReactElement }) => children,
+    Image: (props: Record<string, unknown>) => {
+      const mockReact = require("react");
+      return mockReact.createElement(View, { testID: "expo-image", ...props });
+    },
   };
 });
 
-jest.mock("expo-image", () => {
-  const React = require("react");
-  const { View } = require("react-native");
-  return {
-    Image: (props: Record<string, unknown>) => React.createElement(View, { ...props, testID: "app-image" }),
-  };
-});
+import React from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import AppsScreen from "../app/(tabs)/apps";
+import { useGateway } from "../app/_layout";
+import { GatewayClient } from "../lib/gateway-client";
+import { MOBILE_SHELL_STATE_STORAGE_KEY } from "../lib/mobile-shell-state";
 
 const useGatewayMock = useGateway as jest.MockedFunction<typeof useGateway>;
 type GatewayContextValue = ReturnType<typeof useGateway>;
@@ -40,19 +46,21 @@ function gatewayContext(overrides: Partial<GatewayContextValue>): GatewayContext
 }
 
 describe("AppsScreen", () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
   });
 
   it("keeps native Matrix apps visible before a gateway client is connected", async () => {
     useGatewayMock.mockReturnValue(gatewayContext({}));
 
-    const { getByText } = render(<AppsScreen />);
+    render(<AppsScreen />);
 
-    await waitFor(() => expect(getByText("Chat")).toBeTruthy());
-    expect(getByText("Apps")).toBeTruthy();
-    expect(getByText("Tasks")).toBeTruthy();
-    expect(getByText("Settings")).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("Chat")).toBeTruthy());
+    expect(screen.getByText("Apps")).toBeTruthy();
+    expect(screen.getByText("Tasks")).toBeTruthy();
+    expect(screen.getByText("Settings")).toBeTruthy();
   });
 
   it("keeps native Matrix apps visible when the gateway returns no apps", async () => {
@@ -63,11 +71,11 @@ describe("AppsScreen", () => {
       connectionState: "connected",
     }));
 
-    const { getByText } = render(<AppsScreen />);
+    render(<AppsScreen />);
 
     await waitFor(() => expect(getApps).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(getByText("Chat")).toBeTruthy());
-    expect(getByText("Tasks")).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("Chat")).toBeTruthy());
+    expect(screen.getByText("Tasks")).toBeTruthy();
   });
 
   it("keeps native Matrix apps visible when the gateway app fetch fails", async () => {
@@ -79,12 +87,45 @@ describe("AppsScreen", () => {
       connectionState: "error",
     }));
 
-    const { getByText } = render(<AppsScreen />);
+    render(<AppsScreen />);
 
     await waitFor(() => expect(getApps).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(getByText("Chat")).toBeTruthy());
-    expect(getByText("Settings")).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("Chat")).toBeTruthy());
+    expect(screen.getByText("Settings")).toBeTruthy();
 
     warn.mockRestore();
+  });
+
+  it("offers a real continue card for the last active app and updates persisted state when used", async () => {
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({
+      mode: "app",
+      lastActiveAppSlug: "notes",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    }));
+    const client = new GatewayClient("https://app.matrix-os.test");
+    jest.spyOn(client, "getApps").mockResolvedValue([
+      {
+        name: "Notes",
+        description: "Write and organize notes.",
+        category: "Productivity",
+        file: "notes/index.html",
+        path: "/files/apps/notes/index.html",
+        slug: "notes",
+      },
+    ]);
+    useGatewayMock.mockReturnValue(gatewayContext({
+      client,
+      connectionState: "connected",
+    }));
+
+    render(<AppsScreen />);
+
+    await waitFor(() => expect(screen.getByLabelText("Continue Notes")).toBeTruthy());
+    fireEvent.press(screen.getByLabelText("Continue Notes"));
+
+    await waitFor(() => expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      MOBILE_SHELL_STATE_STORAGE_KEY,
+      expect.stringContaining("\"lastActiveAppSlug\":\"notes\""),
+    ));
   });
 });

--- a/apps/mobile/__tests__/apps.test.ts
+++ b/apps/mobile/__tests__/apps.test.ts
@@ -28,11 +28,28 @@ describe("mobile app helpers", () => {
     expect(getAppSlug(app({ file: "calculator.html" }))).toBe("calculator");
   });
 
+  it("normalizes slugs from gateway paths with casing, duplicate slashes, and cache params", () => {
+    expect(getAppSlug(app({
+      name: "Notes",
+      file: "/files/apps//Notes/index.html?v=abc#top",
+      path: "/files/apps//Notes/index.html?v=abc#top",
+    }))).toBe("notes");
+  });
+
+  it("falls back to a safe name slug for unsafe app paths", () => {
+    expect(getAppSlug(app({
+      name: "Internal Secrets",
+      file: "../system/secrets/index.html",
+      path: "/files/apps/../system/secrets/index.html",
+    }))).toBe("internal-secrets");
+  });
+
   it("routes known Matrix apps to native screens", () => {
     expect(getNativeAppRoute(app({ name: "Task Manager", file: "task-manager/index.html" }))).toBe(
       "/(tabs)/mission-control",
     );
     expect(getNativeAppRoute(app({ name: "Chat", file: "chat/index.html" }))).toBe("/(tabs)/chat");
+    expect(getNativeAppRoute(app({ name: "Terminal", file: "terminal/index.html" }))).toBe("/terminal");
   });
 
   it("leaves generated apps on native detail screens before browser fallback", () => {
@@ -105,18 +122,47 @@ describe("mobile app helpers", () => {
     });
   });
 
+  it("routes non-native launcher apps to the full-screen runtime surface", () => {
+    const workout = app({ name: "Workout Tracker", file: "workout/index.html" });
+
+    expect(getNativeAppRoute(workout)).toBeNull();
+    expect(appRuntimeHref(getAppSlug(workout))).toEqual({
+      pathname: "/runtime/[...slug]",
+      params: { slug: ["workout"] },
+    });
+  });
+
+  it("keeps missing generated apps on runtime routes so the screen can show a safe fallback", () => {
+    const missing = app({ name: "Missing App", file: "missing/index.html" });
+
+    expect(getNativeAppRoute(missing)).toBeNull();
+    expect(getRuntimeSlug(missing)).toBe("missing");
+  });
+
+  it("encodes normalized app runtime URLs without leaking unsafe paths", () => {
+    expect(buildGatewayAppUrl(
+      "https://app.matrix-os.com/",
+      app({ name: "Internal Secrets", file: "../system/secrets/index.html" }),
+    )).toBe("https://app.matrix-os.com/apps/internal-secrets/");
+  });
+
   it("selects useful native symbols for app cards", () => {
     expect(getAppIconName(app({ name: "Pomodoro", category: "productivity" }))).toBe("timer");
     expect(getAppIconName(app({ name: "Snake", category: "game" }))).toBe("game-controller");
+    expect(getAppIconName(app({ name: "Terminal", category: "system" }))).toBe("terminal");
   });
 
   it("keeps native Matrix apps visible when the VPS app list is empty", () => {
     const apps = mergeNativeAndRemoteApps([]);
-    expect(apps.map((entry) => entry.name)).toEqual(["Chat", "Apps", "Tasks", "Settings"]);
+    expect(apps.map((entry) => entry.name)).toEqual(["Chat", "Apps", "Terminal", "Canvas", "Tasks", "Settings"]);
   });
 
   it("appends remote apps after native Matrix apps", () => {
     const apps = mergeNativeAndRemoteApps([app({ name: "Workout Tracker", file: "workout/index.html" })]);
-    expect(apps.map((entry) => entry.name)).toEqual(["Chat", "Apps", "Tasks", "Settings", "Workout Tracker"]);
+    expect(apps.map((entry) => entry.name)).toEqual(["Chat", "Apps", "Terminal", "Canvas", "Tasks", "Settings", "Workout Tracker"]);
+  });
+
+  it("routes Canvas to the native explicit Canvas entry screen", () => {
+    expect(getNativeAppRoute(app({ name: "Canvas", slug: "canvas", file: "canvas/index.html" }))).toBe("/canvas");
   });
 });

--- a/apps/mobile/__tests__/canvas-entry.test.tsx
+++ b/apps/mobile/__tests__/canvas-entry.test.tsx
@@ -1,0 +1,43 @@
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const mockReplace = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+import React from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import CanvasEntryScreen from "../app/canvas";
+import { MOBILE_SHELL_STATE_STORAGE_KEY } from "../lib/mobile-shell-state";
+
+describe("CanvasEntryScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+  });
+
+  it("shows an explicit native Canvas unavailable state and returns to the app launcher", async () => {
+    render(<CanvasEntryScreen />);
+
+    expect(screen.getByText("Canvas opens best in the browser shell")).toBeTruthy();
+    fireEvent.press(screen.getByLabelText("Remember Canvas entry"));
+
+    await waitFor(() => expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      MOBILE_SHELL_STATE_STORAGE_KEY,
+      expect.stringContaining("\"mode\":\"canvas\""),
+    ));
+
+    fireEvent.press(screen.getByLabelText("Apps"));
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/apps");
+  });
+});

--- a/apps/mobile/__tests__/gateway-client.test.ts
+++ b/apps/mobile/__tests__/gateway-client.test.ts
@@ -1,4 +1,5 @@
-import { GatewayClient } from "../lib/gateway-client";
+import { GatewayClient, DEFAULT_GATEWAY_FETCH_TIMEOUT_MS } from "../lib/gateway-client";
+import { jsonResponse } from "./mobile-shell-test-utils";
 
 describe("GatewayClient", () => {
   it("initializes with disconnected state", () => {
@@ -106,16 +107,13 @@ describe("GatewayClient", () => {
   });
 
   it("fetches installed apps from the gateway", async () => {
-    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: jest.fn().mockResolvedValueOnce([
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse([
         {
           name: "Notes",
           file: "notes/index.html",
           path: "/files/apps/notes/index.html",
         },
-      ]),
-    } as unknown as Response);
+      ]));
 
     const client = new GatewayClient("http://localhost:4000", "token");
     await expect(client.getApps()).resolves.toEqual([
@@ -125,15 +123,13 @@ describe("GatewayClient", () => {
         path: "/files/apps/notes/index.html",
       },
     ]);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:4000/api/apps",
-      expect.objectContaining({
-        headers: {
-          Authorization: "Bearer token",
-          "Content-Type": "application/json",
-        },
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/apps", expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: "Bearer token",
+        "Content-Type": "application/json",
       }),
-    );
+      signal: expect.any(Object),
+    }));
 
     fetchMock.mockRestore();
   });
@@ -187,24 +183,22 @@ describe("GatewayClient", () => {
   });
 
   it("fetches per-app manifest details from the gateway", async () => {
-    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: jest.fn().mockResolvedValueOnce({
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({
         manifest: { name: "Notes" },
         runtimeState: { status: "ready" },
-      }),
-    } as unknown as Response);
+      }));
 
     const client = new GatewayClient("http://localhost:4000");
     await expect(client.getAppManifest("notes")).resolves.toEqual({
       manifest: { name: "Notes" },
       runtimeState: { status: "ready" },
     });
-    expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/apps/notes/manifest", {
-      headers: {
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/apps/notes/manifest", expect.objectContaining({
+      headers: expect.objectContaining({
         "Content-Type": "application/json",
-      },
-    });
+      }),
+      signal: expect.any(Object),
+    }));
 
     fetchMock.mockRestore();
   });
@@ -223,11 +217,15 @@ describe("GatewayClient", () => {
       manifest: { name: "Chess" },
       runtimeState: { status: "ready" },
     });
-    expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/apps/games/chess/manifest", {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/api/apps/games/chess/manifest",
+      expect.objectContaining({
+        headers: {
+          "Content-Type": "application/json",
+        },
+        signal: expect.any(Object),
+      }),
+    );
 
     fetchMock.mockRestore();
   });
@@ -262,19 +260,17 @@ describe("GatewayClient", () => {
   });
 
   it("fetches a platform websocket token using bearer auth", async () => {
-    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: jest.fn().mockResolvedValueOnce({ token: "ws-token" }),
-    } as unknown as Response);
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({ token: "ws-token" }));
 
     const client = new GatewayClient("https://app.matrix-os.com", "clerk-token");
     await expect(client.getWsToken()).resolves.toBe("ws-token");
-    expect(fetchMock).toHaveBeenCalledWith("https://app.matrix-os.com/api/auth/ws-token", {
-      headers: {
+    expect(fetchMock).toHaveBeenCalledWith("https://app.matrix-os.com/api/auth/ws-token", expect.objectContaining({
+      headers: expect.objectContaining({
         Authorization: "Bearer clerk-token",
         "Content-Type": "application/json",
-      },
-    });
+      }),
+      signal: expect.any(Object),
+    }));
 
     fetchMock.mockRestore();
   });
@@ -334,5 +330,54 @@ describe("GatewayClient", () => {
     fetchMock.mockRestore();
     global.WebSocket = OriginalWebSocket;
     jest.useRealTimers();
+  });
+
+  it("adds timeout signals to gateway HTTP requests", async () => {
+    const timeoutSpy = jest.spyOn(AbortSignal, "timeout").mockReturnValue("timeout-signal" as unknown as AbortSignal);
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse([]));
+
+    const client = new GatewayClient("http://localhost:4000");
+    await expect(client.getApps()).resolves.toEqual([]);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(DEFAULT_GATEWAY_FETCH_TIMEOUT_MS);
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:4000/api/apps", expect.objectContaining({
+      signal: "timeout-signal",
+    }));
+
+    fetchMock.mockRestore();
+    timeoutSpy.mockRestore();
+  });
+
+  it("returns a safe fallback when app inventory fetch fails", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fetchMock = jest.spyOn(global, "fetch").mockRejectedValueOnce(
+      new Error("network unavailable"),
+    );
+
+    const client = new GatewayClient("http://localhost:4000");
+    await expect(client.getApps()).resolves.toEqual([]);
+
+    expect(warnSpy).toHaveBeenCalledWith("[mobile] /api/apps unavailable", "network unavailable");
+
+    fetchMock.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("returns a generic health error instead of raw network failures", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fetchMock = jest.spyOn(global, "fetch").mockRejectedValueOnce(
+      new Error("ECONNREFUSED /var/run/provider.sock"),
+    );
+
+    const client = new GatewayClient("http://localhost:4000");
+    await expect(client.healthCheck()).resolves.toEqual({
+      ok: false,
+      error: "Gateway unavailable",
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith("[mobile] gateway health check unavailable");
+
+    fetchMock.mockRestore();
+    warnSpy.mockRestore();
   });
 });

--- a/apps/mobile/__tests__/mobile-shell-state.test.ts
+++ b/apps/mobile/__tests__/mobile-shell-state.test.ts
@@ -39,7 +39,7 @@ describe("mobile shell state", () => {
       surface: "browser-shell",
       mode: "desktop",
       lastActiveAppSlug: "../system/secrets",
-      lastActiveTerminalSessionId: "/tmp/socket",
+      lastActiveTerminalSessionId: "terminal_123",
       canvasEnteredAt: "not-a-date",
       updatedAt: "not-a-date",
     })).toMatchObject({
@@ -72,7 +72,7 @@ describe("mobile shell state", () => {
       surface: "native-mobile",
       mode: "app",
       lastActiveAppSlug: "Notes App",
-      lastActiveTerminalSessionId: "/tmp/socket",
+      lastActiveTerminalSessionId: "terminal_123",
       canvasEnteredAt: null,
       updatedAt: "bad-date",
     });

--- a/apps/mobile/__tests__/mobile-shell-state.test.ts
+++ b/apps/mobile/__tests__/mobile-shell-state.test.ts
@@ -1,0 +1,113 @@
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  MOBILE_SHELL_STATE_STORAGE_KEY,
+  loadMobileShellState,
+  parseMobileShellState,
+  saveMobileShellState,
+} from "../lib/mobile-shell-state";
+
+describe("mobile shell state", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("parses valid native mobile shell state", () => {
+    expect(parseMobileShellState({
+      surface: "native-mobile",
+      mode: "app",
+      lastActiveAppSlug: "games/snake",
+      lastActiveTerminalSessionId: "550e8400-e29b-41d4-a716-446655440000",
+      canvasEnteredAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:01:00.000Z",
+    })).toMatchObject({
+      surface: "native-mobile",
+      mode: "app",
+      lastActiveAppSlug: "games/snake",
+      lastActiveTerminalSessionId: "550e8400-e29b-41d4-a716-446655440000",
+      canvasEnteredAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:01:00.000Z",
+    });
+  });
+
+  it("falls back to launcher mode and drops unsafe persisted values", () => {
+    expect(parseMobileShellState({
+      surface: "browser-shell",
+      mode: "desktop",
+      lastActiveAppSlug: "../system/secrets",
+      lastActiveTerminalSessionId: "/tmp/socket",
+      canvasEnteredAt: "not-a-date",
+      updatedAt: "not-a-date",
+    })).toMatchObject({
+      surface: "native-mobile",
+      mode: "launcher",
+      lastActiveAppSlug: null,
+      lastActiveTerminalSessionId: null,
+      canvasEnteredAt: null,
+    });
+  });
+
+  it("loads default state when storage is empty or invalid", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    jest.mocked(AsyncStorage.getItem).mockResolvedValueOnce("{not json");
+
+    await expect(loadMobileShellState()).resolves.toMatchObject({
+      surface: "native-mobile",
+      mode: "launcher",
+      lastActiveAppSlug: null,
+      lastActiveTerminalSessionId: null,
+    });
+    expect(warnSpy).toHaveBeenCalledWith("[mobile] failed to load mobile shell state", expect.any(SyntaxError));
+    warnSpy.mockRestore();
+  });
+
+  it("saves sanitized state to async storage", async () => {
+    jest.mocked(AsyncStorage.setItem).mockResolvedValueOnce();
+
+    await saveMobileShellState({
+      surface: "native-mobile",
+      mode: "app",
+      lastActiveAppSlug: "Notes App",
+      lastActiveTerminalSessionId: "/tmp/socket",
+      canvasEnteredAt: null,
+      updatedAt: "bad-date",
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      MOBILE_SHELL_STATE_STORAGE_KEY,
+      expect.any(String),
+    );
+    const saved = JSON.parse(jest.mocked(AsyncStorage.setItem).mock.calls[0][1]);
+    expect(saved).toMatchObject({
+      surface: "native-mobile",
+      mode: "app",
+      lastActiveAppSlug: null,
+      lastActiveTerminalSessionId: null,
+    });
+    expect(Date.parse(saved.updatedAt)).not.toBeNaN();
+  });
+
+  it("keeps a safe last-active app slug for mobile resume choices", async () => {
+    jest.mocked(AsyncStorage.setItem).mockResolvedValueOnce();
+
+    await saveMobileShellState({
+      surface: "native-mobile",
+      mode: "app",
+      lastActiveAppSlug: "games/minesweeper",
+      lastActiveTerminalSessionId: null,
+      canvasEnteredAt: null,
+      updatedAt: "2026-05-14T00:00:00.000Z",
+    });
+
+    const saved = JSON.parse(jest.mocked(AsyncStorage.setItem).mock.calls[0][1]);
+    expect(saved).toMatchObject({
+      surface: "native-mobile",
+      mode: "app",
+      lastActiveAppSlug: "games/minesweeper",
+    });
+  });
+});

--- a/apps/mobile/__tests__/mobile-shell-test-utils.ts
+++ b/apps/mobile/__tests__/mobile-shell-test-utils.ts
@@ -1,0 +1,89 @@
+import type { MatrixAppEntry, MatrixAppManifestResponse } from "../lib/apps";
+
+export const MOBILE_GATEWAY_URL = "https://app.matrix-os.test";
+
+export function mockMatrixApp(overrides: Partial<MatrixAppEntry> = {}): MatrixAppEntry {
+  const slug = overrides.slug ?? "notes";
+  return {
+    name: "Notes",
+    description: "Write and organize notes.",
+    category: "Productivity",
+    file: `${slug}/index.html`,
+    path: `/files/apps/${slug}/index.html`,
+    slug,
+    runtime: "vite",
+    runtimeState: { status: "ready" },
+    ...overrides,
+  };
+}
+
+export function mockAppManifest(
+  overrides: Partial<MatrixAppManifestResponse> = {},
+): MatrixAppManifestResponse {
+  return {
+    manifest: {
+      name: "Notes",
+      description: "Write and organize notes.",
+      category: "Productivity",
+      runtime: "vite",
+    },
+    runtimeState: { status: "ready" },
+    distributionStatus: { status: "installed" },
+    ...overrides,
+  };
+}
+
+export function mockSessionToken(slug = "notes"): { token: string; launchUrl: string; expiresAt: string } {
+  return {
+    token: `session-token-${slug}`,
+    launchUrl: `/apps/${slug}/?token=session-token-${slug}`,
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  };
+}
+
+export function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+  const status = init.status ?? 200;
+  const ok = init.ok ?? (status >= 200 && status < 300);
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+
+  return {
+    ok,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(text),
+  } as unknown as Response;
+}
+
+export function installGatewayFetchMock(
+  routes: Record<string, unknown | Response>,
+): jest.SpyInstance {
+  return jest.spyOn(global, "fetch").mockImplementation(async (input: Parameters<typeof fetch>[0], _init?: RequestInit) => {
+    const url = String(input);
+    const path = safePathname(url);
+    const route = routes[url] ?? routes[path];
+
+    if (isResponseLike(route)) {
+      return route;
+    }
+
+    return jsonResponse(route ?? {});
+  });
+}
+
+function safePathname(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
+
+function isResponseLike(value: unknown): value is Response {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    "json" in value &&
+    "ok" in value &&
+    "status" in value,
+  );
+}

--- a/apps/mobile/__tests__/mobile-shell-test-utils.ts
+++ b/apps/mobile/__tests__/mobile-shell-test-utils.ts
@@ -56,8 +56,8 @@ export function jsonResponse(body: unknown, init: { ok?: boolean; status?: numbe
 
 export function installGatewayFetchMock(
   routes: Record<string, unknown | Response>,
-): jest.SpyInstance {
-  return jest.spyOn(global, "fetch").mockImplementation(async (input: Parameters<typeof fetch>[0], _init?: RequestInit) => {
+): jest.SpyInstance<ReturnType<typeof fetch>, Parameters<typeof fetch>> {
+  return jest.spyOn(global, "fetch").mockImplementation(async (input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => {
     const url = String(input);
     const path = safePathname(url);
     const route = routes[url] ?? routes[path];

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -138,4 +138,39 @@ describe("mobile terminal client", () => {
       { headers: { Authorization: "Bearer clerk-token" } },
     );
   });
+
+  it("opens unauthenticated terminal sockets when the gateway returns no ws token", async () => {
+    const webSocketMock = jest.fn().mockImplementation(() => new MockWebSocket());
+    global.WebSocket = webSocketMock as unknown as typeof WebSocket;
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({ token: null }));
+
+    const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
+    const terminalClient = new MobileTerminalClient(gateway);
+    const connection = await terminalClient.connect({
+      cwd: "projects",
+      onMessage: jest.fn(),
+    });
+
+    expect(connection).toBeTruthy();
+    expect(webSocketMock).toHaveBeenCalledWith(
+      "wss://app.matrix-os.test/ws/terminal",
+      [],
+      { headers: { Authorization: "Bearer clerk-token" } },
+    );
+  });
+
+  it("closes sockets before open and uses local ready-state constants", () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    (ws as unknown as MockWebSocket).readyState = 0;
+    const connection = new MobileTerminalConnection(ws, {
+      cwd: "projects",
+      onMessage: jest.fn(),
+    });
+
+    connection.attach();
+    connection.detach();
+
+    expect((ws as unknown as MockWebSocket).closed).toBe(true);
+    expect((ws as unknown as MockWebSocket).sent).toEqual([]);
+  });
 });

--- a/apps/mobile/__tests__/terminal-client.test.ts
+++ b/apps/mobile/__tests__/terminal-client.test.ts
@@ -1,0 +1,141 @@
+import { GatewayClient } from "../lib/gateway-client";
+import {
+  MobileTerminalClient,
+  MobileTerminalConnection,
+  buildTerminalWebSocketUrl,
+  isSafeSessionId,
+  parseTerminalSessions,
+} from "../lib/terminal-client";
+import { jsonResponse } from "./mobile-shell-test-utils";
+
+const SESSION_ID = "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9";
+
+class MockWebSocket {
+  static OPEN = 1;
+  readyState = MockWebSocket.OPEN;
+  sent: string[] = [];
+  closed = false;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+describe("mobile terminal client", () => {
+  const OriginalWebSocket = global.WebSocket;
+
+  afterEach(() => {
+    global.WebSocket = OriginalWebSocket;
+    jest.restoreAllMocks();
+  });
+
+  it("parses only safe terminal session summaries", () => {
+    expect(parseTerminalSessions([
+      { sessionId: SESSION_ID, cwd: "/home/matrix/home", state: "running", attachedClients: 1 },
+      { sessionId: "../../../secret", cwd: "/tmp", state: "running" },
+      { cwd: "/tmp" },
+    ])).toEqual([
+      { sessionId: SESSION_ID, cwd: "/home/matrix/home", state: "running", attachedClients: 1 },
+    ]);
+  });
+
+  it("fetches terminal sessions through the authenticated gateway", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse([
+      { sessionId: SESSION_ID, cwd: "/home/matrix/home/projects", state: "running" },
+    ]));
+
+    const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
+    await expect(gateway.getTerminalSessions()).resolves.toEqual([
+      { sessionId: SESSION_ID, cwd: "/home/matrix/home/projects", state: "running" },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://app.matrix-os.test/api/terminal/sessions",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer clerk-token" }),
+      }),
+    );
+  });
+
+  it("deletes terminal sessions idempotently and rejects unsafe IDs locally", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({}, { status: 404 }));
+
+    const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
+    await expect(gateway.deleteTerminalSession(SESSION_ID)).resolves.toBe(true);
+    await expect(gateway.deleteTerminalSession("../bad")).resolves.toBe(false);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://app.matrix-os.test/api/terminal/sessions/${SESSION_ID}`,
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("builds token-authenticated terminal websocket URLs", () => {
+    expect(buildTerminalWebSocketUrl("https://app.matrix-os.test/", "ws token")).toBe(
+      "wss://app.matrix-os.test/ws/terminal?token=ws%20token",
+    );
+    expect(isSafeSessionId(SESSION_ID)).toBe(true);
+    expect(isSafeSessionId("../bad")).toBe(false);
+  });
+
+  it("sends attach, resize, input, and detach frames over the terminal websocket", () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    const messages: unknown[] = [];
+    const statuses: string[] = [];
+    const connection = new MobileTerminalConnection(ws, {
+      sessionId: SESSION_ID,
+      cwd: "projects",
+      cols: 220,
+      rows: 70,
+      onMessage: (frame) => messages.push(frame),
+      onStatus: (status) => statuses.push(status),
+    });
+
+    connection.attach();
+    (ws as unknown as MockWebSocket).onopen?.();
+    connection.sendInput("pwd\r");
+    connection.resize(999, 999);
+    (ws as unknown as MockWebSocket).onmessage?.({ data: JSON.stringify({ type: "output", data: "ok" }) });
+    connection.detach();
+
+    expect(statuses).toEqual(["connecting", "open"]);
+    expect((ws as unknown as MockWebSocket).sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "attach", sessionId: SESSION_ID, cwd: "projects" },
+      { type: "resize", cols: 220, rows: 70 },
+      { type: "input", data: "pwd\r" },
+      { type: "resize", cols: 500, rows: 200 },
+      { type: "detach" },
+    ]);
+    expect(messages).toEqual([{ type: "output", data: "ok" }]);
+    expect((ws as unknown as MockWebSocket).closed).toBe(true);
+  });
+
+  it("opens terminal sockets with browser-compatible query auth and native bearer headers", async () => {
+    const webSocketMock = jest.fn().mockImplementation(() => new MockWebSocket());
+    global.WebSocket = webSocketMock as unknown as typeof WebSocket;
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(jsonResponse({ token: "ws-token" }));
+
+    const gateway = new GatewayClient("https://app.matrix-os.test", "clerk-token");
+    const terminalClient = new MobileTerminalClient(gateway);
+    const connection = await terminalClient.connect({
+      cwd: "projects",
+      onMessage: jest.fn(),
+    });
+
+    expect(connection).toBeTruthy();
+    expect(webSocketMock).toHaveBeenCalledWith(
+      "wss://app.matrix-os.test/ws/terminal?token=ws-token",
+      [],
+      { headers: { Authorization: "Bearer clerk-token" } },
+    );
+  });
+});

--- a/apps/mobile/__tests__/terminal-screen.test.tsx
+++ b/apps/mobile/__tests__/terminal-screen.test.tsx
@@ -7,6 +7,14 @@ import type { GatewayClient } from "../lib/gateway-client";
 
 const SESSION_ID = "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9";
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 jest.mock("@react-native-async-storage/async-storage", () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
@@ -27,6 +35,7 @@ jest.mock("react-native-safe-area-context", () => ({
 class MockTerminalSocket {
   readyState: number = WebSocket.OPEN;
   sent: string[] = [];
+  closed = false;
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: string }) => void) | null = null;
   onerror: (() => void) | null = null;
@@ -37,6 +46,7 @@ class MockTerminalSocket {
   }
 
   close() {
+    this.closed = true;
     this.readyState = WebSocket.CLOSED;
     this.onclose?.();
   }
@@ -172,7 +182,115 @@ describe("TerminalScreen", () => {
     });
 
     expect(socket.sent.map((frame) => JSON.parse(frame))).toEqual(
-      expect.arrayContaining([{ type: "attach", sessionId: SESSION_ID, cwd: "projects" }]),
+      expect.arrayContaining([{ type: "attach", sessionId: SESSION_ID }]),
+    );
+  });
+
+  it("ignores duplicate connect actions while a terminal connection is pending", async () => {
+    global.WebSocket = {
+      OPEN: 1,
+      CLOSED: 3,
+    } as typeof WebSocket;
+    const socket = new MockTerminalSocket();
+    const tokenRequest = createDeferred<string>();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([]),
+      getWsToken: jest.fn(() => tokenRequest.promise),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(true),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+
+    const newSession = screen.getByLabelText("New session");
+    fireEvent.press(newSession);
+    fireEvent.press(newSession);
+
+    expect(gatewayClient.getWsToken).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      tokenRequest.resolve("ws-token");
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps terminal recovery state when deleting a session fails", async () => {
+    global.WebSocket = {
+      OPEN: 1,
+      CLOSED: 3,
+    } as typeof WebSocket;
+    const socket = new MockTerminalSocket();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({
+      mode: "terminal",
+      lastActiveTerminalSessionId: SESSION_ID,
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    }));
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([
+        {
+          sessionId: SESSION_ID,
+          cwd: "/home/matrix/home/projects",
+          state: "running",
+        },
+      ]),
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(false),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+
+    await waitFor(() => expect(screen.getByLabelText("Continue terminal ~/projects")).toBeTruthy());
+    fireEvent.press(screen.getByLabelText("Continue terminal ~/projects"));
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith("ws-token"));
+
+    await act(async () => {
+      socket.onopen?.();
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: "attached",
+          sessionId: SESSION_ID,
+          cwd: "/home/matrix/home/projects",
+        }),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByPlaceholderText("command")).toBeTruthy());
+    fireEvent.press(screen.getByLabelText("Destroy session"));
+
+    await waitFor(() => expect(gatewayClient.deleteTerminalSession).toHaveBeenCalledWith(SESSION_ID));
+    expect(socket.closed).toBe(false);
+    expect(AsyncStorage.setItem).not.toHaveBeenLastCalledWith(
+      expect.any(String),
+      expect.stringContaining('"lastActiveTerminalSessionId":null'),
     );
   });
 

--- a/apps/mobile/__tests__/terminal-screen.test.tsx
+++ b/apps/mobile/__tests__/terminal-screen.test.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import TerminalScreen from "../app/terminal";
+import { useGateway } from "@/app/_layout";
+import type { GatewayClient } from "../lib/gateway-client";
+
+const SESSION_ID = "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9";
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+jest.mock("@/app/_layout", () => ({
+  useGateway: jest.fn(),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ back: jest.fn() }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+class MockTerminalSocket {
+  readyState: number = WebSocket.OPEN;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = WebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+describe("TerminalScreen", () => {
+  const OriginalWebSocket = global.WebSocket;
+
+  afterEach(() => {
+    global.WebSocket = OriginalWebSocket;
+    jest.clearAllMocks();
+  });
+
+  it("opens a mobile terminal session with visible path, output, and command input", async () => {
+    global.WebSocket = {
+      OPEN: 1,
+      CLOSED: 3,
+    } as typeof WebSocket;
+    const socket = new MockTerminalSocket();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(null);
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([
+        {
+          sessionId: SESSION_ID,
+          cwd: "/home/matrix/home/projects",
+          state: "running",
+        },
+      ]),
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(true),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+
+    await waitFor(() => expect(screen.getByLabelText("Resume ~/projects")).toBeTruthy());
+    fireEvent.press(screen.getByLabelText("New session"));
+
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith("ws-token"));
+    await act(async () => {
+      socket.onopen?.();
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: "attached",
+          sessionId: SESSION_ID,
+          cwd: "/home/matrix/home/projects",
+        }),
+      });
+      socket.onmessage?.({
+        data: JSON.stringify({ type: "output", data: "deploy@matrix:~/projects$ " }),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getAllByText("~/projects").length).toBeGreaterThan(0));
+    expect(screen.getByText("deploy@matrix:~/projects$ ")).toBeTruthy();
+
+    fireEvent.changeText(screen.getByPlaceholderText("command"), "pwd");
+    fireEvent.press(screen.getByLabelText("Run command"));
+
+    expect(socket.sent.map((frame) => JSON.parse(frame))).toEqual(
+      expect.arrayContaining([
+        { type: "attach", cwd: "projects" },
+        { type: "input", data: "pwd\r" },
+      ]),
+    );
+  });
+
+  it("offers a real continue action for the persisted terminal session", async () => {
+    global.WebSocket = {
+      OPEN: 1,
+      CLOSED: 3,
+    } as typeof WebSocket;
+    const socket = new MockTerminalSocket();
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({
+      mode: "terminal",
+      lastActiveTerminalSessionId: SESSION_ID,
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    }));
+    jest.mocked(AsyncStorage.setItem).mockResolvedValue();
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([
+        {
+          sessionId: SESSION_ID,
+          cwd: "/home/matrix/home/projects",
+          state: "running",
+        },
+      ]),
+      getWsToken: jest.fn().mockResolvedValue("ws-token"),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(() => socket as unknown as WebSocket),
+      deleteTerminalSession: jest.fn().mockResolvedValue(true),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+
+    await waitFor(() => expect(screen.getByLabelText("Continue terminal ~/projects")).toBeTruthy());
+    fireEvent.press(screen.getByLabelText("Continue terminal ~/projects"));
+
+    await waitFor(() => expect(gatewayClient.openTerminalWebSocket).toHaveBeenCalledWith("ws-token"));
+    await act(async () => {
+      socket.onopen?.();
+      socket.onmessage?.({
+        data: JSON.stringify({
+          type: "attached",
+          sessionId: SESSION_ID,
+          cwd: "/home/matrix/home/projects",
+        }),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(socket.sent.map((frame) => JSON.parse(frame))).toEqual(
+      expect.arrayContaining([{ type: "attach", sessionId: SESSION_ID, cwd: "projects" }]),
+    );
+  });
+
+  it("shows safe recovery when the persisted terminal session is gone", async () => {
+    jest.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({
+      mode: "terminal",
+      lastActiveTerminalSessionId: SESSION_ID,
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    }));
+    const gatewayClient = {
+      getTerminalSessions: jest.fn().mockResolvedValue([
+        {
+          sessionId: "550e8400-e29b-41d4-a716-446655440000",
+          cwd: "/home/matrix/home/projects",
+          state: "running",
+        },
+      ]),
+      getWsToken: jest.fn(),
+      setWebSocketToken: jest.fn(),
+      openTerminalWebSocket: jest.fn(),
+      deleteTerminalSession: jest.fn(),
+    };
+    jest.mocked(useGateway).mockReturnValue({
+      client: gatewayClient as unknown as GatewayClient,
+      connectionState: "connected",
+      gateway: null,
+      setGateway: jest.fn(),
+      unreadCount: 0,
+      incrementUnread: jest.fn(),
+      clearUnread: jest.fn(),
+    });
+
+    render(<TerminalScreen />);
+
+    await waitFor(() => expect(screen.getByText("Last terminal ended. Start a new session to continue.")).toBeTruthy());
+    expect(screen.queryByLabelText("Continue terminal ~/projects")).toBeNull();
+  });
+});

--- a/apps/mobile/__tests__/terminal-state.test.ts
+++ b/apps/mobile/__tests__/terminal-state.test.ts
@@ -1,0 +1,69 @@
+import {
+  buildTerminalControlSequence,
+  formatTerminalCwd,
+  initialTerminalState,
+  MAX_TERMINAL_INPUT_CHARS,
+  MAX_TERMINAL_OUTPUT_CHARS,
+  terminalReducer,
+} from "../lib/terminal-state";
+
+describe("mobile terminal state", () => {
+  it("tracks attached sessions without hiding the current working directory", () => {
+    const state = terminalReducer(initialTerminalState, {
+      type: "terminal.attached",
+      sessionId: "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9",
+      cwd: "/home/matrix/home/projects/matrix-os",
+      replay: "$ pwd\n/home/matrix/home/projects/matrix-os\n",
+    });
+
+    expect(state.status).toBe("attached");
+    expect(state.activeSessionId).toBe("c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9");
+    expect(state.cwd).toBe("~/projects/matrix-os");
+    expect(state.output).toContain("$ pwd");
+  });
+
+  it("caps terminal output and command input for mobile memory safety", () => {
+    const largeOutput = "x".repeat(MAX_TERMINAL_OUTPUT_CHARS + 20);
+    const largeInput = "y".repeat(MAX_TERMINAL_INPUT_CHARS + 20);
+
+    const withOutput = terminalReducer(initialTerminalState, {
+      type: "terminal.output",
+      data: largeOutput,
+    });
+    const withInput = terminalReducer(withOutput, {
+      type: "terminal.input",
+      input: largeInput,
+    });
+
+    expect(withInput.output).toHaveLength(MAX_TERMINAL_OUTPUT_CHARS);
+    expect(withInput.input).toHaveLength(MAX_TERMINAL_INPUT_CHARS);
+  });
+
+  it("keeps control keys explicit for touch terminal use", () => {
+    expect(buildTerminalControlSequence("escape")).toBe("\x1b");
+    expect(buildTerminalControlSequence("tab")).toBe("\t");
+    expect(buildTerminalControlSequence("enter")).toBe("\r");
+    expect(buildTerminalControlSequence("arrow-up")).toBe("\x1b[A");
+    expect(buildTerminalControlSequence("arrow-down")).toBe("\x1b[B");
+    expect(buildTerminalControlSequence("arrow-left")).toBe("\x1b[D");
+    expect(buildTerminalControlSequence("arrow-right")).toBe("\x1b[C");
+    expect(buildTerminalControlSequence("ctrl-c")).toBe("\x03");
+    expect(buildTerminalControlSequence("ctrl-d")).toBe("\x04");
+    expect(buildTerminalControlSequence("ctrl-l")).toBe("\x0c");
+  });
+
+  it("sanitizes raw terminal errors before they reach the screen", () => {
+    const state = terminalReducer(initialTerminalState, {
+      type: "terminal.error",
+      message: "postgres secret leaked from /home/matrix/internal",
+    });
+
+    expect(state.error).toBe("Terminal unavailable");
+  });
+
+  it("formats common home paths compactly for narrow phones", () => {
+    expect(formatTerminalCwd("/home/matrix/home/projects")).toBe("~/projects");
+    expect(formatTerminalCwd("/home/deploy/matrix-os")).toBe("~/matrix-os");
+    expect(formatTerminalCwd("/")).toBe("~");
+  });
+});

--- a/apps/mobile/__tests__/terminal-state.test.ts
+++ b/apps/mobile/__tests__/terminal-state.test.ts
@@ -61,6 +61,34 @@ describe("mobile terminal state", () => {
     expect(state.error).toBe("Terminal unavailable");
   });
 
+  it("preserves terminal errors across immediate socket close callbacks", () => {
+    const errored = terminalReducer(initialTerminalState, {
+      type: "terminal.error",
+      message: "Terminal unavailable",
+    });
+    const closed = terminalReducer(errored, {
+      type: "connection.changed",
+      status: "detached",
+    });
+
+    expect(closed.status).toBe("detached");
+    expect(closed.error).toBe("Terminal unavailable");
+  });
+
+  it("clears the active terminal session when refreshed sessions no longer include it", () => {
+    const attached = terminalReducer(initialTerminalState, {
+      type: "terminal.attached",
+      sessionId: "c4319d6a-a24c-4820-a0f8-f6f8a6ce76b9",
+      cwd: "/home/matrix/home",
+    });
+    const refreshed = terminalReducer(attached, {
+      type: "sessions.loaded",
+      sessions: [],
+    });
+
+    expect(refreshed.activeSessionId).toBeNull();
+  });
+
   it("formats common home paths compactly for narrow phones", () => {
     expect(formatTerminalCwd("/home/matrix/home/projects")).toBe("~/projects");
     expect(formatTerminalCwd("/home/deploy/matrix-os")).toBe("~/matrix-os");

--- a/apps/mobile/app/(tabs)/apps.tsx
+++ b/apps/mobile/app/(tabs)/apps.tsx
@@ -23,6 +23,7 @@ import {
   mergeNativeAndRemoteApps,
   type MatrixAppEntry,
 } from "@/lib/apps";
+import { loadMobileShellState, saveMobileShellState } from "@/lib/mobile-shell-state";
 import { colors, fonts, radius, spacing } from "@/lib/theme";
 
 function AppGlyph({ app, gatewayUrl }: { app: MatrixAppEntry; gatewayUrl?: string }) {
@@ -49,7 +50,17 @@ function AppGlyph({ app, gatewayUrl }: { app: MatrixAppEntry; gatewayUrl?: strin
   );
 }
 
-function AppCard({ app, gatewayUrl }: { app: MatrixAppEntry; gatewayUrl?: string }) {
+function AppCard({
+  app,
+  gatewayUrl,
+  active,
+  onOpen,
+}: {
+  app: MatrixAppEntry;
+  gatewayUrl?: string;
+  active: boolean;
+  onOpen: (slug: string) => void;
+}) {
   const slug = getAppSlug(app);
   const nativeRoute = getNativeAppRoute(app);
   const runtimeLabel = useMemo(
@@ -61,6 +72,7 @@ function AppCard({ app, gatewayUrl }: { app: MatrixAppEntry; gatewayUrl?: string
     <Link href={(nativeRoute ?? appRuntimeHref(slug)) as any} asChild>
       <Pressable
         onPress={() => {
+          onOpen(slug);
           if (process.env.EXPO_OS === "ios") {
             Haptics.selectionAsync();
           }
@@ -141,7 +153,81 @@ function AppCard({ app, gatewayUrl }: { app: MatrixAppEntry; gatewayUrl?: string
               {runtimeLabel}
             </Text>
           ) : null}
+          {active ? (
+            <View
+              accessibilityLabel="Open"
+              style={{
+                marginTop: 6,
+                width: 8,
+                height: 8,
+                borderRadius: 999,
+                backgroundColor: colors.light.primary,
+              }}
+            />
+          ) : null}
         </View>
+      </Pressable>
+    </Link>
+  );
+}
+
+function ContinueAppCard({
+  app,
+  gatewayUrl,
+  onOpen,
+}: {
+  app: MatrixAppEntry;
+  gatewayUrl?: string;
+  onOpen: (slug: string) => void;
+}) {
+  const slug = getAppSlug(app);
+  const nativeRoute = getNativeAppRoute(app);
+
+  return (
+    <Link href={(nativeRoute ?? appRuntimeHref(slug)) as any} asChild>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Continue ${app.name}`}
+        onPress={() => onOpen(slug)}
+        style={({ pressed }) => ({
+          marginHorizontal: spacing.lg,
+          marginBottom: spacing.md,
+          minHeight: 74,
+          borderRadius: radius.lg,
+          borderCurve: "continuous",
+          borderWidth: 1,
+          borderColor: colors.light.primary,
+          backgroundColor: colors.light.card,
+          padding: spacing.md,
+          flexDirection: "row",
+          alignItems: "center",
+          gap: spacing.md,
+          opacity: pressed ? 0.82 : 1,
+          transform: [{ scale: pressed ? 0.98 : 1 }],
+        })}
+      >
+        <View
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: 14,
+            borderCurve: "continuous",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: colors.light.secondary,
+          }}
+        >
+          <AppGlyph app={app} gatewayUrl={gatewayUrl} />
+        </View>
+        <View style={{ flex: 1, minWidth: 0 }}>
+          <Text style={{ fontFamily: fonts.sansSemiBold, fontSize: 14, color: colors.light.primary }}>
+            Continue
+          </Text>
+          <Text numberOfLines={1} style={{ marginTop: 2, fontFamily: fonts.sansBold, fontSize: 17, color: colors.light.foreground }}>
+            {app.name}
+          </Text>
+        </View>
+        <Ionicons name="chevron-forward" size={20} color={colors.light.primary} />
       </Pressable>
     </Link>
   );
@@ -153,6 +239,7 @@ export default function AppsScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
+  const [lastActiveAppSlug, setLastActiveAppSlug] = useState<string | null>(null);
 
   const fetchApps = useCallback(async () => {
     if (!client) {
@@ -176,6 +263,28 @@ export default function AppsScreen() {
     fetchApps();
   }, [fetchApps]);
 
+  useEffect(() => {
+    loadMobileShellState()
+      .then((state) => setLastActiveAppSlug(state.lastActiveAppSlug))
+      .catch((err: unknown) => {
+        console.warn("[mobile] failed to load app open state", err instanceof Error ? err.message : String(err));
+      });
+  }, []);
+
+  const handleOpenApp = useCallback((slug: string) => {
+    setLastActiveAppSlug(slug);
+    loadMobileShellState()
+      .then((state) => saveMobileShellState({
+        ...state,
+        mode: "app",
+        lastActiveAppSlug: slug,
+        updatedAt: new Date().toISOString(),
+      }))
+      .catch((err: unknown) => {
+        console.warn("[mobile] failed to save app open state", err instanceof Error ? err.message : String(err));
+      });
+  }, []);
+
   const filteredApps = useMemo(() => {
     const normalized = query.trim().toLowerCase();
     if (!normalized) return apps;
@@ -185,6 +294,11 @@ export default function AppsScreen() {
     });
   }, [apps, query]);
 
+  const lastActiveApp = useMemo(() => {
+    if (!lastActiveAppSlug) return null;
+    return apps.find((app) => getAppSlug(app) === lastActiveAppSlug) ?? null;
+  }, [apps, lastActiveAppSlug]);
+
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     await fetchApps();
@@ -193,9 +307,14 @@ export default function AppsScreen() {
 
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<MatrixAppEntry>) => (
-      <AppCard app={item} gatewayUrl={client?.httpUrl} />
+      <AppCard
+        app={item}
+        gatewayUrl={client?.httpUrl}
+        active={lastActiveAppSlug === getAppSlug(item)}
+        onOpen={handleOpenApp}
+      />
     ),
-    [client],
+    [client, handleOpenApp, lastActiveAppSlug],
   );
 
   return (
@@ -241,51 +360,56 @@ export default function AppsScreen() {
           <ActivityIndicator color={colors.light.primary} />
         </View>
       ) : (
-        <FlatList
-          data={filteredApps}
-          renderItem={renderItem}
-          keyExtractor={(item) => getAppSlug(item)}
-          contentInsetAdjustmentBehavior="automatic"
-          contentContainerStyle={{ paddingHorizontal: spacing.lg, paddingBottom: 112, gap: spacing.md }}
-          refreshControl={
-            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.light.primary} />
-          }
-          ListEmptyComponent={
-            <View style={{ alignItems: "center", paddingVertical: 72, paddingHorizontal: spacing.xl }}>
-              <View
-                style={{
-                  width: 72,
-                  height: 72,
-                  borderRadius: 18,
-                  borderCurve: "continuous",
-                  backgroundColor: colors.light.card,
-                  alignItems: "center",
-                  justifyContent: "center",
-                  borderWidth: 1,
-                  borderColor: colors.light.border,
-                  marginBottom: spacing.lg,
-                }}
-              >
-                <Ionicons name="apps-outline" size={36} color={colors.light.primary} />
+        <>
+          {lastActiveApp ? (
+            <ContinueAppCard app={lastActiveApp} gatewayUrl={client?.httpUrl} onOpen={handleOpenApp} />
+          ) : null}
+          <FlatList
+            data={filteredApps}
+            renderItem={renderItem}
+            keyExtractor={(item) => getAppSlug(item)}
+            contentInsetAdjustmentBehavior="automatic"
+            contentContainerStyle={{ paddingHorizontal: spacing.lg, paddingBottom: 112, gap: spacing.md }}
+            refreshControl={
+              <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={colors.light.primary} />
+            }
+            ListEmptyComponent={
+              <View style={{ alignItems: "center", paddingVertical: 72, paddingHorizontal: spacing.xl }}>
+                <View
+                  style={{
+                    width: 72,
+                    height: 72,
+                    borderRadius: 18,
+                    borderCurve: "continuous",
+                    backgroundColor: colors.light.card,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    borderWidth: 1,
+                    borderColor: colors.light.border,
+                    marginBottom: spacing.lg,
+                  }}
+                >
+                  <Ionicons name="apps-outline" size={36} color={colors.light.primary} />
+                </View>
+                <Text style={{ fontFamily: fonts.sansSemiBold, fontSize: 17, color: colors.light.foreground }}>
+                  {client ? "No apps found" : "Connecting to Matrix OS"}
+                </Text>
+                <Text
+                  style={{
+                    marginTop: spacing.sm,
+                    fontFamily: fonts.sans,
+                    fontSize: 14,
+                    lineHeight: 20,
+                    color: colors.light.mutedForeground,
+                    textAlign: "center",
+                  }}
+                >
+                  Apps returned by your VPS launcher at app.matrix-os.com show up here.
+                </Text>
               </View>
-              <Text style={{ fontFamily: fonts.sansSemiBold, fontSize: 17, color: colors.light.foreground }}>
-                {client ? "No apps found" : "Connecting to Matrix OS"}
-              </Text>
-              <Text
-                style={{
-                  marginTop: spacing.sm,
-                  fontFamily: fonts.sans,
-                  fontSize: 14,
-                  lineHeight: 20,
-                  color: colors.light.mutedForeground,
-                  textAlign: "center",
-                }}
-              >
-                Apps returned by your VPS launcher at app.matrix-os.com show up here.
-              </Text>
-            </View>
-          }
-        />
+            }
+          />
+        </>
       )}
     </View>
   );

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,7 +23,16 @@ import { authenticateBiometric } from "@/lib/auth";
 import { addNotificationResponseListener, handleNotificationTap } from "@/lib/push";
 import { colors, fonts } from "@/lib/theme";
 
-SplashScreen.preventAutoHideAsync().catch(() => {});
+let nativeSplashRegistered = false;
+const nativeSplashRegistration = SplashScreen.preventAutoHideAsync()
+  .then(() => {
+    nativeSplashRegistered = true;
+    return true;
+  })
+  .catch((err: unknown) => {
+    console.warn("[mobile] Native splash screen was not registered:", err);
+    return false;
+  });
 
 const clerkPublishableKey =
   process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY ??
@@ -86,9 +95,18 @@ export default function RootLayout() {
   }, []);
 
   useEffect(() => {
-    if (fontsLoaded && ready) {
-      SplashScreen.hideAsync().catch(() => {});
-    }
+    if (!fontsLoaded || !ready) return;
+
+    let cancelled = false;
+    nativeSplashRegistration.then((registered) => {
+      if (cancelled || (!registered && !nativeSplashRegistered)) return;
+      void SplashScreen.hideAsync().catch((err: unknown) => {
+        console.warn("[mobile] Native splash screen could not be hidden:", err);
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [fontsLoaded, ready]);
 
   if (!fontsLoaded || !ready) {
@@ -252,7 +270,7 @@ function GatewayShell() {
           <Stack.Screen name="apps" options={{ headerShown: false }} />
           <Stack.Screen name="terminal" options={{ headerShown: false }} />
           <Stack.Screen name="runtime" options={{ headerShown: false }} />
-          <Stack.Screen name="canvas" options={{ headerShown: false }} />
+          <Stack.Screen name="canvas/index" options={{ headerShown: false }} />
           <Stack.Screen
             name="connect"
             options={{

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -230,7 +230,9 @@ function GatewayShell() {
           <Stack.Screen name="index" options={{ headerShown: false }} />
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           <Stack.Screen name="apps" options={{ headerShown: false }} />
+          <Stack.Screen name="terminal" options={{ headerShown: false }} />
           <Stack.Screen name="runtime" options={{ headerShown: false }} />
+          <Stack.Screen name="canvas" options={{ headerShown: false }} />
           <Stack.Screen
             name="connect"
             options={{

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -25,6 +25,10 @@ import { colors, fonts } from "@/lib/theme";
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
+const clerkPublishableKey =
+  process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY ??
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
 const tokenCache = {
   async getToken(key: string) {
     return SecureStore.getItemAsync(key);
@@ -106,10 +110,26 @@ export default function RootLayout() {
     );
   }
 
+  if (!clerkPublishableKey) {
+    return <MissingClerkConfigScreen />;
+  }
+
   return (
-    <ClerkProvider tokenCache={tokenCache}>
+    <ClerkProvider publishableKey={clerkPublishableKey} tokenCache={tokenCache}>
       <GatewayShell />
     </ClerkProvider>
+  );
+}
+
+function MissingClerkConfigScreen() {
+  return (
+    <View style={styles.loadingContainer}>
+      <Text style={styles.loadingTitle}>Matrix OS</Text>
+      <Text style={styles.configTitle}>Missing mobile auth config</Text>
+      <Text style={styles.configBody}>
+        Set EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY before starting Expo.
+      </Text>
+    </View>
   );
 }
 
@@ -296,5 +316,19 @@ const styles = StyleSheet.create({
   },
   loadingSpinner: {
     marginTop: 24,
+  },
+  configTitle: {
+    fontFamily: fonts.sansSemiBold,
+    fontSize: 16,
+    color: colors.light.foreground,
+    marginTop: 16,
+  },
+  configBody: {
+    fontFamily: fonts.sans,
+    fontSize: 14,
+    color: colors.light.mutedForeground,
+    marginTop: 8,
+    maxWidth: 300,
+    textAlign: "center",
   },
 });

--- a/apps/mobile/app/canvas/index.tsx
+++ b/apps/mobile/app/canvas/index.tsx
@@ -1,0 +1,167 @@
+import { useCallback } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { loadMobileShellState, saveMobileShellState } from "@/lib/mobile-shell-state";
+import { colors, fonts, radius, spacing } from "@/lib/theme";
+
+export default function CanvasEntryScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const returnHome = useCallback(() => {
+    loadMobileShellState()
+      .then((state) => saveMobileShellState({
+        ...state,
+        mode: "launcher",
+        updatedAt: new Date().toISOString(),
+      }))
+      .catch((err: unknown) => {
+        console.warn("[mobile] failed to save canvas return state", err instanceof Error ? err.message : String(err));
+      });
+    router.replace("/(tabs)/apps" as any);
+  }, [router]);
+
+  const markCanvas = useCallback(() => {
+    loadMobileShellState()
+      .then((state) => saveMobileShellState({
+        ...state,
+        mode: "canvas",
+        canvasEnteredAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }))
+      .catch((err: unknown) => {
+        console.warn("[mobile] failed to save canvas state", err instanceof Error ? err.message : String(err));
+      });
+  }, []);
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top + spacing.lg, paddingBottom: Math.max(insets.bottom, spacing.lg) }]}>
+      <View style={styles.header}>
+        <Pressable accessibilityRole="button" accessibilityLabel="Return to apps" onPress={returnHome} style={styles.iconButton}>
+          <Ionicons name="chevron-back" size={20} color={colors.light.foreground} />
+        </Pressable>
+        <View style={styles.headerText}>
+          <Text style={styles.title}>Canvas</Text>
+          <Text style={styles.subtitle}>Desktop workspace</Text>
+        </View>
+      </View>
+
+      <View style={styles.card}>
+        <View style={styles.glyph}>
+          <Ionicons name="brush" size={36} color={colors.light.primary} />
+        </View>
+        <Text style={styles.cardTitle}>Canvas opens best in the browser shell</Text>
+        <Text style={styles.cardBody}>
+          The native app keeps Canvas explicit so phone users never get trapped in a panned workspace. Use the browser shell when you need full spatial editing, then return here to keep using apps full-screen.
+        </Text>
+        <Pressable accessibilityRole="button" accessibilityLabel="Remember Canvas entry" onPress={markCanvas} style={styles.primaryButton}>
+          <Text style={styles.primaryText}>Remember Canvas entry</Text>
+        </Pressable>
+        <Pressable accessibilityRole="button" accessibilityLabel="Apps" onPress={returnHome} style={styles.secondaryButton}>
+          <Text style={styles.secondaryText}>Apps</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    paddingHorizontal: spacing.lg,
+    backgroundColor: colors.light.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+  },
+  iconButton: {
+    width: 42,
+    height: 42,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.light.border,
+    backgroundColor: colors.light.card,
+  },
+  headerText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  title: {
+    fontFamily: fonts.sansBold,
+    fontSize: 20,
+    color: colors.light.foreground,
+  },
+  subtitle: {
+    marginTop: 2,
+    fontFamily: fonts.sans,
+    fontSize: 13,
+    color: colors.light.mutedForeground,
+  },
+  card: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: spacing.lg,
+  },
+  glyph: {
+    width: 78,
+    height: 78,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: colors.light.border,
+    backgroundColor: colors.light.card,
+    marginBottom: spacing.lg,
+  },
+  cardTitle: {
+    textAlign: "center",
+    fontFamily: fonts.sansBold,
+    fontSize: 22,
+    color: colors.light.foreground,
+  },
+  cardBody: {
+    marginTop: spacing.md,
+    textAlign: "center",
+    fontFamily: fonts.sans,
+    fontSize: 15,
+    lineHeight: 22,
+    color: colors.light.mutedForeground,
+  },
+  primaryButton: {
+    marginTop: spacing.xl,
+    minHeight: 48,
+    alignSelf: "stretch",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: radius.lg,
+    backgroundColor: colors.light.primary,
+  },
+  primaryText: {
+    fontFamily: fonts.sansSemiBold,
+    color: colors.light.primaryForeground,
+    fontSize: 15,
+  },
+  secondaryButton: {
+    marginTop: spacing.sm,
+    minHeight: 48,
+    alignSelf: "stretch",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.light.border,
+    backgroundColor: colors.light.card,
+  },
+  secondaryText: {
+    fontFamily: fonts.sansSemiBold,
+    color: colors.light.foreground,
+    fontSize: 15,
+  },
+});

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -28,7 +28,7 @@ export default function Index() {
         <View style={styles.heroSection}>
           <View style={styles.iconContainer}>
             <Image
-              source={require("../assets/logo.png")}
+              source={require("../assets/icon.png")}
               style={styles.logo}
               contentFit="contain"
               accessibilityLabel="Matrix OS"

--- a/apps/mobile/app/runtime/[...slug].tsx
+++ b/apps/mobile/app/runtime/[...slug].tsx
@@ -99,6 +99,20 @@ export default function RuntimeScreen() {
       <Stack.Screen
         options={{
           title,
+          headerLeft: () => (
+            <Pressable
+              onPress={() => router.replace("/(tabs)/apps" as any)}
+              style={({ pressed }) => ({
+                minWidth: 34,
+                minHeight: 34,
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: pressed ? 0.65 : 1,
+              })}
+            >
+              <Ionicons name="home-outline" size={22} color={colors.light.foreground} />
+            </Pressable>
+          ),
           headerRight: () => (
             <Pressable
               onPress={() => router.push({ pathname: "/apps/[...slug]", params: { slug: slug.split("/") } } as any)}
@@ -172,6 +186,24 @@ export default function RuntimeScreen() {
             >
               <Text style={{ fontFamily: fonts.sansSemiBold, color: colors.light.primaryForeground }}>
                 Retry
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={() => router.replace("/(tabs)/apps" as any)}
+              style={({ pressed }) => ({
+                marginTop: spacing.sm,
+                borderRadius: radius.lg,
+                borderCurve: "continuous",
+                borderWidth: 1,
+                borderColor: colors.light.border,
+                backgroundColor: colors.light.card,
+                paddingHorizontal: spacing.xl,
+                paddingVertical: spacing.md,
+                opacity: pressed ? 0.82 : 1,
+              })}
+            >
+              <Text style={{ fontFamily: fonts.sansSemiBold, color: colors.light.foreground }}>
+                Apps
               </Text>
             </Pressable>
           </View>

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -8,7 +8,8 @@ import {
   Alert,
 } from "react-native";
 import { useRouter } from "expo-router";
-import { useOAuth, useAuth } from "@clerk/clerk-expo";
+import { makeRedirectUri } from "expo-auth-session";
+import { useSSO, useAuth } from "@clerk/clerk-expo";
 import * as WebBrowser from "expo-web-browser";
 import { Ionicons } from "@expo/vector-icons";
 import { Image } from "expo-image";
@@ -16,10 +17,14 @@ import { colors, fonts, spacing, radius } from "@/lib/theme";
 
 WebBrowser.maybeCompleteAuthSession();
 
+const clerkOAuthRedirectUrl =
+  process.env.EXPO_PUBLIC_CLERK_OAUTH_REDIRECT_URL ??
+  makeRedirectUri({ scheme: "matrixos", path: "sso-callback" });
+
 export default function SignInScreen() {
   const router = useRouter();
   const { isSignedIn } = useAuth();
-  const { startOAuthFlow } = useOAuth({ strategy: "oauth_google" });
+  const { startSSOFlow } = useSSO();
 
   const [loading, setLoading] = useState(false);
   const redirectedRef = useRef(false);
@@ -34,19 +39,22 @@ export default function SignInScreen() {
   const handleGoogleSignIn = useCallback(async () => {
     setLoading(true);
     try {
-      const { createdSessionId, setActive } = await startOAuthFlow();
+      const { createdSessionId, setActive } = await startSSOFlow({
+        strategy: "oauth_google",
+        redirectUrl: clerkOAuthRedirectUrl,
+      });
       if (createdSessionId && setActive) {
         await setActive({ session: createdSessionId });
         redirectedRef.current = true;
         router.replace("/(tabs)/apps" as any);
       }
-    } catch (err: any) {
-      const msg = err?.errors?.[0]?.longMessage || err?.message || "Sign in failed";
-      Alert.alert("Error", msg);
+    } catch (err: unknown) {
+      console.warn("[mobile] Google sign-in failed:", err);
+      Alert.alert("Sign in failed", "Check the mobile OAuth redirect URL and try again.");
     } finally {
       setLoading(false);
     }
-  }, [startOAuthFlow, router]);
+  }, [startSSOFlow, router]);
 
   if (isSignedIn) {
     return null;
@@ -58,7 +66,7 @@ export default function SignInScreen() {
         <View style={styles.header}>
           <View style={styles.logoContainer}>
             <Image
-              source={require("../assets/logo.png")}
+              source={require("../assets/icon.png")}
               style={styles.logo}
               contentFit="contain"
               accessibilityLabel="Matrix OS"

--- a/apps/mobile/app/terminal/_layout.tsx
+++ b/apps/mobile/app/terminal/_layout.tsx
@@ -1,0 +1,15 @@
+import { Stack } from "expo-router";
+import { colors, fonts } from "@/lib/theme";
+
+export default function TerminalLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: "#0f120f" },
+        headerTitleStyle: { fontFamily: fonts.sansSemiBold },
+        headerTintColor: colors.dark.foreground,
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/terminal/index.tsx
+++ b/apps/mobile/app/terminal/index.tsx
@@ -1,0 +1,547 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  useWindowDimensions,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useGateway } from "@/app/_layout";
+import { TerminalControlBar } from "@/components/TerminalControlBar";
+import { loadMobileShellState, saveMobileShellState } from "@/lib/mobile-shell-state";
+import {
+  MobileTerminalClient,
+  type MobileTerminalConnection,
+  type TerminalServerFrame,
+} from "@/lib/terminal-client";
+import {
+  formatTerminalCwd,
+  initialTerminalState,
+  terminalReducer,
+} from "@/lib/terminal-state";
+import { colors, fonts } from "@/lib/theme";
+
+export default function TerminalScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { width, height } = useWindowDimensions();
+  const { client } = useGateway();
+  const [state, dispatch] = useReducer(terminalReducer, initialTerminalState);
+  const [lastTerminalSessionId, setLastTerminalSessionId] = useState<string | null>(null);
+  const terminalClient = useMemo(() => (client ? new MobileTerminalClient(client) : null), [client]);
+  const connectionRef = useRef<MobileTerminalConnection | null>(null);
+  const outputRef = useRef<ScrollView | null>(null);
+  const inputRef = useRef<TextInput | null>(null);
+
+  const cols = Math.max(40, Math.floor(width / (8 * state.fontScale)));
+  const rows = Math.max(18, Math.floor(height / (18 * state.fontScale)));
+
+  const loadSessions = useCallback(async () => {
+    if (!terminalClient) return;
+    const sessions = await terminalClient.listSessions();
+    dispatch({ type: "sessions.loaded", sessions });
+  }, [terminalClient]);
+
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  useEffect(() => {
+    loadMobileShellState()
+      .then((saved) => setLastTerminalSessionId(saved.lastActiveTerminalSessionId))
+      .catch((err: unknown) => {
+        console.warn("[mobile] failed to load terminal resume state", err instanceof Error ? err.message : String(err));
+      });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      connectionRef.current?.detach();
+      connectionRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (state.status === "attached") {
+      connectionRef.current?.resize(cols, rows);
+    }
+  }, [cols, rows, state.status]);
+
+  useEffect(() => {
+    outputRef.current?.scrollToEnd({ animated: true });
+  }, [state.output]);
+
+  const handleFrame = useCallback((frame: TerminalServerFrame) => {
+    if (frame.type === "attached") {
+      dispatch({
+        type: "terminal.attached",
+        sessionId: frame.sessionId,
+        cwd: frame.cwd,
+        replay: frame.replay,
+      });
+      setLastTerminalSessionId(frame.sessionId);
+      loadMobileShellState()
+        .then((saved) => saveMobileShellState({
+          ...saved,
+          mode: "terminal",
+          lastActiveTerminalSessionId: frame.sessionId,
+          updatedAt: new Date().toISOString(),
+        }))
+        .catch((err: unknown) => {
+          console.warn("[mobile] failed to save terminal resume state", err instanceof Error ? err.message : String(err));
+        });
+      loadSessions();
+      return;
+    }
+    if (frame.type === "output") {
+      dispatch({ type: "terminal.output", data: frame.data });
+      return;
+    }
+    if (frame.type === "exit") {
+      dispatch({ type: "terminal.ended", exitCode: frame.exitCode });
+      setLastTerminalSessionId(null);
+      loadSessions();
+      return;
+    }
+    if (frame.type === "error") {
+      dispatch({ type: "terminal.error", message: frame.message ?? "Terminal unavailable" });
+    }
+  }, [loadSessions]);
+
+  const connectSession = useCallback(async (sessionId?: string) => {
+    if (!terminalClient) {
+      dispatch({ type: "terminal.error", message: "Terminal unavailable" });
+      return;
+    }
+
+    connectionRef.current?.detach();
+    connectionRef.current = null;
+    dispatch({ type: "connection.changed", status: "connecting" });
+
+    const nextConnection = await terminalClient.connect({
+      sessionId,
+      cwd: "projects",
+      cols,
+      rows,
+      onMessage: handleFrame,
+      onStatus: (status) => {
+        if (status === "open") dispatch({ type: "connection.changed", status: "attached" });
+        if (status === "closed") dispatch({ type: "connection.changed", status: "detached" });
+        if (status === "error") dispatch({ type: "terminal.error", message: "Terminal unavailable" });
+      },
+    });
+    connectionRef.current = nextConnection;
+    inputRef.current?.focus();
+  }, [cols, handleFrame, rows, terminalClient]);
+
+  const sendData = useCallback((data: string) => {
+    if (!data) return;
+    const sent = connectionRef.current?.sendInput(data) ?? false;
+    if (!sent) dispatch({ type: "terminal.error", message: "Terminal unavailable" });
+  }, []);
+
+  const submitInput = useCallback(() => {
+    if (!state.input) return;
+    sendData(`${state.input}\r`);
+    dispatch({ type: "terminal.clearInput" });
+  }, [sendData, state.input]);
+
+  const destroySession = useCallback(async () => {
+    const sessionId = state.activeSessionId;
+    connectionRef.current?.destroy();
+    connectionRef.current = null;
+    if (sessionId) await terminalClient?.deleteSession(sessionId);
+    setLastTerminalSessionId(null);
+    loadMobileShellState()
+      .then((saved) => saveMobileShellState({
+        ...saved,
+        mode: "terminal",
+        lastActiveTerminalSessionId: null,
+        updatedAt: new Date().toISOString(),
+      }))
+      .catch((err: unknown) => {
+        console.warn("[mobile] failed to clear terminal resume state", err instanceof Error ? err.message : String(err));
+      });
+    dispatch({ type: "reset.output" });
+    dispatch({ type: "connection.changed", status: "idle" });
+    loadSessions();
+  }, [loadSessions, state.activeSessionId, terminalClient]);
+
+  const runningSessions = state.sessions.filter((session) => session.state === "running");
+  const lastRunningSession = lastTerminalSessionId
+    ? runningSessions.find((session) => session.sessionId === lastTerminalSessionId) ?? null
+    : null;
+  const missingLastSession = Boolean(lastTerminalSessionId && state.sessions.length > 0 && !lastRunningSession);
+  const connected = state.status === "attached";
+  const cwd = formatTerminalCwd(state.cwd);
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      style={styles.screen}
+      keyboardVerticalOffset={0}
+    >
+      <View style={[styles.header, { paddingTop: insets.top + 8 }]}>
+        <Pressable accessibilityRole="button" accessibilityLabel="Back" onPress={() => router.back()} style={styles.iconButton}>
+          <Ionicons name="chevron-back" size={20} color={colors.dark.foreground} />
+        </Pressable>
+        <View style={styles.headerTitleGroup}>
+          <Text style={styles.title}>Terminal</Text>
+          <Text style={styles.subtitle} numberOfLines={1}>{cwd}</Text>
+        </View>
+        {state.status === "connecting" ? (
+          <ActivityIndicator color={colors.dark.primary} />
+        ) : (
+          <Pressable accessibilityRole="button" accessibilityLabel="New session" onPress={() => connectSession()} style={styles.iconButton}>
+            <Ionicons name="add" size={21} color={colors.dark.foreground} />
+          </Pressable>
+        )}
+      </View>
+
+      {runningSessions.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.sessionRow}
+          keyboardShouldPersistTaps="handled"
+        >
+          {runningSessions.map((session) => (
+            <Pressable
+              key={session.sessionId}
+              accessibilityRole="button"
+              accessibilityLabel={`Resume ${formatTerminalCwd(session.cwd)}`}
+              onPress={() => connectSession(session.sessionId)}
+              style={[
+                styles.sessionChip,
+                session.sessionId === state.activeSessionId && styles.sessionChipActive,
+              ]}
+            >
+              <Text style={styles.sessionChipText} numberOfLines={1}>
+                {formatTerminalCwd(session.cwd)}
+              </Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      )}
+
+      {lastRunningSession ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Continue terminal ${formatTerminalCwd(lastRunningSession.cwd)}`}
+          onPress={() => connectSession(lastRunningSession.sessionId)}
+          style={styles.continueCard}
+        >
+          <View style={styles.continueIcon}>
+            <Ionicons name="terminal" size={20} color={colors.dark.primary} />
+          </View>
+          <View style={styles.continueTextGroup}>
+            <Text style={styles.continueEyebrow}>Continue terminal</Text>
+            <Text style={styles.continueTitle} numberOfLines={1}>{formatTerminalCwd(lastRunningSession.cwd)}</Text>
+          </View>
+          <Ionicons name="chevron-forward" size={18} color={colors.dark.primary} />
+        </Pressable>
+      ) : null}
+
+      {missingLastSession ? (
+        <View style={styles.resumeNotice}>
+          <Text style={styles.resumeNoticeText}>Last terminal ended. Start a new session to continue.</Text>
+        </View>
+      ) : null}
+
+      <Pressable onPress={() => inputRef.current?.focus()} style={styles.terminalSurface}>
+        <ScrollView
+          ref={outputRef}
+          style={styles.output}
+          contentContainerStyle={styles.outputContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          {state.output ? (
+            <Text selectable style={[styles.outputText, { fontSize: 12 * state.fontScale }]}>
+              {state.output}
+            </Text>
+          ) : (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyTitle}>No terminal session</Text>
+              <Text style={styles.emptySubtitle}>Start a session to run commands on your Matrix VPS.</Text>
+            </View>
+          )}
+        </ScrollView>
+      </Pressable>
+
+      {state.error && (
+        <View style={styles.errorBar}>
+          <Text style={styles.errorText}>{state.error}</Text>
+        </View>
+      )}
+
+      <View style={[styles.commandArea, { paddingBottom: Math.max(insets.bottom, 8) }]}>
+        <View style={styles.promptRow}>
+          <Text style={styles.promptPath} numberOfLines={1}>{cwd}</Text>
+          <Text style={styles.promptSymbol}>$</Text>
+          <TextInput
+            ref={inputRef}
+            value={state.input}
+            onChangeText={(input) => dispatch({ type: "terminal.input", input })}
+            onSubmitEditing={submitInput}
+            editable={connected}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="send"
+            placeholder={connected ? "command" : "start session"}
+            placeholderTextColor="rgba(234, 236, 234, 0.35)"
+            style={[styles.commandInput, { fontSize: 14 * state.fontScale }]}
+          />
+          <Pressable accessibilityRole="button" accessibilityLabel="Run command" disabled={!connected} onPress={submitInput} style={styles.runButton}>
+            <Ionicons name="return-down-forward" size={18} color={connected ? colors.dark.primary : "rgba(234, 236, 234, 0.32)"} />
+          </Pressable>
+        </View>
+        <View style={styles.actionRow}>
+          <Pressable accessibilityRole="button" accessibilityLabel="Detach" disabled={!connected} onPress={() => connectionRef.current?.detach()} style={styles.actionButton}>
+            <Text style={styles.actionButtonText}>Detach</Text>
+          </Pressable>
+          <Pressable accessibilityRole="button" accessibilityLabel="Destroy session" disabled={!state.activeSessionId} onPress={destroySession} style={styles.actionButton}>
+            <Text style={styles.actionButtonText}>End</Text>
+          </Pressable>
+        </View>
+        <TerminalControlBar
+          onSend={sendData}
+          onFontScale={(delta) => dispatch({ type: "font.scale", delta })}
+          onClear={() => dispatch({ type: "reset.output" })}
+        />
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: "#0f120f",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 14,
+    paddingBottom: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(140, 199, 190, 0.14)",
+  },
+  iconButton: {
+    width: 42,
+    height: 42,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 14,
+    backgroundColor: "rgba(234, 236, 234, 0.08)",
+    borderWidth: 1,
+    borderColor: "rgba(140, 199, 190, 0.14)",
+  },
+  headerTitleGroup: {
+    flex: 1,
+    minWidth: 0,
+  },
+  title: {
+    fontFamily: fonts.sansBold,
+    color: colors.dark.foreground,
+    fontSize: 18,
+  },
+  subtitle: {
+    marginTop: 2,
+    fontFamily: fonts.mono,
+    color: colors.dark.primary,
+    fontSize: 12,
+  },
+  sessionRow: {
+    gap: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  sessionChip: {
+    maxWidth: 180,
+    paddingHorizontal: 12,
+    height: 34,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 11,
+    borderWidth: 1,
+    borderColor: "rgba(140, 199, 190, 0.14)",
+    backgroundColor: "rgba(234, 236, 234, 0.07)",
+  },
+  sessionChipActive: {
+    backgroundColor: "rgba(140, 199, 190, 0.18)",
+    borderColor: "rgba(140, 199, 190, 0.38)",
+  },
+  sessionChipText: {
+    fontFamily: fonts.mono,
+    color: colors.dark.foreground,
+    fontSize: 12,
+  },
+  continueCard: {
+    marginHorizontal: 14,
+    marginBottom: 8,
+    minHeight: 62,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 12,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(140, 199, 190, 0.38)",
+    backgroundColor: "rgba(140, 199, 190, 0.12)",
+  },
+  continueIcon: {
+    width: 38,
+    height: 38,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 12,
+    backgroundColor: "rgba(234, 236, 234, 0.08)",
+  },
+  continueTextGroup: {
+    flex: 1,
+    minWidth: 0,
+  },
+  continueEyebrow: {
+    fontFamily: fonts.sansSemiBold,
+    color: colors.dark.primary,
+    fontSize: 12,
+  },
+  continueTitle: {
+    marginTop: 2,
+    fontFamily: fonts.monoBold,
+    color: colors.dark.foreground,
+    fontSize: 14,
+  },
+  resumeNotice: {
+    marginHorizontal: 14,
+    marginBottom: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(245, 158, 11, 0.35)",
+    backgroundColor: "rgba(245, 158, 11, 0.12)",
+  },
+  resumeNoticeText: {
+    fontFamily: fonts.sansMedium,
+    color: "#fde68a",
+    fontSize: 12,
+  },
+  terminalSurface: {
+    flex: 1,
+  },
+  output: {
+    flex: 1,
+  },
+  outputContent: {
+    flexGrow: 1,
+    paddingHorizontal: 14,
+    paddingTop: 12,
+    paddingBottom: 18,
+  },
+  outputText: {
+    fontFamily: fonts.mono,
+    color: colors.dark.foreground,
+    lineHeight: 18,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 28,
+  },
+  emptyTitle: {
+    fontFamily: fonts.sansBold,
+    color: colors.dark.foreground,
+    fontSize: 17,
+  },
+  emptySubtitle: {
+    marginTop: 6,
+    textAlign: "center",
+    fontFamily: fonts.sans,
+    color: colors.dark.mutedForeground,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  errorBar: {
+    marginHorizontal: 14,
+    marginBottom: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(239, 68, 68, 0.38)",
+    backgroundColor: "rgba(239, 68, 68, 0.12)",
+  },
+  errorText: {
+    fontFamily: fonts.sansMedium,
+    color: "#fecaca",
+    fontSize: 12,
+  },
+  commandArea: {
+    borderTopWidth: 1,
+    borderTopColor: "rgba(140, 199, 190, 0.14)",
+    backgroundColor: "#0f120f",
+  },
+  promptRow: {
+    minHeight: 50,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 7,
+    paddingHorizontal: 14,
+  },
+  promptPath: {
+    maxWidth: 118,
+    fontFamily: fonts.mono,
+    color: colors.dark.primary,
+    fontSize: 12,
+  },
+  promptSymbol: {
+    fontFamily: fonts.monoBold,
+    color: colors.dark.foreground,
+    fontSize: 14,
+  },
+  commandInput: {
+    flex: 1,
+    minHeight: 42,
+    paddingVertical: 8,
+    fontFamily: fonts.mono,
+    color: colors.dark.foreground,
+  },
+  runButton: {
+    width: 38,
+    height: 38,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  actionRow: {
+    flexDirection: "row",
+    gap: 8,
+    paddingHorizontal: 14,
+    paddingBottom: 8,
+  },
+  actionButton: {
+    flex: 1,
+    height: 36,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(140, 199, 190, 0.14)",
+    backgroundColor: "rgba(234, 236, 234, 0.07)",
+  },
+  actionButtonText: {
+    fontFamily: fonts.sansSemiBold,
+    color: colors.dark.foreground,
+    fontSize: 13,
+  },
+});

--- a/apps/mobile/app/terminal/index.tsx
+++ b/apps/mobile/app/terminal/index.tsx
@@ -38,6 +38,8 @@ export default function TerminalScreen() {
   const [lastTerminalSessionId, setLastTerminalSessionId] = useState<string | null>(null);
   const terminalClient = useMemo(() => (client ? new MobileTerminalClient(client) : null), [client]);
   const connectionRef = useRef<MobileTerminalConnection | null>(null);
+  const connectAttemptRef = useRef(0);
+  const connectingRef = useRef(false);
   const outputRef = useRef<ScrollView | null>(null);
   const inputRef = useRef<TextInput | null>(null);
 
@@ -64,6 +66,8 @@ export default function TerminalScreen() {
 
   useEffect(() => {
     return () => {
+      connectAttemptRef.current += 1;
+      connectingRef.current = false;
       connectionRef.current?.detach();
       connectionRef.current = null;
     };
@@ -121,25 +125,53 @@ export default function TerminalScreen() {
       dispatch({ type: "terminal.error", message: "Terminal unavailable" });
       return;
     }
+    if (connectingRef.current) return;
 
+    const attemptId = connectAttemptRef.current + 1;
+    connectAttemptRef.current = attemptId;
+    connectingRef.current = true;
     connectionRef.current?.detach();
     connectionRef.current = null;
     dispatch({ type: "connection.changed", status: "connecting" });
 
-    const nextConnection = await terminalClient.connect({
-      sessionId,
-      cwd: "projects",
-      cols,
-      rows,
-      onMessage: handleFrame,
-      onStatus: (status) => {
-        if (status === "open") dispatch({ type: "connection.changed", status: "attached" });
-        if (status === "closed") dispatch({ type: "connection.changed", status: "detached" });
-        if (status === "error") dispatch({ type: "terminal.error", message: "Terminal unavailable" });
-      },
-    });
-    connectionRef.current = nextConnection;
-    inputRef.current?.focus();
+    let nextConnection: MobileTerminalConnection | null = null;
+    try {
+      nextConnection = await terminalClient.connect({
+        sessionId,
+        cwd: sessionId ? undefined : "projects",
+        cols,
+        rows,
+        onMessage: (frame) => {
+          if (connectAttemptRef.current === attemptId) handleFrame(frame);
+        },
+        onStatus: (status) => {
+          if (connectAttemptRef.current !== attemptId) return;
+          if (status === "open") dispatch({ type: "connection.changed", status: "attached" });
+          if (status === "closed") dispatch({ type: "connection.changed", status: "detached" });
+          if (status === "error") dispatch({ type: "terminal.error", message: "Terminal unavailable" });
+        },
+      });
+      if (connectAttemptRef.current !== attemptId) {
+        nextConnection?.detach();
+        return;
+      }
+      if (!nextConnection) {
+        dispatch({ type: "terminal.error", message: "Terminal unavailable" });
+        return;
+      }
+      connectionRef.current = nextConnection;
+      inputRef.current?.focus();
+    } catch (err: unknown) {
+      if (connectAttemptRef.current === attemptId) {
+        console.warn("[mobile] terminal connection failed", err instanceof Error ? err.message : String(err));
+        dispatch({ type: "terminal.error", message: "Terminal unavailable" });
+        dispatch({ type: "connection.changed", status: "detached" });
+      }
+    } finally {
+      if (connectAttemptRef.current === attemptId) {
+        connectingRef.current = false;
+      }
+    }
   }, [cols, handleFrame, rows, terminalClient]);
 
   const sendData = useCallback((data: string) => {
@@ -156,9 +188,18 @@ export default function TerminalScreen() {
 
   const destroySession = useCallback(async () => {
     const sessionId = state.activeSessionId;
+    if (sessionId) {
+      const deleted = await terminalClient?.deleteSession(sessionId);
+      if (!deleted) {
+        dispatch({ type: "terminal.error", message: "Terminal unavailable" });
+        loadSessions();
+        return;
+      }
+    }
+    connectAttemptRef.current += 1;
+    connectingRef.current = false;
     connectionRef.current?.destroy();
     connectionRef.current = null;
-    if (sessionId) await terminalClient?.deleteSession(sessionId);
     setLastTerminalSessionId(null);
     loadMobileShellState()
       .then((saved) => saveMobileShellState({

--- a/apps/mobile/components/TerminalControlBar.tsx
+++ b/apps/mobile/components/TerminalControlBar.tsx
@@ -1,0 +1,159 @@
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import * as Clipboard from "expo-clipboard";
+import { Ionicons } from "@expo/vector-icons";
+import {
+  buildTerminalControlSequence,
+  type TerminalControlKey,
+} from "@/lib/terminal-state";
+import { colors, fonts } from "@/lib/theme";
+
+interface TerminalControlBarProps {
+  onSend: (data: string) => void;
+  onFontScale: (delta: number) => void;
+  onClear: () => void;
+}
+
+export const TERMINAL_CONTROL_KEYS: Array<{ label: string; key: TerminalControlKey }> = [
+  { label: "Esc", key: "escape" },
+  { label: "Tab", key: "tab" },
+  { label: "Enter", key: "enter" },
+  { label: "Ctrl-C", key: "ctrl-c" },
+  { label: "Ctrl-D", key: "ctrl-d" },
+  { label: "Ctrl-L", key: "ctrl-l" },
+];
+
+export function TerminalControlBar({ onSend, onFontScale, onClear }: TerminalControlBarProps) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.arrowRow}>
+        <IconButton icon="remove" label="Smaller text" onPress={() => onFontScale(-0.05)} />
+        <ArrowPad onSend={onSend} />
+        <IconButton icon="add" label="Larger text" onPress={() => onFontScale(0.05)} />
+      </View>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.keyRow}
+        keyboardShouldPersistTaps="handled"
+      >
+        {TERMINAL_CONTROL_KEYS.map((entry) => (
+          <KeyButton
+            key={entry.key}
+            label={entry.label}
+            onPress={() => onSend(buildTerminalControlSequence(entry.key))}
+          />
+        ))}
+        <KeyButton label="Paste" onPress={() => sendTerminalClipboardPaste(onSend)} />
+        <KeyButton label="Clear" onPress={onClear} />
+      </ScrollView>
+    </View>
+  );
+}
+
+export async function sendTerminalClipboardPaste(onSend: (data: string) => void): Promise<void> {
+  const text = await Clipboard.getStringAsync();
+  if (text) onSend(text);
+}
+
+function ArrowPad({ onSend }: { onSend: (data: string) => void }) {
+  return (
+    <View style={styles.arrowPad}>
+      <ArrowButton icon="chevron-up" label="Up" onPress={() => onSend(buildTerminalControlSequence("arrow-up"))} />
+      <View style={styles.arrowPadBottom}>
+        <ArrowButton icon="chevron-back" label="Left" onPress={() => onSend(buildTerminalControlSequence("arrow-left"))} />
+        <ArrowButton icon="chevron-down" label="Down" onPress={() => onSend(buildTerminalControlSequence("arrow-down"))} />
+        <ArrowButton icon="chevron-forward" label="Right" onPress={() => onSend(buildTerminalControlSequence("arrow-right"))} />
+      </View>
+    </View>
+  );
+}
+
+function KeyButton({ label, onPress }: { label: string; onPress: () => void }) {
+  return (
+    <Pressable accessibilityRole="button" accessibilityLabel={label} onPress={onPress} style={styles.keyButton}>
+      <Text style={styles.keyText}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function ArrowButton({ icon, label, onPress }: { icon: keyof typeof Ionicons.glyphMap; label: string; onPress: () => void }) {
+  return (
+    <Pressable accessibilityRole="button" accessibilityLabel={label} onPress={onPress} style={styles.arrowButton}>
+      <Ionicons name={icon} size={16} color={colors.dark.foreground} />
+    </Pressable>
+  );
+}
+
+function IconButton({ icon, label, onPress }: { icon: keyof typeof Ionicons.glyphMap; label: string; onPress: () => void }) {
+  return (
+    <Pressable accessibilityRole="button" accessibilityLabel={label} onPress={onPress} style={styles.iconButton}>
+      <Ionicons name={icon} size={16} color={colors.dark.foreground} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 10,
+    paddingTop: 10,
+    paddingBottom: 8,
+    borderTopWidth: 1,
+    borderTopColor: "rgba(140, 199, 190, 0.16)",
+    backgroundColor: "#0f120f",
+  },
+  arrowRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+    paddingHorizontal: 14,
+  },
+  arrowPad: {
+    alignItems: "center",
+    gap: 4,
+  },
+  arrowPadBottom: {
+    flexDirection: "row",
+    gap: 4,
+  },
+  keyRow: {
+    gap: 8,
+    paddingHorizontal: 14,
+    paddingBottom: 2,
+  },
+  keyButton: {
+    minWidth: 62,
+    height: 38,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(140, 199, 190, 0.18)",
+    backgroundColor: "rgba(234, 236, 234, 0.08)",
+  },
+  keyText: {
+    fontFamily: fonts.monoBold,
+    color: colors.dark.foreground,
+    fontSize: 12,
+  },
+  arrowButton: {
+    width: 44,
+    height: 34,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(140, 199, 190, 0.18)",
+    backgroundColor: "rgba(234, 236, 234, 0.08)",
+  },
+  iconButton: {
+    width: 44,
+    height: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(140, 199, 190, 0.18)",
+    backgroundColor: "rgba(234, 236, 234, 0.08)",
+  },
+});

--- a/apps/mobile/jest.setup.js
+++ b/apps/mobile/jest.setup.js
@@ -38,6 +38,37 @@ jest.mock("expo-clipboard", () => ({
   getStringAsync: jest.fn(() => Promise.resolve("")),
 }));
 
+class MatrixMockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MatrixMockWebSocket.CONNECTING;
+  sent = [];
+  onopen = null;
+  onmessage = null;
+  onerror = null;
+  onclose = null;
+
+  constructor(url, protocols, options) {
+    this.url = url;
+    this.protocols = protocols;
+    this.options = options;
+  }
+
+  send(data) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MatrixMockWebSocket.CLOSED;
+    this.onclose?.({ code: 1000, reason: "" });
+  }
+}
+
+global.WebSocket = MatrixMockWebSocket;
+
 jest.mock("expo-secure-store", () => ({
   getItemAsync: jest.fn(() => Promise.resolve(null)),
   setItemAsync: jest.fn(() => Promise.resolve()),

--- a/apps/mobile/lib/apps.ts
+++ b/apps/mobile/lib/apps.ts
@@ -9,17 +9,24 @@ export type NativeAppRoute =
   | "/(tabs)/chat"
   | "/(tabs)/mission-control"
   | "/(tabs)/apps"
-  | "/(tabs)/settings";
+  | "/(tabs)/settings"
+  | "/canvas"
+  | "/terminal";
 
 const NATIVE_ROUTE_BY_SLUG: Record<string, NativeAppRoute> = {
   chat: "/(tabs)/chat",
+  terminal: "/terminal",
   tasks: "/(tabs)/mission-control",
   todo: "/(tabs)/mission-control",
   "task-manager": "/(tabs)/mission-control",
   "mission-control": "/(tabs)/mission-control",
   apps: "/(tabs)/apps",
   settings: "/(tabs)/settings",
+  canvas: "/canvas",
+  whiteboard: "/canvas",
 };
+
+const SAFE_APP_SLUG_SEGMENT = /^[a-z0-9][a-z0-9_-]*$/;
 
 export const NATIVE_MATRIX_APPS: MatrixAppEntry[] = [
   {
@@ -35,6 +42,22 @@ export const NATIVE_MATRIX_APPS: MatrixAppEntry[] = [
     category: "System",
     file: "apps/index.html",
     path: "/files/apps/apps/index.html",
+  },
+  {
+    name: "Terminal",
+    description: "Open a Matrix VPS shell session.",
+    category: "System",
+    slug: "terminal",
+    file: "terminal/index.html",
+    path: "/files/apps/terminal/index.html",
+  },
+  {
+    name: "Canvas",
+    description: "Open your workspace canvas when spatial context helps.",
+    category: "System",
+    slug: "canvas",
+    file: "canvas/index.html",
+    path: "/files/apps/canvas/index.html",
   },
   {
     name: "Tasks",
@@ -53,12 +76,9 @@ export const NATIVE_MATRIX_APPS: MatrixAppEntry[] = [
 ];
 
 export function getAppSlug(app: Pick<MatrixAppEntry, "file" | "path" | "name" | "slug">): string {
-  const source = app.slug || app.file || app.path || app.name;
-  return source
-    .replace(/^\/?(files\/)?apps\//, "")
-    .replace(/\/index\.html$/, "")
-    .replace(/\.html$/, "")
-    .toLowerCase();
+  const source = app.slug || app.file || app.path;
+  const normalized = source ? normalizeAppSlug(source) : null;
+  return normalized ?? slugifyName(app.name);
 }
 
 export function getRuntimeSlug(app: Pick<MatrixAppEntry, "file" | "path" | "name" | "slug">): string {
@@ -119,6 +139,7 @@ export function getGatewayAppUrlLabel(
 export function getAppIconName(app: Pick<MatrixAppEntry, "category" | "name">): string {
   const label = `${app.category ?? ""} ${app.name}`.toLowerCase();
   if (label.includes("game")) return "game-controller";
+  if (label.includes("terminal") || label.includes("shell")) return "terminal";
   if (label.includes("chat") || label.includes("social")) return "chatbubble";
   if (label.includes("task") || label.includes("todo")) return "checkmark-circle";
   if (label.includes("note")) return "document-text";
@@ -127,6 +148,32 @@ export function getAppIconName(app: Pick<MatrixAppEntry, "category" | "name">): 
   if (label.includes("calculator")) return "calculator";
   if (label.includes("whiteboard") || label.includes("canvas")) return "brush";
   return "apps";
+}
+
+function normalizeAppSlug(source: string): string | null {
+  const withoutCacheParams = source.split(/[?#]/, 1)[0] ?? "";
+  const normalizedPath = withoutCacheParams
+    .replace(/\\/g, "/")
+    .replace(/^https?:\/\/[^/]+/i, "")
+    .replace(/^\/+/, "")
+    .replace(/\/{2,}/g, "/")
+    .replace(/^(files\/)?apps\//i, "")
+    .replace(/\/index\.html$/i, "")
+    .replace(/\.html$/i, "")
+    .toLowerCase();
+
+  const parts = normalizedPath.split("/").filter(Boolean);
+  if (parts.length === 0) return null;
+  if (parts.some((part) => !SAFE_APP_SLUG_SEGMENT.test(part))) return null;
+  return parts.join("/");
+}
+
+function slugifyName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "app";
 }
 
 export function appDetailHref(slug: string): Href {

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -334,8 +334,9 @@ export class GatewayClient {
         return null;
       }
       const data = (await res.json()) as { token?: unknown; expiresAt?: unknown };
+      if (data.token == null) return null;
       if (typeof data.token !== "string") {
-        console.warn("[mobile] /api/auth/ws-token returned no token");
+        console.warn("[mobile] /api/auth/ws-token returned invalid token");
         return null;
       }
       this.setWebSocketToken(data.token, typeof data.expiresAt === "number" ? data.expiresAt : undefined);

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -1,4 +1,9 @@
 import { encodeAppSlugPath } from "@/lib/app-slugs";
+import {
+  isSafeSessionId,
+  parseTerminalSessions,
+  type MobileTerminalSession,
+} from "@/lib/terminal-state";
 
 export type ConnectionState = "disconnected" | "connecting" | "connected" | "error";
 
@@ -71,6 +76,7 @@ type ReactNativeWebSocketConstructor = new (
 
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
+export const DEFAULT_GATEWAY_FETCH_TIMEOUT_MS = 10_000;
 
 export class GatewayClient {
   private ws: WebSocket | null = null;
@@ -107,6 +113,11 @@ export class GatewayClient {
   get wsUrl(): string {
     const url = this.baseUrl.replace(/^http/, "ws");
     return `${url}/ws`;
+  }
+
+  get terminalWsUrl(): string {
+    const url = this.baseUrl.replace(/^http/, "ws");
+    return `${url}/ws/terminal`;
   }
 
   setWebSocketToken(token: string | null, expiresAt?: number): void {
@@ -270,6 +281,17 @@ export class GatewayClient {
     return headers;
   }
 
+  private async fetchGateway(path: string, init: RequestInit = {}): Promise<Response> {
+    return fetch(`${this.httpUrl}${path}`, {
+      ...init,
+      headers: {
+        ...(await this.authHeaders()),
+        ...(init.headers as Record<string, string> | undefined),
+      },
+      signal: init.signal ?? createTimeoutSignal(DEFAULT_GATEWAY_FETCH_TIMEOUT_MS),
+    });
+  }
+
   async webViewHeaders(): Promise<Record<string, string> | undefined> {
     const token = await this.refreshAuthToken();
     if (!token) return undefined;
@@ -278,30 +300,37 @@ export class GatewayClient {
     };
   }
 
+  openTerminalWebSocket(token?: string | null): WebSocket {
+    const wsUrl = token
+      ? `${this.terminalWsUrl}?token=${encodeURIComponent(token)}`
+      : this.terminalWsUrl;
+    const WebSocketWithOptions = WebSocket as unknown as ReactNativeWebSocketConstructor;
+    return new WebSocketWithOptions(
+      wsUrl,
+      [],
+      this.token
+        ? { headers: { Authorization: `Bearer ${this.token}` } }
+        : undefined,
+    );
+  }
+
   async healthCheck(): Promise<{ ok: boolean; data?: unknown; error?: string }> {
     try {
-      const res = await fetch(`${this.httpUrl}/health`, {
-        headers: await this.authHeaders(),
-      });
-      if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+      const res = await this.fetchGateway("/health");
+      if (!res.ok) return { ok: false, error: "Gateway unavailable" };
       const data = await res.json();
       return { ok: true, data };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : "Unknown error" };
+    } catch {
+      console.warn("[mobile] gateway health check unavailable");
+      return { ok: false, error: "Gateway unavailable" };
     }
   }
 
   async getWsToken(): Promise<string | null> {
     try {
-      const res = await fetch(`${this.httpUrl}/api/auth/ws-token`, {
-        headers: await this.authHeaders(),
-      });
+      const res = await this.fetchGateway("/api/auth/ws-token");
       if (!res.ok) {
-        const body = await res.text().catch((err: unknown) => {
-          console.warn("[mobile] failed to read /api/auth/ws-token error body", err instanceof Error ? err.message : String(err));
-          return "";
-        });
-        console.warn("[mobile] /api/auth/ws-token failed", res.status, body.slice(0, 160));
+        console.warn("[mobile] /api/auth/ws-token unavailable", res.status);
         return null;
       }
       const data = (await res.json()) as { token?: unknown; expiresAt?: unknown };
@@ -311,8 +340,8 @@ export class GatewayClient {
       }
       this.setWebSocketToken(data.token, typeof data.expiresAt === "number" ? data.expiresAt : undefined);
       return data.token;
-    } catch (err: unknown) {
-      console.warn("[mobile] /api/auth/ws-token network error", err instanceof Error ? err.message : String(err));
+    } catch {
+      console.warn("[mobile] /api/auth/ws-token network error");
       return null;
     }
   }
@@ -329,55 +358,46 @@ export class GatewayClient {
 
   async getTasks(status?: string): Promise<unknown[]> {
     const url = status
-      ? `${this.httpUrl}/api/tasks?status=${encodeURIComponent(status)}`
-      : `${this.httpUrl}/api/tasks`;
-    const res = await fetch(url, { headers: await this.authHeaders() });
+      ? `/api/tasks?status=${encodeURIComponent(status)}`
+      : "/api/tasks";
+    const res = await this.fetchGateway(url);
     return res.json();
   }
 
   async createTask(input: string, type = "todo"): Promise<unknown> {
-    const res = await fetch(`${this.httpUrl}/api/tasks`, {
+    const res = await this.fetchGateway("/api/tasks", {
       method: "POST",
-      headers: await this.authHeaders(),
       body: JSON.stringify({ input, type }),
     });
     return res.json();
   }
 
   async updateTask(id: string, updates: Record<string, unknown>): Promise<unknown> {
-    const res = await fetch(`${this.httpUrl}/api/tasks/${encodeURIComponent(id)}`, {
+    const res = await this.fetchGateway(`/api/tasks/${encodeURIComponent(id)}`, {
       method: "PATCH",
-      headers: await this.authHeaders(),
       body: JSON.stringify(updates),
     });
     return res.json();
   }
 
   async deleteTask(id: string): Promise<void> {
-    await fetch(`${this.httpUrl}/api/tasks/${encodeURIComponent(id)}`, {
+    await this.fetchGateway(`/api/tasks/${encodeURIComponent(id)}`, {
       method: "DELETE",
-      headers: await this.authHeaders(),
     });
   }
 
   async getCron(): Promise<unknown[]> {
-    const res = await fetch(`${this.httpUrl}/api/cron`, {
-      headers: await this.authHeaders(),
-    });
+    const res = await this.fetchGateway("/api/cron");
     return res.json();
   }
 
   async getChannelStatus(): Promise<unknown> {
-    const res = await fetch(`${this.httpUrl}/api/channels/status`, {
-      headers: await this.authHeaders(),
-    });
+    const res = await this.fetchGateway("/api/channels/status");
     return res.json();
   }
 
   async getSystemInfo(): Promise<unknown> {
-    const res = await fetch(`${this.httpUrl}/api/system/info`, {
-      headers: await this.authHeaders(),
-    });
+    const res = await this.fetchGateway("/api/system/info");
     return res.json();
   }
 
@@ -386,31 +406,25 @@ export class GatewayClient {
     if (sessionId) params.set("sessionId", sessionId);
     if (before) params.set("before", String(before));
     params.set("limit", String(limit));
-    const res = await fetch(`${this.httpUrl}/api/messages?${params}`, {
-      headers: await this.authHeaders(),
-    });
+    const res = await this.fetchGateway(`/api/messages?${params}`);
     if (!res.ok) return [];
     return res.json();
   }
 
   async getConversations(): Promise<unknown[]> {
-    const res = await fetch(`${this.httpUrl}/api/conversations`, {
-      headers: await this.authHeaders(),
-    });
+    const res = await this.fetchGateway("/api/conversations");
     return res.json();
   }
 
   async getApps(): Promise<MatrixAppEntry[]> {
     try {
-      const res = await fetch(`${this.httpUrl}/api/apps`, {
-        headers: await this.authHeaders(),
-      });
+      const res = await this.fetchGateway("/api/apps");
       if (!res.ok) {
         const body = await res.text().catch((err: unknown) => {
           console.warn("[mobile] failed to read /api/apps error body", err instanceof Error ? err.message : String(err));
           return "";
         });
-        console.warn("[mobile] /api/apps failed", res.status, body.slice(0, 160));
+        console.warn("[mobile] /api/apps unavailable", res.status, body.slice(0, 160));
         return [];
       }
       return res.json();
@@ -420,24 +434,51 @@ export class GatewayClient {
     }
   }
 
+  async getTerminalSessions(): Promise<MobileTerminalSession[]> {
+    try {
+      const res = await this.fetchGateway("/api/terminal/sessions");
+      if (!res.ok) {
+        console.warn("[mobile] /api/terminal/sessions unavailable", res.status);
+        return [];
+      }
+      return parseTerminalSessions(await res.json());
+    } catch {
+      console.warn("[mobile] /api/terminal/sessions unavailable");
+      return [];
+    }
+  }
+
+  async deleteTerminalSession(sessionId: string): Promise<boolean> {
+    if (!isSafeSessionId(sessionId)) return false;
+    try {
+      const res = await this.fetchGateway(
+        `/api/terminal/sessions/${encodeURIComponent(sessionId)}`,
+        { method: "DELETE" },
+      );
+      if (res.ok || res.status === 404) return true;
+      console.warn("[mobile] terminal session delete unavailable", res.status);
+      return false;
+    } catch {
+      console.warn("[mobile] terminal session delete unavailable");
+      return false;
+    }
+  }
+
   async getAppManifest(slug: string): Promise<MatrixAppManifestResponse | null> {
     try {
-      const res = await fetch(`${this.httpUrl}/api/apps/${encodeAppSlugPath(slug)}/manifest`, {
-        headers: await this.authHeaders(),
-      });
+      const res = await this.fetchGateway(`/api/apps/${encodeAppSlugPath(slug)}/manifest`);
       if (!res.ok) return null;
       return res.json();
-    } catch (err: unknown) {
-      console.warn("[mobile] /api/apps/:slug/manifest unavailable", slug, err instanceof Error ? err.message : String(err));
+    } catch {
+      console.warn("[mobile] /api/apps/:slug/manifest unavailable", slug);
       return null;
     }
   }
 
   async createAppSessionToken(slug: string): Promise<{ launchUrl: string; expiresAt: number } | null> {
     try {
-      const res = await fetch(`${this.httpUrl}/api/apps/${encodeAppSlugPath(slug)}/session-token`, {
+      const res = await this.fetchGateway(`/api/apps/${encodeAppSlugPath(slug)}/session-token`, {
         method: "POST",
-        headers: await this.authHeaders(),
         body: "{}",
       });
       if (!res.ok) {
@@ -448,7 +489,7 @@ export class GatewayClient {
           );
           return "";
         });
-        console.warn("[mobile] /api/apps/:slug/session-token failed", slug, res.status, body.slice(0, 160));
+        console.warn("[mobile] /api/apps/:slug/session-token unavailable", slug, res.status, body.slice(0, 160));
         return null;
       }
       const data = (await res.json()) as { launchUrl?: unknown; expiresAt?: unknown };
@@ -457,44 +498,48 @@ export class GatewayClient {
         return null;
       }
       return { launchUrl: data.launchUrl, expiresAt: data.expiresAt };
-    } catch (err: unknown) {
-      console.warn(
-        "[mobile] /api/apps/:slug/session-token network error",
-        slug,
-        err instanceof Error ? err.message : String(err),
-      );
+    } catch {
+      console.warn("[mobile] /api/apps/:slug/session-token network error", slug);
       return null;
     }
   }
 
   async getProfile(): Promise<string | null> {
-    const res = await fetch(`${this.httpUrl}/api/profile`, {
-      headers: await this.authHeaders(),
-    });
+    const res = await this.fetchGateway("/api/profile");
     if (!res.ok) return null;
     return res.text();
   }
 
   async getAiProfile(): Promise<string | null> {
-    const res = await fetch(`${this.httpUrl}/api/ai-profile`, {
-      headers: await this.authHeaders(),
-    });
+    const res = await this.fetchGateway("/api/ai-profile");
     if (!res.ok) return null;
     return res.text();
   }
 
   async getIdentity(): Promise<unknown> {
-    const res = await fetch(`${this.httpUrl}/api/identity`, {
-      headers: await this.authHeaders(),
-    });
+    const res = await this.fetchGateway("/api/identity");
     return res.json();
   }
 
   async registerPushToken(token: string, platform: string): Promise<void> {
-    await fetch(`${this.httpUrl}/api/push/register`, {
+    await this.fetchGateway("/api/push/register", {
       method: "POST",
-      headers: await this.authHeaders(),
       body: JSON.stringify({ token, platform }),
     });
   }
+}
+
+function createTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
+  const timeout = (AbortSignal as { timeout?: (milliseconds: number) => AbortSignal }).timeout;
+  if (typeof timeout === "function") {
+    return timeout(timeoutMs);
+  }
+
+  if (typeof AbortController === "undefined") {
+    return undefined;
+  }
+
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeoutMs);
+  return controller.signal;
 }

--- a/apps/mobile/lib/mobile-shell-state.ts
+++ b/apps/mobile/lib/mobile-shell-state.ts
@@ -1,0 +1,93 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export const MOBILE_SHELL_STATE_STORAGE_KEY = "matrix.mobileShellState.v1";
+
+export type MobileShellSurface = "browser-shell" | "native-mobile";
+export type MobileShellMode = "launcher" | "app" | "terminal" | "canvas";
+
+export interface MobileShellState {
+  surface: MobileShellSurface;
+  mode: MobileShellMode;
+  lastActiveAppSlug: string | null;
+  lastActiveTerminalSessionId: string | null;
+  canvasEnteredAt: string | null;
+  updatedAt: string;
+}
+
+type MobileShellStorage = Pick<typeof AsyncStorage, "getItem" | "setItem">;
+
+const MOBILE_SHELL_MODES = new Set<MobileShellMode>(["launcher", "app", "terminal", "canvas"]);
+const SAFE_APP_SLUG = /^[a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)*$/;
+const SAFE_TERMINAL_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+
+export function createDefaultMobileShellState(surface: MobileShellSurface = "native-mobile"): MobileShellState {
+  return {
+    surface,
+    mode: "launcher",
+    lastActiveAppSlug: null,
+    lastActiveTerminalSessionId: null,
+    canvasEnteredAt: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function parseMobileShellState(
+  value: unknown,
+  surface: MobileShellSurface = "native-mobile",
+): MobileShellState {
+  const fallback = createDefaultMobileShellState(surface);
+  if (!value || typeof value !== "object") {
+    return fallback;
+  }
+
+  const record = value as Record<string, unknown>;
+  const mode = typeof record.mode === "string" && MOBILE_SHELL_MODES.has(record.mode as MobileShellMode)
+    ? record.mode as MobileShellMode
+    : "launcher";
+
+  return {
+    surface,
+    mode,
+    lastActiveAppSlug: safeAppSlug(record.lastActiveAppSlug),
+    lastActiveTerminalSessionId: safeTerminalSessionId(record.lastActiveTerminalSessionId),
+    canvasEnteredAt: safeIsoTimestamp(record.canvasEnteredAt),
+    updatedAt: safeIsoTimestamp(record.updatedAt) ?? fallback.updatedAt,
+  };
+}
+
+export async function loadMobileShellState(storage: MobileShellStorage = AsyncStorage): Promise<MobileShellState> {
+  try {
+    const raw = await storage.getItem(MOBILE_SHELL_STATE_STORAGE_KEY);
+    if (!raw) return createDefaultMobileShellState();
+    return parseMobileShellState(JSON.parse(raw));
+  } catch (err) {
+    console.warn("[mobile] failed to load mobile shell state", err);
+    return createDefaultMobileShellState();
+  }
+}
+
+export async function saveMobileShellState(
+  state: MobileShellState,
+  storage: MobileShellStorage = AsyncStorage,
+): Promise<void> {
+  const safeState = parseMobileShellState(state);
+  await storage.setItem(MOBILE_SHELL_STATE_STORAGE_KEY, JSON.stringify(safeState));
+}
+
+function safeAppSlug(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const slug = value.trim().toLowerCase();
+  return SAFE_APP_SLUG.test(slug) ? slug : null;
+}
+
+function safeTerminalSessionId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const sessionId = value.trim();
+  return SAFE_TERMINAL_SESSION_ID.test(sessionId) ? sessionId : null;
+}
+
+function safeIsoTimestamp(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : new Date(timestamp).toISOString();
+}

--- a/apps/mobile/lib/mobile-shell-state.ts
+++ b/apps/mobile/lib/mobile-shell-state.ts
@@ -18,7 +18,8 @@ type MobileShellStorage = Pick<typeof AsyncStorage, "getItem" | "setItem">;
 
 const MOBILE_SHELL_MODES = new Set<MobileShellMode>(["launcher", "app", "terminal", "canvas"]);
 const SAFE_APP_SLUG = /^[a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)*$/;
-const SAFE_TERMINAL_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+const SAFE_TERMINAL_SESSION_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function createDefaultMobileShellState(surface: MobileShellSurface = "native-mobile"): MobileShellState {
   return {

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -1,0 +1,210 @@
+import { GatewayClient } from "@/lib/gateway-client";
+import type { MobileTerminalSession } from "@/lib/terminal-state";
+
+export type TerminalClientFrame =
+  | { type: "attach"; sessionId?: string; cwd?: string; fromSeq?: number }
+  | { type: "input"; data: string }
+  | { type: "resize"; cols: number; rows: number }
+  | { type: "detach" }
+  | { type: "destroy" };
+
+export type TerminalServerFrame =
+  | { type: "attached"; sessionId: string; cwd?: string; replay?: string }
+  | { type: "output"; data: string }
+  | { type: "replay-start"; fromSeq?: number; toSeq?: number }
+  | { type: "replay-end"; nextSeq?: number }
+  | { type: "exit"; exitCode?: number | null }
+  | { type: "error"; message?: string };
+
+export interface MobileTerminalConnectOptions {
+  sessionId?: string;
+  cwd?: string;
+  cols?: number;
+  rows?: number;
+  fromSeq?: number;
+  onMessage: (frame: TerminalServerFrame) => void;
+  onStatus?: (status: "connecting" | "open" | "closed" | "error") => void;
+}
+
+type ReactNativeWebSocketConstructor = new (
+  url: string,
+  protocols?: string | string[],
+  options?: { headers?: Record<string, string> },
+) => WebSocket;
+
+const SAFE_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export class MobileTerminalClient {
+  constructor(private readonly gateway: GatewayClient) {}
+
+  async listSessions(): Promise<MobileTerminalSession[]> {
+    return this.gateway.getTerminalSessions();
+  }
+
+  async deleteSession(sessionId: string): Promise<boolean> {
+    return this.gateway.deleteTerminalSession(sessionId);
+  }
+
+  async connect(options: MobileTerminalConnectOptions): Promise<MobileTerminalConnection | null> {
+    const token = await this.gateway.getWsToken();
+    if (!token) {
+      options.onStatus?.("error");
+      return null;
+    }
+    this.gateway.setWebSocketToken(token);
+    const ws = this.gateway.openTerminalWebSocket(token);
+    const connection = new MobileTerminalConnection(ws, options);
+    connection.attach();
+    return connection;
+  }
+}
+
+export class MobileTerminalConnection {
+  private readonly attachFrame: TerminalClientFrame;
+  private attached = false;
+
+  constructor(
+    private readonly ws: WebSocket,
+    private readonly options: MobileTerminalConnectOptions,
+  ) {
+    this.attachFrame = compactFrame({
+      type: "attach",
+      sessionId: options.sessionId,
+      cwd: options.cwd,
+      fromSeq: options.fromSeq,
+    });
+  }
+
+  attach(): void {
+    this.options.onStatus?.("connecting");
+
+    this.ws.onopen = () => {
+      this.attached = true;
+      this.options.onStatus?.("open");
+      this.sendFrame(this.attachFrame);
+      if (this.options.cols && this.options.rows) {
+        this.resize(this.options.cols, this.options.rows);
+      }
+    };
+
+    this.ws.onmessage = (event) => {
+      const frame = parseTerminalServerFrame(event.data);
+      if (frame) this.options.onMessage(frame);
+    };
+
+    this.ws.onerror = () => {
+      this.options.onStatus?.("error");
+    };
+
+    this.ws.onclose = () => {
+      this.options.onStatus?.("closed");
+    };
+  }
+
+  sendInput(data: string): boolean {
+    return this.sendFrame({ type: "input", data });
+  }
+
+  resize(cols: number, rows: number): boolean {
+    return this.sendFrame({
+      type: "resize",
+      cols: clampInteger(cols, 1, 500),
+      rows: clampInteger(rows, 1, 200),
+    });
+  }
+
+  detach(): boolean {
+    const sent = this.sendFrame({ type: "detach" });
+    this.close();
+    return sent;
+  }
+
+  destroy(): boolean {
+    const sent = this.sendFrame({ type: "destroy" });
+    this.close();
+    return sent;
+  }
+
+  close(): void {
+    if (!this.attached) return;
+    this.attached = false;
+    this.ws.close();
+  }
+
+  private sendFrame(frame: TerminalClientFrame): boolean {
+    if (this.ws.readyState !== WebSocket.OPEN) return false;
+    this.ws.send(JSON.stringify(frame));
+    return true;
+  }
+}
+
+export function parseTerminalSessions(value: unknown): MobileTerminalSession[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const candidate = entry as Record<string, unknown>;
+    if (typeof candidate.sessionId !== "string" || !isSafeSessionId(candidate.sessionId)) {
+      return [];
+    }
+    const session: MobileTerminalSession = {
+      sessionId: candidate.sessionId,
+      cwd: typeof candidate.cwd === "string" ? candidate.cwd : "~",
+      state: typeof candidate.state === "string" ? candidate.state : "running",
+    };
+    if (typeof candidate.createdAt === "string") session.createdAt = candidate.createdAt;
+    if (typeof candidate.lastAttachedAt === "string") session.lastAttachedAt = candidate.lastAttachedAt;
+    if (typeof candidate.attachedClients === "number") session.attachedClients = candidate.attachedClients;
+    if (typeof candidate.exitCode === "number" || candidate.exitCode === null) session.exitCode = candidate.exitCode;
+    return [session];
+  });
+}
+
+export function isSafeSessionId(sessionId: string): boolean {
+  return SAFE_UUID.test(sessionId);
+}
+
+export function buildTerminalWebSocketUrl(baseUrl: string, token?: string | null): string {
+  const url = `${baseUrl.replace(/\/+$/, "").replace(/^http/, "ws")}/ws/terminal`;
+  if (!token) return url;
+  return `${url}?token=${encodeURIComponent(token)}`;
+}
+
+function parseTerminalServerFrame(data: unknown): TerminalServerFrame | null {
+  if (typeof data !== "string") return null;
+  try {
+    const frame = JSON.parse(data) as TerminalServerFrame;
+    if (!frame || typeof frame !== "object" || typeof frame.type !== "string") return null;
+    if (frame.type === "attached" && typeof frame.sessionId === "string") return frame;
+    if (frame.type === "output" && typeof frame.data === "string") return frame;
+    if (frame.type === "replay-start" || frame.type === "replay-end" || frame.type === "exit") return frame;
+    if (frame.type === "error") return { type: "error", message: typeof frame.message === "string" ? frame.message : undefined };
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function compactFrame<T extends Record<string, unknown>>(frame: T): T {
+  return Object.fromEntries(
+    Object.entries(frame).filter(([, value]) => value !== undefined),
+  ) as T;
+}
+
+function clampInteger(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.round(value)));
+}
+
+export function openTerminalWebSocket(
+  baseUrl: string,
+  token?: string | null,
+  bearerToken?: string,
+): WebSocket {
+  const WebSocketWithOptions = WebSocket as unknown as ReactNativeWebSocketConstructor;
+  return new WebSocketWithOptions(
+    buildTerminalWebSocketUrl(baseUrl, token),
+    [],
+    bearerToken ? { headers: { Authorization: `Bearer ${bearerToken}` } } : undefined,
+  );
+}

--- a/apps/mobile/lib/terminal-client.ts
+++ b/apps/mobile/lib/terminal-client.ts
@@ -1,5 +1,9 @@
 import { GatewayClient } from "@/lib/gateway-client";
 import type { MobileTerminalSession } from "@/lib/terminal-state";
+export { isSafeSessionId, parseTerminalSessions } from "@/lib/terminal-state";
+
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
 
 export type TerminalClientFrame =
   | { type: "attach"; sessionId?: string; cwd?: string; fromSeq?: number }
@@ -26,15 +30,6 @@ export interface MobileTerminalConnectOptions {
   onStatus?: (status: "connecting" | "open" | "closed" | "error") => void;
 }
 
-type ReactNativeWebSocketConstructor = new (
-  url: string,
-  protocols?: string | string[],
-  options?: { headers?: Record<string, string> },
-) => WebSocket;
-
-const SAFE_UUID =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
 export class MobileTerminalClient {
   constructor(private readonly gateway: GatewayClient) {}
 
@@ -48,10 +43,6 @@ export class MobileTerminalClient {
 
   async connect(options: MobileTerminalConnectOptions): Promise<MobileTerminalConnection | null> {
     const token = await this.gateway.getWsToken();
-    if (!token) {
-      options.onStatus?.("error");
-      return null;
-    }
     this.gateway.setWebSocketToken(token);
     const ws = this.gateway.openTerminalWebSocket(token);
     const connection = new MobileTerminalConnection(ws, options);
@@ -127,41 +118,16 @@ export class MobileTerminalConnection {
   }
 
   close(): void {
-    if (!this.attached) return;
+    if (this.ws.readyState !== WS_CONNECTING && this.ws.readyState !== WS_OPEN) return;
     this.attached = false;
     this.ws.close();
   }
 
   private sendFrame(frame: TerminalClientFrame): boolean {
-    if (this.ws.readyState !== WebSocket.OPEN) return false;
+    if (this.ws.readyState !== WS_OPEN) return false;
     this.ws.send(JSON.stringify(frame));
     return true;
   }
-}
-
-export function parseTerminalSessions(value: unknown): MobileTerminalSession[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((entry) => {
-    if (!entry || typeof entry !== "object") return [];
-    const candidate = entry as Record<string, unknown>;
-    if (typeof candidate.sessionId !== "string" || !isSafeSessionId(candidate.sessionId)) {
-      return [];
-    }
-    const session: MobileTerminalSession = {
-      sessionId: candidate.sessionId,
-      cwd: typeof candidate.cwd === "string" ? candidate.cwd : "~",
-      state: typeof candidate.state === "string" ? candidate.state : "running",
-    };
-    if (typeof candidate.createdAt === "string") session.createdAt = candidate.createdAt;
-    if (typeof candidate.lastAttachedAt === "string") session.lastAttachedAt = candidate.lastAttachedAt;
-    if (typeof candidate.attachedClients === "number") session.attachedClients = candidate.attachedClients;
-    if (typeof candidate.exitCode === "number" || candidate.exitCode === null) session.exitCode = candidate.exitCode;
-    return [session];
-  });
-}
-
-export function isSafeSessionId(sessionId: string): boolean {
-  return SAFE_UUID.test(sessionId);
 }
 
 export function buildTerminalWebSocketUrl(baseUrl: string, token?: string | null): string {
@@ -194,17 +160,4 @@ function compactFrame<T extends Record<string, unknown>>(frame: T): T {
 function clampInteger(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min;
   return Math.max(min, Math.min(max, Math.round(value)));
-}
-
-export function openTerminalWebSocket(
-  baseUrl: string,
-  token?: string | null,
-  bearerToken?: string,
-): WebSocket {
-  const WebSocketWithOptions = WebSocket as unknown as ReactNativeWebSocketConstructor;
-  return new WebSocketWithOptions(
-    buildTerminalWebSocketUrl(baseUrl, token),
-    [],
-    bearerToken ? { headers: { Authorization: `Bearer ${bearerToken}` } } : undefined,
-  );
 }

--- a/apps/mobile/lib/terminal-state.ts
+++ b/apps/mobile/lib/terminal-state.ts
@@ -1,0 +1,207 @@
+export type TerminalConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "attached"
+  | "detached"
+  | "ended"
+  | "error";
+
+export interface MobileTerminalSession {
+  sessionId: string;
+  cwd: string;
+  state: "running" | "exited" | "destroyed" | string;
+  createdAt?: string;
+  lastAttachedAt?: string;
+  attachedClients?: number;
+  exitCode?: number | null;
+}
+
+export interface TerminalState {
+  status: TerminalConnectionStatus;
+  sessions: MobileTerminalSession[];
+  activeSessionId: string | null;
+  cwd: string;
+  output: string;
+  input: string;
+  error: string | null;
+  fontScale: number;
+}
+
+export type TerminalControlKey =
+  | "escape"
+  | "tab"
+  | "enter"
+  | "arrow-up"
+  | "arrow-down"
+  | "arrow-left"
+  | "arrow-right"
+  | "ctrl-c"
+  | "ctrl-d"
+  | "ctrl-l";
+
+export type TerminalAction =
+  | { type: "connection.changed"; status: TerminalConnectionStatus }
+  | { type: "sessions.loaded"; sessions: MobileTerminalSession[] }
+  | { type: "terminal.attached"; sessionId: string; cwd?: string; replay?: string }
+  | { type: "terminal.output"; data: string }
+  | { type: "terminal.input"; input: string }
+  | { type: "terminal.clearInput" }
+  | { type: "terminal.error"; message: string }
+  | { type: "terminal.ended"; exitCode?: number | null }
+  | { type: "font.scale"; delta: number }
+  | { type: "reset.output" };
+
+export const MAX_TERMINAL_OUTPUT_CHARS = 80_000;
+export const MAX_TERMINAL_INPUT_CHARS = 64_000;
+export const MIN_TERMINAL_FONT_SCALE = 0.85;
+export const MAX_TERMINAL_FONT_SCALE = 1.3;
+const SAFE_TERMINAL_SESSION_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const initialTerminalState: TerminalState = {
+  status: "idle",
+  sessions: [],
+  activeSessionId: null,
+  cwd: "~",
+  output: "",
+  input: "",
+  error: null,
+  fontScale: 1,
+};
+
+export function terminalReducer(
+  state: TerminalState,
+  action: TerminalAction,
+): TerminalState {
+  switch (action.type) {
+    case "connection.changed":
+      return {
+        ...state,
+        status: action.status,
+        error: action.status === "error" || (action.status === "detached" && state.status === "error")
+          ? state.error
+          : null,
+      };
+    case "sessions.loaded": {
+      const activeSessionStillExists = state.activeSessionId
+        ? action.sessions.some((session) => session.sessionId === state.activeSessionId)
+        : false;
+      return {
+        ...state,
+        sessions: action.sessions,
+        activeSessionId: activeSessionStillExists ? state.activeSessionId : null,
+      };
+    }
+    case "terminal.attached":
+      return {
+        ...state,
+        status: "attached",
+        activeSessionId: action.sessionId,
+        cwd: formatTerminalCwd(action.cwd ?? state.cwd),
+        output: action.replay ? trimTerminalOutput(action.replay) : state.output,
+        error: null,
+      };
+    case "terminal.output":
+      return {
+        ...state,
+        output: trimTerminalOutput(`${state.output}${action.data}`),
+      };
+    case "terminal.input":
+      return { ...state, input: action.input.slice(0, MAX_TERMINAL_INPUT_CHARS) };
+    case "terminal.clearInput":
+      return { ...state, input: "" };
+    case "terminal.error":
+      return { ...state, status: "error", error: safeTerminalError(action.message) };
+    case "terminal.ended":
+      return { ...state, status: "ended", error: null };
+    case "font.scale":
+      return {
+        ...state,
+        fontScale: clamp(
+          Number((state.fontScale + action.delta).toFixed(2)),
+          MIN_TERMINAL_FONT_SCALE,
+          MAX_TERMINAL_FONT_SCALE,
+        ),
+      };
+    case "reset.output":
+      return { ...state, output: "" };
+    default:
+      return state;
+  }
+}
+
+export function isSafeSessionId(value: string): boolean {
+  return SAFE_TERMINAL_SESSION_ID.test(value);
+}
+
+export function parseTerminalSessions(value: unknown): MobileTerminalSession[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const candidate = entry as Record<string, unknown>;
+    if (typeof candidate.sessionId !== "string" || !isSafeSessionId(candidate.sessionId)) {
+      return [];
+    }
+    const session: MobileTerminalSession = {
+      sessionId: candidate.sessionId,
+      cwd: typeof candidate.cwd === "string" ? candidate.cwd : "~",
+      state: typeof candidate.state === "string" ? candidate.state : "running",
+    };
+    if (typeof candidate.createdAt === "string") session.createdAt = candidate.createdAt;
+    if (typeof candidate.lastAttachedAt === "string") session.lastAttachedAt = candidate.lastAttachedAt;
+    if (typeof candidate.attachedClients === "number") session.attachedClients = candidate.attachedClients;
+    if (typeof candidate.exitCode === "number" || candidate.exitCode === null) session.exitCode = candidate.exitCode;
+    return [session];
+  });
+}
+
+export function buildTerminalControlSequence(key: TerminalControlKey): string {
+  switch (key) {
+    case "escape":
+      return "\x1b";
+    case "tab":
+      return "\t";
+    case "enter":
+      return "\r";
+    case "arrow-up":
+      return "\x1b[A";
+    case "arrow-down":
+      return "\x1b[B";
+    case "arrow-right":
+      return "\x1b[C";
+    case "arrow-left":
+      return "\x1b[D";
+    case "ctrl-c":
+      return "\x03";
+    case "ctrl-d":
+      return "\x04";
+    case "ctrl-l":
+      return "\x0c";
+    default:
+      return "";
+  }
+}
+
+export function formatTerminalCwd(cwd: string | null | undefined): string {
+  if (!cwd || cwd === "/") return "~";
+  return cwd
+    .replace(/^\/home\/matrix\/home(?=\/|$)/, "~")
+    .replace(/^\/home\/matrix(?=\/|$)/, "~")
+    .replace(/^\/home\/deploy(?=\/|$)/, "~");
+}
+
+function trimTerminalOutput(output: string): string {
+  if (output.length <= MAX_TERMINAL_OUTPUT_CHARS) return output;
+  return output.slice(output.length - MAX_TERMINAL_OUTPUT_CHARS);
+}
+
+function safeTerminalError(message: string): string {
+  const trimmed = message.trim();
+  if (!trimmed || trimmed.length > 180) return "Terminal unavailable";
+  if (/\/home\/|postgres|secret|token|provider/i.test(trimmed)) return "Terminal unavailable";
+  return trimmed;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/apps/mobile/lib/theme.ts
+++ b/apps/mobile/lib/theme.ts
@@ -4,7 +4,7 @@ export const colors = {
   light: {
     background: "#FAFAF9",
     foreground: "#1c1917",
-    card: "#FFFFFF",
+    card: "#ffffff",
     cardForeground: "#1c1917",
     primary: "#8CC7BE",
     primaryForeground: "#141614",

--- a/apps/mobile/lib/theme.ts
+++ b/apps/mobile/lib/theme.ts
@@ -4,7 +4,7 @@ export const colors = {
   light: {
     background: "#FAFAF9",
     foreground: "#1c1917",
-    card: "#ffffff",
+    card: "#FFFFFF",
     cardForeground: "#1c1917",
     primary: "#8CC7BE",
     primaryForeground: "#141614",

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,6 +1,26 @@
 const { getDefaultConfig } = require("expo/metro-config");
+const path = require("path");
+
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, "../..");
 
 /** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname);
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = Array.from(new Set([...(config.watchFolders ?? []), workspaceRoot]));
+config.resolver = {
+  ...config.resolver,
+  disableHierarchicalLookup: true,
+  nodeModulesPaths: [
+    path.resolve(projectRoot, "node_modules"),
+    path.resolve(workspaceRoot, "node_modules"),
+  ],
+  extraNodeModules: {
+    ...(config.resolver?.extraNodeModules ?? {}),
+    react: path.resolve(projectRoot, "node_modules/react"),
+    "react-dom": path.resolve(projectRoot, "node_modules/react-dom"),
+    "react-native": path.resolve(projectRoot, "node_modules/react-native"),
+  },
+};
 
 module.exports = config;

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -6,6 +6,11 @@ const workspaceRoot = path.resolve(projectRoot, "../..");
 
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(projectRoot);
+const defaultResolveRequest = config.resolver?.resolveRequest;
+
+function resolveFromMobileApp(moduleName) {
+  return require.resolve(moduleName, { paths: [projectRoot] });
+}
 
 config.watchFolders = Array.from(new Set([...(config.watchFolders ?? []), workspaceRoot]));
 config.resolver = {
@@ -20,6 +25,20 @@ config.resolver = {
     react: path.resolve(projectRoot, "node_modules/react"),
     "react-dom": path.resolve(projectRoot, "node_modules/react-dom"),
     "react-native": path.resolve(projectRoot, "node_modules/react-native"),
+  },
+  resolveRequest(context, moduleName, platform) {
+    if (moduleName === "react" || moduleName.startsWith("react/")) {
+      return {
+        type: "sourceFile",
+        filePath: resolveFromMobileApp(moduleName),
+      };
+    }
+
+    if (defaultResolveRequest) {
+      return defaultResolveRequest(context, moduleName, platform);
+    }
+
+    return context.resolveRequest(context, moduleName, platform);
   },
 };
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -47,8 +47,13 @@
     "react-native-screens": "~4.23.0",
     "react-native-svg": "~15.15.3",
     "react-native-web": "^0.21.0",
+<<<<<<< HEAD
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2"
+=======
+    "react-native-webview": "13.15.0",
+    "react-native-worklets": "0.5.1"
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -47,13 +47,8 @@
     "react-native-screens": "~4.23.0",
     "react-native-svg": "~15.15.3",
     "react-native-web": "^0.21.0",
-<<<<<<< HEAD
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2"
-=======
-    "react-native-webview": "13.15.0",
-    "react-native-worklets": "0.5.1"
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",

--- a/docs/dev/mobile-shell.md
+++ b/docs/dev/mobile-shell.md
@@ -1,0 +1,66 @@
+# Mobile Shell
+
+The 075 mobile shell work makes the phone experience launcher-first while keeping Canvas explicit and recoverable.
+
+## Runtime Shape
+
+- Browser phone viewport: `Desktop.tsx` switches to the mobile launcher after client-side viewport detection.
+- Native Expo app: `apps/mobile/app/(tabs)/apps.tsx` is the primary launcher.
+- Apps open full screen through `MobileAppSurface` in the browser shell and native runtime routes in Expo.
+- Canvas is reachable through an explicit launcher action, not as the default phone home.
+- Terminal uses Matrix-authenticated gateway sessions and WebSockets; users do not need SSH keys.
+
+## State
+
+Mobile resume state is intentionally small and validated before use.
+
+- Browser shell state: `shell/src/stores/mobile-shell-store.ts`
+- Native mobile state: `apps/mobile/lib/mobile-shell-state.ts`
+- Current fields: mode, last active app slug, last active terminal session id, Canvas entry timestamp, update timestamp.
+
+Do not persist raw paths, user-controlled URLs, or unvalidated terminal identifiers in mobile shell state.
+
+## Terminal Validation
+
+The mobile terminal path should be checked at three layers:
+
+```bash
+bun run test tests/gateway/terminal-ws.test.ts
+pnpm --dir apps/mobile exec jest --runInBand __tests__/terminal-client.test.ts __tests__/terminal-state.test.ts __tests__/terminal-screen.test.tsx __tests__/TerminalControlBar.test.tsx
+bun run test tests/shell/terminal-app-component.test.tsx
+```
+
+Manual terminal checks on a phone:
+
+1. Open Terminal from Apps.
+2. Create a new session and confirm the current folder is visible.
+3. Run `pwd`.
+4. Use Tab, Escape, arrows, Control, paste, and font size controls.
+5. Leave and reopen Terminal, then continue the running session.
+6. End the session and confirm the resume card disappears or shows the safe recovery message.
+
+## Full Mobile Readiness Gates
+
+Use these before handing the branch to a real-device tester:
+
+```bash
+pnpm --dir apps/mobile exec jest --runInBand
+pnpm --dir apps/mobile exec tsc --noEmit
+bun run test tests/shell/terminal-app-component.test.tsx tests/shell/mobile-shell.test.tsx tests/shell/mobile-canvas.test.tsx tests/shell/user-button-hydration.test.tsx tests/shell/app-launch.test.ts tests/shell/app-viewer-slug.test.ts
+pnpm --dir shell exec tsc --noEmit
+bun run test tests/gateway/terminal-ws.test.ts
+bun run typecheck
+bun run check:patterns
+git diff --check
+```
+
+`bun run test` is still the broad root gate, but unrelated platform/integration flakes are recorded in `specs/075-mobile-shell/quickstart.md` when they block a clean root run.
+
+## Real Device Checklist
+
+- Hard refresh/reopen after onboarding and confirm Apps, not Minesweeper or Canvas, is first.
+- Open built-ins from Apps: Terminal, Chat, Files, Whiteboard/Canvas, Notes, Tasks, and at least one game.
+- Confirm each app is full screen and Home returns to Apps.
+- Confirm Continue restores the last app where possible.
+- Confirm unavailable apps show a generic fallback, not raw gateway or filesystem errors.
+- Confirm Terminal path, prompt/cursor, command input, and touch controls are visible in portrait and landscape.

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -194,6 +194,46 @@ function logTerminalDebug(event: string, details: Record<string, unknown> = {}):
   console.info("[terminal-debug][gateway]", event, details);
 }
 
+export const TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES = 1024;
+
+export type TerminalSessionRouteRegistry = Pick<SessionRegistry, "list" | "getSession" | "destroy">;
+
+export function registerTerminalSessionRoutes(
+  app: Hono,
+  options: { homePath: string; sessionRegistry: TerminalSessionRouteRegistry },
+): void {
+  const { homePath, sessionRegistry } = options;
+  const terminalSessionDeleteBodyLimit = bodyLimit({
+    maxSize: TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES,
+  });
+
+  app.get("/api/terminal/sessions", (c) => {
+    const publicSessions = sessionRegistry.list().map((session: SessionInfo) => {
+      const displayCwd = relative(homePath, session.cwd) || "~";
+      return {
+        sessionId: session.sessionId,
+        cwd: displayCwd,
+        state: session.state,
+        exitCode: session.exitCode,
+        createdAt: session.createdAt,
+        lastAttachedAt: session.lastAttachedAt,
+        attachedClients: session.attachedClients,
+      };
+    });
+    return c.json(publicSessions);
+  });
+
+  app.delete("/api/terminal/sessions/:id", terminalSessionDeleteBodyLimit, (c) => {
+    const id = c.req.param("id");
+    logTerminalDebug("rest-destroy-request", { sessionId: id });
+    if (!UUID_REGEX.test(id)) return c.json({ error: "Invalid session ID" }, 400);
+    const session = sessionRegistry.getSession(id);
+    if (!session) return c.json({ ok: true }, 200);
+    sessionRegistry.destroy(id);
+    return c.json({ ok: true });
+  });
+}
+
 const INTEGRATION_PROXY_BODY_LIMIT = 64 * 1024;
 const HANDLE_PATTERN = /^[a-z][a-z0-9-]{2,30}$/;
 
@@ -1270,6 +1310,18 @@ export async function createGateway(config: GatewayConfig) {
   }));
   app.use("*", securityHeadersMiddleware());
   app.use("*", authMiddleware(process.env.MATRIX_AUTH_TOKEN));
+  // Platform normally owns /api/auth/ws-token before proxying to a customer
+  // VPS. Direct gateway/dev shells have no platform layer, so expose an empty
+  // no-store response in open mode and let WebSocket clients fall back to the
+  // unauthenticated local dev upgrade path.
+  app.get("/api/auth/ws-token", (c) => {
+    if (process.env.MATRIX_AUTH_TOKEN) {
+      return c.json({ error: "WebSocket auth unavailable" }, 503);
+    }
+    return c.json({ token: null, expiresAt: 0 }, 200, {
+      "Cache-Control": "no-store",
+    });
+  });
   app.route("/api", createShellRoutes({
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,
@@ -1485,10 +1537,16 @@ export async function createGateway(config: GatewayConfig) {
     const { token, expiresAt } = mobileSessionTokens.mint(slug, Date.now(), {
       routingKey: routingHandle && HANDLE_PATTERN.test(routingHandle) ? routingHandle : undefined,
     });
-    return c.json({
+    return new Response(JSON.stringify({
       token,
       expiresAt,
       launchUrl: `/apps/${slug}/?session=${encodeURIComponent(token)}`,
+    }), {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json; charset=UTF-8",
+      },
     });
   });
 
@@ -2490,31 +2548,7 @@ export async function createGateway(config: GatewayConfig) {
     }
   });
 
-  app.get("/api/terminal/sessions", (c) => {
-    const publicSessions = sessionRegistry.list().map((session: SessionInfo) => {
-      const displayCwd = relative(homePath, session.cwd) || "~";
-      return {
-        sessionId: session.sessionId,
-        cwd: displayCwd,
-        state: session.state,
-        exitCode: session.exitCode,
-        createdAt: session.createdAt,
-        lastAttachedAt: session.lastAttachedAt,
-        attachedClients: session.attachedClients,
-      };
-    });
-    return c.json(publicSessions);
-  });
-
-  app.delete("/api/terminal/sessions/:id", (c) => {
-    const id = c.req.param("id");
-    logTerminalDebug("rest-destroy-request", { sessionId: id });
-    if (!UUID_REGEX.test(id)) return c.json({ error: "Invalid session ID" }, 400);
-    const session = sessionRegistry.getSession(id);
-    if (!session) return c.json({ error: "Session not found" }, 404);
-    sessionRegistry.destroy(id);
-    return c.json({ ok: true });
-  });
+  registerTerminalSessionRoutes(app, { homePath, sessionRegistry });
 
   app.post("/api/message", apiMessageBodyLimit, async (c) => {
     const body = await c.req.json<{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,13 +85,22 @@ importers:
         version: 15.1.1(expo-font@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@gorhom/bottom-sheet':
         specifier: ^5.1.4
+<<<<<<< HEAD
         version: 5.2.8(@types/react@19.2.14)(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native-reanimated@4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+=======
+        version: 5.2.8(@types/react@19.1.17)(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
         version: 2.2.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo:
+<<<<<<< HEAD
         specifier: ~55.0.8
         version: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
+=======
+        specifier: ~54.0.0
+        version: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       expo-auth-session:
         specifier: ~55.0.9
         version: 55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)
@@ -123,8 +132,13 @@ importers:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)
       expo-router:
+<<<<<<< HEAD
         specifier: ~55.0.7
         version: 55.0.7(e3e2d47f900714d5430ba580cb05b211)
+=======
+        specifier: ~6.0.0
+        version: 6.0.23(d5aa1afa926574818b635eaaa94a558e)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       expo-secure-store:
         specifier: ~55.0.9
         version: 55.0.9(expo@55.0.8)
@@ -162,8 +176,13 @@ importers:
         specifier: ~2.30.0
         version: 2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-reanimated:
+<<<<<<< HEAD
         specifier: ~4.2.1
         version: 4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+=======
+        specifier: ~4.1.6
+        version: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       react-native-safe-area-context:
         specifier: ~5.6.0
         version: 5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -177,11 +196,19 @@ importers:
         specifier: ^0.21.0
         version: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-native-webview:
+<<<<<<< HEAD
         specifier: 13.16.0
         version: 13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-worklets:
         specifier: 0.7.2
         version: 0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+=======
+        specifier: 13.15.0
+        version: 13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      react-native-worklets:
+        specifier: 0.5.1
+        version: 0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     devDependencies:
       '@babel/core':
         specifier: ^7.25.0
@@ -10445,8 +10472,13 @@ packages:
     resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
     engines: {node: '>=20.0.0'}
 
+<<<<<<< HEAD
   lan-network@0.2.0:
     resolution: {integrity: sha512-EZgbsXMrGS+oK+Ta12mCjzBFse+SIewGdwrSTr5g+MSymnjpox2x05ceI20PQejJOFvOgzcXrfDk/SdY7dSCtw==}
+=======
+  lan-network@0.2.1:
+    resolution: {integrity: sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==}
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     hasBin: true
 
   langium@3.3.1:
@@ -12156,14 +12188,32 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  react-native-webview@13.15.0:
+    resolution: {integrity: sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   react-native-webview@13.16.0:
     resolution: {integrity: sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==}
     peerDependencies:
       react: '*'
       react-native: '*'
 
+<<<<<<< HEAD
   react-native-worklets@0.7.2:
     resolution: {integrity: sha512-DuLu1kMV/Uyl9pQHp3hehAlThoLw7Yk2FwRTpzASOmI+cd4845FWn3m2bk9MnjUw8FBRIyhwLqYm2AJaXDXsog==}
+=======
+  react-native-worklets@0.5.1:
+    resolution: {integrity: sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+      react: '*'
+      react-native: '*'
+
+  react-native-worklets@0.7.3:
+    resolution: {integrity: sha512-m/CIUCHvLQulboBn0BtgpsesXjOTeubU7t+V0lCPpBj0t2ExigwqDHoKj3ck7OeErnjgkD27wdAtQCubYATe3g==}
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     peerDependencies:
       '@babel/core': '*'
       react: '*'
@@ -12580,6 +12630,11 @@ packages:
 
   semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -14999,6 +15054,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -15027,6 +15083,7 @@ snapshots:
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -15110,6 +15167,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+    optional: true
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -15144,6 +15202,7 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -15293,6 +15352,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
     dependencies:
@@ -16170,7 +16230,87 @@ snapshots:
 
   '@expo-google-fonts/jetbrains-mono@0.2.3': {}
 
+<<<<<<< HEAD
   '@expo-google-fonts/material-symbols@0.4.27': {}
+=======
+  '@expo-google-fonts/material-symbols@0.4.27':
+    optional: true
+
+  '@expo/cli@54.0.24(bufferutil@4.1.0)(expo-router@6.0.23)(expo@54.0.34)(graphql@16.13.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(utf-8-validate@6.0.6)':
+    dependencies:
+      '@0no-co/graphql.web': 1.2.0(graphql@16.13.1)
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/config': 12.0.13
+      '@expo/config-plugins': 54.0.4
+      '@expo/devcert': 1.2.1
+      '@expo/env': 2.0.11
+      '@expo/image-utils': 0.8.12
+      '@expo/json-file': 10.0.12
+      '@expo/metro': 54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@expo/metro-config': 54.0.15(bufferutil@4.1.0)(expo@54.0.34)(utf-8-validate@6.0.6)
+      '@expo/osascript': 2.4.2
+      '@expo/package-manager': 1.10.3
+      '@expo/plist': 0.4.8
+      '@expo/prebuild-config': 54.0.8(expo@54.0.34)
+      '@expo/schema-utils': 0.1.8
+      '@expo/spawn-async': 1.7.2
+      '@expo/ws-tunnel': 1.0.6
+      '@expo/xcpretty': 4.4.1
+      '@react-native/dev-middleware': 0.81.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@urql/core': 5.2.0(graphql@16.13.1)
+      '@urql/exchange-retry': 1.3.2(@urql/core@5.2.0(graphql@16.13.1))
+      accepts: 1.3.8
+      arg: 5.0.2
+      better-opn: 3.0.2
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      compression: 1.8.1
+      connect: 3.7.0
+      debug: 4.4.3(supports-color@8.1.1)
+      env-editor: 0.4.2
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      expo-server: 1.0.6
+      freeport-async: 2.0.0
+      getenv: 2.0.0
+      glob: 13.0.6
+      lan-network: 0.2.1
+      minimatch: 9.0.9
+      node-forge: 1.3.3
+      npm-package-arg: 11.0.3
+      ora: 3.4.0
+      picomatch: 4.0.3
+      pretty-bytes: 5.6.0
+      pretty-format: 29.7.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      qrcode-terminal: 0.11.0
+      require-from-string: 2.0.2
+      requireg: 0.2.2
+      resolve: 1.22.11
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.3
+      semver: 7.7.4
+      send: 0.19.2
+      slugify: 1.6.8
+      source-map-support: 0.5.21
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      tar: 7.5.14
+      terminal-link: 2.1.1
+      undici: 6.25.0
+      wrap-ansi: 7.0.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      expo-router: 6.0.23(d5aa1afa926574818b635eaaa94a558e)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   '@expo/cli@55.0.18(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-router@55.0.7)(expo@55.0.8)(react-dom@19.2.3(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -16211,7 +16351,7 @@ snapshots:
       fetch-nodeshim: 0.4.9
       getenv: 2.0.0
       glob: 13.0.6
-      lan-network: 0.2.0
+      lan-network: 0.2.1
       multitars: 0.2.4
       node-forge: 1.3.3
       npm-package-arg: 11.0.3
@@ -16302,6 +16442,17 @@ snapshots:
     optionalDependencies:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+<<<<<<< HEAD
+=======
+    optional: true
+
+  '@expo/dom-webview@55.0.3(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)':
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+    optional: true
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   '@expo/dom-webview@55.0.3(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
@@ -16364,6 +16515,69 @@ snapshots:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
+<<<<<<< HEAD
+=======
+    optional: true
+
+  '@expo/metro-config@54.0.15(bufferutil@4.1.0)(expo@54.0.34)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@expo/config': 12.0.13
+      '@expo/env': 2.0.11
+      '@expo/json-file': 10.0.12
+      '@expo/metro': 54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@expo/spawn-async': 1.7.2
+      browserslist: 4.28.1
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 16.4.7
+      dotenv-expand: 11.0.7
+      getenv: 2.0.0
+      glob: 13.0.6
+      hermes-parser: 0.29.1
+      jsc-safe-url: 0.2.4
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.4.49
+      resolve-from: 5.0.0
+    optionalDependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@expo/metro-config@55.0.11(bufferutil@4.1.0)(expo@54.0.34)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@expo/config': 55.0.10(typescript@5.9.3)
+      '@expo/env': 2.1.1
+      '@expo/json-file': 10.0.12
+      '@expo/metro': 54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@expo/spawn-async': 1.7.2
+      browserslist: 4.28.1
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      getenv: 2.0.0
+      glob: 13.0.6
+      hermes-parser: 0.32.1
+      jsc-safe-url: 0.2.4
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.4.49
+      resolve-from: 5.0.0
+    optionalDependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   '@expo/metro-config@55.0.11(bufferutil@4.1.0)(expo@55.0.8)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -16408,6 +16622,22 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - '@expo/dom-webview'
+<<<<<<< HEAD
+=======
+    optional: true
+
+  '@expo/metro-runtime@6.1.2(expo@54.0.34)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)':
+    dependencies:
+      anser: 1.4.10
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      pretty-format: 29.7.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   '@expo/metro@54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
@@ -16449,6 +16679,25 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
+<<<<<<< HEAD
+=======
+  '@expo/prebuild-config@54.0.8(expo@54.0.34)':
+    dependencies:
+      '@expo/config': 12.0.13
+      '@expo/config-plugins': 54.0.4
+      '@expo/config-types': 54.0.10
+      '@expo/image-utils': 0.8.12
+      '@expo/json-file': 10.0.12
+      '@react-native/normalize-colors': 0.81.5
+      debug: 4.4.3(supports-color@8.1.1)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
   '@expo/prebuild-config@55.0.10(expo@55.0.8)(typescript@5.9.3)':
     dependencies:
       '@expo/config': 55.0.10(typescript@5.9.3)
@@ -16558,14 +16807,25 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.2
 
+<<<<<<< HEAD
   '@gorhom/bottom-sheet@5.2.8(@types/react@19.2.14)(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native-reanimated@4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
+=======
+  '@gorhom/bottom-sheet@5.2.8(@types/react@19.1.17)(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)':
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     dependencies:
       '@gorhom/portal': 1.0.14(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       invariant: 2.2.4
+<<<<<<< HEAD
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-gesture-handler: 2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-reanimated: 4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+=======
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -21773,6 +22033,41 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
+<<<<<<< HEAD
+=======
+  babel-preset-expo@54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.34)(react-refresh@0.14.2):
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@react-native/babel-preset': 0.81.5(@babel/core@7.29.0)
+      babel-plugin-react-compiler: 1.0.0
+      babel-plugin-react-native-web: 0.21.2
+      babel-plugin-syntax-hermes-parser: 0.29.1
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      react-refresh: 0.14.2
+      resolve-from: 5.0.0
+    optionalDependencies:
+      '@babel/runtime': 7.29.2
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
   babel-preset-expo@55.0.12(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.8)(react-refresh@0.14.2):
     dependencies:
       '@babel/generator': 7.29.1
@@ -23478,7 +23773,21 @@ snapshots:
 
   expo-application@55.0.10(expo@55.0.8):
     dependencies:
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+
+  expo-asset@12.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
+    dependencies:
+      '@expo/image-utils': 0.8.12
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - supports-color
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-asset@55.0.10(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3):
     dependencies:
@@ -23508,18 +23817,46 @@ snapshots:
 
   expo-blur@55.0.10(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-camera@55.0.10(@types/emscripten@1.41.5)(expo@55.0.8)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
+<<<<<<< HEAD
       barcode-detector: 3.1.1(@types/emscripten@1.41.5)
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      react-native-web: 0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
+  expo-clipboard@8.0.8(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+
+  expo-constants@18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      '@expo/config': 12.0.13
+      '@expo/env': 2.0.11
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     transitivePeerDependencies:
       - '@types/emscripten'
 
@@ -23541,10 +23878,16 @@ snapshots:
 
   expo-crypto@55.0.10(expo@55.0.8):
     dependencies:
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
+=======
+      base64-js: 1.5.1
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-dev-client@55.0.18(expo@55.0.8)(typescript@5.9.3):
     dependencies:
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-dev-launcher: 55.0.19(expo@55.0.8)(typescript@5.9.3)
       expo-dev-menu: 55.0.16(expo@55.0.8)
@@ -23554,9 +23897,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+    optional: true
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-dev-launcher@55.0.19(expo@55.0.8)(typescript@5.9.3):
     dependencies:
+<<<<<<< HEAD
       '@expo/schema-utils': 55.0.2
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-dev-menu: 55.0.16(expo@55.0.8)
@@ -23573,11 +23921,26 @@ snapshots:
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-dev-menu-interface: 55.0.1(expo@55.0.8)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-file-system@55.0.11(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+<<<<<<< HEAD
+=======
+    optional: true
+
+  expo-font@14.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      fontfaceobserver: 2.3.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-font@55.0.4(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -23594,7 +23957,11 @@ snapshots:
 
   expo-haptics@55.0.9(expo@55.0.8):
     dependencies:
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-image@55.0.6(expo@55.0.8)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -23605,7 +23972,14 @@ snapshots:
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
+<<<<<<< HEAD
   expo-json-utils@55.0.0: {}
+=======
+  expo-keep-awake@15.0.8(expo@54.0.34)(react@19.1.0):
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      react: 19.1.0
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-keep-awake@55.0.4(expo@55.0.8)(react@19.2.3):
     dependencies:
@@ -23635,7 +24009,23 @@ snapshots:
       expo-json-utils: 55.0.0
     transitivePeerDependencies:
       - supports-color
+<<<<<<< HEAD
       - typescript
+=======
+
+  expo-local-authentication@17.0.8(expo@54.0.34):
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      invariant: 2.2.4
+
+  expo-modules-autolinking@3.0.25:
+    dependencies:
+      '@expo/spawn-async': 1.7.2
+      chalk: 4.1.2
+      commander: 7.2.0
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-modules-autolinking@55.0.11(typescript@5.9.3):
     dependencies:
@@ -23658,11 +24048,19 @@ snapshots:
       '@expo/image-utils': 0.8.12
       abort-controller: 3.0.0
       badgin: 1.2.3
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-application: 55.0.10(expo@55.0.8)
       expo-constants: 55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(typescript@5.9.3)
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      expo-application: 7.0.8(expo@54.0.34)
+      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -23716,20 +24114,79 @@ snapshots:
       - expo-font
       - supports-color
 
+<<<<<<< HEAD
   expo-secure-store@55.0.9(expo@55.0.8):
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
+=======
+  expo-router@6.0.23(d5aa1afa926574818b635eaaa94a558e):
+    dependencies:
+      '@expo/metro-runtime': 6.1.2(expo@54.0.34)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      '@expo/schema-utils': 0.1.8
+      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@react-navigation/bottom-tabs': 7.15.5(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      '@react-navigation/native': 7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      '@react-navigation/native-stack': 7.14.5(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      client-only: 0.0.1
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
+      expo-linking: 8.0.12(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      expo-server: 1.0.6
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 19.1.0
+      react-fast-compare: 3.2.2
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      semver: 7.6.3
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      use-latest-callback: 0.2.6(react@19.1.0)
+      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    optionalDependencies:
+      '@testing-library/react-native': 12.9.0(jest@29.7.0(@types/node@25.5.0)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+      react-dom: 19.1.0(react@19.1.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      react-native-web: 0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-server@55.0.6: {}
 
   expo-speech@55.0.9(expo@55.0.8):
     dependencies:
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-splash-screen@55.0.12(expo@55.0.8)(typescript@5.9.3):
     dependencies:
+<<<<<<< HEAD
       '@expo/prebuild-config': 55.0.10(expo@55.0.8)(typescript@5.9.3)
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+
+  expo-splash-screen@31.0.13(expo@54.0.34):
+    dependencies:
+      '@expo/prebuild-config': 54.0.8(expo@54.0.34)
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -23753,8 +24210,13 @@ snapshots:
     dependencies:
       '@react-native/normalize-colors': 0.83.2
       debug: 4.4.3(supports-color@8.1.1)
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
@@ -23762,12 +24224,54 @@ snapshots:
 
   expo-updates-interface@55.1.3(expo@55.0.8):
     dependencies:
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   expo-web-browser@55.0.10(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+
+  expo@54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@expo/cli': 54.0.24(bufferutil@4.1.0)(expo-router@6.0.23)(expo@54.0.34)(graphql@16.13.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(utf-8-validate@6.0.6)
+      '@expo/config': 12.0.13
+      '@expo/config-plugins': 54.0.4
+      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      '@expo/fingerprint': 0.15.5
+      '@expo/metro': 54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@expo/metro-config': 54.0.15(bufferutil@4.1.0)(expo@54.0.34)(utf-8-validate@6.0.6)
+      '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      '@ungap/structured-clone': 1.3.0
+      babel-preset-expo: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.34)(react-refresh@0.14.2)
+      expo-asset: 12.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
+      expo-file-system: 19.0.22(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
+      expo-font: 14.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      expo-keep-awake: 15.0.8(expo@54.0.34)(react@19.1.0)
+      expo-modules-autolinking: 3.0.25
+      expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      pretty-format: 29.7.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+      react-refresh: 0.14.2
+      whatwg-url-without-unicode: 8.0.0-3
+    optionalDependencies:
+      '@expo/dom-webview': 55.0.3(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      '@expo/metro-runtime': 6.1.2(expo@54.0.34)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      react-native-webview: 13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - expo-router
+      - graphql
+      - supports-color
+      - utf-8-validate
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo@55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
@@ -25291,7 +25795,11 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
+<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
+=======
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       jest-environment-jsdom: 29.7.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
@@ -25741,7 +26249,11 @@ snapshots:
 
   kysely@0.28.14: {}
 
+<<<<<<< HEAD
   lan-network@0.2.0: {}
+=======
+  lan-network@0.2.1: {}
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   langium@3.3.1:
     dependencies:
@@ -28070,7 +28582,19 @@ snapshots:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
+<<<<<<< HEAD
   react-native-reanimated@4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+=======
+  react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      react-native-worklets: 0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
+      semver: 7.7.4
+
+  react-native-reanimated@4.2.2(react-native-worklets@0.7.3(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     dependencies:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
@@ -28117,6 +28641,17 @@ snapshots:
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
+<<<<<<< HEAD
+=======
+    optional: true
+
+  react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
+    dependencies:
+      escape-string-regexp: 4.0.0
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -28125,7 +28660,30 @@ snapshots:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
+<<<<<<< HEAD
   react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+=======
+  react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      convert-source-map: 2.0.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  react-native-worklets@0.7.3(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+>>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -28752,7 +29310,10 @@ snapshots:
 
   semver@7.6.3: {}
 
-  semver@7.7.3: {}
+  semver@7.7.2: {}
+
+  semver@7.7.3:
+    optional: true
 
   semver@7.7.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,22 +85,13 @@ importers:
         version: 15.1.1(expo-font@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@gorhom/bottom-sheet':
         specifier: ^5.1.4
-<<<<<<< HEAD
         version: 5.2.8(@types/react@19.2.14)(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native-reanimated@4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-=======
-        version: 5.2.8(@types/react@19.1.17)(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
         version: 2.2.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))
       expo:
-<<<<<<< HEAD
         specifier: ~55.0.8
         version: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
-=======
-        specifier: ~54.0.0
-        version: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       expo-auth-session:
         specifier: ~55.0.9
         version: 55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)
@@ -132,13 +123,8 @@ importers:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)
       expo-router:
-<<<<<<< HEAD
         specifier: ~55.0.7
         version: 55.0.7(e3e2d47f900714d5430ba580cb05b211)
-=======
-        specifier: ~6.0.0
-        version: 6.0.23(d5aa1afa926574818b635eaaa94a558e)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       expo-secure-store:
         specifier: ~55.0.9
         version: 55.0.9(expo@55.0.8)
@@ -176,13 +162,8 @@ importers:
         specifier: ~2.30.0
         version: 2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-reanimated:
-<<<<<<< HEAD
         specifier: ~4.2.1
         version: 4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-=======
-        specifier: ~4.1.6
-        version: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       react-native-safe-area-context:
         specifier: ~5.6.0
         version: 5.6.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -196,19 +177,11 @@ importers:
         specifier: ^0.21.0
         version: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-native-webview:
-<<<<<<< HEAD
         specifier: 13.16.0
         version: 13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-worklets:
         specifier: 0.7.2
         version: 0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-=======
-        specifier: 13.15.0
-        version: 13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      react-native-worklets:
-        specifier: 0.5.1
-        version: 0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     devDependencies:
       '@babel/core':
         specifier: ^7.25.0
@@ -10472,13 +10445,8 @@ packages:
     resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
     engines: {node: '>=20.0.0'}
 
-<<<<<<< HEAD
   lan-network@0.2.0:
     resolution: {integrity: sha512-EZgbsXMrGS+oK+Ta12mCjzBFse+SIewGdwrSTr5g+MSymnjpox2x05ceI20PQejJOFvOgzcXrfDk/SdY7dSCtw==}
-=======
-  lan-network@0.2.1:
-    resolution: {integrity: sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==}
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     hasBin: true
 
   langium@3.3.1:
@@ -12188,32 +12156,14 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  react-native-webview@13.15.0:
-    resolution: {integrity: sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-
   react-native-webview@13.16.0:
     resolution: {integrity: sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==}
     peerDependencies:
       react: '*'
       react-native: '*'
 
-<<<<<<< HEAD
   react-native-worklets@0.7.2:
     resolution: {integrity: sha512-DuLu1kMV/Uyl9pQHp3hehAlThoLw7Yk2FwRTpzASOmI+cd4845FWn3m2bk9MnjUw8FBRIyhwLqYm2AJaXDXsog==}
-=======
-  react-native-worklets@0.5.1:
-    resolution: {integrity: sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-      react: '*'
-      react-native: '*'
-
-  react-native-worklets@0.7.3:
-    resolution: {integrity: sha512-m/CIUCHvLQulboBn0BtgpsesXjOTeubU7t+V0lCPpBj0t2ExigwqDHoKj3ck7OeErnjgkD27wdAtQCubYATe3g==}
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     peerDependencies:
       '@babel/core': '*'
       react: '*'
@@ -12630,11 +12580,6 @@ packages:
 
   semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -15054,7 +14999,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -15083,7 +15027,6 @@ snapshots:
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -15167,7 +15110,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-    optional: true
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -15202,7 +15144,6 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -15352,7 +15293,6 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
     dependencies:
@@ -16230,87 +16170,7 @@ snapshots:
 
   '@expo-google-fonts/jetbrains-mono@0.2.3': {}
 
-<<<<<<< HEAD
   '@expo-google-fonts/material-symbols@0.4.27': {}
-=======
-  '@expo-google-fonts/material-symbols@0.4.27':
-    optional: true
-
-  '@expo/cli@54.0.24(bufferutil@4.1.0)(expo-router@6.0.23)(expo@54.0.34)(graphql@16.13.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(utf-8-validate@6.0.6)':
-    dependencies:
-      '@0no-co/graphql.web': 1.2.0(graphql@16.13.1)
-      '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 12.0.13
-      '@expo/config-plugins': 54.0.4
-      '@expo/devcert': 1.2.1
-      '@expo/env': 2.0.11
-      '@expo/image-utils': 0.8.12
-      '@expo/json-file': 10.0.12
-      '@expo/metro': 54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@expo/metro-config': 54.0.15(bufferutil@4.1.0)(expo@54.0.34)(utf-8-validate@6.0.6)
-      '@expo/osascript': 2.4.2
-      '@expo/package-manager': 1.10.3
-      '@expo/plist': 0.4.8
-      '@expo/prebuild-config': 54.0.8(expo@54.0.34)
-      '@expo/schema-utils': 0.1.8
-      '@expo/spawn-async': 1.7.2
-      '@expo/ws-tunnel': 1.0.6
-      '@expo/xcpretty': 4.4.1
-      '@react-native/dev-middleware': 0.81.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@urql/core': 5.2.0(graphql@16.13.1)
-      '@urql/exchange-retry': 1.3.2(@urql/core@5.2.0(graphql@16.13.1))
-      accepts: 1.3.8
-      arg: 5.0.2
-      better-opn: 3.0.2
-      bplist-creator: 0.1.0
-      bplist-parser: 0.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      compression: 1.8.1
-      connect: 3.7.0
-      debug: 4.4.3(supports-color@8.1.1)
-      env-editor: 0.4.2
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      expo-server: 1.0.6
-      freeport-async: 2.0.0
-      getenv: 2.0.0
-      glob: 13.0.6
-      lan-network: 0.2.1
-      minimatch: 9.0.9
-      node-forge: 1.3.3
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      picomatch: 4.0.3
-      pretty-bytes: 5.6.0
-      pretty-format: 29.7.0
-      progress: 2.0.3
-      prompts: 2.4.2
-      qrcode-terminal: 0.11.0
-      require-from-string: 2.0.2
-      requireg: 0.2.2
-      resolve: 1.22.11
-      resolve-from: 5.0.0
-      resolve.exports: 2.0.3
-      semver: 7.7.4
-      send: 0.19.2
-      slugify: 1.6.8
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.11
-      structured-headers: 0.4.1
-      tar: 7.5.14
-      terminal-link: 2.1.1
-      undici: 6.25.0
-      wrap-ansi: 7.0.0
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    optionalDependencies:
-      expo-router: 6.0.23(d5aa1afa926574818b635eaaa94a558e)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - graphql
-      - supports-color
-      - utf-8-validate
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   '@expo/cli@55.0.18(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-router@55.0.7)(expo@55.0.8)(react-dom@19.2.3(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -16351,7 +16211,7 @@ snapshots:
       fetch-nodeshim: 0.4.9
       getenv: 2.0.0
       glob: 13.0.6
-      lan-network: 0.2.1
+      lan-network: 0.2.0
       multitars: 0.2.4
       node-forge: 1.3.3
       npm-package-arg: 11.0.3
@@ -16442,17 +16302,6 @@ snapshots:
     optionalDependencies:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-<<<<<<< HEAD
-=======
-    optional: true
-
-  '@expo/dom-webview@55.0.3(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)':
-    dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-    optional: true
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   '@expo/dom-webview@55.0.3(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
@@ -16515,69 +16364,6 @@ snapshots:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
-<<<<<<< HEAD
-=======
-    optional: true
-
-  '@expo/metro-config@54.0.15(bufferutil@4.1.0)(expo@54.0.34)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@expo/config': 12.0.13
-      '@expo/env': 2.0.11
-      '@expo/json-file': 10.0.12
-      '@expo/metro': 54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@expo/spawn-async': 1.7.2
-      browserslist: 4.28.1
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      dotenv: 16.4.7
-      dotenv-expand: 11.0.7
-      getenv: 2.0.0
-      glob: 13.0.6
-      hermes-parser: 0.29.1
-      jsc-safe-url: 0.2.4
-      lightningcss: 1.32.0
-      picomatch: 4.0.3
-      postcss: 8.4.49
-      resolve-from: 5.0.0
-    optionalDependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@expo/metro-config@55.0.11(bufferutil@4.1.0)(expo@54.0.34)(typescript@5.9.3)(utf-8-validate@6.0.6)':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@expo/config': 55.0.10(typescript@5.9.3)
-      '@expo/env': 2.1.1
-      '@expo/json-file': 10.0.12
-      '@expo/metro': 54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@expo/spawn-async': 1.7.2
-      browserslist: 4.28.1
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      getenv: 2.0.0
-      glob: 13.0.6
-      hermes-parser: 0.32.1
-      jsc-safe-url: 0.2.4
-      lightningcss: 1.32.0
-      picomatch: 4.0.3
-      postcss: 8.4.49
-      resolve-from: 5.0.0
-    optionalDependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   '@expo/metro-config@55.0.11(bufferutil@4.1.0)(expo@55.0.8)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -16622,22 +16408,6 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - '@expo/dom-webview'
-<<<<<<< HEAD
-=======
-    optional: true
-
-  '@expo/metro-runtime@6.1.2(expo@54.0.34)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)':
-    dependencies:
-      anser: 1.4.10
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      pretty-format: 29.7.0
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-      stacktrace-parser: 0.1.11
-      whatwg-fetch: 3.6.20
-    optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   '@expo/metro@54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
@@ -16679,25 +16449,6 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-<<<<<<< HEAD
-=======
-  '@expo/prebuild-config@54.0.8(expo@54.0.34)':
-    dependencies:
-      '@expo/config': 12.0.13
-      '@expo/config-plugins': 54.0.4
-      '@expo/config-types': 54.0.10
-      '@expo/image-utils': 0.8.12
-      '@expo/json-file': 10.0.12
-      '@react-native/normalize-colors': 0.81.5
-      debug: 4.4.3(supports-color@8.1.1)
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      resolve-from: 5.0.0
-      semver: 7.7.4
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
   '@expo/prebuild-config@55.0.10(expo@55.0.8)(typescript@5.9.3)':
     dependencies:
       '@expo/config': 55.0.10(typescript@5.9.3)
@@ -16807,25 +16558,14 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.2
 
-<<<<<<< HEAD
   '@gorhom/bottom-sheet@5.2.8(@types/react@19.2.14)(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native-reanimated@4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
-=======
-  '@gorhom/bottom-sheet@5.2.8(@types/react@19.1.17)(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)':
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     dependencies:
       '@gorhom/portal': 1.0.14(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       invariant: 2.2.4
-<<<<<<< HEAD
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-gesture-handler: 2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       react-native-reanimated: 4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-=======
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -22033,41 +21773,6 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-<<<<<<< HEAD
-=======
-  babel-preset-expo@54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.34)(react-refresh@0.14.2):
-    dependencies:
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@react-native/babel-preset': 0.81.5(@babel/core@7.29.0)
-      babel-plugin-react-compiler: 1.0.0
-      babel-plugin-react-native-web: 0.21.2
-      babel-plugin-syntax-hermes-parser: 0.29.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      debug: 4.4.3(supports-color@8.1.1)
-      react-refresh: 0.14.2
-      resolve-from: 5.0.0
-    optionalDependencies:
-      '@babel/runtime': 7.29.2
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
   babel-preset-expo@55.0.12(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.8)(react-refresh@0.14.2):
     dependencies:
       '@babel/generator': 7.29.1
@@ -23773,21 +23478,7 @@ snapshots:
 
   expo-application@55.0.10(expo@55.0.8):
     dependencies:
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-
-  expo-asset@12.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
-    dependencies:
-      '@expo/image-utils': 0.8.12
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - supports-color
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-asset@55.0.10(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3):
     dependencies:
@@ -23817,46 +23508,18 @@ snapshots:
 
   expo-blur@55.0.10(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-camera@55.0.10(@types/emscripten@1.41.5)(expo@55.0.8)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
-<<<<<<< HEAD
       barcode-detector: 3.1.1(@types/emscripten@1.41.5)
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      invariant: 2.2.4
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-    optionalDependencies:
-      react-native-web: 0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-
-  expo-clipboard@8.0.8(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
-    dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-
-  expo-constants@18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)):
-    dependencies:
-      '@expo/config': 12.0.13
-      '@expo/env': 2.0.11
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     transitivePeerDependencies:
       - '@types/emscripten'
 
@@ -23878,16 +23541,10 @@ snapshots:
 
   expo-crypto@55.0.10(expo@55.0.8):
     dependencies:
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
-=======
-      base64-js: 1.5.1
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-dev-client@55.0.18(expo@55.0.8)(typescript@5.9.3):
     dependencies:
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-dev-launcher: 55.0.19(expo@55.0.8)(typescript@5.9.3)
       expo-dev-menu: 55.0.16(expo@55.0.8)
@@ -23897,14 +23554,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-    optional: true
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-dev-launcher@55.0.19(expo@55.0.8)(typescript@5.9.3):
     dependencies:
-<<<<<<< HEAD
       '@expo/schema-utils': 55.0.2
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-dev-menu: 55.0.16(expo@55.0.8)
@@ -23921,26 +23573,11 @@ snapshots:
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-dev-menu-interface: 55.0.1(expo@55.0.8)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-file-system@55.0.11(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-<<<<<<< HEAD
-=======
-    optional: true
-
-  expo-font@14.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
-    dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      fontfaceobserver: 2.3.0
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-font@55.0.4(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -23957,11 +23594,7 @@ snapshots:
 
   expo-haptics@55.0.9(expo@55.0.8):
     dependencies:
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-image@55.0.6(expo@55.0.8)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -23972,14 +23605,7 @@ snapshots:
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-<<<<<<< HEAD
   expo-json-utils@55.0.0: {}
-=======
-  expo-keep-awake@15.0.8(expo@54.0.34)(react@19.1.0):
-    dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      react: 19.1.0
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-keep-awake@55.0.4(expo@55.0.8)(react@19.2.3):
     dependencies:
@@ -24009,23 +23635,7 @@ snapshots:
       expo-json-utils: 55.0.0
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
       - typescript
-=======
-
-  expo-local-authentication@17.0.8(expo@54.0.34):
-    dependencies:
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      invariant: 2.2.4
-
-  expo-modules-autolinking@3.0.25:
-    dependencies:
-      '@expo/spawn-async': 1.7.2
-      chalk: 4.1.2
-      commander: 7.2.0
-      require-from-string: 2.0.2
-      resolve-from: 5.0.0
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-modules-autolinking@55.0.11(typescript@5.9.3):
     dependencies:
@@ -24048,19 +23658,11 @@ snapshots:
       '@expo/image-utils': 0.8.12
       abort-controller: 3.0.0
       badgin: 1.2.3
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       expo-application: 55.0.10(expo@55.0.8)
       expo-constants: 55.0.9(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(typescript@5.9.3)
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      expo-application: 7.0.8(expo@54.0.34)
-      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -24114,79 +23716,20 @@ snapshots:
       - expo-font
       - supports-color
 
-<<<<<<< HEAD
   expo-secure-store@55.0.9(expo@55.0.8):
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
-=======
-  expo-router@6.0.23(d5aa1afa926574818b635eaaa94a558e):
-    dependencies:
-      '@expo/metro-runtime': 6.1.2(expo@54.0.34)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      '@expo/schema-utils': 0.1.8
-      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.17)(react@19.1.0)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@react-navigation/bottom-tabs': 7.15.5(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      '@react-navigation/native': 7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      '@react-navigation/native-stack': 7.14.5(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      client-only: 0.0.1
-      debug: 4.4.3(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
-      expo-linking: 8.0.12(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      expo-server: 1.0.6
-      fast-deep-equal: 3.1.3
-      invariant: 2.2.4
-      nanoid: 3.3.11
-      query-string: 7.1.3
-      react: 19.1.0
-      react-fast-compare: 3.2.2
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      react-native-screens: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      semver: 7.6.3
-      server-only: 0.0.1
-      sf-symbols-typescript: 2.2.0
-      shallowequal: 1.1.0
-      use-latest-callback: 0.2.6(react@19.1.0)
-      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-    optionalDependencies:
-      '@testing-library/react-native': 12.9.0(jest@29.7.0(@types/node@25.5.0)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
-      react-dom: 19.1.0(react@19.1.0)
-      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      react-native-web: 0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-    transitivePeerDependencies:
-      - '@react-native-masked-view/masked-view'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-server@55.0.6: {}
 
   expo-speech@55.0.9(expo@55.0.8):
     dependencies:
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo-splash-screen@55.0.12(expo@55.0.8)(typescript@5.9.3):
     dependencies:
-<<<<<<< HEAD
       '@expo/prebuild-config': 55.0.10(expo@55.0.8)(typescript@5.9.3)
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-
-  expo-splash-screen@31.0.13(expo@54.0.34):
-    dependencies:
-      '@expo/prebuild-config': 54.0.8(expo@54.0.34)
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -24210,13 +23753,8 @@ snapshots:
     dependencies:
       '@react-native/normalize-colors': 0.83.2
       debug: 4.4.3(supports-color@8.1.1)
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
@@ -24224,54 +23762,12 @@ snapshots:
 
   expo-updates-interface@55.1.3(expo@55.0.8):
     dependencies:
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
   expo-web-browser@55.0.10(expo@55.0.8)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)):
     dependencies:
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-
-  expo@54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@expo/cli': 54.0.24(bufferutil@4.1.0)(expo-router@6.0.23)(expo@54.0.34)(graphql@16.13.1)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(utf-8-validate@6.0.6)
-      '@expo/config': 12.0.13
-      '@expo/config-plugins': 54.0.4
-      '@expo/devtools': 0.1.8(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      '@expo/fingerprint': 0.15.5
-      '@expo/metro': 54.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@expo/metro-config': 54.0.15(bufferutil@4.1.0)(expo@54.0.34)(utf-8-validate@6.0.6)
-      '@expo/vector-icons': 15.1.1(expo-font@14.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      '@ungap/structured-clone': 1.3.0
-      babel-preset-expo: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.34)(react-refresh@0.14.2)
-      expo-asset: 12.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
-      expo-file-system: 19.0.22(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))
-      expo-font: 14.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      expo-keep-awake: 15.0.8(expo@54.0.34)(react@19.1.0)
-      expo-modules-autolinking: 3.0.25
-      expo-modules-core: 3.0.30(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      pretty-format: 29.7.0
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-      react-refresh: 0.14.2
-      whatwg-url-without-unicode: 8.0.0-3
-    optionalDependencies:
-      '@expo/dom-webview': 55.0.3(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      '@expo/metro-runtime': 6.1.2(expo@54.0.34)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      react-native-webview: 13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - expo-router
-      - graphql
-      - supports-color
-      - utf-8-validate
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   expo@55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
@@ -25795,11 +25291,7 @@ snapshots:
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
       babel-jest: 29.7.0(@babel/core@7.29.0)
-<<<<<<< HEAD
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@5.9.3)(utf-8-validate@6.0.6)
-=======
-      expo: 54.0.34(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(graphql@16.13.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
       jest-environment-jsdom: 29.7.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
@@ -26249,11 +25741,7 @@ snapshots:
 
   kysely@0.28.14: {}
 
-<<<<<<< HEAD
   lan-network@0.2.0: {}
-=======
-  lan-network@0.2.1: {}
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   langium@3.3.1:
     dependencies:
@@ -28582,19 +28070,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-<<<<<<< HEAD
   react-native-reanimated@4.2.2(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
-=======
-  react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      react-native-worklets: 0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0)
-      semver: 7.7.4
-
-  react-native-reanimated@4.2.2(react-native-worklets@0.7.3(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     dependencies:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
@@ -28641,17 +28117,6 @@ snapshots:
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
-<<<<<<< HEAD
-=======
-    optional: true
-
-  react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
-    dependencies:
-      escape-string-regexp: 4.0.0
-      invariant: 2.2.4
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
 
   react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -28660,30 +28125,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
 
-<<<<<<< HEAD
   react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
-=======
-  react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6))(react@19.1.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      convert-source-map: 2.0.0
-      react: 19.1.0
-      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.6)
-      semver: 7.7.2
-    transitivePeerDependencies:
-      - supports-color
-
-  react-native-worklets@0.7.3(@babel/core@7.29.0)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
->>>>>>> 15fe9d00 (fix(mobile): align Expo Go runtime config)
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -29310,10 +28752,7 @@ snapshots:
 
   semver@7.6.3: {}
 
-  semver@7.7.2: {}
-
-  semver@7.7.3:
-    optional: true
+  semver@7.7.3: {}
 
   semver@7.7.4: {}
 

--- a/shell/next-env.d.ts
+++ b/shell/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -27,8 +27,36 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
+        source: "/gateway/:path*",
+        destination: `${gatewayUrl}/:path*`,
+      },
+      {
+        source: "/api/:path*",
+        destination: `${gatewayUrl}/api/:path*`,
+      },
+      {
         source: "/icons/:path*",
         destination: `${gatewayUrl}/files/system/icons/:path*`,
+      },
+      {
+        source: "/files/:path*",
+        destination: `${gatewayUrl}/files/:path*`,
+      },
+      {
+        source: "/modules/:path*",
+        destination: `${gatewayUrl}/modules/:path*`,
+      },
+      {
+        source: "/apps/:path*",
+        destination: `${gatewayUrl}/apps/:path*`,
+      },
+      {
+        source: "/ws",
+        destination: `${gatewayUrl}/ws`,
+      },
+      {
+        source: "/ws/:path*",
+        destination: `${gatewayUrl}/ws/:path*`,
       },
     ];
   },

--- a/shell/proxy.ts
+++ b/shell/proxy.ts
@@ -1,22 +1,32 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
-import { NextResponse, type NextRequest } from "next/server";
-import { isGatewayProxyPath, isPublicShellPath } from "./lib/proxy-routes";
+import { NextResponse } from "next/server";
+import { isGatewayProxyPath, isPublicShellPath } from "./src/lib/proxy-routes";
 
 const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
 const authToken = process.env.MATRIX_AUTH_TOKEN;
 const expectedClerkUserId = process.env.MATRIX_CLERK_USER_ID;
 const platformUpgradeToken = process.env.UPGRADE_TOKEN;
 
+interface ProxyRequestLike {
+  headers: Headers;
+  nextUrl: {
+    host: string;
+    pathname: string;
+    protocol: string;
+    search: string;
+  };
+}
+
 // Direct path check instead of Clerk's createRouteMatcher -- in Next 16's
 // proxy.ts runtime, createRouteMatcher has been observed to return false for
 // paths it should match, causing gateway-bound requests (/api/*, /files/*,
-// /apps/*)
-// to fall through to the 404 page instead of being rewritten to the gateway.
-function isGatewayProxy(request: NextRequest): boolean {
+// /apps/*) to fall through to the 404 page instead of being rewritten to the
+// gateway.
+function isGatewayProxy(request: ProxyRequestLike): boolean {
   return isGatewayProxyPath(request.nextUrl.pathname);
 }
 
-function getPublicOrigin(request: NextRequest) {
+function getPublicOrigin(request: ProxyRequestLike) {
   const host =
     request.headers.get("x-forwarded-host") ??
     request.headers.get("host") ??
@@ -29,7 +39,7 @@ function getPublicOrigin(request: NextRequest) {
   return `${proto}://${host}`;
 }
 
-function rewriteGatewayRequest(request: NextRequest) {
+function rewriteGatewayRequest(request: ProxyRequestLike) {
   const { pathname } = request.nextUrl;
   const target = pathname.startsWith("/gateway/")
     ? pathname.replace("/gateway", "")
@@ -42,7 +52,7 @@ function rewriteGatewayRequest(request: NextRequest) {
   return NextResponse.rewrite(url, { request: { headers } });
 }
 
-function platformVerifiedResponse(request: NextRequest): NextResponse | null {
+function platformVerifiedResponse(request: ProxyRequestLike): NextResponse | null {
   const platformAuthHeader = request.headers.get("authorization");
   const platformBearer = platformAuthHeader?.startsWith("Bearer ")
     ? platformAuthHeader.slice(7)
@@ -101,8 +111,8 @@ const withClerk = clerkMiddleware(async (auth, request) => {
 });
 
 export function proxy(
-  request: NextRequest,
-  event: import("next/server").NextFetchEvent,
+  request: Parameters<typeof withClerk>[0],
+  event: Parameters<typeof withClerk>[1],
 ) {
   // E2E screenshot tests run against `next start`, which always serves the
   // built app with production semantics. Use the explicit bypass flag alone so
@@ -119,7 +129,7 @@ export function proxy(
   if (isPublicShellPath(request.nextUrl.pathname)) {
     return NextResponse.next();
   }
-  // All requests — including gateway-proxy paths — flow through Clerk so the
+  // All requests -- including gateway-proxy paths -- flow through Clerk so the
   // admin bearer token is never injected onto an unauthenticated request. The
   // platform-verified fast-path above covers the pre-authenticated
   // backend-to-backend case.
@@ -133,8 +143,10 @@ export const config = {
     "/files/:path*",
     "/modules/:path*",
     "/apps/:path*",
+    "/api/:path*",
+    "/trpc/:path*",
+    "/ws",
     "/ws/:path*",
-    "/(api|trpc)(.*)",
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/((?!_next|.*\\..*).*)",
   ],
 };

--- a/shell/proxy.ts
+++ b/shell/proxy.ts
@@ -1,6 +1,10 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
-import { isGatewayProxyPath, isPublicShellPath } from "./src/lib/proxy-routes";
+import {
+  isGatewayProxyPath,
+  isPlatformMobileAppSessionRequest,
+  isPublicShellPath,
+} from "./src/lib/proxy-routes";
 
 const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
 const authToken = process.env.MATRIX_AUTH_TOKEN;
@@ -62,7 +66,12 @@ function platformVerifiedResponse(request: ProxyRequestLike): NextResponse | nul
   }
 
   const platformUserId = request.headers.get("x-platform-user-id");
-  if (expectedClerkUserId && platformUserId !== expectedClerkUserId) {
+  const mobileAppSessionRequest = isPlatformMobileAppSessionRequest(
+    request.nextUrl.pathname,
+    request.nextUrl.search,
+    request.headers.get("cookie"),
+  );
+  if (expectedClerkUserId && platformUserId !== expectedClerkUserId && !mobileAppSessionRequest) {
     return new NextResponse("Forbidden: you do not own this instance", {
       status: 403,
     });

--- a/shell/src/components/AppViewer.tsx
+++ b/shell/src/components/AppViewer.tsx
@@ -16,6 +16,15 @@ import { openAppSession } from "@/lib/app-session";
 const GATEWAY_URL = getGatewayUrl();
 const SESSION_REFRESH_DEBOUNCE_MS = 2000;
 const BRIDGE_FETCH_TIMEOUT_MS = 10_000;
+const LEGACY_NESTED_RUNTIME_APP_SLUGS = new Set([
+  "2048",
+  "backgammon",
+  "chess",
+  "minesweeper",
+  "snake",
+  "solitaire",
+  "tetris",
+]);
 export const APP_IFRAME_SANDBOX = "allow-scripts allow-same-origin allow-forms allow-popups";
 
 interface AppViewerProps {
@@ -35,11 +44,13 @@ export function extractSlug(path: string): string | null {
   const topLevel = path.match(/^apps\/([a-z0-9][a-z0-9-]{0,63})(?:\/(?:index\.html)?)?$/);
   if (topLevel) return topLevel[1];
 
-  // Older saved layouts used filesystem paths for nested bundled apps such as
-  // apps/games/backgammon/index.html. Those apps now have first-class runtime
-  // slugs, so route them through /apps/:slug/ instead of loading source HTML.
+  // Older saved layouts used filesystem paths for migrated bundled games. Only
+  // rewrite known migrated slugs; other nested paths still load as files.
   const nestedIndex = path.match(/^apps\/(?:[a-z0-9][a-z0-9-]{0,63}\/)+([a-z0-9][a-z0-9-]{0,63})\/index\.html$/);
-  return nestedIndex ? nestedIndex[1] : null;
+  if (nestedIndex && LEGACY_NESTED_RUNTIME_APP_SLUGS.has(nestedIndex[1])) {
+    return nestedIndex[1];
+  }
+  return null;
 }
 
 export function shouldRenderAppIframe(path: string): boolean {

--- a/shell/src/components/AppViewer.tsx
+++ b/shell/src/components/AppViewer.tsx
@@ -32,14 +32,14 @@ function appNameFromPath(path: string): string {
 }
 
 export function extractSlug(path: string): string | null {
-  // Only treat a path as a slug-route when it targets the top-level app
-  // directory: "apps/{slug}", "apps/{slug}/", or "apps/{slug}/index.html".
-  // Nested paths like "apps/games/2048/index.html" must fall back to the
-  // legacy /files/ route -- they share a parent slug but are not runtime-
-  // managed apps, so routing them through /apps/:slug/ would serve the
-  // parent app's index.html instead of the requested file.
-  const match = path.match(/^apps\/([a-z0-9][a-z0-9-]{0,63})(?:\/(?:index\.html)?)?$/);
-  return match ? match[1] : null;
+  const topLevel = path.match(/^apps\/([a-z0-9][a-z0-9-]{0,63})(?:\/(?:index\.html)?)?$/);
+  if (topLevel) return topLevel[1];
+
+  // Older saved layouts used filesystem paths for nested bundled apps such as
+  // apps/games/backgammon/index.html. Those apps now have first-class runtime
+  // slugs, so route them through /apps/:slug/ instead of loading source HTML.
+  const nestedIndex = path.match(/^apps\/(?:[a-z0-9][a-z0-9-]{0,63}\/)+([a-z0-9][a-z0-9-]{0,63})\/index\.html$/);
+  return nestedIndex ? nestedIndex[1] : null;
 }
 
 export function shouldRenderAppIframe(path: string): boolean {

--- a/shell/src/components/ChatApp.tsx
+++ b/shell/src/components/ChatApp.tsx
@@ -53,6 +53,7 @@ interface ChatAppProps {
   onNewChat: () => void;
   onSwitchConversation: (id: string) => void;
   onSubmit: (text: string, files?: Array<{ name: string; type: string; data: string }>) => void;
+  mobile?: boolean;
 }
 
 function groupConversationsByTime(conversations: ConversationMeta[]) {
@@ -91,8 +92,9 @@ export function ChatApp({
   onNewChat,
   onSwitchConversation,
   onSubmit,
+  mobile = false,
 }: ChatAppProps) {
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(!mobile);
   const [searchQuery, setSearchQuery] = useState("");
   const grouped = useMemo(() => groupMessages(messages), [messages]);
 
@@ -122,11 +124,13 @@ export function ChatApp({
   const isEmpty = messages.length === 0 && !busy;
 
   return (
-    <div className="flex h-full bg-background">
+    <div className="relative flex h-full bg-background">
       {/* Sidebar */}
       <aside
-        className={`flex flex-col border-r border-border/50 bg-muted/30 transition-all duration-200 ease-out ${
-          sidebarOpen ? "w-[260px]" : "w-0 overflow-hidden"
+        className={`z-20 flex flex-col border-r border-border/50 bg-muted/95 backdrop-blur transition-all duration-200 ease-out ${
+          sidebarOpen
+            ? mobile ? "absolute inset-y-0 left-0 w-[min(86vw,320px)] shadow-2xl" : "w-[260px]"
+            : "w-0 overflow-hidden"
         }`}
       >
         <div className="flex items-center justify-between p-3 pb-2">
@@ -234,11 +238,11 @@ export function ChatApp({
 
         {/* Empty state or conversation */}
         {isEmpty ? (
-          <EmptyState onSubmit={onSubmit} connected={connected} suggestions={suggestions} />
+          <EmptyState onSubmit={onSubmit} connected={connected} suggestions={suggestions} mobile={mobile} />
         ) : (
           <div className="flex flex-1 flex-col min-h-0">
             <Conversation>
-              <ConversationContent className="gap-5 px-4 py-6 md:px-0 mx-auto w-full max-w-[720px]">
+              <ConversationContent className="gap-5 px-4 py-5 md:px-0 mx-auto w-full max-w-[720px]">
                 {grouped.map((group, i) => {
                   if (group.type === "tool_group") {
                     return <ToolCallGroup key={`tg-${i}`} tools={group.messages} />;
@@ -277,7 +281,7 @@ export function ChatApp({
             </Conversation>
 
             {/* Suggestions + Input */}
-            <div className="mx-auto w-full max-w-[720px] px-4 md:px-0 pb-4 pt-2">
+            <div className="mx-auto w-full max-w-[720px] px-3 md:px-0 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-2">
               {!busy && suggestions.length > 0 && (
                 <div className="pb-3">
                   <SuggestionChips
@@ -299,10 +303,12 @@ function EmptyState({
   onSubmit,
   connected,
   suggestions,
+  mobile,
 }: {
   onSubmit: (text: string) => void;
   connected: boolean;
   suggestions: string[];
+  mobile: boolean;
 }) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-4">
@@ -315,7 +321,7 @@ function EmptyState({
         </div>
 
         {/* Input */}
-        <ChatInput connected={connected} busy={false} onSubmit={onSubmit} autoFocus />
+        <ChatInput connected={connected} busy={false} onSubmit={onSubmit} autoFocus={!mobile} />
 
         {/* Suggestions */}
         {suggestions.length > 0 && (

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -543,9 +543,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
   const isPhoneShell = useMobileViewport();
   const [mobileMode, setMobileMode] = useState<"launcher" | "app" | "canvas">("launcher");
   const [lastActiveMobileAppSlug, setLastActiveMobileAppSlug] = useState<string | null>(null);
-  const activeMobileWindow = focusedWindow ?? windows
-    .filter((w) => !w.minimized)
-    .sort((a, b) => b.zIndex - a.zIndex)[0];
+  const activeMobileWindow = focusedWindow;
 
   useEffect(() => {
     if (!isPhoneShell) return;

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
-import { useWindowManager, type LayoutWindow } from "@/hooks/useWindowManager";
+import { useWindowManager, type AppWindow, type LayoutWindow } from "@/hooks/useWindowManager";
+import { useMobileViewport } from "@/hooks/useMobileViewport";
 import { useCommandStore } from "@/stores/commands";
 import { useDesktopMode } from "@/stores/desktop-mode";
 import { useVocalStore } from "@/stores/vocal";
@@ -47,6 +48,8 @@ import { OnboardingScreen } from "./OnboardingScreen";
 import { MenuBar } from "./MenuBar";
 import { CanvasToolbar } from "./canvas/CanvasToolbar";
 import { VocalPanel } from "./VocalPanel";
+import { MobileAppSurface } from "./mobile/MobileAppSurface";
+import { MobileLauncher } from "./mobile/MobileLauncher";
 import { getGatewayUrl } from "@/lib/gateway";
 import { ChatApp } from "./ChatApp";
 import { ChatPopover } from "./ChatPopover";
@@ -55,20 +58,20 @@ import { nameToSlug } from "@/lib/utils";
 import { isSystemApp, applyOrder } from "@/lib/dock-sections";
 import { openAppInStandaloneTab } from "@/lib/open-app-tab";
 import {
+  loadBrowserMobileShellState,
+  saveBrowserMobileShellState,
+} from "@/stores/mobile-shell-store";
+import {
   DEFAULT_PINNED_APPS,
   isBuiltInAppPath,
   normalizeBuiltInAppPath,
   normalizeBuiltInLayoutWindow,
 } from "@/lib/builtin-apps";
+import { canonicalAppLaunchPath, iconUrlForSlug } from "@/lib/app-launch";
 import { Reorder } from "framer-motion";
 
 const GATEWAY_URL = getGatewayUrl();
 const GATEWAY_FETCH_TIMEOUT_MS = 10_000;
-
-function iconUrlForSlug(slug: string | undefined): string | undefined {
-  if (!slug) return undefined;
-  return `/icons/${encodeURIComponent(slug)}.png`;
-}
 
 // Forgiving app-name lookup used by vocal mode's `open_app` tool and the
 // auto-open after a build finishes. Handles exact, substring, reverse
@@ -109,6 +112,15 @@ function findAppByName<T extends { name: string }>(apps: T[], query: string): T 
   }
 
   return null;
+}
+
+function mobileAppSlugFromPath(path: string): string {
+  return path
+    .replace(/^apps\//, "")
+    .replace(/^__/, "")
+    .replace(/__$/, "")
+    .replace(/\/index\.html$/, "")
+    .replace(/\.html$/, "");
 }
 
 interface ModuleRegistryEntry {
@@ -528,6 +540,18 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
   const focusedWindow = windows
     .filter((w) => !w.minimized)
     .sort((a, b) => b.zIndex - a.zIndex)[0];
+  const isPhoneShell = useMobileViewport();
+  const [mobileMode, setMobileMode] = useState<"launcher" | "app" | "canvas">("launcher");
+  const [lastActiveMobileAppSlug, setLastActiveMobileAppSlug] = useState<string | null>(null);
+  const activeMobileWindow = focusedWindow ?? windows
+    .filter((w) => !w.minimized)
+    .sort((a, b) => b.zIndex - a.zIndex)[0];
+
+  useEffect(() => {
+    if (!isPhoneShell) return;
+    const saved = loadBrowserMobileShellState();
+    setLastActiveMobileAppSlug(saved.lastActiveAppSlug);
+  }, [isPhoneShell]);
 
   useEffect(() => {
     const timers = minimizeTimers.current;
@@ -600,7 +624,8 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
   const checkAndGenerateIcon = useCallback((slug: string) => {
     if (checkedRef.current.has(slug) || generatingRef.current.has(slug)) return;
     checkedRef.current.add(slug);
-    const iconPath = `/icons/${slug}.png`;
+    const iconPath = iconUrlForSlug(slug);
+    if (!iconPath) return;
     fetch(`${GATEWAY_URL}${iconPath}`, {
       method: "HEAD",
       signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
@@ -608,7 +633,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
       if (res.ok) {
         const etag = res.headers.get("etag");
         if (etag) {
-          const versionedUrl = versionedIconUrl(`/icons/${slug}.png`, etag);
+          const versionedUrl = versionedIconUrl(iconPath, etag);
           wmSetApps((prev) =>
             prev.map((a) =>
               nameToSlug(a.name) === slug && a.iconUrl !== versionedUrl
@@ -618,7 +643,17 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
           );
         }
       } else {
-        regenerateIcon(slug);
+        if (iconPath.endsWith(".png")) {
+          regenerateIcon(slug);
+        } else {
+          wmSetApps((prev) =>
+            prev.map((a) =>
+              nameToSlug(a.name) === slug && a.iconUrl
+                ? { ...a, iconUrl: undefined }
+                : a,
+            ),
+          );
+        }
       }
     }).catch((err) => console.warn(`[desktop] Failed to check icon for "${slug}":`, err));
   }, [wmSetApps, regenerateIcon]);
@@ -652,7 +687,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                     ...a,
                     name: newName,
                     path: newPath,
-                    iconUrl: `/icons/${ns}.png`,
+                    iconUrl: iconUrlForSlug(ns),
                   };
                 }
                 return a;
@@ -684,7 +719,20 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
   const addApp = useCallback((name: string, path: string, iconSlug?: string) => {
     const iconUrl = iconUrlForSlug(iconSlug);
     wmSetApps((prev) => {
-      if (prev.find((a) => a.path === path)) return prev;
+      const existingPath = prev.find((a) => a.path === path);
+      if (existingPath) {
+        return prev.map((a) => (
+          a.path === path && (a.name !== name || a.iconUrl !== iconUrl)
+            ? { ...a, name, iconUrl }
+            : a
+        ));
+      }
+      if (iconSlug) {
+        const existingName = prev.find((a) => a.name === name);
+        if (existingName) {
+          return prev.map((a) => a.name === name ? { ...a, path, iconUrl } : a);
+        }
+      }
       return [...prev, { name, path, iconUrl }];
     });
     if (iconSlug) checkAndGenerateIcon(iconSlug);
@@ -758,6 +806,93 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
     [focusOrOpen],
   );
 
+  const openMobileWindow = useCallback((name: string, path: string) => {
+    const slug = mobileAppSlugFromPath(path);
+    openWindow(name, path);
+    setMobileMode("app");
+    setLastActiveMobileAppSlug(slug);
+    saveBrowserMobileShellState({
+      ...loadBrowserMobileShellState(),
+      mode: "app",
+      lastActiveAppSlug: slug,
+      updatedAt: new Date().toISOString(),
+    });
+  }, [openWindow]);
+
+  const openMobileCanvas = useCallback(() => {
+    useDesktopMode.getState().setMode("canvas");
+    useCanvasTransform.getState().resetForMobileViewport();
+    setMobileMode("canvas");
+    saveBrowserMobileShellState({
+      ...loadBrowserMobileShellState(),
+      mode: "canvas",
+      canvasEnteredAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isPhoneShell || typeof window === "undefined") return;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const nextWidth = Math.round(Math.min(1040, Math.max(720, vw * 0.62)));
+    const nextHeight = Math.round(Math.min(820, Math.max(520, vh * 0.7)));
+    wmSetWindows((prev) => prev.map((win) => {
+      if (win.minimized || win.width >= 640) return win;
+      return {
+        ...win,
+        x: Math.max(80, Math.min(win.x, Math.max(80, vw - nextWidth - 80))),
+        y: Math.max(56, Math.min(win.y, Math.max(56, vh - nextHeight - 56))),
+        width: nextWidth,
+        height: nextHeight,
+      };
+    }));
+  }, [isPhoneShell, wmSetWindows]);
+
+  const returnMobileHome = useCallback(() => {
+    setMobileMode("launcher");
+    saveBrowserMobileShellState({
+      ...loadBrowserMobileShellState(),
+      mode: "launcher",
+      updatedAt: new Date().toISOString(),
+    });
+  }, []);
+
+  const renderWindowContent = useCallback((win: AppWindow) => {
+    if (win.path.startsWith("__terminal__")) {
+      return <TerminalApp mobile={isPhoneShell} />;
+    }
+    if (win.path === "__workspace__") {
+      return <WorkspaceApp />;
+    }
+    if (win.path === "__file-browser__") {
+      return <FileBrowser windowId={win.id} mobile={isPhoneShell} />;
+    }
+    if (win.path === "__preview-window__") {
+      return <PreviewWindow />;
+    }
+    if (win.path === "__chat__") {
+      return (
+        <div className="h-full overflow-hidden">
+          {chat && (
+            <ChatApp
+              messages={chat.messages}
+              sessionId={chat.sessionId}
+              busy={chat.busy}
+              connected={chat.connected}
+              conversations={chat.conversations}
+              onNewChat={chat.newChat}
+              onSwitchConversation={chat.switchConversation}
+              onSubmit={chat.submitMessage}
+              mobile={isPhoneShell}
+            />
+          )}
+        </div>
+      );
+    }
+    return <AppViewer path={win.path} onOpenApp={openMobileWindow} />;
+  }, [chat, isPhoneShell, openMobileWindow]);
+
   const loadModules = useCallback(async () => {
     try {
       const [layoutRes, modulesRes, appsRes] = await Promise.all([
@@ -806,15 +941,14 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
 
       // Load pre-installed apps from /api/apps (apps/ directory)
       if (appsRes?.ok) {
-        const appsList: { name: string; path: string; icon?: string }[] = await appsRes.json();
+        const appsList: { name: string; path: string; icon?: string; slug?: string; launchUrl?: string }[] = await appsRes.json();
         for (const app of appsList) {
-          // path from API is like "/files/apps/calculator/index.html"
-          // strip leading "/files/" to get relative path for AppViewer
-          const relativePath = normalizeBuiltInAppPath(app.path.replace(/^\/files\//, ""));
-          addApp(app.name, relativePath, app.icon);
+          const legacyPath = normalizeBuiltInAppPath(app.path.replace(/^\/files\//, ""));
+          const canonicalPath = normalizeBuiltInAppPath(canonicalAppLaunchPath(app) ?? legacyPath);
+          addApp(app.name, canonicalPath, app.icon);
 
-          const saved = layoutMap.get(relativePath);
-          queueSavedLayout(saved);
+          const saved = layoutMap.get(canonicalPath) ?? layoutMap.get(legacyPath);
+          queueSavedLayout(saved && saved.path !== canonicalPath ? { ...saved, path: canonicalPath } : saved);
           // Don't auto-open pre-installed apps - let users open from dock/store
         }
       }
@@ -1262,6 +1396,46 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
     return () => window.removeEventListener("keydown", onKey);
   }, [fullscreenWindowId, wmExitFullscreen]);
 
+  if (!showSetup && isPhoneShell && modeConfig.showWindows) {
+    const openWindowPaths = new Set(windows.filter((w) => !w.minimized).map((w) => w.path));
+    const showApp = mobileMode === "app" && activeMobileWindow;
+    const resumeApp = lastActiveMobileAppSlug
+      ? apps.find((app) => mobileAppSlugFromPath(app.path) === lastActiveMobileAppSlug) ?? null
+      : null;
+
+    return (
+      <TooltipProvider delayDuration={300}>
+        <div className="relative flex min-h-0 flex-1 overflow-hidden bg-background">
+          {mobileMode === "canvas" ? (
+            <MobileAppSurface title="Canvas" onHome={returnMobileHome}>
+              <div className="relative h-full w-full overflow-hidden bg-background">
+                <div className="absolute left-3 right-3 top-3 z-20">
+                  <CanvasToolbar />
+                </div>
+                <CanvasRenderer />
+              </div>
+            </MobileAppSurface>
+          ) : showApp ? (
+            <MobileAppSurface title={activeMobileWindow.title} onHome={returnMobileHome}>
+              {renderWindowContent(activeMobileWindow)}
+            </MobileAppSurface>
+          ) : (
+            <MobileLauncher
+              apps={apps}
+              openWindowPaths={openWindowPaths}
+              onOpenApp={openMobileWindow}
+              resumeApp={resumeApp}
+              onResumeApp={openMobileWindow}
+              onOpenCanvas={openMobileCanvas}
+            />
+          )}
+        </div>
+        <Settings open={settingsOpen} onOpenChange={setSettingsOpen} />
+        <ChatPopover open={chatOpen} onOpenChange={setChatOpen} />
+      </TooltipProvider>
+    );
+  }
+
   return (
     <TooltipProvider delayDuration={300}>
       {!showSetup && (
@@ -1274,6 +1448,12 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
       {showSetup && (
         <OnboardingScreen
           onComplete={() => {
+            setMobileMode("launcher");
+            saveBrowserMobileShellState({
+              ...loadBrowserMobileShellState(),
+              mode: "launcher",
+              updatedAt: new Date().toISOString(),
+            });
             // Whether the user finished onboarding or skipped it, land them
             // on the moraine-lake wallpaper. Best-effort persist to the
             // gateway; the local default already matches so the visual is
@@ -1801,11 +1981,11 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
 
                 <CardContent className="relative flex-1 p-0 min-h-0">
                   {win.path.startsWith("__terminal__") ? (
-                    <TerminalApp />
+                    <TerminalApp mobile={isPhoneShell} />
                   ) : win.path === "__workspace__" ? (
                     <WorkspaceApp />
                   ) : win.path === "__file-browser__" ? (
-                    <FileBrowser windowId={win.id} />
+                    <FileBrowser windowId={win.id} mobile={isPhoneShell} />
                   ) : win.path === "__preview-window__" ? (
                     <PreviewWindow />
                   ) : win.path === "__chat__" ? (
@@ -1820,6 +2000,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                           onNewChat={chat.newChat}
                           onSwitchConversation={chat.switchConversation}
                           onSubmit={chat.submitMessage}
+                          mobile={isPhoneShell}
                         />
                       )}
                     </div>
@@ -1875,11 +2056,11 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
         return (
           <div className="fixed inset-0 z-[100] bg-background overflow-hidden">
             {fsWin.path.startsWith("__terminal__") ? (
-              <TerminalApp />
+              <TerminalApp mobile={isPhoneShell} />
             ) : fsWin.path === "__workspace__" ? (
               <WorkspaceApp />
             ) : fsWin.path === "__file-browser__" ? (
-              <FileBrowser windowId={fsWin.id} />
+              <FileBrowser windowId={fsWin.id} mobile={isPhoneShell} />
             ) : fsWin.path === "__preview-window__" ? (
               <PreviewWindow />
             ) : fsWin.path === "__chat__" ? (
@@ -1894,6 +2075,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                     onNewChat={chat.newChat}
                     onSwitchConversation={chat.switchConversation}
                     onSubmit={chat.submitMessage}
+                    mobile={isPhoneShell}
                   />
                 )}
               </div>

--- a/shell/src/components/MenuBar.tsx
+++ b/shell/src/components/MenuBar.tsx
@@ -214,7 +214,12 @@ export function MenuBar({ onOpenCommandPalette, onNewWindow, onMinimizeWindow, c
       if (sel?.toString()) await navigator.clipboard.writeText(sel.toString());
     }},
     { label: "Paste", shortcut: "⌘V", action: async () => {
-      try { const text = await navigator.clipboard.readText(); document.execCommand("insertText", false, text); } catch { /* denied */ }
+      try {
+        const text = await navigator.clipboard.readText();
+        document.execCommand("insertText", false, text);
+      } catch (err: unknown) {
+        console.warn("[menu] Clipboard paste was denied or unavailable:", err);
+      }
     }},
     { separator: true },
     { label: "Select All", shortcut: "⌘A", action: () => document.execCommand("selectAll") },

--- a/shell/src/components/MenuBar.tsx
+++ b/shell/src/components/MenuBar.tsx
@@ -56,9 +56,14 @@ function MenuBarClock() {
 }
 
 function MenuBarUser() {
+  const [mounted, setMounted] = useState(false);
   const { isLoaded, isSignedIn } = useAuth();
 
-  if (!isLoaded || !isSignedIn) {
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || !isLoaded || !isSignedIn) {
     return (
       <div className="px-1 py-0.5 rounded hover:bg-foreground/10">
         <UserIcon className="size-[14px] text-foreground/70" />

--- a/shell/src/components/UserButton.tsx
+++ b/shell/src/components/UserButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { UserButton as ClerkUserButton, useAuth } from "@clerk/nextjs";
 import {
   Tooltip,
@@ -24,6 +25,20 @@ function Placeholder() {
 }
 
 export function UserButton() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return <Placeholder />;
+  }
+
+  return <MountedUserButton />;
+}
+
+function MountedUserButton() {
   const { isLoaded, isSignedIn } = useAuth();
 
   if (!isLoaded || !isSignedIn) {

--- a/shell/src/components/file-browser/FileBrowser.tsx
+++ b/shell/src/components/file-browser/FileBrowser.tsx
@@ -17,9 +17,10 @@ import { QuickLook } from "./QuickLook";
 
 interface FileBrowserProps {
   windowId: string;
+  mobile?: boolean;
 }
 
-export function FileBrowser({ windowId }: FileBrowserProps) {
+export function FileBrowser({ windowId, mobile = false }: FileBrowserProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [showingTrash, setShowingTrash] = useState(false);
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
@@ -273,12 +274,14 @@ export function FileBrowser({ windowId }: FileBrowserProps) {
       tabIndex={0}
       onKeyDown={handleKeyDown}
     >
-      <FileBrowserToolbar />
+      <FileBrowserToolbar mobile={mobile} />
       <div className="flex flex-1 min-h-0">
-        <FileBrowserSidebar
-          onTrashClick={() => setShowingTrash(!showingTrash)}
-          showingTrash={showingTrash}
-        />
+        {!mobile && (
+          <FileBrowserSidebar
+            onTrashClick={() => setShowingTrash(!showingTrash)}
+            showingTrash={showingTrash}
+          />
+        )}
         <FileContextMenu onOpenFile={openFile}>
           <div className="flex-1 min-w-0 overflow-auto">
             {showingTrash ? (
@@ -295,9 +298,9 @@ export function FileBrowser({ windowId }: FileBrowserProps) {
             )}
           </div>
         </FileContextMenu>
-        <PreviewPanel />
+        {!mobile && <PreviewPanel />}
       </div>
-      <StatusBar />
+      {!mobile && <StatusBar />}
       <QuickLook />
     </div>
   );

--- a/shell/src/components/file-browser/FileBrowserToolbar.tsx
+++ b/shell/src/components/file-browser/FileBrowserToolbar.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-export function FileBrowserToolbar() {
+export function FileBrowserToolbar({ mobile = false }: { mobile?: boolean }) {
   const currentPath = useFileBrowser((s) => s.currentPath);
   const historyIndex = useFileBrowser((s) => s.historyIndex);
   const history = useFileBrowser((s) => s.history);
@@ -50,7 +50,7 @@ export function FileBrowserToolbar() {
   const pathSegments = currentPath ? currentPath.split("/") : [];
 
   return (
-    <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border bg-background/80">
+    <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border bg-background/80 overflow-x-auto">
       <div className="flex items-center gap-0.5">
         <Button
           variant="ghost"
@@ -94,7 +94,7 @@ export function FileBrowserToolbar() {
         ))}
       </div>
 
-      <div className="flex items-center border rounded-md">
+      <div className="flex items-center border rounded-md shrink-0">
         {(
           [
             ["icon", LayoutGridIcon],
@@ -118,7 +118,7 @@ export function FileBrowserToolbar() {
         ))}
       </div>
 
-      <div className="relative w-40">
+      <div className={mobile ? "hidden" : "relative w-40"}>
         <SearchIcon className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
         <Input
           className="h-7 pl-7 text-xs"

--- a/shell/src/components/mobile/MobileAppSurface.tsx
+++ b/shell/src/components/mobile/MobileAppSurface.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { HomeIcon } from "lucide-react";
+
+interface MobileAppSurfaceProps {
+  title: string;
+  onHome: () => void;
+  children?: ReactNode;
+  unavailableMessage?: string;
+}
+
+export function MobileAppSurface({ title, onHome, children, unavailableMessage }: MobileAppSurfaceProps) {
+  return (
+    <section data-testid="mobile-app-surface" className="absolute inset-0 flex flex-col overflow-hidden bg-background text-foreground">
+      <header className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/50 px-3 pt-[env(safe-area-inset-top)]">
+        <button
+          type="button"
+          data-testid="mobile-home-button"
+          onClick={onHome}
+          className="inline-flex size-10 items-center justify-center rounded-lg border border-border/60 bg-card text-foreground transition active:scale-95"
+          aria-label="Home"
+        >
+          <HomeIcon className="size-4" />
+        </button>
+        <h1 className="min-w-0 flex-1 truncate text-sm font-medium">{title}</h1>
+      </header>
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        {children ?? (
+          <div className="flex h-full flex-col items-center justify-center px-6 text-center">
+            <div className="text-sm font-semibold">App unavailable</div>
+            <div className="mt-2 max-w-[28ch] text-xs leading-5 text-muted-foreground">
+              {unavailableMessage ?? "Return home and open the app again."}
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/shell/src/components/mobile/MobileLauncher.tsx
+++ b/shell/src/components/mobile/MobileLauncher.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import type { AppEntry } from "@/hooks/useWindowManager";
+import { BrushIcon, ExternalLinkIcon, HomeIcon } from "lucide-react";
+
+interface MobileLauncherProps {
+  apps: AppEntry[];
+  openWindowPaths: Set<string>;
+  onOpenApp: (name: string, path: string) => void;
+  resumeApp?: AppEntry | null;
+  onResumeApp?: (name: string, path: string) => void;
+  onOpenCanvas?: () => void;
+}
+
+export function MobileLauncher({
+  apps,
+  openWindowPaths,
+  onOpenApp,
+  resumeApp,
+  onResumeApp,
+  onOpenCanvas,
+}: MobileLauncherProps) {
+  return (
+    <section data-testid="mobile-launcher" className="absolute inset-0 flex flex-col bg-background text-foreground">
+      <header className="shrink-0 border-b border-border/50 px-5 pb-4 pt-[calc(env(safe-area-inset-top)+1rem)]">
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-xl border border-border/60 bg-card">
+            <HomeIcon className="size-5 text-primary" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-semibold">Matrix</h1>
+            <p className="truncate text-xs text-muted-foreground">Apps</p>
+          </div>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="mb-3 grid gap-3">
+          {resumeApp ? (
+            <button
+              type="button"
+              data-testid="mobile-resume-app"
+              onClick={() => (onResumeApp ?? onOpenApp)(resumeApp.name, resumeApp.path)}
+              className="flex min-h-[72px] items-center gap-3 rounded-lg border border-primary/50 bg-card p-3 text-left shadow-sm transition active:scale-[0.98]"
+            >
+              <div className="flex size-11 items-center justify-center rounded-xl bg-primary/15 text-sm font-semibold text-primary">
+                {resumeApp.name.charAt(0).toUpperCase()}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-semibold text-primary">Continue</div>
+                <div className="truncate text-sm font-medium">{resumeApp.name}</div>
+              </div>
+              <ExternalLinkIcon className="size-4 text-primary" aria-hidden />
+            </button>
+          ) : null}
+          {onOpenCanvas ? (
+            <button
+              type="button"
+              data-testid="mobile-open-canvas"
+              onClick={onOpenCanvas}
+              className="flex min-h-[64px] items-center gap-3 rounded-lg border border-border/60 bg-card p-3 text-left shadow-sm transition active:scale-[0.98]"
+            >
+              <div className="flex size-10 items-center justify-center rounded-xl bg-secondary text-secondary-foreground">
+                <BrushIcon className="size-4" aria-hidden />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium">Canvas</div>
+                <div className="truncate text-xs text-muted-foreground">Open spatial workspace</div>
+              </div>
+            </button>
+          ) : null}
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          {apps.map((app) => {
+            const open = openWindowPaths.has(app.path);
+            return (
+              <button
+                key={app.path}
+                type="button"
+                data-testid={`mobile-launcher-app-${app.path}`}
+                onClick={() => onOpenApp(app.name, app.path)}
+                className="min-h-[118px] rounded-lg border border-border/60 bg-card p-3 text-left shadow-sm transition active:scale-[0.98]"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex size-12 items-center justify-center rounded-xl bg-secondary text-sm font-semibold text-secondary-foreground">
+                    {app.name.charAt(0).toUpperCase()}
+                  </div>
+                  {open ? (
+                    <span className="inline-flex size-2.5 rounded-full bg-primary" aria-label="Open" />
+                  ) : (
+                    <ExternalLinkIcon className="size-4 text-muted-foreground" aria-hidden />
+                  )}
+                </div>
+                <div className="mt-3 min-w-0">
+                  <div className="truncate text-sm font-medium">{app.name}</div>
+                  <div className="mt-1 truncate text-xs text-muted-foreground">
+                    {open ? "Open" : app.path.replace(/^apps\//, "").replace(/\/index\.html$/, "")}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -183,6 +183,7 @@ export function TerminalApp({ initialCommand, initialSessionId, mobile = false }
   activeTabIdRef.current = activeTabId;
   const themeIdRef = useRef(themeId);
   themeIdRef.current = themeId;
+  const initialMobileRef = useRef(mobile);
   const sidebarOpenRef = useRef(sidebarOpen);
   sidebarOpenRef.current = sidebarOpen;
   const pendingPaneSessionsRef = useRef<Map<string, string>>(new Map());
@@ -328,7 +329,7 @@ export function TerminalApp({ initialCommand, initialSessionId, mobile = false }
             const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
             setTabs(data.tabs);
             setActiveTabId(nextActiveTabId);
-            setSidebarOpen(mobile ? false : data.sidebarOpen ?? true);
+            setSidebarOpen(initialMobileRef.current ? false : data.sidebarOpen ?? true);
             setFocusedPaneId(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
             setInitialized(true);
             return;
@@ -350,7 +351,7 @@ export function TerminalApp({ initialCommand, initialSessionId, mobile = false }
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mobile]);
+  }, []);
 
   useEffect(() => {
     if (!initialized) {

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -117,6 +117,19 @@ function getPaneSessionId(node: PaneNode, paneId: string): string | null {
   return getPaneSessionId(node.children[0], paneId) ?? getPaneSessionId(node.children[1], paneId);
 }
 
+function getPaneCwd(node: PaneNode, paneId: string): string | null {
+  if (node.type === "pane") {
+    return node.id === paneId ? node.cwd : null;
+  }
+  return getPaneCwd(node.children[0], paneId) ?? getPaneCwd(node.children[1], paneId);
+}
+
+function formatCwd(value: string): string {
+  if (value === DEFAULT_CWD) return "~/projects";
+  if (value.startsWith(DEFAULT_CWD + "/")) return `~/${value}`;
+  return value;
+}
+
 function getSessionIds(node: PaneNode): string[] {
   if (node.type === "pane") {
     return node.sessionId ? [node.sessionId] : [];
@@ -140,9 +153,10 @@ const countPanes = countPanesFromStore;
 interface TerminalAppProps {
   initialCommand?: string;
   initialSessionId?: string;
+  mobile?: boolean;
 }
 
-export function TerminalApp({ initialCommand, initialSessionId }: TerminalAppProps = {}) {
+export function TerminalApp({ initialCommand, initialSessionId, mobile = false }: TerminalAppProps = {}) {
   const theme = useTheme();
   const themeId = useTerminalSettings((s) => s.themeId);
   const isLightTheme = isLightTerminalTheme(themeId, (theme as { slug?: string }).slug);
@@ -158,7 +172,7 @@ export function TerminalApp({ initialCommand, initialSessionId }: TerminalAppPro
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [activeTabId, setActiveTabId] = useState("");
   const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(!mobile);
   const [sidebarSelectedPath, setSidebarSelectedPath] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
 
@@ -208,6 +222,10 @@ export function TerminalApp({ initialCommand, initialSessionId }: TerminalAppPro
         method: "DELETE",
         keepalive: true,
         signal: AbortSignal.timeout(5_000),
+      }).then((res) => {
+        if (!res.ok && res.status !== 404) {
+          console.warn(`Failed to destroy terminal session "${sessionId}" on explicit close: ${res.status}`);
+        }
       }).catch((err: unknown) => {
         console.warn(
           `Failed to destroy terminal session "${sessionId}" on explicit close:`,
@@ -310,7 +328,7 @@ export function TerminalApp({ initialCommand, initialSessionId }: TerminalAppPro
             const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
             setTabs(data.tabs);
             setActiveTabId(nextActiveTabId);
-            setSidebarOpen(data.sidebarOpen ?? true);
+            setSidebarOpen(mobile ? false : data.sidebarOpen ?? true);
             setFocusedPaneId(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
             setInitialized(true);
             return;
@@ -332,7 +350,7 @@ export function TerminalApp({ initialCommand, initialSessionId }: TerminalAppPro
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [mobile]);
 
   useEffect(() => {
     if (!initialized) {
@@ -526,7 +544,7 @@ export function TerminalApp({ initialCommand, initialSessionId }: TerminalAppPro
 
   // Construct store-compatible interface for child components
   const storeApi = {
-    tabs, activeTabId, sidebarOpen, sidebarSelectedPath, focusedPaneId,
+    tabs, activeTabId, sidebarOpen, sidebarSelectedPath, focusedPaneId, mobile,
     addTab, addSessionTab, closeTab, setActiveTab: setActiveTabId, renameTab, reorderTabs,
     splitPane, closePane, setFocusedPane: setFocusedPaneId,
     setSidebarOpen, setSidebarSelectedPath,
@@ -542,11 +560,11 @@ export function TerminalApp({ initialCommand, initialSessionId }: TerminalAppPro
       <TerminalAppContext.Provider value={storeApi}>
         <LocalTerminalTabBar defaultCwd={DEFAULT_CWD} isLightTheme={isLightTheme} />
         <div className="flex flex-1 min-h-0">
-          <LocalTerminalSidebar />
+          {!mobile && <LocalTerminalSidebar />}
           {activeTab ? (
             <div
               className="flex-1 min-w-0 min-h-0 flex"
-              style={{ padding: "8px 10px 8px 12px", background: terminalBackground }}
+              style={{ padding: mobile ? "6px" : "8px 10px 8px 12px", background: terminalBackground }}
             >
               <PaneGrid
                 paneTree={activeTab.paneTree}
@@ -588,6 +606,7 @@ interface TerminalAppContextType {
   sidebarOpen: boolean;
   sidebarSelectedPath: string | null;
   focusedPaneId: string | null;
+  mobile: boolean;
   addTab: (cwd: string, label?: string, claude?: boolean, startupCommand?: string) => string;
   addSessionTab: (label: string, sessionId: string, cwd?: string) => string;
   closeTab: (tabId: string) => void;
@@ -760,6 +779,11 @@ function LocalTerminalTabBar({ defaultCwd, isLightTheme }: { defaultCwd: string;
   const dragIndexRef = useRef<number | null>(null);
 
   const getCwd = () => ctx.sidebarSelectedPath ?? defaultCwd;
+  const activeTab = ctx.tabs.find((tab) => tab.id === ctx.activeTabId);
+  const activePaneId = activeTab ? ctx.focusedPaneId ?? getFirstPaneId(activeTab.paneTree) : null;
+  const activeCwd = activeTab && activePaneId
+    ? getPaneCwd(activeTab.paneTree, activePaneId) ?? defaultCwd
+    : defaultCwd;
 
   return (
     <div
@@ -767,7 +791,7 @@ function LocalTerminalTabBar({ defaultCwd, isLightTheme }: { defaultCwd: string;
       style={{
         background: "var(--card)",
         borderColor: "var(--border)",
-        height: 40,
+        height: ctx.mobile ? 50 : 40,
         padding: "4px 6px",
         gap: 4,
       }}
@@ -784,9 +808,9 @@ function LocalTerminalTabBar({ defaultCwd, isLightTheme }: { defaultCwd: string;
                 color: active ? "var(--foreground)" : "var(--muted-foreground)",
                 border: `1px solid ${active ? "var(--border)" : "transparent"}`,
                 borderRadius: 6,
-                padding: "0 10px",
+                padding: ctx.mobile ? "0 8px" : "0 10px",
                 fontSize: 12,
-                height: 30,
+                height: ctx.mobile ? 34 : 30,
                 fontWeight: active ? 500 : 400,
               }}
               draggable
@@ -804,7 +828,25 @@ function LocalTerminalTabBar({ defaultCwd, isLightTheme }: { defaultCwd: string;
                   opacity: active ? 1 : 0.5,
                 }}
               />
-              <span style={{ maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis" }}>{tab.label}</span>
+              <span
+                className={ctx.mobile ? "flex min-w-0 flex-col leading-tight" : undefined}
+                style={{ maxWidth: ctx.mobile ? 132 : 160, overflow: "hidden" }}
+              >
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{tab.label}</span>
+                {ctx.mobile && active && (
+                  <span
+                    style={{
+                      color: "var(--muted-foreground)",
+                      fontSize: 10,
+                      fontWeight: 400,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {formatCwd(activeCwd)}
+                  </span>
+                )}
+              </span>
               <button
                 className="cursor-pointer flex items-center justify-center transition-colors"
                 onClick={(e) => { e.stopPropagation(); ctx.closeTab(tab.id); }}
@@ -831,41 +873,52 @@ function LocalTerminalTabBar({ defaultCwd, isLightTheme }: { defaultCwd: string;
         })}
       </div>
       <div className="flex items-center shrink-0" style={{ gap: 4, paddingLeft: 8, borderLeft: "1px solid var(--border)" }}>
-        <ToolbarBtn
-          onClick={() => ctx.addTab(getCwd(), "Claude Code", true)}
-          title="Launch Claude Code (Ctrl+Shift+C)"
-          variant="success"
-        >
-          Claude
-        </ToolbarBtn>
-        <ToolbarBtn
-          onClick={() => ctx.addTab(getCwd(), "Zellij", false, zellijLaunchCommand(themeId, isLightTheme))}
-          title="Launch Zellij (Ctrl+Shift+Z)"
-          variant="primary"
-        >
-          Zellij
-        </ToolbarBtn>
-        <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
-        <ToolbarBtn
-          onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "horizontal"); }}
-          title="Split horizontally (Ctrl+Shift+D)"
-        >
-          <IconSplitH />
-        </ToolbarBtn>
-        <ToolbarBtn
-          onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "vertical"); }}
-          title="Split vertically (Ctrl+Shift+E)"
-        >
-          <IconSplitV />
-        </ToolbarBtn>
-        <ToolbarBtn
-          onClick={() => ctx.addTab(getCwd())}
-          title="New tab (Ctrl+Shift+T)"
-        >
-          <IconPlus />
-        </ToolbarBtn>
-        <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
-        <ThemePickerButton />
+        {ctx.mobile ? (
+          <ToolbarBtn
+            onClick={() => ctx.addTab(getCwd())}
+            title="New tab (Ctrl+Shift+T)"
+          >
+            <IconPlus />
+          </ToolbarBtn>
+        ) : (
+          <>
+            <ToolbarBtn
+              onClick={() => ctx.addTab(getCwd(), "Claude Code", true)}
+              title="Launch Claude Code (Ctrl+Shift+C)"
+              variant="success"
+            >
+              Claude
+            </ToolbarBtn>
+            <ToolbarBtn
+              onClick={() => ctx.addTab(getCwd(), "Zellij", false, zellijLaunchCommand(themeId, isLightTheme))}
+              title="Launch Zellij (Ctrl+Shift+Z)"
+              variant="primary"
+            >
+              Zellij
+            </ToolbarBtn>
+            <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
+            <ToolbarBtn
+              onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "horizontal"); }}
+              title="Split horizontally (Ctrl+Shift+D)"
+            >
+              <IconSplitH />
+            </ToolbarBtn>
+            <ToolbarBtn
+              onClick={() => { if (ctx.focusedPaneId) ctx.splitPane(ctx.focusedPaneId, "vertical"); }}
+              title="Split vertically (Ctrl+Shift+E)"
+            >
+              <IconSplitV />
+            </ToolbarBtn>
+            <ToolbarBtn
+              onClick={() => ctx.addTab(getCwd())}
+              title="New tab (Ctrl+Shift+T)"
+            >
+              <IconPlus />
+            </ToolbarBtn>
+            <div style={{ width: 1, height: 18, background: "var(--border)", margin: "0 4px" }} />
+            <ThemePickerButton />
+          </>
+        )}
       </div>
     </div>
   );

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -66,6 +66,12 @@ function buildTerminalFontStack(fontFamily: TerminalFontFamily, themeMono: strin
   return `${TERMINAL_FONT_STACKS[fontFamily]}, ${fallback}`;
 }
 
+function displayCwd(cwd: string): string {
+  if (cwd === "projects") return "~/projects";
+  if (cwd.startsWith("projects/")) return `~/${cwd}`;
+  return cwd;
+}
+
 type TerminalServerMessage =
   | { type: "attached"; sessionId: string; state: "running" | "exited"; exitCode: number | null }
   | { type: "output"; data: string; seq: number | null }
@@ -277,6 +283,7 @@ export function TerminalPane({
 
   const handleFocus = useCallback(() => {
     onFocus?.(paneId);
+    (termRef.current as { focus?: () => void } | null)?.focus?.();
   }, [paneId, onFocus]);
 
   useEffect(() => {
@@ -353,45 +360,31 @@ export function TerminalPane({
       let searchAddon: unknown = null;
       let webglAddon: unknown = null;
 
-      const attachWebglContextLostHandler = () => {
-        detachWebglContextLostHandler();
-        const canvas = container.querySelector("canvas");
-        if (!(canvas instanceof HTMLCanvasElement)) {
+      const refitAndFocus = () => {
+        if (disposed) {
           return;
         }
-
-        const onWebglContextLost = async () => {
-          if (disposed) {
-            return;
+        try {
+          fitAddon.fit();
+          if (isFocusedRef.current) {
+            term.focus();
           }
+        } catch (err: unknown) {
+          log("fit-failed", { message: err instanceof Error ? err.message : String(err) });
+        }
+      };
 
-          try {
-            (webglAddon as { dispose?: () => void } | null)?.dispose?.();
-          } catch (_err: unknown) {
-            // Ignore disposal errors and fall back to 2D rendering.
-          }
-
-          try {
-            const { WebglAddon } = await import("@xterm/addon-webgl");
-            if (disposed) {
-              return;
-            }
-            const nextWebglAddon = new WebglAddon();
-            term.loadAddon(nextWebglAddon);
-            webglAddon = nextWebglAddon;
-          } catch (_err: unknown) {
-            // Canvas 2D fallback is acceptable if WebGL re-init fails.
-          }
-        };
-
-        webglCanvasRef.current = canvas;
-        webglContextLostHandlerRef.current = onWebglContextLost;
-        canvas.addEventListener("webglcontextlost", onWebglContextLost);
+      const scheduleStableFit = () => {
+        requestAnimationFrame(refitAndFocus);
+        window.setTimeout(refitAndFocus, 80);
+        window.setTimeout(refitAndFocus, 250);
       };
 
       if (canReuseCachedTerminal && cached) {
         const termElement = (cached.terminal as { element?: HTMLElement }).element;
         if (termElement) {
+          termElement.style.width = "100%";
+          termElement.style.height = "100%";
           container.appendChild(termElement);
         }
         term = cached.terminal;
@@ -405,6 +398,7 @@ export function TerminalPane({
         wsRef.current = cached.ws;
         sessionIdRef.current = cachedRestore.sessionId;
         lastSeqRef.current = cachedRestore.lastSeq;
+        scheduleStableFit();
       } else {
         // Cache miss — create fresh terminal
         const { Terminal: XTerm } = await import("@xterm/xterm");
@@ -435,6 +429,8 @@ export function TerminalPane({
         xterm.open(container);
         const xtermElement = (xterm as { element?: HTMLElement }).element;
         if (xtermElement) {
+          xtermElement.style.width = "100%";
+          xtermElement.style.height = "100%";
           xtermElement.style.fontVariantLigatures = terminalLigatures ? "normal" : "none";
         }
         nextFitAddon.fit();
@@ -443,14 +439,7 @@ export function TerminalPane({
         fitAddon = nextFitAddon;
         termRef.current = xterm;
         fitAddonRef.current = nextFitAddon;
-
-        // WebGL addon
-        try {
-          const { WebglAddon } = await import("@xterm/addon-webgl");
-          const addon = new WebglAddon();
-          xterm.loadAddon(addon);
-          webglAddon = addon;
-        } catch (_e: unknown) { /* canvas 2D fallback */ }
+        scheduleStableFit();
 
         // Search addon
         try {
@@ -537,7 +526,6 @@ export function TerminalPane({
         }
       }
 
-      attachWebglContextLostHandler();
       if (isFocusedRef.current) {
         requestAnimationFrame(() => {
           if (!disposed) {
@@ -931,7 +919,7 @@ export function TerminalPane({
       });
 
       const resizeObserver = new ResizeObserver(() => {
-        fitAddon.fit();
+        requestAnimationFrame(refitAndFocus);
       });
       resizeObserver.observe(container);
 
@@ -1059,8 +1047,24 @@ export function TerminalPane({
         outline: isFocused ? "1px solid var(--primary)" : "none",
         outlineOffset: "-1px",
       }}
+      onPointerDown={handleFocus}
       onClick={handleFocus}
     >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute left-2 top-1 z-10 flex items-center gap-1 rounded bg-background/80 px-1.5 py-0.5 font-mono text-[10px] leading-none text-foreground shadow-sm backdrop-blur-sm"
+      >
+        <span>{displayCwd(cwd)}</span>
+        <span
+          className={isFocused ? "opacity-100" : "opacity-45"}
+          style={{
+            display: "inline-block",
+            width: 5,
+            height: 10,
+            background: "currentColor",
+          }}
+        />
+      </div>
       {authUrl && (
         <div
           style={{

--- a/shell/src/hooks/useCanvasTransform.ts
+++ b/shell/src/hooks/useCanvasTransform.ts
@@ -45,6 +45,7 @@ interface CanvasTransformActions {
   fitAll: (windows: WindowRect[], viewportW: number, viewportH: number) => void;
   focusOnWindow: (win: WindowRect, viewportW: number, viewportH: number) => void;
   setTransform: (zoom: number, panX: number, panY: number) => void;
+  resetForMobileViewport: () => void;
 }
 
 export const useCanvasTransform = create<CanvasTransformState & CanvasTransformActions>()(
@@ -135,5 +136,7 @@ export const useCanvasTransform = create<CanvasTransformState & CanvasTransformA
     },
 
     setTransform: (zoom, panX, panY) => set({ zoom: clampZoom(zoom), panX, panY }),
+
+    resetForMobileViewport: () => set({ zoom: 1, panX: 0, panY: 0, isScrolling: false, isAnimating: false }),
   })),
 );

--- a/shell/src/hooks/useMobileViewport.ts
+++ b/shell/src/hooks/useMobileViewport.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const PHONE_VIEWPORT_MAX_WIDTH = 767;
+
+export function isPhoneViewport(width: number): boolean {
+  return width <= PHONE_VIEWPORT_MAX_WIDTH;
+}
+
+export function useMobileViewport(): boolean {
+  const [mobile, setMobile] = useState(false);
+
+  useEffect(() => {
+    const update = () => setMobile(isPhoneViewport(window.innerWidth));
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  return mobile;
+}

--- a/shell/src/lib/app-launch.ts
+++ b/shell/src/lib/app-launch.ts
@@ -1,0 +1,56 @@
+const SAFE_APP_SLUG = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+const SHIPPED_SVG_ICON_SLUGS = new Set([
+  "calendar",
+  "camera",
+  "chart",
+  "chat",
+  "code",
+  "document",
+  "files",
+  "folder",
+  "game",
+  "globe",
+  "mail",
+  "music",
+  "search",
+  "settings",
+  "terminal",
+  "whiteboard",
+  "workspace",
+]);
+
+export interface GatewayAppEntryLike {
+  path?: string;
+  slug?: string;
+  launchUrl?: string;
+}
+
+export function iconUrlForSlug(slug: string | undefined): string | undefined {
+  if (!slug || !SAFE_APP_SLUG.test(slug)) return undefined;
+  const extension = SHIPPED_SVG_ICON_SLUGS.has(slug) ? "svg" : "png";
+  return `/icons/${encodeURIComponent(slug)}.${extension}`;
+}
+
+function slugFromLaunchUrl(launchUrl: string | undefined): string | null {
+  if (!launchUrl) return null;
+  try {
+    const url = new URL(launchUrl, "http://matrix.local");
+    const match = url.pathname.match(/^\/apps\/([a-z0-9][a-z0-9-]{0,63})\/?$/);
+    return match ? match[1] : null;
+  } catch (_err: unknown) {
+    return null;
+  }
+}
+
+export function canonicalAppLaunchPath(app: GatewayAppEntryLike): string | null {
+  const slug = app.slug && SAFE_APP_SLUG.test(app.slug)
+    ? app.slug
+    : slugFromLaunchUrl(app.launchUrl);
+  if (slug) {
+    return `apps/${slug}/index.html`;
+  }
+
+  if (!app.path) return null;
+  return app.path.replace(/^\/files\//, "");
+}

--- a/shell/src/lib/app-launch.ts
+++ b/shell/src/lib/app-launch.ts
@@ -1,4 +1,5 @@
-const SAFE_APP_SLUG = /^[a-z0-9][a-z0-9-]{0,63}$/;
+export const SAFE_APP_SLUG = /^[a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)*$/;
+const SAFE_ICON_SLUG = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
 const SHIPPED_SVG_ICON_SLUGS = new Set([
   "calendar",
@@ -27,7 +28,7 @@ export interface GatewayAppEntryLike {
 }
 
 export function iconUrlForSlug(slug: string | undefined): string | undefined {
-  if (!slug || !SAFE_APP_SLUG.test(slug)) return undefined;
+  if (!slug || !SAFE_ICON_SLUG.test(slug)) return undefined;
   const extension = SHIPPED_SVG_ICON_SLUGS.has(slug) ? "svg" : "png";
   return `/icons/${encodeURIComponent(slug)}.${extension}`;
 }
@@ -36,7 +37,7 @@ function slugFromLaunchUrl(launchUrl: string | undefined): string | null {
   if (!launchUrl) return null;
   try {
     const url = new URL(launchUrl, "http://matrix.local");
-    const match = url.pathname.match(/^\/apps\/([a-z0-9][a-z0-9-]{0,63})\/?$/);
+    const match = url.pathname.match(/^\/apps\/([a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)*)\/?$/);
     return match ? match[1] : null;
   } catch (_err: unknown) {
     return null;

--- a/shell/src/lib/proxy-routes.ts
+++ b/shell/src/lib/proxy-routes.ts
@@ -23,3 +23,29 @@ export function isGatewayProxyPath(pathname: string): boolean {
     pathname.startsWith("/ws/")
   );
 }
+
+const APP_SESSION_PATH = /^\/apps\/([a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?)(?:\/.*)?$/;
+const MOBILE_SESSION_TOKEN = /^[A-Za-z0-9._~-]{1,4096}$/;
+
+export function isPlatformMobileAppSessionRequest(
+  pathname: string,
+  search: string,
+  cookieHeader: string | null,
+): boolean {
+  const match = APP_SESSION_PATH.exec(pathname);
+  if (!match) return false;
+
+  const slug = match[1];
+  const searchParams = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  const session = searchParams.get("session");
+  if (session && MOBILE_SESSION_TOKEN.test(session)) return true;
+
+  const sessionCookie = `matrix_app_session__${slug}=`;
+  return (cookieHeader ?? "")
+    .split(";")
+    .some((part) => {
+      const cookie = part.trim();
+      if (!cookie.startsWith(sessionCookie)) return false;
+      return MOBILE_SESSION_TOKEN.test(cookie.slice(sessionCookie.length));
+    });
+}

--- a/shell/src/stores/mobile-shell-store.ts
+++ b/shell/src/stores/mobile-shell-store.ts
@@ -1,0 +1,95 @@
+"use client";
+
+export const BROWSER_MOBILE_SHELL_STATE_STORAGE_KEY = "matrix.mobileShellState.v1";
+
+export type BrowserMobileShellSurface = "browser-shell" | "native-mobile";
+export type BrowserMobileShellMode = "launcher" | "app" | "terminal" | "canvas";
+
+export interface BrowserMobileShellState {
+  surface: BrowserMobileShellSurface;
+  mode: BrowserMobileShellMode;
+  lastActiveAppSlug: string | null;
+  lastActiveTerminalSessionId: string | null;
+  canvasEnteredAt: string | null;
+  updatedAt: string;
+}
+
+const MOBILE_SHELL_MODES = new Set<BrowserMobileShellMode>(["launcher", "app", "terminal", "canvas"]);
+const SAFE_APP_SLUG = /^[a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)*$/;
+const SAFE_TERMINAL_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+
+export function createDefaultBrowserMobileShellState(): BrowserMobileShellState {
+  return {
+    surface: "browser-shell",
+    mode: "launcher",
+    lastActiveAppSlug: null,
+    lastActiveTerminalSessionId: null,
+    canvasEnteredAt: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function parseBrowserMobileShellState(value: unknown): BrowserMobileShellState {
+  const fallback = createDefaultBrowserMobileShellState();
+  if (!value || typeof value !== "object") {
+    return fallback;
+  }
+
+  const record = value as Record<string, unknown>;
+  const mode = typeof record.mode === "string" && MOBILE_SHELL_MODES.has(record.mode as BrowserMobileShellMode)
+    ? record.mode as BrowserMobileShellMode
+    : "launcher";
+
+  return {
+    surface: "browser-shell",
+    mode,
+    lastActiveAppSlug: safeAppSlug(record.lastActiveAppSlug),
+    lastActiveTerminalSessionId: safeTerminalSessionId(record.lastActiveTerminalSessionId),
+    canvasEnteredAt: safeIsoTimestamp(record.canvasEnteredAt),
+    updatedAt: safeIsoTimestamp(record.updatedAt) ?? fallback.updatedAt,
+  };
+}
+
+export function loadBrowserMobileShellState(storage: Storage | null = getBrowserStorage()): BrowserMobileShellState {
+  if (!storage) return createDefaultBrowserMobileShellState();
+  try {
+    const raw = storage.getItem(BROWSER_MOBILE_SHELL_STATE_STORAGE_KEY);
+    if (!raw) return createDefaultBrowserMobileShellState();
+    return parseBrowserMobileShellState(JSON.parse(raw));
+  } catch (err) {
+    console.warn("[shell] failed to load mobile shell state", err);
+    return createDefaultBrowserMobileShellState();
+  }
+}
+
+export function saveBrowserMobileShellState(
+  state: BrowserMobileShellState,
+  storage: Storage | null = getBrowserStorage(),
+): void {
+  if (!storage) return;
+  const safeState = parseBrowserMobileShellState(state);
+  storage.setItem(BROWSER_MOBILE_SHELL_STATE_STORAGE_KEY, JSON.stringify(safeState));
+}
+
+function getBrowserStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+function safeAppSlug(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const slug = value.trim().toLowerCase();
+  return SAFE_APP_SLUG.test(slug) ? slug : null;
+}
+
+function safeTerminalSessionId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const sessionId = value.trim();
+  return SAFE_TERMINAL_SESSION_ID.test(sessionId) ? sessionId : null;
+}
+
+function safeIsoTimestamp(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : new Date(timestamp).toISOString();
+}

--- a/shell/src/stores/mobile-shell-store.ts
+++ b/shell/src/stores/mobile-shell-store.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { SAFE_APP_SLUG } from "../lib/app-launch";
+
 export const BROWSER_MOBILE_SHELL_STATE_STORAGE_KEY = "matrix.mobileShellState.v1";
 
 export type BrowserMobileShellSurface = "browser-shell" | "native-mobile";
@@ -15,8 +17,8 @@ export interface BrowserMobileShellState {
 }
 
 const MOBILE_SHELL_MODES = new Set<BrowserMobileShellMode>(["launcher", "app", "terminal", "canvas"]);
-const SAFE_APP_SLUG = /^[a-z0-9][a-z0-9_-]*(?:\/[a-z0-9][a-z0-9_-]*)*$/;
-const SAFE_TERMINAL_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+const SAFE_TERMINAL_SESSION_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function createDefaultBrowserMobileShellState(): BrowserMobileShellState {
   return {

--- a/specs/075-mobile-shell/checklists/requirements.md
+++ b/specs/075-mobile-shell/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Mobile Shell
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 completed on 2026-05-12. No clarification markers remain.
+- The spec includes security, validation, ownership, resource-limit, reconnect, and safe-error requirements because the feature includes authenticated terminal access and realtime session behavior.

--- a/specs/075-mobile-shell/contracts/mobile-shell-api.md
+++ b/specs/075-mobile-shell/contracts/mobile-shell-api.md
@@ -1,0 +1,177 @@
+# Contract: Mobile Shell API
+
+This contract documents the gateway/mobile interactions needed by the 075 mobile shell. Existing PR #99 app-runtime endpoints are included because the plan builds on them.
+
+## Auth
+
+All endpoints require the authenticated Matrix owner session unless marked otherwise. Browser/mobile WebSocket routes must support query-token auth where browser APIs cannot set `Authorization` headers.
+
+## App Inventory
+
+### `GET /api/apps`
+
+Returns owner-visible system and user apps.
+
+Response:
+
+```json
+[
+  {
+    "name": "Notes",
+    "description": "Write notes",
+    "icon": "/icons/notes.png",
+    "category": "Productivity",
+    "slug": "notes",
+    "runtime": "vite",
+    "runtimeState": { "status": "ready" },
+    "launchUrl": "/apps/notes/",
+    "file": "notes/index.html",
+    "path": "/files/apps/notes/index.html"
+  }
+]
+```
+
+Rules:
+
+- Response entries must not expose internal filesystem paths.
+- Unreadable apps are skipped with server-side logs and generic runtime state.
+- Mobile clients must treat this as advisory and handle missing apps during launch.
+
+## App Manifest
+
+### `GET /api/apps/:slug/manifest`
+
+Returns a safe app manifest and runtime state for a safe app slug.
+
+Rules:
+
+- `slug` is validated at the route boundary.
+- Unknown or invalid apps return generic not-found/unavailable responses.
+- Provider, filesystem, and process errors are not returned raw.
+
+## Mobile App Session Bootstrap
+
+### `POST /api/apps/:slug/session-token`
+
+Creates a short-lived mobile app runtime session and returns a launch URL.
+
+Request:
+
+```json
+{}
+```
+
+Response:
+
+```json
+{
+  "token": "one-shot-mobile-session-token",
+  "launchUrl": "/apps/notes/?session=one-shot-mobile-session-token",
+  "expiresAt": 1770000000000
+}
+```
+
+Rules:
+
+- Route uses `bodyLimit`.
+- `slug` is validated.
+- Session token is scoped to the authenticated owner and app slug.
+- Errors are generic to the client and detailed only in server logs.
+
+## Terminal Sessions
+
+### `GET /api/terminal/sessions`
+
+Lists resumable terminal sessions owned by the authenticated user.
+
+Response:
+
+```json
+[
+  {
+    "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+    "cwd": "projects/demo",
+    "state": "running",
+    "createdAt": 1770000000000,
+    "lastAttachedAt": 1770000300000,
+    "attachedClients": 0,
+    "exitCode": null
+  }
+]
+```
+
+Rules:
+
+- Only owner-visible sessions are returned.
+- Ended/stale sessions are either omitted or marked terminal according to gateway cleanup policy.
+- Response is bounded to the gateway terminal session cap unless a future implementation changes and tests that cap.
+
+### `DELETE /api/terminal/sessions/:id`
+
+Intentionally ends a terminal session.
+
+Rules:
+
+- DELETE still uses `bodyLimit`.
+- `id` is validated as a terminal session UUID.
+- Repeat deletes do not resurrect or refresh stale sessions.
+
+## Terminal WebSocket
+
+### `GET /ws/terminal?token=...`
+
+Attaches to an existing or newly created terminal session. Terminal creation happens by sending an `attach` frame with `cwd`; resume happens by sending an `attach` frame with `sessionId`.
+
+Client frames:
+
+```json
+{ "type": "attach", "cwd": "projects/demo", "shell": "/bin/zsh" }
+```
+
+```json
+{ "type": "attach", "sessionId": "550e8400-e29b-41d4-a716-446655440000", "fromSeq": 42 }
+```
+
+```json
+{ "type": "input", "data": "ls\n" }
+```
+
+```json
+{ "type": "resize", "cols": 80, "rows": 24 }
+```
+
+```json
+{ "type": "detach" }
+```
+
+```json
+{ "type": "destroy" }
+```
+
+```json
+{ "type": "ping" }
+```
+
+Server frames:
+
+```json
+{ "type": "attached", "sessionId": "550e8400-e29b-41d4-a716-446655440000", "state": "running" }
+```
+
+```json
+{ "type": "output", "data": "output", "seq": 1 }
+```
+
+```json
+{ "type": "exit", "code": 0 }
+```
+
+Rules:
+
+- Query-token path is explicitly allowlisted for browser/mobile WebSocket auth.
+- Every frame is schema-validated after JSON parsing.
+- Input frame size is bounded to the gateway 64KB limit; phone key/control/paste actions map to bounded `input` frames.
+- Resize is bounded to gateway row/column limits: 1-500 columns and 1-200 rows.
+- Subscriber fan-out remains capped by the gateway session subscriber limit.
+- Per-subscriber send failures are isolated and dead senders are evicted.
+- Attach/auth setup completes before any success frame is sent.

--- a/specs/075-mobile-shell/data-model.md
+++ b/specs/075-mobile-shell/data-model.md
@@ -1,0 +1,110 @@
+# Data Model: Mobile Shell
+
+## Mobile Shell State
+
+Represents the phone-oriented shell state for the authenticated owner.
+
+Fields:
+
+- `surface`: `"browser-shell" | "native-mobile"`
+- `mode`: `"launcher" | "app" | "terminal" | "canvas"`
+- `lastActiveAppSlug`: string or null
+- `lastActiveTerminalSessionId`: string or null
+- `canvasEnteredAt`: ISO timestamp or null
+- `updatedAt`: ISO timestamp
+
+Validation:
+
+- App slugs must match the existing safe app slug rules.
+- Terminal session IDs must be opaque IDs returned by the gateway.
+- State loaded from device storage is advisory; the gateway must revalidate app/session existence before opening.
+
+State transitions:
+
+- `launcher -> app`: user taps an app.
+- `launcher -> terminal`: user opens Terminal.
+- `launcher -> canvas`: user explicitly opens Canvas.
+- `app|terminal|canvas -> launcher`: user taps Home/back-to-launcher.
+- `app -> launcher`: app unavailable or session token cannot be issued.
+
+## Mobile App Surface
+
+Represents one full-screen app opened from the mobile launcher.
+
+Fields:
+
+- `slug`: safe app slug
+- `name`: display name from app inventory or manifest
+- `kind`: `"native" | "runtime"`
+- `launchUrl`: runtime URL or null for native routes
+- `sessionExpiresAt`: epoch milliseconds or null
+- `status`: `"loading" | "ready" | "reconnecting" | "unavailable" | "failed"`
+- `safeMessage`: bounded user-visible message or null
+
+Validation:
+
+- Runtime URLs are produced by the gateway or native route resolver, not typed by the user.
+- Raw gateway/provider errors are logged, not displayed.
+- A stale `launchUrl` must be refreshed through `/api/apps/:slug/session-token`.
+
+## Terminal Session
+
+Represents a user-owned gateway terminal session visible to mobile.
+
+Fields:
+
+- `sessionId`: opaque session ID
+- `title`: optional user/session title
+- `cwd`: owner-scoped working directory, if exposed
+- `processState`: `"running" | "exited"`
+- `attachmentState`: `"attached" | "detached" | "reconnecting" | "failed-to-attach" | "ending"`
+- `createdAt`: epoch milliseconds from the gateway
+- `lastAttachedAt`: epoch milliseconds from the gateway
+- `attachedClients`: non-negative integer
+- `exitCode`: number or null
+
+Validation:
+
+- Session ownership is checked server-side for every list/resume/end/write action.
+- CWD must be validated with existing owner-home path helpers before session creation.
+- Session registries must remain bounded and evict stale or exited entries according to gateway policy.
+
+State transitions:
+
+- `attached -> detached`: mobile browser/app disconnects or user backgrounds without ending.
+- `detached -> attached`: user resumes the session.
+- `attached|detached -> ending`: user intentionally ends the session.
+- `running -> exited`: shell process exits.
+- `attached|detached -> failed-to-attach`: attach fails while the server session remains recoverable or is reported missing.
+
+## Terminal Control Action
+
+Represents one phone control bar action sent to a terminal session.
+
+Fields:
+
+- `type`: `"attach" | "input" | "resize" | "detach" | "destroy" | "ping"`
+- `sessionId`: opaque terminal session ID
+- `payload`: per-type bounded payload
+
+Validation:
+
+- Use a Zod discriminated union at the route/WebSocket boundary.
+- Input payloads have byte limits; phone key/control/paste actions are translated to bounded `input` frames.
+- Key/control values are allowlisted.
+- Resize values are bounded positive integers.
+
+## Canvas Access State
+
+Represents explicit mobile Canvas entry.
+
+Fields:
+
+- `enteredFrom`: `"launcher" | "app" | "terminal"`
+- `previousMode`: previous mobile shell mode
+- `enteredAt`: ISO timestamp
+
+Validation:
+
+- Canvas access is a user action, not the phone default.
+- Returning home always resolves to launcher mode, not a panned/zoomed trapped Canvas state.

--- a/specs/075-mobile-shell/plan.md
+++ b/specs/075-mobile-shell/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Mobile Shell
+
+**Branch**: `075-mobile-shell` | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/075-mobile-shell/spec.md`
+
+## Summary
+
+Build the phone-first Matrix shell on top of PR #99 (`feat(mobile): add app runtime experience`). PR #99 is now merged into this branch and provides the first mobile app launcher, app inventory client, app detail/runtime screens, WebView app frame, mobile app session-token bootstrap, and tests around app discovery helpers. The remaining 075 work should turn that baseline into the product-level mobile shell from the spec: launcher-first phone home, full-screen active app surfaces, explicit Canvas access, first-party mobile terminal sessions with resume/detach/end controls, safe error states, and mobile-specific validation.
+
+## Technical Context
+
+**Language/Version**: TypeScript strict, ES modules, Node.js 24+ for gateway; React 19, React Native 0.83, Expo Router 55 for mobile shell
+**Primary Dependencies**: Hono gateway, Zod 4 via `zod/v4`, existing terminal stack (`node-pty`, `@xterm/xterm` on web), Expo Router, React Native WebView, Clerk Expo, AsyncStorage/SecureStore
+**Storage**: Owner-controlled Matrix home files for shell/terminal session metadata (`~/system/terminal-sessions.json`, terminal layout files) plus existing owner Postgres where current workspace/app data already lives. No new embedded database or ORM.
+**Testing**: Vitest for gateway/shell integration, Jest Expo for `apps/mobile`, existing pattern scanner, targeted mobile component/client tests
+**Target Platform**: Phone-sized browser shell, native/Expo mobile app, and existing VPS-native gateway/runtime services
+**Project Type**: Shell frontend plus mobile app plus gateway/runtime integration
+**Performance Goals**: Launcher usable within 20 seconds after sign-in; app open transition under 1 second after inventory/session-token resolution on a healthy gateway; terminal reconnect state visible within 2 seconds of WebSocket close; terminal input submitted immediately to the open WebSocket without UI blocking
+**Constraints**: No SSH keys for users; phone launcher is default on phone-sized surfaces; Canvas remains explicit access; all mutating endpoints need `bodyLimit`; external calls and mobile client fetches need finite timeouts; WebSocket messages require schema validation and ownership checks; no raw provider/internal errors in user-visible mobile states
+**Scale/Scope**: One authenticated owner session per mobile client, up to the existing gateway cap of 10 live terminal sessions per owner runtime, up to 10 subscribers per terminal session, and cleanup through existing terminal TTL/eviction policy
+
+## Existing Baseline From PR #99
+
+PR #99 was incorporated by fast-forwarding this branch to `522e031c`.
+
+Included baseline:
+
+- `apps/mobile/app/(tabs)/apps.tsx` lists native and remote Matrix apps.
+- `apps/mobile/app/runtime/[...slug].tsx` opens remote apps through a mobile session token.
+- `apps/mobile/components/AppRuntimeFrame.tsx` embeds runtime apps in a full-screen WebView.
+- `apps/mobile/lib/apps.ts` merges native app entries with gateway inventory and resolves native/runtime routes.
+- `apps/mobile/lib/gateway-client.ts` calls `/api/apps`, `/api/apps/:slug/manifest`, and `/api/apps/:slug/session-token`.
+- Gateway app runtime session endpoints and tests already exist around `/api/apps/:slug/session-token`.
+
+Known gaps to close in 075 tasks:
+
+- Mobile app launcher exists as a tab, but the spec needs it to be the phone default home and active-app surface in both `apps/mobile` and phone-sized `shell/` sessions.
+- Runtime app state is not yet a durable mobile shell state model with last-active-app resume and safe unavailable-app fallback.
+- Mobile Terminal is not yet a first-party phone experience with list/create-via-attach/resume/detach/end and special-key controls over the existing gateway terminal protocol.
+- Mobile gateway client calls currently need hardening against 075 safety rules: timeouts, safe user-facing errors, bounded payload handling, and no silent catch paths.
+- Canvas access is not yet specified as an explicit mobile shell surface with a reliable return-to-launcher path.
+- PR #99's current CI baseline is not fully green: unit shards 1/4 and 2/4 fail in Symphony/workspace tests unrelated to the mobile runtime. Clear those before treating the merged baseline as review-ready.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Data Belongs to Its Owner**: PASS. Mobile shell state and terminal metadata stay in owner-controlled Matrix runtime state/files; app/workspace data remains in the existing owner data stores.
+- **AI Is the Kernel**: PASS. This feature exposes shell and terminal surfaces; it does not bypass kernel routing for AI workflows.
+- **Headless Core, Multi-Shell**: PASS. Mobile becomes a first-class renderer over existing gateway/app/terminal capabilities instead of moving core logic into the UI.
+- **Defense in Depth**: PASS WITH REQUIRED TASKS. Auth, route validation, body limits, WebSocket schemas, finite timeouts, bounded registries, and safe errors must be explicit task outputs.
+- **TDD**: PASS WITH REQUIRED TASKS. Remaining work starts with focused Jest/Vitest coverage for launcher defaulting, mobile app resume, terminal session lifecycle, WebSocket frame validation, and safe error behavior.
+- **Quality Over Shortcuts**: PASS. The plan builds on the existing Expo/React Native app and Matrix gateway; no bare HTML or throwaway mobile shell.
+- **Postgres/Kysely only for new persistence**: PASS. No new persistence engine is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/075-mobile-shell/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── mobile-shell-api.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/mobile/
+├── app/
+│   ├── (tabs)/apps.tsx
+│   ├── apps/[...slug].tsx
+│   ├── runtime/[...slug].tsx
+│   └── terminal/
+├── components/
+├── lib/
+│   ├── apps.ts
+│   ├── gateway-client.ts
+│   └── mobile-shell-state.ts
+└── __tests__/
+
+shell/src/
+├── components/
+│   ├── Desktop.tsx
+│   ├── AppViewer.tsx
+│   ├── canvas/CanvasWindow.tsx
+│   └── terminal/
+├── hooks/
+└── stores/
+
+packages/gateway/src/
+├── server.ts
+├── auth.ts
+├── session-registry.ts
+└── app-runtime/
+
+tests/gateway/
+├── terminal-ws.test.ts
+├── terminal-zellij-ws.test.ts
+└── app-runtime-phase1.test.ts
+```
+
+**Structure Decision**: Keep native mobile-specific screens in `apps/mobile`, add phone-sized browser shell behavior in `shell/src`, reuse existing gateway app-runtime and terminal session registries, and avoid adding new terminal endpoints unless the existing `GET/DELETE /api/terminal/sessions` plus `/ws/terminal` attach protocol cannot satisfy the mobile UX.
+
+## Phase 0: Research
+
+See [research.md](./research.md).
+
+## Phase 1: Design And Contracts
+
+See [data-model.md](./data-model.md), [quickstart.md](./quickstart.md), and [contracts/mobile-shell-api.md](./contracts/mobile-shell-api.md).
+
+## Phase 2: Task Generation Notes
+
+Tasks should be generated as test-first vertical slices:
+
+1. Clear the PR #99 CI regressions in the Symphony/workspace tests so the branch has a trustworthy baseline.
+2. Harden PR #99 app discovery/runtime baseline with mobile client timeouts, safe errors, and tests.
+3. Make the launcher the phone default home in both `apps/mobile` and phone-sized `shell/` sessions, then model active app/resume state.
+4. Add explicit Canvas entry/exit behavior for mobile browser shell and native mobile entry points where available.
+5. Add mobile terminal lifecycle client state and tests around the existing terminal REST list/delete endpoints and WebSocket attach/input/resize/detach/destroy protocol.
+6. Add the terminal UI: session picker, full-screen terminal, special-key bar, reconnect/resume states.
+7. Run review gates: `bun run check:patterns`, focused mobile Jest tests, focused gateway Vitest tests, and then broader typecheck/test gates when dependencies are installed.
+
+## Complexity Tracking
+
+No constitution violations are currently justified.

--- a/specs/075-mobile-shell/quickstart.md
+++ b/specs/075-mobile-shell/quickstart.md
@@ -1,0 +1,172 @@
+# Quickstart: Mobile Shell
+
+## Baseline
+
+PR #99 is merged into `075-mobile-shell`; the current mobile app already has app discovery and runtime routes.
+
+PR #99 baseline cleanup for 075:
+
+- CI Unit Tests (1/4) failed in `tests/shell/workspace-app.test.tsx` because the duplicate-session test compared a JSON request body as an order-sensitive string after the request payload gained `worktreeId`/`pr` preservation.
+- CI Unit Tests (2/4) failed in `tests/shell/symphony-app-source.test.ts` because the guard expected the old `saveConfig` callback signature without the explicit `Promise<boolean>` return type.
+- Fixed locally on 2026-05-12 and validated with:
+
+```bash
+bun run test tests/shell/workspace-app.test.tsx tests/shell/symphony-app-source.test.ts
+```
+
+Result: 2 test files passed, 10 tests passed.
+
+## Local Setup
+
+```bash
+pnpm install
+bun run dev:gateway
+bun run dev:shell
+pnpm --dir apps/mobile start
+```
+
+Use an authenticated Matrix session in both a phone-sized browser viewport and a mobile simulator/device. Production customer runtime remains VPS-native; do not use Docker as the production deployment path for this feature.
+
+## Focused Validation
+
+Run the mobile app tests that cover PR #99 helpers and the new 075 mobile shell behavior:
+
+```bash
+pnpm --dir apps/mobile test -- apps.test.ts gateway-client.test.ts
+```
+
+Run focused gateway terminal/app-runtime tests:
+
+```bash
+bun run test tests/gateway/app-runtime-phase1.test.ts tests/gateway/terminal-ws.test.ts tests/gateway/terminal-zellij-ws.test.ts
+```
+
+Foundation and US1 MVP validation on 2026-05-12:
+
+```bash
+pnpm --dir apps/mobile exec jest --runInBand __tests__/apps.test.ts __tests__/gateway-client.test.ts __tests__/mobile-shell-state.test.ts
+bun run test tests/shell/mobile-shell.test.tsx tests/shell/mobile-shell-state.test.ts
+bun run test tests/gateway/app-runtime-phase1.test.ts
+```
+
+Result: mobile Jest slice passed 3 suites / 39 tests; browser shell Vitest slice passed 2 files / 9 tests; gateway app-runtime contract passed 1 file / 12 tests.
+
+Additional validation:
+
+```bash
+bun run typecheck
+pnpm --dir shell exec tsc --noEmit
+pnpm --dir apps/mobile exec tsc --noEmit
+bun run check:patterns
+git diff --check
+```
+
+Result: typecheck commands passed; pattern scanner reported 0 violations and existing warnings requiring manual review; diff whitespace check passed.
+
+Live browser-shell hardening validation on 2026-05-13:
+
+```bash
+bun run test tests/shell/terminal-app-component.test.tsx tests/shell/mobile-shell.test.tsx tests/shell/user-button-hydration.test.tsx tests/shell/app-launch.test.ts tests/shell/app-viewer-slug.test.ts
+pnpm --dir shell exec tsc --noEmit
+bun run check:patterns
+```
+
+Result: browser shell Vitest slice passed 5 files / 21 tests; shell TypeScript check passed; pattern scanner reported 0 violations and existing warnings requiring manual review.
+
+Live terminal and app-route smoke checks on 2026-05-13:
+
+```bash
+# Terminal WebSocket via shell preview
+node -e '/* connect ws://127.0.0.1:4121/ws/terminal?cwd=projects, send attach, assert prompt includes ~/projects */'
+
+# Runtime app route after app session minting
+curl -sS -c /tmp/backgammon.cookies -b /tmp/backgammon.cookies -X POST http://127.0.0.1:4121/api/apps/backgammon/session
+curl -sS -b /tmp/backgammon.cookies http://127.0.0.1:4121/apps/backgammon/
+```
+
+Result: terminal WebSocket connected, attached, and emitted `deploy@ubuntu-16gb-matrix-1:~/projects$`; Backgammon served built `assets/...` HTML. Detached preview terminal sessions were cleared when the gateway session cap was reached during smoke testing.
+
+Native mobile terminal and Expo 54 validation on 2026-05-13:
+
+```bash
+pnpm --dir apps/mobile exec jest --runInBand
+pnpm --dir apps/mobile exec tsc --noEmit
+pnpm --dir apps/mobile install --lockfile-only
+```
+
+Result: native mobile Jest passed 19 suites / 145 tests; mobile TypeScript check passed; package manifest and root lockfile now resolve the mobile app on Expo SDK 54, React Native 0.81, and React 19.1. The first offline lockfile refresh lacked cached package metadata, so the lockfile-only refresh was rerun with registry access.
+
+Terminal and browser-shell regression validation on 2026-05-13:
+
+```bash
+bun run test tests/gateway/terminal-ws.test.ts
+bun run test tests/shell/terminal-app-component.test.tsx tests/shell/mobile-shell.test.tsx tests/shell/user-button-hydration.test.tsx tests/shell/app-launch.test.ts tests/shell/app-viewer-slug.test.ts
+pnpm --dir shell exec tsc --noEmit
+pnpm --dir apps/mobile exec tsc --noEmit
+bun run typecheck
+bun run check:patterns
+git diff --check
+```
+
+Result: gateway terminal contract passed 1 file / 33 tests; browser shell slice passed 5 files / 21 tests; shell and mobile TypeScript checks passed; root typecheck passed; pattern scanner reported 0 violations with existing warnings requiring manual review; diff whitespace check passed.
+
+Real mobile resume and Canvas validation on 2026-05-14:
+
+```bash
+pnpm --dir apps/mobile exec jest --runInBand __tests__/apps.test.ts __tests__/apps-screen.test.tsx __tests__/terminal-screen.test.tsx __tests__/canvas-entry.test.tsx __tests__/mobile-shell-state.test.ts
+bun run test tests/shell/mobile-shell.test.tsx tests/shell/mobile-canvas.test.tsx tests/shell/mobile-shell-state.test.ts
+```
+
+Result: native mobile focused slice passed 5 suites / 27 tests; browser mobile shell and Canvas slice passed 3 files / 15 tests. These cover rendered launcher resume, terminal resume/recovery, native Canvas unavailable entry, explicit browser Canvas entry/return, stale Canvas pan/zoom reset, and persisted mobile state validation.
+
+Final focused readiness validation on 2026-05-14:
+
+```bash
+pnpm --dir apps/mobile exec jest --runInBand
+bun run test tests/shell/terminal-app-component.test.tsx tests/shell/mobile-shell.test.tsx tests/shell/mobile-canvas.test.tsx tests/shell/user-button-hydration.test.tsx tests/shell/app-launch.test.ts tests/shell/app-viewer-slug.test.ts
+bun run test tests/gateway/terminal-ws.test.ts
+pnpm --dir apps/mobile exec tsc --noEmit
+pnpm --dir shell exec tsc --noEmit
+bun run typecheck
+bun run check:patterns
+git diff --check
+```
+
+Result: native mobile Jest passed 21 suites / 151 tests; browser shell slice passed 6 files / 26 tests; gateway terminal contract passed 1 file / 33 tests; mobile, shell, and root TypeScript checks passed; pattern scanner reported 0 violations with 5 existing warning groups requiring manual review; diff whitespace check passed.
+
+Full root suite status on 2026-05-13:
+
+```bash
+bun run test
+```
+
+Result: not green. Vitest completed with 396 files passed, 11 failed, 3 skipped; 4488 tests passed, 36 failed, 20 skipped. Failures were outside the focused 075 mobile-shell path:
+
+- `tests/gateway/voice/tts/fallback.test.ts`: edge-tts mock expectations were not reached.
+- `tests/platform/orchestrator.test.ts`: `getaddrinfo EAI_AGAIN db` while exercising platform database orchestration.
+- `tests/gateway/sync/r2-client.test.ts`: AWS presigner mock path did not intercept `getSignedUrl`.
+- `tests/integrations/actions.test.ts` and `tests/integrations/pipedream.test.ts`: live Pipedream SDK returned 401 `invalid_client`.
+- `tests/mcp-browser/server.test.ts`: Playwright persistent-context mock expectations were not reached.
+- Existing shell Canvas/Menu/Preferences/Workspace Canvas suites still hit a shared Zustand/React hook-dispatch test-runner issue when rendered directly in root Vitest.
+- `tests/gateway/auth-jwt-cache.test.ts`: jose key-import error text/fixture behavior differs from the test expectation.
+
+Run review gates before PR review:
+
+```bash
+bun run check:patterns
+bun run typecheck
+bun run test
+```
+
+## Manual Mobile Checks
+
+1. Open Matrix on a phone-sized viewport after sign-in.
+2. Confirm the launcher is the first usable phone shell surface.
+3. Repeat the same entry check in the native mobile app when testing the Expo surface.
+4. Open a native mobile screen from the launcher and return home.
+5. Open a runtime app and confirm it fills the usable screen.
+6. Refresh/background the mobile shell and confirm the last app is recoverable.
+7. Open Terminal, create a session, send commands, detach, reload, resume, and intentionally end the session.
+8. Send Escape, Tab, arrows, Control combinations, paste, and resize/font actions from the phone controls.
+9. Enter Canvas explicitly and return to the launcher.
+10. Force app/session failures and confirm only safe, generic recovery messages are shown.

--- a/specs/075-mobile-shell/quickstart.md
+++ b/specs/075-mobile-shell/quickstart.md
@@ -158,6 +158,15 @@ bun run typecheck
 bun run test
 ```
 
+Native Expo Go smoke validation on 2026-05-14:
+
+```bash
+export EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=<clerk-publishable-key>
+pnpm --dir apps/mobile exec expo start --tunnel --clear
+```
+
+Result: the Expo Go crash path was traced to SDK 54 native package drift and missing mobile auth configuration. `react-native-worklets` is pinned to `0.5.1`, `react-native-webview` is pinned to `13.15.0`, and the root mobile layout now passes `publishableKey` to `ClerkProvider` or shows a safe setup screen instead of throwing. `pnpm --dir apps/mobile exec tsc --noEmit`, the focused native mobile Jest slice, and `pnpm --dir apps/mobile exec expo export --platform ios --clear` passed after the fix. Expo Go still warns that remote push notifications from `expo-notifications` require a development build; that is expected and does not block launcher, chat, terminal, or runtime-app testing.
+
 ## Manual Mobile Checks
 
 1. Open Matrix on a phone-sized viewport after sign-in.

--- a/specs/075-mobile-shell/research.md
+++ b/specs/075-mobile-shell/research.md
@@ -1,0 +1,54 @@
+# Research: Mobile Shell
+
+## Decision: Build on PR #99 instead of re-planning app runtime from scratch
+
+**Rationale**: PR #99 already adds the mobile app inventory screen, native/runtime route resolution, app detail/runtime screens, WebView frame, app session token endpoint usage, and baseline app tests. The 075 plan should treat that as the existing implementation floor and focus remaining work on product behavior, terminal support, and safety hardening.
+
+**Alternatives considered**:
+
+- Rebuild the mobile launcher from the spec alone. Rejected because it would duplicate working PR #99 code and delay terminal/resume work.
+- Merge only selected files from PR #99. Rejected because PR #99 is based on this branch's previous HEAD, is mergeable, and the mobile runtime pieces are interdependent.
+
+## Decision: Mobile shell state stays in existing mobile storage plus owner runtime state
+
+**Rationale**: Last active app, explicit Canvas entry, and mobile UI preferences are shell state. On-device state can use the existing mobile storage helpers for fast resume, while server-authoritative terminal sessions remain in the gateway `SessionRegistry` and owner-controlled Matrix home files.
+
+**Alternatives considered**:
+
+- Add a new mobile database. Rejected by the Postgres/Kysely-only rule and because the state is small.
+- Store all active-app state only in the gateway. Rejected because phone resume should be fast and resilient to short offline windows, while still validating server availability when opening an app.
+
+## Decision: Mobile Terminal reuses the gateway terminal session registry
+
+**Rationale**: The gateway already owns durable terminal session metadata, shell process lifecycle, `/ws/terminal`, and `/api/terminal/sessions`. Mobile should expose this instead of creating a separate SSH-like path. This preserves the "no SSH keys" invariant and keeps ownership on the user's VPS.
+
+**Alternatives considered**:
+
+- SSH from the mobile app to the VPS. Rejected because the spec explicitly removes SSH key management from the user path.
+- A separate mobile-only terminal daemon. Rejected because it would duplicate session lifecycle, auth, cleanup, and audit concerns already handled by the gateway.
+
+## Decision: Terminal input should use a native phone control bar plus validated WebSocket frames
+
+**Rationale**: Mobile users need Escape, Tab, arrows, Control combinations, paste, font controls, and session switching without an external keyboard. The UI can map these controls to bounded terminal WebSocket messages that reuse existing gateway validation and ownership checks.
+
+**Alternatives considered**:
+
+- Depend on the mobile soft keyboard alone. Rejected because common terminal keys are missing or awkward.
+- Expose raw arbitrary action payloads. Rejected because the review rules require per-action payload schemas.
+
+## Decision: Canvas remains available but explicit on phone-sized layouts
+
+**Rationale**: Canvas is core Matrix shell behavior, but phone default should be launcher-first. Mobile should provide a clear Canvas entry point and return-to-launcher path while preserving existing desktop/tablet Canvas behavior.
+
+**Alternatives considered**:
+
+- Keep Canvas as the default everywhere. Rejected by the mobile spec and phone usability goals.
+- Remove Canvas from mobile. Rejected because Canvas remains a first-class shell and should be available when useful.
+
+## Decision: Harden PR #99 mobile gateway calls before building more surfaces on them
+
+**Rationale**: `apps/mobile/lib/gateway-client.ts` is now the mobile trust boundary for app discovery, app runtime, tasks, chat, profile, and push registration. 075 tasks must add timeout wrappers, generic user-visible errors, typed response parsing where needed, and tests for failed/slow calls.
+
+**Alternatives considered**:
+
+- Rely on platform fetch defaults. Rejected because the Matrix review rules require finite timeouts for external calls and safe error handling.

--- a/specs/075-mobile-shell/spec.md
+++ b/specs/075-mobile-shell/spec.md
@@ -1,0 +1,170 @@
+# Feature Specification: Mobile Shell
+
+**Feature Branch**: `075-mobile-shell`
+**Created**: 2026-05-12
+**Status**: Draft
+**Input**: User description: "Users will not have SSH keys to their Matrix VPS. Make Matrix shell easy on mobile: a phone-first shell that shows an app launcher instead of the canvas, opens selected apps full-screen like iOS, keeps Canvas working where appropriate, and provides a first-party mobile terminal experience comparable to Termius inside Matrix."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Launch Apps From Mobile Home (Priority: P1)
+
+As a Matrix user on a phone, I want Matrix to open to a familiar app launcher so I can choose an app without navigating a desktop canvas.
+
+**Why this priority**: This is the primary mobile entry point. If users land on a spatial desktop that is hard to pan, zoom, or inspect on a phone, every mobile workflow starts with friction.
+
+**Independent Test**: Can be tested by signing in on a phone-sized viewport, verifying the launcher is the first usable shell surface, selecting any app, and confirming it opens as the active full-screen experience.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated user opens Matrix on a phone-sized screen with no active app selected, **When** the shell loads, **Then** the user sees a launcher with available system and user apps.
+2. **Given** the launcher is visible, **When** the user selects an app, **Then** the launcher closes and the selected app fills the usable screen.
+3. **Given** an app is open full-screen, **When** the user returns home, **Then** the launcher appears without losing the app's recoverable state.
+
+---
+
+### User Story 2 - Use Terminal Without SSH Keys (Priority: P1)
+
+As a Matrix user on a phone, I want to open a terminal through Matrix using my normal Matrix session so I can run commands on my VPS without managing SSH keys.
+
+**Why this priority**: The mobile terminal is the power-user path and the alternative to third-party SSH apps. It must be useful without exposing SSH as a user-facing requirement.
+
+**Independent Test**: Can be tested by signing in on a phone-sized viewport, opening Terminal from the launcher, running a command, backgrounding or reloading the page, and confirming the session can be reattached.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated user opens Terminal from the mobile launcher, **When** the terminal starts, **Then** the user can type commands into a persistent shell session without providing an SSH key.
+2. **Given** a terminal command is still running, **When** the mobile browser disconnects, sleeps, or reloads, **Then** reopening Terminal offers to resume the running session instead of silently killing it.
+3. **Given** the user needs non-letter terminal input, **When** they use the terminal controls, **Then** they can send common keys such as Escape, Control combinations, Tab, arrows, and paste.
+
+---
+
+### User Story 3 - Resume Recent Mobile Work (Priority: P2)
+
+As a Matrix user who switches apps often on mobile, I want Matrix to remember my last active app and terminal sessions so I can return to work quickly.
+
+**Why this priority**: Mobile sessions are frequently interrupted by app switching, browser tab eviction, network changes, and screen lock.
+
+**Independent Test**: Can be tested by opening an app and a terminal session, leaving Matrix, returning later, and confirming Matrix presents the most relevant resume choices.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user had an app open, **When** they return to Matrix on the same phone, **Then** Matrix restores or offers the last active app before making the user search the launcher again.
+2. **Given** the user has multiple terminal sessions, **When** they open Terminal, **Then** they can choose an existing session or create a new one.
+3. **Given** a restored app is no longer available, **When** Matrix attempts to resume it, **Then** the user sees a safe fallback that returns them to the launcher.
+
+---
+
+### User Story 4 - Access Canvas When It Helps (Priority: P3)
+
+As a Matrix user, I want Canvas to remain available on mobile when I explicitly choose it, while the default phone experience stays launcher-and-app focused.
+
+**Why this priority**: Canvas is a core Matrix shell, but it is not the best default for small screens. Keeping it accessible preserves power-user workflows without making every mobile user manage spatial navigation.
+
+**Independent Test**: Can be tested by switching from the mobile launcher into Canvas on a phone-sized viewport and confirming the user can return to the launcher.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the mobile launcher, **When** they explicitly open Canvas, **Then** Canvas appears as a selectable shell surface rather than the default mobile home.
+2. **Given** Canvas is open on mobile, **When** the user chooses to return home, **Then** Matrix returns to the launcher without losing open app records.
+
+### Edge Cases
+
+- Phone viewport rotates while an app or terminal is open; the active surface must resize without forcing a reload or losing typed-but-unsent terminal input.
+- Browser address bar, safe areas, and virtual keyboard reduce usable height; the active app and terminal controls must remain reachable.
+- Network disconnects during terminal use; the user must see reconnect or resume state without duplicate command submission.
+- A terminal session exits while the phone is asleep; returning to Terminal must show the exited state and offer a new session path.
+- The user opens a desktop-sized viewport on a tablet or foldable device; Matrix may use Canvas by default when there is enough room, but phone-sized layouts must remain launcher-first.
+- An app cannot be loaded, is missing, or requires a refreshed session; the shell must show a generic recovery path and return to the launcher.
+- Multiple browser tabs open Matrix on the same phone; session state must avoid confusing duplicate active-app or terminal ownership messages.
+- The same user opens Matrix through the browser shell and the native mobile app; both surfaces must use the same owner-scoped app and terminal inventory without corrupting each other's resume state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Matrix MUST provide a phone-first shell surface that uses a launcher as the default home on phone-sized screens.
+- **FR-002**: The launcher MUST show system apps and user-created apps in a tappable, scan-friendly layout with clear app identity and open-state indication.
+- **FR-003**: Selecting an app from the mobile launcher MUST open that app as a single active full-screen surface.
+- **FR-004**: The mobile shell MUST provide a home/back path from any full-screen app back to the launcher.
+- **FR-005**: The mobile shell MUST preserve recoverable app state when switching between launcher and full-screen app surfaces.
+- **FR-006**: Terminal MUST be available from the mobile launcher as a first-party Matrix app.
+- **FR-007**: Mobile Terminal MUST allow authenticated users to create, list, resume, detach from, and intentionally end terminal sessions without requiring SSH keys.
+- **FR-008**: Mobile Terminal MUST keep server-side terminal sessions running across mobile browser reloads, sleep, short network interruptions, and app switching unless the user explicitly ends the session.
+- **FR-009**: Mobile Terminal MUST provide phone-friendly controls for Escape, Tab, arrow keys, Control-key combinations, paste, session switching, and font sizing.
+- **FR-010**: Mobile Terminal MUST show clear connection, reconnecting, resumed, exited, and failed-to-attach states using user-safe messages.
+- **FR-011**: The mobile shell MUST avoid using Canvas as the default phone home while still allowing users to explicitly open Canvas.
+- **FR-012**: Canvas on mobile MUST provide a reliable return path to the launcher and must not trap users in a zoomed or panned state.
+- **FR-013**: The mobile shell MUST adapt to portrait, landscape, safe-area insets, browser chrome changes, and virtual keyboard visibility without hiding primary controls.
+- **FR-014**: The mobile shell MUST remember the user's last active mobile app and recent terminal sessions for resume.
+- **FR-015**: The mobile shell MUST prevent unauthenticated access to apps, terminal sessions, and shell state.
+- **FR-016**: Terminal access MUST be scoped to the authenticated owner's Matrix VPS environment and must not expose SSH credentials, private keys, provider tokens, internal paths, or raw upstream errors to the user.
+- **FR-017**: Realtime terminal communication MUST validate message shape, size, session ownership, and allowed actions before input reaches a session.
+- **FR-018**: Terminal and shell session collections MUST have clear limits, stale-session handling, and explicit cleanup behavior for ended sessions.
+- **FR-019**: Mobile shell errors MUST provide safe recovery actions, such as retry, resume, new session, return home, or reopen app.
+- **FR-020**: Mobile shell behavior MUST be testable independently from desktop Canvas behavior so regressions in one shell do not mask regressions in the other.
+- **FR-021**: The phone-first shell behavior MUST apply to phone-sized browser shell sessions and to the native mobile app runtime where that runtime is available.
+- **FR-022**: App runtime launch from mobile MUST use short-lived, owner-scoped session bootstrap tokens or equivalent authenticated session handoff, without exposing reusable credentials to embedded apps.
+- **FR-023**: Terminal resume MUST distinguish server terminal process state from mobile attachment state so a browser/app disconnect detaches the client without implying that the shell process exited.
+
+### Key Entities
+
+- **Mobile Shell State**: The user's phone-oriented shell preferences, active surface, last active app, and launcher/home state.
+- **Mobile App Surface**: A full-screen instance of a system or user app opened from the mobile launcher, including its title, identity, loading state, and recoverable open state.
+- **Terminal Session**: A user-owned shell process record that may be running or exited and can be intentionally destroyed by the owner.
+- **Terminal Attachment State**: The current mobile client's relationship to a terminal session, including attached, detached, reconnecting, failed-to-attach, and intentionally ended states.
+- **Terminal Control Bar**: The mobile-only control set for special keys, paste, session switching, and display adjustments.
+- **Canvas Access State**: Whether the user has explicitly entered Canvas on mobile and the route back to the mobile launcher.
+
+### Assumptions
+
+- Phone-sized screens should default to launcher-and-full-screen app behavior; larger tablet and desktop screens may keep Canvas as the primary shell.
+- Users authenticate through the existing Matrix sign-in path; no SSH credential setup is part of the user-facing mobile terminal flow.
+- A short mobile disconnect should be treated as an expected interruption, not as intent to end a terminal session.
+- The launcher should reuse the same app inventory users already see elsewhere in Matrix, rather than introducing a separate mobile-only app list.
+- Canvas remains a first-class shell, but mobile defaults optimize for repeated daily use on small screens.
+- The existing gateway terminal protocol may remain the server contract; mobile-specific controls can translate to the existing validated terminal frame shapes.
+
+## Security Architecture *(mandatory for endpoints/WebSockets)*
+
+### Auth Matrix
+
+| Surface | Operation | Auth requirement | Public? | Notes |
+|---------|-----------|------------------|---------|-------|
+| Phone browser shell | Load mobile launcher, app surfaces, Canvas entry | Existing Matrix shell authentication | No | Phone-sized layout changes must not bypass normal shell auth. |
+| Native mobile app | Connect to owner's gateway | Existing Matrix mobile authentication and gateway token handling | No | Mobile app stores only user-session material required by existing auth flow. |
+| `GET /api/apps` and app manifest reads | List/open owner-visible apps | Authenticated owner session | No | App inventory remains owner-scoped and safe for mobile display. |
+| App runtime session bootstrap | Launch embedded runtime apps | Authenticated owner session plus short-lived app-scoped handoff | No | Handoff token/cookie must be scoped to app slug and owner session. |
+| `GET /api/terminal/sessions` | List resumable terminal sessions | Authenticated owner session | No | Response must be bounded and owner-scoped. |
+| `DELETE /api/terminal/sessions/:id` | Intentionally end a terminal session | Authenticated owner session | No | DELETE is mutating and still needs body limits and session ID validation. |
+| `/ws/terminal` | Attach/create/resume/detach terminal streams | Authenticated owner session; query-token path allowed for browser/mobile WebSocket APIs | No | Setup/auth must complete before success frames are sent. |
+
+### Input Validation And Resource Limits
+
+- Phone shell route state MUST validate app slugs, terminal session IDs, shell modes, query params, and resume targets before use.
+- Terminal WebSocket frames MUST use the existing Zod-validated gateway protocol or a stricter mobile adapter that maps to it.
+- Terminal input and paste payloads MUST remain bounded; resize values MUST stay within gateway bounds.
+- Mobile terminal UX MUST respect the gateway's current terminal caps unless the implementation deliberately changes and tests them: 10 live sessions per owner runtime, 10 subscribers per terminal session, 64KB maximum input frame, 500 maximum columns, and 200 maximum rows.
+- Mutating HTTP endpoints, including DELETE, MUST use `bodyLimit` even when no body is expected.
+- App/session collections exposed to mobile MUST be capped, stable-sorted, and safe under multiple tabs or reconnects.
+
+### Error Policy And Failure Modes
+
+- Client-visible errors MUST be generic and recovery-oriented; raw provider errors, internal paths, database errors, tokens, or process details must stay in server logs.
+- App runtime launch failure MUST offer retry and return-home paths.
+- Terminal attach failure MUST leave the session list recoverable and must not imply that the underlying terminal process was destroyed unless the user intentionally ended it.
+- Browser sleep, tab eviction, and short network loss are treated as detach/reconnect events, not destructive terminal events.
+- Canvas exit on mobile MUST return to the launcher even if Canvas pan/zoom state is stale.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 95% of users testing on phone-sized screens can open Matrix, find Terminal, and reach a usable terminal session in under 20 seconds after sign-in.
+- **SC-002**: 90% of users can open any listed app from the mobile launcher and return to the launcher without using browser navigation.
+- **SC-003**: Terminal sessions survive at least 10 minutes of phone sleep or browser backgrounding in 95% of test runs where the VPS remains healthy.
+- **SC-004**: 95% of common terminal actions in the mobile usability script can be completed without an external keyboard.
+- **SC-005**: No tested mobile terminal flow requires users to create, paste, upload, or understand SSH keys.
+- **SC-006**: Phone-sized viewport checks show no primary launcher, app, terminal, or return-home control hidden behind browser chrome, safe areas, or the virtual keyboard.
+- **SC-007**: Mobile shell validation catches regressions where phone-sized users land directly on Canvas by default instead of the launcher.
+- **SC-008**: User-safe error handling prevents raw internal errors, provider names, filesystem paths, or secret-looking values from appearing in mobile shell and terminal error states during validation.

--- a/specs/075-mobile-shell/tasks.md
+++ b/specs/075-mobile-shell/tasks.md
@@ -1,0 +1,296 @@
+# Tasks: Mobile Shell
+
+**Input**: Design documents from `specs/075-mobile-shell/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/mobile-shell-api.md](./contracts/mobile-shell-api.md), [quickstart.md](./quickstart.md)
+
+**Tests**: Required. The Matrix OS constitution and this feature plan require TDD, so each implementation phase includes failing tests before implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and validation.
+
+## Current Status Snapshot (2026-05-14)
+
+**Done**
+
+- Phase 1 setup and PR #99 baseline cleanup are complete.
+- Phase 2 foundational app/runtime state, gateway-client hardening, and app session-token contract work are complete.
+- Phase 3 browser/native launcher-first app flow is complete for the implemented surfaces.
+- Browser shell live-preview hardening is complete for app launch paths, shipped icon URLs, shell/gateway proxying, hydration-safe mobile detection, and browser terminal rendering/focus.
+- Native mobile terminal client, state reducer, route, launcher entry, session picker, command row, touch control bar, screen-level regression coverage, and Expo SDK 54 package alignment are complete.
+- Gateway terminal session list/delete validation, delete body limits, idempotent stale-session cleanup, and mobile WebSocket attach/input/resize/detach/destroy protocol coverage are complete.
+- Explicit native/browser mobile resume choices are complete for app and terminal recovery.
+- Explicit browser Canvas entry, mobile Canvas return-home wrapping, stale pan/zoom reset, and native Canvas unavailable-state entry are complete.
+- Public and developer mobile-shell docs are complete.
+- Focused 075 validation gates are green for full native mobile Jest, browser mobile shell/Canvas tests, gateway terminal contract tests, shell/mobile/root TypeScript, pattern scan, and diff whitespace.
+
+**Not Done**
+
+- Full root `bun run test` is last recorded as not green; current failures are outside the focused 075 path and are listed in `quickstart.md`.
+
+## Phase 1: Setup (Shared Baseline)
+
+**Purpose**: Establish a trustworthy branch baseline and task scaffolding before feature work.
+
+- [x] T001 Reproduce PR #99 failing CI shards locally or in CI and record exact failures in `specs/075-mobile-shell/quickstart.md`
+- [x] T002 Fix duplicate-session request assertion failure in `tests/shell/workspace-app.test.tsx`
+- [x] T003 Fix generated Symphony source invariant failure in `tests/shell/symphony-app-source.test.ts`
+- [x] T004 Run focused baseline tests `tests/shell/workspace-app.test.tsx` and `tests/shell/symphony-app-source.test.ts` and record command/result in `specs/075-mobile-shell/quickstart.md`
+- [x] T005 [P] Add mobile shell test fixture helpers for phone-sized viewports in `tests/shell/mobile-shell-test-utils.tsx`
+- [x] T006 [P] Add mobile Expo test fixture helpers for gateway/app runtime responses in `apps/mobile/__tests__/mobile-shell-test-utils.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared contracts, hardening, and state primitives that must be ready before user story implementation.
+
+**CRITICAL**: No user story implementation should begin until this phase is complete.
+
+- [x] T007 [P] Add failing tests for mobile gateway fetch timeout and safe-error behavior in `apps/mobile/__tests__/gateway-client.test.ts`
+- [x] T008 Harden mobile gateway fetch helpers with timeout support and generic client errors in `apps/mobile/lib/gateway-client.ts`
+- [x] T009 [P] Add failing tests for app slug/runtime route normalization edge cases in `apps/mobile/__tests__/apps.test.ts`
+- [x] T010 Tighten app slug/runtime route helpers for mobile shell use in `apps/mobile/lib/apps.ts`
+- [x] T011 [P] Add failing tests for mobile shell state validation in `apps/mobile/__tests__/mobile-shell-state.test.ts`
+- [x] T012 Implement native mobile shell state parser and persistence adapter in `apps/mobile/lib/mobile-shell-state.ts`
+- [x] T013 [P] Add failing tests for browser mobile shell state validation in `tests/shell/mobile-shell-state.test.ts`
+- [x] T014 Implement browser mobile shell state parser and persistence helper in `shell/src/stores/mobile-shell-store.ts`
+- [x] T015 [P] Add failing contract tests for mobile app session-token response shape in `tests/gateway/app-runtime-phase1.test.ts`
+- [x] T016 Verify app session-token response and safe error behavior against the 075 contract in `packages/gateway/src/server.ts`
+
+**Checkpoint**: Foundation ready; user stories can now be implemented independently.
+
+---
+
+## Phase 3: User Story 1 - Launch Apps From Mobile Home (Priority: P1) MVP
+
+**Goal**: Phone-sized users land on a launcher, open apps full-screen, and return home without navigating Canvas.
+
+**Independent Test**: Sign in on a phone-sized browser viewport and in the native mobile app; verify launcher is first usable surface, app opens full-screen, and Home returns to launcher with recoverable state.
+
+### Tests for User Story 1
+
+- [x] T017 [P] [US1] Add failing browser-shell test for launcher-first phone viewport in `tests/shell/mobile-shell.test.tsx`
+- [x] T018 [P] [US1] Add failing browser-shell test for app open and return-home behavior in `tests/shell/mobile-shell.test.tsx`
+- [x] T019 [P] [US1] Add failing native mobile launcher test for full-screen runtime navigation in `apps/mobile/__tests__/apps.test.ts`
+- [x] T020 [P] [US1] Add failing safe unavailable-app fallback test in `apps/mobile/__tests__/apps.test.ts`
+
+### Implementation for User Story 1
+
+- [x] T021 [US1] Implement phone viewport detection hook in `shell/src/hooks/useMobileViewport.ts`
+- [x] T022 [US1] Implement browser mobile launcher surface in `shell/src/components/mobile/MobileLauncher.tsx`
+- [x] T023 [US1] Wire browser launcher-first mode into `shell/src/components/Desktop.tsx`
+- [x] T024 [US1] Implement browser full-screen mobile app surface in `shell/src/components/mobile/MobileAppSurface.tsx`
+- [x] T025 [US1] Wire return-home behavior from mobile app surfaces in `shell/src/components/AppViewer.tsx`
+- [x] T026 [US1] Update native mobile app tab/index routing so Apps is the default launcher in `apps/mobile/app/index.tsx`
+- [x] T027 [US1] Update native runtime fallback and return-home handling in `apps/mobile/app/runtime/[...slug].tsx`
+- [x] T028 [US1] Update launcher card open-state and recovery indicators in `apps/mobile/app/(tabs)/apps.tsx`
+
+**Checkpoint**: User Story 1 is independently functional and is the MVP.
+
+---
+
+## Phase 4: User Story 2 - Use Terminal Without SSH Keys (Priority: P1)
+
+**Goal**: Mobile users open Terminal from Matrix, create/resume/detach/end terminal sessions through authenticated Matrix state, and use common terminal keys without SSH keys.
+
+**Independent Test**: Open Terminal from the mobile launcher, run a command, detach/reload/resume the same session, send special keys, and intentionally end the session without using SSH credentials.
+
+### Tests for User Story 2
+
+- [x] T029 [P] [US2] Add failing gateway tests for terminal list/delete body limits and UUID validation in `tests/gateway/terminal-ws.test.ts`
+- [x] T030 [P] [US2] Add failing WebSocket protocol tests for mobile attach/input/resize/detach/destroy flows in `tests/gateway/terminal-ws.test.ts`
+- [x] T031 [P] [US2] Add failing native mobile terminal client tests in `apps/mobile/__tests__/terminal-client.test.ts`
+- [x] T032 [P] [US2] Add failing native mobile terminal UI tests in `apps/mobile/__tests__/terminal-screen.test.tsx`
+- [x] T033 [P] [US2] Add browser mobile terminal UI regression coverage in `tests/shell/terminal-app-component.test.tsx`
+
+### Implementation for User Story 2
+
+- [x] T034 [US2] Add bodyLimit and safe error handling to terminal session delete route in `packages/gateway/src/server.ts`
+- [x] T035 [US2] Ensure terminal WebSocket attach/input/resize/detach/destroy behavior matches mobile contract in `packages/gateway/src/server.ts`
+- [x] T036 [US2] Implement native mobile terminal gateway client in `apps/mobile/lib/terminal-client.ts`
+- [x] T037 [US2] Implement native mobile terminal state reducer in `apps/mobile/lib/terminal-state.ts`
+- [x] T038 [US2] Implement native mobile terminal screen and session picker in `apps/mobile/app/terminal/index.tsx`
+- [x] T039 [US2] Implement native terminal control bar for Escape Tab arrows Control paste session switching and font sizing in `apps/mobile/components/TerminalControlBar.tsx`
+- [x] T040 [US2] Add Terminal launcher entry and route mapping in `apps/mobile/lib/apps.ts`
+- [x] T041 [US2] Implement browser mobile terminal surface via `TerminalApp mobile` in `shell/src/components/terminal/TerminalApp.tsx`
+- [x] T042 [US2] Wire Terminal launcher entry and full-screen route through `shell/src/components/Desktop.tsx` and `shell/src/components/mobile/MobileLauncher.tsx`
+
+### Browser Shell Terminal Hardening Completed During Live Preview
+
+- [x] T070 [US2] Add visible mobile/desktop terminal cwd strip and cursor fallback in `shell/src/components/terminal/TerminalPane.tsx`
+- [x] T071 [US2] Disable WebGL terminal renderer fallback path and force xterm element sizing in `shell/src/components/terminal/TerminalPane.tsx`
+- [x] T072 [US2] Focus xterm on pointer/touch down in `shell/src/components/terminal/TerminalPane.tsx`
+- [x] T073 [US2] Make stale terminal-session DELETE idempotent for explicit close cleanup in `packages/gateway/src/server.ts`
+- [x] T074 [US2] Verify live terminal WebSocket prompt output through `127.0.0.1:4121/ws/terminal?cwd=projects`
+
+**Checkpoint**: Browser-shell terminal and native mobile terminal are functional for the no-SSH path, with gateway protocol regression tests and native screen-level UI coverage in place.
+
+---
+
+## Phase 5: User Story 3 - Resume Recent Mobile Work (Priority: P2)
+
+**Goal**: Mobile users can return to recent apps and terminal sessions after interruption without losing recoverable state.
+
+**Independent Test**: Open an app and terminal, background/reload Matrix, return later, and verify Matrix offers the last app plus terminal resume choices with safe fallback for missing resources.
+
+### Tests for User Story 3
+
+- [x] T043 [P] [US3] Add failing native mobile last-active app resume tests in `apps/mobile/__tests__/mobile-shell-state.test.ts`
+- [x] T044 [P] [US3] Add browser mobile shell state validation tests in `tests/shell/mobile-shell-state.test.ts`
+- [x] T045 [P] [US3] Add failing terminal resume choice tests in `apps/mobile/__tests__/terminal-screen.test.tsx`
+- [x] T046 [P] [US3] Add browser mobile launcher/home recovery regression tests in `tests/shell/mobile-shell.test.tsx`
+
+### Implementation for User Story 3
+
+- [x] T047 [US3] Persist and validate native last-active app state in `apps/mobile/lib/mobile-shell-state.ts`
+- [x] T048 [US3] Persist and validate browser last-active app state in `shell/src/stores/mobile-shell-store.ts`
+- [x] T049 [US3] Add resume choices to native launcher and terminal screens in `apps/mobile/app/(tabs)/apps.tsx`
+- [x] T050 [US3] Add resume choices to browser mobile launcher in `shell/src/components/mobile/MobileLauncher.tsx`
+- [x] T051 [US3] Handle missing restored apps with safe fallback in `shell/src/components/mobile/MobileAppSurface.tsx`
+- [x] T052 [US3] Handle exited/missing terminal sessions with safe recovery in `apps/mobile/app/terminal/index.tsx`
+
+### Browser Shell Resume Hardening Completed During Live Preview
+
+- [x] T075 [US3] Reset browser mobile hard-refresh/onboarding completion to launcher mode in `shell/src/components/Desktop.tsx`
+- [x] T076 [US3] Prevent SSR/client mobile viewport mismatch by deferring phone detection until mount in `shell/src/hooks/useMobileViewport.ts`
+- [x] T077 [US3] Prevent Clerk user-button hydration mismatch in `shell/src/components/UserButton.tsx` and `shell/src/components/MenuBar.tsx`
+
+**Checkpoint**: Browser and native resume choices are functional for recent apps and terminal sessions, with safe fallbacks for missing resources.
+
+---
+
+## Phase 6: User Story 4 - Access Canvas When It Helps (Priority: P3)
+
+**Goal**: Canvas remains explicitly reachable on mobile, but never becomes the default phone home or traps users in panned/zoomed state.
+
+**Independent Test**: Switch from launcher to Canvas on a phone-sized viewport, then return to launcher without losing open app records.
+
+### Tests for User Story 4
+
+- [x] T053 [P] [US4] Add failing browser mobile Canvas entry/return tests in `tests/shell/mobile-canvas.test.tsx`
+- [x] T054 [P] [US4] Add failing Canvas no-trap regression test for phone viewport in `tests/shell/mobile-canvas.test.tsx`
+- [x] T055 [P] [US4] Add failing native mobile Canvas entry unavailable-state test in `apps/mobile/__tests__/canvas-entry.test.tsx`
+
+### Implementation for User Story 4
+
+- [x] T056 [US4] Add explicit Canvas launcher action in `shell/src/components/mobile/MobileLauncher.tsx`
+- [x] T057 [US4] Add mobile return-to-launcher control around Canvas in `shell/src/components/Desktop.tsx` and `shell/src/components/mobile/MobileAppSurface.tsx`
+- [x] T058 [US4] Gate mobile Canvas pan/zoom restore so stale state cannot trap phone users in `shell/src/hooks/useCanvasTransform.ts`
+- [x] T059 [US4] Add native mobile Canvas entry or unavailable-state screen in `apps/mobile/app/canvas/index.tsx`
+- [x] T060 [US4] Add Canvas entry route mapping in `apps/mobile/lib/apps.ts`
+
+**Checkpoint**: User Story 4 is independently functional and Canvas remains explicit on mobile.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final hardening, docs, and verification across all user stories.
+
+- [x] T061 [P] Update mobile shell public docs in `www/content/docs/`
+- [x] T062 [P] Update developer notes for mobile shell and terminal validation in `docs/dev/mobile-shell.md`
+- [x] T063 [P] Add or update quickstart validation results in `specs/075-mobile-shell/quickstart.md`
+- [x] T064 Run focused native mobile tests and record command coverage in `specs/075-mobile-shell/quickstart.md`
+- [x] T065 Run focused gateway terminal/app-runtime tests and record command coverage in `specs/075-mobile-shell/quickstart.md`
+- [x] T066 Run focused browser shell tests and record command coverage in `specs/075-mobile-shell/quickstart.md`
+- [x] T067 Run `bun run check:patterns` resolve violations in scanner-listed files and record result in `specs/075-mobile-shell/quickstart.md`
+- [x] T068 Run `bun run typecheck` resolve type errors in changed files and record result in `specs/075-mobile-shell/quickstart.md`
+- [x] T069 Run `bun run test` and resolve regressions or document environment blockers in `specs/075-mobile-shell/quickstart.md`
+
+### Live Preview Hardening Completed
+
+- [x] T078 Canonicalize runtime app launch paths and stale nested app paths in `shell/src/lib/app-launch.ts`, `shell/src/components/Desktop.tsx`, and `shell/src/components/AppViewer.tsx`
+- [x] T079 Fix shipped SVG icon URLs for built-ins so browser shell stops requesting missing `.png` files
+- [x] T080 Add shell dev rewrites/proxy coverage for `/api`, `/apps`, `/files`, `/icons`, and WebSocket paths in `shell/next.config.ts` and `shell/proxy.ts`
+- [x] T081 Verify Backgammon runtime route serves built `assets/...` HTML after app session minting
+- [x] T082 Verify live terminal session cap behavior and clear detached preview sessions before live terminal smoke testing
+- [x] T083 Align Expo mobile package manifest and root lockfile back to Expo SDK 54 / React Native 0.81 / React 19.1 in `apps/mobile/package.json` and `pnpm-lock.yaml`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: No dependencies; start immediately.
+- **Phase 2 Foundational**: Depends on Phase 1; blocks all user stories.
+- **Phase 3 US1**: Depends on Phase 2; MVP.
+- **Phase 4 US2**: Depends on Phase 2; can run in parallel with US1 if files are coordinated.
+- **Phase 5 US3**: Depends on US1 and US2 because it resumes app and terminal state.
+- **Phase 6 US4**: Depends on Phase 2 and can run after or alongside US1 if launcher file ownership is coordinated.
+- **Phase 7 Polish**: Depends on desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 Launch Apps From Mobile Home**: MVP; no dependency on other stories after foundation.
+- **US2 Use Terminal Without SSH Keys**: No dependency on US1 after foundation, except launcher entry integration should coordinate with US1 edits.
+- **US3 Resume Recent Mobile Work**: Depends on US1 app surfaces and US2 terminal state.
+- **US4 Access Canvas When It Helps**: Depends on shared launcher shell state from foundation; no dependency on US2.
+
+### Within Each User Story
+
+- Tests must be written first and fail before implementation.
+- State/model helpers before UI wiring.
+- Gateway contract changes before client calls that depend on them.
+- Core surface behavior before recovery and empty states.
+- Validate each story at its checkpoint before moving to the next priority.
+
+---
+
+## Parallel Opportunities
+
+- T005 and T006 can run in parallel.
+- T007, T009, T011, T013, and T015 can run in parallel because they touch separate test files.
+- US1 tests T017-T020 can run in parallel.
+- US2 tests T029-T033 can run in parallel.
+- US3 tests T043-T046 can run in parallel.
+- US4 tests T053-T055 can run in parallel.
+- Documentation tasks T061-T063 can run in parallel after implementation.
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "T017 [P] [US1] Add failing browser-shell test for launcher-first phone viewport in tests/shell/mobile-shell.test.tsx"
+Task: "T019 [P] [US1] Add failing native mobile launcher test for full-screen runtime navigation in apps/mobile/__tests__/apps.test.ts"
+Task: "T020 [P] [US1] Add failing safe unavailable-app fallback test in apps/mobile/__tests__/apps.test.ts"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "T029 [P] [US2] Add failing gateway tests for terminal list/delete body limits and UUID validation in tests/gateway/terminal-ws.test.ts"
+Task: "T031 [P] [US2] Add failing native mobile terminal client tests in apps/mobile/__tests__/terminal-client.test.ts"
+Task: "T033 [P] [US2] Add failing browser mobile terminal UI tests in tests/shell/mobile-terminal.test.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 (US1).
+3. Stop and validate the phone launcher/app-open/home flow in browser shell and native mobile.
+4. Demo or review MVP before adding terminal complexity.
+
+### Incremental Delivery
+
+1. Setup + Foundation -> trustworthy baseline and shared state/contracts.
+2. US1 -> launcher-first app opening.
+3. US2 -> first-party no-SSH terminal.
+4. US3 -> resume interrupted mobile work.
+5. US4 -> explicit Canvas access.
+6. Polish -> docs and full review gates.
+
+### Review Strategy
+
+- Keep PR #99 CI cleanup separate from new mobile behavior in commit history if possible.
+- Avoid pushing while review is in progress unless declaring a new review commit range.
+- Before review, include backend invariants for terminal/app-runtime changes: source of truth, transaction/lock scope, acceptable orphan states, auth source of truth, and deferred scope.
+
+## Notes
+
+- [P] tasks use different files or are test-only setup that can be done independently.
+- Story labels map to `spec.md` user stories.
+- Use existing gateway terminal protocol unless a task explicitly proves a new endpoint is necessary.
+- Do not introduce Docker as a production customer runtime path.

--- a/tests/gateway/app-runtime-phase1.test.ts
+++ b/tests/gateway/app-runtime-phase1.test.ts
@@ -16,6 +16,15 @@ afterEach(async () => {
 });
 
 describe("phase 1: static + vite runtime", () => {
+  it("returns an empty websocket token response in open direct-gateway development mode", async () => {
+    const res = await gateway.app.request("/api/auth/ws-token", {
+      headers: { Authorization: `Bearer ${gateway.token}` },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ token: null, expiresAt: 0 });
+  });
+
   it("installs and serves a static app via the unified /apps/:slug/ dispatcher", async () => {
     await gateway.installAppFromFixture("calculator-static");
     const cookie = await gateway.openAppSession("calculator-static");
@@ -87,6 +96,42 @@ describe("phase 1: static + vite runtime", () => {
     });
     expect(appRes.status).toBe(200);
     expect(await appRes.text()).toContain("Calculator");
+  });
+
+  it("returns the 075 mobile session-token contract shape without cacheable credentials", async () => {
+    await gateway.installAppFromFixture("calculator-static");
+    const res = await gateway.app.request("/api/apps/calculator-static/session-token", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${gateway.token}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = await res.json() as { token?: unknown; launchUrl?: unknown; expiresAt?: unknown };
+    expect(typeof body.token).toBe("string");
+    expect(typeof body.launchUrl).toBe("string");
+    expect(typeof body.expiresAt).toBe("number");
+    expect(body.launchUrl).toBe(`/apps/calculator-static/?session=${encodeURIComponent(body.token as string)}`);
+  });
+
+  it("returns generic safe errors for invalid mobile session-token requests", async () => {
+    const invalidRes = await gateway.app.request("/api/apps/-bad/session-token", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${gateway.token}` },
+    });
+    expect(invalidRes.status).toBe(400);
+    expect(await invalidRes.json()).toEqual({ error: "invalid slug" });
+
+    const missingRes = await gateway.app.request("/api/apps/missing/session-token", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${gateway.token}` },
+    });
+    expect(missingRes.status).toBe(404);
+    expect(await missingRes.json()).toEqual({ error: "not found" });
   });
 
   it("rejects replayed or cross-app mobile session tokens", async () => {

--- a/tests/gateway/terminal-ws.test.ts
+++ b/tests/gateway/terminal-ws.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { Hono } from "hono";
 import {
   ClientMessageSchema,
   AttachNewSchema,
@@ -6,7 +7,21 @@ import {
   InputSchema,
   ResizeSchema,
   DetachSchema,
+  DestroySchema,
 } from "../../packages/gateway/src/session-registry.js";
+import {
+  registerTerminalSessionRoutes,
+  TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES,
+  type TerminalSessionRouteRegistry,
+} from "../../packages/gateway/src/server.js";
+
+const SESSION_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function appWithTerminalRegistry(registry: TerminalSessionRouteRegistry, homePath = "/home/matrix/home") {
+  const app = new Hono();
+  registerTerminalSessionRoutes(app, { homePath, sessionRegistry: registry });
+  return app;
+}
 
 describe("Terminal WebSocket Protocol — Zod Schemas", () => {
   describe("AttachNewSchema", () => {
@@ -106,6 +121,13 @@ describe("Terminal WebSocket Protocol — Zod Schemas", () => {
     });
   });
 
+  describe("DestroySchema", () => {
+    it("accepts valid destroy", () => {
+      const msg = { type: "destroy" };
+      expect(DestroySchema.parse(msg)).toEqual(msg);
+    });
+  });
+
   describe("ClientMessageSchema (union)", () => {
     it("parses attach-new", () => {
       const result = ClientMessageSchema.parse({ type: "attach", cwd: "/home" });
@@ -132,6 +154,24 @@ describe("Terminal WebSocket Protocol — Zod Schemas", () => {
       expect(result).toEqual({ type: "detach" });
     });
 
+    it("parses destroy", () => {
+      const result = ClientMessageSchema.parse({ type: "destroy" });
+      expect(result).toEqual({ type: "destroy" });
+    });
+
+    it("parses the mobile attach/input/resize/detach/destroy flow", () => {
+      const frames = [
+        { type: "attach", cwd: "projects" },
+        { type: "input", data: "pwd\r" },
+        { type: "resize", cols: 42, rows: 24 },
+        { type: "detach" },
+        { type: "attach", sessionId: SESSION_ID, fromSeq: 0 },
+        { type: "destroy" },
+      ];
+
+      expect(frames.map((frame) => ClientMessageSchema.parse(frame))).toEqual(frames);
+    });
+
     it("rejects unknown type", () => {
       expect(() => ClientMessageSchema.parse({ type: "unknown" })).toThrow();
     });
@@ -139,5 +179,89 @@ describe("Terminal WebSocket Protocol — Zod Schemas", () => {
     it("rejects missing type", () => {
       expect(() => ClientMessageSchema.parse({ data: "hello" })).toThrow();
     });
+  });
+});
+
+describe("Terminal session REST routes", () => {
+  it("lists terminal sessions with home-relative cwd values", async () => {
+    const registry = {
+      list: () => [{
+        sessionId: SESSION_ID,
+        cwd: "/home/matrix/home/projects/matrix-os",
+        shell: "/bin/bash",
+        state: "running" as const,
+        createdAt: 1,
+        lastAttachedAt: 2,
+        attachedClients: 1,
+      }],
+      getSession: () => null,
+      destroy: () => undefined,
+    };
+    const app = appWithTerminalRegistry(registry);
+
+    const res = await app.request("/api/terminal/sessions");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([{
+      sessionId: SESSION_ID,
+      cwd: "projects/matrix-os",
+      state: "running",
+      createdAt: 1,
+      lastAttachedAt: 2,
+      attachedClients: 1,
+    }]);
+  });
+
+  it("rejects invalid terminal session delete IDs before touching the registry", async () => {
+    const registry = {
+      list: () => [],
+      getSession: vi.fn(),
+      destroy: vi.fn(),
+    };
+    const app = appWithTerminalRegistry(registry);
+
+    const res = await app.request("/api/terminal/sessions/not-a-uuid", { method: "DELETE" });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid session ID" });
+    expect(registry.getSession).not.toHaveBeenCalled();
+    expect(registry.destroy).not.toHaveBeenCalled();
+  });
+
+  it("treats repeated terminal session deletes as idempotent success", async () => {
+    const registry = {
+      list: () => [],
+      getSession: vi.fn(() => null),
+      destroy: vi.fn(),
+    };
+    const app = appWithTerminalRegistry(registry);
+
+    const res = await app.request(`/api/terminal/sessions/${SESSION_ID}`, { method: "DELETE" });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(registry.destroy).not.toHaveBeenCalled();
+  });
+
+  it("caps ignored terminal delete request bodies before registry access", async () => {
+    const registry = {
+      list: () => [],
+      getSession: vi.fn(() => ({ sessionId: SESSION_ID })),
+      destroy: vi.fn(),
+    };
+    const app = appWithTerminalRegistry(registry);
+
+    const res = await app.request(`/api/terminal/sessions/${SESSION_ID}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "text/plain",
+        "Content-Length": String(TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES + 1),
+      },
+      body: "x".repeat(TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES + 1),
+    });
+
+    expect(res.status).toBe(413);
+    expect(registry.getSession).not.toHaveBeenCalled();
+    expect(registry.destroy).not.toHaveBeenCalled();
   });
 });

--- a/tests/helpers/gateway.ts
+++ b/tests/helpers/gateway.ts
@@ -48,6 +48,10 @@ export async function buildTestGateway(opts?: { home?: string }): Promise<TestGa
   // Auth middleware
   app.use("*", authMiddleware(TEST_TOKEN));
 
+  app.get("/api/auth/ws-token", (c) => c.json({ token: null, expiresAt: 0 }, 200, {
+    "Cache-Control": "no-store",
+  }));
+
   // Manifest API
   app.get("/api/apps/:slug/manifest", async (c) => {
     const slug = c.req.param("slug");
@@ -148,10 +152,16 @@ export async function buildTestGateway(opts?: { home?: string }): Promise<TestGa
       }
     }
     const { token, expiresAt } = mobileSessionTokens.mint(slug);
-    return c.json({
+    return new Response(JSON.stringify({
       token,
       expiresAt,
       launchUrl: `/apps/${slug}/?session=${encodeURIComponent(token)}`,
+    }), {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "application/json; charset=UTF-8",
+      },
     });
   });
 

--- a/tests/shell/app-launch.test.ts
+++ b/tests/shell/app-launch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { canonicalAppLaunchPath, iconUrlForSlug } from "../../shell/src/lib/app-launch.js";
+
+describe("app launch helpers", () => {
+  it("canonicalizes runtime apps to slug routes before iframe rendering", () => {
+    expect(canonicalAppLaunchPath({
+      slug: "backgammon",
+      launchUrl: "/apps/backgammon/",
+      path: "/files/apps/games/backgammon/index.html",
+    })).toBe("apps/backgammon/index.html");
+  });
+
+  it("falls back to legacy file paths for non-runtime apps", () => {
+    expect(canonicalAppLaunchPath({
+      path: "/files/apps/legacy.html",
+    })).toBe("apps/legacy.html");
+  });
+
+  it("uses shipped SVG icon URLs when no PNG is shipped", () => {
+    expect(iconUrlForSlug("terminal")).toBe("/icons/terminal.svg");
+    expect(iconUrlForSlug("folder")).toBe("/icons/folder.svg");
+    expect(iconUrlForSlug("chat")).toBe("/icons/chat.svg");
+    expect(iconUrlForSlug("game-center")).toBe("/icons/game-center.png");
+  });
+});

--- a/tests/shell/app-launch.test.ts
+++ b/tests/shell/app-launch.test.ts
@@ -10,6 +10,15 @@ describe("app launch helpers", () => {
     })).toBe("apps/backgammon/index.html");
   });
 
+  it("canonicalizes nested runtime app slugs without treating them as icon names", () => {
+    expect(canonicalAppLaunchPath({
+      slug: "games/minesweeper",
+      launchUrl: "/apps/games/minesweeper/",
+      path: "/files/apps/games/minesweeper/index.html",
+    })).toBe("apps/games/minesweeper/index.html");
+    expect(iconUrlForSlug("games/minesweeper")).toBeUndefined();
+  });
+
   it("falls back to legacy file paths for non-runtime apps", () => {
     expect(canonicalAppLaunchPath({
       path: "/files/apps/legacy.html",

--- a/tests/shell/app-viewer-slug.test.ts
+++ b/tests/shell/app-viewer-slug.test.ts
@@ -13,7 +13,10 @@ describe("AppViewer extractSlug (spec 063 regression)", () => {
   it("extracts leaf slugs from legacy nested runtime app paths", () => {
     expect(extractSlug("apps/games/2048/index.html")).toBe("2048");
     expect(extractSlug("apps/games/backgammon/index.html")).toBe("backgammon");
-    expect(extractSlug("apps/tools/api-tester/index.html")).toBe("api-tester");
+  });
+
+  it("does not rewrite unknown nested app paths", () => {
+    expect(extractSlug("apps/tools/api-tester/index.html")).toBeNull();
   });
 
   it("returns null for nested non-index app paths", () => {

--- a/tests/shell/app-viewer-slug.test.ts
+++ b/tests/shell/app-viewer-slug.test.ts
@@ -10,11 +10,13 @@ describe("AppViewer extractSlug (spec 063 regression)", () => {
     expect(extractSlug("apps/games/index.html")).toBe("games");
   });
 
-  it("returns null for nested paths (e.g. games/2048)", () => {
-    // Nested paths must NOT route through /apps/{slug}/ — they'd hit the
-    // parent app's dispatcher and get the wrong index.html.
-    expect(extractSlug("apps/games/2048/index.html")).toBeNull();
-    expect(extractSlug("apps/games/backgammon/index.html")).toBeNull();
+  it("extracts leaf slugs from legacy nested runtime app paths", () => {
+    expect(extractSlug("apps/games/2048/index.html")).toBe("2048");
+    expect(extractSlug("apps/games/backgammon/index.html")).toBe("backgammon");
+    expect(extractSlug("apps/tools/api-tester/index.html")).toBe("api-tester");
+  });
+
+  it("returns null for nested non-index app paths", () => {
     expect(extractSlug("apps/foo/bar")).toBeNull();
   });
 

--- a/tests/shell/mobile-canvas.test.tsx
+++ b/tests/shell/mobile-canvas.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MobileAppSurface } from "../../shell/src/components/mobile/MobileAppSurface.js";
+import { MobileLauncher } from "../../shell/src/components/mobile/MobileLauncher.js";
+import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
+
+describe("mobile Canvas entry", () => {
+  it("opens Canvas only through an explicit launcher action", () => {
+    const onOpenCanvas = vi.fn();
+
+    render(
+      <MobileLauncher
+        apps={[{ name: "Notes", path: "apps/notes/index.html" }]}
+        openWindowPaths={new Set()}
+        onOpenApp={vi.fn()}
+        onOpenCanvas={onOpenCanvas}
+      />,
+    );
+
+    expect(screen.getByTestId("mobile-launcher")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("mobile-open-canvas"));
+
+    expect(onOpenCanvas).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps Canvas in a full-screen mobile surface with a return-home control", () => {
+    const onHome = vi.fn();
+
+    render(
+      <MobileAppSurface title="Canvas" onHome={onHome}>
+        <div data-testid="canvas-content" className="h-full w-full overflow-hidden" />
+      </MobileAppSurface>,
+    );
+
+    fireEvent.click(screen.getByTestId("mobile-home-button"));
+
+    expect(onHome).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("mobile-app-surface").className).toContain("overflow-hidden");
+    expect(screen.getByTestId("canvas-content")).toBeTruthy();
+  });
+
+  it("can reset stale Canvas pan and zoom before mobile entry", () => {
+    useCanvasTransform.getState().setTransform(0.2, 7000, -7000);
+
+    useCanvasTransform.getState().resetForMobileViewport();
+
+    expect(useCanvasTransform.getState()).toMatchObject({
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      isScrolling: false,
+    });
+  });
+});

--- a/tests/shell/mobile-shell-state.test.ts
+++ b/tests/shell/mobile-shell-state.test.ts
@@ -18,14 +18,14 @@ describe("browser mobile shell state", () => {
       surface: "browser-shell",
       mode: "terminal",
       lastActiveAppSlug: "task-manager",
-      lastActiveTerminalSessionId: "terminal_123",
+      lastActiveTerminalSessionId: "550e8400-e29b-41d4-a716-446655440000",
       canvasEnteredAt: "2026-05-12T00:00:00.000Z",
       updatedAt: "2026-05-12T00:01:00.000Z",
     })).toMatchObject({
       surface: "browser-shell",
       mode: "terminal",
       lastActiveAppSlug: "task-manager",
-      lastActiveTerminalSessionId: "terminal_123",
+      lastActiveTerminalSessionId: "550e8400-e29b-41d4-a716-446655440000",
       canvasEnteredAt: "2026-05-12T00:00:00.000Z",
       updatedAt: "2026-05-12T00:01:00.000Z",
     });
@@ -45,6 +45,17 @@ describe("browser mobile shell state", () => {
       lastActiveAppSlug: null,
       lastActiveTerminalSessionId: null,
       canvasEnteredAt: null,
+    });
+  });
+
+  it("uses the canonical app slug validator", () => {
+    expect(parseBrowserMobileShellState({
+      mode: "app",
+      lastActiveAppSlug: "my_app",
+      updatedAt: "2026-05-12T00:01:00.000Z",
+    })).toMatchObject({
+      mode: "app",
+      lastActiveAppSlug: null,
     });
   });
 
@@ -90,7 +101,7 @@ describe("browser mobile shell state", () => {
       surface: "browser-shell",
       mode: "app",
       lastActiveAppSlug: null,
-      lastActiveTerminalSessionId: "terminal_123",
+      lastActiveTerminalSessionId: null,
     });
     expect(Date.parse(saved.updatedAt)).not.toBeNaN();
   });

--- a/tests/shell/mobile-shell-state.test.ts
+++ b/tests/shell/mobile-shell-state.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  BROWSER_MOBILE_SHELL_STATE_STORAGE_KEY,
+  loadBrowserMobileShellState,
+  parseBrowserMobileShellState,
+  saveBrowserMobileShellState,
+} from "../../shell/src/stores/mobile-shell-store.js";
+
+describe("browser mobile shell state", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("parses valid browser mobile shell state", () => {
+    expect(parseBrowserMobileShellState({
+      surface: "browser-shell",
+      mode: "terminal",
+      lastActiveAppSlug: "task-manager",
+      lastActiveTerminalSessionId: "terminal_123",
+      canvasEnteredAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:01:00.000Z",
+    })).toMatchObject({
+      surface: "browser-shell",
+      mode: "terminal",
+      lastActiveAppSlug: "task-manager",
+      lastActiveTerminalSessionId: "terminal_123",
+      canvasEnteredAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:01:00.000Z",
+    });
+  });
+
+  it("drops unsafe browser persisted state", () => {
+    expect(parseBrowserMobileShellState({
+      surface: "native-mobile",
+      mode: "desktop",
+      lastActiveAppSlug: "../../secrets",
+      lastActiveTerminalSessionId: "/var/run/socket",
+      canvasEnteredAt: "invalid",
+      updatedAt: "invalid",
+    })).toMatchObject({
+      surface: "browser-shell",
+      mode: "launcher",
+      lastActiveAppSlug: null,
+      lastActiveTerminalSessionId: null,
+      canvasEnteredAt: null,
+    });
+  });
+
+  it("loads state from local storage", () => {
+    localStorage.setItem(BROWSER_MOBILE_SHELL_STATE_STORAGE_KEY, JSON.stringify({
+      mode: "app",
+      lastActiveAppSlug: "notes",
+      updatedAt: "2026-05-12T00:01:00.000Z",
+    }));
+
+    expect(loadBrowserMobileShellState()).toMatchObject({
+      surface: "browser-shell",
+      mode: "app",
+      lastActiveAppSlug: "notes",
+    });
+  });
+
+  it("falls back when local storage cannot be parsed", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    localStorage.setItem(BROWSER_MOBILE_SHELL_STATE_STORAGE_KEY, "{not-json");
+
+    expect(loadBrowserMobileShellState()).toMatchObject({
+      surface: "browser-shell",
+      mode: "launcher",
+    });
+    expect(warnSpy).toHaveBeenCalledWith("[shell] failed to load mobile shell state", expect.any(SyntaxError));
+
+    warnSpy.mockRestore();
+  });
+
+  it("saves sanitized state to local storage", () => {
+    saveBrowserMobileShellState({
+      surface: "browser-shell",
+      mode: "app",
+      lastActiveAppSlug: "../secrets",
+      lastActiveTerminalSessionId: "terminal_123",
+      canvasEnteredAt: null,
+      updatedAt: "invalid",
+    });
+
+    const saved = JSON.parse(localStorage.getItem(BROWSER_MOBILE_SHELL_STATE_STORAGE_KEY) ?? "{}");
+    expect(saved).toMatchObject({
+      surface: "browser-shell",
+      mode: "app",
+      lastActiveAppSlug: null,
+      lastActiveTerminalSessionId: "terminal_123",
+    });
+    expect(Date.parse(saved.updatedAt)).not.toBeNaN();
+  });
+});

--- a/tests/shell/mobile-shell-test-utils.tsx
+++ b/tests/shell/mobile-shell-test-utils.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+export type TestViewport = {
+  width: number;
+  height: number;
+};
+
+export const PHONE_VIEWPORT: TestViewport = { width: 390, height: 844 };
+export const PHONE_LANDSCAPE_VIEWPORT: TestViewport = { width: 844, height: 390 };
+export const DESKTOP_VIEWPORT: TestViewport = { width: 1280, height: 900 };
+
+export function setTestViewport(viewport: TestViewport): void {
+  defineWindowNumber("innerWidth", viewport.width);
+  defineWindowNumber("outerWidth", viewport.width);
+  defineWindowNumber("innerHeight", viewport.height);
+  defineWindowNumber("outerHeight", viewport.height);
+  window.dispatchEvent(new Event("resize"));
+}
+
+export function setPhoneViewport(viewport: TestViewport = PHONE_VIEWPORT): void {
+  setTestViewport(viewport);
+}
+
+export function setDesktopViewport(): void {
+  setTestViewport(DESKTOP_VIEWPORT);
+}
+
+export function installViewportMatchMedia(viewport: TestViewport = PHONE_VIEWPORT): () => void {
+  const previousMatchMedia = window.matchMedia;
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string): MediaQueryList => createMediaQueryList(query, viewport),
+  });
+
+  return () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: previousMatchMedia,
+    });
+  };
+}
+
+function defineWindowNumber(name: "innerWidth" | "outerWidth" | "innerHeight" | "outerHeight", value: number): void {
+  Object.defineProperty(window, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function createMediaQueryList(query: string, viewport: TestViewport): MediaQueryList {
+  return {
+    matches: matchesMediaQuery(query, viewport),
+    media: query,
+    onchange: null,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => true,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+  };
+}
+
+function matchesMediaQuery(query: string, viewport: TestViewport): boolean {
+  const minWidth = query.match(/\(min-width:\s*(\d+)px\)/);
+  if (minWidth && viewport.width < Number(minWidth[1])) return false;
+
+  const maxWidth = query.match(/\(max-width:\s*(\d+)px\)/);
+  if (maxWidth && viewport.width > Number(maxWidth[1])) return false;
+
+  const minHeight = query.match(/\(min-height:\s*(\d+)px\)/);
+  if (minHeight && viewport.height < Number(minHeight[1])) return false;
+
+  const maxHeight = query.match(/\(max-height:\s*(\d+)px\)/);
+  if (maxHeight && viewport.height > Number(maxHeight[1])) return false;
+
+  if (query.includes("(orientation: portrait)") && viewport.width > viewport.height) return false;
+  if (query.includes("(orientation: landscape)") && viewport.width <= viewport.height) return false;
+
+  return true;
+}

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MobileAppSurface } from "../../shell/src/components/mobile/MobileAppSurface.js";
+import { MobileLauncher } from "../../shell/src/components/mobile/MobileLauncher.js";
+import { useMobileViewport } from "../../shell/src/hooks/useMobileViewport.js";
+import { setDesktopViewport, setPhoneViewport } from "./mobile-shell-test-utils.js";
+
+function ViewportProbe() {
+  const mobile = useMobileViewport();
+  return <div data-testid="viewport-mode">{mobile ? "mobile" : "desktop"}</div>;
+}
+
+describe("mobile shell", () => {
+  beforeEach(() => {
+    setDesktopViewport();
+  });
+
+  it("uses launcher-first mode on phone-sized browser viewports", async () => {
+    setPhoneViewport();
+
+    render(<ViewportProbe />);
+
+    await waitFor(() => expect(screen.getByTestId("viewport-mode").textContent).toBe("mobile"));
+  });
+
+  it("updates viewport mode when a phone viewport expands", () => {
+    setPhoneViewport();
+    render(<ViewportProbe />);
+
+    act(() => {
+      setDesktopViewport();
+    });
+
+    expect(screen.getByTestId("viewport-mode").textContent).toBe("desktop");
+  });
+
+  it("opens apps from the mobile launcher and shows active app state", () => {
+    const onOpenApp = vi.fn();
+
+    render(
+      <MobileLauncher
+        apps={[{ name: "Notes", path: "apps/notes/index.html" }]}
+        openWindowPaths={new Set(["apps/notes/index.html"])}
+        onOpenApp={onOpenApp}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("mobile-launcher-app-apps/notes/index.html"));
+
+    expect(onOpenApp).toHaveBeenCalledWith("Notes", "apps/notes/index.html");
+    expect(screen.getByLabelText("Open")).toBeTruthy();
+  });
+
+  it("offers an explicit resume action for the last mobile app", () => {
+    const onResumeApp = vi.fn();
+
+    render(
+      <MobileLauncher
+        apps={[
+          { name: "Notes", path: "apps/notes/index.html" },
+          { name: "Tasks", path: "__workspace__" },
+        ]}
+        openWindowPaths={new Set()}
+        onOpenApp={vi.fn()}
+        resumeApp={{ name: "Notes", path: "apps/notes/index.html" }}
+        onResumeApp={onResumeApp}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("mobile-resume-app"));
+
+    expect(onResumeApp).toHaveBeenCalledWith("Notes", "apps/notes/index.html");
+  });
+
+  it("returns home from a full-screen mobile app without unmounting content", () => {
+    const onHome = vi.fn();
+
+    render(
+      <MobileAppSurface title="Notes" onHome={onHome}>
+        <div data-testid="runtime-content">runtime</div>
+      </MobileAppSurface>,
+    );
+
+    fireEvent.click(screen.getByTestId("mobile-home-button"));
+
+    expect(onHome).toHaveBeenCalled();
+    expect(screen.getByTestId("runtime-content")).toBeTruthy();
+  });
+
+  it("keeps app content inside the mobile surface viewport", () => {
+    render(
+      <MobileAppSurface title="Terminal" onHome={vi.fn()}>
+        <div data-testid="terminal-content" className="h-full w-full overflow-hidden" />
+      </MobileAppSurface>,
+    );
+
+    expect(screen.getByTestId("mobile-app-surface").className).toContain("overflow");
+    expect(screen.getByTestId("terminal-content")).toBeTruthy();
+  });
+
+  it("shows a safe fallback when a restored mobile app is missing", () => {
+    render(
+      <MobileAppSurface title="Missing app" onHome={vi.fn()} unavailableMessage="Open the app from the launcher again." />,
+    );
+
+    expect(screen.getByText("App unavailable")).toBeTruthy();
+    expect(screen.getByText("Open the app from the launcher again.")).toBeTruthy();
+  });
+});

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { isPublicShellPath } from "../../shell/src/lib/proxy-routes";
+import {
+  isPlatformMobileAppSessionRequest,
+  isPublicShellPath,
+} from "../../shell/src/lib/proxy-routes";
 
 /**
  * Unit tests for the proxy.ts auth logic.
@@ -127,6 +130,50 @@ describe("proxy auth: Layer 2 owner verification", () => {
 
   it("allows null user (pre-auth state)", () => {
     expect(isOwnerMatch(null, "user_abc")).toBe(true);
+  });
+});
+
+describe("proxy auth: platform mobile app sessions", () => {
+  it("allows mobile app launch requests with a bounded session query token", () => {
+    expect(isPlatformMobileAppSessionRequest(
+      "/apps/calculator/",
+      "?session=mobile.session-token_1",
+      null,
+    )).toBe(true);
+  });
+
+  it("allows mobile app asset requests with the matching app session cookie", () => {
+    expect(isPlatformMobileAppSessionRequest(
+      "/apps/calculator/assets/index.js",
+      "",
+      "matrix_app_route=alice; matrix_app_session__calculator=session-cookie",
+    )).toBe(true);
+  });
+
+  it("rejects app requests without a session token or matching session cookie", () => {
+    expect(isPlatformMobileAppSessionRequest(
+      "/apps/calculator/assets/index.js",
+      "",
+      "matrix_app_route=alice",
+    )).toBe(false);
+    expect(isPlatformMobileAppSessionRequest(
+      "/apps/calculator/assets/index.js",
+      "",
+      "matrix_app_session__calculator=",
+    )).toBe(false);
+  });
+
+  it("does not treat API paths or unsafe slugs as mobile app session requests", () => {
+    expect(isPlatformMobileAppSessionRequest(
+      "/api/apps/calculator/session-token",
+      "?session=mobile.session-token_1",
+      null,
+    )).toBe(false);
+    expect(isPlatformMobileAppSessionRequest(
+      "/apps/-calculator/",
+      "?session=mobile.session-token_1",
+      null,
+    )).toBe(false);
   });
 });
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -17,6 +17,29 @@ vi.mock("@/hooks/useTheme", () => ({
   useTheme: () => ({ mode: "dark", colors: {}, fonts: {} }),
 }));
 
+vi.mock("@/stores/terminal-settings", () => {
+  const state = {
+    themeId: "system",
+    fontSize: 13,
+    fontFamily: "JetBrains Mono",
+    ligatures: true,
+    cursorStyle: "block",
+    smoothScroll: true,
+    cursorBlink: true,
+    setThemeId: vi.fn(),
+    setFontSize: vi.fn(),
+    setFontFamily: vi.fn(),
+    setLigatures: vi.fn(),
+    setCursorStyle: vi.fn(),
+    setSmoothScroll: vi.fn(),
+    setCursorBlink: vi.fn(),
+  };
+
+  return {
+    useTerminalSettings: (selector: (value: typeof state) => unknown) => selector(state),
+  };
+});
+
 import { TerminalApp } from "../../shell/src/components/terminal/TerminalApp.js";
 
 class ResizeObserverMock {
@@ -66,6 +89,18 @@ describe("TerminalApp", () => {
       type: "pane",
       sessionId: "canvas-session-123",
     });
+  });
+
+  it("keeps the active cwd visible in the mobile terminal chrome", async () => {
+    render(<TerminalApp mobile />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("~/projects")).toBeTruthy();
+    expect(screen.getByTitle("New tab (Ctrl+Shift+T)")).toBeTruthy();
   });
 
   it("persists attached session ids in the saved layout", async () => {

--- a/tests/shell/user-button-hydration.test.tsx
+++ b/tests/shell/user-button-hydration.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({ isLoaded: true, isSignedIn: true }),
+  UserButton: () => <div data-testid="clerk-user-button" data-clerk-component="UserButton" />,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("UserButton hydration shell", () => {
+  it("server-renders the stable placeholder even when Clerk will hydrate signed in", async () => {
+    const { UserButton } = await import("../../shell/src/components/UserButton.js");
+    const html = renderToString(<UserButton />);
+
+    expect(html).toContain("lucide-user");
+    expect(html).not.toContain("data-clerk-component");
+  });
+});

--- a/tests/shell/workspace-app.test.tsx
+++ b/tests/shell/workspace-app.test.tsx
@@ -140,20 +140,18 @@ describe("WorkspaceApp", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /duplicate sess_abc123/i }));
     });
-    expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/api/sessions"),
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          kind: "agent",
-          agent: "codex",
-          projectSlug: "repo",
-          taskId: "task_0",
-          worktreeId: "wt_abc123def456",
-          pr: 77,
-        }),
-      }),
+    const duplicateCall = vi.mocked(global.fetch).mock.calls.find(
+      ([url, init]) => /\/api\/sessions$/.test(String(url)) && init?.method === "POST",
     );
+    expect(duplicateCall).toBeDefined();
+    expect(JSON.parse(String(duplicateCall?.[1]?.body))).toMatchObject({
+      kind: "agent",
+      agent: "codex",
+      projectSlug: "repo",
+      worktreeId: "wt_abc123def456",
+      taskId: "task_0",
+      pr: 77,
+    });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /kill sess_abc123/i }));

--- a/www/content/docs/guide/meta.json
+++ b/www/content/docs/guide/meta.json
@@ -3,5 +3,5 @@
   "title": "Guide",
   "description": "Learn how to use Matrix OS",
   "icon": "BookOpen",
-  "pages": ["index", "getting-started", "integrations", "apps", "app-store", "channels", "social", "storage", "agents", "file-system", "cloud-coding"]
+  "pages": ["index", "getting-started", "mobile", "integrations", "apps", "app-store", "channels", "social", "storage", "agents", "file-system", "cloud-coding"]
 }

--- a/www/content/docs/guide/mobile.mdx
+++ b/www/content/docs/guide/mobile.mdx
@@ -1,0 +1,53 @@
+---
+title: Mobile
+description: Use Matrix OS from a phone without starting in the desktop Canvas.
+---
+
+Matrix OS has a phone-first shell for quick daily use. On a small screen, Matrix opens to Apps instead of dropping you into the desktop workspace.
+
+## What Opens First
+
+On mobile, the launcher is the first usable surface. It shows your apps in a simple grid, plus shortcuts for recent work.
+
+From there you can:
+
+- open an app full screen;
+- return home with the Home button;
+- continue the last app you used;
+- open Terminal without managing SSH keys;
+- enter Canvas only when you choose it.
+
+## Apps On Mobile
+
+Apps open as full-screen views so the available space goes to the tool, not desktop window chrome. Returning home keeps the app recoverable when Matrix can restore it.
+
+If an app cannot be opened, Matrix shows a safe recovery message and lets you go back to the launcher.
+
+## Terminal On Mobile
+
+Terminal is available from the launcher. It connects through your authenticated Matrix session, so normal users do not need SSH keys.
+
+The mobile Terminal screen includes:
+
+- visible current folder;
+- command input;
+- session resume choices;
+- touch controls for Escape, Tab, arrows, Control, paste, and font size;
+- a safe message when a previous terminal session already ended.
+
+## Canvas On Mobile
+
+Canvas is still available, but it is not the default phone home screen. Open it from the launcher when you want the spatial workspace, whiteboard, or visual app layout.
+
+When entering Canvas on mobile, Matrix resets stale pan and zoom state so the workspace is not trapped off screen.
+
+## Testing On A Real Phone
+
+For the most realistic check, install or open Matrix on the phone, sign in, then test:
+
+1. Hard refresh or reopen Matrix and confirm Apps is first.
+2. Open Notes, Terminal, Chat, Files, Whiteboard, and a game from the launcher.
+3. Use Home to return after each app.
+4. Reopen Matrix and confirm the Continue action points to recent work.
+5. Open Terminal, run a command, detach or leave, then resume.
+6. Open Canvas explicitly and return home.


### PR DESCRIPTION
## Summary

- Stack: 2/2 on top of #127 (`075-mobile-runtime`).
- Adds a launcher-first mobile shell for browser phone viewports and the native Expo app.
- Adds full-screen mobile app surfaces, recoverable recent-app state, and explicit Canvas entry instead of defaulting phones into Canvas.
- Adds Matrix-authenticated native mobile Terminal sessions with session listing, attach/resume, detach/destroy, touch controls, and safe recovery for missing sessions.
- Hardens app launch paths, shipped icon handling, shell proxy routing, Clerk hydration, native OAuth redirect handling, splash-screen startup, and terminal rendering/focus regressions observed during live mobile preview.
- Adds 075 Spec Kit artifacts plus public and developer mobile-shell docs.

## Invariants

- Source of truth: mobile shell resume state is a small validated client-side record. Terminal session truth remains the gateway terminal registry and WebSocket protocol; app manifests and runtime routes remain the source of available app metadata.
- Lock/transaction scope: this PR does not add database writes. Gateway terminal session mutations remain bounded to the existing terminal session manager and idempotent stale-session cleanup.
- Acceptable orphan states: a persisted last-active app or terminal id may point to a resource that no longer exists. The mobile UI must show a generic recovery path and return to the launcher instead of clearing state before server confirmation or exposing raw errors.
- Auth source of truth: app and terminal access continue to use Matrix shell authentication and gateway session/WebSocket token paths. Mobile Terminal does not require user-managed SSH keys. Native Clerk OAuth uses the stable `matrixos://sso-callback` redirect by default, overrideable with `EXPO_PUBLIC_CLERK_OAUTH_REDIRECT_URL`.
- Deferred scope: full parity for every desktop Canvas workflow on native mobile remains deferred; native Canvas has an explicit unavailable-state entry while browser mobile Canvas is reachable by choice.

## Validation

- `pnpm --dir apps/mobile exec tsc --noEmit` passed.
- `pnpm --dir shell exec tsc --noEmit` passed.
- `pnpm --dir apps/mobile exec jest --runInBand __tests__/apps.test.ts __tests__/apps-screen.test.tsx __tests__/canvas-entry.test.tsx __tests__/terminal-screen.test.tsx __tests__/mobile-shell-state.test.ts` passed: 5 suites / 27 tests.
- `pnpm --dir apps/mobile exec expo export --platform ios --clear` passed.
- `pnpm --dir apps/mobile exec expo install --check` passed.
- `git diff --check` passed.

## Notes

- Downstack runtime layer: #127.
- For Expo Go OAuth, Clerk must allow `matrixos://sso-callback` as a mobile redirect URL, or set `EXPO_PUBLIC_CLERK_OAUTH_REDIRECT_URL` to another approved native redirect.
