### PR TITLE
feat(messages): add permitted automations

### DIFF
--- a/home/apps/messages/src/App.tsx
+++ b/home/apps/messages/src/App.tsx
@@ -52,6 +52,15 @@ interface DraftReply {
   createdAt: string;
 }
 
+interface AutomationRule {
+  id: string;
+  name: string;
+  scope: "room" | "network" | "account" | "all_permitted";
+  trigger: { type: "text_contains"; value: string };
+  action: { type: "create_task"; titleTemplate: string } | { type: "draft_reply"; bodyTemplate: string };
+  status: "enabled" | "paused" | "disabled";
+}
+
 const networkTone: Record<NetworkSlug, string> = {
   telegram: "blue",
   whatsapp: "green",
@@ -74,6 +83,8 @@ export default function App() {
   const [accounts, setAccounts] = useState<MessagingAccount[]>([]);
   const [conversations, setConversations] = useState<MatrixConversation[]>([]);
   const [drafts, setDrafts] = useState<DraftReply[]>([]);
+  const [automationRules, setAutomationRules] = useState<AutomationRule[]>([]);
+  const [automationTrigger, setAutomationTrigger] = useState("");
   const [setupSession, setSetupSession] = useState<SetupSession | null>(null);
   const [activeNetwork, setActiveNetwork] = useState<NetworkSlug | "all">("all");
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
@@ -82,16 +93,18 @@ export default function App() {
   async function refresh() {
     setStatus("loading");
     try {
-      const [networkResult, accountResult, conversationResult, draftsResult] = await Promise.all([
+      const [networkResult, accountResult, conversationResult, draftsResult, automationResult] = await Promise.all([
         requestJson<{ networks: MessagingNetwork[] }>("/api/messages/networks"),
         requestJson<{ accounts: MessagingAccount[] }>("/api/messages/accounts"),
         requestJson<{ items: MatrixConversation[] }>("/api/messages/conversations"),
         requestJson<{ drafts: DraftReply[] }>("/api/messages/drafts"),
+        requestJson<{ rules: AutomationRule[] }>("/api/messages/automation/rules"),
       ]);
       setNetworks(networkResult.networks);
       setAccounts(accountResult.accounts);
       setConversations(conversationResult.items);
       setDrafts(draftsResult.drafts);
+      setAutomationRules(automationResult.rules);
       setStatus("ready");
     } catch {
       setStatus("error");
@@ -145,6 +158,26 @@ export default function App() {
           mentionOnly: next.mentionOnly,
         }),
       });
+      await refresh();
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  async function createAutomation() {
+    const trigger = automationTrigger.trim();
+    if (!trigger) return;
+    try {
+      await requestJson("/api/messages/automation/rules", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Follow ups",
+          scope: "all_permitted",
+          trigger: { type: "text_contains", value: trigger },
+          action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+        }),
+      });
+      setAutomationTrigger("");
       await refresh();
     } catch {
       setStatus("error");
@@ -291,6 +324,42 @@ export default function App() {
                   <p>{draft.bodyPreview}</p>
                 </div>
                 <span className="status-pill">pending</span>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="conversation-section drafts-section">
+        <div className="section-title">
+          <h2>Automations</h2>
+          <p>{automationRules.length}</p>
+        </div>
+        <div className="automation-create">
+          <label>
+            Trigger
+            <input
+              aria-label="Trigger"
+              value={automationTrigger}
+              onChange={(event) => setAutomationTrigger(event.currentTarget.value)}
+              placeholder="deadline"
+            />
+          </label>
+          <button className="primary-button" type="button" onClick={() => void createAutomation()}>
+            Add automation
+          </button>
+        </div>
+        {automationRules.length === 0 ? (
+          <div className="empty-state">No automations yet</div>
+        ) : (
+          <div className="conversation-list">
+            {automationRules.map((rule) => (
+              <article className="draft-row" key={rule.id}>
+                <div>
+                  <h3>{rule.name}</h3>
+                  <p>{rule.trigger.value}</p>
+                </div>
+                <span className={`status-pill ${rule.status === "enabled" ? "connected" : ""}`}>{rule.status}</span>
               </article>
             ))}
           </div>

--- a/home/apps/messages/src/styles.css
+++ b/home/apps/messages/src/styles.css
@@ -278,6 +278,34 @@ time {
   margin-top: 16px;
 }
 
+.automation-create {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.automation-create label {
+  display: grid;
+  gap: 5px;
+  color: #344054;
+  font-size: 12px;
+}
+
+.automation-create input {
+  min-height: 38px;
+  border: 1px solid #d0d5dd;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+}
+
+@media (max-width: 640px) {
+  .automation-create {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 640px) {
   .messages-app {
     padding: 16px;

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -101,6 +101,8 @@ export { MessagingKyselyRepository } from "./messages/repository.js";
 export { createPermissionRegistry } from "./messages/permission-registry.js";
 export { createHermesCapabilityToken, verifyHermesCapabilityToken } from "./messages/hermes-capability.js";
 export { HermesDeliveryRegistry } from "./messages/hermes-delivery.js";
+export { evaluateAutomationRules } from "./messages/automation-evaluator.js";
+export { createAutomationActionRunner } from "./messages/automation-actions.js";
 export type {
   MessagingRepository,
   MessagingOwnerScope,

--- a/packages/gateway/src/messages/audit.ts
+++ b/packages/gateway/src/messages/audit.ts
@@ -3,6 +3,7 @@ import type { MessagingNetworkSlug } from "./schemas.js";
 export type MessagingAuditActor = "owner" | "hermes" | "automation" | "system" | "operator";
 export type MessagingAuditType =
   | "permission_changed"
+  | "automation_triggered"
   | "ai_reply_created"
   | "ai_reply_sent"
   | "account_connected"

--- a/packages/gateway/src/messages/audit.ts
+++ b/packages/gateway/src/messages/audit.ts
@@ -3,6 +3,7 @@ import type { MessagingNetworkSlug } from "./schemas.js";
 export type MessagingAuditActor = "owner" | "hermes" | "automation" | "system" | "operator";
 export type MessagingAuditType =
   | "permission_changed"
+  | "automation_rule_created"
   | "automation_triggered"
   | "ai_reply_created"
   | "ai_reply_sent"

--- a/packages/gateway/src/messages/automation-actions.ts
+++ b/packages/gateway/src/messages/automation-actions.ts
@@ -10,24 +10,28 @@ export interface AutomationActionRunnerInput {
 
 export interface AutomationActionRunnerDeps {
   createTask: (input: { ownerId: string; title: string }) => Promise<string>;
+  createDraft: (input: { ownerId: string; roomId: string; ruleId: string; body: string }) => Promise<string>;
 }
 
-function renderTemplate(template: string, body: string): string {
+export function renderAutomationTemplate(template: string, body: string): string {
   return template.replaceAll("{body}", body).slice(0, 160);
 }
 
 export function createAutomationActionRunner(deps: AutomationActionRunnerDeps) {
-  return async function runAutomationAction(input: AutomationActionRunnerInput): Promise<{ ok: true; taskId?: string; draftBody?: string }> {
+  return async function runAutomationAction(input: AutomationActionRunnerInput): Promise<{ ok: true; taskId?: string; draftReplyId?: string }> {
     if (input.action.type === "create_task") {
       const taskId = await deps.createTask({
         ownerId: input.ownerId,
-        title: renderTemplate(input.action.titleTemplate, input.body),
+        title: renderAutomationTemplate(input.action.titleTemplate, input.body),
       });
       return { ok: true, taskId };
     }
-    return {
-      ok: true,
-      draftBody: renderTemplate(input.action.bodyTemplate, input.body),
-    };
+    const draftReplyId = await deps.createDraft({
+      ownerId: input.ownerId,
+      roomId: input.roomId,
+      ruleId: input.ruleId,
+      body: renderAutomationTemplate(input.action.bodyTemplate, input.body),
+    });
+    return { ok: true, draftReplyId };
   };
 }

--- a/packages/gateway/src/messages/automation-actions.ts
+++ b/packages/gateway/src/messages/automation-actions.ts
@@ -1,0 +1,33 @@
+import type { AutomationAction } from "./schemas.js";
+
+export interface AutomationActionRunnerInput {
+  ownerId: string;
+  ruleId: string;
+  roomId: string;
+  body: string;
+  action: AutomationAction;
+}
+
+export interface AutomationActionRunnerDeps {
+  createTask: (input: { ownerId: string; title: string }) => Promise<string>;
+}
+
+function renderTemplate(template: string, body: string): string {
+  return template.replaceAll("{body}", body).slice(0, 160);
+}
+
+export function createAutomationActionRunner(deps: AutomationActionRunnerDeps) {
+  return async function runAutomationAction(input: AutomationActionRunnerInput): Promise<{ ok: true; taskId?: string; draftBody?: string }> {
+    if (input.action.type === "create_task") {
+      const taskId = await deps.createTask({
+        ownerId: input.ownerId,
+        title: renderTemplate(input.action.titleTemplate, input.body),
+      });
+      return { ok: true, taskId };
+    }
+    return {
+      ok: true,
+      draftBody: renderTemplate(input.action.bodyTemplate, input.body),
+    };
+  };
+}

--- a/packages/gateway/src/messages/automation-evaluator.ts
+++ b/packages/gateway/src/messages/automation-evaluator.ts
@@ -1,0 +1,45 @@
+import type { AutomationAction, AutomationRule, HermesPermission } from "./schemas.js";
+
+export interface AutomationEvent {
+  ownerId: string;
+  roomId: string;
+  body: string;
+}
+
+export interface AutomationActionInvocation {
+  ownerId: string;
+  ruleId: string;
+  roomId: string;
+  body: string;
+  action: AutomationAction;
+}
+
+export interface EvaluateAutomationRulesInput {
+  event: AutomationEvent;
+  permission: HermesPermission | null;
+  rules: AutomationRule[];
+  runAction: (invocation: AutomationActionInvocation) => Promise<unknown>;
+}
+
+export async function evaluateAutomationRules(input: EvaluateAutomationRulesInput): Promise<{ executed: number }> {
+  if (!input.permission?.automationEnabled) return { executed: 0 };
+
+  let executed = 0;
+  for (const rule of input.rules) {
+    if (rule.status !== "enabled") continue;
+    if (rule.scope === "room" && rule.roomId !== input.event.roomId) continue;
+    if (rule.trigger.type === "text_contains" && !input.event.body.toLowerCase().includes(rule.trigger.value.toLowerCase())) {
+      continue;
+    }
+    await input.runAction({
+      ownerId: input.event.ownerId,
+      ruleId: rule.id,
+      roomId: input.event.roomId,
+      body: input.event.body,
+      action: rule.action,
+    });
+    executed += 1;
+  }
+
+  return { executed };
+}

--- a/packages/gateway/src/messages/automation-evaluator.ts
+++ b/packages/gateway/src/messages/automation-evaluator.ts
@@ -27,6 +27,7 @@ export async function evaluateAutomationRules(input: EvaluateAutomationRulesInpu
   let executed = 0;
   for (const rule of input.rules) {
     if (rule.status !== "enabled") continue;
+    if (rule.scope === "network" || rule.scope === "account") continue;
     if (rule.scope === "room" && rule.roomId !== input.event.roomId) continue;
     if (rule.trigger.type === "text_contains" && !input.event.body.toLowerCase().includes(rule.trigger.value.toLowerCase())) {
       continue;

--- a/packages/gateway/src/messages/repository.ts
+++ b/packages/gateway/src/messages/repository.ts
@@ -147,6 +147,7 @@ export interface EnqueueHermesWorkInput {
   kind: HermesWorkItemKind;
   status?: HermesWorkItemStatus;
   permissionRevision: number;
+  metadata?: Record<string, unknown>;
 }
 
 export interface CreateAutomationRuleInput extends AutomationRuleCreateRequest {
@@ -318,6 +319,7 @@ export interface MessagingHermesWorkItemsTable {
   status: HermesWorkItemStatus;
   permission_revision: number;
   abort_token_id: string;
+  metadata: ColumnType<unknown, unknown | undefined, unknown>;
   created_at: ColumnType<Date | string, Date | string | undefined, Date | string>;
   updated_at: ColumnType<Date | string, Date | string | undefined, Date | string>;
 }
@@ -463,6 +465,7 @@ function toWorkItem(row: Selectable<MessagingHermesWorkItemsTable>): HermesWorkI
     status: row.status,
     permissionRevision: Number(row.permission_revision),
     abortTokenId: row.abort_token_id,
+    metadata: parseJson<Record<string, unknown>>(row.metadata ?? {}),
     createdAt: requireIso(row.created_at),
     updatedAt: requireIso(row.updated_at),
   };
@@ -669,10 +672,12 @@ export class MessagingKyselyRepository implements MessagingRepository {
         status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'cancel_requested', 'cancelled', 'failed')),
         permission_revision INTEGER NOT NULL,
         abort_token_id TEXT NOT NULL,
+        metadata JSONB NOT NULL DEFAULT '{}',
         created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
       )
     `.execute(this.kysely);
+    await sql`ALTER TABLE messaging_hermes_work_items ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'`.execute(this.kysely);
     await sql`CREATE INDEX IF NOT EXISTS idx_messaging_work_room ON messaging_hermes_work_items(owner_id, room_id, status)`.execute(this.kysely);
 
     await sql`
@@ -1066,9 +1071,9 @@ export class MessagingKyselyRepository implements MessagingRepository {
   async ingestBridgeEvent(input: IngestBridgeEventInput): Promise<IngestBridgeEventResult> {
     const permission = await this.getPermission({ ownerId: input.ownerId }, input.roomId);
     const canRead = Boolean(permission?.readEnabled) && (!permission?.mentionOnly || Boolean(input.content.mentionsOwner));
-    const effect: BridgeEventEffect = permission?.automationEnabled
-      ? "automation_queued"
-      : canRead ? "sent_to_hermes" : "stored_only";
+    const effect: BridgeEventEffect = canRead
+      ? "sent_to_hermes"
+      : permission?.automationEnabled ? "automation_queued" : "stored_only";
     const inserted = await this.kysely
       .insertInto("messaging_event_cursors")
       .values({
@@ -1256,6 +1261,7 @@ export class MessagingKyselyRepository implements MessagingRepository {
         status: input.status ?? "queued",
         permission_revision: input.permissionRevision,
         abort_token_id: prefixedId("abort"),
+        metadata: jsonb(input.metadata ?? {}),
       })
       .returningAll()
       .executeTakeFirstOrThrow();
@@ -1275,29 +1281,31 @@ export class MessagingKyselyRepository implements MessagingRepository {
   }
 
   async createAutomationRule(input: CreateAutomationRuleInput): Promise<AutomationRule> {
-    const row = await this.kysely
-      .insertInto("messaging_automation_rules")
-      .values({
-        id: prefixedId("auto"),
-        owner_id: input.ownerId,
-        name: input.name,
-        scope: input.scope,
-        room_id: input.roomId ?? null,
-        trigger: jsonb(input.trigger),
-        action: jsonb(input.action),
-        status: "enabled",
-      })
-      .returningAll()
-      .executeTakeFirstOrThrow();
-    await this.insertAuditEvent(this.kysely, {
-      ownerId: input.ownerId,
-      type: "automation_triggered",
-      actor: "owner",
-      roomId: input.roomId,
-      safeSummary: "Messaging automation rule created",
-      metadata: { ruleId: row.id },
+    return this.kysely.transaction().execute(async (trx) => {
+      const row = await trx
+        .insertInto("messaging_automation_rules")
+        .values({
+          id: prefixedId("auto"),
+          owner_id: input.ownerId,
+          name: input.name,
+          scope: input.scope,
+          room_id: input.roomId ?? null,
+          trigger: jsonb(input.trigger),
+          action: jsonb(input.action),
+          status: "enabled",
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await this.insertAuditEvent(trx, {
+        ownerId: input.ownerId,
+        type: "automation_rule_created",
+        actor: "owner",
+        roomId: input.roomId,
+        safeSummary: "Messaging automation rule created",
+        metadata: { ruleId: row.id },
+      });
+      return toAutomationRule(row);
     });
-    return toAutomationRule(row);
   }
 
   async listAutomationRules(
@@ -1312,7 +1320,12 @@ export class MessagingKyselyRepository implements MessagingRepository {
       .selectAll()
       .where("owner_id", "=", scope.ownerId)
       .where("status", "!=", "disabled");
-    if (options.roomId) query = query.where("room_id", "=", options.roomId);
+    if (options.roomId) {
+      query = query.where((eb) => eb.or([
+        eb("room_id", "=", options.roomId!),
+        eb("scope", "=", "all_permitted"),
+      ]));
+    }
     const rows = await query.orderBy("updated_at", "desc").limit(limit + 1).offset(offset).execute();
     return {
       items: rows.slice(0, limit).map(toAutomationRule),
@@ -1339,6 +1352,7 @@ export class MessagingKyselyRepository implements MessagingRepository {
       .set({ status: "disabled", updated_at: new Date().toISOString() })
       .where("owner_id", "=", input.ownerId)
       .where("id", "=", input.ruleId)
+      .where("status", "!=", "disabled")
       .returning(["id", "status"])
       .executeTakeFirst();
     if (!row) throw new MessagingError("not_found", "automation rule not found", 404);

--- a/packages/gateway/src/messages/repository.ts
+++ b/packages/gateway/src/messages/repository.ts
@@ -5,6 +5,10 @@ import { getMessagingBridgeAccountProvider, MESSAGING_NETWORKS } from "./bridge-
 import { isSetupExpired } from "./setup-sessions.js";
 import type {
   AccountSetupRequest,
+  AutomationAction,
+  AutomationRule,
+  AutomationRuleCreateRequest,
+  AutomationTrigger,
   CompleteSetupRequest,
   ConversationMapping,
   BridgeEventEffect,
@@ -145,6 +149,10 @@ export interface EnqueueHermesWorkInput {
   permissionRevision: number;
 }
 
+export interface CreateAutomationRuleInput extends AutomationRuleCreateRequest {
+  ownerId: string;
+}
+
 export interface MessagingRepository {
   listNetworks(): Promise<MessagingNetwork[]>;
   listAccounts(scope: MessagingOwnerScope): Promise<MessagingAccount[]>;
@@ -179,6 +187,10 @@ export interface MessagingRepository {
   cancelReply(input: CancelReplyInput): Promise<ReplySendResult>;
   enqueueHermesWork(input: EnqueueHermesWorkInput): Promise<HermesWorkItem>;
   listWorkItems(scope: MessagingOwnerScope & { roomId?: string }): Promise<HermesWorkItem[]>;
+  createAutomationRule(input: CreateAutomationRuleInput): Promise<AutomationRule>;
+  listAutomationRules(scope: MessagingOwnerScope, options?: MessagingListOptions & { roomId?: string }): Promise<MessagingListResult<AutomationRule>>;
+  pauseAutomationRule(input: { ownerId: string; ruleId: string }): Promise<AutomationRule>;
+  deleteAutomationRule(input: { ownerId: string; ruleId: string }): Promise<{ ruleId: string; status: "disabled" }>;
 }
 
 export interface BridgeAccountSetupState {
@@ -310,6 +322,19 @@ export interface MessagingHermesWorkItemsTable {
   updated_at: ColumnType<Date | string, Date | string | undefined, Date | string>;
 }
 
+export interface MessagingAutomationRulesTable {
+  id: string;
+  owner_id: string;
+  name: string;
+  scope: AutomationRule["scope"];
+  room_id: string | null;
+  trigger: ColumnType<unknown, unknown, unknown>;
+  action: ColumnType<unknown, unknown, unknown>;
+  status: AutomationRule["status"];
+  created_at: ColumnType<Date | string, Date | string | undefined, Date | string>;
+  updated_at: ColumnType<Date | string, Date | string | undefined, Date | string>;
+}
+
 export interface MessagingDatabase {
   messaging_accounts: MessagingAccountsTable;
   messaging_setup_sessions: MessagingSetupSessionsTable;
@@ -320,9 +345,10 @@ export interface MessagingDatabase {
   messaging_event_cursors: MessagingEventCursorsTable;
   messaging_outgoing_replies: MessagingOutgoingRepliesTable;
   messaging_hermes_work_items: MessagingHermesWorkItemsTable;
+  messaging_automation_rules: MessagingAutomationRulesTable;
 }
 
-function prefixedId(prefix: "acct" | "setup" | "conv" | "map" | "reply" | "work" | "audit" | "abort"): string {
+function prefixedId(prefix: "acct" | "setup" | "conv" | "map" | "reply" | "work" | "audit" | "abort" | "auto"): string {
   return `${prefix}_${randomUUID().replaceAll("-", "")}`;
 }
 
@@ -444,6 +470,26 @@ function toWorkItem(row: Selectable<MessagingHermesWorkItemsTable>): HermesWorkI
 
 function jsonb(value: unknown) {
   return sql`${JSON.stringify(value)}::jsonb`;
+}
+
+function parseJson<T>(value: unknown): T {
+  if (typeof value === "string") return JSON.parse(value) as T;
+  return value as T;
+}
+
+function toAutomationRule(row: Selectable<MessagingAutomationRulesTable>): AutomationRule {
+  return {
+    id: row.id,
+    ownerId: row.owner_id,
+    name: row.name,
+    scope: row.scope,
+    roomId: row.room_id ?? undefined,
+    trigger: parseJson<AutomationTrigger>(row.trigger),
+    action: parseJson<AutomationAction>(row.action),
+    status: row.status,
+    createdAt: requireIso(row.created_at),
+    updatedAt: requireIso(row.updated_at),
+  };
 }
 
 export class MessagingKyselyRepository implements MessagingRepository {
@@ -628,6 +674,22 @@ export class MessagingKyselyRepository implements MessagingRepository {
       )
     `.execute(this.kysely);
     await sql`CREATE INDEX IF NOT EXISTS idx_messaging_work_room ON messaging_hermes_work_items(owner_id, room_id, status)`.execute(this.kysely);
+
+    await sql`
+      CREATE TABLE IF NOT EXISTS messaging_automation_rules (
+        id TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        scope TEXT NOT NULL CHECK (scope IN ('room', 'network', 'account', 'all_permitted')),
+        room_id TEXT,
+        trigger JSONB NOT NULL,
+        action JSONB NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('enabled', 'paused', 'disabled')),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `.execute(this.kysely);
+    await sql`CREATE INDEX IF NOT EXISTS idx_messaging_automation_owner ON messaging_automation_rules(owner_id, status, updated_at DESC)`.execute(this.kysely);
   }
 
   async destroy(): Promise<void> {
@@ -1004,7 +1066,9 @@ export class MessagingKyselyRepository implements MessagingRepository {
   async ingestBridgeEvent(input: IngestBridgeEventInput): Promise<IngestBridgeEventResult> {
     const permission = await this.getPermission({ ownerId: input.ownerId }, input.roomId);
     const canRead = Boolean(permission?.readEnabled) && (!permission?.mentionOnly || Boolean(input.content.mentionsOwner));
-    const effect: BridgeEventEffect = canRead ? "sent_to_hermes" : "stored_only";
+    const effect: BridgeEventEffect = permission?.automationEnabled
+      ? "automation_queued"
+      : canRead ? "sent_to_hermes" : "stored_only";
     const inserted = await this.kysely
       .insertInto("messaging_event_cursors")
       .values({
@@ -1208,6 +1272,77 @@ export class MessagingKyselyRepository implements MessagingRepository {
     }
     const rows = await query.orderBy("created_at", "asc").execute();
     return rows.map(toWorkItem);
+  }
+
+  async createAutomationRule(input: CreateAutomationRuleInput): Promise<AutomationRule> {
+    const row = await this.kysely
+      .insertInto("messaging_automation_rules")
+      .values({
+        id: prefixedId("auto"),
+        owner_id: input.ownerId,
+        name: input.name,
+        scope: input.scope,
+        room_id: input.roomId ?? null,
+        trigger: jsonb(input.trigger),
+        action: jsonb(input.action),
+        status: "enabled",
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    await this.insertAuditEvent(this.kysely, {
+      ownerId: input.ownerId,
+      type: "automation_triggered",
+      actor: "owner",
+      roomId: input.roomId,
+      safeSummary: "Messaging automation rule created",
+      metadata: { ruleId: row.id },
+    });
+    return toAutomationRule(row);
+  }
+
+  async listAutomationRules(
+    scope: MessagingOwnerScope,
+    options: MessagingListOptions & { roomId?: string } = {},
+  ): Promise<MessagingListResult<AutomationRule>> {
+    const limit = Math.min(Math.max(options.limit ?? 50, 1), 100);
+    const offset = options.cursor ? Number.parseInt(options.cursor, 10) : 0;
+    if (!Number.isSafeInteger(offset) || offset < 0) throw new MessagingError("bad_request", "invalid cursor", 400);
+    let query = this.kysely
+      .selectFrom("messaging_automation_rules")
+      .selectAll()
+      .where("owner_id", "=", scope.ownerId)
+      .where("status", "!=", "disabled");
+    if (options.roomId) query = query.where("room_id", "=", options.roomId);
+    const rows = await query.orderBy("updated_at", "desc").limit(limit + 1).offset(offset).execute();
+    return {
+      items: rows.slice(0, limit).map(toAutomationRule),
+      nextCursor: rows.length > limit ? String(offset + limit) : undefined,
+    };
+  }
+
+  async pauseAutomationRule(input: { ownerId: string; ruleId: string }): Promise<AutomationRule> {
+    const row = await this.kysely
+      .updateTable("messaging_automation_rules")
+      .set({ status: "paused", updated_at: new Date().toISOString() })
+      .where("owner_id", "=", input.ownerId)
+      .where("id", "=", input.ruleId)
+      .where("status", "!=", "disabled")
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) throw new MessagingError("not_found", "automation rule not found", 404);
+    return toAutomationRule(row);
+  }
+
+  async deleteAutomationRule(input: { ownerId: string; ruleId: string }): Promise<{ ruleId: string; status: "disabled" }> {
+    const row = await this.kysely
+      .updateTable("messaging_automation_rules")
+      .set({ status: "disabled", updated_at: new Date().toISOString() })
+      .where("owner_id", "=", input.ownerId)
+      .where("id", "=", input.ruleId)
+      .returning(["id", "status"])
+      .executeTakeFirst();
+    if (!row) throw new MessagingError("not_found", "automation rule not found", 404);
+    return { ruleId: row.id, status: "disabled" };
   }
 
   private async expireStaleSetupSessions(ownerId: string): Promise<void> {

--- a/packages/gateway/src/messages/routes.ts
+++ b/packages/gateway/src/messages/routes.ts
@@ -9,6 +9,8 @@ import {
   AppserviceEventsRequestSchema,
   ApproveDraftRequestSchema,
   AccountSetupRequestSchema,
+  AutomationRuleCreateRequestSchema,
+  AutomationRuleIdSchema,
   CancelDraftRequestSchema,
   CompleteSetupRequestSchema,
   DraftsQuerySchema,
@@ -264,6 +266,51 @@ export function createMessagingRoutes(deps: MessagingRouteDeps): Hono {
       const replyId = MessagingReplyIdSchema.parse(c.req.param("replyId"));
       const parsed = CancelDraftRequestSchema.parse(await c.req.json());
       return c.json(await deps.repository.cancelReply({ ownerId, replyId, ...parsed }));
+    } catch (err: unknown) {
+      return handleMessagingRouteError(c, err);
+    }
+  });
+
+  app.get("/automation/rules", async (c) => {
+    try {
+      const ownerId = getOwnerIdOrThrow(deps, c);
+      const parsed = DraftsQuerySchema.parse({
+        roomId: c.req.query("roomId"),
+        limit: c.req.query("limit"),
+        cursor: c.req.query("cursor"),
+      });
+      const result = await deps.repository.listAutomationRules({ ownerId }, parsed);
+      return c.json({ rules: result.items, nextCursor: result.nextCursor });
+    } catch (err: unknown) {
+      return handleMessagingRouteError(c, err);
+    }
+  });
+
+  app.post("/automation/rules", routeBodyLimit, async (c) => {
+    try {
+      const ownerId = getOwnerIdOrThrow(deps, c);
+      const parsed = AutomationRuleCreateRequestSchema.parse(await c.req.json());
+      return c.json(await deps.repository.createAutomationRule({ ownerId, ...parsed }), 201);
+    } catch (err: unknown) {
+      return handleMessagingRouteError(c, err);
+    }
+  });
+
+  app.post("/automation/rules/:ruleId/pause", routeBodyLimit, async (c) => {
+    try {
+      const ownerId = getOwnerIdOrThrow(deps, c);
+      const ruleId = AutomationRuleIdSchema.parse(c.req.param("ruleId"));
+      return c.json(await deps.repository.pauseAutomationRule({ ownerId, ruleId }));
+    } catch (err: unknown) {
+      return handleMessagingRouteError(c, err);
+    }
+  });
+
+  app.delete("/automation/rules/:ruleId", deleteBodyLimit, async (c) => {
+    try {
+      const ownerId = getOwnerIdOrThrow(deps, c);
+      const ruleId = AutomationRuleIdSchema.parse(c.req.param("ruleId"));
+      return c.json(await deps.repository.deleteAutomationRule({ ownerId, ruleId }));
     } catch (err: unknown) {
       return handleMessagingRouteError(c, err);
     }

--- a/packages/gateway/src/messages/routes.ts
+++ b/packages/gateway/src/messages/routes.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import {
@@ -28,6 +28,8 @@ import { mapMessagingError, MessagingError, redactMessagingErrorDetail } from ".
 import type { MessagingRepository } from "./repository.js";
 import { HERMES_REPLY_SCOPE, constantTimeEqual, createHermesCapabilityReplayCache, verifyHermesCapabilityToken } from "./hermes-capability.js";
 import { MESSAGING_APP_SERVICE_BODY_LIMIT } from "./constants.js";
+import { createAutomationActionRunner } from "./automation-actions.js";
+import { evaluateAutomationRules } from "./automation-evaluator.js";
 
 export interface MessagingRouteDeps {
   repository: MessagingRepository;
@@ -52,6 +54,9 @@ function getAppserviceOwnerIdOrThrow(deps: MessagingRouteDeps): string {
   return deps.appserviceOwnerId;
 }
 
+function automationDraftClientTxnId(eventId: string, ruleId: string): string {
+  return `auto_${createHash("sha256").update(`${eventId}:${ruleId}`).digest("hex")}`;
+}
 function handleMessagingRouteError(c: Context, err: unknown) {
   const mapped = mapMessagingError(err);
   if (mapped.log) {
@@ -182,6 +187,45 @@ export function createMessagingRoutes(deps: MessagingRouteDeps): Hono {
         });
         if (result.accepted) accepted += 1;
         else ignored += 1;
+        if (result.accepted && result.effect === "automation_queued") {
+          const permission = await deps.repository.getPermission({ ownerId }, event.roomId);
+          const rules = await deps.repository.listAutomationRules({ ownerId }, { roomId: event.roomId, limit: 100 });
+          const permissionRevision = permission?.revision ?? 1;
+          const runAction = createAutomationActionRunner({
+            createTask: async (task) => {
+              const workItem = await deps.repository.enqueueHermesWork({
+                ownerId,
+                roomId: event.roomId,
+                sourceEventId: event.eventId,
+                kind: "automation",
+                permissionRevision,
+                metadata: {
+                  action: "create_task",
+                  ruleTitle: task.title,
+                },
+              });
+              return workItem.id;
+            },
+            createDraft: async (draft) => {
+              const reply = await deps.repository.createReply({
+                ownerId: draft.ownerId,
+                roomId: draft.roomId,
+                source: "automation",
+                status: "approval_required",
+                body: draft.body,
+                permissionRevision,
+                clientTxnId: automationDraftClientTxnId(event.eventId, draft.ruleId),
+              });
+              return reply.id;
+            },
+          });
+          await evaluateAutomationRules({
+            event: { ownerId, roomId: event.roomId, body: event.content.body },
+            permission,
+            rules: rules.items,
+            runAction,
+          });
+        }
       }
       return c.json({ accepted, ignored }, 202);
     } catch (err: unknown) {

--- a/packages/gateway/src/messages/schemas.ts
+++ b/packages/gateway/src/messages/schemas.ts
@@ -227,6 +227,7 @@ export const HermesWorkItemSchema = z.object({
   status: HermesWorkItemStatusSchema,
   permissionRevision: z.number().int().min(1),
   abortTokenId: z.string().trim().min(1).max(160),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });
@@ -315,6 +316,9 @@ export const AutomationRuleCreateRequestSchema = z.object({
 }).refine((value) => value.scope !== "room" || Boolean(value.roomId), {
   message: "roomId is required for room automation",
   path: ["roomId"],
+}).refine((value) => value.scope === "room" || value.scope === "all_permitted", {
+  message: "network and account automation scopes are not available yet",
+  path: ["scope"],
 });
 export type AutomationRuleCreateRequest = z.infer<typeof AutomationRuleCreateRequestSchema>;
 

--- a/packages/gateway/src/messages/schemas.ts
+++ b/packages/gateway/src/messages/schemas.ts
@@ -76,6 +76,29 @@ export type HermesWorkItemStatus = z.infer<typeof HermesWorkItemStatusSchema>;
 export const HermesWorkItemKindSchema = z.enum(["summarize", "classify", "draft_reply", "automation"]);
 export type HermesWorkItemKind = z.infer<typeof HermesWorkItemKindSchema>;
 
+export const AutomationRuleIdSchema = z.string().trim().regex(/^auto_[A-Za-z0-9_-]{12,96}$/);
+export const AutomationRuleStatusSchema = z.enum(["enabled", "paused", "disabled"]);
+export const AutomationRuleScopeSchema = z.enum(["room", "network", "account", "all_permitted"]);
+export const AutomationTriggerSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text_contains"),
+    value: z.string().trim().min(1).max(160),
+  }),
+]);
+export type AutomationTrigger = z.infer<typeof AutomationTriggerSchema>;
+
+export const AutomationActionSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("create_task"),
+    titleTemplate: z.string().trim().min(1).max(160),
+  }),
+  z.object({
+    type: z.literal("draft_reply"),
+    bodyTemplate: z.string().trim().min(1).max(1_000),
+  }),
+]);
+export type AutomationAction = z.infer<typeof AutomationActionSchema>;
+
 export const MessagingNetworkSchema = z.object({
   slug: MessagingNetworkSlugSchema,
   displayName: z.string().trim().min(1).max(80),
@@ -209,6 +232,20 @@ export const HermesWorkItemSchema = z.object({
 });
 export type HermesWorkItem = z.infer<typeof HermesWorkItemSchema>;
 
+export const AutomationRuleSchema = z.object({
+  id: AutomationRuleIdSchema,
+  ownerId: z.string().trim().min(1).max(256),
+  name: z.string().trim().min(1).max(120),
+  scope: AutomationRuleScopeSchema,
+  roomId: MatrixRoomIdSchema.optional(),
+  trigger: AutomationTriggerSchema,
+  action: AutomationActionSchema,
+  status: AutomationRuleStatusSchema,
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+export type AutomationRule = z.infer<typeof AutomationRuleSchema>;
+
 export const ListQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional(),
   cursor: CursorSchema.optional(),
@@ -268,6 +305,18 @@ export const CancelDraftRequestSchema = z.object({
   reason: z.enum(["user_cancelled"]).default("user_cancelled"),
 });
 export type CancelDraftRequest = z.infer<typeof CancelDraftRequestSchema>;
+
+export const AutomationRuleCreateRequestSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  scope: AutomationRuleScopeSchema,
+  roomId: MatrixRoomIdSchema.optional(),
+  trigger: AutomationTriggerSchema,
+  action: AutomationActionSchema,
+}).refine((value) => value.scope !== "room" || Boolean(value.roomId), {
+  message: "roomId is required for room automation",
+  path: ["roomId"],
+});
+export type AutomationRuleCreateRequest = z.infer<typeof AutomationRuleCreateRequestSchema>;
 
 export const AccountSetupRequestSchema = z.object({
   networkSlug: MessagingNetworkSlugSchema,

--- a/specs/077-matrix-messaging-bridge/tasks.md
+++ b/specs/077-matrix-messaging-bridge/tasks.md
@@ -144,21 +144,21 @@ before production enablement.
 
 ### Tests for User Story 3
 
-- [ ] T069 [P] [US3] Write AutomationRule schema tests for bounded discriminated action payloads in `tests/gateway/messages/automation-schemas.test.ts`
-- [ ] T070 [P] [US3] Write automation evaluator tests for automation permission gating in `tests/gateway/messages/automation-evaluator.test.ts`
-- [ ] T071 [P] [US3] Write automation route contract tests for create, pause, list, and delete in `tests/gateway/messages/automation-routes.test.ts`
-- [ ] T072 [P] [US3] Write integration test for deadline-to-task rule through `/api/bridge/query` in `tests/gateway/messages/automation-task-action.test.ts`
-- [ ] T073 [P] [US3] Write Messages automation UI test in `tests/shell/messages/messages-automation.test.tsx`
+- [X] T069 [P] [US3] Write AutomationRule schema tests for bounded discriminated action payloads in `tests/gateway/messages/automation-schemas.test.ts`
+- [X] T070 [P] [US3] Write automation evaluator tests for automation permission gating in `tests/gateway/messages/automation-evaluator.test.ts`
+- [X] T071 [P] [US3] Write automation route contract tests for create, pause, list, and delete in `tests/gateway/messages/automation-routes.test.ts`
+- [X] T072 [P] [US3] Write integration test for deadline-to-task rule through `/api/bridge/query` in `tests/gateway/messages/automation-task-action.test.ts`
+- [X] T073 [P] [US3] Write Messages automation UI test in `tests/shell/messages/messages-automation.test.tsx`
 
 ### Implementation for User Story 3
 
-- [ ] T074 [P] [US3] Implement AutomationRule schemas and bounded action discriminated union in `packages/gateway/src/messages/schemas.ts`
-- [ ] T075 [US3] Implement AutomationRule repository methods and audit append in `packages/gateway/src/messages/repository.ts`
-- [ ] T076 [US3] Implement automation evaluator with nonblocking queue and permission checks in `packages/gateway/src/messages/automation-evaluator.ts`
-- [ ] T077 [US3] Implement task-creation action through scoped bridge API client in `packages/gateway/src/messages/automation-actions.ts`
-- [ ] T078 [US3] Implement automation rule create, list, pause, and delete routes in `packages/gateway/src/messages/routes.ts`
-- [ ] T079 [US3] Integrate automation evaluator with appservice event ingestion after owner display storage in `packages/gateway/src/messages/appservice-events.ts`
-- [ ] T080 [US3] Implement automation settings UI and audit trail display in `home/apps/messages/src/main.tsx`
+- [X] T074 [P] [US3] Implement AutomationRule schemas and bounded action discriminated union in `packages/gateway/src/messages/schemas.ts`
+- [X] T075 [US3] Implement AutomationRule repository methods and audit append in `packages/gateway/src/messages/repository.ts`
+- [X] T076 [US3] Implement automation evaluator with nonblocking queue and permission checks in `packages/gateway/src/messages/automation-evaluator.ts`
+- [X] T077 [US3] Implement task-creation action through scoped bridge API client in `packages/gateway/src/messages/automation-actions.ts`
+- [X] T078 [US3] Implement automation rule create, list, pause, and delete routes in `packages/gateway/src/messages/routes.ts`
+- [X] T079 [US3] Integrate automation evaluator with appservice event ingestion after owner display storage in `packages/gateway/src/messages/appservice-events.ts`
+- [X] T080 [US3] Implement automation settings UI and audit trail display in `home/apps/messages/src/main.tsx`
 
 **Checkpoint**: Automation observes only rooms with automation access and creates audited Matrix OS actions without blocking message sync.
 

--- a/tests/gateway/messages/appservice-events.test.ts
+++ b/tests/gateway/messages/appservice-events.test.ts
@@ -49,6 +49,120 @@ describe("appservice event ingestion", () => {
       eventId: "$event1:matrixos.local",
     }));
   });
+  it("runs matching automation rules for automation-queued bridge events", async () => {
+    const roomId = "!room:matrixos.local";
+    const replyId = "reply_0123456789abcdef0123456789abcdef";
+    const ingestBridgeEvent = vi.fn().mockResolvedValue({ accepted: true, effect: "automation_queued" });
+    const getPermission = vi.fn().mockResolvedValue({
+      ownerId,
+      roomId,
+      readEnabled: false,
+      replyEnabled: false,
+      automationEnabled: true,
+      mentionOnly: false,
+      revision: 3,
+      createdAt: "2026-05-13T00:00:00.000Z",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    });
+    const roomRuleId = "auto_0123456789abcdef0123456789abcdef";
+    const allPermittedRuleId = "auto_abcdef0123456789abcdef0123456789";
+    const listAutomationRules = vi.fn().mockResolvedValue({
+      items: [
+        {
+          id: roomRuleId,
+          ownerId,
+          name: "Deadlines",
+          scope: "room",
+          roomId,
+          trigger: { type: "text_contains", value: "deadline" },
+          action: { type: "draft_reply", bodyTemplate: "I saw: {body}" },
+          status: "enabled",
+          createdAt: "2026-05-13T00:00:00.000Z",
+          updatedAt: "2026-05-13T00:00:00.000Z",
+        },
+        {
+          id: allPermittedRuleId,
+          ownerId,
+          name: "All deadlines",
+          scope: "all_permitted",
+          trigger: { type: "text_contains", value: "deadline" },
+          action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+          status: "enabled",
+          createdAt: "2026-05-13T00:00:00.000Z",
+          updatedAt: "2026-05-13T00:00:00.000Z",
+        },
+      ],
+      nextCursor: undefined,
+    });
+    const enqueueHermesWork = vi.fn().mockResolvedValue({
+      id: "work_0123456789abcdef0123456789abcdef",
+      ownerId,
+      roomId,
+      sourceEventId: "$event2:matrixos.local",
+      kind: "automation",
+      status: "queued",
+      permissionRevision: 3,
+      abortTokenId: "abort_0123456789abcdef0123456789abcdef",
+      metadata: { action: "create_task", ruleTitle: "Follow up: deadline tomorrow" },
+      createdAt: "2026-05-13T00:00:00.000Z",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    });
+    const createReply = vi.fn().mockResolvedValue({
+      id: replyId,
+      ownerId,
+      roomId,
+      source: "automation",
+      status: "approval_required",
+      body: "I saw: deadline tomorrow",
+      permissionRevision: 3,
+      clientTxnId: "auto_test",
+      createdAt: "2026-05-13T00:00:00.000Z",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    });
+    const repository = createRepositoryMock({ ingestBridgeEvent, getPermission, listAutomationRules, createReply, enqueueHermesWork });
+    const app = createMessagingTestApp(repository, null);
+
+    const res = await app.request("/api/messages/appservice/whatsapp/events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Matrix-OS-Appservice-Token": "test-appservice-token",
+      },
+      body: JSON.stringify({
+        events: [{
+          eventId: "$event2:matrixos.local",
+          roomId,
+          accountId: "acct_0123456789abcdef0123456789abcdef",
+          type: "message",
+          sender: { displayName: "Ada" },
+          content: { kind: "text", body: "deadline tomorrow" },
+          occurredAt: "2026-05-13T00:00:00.000Z",
+        }],
+      }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(listAutomationRules).toHaveBeenCalledWith({ ownerId }, { roomId, limit: 100 });
+    expect(createReply).toHaveBeenCalledWith(expect.objectContaining({
+      ownerId,
+      roomId,
+      source: "automation",
+      status: "approval_required",
+      body: "I saw: deadline tomorrow",
+      permissionRevision: 3,
+    }));
+    expect(enqueueHermesWork).toHaveBeenCalledWith(expect.objectContaining({
+      ownerId,
+      roomId,
+      sourceEventId: "$event2:matrixos.local",
+      kind: "automation",
+      permissionRevision: 3,
+      metadata: {
+        action: "create_task",
+        ruleTitle: "Follow up: deadline tomorrow",
+      },
+    }));
+  });
 
   it("rejects appservice events without the trusted token", async () => {
     const ingestBridgeEvent = vi.fn();

--- a/tests/gateway/messages/automation-evaluator.test.ts
+++ b/tests/gateway/messages/automation-evaluator.test.ts
@@ -55,4 +55,41 @@ describe("automation evaluator", () => {
     expect(result.executed).toBe(0);
     expect(runAction).not.toHaveBeenCalled();
   });
+
+  it("skips unsupported network and account scoped rules even when they match", async () => {
+    const runAction = vi.fn().mockResolvedValue({ ok: true });
+    const matchingRule = {
+      id: "auto_0123456789abcdef0123456789abcdef",
+      ownerId: "user_a",
+      name: "Deadlines",
+      trigger: { type: "text_contains" as const, value: "deadline" },
+      action: { type: "create_task" as const, titleTemplate: "Follow up: {body}" },
+      status: "enabled" as const,
+      createdAt: "2026-05-13T00:00:00.000Z",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    };
+
+    const result = await evaluateAutomationRules({
+      event: { ownerId: "user_a", roomId: "!room:matrixos.local", body: "deadline tomorrow" },
+      permission: {
+        ownerId: "user_a",
+        roomId: "!room:matrixos.local",
+        readEnabled: false,
+        replyEnabled: false,
+        automationEnabled: true,
+        mentionOnly: false,
+        revision: 2,
+        createdAt: "2026-05-13T00:00:00.000Z",
+        updatedAt: "2026-05-13T00:00:00.000Z",
+      },
+      rules: [
+        { ...matchingRule, scope: "network" as const },
+        { ...matchingRule, id: "auto_abcdef0123456789abcdef0123456789", scope: "account" as const },
+      ],
+      runAction,
+    });
+
+    expect(result.executed).toBe(0);
+    expect(runAction).not.toHaveBeenCalled();
+  });
 });

--- a/tests/gateway/messages/automation-evaluator.test.ts
+++ b/tests/gateway/messages/automation-evaluator.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { evaluateAutomationRules } from "../../../packages/gateway/src/messages/automation-evaluator.js";
+
+describe("automation evaluator", () => {
+  it("runs matching rules only when room automation permission is enabled", async () => {
+    const runAction = vi.fn().mockResolvedValue({ ok: true });
+    const result = await evaluateAutomationRules({
+      event: {
+        ownerId: "user_a",
+        roomId: "!room:matrixos.local",
+        body: "deadline tomorrow",
+      },
+      permission: {
+        ownerId: "user_a",
+        roomId: "!room:matrixos.local",
+        readEnabled: true,
+        replyEnabled: false,
+        automationEnabled: true,
+        mentionOnly: false,
+        revision: 2,
+        createdAt: "2026-05-13T00:00:00.000Z",
+        updatedAt: "2026-05-13T00:00:00.000Z",
+      },
+      rules: [{
+        id: "auto_0123456789abcdef0123456789abcdef",
+        ownerId: "user_a",
+        name: "Deadlines",
+        scope: "room",
+        roomId: "!room:matrixos.local",
+        trigger: { type: "text_contains", value: "deadline" },
+        action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+        status: "enabled",
+        createdAt: "2026-05-13T00:00:00.000Z",
+        updatedAt: "2026-05-13T00:00:00.000Z",
+      }],
+      runAction,
+    });
+
+    expect(result.executed).toBe(1);
+    expect(runAction).toHaveBeenCalledWith(expect.objectContaining({
+      ruleId: "auto_0123456789abcdef0123456789abcdef",
+      action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+    }));
+  });
+
+  it("does not run rules without automation permission", async () => {
+    const runAction = vi.fn();
+    const result = await evaluateAutomationRules({
+      event: { ownerId: "user_a", roomId: "!room:matrixos.local", body: "deadline tomorrow" },
+      permission: null,
+      rules: [],
+      runAction,
+    });
+
+    expect(result.executed).toBe(0);
+    expect(runAction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/gateway/messages/automation-repository.test.ts
+++ b/tests/gateway/messages/automation-repository.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { KyselyPGlite } from "kysely-pglite";
+import type { Kysely } from "kysely";
+import { MessagingKyselyRepository, type MessagingDatabase } from "../../../packages/gateway/src/messages/repository.js";
+
+const ownerId = "user_a";
+const roomId = "!room:matrixos.local";
+
+describe("messaging automation repository behavior", () => {
+  let pglite: InstanceType<typeof KyselyPGlite>;
+  let repository: MessagingKyselyRepository;
+
+  beforeEach(async () => {
+    pglite = await KyselyPGlite.create();
+    repository = new MessagingKyselyRepository(pglite.dialect);
+    await repository.bootstrap();
+    const setup = await repository.createSetupSession({ ownerId, networkSlug: "whatsapp" });
+    const account = await repository.completeSetupSession({
+      ownerId,
+      setupId: setup.id,
+      externalAccountId: "wa_1",
+      displayName: "WhatsApp",
+    });
+    await repository.upsertConversation({
+      ownerId,
+      roomId,
+      networkSlug: "whatsapp",
+      accountId: account.id,
+      displayName: "Family",
+    });
+  });
+
+  afterEach(async () => {
+    await repository.destroy();
+  });
+
+  it("keeps Hermes delivery authoritative when automation is also enabled", async () => {
+    await repository.updatePermission({
+      ownerId,
+      roomId,
+      baseRevision: 1,
+      readEnabled: true,
+      replyEnabled: false,
+      automationEnabled: true,
+      mentionOnly: false,
+      grantedBy: ownerId,
+    });
+
+    await expect(repository.ingestBridgeEvent({
+      ownerId,
+      networkSlug: "whatsapp",
+      accountId: "acct_0123456789abcdef0123456789abcdef",
+      roomId,
+      eventId: "$event1:matrixos.local",
+      content: { kind: "text", body: "deadline tomorrow" },
+      occurredAt: "2026-05-13T00:00:00.000Z",
+    })).resolves.toMatchObject({ accepted: true, effect: "sent_to_hermes" });
+  });
+
+  it("rejects deleting an already disabled automation rule", async () => {
+    const rule = await repository.createAutomationRule({
+      ownerId,
+      name: "Deadlines",
+      scope: "room",
+      roomId,
+      trigger: { type: "text_contains", value: "deadline" },
+      action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+    });
+
+    await expect(repository.deleteAutomationRule({ ownerId, ruleId: rule.id })).resolves.toEqual({
+      ruleId: rule.id,
+      status: "disabled",
+    });
+    await expect(repository.deleteAutomationRule({ ownerId, ruleId: rule.id })).rejects.toMatchObject({
+      code: "not_found",
+    });
+  });
+
+  it("records automation creation audit event in the same repository operation", async () => {
+    const rule = await repository.createAutomationRule({
+      ownerId,
+      name: "Deadlines",
+      scope: "room",
+      roomId,
+      trigger: { type: "text_contains", value: "deadline" },
+      action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+    });
+
+    const db = (repository as unknown as { kysely: Kysely<MessagingDatabase> }).kysely;
+    const auditRow = await db
+      .selectFrom("messaging_audit_events")
+      .select(["type", "owner_id", "room_id", "safe_summary", "metadata"])
+      .where("owner_id", "=", ownerId)
+      .where("type", "=", "automation_rule_created")
+      .executeTakeFirstOrThrow();
+
+    expect(auditRow).toMatchObject({
+      type: "automation_rule_created",
+      owner_id: ownerId,
+      room_id: roomId,
+      safe_summary: "Messaging automation rule created",
+    });
+    expect(auditRow.metadata).toMatchObject({ ruleId: rule.id });
+  });
+
+  it("includes all_permitted rules when listing rules for a room dispatch", async () => {
+    const roomRule = await repository.createAutomationRule({
+      ownerId,
+      name: "Room deadlines",
+      scope: "room",
+      roomId,
+      trigger: { type: "text_contains", value: "deadline" },
+      action: { type: "draft_reply", bodyTemplate: "I saw: {body}" },
+    });
+    const allPermittedRule = await repository.createAutomationRule({
+      ownerId,
+      name: "All deadlines",
+      scope: "all_permitted",
+      trigger: { type: "text_contains", value: "deadline" },
+      action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+    });
+
+    await expect(repository.listAutomationRules({ ownerId }, { roomId })).resolves.toMatchObject({
+      items: expect.arrayContaining([
+        expect.objectContaining({ id: roomRule.id }),
+        expect.objectContaining({ id: allPermittedRule.id }),
+      ]),
+    });
+  });
+});

--- a/tests/gateway/messages/automation-routes.test.ts
+++ b/tests/gateway/messages/automation-routes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMessagingTestApp, createRepositoryMock, ownerId, now } from "./helpers.js";
+
+const ruleId = "auto_0123456789abcdef0123456789abcdef";
+
+describe("automation routes", () => {
+  it("creates, lists, pauses, and deletes automation rules", async () => {
+    const rule = {
+      id: ruleId,
+      ownerId,
+      name: "Deadlines",
+      scope: "room",
+      roomId: "!room:matrixos.local",
+      trigger: { type: "text_contains", value: "deadline" },
+      action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+      status: "enabled",
+      createdAt: now,
+      updatedAt: now,
+    };
+    const createAutomationRule = vi.fn().mockResolvedValue(rule);
+    const listAutomationRules = vi.fn().mockResolvedValue({ items: [rule] });
+    const pauseAutomationRule = vi.fn().mockResolvedValue({ ...rule, status: "paused" });
+    const deleteAutomationRule = vi.fn().mockResolvedValue({ ruleId, status: "disabled" });
+    const repository = createRepositoryMock({
+      createAutomationRule,
+      listAutomationRules,
+      pauseAutomationRule,
+      deleteAutomationRule,
+    });
+    const app = createMessagingTestApp(repository);
+
+    const createRes = await app.request("/api/messages/automation/rules", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Deadlines",
+        scope: "room",
+        roomId: "!room:matrixos.local",
+        trigger: { type: "text_contains", value: "deadline" },
+        action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    expect(createAutomationRule).toHaveBeenCalledWith(expect.objectContaining({ ownerId, name: "Deadlines" }));
+
+    const listRes = await app.request("/api/messages/automation/rules");
+    expect(listRes.status).toBe(200);
+    await expect(listRes.json()).resolves.toMatchObject({ rules: [{ id: ruleId }] });
+
+    const pauseRes = await app.request(`/api/messages/automation/rules/${ruleId}/pause`, { method: "POST" });
+    expect(pauseRes.status).toBe(200);
+    expect(pauseAutomationRule).toHaveBeenCalledWith({ ownerId, ruleId });
+
+    const deleteRes = await app.request(`/api/messages/automation/rules/${ruleId}`, { method: "DELETE" });
+    expect(deleteRes.status).toBe(200);
+    expect(deleteAutomationRule).toHaveBeenCalledWith({ ownerId, ruleId });
+  });
+});

--- a/tests/gateway/messages/automation-schemas.test.ts
+++ b/tests/gateway/messages/automation-schemas.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { AutomationRuleCreateRequestSchema } from "../../../packages/gateway/src/messages/schemas.js";
+
+describe("automation schemas", () => {
+  it("accepts bounded discriminated trigger and action payloads", () => {
+    const parsed = AutomationRuleCreateRequestSchema.parse({
+      name: "Deadlines",
+      scope: "room",
+      roomId: "!room:matrixos.local",
+      trigger: { type: "text_contains", value: "deadline" },
+      action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+    });
+
+    expect(parsed.action.type).toBe("create_task");
+  });
+
+  it("rejects unknown action payloads and overlong trigger values", () => {
+    expect(() => AutomationRuleCreateRequestSchema.parse({
+      name: "Bad",
+      scope: "all_permitted",
+      trigger: { type: "text_contains", value: "x".repeat(300) },
+      action: { type: "shell_exec", command: "rm -rf /" },
+    })).toThrow();
+  });
+});

--- a/tests/gateway/messages/automation-schemas.test.ts
+++ b/tests/gateway/messages/automation-schemas.test.ts
@@ -22,4 +22,15 @@ describe("automation schemas", () => {
       action: { type: "shell_exec", command: "rm -rf /" },
     })).toThrow();
   });
+
+  it("rejects network and account scopes until scoped dispatch is implemented", () => {
+    for (const scope of ["network", "account"] as const) {
+      expect(() => AutomationRuleCreateRequestSchema.parse({
+        name: "Unsupported",
+        scope,
+        trigger: { type: "text_contains", value: "deadline" },
+        action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+      })).toThrow(/network and account automation scopes are not available yet/);
+    }
+  });
 });

--- a/tests/gateway/messages/automation-task-action.test.ts
+++ b/tests/gateway/messages/automation-task-action.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAutomationActionRunner } from "../../../packages/gateway/src/messages/automation-actions.js";
+
+describe("automation task action", () => {
+  it("creates a scoped Matrix OS task from a matching message", async () => {
+    const createTask = vi.fn().mockResolvedValue("task_1");
+    const runner = createAutomationActionRunner({ createTask });
+
+    const result = await runner({
+      ownerId: "user_a",
+      ruleId: "auto_0123456789abcdef0123456789abcdef",
+      roomId: "!room:matrixos.local",
+      body: "deadline tomorrow",
+      action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+    });
+
+    expect(result).toEqual({ ok: true, taskId: "task_1" });
+    expect(createTask).toHaveBeenCalledWith({
+      ownerId: "user_a",
+      title: "Follow up: deadline tomorrow",
+    });
+  });
+});

--- a/tests/gateway/messages/automation-task-action.test.ts
+++ b/tests/gateway/messages/automation-task-action.test.ts
@@ -4,7 +4,8 @@ import { createAutomationActionRunner } from "../../../packages/gateway/src/mess
 describe("automation task action", () => {
   it("creates a scoped Matrix OS task from a matching message", async () => {
     const createTask = vi.fn().mockResolvedValue("task_1");
-    const runner = createAutomationActionRunner({ createTask });
+    const createDraft = vi.fn();
+    const runner = createAutomationActionRunner({ createTask, createDraft });
 
     const result = await runner({
       ownerId: "user_a",
@@ -19,5 +20,29 @@ describe("automation task action", () => {
       ownerId: "user_a",
       title: "Follow up: deadline tomorrow",
     });
+    expect(createDraft).not.toHaveBeenCalled();
+  });
+
+  it("persists a scoped draft reply from a matching message", async () => {
+    const createTask = vi.fn();
+    const createDraft = vi.fn().mockResolvedValue("reply_1");
+    const runner = createAutomationActionRunner({ createTask, createDraft });
+
+    const result = await runner({
+      ownerId: "user_a",
+      ruleId: "auto_0123456789abcdef0123456789abcdef",
+      roomId: "!room:matrixos.local",
+      body: "deadline tomorrow",
+      action: { type: "draft_reply", bodyTemplate: "I saw: {body}" },
+    });
+
+    expect(result).toEqual({ ok: true, draftReplyId: "reply_1" });
+    expect(createDraft).toHaveBeenCalledWith({
+      ownerId: "user_a",
+      roomId: "!room:matrixos.local",
+      ruleId: "auto_0123456789abcdef0123456789abcdef",
+      body: "I saw: deadline tomorrow",
+    });
+    expect(createTask).not.toHaveBeenCalled();
   });
 });

--- a/tests/gateway/messages/helpers.ts
+++ b/tests/gateway/messages/helpers.ts
@@ -85,6 +85,10 @@ export function createRepositoryMock(overrides: Partial<MessagingRepository> = {
     getReply: vi.fn().mockResolvedValue(null),
     cancelReply: vi.fn(),
     approveReply: vi.fn(),
+    createAutomationRule: vi.fn(),
+    listAutomationRules: vi.fn().mockResolvedValue({ items: [], nextCursor: undefined }),
+    pauseAutomationRule: vi.fn(),
+    deleteAutomationRule: vi.fn(),
     ...overrides,
   };
 }

--- a/tests/gateway/messages/helpers.ts
+++ b/tests/gateway/messages/helpers.ts
@@ -85,6 +85,8 @@ export function createRepositoryMock(overrides: Partial<MessagingRepository> = {
     getReply: vi.fn().mockResolvedValue(null),
     cancelReply: vi.fn(),
     approveReply: vi.fn(),
+    enqueueHermesWork: vi.fn(),
+    listWorkItems: vi.fn().mockResolvedValue([]),
     createAutomationRule: vi.fn(),
     listAutomationRules: vi.fn().mockResolvedValue({ items: [], nextCursor: undefined }),
     pauseAutomationRule: vi.fn(),

--- a/tests/shell/messages/messages-app-setup.test.tsx
+++ b/tests/shell/messages/messages-app-setup.test.tsx
@@ -76,6 +76,9 @@ describe("Messages app setup flow", () => {
       if (path === "/api/messages/drafts") {
         return jsonResponse({ drafts: [] });
       }
+      if (path === "/api/messages/automation/rules") {
+        return jsonResponse({ rules: [] });
+      }
       if (path === "/api/messages/accounts/setup" && init?.method === "POST") {
         return jsonResponse({
           id: "setup_0123456789abcdef0123456789abcdef",

--- a/tests/shell/messages/messages-automation.test.tsx
+++ b/tests/shell/messages/messages-automation.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import App from "../../../home/apps/messages/src/App";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Messages automation UI", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path === "/api/messages/networks") return jsonResponse({ networks: [] });
+      if (path === "/api/messages/accounts") return jsonResponse({ accounts: [] });
+      if (path === "/api/messages/conversations") return jsonResponse({ items: [] });
+      if (path === "/api/messages/drafts") return jsonResponse({ drafts: [] });
+      if (path === "/api/messages/automation/rules" && init?.method !== "POST") {
+        return jsonResponse({
+          rules: [{
+            id: "auto_0123456789abcdef0123456789abcdef",
+            name: "Deadlines",
+            scope: "all_permitted",
+            trigger: { type: "text_contains", value: "deadline" },
+            action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+            status: "enabled",
+          }],
+        });
+      }
+      if (path === "/api/messages/automation/rules" && init?.method === "POST") {
+        return jsonResponse({
+          id: "auto_new0123456789abcdef0123456789",
+          name: "Follow ups",
+          scope: "all_permitted",
+          trigger: { type: "text_contains", value: "follow up" },
+          action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+          status: "enabled",
+        }, 201);
+      }
+      return jsonResponse({ error: { code: "not_found" } }, 404);
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("lists automation rules and can create a task automation", async () => {
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Automations" })).toBeTruthy();
+    expect(screen.getByText("Deadlines")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Trigger"), { target: { value: "follow up" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add automation" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/api/messages/automation/rules", expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "Follow ups",
+          scope: "all_permitted",
+          trigger: { type: "text_contains", value: "follow up" },
+          action: { type: "create_task", titleTemplate: "Follow up: {body}" },
+        }),
+      }));
+    });
+  });
+});

--- a/tests/shell/messages/messages-permissions.test.tsx
+++ b/tests/shell/messages/messages-permissions.test.tsx
@@ -50,6 +50,9 @@ describe("Messages permissions UI", () => {
           }],
         });
       }
+      if (path === "/api/messages/automation/rules") {
+        return jsonResponse({ rules: [] });
+      }
       if (path === "/api/messages/conversations/!room%3Amatrixos.local/permissions" && init?.method === "PATCH") {
         return jsonResponse({
           roomId: "!room:matrixos.local",


### PR DESCRIPTION
Stack: 4/5. Base: #118. Next: #120.

## Summary
- Adds permitted automation rules for owner-approved message handling.
- Adds bounded rule schemas, evaluator behavior, task-action handling, API routes, and UI coverage.
- Keeps automations default-deny and permission-aware.

## Invariants
- Source of truth: owner-local Postgres stores automation rules and their enabled/paused state.
- Lock/transaction scope: rule creation, pause, and delete are owner-scoped repository writes; evaluator decisions are derived from stored rules plus current room permissions.
- Acceptable orphan states: failed automation actions do not grant new messaging permissions and remain retry/audit concerns outside the evaluator.
- Auth source of truth: Matrix OS request principal owns user-facing rule changes.
- Deferred scope: production host health/recovery scripts and live first-loop bridge testing land in the final stack PR.

## Validation
- Covered by the stack-tip validation in #116.
