### PR TITLE
feat(hermes): add manager gateway foundation

### DIFF
--- a/packages/gateway/src/hermes/auth.ts
+++ b/packages/gateway/src/hermes/auth.ts
@@ -1,0 +1,12 @@
+import type { RequestPrincipal } from "../request-principal.js";
+import type { HermesInstallation } from "./contracts.js";
+
+export function isAuthorizedHermesOperator(principal: RequestPrincipal, installation: HermesInstallation | null): boolean {
+  if (!installation) return true;
+  return installation.ownerId === principal.userId || installation.authorizedOperators.includes(principal.userId);
+}
+
+export function isHermesOwnerOnly(principal: RequestPrincipal, installation: HermesInstallation | null): boolean {
+  if (!installation) return true;
+  return installation.ownerId === principal.userId;
+}

--- a/packages/gateway/src/hermes/bridge.ts
+++ b/packages/gateway/src/hermes/bridge.ts
@@ -1,0 +1,325 @@
+import { execFile } from "node:child_process";
+import { access, realpath } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import { randomUUID } from "node:crypto";
+import {
+  redactLabel,
+  safeMessage,
+  type ApprovalDecisionInput,
+  type ApprovalPrompt,
+  type CreateSessionInput,
+  type GatewayActionInput,
+  type HermesCapability,
+  type HermesConfigInput,
+  type HermesInstallation,
+  type HermesSession,
+  type MessagingChannel,
+  type ModelCredentialInput,
+  type ChannelActionInput,
+  type ModelProviderConnection,
+  type SendPromptInput,
+} from "./contracts.js";
+
+const execFileAsync = promisify(execFile);
+const MAX_ACTIVE_HERMES_PATHS = 200;
+const SAFE_HERMES_PATH_LABEL = /^[A-Za-z0-9._=-]{1,80}$/;
+
+export type HermesBridgeErrorCode = "unavailable" | "timeout" | "invalid_request" | "invalid_upstream_response" | "operation_failed" | "conflict" | "unauthorized" | "not_found";
+
+export class HermesBridgeError extends Error {
+  constructor(readonly code: HermesBridgeErrorCode, message = "Hermes bridge failed") {
+    super(message);
+    this.name = "HermesBridgeError";
+  }
+}
+
+export interface OwnerContext {
+  ownerId: string;
+  installation: HermesInstallation | null;
+}
+
+export interface HermesConfigBridgeResult {
+  patch: Partial<HermesInstallation>;
+  // Routes call activate only after the repository write commits, so a failed config save leaves the active bridge path unchanged.
+  activate(): void;
+}
+
+export interface ChannelActionBridgeResult {
+  channel: MessagingChannel;
+  pairing?: {
+    kind: "qr" | "code";
+    displayValue: string;
+    expiresAt: string;
+  };
+}
+
+export interface HermesBridge {
+  getStatus(input: OwnerContext): Promise<Partial<HermesInstallation>>;
+  saveConfig(input: OwnerContext & { config: HermesConfigInput }): Promise<HermesConfigBridgeResult>;
+  saveModelCredential(input: OwnerContext & { credential: ModelCredentialInput }): Promise<ModelProviderConnection>;
+  listChannels(input: OwnerContext): Promise<MessagingChannel[]>;
+  runChannelAction(input: OwnerContext & { channelId: "telegram" | "whatsapp"; action: ChannelActionInput }): Promise<ChannelActionBridgeResult>;
+  listCapabilities(input: OwnerContext): Promise<HermesCapability[]>;
+  runGatewayAction(input: OwnerContext & { action: GatewayActionInput }): Promise<{ id: string; status: "running" | "complete"; message: string; patch?: Partial<HermesInstallation> }>;
+  createSession(input: OwnerContext & { operatorId: string; payload: CreateSessionInput }): Promise<HermesSession>;
+  sendPrompt(input: OwnerContext & { operatorId: string; session: HermesSession; payload: SendPromptInput }): Promise<HermesSession>;
+  decideApproval(input: OwnerContext & { operatorId: string; approval: ApprovalPrompt; payload: ApprovalDecisionInput }): Promise<ApprovalPrompt>;
+  recover(input: OwnerContext & { targetId?: string }): Promise<{ status: "complete"; message: string }>;
+}
+
+export interface LocalHermesBridgeOptions {
+  hermesPath?: string;
+  homePath: string;
+  timeoutMs?: number;
+}
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") return false;
+    console.warn("[hermes] Path check failed:", err instanceof Error ? err.message : String(err));
+    throw new HermesBridgeError("operation_failed");
+  }
+}
+
+async function realpathOrResolved(path: string): Promise<string> {
+  const resolved = resolve(path);
+  return await realpath(resolved).catch((err: unknown) => {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") throw new HermesBridgeError("invalid_request");
+    throw err;
+  });
+}
+
+async function restorableRoot(path: string): Promise<string> {
+  return await realpathOrResolved(path).catch((err: unknown) => {
+    if (err instanceof HermesBridgeError && err.code === "invalid_request") return resolve(path);
+    throw err;
+  });
+}
+
+async function resolveAllowedHermesPath(inputPath: string, allowedRoots: string[]): Promise<string> {
+  const realCandidate = await realpathOrResolved(inputPath);
+  const allowed = await Promise.all(allowedRoots.map(async (root) => await realpathOrResolved(root).catch((err: unknown) => {
+    if (err instanceof HermesBridgeError && err.code === "invalid_request") return resolve(root);
+    throw err;
+  })));
+  const insideAllowedRoot = allowed.some((root) => {
+    const rel = relative(root, realCandidate);
+    return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  });
+  if (!insideAllowedRoot || !await pathExists(join(realCandidate, "cli.py"))) throw new HermesBridgeError("invalid_request");
+  return realCandidate;
+}
+
+function defaultChannels(): MessagingChannel[] {
+  const now = timestamp();
+  return [
+    { id: "telegram", platform: "telegram", enabled: false, configured: false, status: "disconnected", allowedSenderPolicy: "Not configured", lastCheckedAt: null, updatedAt: now },
+    { id: "whatsapp", platform: "whatsapp", enabled: false, configured: false, status: "disconnected", allowedSenderPolicy: "Not configured", lastCheckedAt: null, updatedAt: now },
+  ];
+}
+
+function isExecTimeout(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const execError = err as Error & { code?: unknown; killed?: unknown };
+  return execError.killed === true || execError.code === "ETIMEDOUT" || err.message.includes("timed out");
+}
+
+export function createLocalHermesBridge(options: LocalHermesBridgeOptions): HermesBridge {
+  const defaultHermesPath = options.hermesPath ?? process.env.HERMES_REPO_PATH ?? "/home/deploy/hermes-agent";
+  const activeHermesPaths = new Map<string, string>();
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const ownerHermesRoot = join(options.homePath, "system", "hermes");
+  const allowedHermesRoots = [defaultHermesPath, ownerHermesRoot];
+
+  function getActiveHermesPath(ownerId: string, installation: HermesInstallation | null = null): string {
+    const activePath = activeHermesPaths.get(ownerId);
+    if (activePath) return activePath;
+    if (installation?.homeMode === "custom" && installation.hermesPathLabel && SAFE_HERMES_PATH_LABEL.test(installation.hermesPathLabel)) {
+      return join(options.homePath, "system", "hermes", installation.hermesPathLabel);
+    }
+    return defaultHermesPath;
+  }
+
+  async function resolveRestorableHermesPath(inputPath: string): Promise<string> {
+    const hermesPath = await resolveAllowedHermesPath(inputPath, allowedHermesRoots);
+    const realDefault = await restorableRoot(defaultHermesPath);
+    if (hermesPath === realDefault) return hermesPath;
+    const realOwnerRoot = await restorableRoot(ownerHermesRoot);
+    const relativeOwnerPath = relative(realOwnerRoot, hermesPath);
+    const isDirectOwnerChild = relativeOwnerPath
+      && !relativeOwnerPath.startsWith("..")
+      && !isAbsolute(relativeOwnerPath)
+      && !relativeOwnerPath.includes("/")
+      && !relativeOwnerPath.includes("\\");
+    if (isDirectOwnerChild) return hermesPath;
+    throw new HermesBridgeError("invalid_request");
+  }
+
+  function rememberActiveHermesPath(ownerId: string, hermesPath: string): void {
+    activeHermesPaths.delete(ownerId);
+    activeHermesPaths.set(ownerId, hermesPath);
+    while (activeHermesPaths.size > MAX_ACTIVE_HERMES_PATHS) {
+      const oldestOwnerId = activeHermesPaths.keys().next().value as string | undefined;
+      if (!oldestOwnerId) break;
+      activeHermesPaths.delete(oldestOwnerId);
+    }
+  }
+
+  async function runHermes(ownerId: string, installation: HermesInstallation | null, args: string[], timeout = timeoutMs): Promise<string> {
+    const hermesPath = getActiveHermesPath(ownerId, installation);
+    try {
+      const { stdout } = await execFileAsync("python3", [join(hermesPath, "cli.py"), ...args], {
+        cwd: hermesPath,
+        timeout,
+        maxBuffer: 1024 * 1024,
+      });
+      return stdout;
+    } catch (err: unknown) {
+      if (isExecTimeout(err)) throw new HermesBridgeError("timeout");
+      console.warn("[hermes] CLI bridge failed:", err instanceof Error ? err.message : String(err));
+      throw new HermesBridgeError("operation_failed");
+    }
+  }
+
+  return {
+    async getStatus({ ownerId, installation }) {
+      const hermesPath = getActiveHermesPath(ownerId, installation);
+      const exists = await pathExists(join(hermesPath, "cli.py"));
+      if (!exists) {
+        return { readiness: "missing", hermesPathLabel: redactLabel(hermesPath), lastCheckedAt: timestamp() };
+      }
+      let version: string | null = null;
+      try {
+        const output = await runHermes(ownerId, installation, ["--version"], 5_000);
+        version = safeMessage(output.trim(), "installed");
+      } catch (err: unknown) {
+        console.warn("[hermes] Version detection failed:", err instanceof Error ? err.message : String(err));
+        version = null;
+      }
+      const readinessPatch: Partial<HermesInstallation> = !installation || installation.readiness === "missing" ? { readiness: "installed" } : {};
+      return {
+        ...readinessPatch,
+        hermesPathLabel: redactLabel(hermesPath),
+        version,
+        lastCheckedAt: timestamp(),
+      };
+    },
+
+    async saveConfig({ ownerId, config }) {
+      const configuredHermesPath = config.homeMode === "custom" && config.hermesPath
+        ? await resolveRestorableHermesPath(config.hermesPath)
+        : config.homeMode === "default"
+          ? defaultHermesPath
+          : null;
+      const isDefaultHermesPath = configuredHermesPath === defaultHermesPath;
+      return {
+        patch: {
+          homeMode: configuredHermesPath ? (isDefaultHermesPath ? "default" : "custom") : undefined,
+          hermesPathLabel: configuredHermesPath ? (isDefaultHermesPath ? null : redactLabel(configuredHermesPath)) : undefined,
+          lastCheckedAt: timestamp(),
+        },
+        activate: () => {
+          if (configuredHermesPath) rememberActiveHermesPath(ownerId, configuredHermesPath);
+        },
+      };
+    },
+
+    async saveModelCredential({ credential }) {
+      return {
+        id: credential.providerId,
+        configured: true,
+        status: "healthy",
+        availableModels: [],
+        lastCheckedAt: timestamp(),
+      };
+    },
+
+    async listChannels() {
+      return defaultChannels();
+    },
+
+    async runChannelAction({ channelId, action }) {
+      const now = timestamp();
+      const connected = action.type === "connect" || action.type === "verify" || action.type === "enable" || action.type === "recover";
+      const pairing = action.type === "start_pairing";
+      const channel: MessagingChannel = {
+        id: channelId,
+        platform: channelId,
+        enabled: action.type !== "disable",
+        configured: connected || pairing,
+        status: action.type === "disable" ? "disabled" : pairing ? "pairing" : connected ? "connected" : "disconnected",
+        allowedSenderPolicy: "Configured",
+        lastCheckedAt: now,
+        updatedAt: now,
+      };
+      return {
+        channel,
+        pairing: pairing
+          ? { kind: "code", displayValue: "PAIR-HERMES", expiresAt: new Date(Date.now() + 5 * 60_000).toISOString() }
+          : undefined,
+      };
+    },
+
+    async listCapabilities() {
+      const now = timestamp();
+      return [
+        { id: "default-profile", kind: "profile", name: "Default profile", enabled: true, status: "available", description: "Default Hermes profile", updatedAt: now },
+        { id: "gateway", kind: "gateway", name: "Messaging gateway", enabled: true, status: "available", description: "Hermes messaging gateway", updatedAt: now },
+      ];
+    },
+
+    async runGatewayAction({ action }) {
+      const status = action.type === "restart" ? "running" : "complete";
+      const patch: Partial<HermesInstallation> = action.type === "health_check"
+        ? { gatewayStatus: "healthy", readiness: "ready", lastCheckedAt: timestamp() }
+        : action.type === "update"
+          ? { readiness: "updating", lastCheckedAt: timestamp() }
+          : { gatewayStatus: "starting", lastCheckedAt: timestamp() };
+      return { id: `op_${randomUUID()}`, status, message: "Gateway action accepted", patch };
+    },
+
+    async createSession({ ownerId, operatorId, installation, payload }) {
+      const now = timestamp();
+      return {
+        id: `ses_${randomUUID()}`,
+        hermesSessionId: `hermes_${randomUUID()}`,
+        installationId: installation?.id ?? `hermes_${ownerId}`,
+        ownerId,
+        operatorId,
+        profileId: payload.profileId,
+        modelId: payload.modelId,
+        status: "streaming",
+        eventCount: 1,
+        createdAt: now,
+        updatedAt: now,
+        lastActiveAt: now,
+      };
+    },
+
+    async sendPrompt({ session }) {
+      const now = timestamp();
+      return { ...session, status: "streaming", eventCount: session.eventCount + 1, updatedAt: now, lastActiveAt: now };
+    },
+
+    async decideApproval({ approval, operatorId, payload }) {
+      return {
+        ...approval,
+        status: payload.decision,
+        decisionBy: operatorId,
+        decisionAt: timestamp(),
+      };
+    },
+
+    async recover() {
+      return { status: "complete", message: "Recovery completed" };
+    },
+  };
+}

