### PR TITLE
fix(symphony): start Codex sessions through zellij

### DIFF
--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -99,7 +99,14 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
     case "codex":
       return {
         command,
-        args: [...codexSandboxArgs(input.sandbox), ...promptArgs(input.prompt)],
+        args: [
+          "exec",
+          "--skip-git-repo-check",
+          "--ask-for-approval",
+          "never",
+          ...codexSandboxArgs(input.sandbox),
+          ...promptArgs(input.prompt),
+        ],
         cwd: input.cwd,
         env: {},
       };

--- a/packages/gateway/src/symphony/linear-source.ts
+++ b/packages/gateway/src/symphony/linear-source.ts
@@ -138,10 +138,10 @@ function includesAllLabels(ticket: TrackedTicket, requiredLabels: string[]): boo
 }
 
 function buildIssuesQuery(input: { projectId?: string; state?: string; labelName?: string; assigneeId?: string }) {
-  const variableDefs = ["$first: Int!", "$after: String", "$teamId: String!"];
+  const variableDefs = ["$first: Int!", "$after: String", "$teamId: ID!"];
   const filters = ["team: { id: { eq: $teamId } }"];
   if (input.projectId) {
-    variableDefs.push("$projectId: String!");
+    variableDefs.push("$projectId: ID!");
     filters.push("project: { id: { eq: $projectId } }");
   }
   if (input.state) {
@@ -153,7 +153,7 @@ function buildIssuesQuery(input: { projectId?: string; state?: string; labelName
     filters.push("labels: { name: { eq: $labelName } }");
   }
   if (input.assigneeId) {
-    variableDefs.push("$assigneeId: String!");
+    variableDefs.push("$assigneeId: ID!");
     filters.push("assignee: { id: { eq: $assigneeId } }");
   }
   return `

--- a/packages/gateway/src/symphony/prompt.ts
+++ b/packages/gateway/src/symphony/prompt.ts
@@ -1,5 +1,5 @@
 import { constants } from "node:fs";
-import { access, readFile } from "node:fs/promises";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { PROJECT_SLUG_REGEX } from "../project-manager.js";
 import { readJsonFile } from "../state-ops.js";
@@ -20,6 +20,17 @@ export class SymphonyWorkflowError extends Error {
   }
 }
 
+const DEFAULT_WORKFLOW = `# Matrix Symphony workflow
+
+You are running as a Matrix-managed coding agent for a claimed Linear ticket.
+
+- Read the ticket context before changing code.
+- Keep changes scoped to the requested worktree.
+- Follow the repository agent instructions and existing project conventions.
+- Run the focused tests for the files you touched before handing off.
+- Do not print provider credentials or secrets.
+`;
+
 function escapeTemplate(value: string): string {
   return value.replace(/[{}]/g, "");
 }
@@ -30,6 +41,16 @@ async function pathExists(path: string): Promise<boolean> {
     return true;
   } catch (err: unknown) {
     if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
+  }
+}
+
+async function createDefaultWorkflow(path: string): Promise<void> {
+  await mkdir(resolve(path, ".."), { recursive: true });
+  try {
+    await writeFile(path, DEFAULT_WORKFLOW, { flag: "wx" });
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EEXIST") return;
     throw err;
   }
 }
@@ -53,12 +74,19 @@ export async function loadWorkflowContract(input: {
   const project = await readProject(input.homePath, input.projectSlug);
   if (!project) throw new SymphonyWorkflowError("workflow_missing");
   const projectRoot = resolve(project.localPath);
-  const workflowPath = resolve(input.workflowPath ? join(projectRoot, input.workflowPath) : join(projectRoot, "WORKFLOW.md"));
+  const hasCustomWorkflowPath = Boolean(input.workflowPath);
+  const workflowPath = resolve(hasCustomWorkflowPath ? join(projectRoot, input.workflowPath!) : join(projectRoot, "WORKFLOW.md"));
   if (workflowPath !== projectRoot && !workflowPath.startsWith(`${projectRoot}/`)) {
     throw new SymphonyWorkflowError("invalid_workflow_path");
   }
   if (!await pathExists(workflowPath)) {
-    throw new SymphonyWorkflowError("workflow_missing");
+    if (hasCustomWorkflowPath) throw new SymphonyWorkflowError("workflow_missing");
+    try {
+      await createDefaultWorkflow(workflowPath);
+    } catch (err: unknown) {
+      console.warn("[symphony] Failed to create default workflow:", err instanceof Error ? err.message : String(err));
+      throw new SymphonyWorkflowError("workflow_read_failed");
+    }
   }
   try {
     const body = (await readFile(workflowPath, "utf8")).trim();

--- a/packages/gateway/src/zellij-runtime.ts
+++ b/packages/gateway/src/zellij-runtime.ts
@@ -12,6 +12,22 @@ type CommandRunner = (
   args: string[],
   options: { cwd: string; timeout: number },
 ) => Promise<{ stdout: string; stderr: string }>;
+type PtyProcess = Pick<import("node-pty").IPty, "kill" | "onExit">;
+type RetainedPty = {
+  process: PtyProcess;
+  startedAtMs: number;
+};
+type PtySpawn = (
+  command: string,
+  args: string[],
+  options: {
+    name: string;
+    cols: number;
+    rows: number;
+    cwd: string;
+    env: Record<string, string>;
+  },
+) => PtyProcess;
 
 export interface ZellijLayoutResult {
   sessionName: string;
@@ -32,6 +48,23 @@ export interface ZellijHealth {
 
 const SessionIdSchema = z.string().regex(/^[A-Za-z0-9_-]{1,128}$/);
 const ZELLIJ_TIMEOUT_MS = 10_000;
+const ZELLIJ_STARTUP_DELAY_MS = 500;
+const MAX_RETAINED_ZELLIJ_PTYS = 128;
+const RETAINED_PTY_TTL_MS = 4 * 60 * 60 * 1000;
+const SAFE_PROCESS_ENV_KEYS = new Set([
+  "COLORTERM",
+  "DISPLAY",
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+  "WAYLAND_DISPLAY",
+  "XAUTHORITY",
+]);
 
 const execFileAsync = promisify(execFile);
 
@@ -44,6 +77,15 @@ const defaultRunCommand: CommandRunner = async (command, args, options) => {
   });
   return { stdout, stderr };
 };
+
+let defaultPtySpawn: PtySpawn | undefined;
+async function getDefaultPtySpawn(): Promise<PtySpawn> {
+  if (!defaultPtySpawn) {
+    const nodePty = await import("node-pty");
+    defaultPtySpawn = nodePty.spawn as unknown as PtySpawn;
+  }
+  return defaultPtySpawn;
+}
 
 function sessionName(sessionId: string): string {
   const parsed = SessionIdSchema.parse(sessionId);
@@ -76,13 +118,27 @@ function renderLayout(input: {
     `// Matrix OS generated layout for ${input.sessionName}`,
     "layout {",
     "  tab name=\"Agent\" {",
-    `    pane cwd ${kdlString(input.launch.cwd)} command ${kdlString(input.launch.command)} {`,
+    `    pane cwd=${kdlString(input.launch.cwd)} command=${kdlString(input.launch.command)} {`,
     argsLine.trimEnd(),
     "    }",
     "  }",
     "}",
     "",
   ].filter((line) => line.length > 0).join("\n");
+}
+
+function ptyEnv(launchEnv: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string" && (SAFE_PROCESS_ENV_KEYS.has(key) || key.startsWith("LC_"))) {
+      env[key] = value;
+    }
+  }
+  return { ...env, ...launchEnv };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function atomicWriteText(path: string, content: string): Promise<void> {
@@ -100,10 +156,28 @@ async function atomicWriteText(path: string, content: string): Promise<void> {
 export function createZellijRuntime(options: {
   homePath: string;
   runCommand?: CommandRunner;
+  spawnPty?: PtySpawn;
+  startupDelayMs?: number;
+  retainedPtyTtlMs?: number;
+  nowMs?: () => number;
 }) {
   const homePath = resolve(options.homePath);
   const runCommand = options.runCommand ?? defaultRunCommand;
+  const spawnPty = options.spawnPty;
+  const startupDelayMs = options.startupDelayMs ?? ZELLIJ_STARTUP_DELAY_MS;
+  const retainedPtyTtlMs = options.retainedPtyTtlMs ?? RETAINED_PTY_TTL_MS;
+  const nowMs = options.nowMs ?? Date.now;
   const layoutDir = join(homePath, "system", "zellij", "layouts");
+  const retainedPtys = new Map<string, RetainedPty>();
+
+  function sweepRetainedPtys(): void {
+    const cutoff = nowMs() - retainedPtyTtlMs;
+    for (const [name, retained] of retainedPtys) {
+      if (retained.startedAtMs > cutoff) continue;
+      retained.process.kill();
+      retainedPtys.delete(name);
+    }
+  }
 
   return {
     async generateLayout(input: {
@@ -122,10 +196,29 @@ export function createZellijRuntime(options: {
       launch: AgentLaunchSpec;
     }): Promise<ZellijStartResult> {
       const layout = await this.generateLayout(input);
-      await runCommand("zellij", ["--session", layout.sessionName, "--layout", layout.layoutPath], {
+      sweepRetainedPtys();
+      if (!retainedPtys.has(layout.sessionName) && retainedPtys.size >= MAX_RETAINED_ZELLIJ_PTYS) {
+        throw new Error("zellij_session_limit");
+      }
+      retainedPtys.get(layout.sessionName)?.process.kill();
+      retainedPtys.delete(layout.sessionName);
+      const resolvedSpawn = spawnPty ?? await getDefaultPtySpawn();
+      const ptyProcess = resolvedSpawn("zellij", ["--session", layout.sessionName, "--new-session-with-layout", layout.layoutPath], {
+        name: "xterm-256color",
+        cols: 120,
+        rows: 40,
         cwd: input.launch.cwd,
-        timeout: ZELLIJ_TIMEOUT_MS,
+        env: ptyEnv(input.launch.env),
       });
+      let exited: { exitCode: number; signal?: number } | null = null;
+      ptyProcess.onExit((event: { exitCode: number; signal?: number }) => {
+        exited = event;
+        retainedPtys.delete(layout.sessionName);
+      });
+      retainedPtys.set(layout.sessionName, { process: ptyProcess, startedAtMs: nowMs() });
+      await delay(startupDelayMs);
+      if (exited) throw new Error("zellij_start_failed");
+      if (!retainedPtys.has(layout.sessionName)) throw new Error("zellij_start_cancelled");
       return { ok: true, status: "running", ...layout };
     },
 
@@ -138,7 +231,11 @@ export function createZellijRuntime(options: {
     },
 
     async kill(sessionId: string): Promise<{ ok: true }> {
-      await runCommand("zellij", ["kill-session", sessionName(sessionId)], {
+      const name = sessionName(sessionId);
+      const ptyProcess = retainedPtys.get(name);
+      retainedPtys.delete(name);
+      ptyProcess?.process.kill();
+      await runCommand("zellij", ["kill-session", name], {
         cwd: homePath,
         timeout: ZELLIJ_TIMEOUT_MS,
       });

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -40,7 +40,7 @@ describe("agent-launcher", () => {
     expect(JSON.stringify(result)).not.toContain("sk-secret");
   });
 
-  it("constructs argv arrays for supported agents without shell interpolation", () => {
+  it("constructs non-interactive Codex exec argv without shell interpolation", () => {
     const launch = buildAgentLaunch({
       agent: "codex",
       cwd: "/home/matrixos/home/projects/repo/worktrees/wt_123",
@@ -51,6 +51,10 @@ describe("agent-launcher", () => {
     expect(launch).toEqual({
       command: "codex",
       args: [
+        "exec",
+        "--skip-git-repo-check",
+        "--ask-for-approval",
+        "never",
         "--sandbox",
         "workspace-write",
         "--writable-root",
@@ -63,7 +67,7 @@ describe("agent-launcher", () => {
     });
   });
 
-  it("inserts end-of-options before prompt to prevent flag injection", () => {
+  it("inserts end-of-options before prompt for interactive agents to prevent flag injection", () => {
     const agents = ["claude", "codex", "opencode", "pi"] as const;
     for (const agent of agents) {
       const launch = buildAgentLaunch({
@@ -72,6 +76,20 @@ describe("agent-launcher", () => {
         prompt: "--dangerously-bypass-sandbox",
         sandbox: agent === "codex" ? { enabled: true, writableRoots: ["/tmp/sandbox"] } : undefined,
       });
+      if (agent === "codex") {
+        expect(launch.args).toEqual([
+          "exec",
+          "--skip-git-repo-check",
+          "--ask-for-approval",
+          "never",
+          "--sandbox",
+          "workspace-write",
+          "--writable-root",
+          "/tmp/sandbox",
+          "--",
+          "--dangerously-bypass-sandbox",
+        ]);
+      }
       const dashDashIndex = launch.args.indexOf("--");
       const promptIndex = launch.args.indexOf("--dangerously-bypass-sandbox");
       expect(dashDashIndex).toBeGreaterThanOrEqual(0);
@@ -94,18 +112,21 @@ describe("agent-launcher", () => {
     expect(launchEmpty.args).not.toContain("--");
   });
 
-  it("places end-of-options after sandbox flags for codex", () => {
+  it("places Codex exec controls before sandbox flags and the prompt last", () => {
     const launch = buildAgentLaunch({
       agent: "codex",
       cwd: "/home/matrixos/home/projects/repo",
       prompt: "--help",
       sandbox: { enabled: true, writableRoots: ["/tmp/sandbox"] },
     });
-    const dashDashIndex = launch.args.indexOf("--");
+    expect(launch.args.slice(0, 4)).toEqual(["exec", "--skip-git-repo-check", "--ask-for-approval", "never"]);
     const sandboxIndex = launch.args.indexOf("--sandbox");
     const writableRootIndex = launch.args.indexOf("--writable-root");
-    expect(sandboxIndex).toBeLessThan(dashDashIndex);
-    expect(writableRootIndex).toBeLessThan(dashDashIndex);
+    const dashDashIndex = launch.args.indexOf("--");
+    expect(sandboxIndex).toBeGreaterThan(3);
+    expect(writableRootIndex).toBeGreaterThan(sandboxIndex);
+    expect(dashDashIndex).toBeGreaterThan(writableRootIndex);
+    expect(launch.args.at(-1)).toBe("--help");
   });
 
   it("requires Codex sandbox metadata unless explicitly overridden", () => {
@@ -120,7 +141,7 @@ describe("agent-launcher", () => {
       cwd: "/home/matrixos/home/projects/repo",
       prompt: "work",
       sandbox: { enabled: false, adminOverride: true },
-    }).args).toEqual(["--dangerously-bypass-sandbox", "--", "work"]);
+    }).args).toEqual(["exec", "--skip-git-repo-check", "--ask-for-approval", "never", "--dangerously-bypass-sandbox", "--", "work"]);
   });
 
   it("validates supported agent IDs", () => {

--- a/tests/gateway/symphony-linear-source.test.ts
+++ b/tests/gateway/symphony-linear-source.test.ts
@@ -89,6 +89,11 @@ describe("Symphony Linear source", () => {
       expect(init.signal).toBeTruthy();
       expect(init.headers).toMatchObject({ Authorization: "lin_api_secret" });
       const body = JSON.parse(String(init.body));
+      expect(body.query).toContain("$teamId: ID!");
+      expect(body.query).toContain("$projectId: ID!");
+      expect(body.query).toContain("$assigneeId: ID!");
+      expect(body.query).toContain("$state: String!");
+      expect(body.query).toContain("$labelName: String!");
       expect(body.variables.assigneeId).toBe("assignee_1");
       return new Response(JSON.stringify({
         data: {
@@ -121,7 +126,7 @@ describe("Symphony Linear source", () => {
     }) as unknown as typeof fetch;
     const source = createLinearSource({ fetch: fetchMock });
 
-    const result = await source.previewTickets(rule, "lin_api_secret", { limit: 10 });
+    const result = await source.previewTickets({ ...rule, projectId: "project_1" }, "lin_api_secret", { limit: 10 });
 
     expect(result.tickets).toEqual([
       expect.objectContaining({ externalId: "issue_1", identifier: "MAT-1", assigneeId: "assignee_1" }),

--- a/tests/gateway/symphony-orchestrator.test.ts
+++ b/tests/gateway/symphony-orchestrator.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -673,10 +673,27 @@ describe("Matrix Symphony orchestrator", () => {
     }
   });
 
-  it("marks workflow failures as blocked attention states", async () => {
+  it("creates a default workflow and dispatches registered projects without a hand-written workflow", async () => {
     const repository = memoryRepo(structuredClone(baseSnapshot));
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-symphony-default-workflow-"));
+    const repoPath = join(homePath, "projects", "matrix-os", "repo");
+    await mkdir(repoPath, { recursive: true });
+    await atomicWriteJson(join(homePath, "projects", "matrix-os", "config.json"), {
+      id: "proj_matrix",
+      slug: "matrix-os",
+      name: "Matrix OS",
+      localPath: repoPath,
+      addedAt: "2026-05-13T00:00:00.000Z",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+      ownerScope: { type: "user", id: "user_123" },
+    });
+    const worktreeManager = { createWorktree: vi.fn(async () => ({ ok: true, worktree: { id: "wt_123456789abc", path: join(repoPath, ".worktrees", "mat-1") } })) };
+    const agentSessionManager = {
+      startSession: vi.fn(async () => ({ ok: true, status: 201, session: { id: "sess_run_1" } })),
+      killSession: vi.fn(),
+    };
     const orchestrator = createMatrixSymphonyOrchestrator({
-      homePath: "/tmp/matrix",
+      homePath,
       repository,
       credentialStore: { readLinearCredential: vi.fn(async () => "lin_api_secret"), hasLinearCredential: vi.fn(), writeLinearCredential: vi.fn(), deleteLinearCredential: vi.fn() },
       linearSource: {
@@ -685,14 +702,24 @@ describe("Matrix Symphony orchestrator", () => {
           tickets: [{ externalId: "issue_1", identifier: "MAT-1", title: "One", stateName: "Todo", assigneeId: "assignee_1", labels: ["symphony"] }],
         })),
       },
-      worktreeManager: { createWorktree: vi.fn() },
-      agentSessionManager: { startSession: vi.fn(), killSession: vi.fn() },
+      worktreeManager,
+      agentSessionManager,
     });
 
-    await orchestrator.poll("user_123");
+    try {
+      await orchestrator.poll("user_123");
 
-    const runs = await repository.listRuns("user_123");
-    expect(runs[0]).toMatchObject({ status: "blocked", lastErrorCode: "workflow_missing" });
+      const runs = await repository.listRuns("user_123");
+      expect(runs[0]).toMatchObject({
+        status: "running",
+        lastEvent: "Agent session started",
+        worktreeId: "wt_123456789abc",
+        sessionId: "sess_run_1",
+      });
+      await expect(readFile(join(repoPath, "WORKFLOW.md"), "utf8")).resolves.toContain("Matrix Symphony workflow");
+    } finally {
+      rmSync(homePath, { recursive: true, force: true });
+    }
   });
 
   it("does not overwrite stopped runs with blocked dispatch failures", async () => {

--- a/tests/gateway/symphony-workflow.test.ts
+++ b/tests/gateway/symphony-workflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -38,9 +38,25 @@ describe("Symphony workflow", () => {
     });
   });
 
+  it("creates a default workflow contract in registered projects when none exists", async () => {
+    const workflow = await loadWorkflowContract({ homePath, projectSlug: "matrix-os" });
+
+    expect(workflow).toMatchObject({
+      projectSlug: "matrix-os",
+      path: join(repoPath, "WORKFLOW.md"),
+    });
+    expect(workflow.body).toContain("Matrix Symphony workflow");
+    await expect(readFile(join(repoPath, "WORKFLOW.md"), "utf8")).resolves.toContain("Matrix Symphony workflow");
+  });
+
   it("rejects workflow paths outside the Matrix project", async () => {
     await expect(loadWorkflowContract({ homePath, projectSlug: "matrix-os", workflowPath: "../secret.md" }))
       .rejects.toBeInstanceOf(SymphonyWorkflowError);
+  });
+
+  it("reports a clear setup error when a custom workflow path is missing", async () => {
+    await expect(loadWorkflowContract({ homePath, projectSlug: "matrix-os", workflowPath: "docs/WORKFLOW.md" }))
+      .rejects.toMatchObject({ code: "workflow_missing" });
   });
 
   it("composes prompt from workflow and ticket context without secrets", () => {

--- a/tests/gateway/zellij-runtime.test.ts
+++ b/tests/gateway/zellij-runtime.test.ts
@@ -6,6 +6,22 @@ import { join } from "node:path";
 import { createZellijRuntime } from "../../packages/gateway/src/zellij-runtime.js";
 import type { AgentLaunchSpec } from "../../packages/gateway/src/agent-launcher.js";
 
+function createPty() {
+  const handlers: Array<(event: { exitCode: number; signal?: number }) => void> = [];
+  return {
+    process: {
+      kill: vi.fn(),
+      onExit: vi.fn((handler: (event: { exitCode: number; signal?: number }) => void) => {
+        handlers.push(handler);
+        return { dispose: vi.fn() };
+      }),
+    },
+    exit(event: { exitCode: number; signal?: number }) {
+      for (const handler of handlers) handler(event);
+    },
+  };
+}
+
 describe("zellij-runtime", () => {
   let homePath: string;
   const launch: AgentLaunchSpec = {
@@ -21,6 +37,7 @@ describe("zellij-runtime", () => {
 
   afterEach(() => {
     rmSync(homePath, { recursive: true, force: true });
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -31,15 +48,18 @@ describe("zellij-runtime", () => {
 
     expect(result.layoutPath).toBe(join(homePath, "system", "zellij", "layouts", "sess_abc123.kdl"));
     const layout = await readFile(result.layoutPath, "utf-8");
-    expect(layout).toContain('command "codex"');
+    expect(layout).toContain('pane cwd="/home/matrixos/home/projects/repo/worktrees/wt_123" command="codex" {');
     expect(layout).toContain('args "--sandbox" "workspace-write" "--" "fix tests; rm -rf /"');
-    expect(layout).toContain('cwd "/home/matrixos/home/projects/repo/worktrees/wt_123"');
+    expect(layout).not.toContain('pane cwd "');
+    expect(layout).not.toContain('command "codex" {');
     expect(layout).not.toContain("sh -c");
   });
 
-  it("starts, attaches, observes, and kills sessions through argv arrays", async () => {
+  it("starts zellij through a retained PTY, then attaches, observes, and kills by argv", async () => {
     const runCommand = vi.fn(async () => ({ stdout: "ok\n", stderr: "" }));
-    const runtime = createZellijRuntime({ homePath, runCommand });
+    const pty = createPty();
+    const spawnPty = vi.fn(() => pty.process);
+    const runtime = createZellijRuntime({ homePath, runCommand, spawnPty, startupDelayMs: 1 });
 
     const started = await runtime.start({ sessionId: "sess_abc123", launch });
     expect(started).toMatchObject({
@@ -47,19 +67,107 @@ describe("zellij-runtime", () => {
       sessionName: "matrix-sess_abc123",
       status: "running",
     });
-    expect(runCommand).toHaveBeenCalledWith(
+    expect(spawnPty).toHaveBeenCalledWith(
       "zellij",
-      ["--session", "matrix-sess_abc123", "--layout", started.layoutPath],
-      expect.any(Object),
+      ["--session", "matrix-sess_abc123", "--new-session-with-layout", started.layoutPath],
+      expect.objectContaining({
+        name: "xterm-256color",
+        cols: 120,
+        rows: 40,
+        cwd: launch.cwd,
+        env: expect.objectContaining(launch.env),
+      }),
     );
+    expect(runCommand).not.toHaveBeenCalledWith("zellij", expect.arrayContaining(["--layout"]), expect.any(Object));
 
     expect(runtime.attachCommand("sess_abc123")).toEqual(["zellij", "attach", "matrix-sess_abc123"]);
     expect(runtime.observeCommand("sess_abc123")).toEqual(["zellij", "attach", "matrix-sess_abc123", "--index", "0"]);
 
     await expect(runtime.kill("sess_abc123")).resolves.toEqual({ ok: true });
+    expect(pty.process.kill).toHaveBeenCalledTimes(1);
     expect(runCommand).toHaveBeenCalledWith(
       "zellij",
       ["kill-session", "matrix-sess_abc123"],
+      expect.any(Object),
+    );
+  });
+
+  it("passes only safe process environment keys plus explicit launch env to zellij", async () => {
+    vi.stubEnv("DATABASE_URL", "postgres://secret");
+    vi.stubEnv("LINEAR_API_KEY", "lin_api_secret");
+    vi.stubEnv("PATH", "/usr/bin");
+    vi.stubEnv("LANG", "en_US.UTF-8");
+    vi.stubEnv("LC_ALL", "C.UTF-8");
+    const pty = createPty();
+    const spawnPty = vi.fn(() => pty.process);
+    const runtime = createZellijRuntime({ homePath, runCommand: vi.fn(), spawnPty, startupDelayMs: 1 });
+
+    await runtime.start({
+      sessionId: "sess_env",
+      launch: { ...launch, env: { MATRIX_EXPLICIT: "allowed" } },
+    });
+
+    const env = spawnPty.mock.calls[0]?.[2].env;
+    expect(env).toMatchObject({
+      PATH: "/usr/bin",
+      LANG: "en_US.UTF-8",
+      LC_ALL: "C.UTF-8",
+      MATRIX_EXPLICIT: "allowed",
+    });
+    expect(env).not.toHaveProperty("DATABASE_URL");
+    expect(env).not.toHaveProperty("LINEAR_API_KEY");
+  });
+
+  it("evicts stale retained PTYs before starting another session", async () => {
+    let nowMs = 0;
+    const oldPty = createPty();
+    const newPty = createPty();
+    const spawnPty = vi.fn()
+      .mockReturnValueOnce(oldPty.process)
+      .mockReturnValueOnce(newPty.process);
+    const runtime = createZellijRuntime({
+      homePath,
+      runCommand: vi.fn(),
+      spawnPty,
+      startupDelayMs: 1,
+      retainedPtyTtlMs: 10,
+      nowMs: () => nowMs,
+    });
+
+    await runtime.start({ sessionId: "sess_old", launch });
+    nowMs = 11;
+    await runtime.start({ sessionId: "sess_new", launch });
+
+    expect(oldPty.process.kill).toHaveBeenCalledTimes(1);
+    expect(newPty.process.kill).not.toHaveBeenCalled();
+  });
+
+  it("fails startup if the zellij PTY exits before the startup delay", async () => {
+    const pty = createPty();
+    const spawnPty = vi.fn(() => {
+      setTimeout(() => pty.exit({ exitCode: 1 }), 0);
+      return pty.process;
+    });
+    const runtime = createZellijRuntime({ homePath, runCommand: vi.fn(), spawnPty, startupDelayMs: 10 });
+
+    await expect(runtime.start({ sessionId: "sess_exits", launch })).rejects.toThrow("zellij_start_failed");
+  });
+
+  it("lets kill reach a session during the startup delay", async () => {
+    const pty = createPty();
+    const runCommand = vi.fn(async () => ({ stdout: "ok\n", stderr: "" }));
+    let runtime: ReturnType<typeof createZellijRuntime>;
+    const spawnPty = vi.fn(() => {
+      setTimeout(() => void runtime.kill("sess_cancel"), 0);
+      return pty.process;
+    });
+    runtime = createZellijRuntime({ homePath, runCommand, spawnPty, startupDelayMs: 10 });
+
+    await expect(runtime.start({ sessionId: "sess_cancel", launch })).rejects.toThrow("zellij_start_cancelled");
+    expect(pty.process.kill).toHaveBeenCalledTimes(1);
+    expect(runCommand).toHaveBeenCalledWith(
+      "zellij",
+      ["kill-session", "matrix-sess_cancel"],
       expect.any(Object),
     );
   });


### PR DESCRIPTION
## Summary

- Fix Linear ticket preview GraphQL variables so Linear IDs use `ID!` while state/label filters remain strings.
- Generate valid zellij KDL pane properties and start zellij sessions through a retained node-pty process instead of execFile.
- Launch Codex in non-interactive `codex exec` mode with repo trust bypass and approval disabled, and create a safe default `WORKFLOW.md` for registered projects when missing.

## Tests

- `pnpm exec vitest run tests/gateway/symphony-linear-source.test.ts tests/gateway/zellij-runtime.test.ts tests/gateway/agent-launcher.test.ts tests/gateway/symphony-workflow.test.ts tests/gateway/symphony-orchestrator.test.ts`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing scanner warnings only)
- `bun run test` was started after the focused suite and typecheck, but produced no worker output for several minutes and was stopped with SIGTERM to avoid leaving a hung local process.

## Invariants

- Source of truth: Symphony installation/run state remains in the existing Symphony repository; project workflow contracts live in the registered project root as `WORKFLOW.md`, with a generated default only when the default path is missing.
- Lock/transaction scope: this change does not add database writes or change repository transaction boundaries; dispatch still claims the run before creating the worktree and session.
- Process lifecycle: zellij startup now requires a PTY and is considered running only after the startup delay without exit; retained PTYs are capped and killed before `zellij kill-session` on cleanup.
- Acceptable orphan states: if worktree creation or runtime startup fails, existing dispatch failure handling keeps the run in retrying/blocked with generic error codes and preserves worktree metadata when available.
- Auth source of truth: Linear credentials remain server-side, and Codex launches in workspace-write sandbox mode unless the existing explicit admin override is provided.
- Deferred scope: this PR does not change dashboard UI, Linear state transitions, or production deployment; it only fixes preview/query, workflow preflight, launch args, and zellij runtime startup.
