### PR TITLE
fix(sync-client): preserve local edits during remote reconciliation

### DIFF
--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { copyFile, link, mkdir, readFile, writeFile, unlink, stat } from "node:fs/promises";
 import { dirname, extname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mkdir, readFile, writeFile, unlink, stat } from "node:fs/promises";
 import pino from "pino";
 import {
   loadConfig,
@@ -348,7 +350,15 @@ export function capSyncStateFiles(syncState: SyncState): boolean {
   }
 
   entries
-    .sort(([, left], [, right]) => left.mtime - right.mtime)
+    .sort(([, left], [, right]) => {
+      if (left.localOnly === true && right.localOnly !== true) {
+        return 1;
+      }
+      if (left.localOnly !== true && right.localOnly === true) {
+        return -1;
+      }
+      return left.mtime - right.mtime;
+    })
     .slice(0, entries.length - SYNC_STATE_FILE_CAP)
     .forEach(([path]) => {
       delete syncState.files[path];
@@ -412,15 +422,51 @@ function recordSyncConflict(
   capSyncStateConflicts(syncState);
 }
 
-function appendConflictCollisionSuffix(conflictPath: string, attempt: number): string {
-  const ext = extname(conflictPath);
-  const base = conflictPath.slice(0, conflictPath.length - ext.length);
+function appendConflictCollisionSuffix(basePath: string, attempt: number): string {
+  const ext = extname(basePath);
+  const base = basePath.slice(0, basePath.length - ext.length);
   return `${base} ${attempt}${ext}`;
 }
 
-async function reserveAvailableConflictPath(
+async function createConflictDownloadTempPath(syncRoot: string): Promise<string> {
+  const tempDir = resolveWithinSyncRoot(
+    syncRoot,
+    join(".cache", "matrixos-sync-conflicts"),
+  );
+  await mkdir(tempDir, { recursive: true, mode: 0o700 });
+  return join(tempDir, `download.matrixos-${randomUUID()}.tmp`);
+}
+
+async function linkOrCopyExclusive(sourcePath: string, targetPath: string): Promise<void> {
+  try {
+    await link(sourcePath, targetPath);
+    return;
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "EEXIST"
+    ) {
+      throw err;
+    }
+    if (
+      !(err instanceof Error) ||
+      !("code" in err) ||
+      !["EXDEV", "EPERM", "ENOSYS"].includes(
+        String((err as NodeJS.ErrnoException).code),
+      )
+    ) {
+      throw err;
+    }
+  }
+
+  await copyFile(sourcePath, targetPath, constants.COPYFILE_EXCL);
+}
+
+async function publishDownloadedConflictPath(
   syncRoot: string,
   preferredPath: string,
+  tempPath: string,
 ): Promise<{ conflictPath: string; absolutePath: string }> {
   for (let attempt = 1; attempt <= 1_000; attempt++) {
     const conflictPath = attempt === 1
@@ -429,7 +475,7 @@ async function reserveAvailableConflictPath(
     const absolutePath = resolveWithinSyncRoot(syncRoot, conflictPath);
     try {
       await mkdir(dirname(absolutePath), { recursive: true, mode: 0o700 });
-      await writeFile(absolutePath, "", { flag: "wx", mode: 0o600 });
+      await linkOrCopyExclusive(tempPath, absolutePath);
       return { conflictPath, absolutePath };
     } catch (err: unknown) {
       if (
@@ -470,12 +516,125 @@ interface RemoteFileReconcileInput {
 export function shouldSkipWatcherUpload(
   existing: LocalFileState | undefined,
   eventHash: string,
+  isUnresolvedConflictCopy = false,
 ): boolean {
-  return existing?.localOnly === true || existing?.lastSyncedHash === eventHash;
+  return (
+    isUnresolvedConflictCopy ||
+    existing?.localOnly === true ||
+    existing?.lastSyncedHash === eventHash
+  );
 }
 
-export function shouldCommitWatcherDelete(entry: LocalFileState | undefined): boolean {
-  return Boolean(entry?.lastSyncedHash && entry.localOnly !== true);
+export type ConflictCopyPathIndex = Record<string, string>;
+
+export function buildUnresolvedConflictCopyPathIndex(
+  syncState: Pick<SyncState, "conflicts">,
+): ConflictCopyPathIndex {
+  const index = Object.create(null) as ConflictCopyPathIndex;
+  for (const [parentPath, conflict] of Object.entries(syncState.conflicts ?? {})) {
+    if (conflict.conflictPath && !conflict.resolved) {
+      index[conflict.conflictPath] = parentPath;
+    }
+  }
+  return index;
+}
+
+export function hasUnresolvedConflictCopyPath(
+  conflictCopyPathIndex: ConflictCopyPathIndex,
+  remotePath: string,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(conflictCopyPathIndex, remotePath);
+}
+
+export function resolveConflictCopyPath(
+  syncState: SyncState,
+  conflictCopyPathIndex: ConflictCopyPathIndex,
+  conflictPath: string,
+  resolvedAt = Date.now(),
+): boolean {
+  const parentPath = conflictCopyPathIndex[conflictPath];
+  if (!parentPath) {
+    return false;
+  }
+
+  delete conflictCopyPathIndex[conflictPath];
+  const conflict = syncState.conflicts?.[parentPath];
+  if (!conflict || conflict.conflictPath !== conflictPath || conflict.resolved) {
+    return false;
+  }
+
+  delete conflict.conflictPath;
+  conflict.resolved = true;
+  conflict.resolvedAt = resolvedAt;
+  return true;
+}
+
+export async function reconcileMissingConflictCopies(
+  syncState: SyncState,
+  options: {
+    syncRoot: string;
+    toLocalPath: (remotePath: string) => string | null;
+    resolvedAt?: number;
+  },
+): Promise<boolean> {
+  let changed = false;
+  for (const [, conflict] of Object.entries(syncState.conflicts ?? {})) {
+    if (!conflict.conflictPath || conflict.resolved) {
+      continue;
+    }
+
+    const localRel = options.toLocalPath(conflict.conflictPath);
+    if (!localRel) {
+      continue;
+    }
+
+    try {
+      await stat(resolveWithinSyncRoot(options.syncRoot, localRel));
+    } catch (err: unknown) {
+      if (!isENOENT(err)) {
+        throw err;
+      }
+      delete syncState.files[conflict.conflictPath];
+      delete conflict.conflictPath;
+      conflict.resolved = true;
+      conflict.resolvedAt = options.resolvedAt ?? Date.now();
+      changed = true;
+    }
+  }
+
+  for (const [remotePath, fileState] of Object.entries(syncState.files)) {
+    if (fileState.localOnly !== true) {
+      continue;
+    }
+
+    const localRel = options.toLocalPath(remotePath);
+    if (!localRel) {
+      continue;
+    }
+
+    try {
+      await stat(resolveWithinSyncRoot(options.syncRoot, localRel));
+    } catch (err: unknown) {
+      if (!isENOENT(err)) {
+        throw err;
+      }
+      delete syncState.files[remotePath];
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+export function shouldCommitWatcherDelete(
+  entry: LocalFileState | undefined,
+  isUnresolvedConflictCopy = false,
+): boolean {
+  return Boolean(
+    entry?.lastSyncedHash &&
+    entry.localOnly !== true &&
+    !isUnresolvedConflictCopy,
+  );
 }
 
 export async function reconcileRemoteFileChange(
@@ -538,9 +697,14 @@ export async function reconcileRemoteFileChange(
     return { status: "downloaded" };
   }
 
-  if (cached?.hash === localHash && cached.lastSyncedHash === input.remoteHash) {
+  const existingConflict = syncState.conflicts?.[input.remotePath];
+  if (
+    existingConflict?.conflictPath &&
+    existingConflict.remoteHash === input.remoteHash &&
+    !existingConflict.resolved
+  ) {
+    existingConflict.localHash = localHash;
     syncState.files[input.remotePath] = {
-      ...cached,
       hash: localHash,
       mtime: localMtime,
       size: localSize,
@@ -549,7 +713,7 @@ export async function reconcileRemoteFileChange(
     capSyncStateFiles(syncState);
     return {
       status: "conflict-existing",
-      conflictPath: syncState.conflicts?.[input.remotePath]?.conflictPath,
+      conflictPath: existingConflict.conflictPath,
     };
   }
 
@@ -558,22 +722,28 @@ export async function reconcileRemoteFileChange(
     input.remotePeerId,
     input.date ?? new Date(),
   );
-  const {
-    conflictPath,
-    absolutePath: conflictAbsPath,
-  } = await reserveAvailableConflictPath(input.syncRoot, preferredConflictPath);
-  const conflictRemotePath = input.toRemotePath?.(conflictPath) ?? conflictPath;
+  const conflictTempPath = await createConflictDownloadTempPath(input.syncRoot);
+  let conflictPath = preferredConflictPath;
+  let conflictAbsPath = resolveWithinSyncRoot(input.syncRoot, preferredConflictPath);
+  let conflictRemotePath = input.toRemotePath?.(conflictPath) ?? conflictPath;
   try {
-    await input.downloadRemote(conflictAbsPath);
-  } catch (err) {
+    await input.downloadRemote(conflictTempPath);
+    const published = await publishDownloadedConflictPath(
+      input.syncRoot,
+      preferredConflictPath,
+      conflictTempPath,
+    );
+    conflictPath = published.conflictPath;
+    conflictAbsPath = published.absolutePath;
+    conflictRemotePath = input.toRemotePath?.(conflictPath) ?? conflictPath;
+  } finally {
     try {
-      await unlink(conflictAbsPath);
+      await unlink(conflictTempPath);
     } catch (cleanupErr: unknown) {
       if (!isENOENT(cleanupErr)) {
         input.onConflictCleanupError?.(cleanupErr, conflictRemotePath);
       }
     }
-    throw err;
   }
   await updateDownloadedState(conflictAbsPath, conflictRemotePath, {
     localOnly: true,
@@ -633,18 +803,6 @@ export async function reconcileRemoteDelete(
     return { status: "deleted-local" };
   }
 
-  if (localHash === input.remoteHash || (cached?.lastSyncedHash && localHash === cached.lastSyncedHash)) {
-    try {
-      await unlink(localPath);
-    } catch (err: unknown) {
-      if (!isENOENT(err)) {
-        throw err;
-      }
-    }
-    delete syncState.files[input.remotePath];
-    return { status: "deleted-local" };
-  }
-
   const existingConflict = syncState.conflicts?.[input.remotePath];
   if (
     cached?.hash === localHash &&
@@ -665,6 +823,18 @@ export async function reconcileRemoteDelete(
       status: "conflict-existing",
       conflictPath: syncState.conflicts?.[input.remotePath]?.conflictPath,
     };
+  }
+
+  if (cached?.lastSyncedHash && localHash === cached.lastSyncedHash) {
+    try {
+      await unlink(localPath);
+    } catch (err: unknown) {
+      if (!isENOENT(err)) {
+        throw err;
+      }
+    }
+    delete syncState.files[input.remotePath];
+    return { status: "deleted-local" };
   }
 
   syncState.files[input.remotePath] = {
@@ -823,6 +993,12 @@ export async function startDaemon(): Promise<void> {
   // get prefixed with `audit/` on the remote and incoming events outside
   // that subtree are ignored. See specs/066-file-sync/follow-ups.md F1.
   const { toRemote, toLocal } = createRemotePrefixMapper(config.gatewayFolder ?? "");
+  if (await reconcileMissingConflictCopies(syncState, {
+    syncRoot: config.syncPath,
+    toLocalPath: toLocal,
+  })) {
+    await saveSyncState(stateFile, syncState);
+  }
 
   const gatewayClient = {
     gatewayUrl: config.gatewayUrl,
@@ -836,6 +1012,10 @@ export async function startDaemon(): Promise<void> {
   const enqueue = createSerialTaskQueue((err) => {
     logger.error({ err }, "Serialized sync task failed");
   });
+  let conflictCopyPathIndex = buildUnresolvedConflictCopyPathIndex(syncState);
+  const refreshConflictCopyPathIndex = () => {
+    conflictCopyPathIndex = buildUnresolvedConflictCopyPathIndex(syncState);
+  };
 
   const watcher = new FileWatcher({
     syncRoot: config.syncPath,
@@ -848,12 +1028,16 @@ export async function startDaemon(): Promise<void> {
       // gateway sees. Two daemons watching `~/foo` and `~/bar` then write
       // disjoint key spaces (`foo/...` vs `bar/...`).
       const remotePath = toRemote(event.path);
+      const isUnresolvedConflictCopy = hasUnresolvedConflictCopyPath(
+        conflictCopyPathIndex,
+        remotePath,
+      );
 
       if (event.type === "change") {
         const existing = syncState.files[remotePath];
         // Skip remote-synced files on watcher replay and local-only conflict
         // copies that should never be uploaded to the remote manifest.
-        if (shouldSkipWatcherUpload(existing, event.hash)) {
+        if (shouldSkipWatcherUpload(existing, event.hash, isUnresolvedConflictCopy)) {
           if (
             existing &&
             (existing.hash !== event.hash ||
@@ -863,6 +1047,17 @@ export async function startDaemon(): Promise<void> {
             existing.hash = event.hash;
             existing.mtime = event.mtime;
             existing.size = event.size;
+            await saveSyncState(stateFile, syncState);
+          }
+          if (isUnresolvedConflictCopy && !existing) {
+            syncState.files[remotePath] = {
+              hash: event.hash,
+              mtime: event.mtime,
+              size: event.size,
+              lastSyncedHash: event.hash,
+              localOnly: true,
+            };
+            capSyncStateFiles(syncState);
             await saveSyncState(stateFile, syncState);
           }
           return;
@@ -907,7 +1102,7 @@ export async function startDaemon(): Promise<void> {
         }
       } else if (event.type === "unlink") {
         const entry = syncState.files[remotePath];
-        if (shouldCommitWatcherDelete(entry)) {
+        if (shouldCommitWatcherDelete(entry, isUnresolvedConflictCopy)) {
           try {
             const deleteResult = await commitFiles(gatewayClient, [
               {
@@ -927,8 +1122,11 @@ export async function startDaemon(): Promise<void> {
             });
             logger.error({ err, path: remotePath }, "Delete commit failed");
           }
-        } else if (entry?.localOnly) {
+        } else if (entry?.localOnly || isUnresolvedConflictCopy) {
           delete syncState.files[remotePath];
+          if (isUnresolvedConflictCopy) {
+            resolveConflictCopyPath(syncState, conflictCopyPathIndex, remotePath);
+          }
           await saveSyncState(stateFile, syncState);
         }
       }
@@ -987,6 +1185,7 @@ export async function startDaemon(): Promise<void> {
                 "Remote change conflicted with local edits; preserved both files",
               );
             }
+            refreshConflictCopyPathIndex();
             await saveSyncState(stateFile, syncState);
           } catch (err) {
             shouldAdvanceManifestVersion = false;
@@ -1009,6 +1208,7 @@ export async function startDaemon(): Promise<void> {
                 "Remote delete conflicted with local edits; kept local file",
               );
             }
+            refreshConflictCopyPathIndex();
             await saveSyncState(stateFile, syncState);
           } catch (err) {
             shouldAdvanceManifestVersion = false;
@@ -1156,6 +1356,7 @@ export async function startDaemon(): Promise<void> {
             "Initial pull conflicted with local edits; preserved both files",
           );
         }
+        refreshConflictCopyPathIndex();
         pulled++;
       } catch (err) {
         if (exitOnAuthFailure(err, logger)) return;

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -1,6 +1,6 @@
-import { join, resolve, sep } from "node:path";
+import { extname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mkdir, readFile, writeFile, unlink, stat } from "node:fs/promises";
+import { lstat, mkdir, readFile, writeFile, unlink, stat } from "node:fs/promises";
 import pino from "pino";
 import {
   loadConfig,
@@ -19,6 +19,7 @@ import {
 import { loadProfiles } from "../lib/profiles.js";
 import { loadSyncIgnore } from "../lib/syncignore.js";
 import { cleanupStaleMatrixosTempFiles } from "../lib/temp-files.js";
+import { hashFile } from "../lib/hash.js";
 import { loadSyncState, saveSyncState } from "./manifest-cache.js";
 import { FileWatcher } from "./watcher.js";
 import { SyncWsClient } from "./ws-client.js";
@@ -26,15 +27,16 @@ import { IpcServer } from "./ipc-server.js";
 import { createIpcHandler } from "./ipc-handler.js";
 import { createDaemonShellControlClient } from "./shell-control-client.js";
 import { createRemotePrefixMapper } from "./remote-prefix.js";
+import { generateConflictPath } from "./conflict-resolver.js";
 import {
   requestPresignedUrls,
   uploadFile,
   downloadFile,
   commitFiles,
-    fetchManifest,
-    AuthRejectedError,
-    VersionConflictError,
-  } from "./r2-client.js";
+  fetchManifest,
+  AuthRejectedError,
+  VersionConflictError,
+} from "./r2-client.js";
 import {
   RemoteManifestEnvelopeSchema,
   type RemoteManifestEnvelope,
@@ -47,6 +49,7 @@ const stateFile = join(configDir, "sync-state.json");
 const socketPath = join(configDir, "daemon.sock");
 const pidFile = join(configDir, "daemon.pid");
 const SYNC_STATE_FILE_CAP = 50_000;
+const SYNC_STATE_CONFLICT_CAP = 500;
 
 interface PollLogger {
   info: (msg: string) => void;
@@ -353,6 +356,254 @@ export function capSyncStateFiles(syncState: SyncState): boolean {
   return true;
 }
 
+export function capSyncStateConflicts(syncState: SyncState): boolean {
+  const entries = Object.entries(syncState.conflicts ?? {});
+  if (entries.length <= SYNC_STATE_CONFLICT_CAP) {
+    return false;
+  }
+
+  syncState.conflicts ??= {};
+  entries
+    .sort(([, left], [, right]) => left.detectedAt - right.detectedAt)
+    .slice(0, entries.length - SYNC_STATE_CONFLICT_CAP)
+    .forEach(([path]) => {
+      delete syncState.conflicts![path];
+    });
+
+  return true;
+}
+
+function isENOENT(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function recordSyncConflict(
+  syncState: SyncState,
+  input: {
+    path: string;
+    conflictPath?: string;
+    localHash: string;
+    remoteHash: string;
+    remotePeerId: string;
+    detectedAt?: number;
+  },
+): void {
+  syncState.conflicts ??= {};
+  syncState.conflicts[input.path] = {
+    path: input.path,
+    ...(input.conflictPath ? { conflictPath: input.conflictPath } : {}),
+    localHash: input.localHash,
+    remoteHash: input.remoteHash,
+    remotePeerId: input.remotePeerId,
+    detectedAt: input.detectedAt ?? Date.now(),
+    resolved: false,
+  };
+  capSyncStateConflicts(syncState);
+}
+
+function appendConflictCollisionSuffix(conflictPath: string, attempt: number): string {
+  const ext = extname(conflictPath);
+  const base = conflictPath.slice(0, conflictPath.length - ext.length);
+  return `${base} ${attempt}${ext}`;
+}
+
+async function reserveAvailableConflictPath(
+  syncRoot: string,
+  preferredPath: string,
+): Promise<{ conflictPath: string; absolutePath: string }> {
+  for (let attempt = 1; attempt <= 1_000; attempt++) {
+    const conflictPath = attempt === 1
+      ? preferredPath
+      : appendConflictCollisionSuffix(preferredPath, attempt);
+    const absolutePath = resolveWithinSyncRoot(syncRoot, conflictPath);
+    try {
+      await lstat(absolutePath);
+    } catch (err: unknown) {
+      if (isENOENT(err)) {
+        return { conflictPath, absolutePath };
+      }
+      throw err;
+    }
+  }
+
+  throw new Error("Could not reserve a unique sync conflict path");
+}
+
+export type RemoteReconcileStatus =
+  | "downloaded"
+  | "already-synced"
+  | "conflict-created"
+  | "delete-skipped-conflict"
+  | "deleted-local";
+
+interface RemoteFileReconcileInput {
+  syncRoot: string;
+  localRel: string;
+  remotePath: string;
+  remoteHash: string;
+  remoteSize: number;
+  remotePeerId: string;
+  downloadRemote: (targetPath: string) => Promise<void>;
+  toRemotePath?: (localRel: string) => string;
+  date?: Date;
+}
+
+export async function reconcileRemoteFileChange(
+  syncState: SyncState,
+  input: RemoteFileReconcileInput,
+): Promise<{ status: RemoteReconcileStatus; conflictPath?: string }> {
+  const localPath = resolveWithinSyncRoot(input.syncRoot, input.localRel);
+  const cached = syncState.files[input.remotePath];
+
+  let localHash: string | null = null;
+  let localSize = 0;
+  let localMtime = 0;
+  try {
+    const [hash, fileStat] = await Promise.all([hashFile(localPath), stat(localPath)]);
+    localHash = hash;
+    localSize = fileStat.size;
+    localMtime = fileStat.mtimeMs;
+  } catch (err: unknown) {
+    if (!isENOENT(err)) {
+      throw err;
+    }
+  }
+
+  const updateDownloadedState = async (targetPath: string, remotePath: string) => {
+    const downloadedStat = await stat(targetPath);
+    syncState.files[remotePath] = {
+      hash: input.remoteHash,
+      mtime: downloadedStat.mtimeMs,
+      size: downloadedStat.size,
+      lastSyncedHash: input.remoteHash,
+    };
+    capSyncStateFiles(syncState);
+  };
+
+  if (!localHash) {
+    await input.downloadRemote(localPath);
+    await updateDownloadedState(localPath, input.remotePath);
+    return { status: "downloaded" };
+  }
+
+  if (localHash === input.remoteHash) {
+    syncState.files[input.remotePath] = {
+      hash: input.remoteHash,
+      mtime: localMtime,
+      size: localSize,
+      lastSyncedHash: input.remoteHash,
+    };
+    capSyncStateFiles(syncState);
+    return { status: "already-synced" };
+  }
+
+  if (cached?.lastSyncedHash && localHash === cached.lastSyncedHash) {
+    await input.downloadRemote(localPath);
+    await updateDownloadedState(localPath, input.remotePath);
+    return { status: "downloaded" };
+  }
+
+  const preferredConflictPath = generateConflictPath(
+    input.localRel,
+    input.remotePeerId,
+    input.date ?? new Date(),
+  );
+  const {
+    conflictPath,
+    absolutePath: conflictAbsPath,
+  } = await reserveAvailableConflictPath(input.syncRoot, preferredConflictPath);
+  const conflictRemotePath = input.toRemotePath?.(conflictPath) ?? conflictPath;
+  await input.downloadRemote(conflictAbsPath);
+  await updateDownloadedState(conflictAbsPath, conflictRemotePath);
+  syncState.files[input.remotePath] = {
+    hash: localHash,
+    mtime: localMtime,
+    size: localSize,
+    lastSyncedHash: cached?.lastSyncedHash,
+  };
+  capSyncStateFiles(syncState);
+  recordSyncConflict(syncState, {
+    path: input.remotePath,
+    conflictPath: conflictRemotePath,
+    localHash,
+    remoteHash: input.remoteHash,
+    remotePeerId: input.remotePeerId,
+    detectedAt: input.date?.getTime(),
+  });
+
+  return { status: "conflict-created", conflictPath: conflictRemotePath };
+}
+
+interface RemoteDeleteReconcileInput {
+  syncRoot: string;
+  localRel: string;
+  remotePath: string;
+  remoteHash: string;
+  remotePeerId: string;
+  toRemotePath?: (localRel: string) => string;
+  date?: Date;
+}
+
+export async function reconcileRemoteDelete(
+  syncState: SyncState,
+  input: RemoteDeleteReconcileInput,
+): Promise<{ status: RemoteReconcileStatus; conflictPath?: string }> {
+  const localPath = resolveWithinSyncRoot(input.syncRoot, input.localRel);
+  const cached = syncState.files[input.remotePath];
+
+  let localHash: string | null = null;
+  let localSize = 0;
+  let localMtime = 0;
+  try {
+    const [hash, fileStat] = await Promise.all([hashFile(localPath), stat(localPath)]);
+    localHash = hash;
+    localSize = fileStat.size;
+    localMtime = fileStat.mtimeMs;
+  } catch (err: unknown) {
+    if (!isENOENT(err)) {
+      throw err;
+    }
+  }
+
+  if (!localHash) {
+    delete syncState.files[input.remotePath];
+    return { status: "deleted-local" };
+  }
+
+  if (localHash === input.remoteHash || (cached?.lastSyncedHash && localHash === cached.lastSyncedHash)) {
+    try {
+      await unlink(localPath);
+    } catch (err: unknown) {
+      if (!isENOENT(err)) {
+        throw err;
+      }
+    }
+    delete syncState.files[input.remotePath];
+    return { status: "deleted-local" };
+  }
+
+  syncState.files[input.remotePath] = {
+    hash: localHash,
+    mtime: localMtime,
+    size: localSize,
+    lastSyncedHash: cached?.lastSyncedHash,
+  };
+  capSyncStateFiles(syncState);
+  recordSyncConflict(syncState, {
+    path: input.remotePath,
+    localHash,
+    remoteHash: input.remoteHash,
+    remotePeerId: input.remotePeerId,
+    detectedAt: input.date?.getTime(),
+  });
+
+  return { status: "delete-skipped-conflict" };
+}
+
 export function exitOnAuthFailure(
   err: unknown,
   logger: { error: (msg: string) => void },
@@ -622,20 +873,26 @@ export async function startDaemon(): Promise<void> {
               shouldAdvanceManifestVersion = false;
               continue;
             }
-            const localPath = resolveWithinSyncRoot(config.syncPath, localRel);
-            await downloadFile(
-              urls[0].url,
-              localPath,
-              file.hash,
-            );
-            const downloadedStat = await stat(localPath);
-            syncState.files[file.path] = {
-              hash: file.hash,
-              mtime: downloadedStat.mtimeMs,
-              size: downloadedStat.size,
-              lastSyncedHash: file.hash,
-            };
-            capSyncStateFiles(syncState);
+            const result = await reconcileRemoteFileChange(syncState, {
+              syncRoot: config.syncPath,
+              localRel,
+              remotePath: file.path,
+              remoteHash: file.hash,
+              remoteSize: file.size,
+              remotePeerId: event.peerId,
+              toRemotePath: toRemote,
+              downloadRemote: (targetPath) => downloadFile(
+                urls[0]!.url,
+                targetPath,
+                file.hash,
+              ),
+            });
+            if (result.status === "conflict-created") {
+              logger.warn(
+                { path: file.path, conflictPath: result.conflictPath },
+                "Remote change conflicted with local edits; preserved both files",
+              );
+            }
             await saveSyncState(stateFile, syncState);
           } catch (err) {
             shouldAdvanceManifestVersion = false;
@@ -644,20 +901,20 @@ export async function startDaemon(): Promise<void> {
           }
         } else {
           try {
-            const localPath = resolveWithinSyncRoot(config.syncPath, localRel);
-            const { unlink: unlinkFile } = await import("node:fs/promises");
-            try {
-              await unlinkFile(localPath);
-            } catch (err: unknown) {
-              if (
-                !(err instanceof Error) ||
-                !("code" in err) ||
-                (err as NodeJS.ErrnoException).code !== "ENOENT"
-              ) {
-                throw err;
-              }
+            const result = await reconcileRemoteDelete(syncState, {
+              syncRoot: config.syncPath,
+              localRel,
+              remotePath: file.path,
+              remoteHash: file.hash,
+              remotePeerId: event.peerId,
+              toRemotePath: toRemote,
+            });
+            if (result.status === "delete-skipped-conflict") {
+              logger.warn(
+                { path: file.path, conflictPath: result.conflictPath },
+                "Remote delete conflicted with local edits; kept local file",
+              );
             }
-            delete syncState.files[file.path];
             await saveSyncState(stateFile, syncState);
           } catch (err) {
             shouldAdvanceManifestVersion = false;
@@ -779,14 +1036,26 @@ export async function startDaemon(): Promise<void> {
         ]);
         if (!urls[0]) continue;
 
-        const localAbsPath = resolveWithinSyncRoot(config.syncPath, localRel);
-        await downloadFile(urls[0].url, localAbsPath, entry.hash);
-        syncState.files[remotePath] = {
-          hash: entry.hash,
-          mtime: entry.mtime,
-          size: entry.size,
-          lastSyncedHash: entry.hash,
-        };
+        const result = await reconcileRemoteFileChange(syncState, {
+          syncRoot: config.syncPath,
+          localRel,
+          remotePath,
+          remoteHash: entry.hash,
+          remoteSize: entry.size,
+          remotePeerId: entry.peerId,
+          toRemotePath: toRemote,
+          downloadRemote: (targetPath) => downloadFile(
+            urls[0]!.url,
+            targetPath,
+            entry.hash,
+          ),
+        });
+        if (result.status === "conflict-created") {
+          logger.warn(
+            { path: remotePath, conflictPath: result.conflictPath },
+            "Initial pull conflicted with local edits; preserved both files",
+          );
+        }
         pulled++;
       } catch (err) {
         if (exitOnAuthFailure(err, logger)) return;

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -449,6 +449,7 @@ export type RemoteReconcileStatus =
   | "downloaded"
   | "already-synced"
   | "conflict-created"
+  | "conflict-existing"
   | "delete-skipped-conflict"
   | "deleted-local";
 
@@ -521,6 +522,21 @@ export async function reconcileRemoteFileChange(
     await input.downloadRemote(localPath);
     await updateDownloadedState(localPath, input.remotePath);
     return { status: "downloaded" };
+  }
+
+  if (cached?.hash === localHash && cached.lastSyncedHash === input.remoteHash) {
+    syncState.files[input.remotePath] = {
+      ...cached,
+      hash: localHash,
+      mtime: localMtime,
+      size: localSize,
+      lastSyncedHash: input.remoteHash,
+    };
+    capSyncStateFiles(syncState);
+    return {
+      status: "conflict-existing",
+      conflictPath: syncState.conflicts?.[input.remotePath]?.conflictPath,
+    };
   }
 
   const preferredConflictPath = generateConflictPath(

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -1,6 +1,6 @@
-import { extname, join, resolve, sep } from "node:path";
+import { dirname, extname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { lstat, mkdir, readFile, writeFile, unlink, stat } from "node:fs/promises";
+import { mkdir, readFile, writeFile, unlink, stat } from "node:fs/promises";
 import pino from "pino";
 import {
   loadConfig,
@@ -373,6 +373,12 @@ export function capSyncStateConflicts(syncState: SyncState): boolean {
   return true;
 }
 
+export function capLoadedSyncState(syncState: SyncState): boolean {
+  const filesTrimmed = capSyncStateFiles(syncState);
+  const conflictsTrimmed = capSyncStateConflicts(syncState);
+  return filesTrimmed || conflictsTrimmed;
+}
+
 function isENOENT(err: unknown): boolean {
   return (
     err instanceof Error &&
@@ -421,10 +427,16 @@ async function reserveAvailableConflictPath(
       : appendConflictCollisionSuffix(preferredPath, attempt);
     const absolutePath = resolveWithinSyncRoot(syncRoot, conflictPath);
     try {
-      await lstat(absolutePath);
+      await mkdir(dirname(absolutePath), { recursive: true, mode: 0o700 });
+      await writeFile(absolutePath, "", { flag: "wx", mode: 0o600 });
+      return { conflictPath, absolutePath };
     } catch (err: unknown) {
-      if (isENOENT(err)) {
-        return { conflictPath, absolutePath };
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "EEXIST"
+      ) {
+        continue;
       }
       throw err;
     }
@@ -473,13 +485,17 @@ export async function reconcileRemoteFileChange(
     }
   }
 
-  const updateDownloadedState = async (targetPath: string, remotePath: string) => {
+  const updateDownloadedState = async (
+    targetPath: string,
+    remotePath: string,
+    options: { markRemoteSynced?: boolean } = { markRemoteSynced: true },
+  ) => {
     const downloadedStat = await stat(targetPath);
     syncState.files[remotePath] = {
       hash: input.remoteHash,
       mtime: downloadedStat.mtimeMs,
       size: downloadedStat.size,
-      lastSyncedHash: input.remoteHash,
+      ...(options.markRemoteSynced === false ? {} : { lastSyncedHash: input.remoteHash }),
     };
     capSyncStateFiles(syncState);
   };
@@ -517,13 +533,26 @@ export async function reconcileRemoteFileChange(
     absolutePath: conflictAbsPath,
   } = await reserveAvailableConflictPath(input.syncRoot, preferredConflictPath);
   const conflictRemotePath = input.toRemotePath?.(conflictPath) ?? conflictPath;
-  await input.downloadRemote(conflictAbsPath);
-  await updateDownloadedState(conflictAbsPath, conflictRemotePath);
+  try {
+    await input.downloadRemote(conflictAbsPath);
+  } catch (err) {
+    try {
+      await unlink(conflictAbsPath);
+    } catch (cleanupErr: unknown) {
+      if (!isENOENT(cleanupErr)) {
+        throw cleanupErr;
+      }
+    }
+    throw err;
+  }
+  await updateDownloadedState(conflictAbsPath, conflictRemotePath, {
+    markRemoteSynced: false,
+  });
   syncState.files[input.remotePath] = {
     hash: localHash,
     mtime: localMtime,
     size: localSize,
-    lastSyncedHash: cached?.lastSyncedHash,
+    lastSyncedHash: input.remoteHash,
   };
   capSyncStateFiles(syncState);
   recordSyncConflict(syncState, {
@@ -732,7 +761,7 @@ export async function startDaemon(): Promise<void> {
 
   const ignorePatterns = await loadSyncIgnore(config.syncPath);
   let syncState = await loadSyncState(stateFile);
-  if (capSyncStateFiles(syncState)) {
+  if (capLoadedSyncState(syncState)) {
     await saveSyncState(stateFile, syncState);
   }
 

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -645,11 +645,33 @@ export async function reconcileRemoteDelete(
     return { status: "deleted-local" };
   }
 
+  const existingConflict = syncState.conflicts?.[input.remotePath];
+  if (
+    cached?.hash === localHash &&
+    cached.lastSyncedHash === input.remoteHash &&
+    existingConflict?.localHash === localHash &&
+    existingConflict.remoteHash === input.remoteHash &&
+    !existingConflict.resolved
+  ) {
+    syncState.files[input.remotePath] = {
+      ...cached,
+      hash: localHash,
+      mtime: localMtime,
+      size: localSize,
+      lastSyncedHash: input.remoteHash,
+    };
+    capSyncStateFiles(syncState);
+    return {
+      status: "conflict-existing",
+      conflictPath: syncState.conflicts?.[input.remotePath]?.conflictPath,
+    };
+  }
+
   syncState.files[input.remotePath] = {
     hash: localHash,
     mtime: localMtime,
     size: localSize,
-    lastSyncedHash: cached?.lastSyncedHash,
+    lastSyncedHash: input.remoteHash,
   };
   capSyncStateFiles(syncState);
   recordSyncConflict(syncState, {

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -39,6 +39,7 @@ import {
 } from "./r2-client.js";
 import {
   RemoteManifestEnvelopeSchema,
+  type LocalFileState,
   type RemoteManifestEnvelope,
   type SyncChangeEvent,
   type SyncState,
@@ -463,6 +464,18 @@ interface RemoteFileReconcileInput {
   downloadRemote: (targetPath: string) => Promise<void>;
   toRemotePath?: (localRel: string) => string;
   date?: Date;
+  onConflictCleanupError?: (err: unknown, conflictPath: string) => void;
+}
+
+export function shouldSkipWatcherUpload(
+  existing: LocalFileState | undefined,
+  eventHash: string,
+): boolean {
+  return existing?.localOnly === true || existing?.lastSyncedHash === eventHash;
+}
+
+export function shouldCommitWatcherDelete(entry: LocalFileState | undefined): boolean {
+  return Boolean(entry?.lastSyncedHash && entry.localOnly !== true);
 }
 
 export async function reconcileRemoteFileChange(
@@ -489,14 +502,15 @@ export async function reconcileRemoteFileChange(
   const updateDownloadedState = async (
     targetPath: string,
     remotePath: string,
-    options: { markRemoteSynced?: boolean } = { markRemoteSynced: true },
+    options: { localOnly?: boolean } = {},
   ) => {
     const downloadedStat = await stat(targetPath);
     syncState.files[remotePath] = {
       hash: input.remoteHash,
       mtime: downloadedStat.mtimeMs,
       size: downloadedStat.size,
-      ...(options.markRemoteSynced === false ? {} : { lastSyncedHash: input.remoteHash }),
+      lastSyncedHash: input.remoteHash,
+      ...(options.localOnly ? { localOnly: true } : {}),
     };
     capSyncStateFiles(syncState);
   };
@@ -556,13 +570,13 @@ export async function reconcileRemoteFileChange(
       await unlink(conflictAbsPath);
     } catch (cleanupErr: unknown) {
       if (!isENOENT(cleanupErr)) {
-        throw cleanupErr;
+        input.onConflictCleanupError?.(cleanupErr, conflictRemotePath);
       }
     }
     throw err;
   }
   await updateDownloadedState(conflictAbsPath, conflictRemotePath, {
-    markRemoteSynced: false,
+    localOnly: true,
   });
   syncState.files[input.remotePath] = {
     hash: localHash,
@@ -815,12 +829,16 @@ export async function startDaemon(): Promise<void> {
 
       if (event.type === "change") {
         const existing = syncState.files[remotePath];
-        // Skip if the on-disk hash already matches what we previously
-        // synced AND it's already in the remote manifest. Makes
-        // ignoreInitial=false safe on restart -- existing files don't get
-        // re-uploaded.
-        if (existing?.lastSyncedHash === event.hash) {
-          if (existing.mtime !== event.mtime || existing.size !== event.size) {
+        // Skip remote-synced files on watcher replay and local-only conflict
+        // copies that should never be uploaded to the remote manifest.
+        if (shouldSkipWatcherUpload(existing, event.hash)) {
+          if (
+            existing &&
+            (existing.hash !== event.hash ||
+              existing.mtime !== event.mtime ||
+              existing.size !== event.size)
+          ) {
+            existing.hash = event.hash;
             existing.mtime = event.mtime;
             existing.size = event.size;
             await saveSyncState(stateFile, syncState);
@@ -867,7 +885,7 @@ export async function startDaemon(): Promise<void> {
         }
       } else if (event.type === "unlink") {
         const entry = syncState.files[remotePath];
-        if (entry?.lastSyncedHash) {
+        if (shouldCommitWatcherDelete(entry)) {
           try {
             const deleteResult = await commitFiles(gatewayClient, [
               {
@@ -887,6 +905,9 @@ export async function startDaemon(): Promise<void> {
             });
             logger.error({ err, path: remotePath }, "Delete commit failed");
           }
+        } else if (entry?.localOnly) {
+          delete syncState.files[remotePath];
+          await saveSyncState(stateFile, syncState);
         }
       }
     }),
@@ -926,6 +947,12 @@ export async function startDaemon(): Promise<void> {
               remoteSize: file.size,
               remotePeerId: event.peerId,
               toRemotePath: toRemote,
+              onConflictCleanupError: (cleanupErr, conflictPath) => {
+                logger.warn(
+                  { err: cleanupErr, path: conflictPath },
+                  "Failed to clean up reserved conflict path after download error",
+                );
+              },
               downloadRemote: (targetPath) => downloadFile(
                 urls[0]!.url,
                 targetPath,
@@ -1089,6 +1116,12 @@ export async function startDaemon(): Promise<void> {
           remoteSize: entry.size,
           remotePeerId: entry.peerId,
           toRemotePath: toRemote,
+          onConflictCleanupError: (cleanupErr, conflictPath) => {
+            logger.warn(
+              { err: cleanupErr, path: conflictPath },
+              "Failed to clean up reserved conflict path after download error",
+            );
+          },
           downloadRemote: (targetPath) => downloadFile(
             urls[0]!.url,
             targetPath,

--- a/packages/sync-client/src/daemon/types.ts
+++ b/packages/sync-client/src/daemon/types.ts
@@ -1,7 +1,9 @@
 import { z } from "zod/v4";
 
+const Sha256HashSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+
 export const ManifestEntrySchema = z.object({
-  hash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  hash: Sha256HashSchema,
   size: z.int().nonnegative(),
   mtime: z.int().nonnegative(),
   peerId: z.string().min(1).max(128),
@@ -24,18 +26,18 @@ export const RemoteManifestEnvelopeSchema = z.object({
 export type RemoteManifestEnvelope = z.infer<typeof RemoteManifestEnvelopeSchema>;
 
 export const LocalFileStateSchema = z.object({
-  hash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  hash: Sha256HashSchema,
   mtime: z.int().nonnegative(),
   size: z.int().nonnegative(),
-  lastSyncedHash: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional(),
+  lastSyncedHash: Sha256HashSchema.optional(),
 });
 export type LocalFileState = z.infer<typeof LocalFileStateSchema>;
 
 export const ConflictRecordSchema = z.object({
   path: z.string().min(1).max(1024),
-  conflictPath: z.string().min(1),
-  localHash: z.string(),
-  remoteHash: z.string(),
+  conflictPath: z.string().min(1).optional(),
+  localHash: Sha256HashSchema,
+  remoteHash: Sha256HashSchema,
   remotePeerId: z.string(),
   detectedAt: z.int().nonnegative(),
   resolved: z.boolean().default(false),

--- a/packages/sync-client/src/daemon/types.ts
+++ b/packages/sync-client/src/daemon/types.ts
@@ -30,6 +30,7 @@ export const LocalFileStateSchema = z.object({
   mtime: z.int().nonnegative(),
   size: z.int().nonnegative(),
   lastSyncedHash: Sha256HashSchema.optional(),
+  localOnly: z.boolean().optional(),
 });
 export type LocalFileState = z.infer<typeof LocalFileStateSchema>;
 

--- a/packages/sync-client/src/lib/profiles.ts
+++ b/packages/sync-client/src/lib/profiles.ts
@@ -34,7 +34,7 @@ function assertNoCaseCollidingProfileNames(profiles: ProfilesFile): void {
   for (const name of Object.keys(profiles.profiles)) {
     const normalized = name.toLowerCase();
     const existing = seen.get(normalized);
-    if (existing && existing !== name) {
+    if (existing) {
       throw profileNameConflictError();
     }
     seen.set(normalized, name);

--- a/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
+++ b/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import {
   adoptRemoteManifestVersion,
   adoptSyncChangeManifestVersion,
+  capLoadedSyncState,
   capSyncStateConflicts,
   capSyncStateFiles,
   createDaemonAuthFileAccessors,
@@ -390,6 +391,42 @@ describe("daemon runtime guards", () => {
     expect(syncState.files["file-50001.txt"]).toBeDefined();
   });
 
+  it("caps files and conflicts together after loading sync state", () => {
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {},
+      conflicts: {},
+    };
+
+    for (let i = 0; i < 50_002; i++) {
+      syncState.files[`file-${i}.txt`] = {
+        hash: `sha256:${"a".repeat(63)}${i % 10}`,
+        mtime: i,
+        size: i,
+      };
+    }
+    for (let i = 0; i < 502; i++) {
+      syncState.conflicts![`conflict-${i}.txt`] = {
+        path: `conflict-${i}.txt`,
+        conflictPath: `conflict-${i} (conflict).txt`,
+        localHash: `sha256:${"a".repeat(63)}${i % 10}`,
+        remoteHash: `sha256:${"b".repeat(63)}${i % 10}`,
+        remotePeerId: "peer",
+        detectedAt: i,
+        resolved: false,
+      };
+    }
+
+    const trimmed = capLoadedSyncState(syncState);
+
+    expect(trimmed).toBe(true);
+    expect(Object.keys(syncState.files)).toHaveLength(50_000);
+    expect(Object.keys(syncState.conflicts ?? {})).toHaveLength(500);
+    expect(syncState.files["file-0.txt"]).toBeUndefined();
+    expect(syncState.conflicts?.["conflict-0.txt"]).toBeUndefined();
+  });
+
   it("preserves local edits and writes remote content to a conflict copy", async () => {
     const syncRoot = join(tempDir, "sync");
     await mkdir(syncRoot, { recursive: true });
@@ -413,6 +450,7 @@ describe("daemon runtime guards", () => {
         },
       },
     };
+    let reservedBeforeDownload = false;
 
     const result = await reconcileRemoteFileChange(syncState, {
       syncRoot,
@@ -423,21 +461,26 @@ describe("daemon runtime guards", () => {
       remotePeerId: "peer/with/slashes",
       date: new Date("2026-05-20T12:00:00Z"),
       downloadRemote: async (targetPath) => {
+        reservedBeforeDownload = (await readFile(targetPath, "utf-8")) === "";
         await writeFile(targetPath, remoteContent);
       },
     });
 
     expect(result.status).toBe("conflict-created");
+    expect(reservedBeforeDownload).toBe(true);
     expect(await readFile(localPath, "utf-8")).toBe(localContent);
     expect(await readFile(join(syncRoot, "note (conflict - peer_with_slashes - 2026-05-20).md"), "utf-8")).toBe(remoteContent);
     expect(syncState.files[remotePath]).toMatchObject({
       hash: sha256(localContent),
-      lastSyncedHash: sha256(baseContent),
+      lastSyncedHash: sha256(remoteContent),
     });
     expect(syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"]).toMatchObject({
       hash: sha256(remoteContent),
-      lastSyncedHash: sha256(remoteContent),
     });
+    expect(
+      syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"]
+        ?.lastSyncedHash,
+    ).toBeUndefined();
     expect(syncState.conflicts?.[remotePath]).toMatchObject({
       path: remotePath,
       conflictPath: "note (conflict - peer_with_slashes - 2026-05-20).md",

--- a/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
+++ b/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
@@ -18,6 +18,8 @@ import {
   reconcileRemoteFileChange,
   resolveDaemonAuth,
   resolveWithinSyncRoot,
+  shouldCommitWatcherDelete,
+  shouldSkipWatcherUpload,
   writePidFileExclusive,
 } from "../../src/daemon/index.js";
 import { loadAuth, loadProfileAuth, saveAuth, saveProfileAuth } from "../../src/auth/token-store.js";
@@ -476,11 +478,16 @@ describe("daemon runtime guards", () => {
     });
     expect(syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"]).toMatchObject({
       hash: sha256(remoteContent),
+      lastSyncedHash: sha256(remoteContent),
+      localOnly: true,
     });
-    expect(
-      syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"]
-        ?.lastSyncedHash,
-    ).toBeUndefined();
+    expect(shouldSkipWatcherUpload(
+      syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"],
+      sha256(remoteContent),
+    )).toBe(true);
+    expect(shouldCommitWatcherDelete(
+      syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"],
+    )).toBe(false);
     expect(syncState.conflicts?.[remotePath]).toMatchObject({
       path: remotePath,
       conflictPath: "note (conflict - peer_with_slashes - 2026-05-20).md",
@@ -572,6 +579,8 @@ describe("daemon runtime guards", () => {
           hash: sha256(remoteContent),
           mtime: (await stat(conflictPath)).mtimeMs,
           size: Buffer.byteLength(remoteContent),
+          lastSyncedHash: sha256(remoteContent),
+          localOnly: true,
         },
       },
       conflicts: {
@@ -611,6 +620,62 @@ describe("daemon runtime guards", () => {
       conflictPath: conflictRel,
       remoteHash: sha256(remoteContent),
       resolved: false,
+    });
+  });
+
+  it("keeps the original download error when conflict cleanup fails", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localRel = "note.md";
+    const remotePath = "note.md";
+    const localPath = join(syncRoot, localRel);
+    const baseContent = "base\n";
+    const localContent = "local edit\n";
+    const remoteContent = "remote edit\n";
+    await writeFile(localPath, localContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        [remotePath]: {
+          hash: sha256(localContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(localContent),
+          lastSyncedHash: sha256(baseContent),
+        },
+      },
+    };
+    const downloadError = new Error("download failed");
+    const onCleanupError = vi.fn();
+
+    await expect(reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel,
+      remotePath,
+      remoteHash: sha256(remoteContent),
+      remoteSize: Buffer.byteLength(remoteContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+      onConflictCleanupError: onCleanupError,
+      downloadRemote: async (targetPath) => {
+        await rm(targetPath);
+        await mkdir(targetPath);
+        throw downloadError;
+      },
+    })).rejects.toBe(downloadError);
+
+    expect(onCleanupError).toHaveBeenCalledTimes(1);
+    expect(onCleanupError.mock.calls[0]?.[0]).toMatchObject({
+      code: expect.any(String),
+    });
+    expect(onCleanupError.mock.calls[0]?.[1]).toBe(
+      "note (conflict - peer-2 - 2026-05-20).md",
+    );
+    expect(syncState.conflicts).toBeUndefined();
+    expect(syncState.files[remotePath]).toMatchObject({
+      hash: sha256(localContent),
+      lastSyncedHash: sha256(baseContent),
     });
   });
 

--- a/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
+++ b/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
@@ -545,6 +545,75 @@ describe("daemon runtime guards", () => {
     ).toBe(secondRemoteContent);
   });
 
+  it("does not create duplicate conflict copies for replayed remote revisions", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localRel = "note.md";
+    const remotePath = "note.md";
+    const localPath = join(syncRoot, localRel);
+    const conflictRel = "note (conflict - peer-2 - 2026-05-20).md";
+    const conflictPath = join(syncRoot, conflictRel);
+    const localContent = "local edit\n";
+    const remoteContent = "remote edit\n";
+    await writeFile(localPath, localContent);
+    await writeFile(conflictPath, remoteContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        [remotePath]: {
+          hash: sha256(localContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(localContent),
+          lastSyncedHash: sha256(remoteContent),
+        },
+        [conflictRel]: {
+          hash: sha256(remoteContent),
+          mtime: (await stat(conflictPath)).mtimeMs,
+          size: Buffer.byteLength(remoteContent),
+        },
+      },
+      conflicts: {
+        [remotePath]: {
+          path: remotePath,
+          conflictPath: conflictRel,
+          localHash: sha256(localContent),
+          remoteHash: sha256(remoteContent),
+          remotePeerId: "peer-2",
+          detectedAt: new Date("2026-05-20T12:00:00Z").getTime(),
+          resolved: false,
+        },
+      },
+    };
+    const downloadRemote = vi.fn(async (targetPath: string) => {
+      await writeFile(targetPath, remoteContent);
+    });
+
+    const result = await reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel,
+      remotePath,
+      remoteHash: sha256(remoteContent),
+      remoteSize: Buffer.byteLength(remoteContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+      downloadRemote,
+    });
+
+    expect(result.status).toBe("conflict-existing");
+    expect(result.conflictPath).toBe(conflictRel);
+    expect(downloadRemote).not.toHaveBeenCalled();
+    await expect(
+      readFile(join(syncRoot, "note (conflict - peer-2 - 2026-05-20) 2.md"), "utf-8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(syncState.conflicts?.[remotePath]).toMatchObject({
+      conflictPath: conflictRel,
+      remoteHash: sha256(remoteContent),
+      resolved: false,
+    });
+  });
+
   it("replaces local content when local still matches lastSyncedHash", async () => {
     const syncRoot = join(tempDir, "sync");
     await mkdir(syncRoot, { recursive: true });

--- a/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
+++ b/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
@@ -854,6 +854,57 @@ describe("daemon runtime guards", () => {
     expect(syncState.conflicts?.["note.md"]?.conflictPath).toBeUndefined();
   });
 
+  it("does not re-detect the same remote delete conflict on replay", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const baseContent = "base\n";
+    const localContent = "local edit\n";
+    const deletedRemoteContent = "remote edit before delete\n";
+    const localPath = join(syncRoot, "note.md");
+    await writeFile(localPath, localContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        "note.md": {
+          hash: sha256(localContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(localContent),
+          lastSyncedHash: sha256(baseContent),
+        },
+      },
+    };
+
+    const first = await reconcileRemoteDelete(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(deletedRemoteContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+    });
+
+    const firstConflict = syncState.conflicts?.["note.md"];
+    const second = await reconcileRemoteDelete(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(deletedRemoteContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T13:00:00Z"),
+    });
+
+    expect(first.status).toBe("delete-skipped-conflict");
+    expect(second.status).toBe("conflict-existing");
+    expect(await readFile(localPath, "utf-8")).toBe(localContent);
+    expect(syncState.files["note.md"]).toMatchObject({
+      hash: sha256(localContent),
+      lastSyncedHash: sha256(deletedRemoteContent),
+    });
+    expect(syncState.conflicts?.["note.md"]).toEqual(firstConflict);
+  });
+
   it("keeps local content on remote delete when there is no cached base hash", async () => {
     const syncRoot = join(tempDir, "sync");
     await mkdir(syncRoot, { recursive: true });
@@ -876,7 +927,7 @@ describe("daemon runtime guards", () => {
     expect(await readFile(localPath, "utf-8")).toBe(localContent);
     expect(syncState.files["note.md"]).toMatchObject({
       hash: sha256(localContent),
-      lastSyncedHash: undefined,
+      lastSyncedHash: sha256(remoteContent),
     });
   });
 

--- a/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
+++ b/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
@@ -6,16 +6,20 @@ import { tmpdir } from "node:os";
 import {
   adoptRemoteManifestVersion,
   adoptSyncChangeManifestVersion,
+  buildUnresolvedConflictCopyPathIndex,
   capLoadedSyncState,
   capSyncStateConflicts,
   capSyncStateFiles,
   createDaemonAuthFileAccessors,
   createSerialTaskQueue,
   exitOnAuthFailure,
+  hasUnresolvedConflictCopyPath,
   parseRemoteManifestEnvelope,
   persistPauseState,
   reconcileRemoteDelete,
   reconcileRemoteFileChange,
+  reconcileMissingConflictCopies,
+  resolveConflictCopyPath,
   resolveDaemonAuth,
   resolveWithinSyncRoot,
   shouldCommitWatcherDelete,
@@ -393,6 +397,38 @@ describe("daemon runtime guards", () => {
     expect(syncState.files["file-50001.txt"]).toBeDefined();
   });
 
+  it("prefers ordinary file states over local-only conflict copies when capping files", () => {
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        "note (conflict - peer-2 - 2026-05-20).md": {
+          hash: sha256("remote\n"),
+          mtime: 0,
+          size: Buffer.byteLength("remote\n"),
+          lastSyncedHash: sha256("remote\n"),
+          localOnly: true,
+        },
+      },
+    };
+
+    for (let i = 0; i < 50_000; i++) {
+      syncState.files[`normal-${i}.txt`] = {
+        hash: `sha256:${"a".repeat(63)}${i % 10}`,
+        mtime: i + 1,
+        size: i,
+        lastSyncedHash: `sha256:${"a".repeat(63)}${i % 10}`,
+      };
+    }
+
+    const trimmed = capSyncStateFiles(syncState);
+
+    expect(trimmed).toBe(true);
+    expect(Object.keys(syncState.files)).toHaveLength(50_000);
+    expect(syncState.files["note (conflict - peer-2 - 2026-05-20).md"]).toBeDefined();
+    expect(syncState.files["normal-0.txt"]).toBeUndefined();
+  });
+
   it("caps files and conflicts together after loading sync state", () => {
     const syncState: SyncState = {
       manifestVersion: 1,
@@ -452,7 +488,12 @@ describe("daemon runtime guards", () => {
         },
       },
     };
-    let reservedBeforeDownload = false;
+    const finalConflictPath = join(
+      syncRoot,
+      "note (conflict - peer_with_slashes - 2026-05-20).md",
+    );
+    let downloadedToIgnoredTemp = false;
+    let finalMissingBeforeDownload = false;
 
     const result = await reconcileRemoteFileChange(syncState, {
       syncRoot,
@@ -463,15 +504,26 @@ describe("daemon runtime guards", () => {
       remotePeerId: "peer/with/slashes",
       date: new Date("2026-05-20T12:00:00Z"),
       downloadRemote: async (targetPath) => {
-        reservedBeforeDownload = (await readFile(targetPath, "utf-8")) === "";
+        downloadedToIgnoredTemp = targetPath.startsWith(
+          join(syncRoot, ".cache", "matrixos-sync-conflicts"),
+        );
+        try {
+          await stat(finalConflictPath);
+        } catch (err: unknown) {
+          finalMissingBeforeDownload =
+            err instanceof Error &&
+            "code" in err &&
+            (err as NodeJS.ErrnoException).code === "ENOENT";
+        }
         await writeFile(targetPath, remoteContent);
       },
     });
 
     expect(result.status).toBe("conflict-created");
-    expect(reservedBeforeDownload).toBe(true);
+    expect(downloadedToIgnoredTemp).toBe(true);
+    expect(finalMissingBeforeDownload).toBe(true);
     expect(await readFile(localPath, "utf-8")).toBe(localContent);
-    expect(await readFile(join(syncRoot, "note (conflict - peer_with_slashes - 2026-05-20).md"), "utf-8")).toBe(remoteContent);
+    expect(await readFile(finalConflictPath, "utf-8")).toBe(remoteContent);
     expect(syncState.files[remotePath]).toMatchObject({
       hash: sha256(localContent),
       lastSyncedHash: sha256(remoteContent),
@@ -485,9 +537,59 @@ describe("daemon runtime guards", () => {
       syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"],
       sha256(remoteContent),
     )).toBe(true);
+    const conflictCopyPathIndex = buildUnresolvedConflictCopyPathIndex(syncState);
+    expect(hasUnresolvedConflictCopyPath(
+      conflictCopyPathIndex,
+      "note (conflict - peer_with_slashes - 2026-05-20).md",
+    )).toBe(true);
+    expect(shouldSkipWatcherUpload(
+      undefined,
+      sha256(remoteContent),
+      hasUnresolvedConflictCopyPath(
+        conflictCopyPathIndex,
+        "note (conflict - peer_with_slashes - 2026-05-20).md",
+      ),
+    )).toBe(true);
+    expect(shouldSkipWatcherUpload(
+      undefined,
+      sha256(remoteContent),
+      hasUnresolvedConflictCopyPath(
+        conflictCopyPathIndex,
+        "report (conflict - laptop - 2026-05-20).md",
+      ),
+    )).toBe(false);
+    expect(shouldSkipWatcherUpload(
+      undefined,
+      sha256(remoteContent),
+      false,
+    )).toBe(false);
     expect(shouldCommitWatcherDelete(
       syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"],
     )).toBe(false);
+    expect(shouldCommitWatcherDelete(
+      {
+        hash: sha256(remoteContent),
+        mtime: 0,
+        size: Buffer.byteLength(remoteContent),
+        lastSyncedHash: sha256(remoteContent),
+      },
+      hasUnresolvedConflictCopyPath(
+        conflictCopyPathIndex,
+        "note (conflict - peer_with_slashes - 2026-05-20).md",
+      ),
+    )).toBe(false);
+    expect(shouldCommitWatcherDelete(
+      {
+        hash: sha256(remoteContent),
+        mtime: 0,
+        size: Buffer.byteLength(remoteContent),
+        lastSyncedHash: sha256(remoteContent),
+      },
+      hasUnresolvedConflictCopyPath(
+        conflictCopyPathIndex,
+        "report (conflict - laptop - 2026-05-20).md",
+      ),
+    )).toBe(true);
     expect(syncState.conflicts?.[remotePath]).toMatchObject({
       path: remotePath,
       conflictPath: "note (conflict - peer_with_slashes - 2026-05-20).md",
@@ -496,6 +598,139 @@ describe("daemon runtime guards", () => {
       remotePeerId: "peer/with/slashes",
       resolved: false,
     });
+  });
+
+  it("clears the owning conflict record when a conflict copy is deleted", () => {
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        "note (conflict - peer-2 - 2026-05-20).md": {
+          hash: sha256("remote\n"),
+          mtime: 0,
+          size: Buffer.byteLength("remote\n"),
+          lastSyncedHash: sha256("remote\n"),
+          localOnly: true,
+        },
+      },
+      conflicts: {
+        "note.md": {
+          path: "note.md",
+          conflictPath: "note (conflict - peer-2 - 2026-05-20).md",
+          localHash: sha256("local\n"),
+          remoteHash: sha256("remote\n"),
+          remotePeerId: "peer-2",
+          detectedAt: 0,
+          resolved: false,
+        },
+      },
+    };
+    const conflictCopyPathIndex = buildUnresolvedConflictCopyPathIndex(syncState);
+
+    expect(hasUnresolvedConflictCopyPath(
+      conflictCopyPathIndex,
+      "note (conflict - peer-2 - 2026-05-20).md",
+    )).toBe(true);
+    expect(resolveConflictCopyPath(
+      syncState,
+      conflictCopyPathIndex,
+      "note (conflict - peer-2 - 2026-05-20).md",
+      123,
+    )).toBe(true);
+
+    expect(hasUnresolvedConflictCopyPath(
+      conflictCopyPathIndex,
+      "note (conflict - peer-2 - 2026-05-20).md",
+    )).toBe(false);
+    expect(syncState.conflicts?.["note.md"]).toMatchObject({
+      path: "note.md",
+      resolved: true,
+      resolvedAt: 123,
+    });
+    expect(syncState.conflicts?.["note.md"]?.conflictPath).toBeUndefined();
+    expect(shouldSkipWatcherUpload(
+      undefined,
+      sha256("new user file\n"),
+      hasUnresolvedConflictCopyPath(
+        conflictCopyPathIndex,
+        "note (conflict - peer-2 - 2026-05-20).md",
+      ),
+    )).toBe(false);
+  });
+
+  it("clears missing conflict copies before building the watcher index", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const conflictPath = "note (conflict - peer-2 - 2026-05-20).md";
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        [conflictPath]: {
+          hash: sha256("remote\n"),
+          mtime: 0,
+          size: Buffer.byteLength("remote\n"),
+          lastSyncedHash: sha256("remote\n"),
+          localOnly: true,
+        },
+      },
+      conflicts: {
+        "note.md": {
+          path: "note.md",
+          conflictPath,
+          localHash: sha256("local\n"),
+          remoteHash: sha256("remote\n"),
+          remotePeerId: "peer-2",
+          detectedAt: 0,
+          resolved: false,
+        },
+      },
+    };
+
+    const changed = await reconcileMissingConflictCopies(syncState, {
+      syncRoot,
+      toLocalPath: (remotePath) => remotePath,
+      resolvedAt: 456,
+    });
+    const conflictCopyPathIndex = buildUnresolvedConflictCopyPathIndex(syncState);
+
+    expect(changed).toBe(true);
+    expect(syncState.files[conflictPath]).toBeUndefined();
+    expect(syncState.conflicts?.["note.md"]).toMatchObject({
+      resolved: true,
+      resolvedAt: 456,
+    });
+    expect(syncState.conflicts?.["note.md"]?.conflictPath).toBeUndefined();
+    expect(hasUnresolvedConflictCopyPath(conflictCopyPathIndex, conflictPath)).toBe(false);
+  });
+
+  it("clears missing local-only conflict copy state without a conflict record", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const conflictPath = "note (conflict - peer-2 - 2026-05-20).md";
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        [conflictPath]: {
+          hash: sha256("remote\n"),
+          mtime: 0,
+          size: Buffer.byteLength("remote\n"),
+          lastSyncedHash: sha256("remote\n"),
+          localOnly: true,
+        },
+      },
+      conflicts: {},
+    };
+
+    const changed = await reconcileMissingConflictCopies(syncState, {
+      syncRoot,
+      toLocalPath: (remotePath) => remotePath,
+      resolvedAt: 456,
+    });
+
+    expect(changed).toBe(true);
+    expect(syncState.files[conflictPath]).toBeUndefined();
   });
 
   it("does not overwrite an earlier conflict copy for the same file and peer", async () => {
@@ -623,6 +858,131 @@ describe("daemon runtime guards", () => {
     });
   });
 
+  it("updates the existing conflict when the local file is edited again", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localRel = "note.md";
+    const remotePath = "note.md";
+    const localPath = join(syncRoot, localRel);
+    const conflictRel = "note (conflict - peer-2 - 2026-05-20).md";
+    const conflictPath = join(syncRoot, conflictRel);
+    const firstLocalContent = "local edit\n";
+    const secondLocalContent = "local edit again\n";
+    const remoteContent = "remote edit\n";
+    await writeFile(localPath, secondLocalContent);
+    await writeFile(conflictPath, remoteContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        [remotePath]: {
+          hash: sha256(firstLocalContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(firstLocalContent),
+          lastSyncedHash: sha256(remoteContent),
+        },
+        [conflictRel]: {
+          hash: sha256(remoteContent),
+          mtime: (await stat(conflictPath)).mtimeMs,
+          size: Buffer.byteLength(remoteContent),
+          lastSyncedHash: sha256(remoteContent),
+          localOnly: true,
+        },
+      },
+      conflicts: {
+        [remotePath]: {
+          path: remotePath,
+          conflictPath: conflictRel,
+          localHash: sha256(firstLocalContent),
+          remoteHash: sha256(remoteContent),
+          remotePeerId: "peer-2",
+          detectedAt: new Date("2026-05-20T12:00:00Z").getTime(),
+          resolved: false,
+        },
+      },
+    };
+    const downloadRemote = vi.fn(async (targetPath: string) => {
+      await writeFile(targetPath, remoteContent);
+    });
+
+    const result = await reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel,
+      remotePath,
+      remoteHash: sha256(remoteContent),
+      remoteSize: Buffer.byteLength(remoteContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+      downloadRemote,
+    });
+
+    expect(result.status).toBe("conflict-existing");
+    expect(result.conflictPath).toBe(conflictRel);
+    expect(downloadRemote).not.toHaveBeenCalled();
+    await expect(
+      readFile(join(syncRoot, "note (conflict - peer-2 - 2026-05-20) 2.md"), "utf-8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(syncState.files[remotePath]).toMatchObject({
+      hash: sha256(secondLocalContent),
+      lastSyncedHash: sha256(remoteContent),
+    });
+    expect(syncState.conflicts?.[remotePath]).toMatchObject({
+      conflictPath: conflictRel,
+      localHash: sha256(secondLocalContent),
+      remoteHash: sha256(remoteContent),
+      resolved: false,
+    });
+  });
+
+  it("creates a conflict copy when the conflict-existing guard has no record", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localRel = "note.md";
+    const remotePath = "note.md";
+    const localPath = join(syncRoot, localRel);
+    const localContent = "local edit still uploading\n";
+    const remoteContent = "base content replayed remotely\n";
+    await writeFile(localPath, localContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        [remotePath]: {
+          hash: sha256(localContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(localContent),
+          lastSyncedHash: sha256(remoteContent),
+        },
+      },
+    };
+    const downloadRemote = vi.fn(async (targetPath: string) => {
+      await writeFile(targetPath, remoteContent);
+    });
+
+    const result = await reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel,
+      remotePath,
+      remoteHash: sha256(remoteContent),
+      remoteSize: Buffer.byteLength(remoteContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+      downloadRemote,
+    });
+
+    expect(result.status).toBe("conflict-created");
+    expect(result.conflictPath).toBe("note (conflict - peer-2 - 2026-05-20).md");
+    expect(downloadRemote).toHaveBeenCalledTimes(1);
+    expect(syncState.conflicts?.[remotePath]).toMatchObject({
+      conflictPath: "note (conflict - peer-2 - 2026-05-20).md",
+      localHash: sha256(localContent),
+      remoteHash: sha256(remoteContent),
+      resolved: false,
+    });
+  });
+
   it("keeps the original download error when conflict cleanup fails", async () => {
     const syncRoot = join(tempDir, "sync");
     await mkdir(syncRoot, { recursive: true });
@@ -659,7 +1019,7 @@ describe("daemon runtime guards", () => {
       date: new Date("2026-05-20T12:00:00Z"),
       onConflictCleanupError: onCleanupError,
       downloadRemote: async (targetPath) => {
-        await rm(targetPath);
+        await rm(targetPath, { force: true });
         await mkdir(targetPath);
         throw downloadError;
       },
@@ -931,6 +1291,45 @@ describe("daemon runtime guards", () => {
     });
   });
 
+  it("keeps local content on remote delete when only the remote delete hash matches", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localContent = "same unsynced content on two peers\n";
+    const localPath = join(syncRoot, "note.md");
+    await writeFile(localPath, localContent);
+    const syncState: SyncState = { manifestVersion: 1, lastSyncAt: 0, files: {} };
+
+    const first = await reconcileRemoteDelete(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(localContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+    });
+    const second = await reconcileRemoteDelete(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(localContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T13:00:00Z"),
+    });
+
+    expect(first.status).toBe("delete-skipped-conflict");
+    expect(second.status).toBe("conflict-existing");
+    expect(await readFile(localPath, "utf-8")).toBe(localContent);
+    expect(syncState.files["note.md"]).toMatchObject({
+      hash: sha256(localContent),
+      lastSyncedHash: sha256(localContent),
+    });
+    expect(syncState.conflicts?.["note.md"]).toMatchObject({
+      localHash: sha256(localContent),
+      remoteHash: sha256(localContent),
+      resolved: false,
+    });
+  });
+
   it("caps syncState.conflicts to the most recent 500 entries", () => {
     const syncState: SyncState = {
       manifestVersion: 1,
@@ -940,6 +1339,13 @@ describe("daemon runtime guards", () => {
     };
 
     for (let i = 0; i < 502; i++) {
+      syncState.files[`file-${i} (conflict).txt`] = {
+        hash: `sha256:${"b".repeat(63)}${i % 10}`,
+        mtime: i,
+        size: i,
+        lastSyncedHash: `sha256:${"b".repeat(63)}${i % 10}`,
+        localOnly: true,
+      };
       syncState.conflicts![`file-${i}.txt`] = {
         path: `file-${i}.txt`,
         conflictPath: `file-${i} (conflict).txt`,
@@ -958,6 +1364,9 @@ describe("daemon runtime guards", () => {
     expect(syncState.conflicts?.["file-0.txt"]).toBeUndefined();
     expect(syncState.conflicts?.["file-1.txt"]).toBeUndefined();
     expect(syncState.conflicts?.["file-501.txt"]).toBeDefined();
+    expect(syncState.files["file-0 (conflict).txt"]).toBeDefined();
+    expect(syncState.files["file-1 (conflict).txt"]).toBeDefined();
+    expect(syncState.files["file-501 (conflict).txt"]).toBeDefined();
   });
 
   it("rejects malformed conflict hashes in sync state", () => {

--- a/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
+++ b/packages/sync-client/tests/unit/daemon-runtime-guards.test.ts
@@ -1,16 +1,20 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import {
   adoptRemoteManifestVersion,
   adoptSyncChangeManifestVersion,
+  capSyncStateConflicts,
   capSyncStateFiles,
   createDaemonAuthFileAccessors,
   createSerialTaskQueue,
   exitOnAuthFailure,
   parseRemoteManifestEnvelope,
   persistPauseState,
+  reconcileRemoteDelete,
+  reconcileRemoteFileChange,
   resolveDaemonAuth,
   resolveWithinSyncRoot,
   writePidFileExclusive,
@@ -19,7 +23,11 @@ import { loadAuth, loadProfileAuth, saveAuth, saveProfileAuth } from "../../src/
 import { loadConfig, type SyncConfig } from "../../src/lib/config.js";
 import { saveProfiles } from "../../src/lib/profiles.js";
 import { AuthRejectedError, VersionConflictError } from "../../src/daemon/r2-client.js";
-import type { SyncState } from "../../src/daemon/types.js";
+import { SyncStateSchema, type SyncState } from "../../src/daemon/types.js";
+
+function sha256(content: string | Buffer): string {
+  return `sha256:${createHash("sha256").update(content).digest("hex")}`;
+}
 
 describe("daemon runtime guards", () => {
   let tempDir: string;
@@ -380,6 +388,384 @@ describe("daemon runtime guards", () => {
     expect(syncState.files["file-0.txt"]).toBeUndefined();
     expect(syncState.files["file-1.txt"]).toBeUndefined();
     expect(syncState.files["file-50001.txt"]).toBeDefined();
+  });
+
+  it("preserves local edits and writes remote content to a conflict copy", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localRel = "note.md";
+    const remotePath = "note.md";
+    const localPath = join(syncRoot, localRel);
+    const baseContent = "hello from base\n";
+    const localContent = "hello from LOCAL EDIT\n";
+    const remoteContent = "hello from REMOTE EDIT\n";
+    await writeFile(localPath, localContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        [remotePath]: {
+          hash: sha256(localContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(localContent),
+          lastSyncedHash: sha256(baseContent),
+        },
+      },
+    };
+
+    const result = await reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel,
+      remotePath,
+      remoteHash: sha256(remoteContent),
+      remoteSize: Buffer.byteLength(remoteContent),
+      remotePeerId: "peer/with/slashes",
+      date: new Date("2026-05-20T12:00:00Z"),
+      downloadRemote: async (targetPath) => {
+        await writeFile(targetPath, remoteContent);
+      },
+    });
+
+    expect(result.status).toBe("conflict-created");
+    expect(await readFile(localPath, "utf-8")).toBe(localContent);
+    expect(await readFile(join(syncRoot, "note (conflict - peer_with_slashes - 2026-05-20).md"), "utf-8")).toBe(remoteContent);
+    expect(syncState.files[remotePath]).toMatchObject({
+      hash: sha256(localContent),
+      lastSyncedHash: sha256(baseContent),
+    });
+    expect(syncState.files["note (conflict - peer_with_slashes - 2026-05-20).md"]).toMatchObject({
+      hash: sha256(remoteContent),
+      lastSyncedHash: sha256(remoteContent),
+    });
+    expect(syncState.conflicts?.[remotePath]).toMatchObject({
+      path: remotePath,
+      conflictPath: "note (conflict - peer_with_slashes - 2026-05-20).md",
+      localHash: sha256(localContent),
+      remoteHash: sha256(remoteContent),
+      remotePeerId: "peer/with/slashes",
+      resolved: false,
+    });
+  });
+
+  it("does not overwrite an earlier conflict copy for the same file and peer", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localRel = "note.md";
+    const remotePath = "note.md";
+    const localPath = join(syncRoot, localRel);
+    const existingConflictPath = join(
+      syncRoot,
+      "note (conflict - peer-2 - 2026-05-20).md",
+    );
+    const baseContent = "base\n";
+    const localContent = "local edit\n";
+    const firstRemoteContent = "first remote edit\n";
+    const secondRemoteContent = "second remote edit\n";
+    await writeFile(localPath, localContent);
+    await writeFile(existingConflictPath, firstRemoteContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        [remotePath]: {
+          hash: sha256(localContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(localContent),
+          lastSyncedHash: sha256(baseContent),
+        },
+      },
+    };
+
+    const result = await reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel,
+      remotePath,
+      remoteHash: sha256(secondRemoteContent),
+      remoteSize: Buffer.byteLength(secondRemoteContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+      downloadRemote: async (targetPath) => {
+        await writeFile(targetPath, secondRemoteContent);
+      },
+    });
+
+    expect(result.status).toBe("conflict-created");
+    expect(result.conflictPath).toBe("note (conflict - peer-2 - 2026-05-20) 2.md");
+    expect(await readFile(existingConflictPath, "utf-8")).toBe(firstRemoteContent);
+    expect(
+      await readFile(
+        join(syncRoot, "note (conflict - peer-2 - 2026-05-20) 2.md"),
+        "utf-8",
+      ),
+    ).toBe(secondRemoteContent);
+  });
+
+  it("replaces local content when local still matches lastSyncedHash", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localPath = join(syncRoot, "note.md");
+    const baseContent = "hello from base\n";
+    const remoteContent = "hello from REMOTE EDIT\n";
+    await writeFile(localPath, baseContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        "note.md": {
+          hash: sha256(baseContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(baseContent),
+          lastSyncedHash: sha256(baseContent),
+        },
+      },
+    };
+
+    const result = await reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(remoteContent),
+      remoteSize: Buffer.byteLength(remoteContent),
+      remotePeerId: "peer-2",
+      downloadRemote: async (targetPath) => {
+        await writeFile(targetPath, remoteContent);
+      },
+    });
+
+    expect(result.status).toBe("downloaded");
+    expect(await readFile(localPath, "utf-8")).toBe(remoteContent);
+    expect(syncState.files["note.md"]).toMatchObject({
+      hash: sha256(remoteContent),
+      lastSyncedHash: sha256(remoteContent),
+    });
+    expect(syncState.conflicts).toBeUndefined();
+  });
+
+  it("downloads remote content when the local file is missing", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const remoteContent = "remote-only\n";
+    const syncState: SyncState = { manifestVersion: 1, lastSyncAt: 0, files: {} };
+
+    const result = await reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel: "nested/note.md",
+      remotePath: "nested/note.md",
+      remoteHash: sha256(remoteContent),
+      remoteSize: Buffer.byteLength(remoteContent),
+      remotePeerId: "peer-2",
+      downloadRemote: async (targetPath) => {
+        await mkdir(dirname(targetPath), { recursive: true });
+        await writeFile(targetPath, remoteContent);
+      },
+    });
+
+    expect(result.status).toBe("downloaded");
+    expect(await readFile(join(syncRoot, "nested/note.md"), "utf-8")).toBe(remoteContent);
+    expect(syncState.files["nested/note.md"]).toMatchObject({
+      hash: sha256(remoteContent),
+      lastSyncedHash: sha256(remoteContent),
+    });
+  });
+
+  it("marks equal local and remote hashes as synced without downloading", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const content = "same\n";
+    await writeFile(join(syncRoot, "note.md"), content);
+    const syncState: SyncState = { manifestVersion: 1, lastSyncAt: 0, files: {} };
+    const downloadRemote = vi.fn();
+
+    const result = await reconcileRemoteFileChange(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(content),
+      remoteSize: Buffer.byteLength(content),
+      remotePeerId: "peer-2",
+      downloadRemote,
+    });
+
+    expect(result.status).toBe("already-synced");
+    expect(downloadRemote).not.toHaveBeenCalled();
+    expect(syncState.files["note.md"]).toMatchObject({
+      hash: sha256(content),
+      lastSyncedHash: sha256(content),
+    });
+  });
+
+  it("deletes local content when a remote delete targets an unchanged file", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const content = "synced\n";
+    const localPath = join(syncRoot, "note.md");
+    await writeFile(localPath, content);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        "note.md": {
+          hash: sha256(content),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(content),
+          lastSyncedHash: sha256(content),
+        },
+      },
+    };
+
+    const result = await reconcileRemoteDelete(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(content),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+    });
+
+    expect(result.status).toBe("deleted-local");
+    await expect(readFile(localPath, "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
+    expect(syncState.files["note.md"]).toBeUndefined();
+  });
+
+  it("keeps locally edited content when a remote delete conflicts", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const baseContent = "base\n";
+    const localContent = "local edit\n";
+    const localPath = join(syncRoot, "note.md");
+    await writeFile(localPath, localContent);
+    const localStat = await stat(localPath);
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        "note.md": {
+          hash: sha256(localContent),
+          mtime: localStat.mtimeMs,
+          size: Buffer.byteLength(localContent),
+          lastSyncedHash: sha256(baseContent),
+        },
+      },
+    };
+
+    const result = await reconcileRemoteDelete(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(baseContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+    });
+
+    expect(result.status).toBe("delete-skipped-conflict");
+    expect(result.conflictPath).toBeUndefined();
+    expect(await readFile(localPath, "utf-8")).toBe(localContent);
+    expect(syncState.files["note.md"]).toMatchObject({
+      hash: sha256(localContent),
+      lastSyncedHash: sha256(baseContent),
+    });
+    expect(syncState.conflicts?.["note.md"]).toMatchObject({
+      path: "note.md",
+      localHash: sha256(localContent),
+      remoteHash: sha256(baseContent),
+      remotePeerId: "peer-2",
+    });
+    expect(syncState.conflicts?.["note.md"]?.conflictPath).toBeUndefined();
+  });
+
+  it("keeps local content on remote delete when there is no cached base hash", async () => {
+    const syncRoot = join(tempDir, "sync");
+    await mkdir(syncRoot, { recursive: true });
+    const localContent = "unsynced local file\n";
+    const remoteContent = "remote file that got deleted\n";
+    const localPath = join(syncRoot, "note.md");
+    await writeFile(localPath, localContent);
+    const syncState: SyncState = { manifestVersion: 1, lastSyncAt: 0, files: {} };
+
+    const result = await reconcileRemoteDelete(syncState, {
+      syncRoot,
+      localRel: "note.md",
+      remotePath: "note.md",
+      remoteHash: sha256(remoteContent),
+      remotePeerId: "peer-2",
+      date: new Date("2026-05-20T12:00:00Z"),
+    });
+
+    expect(result.status).toBe("delete-skipped-conflict");
+    expect(await readFile(localPath, "utf-8")).toBe(localContent);
+    expect(syncState.files["note.md"]).toMatchObject({
+      hash: sha256(localContent),
+      lastSyncedHash: undefined,
+    });
+  });
+
+  it("caps syncState.conflicts to the most recent 500 entries", () => {
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {},
+      conflicts: {},
+    };
+
+    for (let i = 0; i < 502; i++) {
+      syncState.conflicts![`file-${i}.txt`] = {
+        path: `file-${i}.txt`,
+        conflictPath: `file-${i} (conflict).txt`,
+        localHash: `sha256:${"a".repeat(63)}${i % 10}`,
+        remoteHash: `sha256:${"b".repeat(63)}${i % 10}`,
+        remotePeerId: "peer",
+        detectedAt: i,
+        resolved: false,
+      };
+    }
+
+    const trimmed = capSyncStateConflicts(syncState);
+
+    expect(trimmed).toBe(true);
+    expect(Object.keys(syncState.conflicts ?? {})).toHaveLength(500);
+    expect(syncState.conflicts?.["file-0.txt"]).toBeUndefined();
+    expect(syncState.conflicts?.["file-1.txt"]).toBeUndefined();
+    expect(syncState.conflicts?.["file-501.txt"]).toBeDefined();
+  });
+
+  it("rejects malformed conflict hashes in sync state", () => {
+    const parsed = SyncStateSchema.safeParse({
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {},
+      conflicts: {
+        "note.md": {
+          path: "note.md",
+          conflictPath: "note.conflict.md",
+          localHash: "not-a-hash",
+          remoteHash: `sha256:${"a".repeat(64)}`,
+          remotePeerId: "peer-2",
+          detectedAt: 0,
+          resolved: false,
+        },
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("loads old sync state files without conflicts", async () => {
+    const statePath = join(tempDir, "sync-state.json");
+    await writeFile(statePath, JSON.stringify({
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {},
+    }));
+
+    const { loadSyncState } = await import("../../src/daemon/manifest-cache.js");
+    await expect(loadSyncState(statePath)).resolves.toMatchObject({
+      manifestVersion: 1,
+      files: {},
+    });
   });
 
   it("rejects malformed remote manifest envelopes", () => {

--- a/packages/sync-client/tests/unit/ipc-handler.test.ts
+++ b/packages/sync-client/tests/unit/ipc-handler.test.ts
@@ -24,15 +24,15 @@ function baseState(): SyncState {
     manifestVersion: 4,
     lastSyncAt: 1234,
     files: {
-      "a.md": { hash: "sha256:aa", mtime: 1, size: 1 },
-      "b.md": { hash: "sha256:bb", mtime: 2, size: 2 },
+      "a.md": { hash: `sha256:${"a".repeat(64)}`, mtime: 1, size: 1 },
+      "b.md": { hash: `sha256:${"b".repeat(64)}`, mtime: 2, size: 2 },
     },
     conflicts: {
       "a.md": {
         path: "a.md",
         conflictPath: "a (conflict - peer-2 - 2026-05-20).md",
-        localHash: "sha256:aa",
-        remoteHash: "sha256:bb",
+        localHash: `sha256:${"a".repeat(64)}`,
+        remoteHash: `sha256:${"b".repeat(64)}`,
         remotePeerId: "peer-2",
         detectedAt: 1234,
         resolved: false,


### PR DESCRIPTION
Parent PR: #155

## Summary

This PR makes remote sync reconciliation safe for locally edited files. Before the daemon applies a remote download or delete, it now compares the current local file against `lastSyncedHash` and the remote hash. If both sides changed independently, the daemon keeps the local file untouched and writes the remote version as a conflict copy.

## What Changed

- Route startup manifest pulls and live `sync:change` events through shared reconciliation logic.
- Preserve unsynced local edits instead of overwriting them with remote content.
- Save conflicting remote versions as conflict copies, e.g. `file (conflict - peer - YYYY-MM-DD).ext`.
- Keep remote deletes from removing locally edited files.
- Add bounded conflict tracking to sync state with a 500-entry cap.

## Tests

- `flox activate -- pnpm --filter @finnaai/matrix exec vitest run`
- `flox activate -- pnpm --filter @finnaai/matrix exec tsc --noEmit`
- `flox activate -- bun run test tests/cli/profile-auth.test.ts tests/cli/profile.test.ts tests/gateway/sync/ws-events.test.ts tests/gateway/sync/commit.test.ts tests/gateway/sync/manifest.test.ts tests/gateway/sync/home-mirror.test.ts tests/gateway/sync/db-impl.test.ts tests/platform/internal-sync-routes.test.ts`

## Invariants

- **Source of truth**: Local disk remains authoritative for unsynced local edits. Remote manifest entries are applied directly only when the local file is missing, unchanged from `lastSyncedHash`, or already matches the remote hash.
- **Lock/transaction scope**: No database writes are introduced. Reconciliation runs inside the daemon serial sync queue before any local overwrite or delete.
- **Acceptable orphan states**: If downloading a conflict copy fails, the original local file remains untouched and sync state is not advanced for that remote file.
- **Auth source of truth**: Unchanged. The daemon continues to use configured profile auth and the existing gateway bearer token.
- **Deferred scope**: This PR does not add text auto-merge, conflict-resolution UI/commands, or launchd/systemd service-path changes.