### PR TITLE
feat(icons): enforce generate-once lock

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -3238,6 +3238,21 @@ export async function createGateway(config: GatewayConfig) {
         shipped: true,
       });
     }
+
+    const iconsDir = join(homePath, "system/icons");
+    const iconPath = join(iconsDir, `${slug}.png`);
+    if (existsSync(iconPath)) {
+      const stat = statSync(iconPath);
+      const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
+      c.header("ETag", etag);
+      return c.json({
+        iconUrl: `/files/system/icons/${slug}.png`,
+        etag,
+        generated: false,
+        alreadyExists: true,
+      });
+    }
+
     const geminiKey = process.env.GEMINI_API_KEY ?? "";
     if (!geminiKey) {
       return c.json({
@@ -3259,13 +3274,11 @@ export async function createGateway(config: GatewayConfig) {
       const iconStyle = body.style || loadIconStyle(homePath);
       const client = createImageClient(geminiKey);
       const prompt = buildIconPrompt(slug, iconStyle);
-      const iconsDir = join(homePath, "system/icons");
       const result = await client.generateImage(prompt, {
         aspectRatio: "1:1",
         imageDir: iconsDir,
         saveAs: `${slug}.png`,
       });
-      const iconPath = join(iconsDir, `${slug}.png`);
       const stat = statSync(iconPath);
       const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
       c.header("ETag", etag);
@@ -3281,51 +3294,43 @@ export async function createGateway(config: GatewayConfig) {
     }
   });
 
-  app.post("/api/icons/regenerate-all", appIconBodyLimit, async (c) => {
+  app.post("/api/icons/generate-missing", appIconBodyLimit, async (c) => {
     const geminiKey = process.env.GEMINI_API_KEY ?? "";
     if (!geminiKey) {
-      return c.json({ regenerated: 0, failed: [], generated: false });
+      return c.json({ generated: 0, failed: [] });
     }
 
     const iconsDir = join(homePath, "system/icons");
-    if (!existsSync(iconsDir)) {
-      return c.json({ regenerated: 0, failed: [] });
+    const apps = await listApps(homePath);
+    const slugs = apps.map((a) => a.slug).filter((s): s is string => Boolean(s));
+    const missing = slugs.filter((s) => !existsSync(join(iconsDir, `${s}.png`)));
+
+    if (missing.length === 0) {
+      return c.json({ generated: 0, total: slugs.length, missing: 0 });
     }
 
-    const apps = await listApps(homePath);
-    const appSlugs = new Set(apps.map((a) => a.slug).filter(Boolean));
-    const pngFiles = readdirSync(iconsDir)
-      .filter((f: string) => f.endsWith(".png"))
-      .filter((f: string) => appSlugs.has(f.replace(/\.png$/, "")));
-
     const iconStyle = loadIconStyle(homePath);
-    const total = pngFiles.length;
-
-    // Return 202 immediately, regenerate in background
-    const regeneration = (async () => {
-      const client = createImageClient(geminiKey);
-      let regenerated = 0;
+    const client = createImageClient(geminiKey);
+    (async () => {
+      let generated = 0;
       const failed: string[] = [];
-      for (const file of pngFiles) {
-        const slug = file.replace(/\.png$/, "");
+      for (const slug of missing) {
         try {
           await client.generateImage(buildIconPrompt(slug, iconStyle), {
             aspectRatio: "1:1",
             imageDir: iconsDir,
             saveAs: `${slug}.png`,
           });
-          regenerated++;
+          generated++;
         } catch (err) {
-          const msg = err instanceof Error ? err.message : "Unknown error";
-          console.error(`Icon regeneration failed for "${slug}":`, msg);
+          console.error(`[icons] Generate-missing failed for "${slug}":`, err instanceof Error ? err.message : String(err));
           failed.push(slug);
         }
       }
-      console.log(`[icons] Regeneration complete: ${regenerated}/${total} succeeded, ${failed.length} failed`);
-    })();
-    regeneration.catch((err) => console.error("[icons] Regeneration error:", err));
+      console.log(`[icons] Generated missing: ${generated}/${missing.length} succeeded, ${failed.length} failed`);
+    })().catch((err) => console.error("[icons] Generate-missing error:", err));
 
-    return c.json({ accepted: true, total }, 202);
+    return c.json({ accepted: true, total: slugs.length, missing: missing.length }, 202);
   });
 
   app.get("/api/cron", (c) => {

--- a/shell/e2e/icon-no-regenerate.spec.ts
+++ b/shell/e2e/icon-no-regenerate.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Icon generate-once: no regeneration UI", () => {
+  const mockApps = [
+    {
+      name: "Todo",
+      slug: "todo",
+      path: "~/apps/todo",
+      runtime: "static",
+      category: "productivity",
+      description: "A todo app",
+      iconUrl: "/files/system/icons/todo.png",
+    },
+    {
+      name: "Notes",
+      slug: "notes",
+      path: "~/apps/notes",
+      runtime: "static",
+      category: "productivity",
+      description: "A notes app",
+      iconUrl: "/files/system/icons/notes.png",
+    },
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/settings/**", (route) => {
+      const pathname = new URL(route.request().url()).pathname;
+      const body = pathname.endsWith("/onboarding-status")
+        ? { complete: true }
+        : {
+            background: { type: "pattern" },
+            dock: { position: "left", size: 56, iconSize: 40, autoHide: false },
+            pinnedApps: ["~/apps/todo"],
+            hasKey: true,
+          };
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+    });
+    await page.route("**/api/identity", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ handle: "test", displayName: "Test User" }),
+      }),
+    );
+    await page.route("**/api/apps**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockApps),
+      }),
+    );
+    await page.route("**/files/system/icons/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        body: Buffer.from("fake-png"),
+      }),
+    );
+    await page.route("**/ws/**", (route) => route.abort());
+
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='dock-settings']", {
+      timeout: 15000,
+    });
+  });
+
+  test("context menu on app tile does not show Regenerate Icon", async ({
+    page,
+  }) => {
+    const launcherBtn = page.locator("[data-testid='dock-tasks']");
+    await expect(launcherBtn).toBeVisible({ timeout: 10000 });
+    await launcherBtn.click();
+
+    const appTile = page.locator("[data-app-tile]").first();
+    await expect(appTile).toBeVisible({ timeout: 10000 });
+
+    await appTile.click({ button: "right" });
+
+    const contextMenu = page.locator("[role='menu']");
+    await expect(contextMenu).toBeVisible({ timeout: 5000 });
+
+    const menuItems = contextMenu.locator("[role='menuitem']");
+    const count = await menuItems.count();
+    for (let i = 0; i < count; i++) {
+      const text = await menuItems.nth(i).textContent();
+      expect(text).not.toContain("Regenerate");
+    }
+  });
+
+  test("context menu on dock icon does not show Regenerate Icon", async ({
+    page,
+  }) => {
+    const dockIcon = page.locator("[data-dock-icon]").first();
+    if (await dockIcon.isVisible()) {
+      await dockIcon.click({ button: "right" });
+
+      const contextMenu = page.locator("[role='menu']");
+      if (await contextMenu.isVisible({ timeout: 3000 }).catch(() => false)) {
+        const menuItems = contextMenu.locator("[role='menuitem']");
+        const count = await menuItems.count();
+        for (let i = 0; i < count; i++) {
+          const text = await menuItems.nth(i).textContent();
+          expect(text).not.toContain("Regenerate");
+        }
+      }
+    }
+  });
+
+  test("no regenerate-all API call is made on page load", async ({ page }) => {
+    const regenerateRequests: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("regenerate-all")) {
+        regenerateRequests.push(req.url());
+      }
+    });
+
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='dock-settings']", {
+      timeout: 15000,
+    });
+    await page.waitForTimeout(2000);
+
+    expect(regenerateRequests).toHaveLength(0);
+  });
+});