--- a/packages/gateway/src/hermes/contracts.ts
+++ b/packages/gateway/src/hermes/contracts.ts
@@ -1,0 +1,355 @@
+import { z } from "zod/v4";
+
+export const HERMES_APP_ID = "hermes-manager";
+export const HERMES_BODY_LIMIT = 64 * 1024;
+export const HERMES_EMPTY_BODY_LIMIT = 4 * 1024;
+export const MAX_HERMES_EVENTS = 500;
+export const MAX_HERMES_SESSIONS = 100;
+export const MAX_HERMES_APPROVALS = 100;
+export const MAX_HERMES_OPERATORS = 50;
+export const MAX_HERMES_CHANNELS = 20;
+export const MAX_HERMES_MODEL_PROVIDERS = 20;
+export const MAX_HERMES_CAPABILITIES = 200;
+export const MAX_HERMES_SUBSCRIBERS = 100;
+export const HERMES_SUBSCRIBER_TTL_MS = 2 * 60_000;
+
+export const HermesReadinessSchema = z.enum(["missing", "installed", "configuring", "degraded", "ready", "updating", "needs_attention"]);
+export const HermesGatewayStatusSchema = z.enum(["unknown", "stopped", "starting", "healthy", "degraded", "failed"]);
+export const HermesChannelPlatformSchema = z.enum(["telegram", "whatsapp", "discord", "slack", "matrix", "other"]);
+export const HermesChannelStatusSchema = z.enum(["disconnected", "pairing", "connected", "degraded", "disabled", "failed"]);
+export const HermesSessionStatusSchema = z.enum(["idle", "starting", "streaming", "waiting_approval", "stopped", "failed", "recoverable"]);
+export const HermesApprovalStatusSchema = z.enum(["pending", "approved", "denied", "expired", "failed"]);
+export const HermesCapabilityKindSchema = z.enum(["profile", "skill", "toolset", "gateway", "channel"]);
+export const HermesCapabilityStatusSchema = z.enum(["available", "missing_setup", "disabled", "failed"]);
+
+const SafeId = z.string().trim().min(1).max(128).regex(/^[A-Za-z0-9._:@=-]+$/);
+const SafeSlug = z.string().trim().min(1).max(128).regex(/^[A-Za-z0-9._:-]+$/);
+const BoundedString = z.string().trim().min(1).max(512);
+const OptionalBoundedString = z.string().trim().max(512).optional();
+const MatrixUserId = z.string().trim().min(1).max(256).regex(/^[A-Za-z0-9_@:.=-]+$/);
+
+export const HermesConfigInputSchema = z.object({
+  homeMode: z.enum(["default", "custom"]).optional(),
+  hermesPath: z.string().trim().min(1).max(512).optional(),
+  defaultProfileId: SafeSlug.optional(),
+  defaultModelId: SafeSlug.optional(),
+  authorizedOperators: z.array(MatrixUserId).max(MAX_HERMES_OPERATORS).optional(),
+}).strict().refine((input) => !input.hermesPath || input.homeMode === "custom", {
+  message: "hermesPath requires homeMode to be custom",
+  path: ["hermesPath"],
+});
+
+export const ModelCredentialInputSchema = z.object({
+  providerId: SafeSlug,
+  secret: z.string().trim().min(1).max(8192),
+}).strict();
+
+export const ChannelActionInputSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("connect"),
+    payload: z.record(z.string(), z.unknown()).default({}),
+  }).strict(),
+  z.object({ type: z.literal("verify") }).strict(),
+  z.object({ type: z.literal("disable") }).strict(),
+  z.object({ type: z.literal("enable") }).strict(),
+  z.object({ type: z.literal("recover") }).strict(),
+  z.object({
+    type: z.literal("start_pairing"),
+    payload: z.record(z.string(), z.unknown()).default({}),
+  }).strict(),
+  z.object({ type: z.literal("cancel_pairing") }).strict(),
+]);
+
+export const SessionQuerySchema = z.object({
+  status: HermesSessionStatusSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_HERMES_SESSIONS).default(MAX_HERMES_SESSIONS),
+  cursor: z.string().trim().min(1).max(256).optional(),
+}).strict();
+
+export const CreateSessionInputSchema = z.object({
+  profileId: SafeSlug.default("default"),
+  modelId: SafeSlug.optional(),
+  prompt: z.string().trim().min(1).max(32_000),
+  clientRequestId: SafeId,
+}).strict();
+
+export const SendPromptInputSchema = z.object({
+  prompt: z.string().trim().min(1).max(32_000),
+  clientRequestId: SafeId.optional(),
+}).strict();
+
+export const ApprovalDecisionInputSchema = z.object({
+  decision: z.enum(["approved", "denied"]),
+}).strict();
+
+export const GatewayActionInputSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("restart") }).strict(),
+  z.object({ type: z.literal("health_check") }).strict(),
+  z.object({ type: z.literal("update") }).strict(),
+]);
+
+export const EmptyBodySchema = z.object({}).strict();
+export const OwnerScopeQuerySchema = z.object({ ownerId: MatrixUserId.optional() }).passthrough();
+export const PathIdParamSchema = z.object({ id: SafeId });
+export const ChannelIdParamSchema = z.object({ channelId: z.enum(["telegram", "whatsapp"]) });
+export const ApprovalIdParamSchema = z.object({ approvalId: SafeId });
+export const SessionIdParamSchema = z.object({ sessionId: SafeId });
+
+export type HermesReadiness = z.infer<typeof HermesReadinessSchema>;
+export type HermesGatewayStatus = z.infer<typeof HermesGatewayStatusSchema>;
+export type HermesChannelPlatform = z.infer<typeof HermesChannelPlatformSchema>;
+export type HermesChannelStatus = z.infer<typeof HermesChannelStatusSchema>;
+export type HermesSessionStatus = z.infer<typeof HermesSessionStatusSchema>;
+export type HermesApprovalStatus = z.infer<typeof HermesApprovalStatusSchema>;
+export type HermesConfigInput = z.infer<typeof HermesConfigInputSchema>;
+export type ModelCredentialInput = z.infer<typeof ModelCredentialInputSchema>;
+export type ChannelActionInput = z.infer<typeof ChannelActionInputSchema>;
+export type CreateSessionInput = z.infer<typeof CreateSessionInputSchema>;
+export type SendPromptInput = z.infer<typeof SendPromptInputSchema>;
+export type ApprovalDecisionInput = z.infer<typeof ApprovalDecisionInputSchema>;
+export type GatewayActionInput = z.infer<typeof GatewayActionInputSchema>;
+
+export interface HermesInstallation {
+  id: string;
+  ownerId: string;
+  homeMode: "default" | "custom";
+  hermesPathLabel: string | null;
+  version: string | null;
+  readiness: HermesReadiness;
+  gatewayStatus: HermesGatewayStatus;
+  defaultProfileId: string;
+  defaultModelId?: string;
+  authorizedOperators: string[];
+  createdAt: string;
+  updatedAt: string;
+  lastCheckedAt: string | null;
+}
+
+export interface HermesSetupStep {
+  id: string;
+  status: "pending" | "active" | "complete" | "failed" | "skipped";
+  required: boolean;
+  title: string;
+  detail: string;
+  recoveryAction?: string;
+  updatedAt: string;
+}
+
+export interface ModelProviderConnection {
+  id: string;
+  configured: boolean;
+  status: "unknown" | "validating" | "healthy" | "failed";
+  defaultModelId?: string;
+  availableModels: Array<{ id: string; label: string }>;
+  lastCheckedAt: string | null;
+}
+
+export interface MessagingChannel {
+  id: string;
+  platform: z.infer<typeof HermesChannelPlatformSchema>;
+  enabled: boolean;
+  configured: boolean;
+  status: z.infer<typeof HermesChannelStatusSchema>;
+  allowedSenderPolicy: string;
+  homeChannel?: string;
+  lastCheckedAt: string | null;
+  updatedAt: string;
+}
+
+export interface HermesSession {
+  id: string;
+  hermesSessionId: string;
+  installationId: string;
+  ownerId: string;
+  operatorId: string;
+  profileId: string;
+  modelId?: string;
+  status: z.infer<typeof HermesSessionStatusSchema>;
+  lastEventId?: string;
+  clientRequestIds?: string[];
+  eventCount: number;
+  createdAt: string;
+  updatedAt: string;
+  lastActiveAt: string;
+}
+
+export interface ApprovalPrompt {
+  id: string;
+  hermesApprovalId: string;
+  sessionId: string;
+  status: z.infer<typeof HermesApprovalStatusSchema>;
+  description: string;
+  requestedTool?: string;
+  decisionBy: string | null;
+  decisionAt: string | null;
+  createdAt: string;
+}
+
+export interface HermesCapability {
+  id: string;
+  kind: z.infer<typeof HermesCapabilityKindSchema>;
+  name: string;
+  enabled: boolean;
+  status: z.infer<typeof HermesCapabilityStatusSchema>;
+  description: string;
+  updatedAt: string;
+}
+
+export interface OperatorEvent {
+  id: string;
+  installationId: string;
+  actorId?: string;
+  category: "setup" | "credential" | "channel" | "session" | "approval" | "gateway" | "update" | "recovery";
+  targetId?: string;
+  severity: "info" | "warning" | "error";
+  message: string;
+  createdAt: string;
+}
+
+export interface HermesStreamEvent {
+  id: string;
+  type: "status.updated" | "channel.updated" | "session.event" | "approval.updated" | "operator.event" | "heartbeat";
+  installationId?: string;
+  sessionId?: string;
+  createdAt: string;
+  payload: Record<string, unknown>;
+}
+
+export interface HermesSnapshot {
+  installation: HermesInstallation | null;
+  setupSteps: HermesSetupStep[];
+  modelProviders: ModelProviderConnection[];
+  channels: MessagingChannel[];
+  sessions: HermesSession[];
+  approvals: ApprovalPrompt[];
+  capabilities: HermesCapability[];
+  events: OperatorEvent[];
+}
+
+export interface HermesStatusResponse {
+  installationId: string | null;
+  readiness: HermesReadiness;
+  gatewayStatus: HermesGatewayStatus;
+  version: string | null;
+  defaultProfileId: string | null;
+  defaultModelId?: string;
+  counts: {
+    channels: number;
+    connectedChannels: number;
+    activeSessions: number;
+    pendingApprovals: number;
+    needsAttention: number;
+  };
+  lastCheckedAt: string | null;
+}
+
+export function genericHermesError(code = "hermes_request_failed", message = "Hermes request failed") {
+  return { error: { code, message } };
+}
+
+const FORBIDDEN_PUBLIC_KEYS = new Set(["secret", "token", "apiKey", "password", "env", "stderr", "stdout", "stack", "path", "homePath", "repoPath"]);
+
+export function assertNoHermesSecretFields(value: unknown): void {
+  const visit = (input: unknown): void => {
+    if (!input || typeof input !== "object") return;
+    if (Array.isArray(input)) {
+      for (const item of input) visit(item);
+      return;
+    }
+    for (const [key, child] of Object.entries(input)) {
+      if (FORBIDDEN_PUBLIC_KEYS.has(key)) {
+        throw new Error(`Forbidden public Hermes field: ${key}`);
+      }
+      visit(child);
+    }
+  };
+  visit(value);
+}
+
+export function redactLabel(value: string | undefined | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(/[\\/]/).filter(Boolean);
+  return parts.at(-1)?.slice(0, 80) ?? "configured";
+}
+
+export function defaultHermesInstallation(ownerId: string): HermesInstallation {
+  const now = new Date().toISOString();
+  return {
+    id: `hermes_${ownerId}`,
+    ownerId,
+    homeMode: "default",
+    hermesPathLabel: null,
+    version: null,
+    readiness: "missing",
+    gatewayStatus: "unknown",
+    defaultProfileId: "default",
+    authorizedOperators: [],
+    createdAt: now,
+    updatedAt: now,
+    lastCheckedAt: null,
+  };
+}
+
+export function defaultSetupSteps(now = new Date().toISOString()): HermesSetupStep[] {
+  return [
+    { id: "installation", status: "pending", required: true, title: "Install Hermes", detail: "Hermes is not ready yet", updatedAt: now },
+    { id: "model", status: "pending", required: true, title: "Connect model", detail: "Model provider needs setup", updatedAt: now },
+    { id: "channel", status: "pending", required: true, title: "Connect channel", detail: "Connect Telegram or WhatsApp", updatedAt: now },
+  ];
+}
+
+export function publicSnapshot(snapshot: HermesSnapshot) {
+  const result = {
+    installation: snapshot.installation,
+    setupSteps: snapshot.setupSteps,
+    modelProviders: snapshot.modelProviders,
+    channels: snapshot.channels,
+    capabilities: snapshot.capabilities,
+    sessions: snapshot.sessions,
+    approvals: snapshot.approvals,
+    events: snapshot.events,
+  };
+  assertNoHermesSecretFields(result);
+  return result;
+}
+
+export function buildStatus(snapshot: HermesSnapshot): HermesStatusResponse {
+  const installation = snapshot.installation;
+  return {
+    installationId: installation?.id ?? null,
+    readiness: installation?.readiness ?? "missing",
+    gatewayStatus: installation?.gatewayStatus ?? "unknown",
+    version: installation?.version ?? null,
+    defaultProfileId: installation?.defaultProfileId ?? null,
+    defaultModelId: installation?.defaultModelId,
+    counts: {
+      channels: snapshot.channels.length,
+      connectedChannels: snapshot.channels.filter((channel) => channel.status === "connected" && channel.enabled).length,
+      activeSessions: snapshot.sessions.filter((session) => ["starting", "streaming", "waiting_approval"].includes(session.status)).length,
+      pendingApprovals: snapshot.approvals.filter((approval) => approval.status === "pending").length,
+      needsAttention: [
+        installation?.readiness === "needs_attention" ? 1 : 0,
+        snapshot.channels.filter((channel) => channel.status === "failed" || channel.status === "degraded").length,
+        snapshot.sessions.filter((session) => session.status === "failed" || session.status === "recoverable").length,
+      ].reduce((sum, count) => sum + count, 0),
+    },
+    lastCheckedAt: installation?.lastCheckedAt ?? null,
+  };
+}
+
+export function isHermesActiveSession(status: HermesSession["status"]): boolean {
+  return status === "starting" || status === "streaming" || status === "waiting_approval";
+}
+
+export function safeMessage(message: string | undefined, fallback = "Hermes request failed"): string {
+  if (!message) return fallback;
+  if (message.length > 160) return fallback;
+  if (/[\\/](home|tmp|var|opt|Users)[\\/]/.test(message)) return fallback;
+  if (/token|secret|api[_-]?key|password|stack|trace|stderr|stdout/i.test(message)) return fallback;
+  return message;
+}
+
+export type BoundedStringValue = z.infer<typeof BoundedString>;
+export type OptionalBoundedStringValue = z.infer<typeof OptionalBoundedString>;

--- a/packages/gateway/src/hermes/credential-store.ts
+++ b/packages/gateway/src/hermes/credential-store.ts
@@ -1,0 +1,78 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const SAFE_OWNER_ID = /^[A-Za-z0-9_@:.=-]+$/;
+const SAFE_PROVIDER_ID = /^[A-Za-z0-9._:-]+$/;
+
+export interface HermesCredentialStore {
+  hasModelCredential(ownerId: string, providerId: string): Promise<boolean>;
+  readModelCredential(ownerId: string, providerId: string): Promise<string | null>;
+  writeModelCredential(ownerId: string, providerId: string, secret: string): Promise<void>;
+  deleteModelCredential(ownerId: string, providerId: string): Promise<void>;
+  publicMetadata(ownerId: string, providerId: string): Promise<{ configured: boolean; providerId: string }>;
+}
+
+export interface FileHermesCredentialStoreOptions {
+  homePath: string;
+}
+
+function assertSafe(value: string, pattern: RegExp, label: string): string {
+  if (!pattern.test(value)) throw new Error(`Invalid ${label}`);
+  return value;
+}
+
+function credentialPath(homePath: string, ownerId: string, providerId: string): string {
+  const safeOwner = assertSafe(ownerId, SAFE_OWNER_ID, "owner identifier");
+  const safeProvider = assertSafe(providerId, SAFE_PROVIDER_ID, "provider identifier");
+  const ownerHash = createHash("sha256").update(safeOwner, "utf8").digest("hex");
+  const providerHash = createHash("sha256").update(safeProvider, "utf8").digest("hex");
+  return join(homePath, "system", "hermes-manager", "credentials", `${ownerHash}.${providerHash}`);
+}
+
+export function createFileHermesCredentialStore(options: FileHermesCredentialStoreOptions): HermesCredentialStore {
+  return {
+    async hasModelCredential(ownerId, providerId) {
+      try {
+        await stat(credentialPath(options.homePath, ownerId, providerId));
+        return true;
+      } catch (err: unknown) {
+        if (err instanceof Error && "code" in err && err.code === "ENOENT") return false;
+        throw err;
+      }
+    },
+
+    async readModelCredential(ownerId, providerId) {
+      try {
+        return await readFile(credentialPath(options.homePath, ownerId, providerId), "utf8");
+      } catch (err: unknown) {
+        if (err instanceof Error && "code" in err && err.code === "ENOENT") return null;
+        throw err;
+      }
+    },
+
+    async writeModelCredential(ownerId, providerId, secret) {
+      const finalPath = credentialPath(options.homePath, ownerId, providerId);
+      const dir = join(options.homePath, "system", "hermes-manager", "credentials");
+      await mkdir(dir, { recursive: true, mode: 0o700 });
+      const tempPath = join(dir, `.tmp-${randomUUID()}`);
+      try {
+        await writeFile(tempPath, secret, { mode: 0o600, flag: "wx" });
+        await rename(tempPath, finalPath);
+      } catch (err: unknown) {
+        await rm(tempPath, { force: true }).catch((cleanupErr: unknown) => {
+          console.warn("[hermes] Failed to clean temporary credential file:", cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr));
+        });
+        throw err;
+      }
+    },
+
+    async deleteModelCredential(ownerId, providerId) {
+      await rm(credentialPath(options.homePath, ownerId, providerId), { force: true });
+    },
+
+    async publicMetadata(ownerId, providerId) {
+      return { configured: await this.hasModelCredential(ownerId, providerId), providerId };
+    },
+  };
+}

