### PR TITLE
fix(sync-client): validate shell tab and pane inputs

### DIFF
--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { loadProfileAuth } from "../../auth/token-store.js";
+import { isExpired, loadProfileAuth } from "../../auth/token-store.js";
 import { resolveCliProfile } from "../profiles.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 import { createShellClient } from "../shell-client.js";
@@ -9,7 +9,13 @@ const SHELL_USAGE = "Usage: matrix shell ls|new|attach|rm|tab|pane|layout";
 async function clientFromArgs(args: Record<string, unknown>) {
   const profile = await resolveCliProfile(args);
   const auth = profile.token ? null : await loadProfileAuth(profile.name);
-  const token = profile.token ?? auth?.accessToken;
+  const token = profile.token ?? (auth && !isExpired(auth) ? auth.accessToken : undefined);
+  if (!token) {
+    throw Object.assign(
+      new Error(`Not logged in for profile "${profile.name}". Run \`matrix login\` first.`),
+      { code: "not_authenticated" },
+    );
+  }
   return createShellClient({ gatewayUrl: profile.gatewayUrl, token });
 }
 
@@ -43,7 +49,11 @@ function writeError(err: unknown, json: boolean): void {
     err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
       ? (err as { code: string }).code
       : "request_failed";
-  const output = json ? formatCliError(code) : `Error: Request failed (${code})`;
+  const safeMessage =
+    code === "not_authenticated" && err instanceof Error ? err.message : undefined;
+  const output = json
+    ? formatCliError(code, safeMessage)
+    : safeMessage ?? `Error: Request failed (${code})`;
   console.error(output);
 }
 
@@ -320,7 +330,10 @@ export const shellCommand = defineCommand({
       },
     }),
   },
-  run: () => {
-    console.log(SHELL_USAGE);
+  run: ({ rawArgs }) => {
+    const hasSubCommand = Array.isArray(rawArgs) && rawArgs.some((arg) => !arg.startsWith("-"));
+    if (!hasSubCommand) {
+      console.log(SHELL_USAGE);
+    }
   },
 });

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -4,11 +4,38 @@ import { resolveCliProfile } from "../profiles.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 import { createShellClient } from "../shell-client.js";
 
+const SHELL_USAGE = "Usage: matrix shell ls|new|attach|rm|tab|pane|layout";
+
 async function clientFromArgs(args: Record<string, unknown>) {
   const profile = await resolveCliProfile(args);
   const auth = profile.token ? null : await loadProfileAuth(profile.name);
   const token = profile.token ?? auth?.accessToken;
   return createShellClient({ gatewayUrl: profile.gatewayUrl, token });
+}
+
+function invalidRequestError(): Error {
+  return Object.assign(new Error("Request failed"), { code: "invalid_request" });
+}
+
+function parseTabIndex(value: unknown): number {
+  if (typeof value !== "string" || !/^(?:0|[1-9]\d*)$/.test(value)) {
+    throw invalidRequestError();
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw invalidRequestError();
+  }
+  return parsed;
+}
+
+function parsePaneDirection(value: unknown): "right" | "down" {
+  if (value === undefined) {
+    return "right";
+  }
+  if (value !== "right" && value !== "down") {
+    throw invalidRequestError();
+  }
+  return value;
 }
 
 function writeError(err: unknown, json: boolean): void {
@@ -204,14 +231,14 @@ export const shellCommand = defineCommand({
           meta: { name: "go", description: "Switch tab" },
           args: { session: { type: "string", required: true }, tab: { type: "string", required: true }, ...commonArgs },
           run: async ({ args }) => runShellJsonCommand(args, async () => (
-            await (await clientFromArgs(args)).switchTab(String(args.session), Number(args.tab))
+            await (await clientFromArgs(args)).switchTab(String(args.session), parseTabIndex(args.tab))
           ), () => "Switched tab"),
         }),
         close: defineCommand({
           meta: { name: "close", description: "Close tab" },
           args: { session: { type: "string", required: true }, tab: { type: "string", required: true }, ...commonArgs },
           run: async ({ args }) => runShellJsonCommand(args, async () => (
-            await (await clientFromArgs(args)).closeTab(String(args.session), Number(args.tab))
+            await (await clientFromArgs(args)).closeTab(String(args.session), parseTabIndex(args.tab))
           ), () => "Closed tab"),
         }),
       },