--- a/shell/src/components/AppTile.tsx
+++ b/shell/src/components/AppTile.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
-import { PinIcon, RefreshCwIcon, PencilIcon, EyeOffIcon } from "lucide-react";
+import { PinIcon, PencilIcon, EyeOffIcon } from "lucide-react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -16,12 +16,11 @@ interface AppTileProps {
   pinned?: boolean;
   onTogglePin?: () => void;
   iconUrl?: string;
-  onRegenerateIcon?: () => void;
   onRename?: (newName: string) => void;
   onRemoveFromCanvas?: () => void;
 }
 
-export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, onRegenerateIcon, onRename, onRemoveFromCanvas }: AppTileProps) {
+export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, onRename, onRemoveFromCanvas }: AppTileProps) {
   const initial = name.charAt(0).toUpperCase();
   const [imgError, setImgError] = useState(false);
   useEffect(() => setImgError(false), [iconUrl]);
@@ -75,7 +74,7 @@ export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, o
     </button>
   );
 
-  const hasContextMenu = onTogglePin || onRegenerateIcon || onRename || onRemoveFromCanvas;
+  const hasContextMenu = onTogglePin || onRename || onRemoveFromCanvas;
   if (!hasContextMenu) return tile;
 
   return (
@@ -90,13 +89,7 @@ export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, o
             {pinned ? "Unpin from Dock" : "Pin to Dock"}
           </ContextMenuItem>
         )}
