### PR TITLE
docs(hermes): plan manager implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,8 @@ Read these on demand, not every session:
 - Owner-controlled Matrix home files for shell/terminal session metadata (`~/system/terminal-sessions.json`, terminal layout files) plus existing owner Postgres where current workspace/app data already lives. No new embedded database or ORM. (075-mobile-shell)
 - TypeScript 5.5+ strict, ES modules, Node.js 24+, React 19, Next.js 16 + Hono gateway routes, Zod 4 via `zod/v4`, Kysely/Postgres, Matrix homeserver appservice support, self-hosted Telegram and WhatsApp bridge runtimes, existing Matrix OS shell/app bridge, Hermes/Claude Agent SDK V1 `query()` path (077-matrix-messaging-bridge)
 - Owner-local Postgres on the customer VPS for Matrix OS permission/audit data; separate homeserver database; separate Telegram bridge database; separate WhatsApp bridge database; owner-local media/cache paths covered by backup/restore policy (077-matrix-messaging-bridge)
+- TypeScript 5.5+ strict, Node.js 24+, React 19, ES modules + Hono, Zod 4 via `zod/v4`, Kysely/Postgres where relational state is needed, Node `child_process`/`fs/promises` for Hermes CLI bridge, EventSource/WebSocket-compatible gateway primitives, Vite + React + Tailwind/shadcn-style components for the app (080-hermes-manager)
+- Owner-controlled Matrix state. Use owner Postgres/Kysely for structured Hermes Manager records where gateway DB is available; use owner home files under `~/system/hermes-manager/` for redacted config/credential references and runtime-safe export snapshots. Never add new embedded databases. (080-hermes-manager)
 
 - TypeScript 5.5+ strict, ES modules + node-pty (backend), @xterm/xterm + addon-webgl + addon-search + addon-serialize + addon-fit (frontend), Hono WebSocket (gateway), Zod 4 (validation) (056-terminal-upgrade)
 - Files — `~/system/terminal-sessions.json` (session metadata), `~/system/terminal-layout.json` (layout with sessionId) (056-terminal-upgrade)