@@ -230,7 +257,7 @@ export const shellCommand = defineCommand({
           },
           run: async ({ args }) => runShellJsonCommand(args, async () => (
             await (await clientFromArgs(args)).splitPane(String(args.session), {
-              direction: args.direction === "down" ? "down" : "right",
+              direction: parsePaneDirection(args.direction),
               cwd: typeof args.cwd === "string" ? args.cwd : undefined,
               cmd: typeof args.cmd === "string" ? args.cmd : undefined,
             })
@@ -294,6 +321,6 @@ export const shellCommand = defineCommand({
     }),
   },
   run: () => {
-    console.log("Usage: matrix shell ls|new|attach|rm");
+    console.log(SHELL_USAGE);
   },
 });

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -6,6 +6,29 @@ import { createShellClient } from "../shell-client.js";
 
 const SHELL_USAGE = "Usage: matrix shell ls|new|attach|rm|tab|pane|layout";
 const SHELL_SUBCOMMANDS = new Set(["ls", "new", "attach", "rm", "tab", "pane", "layout"]);
+const SHELL_VALUE_OPTIONS = new Set(["--gateway", "--profile", "--token"]);
+
+function hasShellSubCommand(rawArgs: string[] | undefined): boolean {
+  if (!Array.isArray(rawArgs)) {
+    return false;
+  }
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (arg === "--") {
+      const next = rawArgs[i + 1];
+      return typeof next === "string" && SHELL_SUBCOMMANDS.has(next);
+    }
+    if (arg.startsWith("--")) {
+      const [option] = arg.split("=", 1);
+      if (SHELL_VALUE_OPTIONS.has(option) && !arg.includes("=")) {
+        i += 1;
+      }
+      continue;
+    }
+    return SHELL_SUBCOMMANDS.has(arg);
+  }
+  return false;
+}
 
 async function clientFromArgs(args: Record<string, unknown>) {
   const profile = await resolveCliProfile(args);
@@ -332,9 +355,7 @@ export const shellCommand = defineCommand({
     }),
   },
   run: ({ rawArgs }) => {
-    const hasSubCommand =
-      Array.isArray(rawArgs) && rawArgs.some((arg) => SHELL_SUBCOMMANDS.has(arg));
-    if (!hasSubCommand) {
+    if (!hasShellSubCommand(rawArgs)) {
       console.log(SHELL_USAGE);
     }
   },

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -5,6 +5,7 @@ import { formatCliError, formatCliSuccess } from "../output.js";
 import { createShellClient } from "../shell-client.js";
 
 const SHELL_USAGE = "Usage: matrix shell ls|new|attach|rm|tab|pane|layout";
+const SHELL_SUBCOMMANDS = new Set(["ls", "new", "attach", "rm", "tab", "pane", "layout"]);
 
 async function clientFromArgs(args: Record<string, unknown>) {
   const profile = await resolveCliProfile(args);
@@ -331,7 +332,8 @@ export const shellCommand = defineCommand({
     }),
   },
   run: ({ rawArgs }) => {
-    const hasSubCommand = Array.isArray(rawArgs) && rawArgs.some((arg) => !arg.startsWith("-"));
+    const hasSubCommand =
+      Array.isArray(rawArgs) && rawArgs.some((arg) => SHELL_SUBCOMMANDS.has(arg));
     if (!hasSubCommand) {
       console.log(SHELL_USAGE);
     }

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -50,6 +50,8 @@ export interface ShellAttachOptions {
   WebSocketImpl?: new (url: string, options?: { headers?: Record<string, string> }) => AttachWebSocket;
 }
 
+export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
+
 export function createShellClient(options: ShellClientOptions): ShellClient {
   const fetchImpl = options.fetch ?? fetch;
   const timeoutMs = options.timeoutMs ?? 10_000;
@@ -212,6 +214,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         let settled = false;
         let socketOpen = false;
         const queuedFrames: string[] = [];
+        let queuedFrameBytes = 0;
         const timeout = setTimeout(() => {
           ws.close();
           settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_timeout" })));
@@ -242,9 +245,23 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           for (const frame of queuedFrames.splice(0)) {
             sendFrame(frame);
           }
+          queuedFrameBytes = 0;
         };
         const sendFrame = (frame: string) => {
+          if (settled) {
+            return;
+          }
           if (!socketOpen) {
+            const nextQueuedBytes = queuedFrameBytes + Buffer.byteLength(frame, "utf8");
+            if (nextQueuedBytes > SHELL_ATTACH_MAX_QUEUED_BYTES) {
+              errorOutput.write("Shell attach failed\n");
+              settle(() => reject(Object.assign(new Error("Request failed"), {
+                code: "attach_failed",
+              })));
+              ws.close();
+              return;
+            }
+            queuedFrameBytes = nextQueuedBytes;
             queuedFrames.push(frame);
             return;
           }

--- a/packages/sync-client/src/daemon/ipc-handler.ts
+++ b/packages/sync-client/src/daemon/ipc-handler.ts
@@ -82,7 +82,7 @@ const ShellTabCreateArgsSchema = z.object({
 }).strict();
 const ShellPaneSplitArgsSchema = z.object({
   session: ShellSessionNameSchema,
-  direction: z.enum(["right", "down"]),
+  direction: z.enum(["right", "down"]).optional().default("right"),
   cwd: ShellCwdSchema.optional(),
   cmd: ShellCommandSchema.optional(),
 }).strict();

--- a/packages/sync-client/src/daemon/shell-control-client.ts
+++ b/packages/sync-client/src/daemon/shell-control-client.ts
@@ -2,6 +2,13 @@ import type { AuthData } from "../auth/token-store.js";
 import type { SyncConfig } from "../lib/config.js";
 import { createShellClient } from "../cli/shell-client.js";
 
+function parsePaneDirection(value: unknown): "right" | "down" {
+  if (value !== "right" && value !== "down") {
+    throw new Error("invalid_request");
+  }
+  return value;
+}
+
 export interface DaemonShellControlClientOptions {
   config: SyncConfig;
   loadAuth: () => Promise<AuthData | null>;
@@ -50,7 +57,7 @@ export function createDaemonShellControlClient(options: DaemonShellControlClient
     },
     async splitPane(session: string, input: Record<string, unknown>) {
       return (await client()).splitPane(session, {
-        direction: input.direction === "down" ? "down" : "right",
+        direction: parsePaneDirection(input.direction),
         cwd: typeof input.cwd === "string" ? input.cwd : undefined,
         cmd: typeof input.cmd === "string" ? input.cmd : undefined,
       });

--- a/packages/sync-client/src/daemon/shell-control-client.ts
+++ b/packages/sync-client/src/daemon/shell-control-client.ts
@@ -2,9 +2,16 @@ import type { AuthData } from "../auth/token-store.js";
 import type { SyncConfig } from "../lib/config.js";
 import { createShellClient } from "../cli/shell-client.js";
 
+function invalidRequestError(): Error {
+  return Object.assign(new Error("Request failed"), { code: "invalid_request" });
+}
+
 function parsePaneDirection(value: unknown): "right" | "down" {
+  if (value === undefined) {
+    return "right";
+  }
   if (value !== "right" && value !== "down") {
-    throw new Error("invalid_request");
+    throw invalidRequestError();
   }
   return value;
 }

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
-import { createShellClient } from "../../packages/sync-client/src/cli/shell-client.js";
+import {
+  createShellClient,
+  SHELL_ATTACH_MAX_QUEUED_BYTES,
+} from "../../packages/sync-client/src/cli/shell-client.js";
 
 describe("shell REST client", () => {
   it("lists sessions with bearer auth, JSON parsing, and fetch timeout", async () => {
@@ -189,5 +192,59 @@ describe("shell REST client", () => {
     ]);
     ControlledWebSocket.last?.emit("close");
     await expect(attached).resolves.toEqual({ detached: true });
+  });
+
+  it("rejects when pre-open stdin exceeds the queued frame cap", async () => {
+    class ControlledWebSocket {
+      static last: ControlledWebSocket | null = null;
+      closed = false;
+      listeners = new Map<string, (...args: unknown[]) => void>();
+      sent: string[] = [];
+
+      constructor() {
+        ControlledWebSocket.last = this;
+      }
+
+      send(data: string) {
+        this.sent.push(data);
+      }
+
+      close() {
+        this.closed = true;
+        this.listeners.get("close")?.();
+      }
+
+      on(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void) {
+        this.listeners.set(event, listener);
+        return this;
+      }
+
+      off(event: "open" | "message" | "close" | "error") {
+        this.listeners.delete(event);
+        return this;
+      }
+
+      emit(event: "open" | "message" | "close" | "error", value?: unknown) {
+        this.listeners.get(event)?.(value);
+      }
+    }
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    input.emit("data", "x".repeat(SHELL_ATTACH_MAX_QUEUED_BYTES));
+
+    await expect(attached).rejects.toMatchObject({ code: "attach_failed" });
+    expect(errorOutput.write).toHaveBeenCalledWith("Shell attach failed\n");
+    expect(ControlledWebSocket.last?.closed).toBe(true);
+    ControlledWebSocket.last?.emit("open");
+    expect(ControlledWebSocket.last?.sent).toEqual([]);
   });
 });

--- a/tests/cli/shell-workspace.test.ts
+++ b/tests/cli/shell-workspace.test.ts
@@ -8,6 +8,7 @@ const roots: string[] = [];
 const originalHome = process.env.HOME;
 
 beforeEach(async () => {
+  process.exitCode = undefined;
   const root = await mkdtemp(join(tmpdir(), "matrix-shell-workspace-cli-"));
   roots.push(root);
   process.env.HOME = root;
@@ -15,6 +16,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   process.env.HOME = originalHome;
+  process.exitCode = undefined;
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
@@ -66,6 +68,91 @@ describe("shell workspace CLI commands", () => {
       { v: 1, ok: true, data: { tab: { idx: 1, name: "api" } } },
       { v: 1, ok: true, data: { pane: { paneId: "pane-2" } } },
       { v: 1, ok: true, data: { ok: true } },
+    ]);
+  });
+
+  it("rejects invalid tab indices before sending tab requests", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
+    vi.stubGlobal("fetch", fetchImpl);
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((line?: unknown) => {
+      errors.push(String(line));
+    });
+
+    await shellCommand.subCommands!.tab.subCommands!.go.run!({
+      args: { session: "main", tab: "abc", dev: true, token: "tok", json: true },
+    } as never);
+    await shellCommand.subCommands!.tab.subCommands!.close.run!({
+      args: { session: "main", tab: "-1", dev: true, token: "tok", json: true },
+    } as never);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(errors.map((line) => JSON.parse(line))).toEqual([
+      { v: 1, error: { code: "invalid_request", message: "Request failed" } },
+      { v: 1, error: { code: "invalid_request", message: "Request failed" } },
+    ]);
+  });
+
+  it("sends validated tab indices for tab switch and close", async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method });
+      return new Response(JSON.stringify({ ok: true }));
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await shellCommand.subCommands!.tab.subCommands!.go.run!({
+      args: { session: "main", tab: "1", dev: true, token: "tok", json: true },
+    } as never);
+    await shellCommand.subCommands!.tab.subCommands!.close.run!({
+      args: { session: "main", tab: "1", dev: true, token: "tok", json: true },
+    } as never);
+
+    expect(calls).toEqual([
+      { url: "http://localhost:4000/api/sessions/main/tabs/1/go", method: "POST" },
+      { url: "http://localhost:4000/api/sessions/main/tabs/1", method: "DELETE" },
+    ]);
+  });
+
+  it("rejects invalid pane directions before sending split requests", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
+    vi.stubGlobal("fetch", fetchImpl);
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((line?: unknown) => {
+      errors.push(String(line));
+    });
+
+    await shellCommand.subCommands!.pane.subCommands!.split.run!({
+      args: { session: "main", direction: "sideways", dev: true, token: "tok", json: true },
+    } as never);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(JSON.parse(errors[0]!)).toEqual({
+      v: 1,
+      error: { code: "invalid_request", message: "Request failed" },
+    });
+  });
+
+  it("sends explicit and default pane directions", async () => {
+    const bodies: unknown[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(init?.body ? JSON.parse(String(init.body)) : null);
+      return new Response(JSON.stringify({ pane: { paneId: "pane-2" } }));
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await shellCommand.subCommands!.pane.subCommands!.split.run!({
+      args: { session: "main", direction: "down", dev: true, token: "tok", json: true },
+    } as never);
+    await shellCommand.subCommands!.pane.subCommands!.split.run!({
+      args: { session: "main", dev: true, token: "tok", json: true },
+    } as never);
+
+    expect(bodies).toEqual([
+      { direction: "down" },
+      { direction: "right" },
     ]);
   });
 });

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -1,7 +1,9 @@
+import { spawnSync } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveProfileAuth } from "../../packages/sync-client/src/auth/token-store.js";
 import { shellCommand } from "../../packages/sync-client/src/cli/commands/shell.js";
 
 const roots: string[] = [];