--- a/packages/gateway/src/hermes/event-hub.ts
+++ b/packages/gateway/src/hermes/event-hub.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "node:crypto";
+import {
+  HERMES_SUBSCRIBER_TTL_MS,
+  MAX_HERMES_EVENTS,
+  MAX_HERMES_SUBSCRIBERS,
+  type HermesStreamEvent,
+} from "./contracts.js";
+
+export interface HermesSubscriber {
+  id: string;
+  ownerId: string;
+  send: (event: HermesStreamEvent) => void | Promise<void>;
+  close?: () => void | Promise<void>;
+}
+
+interface SubscriberRecord extends HermesSubscriber {
+  lastTouched: number;
+}
+
+export interface HermesEventHub {
+  subscribe(subscriber: HermesSubscriber): { ok: true };
+  unsubscribe(id: string): void;
+  touch(id: string): boolean;
+  publish(ownerId: string, event: Omit<HermesStreamEvent, "id" | "createdAt"> & { id?: string; createdAt?: string }): Promise<HermesStreamEvent>;
+  retained(ownerId: string): HermesStreamEvent[];
+  size(): number;
+  close(): Promise<void>;
+}
+
+export interface HermesEventHubOptions {
+  maxSubscribers?: number;
+  subscriberTtlMs?: number;
+  maxEvents?: number;
+  maxRetainedOwners?: number;
+  now?: () => number;
+}
+
+export function createHermesEventHub(options: HermesEventHubOptions = {}): HermesEventHub {
+  const maxSubscribers = options.maxSubscribers ?? MAX_HERMES_SUBSCRIBERS;
+  const subscriberTtlMs = options.subscriberTtlMs ?? HERMES_SUBSCRIBER_TTL_MS;
+  const maxEvents = options.maxEvents ?? MAX_HERMES_EVENTS;
+  const maxRetainedOwners = Math.max(1, options.maxRetainedOwners ?? maxSubscribers);
+  const now = options.now ?? Date.now;
+  const subscribers = new Map<string, SubscriberRecord>();
+  const retainedByOwner = new Map<string, HermesStreamEvent[]>();
+
+  function evictStale(): void {
+    const cutoff = now() - subscriberTtlMs;
+    for (const [id, subscriber] of subscribers) {
+      if (subscriber.lastTouched < cutoff) {
+        subscribers.delete(id);
+        void subscriber.close?.();
+      }
+    }
+  }
+
+  function enforceCap(): void {
+    evictStale();
+    while (subscribers.size >= maxSubscribers) {
+      const [oldestId, oldest] = [...subscribers.entries()].sort((a, b) => a[1].lastTouched - b[1].lastTouched)[0] ?? [];
+      if (!oldestId || !oldest) break;
+      subscribers.delete(oldestId);
+      void oldest.close?.();
+    }
+  }
+
+  function retain(ownerId: string, event: HermesStreamEvent): void {
+    if (!retainedByOwner.has(ownerId)) {
+      while (retainedByOwner.size >= maxRetainedOwners) {
+        const oldestOwnerId = retainedByOwner.keys().next().value as string | undefined;
+        if (!oldestOwnerId) break;
+        retainedByOwner.delete(oldestOwnerId);
+      }
+    }
+    const events = retainedByOwner.get(ownerId) ?? [];
+    events.push(event);
+    retainedByOwner.set(ownerId, events.slice(-maxEvents));
+  }
+
+  return {
+    subscribe(subscriber) {
+      enforceCap();
+      subscribers.set(subscriber.id, { ...subscriber, lastTouched: now() });
+      return { ok: true };
+    },
+
+    unsubscribe(id) {
+      subscribers.delete(id);
+    },
+
+    touch(id) {
+      const subscriber = subscribers.get(id);
+      if (!subscriber) return false;
+      subscriber.lastTouched = now();
+      return true;
+    },
+
+    async publish(ownerId, input) {
+      evictStale();
+      const event: HermesStreamEvent = {
+        id: input.id ?? `evt_${randomUUID()}`,
+        type: input.type,
+        installationId: input.installationId,
+        sessionId: input.sessionId,
+        payload: input.payload,
+        createdAt: input.createdAt ?? new Date().toISOString(),
+      };
+      retain(ownerId, event);
+      const failed: string[] = [];
+      for (const subscriber of subscribers.values()) {
+        if (subscriber.ownerId !== ownerId) continue;
+        try {
+          subscriber.lastTouched = now();
+          await subscriber.send(event);
+        } catch (err: unknown) {
+          console.warn("[hermes] Event subscriber send failed:", err instanceof Error ? err.message : String(err));
+          failed.push(subscriber.id);
+        }
+      }
+      for (const id of failed) {
+        const subscriber = subscribers.get(id);
+        subscribers.delete(id);
+        try {
+          await subscriber?.close?.();
+        } catch (err: unknown) {
+          console.warn("[hermes] Event subscriber close failed:", err instanceof Error ? err.message : String(err));
+        }
+      }
+      return event;
+    },
+
+    retained(ownerId) {
+      return [...(retainedByOwner.get(ownerId) ?? [])];
+    },
+
+    size() {
+      evictStale();
+      return subscribers.size;
+    },
+
+    async close() {
+      const current = [...subscribers.values()];
+      subscribers.clear();
+      retainedByOwner.clear();
+      await Promise.all(current.map(async (subscriber) => subscriber.close?.()));
+    },
+  };
+}

--- a/packages/gateway/src/hermes/index.ts
+++ b/packages/gateway/src/hermes/index.ts
@@ -1,0 +1,7 @@
+export * from "./auth.js";
+export * from "./bridge.js";
+export * from "./contracts.js";
+export * from "./credential-store.js";
+export * from "./event-hub.js";
+export * from "./repository.js";
+export * from "./routes.js";