-        {onRegenerateIcon && (
-          <ContextMenuItem onSelect={onRegenerateIcon}>
-            <RefreshCwIcon className="size-3.5 mr-2" />
-            Regenerate Icon
-          </ContextMenuItem>
-        )}
-        {(onRename || onRemoveFromCanvas) && (onTogglePin || onRegenerateIcon) && (
+        {(onRename || onRemoveFromCanvas) && onTogglePin && (
           <ContextMenuSeparator />
         )}
         {onRename && (

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -40,7 +40,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { KanbanSquareIcon, MonitorIcon, SettingsIcon, PinOffIcon, RefreshCwIcon, CheckIcon, PencilIcon, XCircleIcon, MessageSquareIcon, MicIcon, ExternalLinkIcon } from "lucide-react";
+import { KanbanSquareIcon, MonitorIcon, SettingsIcon, PinOffIcon, CheckIcon, PencilIcon, XCircleIcon, MessageSquareIcon, MicIcon, ExternalLinkIcon } from "lucide-react";
 import { UserButton } from "./UserButton";
 import { ConnectionIndicator } from "./ConnectionIndicator";
 import { AmbientClock } from "./AmbientClock";
@@ -207,7 +207,6 @@ function DockIcon({
   tooltipSide = "right",
   iconUrl,
   onUnpin,
-  onRegenerateIcon,
   onRename,
   onQuit,
   canQuit,
@@ -219,7 +218,6 @@ function DockIcon({
   tooltipSide?: "left" | "right" | "top" | "bottom";
   iconUrl?: string;
   onUnpin?: () => void;
-  onRegenerateIcon?: () => void;
   onRename?: (newName: string) => void;
   onQuit?: () => void;
   canQuit?: boolean;
@@ -248,7 +246,7 @@ function DockIcon({
     </button>
   );
 
-  const hasContextMenu = onUnpin || onRegenerateIcon || onRename || onQuit;
+  const hasContextMenu = onUnpin || onRename || onQuit;
   if (!hasContextMenu) {
     return (
       <Tooltip>
@@ -275,13 +273,7 @@ function DockIcon({
             Unpin from Dock
           </ContextMenuItem>
         )}
-        {onRegenerateIcon && (
-          <ContextMenuItem onSelect={onRegenerateIcon}>
-            <RefreshCwIcon className="size-3.5 mr-2" />
-            Regenerate Icon
-          </ContextMenuItem>
-        )}
-        {onRename && (onUnpin || onRegenerateIcon) && (
+        {onRename && onUnpin && (
           <ContextMenuSeparator />
         )}
         {onRename && (
@@ -299,7 +291,7 @@ function DockIcon({
         )}
         {onQuit && (
           <>
-            {(onUnpin || onRegenerateIcon || onRename) && <ContextMenuSeparator />}
+            {(onUnpin || onRename) && <ContextMenuSeparator />}
             <ContextMenuItem
               disabled={!canQuit}
               onSelect={() => {
@@ -592,7 +584,8 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
   const generatingRef = useRef(new Set<string>());
   const checkedRef = useRef(new Set<string>());
 
-  const regenerateIcon = useCallback((slug: string) => {
+  const generateIconIfMissing = useCallback((slug: string) => {
+    if (generatingRef.current.has(slug)) return;
     generatingRef.current.add(slug);
     fetch(`${GATEWAY_URL}/api/apps/${slug}/icon`, {
       method: "POST",
@@ -601,8 +594,8 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
       .then((r) => {
         if (!r.ok) {
           r.json()
-            .then((d: { error?: string }) => console.warn(`Icon regen failed for "${slug}":`, d.error))
-            .catch((err) => console.warn(`[desktop] Failed to parse icon regeneration error for "${slug}":`, err));
+            .then((d: { error?: string }) => console.warn(`Icon generation failed for "${slug}":`, d.error))
+            .catch((err) => console.warn(`[desktop] Failed to parse icon generation error for "${slug}":`, err));
           return;
         }
         return r.json().then((data: { iconUrl: string; etag?: string }) => {
@@ -615,7 +608,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
           );
         });
       })
-      .catch((err) => console.warn(`Icon regen request failed for "${slug}":`, err))
+      .catch((err) => console.warn(`Icon generation request failed for "${slug}":`, err))
       .finally(() => generatingRef.current.delete(slug));
   }, [wmSetApps]);
 
@@ -642,7 +635,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
         }
       } else {
         if (iconPath.endsWith(".png")) {
-          regenerateIcon(slug);
+          generateIconIfMissing(slug);
         } else {
           wmSetApps((prev) =>
             prev.map((a) =>
@@ -654,7 +647,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
         }
       }
     }).catch((err) => console.warn(`[desktop] Failed to check icon for "${slug}":`, err));
-  }, [wmSetApps, regenerateIcon]);
+  }, [wmSetApps, generateIconIfMissing]);
 
   const renameAppOnServer = useCallback((slug: string, newName: string) => {
     fetch(`${GATEWAY_URL}/api/apps/${slug}/rename`, {
@@ -1559,7 +1552,6 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
                         tooltipSide={tooltipSide}
                         iconUrl={app.iconUrl}
                         onUnpin={pinnedSet.has(app.path) ? () => togglePin(app.path) : undefined}
-                        onRegenerateIcon={() => regenerateIcon(nameToSlug(app.name))}
                         onRename={(newName) => renameAppOnServer(nameToSlug(app.name), newName)}
                         onQuit={() => removeFromCanvas(app.path)}
                         canQuit={hasAny}
@@ -1831,7 +1823,6 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
             onClose={() => setTaskBoardOpen(false)}
             pinnedApps={pinnedApps}
             onTogglePin={togglePin}
-            onRegenerateIcon={regenerateIcon}
             onRenameApp={renameAppOnServer}
             onRemoveFromCanvas={removeFromCanvas}
           />

--- a/shell/src/components/MissionControl.tsx
+++ b/shell/src/components/MissionControl.tsx
@@ -27,7 +27,6 @@ interface MissionControlProps {
   onClose: () => void;
   pinnedApps: string[];
   onTogglePin: (path: string) => void;
-  onRegenerateIcon: (slug: string) => void;
   onRenameApp?: (slug: string, newName: string) => void;
   onRemoveFromCanvas?: (path: string) => void;
 }
@@ -40,7 +39,6 @@ export function MissionControl({
   onClose,
   pinnedApps,
   onTogglePin,
-  onRegenerateIcon,
   onRenameApp,
   onRemoveFromCanvas,
 }: MissionControlProps) {
@@ -139,7 +137,6 @@ export function MissionControl({
           onOpenApp={onOpenApp}
           onClose={onClose}
           onTogglePin={onTogglePin}
-          onRegenerateIcon={onRegenerateIcon}
           onRenameApp={onRenameApp}
           onRemoveFromCanvas={onRemoveFromCanvas}
           visible={visible}
@@ -164,7 +161,6 @@ function LauncherGrid({
   onOpenApp,
   onClose,
   onTogglePin,
-  onRegenerateIcon,
   onRenameApp,
   onRemoveFromCanvas,
   visible,
@@ -176,7 +172,6 @@ function LauncherGrid({
   onOpenApp: (name: string, path: string) => void;
   onClose: () => void;
   onTogglePin: (path: string) => void;
-  onRegenerateIcon: (slug: string) => void;
   onRenameApp?: (slug: string, newName: string) => void;
   onRemoveFromCanvas?: (path: string) => void;
   visible: boolean;
@@ -226,7 +221,6 @@ function LauncherGrid({
           pinned={pinnedApps.includes(app.path)}
           onTogglePin={() => onTogglePin(app.path)}
           iconUrl={app.iconUrl}
-          onRegenerateIcon={() => onRegenerateIcon(slug)}
           onRename={onRenameApp ? (newName) => onRenameApp(slug, newName) : undefined}
           onRemoveFromCanvas={onRemoveFromCanvas ? () => onRemoveFromCanvas(app.path) : undefined}
         />

--- a/tests/e2e/api/icon-generate-once.e2e.test.ts
+++ b/tests/e2e/api/icon-generate-once.e2e.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { startTestGateway, type TestGateway } from "../fixtures/gateway.js";
+
+describe("E2E: Icon generate-once lock", () => {
+  let gw: TestGateway;
+
+  beforeAll(async () => {
+    gw = await startTestGateway();
+  });
+
+  afterAll(async () => {
+    await gw?.close();
+  });
+
+  it("returns existing icon without regenerating on second call", async () => {
+    const iconsDir = join(gw.homePath, "system/icons");
+    mkdirSync(iconsDir, { recursive: true });
+    writeFileSync(join(iconsDir, "custom-test-app.png"), "existing-icon-data");
+
+    const res = await fetch(`${gw.url}/api/apps/custom-test-app/icon`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { iconUrl: string; alreadyExists: boolean; cost?: number };
+    expect(body.iconUrl).toBe("/files/system/icons/custom-test-app.png");
+    expect(body.alreadyExists).toBe(true);
+    expect(body.cost).toBeUndefined();
+  });
+
+  it("does not provide a regenerate-all endpoint", async () => {
+    const res = await fetch(`${gw.url}/api/icons/regenerate-all`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("provides generate-missing endpoint that skips existing icons", async () => {
+    const iconsDir = join(gw.homePath, "system/icons");
+    mkdirSync(iconsDir, { recursive: true });
+    writeFileSync(join(iconsDir, "existing-app.png"), "existing-icon");
+
+    const res = await fetch(`${gw.url}/api/icons/generate-missing`, {
+      method: "POST",
+    });
+    expect(res.status).toBeGreaterThanOrEqual(200);
+    expect(res.status).toBeLessThan(300);
+  });
+});

--- a/tests/gateway/icon-gen.test.ts
+++ b/tests/gateway/icon-gen.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { Hono } from "hono";
@@ -31,6 +31,19 @@ function createIconApp(homePath: string) {
       return c.json({ error: "Invalid slug" }, 400);
     }
 
+    const iconsDir = join(homePath, "system/icons");
+    const iconPath = join(iconsDir, `${slug}.png`);
+    if (existsSync(iconPath)) {
+      const stat = statSync(iconPath);
+      const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}"`;
+      return c.json({
+        iconUrl: `/files/system/icons/${slug}.png`,
+        etag,
+        generated: false,
+        alreadyExists: true,
+      });
+    }
+
     let body: { style?: string } = {};
     try { body = await c.req.json(); } catch { /* no body is fine */ }
 
@@ -48,7 +61,6 @@ function createIconApp(homePath: string) {
     const client = createImageClient("test-key");
     const name = slug.replace(/-/g, " ").replace(/_/g, " ");
     const prompt = `App icon for '${name}': ${iconStyle}, no text, 1:1 square`;
-    const iconsDir = join(homePath, "system/icons");
     const result = await client.generateImage(prompt, {
       aspectRatio: "1:1",
       imageDir: iconsDir,
@@ -140,5 +152,40 @@ describe("POST /api/apps/:slug/icon", () => {
     const body = await res.json() as { prompt: string };
     expect(body.prompt).toContain("watercolor painting soft edges");
     expect(body.prompt).not.toContain("pixel art");
+  });
+
+  it("returns existing icon without regenerating when icon already exists", async () => {
+    const res1 = await app.request("/api/apps/calculator/icon", {
+      method: "POST",
+    });
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json() as { iconUrl: string; cost: number };
+    expect(body1.iconUrl).toBe("/files/system/icons/calculator.png");
+    expect(typeof body1.cost).toBe("number");
+
+    const res2 = await app.request("/api/apps/calculator/icon", {
+      method: "POST",
+    });
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json() as { iconUrl: string; alreadyExists: boolean; cost?: number };
+    expect(body2.iconUrl).toBe("/files/system/icons/calculator.png");
+    expect(body2.alreadyExists).toBe(true);
+    expect(body2.cost).toBeUndefined();
+  });
+
+  it("generates different icons independently then locks both", async () => {
+    await app.request("/api/apps/notes/icon", { method: "POST" });
+    await app.request("/api/apps/timer/icon", { method: "POST" });
+
+    expect(existsSync(join(homePath, "system/icons/notes.png"))).toBe(true);
+    expect(existsSync(join(homePath, "system/icons/timer.png"))).toBe(true);
+
+    const res1 = await app.request("/api/apps/notes/icon", { method: "POST" });
+    const body1 = await res1.json() as { alreadyExists: boolean };
+    expect(body1.alreadyExists).toBe(true);
+
+    const res2 = await app.request("/api/apps/timer/icon", { method: "POST" });
+    const body2 = await res2.json() as { alreadyExists: boolean };
+    expect(body2.alreadyExists).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Icons are now generated once per app and cannot be regenerated
- Gateway returns existing icon if `system/icons/{slug}.png` already exists on disk (no AI call)
- Replaced `POST /api/icons/regenerate-all` with `POST /api/icons/generate-missing` (only fills gaps for apps without icons)
- Removed all "Regenerate Icon" context menu items from AppTile, DockIcon, and MissionControl
- Removed `regenerateIcon` callback from Desktop.tsx, replaced with `generateIconIfMissing` (backend-enforced)

## Test plan
- [x] Unit tests: 8/8 pass (`tests/gateway/icon-gen.test.ts`) — includes 2 new tests for generate-once lock
- [x] E2E API tests: 3/3 pass (`tests/e2e/api/icon-generate-once.e2e.test.ts`) — verifies backend blocks re-generation, regenerate-all is gone, generate-missing works
- [x] Playwright browser tests: 3/3 pass (`shell/e2e/icon-no-regenerate.spec.ts`) — verifies no "Regenerate Icon" in context menus, no regenerate-all API calls on page load
- [x] TypeScript compiles clean (both shell and gateway)
- [x] Source grep confirms zero remaining regeneration references