### PR TITLE
fix(symphony): reuse Matrix CLI agent auth

### DIFF
--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -6,6 +6,15 @@ import { Badge } from "@/components/ui/badge";
 
 type RunStatus = "queued" | "running" | "retrying" | "blocked" | "stopped" | "failed" | "handoff" | "completed";
 type Agent = "codex" | "claude" | "opencode" | "pi";
+type AgentAuthState = "unknown" | "ok" | "required" | "error";
+
+interface AgentStatus {
+  id: Agent;
+  displayName?: string;
+  installed: boolean;
+  authState: AgentAuthState;
+  errorCode: string | null;
+}
 
 interface SymphonyStatus {
   running: boolean;
@@ -69,6 +78,7 @@ interface Run {
   projectSlug: string;
   worktreeId?: string;
   sessionId?: string;
+  lastErrorCode?: string;
   lastEvent: string;
   updatedAt: string;
 }
@@ -146,6 +156,10 @@ function statusTone(status: RunStatus): string {
   return "bg-zinc-100 text-zinc-700";
 }
 
+function eventTone(run: Run): string {
+  return run.lastErrorCode === "agent_auth_required" ? "text-amber-900" : "text-muted-foreground";
+}
+
 function openWorkspaceInShell() {
   if (window.MatrixOS?.openApp) {
     window.MatrixOS.openApp("Workspace", "__workspace__");
@@ -163,6 +177,7 @@ export default function App() {
   const [status, setStatus] = useState<SymphonyStatus | null>(null);
   const [config, setConfig] = useState<SymphonyConfigResponse | null>(null);
   const [runs, setRuns] = useState<Run[]>([]);
+  const [agents, setAgents] = useState<AgentStatus[]>([]);
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [setupOptions, setSetupOptions] = useState<SetupOptions | null>(null);
   const [setupLoading, setSetupLoading] = useState(false);
@@ -178,14 +193,19 @@ export default function App() {
 
   const load = useCallback(async (options: LoadOptions = {}) => {
     setError(null);
-    const [nextStatus, nextConfig, runList] = await Promise.all([
+    const [nextStatus, nextConfig, runList, agentList] = await Promise.all([
       fetchJson<SymphonyStatus>("/api/symphony/status"),
       fetchJson<SymphonyConfigResponse>("/api/symphony/config"),
       fetchJson<{ runs: Run[] }>("/api/symphony/runs"),
+      fetchJson<{ agents: AgentStatus[] }>("/api/agents").catch((err: unknown) => {
+        console.warn("[symphony] agent status load failed:", err instanceof Error ? err.message : String(err));
+        return { agents: [] };
+      }),
     ]);
     setStatus(nextStatus);
     setConfig(nextConfig);
     setRuns(runList.runs);
+    setAgents(Array.isArray(agentList.agents) ? agentList.agents : []);
     if ((options.hydrateForm ?? true) && !settingsOpenRef.current && (nextConfig.installation || nextConfig.rule)) {
       setForm({
         projectSlug: nextConfig.installation?.projectSlug ?? DEFAULT_FORM.projectSlug,
@@ -244,6 +264,15 @@ export default function App() {
   }, [load]);
 
   const grouped = useMemo(() => groupRuns(runs), [runs]);
+  const selectedAgent = config?.installation?.defaultAgent ?? form.defaultAgent;
+  const selectedAgentStatus = agents.find((agent) => agent.id === selectedAgent);
+  const agentAuthIssue = selectedAgentStatus && (
+    !selectedAgentStatus.installed ||
+    selectedAgentStatus.authState === "required" ||
+    selectedAgentStatus.authState === "error"
+  )
+    ? selectedAgentStatus
+    : null;
   const filteredLinearProjects = useMemo(() => {
     const projects = setupOptions?.linear.projects ?? [];
     if (!form.teamId) return projects;
@@ -447,6 +476,18 @@ export default function App() {
         </div>
       )}
 
+      {agentAuthIssue && (
+        <div className="mx-6 mt-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          <div className="flex min-w-0 items-center gap-2">
+            <AlertTriangle className="size-4 shrink-0" />
+            <span>{agentAuthIssue.displayName ?? agentAuthIssue.id} needs authentication in this Matrix runtime.</span>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => void load()} disabled={Boolean(busy)}>
+            <RefreshCw className="size-4" /> Refresh
+          </Button>
+        </div>
+      )}
+
       <section className="grid gap-4 p-6 md:grid-cols-4">
         <Metric label="Queue" value={status?.counts.queued ?? 0} />
         <Metric label="Running" value={status?.counts.running ?? 0} />
@@ -619,7 +660,7 @@ function RunRow({ run, busy, onAction }: { run: Run; busy: string | null; onActi
           <span className="text-sm text-muted-foreground">{run.agent}</span>
         </div>
         <div className="mt-1 text-sm">{run.ticketTitle}</div>
-        <div className="mt-1 text-xs text-muted-foreground">{run.lastEvent}</div>
+        <div className={`mt-1 text-xs ${eventTone(run)}`}>{run.lastEvent}</div>
       </div>
       <div className="flex items-center gap-2">
         {run.ticketUrl && (

--- a/packages/gateway/src/agent-launcher.ts
+++ b/packages/gateway/src/agent-launcher.ts
@@ -28,6 +28,7 @@ export interface AgentLaunchInput {
   cwd: string;
   prompt?: string;
   sandbox?: AgentLaunchSandbox;
+  runtimeHome?: string;
 }
 
 export interface AgentLaunchSpec {
@@ -40,7 +41,7 @@ export interface AgentLaunchSpec {
 type CommandRunner = (
   command: string,
   args: string[],
-  options: { cwd: string; timeout: number },
+  options: { cwd: string; timeout: number; env?: Record<string, string> },
 ) => Promise<{ stdout: string; stderr: string }>;
 
 const execFileAsync = promisify(execFile);
@@ -59,6 +60,7 @@ const defaultRunCommand: CommandRunner = async (command, args, options) => {
     timeout: options.timeout,
     encoding: "utf-8",
     maxBuffer: 1024 * 1024,
+    env: options.env ? { ...process.env, ...options.env } : process.env,
   });
   return { stdout, stderr };
 };
@@ -71,6 +73,14 @@ function firstLine(value: string): string | undefined {
 function promptArgs(prompt?: string): string[] {
   if (!prompt || prompt.length === 0) return [];
   return ["--", prompt];
+}
+
+function agentRuntimeEnv(runtimeHome?: string): Record<string, string> {
+  if (!runtimeHome) return {};
+  return {
+    HOME: runtimeHome,
+    MATRIX_HOME: runtimeHome,
+  };
 }
 
 function codexSandboxArgs(sandbox?: AgentLaunchSandbox): string[] {
@@ -97,9 +107,10 @@ function authStatusArgs(agent: SupportedAgent): string[] {
 export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
   const parsed = SupportedAgentSchema.parse(input.agent);
   const command = AGENTS[parsed].command;
+  const env = agentRuntimeEnv(input.runtimeHome);
   switch (parsed) {
     case "claude":
-      return { command, args: promptArgs(input.prompt), cwd: input.cwd, env: {} };
+      return { command, args: promptArgs(input.prompt), cwd: input.cwd, env };
     case "codex":
       return {
         command,
@@ -112,21 +123,23 @@ export function buildAgentLaunch(input: AgentLaunchInput): AgentLaunchSpec {
           ...promptArgs(input.prompt),
         ],
         cwd: input.cwd,
-        env: {},
+        env,
       };
     case "opencode":
-      return { command, args: ["run", ...promptArgs(input.prompt)], cwd: input.cwd, env: {} };
+      return { command, args: ["run", ...promptArgs(input.prompt)], cwd: input.cwd, env };
     case "pi":
-      return { command, args: promptArgs(input.prompt), cwd: input.cwd, env: {} };
+      return { command, args: promptArgs(input.prompt), cwd: input.cwd, env };
   }
 }
 
 export function createAgentLauncher(options: {
   runCommand?: CommandRunner;
   cwd?: string;
+  runtimeHome?: string;
 } = {}) {
   const runCommand = options.runCommand ?? defaultRunCommand;
   const cwd = options.cwd ?? process.cwd();
+  const detectEnv = agentRuntimeEnv(options.runtimeHome);
 
   return {
     async detectAgents(): Promise<{ agents: AgentStatus[] }> {
@@ -138,6 +151,7 @@ export function createAgentLauncher(options: {
           const result = await runCommand(config.command, ["--version"], {
             cwd,
             timeout: DETECT_TIMEOUT_MS,
+            env: detectEnv,
           });
           version = firstLine(result.stdout) ?? firstLine(result.stderr);
         } catch (err: unknown) {
@@ -159,6 +173,7 @@ export function createAgentLauncher(options: {
           await runCommand(config.command, authStatusArgs(id), {
             cwd,
             timeout: DETECT_TIMEOUT_MS,
+            env: detectEnv,
           });
           agents.push({
             id,
@@ -188,7 +203,7 @@ export function createAgentLauncher(options: {
     },
 
     buildLaunch(input: AgentLaunchInput): AgentLaunchSpec {
-      return buildAgentLaunch(input);
+      return buildAgentLaunch({ ...input, runtimeHome: input.runtimeHome ?? options.runtimeHome });
     },
   };
 }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2387,7 +2387,7 @@ export async function createGateway(config: GatewayConfig) {
       : createLinearSource();
     const projectManager = createProjectManager({ homePath });
     const worktreeManager = createWorktreeManager({ homePath });
-    const agentLauncher = createAgentLauncher({ cwd: homePath });
+    const agentLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
     const agentSessionManager = createAgentSessionManager({
       homePath,
       worktreeManager,
@@ -2402,6 +2402,7 @@ export async function createGateway(config: GatewayConfig) {
       linearSource,
       worktreeManager,
       agentSessionManager,
+      agentStatusProvider: agentLauncher,
       statusHub: matrixSymphonyStatusHub,
     });
     await matrixSymphonyOrchestrator.resumeEnabledInstallations();

--- a/packages/gateway/src/symphony/orchestrator.ts
+++ b/packages/gateway/src/symphony/orchestrator.ts
@@ -16,6 +16,16 @@ import type { SymphonyStatusHub } from "./status-hub.js";
 
 type WorktreeManager = Pick<ReturnType<typeof createWorktreeManager>, "createWorktree">;
 type AgentSessionManager = Pick<ReturnType<typeof createAgentSessionManager>, "startSession" | "killSession">;
+type AgentStatusProvider = {
+  detectAgents(): Promise<{
+    agents: Array<{
+      id: SymphonyInstallation["defaultAgent"];
+      installed: boolean;
+      authState: "unknown" | "ok" | "required" | "error";
+      errorCode: string | null;
+    }>;
+  }>;
+};
 
 const RETRYABLE_RUN_STATUSES: SymphonyRun["status"][] = ["queued", "running", "retrying", "blocked", "failed", "stopped"];
 const RETRYABLE_RUN_STATUSES_WITHOUT_RUNNING: SymphonyRun["status"][] = RETRYABLE_RUN_STATUSES.filter((status) => status !== "running");
@@ -125,6 +135,7 @@ export function createMatrixSymphonyOrchestrator(options: {
   linearSource: LinearSource;
   worktreeManager: WorktreeManager;
   agentSessionManager: AgentSessionManager;
+  agentStatusProvider?: AgentStatusProvider;
   statusHub?: SymphonyStatusHub;
 }) {
   const pollTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -162,6 +173,21 @@ export function createMatrixSymphonyOrchestrator(options: {
       actorId,
     });
     return updated;
+  }
+
+  async function agentReadinessFailure(agent: SymphonyInstallation["defaultAgent"]): Promise<{ code: string; message: string } | null> {
+    if (!options.agentStatusProvider) return null;
+    try {
+      const status = (await options.agentStatusProvider.detectAgents()).agents.find((candidate) => candidate.id === agent);
+      if (!status) return { code: "agent_missing", message: "Agent is not installed" };
+      if (!status.installed) return { code: status.errorCode ?? "agent_missing", message: "Agent is not installed" };
+      if (status.authState === "required") return { code: status.errorCode ?? "agent_auth_required", message: "Agent authentication required" };
+      if (status.authState === "error") return { code: status.errorCode ?? "agent_auth_error", message: "Agent authentication could not be checked" };
+      return null;
+    } catch (err: unknown) {
+      console.warn("[symphony] Agent readiness check failed:", err instanceof Error ? err.message : String(err));
+      return null;
+    }
   }
 
   async function reconcileIneligibleRunningRuns(
@@ -227,6 +253,23 @@ export function createMatrixSymphonyOrchestrator(options: {
     };
     if (!active) await options.repository.upsertRun(ownerId, run);
     try {
+      const readinessFailure = await agentReadinessFailure(installation.defaultAgent);
+      if (readinessFailure) {
+        const updated = await options.repository.updateRun(ownerId, run.id, {
+          status: "blocked",
+          lastErrorCode: readinessFailure.code,
+          lastEvent: readinessFailure.message,
+          nextRetryAt: undefined,
+        }, { allowedStatuses: ["queued", "retrying"] }) ?? run;
+        await append(ownerId, {
+          installationId: installation.id,
+          runId: run.id,
+          type: "symphony.run.updated",
+          message: readinessFailure.message,
+          severity: "warning",
+        });
+        return updated;
+      }
       const workflow = await loadWorkflowContract({ homePath: options.homePath, projectSlug: installation.projectSlug });
       const worktreeResult = await options.worktreeManager.createWorktree({
         projectSlug: installation.projectSlug,

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -99,6 +99,13 @@ describe("Symphony app", () => {
           ],
         });
       }
+      if (url === "/api/agents") {
+        return json({
+          agents: [
+            { id: "codex", command: "codex", displayName: "Codex", installed: true, authState: "ok", errorCode: null },
+          ],
+        });
+      }
       if (url === "/api/symphony/setup-options") {
         return json({
           credentialConfigured: true,
@@ -171,6 +178,73 @@ describe("Symphony app", () => {
     expect(screen.getAllByText("Needs Attention").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Done / Handoff").length).toBeGreaterThan(0);
     expect(screen.getByText("Linear account")).toBeTruthy();
+  });
+
+  it("shows an agent auth notice when the selected runtime needs login", async () => {
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url === "/api/agents") {
+        return json({
+          agents: [
+            { id: "codex", command: "codex", displayName: "Codex", installed: true, authState: "required", errorCode: "agent_auth_required" },
+          ],
+        });
+      }
+      if (url === "/api/symphony/status") {
+        return json({
+          running: true,
+          installationId: "sym_user_123",
+          credentialConfigured: true,
+          pollIntervalMs: 30000,
+          maxConcurrentAgents: 3,
+          counts: { queued: 0, running: 0, needsAttention: 1, handoff: 0 },
+          lastPollAt: null,
+        });
+      }
+      if (url === "/api/symphony/config") {
+        return json({
+          installation: {
+            projectSlug: "matrix-os",
+            enabled: true,
+            credentialConfigured: true,
+            pollIntervalMs: 30000,
+            maxConcurrentAgents: 3,
+            defaultAgent: "codex",
+            authorizedOperators: [],
+          },
+          rule: {
+            teamId: "team_1",
+            teamKey: "MAT",
+            requiredLabels: ["symphony"],
+            activeStates: ["Todo"],
+            terminalStates: ["Done"],
+            assigneeIds: [],
+          },
+        });
+      }
+      if (url === "/api/symphony/runs") {
+        return json({
+          runs: [{
+            id: "run_1",
+            status: "blocked",
+            ticketIdentifier: "MAT-1",
+            ticketTitle: "Build Symphony",
+            agent: "codex",
+            projectSlug: "matrix-os",
+            lastErrorCode: "agent_auth_required",
+            lastEvent: "Agent authentication required",
+            updatedAt: "2026-05-13T00:00:00.000Z",
+          }],
+        });
+      }
+      return json({ ok: true });
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Codex needs authentication in this Matrix runtime.")).toBeTruthy());
+    expect(screen.getByText("Agent authentication required")).toBeTruthy();
   });
 
   it("saves a server-side Linear secret and non-secret rule set", async () => {

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -40,6 +40,25 @@ describe("agent-launcher", () => {
     expect(JSON.stringify(result)).not.toContain("sk-secret");
   });
 
+  it("checks auth with the Matrix runtime home so terminal logins are reused", async () => {
+    const runCommand = vi.fn(async () => ({ stdout: "ok\n", stderr: "" }));
+    const launcher = createAgentLauncher({
+      runCommand,
+      cwd: "/home/matrix/home",
+      runtimeHome: "/home/matrix/home",
+    });
+
+    await launcher.detectAgents();
+
+    expect(runCommand).toHaveBeenCalledWith("codex", ["auth", "status"], expect.objectContaining({
+      cwd: "/home/matrix/home",
+      env: expect.objectContaining({
+        HOME: "/home/matrix/home",
+        MATRIX_HOME: "/home/matrix/home",
+      }),
+    }));
+  });
+
   it("constructs non-interactive Codex exec argv without shell interpolation", () => {
     const launch = buildAgentLaunch({
       agent: "codex",
@@ -64,6 +83,22 @@ describe("agent-launcher", () => {
       ],
       cwd: "/home/matrixos/home/projects/repo/worktrees/wt_123",
       env: {},
+    });
+  });
+
+  it("launches agents with the Matrix runtime home so CLI auth files are visible", () => {
+    const launcher = createAgentLauncher({ runtimeHome: "/home/matrix/home" });
+
+    const launch = launcher.buildLaunch({
+      agent: "codex",
+      cwd: "/home/matrix/home/projects/repo/worktrees/wt_123",
+      prompt: "fix tests",
+      sandbox: { enabled: true, writableRoots: ["/home/matrix/home/projects/repo/worktrees/wt_123"] },
+    });
+
+    expect(launch.env).toMatchObject({
+      HOME: "/home/matrix/home",
+      MATRIX_HOME: "/home/matrix/home",
     });
   });
 

--- a/tests/gateway/symphony-orchestrator.test.ts
+++ b/tests/gateway/symphony-orchestrator.test.ts
@@ -140,6 +140,46 @@ describe("Matrix Symphony orchestrator", () => {
     expect(agentSessionManager.startSession).toHaveBeenCalledTimes(1);
   });
 
+  it("blocks dispatch before creating a worktree when the selected agent needs auth", async () => {
+    const repository = memoryRepo(structuredClone(baseSnapshot));
+    const worktreeManager = {
+      createWorktree: vi.fn(async () => ({ ok: true as const, status: 201 as const, worktree: { id: "wt_abc123def456", path: "/repo/wt", projectSlug: "matrix-os" } })),
+    };
+    const agentSessionManager = {
+      startSession: vi.fn(async () => ({ ok: true as const, status: 201 as const, session: { id: "sess_run_abc", runtime: { status: "running" } } })),
+      killSession: vi.fn(),
+    };
+    const orchestrator = createMatrixSymphonyOrchestrator({
+      homePath,
+      repository,
+      credentialStore: { readLinearCredential: vi.fn(async () => "lin_api_secret"), hasLinearCredential: vi.fn(), writeLinearCredential: vi.fn(), deleteLinearCredential: vi.fn() },
+      linearSource: {
+        previewTickets: vi.fn(async () => ({
+          truncated: false,
+          tickets: [{ externalId: "issue_1", identifier: "MAT-1", title: "One", stateName: "Todo", assigneeId: "assignee_1", labels: ["symphony"] }],
+        })),
+      },
+      worktreeManager,
+      agentSessionManager,
+      agentStatusProvider: {
+        detectAgents: vi.fn(async () => ({
+          agents: [{ id: "codex", installed: true, authState: "required", errorCode: "agent_auth_required" }],
+        })),
+      },
+    });
+
+    await orchestrator.poll("user_123");
+
+    expect(worktreeManager.createWorktree).not.toHaveBeenCalled();
+    expect(agentSessionManager.startSession).not.toHaveBeenCalled();
+    const runId = `run_${createHash("sha256").update("user_123:issue_1").digest("hex").slice(0, 16)}`;
+    await expect(repository.getRun("user_123", runId)).resolves.toMatchObject({
+      status: "blocked",
+      lastErrorCode: "agent_auth_required",
+      lastEvent: "Agent authentication required",
+    });
+  });
+
   it("scopes generated run IDs by Matrix owner for shared Linear tickets", async () => {
     const snapshots = new Map<string, SymphonySnapshot>([
       ["owner_1", { ...structuredClone(baseSnapshot), installation: { ...baseSnapshot.installation!, ownerId: "owner_1", id: "sym_owner_1" } }],


### PR DESCRIPTION
## Summary

- Reuse the Matrix runtime home for Symphony agent detection and launches so `codex login` from the Matrix terminal is visible to Symphony runs.
- Block Symphony dispatch early when the selected agent is missing or needs auth, instead of creating a worktree/session that later exits with an opaque 401.
- Add a small Symphony app notice with refresh support when the selected agent needs authentication.

## Invariants

- **Source of truth**: Agent CLI auth remains owned by the runtime CLI under the Matrix home. Symphony only points launched/detected agent processes at that same runtime home with `HOME` and `MATRIX_HOME`.
- **Lock/transaction scope**: No database write path changes. The new preflight runs before worktree/session creation.
- **Acceptable orphan states**: If agent auth is missing or detection fails, the run is marked blocked and no worktree/session is created for that dispatch.
- **Auth source of truth**: The agent CLI remains responsible for auth state via commands such as `codex auth status`; Matrix only reports and gates on that state.
- **Deferred scope**: This does not automate provider login. Users still authenticate the CLI from the Matrix terminal, then refresh/retry Symphony.

## Tests

- `bun run test tests/gateway/agent-launcher.test.ts tests/gateway/symphony-orchestrator.test.ts tests/default-apps/symphony-app.test.tsx`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warning categories only)
- `bun run test` attempted after rebase, but the full suite produced no test output for several minutes and was terminated to avoid leaving a stray process.
