### PR TITLE
chore(deps): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,126 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      runtime-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      tooling-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/home/apps/notes"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 2
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      default-app-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/home/apps/task-manager"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 2
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      default-app-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/home/apps/whiteboard"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 2
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      default-app-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/home/apps/symphony"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 2
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      default-app-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Add weekly Dependabot updates for the root pnpm workspace and shipped standalone default apps with their own lockfiles.
- Add weekly grouped GitHub Actions updates.
- Keep update volume low and group minor/patch dependency updates while leaving majors as separate reviewable PRs.
- Intentionally skip Docker image updates because production Matrix OS runtime ships as VPS host bundles, not customer Docker images.

## Tests
- `bun run typecheck` passed.
- `git diff --check` passed.
- `node -e "const fs=require('fs'); for (const d of ['/', '/home/apps/notes', '/home/apps/task-manager', '/home/apps/whiteboard', '/home/apps/symphony']) { const lock = d === '/' ? 'pnpm-lock.yaml' : d.slice(1) + '/pnpm-lock.yaml'; if (!fs.existsSync(lock)) throw new Error('missing lockfile: '+lock); } console.log('dependabot targets ok');"` passed.
- `bun run check:patterns` failed on an existing unrelated violation: `shell/src/stores/terminal-store.ts:326` fetch without `AbortSignal.timeout`.
- `bun run test` was terminated after Vitest stalled without test output after the banner.
