### PR TITLE
fix(symphony): align dispatch with Linear integrations

### DIFF
--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -110,7 +110,7 @@ const DEFAULT_FORM: FormState = {
   linearProjectSlug: "",
   linearSecret: "",
   requiredLabels: "symphony",
-  activeStates: "Todo, In Progress",
+  activeStates: "Todo, In Progress, Merging, Rework",
   terminalStates: "Done, Canceled, Cancelled, Duplicate",
   assigneeIds: [],
   maxConcurrentAgents: 3,
@@ -479,10 +479,10 @@ export default function App() {
         <aside className="rounded-md border bg-white p-4">
           <h2 className="text-base font-semibold">Setup</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            {needsSetup ? "Connect Linear and choose which assigned tickets Symphony can claim." : "Linear and ticket rules are configured."}
+            {needsSetup ? "Connect Linear and choose which tickets Symphony can claim." : "Linear and ticket rules are configured."}
           </p>
           <div className="mt-4 space-y-2 text-sm">
-            <StatusLine label="Linear credential" value={status?.credentialConfigured ? "Configured" : "Missing"} />
+            <StatusLine label="Linear account" value={status?.credentialConfigured ? "Configured" : "Missing"} />
             <StatusLine label="Project" value={config?.installation?.projectSlug ?? "Not set"} />
             <StatusLine label="Team" value={config?.rule?.teamKey ?? "Not set"} />
             <StatusLine label="Assignees" value={config?.rule?.assigneeIds.length ? `${config.rule.assigneeIds.length} selected` : "Any matching assignee"} />

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -79,15 +79,19 @@ function codexSandboxArgs(sandbox?: AgentLaunchSandbox): string[] {
   }
   if (!sandbox.enabled) {
     if (sandbox.adminOverride === true) {
-      return ["--dangerously-bypass-sandbox"];
+      return ["--dangerously-bypass-approvals-and-sandbox"];
     }
     throw new Error("Codex sandbox preflight is required");
   }
   const args = ["--sandbox", "workspace-write"];
   for (const root of sandbox.writableRoots ?? []) {
-    args.push("--writable-root", root);
+    args.push("--add-dir", root);
   }
   return args;
+}
+
+function authStatusArgs(agent: SupportedAgent): string[] {
+  return agent === "codex" ? ["login", "status"] : ["auth", "status"];
 }
 
 export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
@@ -100,10 +104,10 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
       return {
         command,
         args: [
-          "exec",
-          "--skip-git-repo-check",
           "--ask-for-approval",
           "never",
+          "exec",
+          "--skip-git-repo-check",
           ...codexSandboxArgs(input.sandbox),
           ...promptArgs(input.prompt),
         ],
@@ -152,7 +156,7 @@ export function createAgentLauncher(options: {
         }
 
         try {
-          await runCommand(config.command, ["auth", "status"], {
+          await runCommand(config.command, authStatusArgs(id), {
             cwd,
             timeout: DETECT_TIMEOUT_MS,
           });

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -30,7 +30,8 @@ import { createSymphonyRunner, SymphonyConfigLoadError } from "./symphony-runner
 import { createAgentLauncher } from "./agent-launcher.js";
 import { createAgentSessionManager } from "./agent-session-manager.js";
 import { createWorktreeManager } from "./worktree-manager.js";
-import { createFileSymphonyCredentialStore } from "./symphony/credential-store.js";
+import { createCompositeSymphonyCredentialStore, createFileSymphonyCredentialStore } from "./symphony/credential-store.js";
+import { createIntegrationAwareLinearGraphql, hasConnectedLinearIntegration } from "./symphony/linear-integration.js";
 import { createLinearSource } from "./symphony/linear-source.js";
 import { createMatrixSymphonyOrchestrator } from "./symphony/orchestrator.js";
 import { KyselySymphonyRepository } from "./symphony/repository.js";
@@ -2390,8 +2391,16 @@ export async function createGateway(config: GatewayConfig) {
   if (kyselyInstance) {
     const repository = new KyselySymphonyRepository(kyselyInstance as Kysely<any>);
     await repository.bootstrap();
-    const credentialStore = createFileSymphonyCredentialStore({ homePath });
-    const linearSource = createLinearSource();
+    const fileCredentialStore = createFileSymphonyCredentialStore({ homePath });
+    const credentialStore = platformDb && pipedreamClient
+      ? createCompositeSymphonyCredentialStore({
+        primary: fileCredentialStore,
+        hasLinearIntegration: (ownerId) => hasConnectedLinearIntegration(platformDb!, ownerId),
+      })
+      : fileCredentialStore;
+    const linearSource = platformDb && pipedreamClient
+      ? createLinearSource({ graphql: createIntegrationAwareLinearGraphql({ platformDb, pipedream: pipedreamClient }) })
+      : createLinearSource();
     const projectManager = createProjectManager({ homePath });
     const worktreeManager = createWorktreeManager({ homePath });
     const agentLauncher = createAgentLauncher({ cwd: homePath });

--- a/packages/gateway/src/symphony/contracts.ts
+++ b/packages/gateway/src/symphony/contracts.ts
@@ -44,7 +44,7 @@ export const SymphonyRuleInputSchema = z.object({
   projectId: LinearId.optional(),
   projectSlug: z.string().trim().min(1).max(128).optional(),
   requiredLabels: z.array(LabelOrState).max(20).default([]),
-  activeStates: z.array(LabelOrState).min(1).max(20).default(["Todo", "In Progress"]),
+  activeStates: z.array(LabelOrState).min(1).max(20).default(["Todo", "In Progress", "Merging", "Rework"]),
   terminalStates: z.array(LabelOrState).min(1).max(20).default(["Done", "Canceled", "Cancelled", "Duplicate"]),
   assigneeIds: z.array(LinearId).max(50).default([]),
 }).strict();
@@ -136,6 +136,7 @@ export interface TrackedTicket {
   externalId: string;
   identifier: string;
   title: string;
+  description?: string | null;
   url?: string;
   teamId?: string;
   teamKey?: string;
@@ -146,8 +147,10 @@ export interface TrackedTicket {
   assigneeId?: string;
   assigneeName?: string;
   labels: string[];
+  blockedBy?: Array<{ id?: string | null; identifier?: string | null; stateName?: string | null }>;
   priority?: number | null;
   branchName?: string | null;
+  createdAt?: string;
   updatedAt?: string;
 }
 

--- a/packages/gateway/src/symphony/credential-store.ts
+++ b/packages/gateway/src/symphony/credential-store.ts
@@ -11,11 +11,24 @@ export interface SymphonyCredentialStore {
 }
 
 const OWNER_ID_RE = /^[A-Za-z0-9_-]{1,256}$/;
+const LINEAR_INTEGRATION_CREDENTIAL_PREFIX = "matrixos:integration:linear:";
 
 function assertOwnerId(ownerId: string): void {
   if (!OWNER_ID_RE.test(ownerId)) {
     throw new Error("Invalid owner identifier");
   }
+}
+
+export function encodeLinearIntegrationCredential(ownerId: string): string {
+  assertOwnerId(ownerId);
+  return `${LINEAR_INTEGRATION_CREDENTIAL_PREFIX}${ownerId}`;
+}
+
+export function parseLinearIntegrationCredential(credential: string): string | null {
+  if (!credential.startsWith(LINEAR_INTEGRATION_CREDENTIAL_PREFIX)) return null;
+  const ownerId = credential.slice(LINEAR_INTEGRATION_CREDENTIAL_PREFIX.length);
+  assertOwnerId(ownerId);
+  return ownerId;
 }
 
 function credentialPath(homePath: string, ownerId: string): string {
@@ -75,6 +88,34 @@ export function createFileSymphonyCredentialStore(options: { homePath: string })
 
     async deleteLinearCredential(ownerId: string): Promise<void> {
       await rm(credentialPath(homePath, ownerId), { force: true });
+    },
+  };
+}
+
+export function createCompositeSymphonyCredentialStore(options: {
+  primary: SymphonyCredentialStore;
+  hasLinearIntegration: (ownerId: string) => Promise<boolean>;
+}): SymphonyCredentialStore {
+  const { primary, hasLinearIntegration } = options;
+
+  return {
+    async hasLinearCredential(ownerId: string): Promise<boolean> {
+      if (await primary.hasLinearCredential(ownerId)) return true;
+      return hasLinearIntegration(ownerId);
+    },
+
+    async readLinearCredential(ownerId: string): Promise<string | null> {
+      const apiKey = await primary.readLinearCredential(ownerId);
+      if (apiKey) return apiKey;
+      return await hasLinearIntegration(ownerId) ? encodeLinearIntegrationCredential(ownerId) : null;
+    },
+
+    writeLinearCredential(ownerId: string, secret: string): Promise<void> {
+      return primary.writeLinearCredential(ownerId, secret);
+    },
+
+    deleteLinearCredential(ownerId: string): Promise<void> {
+      return primary.deleteLinearCredential(ownerId);
     },
   };
 }

--- a/packages/gateway/src/symphony/linear-integration.ts
+++ b/packages/gateway/src/symphony/linear-integration.ts
@@ -1,0 +1,70 @@
+import type { PipedreamConnectClient } from "../integrations/pipedream.js";
+import { getAction, getService } from "../integrations/registry.js";
+import { executeIntegrationAction } from "../integrations/routes.js";
+import type { ConnectedServicesTable, PlatformDb } from "../platform-db.js";
+import { parseLinearIntegrationCredential } from "./credential-store.js";
+import { defaultLinearGraphqlTransport, type LinearGraphqlRequest, type LinearGraphqlTransport } from "./linear-source.js";
+
+const LINEAR_SERVICE_ID = "linear";
+const LINEAR_GRAPHQL_ACTION_ID = "graphql";
+
+function findLinearConnection(connections: ConnectedServicesTable[]): ConnectedServicesTable | undefined {
+  return connections.find((connection) => connection.service === LINEAR_SERVICE_ID);
+}
+
+export async function hasConnectedLinearIntegration(platformDb: PlatformDb, ownerId: string): Promise<boolean> {
+  const connections = await platformDb.listConnectedServices(ownerId);
+  return Boolean(findLinearConnection(connections));
+}
+
+async function getOrCreateExternalId(platformDb: PlatformDb, ownerId: string): Promise<string> {
+  const user = await platformDb.getUserById(ownerId);
+  if (user?.pipedream_external_id) return user.pipedream_external_id;
+  await platformDb.updatePipedreamExternalId(ownerId, ownerId);
+  return ownerId;
+}
+
+export function createIntegrationAwareLinearGraphql(options: {
+  platformDb: PlatformDb;
+  pipedream: PipedreamConnectClient;
+}): LinearGraphqlTransport {
+  const serviceDefinition = getService(LINEAR_SERVICE_ID);
+  const actionDefinition = getAction(LINEAR_SERVICE_ID, LINEAR_GRAPHQL_ACTION_ID);
+
+  return async (request: LinearGraphqlRequest): Promise<unknown> => {
+    const ownerId = parseLinearIntegrationCredential(request.credential);
+    if (!ownerId) return defaultLinearGraphqlTransport(request);
+    if (!serviceDefinition || !actionDefinition) {
+      console.error("[symphony] Linear integration registry action is missing");
+      throw new Error("linear_integration_unavailable");
+    }
+
+    const connections = await options.platformDb.listConnectedServices(ownerId);
+    const connection = findLinearConnection(connections);
+    if (!connection) throw new Error("linear_integration_unavailable");
+
+    try {
+      const externalUserId = await getOrCreateExternalId(options.platformDb, ownerId);
+      const result = await executeIntegrationAction({
+        pipedream: options.pipedream,
+        externalUserId,
+        connection,
+        def: serviceDefinition,
+        actionDef: actionDefinition,
+        serviceId: LINEAR_SERVICE_ID,
+        actionId: LINEAR_GRAPHQL_ACTION_ID,
+        params: {
+          query: request.query,
+          ...(request.variables ? { variables: request.variables } : {}),
+        },
+      });
+      await options.platformDb.touchServiceUsage(connection.id).catch((err: unknown) => {
+        console.warn("[symphony] Linear integration usage touch failed:", err instanceof Error ? err.message : String(err));
+      });
+      return result.data;
+    } catch (err: unknown) {
+      console.warn("[symphony] Linear integration GraphQL failed:", err instanceof Error ? err.message : String(err));
+      throw new Error("linear_integration_unavailable");
+    }
+  };
+}

--- a/packages/gateway/src/symphony/linear-source.ts
+++ b/packages/gateway/src/symphony/linear-source.ts
@@ -27,12 +27,19 @@ interface LinearIssueNode {
   description?: string | null;
   url?: string;
   priority?: number | null;
+  createdAt?: string;
   updatedAt?: string;
   branchName?: string | null;
   assignee?: { id?: string; name?: string; displayName?: string } | null;
   state?: { id?: string; name?: string; type?: string } | null;
   team?: { id?: string; key?: string; name?: string } | null;
   labels?: { nodes?: Array<{ id?: string; name?: string }> } | null;
+  inverseRelations?: {
+    nodes?: Array<{
+      type?: string;
+      issue?: { id?: string | null; identifier?: string | null; state?: { name?: string | null } | null } | null;
+    }>;
+  } | null;
   project?: { id?: string; name?: string; slugId?: string } | null;
 }
 
@@ -67,6 +74,37 @@ interface LinearSetupPayload {
     };
   };
   errors?: unknown[];
+}
+
+export interface LinearGraphqlRequest {
+  credential: string;
+  query: string;
+  variables?: Record<string, unknown>;
+  endpoint: string;
+  fetch: FetchLike;
+  timeoutMs: number;
+}
+
+export type LinearGraphqlTransport = (request: LinearGraphqlRequest) => Promise<unknown>;
+
+export async function defaultLinearGraphqlTransport(request: LinearGraphqlRequest): Promise<unknown> {
+  const response = await request.fetch(request.endpoint, {
+    method: "POST",
+    headers: {
+      "Authorization": request.credential,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: request.query,
+      ...(request.variables ? { variables: request.variables } : {}),
+    }),
+    signal: AbortSignal.timeout(request.timeoutMs),
+  });
+  if (!response.ok) {
+    console.warn("[symphony] Linear GraphQL request failed with status", response.status);
+    throw new Error("linear_graphql_failed");
+  }
+  return response.json();
 }
 
 function normalizeSetupOptions(payloads: LinearSetupPayload[]): LinearSetupOptions {
@@ -116,6 +154,7 @@ function normalizeIssue(node: LinearIssueNode): TrackedTicket | null {
     externalId: node.id,
     identifier: node.identifier,
     title: node.title,
+    description: node.description ?? null,
     url: node.url,
     teamId: node.team?.id,
     teamKey: node.team?.key,
@@ -126,10 +165,23 @@ function normalizeIssue(node: LinearIssueNode): TrackedTicket | null {
     assigneeId: node.assignee?.id,
     assigneeName: node.assignee?.displayName ?? node.assignee?.name,
     labels: sanitizeLabels(node.labels?.nodes?.map((label) => label.name ?? "") ?? []).map((label) => label.toLowerCase()),
+    blockedBy: extractBlockers(node),
     priority: node.priority,
     branchName: node.branchName ?? null,
+    createdAt: node.createdAt,
     updatedAt: node.updatedAt,
   };
+}
+
+function extractBlockers(node: LinearIssueNode): TrackedTicket["blockedBy"] {
+  return (node.inverseRelations?.nodes ?? []).flatMap((relation) => {
+    if (relation.type?.trim().toLowerCase() !== "blocks" || !relation.issue) return [];
+    return [{
+      id: relation.issue.id ?? null,
+      identifier: relation.issue.identifier ?? null,
+      stateName: relation.issue.state?.name ?? null,
+    }];
+  });
 }
 
 function includesAllLabels(ticket: TrackedTicket, requiredLabels: string[]): boolean {
@@ -137,7 +189,7 @@ function includesAllLabels(ticket: TrackedTicket, requiredLabels: string[]): boo
   return requiredLabels.every((label) => actual.has(label.toLowerCase()));
 }
 
-function buildIssuesQuery(input: { projectId?: string; state?: string; labelName?: string; assigneeId?: string }) {
+function buildIssuesQuery(input: { projectId?: string; state?: string; assigneeId?: string }) {
   const variableDefs = ["$first: Int!", "$after: String", "$teamId: ID!"];
   const filters = ["team: { id: { eq: $teamId } }"];
   if (input.projectId) {
@@ -147,10 +199,6 @@ function buildIssuesQuery(input: { projectId?: string; state?: string; labelName
   if (input.state) {
     variableDefs.push("$state: String!");
     filters.push("state: { name: { eq: $state } }");
-  }
-  if (input.labelName) {
-    variableDefs.push("$labelName: String!");
-    filters.push("labels: { name: { eq: $labelName } }");
   }
   if (input.assigneeId) {
     variableDefs.push("$assigneeId: ID!");
@@ -169,11 +217,17 @@ function buildIssuesQuery(input: { projectId?: string; state?: string; labelName
         }
       ) {
         nodes {
-          id identifier title description url priority updatedAt branchName
+          id identifier title description url priority createdAt updatedAt branchName
           assignee { id name displayName }
           state { id name type color }
           team { id key name }
           labels { nodes { id name } }
+          inverseRelations(first: 50) {
+            nodes {
+              type
+              issue { id identifier state { name } }
+            }
+          }
           project { id name slugId }
         }
         pageInfo { hasNextPage endCursor }
@@ -215,10 +269,12 @@ const SETUP_OPTIONS_QUERY = `
 export function createLinearSource(options: {
   endpoint?: string;
   fetch?: FetchLike;
+  graphql?: LinearGraphqlTransport;
   timeoutMs?: number;
 } = {}): LinearSource {
   const endpoint = options.endpoint ?? "https://api.linear.app/graphql";
   const fetchImpl = options.fetch ?? fetch;
+  const graphql = options.graphql ?? defaultLinearGraphqlTransport;
   const timeoutMs = options.timeoutMs ?? 10_000;
   const scanOffsets = new Map<string, number>();
 
@@ -226,7 +282,6 @@ export function createLinearSource(options: {
     return JSON.stringify({
       teamId: rule.teamId,
       projectId: rule.projectId ?? null,
-      label: rule.requiredLabels[0] ?? null,
       states,
       assigneeIds,
     });
@@ -258,31 +313,22 @@ export function createLinearSource(options: {
           throw new Error("linear_setup_failed");
         }
 
-        const response = await fetchImpl(endpoint, {
-          method: "POST",
-          headers: {
-            "Authorization": credential,
-            "Content-Type": "application/json",
+        const payload = await graphql({
+          credential,
+          query: SETUP_OPTIONS_QUERY,
+          variables: {
+            first: LINEAR_SETUP_PAGE_SIZE,
+            teamsAfter,
+            projectsAfter,
+            usersAfter,
+            includeTeams,
+            includeProjects,
+            includeUsers,
           },
-          body: JSON.stringify({
-            query: SETUP_OPTIONS_QUERY,
-            variables: {
-              first: LINEAR_SETUP_PAGE_SIZE,
-              teamsAfter,
-              projectsAfter,
-              usersAfter,
-              includeTeams,
-              includeProjects,
-              includeUsers,
-            },
-          }),
-          signal: AbortSignal.timeout(timeoutMs),
-        });
-        if (!response.ok) {
-          console.warn("[symphony] Linear setup discovery failed with status", response.status);
-          throw new Error("linear_setup_failed");
-        }
-        const payload = await response.json() as LinearSetupPayload;
+          endpoint,
+          fetch: fetchImpl,
+          timeoutMs,
+        }) as LinearSetupPayload;
         if (payload.errors) {
           console.warn("[symphony] Linear setup discovery returned GraphQL errors");
           throw new Error("linear_setup_failed");
@@ -309,7 +355,6 @@ export function createLinearSource(options: {
     async previewTickets(rule: TicketSourceRule, credential: string, input: { limit?: number; state?: string } = {}) {
       const limit = Math.min(input.limit ?? 25, MAX_PREVIEW_TICKETS);
       const states = input.state ? [input.state] : rule.activeStates;
-      const labelForServer = rule.requiredLabels[0];
       const assigneeIds = rule.assigneeIds.length > 0 ? rule.assigneeIds : [undefined];
       const activeStateNames = new Set(states.map((state) => state.toLowerCase()));
       const combinations = states.flatMap((state) => assigneeIds.map((assigneeId) => ({ state, assigneeId })));
@@ -329,36 +374,25 @@ export function createLinearSource(options: {
         }
         const item = queue.shift()!;
         requests += 1;
-        const response = await fetchImpl(endpoint, {
-          method: "POST",
-          headers: {
-            "Authorization": credential,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            query: buildIssuesQuery({
-              projectId: rule.projectId,
-              state: item.state,
-              labelName: labelForServer,
-              assigneeId: item.assigneeId,
-            }),
-            variables: {
-              first: Math.min(MAX_PREVIEW_TICKETS, 100),
-              after: item.after,
-              teamId: rule.teamId,
-              ...(rule.projectId ? { projectId: rule.projectId } : {}),
-              ...(item.state ? { state: item.state } : {}),
-              ...(labelForServer ? { labelName: labelForServer } : {}),
-              ...(item.assigneeId ? { assigneeId: item.assigneeId } : {}),
-            },
+        const payload = await graphql({
+          credential,
+          query: buildIssuesQuery({
+            projectId: rule.projectId,
+            state: item.state,
+            assigneeId: item.assigneeId,
           }),
-          signal: AbortSignal.timeout(timeoutMs),
-        });
-        if (!response.ok) {
-          console.warn("[symphony] Linear preview failed with status", response.status);
-          throw new Error("linear_preview_failed");
-        }
-        const payload = await response.json() as LinearIssuesPayload;
+          variables: {
+            first: Math.min(MAX_PREVIEW_TICKETS, 100),
+            after: item.after,
+            teamId: rule.teamId,
+            ...(rule.projectId ? { projectId: rule.projectId } : {}),
+            ...(item.state ? { state: item.state } : {}),
+            ...(item.assigneeId ? { assigneeId: item.assigneeId } : {}),
+          },
+          endpoint,
+          fetch: fetchImpl,
+          timeoutMs,
+        }) as LinearIssuesPayload;
         if (payload.errors) {
           console.warn("[symphony] Linear preview returned GraphQL errors");
           throw new Error("linear_preview_failed");

--- a/packages/gateway/src/symphony/orchestrator.ts
+++ b/packages/gateway/src/symphony/orchestrator.ts
@@ -38,11 +38,50 @@ function branchFor(ticket: TrackedTicket): string {
   return ticket.branchName?.trim() || `symphony/${ticket.identifier.toLowerCase().replace(/[^a-z0-9._/-]+/g, "-")}`;
 }
 
+function normalizeState(state: string): string {
+  return state.trim().toLowerCase();
+}
+
+function includesAllRequiredLabels(ticket: TrackedTicket, requiredLabels: string[]): boolean {
+  const actual = new Set(ticket.labels.map((label) => label.toLowerCase()));
+  return requiredLabels.every((label) => actual.has(label.toLowerCase()));
+}
+
+function todoBlockedByNonTerminal(ticket: TrackedTicket, terminalStates: string[]): boolean {
+  if (normalizeState(ticket.stateName) !== "todo") return false;
+  const terminal = new Set(terminalStates.map(normalizeState));
+  return (ticket.blockedBy ?? []).some((blocker) => {
+    if (!blocker.stateName) return true;
+    return !terminal.has(normalizeState(blocker.stateName));
+  });
+}
+
 function shouldDispatch(ticket: TrackedTicket, rule: TicketSourceRule): boolean {
-  if (!rule.activeStates.map((state) => state.toLowerCase()).includes(ticket.stateName.toLowerCase())) return false;
-  if (rule.terminalStates.map((state) => state.toLowerCase()).includes(ticket.stateName.toLowerCase())) return false;
+  if (!rule.activeStates.map(normalizeState).includes(normalizeState(ticket.stateName))) return false;
+  if (rule.terminalStates.map(normalizeState).includes(normalizeState(ticket.stateName))) return false;
+  if (!includesAllRequiredLabels(ticket, rule.requiredLabels)) return false;
   if (rule.assigneeIds.length > 0 && (!ticket.assigneeId || !rule.assigneeIds.includes(ticket.assigneeId))) return false;
+  if (todoBlockedByNonTerminal(ticket, rule.terminalStates)) return false;
   return true;
+}
+
+function priorityRank(priority: number | null | undefined): number {
+  return typeof priority === "number" && Number.isInteger(priority) && priority >= 1 && priority <= 4 ? priority : 5;
+}
+
+function createdAtSortKey(ticket: TrackedTicket): number {
+  if (!ticket.createdAt) return Number.MAX_SAFE_INTEGER;
+  const value = Date.parse(ticket.createdAt);
+  return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+}
+
+function sortTicketsForDispatch(tickets: TrackedTicket[]): TrackedTicket[] {
+  return [...tickets].sort((a, b) =>
+    priorityRank(a.priority) - priorityRank(b.priority) ||
+    createdAtSortKey(a) - createdAtSortKey(b) ||
+    a.identifier.localeCompare(b.identifier) ||
+    a.externalId.localeCompare(b.externalId)
+  );
 }
 
 function isRetryBackoffActive(run: SymphonyRun, nowMs = Date.now()): boolean {
@@ -304,7 +343,7 @@ export function createMatrixSymphonyOrchestrator(options: {
       options.repository.listRuns(ownerId, { status: "blocked", limit: 100 }),
     ]);
     const blockedLiveRuns = blockedRuns.filter((run) => Boolean(run.sessionId));
-    const eligibleTickets = preview.tickets.filter((ticket) => shouldDispatch(ticket, rule));
+    const eligibleTickets = sortTicketsForDispatch(preview.tickets.filter((ticket) => shouldDispatch(ticket, rule)));
     const eligibleClaimKeys = new Set(eligibleTickets.map((ticket) => claimKey(ticket)));
     if (!preview.truncated) await reconcileIneligibleRunningRuns(ownerId, installation, activeRuns, eligibleClaimKeys);
     const countedRunning = preview.truncated
@@ -312,9 +351,8 @@ export function createMatrixSymphonyOrchestrator(options: {
       : activeRuns.filter((run) => eligibleClaimKeys.has(run.claimKey)).length;
     const capacity = Math.max(0, (snapshot.installation.maxConcurrentAgents ?? DEFAULT_MAX_CONCURRENT_AGENTS) - countedRunning - blockedLiveRuns.length);
     let dispatched = 0;
-    for (const ticket of preview.tickets) {
+    for (const ticket of eligibleTickets) {
       if (dispatched >= capacity) break;
-      if (!shouldDispatch(ticket, rule)) continue;
       const existing = await options.repository.findActiveRunByClaim(ownerId, claimKey(ticket));
       if (existing && isRetryBackoffActive(existing)) continue;
       if (existing && existing.status !== "queued" && existing.status !== "retrying") continue;
@@ -473,7 +511,12 @@ export function createMatrixSymphonyOrchestrator(options: {
       const ownerIds = await options.repository.listEnabledOwnerIds();
       for (const ownerId of ownerIds) {
         const snapshot = await options.repository.getSnapshot(ownerId);
-        if (snapshot.installation?.enabled) ensurePolling(ownerId, snapshot.installation.pollIntervalMs);
+        if (snapshot.installation?.enabled) {
+          ensurePolling(ownerId, snapshot.installation.pollIntervalMs);
+          void poll(ownerId).catch((err: unknown) => {
+            console.warn("[symphony] Initial poll after resume failed:", err instanceof Error ? err.message : String(err));
+          });
+        }
       }
       return ownerIds;
     },

--- a/packages/gateway/src/symphony/routes.ts
+++ b/packages/gateway/src/symphony/routes.ts
@@ -232,14 +232,15 @@ export function createMatrixSymphonyRoutes(deps: MatrixSymphonyRouteDeps) {
     const parsed = await parseJson(c, EmptyBodySchema);
     if (!parsed.ok) return parsed.response;
     await deps.credentialStore.deleteLinearCredential(principal.userId);
-    await deps.repository.setCredentialConfigured(principal.userId, false, principal.userId);
+    const credentialConfigured = await deps.credentialStore.hasLinearCredential(principal.userId);
+    await deps.repository.setCredentialConfigured(principal.userId, credentialConfigured, principal.userId);
     await publishSimpleOperatorEvent(deps, principal.userId, {
       installationId: snapshot.installation?.id ?? `sym_${principal.userId}`,
       type: "symphony.credential.deleted",
       message: "Linear credential removed",
       actorId: principal.userId,
     });
-    return c.json({ credentialConfigured: false });
+    return c.json({ credentialConfigured });
   }));
 
   app.get("/tickets/preview", (c) => withPrincipal(c, deps, async (principal) => {

--- a/scripts/review/check-patterns.sh
+++ b/scripts/review/check-patterns.sh
@@ -158,7 +158,7 @@ if [[ -n "$MATCHES" ]]; then
     fi
     window_end=$((line_no + 12))
     call_window=$(sed -n "${line_no},${window_end}p" "$file" 2>/dev/null || true)
-    if ! echo "$call_window" | grep -Eq 'signal\s*:'; then
+    if ! echo "$call_window" | grep -Eq 'signal[[:space:]]*:'; then
       MISSING_SIGNAL+="$line"$'\n'
     fi
   done <<< "$MATCHES"

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -170,7 +170,7 @@ describe("Symphony app", () => {
     expect(screen.getAllByText("Running").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Needs Attention").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Done / Handoff").length).toBeGreaterThan(0);
-    expect(screen.getByText("Linear credential")).toBeTruthy();
+    expect(screen.getByText("Linear account")).toBeTruthy();
   });
 
   it("saves a server-side Linear secret and non-secret rule set", async () => {

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -14,7 +14,7 @@ describe("agent-launcher", () => {
       if (args[0] === "--version" && command === "opencode") {
         throw new Error("ENOENT: opencode missing from /usr/bin");
       }
-      if (args[0] === "auth" && command === "codex") {
+      if (args[0] === "login" && args[1] === "status" && command === "codex") {
         throw new Error("not logged in: token sk-secret");
       }
       return { stdout: "ok\n", stderr: "" };
@@ -51,13 +51,13 @@ describe("agent-launcher", () => {
     expect(launch).toEqual({
       command: "codex",
       args: [
-        "exec",
-        "--skip-git-repo-check",
         "--ask-for-approval",
         "never",
+        "exec",
+        "--skip-git-repo-check",
         "--sandbox",
         "workspace-write",
-        "--writable-root",
+        "--add-dir",
         "/tmp/matrixos-codex",
         "--",
         "fix tests; rm -rf /",
@@ -78,13 +78,13 @@ describe("agent-launcher", () => {
       });
       if (agent === "codex") {
         expect(launch.args).toEqual([
-          "exec",
-          "--skip-git-repo-check",
           "--ask-for-approval",
           "never",
+          "exec",
+          "--skip-git-repo-check",
           "--sandbox",
           "workspace-write",
-          "--writable-root",
+          "--add-dir",
           "/tmp/sandbox",
           "--",
           "--dangerously-bypass-sandbox",
@@ -119,9 +119,9 @@ describe("agent-launcher", () => {
       prompt: "--help",
       sandbox: { enabled: true, writableRoots: ["/tmp/sandbox"] },
     });
-    expect(launch.args.slice(0, 4)).toEqual(["exec", "--skip-git-repo-check", "--ask-for-approval", "never"]);
+    expect(launch.args.slice(0, 4)).toEqual(["--ask-for-approval", "never", "exec", "--skip-git-repo-check"]);
     const sandboxIndex = launch.args.indexOf("--sandbox");
-    const writableRootIndex = launch.args.indexOf("--writable-root");
+    const writableRootIndex = launch.args.indexOf("--add-dir");
     const dashDashIndex = launch.args.indexOf("--");
     expect(sandboxIndex).toBeGreaterThan(3);
     expect(writableRootIndex).toBeGreaterThan(sandboxIndex);
@@ -141,7 +141,7 @@ describe("agent-launcher", () => {
       cwd: "/home/matrixos/home/projects/repo",
       prompt: "work",
       sandbox: { enabled: false, adminOverride: true },
-    }).args).toEqual(["exec", "--skip-git-repo-check", "--ask-for-approval", "never", "--dangerously-bypass-sandbox", "--", "work"]);
+    }).args).toEqual(["--ask-for-approval", "never", "exec", "--skip-git-repo-check", "--dangerously-bypass-approvals-and-sandbox", "--", "work"]);
   });
 
   it("validates supported agent IDs", () => {

--- a/tests/gateway/symphony-credential-store.test.ts
+++ b/tests/gateway/symphony-credential-store.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, stat } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createFileSymphonyCredentialStore } from "../../packages/gateway/src/symphony/credential-store.js";
+import {
+  createCompositeSymphonyCredentialStore,
+  createFileSymphonyCredentialStore,
+  encodeLinearIntegrationCredential,
+} from "../../packages/gateway/src/symphony/credential-store.js";
 
 describe("Symphony credential store", () => {
   let homePath: string;
@@ -41,5 +45,26 @@ describe("Symphony credential store", () => {
 
     await expect(store.hasLinearCredential("user_123")).resolves.toBe(false);
     await expect(store.readLinearCredential("user_123")).resolves.toBeNull();
+  });
+
+  it("falls back to an opaque Linear integration reference when no API key is stored", async () => {
+    const primary = createFileSymphonyCredentialStore({ homePath });
+    const hasLinearIntegration = vi.fn(async (ownerId: string) => ownerId === "user_123");
+    const store = createCompositeSymphonyCredentialStore({ primary, hasLinearIntegration });
+
+    await expect(store.hasLinearCredential("user_123")).resolves.toBe(true);
+    await expect(store.readLinearCredential("user_123")).resolves.toBe(encodeLinearIntegrationCredential("user_123"));
+    expect(hasLinearIntegration).toHaveBeenCalledWith("user_123");
+  });
+
+  it("prefers a stored Linear API key over the integration fallback", async () => {
+    const primary = createFileSymphonyCredentialStore({ homePath });
+    await primary.writeLinearCredential("user_123", "lin_api_secret");
+    const store = createCompositeSymphonyCredentialStore({
+      primary,
+      hasLinearIntegration: vi.fn(async () => true),
+    });
+
+    await expect(store.readLinearCredential("user_123")).resolves.toBe("lin_api_secret");
   });
 });

--- a/tests/gateway/symphony-linear-integration.test.ts
+++ b/tests/gateway/symphony-linear-integration.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PlatformDb } from "../../packages/gateway/src/platform-db.js";
+import type { PipedreamConnectClient } from "../../packages/gateway/src/integrations/pipedream.js";
+import { encodeLinearIntegrationCredential } from "../../packages/gateway/src/symphony/credential-store.js";
+import {
+  createIntegrationAwareLinearGraphql,
+  hasConnectedLinearIntegration,
+} from "../../packages/gateway/src/symphony/linear-integration.js";
+
+const linearConnection = {
+  id: "svc_1",
+  user_id: "user_123",
+  service: "linear",
+  pipedream_account_id: "pd_acc_123",
+  account_label: "Linear",
+  account_email: null,
+  scopes: [],
+  status: "active" as const,
+  connected_at: new Date("2026-05-13T00:00:00.000Z"),
+  last_used_at: null,
+};
+
+describe("Symphony Linear integration transport", () => {
+  it("detects an active connected Linear integration", async () => {
+    const db = {
+      listConnectedServices: vi.fn(async () => [linearConnection]),
+    } as unknown as PlatformDb;
+
+    await expect(hasConnectedLinearIntegration(db, "user_123")).resolves.toBe(true);
+    expect(db.listConnectedServices).toHaveBeenCalledWith("user_123");
+  });
+
+  it("executes integration credentials through Pipedream without exposing provider tokens", async () => {
+    const db = {
+      listConnectedServices: vi.fn(async () => [linearConnection]),
+      getUserById: vi.fn(async () => ({ id: "user_123", pipedream_external_id: null })),
+      updatePipedreamExternalId: vi.fn(async () => undefined),
+      touchServiceUsage: vi.fn(async () => undefined),
+    } as unknown as PlatformDb;
+    const pipedream = {
+      proxyPost: vi.fn(async () => ({ data: { viewer: { id: "viewer_1" } } })),
+    } as unknown as PipedreamConnectClient;
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    const transport = createIntegrationAwareLinearGraphql({ platformDb: db, pipedream });
+
+    const result = await transport({
+      credential: encodeLinearIntegrationCredential("user_123"),
+      query: "query Test($first: Int!) { viewer { id } }",
+      variables: { first: 1 },
+      endpoint: "https://api.linear.app/graphql",
+      fetch: fetchMock,
+      timeoutMs: 10_000,
+    });
+
+    expect(result).toEqual({ data: { viewer: { id: "viewer_1" } } });
+    expect(pipedream.proxyPost).toHaveBeenCalledWith({
+      externalUserId: "user_123",
+      accountId: "pd_acc_123",
+      url: "https://api.linear.app/graphql",
+      body: {
+        query: "query Test($first: Int!) { viewer { id } }",
+        variables: { first: 1 },
+      },
+    });
+    expect(db.updatePipedreamExternalId).toHaveBeenCalledWith("user_123", "user_123");
+    expect(db.touchServiceUsage).toHaveBeenCalledWith("svc_1");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes Pipedream proxy failures for integration-backed GraphQL", async () => {
+    const db = {
+      listConnectedServices: vi.fn(async () => [linearConnection]),
+      getUserById: vi.fn(async () => ({ id: "user_123", pipedream_external_id: "ext_123" })),
+      updatePipedreamExternalId: vi.fn(async () => undefined),
+      touchServiceUsage: vi.fn(async () => undefined),
+    } as unknown as PlatformDb;
+    const pipedream = {
+      proxyPost: vi.fn(async () => {
+        throw new Error("provider timeout with raw details");
+      }),
+    } as unknown as PipedreamConnectClient;
+    const transport = createIntegrationAwareLinearGraphql({ platformDb: db, pipedream });
+
+    await expect(transport({
+      credential: encodeLinearIntegrationCredential("user_123"),
+      query: "query Test { viewer { id } }",
+      endpoint: "https://api.linear.app/graphql",
+      fetch: vi.fn() as unknown as typeof fetch,
+      timeoutMs: 10_000,
+    })).rejects.toThrow("linear_integration_unavailable");
+    expect(db.touchServiceUsage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/gateway/symphony-linear-source.test.ts
+++ b/tests/gateway/symphony-linear-source.test.ts
@@ -13,6 +13,28 @@ const rule = {
 };
 
 describe("Symphony Linear source", () => {
+  it("can execute Linear GraphQL through a server-side integration transport", async () => {
+    const graphql = vi.fn(async ({ query, variables, credential }) => {
+      expect(credential).toBe("matrixos_linear_integration");
+      expect(query).toContain("MatrixSymphonySetupOptions");
+      expect(variables).toMatchObject({ first: 100, includeTeams: true });
+      return {
+        data: {
+          teams: { nodes: [{ id: "team_123", key: "MAT", name: "Matrix" }], pageInfo: { hasNextPage: false, endCursor: null } },
+          projects: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+          users: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+        },
+      };
+    });
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    const source = createLinearSource({ fetch: fetchMock, graphql });
+
+    const result = await source.discoverSetupOptions("matrixos_linear_integration");
+
+    expect(result.teams).toEqual([{ id: "team_123", key: "MAT", name: "Matrix" }]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("discovers teams, projects, and users without exposing the credential", async () => {
     const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
       expect(init.signal).toBeTruthy();
@@ -93,8 +115,9 @@ describe("Symphony Linear source", () => {
       expect(body.query).toContain("$projectId: ID!");
       expect(body.query).toContain("$assigneeId: ID!");
       expect(body.query).toContain("$state: String!");
-      expect(body.query).toContain("$labelName: String!");
+      expect(body.query).not.toContain("$labelName: String!");
       expect(body.variables.assigneeId).toBe("assignee_1");
+      expect(body.variables).not.toHaveProperty("labelName");
       return new Response(JSON.stringify({
         data: {
           issues: {
@@ -132,6 +155,66 @@ describe("Symphony Linear source", () => {
       expect.objectContaining({ externalId: "issue_1", identifier: "MAT-1", assigneeId: "assignee_1" }),
     ]);
     expect(JSON.stringify(result)).not.toContain("lin_api_secret");
+  });
+
+  it("fetches candidates without server-side label narrowing so new labels are detected reliably", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      expect(body.query).not.toContain("$labelName");
+      expect(body.query).not.toContain("labels: { name:");
+      expect(body.variables).not.toHaveProperty("labelName");
+      return new Response(JSON.stringify({
+        data: {
+          issues: {
+            nodes: [{
+              id: "issue_1",
+              identifier: "MAT-1",
+              title: "Newly labeled",
+              assignee: { id: "assignee_1" },
+              state: { name: "Todo" },
+              labels: { nodes: [{ name: "symphony" }, { name: "urgent" }] },
+            }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      }));
+    }) as unknown as typeof fetch;
+    const source = createLinearSource({ fetch: fetchMock });
+
+    const result = await source.previewTickets(rule, "lin_api_secret", { limit: 10 });
+
+    expect(result.tickets).toEqual([expect.objectContaining({ externalId: "issue_1" })]);
+  });
+
+  it("shares scan offsets across rules that only differ by required labels", async () => {
+    const statesSeen: string[] = [];
+    const graphql = vi.fn(async ({ variables }) => {
+      const state = String(variables?.state);
+      statesSeen.push(state);
+      const label = statesSeen.length === 1 ? "symphony" : "urgent";
+      return {
+        data: {
+          issues: {
+            nodes: [{
+              id: `issue_${statesSeen.length}`,
+              identifier: `MAT-${statesSeen.length}`,
+              title: state,
+              assignee: { id: "assignee_1" },
+              state: { name: state },
+              labels: { nodes: [{ name: label }] },
+            }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      };
+    });
+    const source = createLinearSource({ graphql });
+    const twoStateRule = { ...rule, requiredLabels: ["symphony"], activeStates: ["Todo", "In Progress"] };
+
+    await source.previewTickets(twoStateRule, "lin_api_secret", { limit: 1 });
+    await source.previewTickets({ ...twoStateRule, requiredLabels: ["urgent"] }, "lin_api_secret", { limit: 1 });
+
+    expect(statesSeen).toEqual(["Todo", "In Progress"]);
   });
 
   it("uses no assignee filter when assigneeIds is empty", async () => {

--- a/tests/gateway/symphony-orchestrator.test.ts
+++ b/tests/gateway/symphony-orchestrator.test.ts
@@ -244,6 +244,71 @@ describe("Matrix Symphony orchestrator", () => {
     expect(agentSessionManager.startSession).toHaveBeenCalledTimes(1);
   });
 
+  it("uses Elixir-style priority ordering before dispatching eligible labeled tickets", async () => {
+    const repository = memoryRepo(structuredClone(baseSnapshot));
+    const worktreeManager = {
+      createWorktree: vi.fn(async (input: { branch: string }) => ({
+        ok: true as const,
+        status: 201 as const,
+        worktree: { id: `wt_${input.branch.split("/").pop()}`, path: "/repo/wt", projectSlug: "matrix-os" },
+      })),
+    };
+    const agentSessionManager = {
+      startSession: vi.fn(async () => ({ ok: true as const, status: 201 as const, session: { id: "sess_priority", runtime: { status: "running" } } })),
+      killSession: vi.fn(),
+    };
+    const orchestrator = createMatrixSymphonyOrchestrator({
+      homePath,
+      repository,
+      credentialStore: { readLinearCredential: vi.fn(async () => "lin_api_secret"), hasLinearCredential: vi.fn(), writeLinearCredential: vi.fn(), deleteLinearCredential: vi.fn() },
+      linearSource: {
+        previewTickets: vi.fn(async () => ({
+          truncated: false,
+          tickets: [
+            { externalId: "issue_low", identifier: "MAT-20", title: "Low", stateName: "Todo", assigneeId: "assignee_1", labels: ["symphony"], priority: 4, createdAt: "2026-05-13T00:01:00.000Z" },
+            { externalId: "issue_high", identifier: "MAT-10", title: "High", stateName: "Todo", assigneeId: "assignee_1", labels: ["symphony"], priority: 1, createdAt: "2026-05-13T00:02:00.000Z" },
+          ],
+        })),
+      },
+      worktreeManager,
+      agentSessionManager,
+    });
+
+    await orchestrator.poll("user_123");
+
+    expect(worktreeManager.createWorktree).toHaveBeenCalledWith(expect.objectContaining({ branch: "symphony/mat-10" }));
+  });
+
+  it("does not dispatch Todo tickets blocked by non-terminal dependencies", async () => {
+    const repository = memoryRepo(structuredClone(baseSnapshot));
+    const worktreeManager = { createWorktree: vi.fn() };
+    const orchestrator = createMatrixSymphonyOrchestrator({
+      homePath,
+      repository,
+      credentialStore: { readLinearCredential: vi.fn(async () => "lin_api_secret"), hasLinearCredential: vi.fn(), writeLinearCredential: vi.fn(), deleteLinearCredential: vi.fn() },
+      linearSource: {
+        previewTickets: vi.fn(async () => ({
+          truncated: false,
+          tickets: [{
+            externalId: "issue_blocked",
+            identifier: "MAT-30",
+            title: "Blocked",
+            stateName: "Todo",
+            assigneeId: "assignee_1",
+            labels: ["symphony"],
+            blockedBy: [{ id: "issue_dependency", identifier: "MAT-29", stateName: "In Progress" }],
+          }],
+        })),
+      },
+      worktreeManager,
+      agentSessionManager: { startSession: vi.fn(), killSession: vi.fn() },
+    });
+
+    await expect(orchestrator.poll("user_123")).resolves.toMatchObject({ dispatched: 0, skipped: 1 });
+
+    expect(worktreeManager.createWorktree).not.toHaveBeenCalled();
+  });
+
   it("serializes concurrent polls for the same owner", async () => {
     const repository = memoryRepo(structuredClone(baseSnapshot));
     const linearSource = {
@@ -665,9 +730,11 @@ describe("Matrix Symphony orchestrator", () => {
       });
 
       await expect(orchestrator.resumeEnabledInstallations()).resolves.toEqual(["user_123"]);
+      await Promise.resolve();
+      expect(linearSource.previewTickets).toHaveBeenCalledTimes(1);
       await vi.advanceTimersByTimeAsync(1_000);
 
-      expect(linearSource.previewTickets).toHaveBeenCalledTimes(1);
+      expect(linearSource.previewTickets).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Summary

- Align Matrix-native Symphony dispatch with the upstream Elixir behavior: immediate startup polling, local required-label filtering, priority/created ordering, and blocked Todo suppression.
- Add a server-side Linear integration fallback so Symphony can use an existing connected Linear account when no runner-specific API key is stored.
- Fix Codex launcher compatibility with the installed CLI by using `codex login status` and current `codex exec` flags.

## Tests

- `bun run test tests/gateway/symphony-*.test.ts tests/default-apps/symphony-app.test.tsx tests/gateway/agent-launcher.test.ts tests/gateway/agent-session-manager.test.ts tests/gateway/workspace-routes.test.ts tests/gateway/seed-manifests.test.ts tests/gateway/apps.test.ts`
- `bun run typecheck`
- `bun run check:patterns`
- `codex login status`
- Attempted full `bun run test`; local Vitest run produced no progress for several minutes and was terminated cleanly.

## Invariants

- **Source of truth**: Symphony installation/rule/run state remains in the owner Postgres repository. Linear credentials remain server-side, either as owner-local API-key files or platform-owned connected-service rows.
- **Lock/transaction scope**: This change does not introduce multi-row write flows. Dispatch still relies on existing repository claim/run guards; Linear discovery and preview network calls stay outside database transactions.
- **Acceptable orphan states**: If a connected Linear integration exists but Pipedream/Linear execution fails, Symphony returns a generic setup/preview failure and does not mark tickets claimed. Existing API-key credentials continue to work independently.
- **Auth source of truth**: Symphony route authorization continues through request-principal ownership/operator checks. Integration credentials are resolved server-side from the authenticated owner id; provider tokens are never returned to the browser.
- **Deferred scope**: This does not add a new org-wide Symphony admin rollout UI. It keeps the first-party bundled app and makes its Linear setup path work with either existing integrations or API keys.