@@ -23,6 +25,7 @@ afterEach(async () => {
   process.env.HOME = originalHome;
   process.exitCode = undefined;
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
@@ -52,6 +55,93 @@ describe("shell CLI command", () => {
     await shellCommand.run?.({ args: {} } as never);
 
     expect(logs).toEqual(["Usage: matrix shell ls|new|attach|rm|tab|pane|layout"]);
+  });
+
+  it("does not print usage after subcommands run", async () => {
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+
+    await shellCommand.run?.({ rawArgs: ["ls", "--dev", "--json"], args: {} } as never);
+
+    expect(logs).toEqual([]);
+  });
+
+  it("fails before fetch when profile auth is missing", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ sessions: [] })));
+    vi.stubGlobal("fetch", fetchImpl);
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((line?: unknown) => {
+      errors.push(String(line));
+    });
+
+    await shellCommand.subCommands!.ls.run!({
+      args: { dev: true, json: true },
+    } as never);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(errors.map((line) => JSON.parse(line))).toEqual([
+      {
+        v: 1,
+        error: {
+          code: "not_authenticated",
+          message: 'Not logged in for profile "local". Run `matrix login` first.',
+        },
+      },
+    ]);
+  });
+
+  it("treats expired profile auth as not authenticated", async () => {
+    await saveProfileAuth("local", {
+      accessToken: "expired-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() - 1,
+      userId: "user-1",
+      handle: "local",
+    });
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ sessions: [] })));
+    vi.stubGlobal("fetch", fetchImpl);
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((line?: unknown) => {
+      errors.push(String(line));
+    });
+
+    await shellCommand.subCommands!.ls.run!({
+      args: { dev: true, json: true },
+    } as never);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(JSON.parse(errors[0]!)).toEqual({
+      v: 1,
+      error: {
+        code: "not_authenticated",
+        message: 'Not logged in for profile "local". Run `matrix login` first.',
+      },
+    });
+  });
+
+  it("emits one clean JSON error from the real CLI when auth is missing", () => {
+    const bin = join(process.cwd(), "packages/sync-client/bin/matrix.mjs");
+
+    const result = spawnSync(process.execPath, [bin, "shell", "ls", "--dev", "--json"], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: process.env.HOME ?? "" },
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr.trim()).toBe(
+      JSON.stringify({
+        v: 1,
+        error: {
+          code: "not_authenticated",
+          message: 'Not logged in for profile "local". Run `matrix login` first.',
+        },
+      }),
+    );
   });
 
   it("emits versioned JSON for ls, new, and rm", async () => {

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -71,6 +71,20 @@ describe("shell CLI command", () => {
     expect(logs).toEqual(["Usage: matrix shell ls|new|attach|rm|tab|pane|layout"]);
   });
 
+  it("prints usage when a root flag value matches a shell subcommand", async () => {
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+
+    await shellCommand.run?.({
+      rawArgs: ["--profile", "ls", "--gateway=tab", "--json"],
+      args: {},
+    } as never);
+
+    expect(logs).toEqual(["Usage: matrix shell ls|new|attach|rm|tab|pane|layout"]);
+  });
+
   it("does not print usage after subcommands run", async () => {
     const logs: string[] = [];
     vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
@@ -78,6 +92,20 @@ describe("shell CLI command", () => {
     });
 
     await shellCommand.run?.({ rawArgs: ["ls", "--dev", "--json"], args: {} } as never);
+
+    expect(logs).toEqual([]);
+  });
+
+  it("does not print usage when root flags precede a subcommand", async () => {
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+
+    await shellCommand.run?.({
+      rawArgs: ["--profile", "local", "--json", "ls"],
+      args: {},
+    } as never);
 
     expect(logs).toEqual([]);
   });

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -57,6 +57,20 @@ describe("shell CLI command", () => {
     expect(logs).toEqual(["Usage: matrix shell ls|new|attach|rm|tab|pane|layout"]);
   });
 
+  it("prints usage for the bare shell command with valued root flags", async () => {
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+
+    await shellCommand.run?.({
+      rawArgs: ["--profile", "local", "--gateway", "https://gateway.example", "--json"],
+      args: {},
+    } as never);
+
+    expect(logs).toEqual(["Usage: matrix shell ls|new|attach|rm|tab|pane|layout"]);
+  });
+
   it("does not print usage after subcommands run", async () => {
     const logs: string[] = [];
     vi.spyOn(console, "log").mockImplementation((line?: unknown) => {

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -15,11 +15,13 @@ async function tempHome() {
 }
 
 beforeEach(async () => {
+  process.exitCode = undefined;
   await tempHome();
 });
 
 afterEach(async () => {
   process.env.HOME = originalHome;
+  process.exitCode = undefined;
   vi.restoreAllMocks();
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -39,6 +41,17 @@ describe("shell CLI command", () => {
       "rm",
       "tab",
     ]);
+  });
+
+  it("prints complete usage for the bare shell command", async () => {
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+
+    await shellCommand.run?.({ args: {} } as never);
+
+    expect(logs).toEqual(["Usage: matrix shell ls|new|attach|rm|tab|pane|layout"]);
   });
 
   it("emits versioned JSON for ls, new, and rm", async () => {

--- a/tests/sync-client/daemon-ipc-v1.test.ts
+++ b/tests/sync-client/daemon-ipc-v1.test.ts
@@ -92,6 +92,7 @@ describe("daemon IPC v1 envelopes", () => {
   });
 
   it("dispatches tab, pane, layout, and sync v1 aliases", async () => {
+    const splitPane = vi.fn(async () => ({ paneId: "pane-2" }));
     const handler = createIpcHandler({
       config: baseConfig(),
       syncState: baseSyncState(),
@@ -105,7 +106,7 @@ describe("daemon IPC v1 envelopes", () => {
         createTab: async () => ({ ok: true }),
         switchTab: async () => ({ ok: true }),
         closeTab: async () => ({ ok: true }),
-        splitPane: async () => ({ paneId: "pane-2" }),
+        splitPane,
         closePane: async () => ({ ok: true }),
         listLayouts: async () => [{ name: "dev" }],
         showLayout: async () => ({ name: "dev", kdl: "layout {}" }),
@@ -117,10 +118,32 @@ describe("daemon IPC v1 envelopes", () => {
 
     await expect(handler("tab.list", { session: "main" })).resolves.toEqual({ tabs: [{ idx: 0, name: "main" }] });
     await expect(handler("pane.split", { session: "main", direction: "right" })).resolves.toEqual({ paneId: "pane-2" });
+    await expect(handler("pane.split", { session: "main", direction: "down" })).resolves.toEqual({ paneId: "pane-2" });
+    expect(splitPane).toHaveBeenNthCalledWith(1, "main", { direction: "right" });
+    expect(splitPane).toHaveBeenNthCalledWith(2, "main", { direction: "down" });
     await expect(handler("layout.list", {})).resolves.toEqual({ layouts: [{ name: "dev" }] });
     await expect(handler("sync.status", {})).resolves.toMatchObject({ syncing: true, fileCount: 0 });
     await expect(handler("sync.pause", {})).resolves.toEqual({ paused: true });
     await expect(handler("sync.resume", {})).resolves.toEqual({ paused: false });
+  });
+
+  it("rejects invalid pane split directions before dispatch", async () => {
+    const shell = {
+      splitPane: vi.fn(async () => ({ paneId: "pane-2" })),
+    };
+    const handler = createIpcHandler({
+      config: baseConfig(),
+      syncState: baseSyncState(),
+      logger: { info: () => undefined },
+      saveConfig: async () => undefined,
+      persistPauseState: async () => undefined,
+      clearAuth: async () => undefined,
+      exit: () => undefined,
+      shell,
+    });
+
+    await expect(handler("pane.split", { session: "main", direction: "sideways" })).rejects.toThrow("invalid_request");
+    expect(shell.splitPane).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/sync-client/daemon-ipc-v1.test.ts
+++ b/tests/sync-client/daemon-ipc-v1.test.ts
@@ -6,6 +6,7 @@ import {
   parseDaemonRequest,
 } from "../../packages/sync-client/src/daemon/types.js";
 import { createIpcHandler } from "../../packages/sync-client/src/daemon/ipc-handler.js";
+import { createDaemonShellControlClient } from "../../packages/sync-client/src/daemon/shell-control-client.js";
 
 describe("daemon IPC v1 envelopes", () => {
   it("requires protocol version 1 and bounded command names", () => {
@@ -119,8 +120,10 @@ describe("daemon IPC v1 envelopes", () => {
     await expect(handler("tab.list", { session: "main" })).resolves.toEqual({ tabs: [{ idx: 0, name: "main" }] });
     await expect(handler("pane.split", { session: "main", direction: "right" })).resolves.toEqual({ paneId: "pane-2" });
     await expect(handler("pane.split", { session: "main", direction: "down" })).resolves.toEqual({ paneId: "pane-2" });
+    await expect(handler("pane.split", { session: "main" })).resolves.toEqual({ paneId: "pane-2" });
     expect(splitPane).toHaveBeenNthCalledWith(1, "main", { direction: "right" });
     expect(splitPane).toHaveBeenNthCalledWith(2, "main", { direction: "down" });
+    expect(splitPane).toHaveBeenNthCalledWith(3, "main", { direction: "right" });
     await expect(handler("layout.list", {})).resolves.toEqual({ layouts: [{ name: "dev" }] });
     await expect(handler("sync.status", {})).resolves.toMatchObject({ syncing: true, fileCount: 0 });
     await expect(handler("sync.pause", {})).resolves.toEqual({ paused: true });
@@ -144,6 +147,29 @@ describe("daemon IPC v1 envelopes", () => {
 
     await expect(handler("pane.split", { session: "main", direction: "sideways" })).rejects.toThrow("invalid_request");
     expect(shell.splitPane).not.toHaveBeenCalled();
+  });
+
+  it("keeps daemon shell-control pane direction errors typed", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ paneId: "pane-2" })));
+    vi.stubGlobal("fetch", fetchImpl);
+    const client = createDaemonShellControlClient({
+      config: baseConfig(),
+      loadAuth: async () => ({
+        accessToken: "tok",
+        expiresAt: 4102444800000,
+        userId: "user_1",
+        handle: "neo",
+      }),
+    });
+
+    try {
+      await expect(client.splitPane("main", { direction: "sideways" })).rejects.toMatchObject({
+        code: "invalid_request",
+      });
+      expect(fetchImpl).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 


### PR DESCRIPTION
Parent PR: #163 

## Summary

Hardens `matrix shell` command handling across CLI, daemon IPC, and attach flows. This PR makes shell subcommands fail earlier with clearer errors, validates tab/pane inputs before dispatch, and bounds pre-open attach input buffering so the CLI cannot grow memory unbounded while waiting for a WebSocket connection.

## Changes

- Validate tab indices before sending tab switch/close requests.
- Validate pane split direction at both CLI and daemon IPC boundaries.
- Require valid, non-expired profile auth before shell subcommands call the gateway.
- Emit a single clean `not_authenticated` error for missing/expired auth, including JSON-safe output.
- Cap queued shell attach input before WebSocket open and fail with `attach_failed` when exceeded.
- Update bare `matrix shell` usage to include `tab`, `pane`, and `layout`.
- Add regression coverage for invalid input rejection, auth failures, clean CLI stderr, and attach queue limits.

## Validation

- `flox activate -- bun run test tests/cli/shell-workspace.test.ts tests/cli/shell.test.ts tests/sync-client/daemon-ipc-v1.test.ts`
- `flox activate -- bun run test tests/cli/shell-client.test.ts`
- `flox activate -- bun run check:patterns`

## Notes

This keeps validation on both sides of the CLI/daemon boundary so non-CLI IPC callers cannot bypass pane direction checks. The attach queue cap also gives bounded memory behavior before the WebSocket is open.