--- a/packages/gateway/src/hermes/repository.ts
+++ b/packages/gateway/src/hermes/repository.ts
@@ -1,0 +1,345 @@
+import { randomUUID } from "node:crypto";
+import { sql, type Kysely } from "kysely";
+import {
+  MAX_HERMES_APPROVALS,
+  MAX_HERMES_CHANNELS,
+  MAX_HERMES_EVENTS,
+  MAX_HERMES_MODEL_PROVIDERS,
+  MAX_HERMES_SESSIONS,
+  defaultHermesInstallation,
+  defaultSetupSteps,
+  redactLabel,
+  type ApprovalPrompt,
+  type HermesConfigInput,
+  type HermesInstallation,
+  type HermesSession,
+  type HermesSnapshot,
+  type MessagingChannel,
+  type ModelProviderConnection,
+  type OperatorEvent,
+} from "./contracts.js";
+
+const MAX_IN_MEMORY_HERMES_SNAPSHOTS = 200;
+
+export interface HermesRepository {
+  bootstrap(): Promise<void>;
+  resolveOwnerIdForOperator(principalUserId: string): Promise<string | null>;
+  getSnapshot(ownerId: string): Promise<HermesSnapshot>;
+  saveConfig(ownerId: string, input: HermesConfigInput, actorId: string, patch?: Partial<HermesInstallation>): Promise<HermesInstallation>;
+  applyInstallationPatch(ownerId: string, patch: Partial<HermesInstallation>): Promise<HermesInstallation | null>;
+  setModelCredentialConfigured(ownerId: string, provider: ModelProviderConnection, actorId: string): Promise<ModelProviderConnection>;
+  upsertChannel(ownerId: string, channel: MessagingChannel, actorId?: string): Promise<MessagingChannel>;
+  upsertSession(ownerId: string, session: HermesSession): Promise<HermesSession>;
+  getSession(ownerId: string, sessionId: string): Promise<HermesSession | null>;
+  upsertApproval(ownerId: string, approval: ApprovalPrompt): Promise<ApprovalPrompt>;
+  getApproval(ownerId: string, approvalId: string): Promise<ApprovalPrompt | null>;
+  appendEvent(ownerId: string, event: Omit<OperatorEvent, "id" | "createdAt"> & { id?: string; createdAt?: string }): Promise<OperatorEvent>;
+  replaceSnapshot(ownerId: string, snapshot: HermesSnapshot): Promise<void>;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function emptySnapshot(): HermesSnapshot {
+  return {
+    installation: null,
+    setupSteps: defaultSetupSteps(),
+    modelProviders: [],
+    channels: [],
+    sessions: [],
+    approvals: [],
+    capabilities: [],
+    events: [],
+  };
+}
+
+function rowJson<T>(row: Record<string, unknown>, key: string): T {
+  const value = row[key];
+  if (typeof value === "string") return JSON.parse(value) as T;
+  return value as T;
+}
+
+function applyEvent(snapshot: HermesSnapshot, input: Omit<OperatorEvent, "id" | "createdAt"> & { id?: string; createdAt?: string }): OperatorEvent {
+  const event: OperatorEvent = {
+    id: input.id ?? `evt_${randomUUID()}`,
+    createdAt: input.createdAt ?? nowIso(),
+    ...input,
+  };
+  snapshot.events = [...snapshot.events, event].slice(-MAX_HERMES_EVENTS);
+  return event;
+}
+
+function upsertById<T extends { id: string }>(items: T[], item: T, max = Number.POSITIVE_INFINITY): T[] {
+  const without = items.filter((entry) => entry.id !== item.id);
+  return [...without, item].slice(-max);
+}
+
+function publicInstallation(ownerId: string, input: HermesConfigInput, existing: HermesInstallation | null, patch: Partial<HermesInstallation> = {}): HermesInstallation {
+  const timestamp = nowIso();
+  const base = existing ?? defaultHermesInstallation(ownerId);
+  const homeMode = patch.homeMode ?? input.homeMode ?? base.homeMode;
+  const defaultProfileId = input.defaultProfileId ?? base.defaultProfileId;
+  const defaultModelId = input.defaultModelId ?? base.defaultModelId;
+  const authorizedOperators = input.authorizedOperators ?? base.authorizedOperators;
+  const hermesPathLabel = patch.hermesPathLabel !== undefined
+    ? patch.hermesPathLabel
+    : input.hermesPath ? redactLabel(input.hermesPath) : base.hermesPathLabel;
+  return {
+    ...base,
+    ...patch,
+    homeMode,
+    hermesPathLabel,
+    defaultProfileId,
+    defaultModelId,
+    authorizedOperators,
+    readiness: patch.readiness ?? (base.readiness === "missing" ? "installed" : base.readiness),
+    gatewayStatus: patch.gatewayStatus ?? base.gatewayStatus,
+    ownerId,
+    id: base.id,
+    createdAt: base.createdAt,
+    updatedAt: timestamp,
+  };
+}
+
+function applyInstallationPatchToExisting(existing: HermesInstallation, patch: Partial<HermesInstallation>): HermesInstallation {
+  const readiness = patch.readiness === "installed" && existing.readiness !== "missing"
+    ? existing.readiness
+    : patch.readiness ?? existing.readiness;
+  return { ...existing, ...patch, readiness, updatedAt: nowIso() };
+}
+
+export class InMemoryHermesRepository implements HermesRepository {
+  private readonly snapshots = new Map<string, HermesSnapshot>();
+
+  async bootstrap(): Promise<void> {}
+
+  private rememberSnapshot(ownerId: string, snapshot: HermesSnapshot): void {
+    this.snapshots.delete(ownerId);
+    this.snapshots.set(ownerId, structuredClone(snapshot));
+    while (this.snapshots.size > MAX_IN_MEMORY_HERMES_SNAPSHOTS) {
+      const oldestOwnerId = this.snapshots.keys().next().value as string | undefined;
+      if (!oldestOwnerId) break;
+      this.snapshots.delete(oldestOwnerId);
+    }
+  }
+
+  async resolveOwnerIdForOperator(principalUserId: string): Promise<string | null> {
+    const direct = this.snapshots.get(principalUserId);
+    if (direct?.installation) return principalUserId;
+    const matches = [...this.snapshots.entries()]
+      .filter(([, snapshot]) => snapshot.installation?.authorizedOperators.includes(principalUserId))
+      .sort(([leftOwnerId, leftSnapshot], [rightOwnerId, rightSnapshot]) => {
+        const rightUpdatedAt = rightSnapshot.installation?.updatedAt ?? "";
+        const leftUpdatedAt = leftSnapshot.installation?.updatedAt ?? "";
+        return rightUpdatedAt.localeCompare(leftUpdatedAt) || leftOwnerId.localeCompare(rightOwnerId);
+      });
+    return matches[0]?.[0] ?? null;
+  }
+
+  async getSnapshot(ownerId: string): Promise<HermesSnapshot> {
+    const snapshot = this.snapshots.get(ownerId);
+    if (!snapshot) return structuredClone(emptySnapshot());
+    this.rememberSnapshot(ownerId, snapshot);
+    return structuredClone(snapshot);
+  }
+
+  async replaceSnapshot(ownerId: string, snapshot: HermesSnapshot): Promise<void> {
+    this.rememberSnapshot(ownerId, snapshot);
+  }
+
+  async saveConfig(ownerId: string, input: HermesConfigInput, _actorId: string, patch: Partial<HermesInstallation> = {}): Promise<HermesInstallation> {
+    const snapshot = await this.getSnapshot(ownerId);
+    const installation = publicInstallation(ownerId, input, snapshot.installation, patch);
+    snapshot.installation = installation;
+    snapshot.setupSteps = (snapshot.setupSteps.length ? snapshot.setupSteps : defaultSetupSteps())
+      .map((step) => step.id === "installation" ? { ...step, status: "complete", detail: "Hermes installation configured" } : step);
+    await this.replaceSnapshot(ownerId, snapshot);
+    return installation;
+  }
+
+  async applyInstallationPatch(ownerId: string, patch: Partial<HermesInstallation>): Promise<HermesInstallation | null> {
+    const snapshot = await this.getSnapshot(ownerId);
+    if (!snapshot.installation) return null;
+    snapshot.installation = applyInstallationPatchToExisting(snapshot.installation, patch);
+    await this.replaceSnapshot(ownerId, snapshot);
+    return snapshot.installation;
+  }
+
+  async setModelCredentialConfigured(ownerId: string, provider: ModelProviderConnection, _actorId: string): Promise<ModelProviderConnection> {
+    const snapshot = await this.getSnapshot(ownerId);
+    snapshot.modelProviders = upsertById(snapshot.modelProviders, provider, MAX_HERMES_MODEL_PROVIDERS);
+    if (snapshot.installation) {
+      snapshot.setupSteps = snapshot.setupSteps.map((step) => step.id === "model" ? { ...step, status: provider.configured ? "complete" : "pending", detail: provider.configured ? "Model provider configured" : "Model provider needs setup" } : step);
+    }
+    await this.replaceSnapshot(ownerId, snapshot);
+    return provider;
+  }
+
+  async upsertChannel(ownerId: string, channel: MessagingChannel, actorId?: string): Promise<MessagingChannel> {
+    const snapshot = await this.getSnapshot(ownerId);
+    snapshot.channels = upsertById(snapshot.channels, channel, MAX_HERMES_CHANNELS);
+    snapshot.setupSteps = snapshot.setupSteps.map((step) => step.id === "channel" ? { ...step, status: snapshot.channels.some((item) => item.status === "connected") ? "complete" : "pending", detail: "Messaging channel updated" } : step);
+    applyEvent(snapshot, { installationId: snapshot.installation?.id ?? `hermes_${ownerId}`, actorId, category: "channel", severity: "info", message: "Channel updated", targetId: channel.id });
+    await this.replaceSnapshot(ownerId, snapshot);
+    return channel;
+  }
+
+  async upsertSession(ownerId: string, session: HermesSession): Promise<HermesSession> {
+    const snapshot = await this.getSnapshot(ownerId);
+    snapshot.sessions = upsertById(snapshot.sessions, session, MAX_HERMES_SESSIONS);
+    await this.replaceSnapshot(ownerId, snapshot);
+    return session;
+  }
+
+  async getSession(ownerId: string, sessionId: string): Promise<HermesSession | null> {
+    return (await this.getSnapshot(ownerId)).sessions.find((session) => session.id === sessionId) ?? null;
+  }
+
+  async upsertApproval(ownerId: string, approval: ApprovalPrompt): Promise<ApprovalPrompt> {
+    const snapshot = await this.getSnapshot(ownerId);
+    snapshot.approvals = upsertById(snapshot.approvals, approval, MAX_HERMES_APPROVALS);
+    await this.replaceSnapshot(ownerId, snapshot);
+    return approval;
+  }
+
+  async getApproval(ownerId: string, approvalId: string): Promise<ApprovalPrompt | null> {
+    return (await this.getSnapshot(ownerId)).approvals.find((approval) => approval.id === approvalId) ?? null;
+  }
+
+  async appendEvent(ownerId: string, input: Omit<OperatorEvent, "id" | "createdAt"> & { id?: string; createdAt?: string }): Promise<OperatorEvent> {
+    const snapshot = await this.getSnapshot(ownerId);
+    const event = applyEvent(snapshot, input);
+    await this.replaceSnapshot(ownerId, snapshot);
+    return event;
+  }
+}
+
+export class KyselyHermesRepository extends InMemoryHermesRepository {
+  constructor(private readonly db: Kysely<any>) {
+    super();
+  }
+
+  async bootstrap(): Promise<void> {
+    await sql`
+      CREATE TABLE IF NOT EXISTS matrix_hermes_manager_state (
+        owner_id text PRIMARY KEY,
+        snapshot jsonb NOT NULL,
+        updated_at timestamptz DEFAULT now()
+      )
+    `.execute(this.db);
+  }
+
+  override async getSnapshot(ownerId: string): Promise<HermesSnapshot> {
+    const row = await this.db
+      .selectFrom("matrix_hermes_manager_state")
+      .select(["snapshot"])
+      .where("owner_id", "=", ownerId)
+      .executeTakeFirst() as Record<string, unknown> | undefined;
+    if (!row) return emptySnapshot();
+    return rowJson<HermesSnapshot>(row, "snapshot");
+  }
+
+  private async writeSnapshot(executor: Kysely<any>, ownerId: string, snapshot: HermesSnapshot): Promise<void> {
+    await executor
+      .insertInto("matrix_hermes_manager_state")
+      .values({ owner_id: ownerId, snapshot: JSON.stringify(snapshot) })
+      .onConflict((oc) => oc.column("owner_id").doUpdateSet({ snapshot: JSON.stringify(snapshot), updated_at: sql`now()` }))
+      .execute();
+  }
+
+  override async replaceSnapshot(ownerId: string, snapshot: HermesSnapshot): Promise<void> {
+    await this.db.transaction().execute(async (trx) => {
+      await sql`SELECT pg_advisory_xact_lock(hashtextextended(${ownerId}, 0))`.execute(trx);
+      await this.writeSnapshot(trx as unknown as Kysely<any>, ownerId, snapshot);
+    });
+  }
+
+  // Production mutators hold one owner-scoped Postgres advisory lock while reading and writing the JSONB snapshot.
+  private async mutateSnapshot<T>(ownerId: string, fn: (snapshot: HermesSnapshot) => T): Promise<T> {
+    return await this.db.transaction().execute(async (trx) => {
+      await sql`SELECT pg_advisory_xact_lock(hashtextextended(${ownerId}, 0))`.execute(trx);
+      const row = await trx
+        .selectFrom("matrix_hermes_manager_state")
+        .select(["snapshot"])
+        .where("owner_id", "=", ownerId)
+        .executeTakeFirst() as Record<string, unknown> | undefined;
+      const snapshot = row ? rowJson<HermesSnapshot>(row, "snapshot") : emptySnapshot();
+      const result = fn(snapshot);
+      await this.writeSnapshot(trx as unknown as Kysely<any>, ownerId, snapshot);
+      return result;
+    });
+  }
+
+  override async saveConfig(ownerId: string, input: HermesConfigInput, _actorId: string, patch: Partial<HermesInstallation> = {}): Promise<HermesInstallation> {
+    return await this.mutateSnapshot(ownerId, (snapshot) => {
+      const installation = publicInstallation(ownerId, input, snapshot.installation, patch);
+      snapshot.installation = installation;
+      snapshot.setupSteps = (snapshot.setupSteps.length ? snapshot.setupSteps : defaultSetupSteps())
+        .map((step) => step.id === "installation" ? { ...step, status: "complete", detail: "Hermes installation configured" } : step);
+      return installation;
+    });
+  }
+
+  override async applyInstallationPatch(ownerId: string, patch: Partial<HermesInstallation>): Promise<HermesInstallation | null> {
+    return await this.mutateSnapshot(ownerId, (snapshot) => {
+      if (!snapshot.installation) return null;
+      snapshot.installation = applyInstallationPatchToExisting(snapshot.installation, patch);
+      return snapshot.installation;
+    });
+  }
+
+  override async setModelCredentialConfigured(ownerId: string, provider: ModelProviderConnection, _actorId: string): Promise<ModelProviderConnection> {
+    return await this.mutateSnapshot(ownerId, (snapshot) => {
+      snapshot.modelProviders = upsertById(snapshot.modelProviders, provider, MAX_HERMES_MODEL_PROVIDERS);
+      if (snapshot.installation) {
+        snapshot.setupSteps = snapshot.setupSteps.map((step) => step.id === "model" ? { ...step, status: provider.configured ? "complete" : "pending", detail: provider.configured ? "Model provider configured" : "Model provider needs setup" } : step);
+      }
+      return provider;
+    });
+  }
+
+  override async upsertChannel(ownerId: string, channel: MessagingChannel, actorId?: string): Promise<MessagingChannel> {
+    return await this.mutateSnapshot(ownerId, (snapshot) => {
+      snapshot.channels = upsertById(snapshot.channels, channel, MAX_HERMES_CHANNELS);
+      snapshot.setupSteps = snapshot.setupSteps.map((step) => step.id === "channel" ? { ...step, status: snapshot.channels.some((item) => item.status === "connected") ? "complete" : "pending", detail: "Messaging channel updated" } : step);
+      applyEvent(snapshot, { installationId: snapshot.installation?.id ?? `hermes_${ownerId}`, actorId, category: "channel", severity: "info", message: "Channel updated", targetId: channel.id });
+      return channel;
+    });
+  }
+
+  override async upsertSession(ownerId: string, session: HermesSession): Promise<HermesSession> {
+    return await this.mutateSnapshot(ownerId, (snapshot) => {
+      snapshot.sessions = upsertById(snapshot.sessions, session, MAX_HERMES_SESSIONS);
+      return session;
+    });
+  }
+
+  override async upsertApproval(ownerId: string, approval: ApprovalPrompt): Promise<ApprovalPrompt> {
+    return await this.mutateSnapshot(ownerId, (snapshot) => {
+      snapshot.approvals = upsertById(snapshot.approvals, approval, MAX_HERMES_APPROVALS);
+      return approval;
+    });
+  }
+
+  override async appendEvent(ownerId: string, input: Omit<OperatorEvent, "id" | "createdAt"> & { id?: string; createdAt?: string }): Promise<OperatorEvent> {
+    return await this.mutateSnapshot(ownerId, (snapshot) => applyEvent(snapshot, input));
+  }
+
+  override async resolveOwnerIdForOperator(principalUserId: string): Promise<string | null> {
+    const direct = await this.db
+      .selectFrom("matrix_hermes_manager_state")
+      .select(["owner_id", "snapshot"])
+      .where("owner_id", "=", principalUserId)
+      .executeTakeFirst() as Record<string, unknown> | undefined;
+    if (direct && rowJson<HermesSnapshot>(direct, "snapshot").installation) return principalUserId;
+    const delegated = await this.db
+      .selectFrom("matrix_hermes_manager_state")
+      .select(["owner_id", "snapshot"])
+      .where(sql<boolean>`snapshot->'installation'->'authorizedOperators' ? ${principalUserId}`)
+      .orderBy("updated_at", "desc")
+      .orderBy("owner_id", "asc")
+      .executeTakeFirst() as Record<string, unknown> | undefined;
+    return delegated ? String(delegated.owner_id) : null;
+  }
+}

--- a/packages/gateway/src/hermes/routes.ts
+++ b/packages/gateway/src/hermes/routes.ts
@@ -1,0 +1,555 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { randomUUID } from "node:crypto";
+import { requestHasBody } from "../http-body.js";
+import { isRequestPrincipalError, mapRequestPrincipalError, requireRequestPrincipal, type RequestPrincipal } from "../request-principal.js";
+import { isAuthorizedHermesOperator, isHermesOwnerOnly } from "./auth.js";
+import type { HermesBridge } from "./bridge.js";
+import { HermesBridgeError } from "./bridge.js";
+import {
+  ApprovalDecisionInputSchema,
+  ChannelActionInputSchema,
+  ChannelIdParamSchema,
+  CreateSessionInputSchema,
+  EmptyBodySchema,
+  GatewayActionInputSchema,
+  HERMES_BODY_LIMIT,
+  HERMES_EMPTY_BODY_LIMIT,
+  MAX_HERMES_CAPABILITIES,
+  MAX_HERMES_CHANNELS,
+  ApprovalIdParamSchema,
+  HermesConfigInputSchema,
+  ModelCredentialInputSchema,
+  OwnerScopeQuerySchema,
+  SendPromptInputSchema,
+  SessionIdParamSchema,
+  SessionQuerySchema,
+  buildStatus,
+  defaultHermesInstallation,
+  genericHermesError,
+  publicSnapshot,
+  safeMessage,
+  type HermesCapability,
+  type HermesInstallation,
+  type HermesSession,
+  type HermesStreamEvent,
+  type MessagingChannel,
+  type OperatorEvent,
+} from "./contracts.js";
+import type { HermesCredentialStore } from "./credential-store.js";
+import type { HermesEventHub } from "./event-hub.js";
+import type { HermesRepository } from "./repository.js";
+
+export interface HermesRouteDeps {
+  repository: HermesRepository;
+  credentialStore: HermesCredentialStore;
+  bridge: HermesBridge;
+  eventHub?: HermesEventHub;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+interface ActionLockEntry {
+  token: string;
+  expiresAt: number;
+}
+
+interface ActionLockOptions {
+  maxLocks: number;
+  ttlMs: number;
+}
+
+function status(code: number): ContentfulStatusCode {
+  return code as ContentfulStatusCode;
+}
+
+async function withActionLock<T>(activeActions: Map<string, ActionLockEntry>, key: string, options: ActionLockOptions, fn: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  for (const [lockKey, entry] of activeActions) {
+    if (entry.expiresAt <= now) activeActions.delete(lockKey);
+  }
+  if (activeActions.has(key)) throw new HermesBridgeError("conflict");
+  if (activeActions.size >= options.maxLocks) throw new HermesBridgeError("unavailable");
+  const token = randomUUID();
+  activeActions.set(key, { token, expiresAt: now + options.ttlMs });
+  try {
+    return await fn();
+  } finally {
+    if (activeActions.get(key)?.token === token) activeActions.delete(key);
+  }
+}
+
+async function parseJson<T>(c: Context, schema: { safeParse: (input: unknown) => { success: true; data: T } | { success: false } }): Promise<
+  { ok: true; value: T } | { ok: false; response: Response }
+> {
+  let raw: unknown = {};
+  if (requestHasBody(c)) {
+    try {
+      raw = await c.req.json();
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "BodyLimitError") {
+        return { ok: false, response: c.json(genericHermesError("payload_too_large", "Request body is too large"), status(413)) };
+      }
+      if (!(err instanceof SyntaxError)) console.error("[hermes] Failed to parse request body:", err);
+      return { ok: false, response: c.json(genericHermesError("invalid_json", "Request body must be valid JSON"), status(400)) };
+    }
+  }
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) return { ok: false, response: c.json(genericHermesError("invalid_request", "Request body is invalid"), status(400)) };
+  return { ok: true, value: parsed.data };
+}
+
+async function withPrincipal(c: Context, deps: HermesRouteDeps, fn: (principal: RequestPrincipal) => Promise<Response>): Promise<Response> {
+  try {
+    const principal = deps.getPrincipal?.(c) ?? requireRequestPrincipal(c, { requireAuthContextReady: false });
+    return await fn(principal);
+  } catch (err: unknown) {
+    if (!isRequestPrincipalError(err)) throw err;
+    const mapped = mapRequestPrincipalError(err, "Hermes request failed");
+    if (mapped.log) console.error("[hermes] Principal resolution failed:", err);
+    return c.json(genericHermesError("unauthorized", mapped.body.error), status(mapped.status));
+  }
+}
+
+function mapError(c: Context, err: unknown): Response {
+  if (err instanceof HermesBridgeError) {
+    const code = err.code === "invalid_request" ? 400 : err.code === "not_found" ? 404 : err.code === "conflict" ? 409 : err.code === "timeout" ? 504 : err.code === "unavailable" ? 503 : 502;
+    return c.json(genericHermesError(err.code, safeMessage(err.message, "Hermes request failed")), status(code));
+  }
+  console.error("[hermes] Request failed:", err);
+  return c.json(genericHermesError(), status(500));
+}
+
+function mergeLiveChannels(storedChannels: MessagingChannel[], liveChannels: MessagingChannel[]): MessagingChannel[] {
+  const storedById = new Map(storedChannels.map((channel) => [channel.id, channel]));
+  const liveIds = new Set(liveChannels.map((channel) => channel.id));
+  const merged = liveChannels.map((live) => {
+    const stored = storedById.get(live.id);
+    if (!stored) return live;
+    const liveHasConfiguredState = live.configured || live.enabled || !["disabled", "disconnected"].includes(live.status);
+    if (liveHasConfiguredState) return { ...stored, ...live };
+    return { ...live, ...stored, lastCheckedAt: live.lastCheckedAt ?? stored.lastCheckedAt };
+  });
+  return [...merged, ...storedChannels.filter((channel) => !liveIds.has(channel.id))].slice(0, MAX_HERMES_CHANNELS);
+}
+
+function mergeLiveCapabilities(storedCapabilities: HermesCapability[], liveCapabilities: HermesCapability[]): HermesCapability[] {
+  const storedById = new Map(storedCapabilities.map((capability) => [capability.id, capability]));
+  const liveIds = new Set(liveCapabilities.map((capability) => capability.id));
+  const merged = liveCapabilities.map((live) => ({ ...(storedById.get(live.id) ?? {}), ...live }));
+  return [...merged, ...storedCapabilities.filter((capability) => !liveIds.has(capability.id))].slice(0, MAX_HERMES_CAPABILITIES);
+}
+
+function responseInstallationWithStatusPatch(existing: HermesInstallation, patch: Partial<HermesInstallation>): HermesInstallation {
+  const readiness = patch.readiness === "installed" && existing.readiness !== "missing"
+    ? existing.readiness
+    : patch.readiness ?? existing.readiness;
+  return { ...existing, ...patch, readiness };
+}
+
+function shouldPersistStatusPatch(existing: HermesInstallation, patch: Partial<HermesInstallation>): boolean {
+  if (patch.readiness && !(patch.readiness === "installed" && existing.readiness !== "missing") && patch.readiness !== existing.readiness) return true;
+  if (patch.gatewayStatus && patch.gatewayStatus !== existing.gatewayStatus) return true;
+  if (patch.version != null && patch.version !== existing.version) return true;
+  if (patch.hermesPathLabel !== undefined && patch.hermesPathLabel !== existing.hermesPathLabel) return true;
+  return false;
+}
+
+async function requireOperator(c: Context, deps: HermesRouteDeps, principal: RequestPrincipal) {
+  const ownerScope = OwnerScopeQuerySchema.safeParse(c.req.query());
+  if (!ownerScope.success) {
+    return { ok: false as const, response: c.json(genericHermesError("invalid_request", "Request query is invalid"), status(400)) };
+  }
+  const ownerId = ownerScope.data.ownerId ?? await deps.repository.resolveOwnerIdForOperator(principal.userId) ?? principal.userId;
+  const snapshot = await deps.repository.getSnapshot(ownerId);
+  if (ownerScope.data.ownerId && ownerScope.data.ownerId !== principal.userId && !snapshot.installation) {
+    return { ok: false as const, response: c.json(genericHermesError("unauthorized", "Unauthorized"), status(401)) };
+  }
+  if (!isAuthorizedHermesOperator(principal, snapshot.installation)) {
+    return { ok: false as const, response: c.json(genericHermesError("unauthorized", "Unauthorized"), status(401)) };
+  }
+  return { ok: true as const, ownerId, snapshot };
+}
+
+async function requireOwner(c: Context, deps: HermesRouteDeps, principal: RequestPrincipal) {
+  const auth = await requireOperator(c, deps, principal);
+  if (!auth.ok) return auth;
+  if (!isHermesOwnerOnly(principal, auth.snapshot.installation)) {
+    return { ok: false as const, response: c.json(genericHermesError("unauthorized", "Unauthorized"), status(401)) };
+  }
+  return auth;
+}
+
+async function appendOperatorEvent(deps: HermesRouteDeps, ownerId: string, input: Omit<OperatorEvent, "id" | "createdAt"> & { id?: string; createdAt?: string }) {
+  const event = await deps.repository.appendEvent(ownerId, input);
+  await deps.eventHub?.publish(ownerId, {
+    type: "operator.event",
+    installationId: event.installationId,
+    payload: { category: event.category, severity: event.severity, message: event.message, targetId: event.targetId },
+  });
+  return event;
+}
+
+export function createHermesRoutes(deps: HermesRouteDeps) {
+  const app = new Hono();
+  const limited = bodyLimit({ maxSize: HERMES_BODY_LIMIT });
+  const emptyLimited = bodyLimit({ maxSize: HERMES_EMPTY_BODY_LIMIT });
+  const activeActions = new Map<string, ActionLockEntry>();
+  const actionLockOptions: ActionLockOptions = { maxLocks: 500, ttlMs: 60_000 };
+
+  app.get("/status", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    try {
+      const patch = await deps.bridge.getStatus({ ownerId: auth.ownerId, installation: auth.snapshot.installation });
+      if (auth.snapshot.installation && shouldPersistStatusPatch(auth.snapshot.installation, patch)) {
+        await deps.repository.applyInstallationPatch(auth.ownerId, patch);
+        return c.json(buildStatus(await deps.repository.getSnapshot(auth.ownerId)));
+      }
+      const snapshot = auth.snapshot.installation
+        ? { ...auth.snapshot, installation: responseInstallationWithStatusPatch(auth.snapshot.installation, patch) }
+        : auth.snapshot;
+      return c.json(buildStatus(snapshot));
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.get("/config", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    return c.json(publicSnapshot(auth.snapshot));
+  }));
+
+  app.post("/config", limited, (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOwner(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const parsed = await parseJson(c, HermesConfigInputSchema);
+    if (!parsed.ok) return parsed.response;
+    try {
+      const result = await deps.bridge.saveConfig({ ownerId: auth.ownerId, installation: auth.snapshot.installation, config: parsed.value });
+      await deps.repository.saveConfig(auth.ownerId, parsed.value, principal.userId, result.patch);
+      result.activate();
+      await appendOperatorEvent(deps, auth.ownerId, {
+        installationId: auth.snapshot.installation?.id ?? defaultHermesInstallation(auth.ownerId).id,
+        actorId: principal.userId,
+        category: "setup",
+        severity: "info",
+        message: "Hermes configuration updated",
+      });
+      return c.json(publicSnapshot(await deps.repository.getSnapshot(auth.ownerId)));
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.post("/credentials/model", limited, (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOwner(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const parsed = await parseJson(c, ModelCredentialInputSchema);
+    if (!parsed.ok) return parsed.response;
+    try {
+      const provider = await withActionLock(activeActions, `${auth.ownerId}:credential:${parsed.value.providerId}`, actionLockOptions, async () => {
+        const currentSnapshot = await deps.repository.getSnapshot(auth.ownerId);
+        const savedProvider = await deps.bridge.saveModelCredential({ ownerId: auth.ownerId, installation: currentSnapshot.installation, credential: parsed.value });
+        await deps.credentialStore.writeModelCredential(auth.ownerId, parsed.value.providerId, parsed.value.secret);
+        return await deps.repository.setModelCredentialConfigured(auth.ownerId, savedProvider, principal.userId);
+      });
+      await appendOperatorEvent(deps, auth.ownerId, {
+        installationId: auth.snapshot.installation?.id ?? defaultHermesInstallation(auth.ownerId).id,
+        actorId: principal.userId,
+        category: "credential",
+        severity: "info",
+        message: "Model credential updated",
+        targetId: parsed.value.providerId,
+      });
+      return c.json({ configured: provider.configured, providerId: provider.id, status: provider.status });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.get("/channels", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    try {
+      const liveChannels = await deps.bridge.listChannels({ ownerId: auth.ownerId, installation: auth.snapshot.installation });
+      return c.json({ channels: mergeLiveChannels(auth.snapshot.channels, liveChannels) });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.post("/channels/:channelId/action", limited, (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const params = ChannelIdParamSchema.safeParse({ channelId: c.req.param("channelId") });
+    if (!params.success) return c.json(genericHermesError("invalid_request", "Request path is invalid"), status(400));
+    const parsed = await parseJson(c, ChannelActionInputSchema);
+    if (!parsed.ok) return parsed.response;
+    try {
+      const saved = await withActionLock(activeActions, `${auth.ownerId}:channel:${params.data.channelId}`, actionLockOptions, async () => {
+        const currentSnapshot = await deps.repository.getSnapshot(auth.ownerId);
+        const result = await deps.bridge.runChannelAction({ ownerId: auth.ownerId, installation: currentSnapshot.installation, channelId: params.data.channelId, action: parsed.value });
+        const channel = await deps.repository.upsertChannel(auth.ownerId, result.channel, principal.userId);
+        return { channel, pairing: result.pairing };
+      });
+      await deps.eventHub?.publish(auth.ownerId, {
+        type: "channel.updated",
+        installationId: auth.snapshot.installation?.id,
+        payload: {
+          id: saved.channel.id,
+          platform: saved.channel.platform,
+          status: saved.channel.status,
+          enabled: saved.channel.enabled,
+          configured: saved.channel.configured,
+          allowedSenderPolicy: saved.channel.allowedSenderPolicy,
+          lastCheckedAt: saved.channel.lastCheckedAt,
+          updatedAt: saved.channel.updatedAt,
+          pairing: saved.pairing,
+        },
+      });
+      return c.json({
+        channel: saved.channel,
+        operation: { id: `op_${randomUUID()}`, status: "complete", message: "Channel updated", pairing: saved.pairing },
+      });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.get("/sessions", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const query = SessionQuerySchema.safeParse(c.req.query());
+    if (!query.success) return c.json(genericHermesError("invalid_request", "Request query is invalid"), status(400));
+    const filteredSessions = auth.snapshot.sessions
+      .filter((session) => !query.data.status || session.status === query.data.status);
+    const unfilteredIndex = query.data.cursor ? auth.snapshot.sessions.findIndex((session) => session.id === query.data.cursor) : -1;
+    if (query.data.cursor && unfilteredIndex < 0) return c.json(genericHermesError("invalid_request", "Cursor not found"), status(400));
+    const cursorIndex = query.data.cursor ? filteredSessions.findIndex((session) => session.id === query.data.cursor) : -1;
+    if (query.data.cursor && cursorIndex < 0) return c.json(genericHermesError("invalid_request", "Cursor is outside the filtered result"), status(400));
+    const startIndex = cursorIndex >= 0 ? cursorIndex + 1 : 0;
+    const sessions = filteredSessions.slice(startIndex, startIndex + query.data.limit);
+    const nextCursor = startIndex + query.data.limit < filteredSessions.length ? sessions.at(-1)?.id ?? null : null;
+    return c.json({ sessions, nextCursor });
+  }));
+
+  app.post("/sessions", limited, (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const parsed = await parseJson(c, CreateSessionInputSchema);
+    if (!parsed.ok) return parsed.response;
+    try {
+      const existing = auth.snapshot.sessions.find((session) => session.clientRequestIds?.includes(parsed.value.clientRequestId));
+      if (existing) return c.json({ session: existing });
+      const saved = await withActionLock(activeActions, `${auth.ownerId}:session-create:${parsed.value.clientRequestId}`, actionLockOptions, async () => {
+        const current = await deps.repository.getSnapshot(auth.ownerId);
+        const duplicate = current.sessions.find((session) => session.clientRequestIds?.includes(parsed.value.clientRequestId));
+        if (duplicate) return duplicate;
+        const session = await deps.bridge.createSession({ ownerId: auth.ownerId, installation: current.installation, operatorId: principal.userId, payload: parsed.value });
+        return await deps.repository.upsertSession(auth.ownerId, { ...session, clientRequestIds: [parsed.value.clientRequestId] });
+      });
+      await deps.eventHub?.publish(auth.ownerId, { type: "session.event", installationId: saved.installationId, sessionId: saved.id, payload: { kind: "session_status", status: saved.status } });
+      return c.json({ session: saved });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.post("/sessions/:sessionId/prompt", limited, (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const params = SessionIdParamSchema.safeParse({ sessionId: c.req.param("sessionId") });
+    if (!params.success) return c.json(genericHermesError("invalid_request", "Request path is invalid"), status(400));
+    const parsed = await parseJson(c, SendPromptInputSchema);
+    if (!parsed.ok) return parsed.response;
+    try {
+      const session = await deps.repository.getSession(auth.ownerId, params.data.sessionId);
+      if (!session) return c.json(genericHermesError("not_found", "Session not found"), status(404));
+      if (parsed.value.clientRequestId && session.clientRequestIds?.includes(parsed.value.clientRequestId)) return c.json({ session });
+      const updated = await withActionLock(activeActions, `${auth.ownerId}:session:${session.id}`, actionLockOptions, async () => {
+        const currentSnapshot = await deps.repository.getSnapshot(auth.ownerId);
+        const current = currentSnapshot.sessions.find((item) => item.id === session.id);
+        if (!current) throw new HermesBridgeError("operation_failed");
+        if (parsed.value.clientRequestId && current.clientRequestIds?.includes(parsed.value.clientRequestId)) return current;
+        const next = await deps.bridge.sendPrompt({ ownerId: auth.ownerId, installation: currentSnapshot.installation, operatorId: principal.userId, session: current, payload: parsed.value });
+        const clientRequestIds = parsed.value.clientRequestId
+          ? [...(current.clientRequestIds ?? []), parsed.value.clientRequestId].slice(-50)
+          : current.clientRequestIds;
+        return await deps.repository.upsertSession(auth.ownerId, { ...next, clientRequestIds });
+      });
+      await deps.eventHub?.publish(auth.ownerId, { type: "session.event", installationId: updated.installationId, sessionId: updated.id, payload: { kind: "session_status", status: updated.status } });
+      return c.json({ session: updated });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.post("/approvals/:approvalId/decision", limited, (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const params = ApprovalIdParamSchema.safeParse({ approvalId: c.req.param("approvalId") });
+    if (!params.success) return c.json(genericHermesError("invalid_request", "Request path is invalid"), status(400));
+    const parsed = await parseJson(c, ApprovalDecisionInputSchema);
+    if (!parsed.ok) return parsed.response;
+    try {
+      const updated = await withActionLock(activeActions, `${auth.ownerId}:approval:${params.data.approvalId}`, actionLockOptions, async () => {
+        const currentSnapshot = await deps.repository.getSnapshot(auth.ownerId);
+        const approval = currentSnapshot.approvals.find((item) => item.id === params.data.approvalId);
+        if (!approval) throw new HermesBridgeError("not_found", "Approval not found");
+        if (approval.status !== "pending") throw new HermesBridgeError("conflict", "Approval is no longer pending");
+        const decided = await deps.bridge.decideApproval({ ownerId: auth.ownerId, installation: currentSnapshot.installation, operatorId: principal.userId, approval, payload: parsed.value });
+        return await deps.repository.upsertApproval(auth.ownerId, decided);
+      });
+      await deps.eventHub?.publish(auth.ownerId, { type: "approval.updated", installationId: auth.snapshot.installation?.id, sessionId: updated.sessionId, payload: { approvalId: updated.id, status: updated.status } });
+      return c.json({ approval: updated });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.get("/capabilities", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    try {
+      const capabilities = await deps.bridge.listCapabilities({ ownerId: auth.ownerId, installation: auth.snapshot.installation });
+      return c.json({ capabilities: mergeLiveCapabilities(auth.snapshot.capabilities, capabilities) });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.post("/gateway/action", limited, (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOwner(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const parsed = await parseJson(c, GatewayActionInputSchema);
+    if (!parsed.ok) return parsed.response;
+    try {
+      const { operation, installation } = await withActionLock(activeActions, `${auth.ownerId}:gateway`, actionLockOptions, async () => {
+        const currentSnapshot = await deps.repository.getSnapshot(auth.ownerId);
+        const result = await deps.bridge.runGatewayAction({ ownerId: auth.ownerId, installation: currentSnapshot.installation, action: parsed.value });
+        if (currentSnapshot.installation && result.patch) {
+          await deps.repository.applyInstallationPatch(auth.ownerId, result.patch);
+        }
+        return { operation: result, installation: currentSnapshot.installation };
+      });
+      await appendOperatorEvent(deps, auth.ownerId, {
+        installationId: installation?.id ?? defaultHermesInstallation(auth.ownerId).id,
+        actorId: principal.userId,
+        category: parsed.value.type === "update" ? "update" : "gateway",
+        severity: "info",
+        message: "Gateway action accepted",
+      });
+      return c.json({ operation });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.get("/audit", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    return c.json({ events: auth.snapshot.events });
+  }));
+
+  app.get("/export", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOwner(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    return c.json(publicSnapshot(auth.snapshot));
+  }));
+
+  app.post("/recover", emptyLimited, (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOwner(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    const parsed = await parseJson(c, EmptyBodySchema);
+    if (!parsed.ok) return parsed.response;
+    try {
+      const result = await withActionLock(activeActions, `${auth.ownerId}:recover`, actionLockOptions, async () => {
+        const currentSnapshot = await deps.repository.getSnapshot(auth.ownerId);
+        return deps.bridge.recover({ ownerId: auth.ownerId, installation: currentSnapshot.installation });
+      });
+      await appendOperatorEvent(deps, auth.ownerId, {
+        installationId: auth.snapshot.installation?.id ?? defaultHermesInstallation(auth.ownerId).id,
+        actorId: principal.userId,
+        category: "recovery",
+        severity: "info",
+        message: "Recovery completed",
+      });
+      return c.json({ recovery: result });
+    } catch (err: unknown) {
+      return mapError(c, err);
+    }
+  }));
+
+  app.get("/events", (c) => withPrincipal(c, deps, async (principal) => {
+    const auth = await requireOperator(c, deps, principal);
+    if (!auth.ok) return auth.response;
+    let subscriberId: string | null = null;
+    let heartbeat: ReturnType<typeof setInterval> | null = null;
+    const stream = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        subscriberId = `sub_${randomUUID()}`;
+        let streamClosed = false;
+        const cleanup = () => {
+          if (heartbeat) {
+            clearInterval(heartbeat);
+            heartbeat = null;
+          }
+          if (subscriberId) {
+            deps.eventHub?.unsubscribe(subscriberId);
+            subscriberId = null;
+          }
+        };
+        const closeController = () => {
+          if (streamClosed) return;
+          streamClosed = true;
+          try {
+            controller.close();
+          } catch (err: unknown) {
+            console.warn("[hermes] SSE close failed:", err instanceof Error ? err.message : String(err));
+          }
+        };
+        const send = (event: HermesStreamEvent) => {
+          controller.enqueue(encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
+        };
+        for (const event of deps.eventHub?.retained(auth.ownerId) ?? []) send(event);
+        deps.eventHub?.subscribe({
+          id: subscriberId,
+          ownerId: auth.ownerId,
+          send,
+          close: () => {
+            cleanup();
+            closeController();
+          },
+        });
+        heartbeat = setInterval(() => {
+          if (subscriberId) deps.eventHub?.touch(subscriberId);
+          try {
+            send({ type: "heartbeat", id: `hb_${randomUUID()}`, createdAt: new Date().toISOString(), payload: {} });
+          } catch (err: unknown) {
+            console.warn("[hermes] SSE heartbeat failed:", err instanceof Error ? err.message : String(err));
+            cleanup();
+            closeController();
+          }
+        }, 30_000);
+      },
+      cancel() {
+        if (heartbeat) {
+          clearInterval(heartbeat);
+          heartbeat = null;
+        }
+        if (subscriberId) {
+          deps.eventHub?.unsubscribe(subscriberId);
+          subscriberId = null;
+        }
+      },
+    });
+    return new Response(stream, {
+      headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-store", Connection: "keep-alive" },
+    });
+  }));
+
+  return app;
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -115,6 +115,15 @@ export { createSymphonyRunner, SymphonyConfigSchema, SymphonyConfigUpdateSchema,
 export type { SymphonyConfig, SymphonyConfigUpdate, SymphonyStatus, SymphonyStartResult } from "./symphony-runner.js";
 export { createSymphonyRoutes } from "./symphony-routes.js";
 export * from "./symphony/index.js";
+export {
+  createFileHermesCredentialStore,
+  createHermesEventHub,
+  createHermesRoutes,
+  createLocalHermesBridge,
+  InMemoryHermesRepository,
+  KyselyHermesRepository,
+} from "./hermes/index.js";
+export type { HermesBridge, HermesCredentialStore, HermesEventHub, HermesRepository } from "./hermes/index.js";
 export { createConversationStore } from "./conversations.js";
 export type { ConversationStore, ConversationFile, ConversationMeta, SearchResult } from "./conversations.js";
 export { createApprovalBridge } from "./approval.js";

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -35,6 +35,7 @@ import { createLinearSource } from "./symphony/linear-source.js";
 import { createMatrixSymphonyOrchestrator } from "./symphony/orchestrator.js";
 import { KyselySymphonyRepository } from "./symphony/repository.js";
 import { createSymphonyStatusHub } from "./symphony/status-hub.js";
+import { createFileHermesCredentialStore, createHermesEventHub, createHermesRoutes, createLocalHermesBridge, KyselyHermesRepository, type HermesEventHub } from "./hermes/index.js";
 import { createZellijRuntime } from "./zellij-runtime.js";
 import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import { createWorkspaceStartupRecovery } from "./workspace-startup-recovery.js";
@@ -443,6 +444,7 @@ export async function createGateway(config: GatewayConfig) {
   let canvasSubscriptionHub: CanvasSubscriptionHub | null = null;
   let canvasCleanupTimer: ReturnType<typeof setInterval> | null = null;
   let messagingRepository: MessagingKyselyRepository | null = null;
+  let hermesEventHub: HermesEventHub | null = null;
 
   if (databaseUrl) {
     try {
@@ -2434,6 +2436,24 @@ export async function createGateway(config: GatewayConfig) {
     unavailable.all("*", (c) => c.json({ error: { code: "symphony_unavailable", message: "Symphony is unavailable" } }, 503));
     app.route("/api/symphony", unavailable);
   }
+  if (kyselyInstance) {
+    const hermesRepository = new KyselyHermesRepository(kyselyInstance as Kysely<any>);
+    await hermesRepository.bootstrap();
+    const hermesCredentialStore = createFileHermesCredentialStore({ homePath });
+    hermesEventHub = createHermesEventHub();
+    const hermesBridge = createLocalHermesBridge({ homePath });
+    app.route("/api/hermes", createHermesRoutes({
+      repository: hermesRepository,
+      credentialStore: hermesCredentialStore,
+      bridge: hermesBridge,
+      eventHub: hermesEventHub,
+    }));
+  } else {
+    console.warn("[hermes] Hermes Manager requires owner Postgres; routes are disabled");
+    const unavailable = new Hono();
+    unavailable.all("*", (c) => c.json({ error: { code: "hermes_unavailable", message: "Hermes is unavailable" } }, 503));
+    app.route("/api/hermes", unavailable);
+  }
   const workspaceStartupRecovery = await createWorkspaceStartupRecovery({ homePath }).run();
   if (workspaceStartupRecovery.status === "degraded") {
     console.warn("[gateway] Workspace startup recovery completed with degraded steps");
@@ -3830,6 +3850,7 @@ export async function createGateway(config: GatewayConfig) {
       cronService.stop();
       if (canvasCleanupTimer) clearInterval(canvasCleanupTimer);
       canvasSubscriptionHub?.close();
+      await hermesEventHub?.close();
       await channelManager.stop();
       await processManager.shutdownAll();
       await matrixSymphonyOrchestrator?.shutdown();

--- a/tests/gateway/hermes-bridge.test.ts
+++ b/tests/gateway/hermes-bridge.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createLocalHermesBridge } from "../../packages/gateway/src/hermes/bridge.js";
+import { defaultHermesInstallation } from "../../packages/gateway/src/hermes/contracts.js";
+
+describe("Hermes bridge", () => {
+  it("reports missing Hermes without exposing raw paths", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-bridge-"));
+    const bridge = createLocalHermesBridge({ homePath, hermesPath: join(homePath, "missing-hermes") });
+
+    const status = await bridge.getStatus({ ownerId: "user_123", installation: null });
+
+    expect(status).toMatchObject({ readiness: "missing", hermesPathLabel: "missing-hermes" });
+    expect(status.gatewayStatus).toBeUndefined();
+    expect(JSON.stringify(status)).not.toContain(homePath);
+  });
+
+  it("returns redacted channel action results for Telegram and WhatsApp", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-bridge-"));
+    const bridge = createLocalHermesBridge({ homePath, hermesPath: join(homePath, "missing-hermes") });
+
+    await expect(bridge.runChannelAction({ ownerId: "user_123", installation: null, channelId: "telegram", action: { type: "connect", payload: {} } }))
+      .resolves.toMatchObject({ channel: { id: "telegram", status: "connected", enabled: true } });
+    await expect(bridge.runChannelAction({ ownerId: "user_123", installation: null, channelId: "whatsapp", action: { type: "start_pairing", payload: {} } }))
+      .resolves.toMatchObject({ channel: { id: "whatsapp", status: "pairing", configured: true }, pairing: { kind: "code", displayValue: "PAIR-HERMES" } });
+  });
+
+  it("uses the validated custom Hermes path for follow-up CLI status checks", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-bridge-"));
+    const customHermesPath = join(homePath, "system", "hermes", "custom");
+    await mkdir(customHermesPath, { recursive: true });
+    await writeFile(join(customHermesPath, "cli.py"), "print('custom-hermes 1.2.3')\n");
+    const bridge = createLocalHermesBridge({ homePath, hermesPath: join(homePath, "missing-hermes") });
+
+    const saved = await bridge.saveConfig({
+      ownerId: "user_123",
+      installation: null,
+      config: {
+        homeMode: "custom",
+        hermesPath: customHermesPath,
+        defaultProfileId: "default",
+        authorizedOperators: [],
+      },
+    });
+    const beforeActivation = await bridge.getStatus({ ownerId: "user_123", installation: null });
+    saved.activate();
+    const status = await bridge.getStatus({ ownerId: "user_123", installation: null });
+
+    expect(saved.patch).toMatchObject({ hermesPathLabel: "custom" });
+    expect(saved.patch.readiness).toBeUndefined();
+    expect(beforeActivation).toMatchObject({ readiness: "missing", hermesPathLabel: "missing-hermes" });
+    expect(beforeActivation.gatewayStatus).toBeUndefined();
+    expect(status).toMatchObject({ readiness: "installed", hermesPathLabel: "custom", version: "custom-hermes 1.2.3" });
+    expect(status.gatewayStatus).toBeUndefined();
+    expect(JSON.stringify(status)).not.toContain(homePath);
+  });
+
+  it("does not emit installed readiness when an existing installation is already ready", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-bridge-"));
+    await writeFile(join(homePath, "cli.py"), "print('ready-hermes 1.0.0')\n");
+    const bridge = createLocalHermesBridge({ homePath, hermesPath: homePath });
+    const installation = { ...defaultHermesInstallation("user_123"), readiness: "ready" as const };
+
+    const status = await bridge.getStatus({ ownerId: "user_123", installation });
+
+    expect(status.readiness).toBeUndefined();
+    expect(status.version).toBe("ready-hermes 1.0.0");
+  });
+
+  it("keeps custom Hermes paths scoped per owner", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-bridge-"));
+    const ownerAPath = join(homePath, "system", "hermes", "owner-a");
+    const ownerBPath = join(homePath, "system", "hermes", "owner-b");
+    await mkdir(ownerAPath, { recursive: true });
+    await mkdir(ownerBPath, { recursive: true });
+    await writeFile(join(ownerAPath, "cli.py"), "print('owner-a 1.0.0')\n");
+    await writeFile(join(ownerBPath, "cli.py"), "print('owner-b 1.0.0')\n");
+    const bridge = createLocalHermesBridge({ homePath, hermesPath: join(homePath, "missing-hermes") });
+
+    const ownerA = await bridge.saveConfig({
+      ownerId: "user_a",
+      installation: null,
+      config: { homeMode: "custom", hermesPath: ownerAPath, defaultProfileId: "default", authorizedOperators: [] },
+    });
+    ownerA.activate();
+    const ownerB = await bridge.saveConfig({
+      ownerId: "user_b",
+      installation: null,
+      config: { homeMode: "custom", hermesPath: ownerBPath, defaultProfileId: "default", authorizedOperators: [] },
+    });
+    ownerB.activate();
+
+    await expect(bridge.getStatus({ ownerId: "user_a", installation: null }))
+      .resolves.toMatchObject({ hermesPathLabel: "owner-a", version: "owner-a 1.0.0" });
+    await expect(bridge.getStatus({ ownerId: "user_b", installation: null }))
+      .resolves.toMatchObject({ hermesPathLabel: "owner-b", version: "owner-b 1.0.0" });
+  });
+
+  it("restores owner-home custom Hermes paths from persisted installation labels after restart", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-bridge-"));
+    const customHermesPath = join(homePath, "system", "hermes", "custom");
+    await mkdir(customHermesPath, { recursive: true });
+    await writeFile(join(customHermesPath, "cli.py"), "print('restored 1.0.0')\n");
+    const first = createLocalHermesBridge({ homePath, hermesPath: join(homePath, "missing-hermes") });
+    const saved = await first.saveConfig({
+      ownerId: "user_123",
+      installation: null,
+      config: { homeMode: "custom", hermesPath: customHermesPath, defaultProfileId: "default", authorizedOperators: [] },
+    });
+    const restarted = createLocalHermesBridge({ homePath, hermesPath: join(homePath, "missing-hermes") });
+    const installation = {
+      ...defaultHermesInstallation("user_123"),
+      homeMode: "custom" as const,
+      hermesPathLabel: saved.patch.hermesPathLabel ?? null,
+    };
+
+    await expect(restarted.getStatus({ ownerId: "user_123", installation }))
+      .resolves.toMatchObject({ readiness: "installed", hermesPathLabel: "custom", version: "restored 1.0.0" });
+  });
+
+  it("restores owner-home custom paths even when their label matches the default path", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-bridge-"));
+    const defaultHermesPath = join(homePath, "default-root", "custom");
+    const customHermesPath = join(homePath, "system", "hermes", "custom");
+    await mkdir(defaultHermesPath, { recursive: true });
+    await mkdir(customHermesPath, { recursive: true });
+    await writeFile(join(defaultHermesPath, "cli.py"), "print('default 1.0.0')\n");
+    await writeFile(join(customHermesPath, "cli.py"), "print('owner 1.0.0')\n");
+    const restarted = createLocalHermesBridge({ homePath, hermesPath: defaultHermesPath });
+    const installation = {
+      ...defaultHermesInstallation("user_123"),
+      homeMode: "custom" as const,
+      hermesPathLabel: "custom",
+    };
+
+    await expect(restarted.getStatus({ ownerId: "user_123", installation }))
+      .resolves.toMatchObject({ readiness: "installed", hermesPathLabel: "custom", version: "owner 1.0.0" });
+  });
+
+  it("normalizes the configured default Hermes root to default mode", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-bridge-"));
+    const externalHermesPath = await mkdtemp(join(tmpdir(), "matrix-hermes-external-"));
+    await writeFile(join(externalHermesPath, "cli.py"), "print('external 1.0.0')\n");
+    const first = createLocalHermesBridge({ homePath, hermesPath: externalHermesPath });
+    const saved = await first.saveConfig({
+      ownerId: "user_123",
+      installation: null,
+      config: { homeMode: "custom", hermesPath: externalHermesPath, defaultProfileId: "default", authorizedOperators: [] },
+    });
+    const restarted = createLocalHermesBridge({ homePath, hermesPath: externalHermesPath });
+    const installation = { ...defaultHermesInstallation("user_123"), ...saved.patch };
+
+    const status = await restarted.getStatus({ ownerId: "user_123", installation });
+
+    expect(saved.patch).toMatchObject({ homeMode: "default", hermesPathLabel: null });
+    expect(status).toMatchObject({ readiness: "installed", version: "external 1.0.0" });
+    expect(status.hermesPathLabel).toContain("matrix-hermes-external-");
+  });
+});

--- a/tests/gateway/hermes-credential-store.test.ts
+++ b/tests/gateway/hermes-credential-store.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readdir, stat } from "node:fs/promises";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFileHermesCredentialStore } from "../../packages/gateway/src/hermes/credential-store.js";
+
+describe("Hermes credential store", () => {
+  let homePath: string;
+
+  beforeEach(async () => {
+    homePath = await mkdtemp(join(tmpdir(), "matrix-hermes-credentials-"));
+  });
+
+  afterEach(() => {
+    rmSync(homePath, { recursive: true, force: true });
+  });
+
+  it("stores model credentials server-side with owner-only permissions", async () => {
+    const store = createFileHermesCredentialStore({ homePath });
+
+    await store.writeModelCredential("user_123", "anthropic", "model_secret");
+
+    await expect(store.hasModelCredential("user_123", "anthropic")).resolves.toBe(true);
+    await expect(store.readModelCredential("user_123", "anthropic")).resolves.toBe("model_secret");
+    const credentialDir = join(homePath, "system", "hermes-manager", "credentials");
+    const [credentialFile] = await readdir(credentialDir);
+    const file = await stat(join(credentialDir, credentialFile));
+    expect(file.mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects unsafe owner ids before touching the filesystem", async () => {
+    const store = createFileHermesCredentialStore({ homePath });
+
+    await expect(store.writeModelCredential("../other", "anthropic", "secret")).rejects.toThrow("Invalid owner identifier");
+  });
+
+  it("keeps owner and provider identifiers collision-safe", async () => {
+    const store = createFileHermesCredentialStore({ homePath });
+
+    await store.writeModelCredential("a.b", "c", "first_secret");
+    await store.writeModelCredential("a", "b.c", "second_secret");
+
+    await expect(store.readModelCredential("a.b", "c")).resolves.toBe("first_secret");
+    await expect(store.readModelCredential("a", "b.c")).resolves.toBe("second_secret");
+  });
+
+  it("keeps credential filenames bounded for long Matrix identifiers", async () => {
+    const store = createFileHermesCredentialStore({ homePath });
+    const ownerId = `@${"a".repeat(250)}:m`;
+    const providerId = "p".repeat(128);
+
+    await store.writeModelCredential(ownerId, providerId, "long_secret");
+
+    await expect(store.readModelCredential(ownerId, providerId)).resolves.toBe("long_secret");
+    const credentialDir = join(homePath, "system", "hermes-manager", "credentials");
+    const [credentialFile] = await readdir(credentialDir);
+    expect(Buffer.byteLength(credentialFile, "utf8")).toBeLessThanOrEqual(255);
+  });
+});

--- a/tests/gateway/hermes-event-hub.test.ts
+++ b/tests/gateway/hermes-event-hub.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHermesEventHub } from "../../packages/gateway/src/hermes/event-hub.js";
+
+describe("Hermes event hub", () => {
+  it("caps subscribers and closes the oldest entry", () => {
+    const closeA = vi.fn();
+    const hub = createHermesEventHub({ maxSubscribers: 2 });
+
+    hub.subscribe({ id: "a", ownerId: "user_1", send: vi.fn(), close: closeA });
+    hub.subscribe({ id: "b", ownerId: "user_1", send: vi.fn() });
+    hub.subscribe({ id: "c", ownerId: "user_1", send: vi.fn() });
+
+    expect(closeA).toHaveBeenCalledOnce();
+    expect(hub.size()).toBe(2);
+  });
+
+  it("isolates failed sends and keeps retained events bounded", async () => {
+    const failing = vi.fn(async () => {
+      throw new Error("closed");
+    });
+    const closeFailing = vi.fn();
+    const healthy = vi.fn();
+    const hub = createHermesEventHub({ maxEvents: 1 });
+    hub.subscribe({ id: "a", ownerId: "user_1", send: failing, close: closeFailing });
+    hub.subscribe({ id: "b", ownerId: "user_1", send: healthy });
+
+    await hub.publish("user_1", { type: "operator.event", payload: { message: "one" } });
+    await hub.publish("user_1", { type: "operator.event", payload: { message: "two" } });
+
+    expect(failing).toHaveBeenCalledOnce();
+    expect(closeFailing).toHaveBeenCalledOnce();
+    expect(healthy).toHaveBeenCalledTimes(2);
+    expect(hub.size()).toBe(1);
+    expect(hub.retained("user_1")).toHaveLength(1);
+  });
+
+  it("continues failed-subscriber cleanup when close throws", async () => {
+    const failingSend = vi.fn(async () => {
+      throw new Error("send failed");
+    });
+    const throwingClose = vi.fn(async () => {
+      throw new Error("close failed");
+    });
+    const laterClose = vi.fn();
+    const hub = createHermesEventHub();
+    hub.subscribe({ id: "a", ownerId: "user_1", send: failingSend, close: throwingClose });
+    hub.subscribe({ id: "b", ownerId: "user_1", send: failingSend, close: laterClose });
+
+    await expect(hub.publish("user_1", { type: "operator.event", payload: { message: "one" } })).resolves.toMatchObject({ type: "operator.event" });
+
+    expect(throwingClose).toHaveBeenCalledOnce();
+    expect(laterClose).toHaveBeenCalledOnce();
+    expect(hub.size()).toBe(0);
+  });
+
+  it("caps retained owner buckets", async () => {
+    const hub = createHermesEventHub({ maxEvents: 2, maxRetainedOwners: 1 });
+
+    await hub.publish("user_1", { type: "operator.event", payload: { message: "one" } });
+    await hub.publish("user_2", { type: "operator.event", payload: { message: "two" } });
+
+    expect(hub.retained("user_1")).toEqual([]);
+    expect(hub.retained("user_2")).toHaveLength(1);
+  });
+});

--- a/tests/gateway/hermes-routes.test.ts
+++ b/tests/gateway/hermes-routes.test.ts
@@ -1,0 +1,847 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHermesRoutes } from "../../packages/gateway/src/hermes/routes.js";
+import { InMemoryHermesRepository } from "../../packages/gateway/src/hermes/repository.js";
+import { createHermesEventHub } from "../../packages/gateway/src/hermes/event-hub.js";
+import type { HermesBridge } from "../../packages/gateway/src/hermes/bridge.js";
+import type { HermesCredentialStore } from "../../packages/gateway/src/hermes/credential-store.js";
+import { MAX_HERMES_APPROVALS, MAX_HERMES_MODEL_PROVIDERS, redactLabel } from "../../packages/gateway/src/hermes/contracts.js";
+
+function jsonRequest(path: string, method: "POST", body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function deps(userId = "user_123") {
+  const repository = new InMemoryHermesRepository();
+  const eventHub = createHermesEventHub();
+  const credentialStore: HermesCredentialStore = {
+    hasModelCredential: vi.fn(async () => false),
+    readModelCredential: vi.fn(async () => null),
+    writeModelCredential: vi.fn(async () => undefined),
+    deleteModelCredential: vi.fn(async () => undefined),
+    publicMetadata: vi.fn(async (_ownerId, providerId) => ({ configured: false, providerId })),
+  };
+  const bridge: HermesBridge = {
+    getStatus: vi.fn(async () => ({ readiness: "installed", version: "test", lastCheckedAt: "2026-05-15T00:00:00.000Z" })),
+    saveConfig: vi.fn(async ({ config }) => ({
+      patch: { hermesPathLabel: config.homeMode === "default" ? null : config.homeMode === "custom" ? redactLabel(config.hermesPath) : undefined, lastCheckedAt: "2026-05-15T00:00:00.000Z" },
+      activate: vi.fn(),
+    })),
+    saveModelCredential: vi.fn(async ({ credential }) => ({ id: credential.providerId, configured: true, status: "healthy", availableModels: [], lastCheckedAt: "2026-05-15T00:00:00.000Z" })),
+    listChannels: vi.fn(async () => []),
+    runChannelAction: vi.fn(async ({ channelId, action }) => ({
+      channel: { id: channelId, platform: channelId, enabled: true, configured: true, status: action.type === "start_pairing" ? "pairing" : "connected", allowedSenderPolicy: "Configured", lastCheckedAt: "2026-05-15T00:00:00.000Z", updatedAt: "2026-05-15T00:00:00.000Z" },
+      pairing: action.type === "start_pairing" ? { kind: "code", displayValue: "PAIR-HERMES", expiresAt: "2026-05-15T00:05:00.000Z" } : undefined,
+    })),
+    listCapabilities: vi.fn(async () => []),
+    runGatewayAction: vi.fn(async () => ({ id: "op_1", status: "complete", message: "Gateway action accepted", patch: { gatewayStatus: "healthy" } })),
+    createSession: vi.fn(async ({ ownerId, operatorId, installation, payload }) => ({ id: "ses_1", hermesSessionId: "hermes_1", installationId: installation?.id ?? "hermes_user_123", ownerId, operatorId, profileId: payload.profileId, modelId: payload.modelId, status: "streaming", eventCount: 1, createdAt: "2026-05-15T00:00:00.000Z", updatedAt: "2026-05-15T00:00:00.000Z", lastActiveAt: "2026-05-15T00:00:00.000Z" })),
+    sendPrompt: vi.fn(async ({ session }) => ({ ...session, eventCount: session.eventCount + 1 })),
+    decideApproval: vi.fn(async ({ approval, operatorId, payload }) => ({ ...approval, status: payload.decision, decisionBy: operatorId, decisionAt: "2026-05-15T00:00:00.000Z" })),
+    recover: vi.fn(async () => ({ status: "complete", message: "Recovery completed" })),
+  };
+  return {
+    app: createHermesRoutes({
+      repository,
+      credentialStore,
+      bridge,
+      eventHub,
+      getPrincipal: () => ({ userId, source: "dev-default" }),
+    }),
+    repository,
+    credentialStore,
+    bridge,
+    eventHub,
+  };
+}
+
+describe("Hermes routes", () => {
+  it("saves config and returns redacted status", async () => {
+    const { app, repository } = deps();
+
+    const res = await app.request(jsonRequest("/config", "POST", {
+      homeMode: "custom",
+      hermesPath: "/home/deploy/hermes-agent",
+      defaultProfileId: "default",
+      defaultModelId: "claude-opus",
+      authorizedOperators: ["user_456"],
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.installation).toMatchObject({ readiness: "installed", defaultProfileId: "default" });
+    expect(JSON.stringify(body)).not.toContain("/home/deploy");
+    const snapshot = await repository.getSnapshot("user_123");
+    expect(snapshot.events.filter((event) => event.message === "Hermes configuration updated")).toHaveLength(1);
+  });
+
+  it("rejects a Hermes path unless custom home mode is explicit", async () => {
+    const { app, bridge } = deps();
+
+    const defaultMode = await app.request(jsonRequest("/config", "POST", {
+      homeMode: "default",
+      hermesPath: "/home/deploy/hermes-agent",
+      defaultProfileId: "default",
+      authorizedOperators: [],
+    }));
+    const omittedMode = await app.request(jsonRequest("/config", "POST", {
+      hermesPath: "/home/deploy/hermes-agent",
+      defaultProfileId: "default",
+      authorizedOperators: [],
+    }));
+
+    expect(defaultMode.status).toBe(400);
+    expect(omittedMode.status).toBe(400);
+    await expect(defaultMode.json()).resolves.toMatchObject({ error: { code: "invalid_request" } });
+    await expect(omittedMode.json()).resolves.toMatchObject({ error: { code: "invalid_request" } });
+    expect(bridge.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it("activates bridge config only after the repository save succeeds", async () => {
+    const { app, bridge, repository } = deps();
+    const order: string[] = [];
+    const activate = vi.fn(() => order.push("activate"));
+    const saveConfig = repository.saveConfig.bind(repository);
+    vi.mocked(bridge.saveConfig).mockResolvedValueOnce({
+      patch: { hermesPathLabel: "custom" },
+      activate,
+    });
+    vi.spyOn(repository, "saveConfig").mockImplementationOnce(async (...args) => {
+      order.push("repository");
+      return await saveConfig(...args);
+    });
+
+    const res = await app.request(jsonRequest("/config", "POST", {
+      homeMode: "default",
+      defaultProfileId: "default",
+      authorizedOperators: [],
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ installation: { hermesPathLabel: "custom" } });
+    expect(order).toEqual(["repository", "activate"]);
+  });
+
+  it("preserves homeMode, defaultProfileId, and defaultModelId when partial config updates omit them", async () => {
+    const { app, repository } = deps();
+    await app.request(jsonRequest("/config", "POST", {
+      homeMode: "custom",
+      hermesPath: "/home/deploy/hermes-agent",
+      defaultProfileId: "ops",
+      defaultModelId: "claude-opus",
+      authorizedOperators: ["user_456"],
+    }));
+
+    const res = await app.request(jsonRequest("/config", "POST", {
+      authorizedOperators: ["user_789"],
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      installation: {
+        authorizedOperators: ["user_789"],
+        defaultModelId: "claude-opus",
+        defaultProfileId: "ops",
+        homeMode: "custom",
+      },
+    });
+    await expect(repository.getSnapshot("user_123")).resolves.toMatchObject({
+      installation: { authorizedOperators: ["user_789"], defaultModelId: "claude-opus", defaultProfileId: "ops", homeMode: "custom" },
+    });
+  });
+
+  it("allows owners to explicitly clear authorized operators", async () => {
+    const { app } = deps();
+    await app.request(jsonRequest("/config", "POST", {
+      homeMode: "default",
+      defaultProfileId: "default",
+      authorizedOperators: ["user_456"],
+    }));
+
+    const res = await app.request(jsonRequest("/config", "POST", {
+      homeMode: "default",
+      defaultProfileId: "default",
+      authorizedOperators: [],
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ installation: { authorizedOperators: [] } });
+  });
+
+  it("clears the custom Hermes path label when switching back to default mode", async () => {
+    const { app } = deps();
+    await app.request(jsonRequest("/config", "POST", {
+      homeMode: "custom",
+      hermesPath: "/home/deploy/hermes-agent",
+      defaultProfileId: "default",
+      authorizedOperators: [],
+    }));
+
+    const res = await app.request(jsonRequest("/config", "POST", {
+      homeMode: "default",
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ installation: { homeMode: "default", hermesPathLabel: null } });
+  });
+
+  it("does not activate bridge config when the repository save fails", async () => {
+    const { app, bridge, repository } = deps();
+    const activate = vi.fn();
+    vi.mocked(bridge.saveConfig).mockResolvedValueOnce({
+      patch: { hermesPathLabel: "custom" },
+      activate,
+    });
+    vi.spyOn(repository, "saveConfig").mockRejectedValueOnce(new Error("database unavailable"));
+
+    const res = await app.request(jsonRequest("/config", "POST", {
+      homeMode: "default",
+      defaultProfileId: "default",
+      authorizedOperators: [],
+    }));
+
+    expect(res.status).toBe(500);
+    expect(activate).not.toHaveBeenCalled();
+  });
+
+  it("truncates custom Hermes path labels consistently", async () => {
+    const { app } = deps();
+    const longName = "x".repeat(120);
+
+    const res = await app.request(jsonRequest("/config", "POST", {
+      homeMode: "custom",
+      hermesPath: `/home/deploy/${longName}`,
+      defaultProfileId: "default",
+      authorizedOperators: [],
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.installation.hermesPathLabel).toBe("x".repeat(80));
+  });
+
+  it("does not overwrite a gateway action health result with an unqueried status patch", async () => {
+    const { app, bridge } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+    vi.mocked(bridge.runGatewayAction).mockResolvedValueOnce({
+      id: "op_1",
+      status: "complete",
+      message: "Gateway action accepted",
+      patch: { gatewayStatus: "healthy", readiness: "ready" },
+    });
+    vi.mocked(bridge.getStatus).mockResolvedValueOnce({
+      readiness: "installed",
+      lastCheckedAt: "2026-05-15T00:02:00.000Z",
+    });
+
+    const action = await app.request(jsonRequest("/gateway/action", "POST", { type: "health_check" }));
+    const status = await app.request("/status");
+
+    expect(action.status).toBe(200);
+    expect(await status.json()).toMatchObject({ readiness: "ready", gatewayStatus: "healthy", lastCheckedAt: "2026-05-15T00:02:00.000Z" });
+  });
+
+  it("does not persist status polls when only lastCheckedAt changes", async () => {
+    const { app, bridge, repository } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+    const applyInstallationPatch = vi.spyOn(repository, "applyInstallationPatch");
+    vi.mocked(bridge.getStatus).mockResolvedValueOnce({ lastCheckedAt: "2026-05-15T00:02:00.000Z" });
+
+    const res = await app.request("/status");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ lastCheckedAt: "2026-05-15T00:02:00.000Z" });
+    expect(applyInstallationPatch).not.toHaveBeenCalled();
+  });
+
+  it("does not clear a stored version when a status poll cannot read the CLI version", async () => {
+    const { app, bridge, repository } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+    await repository.applyInstallationPatch("user_123", { version: "1.2.3" });
+    const applyInstallationPatch = vi.spyOn(repository, "applyInstallationPatch");
+    vi.mocked(bridge.getStatus).mockResolvedValueOnce({ version: null, lastCheckedAt: "2026-05-15T00:02:00.000Z" });
+
+    const res = await app.request("/status");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ version: null, lastCheckedAt: "2026-05-15T00:02:00.000Z" });
+    expect(applyInstallationPatch).not.toHaveBeenCalled();
+    await expect(repository.getSnapshot("user_123")).resolves.toMatchObject({
+      installation: { version: "1.2.3" },
+    });
+  });
+
+  it("persists a newly discovered non-null version from status polls", async () => {
+    const { app, bridge, repository } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+    vi.mocked(bridge.getStatus).mockResolvedValueOnce({ version: "1.2.4", lastCheckedAt: "2026-05-15T00:02:00.000Z" });
+
+    const res = await app.request("/status");
+
+    expect(res.status).toBe(200);
+    await expect(repository.getSnapshot("user_123")).resolves.toMatchObject({
+      installation: { version: "1.2.4" },
+    });
+  });
+
+  it("stores model credentials server-side and returns only presence", async () => {
+    const { app, credentialStore, repository } = deps();
+
+    const res = await app.request(jsonRequest("/credentials/model", "POST", { providerId: "anthropic", secret: "model_secret" }));
+
+    expect(res.status).toBe(200);
+    expect(credentialStore.writeModelCredential).toHaveBeenCalledWith("user_123", "anthropic", "model_secret");
+    expect(await res.json()).toEqual({ configured: true, providerId: "anthropic", status: "healthy" });
+    const snapshot = await repository.getSnapshot("user_123");
+    expect(snapshot.events.filter((event) => event.message === "Model credential updated")).toHaveLength(1);
+  });
+
+  it("rejects concurrent model credential writes for the same provider", async () => {
+    const { app, bridge } = deps();
+    let releaseCredential: (() => void) | null = null;
+    vi.mocked(bridge.saveModelCredential).mockImplementationOnce(async ({ credential }) => {
+      await new Promise<void>((resolve) => {
+        releaseCredential = resolve;
+      });
+      return { id: credential.providerId, configured: true, status: "healthy", availableModels: [], lastCheckedAt: "2026-05-15T00:00:00.000Z" };
+    });
+
+    const first = app.request(jsonRequest("/credentials/model", "POST", { providerId: "anthropic", secret: "model_secret_1" }));
+    await vi.waitFor(() => expect(bridge.saveModelCredential).toHaveBeenCalledOnce());
+    const second = await app.request(jsonRequest("/credentials/model", "POST", { providerId: "anthropic", secret: "model_secret_2" }));
+    releaseCredential?.();
+    const firstResponse = await first;
+
+    expect(second.status).toBe(409);
+    expect(firstResponse.status).toBe(200);
+  });
+
+  it("persists bridge-validated model provider metadata", async () => {
+    const { app, bridge, repository } = deps();
+    vi.mocked(bridge.saveModelCredential).mockResolvedValueOnce({
+      id: "anthropic",
+      configured: true,
+      status: "validating",
+      defaultModelId: "claude-opus",
+      availableModels: [{ id: "claude-opus", label: "Claude Opus" }],
+      lastCheckedAt: "2026-05-15T00:01:00.000Z",
+    });
+
+    const res = await app.request(jsonRequest("/credentials/model", "POST", { providerId: "anthropic", secret: "model_secret" }));
+
+    expect(await res.json()).toEqual({ configured: true, providerId: "anthropic", status: "validating" });
+    const snapshot = await repository.getSnapshot("user_123");
+    expect(snapshot.modelProviders[0]).toMatchObject({
+      id: "anthropic",
+      status: "validating",
+      defaultModelId: "claude-opus",
+      availableModels: [{ id: "claude-opus", label: "Claude Opus" }],
+    });
+  });
+
+  it("does not persist model credential files when bridge validation fails", async () => {
+    const { app, bridge, credentialStore, repository } = deps();
+    vi.mocked(bridge.saveModelCredential).mockRejectedValueOnce(new Error("bridge unavailable"));
+
+    const res = await app.request(jsonRequest("/credentials/model", "POST", { providerId: "anthropic", secret: "model_secret" }));
+
+    expect(res.status).toBe(500);
+    expect(credentialStore.writeModelCredential).not.toHaveBeenCalled();
+    await expect(repository.getSnapshot("user_123")).resolves.toMatchObject({ modelProviders: [] });
+  });
+
+  it("caps retained model provider metadata", async () => {
+    const { app, repository } = deps();
+
+    for (let index = 0; index < MAX_HERMES_MODEL_PROVIDERS + 5; index += 1) {
+      const res = await app.request(jsonRequest("/credentials/model", "POST", { providerId: `provider${index}`, secret: "model_secret" }));
+      expect(res.status).toBe(200);
+    }
+
+    const snapshot = await repository.getSnapshot("user_123");
+    expect(snapshot.modelProviders).toHaveLength(MAX_HERMES_MODEL_PROVIDERS);
+    expect(snapshot.modelProviders.map((provider) => provider.id)).not.toContain("provider0");
+  });
+
+  it("caps retained approval prompts independently from sessions", async () => {
+    const { repository } = deps();
+
+    for (let index = 0; index < MAX_HERMES_APPROVALS + 5; index += 1) {
+      await repository.upsertApproval("user_123", {
+        id: `approval${index}`,
+        hermesApprovalId: `hermesApproval${index}`,
+        sessionId: "session_1",
+        status: "pending",
+        description: "Approve tool",
+        decisionBy: null,
+        decisionAt: null,
+        createdAt: "2026-05-15T00:00:00.000Z",
+      });
+    }
+
+    const snapshot = await repository.getSnapshot("user_123");
+    expect(snapshot.approvals).toHaveLength(MAX_HERMES_APPROVALS);
+    expect(snapshot.approvals.map((approval) => approval.id)).not.toContain("approval0");
+  });
+
+  it("returns bridge-discovered capabilities on GET without persisting a read snapshot", async () => {
+    const { app, bridge, repository } = deps();
+    vi.mocked(bridge.listCapabilities).mockResolvedValueOnce([
+      {
+        id: "gateway",
+        kind: "gateway",
+        name: "Messaging gateway",
+        enabled: true,
+        status: "available",
+        description: "Hermes messaging gateway",
+        updatedAt: "2026-05-15T00:00:00.000Z",
+      },
+    ]);
+
+    const res = await app.request("/capabilities");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ capabilities: [{ id: "gateway" }] });
+    await expect(repository.getSnapshot("user_123")).resolves.toMatchObject({ capabilities: [] });
+  });
+
+  it("merges live capabilities with stored capabilities on GET", async () => {
+    const { app, bridge, repository } = deps();
+    const snapshot = await repository.getSnapshot("user_123");
+    await repository.replaceSnapshot("user_123", {
+      ...snapshot,
+      capabilities: [
+        {
+          id: "memory",
+          kind: "tool",
+          name: "Memory",
+          enabled: true,
+          status: "available",
+          updatedAt: "2026-05-15T00:00:00.000Z",
+        },
+      ],
+    });
+    vi.mocked(bridge.listCapabilities).mockResolvedValueOnce([
+      {
+        id: "gateway",
+        kind: "gateway",
+        name: "Messaging gateway",
+        enabled: true,
+        status: "available",
+        updatedAt: "2026-05-15T00:01:00.000Z",
+      },
+    ]);
+
+    const res = await app.request("/capabilities");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ capabilities: [{ id: "gateway" }, { id: "memory" }] });
+  });
+
+  it("returns bridge-discovered channels on GET without persisting a read snapshot", async () => {
+    const { app, bridge, repository } = deps();
+    vi.mocked(bridge.listChannels).mockResolvedValueOnce([
+      {
+        id: "telegram",
+        platform: "telegram",
+        enabled: true,
+        configured: true,
+        status: "connected",
+        allowedSenderPolicy: "Configured",
+        lastCheckedAt: "2026-05-15T00:00:00.000Z",
+        updatedAt: "2026-05-15T00:00:00.000Z",
+      },
+    ]);
+
+    const res = await app.request("/channels");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ channels: [{ id: "telegram", status: "connected" }] });
+    await expect(repository.getSnapshot("user_123")).resolves.toMatchObject({ channels: [] });
+  });
+
+  it("does not let channel reads revert stored channel action state", async () => {
+    const { app, bridge, repository } = deps();
+    await repository.upsertChannel("user_123", {
+      id: "telegram",
+      platform: "telegram",
+      enabled: true,
+      configured: true,
+      status: "connected",
+      allowedSenderPolicy: "Configured",
+      lastCheckedAt: "2026-05-15T00:00:00.000Z",
+      updatedAt: "2026-05-15T00:00:00.000Z",
+    });
+    vi.mocked(bridge.listChannels).mockResolvedValueOnce([
+      {
+        id: "telegram",
+        platform: "telegram",
+        enabled: false,
+        configured: false,
+        status: "disconnected",
+        allowedSenderPolicy: "Not configured",
+        lastCheckedAt: "2026-05-15T00:01:00.000Z",
+        updatedAt: "2026-05-15T00:01:00.000Z",
+      },
+    ]);
+
+    const res = await app.request("/channels");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ channels: [{ id: "telegram", status: "connected", enabled: true, configured: true }] });
+    await expect(repository.getSnapshot("user_123")).resolves.toMatchObject({ channels: [{ id: "telegram", status: "connected", enabled: true, configured: true }] });
+  });
+
+  it("passes a freshly loaded installation to channel actions", async () => {
+    const { app, repository, bridge } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", defaultModelId: "before", authorizedOperators: [] }));
+    const getSnapshot = repository.getSnapshot.bind(repository);
+    vi.spyOn(repository, "getSnapshot").mockImplementationOnce(async (...args) => {
+      const snapshot = await getSnapshot(...args);
+      if (snapshot.installation) {
+        await repository.saveConfig("user_123", { homeMode: "default", defaultProfileId: "default", defaultModelId: "after", authorizedOperators: [] }, "user_123");
+      }
+      return snapshot;
+    });
+
+    const res = await app.request(jsonRequest("/channels/telegram/action", "POST", { type: "connect", payload: { token: "bot_secret" } }));
+
+    expect(res.status).toBe(200);
+    expect(bridge.runChannelAction).toHaveBeenCalledWith(expect.objectContaining({
+      installation: expect.objectContaining({ defaultModelId: "after" }),
+    }));
+  });
+
+  it("performs Telegram and WhatsApp channel actions without leaking payload secrets", async () => {
+    const { app } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+
+    const res = await app.request(jsonRequest("/channels/telegram/action", "POST", { type: "connect", payload: { token: "bot_secret" } }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.channel).toMatchObject({ id: "telegram", status: "connected" });
+    expect(JSON.stringify(body)).not.toContain("bot_secret");
+  });
+
+  it("returns WhatsApp pairing data from the bridge operation result", async () => {
+    const { app, eventHub } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+
+    const res = await app.request(jsonRequest("/channels/whatsapp/action", "POST", { type: "start_pairing", payload: {} }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      channel: { id: "whatsapp", status: "pairing" },
+      operation: { status: "complete", message: "Channel updated", pairing: { kind: "code", displayValue: "PAIR-HERMES" } },
+    });
+    expect(eventHub.retained("user_123")).toContainEqual(expect.objectContaining({
+      type: "channel.updated",
+      payload: expect.objectContaining({ id: "whatsapp", platform: "whatsapp", pairing: { kind: "code", displayValue: "PAIR-HERMES", expiresAt: "2026-05-15T00:05:00.000Z" } }),
+    }));
+  });
+
+  it("preserves completed setup steps across later config saves", async () => {
+    const { app, repository } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+    await app.request(jsonRequest("/credentials/model", "POST", { providerId: "anthropic", secret: "model_secret" }));
+    await app.request(jsonRequest("/channels/telegram/action", "POST", { type: "connect", payload: { token: "bot_secret" } }));
+
+    const res = await app.request(jsonRequest("/config", "POST", {
+      homeMode: "default",
+      defaultProfileId: "default",
+      defaultModelId: "claude-opus",
+      authorizedOperators: ["user_456"],
+    }));
+
+    expect(res.status).toBe(200);
+    const steps = (await repository.getSnapshot("user_123")).setupSteps;
+    expect(steps.find((step) => step.id === "model")).toMatchObject({ status: "complete" });
+    expect(steps.find((step) => step.id === "channel")).toMatchObject({ status: "complete" });
+  });
+
+  it("creates sessions and accepts follow-up prompts", async () => {
+    const { app } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+
+    const created = await app.request(jsonRequest("/sessions", "POST", { profileId: "default", prompt: "hello", clientRequestId: "create_1" }));
+    const sessionBody = await created.json();
+    const prompted = await app.request(jsonRequest(`/sessions/${sessionBody.session.id}/prompt`, "POST", { prompt: "continue", clientRequestId: "req_1" }));
+
+    expect(created.status).toBe(200);
+    expect(prompted.status).toBe(200);
+    expect(await prompted.json()).toMatchObject({ session: { id: "ses_1", eventCount: 2 } });
+  });
+
+  it("uses the latest installation snapshot when sending a follow-up prompt", async () => {
+    const { app, bridge, repository } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", defaultModelId: "old-model", authorizedOperators: [] }));
+    const created = await app.request(jsonRequest("/sessions", "POST", { profileId: "default", prompt: "hello", clientRequestId: "create_1" }));
+    const sessionBody = await created.json();
+    const getSession = repository.getSession.bind(repository);
+    vi.spyOn(repository, "getSession").mockImplementationOnce(async (...args) => {
+      const session = await getSession(...args);
+      await repository.saveConfig("user_123", { homeMode: "default", defaultProfileId: "default", defaultModelId: "fresh-model", authorizedOperators: [] }, "user_123", { readiness: "ready" });
+      return session;
+    });
+    vi.mocked(bridge.sendPrompt).mockImplementationOnce(async ({ installation, session }) => {
+      expect(installation?.defaultModelId).toBe("fresh-model");
+      return { ...session, eventCount: session.eventCount + 1 };
+    });
+
+    const prompted = await app.request(jsonRequest(`/sessions/${sessionBody.session.id}/prompt`, "POST", { prompt: "continue", clientRequestId: "req_fresh" }));
+
+    expect(prompted.status).toBe(200);
+  });
+
+  it("paginates sessions with cursor instead of dropping it", async () => {
+    const { app, repository } = deps();
+    for (const id of ["ses_1", "ses_2", "ses_3"]) {
+      await repository.upsertSession("user_123", {
+        id,
+        hermesSessionId: `hermes_${id}`,
+        installationId: "hermes_user_123",
+        ownerId: "user_123",
+        operatorId: "user_123",
+        profileId: "default",
+        status: "idle",
+        eventCount: 0,
+        createdAt: "2026-05-15T00:00:00.000Z",
+        updatedAt: "2026-05-15T00:00:00.000Z",
+        lastActiveAt: "2026-05-15T00:00:00.000Z",
+      });
+    }
+
+    const first = await app.request("/sessions?limit=2");
+    const firstBody = await first.json();
+    const second = await app.request(`/sessions?limit=2&cursor=${firstBody.nextCursor}`);
+
+    expect(firstBody).toMatchObject({ sessions: [{ id: "ses_1" }, { id: "ses_2" }], nextCursor: "ses_2" });
+    await expect(second.json()).resolves.toMatchObject({ sessions: [{ id: "ses_3" }], nextCursor: null });
+  });
+
+  it("rejects filtered-out session cursors instead of silently restarting pagination", async () => {
+    const { app, repository } = deps();
+    for (const [id, status] of [["ses_1", "streaming"], ["ses_2", "streaming"]] as const) {
+      await repository.upsertSession("user_123", {
+        id,
+        hermesSessionId: `hermes_${id}`,
+        installationId: "hermes_user_123",
+        ownerId: "user_123",
+        operatorId: "user_123",
+        profileId: "default",
+        status,
+        eventCount: 0,
+        createdAt: "2026-05-15T00:00:00.000Z",
+        updatedAt: "2026-05-15T00:00:00.000Z",
+        lastActiveAt: "2026-05-15T00:00:00.000Z",
+      });
+    }
+    const first = await app.request("/sessions?status=streaming&limit=1");
+    const firstBody = await first.json();
+    const existing = await repository.getSession("user_123", "ses_1");
+    if (!existing) throw new Error("missing test session");
+    await repository.upsertSession("user_123", { ...existing, status: "stopped" });
+
+    const second = await app.request(`/sessions?status=streaming&limit=1&cursor=${firstBody.nextCursor}`);
+
+    expect(second.status).toBe(400);
+    await expect(second.json()).resolves.toMatchObject({ error: { code: "invalid_request" } });
+  });
+
+  it("rejects concurrent recovery actions for the same owner", async () => {
+    const { app, bridge } = deps();
+    let releaseRecovery: (() => void) | null = null;
+    vi.mocked(bridge.recover).mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseRecovery = resolve;
+      });
+      return { status: "complete", message: "Recovery completed" };
+    });
+
+    const first = app.request(jsonRequest("/recover", "POST", {}));
+    await vi.waitFor(() => expect(bridge.recover).toHaveBeenCalledOnce());
+    const second = await app.request(jsonRequest("/recover", "POST", {}));
+    releaseRecovery?.();
+    const firstResponse = await first;
+
+    expect(second.status).toBe(409);
+    expect(firstResponse.status).toBe(200);
+  });
+
+  it("passes a freshly loaded installation to recovery actions", async () => {
+    const { app, repository, bridge } = deps();
+    await app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", defaultModelId: "before", authorizedOperators: [] }));
+    const getSnapshot = repository.getSnapshot.bind(repository);
+    vi.spyOn(repository, "getSnapshot").mockImplementationOnce(async (...args) => {
+      const snapshot = await getSnapshot(...args);
+      if (snapshot.installation) {
+        await repository.saveConfig("user_123", { homeMode: "default", defaultProfileId: "default", defaultModelId: "after", authorizedOperators: [] }, "user_123");
+      }
+      return snapshot;
+    });
+
+    const res = await app.request(jsonRequest("/recover", "POST", {}));
+
+    expect(res.status).toBe(200);
+    expect(bridge.recover).toHaveBeenCalledWith(expect.objectContaining({
+      installation: expect.objectContaining({ defaultModelId: "after" }),
+    }));
+  });
+
+  it("rejects recovery requests from delegated operators", async () => {
+    const owner = deps("user_123");
+    await owner.app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: ["user_456"] }));
+    const operator = createHermesRoutes({
+      repository: owner.repository,
+      credentialStore: owner.credentialStore,
+      bridge: owner.bridge,
+      eventHub: createHermesEventHub(),
+      getPrincipal: () => ({ userId: "user_456", source: "dev-default" }),
+    });
+
+    const res = await operator.request(jsonRequest("/recover?ownerId=user_123", "POST", {}));
+
+    expect(res.status).toBe(401);
+    expect(owner.bridge.recover).not.toHaveBeenCalled();
+  });
+
+  it("rejects concurrent gateway actions for the same owner", async () => {
+    const { app, bridge } = deps();
+    let releaseGatewayAction: (() => void) | null = null;
+    vi.mocked(bridge.runGatewayAction).mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseGatewayAction = resolve;
+      });
+      return { id: "op_1", status: "complete", message: "Gateway action accepted", patch: { gatewayStatus: "healthy" } };
+    });
+
+    const first = app.request(jsonRequest("/gateway/action", "POST", { type: "restart" }));
+    await vi.waitFor(() => expect(bridge.runGatewayAction).toHaveBeenCalledOnce());
+    const second = await app.request(jsonRequest("/gateway/action", "POST", { type: "health_check" }));
+    releaseGatewayAction?.();
+    const firstResponse = await first;
+
+    expect(second.status).toBe(409);
+    expect(firstResponse.status).toBe(200);
+  });
+
+  it("expires stale action locks after the operation deadline", async () => {
+    const { app, bridge } = deps();
+    const now = vi.spyOn(Date, "now").mockReturnValue(0);
+    let releaseFirst: (() => void) | null = null;
+    vi.mocked(bridge.runGatewayAction)
+      .mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        return { id: "op_1", status: "complete", message: "Gateway action accepted", patch: { gatewayStatus: "healthy" } };
+      });
+
+    try {
+      const first = app.request(jsonRequest("/gateway/action", "POST", { type: "restart" }));
+      await vi.waitFor(() => expect(bridge.runGatewayAction).toHaveBeenCalledOnce());
+      now.mockReturnValue(60_001);
+      const second = await app.request(jsonRequest("/gateway/action", "POST", { type: "restart" }));
+
+      expect(second.status).toBe(200);
+      expect(bridge.runGatewayAction).toHaveBeenCalledTimes(2);
+      releaseFirst?.();
+      expect((await first).status).toBe(200);
+    } finally {
+      now.mockRestore();
+      releaseFirst?.();
+    }
+  });
+
+  it("keeps channel persistence inside the duplicate action lock", async () => {
+    const { app, repository } = deps();
+    const upsertChannel = repository.upsertChannel.bind(repository);
+    let releaseUpsert: (() => void) | null = null;
+    vi.spyOn(repository, "upsertChannel").mockImplementationOnce(async (...args) => {
+      await new Promise<void>((resolve) => {
+        releaseUpsert = resolve;
+      });
+      return await upsertChannel(...args);
+    });
+
+    const first = app.request(jsonRequest("/channels/telegram/action", "POST", { type: "connect", payload: { token: "bot_secret" } }));
+    await vi.waitFor(() => expect(repository.upsertChannel).toHaveBeenCalledOnce());
+    const second = await app.request(jsonRequest("/channels/telegram/action", "POST", { type: "verify" }));
+    releaseUpsert?.();
+    const firstResponse = await first;
+
+    expect(second.status).toBe(409);
+    expect(firstResponse.status).toBe(200);
+  });
+
+  it("keeps approval status guard and persistence inside the approval lock", async () => {
+    const { app, repository, bridge } = deps();
+    await repository.upsertApproval("user_123", {
+      id: "approval_1",
+      hermesApprovalId: "hermes_approval_1",
+      sessionId: "session_1",
+      status: "pending",
+      description: "Approve tool",
+      decisionBy: null,
+      decisionAt: null,
+      createdAt: "2026-05-15T00:00:00.000Z",
+    });
+    const upsertApproval = repository.upsertApproval.bind(repository);
+    let releaseUpsert: (() => void) | null = null;
+    vi.spyOn(repository, "upsertApproval").mockImplementationOnce(async (...args) => {
+      await new Promise<void>((resolve) => {
+        releaseUpsert = resolve;
+      });
+      return await upsertApproval(...args);
+    });
+
+    const first = app.request(jsonRequest("/approvals/approval_1/decision", "POST", { decision: "approved" }));
+    await vi.waitFor(() => expect(bridge.decideApproval).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(repository.upsertApproval).toHaveBeenCalledOnce());
+    const second = await app.request(jsonRequest("/approvals/approval_1/decision", "POST", { decision: "denied" }));
+    releaseUpsert?.();
+    const firstResponse = await first;
+
+    expect(second.status).toBe(409);
+    expect(firstResponse.status).toBe(200);
+  });
+
+  it("rejects unauthorized delegated owner reads without details", async () => {
+    const owner = deps("user_123");
+    await owner.app.request(jsonRequest("/config", "POST", { homeMode: "default", defaultProfileId: "default", authorizedOperators: [] }));
+    const attacker = createHermesRoutes({
+      repository: owner.repository,
+      credentialStore: owner.credentialStore,
+      bridge: owner.bridge,
+      eventHub: createHermesEventHub(),
+      getPrincipal: () => ({ userId: "user_999", source: "dev-default" }),
+    });
+
+    const res = await attacker.request("/config?ownerId=user_123");
+
+    expect(res.status).toBe(401);
+    expect(JSON.stringify(await res.json())).not.toContain("defaultProfileId");
+  });
+
+  it("resolves shared operators deterministically to the most recently updated owner", async () => {
+    const repository = new InMemoryHermesRepository();
+    await repository.saveConfig("owner_old", { homeMode: "default", defaultProfileId: "default", authorizedOperators: ["operator_1"] }, "owner_old");
+    await repository.saveConfig("owner_new", { homeMode: "default", defaultProfileId: "default", authorizedOperators: ["operator_1"] }, "owner_new");
+    const oldSnapshot = await repository.getSnapshot("owner_old");
+    const newSnapshot = await repository.getSnapshot("owner_new");
+    await repository.replaceSnapshot("owner_old", {
+      ...oldSnapshot,
+      installation: oldSnapshot.installation ? { ...oldSnapshot.installation, updatedAt: "2026-05-15T00:00:00.000Z" } : null,
+    });
+    await repository.replaceSnapshot("owner_new", {
+      ...newSnapshot,
+      installation: newSnapshot.installation ? { ...newSnapshot.installation, updatedAt: "2026-05-15T00:01:00.000Z" } : null,
+    });
+
+    await expect(repository.resolveOwnerIdForOperator("operator_1")).resolves.toBe("owner_new");
+  });
+});


### PR DESCRIPTION
Stack: 4/5

Summary:
- Adds the /api/hermes gateway subsystem with typed contracts, owner/operator auth, redacted credential storage, Kysely-backed owner state, bounded event hub, Hermes bridge abstraction, and route surface for setup, channels, sessions, approvals, operations, audit, export, and recovery.
- Mounts unavailable-safe Hermes Manager routes in the gateway.
- Adds focused gateway tests for routes, bridge, credential storage, and event hub behavior.

Validation:
- bun run typecheck
- bun run check:patterns: zero violations; remaining output is warnings only
- bun run test tests/gateway/hermes-routes.test.ts tests/gateway/hermes-bridge.test.ts tests/gateway/hermes-credential-store.test.ts tests/gateway/hermes-event-hub.test.ts tests/default-apps/hermes-manager-app.test.tsx tests/gateway/apps.test.ts
- git diff --check

Invariants:
- Source of truth: Hermes Manager structured state is owner-scoped Postgres via Kysely table matrix_hermes_manager_state; model credentials live server-side under owner home credentials and are never serialized to clients. Hermes runtime behavior remains behind the HermesBridge abstraction.
- Lock/transaction scope: Repository writes update one owner snapshot at a time; duplicate setup/channel/session/approval/gateway actions are guarded by bounded in-process locks with TTL. External Hermes process calls stay behind HermesBridge and outside repository state mutation helpers.
- Acceptable orphan states: If a Hermes bridge action succeeds but follow-up status/event publishing fails, the route returns generic failure where applicable and the next read reconciles persisted state. Channel/session stale live refs are represented as recoverable/degraded state instead of raw crashes.
- Auth source of truth: Matrix request principal is the only browser auth source. Owners can configure credentials and gateway actions; authorized operators can use messaging/channel/session surfaces without seeing secrets.
- Deferred scope: Real upstream OAuth/pairing nuances and every Hermes-supported channel beyond Telegram/WhatsApp are deferred behind the bridge contract; no raw Hermes internals are copied into Matrix.