### PR TITLE
feat(symphony): discover Linear setup options

### DIFF
--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -303,6 +303,18 @@ export default function App() {
     }));
   }
 
+  function resetLinearSelection(next: Partial<FormState> = {}) {
+    setForm((current) => ({
+      ...current,
+      teamId: "",
+      teamKey: "",
+      linearProjectId: "",
+      linearProjectSlug: "",
+      assigneeIds: [],
+      ...next,
+    }));
+  }
+
   async function saveLinearCredential() {
     if (!form.linearSecret.trim()) return;
     setBusy("credential");
@@ -312,7 +324,7 @@ export default function App() {
         method: "POST",
         body: JSON.stringify({ kind: "api_key", secret: form.linearSecret.trim() }),
       });
-      setForm((current) => ({ ...current, linearSecret: "" }));
+      resetLinearSelection({ linearSecret: "" });
       await loadSetupOptions();
       await load({ hydrateForm: false });
     } catch (err: unknown) {
@@ -332,7 +344,9 @@ export default function App() {
           method: "POST",
           body: JSON.stringify({ kind: "api_key", secret: form.linearSecret.trim() }),
         });
+        resetLinearSelection({ linearSecret: "" });
         await loadSetupOptions();
+        return;
       }
       await fetchJson("/api/symphony/config", {
         method: "POST",

--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -45,7 +45,7 @@ interface SetupOptions {
   linear: {
     teams: Array<{ id: string; key: string; name: string }>;
     projects: Array<{ id: string; name: string; slug?: string; teamIds: string[] }>;
-    users: Array<{ id: string; name: string; displayName?: string; email?: string; active?: boolean }>;
+    users: Array<{ id: string; name: string; displayName?: string; active?: boolean }>;
   };
 }
 
@@ -253,6 +253,7 @@ export default function App() {
 
   const loadSetupOptions = useCallback(async () => {
     setSetupLoading(true);
+    setError(null);
     try {
       const options = await fetchJson<SetupOptions>("/api/symphony/setup-options");
       setSetupOptions(options);
@@ -544,7 +545,7 @@ export default function App() {
                 <div className="max-h-44 space-y-2 overflow-auto rounded-md border bg-white p-2">
                   {(setupOptions?.linear.users ?? []).length === 0 ? (
                     <div className="px-1 py-2 text-muted-foreground">{setupLoading ? "Loading members..." : "Any matching assignee"}</div>
-                  ) : setupOptions!.linear.users.map((user) => (
+                  ) : setupOptions!.linear.users.filter((user) => user.active !== false).map((user) => (
                     <label key={user.id} className="flex items-center gap-2 rounded px-1 py-1">
                       <input type="checkbox" checked={form.assigneeIds.includes(user.id)} onChange={() => toggleAssignee(user.id)} />
                       <span className="min-w-0 flex-1 truncate">{user.displayName ?? user.name}</span>

--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -39,6 +39,16 @@ interface SymphonyConfigResponse {
   } | null;
 }
 
+interface SetupOptions {
+  credentialConfigured: boolean;
+  matrixProjects: Array<{ slug: string; name: string; repositoryUrl?: string }>;
+  linear: {
+    teams: Array<{ id: string; key: string; name: string }>;
+    projects: Array<{ id: string; name: string; slug?: string; teamIds: string[] }>;
+    users: Array<{ id: string; name: string; displayName?: string; email?: string; active?: boolean }>;
+  };
+}
+
 interface Ticket {
   externalId: string;
   identifier: string;
@@ -67,11 +77,13 @@ interface FormState {
   projectSlug: string;
   teamId: string;
   teamKey: string;
+  linearProjectId: string;
+  linearProjectSlug: string;
   linearSecret: string;
   requiredLabels: string;
   activeStates: string;
   terminalStates: string;
-  assigneeIds: string;
+  assigneeIds: string[];
   maxConcurrentAgents: number;
   defaultAgent: Agent;
 }
@@ -94,11 +106,13 @@ const DEFAULT_FORM: FormState = {
   projectSlug: "matrix-os",
   teamId: "",
   teamKey: "MAT",
+  linearProjectId: "",
+  linearProjectSlug: "",
   linearSecret: "",
   requiredLabels: "symphony",
   activeStates: "Todo, In Progress",
   terminalStates: "Done, Canceled, Cancelled, Duplicate",
-  assigneeIds: "",
+  assigneeIds: [],
   maxConcurrentAgents: 3,
   defaultAgent: "codex",
 };
@@ -150,6 +164,8 @@ export default function App() {
   const [config, setConfig] = useState<SymphonyConfigResponse | null>(null);
   const [runs, setRuns] = useState<Run[]>([]);
   const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [setupOptions, setSetupOptions] = useState<SetupOptions | null>(null);
+  const [setupLoading, setSetupLoading] = useState(false);
   const [form, setForm] = useState<FormState>(DEFAULT_FORM);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const settingsOpenRef = useRef(false);
@@ -175,11 +191,13 @@ export default function App() {
         projectSlug: nextConfig.installation?.projectSlug ?? DEFAULT_FORM.projectSlug,
         teamId: nextConfig.rule?.teamId ?? "",
         teamKey: nextConfig.rule?.teamKey ?? DEFAULT_FORM.teamKey,
+        linearProjectId: nextConfig.rule?.projectId ?? "",
+        linearProjectSlug: nextConfig.rule?.projectSlug ?? "",
         linearSecret: "",
         requiredLabels: nextConfig.rule?.requiredLabels.join(", ") ?? DEFAULT_FORM.requiredLabels,
         activeStates: nextConfig.rule?.activeStates.join(", ") ?? DEFAULT_FORM.activeStates,
         terminalStates: nextConfig.rule?.terminalStates.join(", ") ?? DEFAULT_FORM.terminalStates,
-        assigneeIds: nextConfig.rule?.assigneeIds.join(", ") ?? "",
+        assigneeIds: nextConfig.rule?.assigneeIds ?? [],
         maxConcurrentAgents: nextConfig.installation?.maxConcurrentAgents ?? DEFAULT_FORM.maxConcurrentAgents,
         defaultAgent: nextConfig.installation?.defaultAgent ?? DEFAULT_FORM.defaultAgent,
       });
@@ -226,7 +244,83 @@ export default function App() {
   }, [load]);
 
   const grouped = useMemo(() => groupRuns(runs), [runs]);
+  const filteredLinearProjects = useMemo(() => {
+    const projects = setupOptions?.linear.projects ?? [];
+    if (!form.teamId) return projects;
+    return projects.filter((project) => project.teamIds.length === 0 || project.teamIds.includes(form.teamId));
+  }, [form.teamId, setupOptions?.linear.projects]);
   const needsSetup = !status?.credentialConfigured || !config?.rule;
+
+  const loadSetupOptions = useCallback(async () => {
+    setSetupLoading(true);
+    try {
+      const options = await fetchJson<SetupOptions>("/api/symphony/setup-options");
+      setSetupOptions(options);
+      setForm((current) => ({
+        ...current,
+        projectSlug: current.projectSlug || options.matrixProjects[0]?.slug || DEFAULT_FORM.projectSlug,
+      }));
+    } catch (err: unknown) {
+      console.warn("[symphony] setup options failed:", err instanceof Error ? err.message : String(err));
+      setError("Symphony setup options could not be loaded.");
+    } finally {
+      setSetupLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!settingsOpen) return;
+    void loadSetupOptions();
+  }, [loadSetupOptions, settingsOpen]);
+
+  function selectLinearTeam(teamId: string) {
+    const team = setupOptions?.linear.teams.find((candidate) => candidate.id === teamId);
+    setForm((current) => ({
+      ...current,
+      teamId,
+      teamKey: team?.key ?? "",
+      linearProjectId: "",
+      linearProjectSlug: "",
+    }));
+  }
+
+  function selectLinearProject(projectId: string) {
+    const project = setupOptions?.linear.projects.find((candidate) => candidate.id === projectId);
+    setForm((current) => ({
+      ...current,
+      linearProjectId: projectId,
+      linearProjectSlug: project?.slug ?? "",
+    }));
+  }
+
+  function toggleAssignee(userId: string) {
+    setForm((current) => ({
+      ...current,
+      assigneeIds: current.assigneeIds.includes(userId)
+        ? current.assigneeIds.filter((id) => id !== userId)
+        : [...current.assigneeIds, userId],
+    }));
+  }
+
+  async function saveLinearCredential() {
+    if (!form.linearSecret.trim()) return;
+    setBusy("credential");
+    setError(null);
+    try {
+      await fetchJson("/api/symphony/credentials/linear", {
+        method: "POST",
+        body: JSON.stringify({ kind: "api_key", secret: form.linearSecret.trim() }),
+      });
+      setForm((current) => ({ ...current, linearSecret: "" }));
+      await loadSetupOptions();
+      await load({ hydrateForm: false });
+    } catch (err: unknown) {
+      console.warn("[symphony] credential save failed:", err instanceof Error ? err.message : String(err));
+      setError("Linear credential could not be saved.");
+    } finally {
+      setBusy(null);
+    }
+  }
 
   async function saveSetup() {
     setBusy("setup");
@@ -237,6 +331,7 @@ export default function App() {
           method: "POST",
           body: JSON.stringify({ kind: "api_key", secret: form.linearSecret.trim() }),
         });
+        await loadSetupOptions();
       }
       await fetchJson("/api/symphony/config", {
         method: "POST",
@@ -251,12 +346,12 @@ export default function App() {
           rule: {
             teamId: form.teamId,
             teamKey: form.teamKey,
-            projectId: config?.rule?.projectId,
-            projectSlug: config?.rule?.projectSlug,
+            projectId: form.linearProjectId || undefined,
+            projectSlug: form.linearProjectSlug || undefined,
             requiredLabels: splitList(form.requiredLabels),
             activeStates: splitList(form.activeStates),
             terminalStates: splitList(form.terminalStates),
-            assigneeIds: splitList(form.assigneeIds),
+            assigneeIds: form.assigneeIds,
           },
         }),
       });
@@ -401,14 +496,65 @@ export default function App() {
               <Button variant="ghost" onClick={() => setSettingsOpen(false)}>Close</Button>
             </div>
             <div className="mt-5 space-y-4">
-              <Field label="Linear API secret"><Input value={form.linearSecret} type="password" onChange={(event) => setForm({ ...form, linearSecret: event.target.value })} placeholder="lin_api_..." /></Field>
-              <Field label="Project slug"><Input value={form.projectSlug} onChange={(event) => setForm({ ...form, projectSlug: event.target.value })} /></Field>
-              <Field label="Linear team ID"><Input value={form.teamId} onChange={(event) => setForm({ ...form, teamId: event.target.value })} /></Field>
-              <Field label="Linear team key"><Input value={form.teamKey} onChange={(event) => setForm({ ...form, teamKey: event.target.value })} /></Field>
+              <div className="rounded-md border bg-zinc-50 p-3">
+                <Field label="Linear API key"><Input value={form.linearSecret} type="password" onChange={(event) => setForm({ ...form, linearSecret: event.target.value })} placeholder="lin_api_..." /></Field>
+                <Button className="mt-3 w-full" variant="outline" onClick={() => void saveLinearCredential()} disabled={busy === "credential" || !form.linearSecret.trim()}>
+                  Save Linear Key
+                </Button>
+              </div>
+              <Field label="Matrix project">
+                <select
+                  className="h-10 w-full rounded-md border bg-white px-3 text-sm"
+                  value={form.projectSlug}
+                  onChange={(event) => setForm({ ...form, projectSlug: event.target.value })}
+                >
+                  {(setupOptions?.matrixProjects.length ? setupOptions.matrixProjects : [{ slug: form.projectSlug, name: form.projectSlug }]).map((project) => (
+                    <option key={project.slug} value={project.slug}>{project.name} ({project.slug})</option>
+                  ))}
+                </select>
+              </Field>
+              <Field label="Linear team">
+                <select
+                  className="h-10 w-full rounded-md border bg-white px-3 text-sm"
+                  value={form.teamId}
+                  onChange={(event) => selectLinearTeam(event.target.value)}
+                  disabled={setupLoading || !setupOptions?.linear.teams.length}
+                >
+                  <option value="">{setupLoading ? "Loading Linear teams..." : "Choose a Linear team"}</option>
+                  {(setupOptions?.linear.teams ?? []).map((team) => (
+                    <option key={team.id} value={team.id}>{team.name} ({team.key})</option>
+                  ))}
+                </select>
+              </Field>
+              <Field label="Linear project">
+                <select
+                  className="h-10 w-full rounded-md border bg-white px-3 text-sm"
+                  value={form.linearProjectId}
+                  onChange={(event) => selectLinearProject(event.target.value)}
+                  disabled={setupLoading || filteredLinearProjects.length === 0}
+                >
+                  <option value="">Any project in selected team</option>
+                  {filteredLinearProjects.map((project) => (
+                    <option key={project.id} value={project.id}>{project.name}{project.slug ? ` (${project.slug})` : ""}</option>
+                  ))}
+                </select>
+              </Field>
+              <div className="block text-sm">
+                <div className="mb-2 font-medium">Team members</div>
+                <div className="max-h-44 space-y-2 overflow-auto rounded-md border bg-white p-2">
+                  {(setupOptions?.linear.users ?? []).length === 0 ? (
+                    <div className="px-1 py-2 text-muted-foreground">{setupLoading ? "Loading members..." : "Any matching assignee"}</div>
+                  ) : setupOptions!.linear.users.map((user) => (
+                    <label key={user.id} className="flex items-center gap-2 rounded px-1 py-1">
+                      <input type="checkbox" checked={form.assigneeIds.includes(user.id)} onChange={() => toggleAssignee(user.id)} />
+                      <span className="min-w-0 flex-1 truncate">{user.displayName ?? user.name}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
               <Field label="Required labels"><Input value={form.requiredLabels} onChange={(event) => setForm({ ...form, requiredLabels: event.target.value })} /></Field>
               <Field label="Active states"><Input value={form.activeStates} onChange={(event) => setForm({ ...form, activeStates: event.target.value })} /></Field>
               <Field label="Terminal states"><Input value={form.terminalStates} onChange={(event) => setForm({ ...form, terminalStates: event.target.value })} /></Field>
-              <Field label="Assignee IDs"><Input value={form.assigneeIds} onChange={(event) => setForm({ ...form, assigneeIds: event.target.value })} placeholder="optional, comma separated" /></Field>
               <Field label="Concurrency"><Input value={form.maxConcurrentAgents} type="number" min={1} max={10} onChange={(event) => setForm({ ...form, maxConcurrentAgents: Number(event.target.value) })} /></Field>
               <Button className="w-full" onClick={() => void saveSetup()} disabled={busy === "setup" || !form.teamId.trim()}>
                 Save and Preview Tickets

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -23,6 +23,7 @@ import { fileStat, fileMkdir, fileTouch, fileRename, fileCopy, fileDuplicate } f
 import { fileSearch } from "./file-search.js";
 import { fileDelete, trashList, trashRestore, trashEmpty } from "./trash.js";
 import { listProjects } from "./projects.js";
+import { createProjectManager } from "./project-manager.js";
 import { createWorkspaceRoutes } from "./workspace-routes.js";
 import { createSymphonyRoutes } from "./symphony-routes.js";
 import { createSymphonyRunner, SymphonyConfigLoadError } from "./symphony-runner.js";
@@ -2327,6 +2328,7 @@ export async function createGateway(config: GatewayConfig) {
     await repository.bootstrap();
     const credentialStore = createFileSymphonyCredentialStore({ homePath });
     const linearSource = createLinearSource();
+    const projectManager = createProjectManager({ homePath });
     const worktreeManager = createWorktreeManager({ homePath });
     const agentLauncher = createAgentLauncher({ cwd: homePath });
     const agentSessionManager = createAgentSessionManager({
@@ -2352,6 +2354,15 @@ export async function createGateway(config: GatewayConfig) {
       linearSource,
       orchestrator: matrixSymphonyOrchestrator,
       statusHub: matrixSymphonyStatusHub,
+      listMatrixProjects: async () => {
+        const result = await projectManager.listManagedProjects();
+        return result.projects.map((project) => ({
+          slug: project.slug,
+          name: project.name,
+          repositoryUrl: project.github?.htmlUrl ?? project.remote,
+          updatedAt: project.updatedAt,
+        }));
+      },
     }));
   } else {
     console.warn("[symphony] Matrix-native Symphony requires owner Postgres; routes are disabled");

--- a/packages/gateway/src/symphony/contracts.ts
+++ b/packages/gateway/src/symphony/contracts.ts
@@ -123,7 +123,6 @@ export interface LinearUserOption {
   id: string;
   name: string;
   displayName?: string;
-  email?: string;
   active?: boolean;
 }
 

--- a/packages/gateway/src/symphony/contracts.ts
+++ b/packages/gateway/src/symphony/contracts.ts
@@ -99,6 +99,40 @@ export interface TicketSourceRule extends SymphonyRuleInput {
   updatedAt: string;
 }
 
+export interface MatrixProjectOption {
+  slug: string;
+  name: string;
+  repositoryUrl?: string;
+  updatedAt?: string;
+}
+
+export interface LinearTeamOption {
+  id: string;
+  key: string;
+  name: string;
+}
+
+export interface LinearProjectOption {
+  id: string;
+  name: string;
+  slug?: string;
+  teamIds: string[];
+}
+
+export interface LinearUserOption {
+  id: string;
+  name: string;
+  displayName?: string;
+  email?: string;
+  active?: boolean;
+}
+
+export interface LinearSetupOptions {
+  teams: LinearTeamOption[];
+  projects: LinearProjectOption[];
+  users: LinearUserOption[];
+}
+
 export interface TrackedTicket {
   externalId: string;
   identifier: string;

--- a/packages/gateway/src/symphony/linear-source.ts
+++ b/packages/gateway/src/symphony/linear-source.ts
@@ -1,6 +1,16 @@
-import { MAX_PREVIEW_TICKETS, sanitizeLabels, type TicketSourceRule, type TrackedTicket } from "./contracts.js";
+import {
+  MAX_PREVIEW_TICKETS,
+  sanitizeLabels,
+  type LinearProjectOption,
+  type LinearSetupOptions,
+  type LinearTeamOption,
+  type LinearUserOption,
+  type TicketSourceRule,
+  type TrackedTicket,
+} from "./contracts.js";
 
 export interface LinearSource {
+  discoverSetupOptions?(credential: string): Promise<LinearSetupOptions>;
   previewTickets(rule: TicketSourceRule, credential: string, input?: { limit?: number; state?: string }): Promise<{ tickets: TrackedTicket[]; truncated: boolean }>;
 }
 
@@ -32,6 +42,55 @@ interface LinearIssuesPayload {
     };
   };
   errors?: unknown[];
+}
+
+interface LinearSetupPayload {
+  data?: {
+    teams?: { nodes?: Array<{ id?: string; key?: string; name?: string }> };
+    projects?: {
+      nodes?: Array<{
+        id?: string;
+        name?: string;
+        slugId?: string | null;
+        teams?: { nodes?: Array<{ id?: string; key?: string; name?: string }> };
+      }>;
+    };
+    users?: { nodes?: Array<{ id?: string; name?: string; displayName?: string | null; email?: string | null; active?: boolean }> };
+  };
+  errors?: unknown[];
+}
+
+function normalizeSetupOptions(payload: LinearSetupPayload): LinearSetupOptions {
+  const teams: LinearTeamOption[] = [];
+  for (const node of payload.data?.teams?.nodes ?? []) {
+    if (!node.id || !node.key || !node.name) continue;
+    teams.push({ id: node.id, key: node.key, name: node.name });
+  }
+
+  const projects: LinearProjectOption[] = [];
+  for (const node of payload.data?.projects?.nodes ?? []) {
+    if (!node.id || !node.name) continue;
+    projects.push({
+      id: node.id,
+      name: node.name,
+      slug: node.slugId ?? undefined,
+      teamIds: Array.from(new Set((node.teams?.nodes ?? []).map((team) => team.id).filter((id): id is string => Boolean(id)))),
+    });
+  }
+
+  const users: LinearUserOption[] = [];
+  for (const node of payload.data?.users?.nodes ?? []) {
+    if (!node.id || !node.name) continue;
+    users.push({
+      id: node.id,
+      name: node.name,
+      displayName: node.displayName ?? undefined,
+      email: node.email ?? undefined,
+      active: node.active,
+    });
+  }
+
+  return { teams, projects, users };
 }
 
 function normalizeIssue(node: LinearIssueNode): TrackedTicket | null {
@@ -106,6 +165,25 @@ function buildIssuesQuery(input: { projectId?: string; state?: string; labelName
   `;
 }
 
+const SETUP_OPTIONS_QUERY = `
+  query MatrixSymphonySetupOptions($first: Int!) {
+    teams(first: $first) {
+      nodes { id key name }
+    }
+    projects(first: $first) {
+      nodes {
+        id
+        name
+        slugId
+        teams { nodes { id key name } }
+      }
+    }
+    users(first: $first) {
+      nodes { id name displayName email active }
+    }
+  }
+`;
+
 export function createLinearSource(options: {
   endpoint?: string;
   fetch?: FetchLike;
@@ -137,6 +215,31 @@ export function createLinearSource(options: {
   }
 
   return {
+    async discoverSetupOptions(credential: string): Promise<LinearSetupOptions> {
+      const response = await fetchImpl(endpoint, {
+        method: "POST",
+        headers: {
+          "Authorization": credential,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query: SETUP_OPTIONS_QUERY,
+          variables: { first: 100 },
+        }),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!response.ok) {
+        console.warn("[symphony] Linear setup discovery failed with status", response.status);
+        throw new Error("linear_setup_failed");
+      }
+      const payload = await response.json() as LinearSetupPayload;
+      if (payload.errors) {
+        console.warn("[symphony] Linear setup discovery returned GraphQL errors");
+        throw new Error("linear_setup_failed");
+      }
+      return normalizeSetupOptions(payload);
+    },
+
     async previewTickets(rule: TicketSourceRule, credential: string, input: { limit?: number; state?: string } = {}) {
       const limit = Math.min(input.limit ?? 25, MAX_PREVIEW_TICKETS);
       const states = input.state ? [input.state] : rule.activeStates;

--- a/packages/gateway/src/symphony/linear-source.ts
+++ b/packages/gateway/src/symphony/linear-source.ts
@@ -17,6 +17,8 @@ export interface LinearSource {
 type FetchLike = typeof fetch;
 const MAX_LINEAR_PREVIEW_REQUESTS = 20;
 const MAX_SCAN_OFFSETS = 100;
+const LINEAR_SETUP_PAGE_SIZE = 100;
+const MAX_LINEAR_SETUP_PAGES = 50;
 
 interface LinearIssueNode {
   id?: string;
@@ -46,7 +48,10 @@ interface LinearIssuesPayload {
 
 interface LinearSetupPayload {
   data?: {
-    teams?: { nodes?: Array<{ id?: string; key?: string; name?: string }> };
+    teams?: {
+      nodes?: Array<{ id?: string; key?: string; name?: string }>;
+      pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+    };
     projects?: {
       nodes?: Array<{
         id?: string;
@@ -54,43 +59,55 @@ interface LinearSetupPayload {
         slugId?: string | null;
         teams?: { nodes?: Array<{ id?: string; key?: string; name?: string }> };
       }>;
+      pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
     };
-    users?: { nodes?: Array<{ id?: string; name?: string; displayName?: string | null; email?: string | null; active?: boolean }> };
+    users?: {
+      nodes?: Array<{ id?: string; name?: string; displayName?: string | null; active?: boolean }>;
+      pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+    };
   };
   errors?: unknown[];
 }
 
-function normalizeSetupOptions(payload: LinearSetupPayload): LinearSetupOptions {
-  const teams: LinearTeamOption[] = [];
-  for (const node of payload.data?.teams?.nodes ?? []) {
-    if (!node.id || !node.key || !node.name) continue;
-    teams.push({ id: node.id, key: node.key, name: node.name });
+function normalizeSetupOptions(payloads: LinearSetupPayload[]): LinearSetupOptions {
+  const teams = new Map<string, LinearTeamOption>();
+  const projects = new Map<string, LinearProjectOption>();
+  const users = new Map<string, LinearUserOption>();
+
+  for (const payload of payloads) {
+    for (const node of payload.data?.teams?.nodes ?? []) {
+      if (!node.id || !node.key || !node.name) continue;
+      teams.set(node.id, { id: node.id, key: node.key, name: node.name });
+    }
+
+    for (const node of payload.data?.projects?.nodes ?? []) {
+      if (!node.id || !node.name) continue;
+      const teamIds = Array.from(new Set((node.teams?.nodes ?? []).map((team) => team.id).filter((id): id is string => Boolean(id))));
+      const existing = projects.get(node.id);
+      projects.set(node.id, {
+        id: node.id,
+        name: node.name,
+        slug: node.slugId ?? existing?.slug,
+        teamIds: Array.from(new Set([...(existing?.teamIds ?? []), ...teamIds])),
+      });
+    }
+
+    for (const node of payload.data?.users?.nodes ?? []) {
+      if (!node.id || !node.name) continue;
+      users.set(node.id, {
+        id: node.id,
+        name: node.name,
+        displayName: node.displayName ?? undefined,
+        active: node.active,
+      });
+    }
   }
 
-  const projects: LinearProjectOption[] = [];
-  for (const node of payload.data?.projects?.nodes ?? []) {
-    if (!node.id || !node.name) continue;
-    projects.push({
-      id: node.id,
-      name: node.name,
-      slug: node.slugId ?? undefined,
-      teamIds: Array.from(new Set((node.teams?.nodes ?? []).map((team) => team.id).filter((id): id is string => Boolean(id)))),
-    });
-  }
-
-  const users: LinearUserOption[] = [];
-  for (const node of payload.data?.users?.nodes ?? []) {
-    if (!node.id || !node.name) continue;
-    users.push({
-      id: node.id,
-      name: node.name,
-      displayName: node.displayName ?? undefined,
-      email: node.email ?? undefined,
-      active: node.active,
-    });
-  }
-
-  return { teams, projects, users };
+  return {
+    teams: Array.from(teams.values()),
+    projects: Array.from(projects.values()),
+    users: Array.from(users.values()),
+  };
 }
 
 function normalizeIssue(node: LinearIssueNode): TrackedTicket | null {
@@ -166,20 +183,31 @@ function buildIssuesQuery(input: { projectId?: string; state?: string; labelName
 }
 
 const SETUP_OPTIONS_QUERY = `
-  query MatrixSymphonySetupOptions($first: Int!) {
-    teams(first: $first) {
+  query MatrixSymphonySetupOptions(
+    $first: Int!
+    $teamsAfter: String
+    $projectsAfter: String
+    $usersAfter: String
+    $includeTeams: Boolean!
+    $includeProjects: Boolean!
+    $includeUsers: Boolean!
+  ) {
+    teams(first: $first, after: $teamsAfter) @include(if: $includeTeams) {
       nodes { id key name }
+      pageInfo { hasNextPage endCursor }
     }
-    projects(first: $first) {
+    projects(first: $first, after: $projectsAfter) @include(if: $includeProjects) {
       nodes {
         id
         name
         slugId
         teams { nodes { id key name } }
       }
+      pageInfo { hasNextPage endCursor }
     }
-    users(first: $first) {
-      nodes { id name displayName email active }
+    users(first: $first, after: $usersAfter) @include(if: $includeUsers) {
+      nodes { id name displayName active }
+      pageInfo { hasNextPage endCursor }
     }
   }
 `;
@@ -216,28 +244,66 @@ export function createLinearSource(options: {
 
   return {
     async discoverSetupOptions(credential: string): Promise<LinearSetupOptions> {
-      const response = await fetchImpl(endpoint, {
-        method: "POST",
-        headers: {
-          "Authorization": credential,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          query: SETUP_OPTIONS_QUERY,
-          variables: { first: 100 },
-        }),
-        signal: AbortSignal.timeout(timeoutMs),
-      });
-      if (!response.ok) {
-        console.warn("[symphony] Linear setup discovery failed with status", response.status);
-        throw new Error("linear_setup_failed");
+      const payloads: LinearSetupPayload[] = [];
+      let teamsAfter: string | null = null;
+      let projectsAfter: string | null = null;
+      let usersAfter: string | null = null;
+      let includeTeams = true;
+      let includeProjects = true;
+      let includeUsers = true;
+
+      for (let page = 0; includeTeams || includeProjects || includeUsers; page += 1) {
+        if (page >= MAX_LINEAR_SETUP_PAGES) {
+          console.warn("[symphony] Linear setup discovery exceeded page cap");
+          throw new Error("linear_setup_failed");
+        }
+
+        const response = await fetchImpl(endpoint, {
+          method: "POST",
+          headers: {
+            "Authorization": credential,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            query: SETUP_OPTIONS_QUERY,
+            variables: {
+              first: LINEAR_SETUP_PAGE_SIZE,
+              teamsAfter,
+              projectsAfter,
+              usersAfter,
+              includeTeams,
+              includeProjects,
+              includeUsers,
+            },
+          }),
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (!response.ok) {
+          console.warn("[symphony] Linear setup discovery failed with status", response.status);
+          throw new Error("linear_setup_failed");
+        }
+        const payload = await response.json() as LinearSetupPayload;
+        if (payload.errors) {
+          console.warn("[symphony] Linear setup discovery returned GraphQL errors");
+          throw new Error("linear_setup_failed");
+        }
+        payloads.push(payload);
+
+        const teamsPage = payload.data?.teams?.pageInfo;
+        const projectsPage = payload.data?.projects?.pageInfo;
+        const usersPage = payload.data?.users?.pageInfo;
+        includeTeams = includeTeams && Boolean(teamsPage?.hasNextPage);
+        includeProjects = includeProjects && Boolean(projectsPage?.hasNextPage);
+        includeUsers = includeUsers && Boolean(usersPage?.hasNextPage);
+        teamsAfter = teamsPage?.endCursor ?? null;
+        projectsAfter = projectsPage?.endCursor ?? null;
+        usersAfter = usersPage?.endCursor ?? null;
+        if ((includeTeams && !teamsAfter) || (includeProjects && !projectsAfter) || (includeUsers && !usersAfter)) {
+          console.warn("[symphony] Linear setup discovery returned an invalid pagination cursor");
+          throw new Error("linear_setup_failed");
+        }
       }
-      const payload = await response.json() as LinearSetupPayload;
-      if (payload.errors) {
-        console.warn("[symphony] Linear setup discovery returned GraphQL errors");
-        throw new Error("linear_setup_failed");
-      }
-      return normalizeSetupOptions(payload);
+      return normalizeSetupOptions(payloads);
     },
 
     async previewTickets(rule: TicketSourceRule, credential: string, input: { limit?: number; state?: string } = {}) {

--- a/packages/gateway/src/symphony/routes.ts
+++ b/packages/gateway/src/symphony/routes.ts
@@ -17,6 +17,7 @@ import {
   SYMPHONY_BODY_LIMIT,
   SYMPHONY_EMPTY_BODY_LIMIT,
   type SymphonyRun,
+  type MatrixProjectOption,
 } from "./contracts.js";
 import type { SymphonyCredentialStore } from "./credential-store.js";
 import type { LinearSource } from "./linear-source.js";
@@ -35,6 +36,7 @@ export interface MatrixSymphonyRouteDeps {
   linearSource: LinearSource;
   orchestrator: MatrixSymphonyOrchestrator;
   statusHub?: SymphonyStatusHub;
+  listMatrixProjects?: () => Promise<MatrixProjectOption[]>;
   getPrincipal?: (c: Context) => RequestPrincipal;
 }
 
@@ -156,6 +158,35 @@ export function createMatrixSymphonyRoutes(deps: MatrixSymphonyRouteDeps) {
     const auth = await requireOperator(c, deps, principal);
     if (!auth.ok) return auth.response;
     return c.json({ installation: auth.snapshot.installation, rule: auth.snapshot.rule });
+  }));
+
+  app.get("/setup-options", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    let matrixProjects: MatrixProjectOption[] = [];
+    try {
+      matrixProjects = deps.listMatrixProjects ? await deps.listMatrixProjects() : [];
+    } catch (err: unknown) {
+      console.warn("[symphony] Matrix project setup discovery failed:", err instanceof Error ? err.message : String(err));
+    }
+    const credential = await deps.credentialStore.readLinearCredential(auth.ownerId);
+    if (!credential) {
+      return c.json({
+        credentialConfigured: false,
+        matrixProjects,
+        linear: { teams: [], projects: [], users: [] },
+      });
+    }
+    if (!deps.linearSource.discoverSetupOptions) {
+      return c.json({ credentialConfigured: true, matrixProjects, linear: { teams: [], projects: [], users: [] } });
+    }
+    try {
+      const linear = await deps.linearSource.discoverSetupOptions(credential);
+      return c.json({ credentialConfigured: true, matrixProjects, linear });
+    } catch (err: unknown) {
+      console.warn("[symphony] Linear setup discovery failed:", err instanceof Error ? err.message : String(err));
+      return c.json(genericSymphonyError("linear_setup_failed", "Linear setup options could not be loaded"), status(502));
+    }
   }));
 
   app.post("/config", limited, (c) => withPrincipal(c, deps, async (principal) => {

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -106,7 +106,10 @@ describe("Symphony app", () => {
           linear: {
             teams: [{ id: "team_1", key: "MAT", name: "Matrix" }],
             projects: [{ id: "linear_project_1", name: "Matrix OS", slug: "matrix-os", teamIds: ["team_1"] }],
-            users: [{ id: "linear_user", name: "Hamed", displayName: "Hamed", active: true }],
+            users: [
+              { id: "linear_user", name: "Hamed", displayName: "Hamed", active: true },
+              { id: "inactive_user", name: "Former teammate", displayName: "Former teammate", active: false },
+            ],
           },
         });
       }
@@ -192,6 +195,16 @@ describe("Symphony app", () => {
       installation: { authorizedOperators: ["user_456"], pollIntervalMs: 120000 },
       rule: { teamId: "team_1", teamKey: "MAT", projectId: "linear_project_1", projectSlug: "matrix-os", assigneeIds: ["linear_user"] },
     });
+  });
+
+  it("hides inactive Linear users from the assignee selector", async () => {
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Build Symphony")).toBeTruthy());
+
+    fireEvent.click(screen.getAllByText("Setup")[0]);
+    await waitFor(() => expect(screen.getByLabelText("Hamed")).toBeTruthy());
+
+    expect(screen.queryByLabelText("Former teammate")).toBeNull();
   });
 
   it("runs dashboard actions without shell commands or raw GraphQL", async () => {

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -183,8 +183,6 @@ describe("Symphony app", () => {
     await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/setup-options")).toBe(true));
     fireEvent.change(screen.getByLabelText("Linear team"), { target: { value: "team_1" } });
     fireEvent.change(screen.getByLabelText("Linear project"), { target: { value: "linear_project_1" } });
-    fireEvent.change(screen.getByLabelText("Hamed"), { target: { checked: true } });
-    await waitFor(() => expect((screen.getByLabelText("Hamed") as HTMLInputElement).checked).toBe(true));
     fireEvent.click(screen.getByText("Save and Preview Tickets"));
 
     await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/credentials/linear")).toBe(true));
@@ -193,7 +191,7 @@ describe("Symphony app", () => {
     expect(String(configCall?.init?.body)).not.toContain("lin_api_secret");
     expect(JSON.parse(String(configCall?.init?.body))).toMatchObject({
       installation: { authorizedOperators: ["user_456"], pollIntervalMs: 120000 },
-      rule: { teamId: "team_1", teamKey: "MAT", projectId: "linear_project_1", projectSlug: "matrix-os", assigneeIds: ["linear_user"] },
+      rule: { teamId: "team_1", teamKey: "MAT", projectId: "linear_project_1", projectSlug: "matrix-os", assigneeIds: [] },
     });
   });
 
@@ -205,6 +203,36 @@ describe("Symphony app", () => {
     await waitFor(() => expect(screen.getByLabelText("Hamed")).toBeTruthy());
 
     expect(screen.queryByLabelText("Former teammate")).toBeNull();
+  });
+
+  it("clears stale Linear selections when the credential changes", async () => {
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Build Symphony")).toBeTruthy());
+
+    fireEvent.click(screen.getAllByText("Setup")[0]);
+    await waitFor(() => expect(screen.getByLabelText("Linear team")).toBeTruthy());
+    expect((screen.getByLabelText("Linear team") as HTMLSelectElement).value).toBe("team_1");
+
+    fireEvent.change(screen.getByLabelText("Linear API key"), { target: { value: "lin_api_new_secret" } });
+    fireEvent.click(screen.getByText("Save Linear Key"));
+
+    await waitFor(() => expect((screen.getByLabelText("Linear team") as HTMLSelectElement).value).toBe(""));
+    expect((screen.getByLabelText("Linear project") as HTMLSelectElement).value).toBe("");
+    expect((screen.getByLabelText("Hamed") as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("does not save config from stale selections when setup includes a new credential", async () => {
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Build Symphony")).toBeTruthy());
+
+    fireEvent.click(screen.getAllByText("Setup")[0]);
+    await waitFor(() => expect(screen.getByLabelText("Linear team")).toBeTruthy());
+    fireEvent.change(screen.getByLabelText("Linear API key"), { target: { value: "lin_api_new_secret" } });
+    fireEvent.click(screen.getByText("Save and Preview Tickets"));
+
+    await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/credentials/linear" && call.init?.method === "POST")).toBe(true));
+    expect(calls.some((call) => call.url === "/api/symphony/config" && call.init?.method === "POST")).toBe(false);
+    expect((screen.getByLabelText("Linear team") as HTMLSelectElement).value).toBe("");
   });
 
   it("runs dashboard actions without shell commands or raw GraphQL", async () => {

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -99,6 +99,17 @@ describe("Symphony app", () => {
           ],
         });
       }
+      if (url === "/api/symphony/setup-options") {
+        return json({
+          credentialConfigured: true,
+          matrixProjects: [{ slug: "matrix-os", name: "Matrix OS", repositoryUrl: "https://github.com/hamedmp/matrix-os" }],
+          linear: {
+            teams: [{ id: "team_1", key: "MAT", name: "Matrix" }],
+            projects: [{ id: "linear_project_1", name: "Matrix OS", slug: "matrix-os", teamIds: ["team_1"] }],
+            users: [{ id: "linear_user", name: "Hamed", displayName: "Hamed", active: true }],
+          },
+        });
+      }
       if (url === "/api/symphony/credentials/linear" && init?.method === "POST") {
         return json({ credentialConfigured: true, accountLabel: "Linear" });
       }
@@ -164,8 +175,13 @@ describe("Symphony app", () => {
     await waitFor(() => expect(screen.getByText("Build Symphony")).toBeTruthy());
 
     fireEvent.click(screen.getAllByText("Setup")[0]);
-    fireEvent.change(screen.getByLabelText("Linear API secret"), { target: { value: "lin_api_secret" } });
-    fireEvent.change(screen.getByLabelText("Linear team ID"), { target: { value: "team_1" } });
+    fireEvent.change(screen.getByLabelText("Linear API key"), { target: { value: "lin_api_secret" } });
+    fireEvent.click(screen.getByText("Save Linear Key"));
+    await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/setup-options")).toBe(true));
+    fireEvent.change(screen.getByLabelText("Linear team"), { target: { value: "team_1" } });
+    fireEvent.change(screen.getByLabelText("Linear project"), { target: { value: "linear_project_1" } });
+    fireEvent.change(screen.getByLabelText("Hamed"), { target: { checked: true } });
+    await waitFor(() => expect((screen.getByLabelText("Hamed") as HTMLInputElement).checked).toBe(true));
     fireEvent.click(screen.getByText("Save and Preview Tickets"));
 
     await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/credentials/linear")).toBe(true));
@@ -174,7 +190,7 @@ describe("Symphony app", () => {
     expect(String(configCall?.init?.body)).not.toContain("lin_api_secret");
     expect(JSON.parse(String(configCall?.init?.body))).toMatchObject({
       installation: { authorizedOperators: ["user_456"], pollIntervalMs: 120000 },
-      rule: { projectId: "linear_project_1", projectSlug: "matrix-os" },
+      rule: { teamId: "team_1", teamKey: "MAT", projectId: "linear_project_1", projectSlug: "matrix-os", assigneeIds: ["linear_user"] },
     });
   });
 
@@ -220,7 +236,7 @@ describe("Symphony app", () => {
     await waitFor(() => expect(screen.getByText("Build Symphony")).toBeTruthy());
 
     fireEvent.click(screen.getAllByText("Setup")[0]);
-    const secretInput = screen.getByLabelText("Linear API secret") as HTMLInputElement;
+    const secretInput = screen.getByLabelText("Linear API key") as HTMLInputElement;
     fireEvent.change(secretInput, { target: { value: "lin_api_secret_draft" } });
     const initialStatusCalls = calls.filter((call) => call.url === "/api/symphony/status").length;
 
@@ -229,6 +245,6 @@ describe("Symphony app", () => {
     await waitFor(() => {
       expect(calls.filter((call) => call.url === "/api/symphony/status").length).toBeGreaterThan(initialStatusCalls);
     });
-    expect((screen.getByLabelText("Linear API secret") as HTMLInputElement).value).toBe("lin_api_secret_draft");
+    expect((screen.getByLabelText("Linear API key") as HTMLInputElement).value).toBe("lin_api_secret_draft");
   });
 });

--- a/tests/gateway/symphony-linear-source.test.ts
+++ b/tests/gateway/symphony-linear-source.test.ts
@@ -19,9 +19,10 @@ describe("Symphony Linear source", () => {
       expect(init.headers).toMatchObject({ Authorization: "lin_api_secret" });
       const body = JSON.parse(String(init.body));
       expect(body.query).toContain("MatrixSymphonySetupOptions");
+      expect(body.query).not.toContain("email");
       return new Response(JSON.stringify({
         data: {
-          teams: { nodes: [{ id: "team_123", key: "MAT", name: "Matrix" }] },
+          teams: { nodes: [{ id: "team_123", key: "MAT", name: "Matrix" }], pageInfo: { hasNextPage: false, endCursor: null } },
           projects: {
             nodes: [{
               id: "linear_project_1",
@@ -29,8 +30,9 @@ describe("Symphony Linear source", () => {
               slugId: "matrix-os",
               teams: { nodes: [{ id: "team_123", key: "MAT", name: "Matrix" }] },
             }],
+            pageInfo: { hasNextPage: false, endCursor: null },
           },
-          users: { nodes: [{ id: "user_1", name: "Hamed", displayName: "Hamed", email: "hamed@example.com", active: true }] },
+          users: { nodes: [{ id: "user_1", name: "Hamed", displayName: "Hamed", active: true }], pageInfo: { hasNextPage: false, endCursor: null } },
         },
       }));
     }) as unknown as typeof fetch;
@@ -41,9 +43,45 @@ describe("Symphony Linear source", () => {
     expect(result).toEqual({
       teams: [{ id: "team_123", key: "MAT", name: "Matrix" }],
       projects: [{ id: "linear_project_1", name: "Matrix OS", slug: "matrix-os", teamIds: ["team_123"] }],
-      users: [{ id: "user_1", name: "Hamed", displayName: "Hamed", email: "hamed@example.com", active: true }],
+      users: [{ id: "user_1", name: "Hamed", displayName: "Hamed", active: true }],
     });
     expect(JSON.stringify(result)).not.toContain("lin_api_secret");
+    expect(JSON.stringify(result)).not.toContain("hamed@example.com");
+  });
+
+  it("pages through Linear setup options before returning selectors", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      if (body.variables.usersAfter === null) {
+        return new Response(JSON.stringify({
+          data: {
+            teams: { nodes: [{ id: "team_123", key: "MAT", name: "Matrix" }], pageInfo: { hasNextPage: false, endCursor: null } },
+            projects: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+            users: { nodes: [{ id: "user_1", name: "First" }], pageInfo: { hasNextPage: true, endCursor: "user_cursor_1" } },
+          },
+        }));
+      }
+      expect(body.variables).toMatchObject({
+        includeTeams: false,
+        includeProjects: false,
+        includeUsers: true,
+        usersAfter: "user_cursor_1",
+      });
+      return new Response(JSON.stringify({
+        data: {
+          users: { nodes: [{ id: "user_2", name: "Second" }], pageInfo: { hasNextPage: false, endCursor: null } },
+        },
+      }));
+    }) as unknown as typeof fetch;
+    const source = createLinearSource({ fetch: fetchMock });
+
+    const result = await source.discoverSetupOptions("lin_api_secret");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.users).toEqual([
+      { id: "user_1", name: "First", displayName: undefined, active: undefined },
+      { id: "user_2", name: "Second", displayName: undefined, active: undefined },
+    ]);
   });
 
   it("filters by assignee and required labels without exposing the credential", async () => {

--- a/tests/gateway/symphony-linear-source.test.ts
+++ b/tests/gateway/symphony-linear-source.test.ts
@@ -13,6 +13,39 @@ const rule = {
 };
 
 describe("Symphony Linear source", () => {
+  it("discovers teams, projects, and users without exposing the credential", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(init.signal).toBeTruthy();
+      expect(init.headers).toMatchObject({ Authorization: "lin_api_secret" });
+      const body = JSON.parse(String(init.body));
+      expect(body.query).toContain("MatrixSymphonySetupOptions");
+      return new Response(JSON.stringify({
+        data: {
+          teams: { nodes: [{ id: "team_123", key: "MAT", name: "Matrix" }] },
+          projects: {
+            nodes: [{
+              id: "linear_project_1",
+              name: "Matrix OS",
+              slugId: "matrix-os",
+              teams: { nodes: [{ id: "team_123", key: "MAT", name: "Matrix" }] },
+            }],
+          },
+          users: { nodes: [{ id: "user_1", name: "Hamed", displayName: "Hamed", email: "hamed@example.com", active: true }] },
+        },
+      }));
+    }) as unknown as typeof fetch;
+    const source = createLinearSource({ fetch: fetchMock });
+
+    const result = await source.discoverSetupOptions("lin_api_secret");
+
+    expect(result).toEqual({
+      teams: [{ id: "team_123", key: "MAT", name: "Matrix" }],
+      projects: [{ id: "linear_project_1", name: "Matrix OS", slug: "matrix-os", teamIds: ["team_123"] }],
+      users: [{ id: "user_1", name: "Hamed", displayName: "Hamed", email: "hamed@example.com", active: true }],
+    });
+    expect(JSON.stringify(result)).not.toContain("lin_api_secret");
+  });
+
   it("filters by assignee and required labels without exposing the credential", async () => {
     const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
       expect(init.signal).toBeTruthy();

--- a/tests/gateway/symphony-routes.test.ts
+++ b/tests/gateway/symphony-routes.test.ts
@@ -78,6 +78,11 @@ function deps(snapshot: SymphonySnapshot, principal: RequestPrincipal = { userId
     idForNewRun: vi.fn(),
   };
   const linearSource = {
+    discoverSetupOptions: vi.fn(async () => ({
+      teams: [{ id: "team_1", key: "MAT", name: "Matrix" }],
+      projects: [{ id: "linear_project_1", name: "Matrix OS", slug: "matrix-os", teamIds: ["team_1"] }],
+      users: [{ id: "linear_user", name: "Hamed", displayName: "Hamed" }],
+    })),
     previewTickets: vi.fn(async () => ({ tickets: [{ externalId: "issue_1", identifier: "MAT-1", title: "Build", stateName: "Todo", labels: ["symphony"] }], truncated: false })),
   };
   const statusHub = {
@@ -103,6 +108,7 @@ function deps(snapshot: SymphonySnapshot, principal: RequestPrincipal = { userId
       linearSource,
       orchestrator,
       statusHub,
+      listMatrixProjects: vi.fn(async () => [{ slug: "matrix-os", name: "Matrix OS", repositoryUrl: "https://github.com/hamedmp/matrix-os" }]),
       getPrincipal: () => principal,
     }),
     repository,
@@ -201,6 +207,27 @@ describe("Matrix Symphony routes", () => {
       actorId: "user_123",
     }));
     expect(JSON.stringify(await res.json())).not.toContain("lin_api");
+  });
+
+  it("discovers setup options from Matrix projects and the stored Linear credential", async () => {
+    const { app, credentialStore, linearSource } = deps(structuredClone(baseSnapshot));
+
+    const res = await app.request("/setup-options");
+
+    expect(res.status).toBe(200);
+    expect(credentialStore.readLinearCredential).toHaveBeenCalledWith("user_123");
+    expect(linearSource.discoverSetupOptions).toHaveBeenCalledWith("lin_api_secret");
+    const body = await res.json();
+    expect(body).toMatchObject({
+      credentialConfigured: true,
+      matrixProjects: [{ slug: "matrix-os", name: "Matrix OS" }],
+      linear: {
+        teams: [{ id: "team_1", key: "MAT", name: "Matrix" }],
+        projects: [{ id: "linear_project_1", slug: "matrix-os", teamIds: ["team_1"] }],
+        users: [{ id: "linear_user", displayName: "Hamed" }],
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain("lin_api_secret");
   });
 
   it("lets delegated operators create their own owner config", async () => {


### PR DESCRIPTION
## Summary
- add `/api/symphony/setup-options` so Symphony can list Matrix projects plus Linear teams, projects, and users from the stored server-side Linear credential
- replace raw team/project/assignee ID inputs in the Symphony app with Matrix project, Linear team, Linear project, and team-member selectors
- keep Linear API keys server-side and extend route/source/app tests for discovery and non-secret config saves

## Invariants
- **Source of truth**: Symphony config remains canonical in the Symphony repository; Linear credentials remain in the server-side credential store; setup options are read-only snapshots from Linear and Matrix project config.
- **Lock/transaction scope**: This PR adds no multi-write database transactions. Credential writes still go through the existing credential endpoint; config writes still use the existing repository save path.
- **Acceptable orphan states**: A saved Linear credential can exist before a Symphony rule is saved; the UI treats that as setup-in-progress and uses discovery to complete the rule. Linear discovery failure does not mutate config or credentials.
- **Auth source of truth**: `/api/symphony/setup-options` uses the existing Symphony principal/operator checks, then reads only the authorized owner credential.
- **Deferred scope**: Integration-backed unattended runner credentials are not changed here; this PR implements the server-side Linear API key discovery path and selector UX.

## Validation
- `bun run test tests/gateway/symphony-routes.test.ts tests/gateway/symphony-linear-source.test.ts tests/default-apps/symphony-app.test.tsx`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing scanner warnings only)
- `bun run test` was attempted; Vitest workers completed but the parent process stayed open without a final result and was terminated after inspection.