### PR TITLE
fix(canvas): preserve iframe shield wheel pan

### DIFF
--- a/.agents/skills/worktree-pr-monitor/SKILL.md
+++ b/.agents/skills/worktree-pr-monitor/SKILL.md
@@ -5,17 +5,25 @@ description: Create or continue an isolated Matrix OS worktree PR, validate it, 
 
 # Worktree PR Monitor
 
-Use this skill for Codex-driven publish loops that must keep `/home/deploy/matrix-os`
-on `main` while implementation happens in `/home/deploy/matrix-os.worktrees/<slug>`.
+Use this skill only when the requester explicitly asks for the manual git
+worktree -> PR -> monitor workflow. It keeps `/home/deploy/matrix-os` on `main`
+while implementation happens in `/home/deploy/matrix-os.worktrees/<slug>`.
+
+Do not use this skill for Swarm or multi-agent runs. The repo-level Swarm ban on
+`isolation: "worktree"` still applies; this workflow is a user-requested manual
+git worktree flow for isolated PR publication.
 
 ## Preconditions
 
 - `gh` is installed and authenticated.
 - The current repository is `HamedMP/matrix-os`.
-- The requester wants a PR, not only a local patch.
+- The requester wants a PR in a worktree, not only a local patch.
+- The requester explicitly asked for a worktree or invoked this workflow.
 
 ## Rules
 
+- If the requester did not explicitly ask for a worktree, follow the current
+  branch workflow instead.
 - Keep `/home/deploy/matrix-os` on `main`.
 - Put feature work in `/home/deploy/matrix-os.worktrees/<slug>`.
 - Use a semantic branch and PR title. Do not prefix titles with agent/tool tags.

--- a/.claude/commands/worktree-pr-monitor.md
+++ b/.claude/commands/worktree-pr-monitor.md
@@ -14,7 +14,8 @@ $ARGUMENTS
 
 ## Goal
 
-Move the requested change through the full Matrix OS PR loop:
+Move an explicitly requested manual git worktree change through the full Matrix
+OS PR loop:
 
 1. create or use an isolated git worktree,
 2. implement and validate the change,
@@ -25,6 +26,10 @@ Move the requested change through the full Matrix OS PR loop:
 
 ## Rules
 
+- Use this command only when the requester explicitly asks for a worktree PR
+  workflow. Otherwise, follow the repo's current-branch agent workflow.
+- This command does not authorize Swarm `isolation: "worktree"`; that repo-level
+  Swarm ban still applies.
 - Keep `/home/deploy/matrix-os` on `main`. Put feature work under `/home/deploy/matrix-os.worktrees/<slug>`.
 - Use a semantic branch and PR title. Do not prefix the PR title with agent/tool tags.
 - Never stage unrelated changes. Inspect `git status --short --branch` before staging.

--- a/shell/src/components/canvas/CanvasTransform.tsx
+++ b/shell/src/components/canvas/CanvasTransform.tsx
@@ -62,6 +62,9 @@ export function CanvasTransform({
       target === zoomOverlayRef.current ||
       target === transformRef.current
     ) return true;
+    if (target instanceof Element && target.closest("[data-canvas-interaction-overlay]")) {
+      return true;
+    }
     return false;
   }, []);
 

--- a/tests/shell/canvas-transform-interaction.test.tsx
+++ b/tests/shell/canvas-transform-interaction.test.tsx
@@ -77,6 +77,26 @@ describe("CanvasTransform app focus interactions", () => {
     expect(useCanvasTransform.getState().panY).toBe(0);
   });
 
+  it("pans wheel input from the iframe interaction shield", () => {
+    const { container } = render(
+      <CanvasTransform panEnabled>
+        <div data-canvas-interaction-overlay />
+      </CanvasTransform>,
+    );
+    const shield = container.querySelector("[data-canvas-interaction-overlay]")!;
+    const event = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 80,
+    });
+    const preventDefault = vi.spyOn(event, "preventDefault");
+
+    shield.dispatchEvent(event);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(useCanvasTransform.getState().panY).toBe(-80);
+  });
+
   it("does not treat built-in app window content as canvas background for grab panning", () => {
     useCanvasSettings.setState({ navMode: "grab", showTitles: true });
     const clearFocus = vi.fn();


### PR DESCRIPTION
## Summary
- Preserves canvas wheel pan/zoom handling when wheel events originate on the iframe click-to-interact shield.
- Clarifies the worktree PR monitor command/skill is only for explicit manual git worktree requests and does not authorize Swarm worktree isolation.

## Tests
- bun run test tests/shell/canvas-window-terminal-overlay.test.tsx tests/shell/canvas-transform-interaction.test.tsx tests/shell/canvas-renderer.test.ts tests/shell/terminal-app-component.test.tsx tests/shell/canvas-interaction-safety.test.ts
- bun run typecheck
- bun run check:patterns (warnings only, 0 violations)
- git diff --check HEAD~1..HEAD

## Review/Monitoring
- Follow-up for hidden Codex review comments on #156 that landed after #156 was already merged.
- Monitor CI plus Codex/Greptile feedback; latest trusted Greptile result must be 5/5 before considering this done.

## Invariants
- Source of truth: canvas window state remains in existing shell stores; no persistence or backend state changes.
- Lock/transaction scope: no database or filesystem writes.
- Acceptable orphan states: not applicable; UI-only event routing and docs changes.
- Auth source of truth: unchanged.
- Deferred scope: no redesign of Canvas input model beyond the iframe shield and built-in window event routing regression.