@@ -343,5 +345,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/077-matrix-messaging-bridge/plan.md`.
+Current Spec Kit plan: `specs/080-hermes-manager/plan.md`.
 <!-- SPECKIT END -->

--- a/specs/080-hermes-manager/contracts/events.md
+++ b/specs/080-hermes-manager/contracts/events.md
@@ -1,0 +1,128 @@
+# Contract: Hermes Manager Events
+
+Hermes Manager exposes browser-facing events through `/api/hermes/events`.
+
+## Common Fields
+
+```json
+{
+  "id": "evt_123",
+  "type": "session.event",
+  "installationId": "hermes_owner",
+  "createdAt": "2026-05-15T00:00:00.000Z"
+}
+```
+
+Every event merges these common fields with the type-specific fields below. The examples focus on type-specific payloads, but `id`, `installationId`, and `createdAt` are required on the wire for every event, including `heartbeat`. All payloads are bounded and redacted.
+
+## Visibility
+
+Events are installation-scoped. Owners and authorized operators receive the same redacted event stream for the Hermes installation they operate; `session.event` and `approval.updated` are not per-operator private streams. Payloads must include actor/session identifiers where relevant so the app can make shared operator visibility clear.
+
+## Event Types
+
+### status.updated
+
+```json
+{
+  "type": "status.updated",
+  "readiness": "ready",
+  "gatewayStatus": "healthy"
+}
+```
+
+### channel.updated
+
+```json
+{
+  "type": "channel.updated",
+  "id": "whatsapp",
+  "platform": "whatsapp",
+  "status": "connected",
+  "configured": true,
+  "enabled": true,
+  "allowedSenderPolicy": "Owner + allowlisted contacts",
+  "lastCheckedAt": "2026-05-15T00:04:00.000Z",
+  "updatedAt": "2026-05-15T00:04:00.000Z",
+  "pairing": {
+    "kind": "qr",
+    "displayValue": "short-lived-code",
+    "expiresAt": "2026-05-15T00:05:00.000Z"
+  }
+}
+```
+
+`channel.updated` uses the same channel identity key as `MessagingChannelDto.id`; it never emits a separate `channelId`. The payload includes this redacted subset of `MessagingChannelDto`: `id`, `platform`, `status`, `configured`, `enabled`, `allowedSenderPolicy`, `lastCheckedAt`, and `updatedAt`. `pairing` is present only for WhatsApp pairing flows. It is short-lived display data and must not be persisted as a channel secret.
+
+### session.event
+
+```json
+{
+  "type": "session.event",
+  "sessionId": "ses_123",
+  "event": {
+    "kind": "assistant_delta",
+    "text": "Hello"
+  }
+}
+```
+
+Allowed `event.kind` values:
+
+- `assistant_delta`
+- `assistant_message`
+- `tool_start`
+- `tool_result`
+- `approval_requested`
+- `session_status`
+- `error`
+
+Payload schemas by `event.kind`:
+
+- `assistant_delta`: `{ "kind": "assistant_delta", "text": string }`, where `text` is bounded to 8 KiB per event.
+- `assistant_message`: `{ "kind": "assistant_message", "messageId": string, "text": string }`, where `text` is bounded to 32 KiB and redacted before broadcast.
+- `tool_start`: `{ "kind": "tool_start", "toolCallId": string, "toolName": string, "displayName"?: string }`; arguments, paths, tokens, and raw command lines are never included.
+- `tool_result`: `{ "kind": "tool_result", "toolCallId": string, "status": "complete" | "failed", "summary": string }`; `summary` is bounded to 1 KiB and must not include raw stdout, stderr, stack traces, filesystem paths, or provider errors.
+- `approval_requested`: `{ "kind": "approval_requested", "approvalId": string, "requestedTool"?: string, "description": string }`; `requestedTool` matches the optional `ApprovalPrompt.requestedTool` field when Hermes provides a safe tool display name. `description` is bounded and redacted.
+- `session_status`: `{ "kind": "session_status", "status": "idle" | "starting" | "streaming" | "waiting_approval" | "stopped" | "failed" | "recoverable" }`.
+- `error`: `{ "kind": "error", "code": "unavailable" | "timeout" | "invalid_upstream_response" | "operation_failed" | "conflict", "message": string }`; `message` is a generic client-safe string and never contains upstream/provider names, raw errors, or paths.
+
+### approval.updated
+
+```json
+{
+  "type": "approval.updated",
+  "approvalId": "appr_123",
+  "sessionId": "ses_123",
+  "status": "pending",
+  "decisionBy": null
+}
+```
+
+Emitted when an approval is created and on each status transition to `approved`, `denied`, `expired`, or `failed`; `status` always reflects the new state and `decisionBy` is set for operator decisions.
+
+### operator.event
+
+```json
+{
+  "type": "operator.event",
+  "actorId": "user_123",
+  "category": "channel",
+  "targetId": "telegram",
+  "severity": "info",
+  "message": "Channel updated"
+}
+```
+
+### heartbeat
+
+```json
+{ "type": "heartbeat" }
+```
+
+## Resource Rules
+
+- Per-owner subscribers are capped.
+- Per-session retained events are capped.
+- Failed sends evict subscribers after the broadcast loop.
+- Shutdown drains all subscribers with a final generic event.

--- a/specs/080-hermes-manager/contracts/hermes-bridge.md
+++ b/specs/080-hermes-manager/contracts/hermes-bridge.md
@@ -1,0 +1,307 @@
+# Contract: Hermes Bridge
+
+The gateway uses a typed `HermesBridge` so routes never shell out or call upstream Hermes endpoints directly.
+
+## Dependency Resolution
+
+All required dependencies are resolved when the bridge is created:
+
+- Hermes repository or CLI path.
+- Owner-scoped Hermes home.
+- Process runner with timeout support.
+- Optional local API endpoint.
+- Optional session WebSocket endpoint.
+- Credential store.
+- Logger.
+
+Creation fails with a server-side diagnostic if a required dependency is missing. Routes return a generic unavailable response.
+
+## Startup Sequence
+
+Gateway startup wires Hermes Manager in this order:
+
+1. `new KyselyHermesRepository(kyselyInstance)` is created only when owner Postgres is available.
+2. `repository.bootstrap()` creates or verifies the Hermes Manager state table before routes are mounted.
+3. `createFileHermesCredentialStore({ homePath })` resolves the owner home credential directory.
+4. `createHermesEventHub()` creates bounded in-process event/subscriber retention.
+5. `createLocalHermesBridge({ homePath })` resolves Hermes CLI/API dependencies and timeout runner configuration.
+6. `createHermesRoutes({ repository, credentialStore, bridge, eventHub })` registers `/api/hermes`.
+7. If any required startup dependency is unavailable, gateway mounts an unavailable `/api/hermes/*` router that returns generic `503 hermes_unavailable`; it must not partially mount live routes with undefined dependencies.
+
+## Interface
+
+```ts
+type OwnerContext = {
+  ownerId: string;
+  installation: {
+    id: string;
+    ownerId: string;
+    readiness: "missing" | "installed" | "configuring" | "degraded" | "ready" | "updating" | "needs_attention";
+    gatewayStatus: "unknown" | "stopped" | "starting" | "healthy" | "degraded" | "failed";
+    defaultProfileId: string;
+    defaultModelId?: string;
+    authorizedOperators: string[];
+  } | null;
+};
+
+type RecoveryInput = OwnerContext & {
+  scope?: "installation";
+};
+
+type RecoveryResult = {
+  status: "complete" | "degraded" | "failed";
+  message: string;
+};
+
+type HermesStatusResult = {
+  installationId: string | null;
+  readiness: "missing" | "installed" | "configuring" | "degraded" | "ready" | "updating" | "needs_attention";
+  gatewayStatus: "unknown" | "stopped" | "starting" | "healthy" | "degraded" | "failed";
+  version: string | null;
+  defaultProfileId: string | null;
+  defaultModelId?: string;
+  counts: {
+    channels: number;
+    connectedChannels: number;
+    activeSessions: number;
+    pendingApprovals: number;
+    needsAttention: number;
+  };
+  lastCheckedAt: string | null;
+};
+
+type HermesInstallationPatch = Partial<NonNullable<OwnerContext["installation"]>> & {
+  hermesPathLabel?: string | null;
+  version?: string | null;
+  lastCheckedAt: string;
+};
+
+// hermesPathLabel is a private, redacted installation-state patch field. Route
+// handlers may persist it to the owner installation record, but must not spread
+// it into the public HermesStatusResult response. The public status response
+// exposes installationId, readiness, gatewayStatus, counts, version, model/profile
+// identifiers, and lastCheckedAt only.
+
+type HermesConfigResult = {
+  installation: NonNullable<OwnerContext["installation"]> | null;
+  setupSteps: HermesSetupStepDto[];
+  modelProviders: ModelCredentialResult[];
+  capabilities: HermesCapabilityDto[];
+  channels: MessagingChannelDto[];
+};
+
+type HermesSetupStepDto = {
+  id: string;
+  status: "pending" | "active" | "complete" | "failed" | "skipped";
+  required: boolean;
+  title: string;
+  detail: string;
+  recoveryAction?: string;
+  updatedAt: string;
+};
+
+type SaveConfigInput = OwnerContext & {
+  config: {
+    homeMode: "default" | "custom";
+    hermesPath?: string;
+    defaultProfileId: string;
+    defaultModelId?: string;
+    authorizedOperators: string[];
+  };
+};
+
+type SaveModelCredentialInput = OwnerContext & {
+  credential: {
+    providerId: string;
+    secret: string;
+  };
+};
+
+type ModelCredentialResult = {
+  id: string;
+  configured: boolean;
+  status: "unknown" | "validating" | "healthy" | "failed";
+  availableModels: Array<{ id: string; label: string }>;
+  lastCheckedAt: string | null;
+};
+
+type ModelCredentialSaveResponse = {
+  configured: boolean;
+  providerId: string;
+  status: ModelCredentialResult["status"];
+};
+
+// ModelCredentialSaveResponse is a REST route mapper result, not the bridge
+// return type. The bridge/repository canonical provider key is id; POST
+// /credentials/model maps id to providerId for the one-shot save response.
+
+type MessagingChannelDto = {
+  id: string;
+  platform: "telegram" | "whatsapp" | "discord" | "slack" | "matrix" | "other";
+  enabled: boolean;
+  configured: boolean;
+  status: "disconnected" | "pairing" | "connected" | "degraded" | "disabled" | "failed";
+  allowedSenderPolicy: string;
+  homeChannel?: string;
+  lastCheckedAt: string | null;
+  updatedAt: string;
+};
+
+// id is the canonical Hermes channel key used by routes and persisted state.
+// platform is the provider family. P1 mutating routes only allow id values
+// "telegram" and "whatsapp", but read-only channel lists may include future
+// channel ids with platform "discord" | "slack" | "matrix" | "other".
+
+type ChannelActionInput = OwnerContext & {
+  channelId: "telegram" | "whatsapp";
+  action: { type: "connect" | "verify" | "disable" | "enable" | "recover" | "start_pairing" | "cancel_pairing"; payload?: Record<string, unknown> };
+};
+
+type ChannelActionBridgeResult = {
+  channel: MessagingChannelDto;
+  pairing?: {
+    kind: "qr" | "code";
+    displayValue: string;
+    expiresAt: string;
+  };
+};
+
+type ChannelActionResult = {
+  channel: MessagingChannelDto;
+  operation: {
+    id: string;
+    status: "running" | "complete" | "failed";
+    message: string;
+    pairing?: {
+      kind: "qr" | "code";
+      displayValue: string;
+      expiresAt: string;
+    };
+  };
+};
+
+// The bridge returns ChannelActionBridgeResult. The route persists result.channel
+// and then wraps it into the REST ChannelActionResult { channel, operation }.
+// The route generates operation.id as an opaque op_* reference, sets
+// operation.status to "complete" when the bridge returns successfully, and uses
+// a client-safe channel-action message such as "Channel updated". For WhatsApp
+// start_pairing, result.pairing is the only source for operation.pairing display
+// data; routes must not synthesize QR/code values.
+
+type HermesCapabilityDto = {
+  id: string;
+  kind: "profile" | "skill" | "toolset" | "gateway" | "channel";
+  name: string;
+  enabled: boolean;
+  status: "available" | "missing_setup" | "disabled" | "failed";
+  description: string;
+  updatedAt: string;
+};
+
+type GatewayActionInput = OwnerContext & {
+  action: { type: "restart" | "health_check" | "update" };
+};
+
+type GatewayActionResult = {
+  id: string;
+  status: "running" | "complete";
+  message: string;
+  patch?: Partial<NonNullable<OwnerContext["installation"]>>;
+};
+
+type HermesSessionDto = {
+  id: string;
+  hermesSessionId: string;
+  installationId: string;
+  ownerId: string;
+  operatorId: string;
+  profileId: string;
+  modelId?: string;
+  status: "idle" | "starting" | "streaming" | "waiting_approval" | "stopped" | "failed" | "recoverable";
+  clientRequestIds: string[];
+  eventCount: number;
+  createdAt: string;
+  updatedAt: string;
+  lastActiveAt: string;
+};
+
+type CreateSessionInput = OwnerContext & {
+  operatorId: string;
+  payload: {
+    profileId: string;
+    modelId?: string;
+    prompt: string;
+    clientRequestId: string;
+  };
+};
+
+type SendPromptInput = OwnerContext & {
+  operatorId: string;
+  session: HermesSessionDto;
+  payload: {
+    prompt: string;
+    clientRequestId: string;
+  };
+};
+
+type ApprovalPromptDto = {
+  id: string;
+  hermesApprovalId: string;
+  sessionId: string;
+  status: "pending" | "approved" | "denied" | "expired" | "failed";
+  description: string;
+  requestedTool?: string;
+  decisionBy: string | null;
+  decisionAt: string | null;
+  createdAt: string;
+};
+
+type ApprovalDecisionInput = OwnerContext & {
+  operatorId: string;
+  approval: ApprovalPromptDto;
+  payload: { decision: "approved" | "denied" };
+};
+
+interface HermesBridge {
+  // Bridge status is an installation patch. The route composes the public
+  // HermesStatusResult, including installationId and counts, from repository state.
+  getStatus(input: OwnerContext): Promise<HermesInstallationPatch>;
+  readConfig(input: OwnerContext): Promise<HermesConfigResult>;
+  saveConfig(input: SaveConfigInput): Promise<HermesConfigResult>;
+  saveModelCredential(input: SaveModelCredentialInput): Promise<ModelCredentialResult>;
+  listChannels(input: OwnerContext): Promise<MessagingChannelDto[]>;
+  runChannelAction(input: ChannelActionInput): Promise<ChannelActionBridgeResult>;
+  listCapabilities(input: OwnerContext): Promise<HermesCapabilityDto[]>;
+  runGatewayAction(input: GatewayActionInput): Promise<GatewayActionResult>;
+  createSession(input: CreateSessionInput): Promise<HermesSessionDto>;
+  sendPrompt(input: SendPromptInput): Promise<HermesSessionDto>;
+  decideApproval(input: ApprovalDecisionInput): Promise<ApprovalPromptDto>;
+  recover(input: RecoveryInput): Promise<RecoveryResult>;
+}
+```
+
+## Error Policy
+
+- Bridge methods throw typed errors: `unavailable`, `timeout`, `invalid_upstream_response`, `operation_failed`, `conflict`, `unauthorized`.
+- Route mappers convert typed errors to generic client messages.
+- Raw Hermes stderr/stdout, provider responses, paths, and stack traces are logged server-side only.
+
+## Timeout Policy
+
+- Status/config/model list: 10 seconds.
+- Channel verify/connect/pairing poll: 30 seconds per step.
+- Gateway restart: 45 seconds.
+- Hermes update: operation event stream with 60 second heartbeat and server-side max duration.
+- Session prompt submit: 10 seconds to enqueue, streaming continues through event hub with heartbeat.
+
+## Redaction Policy
+
+Bridge DTOs returned to routes must already be redacted. Routes perform a second shape validation before responding to clients.
+
+Forbidden public fields:
+
+- `secret`, `token`, `apiKey`, `password`, `env`, `stderr`, `stdout`, `stack`, `path`, `homePath`, `repoPath`, `hermesPath`.
+
+## Upstream Drift
+
+If Hermes local API or WebSocket responses miss required fields, bridge returns `invalid_upstream_response`, marks readiness `needs_attention` where safe, and records a redacted operator event.

--- a/specs/080-hermes-manager/contracts/rest-api.md
+++ b/specs/080-hermes-manager/contracts/rest-api.md
@@ -1,0 +1,374 @@
+# Contract: Hermes Manager REST API
+
+Base path: `/api/hermes`
+
+All routes require a Matrix request principal. Owner-only routes are marked explicitly. All errors use:
+
+```json
+{ "error": { "code": "hermes_request_failed", "message": "Hermes request failed" } }
+```
+
+Messages are generic and never contain provider names, secrets, raw command output, stack traces, or filesystem paths.
+
+## Auth Matrix
+
+| Route | Method | Auth Method | Access | Public? |
+| --- | --- | --- | --- | --- |
+| `/status` | GET | Matrix request principal | Owner or authorized operator | No |
+| `/config` | GET | Matrix request principal | Owner or authorized operator | No |
+| `/config` | POST | Matrix request principal | Owner only by default | No |
+| `/credentials/model` | POST | Matrix request principal | Owner only | No |
+| `/channels` | GET | Matrix request principal | Owner or authorized operator | No |
+| `/channels/:channelId/action` | POST | Matrix request principal | Owner or authorized operator, allowlisted P1 channels only | No |
+| `/sessions` | GET | Matrix request principal | Owner or authorized operator | No |
+| `/sessions` | POST | Matrix request principal | Owner or authorized operator | No |
+| `/sessions/:sessionId/prompt` | POST | Matrix request principal plus session ownership | Owner or authorized operator for that installation | No |
+| `/approvals/:approvalId/decision` | POST | Matrix request principal plus approval ownership | Owner or authorized operator for that installation | No |
+| `/capabilities` | GET | Matrix request principal | Owner or authorized operator | No |
+| `/gateway/action` | POST | Matrix request principal | Owner only by default | No |
+| `/recover` | POST | Matrix request principal | Owner only by default | No |
+| `/events` | GET | Matrix request principal | Owner or authorized operator | No |
+| `/audit` | GET | Matrix request principal | Owner or authorized operator | No |
+| `/export` | GET | Matrix request principal | Owner only by default | No |
+
+`Owner only by default` is intentionally fixed for P1. P1 has no delegation override for installation config, model credentials, gateway restart/update, or export; future delegation requires an explicit reviewed permission field in `POST /config` or a separate owner-managed delegation contract.
+
+## GET /status
+
+Auth: owner or authorized operator.
+
+Response:
+
+```json
+{
+  "installationId": "hermes_owner",
+  "readiness": "ready",
+  "gatewayStatus": "healthy",
+  "version": "1.2.3",
+  "defaultProfileId": "default",
+  "defaultModelId": "claude-opus-4.6",
+  "counts": {
+    "channels": 2,
+    "connectedChannels": 1,
+    "activeSessions": 1,
+    "pendingApprovals": 0,
+    "needsAttention": 0
+  },
+  "lastCheckedAt": "2026-05-15T00:00:00.000Z"
+}
+```
+
+## GET /config
+
+Auth: owner or authorized operator.
+
+Response:
+
+```json
+{
+  "installation": {},
+  "modelProviders": [],
+  "channels": [],
+  "capabilities": [],
+  "setupSteps": []
+}
+```
+
+All fields are public DTOs with secrets and raw paths redacted.
+
+## POST /config
+
+Auth: owner only by default. Body limit: 32 KiB.
+
+Request:
+
+```json
+{
+  "homeMode": "default",
+  "hermesPath": "/home/deploy/hermes-agent",
+  "defaultProfileId": "default",
+  "defaultModelId": "claude-opus-4.6",
+  "authorizedOperators": ["user_123"]
+}
+```
+
+`authorizedOperators` is capped at 50 entries. Requests above that cap are rejected with `400 invalid_request`; the server must not silently truncate operator lists.
+
+Response: same shape as `GET /config`.
+
+`homeMode` is an enum. `"default"` means the gateway uses its configured Hermes installation root (`HERMES_REPO_PATH` or the packaged owner-home default) and ignores `hermesPath`. `"custom"` means the owner is selecting an alternate Hermes checkout under an allowed owner-controlled installation root, and `hermesPath` is required.
+
+`hermesPath`, when supplied, is never used directly. The server resolves and validates it against the allowed owner-controlled Hermes installation roots before persisting a redacted label or passing a resolved path to the bridge. Invalid, absolute-outside-root, traversal, symlink-escape, or non-Hermes paths are rejected with a generic validation error.
+
+## POST /credentials/model
+
+Auth: owner only. Body limit: 32 KiB.
+
+Request:
+
+```json
+{
+  "providerId": "anthropic",
+  "secret": "server-side-only"
+}
+```
+
+Response:
+
+```json
+{ "configured": true, "providerId": "anthropic", "status": "healthy" }
+```
+
+The bridge returns model-provider metadata as `ModelCredentialResult` with canonical key `id`. This route deliberately maps that bridge `id` to `providerId` in the one-shot save response because the client just submitted a provider credential. `GET /config` keeps provider metadata in `modelProviders[]` with `id`.
+
+## GET /channels
+
+Auth: owner or authorized operator.
+
+Response:
+
+```json
+{ "channels": [] }
+```
+
+## POST /channels/:channelId/action
+
+Auth: owner or authorized operator. Body limit: 32 KiB.
+
+Supported P1 `channelId`: `telegram`, `whatsapp`. Unknown `channelId` values are rejected before action parsing with `400 invalid_request`; future channels may be listed read-only by `GET /channels` but cannot receive mutating actions until they are explicitly allowlisted.
+
+Request discriminated union. Payload schemas are per action and per P1 channel:
+
+```json
+{ "type": "connect", "payload": { "botToken": "server-side-only", "allowedSenders": ["123456"], "homeChannel": "owner-home" } }
+```
+
+Action types:
+
+- `connect`
+  - `telegram` payload: `{ "botToken": string, "allowedSenders": string[], "homeChannel"?: string }`
+  - `whatsapp` payload: `{ "pairingLabel"?: string, "allowedSenders"?: string[], "homeChannel"?: string }`
+- `verify`: `{ "type": "verify" }`
+- `disable`: `{ "type": "disable" }`
+- `enable`: `{ "type": "enable" }`
+- `recover`: `{ "type": "recover" }`
+- `start_pairing`
+  - `whatsapp` payload: `{ "pairingLabel"?: string }`
+  - `telegram` is rejected for `start_pairing`
+- `cancel_pairing`: `{ "type": "cancel_pairing" }`
+
+The route validates the path `channelId` first, then validates the action with the channel-specific schema. It never accepts an arbitrary payload record for persistence.
+
+Response:
+
+```json
+{
+  "channel": {},
+  "operation": {
+    "id": "op_123",
+    "status": "complete",
+    "message": "Channel updated",
+    "pairing": {
+      "kind": "qr" | "code",
+      "displayValue": "redacted-or-short-lived-code",
+      "expiresAt": "2026-05-15T00:05:00.000Z"
+    }
+  }
+}
+```
+
+`operation.pairing` is only returned for WhatsApp `start_pairing`, is short-lived, and is also emitted through a redacted `channel.updated` event so the app can show QR/code instructions without storing them in channel state.
+
+## GET /sessions
+
+Auth: owner or authorized operator.
+
+Query:
+
+- `status`: optional session status.
+- `limit`: integer 1-100.
+- `cursor`: bounded cursor.
+
+Response:
+
+```json
+{ "sessions": [], "nextCursor": null }
+```
+
+Scope rule: owners see all installation sessions. Authorized operators see sessions for the installation they are authorized to operate; this is full operator visibility by design for the shared Hermes orchestrator, and the UI/audit trail must show the actor for each session/action.
+
+## POST /sessions
+
+Auth: owner or authorized operator. Body limit: 64 KiB.
+
+Request:
+
+```json
+{ "profileId": "default", "modelId": "claude-opus-4.6", "prompt": "hello", "clientRequestId": "req_123" }
+```
+
+`clientRequestId` is required, bounded, and persisted per owner/session so retries do not create duplicate upstream Hermes sessions.
+
+First-time session creation returns `200` with `{ "session": ... }`. If `clientRequestId` already maps to an existing session for the same owner, the route also returns `200` with the existing `{ "session": ... }` response body and does not create or enqueue a second upstream Hermes session. The route never uses `201`; clients distinguish first-time and retry responses by session identity and persisted `clientRequestIds`, not by HTTP status code.
+
+Response:
+
+```json
+{ "session": {} }
+```
+
+## POST /sessions/:sessionId/prompt
+
+Auth: owner or authorized operator. Body limit: 64 KiB.
+
+Request:
+
+```json
+{ "prompt": "continue", "clientRequestId": "req_123" }
+```
+
+Duplicate `clientRequestId` for the same session is deduplicated or rejected safely.
+
+Response:
+
+```json
+{ "session": {} }
+```
+
+## POST /approvals/:approvalId/decision
+
+Auth: owner or authorized operator. Body limit: 8 KiB.
+
+Request:
+
+```json
+{ "decision": "approved" | "denied" }
+```
+
+Response:
+
+```json
+{ "approval": {} }
+```
+
+## GET /capabilities
+
+Auth: owner or authorized operator.
+
+Response:
+
+```json
+{ "capabilities": [] }
+```
+
+## POST /gateway/action
+
+Auth: owner only by default. Body limit: 8 KiB.
+
+Request:
+
+```json
+{ "type": "restart" }
+```
+
+Action types:
+
+- `restart`
+- `health_check`
+- `update`
+
+Response:
+
+```json
+{
+  "operation": {
+    "id": "op_123",
+    "status": "running",
+    "message": "Gateway restart accepted",
+    "patch": {
+      "gatewayStatus": "starting"
+    }
+  }
+}
+```
+
+`operation.message` is always present and client-safe. `operation.patch` is present when the bridge can return an optimistic installation-state update; routes apply the same patch to persisted installation state before returning it.
+
+## POST /recover
+
+Auth: owner only by default. Body limit: 4 KiB.
+
+Request:
+
+```json
+{}
+```
+
+P1 recovery is always installation-scoped. The REST contract intentionally does not expose `sessionIds`, `channelIds`, or other targeting fields; route handlers pass `scope: "installation"` to `HermesBridge.recover()` when needed.
+
+Response:
+
+```json
+{ "recovery": { "status": "complete", "message": "Recovery completed" } }
+```
+
+This endpoint invokes `HermesBridge.recover()` for the current installation and publishes a redacted `operator.event` with category `recovery`.
+
+Recovery is guarded by the same owner-scoped action lock map as setup, pairing, restart, update, approval, and prompt-send actions. The lock key is `ownerId:recover`, has the standard mutating-action TTL, and returns a generic conflict response when a retry or double-click arrives while recovery is already running. P1 does not require a client idempotency key because recovery is an installation reconciliation action, not a new user-created resource.
+
+## GET /events
+
+Auth: owner or authorized operator.
+
+EventSource stream. Events:
+
+- `status.updated`
+- `channel.updated`
+- `session.event`
+- `approval.updated`
+- `operator.event`
+- `heartbeat`
+
+Subscribers are capped per owner and evicted on stale or failed sends.
+
+Scope rule: the Hermes Manager SSE stream is installation-scoped by design. Owners and authorized operators receive the same redacted `status.updated`, `channel.updated`, `session.event`, `approval.updated`, and `operator.event` stream for the installation they are authorized to operate. Events that may contain conversation/tool context must include actor/session identifiers so shared operator visibility is explicit in the UI and audit trail.
+
+## GET /audit
+
+Auth: owner or authorized operator.
+
+Query:
+
+- `limit`: integer 1-100.
+- `cursor`: bounded cursor.
+
+Response:
+
+```json
+{ "events": [], "nextCursor": null }
+```
+
+Scope rule: owners and authorized operators see the redacted installation audit log. Events include actor/category/target/timestamp so shared operator visibility is explicit.
+
+## GET /export
+
+Auth: owner only by default.
+
+Response:
+
+```json
+{
+  "installation": {},
+  "setupSteps": [],
+  "modelProviders": [],
+  "channels": [],
+  "capabilities": [],
+  "sessions": [],
+  "approvals": [],
+  "events": []
+}
+```
+
+The response mirrors the redacted subset of `GET /config`. It never includes credentials, raw paths, credential references, raw errors, or command output.
+
+Export arrays are bounded by the same retained-state caps used by the gateway: `sessions` returns at most the latest 100 redacted session summaries, `approvals` returns at most the latest 100 approval prompts, and `events` returns at most the latest 500 retained redacted events. P1 does not paginate export because the payload is intentionally capped for owner portability and operator review.

--- a/specs/080-hermes-manager/data-model.md
+++ b/specs/080-hermes-manager/data-model.md
@@ -1,0 +1,151 @@
+# Data Model: Hermes Manager
+
+## HermesInstallation
+
+- `id`: stable owner-scoped installation ID.
+- `ownerId`: Matrix owner user ID.
+- `homePath`: redacted owner-scoped Hermes home reference.
+- `hermesPath`: redacted Hermes repository/CLI reference.
+- `version`: detected Hermes version or `null`.
+- `readiness`: `missing | installed | configuring | degraded | ready | updating | needs_attention`.
+- `gatewayStatus`: `unknown | stopped | starting | healthy | degraded | failed`.
+- `defaultProfileId`: selected Hermes profile ID.
+- `defaultModelId`: selected model ID.
+- `authorizedOperators`: bounded list of Matrix user IDs, maximum 50.
+- `createdAt`, `updatedAt`, `lastCheckedAt`: ISO timestamps.
+
+Validation:
+
+- Owner/operator IDs are bounded Matrix-safe strings.
+- Paths are resolved within allowed Matrix owner/Hermes roots and are never returned raw to the browser.
+- Readiness transitions must be monotonic for one action result: action start sets `configuring`/`updating`, action finish sets `ready` or `needs_attention`.
+
+## HermesSetupStep
+
+- `id`: stable setup step key.
+- `installationId`: parent installation.
+- `status`: `pending | active | complete | failed | skipped`.
+- `required`: boolean.
+- `title`: short display label.
+- `detail`: redacted display detail.
+- `recoveryAction`: optional action key.
+- `updatedAt`: ISO timestamp.
+
+Validation:
+
+- Step IDs are allowlisted by contract.
+- Failed steps use generic detail and server logs hold raw diagnostics.
+
+## ModelProviderConnection
+
+- `id`: provider key.
+- `installationId`: parent installation.
+- `credentialRef`: server-side reference only.
+- `configured`: boolean.
+- `status`: `unknown | validating | healthy | failed`.
+- `defaultModelId`: optional selected model.
+- `availableModels`: bounded list of redacted model options.
+- `lastCheckedAt`: ISO timestamp or `null`.
+
+Validation:
+
+- Model IDs are bounded provider-safe strings.
+- Credentials are never serialized into public DTOs.
+
+## MessagingChannel
+
+- `id`: channel key.
+- `installationId`: parent installation.
+- `platform`: `telegram | whatsapp | discord | slack | matrix | other`.
+- `enabled`: boolean.
+- `configured`: boolean.
+- `status`: `disconnected | pairing | connected | degraded | disabled | failed`.
+- `allowedSenderPolicy`: redacted channel-specific policy summary.
+- `homeChannel`: optional redacted target summary.
+- `credentialRef`: server-side reference only.
+- `lastCheckedAt`: ISO timestamp or `null`.
+- `updatedAt`: ISO timestamp.
+
+Validation:
+
+- P1 write actions are limited to Telegram and WhatsApp.
+- Unknown future platforms may be listed read-only when reported by Hermes.
+- Channel IDs and action payloads are schema-validated at the route boundary.
+- Public DTOs keep `id` as the channel resource key and `platform` as the provider family. For P1, mutating route `channelId` values are exactly `telegram` and `whatsapp`; future read-only channel rows may have different `id` values with `platform` set to `discord`, `slack`, `matrix`, or `other`.
+
+## HermesSession
+
+- `id`: Matrix-side session ID.
+- `hermesSessionId`: upstream Hermes session reference.
+- `installationId`: parent installation.
+- `ownerId`: Matrix owner.
+- `operatorId`: Matrix operator who started or resumed the session.
+- `profileId`: Hermes profile.
+- `modelId`: model used by session.
+- `status`: `idle | starting | streaming | waiting_approval | stopped | failed | recoverable`.
+- `lastEventId`: last retained event ID.
+- `clientRequestIds`: last 50 idempotency keys for session creation and prompt submission retries, evicted oldest-first.
+- `eventCount`: retained event count.
+- `createdAt`, `updatedAt`, `lastActiveAt`: ISO timestamps.
+
+Validation:
+
+- Session references are owner-scoped.
+- `clientRequestIds` are bounded to 50 safe IDs per session and retained oldest-first so duplicate creates/prompts can be deduplicated or rejected within the retention window.
+- Read paths reconcile stale live stream references and mark sessions recoverable.
+- Event retention is capped per session.
+
+## ApprovalPrompt
+
+- `id`: Matrix-side approval ID.
+- `hermesApprovalId`: upstream approval reference.
+- `sessionId`: parent Hermes session.
+- `status`: `pending | approved | denied | expired | failed`.
+- `description`: redacted operator-facing action summary.
+- `requestedTool`: optional redacted tool name.
+- `decisionBy`: Matrix operator ID or `null`.
+- `decisionAt`: ISO timestamp or `null`.
+- `createdAt`: ISO timestamp.
+
+Validation:
+
+- Pending approval can be resolved once.
+- Duplicate decisions are rejected or treated as idempotent if identical and already persisted.
+
+## HermesCapability
+
+- `id`: capability key.
+- `installationId`: parent installation.
+- `kind`: `profile | skill | toolset | gateway | channel`.
+- `name`: display name.
+- `enabled`: boolean.
+- `status`: `available | missing_setup | disabled | failed`.
+- `description`: redacted bounded string.
+- `updatedAt`: ISO timestamp.
+
+Validation:
+
+- Capability lists are bounded and sanitized before display.
+
+## OperatorEvent
+
+- `id`: event ID.
+- `installationId`: parent installation.
+- `actorId`: Matrix actor ID.
+- `category`: `setup | credential | channel | session | approval | gateway | update | recovery`.
+- `targetId`: optional target ID.
+- `severity`: `info | warning | error`.
+- `message`: generic redacted message.
+- `createdAt`: ISO timestamp.
+
+Validation:
+
+- Retention capped per owner.
+- No secret, path, raw provider error, stack trace, or command output fields are allowed.
+
+## Relationships
+
+- One `HermesInstallation` belongs to one Matrix owner.
+- One installation has many setup steps, model provider connections, messaging channels, sessions, capabilities, and operator events.
+- One session has many retained stream events and approval prompts.
+- Credential references point to server-side owner storage and are never dereferenced by app clients.

--- a/specs/080-hermes-manager/plan.md
+++ b/specs/080-hermes-manager/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Hermes Manager
+
+**Branch**: `080-hermes-manager` | **Date**: 2026-05-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/080-hermes-manager/spec.md`
+
+**Goal**: Build a first-party Matrix OS Hermes Manager app that onboards Hermes, configures model and messaging channels, lets operators message Hermes, and manages Hermes lifecycle through supported Hermes CLI/IPC/API surfaces.
+
+## Summary
+
+Hermes Manager makes Hermes the Matrix-native agent/orchestrator surface. The implementation adds an owner-scoped gateway subsystem under `/api/hermes`, a first-party Vite app under `home/apps/hermes-manager`, redacted credential/config handling under the Matrix owner home, and a typed bridge that adapts Hermes CLI/local API/WebSocket capabilities without duplicating Hermes internals.
+
+The stack is intentionally split into four reviewable phases:
+
+1. Gateway foundation: contracts, repository, credential store, Hermes bridge, status/config routes, tests.
+2. Setup and channel operations: onboarding, Telegram/WhatsApp connect/status/recovery, operator events, tests.
+3. Messaging session surface: Hermes session create/resume/prompt stream/approval flow, bounded event hub, tests.
+4. First-party app and docs: polished Vite app, manifest/icon, docs, default app build, UI tests.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.5+ strict, Node.js 24+, React 19, ES modules  
+**Primary Dependencies**: Hono, Zod 4 via `zod/v4`, Kysely/Postgres where relational state is needed, Node `child_process`/`fs/promises` for Hermes CLI bridge, EventSource/WebSocket-compatible gateway primitives, Vite + React + Tailwind/shadcn-style components for the app  
+**Storage**: Owner-controlled Matrix state. Use owner Postgres/Kysely for structured Hermes Manager records where gateway DB is available; use owner home files under `~/system/hermes-manager/` for redacted config/credential references and runtime-safe export snapshots. Never add new embedded databases.  
+**Testing**: Vitest unit/integration tests, default app React tests, pattern scanner, typecheck  
+**Target Platform**: Matrix OS customer VPS gateway and first-party bundled Vite app  
+**Project Type**: Web app plus gateway subsystem  
+**Performance Goals**: setup/status endpoints p95 under 300 ms with mocked Hermes, initial app render under 2 s after static load, stream at least 100 Hermes events without unbounded memory growth, default event retention capped to 500 per owner/session  
+**Constraints**: no secrets in browser-visible payloads, all mutating endpoints use `bodyLimit`, every external/provider/network call has timeout, all Hermes process calls bounded by timeout, all Maps/Sets capped or TTL-evicted, app works as a shell over a headless Hermes core  
+**Scale/Scope**: personal-owner first; up to 50 authorized operators, 20 channels reported by Hermes, 100 session summaries, 500 retained events, Telegram and WhatsApp are P1 connect/recovery targets
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Data Belongs to Its Owner**: PASS. All Hermes Manager state is owner-scoped. Secrets remain server-side in owner-controlled storage. Exports are redacted.
+- **AI Is the Kernel**: PASS. Hermes is treated as the orchestrator/kernel-facing agent surface. Matrix does not duplicate Hermes reasoning internals.
+- **Headless Core, Multi-Shell**: PASS. Hermes remains operable through CLI/IPC/API; the Matrix app is a renderer/operator shell.
+- **Defense in Depth**: PASS. The spec includes auth matrix, input validation, body limits, secret redaction, bounded resources, timeout policy, startup dependency checks, and integration wiring tests.
+- **TDD**: PASS. Tasks must start with failing route/bridge/repository/UI tests before implementation.
+- **App Ecosystem**: PASS. App is packaged as a first-party Vite app with `matrix.json`, shipped icon, and explicit permissions.
+- **No New Persistence Stack**: PASS. Uses existing owner Postgres/Kysely or owner files only; no new database/ORM.
+- **Documentation**: PASS. Public docs and developer wiring docs are explicit deliverables.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/080-hermes-manager/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+packages/gateway/src/hermes/
+├── auth.ts
+├── bridge.ts
+├── contracts.ts
+├── credential-store.ts
+├── event-hub.ts
+├── index.ts
+├── repository.ts
+└── routes.ts
+
+home/apps/hermes-manager/
+├── index.html
+├── matrix.json
+├── package.json
+├── src/
+│   ├── App.tsx
+│   ├── components/
+│   ├── lib/
+│   └── main.tsx
+├── tsconfig.json
+└── vite.config.ts
+
+home/system/icons/
+└── hermes-manager.svg
+
+www/content/docs/
+└── hermes.mdx
+
+docs/platform/dev/
+└── hermes-manager.md
+
+tests/
+├── default-apps/hermes-manager-app.test.tsx
+├── gateway/hermes-auth.test.ts
+├── gateway/hermes-bridge.test.ts
+├── gateway/hermes-credential-store.test.ts
+├── gateway/hermes-event-hub.test.ts
+├── gateway/hermes-repository.test.ts
+├── gateway/hermes-routes.test.ts
+└── gateway/hermes-restart-recovery.test.ts
+```
+
+**Structure Decision**: Add a dedicated `packages/gateway/src/hermes/` subsystem following the Matrix-native Symphony route/repository/auth pattern, plus a first-party app under `home/apps/hermes-manager/`. Keep Hermes-specific runtime adaptation in `bridge.ts`; the app talks only to `/api/hermes/*`.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |
+
+## Post-Design Constitution Check
+
+- **Defense in Depth**: PASS. Contracts define route auth, body limits, redaction, bounded event streams, and startup dependency checks.
+- **TDD**: PASS. Tasks must create failing tests for each phase before implementation.
+- **Owner Data**: PASS. Data model separates redacted owner state from server-side credential references.
+- **Headless Core**: PASS. Contracts document Hermes bridge inputs/outputs while preserving CLI/IPC/API as the source of truth.
+- **App Ecosystem**: PASS. App manifest/icon/build/test tasks are included.
+
+## Graphite Stack Plan
+
+1. `docs(hermes): specify manager app` - spec/plan/tasks only.
+2. `feat(hermes): add manager gateway foundation` - contracts, repository, credential store, bridge, status/config routes, tests.
+3. `feat(hermes): add setup and channel operations` - onboarding actions, Telegram/WhatsApp operations, recovery/audit events, tests.
+4. `feat(hermes): add messaging session bridge` - sessions, streaming/event hub, approvals, restart recovery, tests.
+5. `feat(hermes): add first-party manager app` - Vite app, manifest/icon, docs, app tests, default app build.
+
+Each PR must be ready for review, not draft, and must include backend invariants where backend surfaces change.

--- a/specs/080-hermes-manager/quickstart.md
+++ b/specs/080-hermes-manager/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart: Hermes Manager
+
+## Prerequisites
+
+- Matrix OS running from the 080 worktree.
+- Hermes repo available locally for development, defaulting to `/home/deploy/hermes-agent` when present.
+- Node.js 24+, pnpm 10.33.4, and bun available through the existing Matrix OS setup.
+
+## Development Loop
+
+1. Install dependencies after app/package changes:
+
+   ```bash
+   pnpm install
+   ```
+
+2. Run the focused Hermes Manager tests during implementation:
+
+   ```bash
+   bun run test tests/gateway/hermes-auth.test.ts tests/gateway/hermes-routes.test.ts tests/gateway/hermes-bridge.test.ts tests/gateway/hermes-credential-store.test.ts tests/gateway/hermes-event-hub.test.ts tests/gateway/hermes-repository.test.ts tests/gateway/hermes-restart-recovery.test.ts tests/default-apps/hermes-manager-app.test.tsx
+   ```
+
+   The focused loop intentionally includes `hermes-event-hub.test.ts` for bounded subscriber/event retention, `hermes-repository.test.ts` for idempotency and retained-state caps, and `hermes-restart-recovery.test.ts` for stale live-reference reconciliation.
+
+3. Run the mandatory pre-PR gates:
+
+   ```bash
+   bun run typecheck
+   bun run check:patterns
+   bun run test
+   bun run test tests/gateway/hermes-auth.test.ts tests/gateway/hermes-routes.test.ts tests/gateway/hermes-bridge.test.ts tests/gateway/hermes-credential-store.test.ts tests/gateway/hermes-event-hub.test.ts tests/gateway/hermes-repository.test.ts tests/gateway/hermes-restart-recovery.test.ts tests/default-apps/hermes-manager-app.test.tsx
+   ```
+
+   The full `bun run test` run is the project-wide gate from `CLAUDE.md`. The focused Hermes subset must also pass and must keep `hermes-event-hub.test.ts` and `hermes-repository.test.ts`; they cover resource-management and persistence invariants that route/app tests do not fully exercise.
+
+4. Build default apps before bundling or validating installable app output:
+
+   ```bash
+   node scripts/build-default-apps.mjs home/apps
+   ```
+
+5. Launch local Matrix OS for manual validation:
+
+   ```bash
+   bun run dev
+   ```
+
+6. Open Hermes Manager from the Matrix app launcher. Expected P1 path:
+
+   - readiness shows Hermes installed or actionable setup state
+   - owner can save model provider state without browser-visible secrets
+   - Telegram and WhatsApp can be connected/disabled/recovered through mocked or local Hermes bridge
+   - user can start a Hermes session, stream events, and resolve an approval
+
+## Manual Review Checklist
+
+- Browser network responses contain no provider tokens, gateway secrets, raw stack traces, command output, or filesystem paths.
+- Unauthorized requests to `/api/hermes/*` return generic auth errors and no owner state.
+- Mutating endpoints apply body limits and reject invalid action payloads.
+- Hermes bridge dependencies fail fast at route registration/startup when missing.
+- Event history and in-memory lock maps are capped.
+- App works in Canvas and Desktop launch paths.

--- a/specs/080-hermes-manager/research.md
+++ b/specs/080-hermes-manager/research.md
@@ -1,0 +1,63 @@
+# Research: Hermes Manager
+
+## Decision: Build a Matrix-native manager rather than iframe the Hermes dashboard
+
+**Rationale**: Matrix OS needs owner-scoped auth, redacted credential handling, Canvas/Desktop consistency, app packaging, and channel/session controls that fit the OS shell. The upstream Hermes dashboard remains useful as a reference but should not be the everyday product surface.
+
+**Alternatives considered**:
+
+- Iframe the Hermes dashboard: rejected because auth, secret redaction, app permissions, and Matrix shell integration would be weak.
+- Copy Hermes internals into Matrix: rejected because Hermes should stay the source of truth for its own IPC/CLI/API behavior.
+
+## Decision: Add a dedicated gateway subsystem under `/api/hermes`
+
+**Rationale**: Symphony already shows the right Matrix-native pattern: typed contracts, route-level auth, owner-scoped repositories, redacted credential stores, and optional event streams. Hermes needs similar isolation and reviewability because it touches secrets, messaging channels, process lifecycle, and AI sessions.
+
+**Alternatives considered**:
+
+- Put all logic in the app using app bridge calls: rejected because secrets and Hermes process control must stay server-side.
+- Add generic `/api/bridge/service` calls only: rejected because Hermes needs first-party auth, validation, body limits, and redaction guarantees.
+
+## Decision: Use Hermes CLI/local API/WebSocket surfaces through a typed bridge
+
+**Rationale**: The pulled Hermes repo exposes CLI setup/config/model/gateway flows, FastAPI dashboard endpoints, and a WebSocket/TUI JSON-RPC path for sessions. A `HermesBridge` interface lets Matrix mock and test those surfaces while keeping upstream Hermes behavior authoritative.
+
+**Alternatives considered**:
+
+- Shell directly from every route: rejected because route code would duplicate timeout, error, redaction, and concurrency handling.
+- Depend only on Hermes dashboard HTTP endpoints: rejected because some session/IPC operations are already modeled through the TUI gateway/WebSocket protocol.
+
+## Decision: Telegram and WhatsApp are P1 channel operations
+
+**Rationale**: The user explicitly narrowed earlier messaging work toward WhatsApp and Telegram first, and Hermes gateway configuration supports both. Other providers should be visible if discovered but should not block the first implementation.
+
+**Alternatives considered**:
+
+- Implement all Hermes-supported channels at once: rejected as oversized for one stack and harder to test to PR-ready quality.
+- Build Matrix protocol bridge first: rejected because the user asked for Hermes as orchestrator across channels, with Telegram/WhatsApp first.
+
+## Decision: Owner Postgres for structured runtime state, owner files for redacted config/export snapshots
+
+**Rationale**: Matrix OS requires Kysely/Postgres for new structured persistence. Owner-controlled files remain appropriate for inspectable identity/config/export state. The design uses repository abstraction so local tests can run against in-memory fakes while production uses existing gateway storage.
+
+**Alternatives considered**:
+
+- Add SQLite or another embedded database: rejected by the Matrix OS constitution.
+- Store everything in JSON files: rejected for sessions/events/concurrency because structured records and locks need queryable state.
+
+## Decision: EventSource for app status streams in the first slice
+
+**Rationale**: Symphony already uses EventSource for dashboard refresh. Hermes session events can be represented as bounded server-side event streams in the gateway while route tests stay simple. Browser WebSocket support can be added later if Hermes session control needs bidirectional low-latency transport beyond prompt/approval POSTs.
+
+**Alternatives considered**:
+
+- Browser WebSocket first: deferred because it requires query-token auth allowlisting and a larger security surface.
+- Polling only: rejected because streamed Hermes responses and tool activity are core UX.
+
+## Decision: Concurrency locks per logical target
+
+**Rationale**: Setup, pairing, restart, update, approval, and prompt-send actions need dedupe or rejection to avoid duplicate process calls and double approvals. A bounded in-memory lock map with TTL plus repository state prevents obvious duplicate actions in one gateway process; future multi-process support can move locks into Postgres.
+
+**Alternatives considered**:
+
+- Let Hermes handle all duplication: rejected because Matrix must provide clear operator feedback and cannot assume upstream idempotency for every action.


### PR DESCRIPTION
Stack: 2/5

Summary:
- Adds the Hermes Manager implementation plan, research, data model, REST/API contracts, bridge contract, event contract, and quickstart.
- Updates AGENTS.md Spec Kit context to the 080 plan.

Validation:
- Plan artifacts checked for placeholders and unresolved clarification markers.
- Rebased on origin/main before submit.

Deferred scope:
- Concrete implementation is in upstack PRs.