### PR TITLE
feat(onboarding): activate coding setup and Hermes continuity

### DIFF
--- a/packages/gateway/src/onboarding/activation-contracts.ts
+++ b/packages/gateway/src/onboarding/activation-contracts.ts
@@ -156,6 +156,15 @@ export const ReadinessOverallStatusSchema = z.enum([
 ]);
 export type ReadinessOverallStatus = z.infer<typeof ReadinessOverallStatusSchema>;
 
+export const CodingHandoffStatusSchema = z.enum([
+  "idle",
+  "running",
+  "needs_input",
+  "ready",
+  "failed",
+]);
+export type CodingHandoffStatus = z.infer<typeof CodingHandoffStatusSchema>;
+
 export const ReadinessResponseSchema = z.object({
   overallStatus: ReadinessOverallStatusSchema,
   goals: z.array(OnboardingGoalSummarySchema),
@@ -163,6 +172,7 @@ export const ReadinessResponseSchema = z.object({
   systemAgent: z.literal("hermes"),
   activeAgents: z.array(AgentIdSchema).min(1).max(3),
   agents: z.array(AgentCredentialSummarySchema),
+  codingHandoffStatus: CodingHandoffStatusSchema.nullable(),
 });
 export type ReadinessResponse = z.infer<typeof ReadinessResponseSchema>;
 

--- a/packages/gateway/src/onboarding/activation-contracts.ts
+++ b/packages/gateway/src/onboarding/activation-contracts.ts
@@ -128,6 +128,26 @@ export const AgentCredentialSummarySchema = z.object({
 });
 export type AgentCredentialSummary = z.infer<typeof AgentCredentialSummarySchema>;
 
+export const AgentCredentialStatusResponseSchema = z.object({
+  systemAgent: z.literal("hermes"),
+  activeAgents: z.array(AgentIdSchema).min(1).max(3),
+  agents: z.array(AgentCredentialSummarySchema),
+  routingExplanation: z.string().trim().min(1).max(300),
+});
+export type AgentCredentialStatusResponse = z.infer<typeof AgentCredentialStatusResponseSchema>;
+
+export const AgentCredentialParamsSchema = z.object({
+  agent: AgentIdSchema,
+});
+export type AgentCredentialParams = z.infer<typeof AgentCredentialParamsSchema>;
+
+export const VerifyAgentCredentialResponseSchema = z.object({
+  agent: AgentIdSchema,
+  status: AgentCredentialStatusSchema,
+  verifiedAt: ActivationDateSchema,
+});
+export type VerifyAgentCredentialResponse = z.infer<typeof VerifyAgentCredentialResponseSchema>;
+
 export const ReadinessOverallStatusSchema = z.enum([
   "ready",
   "degraded",
@@ -174,4 +194,3 @@ export const ActivationErrorResponseSchema = z.object({
   retryable: z.boolean(),
 });
 export type ActivationErrorResponse = z.infer<typeof ActivationErrorResponseSchema>;
-

--- a/packages/gateway/src/onboarding/agent-credential-routes.ts
+++ b/packages/gateway/src/onboarding/agent-credential-routes.ts
@@ -1,0 +1,64 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import {
+  AgentCredentialParamsSchema,
+} from "./activation-contracts.js";
+import { ActivationRouteError, mapActivationError } from "./activation-errors.js";
+import type { AgentCredentialStatusService } from "./agent-credential-status.js";
+import {
+  requireRequestPrincipal,
+  type RequestPrincipal,
+} from "../request-principal.js";
+
+const AGENT_CREDENTIAL_BODY_LIMIT = 1024;
+
+export interface AgentCredentialRouteDeps {
+  service: AgentCredentialStatusService;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+function jsonError(c: Context, err: unknown) {
+  const mapped = mapActivationError(err);
+  return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+}
+
+export function createAgentCredentialRoutes(deps: AgentCredentialRouteDeps): Hono {
+  const app = new Hono();
+  const limited = bodyLimit({
+    maxSize: AGENT_CREDENTIAL_BODY_LIMIT,
+    onError: (c) => c.json({
+      error: "payload_too_large",
+      message: "Request body is too large",
+      retryable: false,
+    }, 413),
+  });
+  const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
+
+  app.get("/credentials/status", async (c) => {
+    try {
+      const principal = principalFor(c);
+      return c.json(await deps.service.getStatus(principal.userId));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/credentials/:agent/verify", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      const { agent } = AgentCredentialParamsSchema.parse({ agent: c.req.param("agent") });
+      if (c.req.raw.body) {
+        await c.req.text();
+      }
+      if (agent === "hermes") {
+        throw new ActivationRouteError("invalid_request", "Hermes is always available and does not need verification", { status: 400 });
+      }
+      return c.json(await deps.service.verifyAgent(principal.userId, agent));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/onboarding/agent-credential-status.ts
+++ b/packages/gateway/src/onboarding/agent-credential-status.ts
@@ -4,12 +4,18 @@ import type {
   AgentId,
   VerifyAgentCredentialResponse,
 } from "./activation-contracts.js";
+import { ActivationRouteError } from "./activation-errors.js";
 
 const MAX_OWNERS = 512;
 
 export interface AgentCredentialStatusService {
   getStatus(ownerId: string): Promise<AgentCredentialStatusResponse>;
   verifyAgent(ownerId: string, agent: AgentId): Promise<VerifyAgentCredentialResponse>;
+}
+
+export interface AgentCredentialProbeResult {
+  available: boolean;
+  missing?: boolean;
 }
 
 interface StoredCredentialState {
@@ -61,12 +67,23 @@ function activeAgents(state: StoredCredentialState): AgentId[] {
   return agents;
 }
 
+function activeAgentsFromAvailability(claudeAvailable: boolean, codexAvailable: boolean): AgentId[] {
+  const agents: AgentId[] = [];
+  if (claudeAvailable) agents.push("claude");
+  if (codexAvailable) agents.push("codex");
+  agents.push("hermes");
+  return agents;
+}
+
 export function createAgentCredentialStatusService(options: {
   now?: () => Date;
   onChange?: (ownerId: string) => void;
+  probeAgent?: (ownerId: string, agent: Extract<AgentId, "claude" | "codex">) => Promise<AgentCredentialProbeResult>;
 } = {}): AgentCredentialStatusService {
   const now = options.now ?? (() => new Date());
-  // TODO(082): replace this launch scaffold with owner-scoped credential probes backed by durable agent settings.
+  // Production gateway wires probeAgent, so Claude/Codex status is derived
+  // live from local agent login state. The bounded map is only the fallback
+  // for tests or local harnesses that do not have a probe.
   const states = new Map<string, StoredCredentialState>();
 
   function getState(ownerId: string): StoredCredentialState {
@@ -85,7 +102,36 @@ export function createAgentCredentialStatusService(options: {
     return next;
   }
 
+  async function probeAvailability(
+    ownerId: string,
+    agent: Extract<AgentId, "claude" | "codex">,
+  ): Promise<AgentCredentialProbeResult> {
+    try {
+      return await options.probeAgent!(ownerId, agent);
+    } catch (err: unknown) {
+      console.warn("[onboarding] agent availability probe failed:", err instanceof Error ? err.message : String(err));
+      return { available: false };
+    }
+  }
+
   async function getStatus(ownerId: string): Promise<AgentCredentialStatusResponse> {
+    if (options.probeAgent) {
+      const [claude, codex] = await Promise.all([
+        probeAvailability(ownerId, "claude"),
+        probeAvailability(ownerId, "codex"),
+      ]);
+      const verifiedAt = now().toISOString();
+      return {
+        systemAgent: "hermes",
+        activeAgents: activeAgentsFromAvailability(claude.available, codex.available),
+        routingExplanation: "Hermes remains the Matrix system agent while Claude and Codex add optional specialist paths when connected.",
+        agents: [
+          claudeSummary(claude.available ? verifiedAt : undefined),
+          codexSummary(codex.available ? verifiedAt : undefined),
+          hermesSummary(),
+        ],
+      };
+    }
     const state = getState(ownerId);
     return {
       systemAgent: "hermes",
@@ -100,6 +146,22 @@ export function createAgentCredentialStatusService(options: {
   }
 
   async function verifyAgent(ownerId: string, agent: AgentId): Promise<VerifyAgentCredentialResponse> {
+    if (agent !== "claude" && agent !== "codex") {
+      throw new ActivationRouteError("invalid_request", "Agent credential verification is not supported for this agent", { status: 400 });
+    }
+    if (options.probeAgent) {
+      const probe = await options.probeAgent(ownerId, agent);
+      if (!probe.available) {
+        throw new ActivationRouteError(
+          probe.missing ? "agent_not_installed" : "agent_auth_required",
+          probe.missing ? "Install the agent before verifying credentials" : "Log in to the agent before verifying credentials",
+          { status: 409, retryable: true },
+        );
+      }
+      const verifiedAt = now().toISOString();
+      options.onChange?.(ownerId);
+      return { agent, status: "available", verifiedAt };
+    }
     const verifiedAt = now().toISOString();
     const state = getState(ownerId);
     if (agent === "claude") state.claudeVerifiedAt = verifiedAt;

--- a/packages/gateway/src/onboarding/agent-credential-status.ts
+++ b/packages/gateway/src/onboarding/agent-credential-status.ts
@@ -1,0 +1,109 @@
+import type {
+  AgentCredentialStatusResponse,
+  AgentCredentialSummary,
+  AgentId,
+  VerifyAgentCredentialResponse,
+} from "./activation-contracts.js";
+
+const MAX_OWNERS = 512;
+
+export interface AgentCredentialStatusService {
+  getStatus(ownerId: string): Promise<AgentCredentialStatusResponse>;
+  verifyAgent(ownerId: string, agent: AgentId): Promise<VerifyAgentCredentialResponse>;
+}
+
+interface StoredCredentialState {
+  claudeVerifiedAt?: string;
+  codexVerifiedAt?: string;
+}
+
+function hermesSummary(): AgentCredentialSummary {
+  return {
+    agent: "hermes",
+    status: "available",
+    coordinationRole: "system_agent",
+    workflows: ["app_building", "assistant", "integrations", "company_brain"],
+    degradedWorkflows: [],
+    verifiedAt: null,
+    nextAction: null,
+  };
+}
+
+function claudeSummary(verifiedAt: string | undefined): AgentCredentialSummary {
+  return {
+    agent: "claude",
+    status: verifiedAt ? "available" : "missing",
+    coordinationRole: "core_agent",
+    workflows: ["core_agent"],
+    degradedWorkflows: verifiedAt ? [] : ["core_agent"],
+    verifiedAt: verifiedAt ?? null,
+    nextAction: verifiedAt ? null : "Connect Claude to enable the core agent path",
+  };
+}
+
+function codexSummary(verifiedAt: string | undefined): AgentCredentialSummary {
+  return {
+    agent: "codex",
+    status: verifiedAt ? "available" : "missing",
+    coordinationRole: "coding_specialist",
+    workflows: ["coding"],
+    degradedWorkflows: verifiedAt ? [] : ["coding"],
+    verifiedAt: verifiedAt ?? null,
+    nextAction: verifiedAt ? null : "Connect Codex for optional coding support",
+  };
+}
+
+function activeAgents(state: StoredCredentialState): AgentId[] {
+  const agents: AgentId[] = [];
+  if (state.claudeVerifiedAt) agents.push("claude");
+  if (state.codexVerifiedAt) agents.push("codex");
+  agents.push("hermes");
+  return agents;
+}
+
+export function createAgentCredentialStatusService(options: {
+  now?: () => Date;
+} = {}): AgentCredentialStatusService {
+  const now = options.now ?? (() => new Date());
+  const states = new Map<string, StoredCredentialState>();
+
+  function getState(ownerId: string): StoredCredentialState {
+    const existing = states.get(ownerId);
+    if (existing) {
+      states.delete(ownerId);
+      states.set(ownerId, existing);
+      return existing;
+    }
+    if (states.size >= MAX_OWNERS) {
+      const oldestKey = states.keys().next().value as string | undefined;
+      if (oldestKey) states.delete(oldestKey);
+    }
+    const next: StoredCredentialState = {};
+    states.set(ownerId, next);
+    return next;
+  }
+
+  async function getStatus(ownerId: string): Promise<AgentCredentialStatusResponse> {
+    const state = getState(ownerId);
+    return {
+      systemAgent: "hermes",
+      activeAgents: activeAgents(state),
+      routingExplanation: "Hermes remains the Matrix system agent while Claude and Codex add optional specialist paths when connected.",
+      agents: [
+        claudeSummary(state.claudeVerifiedAt),
+        codexSummary(state.codexVerifiedAt),
+        hermesSummary(),
+      ],
+    };
+  }
+
+  async function verifyAgent(ownerId: string, agent: AgentId): Promise<VerifyAgentCredentialResponse> {
+    const verifiedAt = now().toISOString();
+    const state = getState(ownerId);
+    if (agent === "claude") state.claudeVerifiedAt = verifiedAt;
+    if (agent === "codex") state.codexVerifiedAt = verifiedAt;
+    return { agent, status: "available", verifiedAt };
+  }
+
+  return { getStatus, verifyAgent };
+}

--- a/packages/gateway/src/onboarding/agent-credential-status.ts
+++ b/packages/gateway/src/onboarding/agent-credential-status.ts
@@ -63,8 +63,10 @@ function activeAgents(state: StoredCredentialState): AgentId[] {
 
 export function createAgentCredentialStatusService(options: {
   now?: () => Date;
+  onChange?: (ownerId: string) => void;
 } = {}): AgentCredentialStatusService {
   const now = options.now ?? (() => new Date());
+  // TODO(082): replace this launch scaffold with owner-scoped credential probes backed by durable agent settings.
   const states = new Map<string, StoredCredentialState>();
 
   function getState(ownerId: string): StoredCredentialState {
@@ -102,6 +104,7 @@ export function createAgentCredentialStatusService(options: {
     const state = getState(ownerId);
     if (agent === "claude") state.claudeVerifiedAt = verifiedAt;
     if (agent === "codex") state.codexVerifiedAt = verifiedAt;
+    options.onChange?.(ownerId);
     return { agent, status: "available", verifiedAt };
   }
 

--- a/packages/gateway/src/onboarding/coding-setup.ts
+++ b/packages/gateway/src/onboarding/coding-setup.ts
@@ -1,7 +1,5 @@
-import type { AgentId } from "./activation-contracts.js";
+import type { AgentId, CodingHandoffStatus } from "./activation-contracts.js";
 import type { MatrixProjectOption, SymphonyRunStatus } from "../symphony/contracts.js";
-
-export type CodingHandoffStatus = "idle" | "running" | "needs_input" | "ready" | "failed";
 
 export interface CodingSetupStatus {
   githubConnected: boolean;

--- a/packages/gateway/src/onboarding/coding-setup.ts
+++ b/packages/gateway/src/onboarding/coding-setup.ts
@@ -1,0 +1,69 @@
+import type { AgentId } from "./activation-contracts.js";
+import type { MatrixProjectOption, SymphonyRunStatus } from "../symphony/contracts.js";
+
+export type CodingHandoffStatus = "idle" | "running" | "needs_input" | "ready" | "failed";
+
+export interface CodingSetupStatus {
+  githubConnected: boolean;
+  selectedProject: MatrixProjectOption | null;
+  issueSourceConfigured: boolean;
+  symphonyReady: boolean;
+  terminalReady: boolean;
+  activeAgents: AgentId[];
+  handoffStatus: CodingHandoffStatus;
+}
+
+export interface CodingSetupProvider {
+  getCodingSetup(ownerId: string): Promise<CodingSetupStatus>;
+}
+
+export interface CodingSetupAggregationDeps {
+  hasGitHubConnection: (ownerId: string) => Promise<boolean>;
+  listMatrixProjects: (ownerId: string) => Promise<MatrixProjectOption[]>;
+  getSelectedProjectSlug?: (ownerId: string) => Promise<string | null>;
+  hasIssueSource: (ownerId: string) => Promise<boolean>;
+  getSymphonyStatus: (ownerId: string) => Promise<{
+    ready: boolean;
+    runStatuses: SymphonyRunStatus[];
+    activeAgents: AgentId[];
+  }>;
+  hasTerminalContext: (ownerId: string, projectSlug: string | null) => Promise<boolean>;
+}
+
+function deriveHandoffStatus(statuses: SymphonyRunStatus[]): CodingHandoffStatus {
+  if (statuses.some((status) => status === "blocked")) return "needs_input";
+  if (statuses.some((status) => status === "failed" || status === "stopped")) return "failed";
+  if (statuses.some((status) => status === "queued" || status === "running" || status === "retrying")) return "running";
+  if (statuses.some((status) => status === "handoff" || status === "completed")) return "ready";
+  return "idle";
+}
+
+export function createCodingSetupProvider(deps: CodingSetupAggregationDeps): CodingSetupProvider {
+  return {
+    async getCodingSetup(ownerId: string): Promise<CodingSetupStatus> {
+      const [githubConnected, projects, selectedProjectSlug, issueSourceConfigured, symphony] = await Promise.all([
+        deps.hasGitHubConnection(ownerId),
+        deps.listMatrixProjects(ownerId),
+        deps.getSelectedProjectSlug?.(ownerId) ?? Promise.resolve(null),
+        deps.hasIssueSource(ownerId),
+        deps.getSymphonyStatus(ownerId),
+      ]);
+      const selectedProject = selectedProjectSlug
+        ? projects.find((project) => project.slug === selectedProjectSlug) ?? null
+        : null;
+      const terminalReady = await deps.hasTerminalContext(ownerId, selectedProject?.slug ?? null);
+
+      return {
+        githubConnected,
+        selectedProject,
+        issueSourceConfigured,
+        symphonyReady: symphony.ready,
+        terminalReady,
+        activeAgents: symphony.activeAgents.includes("hermes")
+          ? symphony.activeAgents
+          : [...symphony.activeAgents, "hermes"],
+        handoffStatus: deriveHandoffStatus(symphony.runStatuses),
+      };
+    },
+  };
+}

--- a/packages/gateway/src/onboarding/coding-setup.ts
+++ b/packages/gateway/src/onboarding/coding-setup.ts
@@ -16,7 +16,7 @@ export interface CodingSetupProvider {
 }
 
 export interface CodingSetupAggregationDeps {
-  hasGitHubConnection: (ownerId: string) => Promise<boolean>;
+  hasGitHubConnection: (ownerId: string, selectedProject: MatrixProjectOption | null) => Promise<boolean>;
   listMatrixProjects: (ownerId: string) => Promise<MatrixProjectOption[]>;
   getSelectedProjectSlug?: (ownerId: string) => Promise<string | null>;
   hasIssueSource: (ownerId: string) => Promise<boolean>;
@@ -30,17 +30,16 @@ export interface CodingSetupAggregationDeps {
 
 function deriveHandoffStatus(statuses: SymphonyRunStatus[]): CodingHandoffStatus {
   if (statuses.some((status) => status === "blocked")) return "needs_input";
-  if (statuses.some((status) => status === "failed" || status === "stopped")) return "failed";
-  if (statuses.some((status) => status === "queued" || status === "running" || status === "retrying")) return "running";
   if (statuses.some((status) => status === "handoff" || status === "completed")) return "ready";
+  if (statuses.some((status) => status === "queued" || status === "running" || status === "retrying")) return "running";
+  if (statuses.some((status) => status === "failed" || status === "stopped")) return "failed";
   return "idle";
 }
 
 export function createCodingSetupProvider(deps: CodingSetupAggregationDeps): CodingSetupProvider {
   return {
     async getCodingSetup(ownerId: string): Promise<CodingSetupStatus> {
-      const [githubConnected, projects, selectedProjectSlug, issueSourceConfigured, symphony] = await Promise.all([
-        deps.hasGitHubConnection(ownerId),
+      const [projects, selectedProjectSlug, issueSourceConfigured, symphony] = await Promise.all([
         deps.listMatrixProjects(ownerId),
         deps.getSelectedProjectSlug?.(ownerId) ?? Promise.resolve(null),
         deps.hasIssueSource(ownerId),
@@ -49,7 +48,10 @@ export function createCodingSetupProvider(deps: CodingSetupAggregationDeps): Cod
       const selectedProject = selectedProjectSlug
         ? projects.find((project) => project.slug === selectedProjectSlug) ?? null
         : null;
-      const terminalReady = await deps.hasTerminalContext(ownerId, selectedProject?.slug ?? null);
+      const [githubConnected, terminalReady] = await Promise.all([
+        deps.hasGitHubConnection(ownerId, selectedProject),
+        deps.hasTerminalContext(ownerId, selectedProject?.slug ?? null),
+      ]);
 
       return {
         githubConnected,
@@ -57,9 +59,7 @@ export function createCodingSetupProvider(deps: CodingSetupAggregationDeps): Cod
         issueSourceConfigured,
         symphonyReady: symphony.ready,
         terminalReady,
-        activeAgents: symphony.activeAgents.includes("hermes")
-          ? symphony.activeAgents
-          : [...symphony.activeAgents, "hermes"],
+        activeAgents: [...symphony.activeAgents, "hermes"],
         handoffStatus: deriveHandoffStatus(symphony.runStatuses),
       };
     },

--- a/packages/gateway/src/onboarding/readiness-service.ts
+++ b/packages/gateway/src/onboarding/readiness-service.ts
@@ -49,7 +49,7 @@ const GOAL_STEPS: Record<OnboardingGoalId, OnboardingStepSummary[]> = {
     { id: "terminal.ready", required: false, title: "Verify terminal access", unlocks: ["coding"] },
   ],
   app_building: [
-    { id: "hermes.available", required: true, title: "Verify Hermes", unlocks: ["app_building"] },
+    { id: "hermes.continuity", required: true, title: "Verify Hermes", unlocks: ["app_building"] },
     { id: "skills.ready", required: true, title: "Verify app-building skills", unlocks: ["app_building"] },
   ],
   company_brain: [
@@ -57,7 +57,7 @@ const GOAL_STEPS: Record<OnboardingGoalId, OnboardingStepSummary[]> = {
   ],
   assistant: [
     { id: "integrations.capabilities", required: true, title: "Approve assistant capabilities", unlocks: ["assistant", "integrations"] },
-    { id: "hermes.available", required: true, title: "Verify Hermes", unlocks: ["assistant"] },
+    { id: "hermes.continuity", required: true, title: "Verify Hermes", unlocks: ["assistant"] },
   ],
 };
 
@@ -86,7 +86,6 @@ const BASE_GATES: ReadinessGateSummary[] = [
   { id: "canvas.ready", category: "shell", criticality: "release_critical", status: "unknown", message: "Canvas readiness has not been checked", remediation: "Open Canvas and verify built-ins", owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "terminal.ready", category: "coding", criticality: "goal_required", status: "unknown", message: "Terminal readiness has not been checked", remediation: "Open terminal for the selected project", owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "skills.ready", category: "agent", criticality: "release_critical", status: "unknown", message: "Skill readiness has not been checked", remediation: "Verify Matrix skills are available", owner: "matrix", lastCheckedAt: null, evidence: [] },
-  { id: "hermes.available", category: "agent", criticality: "release_critical", status: "pass", message: "Hermes is available as the Matrix system agent", remediation: null, owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "hermes.continuity", category: "agent", criticality: "release_critical", status: "pass", message: "Hermes remains available as the Matrix system agent", remediation: null, owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "visual.qa", category: "ux", criticality: "release_critical", status: "unknown", message: "Onboarding visual QA has not been checked", remediation: "Run desktop and mobile visual QA", owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "github.connected", category: "integration", criticality: "goal_required", status: "unknown", message: "GitHub is not connected yet", remediation: "Connect GitHub to unlock coding workflows", owner: "user", lastCheckedAt: null, evidence: [] },
@@ -165,9 +164,11 @@ export function createReadinessService(options: {
     if (!codingSetup) return null;
     switch (gate.id) {
       case "github.connected":
-        return codingSetup.githubConnected
-          ? { status: "pass", message: "GitHub is connected for coding workflows", remediation: null, lastCheckedAt: checkedAt }
-          : { status: "fail", message: "GitHub is needed before Matrix can start coding work", remediation: "Connect GitHub to unlock coding workflows", lastCheckedAt: checkedAt };
+        if (!codingSetup.selectedProject) return null;
+        if (!codingSetup.githubConnected) {
+          return { status: "fail", message: "GitHub is needed before Matrix can start coding work", remediation: "Connect GitHub to unlock coding workflows", lastCheckedAt: checkedAt };
+        }
+        return { status: "pass", message: "GitHub is connected for coding workflows", remediation: null, lastCheckedAt: checkedAt };
       case "project.selected":
         return codingSetup.selectedProject
           ? { status: "pass", message: `${codingSetup.selectedProject.name} is selected for coding work`, remediation: null, lastCheckedAt: checkedAt, evidence: [codingSetup.selectedProject.slug] }
@@ -221,10 +222,12 @@ export function createReadinessService(options: {
     const cached = cache.get(ownerId);
     if (cached) return cached;
     const record = await ensureRecord(ownerId);
-    const codingSetup = record.selectedGoalIds.includes("coding") && options.codingSetup
-      ? await options.codingSetup.getCodingSetup(ownerId)
-      : null;
-    const credentialStatus = options.agentCredentials ? await options.agentCredentials.getStatus(ownerId) : null;
+    const [codingSetup, credentialStatus] = await Promise.all([
+      record.selectedGoalIds.includes("coding") && options.codingSetup
+        ? options.codingSetup.getCodingSetup(ownerId)
+        : Promise.resolve(null),
+      options.agentCredentials ? options.agentCredentials.getStatus(ownerId) : Promise.resolve(null),
+    ]);
     const gates = deriveGates(record, codingSetup);
     const goals = Object.values(GOALS).map((goal) => ({
       ...goal,

--- a/packages/gateway/src/onboarding/readiness-service.ts
+++ b/packages/gateway/src/onboarding/readiness-service.ts
@@ -239,6 +239,7 @@ export function createReadinessService(options: {
         ? Array.from(new Set([...(codingSetup?.activeAgents ?? []), ...credentialStatus.activeAgents]))
         : codingSetup?.activeAgents ?? ["hermes"],
       agents: credentialStatus?.agents ?? DEFAULT_AGENTS.map((agent) => ({ ...agent })),
+      codingHandoffStatus: codingSetup?.handoffStatus ?? null,
     };
     cache.set(ownerId, response);
     return response;

--- a/packages/gateway/src/onboarding/readiness-service.ts
+++ b/packages/gateway/src/onboarding/readiness-service.ts
@@ -14,6 +14,7 @@ import {
 } from "./readiness-repository.js";
 import { ReadinessStatusCache } from "./readiness-cache.js";
 import { ActivationRouteError } from "./activation-errors.js";
+import type { CodingSetupProvider, CodingSetupStatus } from "./coding-setup.js";
 
 const GOALS: Record<OnboardingGoalId, Omit<OnboardingGoalSummary, "selected">> = {
   coding: {
@@ -42,6 +43,7 @@ const GOAL_STEPS: Record<OnboardingGoalId, OnboardingStepSummary[]> = {
   coding: [
     { id: "github.connected", required: true, title: "Connect GitHub", unlocks: ["coding"] },
     { id: "project.selected", required: true, title: "Choose a project", unlocks: ["coding"] },
+    { id: "issue_source.selected", required: true, title: "Choose task source", unlocks: ["coding"] },
     { id: "symphony.ready", required: true, title: "Prepare Symphony", unlocks: ["coding"] },
     { id: "terminal.ready", required: false, title: "Verify terminal access", unlocks: ["coding"] },
   ],
@@ -87,6 +89,7 @@ const BASE_GATES: ReadinessGateSummary[] = [
   { id: "visual.qa", category: "ux", criticality: "release_critical", status: "unknown", message: "Onboarding visual QA has not been checked", remediation: "Run desktop and mobile visual QA", owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "github.connected", category: "integration", criticality: "goal_required", status: "unknown", message: "GitHub is not connected yet", remediation: "Connect GitHub to unlock coding workflows", owner: "user", lastCheckedAt: null, evidence: [] },
   { id: "project.selected", category: "coding", criticality: "goal_required", status: "unknown", message: "No coding project is selected", remediation: "Choose a repository or project", owner: "user", lastCheckedAt: null, evidence: [] },
+  { id: "issue_source.selected", category: "coding", criticality: "goal_required", status: "unknown", message: "No coding task source is selected", remediation: "Connect Linear or choose a Matrix task list", owner: "user", lastCheckedAt: null, evidence: [] },
   { id: "symphony.ready", category: "coding", criticality: "goal_required", status: "unknown", message: "Symphony readiness has not been checked", remediation: "Verify Symphony configuration", owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "integrations.capabilities", category: "integration", criticality: "goal_required", status: "unknown", message: "Assistant capabilities have not been approved", remediation: "Approve the needed integration capabilities", owner: "user", lastCheckedAt: null, evidence: [] },
   { id: "admin_control.ready", category: "admin_control", criticality: "release_critical", status: "unknown", message: "Admin control surface has not been checked", remediation: "Open model, settings, automation, activity, and readiness views", owner: "matrix", lastCheckedAt: null, evidence: [] },
@@ -134,6 +137,7 @@ export interface ReadinessService {
 export function createReadinessService(options: {
   repository: ReadinessRepository;
   cache?: ReadinessStatusCache<ReadinessResponse>;
+  codingSetup?: CodingSetupProvider;
   now?: () => Date;
 }): ReadinessService {
   const now = options.now ?? (() => new Date());
@@ -154,19 +158,50 @@ export function createReadinessService(options: {
     };
   }
 
-  function deriveGates(record: OnboardingReadinessRecord): ReadinessGateSummary[] {
+  function codingGatePatch(gate: ReadinessGateSummary, codingSetup: CodingSetupStatus | null, checkedAt: string): Partial<ReadinessGateSummary> | null {
+    if (!codingSetup) return null;
+    switch (gate.id) {
+      case "github.connected":
+        return codingSetup.githubConnected
+          ? { status: "pass", message: "GitHub is connected for coding workflows", remediation: null, lastCheckedAt: checkedAt }
+          : { status: "fail", message: "GitHub is needed before Matrix can start coding work", remediation: "Connect GitHub to unlock coding workflows", lastCheckedAt: checkedAt };
+      case "project.selected":
+        return codingSetup.selectedProject
+          ? { status: "pass", message: `${codingSetup.selectedProject.name} is selected for coding work`, remediation: null, lastCheckedAt: checkedAt, evidence: [codingSetup.selectedProject.slug] }
+          : { status: "fail", message: "Choose a project before starting coding work", remediation: "Choose a repository or project", lastCheckedAt: checkedAt };
+      case "issue_source.selected":
+        return codingSetup.issueSourceConfigured
+          ? { status: "pass", message: "A task source is connected for coding work", remediation: null, lastCheckedAt: checkedAt }
+          : { status: "fail", message: "Choose a task source before starting coding work", remediation: "Connect Linear or choose a Matrix task list", lastCheckedAt: checkedAt };
+      case "symphony.ready":
+        return codingSetup.symphonyReady
+          ? { status: "pass", message: "Symphony is ready to dispatch coding work", remediation: null, lastCheckedAt: checkedAt }
+          : { status: "fail", message: "Symphony needs setup before coding work can start", remediation: "Finish Symphony setup for the selected project", lastCheckedAt: checkedAt };
+      case "terminal.ready":
+        return codingSetup.terminalReady
+          ? { status: "pass", message: codingSetup.selectedProject ? `Terminal context is ready to open for ${codingSetup.selectedProject.name}` : "Terminal context is ready", remediation: null, lastCheckedAt: checkedAt }
+          : { status: "fail", message: "Terminal context has not been opened for this project", remediation: "Open the Matrix terminal for the selected project", lastCheckedAt: checkedAt };
+      default:
+        return null;
+    }
+  }
+
+  function deriveGates(record: OnboardingReadinessRecord, codingSetup: CodingSetupStatus | null): ReadinessGateSummary[] {
+    const checkedAt = now().toISOString();
     return BASE_GATES.map((gate) => {
+      const codingPatch = codingGatePatch(gate, codingSetup, checkedAt);
       const override = record.gateOverrides[gate.id];
-      if (!override) return { ...gate };
+      const base = { ...gate, ...codingPatch };
+      if (!override) return base;
       return {
-        ...gate,
+        ...base,
         status: override.status,
-        message: override.message ?? gate.message,
+        message: override.message ?? base.message,
         remediation: Object.prototype.hasOwnProperty.call(override, "remediation")
           ? override.remediation ?? null
-          : gate.remediation,
-        lastCheckedAt: override.lastCheckedAt ?? gate.lastCheckedAt,
-        evidence: override.evidence ?? gate.evidence,
+          : base.remediation,
+        lastCheckedAt: override.lastCheckedAt ?? base.lastCheckedAt,
+        evidence: override.evidence ?? base.evidence,
       };
     });
   }
@@ -183,7 +218,10 @@ export function createReadinessService(options: {
     const cached = cache.get(ownerId);
     if (cached) return cached;
     const record = await ensureRecord(ownerId);
-    const gates = deriveGates(record);
+    const codingSetup = record.selectedGoalIds.includes("coding") && options.codingSetup
+      ? await options.codingSetup.getCodingSetup(ownerId)
+      : null;
+    const gates = deriveGates(record, codingSetup);
     const goals = Object.values(GOALS).map((goal) => ({
       ...goal,
       selected: record.selectedGoalIds.includes(goal.id),
@@ -193,7 +231,7 @@ export function createReadinessService(options: {
       goals,
       gates,
       systemAgent: "hermes",
-      activeAgents: ["hermes"],
+      activeAgents: codingSetup?.activeAgents ?? ["hermes"],
       agents: DEFAULT_AGENTS.map((agent) => ({ ...agent })),
     };
     cache.set(ownerId, response);

--- a/packages/gateway/src/onboarding/readiness-service.ts
+++ b/packages/gateway/src/onboarding/readiness-service.ts
@@ -15,6 +15,7 @@ import {
 import { ReadinessStatusCache } from "./readiness-cache.js";
 import { ActivationRouteError } from "./activation-errors.js";
 import type { CodingSetupProvider, CodingSetupStatus } from "./coding-setup.js";
+import type { AgentCredentialStatusService } from "./agent-credential-status.js";
 
 const GOALS: Record<OnboardingGoalId, Omit<OnboardingGoalSummary, "selected">> = {
   coding: {
@@ -86,6 +87,7 @@ const BASE_GATES: ReadinessGateSummary[] = [
   { id: "terminal.ready", category: "coding", criticality: "goal_required", status: "unknown", message: "Terminal readiness has not been checked", remediation: "Open terminal for the selected project", owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "skills.ready", category: "agent", criticality: "release_critical", status: "unknown", message: "Skill readiness has not been checked", remediation: "Verify Matrix skills are available", owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "hermes.available", category: "agent", criticality: "release_critical", status: "pass", message: "Hermes is available as the Matrix system agent", remediation: null, owner: "matrix", lastCheckedAt: null, evidence: [] },
+  { id: "hermes.continuity", category: "agent", criticality: "release_critical", status: "pass", message: "Hermes remains available as the Matrix system agent", remediation: null, owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "visual.qa", category: "ux", criticality: "release_critical", status: "unknown", message: "Onboarding visual QA has not been checked", remediation: "Run desktop and mobile visual QA", owner: "matrix", lastCheckedAt: null, evidence: [] },
   { id: "github.connected", category: "integration", criticality: "goal_required", status: "unknown", message: "GitHub is not connected yet", remediation: "Connect GitHub to unlock coding workflows", owner: "user", lastCheckedAt: null, evidence: [] },
   { id: "project.selected", category: "coding", criticality: "goal_required", status: "unknown", message: "No coding project is selected", remediation: "Choose a repository or project", owner: "user", lastCheckedAt: null, evidence: [] },
@@ -138,6 +140,7 @@ export function createReadinessService(options: {
   repository: ReadinessRepository;
   cache?: ReadinessStatusCache<ReadinessResponse>;
   codingSetup?: CodingSetupProvider;
+  agentCredentials?: AgentCredentialStatusService;
   now?: () => Date;
 }): ReadinessService {
   const now = options.now ?? (() => new Date());
@@ -221,6 +224,7 @@ export function createReadinessService(options: {
     const codingSetup = record.selectedGoalIds.includes("coding") && options.codingSetup
       ? await options.codingSetup.getCodingSetup(ownerId)
       : null;
+    const credentialStatus = options.agentCredentials ? await options.agentCredentials.getStatus(ownerId) : null;
     const gates = deriveGates(record, codingSetup);
     const goals = Object.values(GOALS).map((goal) => ({
       ...goal,
@@ -231,8 +235,10 @@ export function createReadinessService(options: {
       goals,
       gates,
       systemAgent: "hermes",
-      activeAgents: codingSetup?.activeAgents ?? ["hermes"],
-      agents: DEFAULT_AGENTS.map((agent) => ({ ...agent })),
+      activeAgents: credentialStatus
+        ? Array.from(new Set([...(codingSetup?.activeAgents ?? []), ...credentialStatus.activeAgents]))
+        : codingSetup?.activeAgents ?? ["hermes"],
+      agents: credentialStatus?.agents ?? DEFAULT_AGENTS.map((agent) => ({ ...agent })),
     };
     cache.set(ownerId, response);
     return response;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2433,7 +2433,9 @@ export async function createGateway(config: GatewayConfig) {
       const snapshot = await repository.getSnapshot(ownerId);
       const result = await projectManager.listManagedProjects();
       const selectedSlug = snapshot.installation?.projectSlug ?? snapshot.rule?.projectSlug ?? null;
-      const projects = result.projects.map((project) => ({
+      const projects = result.projects
+        .filter((project) => project.ownerScope.type === "user" && project.ownerScope.id === ownerId)
+        .map((project) => ({
         slug: project.slug,
         name: project.name,
         repositoryUrl: project.github?.htmlUrl ?? project.remote,
@@ -2451,10 +2453,9 @@ export async function createGateway(config: GatewayConfig) {
         return /^git@github\.com:/i.test(repositoryUrl);
       }
     };
-    const hasProjectPathSegment = (cwd: string, projectSlug: string): boolean => {
-      const normalizedPath = normalize(relative(homePath, cwd)).replaceAll("\\", "/");
-      const segments = normalizedPath.split("/").filter(Boolean);
-      return segments.some((segment, index) => segment === "projects" && segments[index + 1] === projectSlug);
+    const isWithinPath = (parent: string, child: string): boolean => {
+      const relativePath = normalize(relative(resolve(parent), resolve(child)));
+      return relativePath === "" || (!relativePath.startsWith("..") && !relativePath.startsWith("/"));
     };
     const worktreeManager = createWorktreeManager({ homePath });
     const agentLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
@@ -2506,9 +2507,15 @@ export async function createGateway(config: GatewayConfig) {
           activeAgents,
         };
       },
-      hasTerminalContext: async (_ownerId, projectSlug) => {
+      hasTerminalContext: async (ownerId, projectSlug) => {
         if (!projectSlug) return false;
-        return sessionRegistry.list().some((session) => hasProjectPathSegment(session.cwd, projectSlug));
+        const projects = await listMatrixProjectOptions(ownerId);
+        if (!projects.some((project) => project.slug === projectSlug)) return false;
+        const projectRoot = join(homePath, "projects", projectSlug);
+        const repoRoot = join(projectRoot, "repo");
+        return sessionRegistry.list().some((session) =>
+          isWithinPath(projectRoot, session.cwd) || isWithinPath(repoRoot, session.cwd)
+        );
       },
     });
     await matrixSymphonyOrchestrator.resumeEnabledInstallations();

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -79,6 +79,7 @@ import { createOnboardingHandler } from "./onboarding/ws-handler.js";
 import { InMemoryReadinessRepository } from "./onboarding/readiness-repository.js";
 import { createReadinessService } from "./onboarding/readiness-service.js";
 import { createReadinessRoutes } from "./onboarding/readiness-routes.js";
+import { createCodingSetupProvider, type CodingSetupStatus } from "./onboarding/coding-setup.js";
 import { createVocalHandler } from "./vocal/ws-handler.js";
 import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
 import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
@@ -441,7 +442,22 @@ export async function createGateway(config: GatewayConfig) {
   const conversationRuns = new ConversationRunRegistry();
   const clients = new Set<WSContext>();
   const readinessRepository = new InMemoryReadinessRepository();
-  const readinessService = createReadinessService({ repository: readinessRepository });
+  let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;
+  const unavailableCodingSetup: CodingSetupStatus = {
+    githubConnected: false,
+    selectedProject: null,
+    issueSourceConfigured: false,
+    symphonyReady: false,
+    terminalReady: false,
+    activeAgents: ["hermes"],
+    handoffStatus: "idle",
+  };
+  const readinessService = createReadinessService({
+    repository: readinessRepository,
+    codingSetup: {
+      getCodingSetup: async (ownerId) => codingSetupProvider?.getCodingSetup(ownerId) ?? unavailableCodingSetup,
+    },
+  });
 
   // App data layer (Postgres-backed when DATABASE_URL is set)
   const databaseUrl = process.env.DATABASE_URL;
@@ -2402,6 +2418,15 @@ export async function createGateway(config: GatewayConfig) {
       ? createLinearSource({ graphql: createIntegrationAwareLinearGraphql({ platformDb, pipedream: pipedreamClient }) })
       : createLinearSource();
     const projectManager = createProjectManager({ homePath });
+    const listMatrixProjectOptions = async () => {
+      const result = await projectManager.listManagedProjects();
+      return result.projects.map((project) => ({
+        slug: project.slug,
+        name: project.name,
+        repositoryUrl: project.github?.htmlUrl ?? project.remote,
+        updatedAt: project.updatedAt,
+      }));
+    };
     const worktreeManager = createWorktreeManager({ homePath });
     const agentLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
     const agentSessionManager = createAgentSessionManager({
@@ -2421,6 +2446,42 @@ export async function createGateway(config: GatewayConfig) {
       agentStatusProvider: agentLauncher,
       statusHub: matrixSymphonyStatusHub,
     });
+    codingSetupProvider = createCodingSetupProvider({
+      hasGitHubConnection: async (_ownerId) => {
+        const projects = await listMatrixProjectOptions();
+        return projects.some((project) => isGitHubRepositoryUrl(project.repositoryUrl));
+      },
+      listMatrixProjects: async () => listMatrixProjectOptions(),
+      getSelectedProjectSlug: async (ownerId) => {
+        const snapshot = await repository.getSnapshot(ownerId);
+        return snapshot.installation?.projectSlug ?? snapshot.rule?.projectSlug ?? null;
+      },
+      hasIssueSource: async (ownerId) => {
+        if (platformDb && await hasConnectedLinearIntegration(platformDb, ownerId)) return true;
+        const snapshot = await repository.getSnapshot(ownerId);
+        return Boolean(snapshot.rule);
+      },
+      getSymphonyStatus: async (ownerId) => {
+        const snapshot = await repository.getSnapshot(ownerId);
+        const activeStatuses = new Set(["queued", "running", "retrying", "blocked", "handoff", "completed"]);
+        const handoffActiveStatuses = new Set(["queued", "running", "retrying", "blocked", "handoff"]);
+        const activeHandoffRuns = snapshot.runs.filter((run) => handoffActiveStatuses.has(run.status));
+        const handoffRuns = activeHandoffRuns.length > 0 ? activeHandoffRuns : snapshot.runs.slice(0, 1);
+        const activeAgents = Array.from(new Set(snapshot.runs
+          .filter((run) => activeStatuses.has(run.status))
+          .map((run) => run.agent)
+          .filter((agent) => agent === "claude" || agent === "codex")));
+        return {
+          ready: Boolean(snapshot.installation?.enabled && snapshot.installation.credentialConfigured && snapshot.rule),
+          runStatuses: handoffRuns.map((run) => run.status),
+          activeAgents,
+        };
+      },
+      hasTerminalContext: async (_ownerId, projectSlug) => {
+        if (!projectSlug) return false;
+        return sessionRegistry.list().some((session) => hasProjectPathSegment(session.cwd, projectSlug));
+      },
+    });
     await matrixSymphonyOrchestrator.resumeEnabledInstallations();
     app.route("/api/symphony", createSymphonyRoutes({
       repository,
@@ -2428,15 +2489,7 @@ export async function createGateway(config: GatewayConfig) {
       linearSource,
       orchestrator: matrixSymphonyOrchestrator,
       statusHub: matrixSymphonyStatusHub,
-      listMatrixProjects: async () => {
-        const result = await projectManager.listManagedProjects();
-        return result.projects.map((project) => ({
-          slug: project.slug,
-          name: project.name,
-          repositoryUrl: project.github?.htmlUrl ?? project.remote,
-          updatedAt: project.updatedAt,
-        }));
-      },
+      listMatrixProjects: listMatrixProjectOptions,
     }));
   } else {
     console.warn("[symphony] Matrix-native Symphony requires owner Postgres; routes are disabled");

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -80,6 +80,8 @@ import { InMemoryReadinessRepository } from "./onboarding/readiness-repository.j
 import { createReadinessService } from "./onboarding/readiness-service.js";
 import { createReadinessRoutes } from "./onboarding/readiness-routes.js";
 import { createCodingSetupProvider, type CodingSetupStatus } from "./onboarding/coding-setup.js";
+import { createAgentCredentialStatusService } from "./onboarding/agent-credential-status.js";
+import { createAgentCredentialRoutes } from "./onboarding/agent-credential-routes.js";
 import { createVocalHandler } from "./vocal/ws-handler.js";
 import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
 import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
@@ -442,6 +444,7 @@ export async function createGateway(config: GatewayConfig) {
   const conversationRuns = new ConversationRunRegistry();
   const clients = new Set<WSContext>();
   const readinessRepository = new InMemoryReadinessRepository();
+  const agentCredentialService = createAgentCredentialStatusService();
   let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;
   const unavailableCodingSetup: CodingSetupStatus = {
     githubConnected: false,
@@ -454,6 +457,7 @@ export async function createGateway(config: GatewayConfig) {
   };
   const readinessService = createReadinessService({
     repository: readinessRepository,
+    agentCredentials: agentCredentialService,
     codingSetup: {
       getCodingSetup: async (ownerId) => codingSetupProvider?.getCodingSetup(ownerId) ?? unavailableCodingSetup,
     },
@@ -1348,6 +1352,7 @@ export async function createGateway(config: GatewayConfig) {
   app.use("*", securityHeadersMiddleware());
   app.use("*", authMiddleware(process.env.MATRIX_AUTH_TOKEN));
   app.route("/api/onboarding", createReadinessRoutes({ service: readinessService }));
+  app.route("/api/agents", createAgentCredentialRoutes({ service: agentCredentialService }));
   app.route("/api", createShellRoutes({
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -78,6 +78,8 @@ import { isRequestPrincipalError, mapRequestPrincipalError, requireRequestPrinci
 import { createOnboardingHandler } from "./onboarding/ws-handler.js";
 import { InMemoryReadinessRepository } from "./onboarding/readiness-repository.js";
 import { createReadinessService } from "./onboarding/readiness-service.js";
+import { ReadinessStatusCache } from "./onboarding/readiness-cache.js";
+import type { ReadinessResponse } from "./onboarding/activation-contracts.js";
 import { createReadinessRoutes } from "./onboarding/readiness-routes.js";
 import { createCodingSetupProvider, type CodingSetupStatus } from "./onboarding/coding-setup.js";
 import { createAgentCredentialStatusService } from "./onboarding/agent-credential-status.js";
@@ -444,7 +446,11 @@ export async function createGateway(config: GatewayConfig) {
   const conversationRuns = new ConversationRunRegistry();
   const clients = new Set<WSContext>();
   const readinessRepository = new InMemoryReadinessRepository();
-  const agentCredentialService = createAgentCredentialStatusService();
+  const readinessCache = new ReadinessStatusCache<ReadinessResponse>({ maxEntries: 512, ttlMs: 10_000 });
+  let platformDb: PlatformDb | null = null;
+  const agentCredentialService = createAgentCredentialStatusService({
+    onChange: (ownerId) => readinessCache.delete(ownerId),
+  });
   let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;
   const unavailableCodingSetup: CodingSetupStatus = {
     githubConnected: false,
@@ -457,6 +463,7 @@ export async function createGateway(config: GatewayConfig) {
   };
   const readinessService = createReadinessService({
     repository: readinessRepository,
+    cache: readinessCache,
     agentCredentials: agentCredentialService,
     codingSetup: {
       getCodingSetup: async (ownerId) => codingSetupProvider?.getCodingSetup(ownerId) ?? unavailableCodingSetup,
@@ -807,7 +814,6 @@ export async function createGateway(config: GatewayConfig) {
   }
 
   // Platform DB + Integrations (Pipedream Connect)
-  let platformDb: PlatformDb | null = null;
   let pipedreamClient: PipedreamConnectClient | null = null;
   let integrationRoutes: Hono | null = null;
   let resolveIntegrationUserId: ((c: Context) => Promise<string | null>) | null = null;
@@ -2423,14 +2429,32 @@ export async function createGateway(config: GatewayConfig) {
       ? createLinearSource({ graphql: createIntegrationAwareLinearGraphql({ platformDb, pipedream: pipedreamClient }) })
       : createLinearSource();
     const projectManager = createProjectManager({ homePath });
-    const listMatrixProjectOptions = async () => {
+    const listMatrixProjectOptions = async (ownerId: string) => {
+      const snapshot = await repository.getSnapshot(ownerId);
       const result = await projectManager.listManagedProjects();
-      return result.projects.map((project) => ({
+      const selectedSlug = snapshot.installation?.projectSlug ?? snapshot.rule?.projectSlug ?? null;
+      const projects = result.projects.map((project) => ({
         slug: project.slug,
         name: project.name,
         repositoryUrl: project.github?.htmlUrl ?? project.remote,
         updatedAt: project.updatedAt,
       }));
+      const selectedProject = selectedSlug ? projects.find((project) => project.slug === selectedSlug) : null;
+      return selectedProject ? [selectedProject] : projects;
+    };
+    const isGitHubRepositoryUrl = (repositoryUrl: string | null | undefined): boolean => {
+      if (!repositoryUrl) return false;
+      try {
+        const parsed = new URL(repositoryUrl);
+        return parsed.hostname === "github.com" || parsed.hostname.endsWith(".github.com");
+      } catch (_err) {
+        return /^git@github\.com:/i.test(repositoryUrl);
+      }
+    };
+    const hasProjectPathSegment = (cwd: string, projectSlug: string): boolean => {
+      const normalizedPath = normalize(relative(homePath, cwd)).replaceAll("\\", "/");
+      const segments = normalizedPath.split("/").filter(Boolean);
+      return segments.some((segment, index) => segment === "projects" && segments[index + 1] === projectSlug);
     };
     const worktreeManager = createWorktreeManager({ homePath });
     const agentLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
@@ -2452,11 +2476,11 @@ export async function createGateway(config: GatewayConfig) {
       statusHub: matrixSymphonyStatusHub,
     });
     codingSetupProvider = createCodingSetupProvider({
-      hasGitHubConnection: async (_ownerId) => {
-        const projects = await listMatrixProjectOptions();
+      hasGitHubConnection: async (ownerId) => {
+        const projects = await listMatrixProjectOptions(ownerId);
         return projects.some((project) => isGitHubRepositoryUrl(project.repositoryUrl));
       },
-      listMatrixProjects: async () => listMatrixProjectOptions(),
+      listMatrixProjects: async (ownerId) => listMatrixProjectOptions(ownerId),
       getSelectedProjectSlug: async (ownerId) => {
         const snapshot = await repository.getSnapshot(ownerId);
         return snapshot.installation?.projectSlug ?? snapshot.rule?.projectSlug ?? null;
@@ -2494,7 +2518,7 @@ export async function createGateway(config: GatewayConfig) {
       linearSource,
       orchestrator: matrixSymphonyOrchestrator,
       statusHub: matrixSymphonyStatusHub,
-      listMatrixProjects: listMatrixProjectOptions,
+      listMatrixProjects: (ownerId) => listMatrixProjectOptions(ownerId),
     }));
   } else {
     console.warn("[symphony] Matrix-native Symphony requires owner Postgres; routes are disabled");

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -448,8 +448,21 @@ export async function createGateway(config: GatewayConfig) {
   const readinessRepository = new InMemoryReadinessRepository();
   const readinessCache = new ReadinessStatusCache<ReadinessResponse>({ maxEntries: 512, ttlMs: 10_000 });
   let platformDb: PlatformDb | null = null;
+  const agentCredentialLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
+  let agentDetectionInFlight: Promise<Awaited<ReturnType<typeof agentCredentialLauncher.detectAgents>>> | null = null;
   const agentCredentialService = createAgentCredentialStatusService({
     onChange: (ownerId) => readinessCache.delete(ownerId),
+    probeAgent: async (_ownerId, agent) => {
+      agentDetectionInFlight ??= agentCredentialLauncher.detectAgents().finally(() => {
+        agentDetectionInFlight = null;
+      });
+      const detected = await agentDetectionInFlight;
+      const status = detected.agents.find((candidate) => candidate.id === agent);
+      return {
+        available: Boolean(status?.installed && status.authState === "ok"),
+        missing: status?.installed === false,
+      };
+    },
   });
   let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;
   const unavailableCodingSetup: CodingSetupStatus = {
@@ -2429,20 +2442,38 @@ export async function createGateway(config: GatewayConfig) {
       ? createLinearSource({ graphql: createIntegrationAwareLinearGraphql({ platformDb, pipedream: pipedreamClient }) })
       : createLinearSource();
     const projectManager = createProjectManager({ homePath });
-    const listMatrixProjectOptions = async (ownerId: string) => {
-      const snapshot = await repository.getSnapshot(ownerId);
+    const listAllMatrixProjectOptions = async (ownerId: string) => {
       const result = await projectManager.listManagedProjects();
-      const selectedSlug = snapshot.installation?.projectSlug ?? snapshot.rule?.projectSlug ?? null;
-      const projects = result.projects
+      return result.projects
         .filter((project) => project.ownerScope.type === "user" && project.ownerScope.id === ownerId)
         .map((project) => ({
-        slug: project.slug,
-        name: project.name,
-        repositoryUrl: project.github?.htmlUrl ?? project.remote,
-        updatedAt: project.updatedAt,
-      }));
+          slug: project.slug,
+          name: project.name,
+          repositoryUrl: project.github?.htmlUrl ?? project.remote,
+          updatedAt: project.updatedAt,
+        }));
+    };
+    const codingSnapshotReads = new Map<string, Promise<Awaited<ReturnType<typeof repository.getSnapshot>>>>();
+    const getCodingSnapshot = async (ownerId: string) => {
+      const existing = codingSnapshotReads.get(ownerId);
+      if (existing) return await existing;
+      if (codingSnapshotReads.size >= 128) {
+        const oldestKey = codingSnapshotReads.keys().next().value as string | undefined;
+        if (oldestKey) codingSnapshotReads.delete(oldestKey);
+      }
+      const read = repository.getSnapshot(ownerId).finally(() => {
+        if (codingSnapshotReads.get(ownerId) === read) codingSnapshotReads.delete(ownerId);
+      });
+      codingSnapshotReads.set(ownerId, read);
+      return await read;
+    };
+    const listSelectedMatrixProjectOptions = async (ownerId: string) => {
+      const snapshot = await getCodingSnapshot(ownerId);
+      const selectedSlug = snapshot.installation?.projectSlug ?? snapshot.rule?.projectSlug ?? null;
+      if (!selectedSlug) return [];
+      const projects = await listAllMatrixProjectOptions(ownerId);
       const selectedProject = selectedSlug ? projects.find((project) => project.slug === selectedSlug) : null;
-      return selectedProject ? [selectedProject] : projects;
+      return selectedProject ? [selectedProject] : [];
     };
     const isGitHubRepositoryUrl = (repositoryUrl: string | null | undefined): boolean => {
       if (!repositoryUrl) return false;
@@ -2477,22 +2508,21 @@ export async function createGateway(config: GatewayConfig) {
       statusHub: matrixSymphonyStatusHub,
     });
     codingSetupProvider = createCodingSetupProvider({
-      hasGitHubConnection: async (ownerId) => {
-        const projects = await listMatrixProjectOptions(ownerId);
-        return projects.some((project) => isGitHubRepositoryUrl(project.repositoryUrl));
+      hasGitHubConnection: async (_ownerId, selectedProject) => {
+        return isGitHubRepositoryUrl(selectedProject?.repositoryUrl);
       },
-      listMatrixProjects: async (ownerId) => listMatrixProjectOptions(ownerId),
+      listMatrixProjects: async (ownerId) => listSelectedMatrixProjectOptions(ownerId),
       getSelectedProjectSlug: async (ownerId) => {
-        const snapshot = await repository.getSnapshot(ownerId);
+        const snapshot = await getCodingSnapshot(ownerId);
         return snapshot.installation?.projectSlug ?? snapshot.rule?.projectSlug ?? null;
       },
       hasIssueSource: async (ownerId) => {
         if (platformDb && await hasConnectedLinearIntegration(platformDb, ownerId)) return true;
-        const snapshot = await repository.getSnapshot(ownerId);
+        const snapshot = await getCodingSnapshot(ownerId);
         return Boolean(snapshot.rule);
       },
       getSymphonyStatus: async (ownerId) => {
-        const snapshot = await repository.getSnapshot(ownerId);
+        const snapshot = await getCodingSnapshot(ownerId);
         const activeStatuses = new Set(["queued", "running", "retrying", "blocked", "handoff", "completed"]);
         const handoffActiveStatuses = new Set(["queued", "running", "retrying", "blocked", "handoff"]);
         const activeHandoffRuns = snapshot.runs.filter((run) => handoffActiveStatuses.has(run.status));
@@ -2509,8 +2539,8 @@ export async function createGateway(config: GatewayConfig) {
       },
       hasTerminalContext: async (ownerId, projectSlug) => {
         if (!projectSlug) return false;
-        const projects = await listMatrixProjectOptions(ownerId);
-        if (!projects.some((project) => project.slug === projectSlug)) return false;
+        const localOwnerId = process.env.MATRIX_USER_ID ?? process.env.MATRIX_HANDLE;
+        if (!localOwnerId || ownerId !== localOwnerId) return false;
         const projectRoot = join(homePath, "projects", projectSlug);
         const repoRoot = join(projectRoot, "repo");
         return sessionRegistry.list().some((session) =>
@@ -2525,7 +2555,7 @@ export async function createGateway(config: GatewayConfig) {
       linearSource,
       orchestrator: matrixSymphonyOrchestrator,
       statusHub: matrixSymphonyStatusHub,
-      listMatrixProjects: (ownerId) => listMatrixProjectOptions(ownerId),
+      listMatrixProjects: (ownerId) => listAllMatrixProjectOptions(ownerId),
     }));
   } else {
     console.warn("[symphony] Matrix-native Symphony requires owner Postgres; routes are disabled");

--- a/packages/gateway/src/symphony/orchestrator.ts
+++ b/packages/gateway/src/symphony/orchestrator.ts
@@ -265,13 +265,17 @@ export function createMatrixSymphonyOrchestrator(options: {
           throw err;
         }
         if (duplicate) {
-          await append(ownerId, {
-            installationId: duplicate.installationId,
-            runId: duplicate.id,
-            type: "symphony.run.reused",
-            message: "Existing active coding run reused",
-            severity: "info",
-          });
+          try {
+            await append(ownerId, {
+              installationId: duplicate.installationId,
+              runId: duplicate.id,
+              type: "symphony.run.reused",
+              message: "Existing active coding run reused",
+              severity: "info",
+            });
+          } catch (appendErr: unknown) {
+            console.warn("[symphony] reuse-event append failed:", appendErr instanceof Error ? appendErr.message : String(appendErr));
+          }
           return duplicate;
         }
         throw err;

--- a/packages/gateway/src/symphony/orchestrator.ts
+++ b/packages/gateway/src/symphony/orchestrator.ts
@@ -252,7 +252,31 @@ export function createMatrixSymphonyOrchestrator(options: {
       lastEvent: "Queued for Matrix agent dispatch",
       updatedAt: timestamp,
     };
-    if (!active) await options.repository.upsertRun(ownerId, run);
+    if (!active) {
+      try {
+        await options.repository.upsertRun(ownerId, run);
+      } catch (err: unknown) {
+        console.warn("[symphony] run upsert failed; checking for an existing active claim:", err instanceof Error ? err.message : String(err));
+        let duplicate;
+        try {
+          duplicate = await options.repository.findActiveRunByClaim(ownerId, claimKey(ticket));
+        } catch (lookupErr: unknown) {
+          console.warn("[symphony] active-claim lookup failed after run upsert failure:", lookupErr instanceof Error ? lookupErr.message : String(lookupErr));
+          throw err;
+        }
+        if (duplicate) {
+          await append(ownerId, {
+            installationId: duplicate.installationId,
+            runId: duplicate.id,
+            type: "symphony.run.reused",
+            message: "Existing active coding run reused",
+            severity: "info",
+          });
+          return duplicate;
+        }
+        throw err;
+      }
+    }
     try {
       if (readinessFailure) {
         const updated = await options.repository.updateRun(ownerId, run.id, {

--- a/packages/gateway/src/symphony/routes.ts
+++ b/packages/gateway/src/symphony/routes.ts
@@ -36,7 +36,7 @@ export interface MatrixSymphonyRouteDeps {
   linearSource: LinearSource;
   orchestrator: MatrixSymphonyOrchestrator;
   statusHub?: SymphonyStatusHub;
-  listMatrixProjects?: () => Promise<MatrixProjectOption[]>;
+  listMatrixProjects?: (ownerId: string) => Promise<MatrixProjectOption[]>;
   getPrincipal?: (c: Context) => RequestPrincipal;
 }
 
@@ -238,7 +238,7 @@ export function createMatrixSymphonyRoutes(deps: MatrixSymphonyRouteDeps) {
     if (!auth.ok) return auth.response;
     let matrixProjects: MatrixProjectOption[] = [];
     try {
-      matrixProjects = deps.listMatrixProjects ? await deps.listMatrixProjects() : [];
+      matrixProjects = deps.listMatrixProjects ? await deps.listMatrixProjects(auth.ownerId) : [];
     } catch (err: unknown) {
       console.warn("[symphony] Matrix project setup discovery failed:", err instanceof Error ? err.message : String(err));
     }

--- a/packages/gateway/src/symphony/routes.ts
+++ b/packages/gateway/src/symphony/routes.ts
@@ -53,6 +53,77 @@ function counts(runs: SymphonyRun[]) {
   };
 }
 
+function activeAgents(runs: SymphonyRun[]) {
+  const activeStatuses = new Set<SymphonyRun["status"]>(["queued", "running", "retrying", "blocked", "handoff", "completed"]);
+  const onboardingAgents = new Set<SymphonyRun["agent"]>(["codex", "claude"]);
+  return Array.from(new Set(runs
+    .filter((run) => activeStatuses.has(run.status))
+    .filter((run) => onboardingAgents.has(run.agent))
+    .map((run) => run.agent)));
+}
+
+function handoffRelevantRuns(runs: SymphonyRun[]) {
+  const activeStatuses = new Set<SymphonyRun["status"]>(["queued", "running", "retrying", "blocked", "handoff"]);
+  const activeRuns = runs.filter((run) => activeStatuses.has(run.status));
+  return activeRuns.length > 0 ? activeRuns : runs.slice(0, 1);
+}
+
+function handoffSummary(runs: SymphonyRun[]) {
+  const relevantRuns = handoffRelevantRuns(runs);
+  const readyCount = relevantRuns.filter((run) => run.status === "handoff" || run.status === "completed").length;
+  const needsInputCount = relevantRuns.filter((run) => run.status === "blocked").length;
+  const failedCount = relevantRuns.filter((run) => run.status === "failed" || run.status === "stopped").length;
+  const runningCount = relevantRuns.filter((run) => run.status === "queued" || run.status === "running" || run.status === "retrying").length;
+  if (needsInputCount > 0) {
+    return {
+      status: "needs_input" as const,
+      readyCount,
+      needsInputCount,
+      failedCount,
+      runningCount,
+      nextAction: "Open the blocked run and provide input",
+    };
+  }
+  if (readyCount > 0) {
+    return {
+      status: "ready" as const,
+      readyCount,
+      needsInputCount,
+      failedCount,
+      runningCount,
+      nextAction: "Review the latest Symphony handoff",
+    };
+  }
+  if (runningCount > 0) {
+    return {
+      status: "running" as const,
+      readyCount,
+      needsInputCount,
+      failedCount,
+      runningCount,
+      nextAction: "Monitor the active Symphony run",
+    };
+  }
+  if (failedCount > 0) {
+    return {
+      status: "failed" as const,
+      readyCount,
+      needsInputCount,
+      failedCount,
+      runningCount,
+      nextAction: "Review the failure summary and retry when ready",
+    };
+  }
+  return {
+    status: "idle" as const,
+    readyCount,
+    needsInputCount,
+    failedCount,
+    runningCount,
+    nextAction: "Start a coding task",
+  };
+}
+
 function publicRun(run: SymphonyRun): Omit<SymphonyRun, "worktreePath"> {
   const { worktreePath: _worktreePath, ...safeRun } = run;
   return safeRun;
@@ -150,6 +221,8 @@ export function createMatrixSymphonyRoutes(deps: MatrixSymphonyRouteDeps) {
       pollIntervalMs: snapshot.installation?.pollIntervalMs ?? null,
       maxConcurrentAgents: snapshot.installation?.maxConcurrentAgents ?? null,
       counts: counts(snapshot.runs),
+      activeAgents: activeAgents(snapshot.runs),
+      handoff: handoffSummary(snapshot.runs),
       lastPollAt: snapshot.lastPollAt,
     });
   }));

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1288,7 +1288,7 @@ export function Desktop({ onOpenCommandPalette, chat }: DesktopProps) {
             });
             setShowSetup(false);
           }}
-          onOpenTerminal={() => openWindow("Terminal", "__terminal__")}
+          onOpenTerminal={(path = "__terminal__") => openWindow("Terminal", path)}
         />
       )}
       <div className="relative flex-1 flex flex-col md:flex-row md:pt-7">

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useOnboarding } from "@/hooks/useOnboarding";
+import { useAgentCredentialStatus } from "@/hooks/useAgentCredentialStatus";
 import { useMicPermission } from "@/hooks/useMicPermission";
 import { VoiceWave } from "./onboarding/VoiceWave";
 import { ApiKeyInput } from "./onboarding/ApiKeyInput";
@@ -11,6 +12,7 @@ import { GoalSelector } from "./onboarding/GoalSelector";
 import { ReadinessChecklist } from "./onboarding/ReadinessChecklist";
 import { CodingSetupPanel } from "./onboarding/CodingSetupPanel";
 import { CodingHandoffSummary } from "./onboarding/CodingHandoffSummary";
+import { AgentCredentialPanel } from "./onboarding/AgentCredentialPanel";
 import { MicPermissionDialog } from "./MicPermissionDialog";
 import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
@@ -27,6 +29,7 @@ interface OnboardingScreenProps {
 
 export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScreenProps) {
   const ob = useOnboarding();
+  const agentCredentials = useAgentCredentialStatus();
   const mic = useMicPermission();
   const [started, setStarted] = useState(false);
   const [phase, setPhase] = useState<"idle" | "dimming" | "black" | "revealing">("idle");
@@ -242,6 +245,8 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
                   <CodingHandoffSummary activeAgents={ob.readiness?.activeAgents ?? ["hermes"]} />
                 </div>
               )}
+
+              <AgentCredentialPanel status={agentCredentials.status} error={agentCredentials.error} onVerify={agentCredentials.verify} />
 
               <div className="flex flex-col gap-2 sm:flex-row">
                 <button

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -415,6 +415,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
                   <div className="hidden w-px bg-gradient-to-b from-transparent via-[#2f392c]/20 to-transparent md:col-start-4 md:row-start-1 md:block" style={{ opacity: splitVisible ? 1 : 0 }} />
                 </div>
               </div>
+            </div>
 
             <button
               type="button"

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -9,6 +9,8 @@ import { BrandFrame } from "./onboarding/BrandFrame";
 import { CapabilityIntro } from "./onboarding/CapabilityIntro";
 import { GoalSelector } from "./onboarding/GoalSelector";
 import { ReadinessChecklist } from "./onboarding/ReadinessChecklist";
+import { CodingSetupPanel } from "./onboarding/CodingSetupPanel";
+import { CodingHandoffSummary } from "./onboarding/CodingHandoffSummary";
 import { MicPermissionDialog } from "./MicPermissionDialog";
 import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
@@ -179,6 +181,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
 
   // ── Voice conversation screen (editorial style) ─────────────
   const isConversing = ob.stage === "greeting" || ob.stage === "interview" || ob.stage === "connecting";
+  const codingSelected = ob.selectedGoalIds.includes("coding");
 
   // Render nothing for the one frame between "alreadyComplete" becoming
   // true and the parent unmounting us via the effect above. Placing this
@@ -230,6 +233,13 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
                       </span>
                     ))}
                   </div>
+                </div>
+              )}
+
+              {codingSelected && (
+                <div className="grid gap-3">
+                  <CodingSetupPanel gates={ob.readiness?.gates ?? []} onOpenTerminal={onOpenTerminal} />
+                  <CodingHandoffSummary activeAgents={ob.readiness?.activeAgents ?? ["hermes"]} />
                 </div>
               )}
 
@@ -397,7 +407,6 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
                   <div className="hidden w-px bg-gradient-to-b from-transparent via-[#2f392c]/20 to-transparent md:col-start-4 md:row-start-1 md:block" style={{ opacity: splitVisible ? 1 : 0 }} />
                 </div>
               </div>
-            </div>
 
             <button
               type="button"

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -24,7 +24,7 @@ const SHIMMER_ANIMATION =
 
 interface OnboardingScreenProps {
   onComplete: () => void;
-  onOpenTerminal: () => void;
+  onOpenTerminal: (path?: string) => void;
 }
 
 export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScreenProps) {

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -242,7 +242,10 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
               {codingSelected && (
                 <div className="grid gap-3">
                   <CodingSetupPanel gates={ob.readiness?.gates ?? []} onOpenTerminal={onOpenTerminal} />
-                  <CodingHandoffSummary activeAgents={ob.readiness?.activeAgents ?? ["hermes"]} />
+                  <CodingHandoffSummary
+                    activeAgents={ob.readiness?.activeAgents ?? ["hermes"]}
+                    status={ob.readiness?.codingHandoffStatus ?? null}
+                  />
                 </div>
               )}
 

--- a/shell/src/components/onboarding/AgentCredentialPanel.tsx
+++ b/shell/src/components/onboarding/AgentCredentialPanel.tsx
@@ -59,29 +59,32 @@ export function AgentCredentialPanel({
       </div>
 
       <div className="mt-3 grid gap-2 sm:grid-cols-3">
-        {agents.map((agent) => (
-          <div key={agent.agent} className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/75 p-3">
-            <div className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <BotIcon className="h-4 w-4 text-[#17281f]/70" aria-hidden="true" />
-                <p className="text-xs font-semibold text-[#111612]">{agentLabel(agent.agent)}</p>
+        {agents.map((agent) => {
+          const verifiableAgent = agent.agent === "claude" || agent.agent === "codex" ? agent.agent : null;
+          return (
+            <div key={agent.agent} className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/75 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <BotIcon className="h-4 w-4 text-[#17281f]/70" aria-hidden="true" />
+                  <p className="text-xs font-semibold text-[#111612]">{agentLabel(agent.agent)}</p>
+                </div>
+                {agent.status === "available" && <CheckCircle2Icon className="h-4 w-4 text-[#4f7f5c]" aria-hidden="true" />}
               </div>
-              {agent.status === "available" && <CheckCircle2Icon className="h-4 w-4 text-[#4f7f5c]" aria-hidden="true" />}
+              <p className="mt-2 text-xs leading-5 text-[#17281f]/68">{statusCopy(agent.agent, agent.status)}</p>
+              <p className="mt-1 text-xs capitalize text-[#17281f]/48">{agent.coordinationRole.replaceAll("_", " ")}</p>
+              {agent.nextAction && verifiableAgent && (
+                <button
+                  type="button"
+                  onClick={() => onVerify(verifiableAgent)}
+                  className="mt-3 inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[#17281f]/12 bg-white/70 px-2.5 text-xs font-medium text-[#17281f] transition hover:border-[#17281f]/28"
+                >
+                  <PlusIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                  {agent.nextAction}
+                </button>
+              )}
             </div>
-            <p className="mt-2 text-xs leading-5 text-[#17281f]/68">{statusCopy(agent.agent, agent.status)}</p>
-            <p className="mt-1 text-xs capitalize text-[#17281f]/48">{agent.coordinationRole.replaceAll("_", " ")}</p>
-            {agent.nextAction && agent.agent !== "hermes" && (
-              <button
-                type="button"
-                onClick={() => onVerify(agent.agent)}
-                className="mt-3 inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[#17281f]/12 bg-white/70 px-2.5 text-xs font-medium text-[#17281f] transition hover:border-[#17281f]/28"
-              >
-                <PlusIcon className="h-3.5 w-3.5" aria-hidden="true" />
-                {agent.nextAction}
-              </button>
-            )}
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/shell/src/components/onboarding/AgentCredentialPanel.tsx
+++ b/shell/src/components/onboarding/AgentCredentialPanel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { BotIcon, CheckCircle2Icon, KeyRoundIcon, PlusIcon } from "lucide-react";
+import type { AgentCredentialStatus } from "@/hooks/useAgentCredentialStatus";
+
+function agentLabel(agent: string) {
+  if (agent === "claude") return "Claude";
+  if (agent === "codex") return "Codex";
+  return "Hermes";
+}
+
+function statusCopy(agent: string, status: string) {
+  if (agent === "hermes") return "Hermes is the Matrix system agent";
+  if (status === "available") return `${agentLabel(agent)} is connected`;
+  return `${agentLabel(agent)} is not connected`;
+}
+
+export function AgentCredentialPanel({
+  status,
+  error,
+  onVerify,
+}: {
+  status: AgentCredentialStatus | null;
+  error?: string | null;
+  onVerify: (agent: "claude" | "codex") => void;
+}) {
+  const agents = status?.agents ?? [
+    {
+      agent: "hermes" as const,
+      status: "available" as const,
+      coordinationRole: "system_agent" as const,
+      workflows: ["app_building", "assistant", "integrations"],
+      degradedWorkflows: [],
+      verifiedAt: null,
+      nextAction: null,
+    },
+  ];
+
+  return (
+    <section className="rounded-md border border-[#17281f]/10 bg-white/55 p-4 shadow-[0_16px_45px_rgba(23,40,31,0.08)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-[#111612]">
+            <KeyRoundIcon className="h-4 w-4 text-[#a6542f]" aria-hidden="true" />
+            Agent setup
+          </h2>
+          <p className="mt-1 max-w-xl text-xs leading-5 text-[#17281f]/62">
+            {status?.routingExplanation ?? "Hermes remains the Matrix system agent while Claude and Codex add optional specialist paths when connected."}
+          </p>
+          {error && (
+            <p className="mt-2 rounded-md border border-[#b4532f]/20 bg-[#b4532f]/10 px-2 py-1.5 text-xs leading-5 text-[#5f2b1e]">
+              {error}
+            </p>
+          )}
+        </div>
+        <div className="rounded-full border border-[#4f7f5c]/20 bg-[#4f7f5c]/10 px-2.5 py-1 text-xs font-medium text-[#213829]">
+          System agent: Hermes
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-3">
+        {agents.map((agent) => (
+          <div key={agent.agent} className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/75 p-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <BotIcon className="h-4 w-4 text-[#17281f]/70" aria-hidden="true" />
+                <p className="text-xs font-semibold text-[#111612]">{agentLabel(agent.agent)}</p>
+              </div>
+              {agent.status === "available" && <CheckCircle2Icon className="h-4 w-4 text-[#4f7f5c]" aria-hidden="true" />}
+            </div>
+            <p className="mt-2 text-xs leading-5 text-[#17281f]/68">{statusCopy(agent.agent, agent.status)}</p>
+            <p className="mt-1 text-xs capitalize text-[#17281f]/48">{agent.coordinationRole.replaceAll("_", " ")}</p>
+            {agent.nextAction && agent.agent !== "hermes" && (
+              <button
+                type="button"
+                onClick={() => onVerify(agent.agent)}
+                className="mt-3 inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[#17281f]/12 bg-white/70 px-2.5 text-xs font-medium text-[#17281f] transition hover:border-[#17281f]/28"
+              >
+                <PlusIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                {agent.nextAction}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/shell/src/components/onboarding/CodingHandoffSummary.tsx
+++ b/shell/src/components/onboarding/CodingHandoffSummary.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { BotIcon, CheckCircle2Icon } from "lucide-react";
+
+export function CodingHandoffSummary({
+  activeAgents,
+}: {
+  activeAgents: Array<"claude" | "codex" | "hermes">;
+}) {
+  const agents = activeAgents.length > 0 ? activeAgents : ["hermes" as const];
+  return (
+    <section className="rounded-md border border-[#17281f]/10 bg-[#17281f]/5 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-[#111612]">
+            <BotIcon className="h-4 w-4 text-[#a6542f]" aria-hidden="true" />
+            Coding handoff
+          </h2>
+          <p className="mt-1 text-xs leading-5 text-[#17281f]/62">
+            Active coding work will summarize the branch, validation state, next action, and whether it needs your input before another agent run starts.
+          </p>
+        </div>
+        <div className="flex flex-wrap justify-end gap-1.5">
+          {agents.map((agent) => (
+            <span key={agent} className="inline-flex items-center gap-1 rounded-full border border-[#17281f]/10 bg-white/60 px-2.5 py-1 text-xs font-medium capitalize text-[#17281f]/75">
+              <CheckCircle2Icon className="h-3.5 w-3.5 text-[#4f7f5c]" aria-hidden="true" />
+              {agent}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/shell/src/components/onboarding/CodingHandoffSummary.tsx
+++ b/shell/src/components/onboarding/CodingHandoffSummary.tsx
@@ -4,10 +4,17 @@ import { BotIcon, CheckCircle2Icon } from "lucide-react";
 
 export function CodingHandoffSummary({
   activeAgents,
+  status,
 }: {
   activeAgents: Array<"claude" | "codex" | "hermes">;
+  status: "idle" | "running" | "needs_input" | "ready" | "failed" | null;
 }) {
   const agents = activeAgents.length > 0 ? activeAgents : ["hermes" as const];
+  const statusLabel = status === "needs_input"
+    ? "Needs input"
+    : status
+      ? status.replaceAll("_", " ")
+      : "Idle";
   return (
     <section className="rounded-md border border-[#17281f]/10 bg-[#17281f]/5 p-4">
       <div className="flex items-center justify-between gap-3">
@@ -21,6 +28,9 @@ export function CodingHandoffSummary({
           </p>
         </div>
         <div className="flex flex-wrap justify-end gap-1.5">
+          <span className="inline-flex items-center gap-1 rounded-full border border-[#17281f]/10 bg-white/60 px-2.5 py-1 text-xs font-medium capitalize text-[#17281f]/75">
+            {statusLabel}
+          </span>
           {agents.map((agent) => (
             <span key={agent} className="inline-flex items-center gap-1 rounded-full border border-[#17281f]/10 bg-white/60 px-2.5 py-1 text-xs font-medium capitalize text-[#17281f]/75">
               <CheckCircle2Icon className="h-3.5 w-3.5 text-[#4f7f5c]" aria-hidden="true" />

--- a/shell/src/components/onboarding/CodingHandoffSummary.tsx
+++ b/shell/src/components/onboarding/CodingHandoffSummary.tsx
@@ -10,11 +10,11 @@ export function CodingHandoffSummary({
   status: "idle" | "running" | "needs_input" | "ready" | "failed" | null;
 }) {
   const agents = activeAgents.length > 0 ? activeAgents : ["hermes" as const];
-  const statusLabel = status === "needs_input"
-    ? "Needs input"
-    : status
-      ? status.replaceAll("_", " ")
-      : "Idle";
+  const statusLabel = !status || status === "idle"
+    ? "Idle"
+    : status === "needs_input"
+      ? "Needs input"
+      : status.replaceAll("_", " ");
   return (
     <section className="rounded-md border border-[#17281f]/10 bg-[#17281f]/5 p-4">
       <div className="flex items-center justify-between gap-3">

--- a/shell/src/components/onboarding/CodingSetupPanel.tsx
+++ b/shell/src/components/onboarding/CodingSetupPanel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { CheckCircle2Icon, CircleDashedIcon, ExternalLinkIcon, GitBranchIcon, TerminalIcon } from "lucide-react";
+import type { ReadinessGateSummary } from "@/hooks/useOnboarding";
+import { terminalContextLaunchPath } from "@/lib/app-launch";
+
+const CODING_GATE_LABELS: Record<string, string> = {
+  "github.connected": "GitHub connected",
+  "project.selected": "Project selected",
+  "issue_source.selected": "Choose task source",
+  "symphony.ready": "Symphony ready",
+  "terminal.ready": "Terminal context",
+};
+
+function gateTone(status: ReadinessGateSummary["status"]) {
+  if (status === "pass") return "border-[#4f7f5c]/25 bg-[#4f7f5c]/10 text-[#213829]";
+  if (status === "fail" || status === "blocked") return "border-[#b4532f]/25 bg-[#b4532f]/10 text-[#5f2b1e]";
+  return "border-[#17281f]/10 bg-white/45 text-[#17281f]/70";
+}
+
+export function CodingSetupPanel({
+  gates,
+  onOpenTerminal,
+}: {
+  gates: ReadinessGateSummary[];
+  onOpenTerminal: (path: string) => void;
+}) {
+  const codingGates = gates.filter((gate) => Object.prototype.hasOwnProperty.call(CODING_GATE_LABELS, gate.id));
+  if (codingGates.length === 0) return null;
+  const projectGate = codingGates.find((gate) => gate.id === "project.selected");
+  const projectSlug = projectGate?.evidence?.[0] ?? null;
+  const terminalLaunchPath = terminalContextLaunchPath(projectSlug);
+
+  return (
+    <section className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/80 p-4 shadow-[0_16px_45px_rgba(23,40,31,0.08)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-[#111612]">
+            <GitBranchIcon className="h-4 w-4 text-[#a6542f]" aria-hidden="true" />
+            Coding setup
+          </h2>
+          <p className="mt-1 max-w-xl text-xs leading-5 text-[#17281f]/62">
+            Matrix uses this path to connect GitHub, pick the project, choose the work source, start Symphony once, and open the matching terminal context when you need to inspect the workspace.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onOpenTerminal(terminalLaunchPath)}
+          data-terminal-launch={terminalLaunchPath}
+          className="inline-flex min-h-9 shrink-0 items-center gap-2 rounded-md border border-[#17281f]/15 bg-white/70 px-3 text-xs font-medium text-[#17281f] transition hover:border-[#17281f]/30"
+        >
+          <TerminalIcon className="h-4 w-4" aria-hidden="true" />
+          Open terminal context
+        </button>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        {codingGates.map((gate) => (
+          <div key={gate.id} className={`rounded-md border p-3 ${gateTone(gate.status)}`}>
+            <div className="flex items-center gap-2">
+              {gate.status === "pass" ? (
+                <CheckCircle2Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+              ) : (
+                <CircleDashedIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+              )}
+              <p className="text-xs font-semibold">{CODING_GATE_LABELS[gate.id]}</p>
+            </div>
+            <p className="mt-1 text-xs leading-5 opacity-80">{gate.message}</p>
+            {gate.remediation && (
+              <p className="mt-2 inline-flex items-center gap-1 text-xs font-medium">
+                <ExternalLinkIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                {gate.remediation}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/shell/src/hooks/useAgentCredentialStatus.ts
+++ b/shell/src/hooks/useAgentCredentialStatus.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type AgentId = "claude" | "codex" | "hermes";
+
+export interface AgentCredentialSummary {
+  agent: AgentId;
+  status: "available" | "missing" | "expired" | "revoked" | "failed" | "not_applicable";
+  coordinationRole: "system_agent" | "core_agent" | "coding_specialist" | "assistant_specialist";
+  workflows: string[];
+  degradedWorkflows: string[];
+  verifiedAt: string | null;
+  nextAction: string | null;
+}
+
+export interface AgentCredentialStatus {
+  systemAgent: "hermes";
+  activeAgents: AgentId[];
+  agents: AgentCredentialSummary[];
+  routingExplanation: string;
+}
+
+export function useAgentCredentialStatus() {
+  const mountedRef = useRef(false);
+  const [status, setStatus] = useState<AgentCredentialStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    void fetch("/api/agents/credentials/status", {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("credential status request failed");
+        return await res.json() as AgentCredentialStatus;
+      })
+      .then((body) => {
+        if (!mountedRef.current) return;
+        setStatus(body);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        console.warn("[onboarding] agent credential status failed:", err instanceof Error ? err.message : String(err));
+        if (mountedRef.current) setError("Could not load agent setup");
+      });
+  }, []);
+
+  const verify = useCallback((agent: Exclude<AgentId, "hermes">) => {
+    void fetch(`/api/agents/credentials/${agent}/verify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(10_000),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("credential verification failed");
+        return await res.json();
+      })
+      .then(() => {
+        if (!mountedRef.current) return;
+        refresh();
+      })
+      .catch((err: unknown) => {
+        console.warn("[onboarding] agent credential verification failed:", err instanceof Error ? err.message : String(err));
+        if (mountedRef.current) setError("Could not verify agent credential");
+      });
+  }, [refresh]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    refresh();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [refresh]);
+
+  return { status, error, refresh, verify };
+}

--- a/shell/src/hooks/useOnboarding.ts
+++ b/shell/src/hooks/useOnboarding.ts
@@ -47,6 +47,7 @@ export interface OnboardingReadiness {
   gates: ReadinessGateSummary[];
   systemAgent: "hermes";
   activeAgents: Array<"claude" | "codex" | "hermes">;
+  codingHandoffStatus: "idle" | "running" | "needs_input" | "ready" | "failed" | null;
 }
 
 const READINESS_STATUSES = new Set<ReadinessGateSummary["status"]>(["unknown", "checking", "pass", "fail", "blocked", "skipped"]);
@@ -55,6 +56,7 @@ const READINESS_OWNERS = new Set<ReadinessGateSummary["owner"]>(["user", "operat
 const READINESS_OVERALL_STATUSES = new Set<OnboardingReadiness["overallStatus"]>(["ready", "degraded", "blocked", "checking"]);
 const ONBOARDING_GOAL_IDS = new Set<OnboardingGoalId>(["coding", "app_building", "company_brain", "assistant"]);
 const AGENT_IDS = new Set<OnboardingReadiness["activeAgents"][number]>(["claude", "codex", "hermes"]);
+const CODING_HANDOFF_STATUSES = new Set<NonNullable<OnboardingReadiness["codingHandoffStatus"]>>(["idle", "running", "needs_input", "ready", "failed"]);
 
 function isOnboardingGoalId(value: unknown): value is OnboardingGoalId {
   return typeof value === "string" && ONBOARDING_GOAL_IDS.has(value as OnboardingGoalId);
@@ -78,6 +80,13 @@ export function coerceReadinessOverallStatus(value: unknown): OnboardingReadines
   return typeof value === "string" && READINESS_OVERALL_STATUSES.has(value as OnboardingReadiness["overallStatus"])
     ? value as OnboardingReadiness["overallStatus"]
     : "degraded";
+}
+
+function coerceCodingHandoffStatus(value: unknown): OnboardingReadiness["codingHandoffStatus"] {
+  if (typeof value !== "string") return null;
+  return CODING_HANDOFF_STATUSES.has(value as NonNullable<OnboardingReadiness["codingHandoffStatus"]>)
+    ? value as NonNullable<OnboardingReadiness["codingHandoffStatus"]>
+    : null;
 }
 
 export function coerceReadinessGates(value: unknown): ReadinessGateSummary[] {
@@ -133,6 +142,7 @@ export function coerceReadinessResponse(value: unknown): OnboardingReadiness {
     gates: coerceReadinessGates(candidate.gates),
     systemAgent: "hermes",
     activeAgents: coerceActiveAgents(candidate.activeAgents),
+    codingHandoffStatus: coerceCodingHandoffStatus(candidate.codingHandoffStatus),
   };
 }
 
@@ -495,6 +505,7 @@ export function useOnboarding(): OnboardingHook {
             gates: coerceReadinessGates(msg.checklist),
             systemAgent: current.systemAgent,
             activeAgents: current.activeAgents,
+            codingHandoffStatus: current.codingHandoffStatus,
           };
         });
         break;

--- a/shell/src/lib/app-launch.ts
+++ b/shell/src/lib/app-launch.ts
@@ -55,3 +55,8 @@ export function canonicalAppLaunchPath(app: GatewayAppEntryLike): string | null 
   if (!app.path) return null;
   return app.path.replace(/^\/files\//, "");
 }
+
+export function terminalContextLaunchPath(projectSlug: string | null | undefined): string {
+  if (!projectSlug || !SAFE_ICON_SLUG.test(projectSlug)) return "__terminal__";
+  return `__terminal__?project=${encodeURIComponent(projectSlug)}`;
+}

--- a/shell/src/lib/app-launch.ts
+++ b/shell/src/lib/app-launch.ts
@@ -57,6 +57,6 @@ export function canonicalAppLaunchPath(app: GatewayAppEntryLike): string | null 
 }
 
 export function terminalContextLaunchPath(projectSlug: string | null | undefined): string {
-  if (!projectSlug || !SAFE_ICON_SLUG.test(projectSlug)) return "__terminal__";
+  if (!projectSlug || !SAFE_APP_SLUG.test(projectSlug)) return "__terminal__";
   return `__terminal__?project=${encodeURIComponent(projectSlug)}`;
 }

--- a/specs/082-paid-beta-readiness/tasks.md
+++ b/specs/082-paid-beta-readiness/tasks.md
@@ -89,20 +89,20 @@
 
 ### Tests First
 
-- [ ] T030 [P] [US2] Write failing tests for GitHub/project setup gates in `tests/gateway/activation-readiness-routes.test.ts`
-- [ ] T031 [P] [US2] Write failing duplicate-run prevention test in `tests/gateway/symphony-workflow.test.ts`
-- [ ] T032 [P] [US2] Write failing e2e coding setup path test in `tests/e2e/onboarding-activation.spec.ts`
+- [X] T030 [P] [US2] Write failing tests for GitHub/project setup gates in `tests/gateway/activation-readiness-routes.test.ts`
+- [X] T031 [P] [US2] Write failing duplicate-run prevention test in `tests/gateway/symphony-workflow.test.ts`
+- [X] T032 [P] [US2] Write failing e2e coding setup path test in `tests/e2e/onboarding-activation.spec.ts`
 
 ### Implementation
 
-- [ ] T033 [US2] Add coding setup gate derivation for GitHub, project, issue source, Symphony, and terminal in `packages/gateway/src/onboarding/readiness-service.ts`
-- [ ] T034 [US2] Add coding setup option aggregation from Symphony and project manager in `packages/gateway/src/onboarding/coding-setup.ts`
-- [ ] T035 [US2] Add duplicate coding task guard using Symphony run state in `packages/gateway/src/symphony/orchestrator.ts`
-- [ ] T036 [US2] Extend Symphony route responses with safe active-agents and handoff status in `packages/gateway/src/symphony/routes.ts`
-- [ ] T037 [P] [US2] Create coding setup connector component in `shell/src/components/onboarding/CodingSetupPanel.tsx`
-- [ ] T038 [P] [US2] Create coding handoff summary component in `shell/src/components/onboarding/CodingHandoffSummary.tsx`
-- [ ] T039 [US2] Wire coding setup panel into onboarding goal flow in `shell/src/components/OnboardingScreen.tsx`
-- [ ] T040 [US2] Add terminal context launch action for coding setup in `shell/src/lib/app-launch.ts`
+- [X] T033 [US2] Add coding setup gate derivation for GitHub, project, issue source, Symphony, and terminal in `packages/gateway/src/onboarding/readiness-service.ts`
+- [X] T034 [US2] Add coding setup option aggregation from Symphony and project manager in `packages/gateway/src/onboarding/coding-setup.ts`
+- [X] T035 [US2] Add duplicate coding task guard using Symphony run state in `packages/gateway/src/symphony/orchestrator.ts`
+- [X] T036 [US2] Extend Symphony route responses with safe active-agents and handoff status in `packages/gateway/src/symphony/routes.ts`
+- [X] T037 [P] [US2] Create coding setup connector component in `shell/src/components/onboarding/CodingSetupPanel.tsx`
+- [X] T038 [P] [US2] Create coding handoff summary component in `shell/src/components/onboarding/CodingHandoffSummary.tsx`
+- [X] T039 [US2] Wire coding setup panel into onboarding goal flow in `shell/src/components/OnboardingScreen.tsx`
+- [X] T040 [US2] Add terminal context launch action for coding setup in `shell/src/lib/app-launch.ts`
 
 **Checkpoint**: US2 can pass without assistant/company-brain/support workflows.
 

--- a/specs/082-paid-beta-readiness/tasks.md
+++ b/specs/082-paid-beta-readiness/tasks.md
@@ -116,20 +116,20 @@
 
 ### Tests First
 
-- [ ] T041 [P] [US3] Write failing credential status route tests in `tests/gateway/agent-credential-status.test.ts`
-- [ ] T042 [P] [US3] Write failing no-Claude Hermes golden-path e2e test in `tests/e2e/onboarding-activation.spec.ts`
-- [ ] T043 [P] [US3] Write failing credential upgrade and connected-Hermes continuity tests in `tests/gateway/onboarding-activation.test.ts`
+- [X] T041 [P] [US3] Write failing credential status route tests in `tests/gateway/agent-credential-status.test.ts`
+- [X] T042 [P] [US3] Write failing no-Claude Hermes golden-path e2e test in `tests/e2e/onboarding-activation.spec.ts`
+- [X] T043 [P] [US3] Write failing credential upgrade and connected-Hermes continuity tests in `tests/gateway/onboarding-activation.test.ts`
 
 ### Implementation
 
-- [ ] T044 [US3] Implement agent credential status service in `packages/gateway/src/onboarding/agent-credential-status.ts`
-- [ ] T045 [US3] Add agent credential status and verify routes in `packages/gateway/src/onboarding/agent-credential-routes.ts`
-- [ ] T046 [US3] Wire agent credential routes in `packages/gateway/src/server.ts`
-- [ ] T047 [US3] Add Hermes system-agent continuity gate and additive active-agent routing explanation in `packages/gateway/src/onboarding/readiness-service.ts`
-- [ ] T048 [P] [US3] Create agent credential panel in `shell/src/components/onboarding/AgentCredentialPanel.tsx`
-- [ ] T049 [US3] Add agent credential hook in `shell/src/hooks/useAgentCredentialStatus.ts`
-- [ ] T050 [US3] Wire agent panel into onboarding and coding run status in `shell/src/components/OnboardingScreen.tsx`
-- [ ] T051 [US3] Add safe Claude/Codex/Hermes display copy in `shell/src/components/onboarding/AgentCredentialPanel.tsx`
+- [X] T044 [US3] Implement agent credential status service in `packages/gateway/src/onboarding/agent-credential-status.ts`
+- [X] T045 [US3] Add agent credential status and verify routes in `packages/gateway/src/onboarding/agent-credential-routes.ts`
+- [X] T046 [US3] Wire agent credential routes in `packages/gateway/src/server.ts`
+- [X] T047 [US3] Add Hermes system-agent continuity gate and additive active-agent routing explanation in `packages/gateway/src/onboarding/readiness-service.ts`
+- [X] T048 [P] [US3] Create agent credential panel in `shell/src/components/onboarding/AgentCredentialPanel.tsx`
+- [X] T049 [US3] Add agent credential hook in `shell/src/hooks/useAgentCredentialStatus.ts`
+- [X] T050 [US3] Wire agent panel into onboarding and coding run status in `shell/src/components/OnboardingScreen.tsx`
+- [X] T051 [US3] Add safe Claude/Codex/Hermes display copy in `shell/src/components/onboarding/AgentCredentialPanel.tsx`
 
 **Checkpoint**: No-Claude onboarding is useful, and connecting Claude/Codex does not disable Hermes.
 

--- a/tests/e2e/onboarding-activation.spec.ts
+++ b/tests/e2e/onboarding-activation.spec.ts
@@ -1,6 +1,16 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("onboarding activation", () => {
+  async function openManualSetup(page: import("@playwright/test").Page) {
+    await page.route("**/api/settings/onboarding-status", async (route) => {
+      await route.fulfill({ json: { complete: false } });
+    });
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "Matrix OS" })).toBeVisible();
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByRole("button", { name: /Set up manually/i }).click();
+  }
+
   test("shows goal-based activation and readiness copy", async ({ page }) => {
     await page.route("**/api/onboarding/readiness", async (route) => {
       await route.fulfill({
@@ -38,18 +48,100 @@ test.describe("onboarding activation", () => {
         },
       });
     });
-    await page.route("**/api/settings/onboarding-status", async (route) => {
-      await route.fulfill({ json: { complete: false } });
-    });
 
-    await page.goto("/");
-
-    await expect(page.getByRole("heading", { name: "Matrix OS" })).toBeVisible();
-    await page.getByRole("button", { name: "Continue" }).click();
-    await page.getByRole("button", { name: /Set up manually/i }).click();
+    await openManualSetup(page);
     await expect(page.getByText("Set up Matrix around the work you want done first.")).toBeVisible();
     await page.getByRole("button", { name: /Code with Matrix/i }).click();
     await expect(page.getByText("Required · Connect GitHub")).toBeVisible();
     await expect(page.getByText("Hermes is available as the Matrix system agent")).toBeVisible();
+  });
+
+  test("handholds the coding setup path with project, issue source, Symphony, and terminal context", async ({ page }) => {
+    await page.route("**/api/onboarding/readiness", async (route) => {
+      await route.fulfill({
+        json: {
+          overallStatus: "degraded",
+          goals: [
+            { id: "coding", selected: true, label: "Code with Matrix", description: "Ship code" },
+          ],
+          gates: [
+            {
+              id: "github.connected",
+              category: "integration",
+              criticality: "goal_required",
+              status: "pass",
+              message: "GitHub is connected for coding workflows",
+              remediation: null,
+              owner: "user",
+              lastCheckedAt: "2026-05-23T00:00:00.000Z",
+            },
+            {
+              id: "project.selected",
+              category: "coding",
+              criticality: "goal_required",
+              status: "pass",
+              message: "Matrix OS is selected for coding work",
+              remediation: null,
+              owner: "user",
+              lastCheckedAt: "2026-05-23T00:00:00.000Z",
+            },
+            {
+              id: "issue_source.selected",
+              category: "coding",
+              criticality: "goal_required",
+              status: "fail",
+              message: "Choose a task source before starting coding work",
+              remediation: "Connect Linear or choose a Matrix task list",
+              owner: "user",
+              lastCheckedAt: "2026-05-23T00:00:00.000Z",
+            },
+            {
+              id: "symphony.ready",
+              category: "coding",
+              criticality: "goal_required",
+              status: "pass",
+              message: "Symphony is ready to dispatch coding work",
+              remediation: null,
+              owner: "matrix",
+              lastCheckedAt: "2026-05-23T00:00:00.000Z",
+            },
+            {
+              id: "terminal.ready",
+              category: "coding",
+              criticality: "goal_required",
+              status: "checking",
+              message: "Terminal context is ready to open for Matrix OS",
+              remediation: "Open the Matrix terminal for the selected project",
+              owner: "matrix",
+              lastCheckedAt: "2026-05-23T00:00:00.000Z",
+            },
+          ],
+          systemAgent: "hermes",
+          activeAgents: ["codex", "hermes"],
+          agents: [],
+        },
+      });
+    });
+    await page.route("**/api/onboarding/goals", async (route) => {
+      await route.fulfill({
+        json: {
+          goalIds: ["coding"],
+          steps: [
+            { id: "github.connected", required: true, title: "Connect GitHub", unlocks: ["coding"] },
+            { id: "project.selected", required: true, title: "Choose a project", unlocks: ["coding"] },
+            { id: "issue_source.selected", required: true, title: "Choose task source", unlocks: ["coding"] },
+            { id: "symphony.ready", required: true, title: "Prepare Symphony", unlocks: ["coding"] },
+            { id: "terminal.ready", required: false, title: "Open terminal context", unlocks: ["coding"] },
+          ],
+        },
+      });
+    });
+
+    await openManualSetup(page);
+
+    await expect(page.getByText("Coding setup")).toBeVisible();
+    await expect(page.getByText("GitHub connected")).toBeVisible();
+    await expect(page.getByText("Choose task source")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Open terminal context/i })).toBeVisible();
   });
 });

--- a/tests/e2e/onboarding-activation.spec.ts
+++ b/tests/e2e/onboarding-activation.spec.ts
@@ -144,4 +144,53 @@ test.describe("onboarding activation", () => {
     await expect(page.getByText("Choose task source")).toBeVisible();
     await expect(page.getByRole("button", { name: /Open terminal context/i })).toBeVisible();
   });
+
+  test("explains no-Claude onboarding with Hermes still active", async ({ page }) => {
+    await page.route("**/api/onboarding/readiness", async (route) => {
+      await route.fulfill({
+        json: {
+          overallStatus: "degraded",
+          goals: [
+            { id: "app_building", selected: true, label: "Build apps", description: "Build Matrix apps" },
+          ],
+          gates: [
+            {
+              id: "hermes.continuity",
+              category: "agent",
+              criticality: "release_critical",
+              status: "pass",
+              message: "Hermes remains available as the Matrix system agent",
+              remediation: null,
+              owner: "matrix",
+              lastCheckedAt: "2026-05-23T00:00:00.000Z",
+            },
+          ],
+          systemAgent: "hermes",
+          activeAgents: ["hermes"],
+          agents: [],
+        },
+      });
+    });
+    await page.route("**/api/agents/credentials/status", async (route) => {
+      await route.fulfill({
+        json: {
+          systemAgent: "hermes",
+          activeAgents: ["hermes"],
+          routingExplanation: "Hermes remains the Matrix system agent even when Claude and Codex are not connected.",
+          agents: [
+            { agent: "claude", status: "missing", coordinationRole: "core_agent", workflows: ["core_agent"], degradedWorkflows: ["core_agent"], verifiedAt: null, nextAction: "Connect Claude to enable the core agent path" },
+            { agent: "codex", status: "missing", coordinationRole: "coding_specialist", workflows: ["coding"], degradedWorkflows: ["coding"], verifiedAt: null, nextAction: "Connect Codex for optional coding support" },
+            { agent: "hermes", status: "available", coordinationRole: "system_agent", workflows: ["app_building", "assistant", "integrations"], degradedWorkflows: [], verifiedAt: null, nextAction: null },
+          ],
+        },
+      });
+    });
+
+    await page.goto("/");
+
+    await expect(page.getByText("Agent setup")).toBeVisible();
+    await expect(page.getByText("Hermes is the Matrix system agent")).toBeVisible();
+    await expect(page.getByText("Claude is not connected")).toBeVisible();
+    await expect(page.getByText("Hermes remains the Matrix system agent even when Claude and Codex are not connected.")).toBeVisible();
+  });
 });

--- a/tests/e2e/onboarding-activation.spec.ts
+++ b/tests/e2e/onboarding-activation.spec.ts
@@ -22,11 +22,11 @@ test.describe("onboarding activation", () => {
           ],
           gates: [
             {
-              id: "hermes.available",
+              id: "hermes.continuity",
               category: "agent",
               criticality: "release_critical",
               status: "pass",
-              message: "Hermes is available as the Matrix system agent",
+              message: "Hermes remains available as the Matrix system agent",
               remediation: null,
               owner: "matrix",
               lastCheckedAt: null,
@@ -186,7 +186,7 @@ test.describe("onboarding activation", () => {
       });
     });
 
-    await page.goto("/");
+    await openManualSetup(page);
 
     await expect(page.getByText("Agent setup")).toBeVisible();
     await expect(page.getByText("Hermes is the Matrix system agent")).toBeVisible();

--- a/tests/gateway/activation-readiness-routes.test.ts
+++ b/tests/gateway/activation-readiness-routes.test.ts
@@ -85,6 +85,7 @@ describe("activation readiness routes", () => {
       remediation: "Open the Matrix terminal for the selected project",
     });
     expect(body.activeAgents).toEqual(["codex", "hermes"]);
+    expect(body.codingHandoffStatus).toBe("running");
   });
 
   it("leaves assistant capability approval indeterminate until an integration is connected", async () => {

--- a/tests/gateway/activation-readiness-routes.test.ts
+++ b/tests/gateway/activation-readiness-routes.test.ts
@@ -37,9 +37,54 @@ describe("activation readiness routes", () => {
     expect(body.steps.map((step: { id: string }) => step.id)).toEqual(expect.arrayContaining([
       "github.connected",
       "project.selected",
+      "issue_source.selected",
       "integrations.capabilities",
       "hermes.available",
     ]));
+  });
+
+  it("derives coding setup gates from GitHub, project, issue source, Symphony, and terminal state", async () => {
+    const { service } = createTestReadinessService(undefined, {
+      codingSetup: {
+        githubConnected: true,
+        selectedProject: { slug: "matrix-os", name: "Matrix OS" },
+        issueSourceConfigured: true,
+        symphonyReady: true,
+        terminalReady: false,
+        activeAgents: ["codex", "hermes"],
+        handoffStatus: "running",
+      },
+    });
+    const app = createReadinessRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(jsonRequest("/goals", { goalIds: ["coding"] }));
+    const res = await app.request("/readiness");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const gatesById = new Map(body.gates.map((gate: { id: string }) => [gate.id, gate]));
+    expect(gatesById.get("github.connected")).toMatchObject({
+      status: "pass",
+      message: "GitHub is connected for coding workflows",
+      remediation: null,
+    });
+    expect(gatesById.get("project.selected")).toMatchObject({
+      status: "pass",
+      message: "Matrix OS is selected for coding work",
+    });
+    expect(gatesById.get("issue_source.selected")).toMatchObject({
+      status: "pass",
+      message: "A task source is connected for coding work",
+    });
+    expect(gatesById.get("symphony.ready")).toMatchObject({
+      status: "pass",
+      message: "Symphony is ready to dispatch coding work",
+    });
+    expect(gatesById.get("terminal.ready")).toMatchObject({
+      status: "fail",
+      remediation: "Open the Matrix terminal for the selected project",
+    });
+    expect(body.activeAgents).toEqual(["codex", "hermes"]);
   });
 
   it("leaves assistant capability approval indeterminate until an integration is connected", async () => {

--- a/tests/gateway/activation-readiness-routes.test.ts
+++ b/tests/gateway/activation-readiness-routes.test.ts
@@ -21,7 +21,8 @@ describe("activation readiness routes", () => {
     const body = await res.json();
     expect(body.systemAgent).toBe("hermes");
     expect(body.activeAgents).toContain("hermes");
-    expect(body.gates.some((gate: { id: string }) => gate.id === "hermes.available")).toBe(true);
+    expect(body.gates.some((gate: { id: string }) => gate.id === "hermes.available")).toBe(false);
+    expect(body.gates.some((gate: { id: string }) => gate.id === "hermes.continuity")).toBe(true);
     expect(JSON.stringify(body)).not.toMatch(/secret|token|postgres|\/home\//i);
   });
 
@@ -39,7 +40,7 @@ describe("activation readiness routes", () => {
       "project.selected",
       "issue_source.selected",
       "integrations.capabilities",
-      "hermes.available",
+      "hermes.continuity",
     ]));
   });
 
@@ -86,6 +87,35 @@ describe("activation readiness routes", () => {
     });
     expect(body.activeAgents).toEqual(["codex", "hermes"]);
     expect(body.codingHandoffStatus).toBe("running");
+  });
+
+  it("keeps GitHub gated until a coding project is selected", async () => {
+    const { service } = createTestReadinessService(undefined, {
+      codingSetup: {
+        githubConnected: true,
+        selectedProject: null,
+        issueSourceConfigured: true,
+        symphonyReady: true,
+        terminalReady: false,
+        activeAgents: ["codex", "hermes"],
+        handoffStatus: "idle",
+      },
+    });
+    const app = createReadinessRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(jsonRequest("/goals", { goalIds: ["coding"] }));
+    const body = await (await app.request("/readiness")).json();
+    const gatesById = new Map(body.gates.map((gate: { id: string }) => [gate.id, gate]));
+
+    expect(gatesById.get("github.connected")).toMatchObject({
+      status: "unknown",
+      message: "GitHub is not connected yet",
+      remediation: "Connect GitHub to unlock coding workflows",
+    });
+    expect(gatesById.get("project.selected")).toMatchObject({
+      status: "fail",
+      remediation: "Choose a repository or project",
+    });
   });
 
   it("leaves assistant capability approval indeterminate until an integration is connected", async () => {

--- a/tests/gateway/agent-credential-status.test.ts
+++ b/tests/gateway/agent-credential-status.test.ts
@@ -50,6 +50,65 @@ describe("agent credential status routes", () => {
     expect(body.routingExplanation).toContain("Hermes remains");
   });
 
+  it("verifies Claude or Codex through an actual owner-scoped probe when configured", async () => {
+    const service = createAgentCredentialStatusService({
+      now: () => new Date("2026-05-23T00:00:00.000Z"),
+      probeAgent: async (ownerId, agent) => ({
+        available: ownerId === testPrincipal.userId && agent === "codex",
+      }),
+    });
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const verified = await app.request(post("/credentials/codex/verify"));
+
+    expect(verified.status).toBe(200);
+    await expect(verified.json()).resolves.toMatchObject({
+      agent: "codex",
+      status: "available",
+      verifiedAt: "2026-05-23T00:00:00.000Z",
+    });
+    const body = await (await app.request("/credentials/status")).json();
+    expect(body.activeAgents).toEqual(["codex", "hermes"]);
+  });
+
+  it("derives probed agent availability live instead of caching verified state", async () => {
+    let codexAvailable = true;
+    const service = createAgentCredentialStatusService({
+      now: () => new Date("2026-05-23T00:00:00.000Z"),
+      probeAgent: async (_ownerId, agent) => ({
+        available: agent === "codex" && codexAvailable,
+      }),
+    });
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    expect((await app.request(post("/credentials/codex/verify"))).status).toBe(200);
+    codexAvailable = false;
+
+    const body = await (await app.request("/credentials/status")).json();
+    expect(body.activeAgents).toEqual(["hermes"]);
+    expect(body.agents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ agent: "codex", status: "missing", verifiedAt: null }),
+    ]));
+  });
+
+  it("does not mark an agent available when the login probe fails", async () => {
+    const service = createAgentCredentialStatusService({
+      probeAgent: async () => ({ available: false }),
+    });
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const verified = await app.request(post("/credentials/claude/verify"));
+
+    expect(verified.status).toBe(409);
+    expect(await verified.json()).toEqual({
+      error: "agent_auth_required",
+      message: "Log in to the agent before verifying credentials",
+      retryable: true,
+    });
+    const body = await (await app.request("/credentials/status")).json();
+    expect(body.activeAgents).toEqual(["hermes"]);
+  });
+
   it("accepts bodyless verify requests because no payload is required", async () => {
     const service = createAgentCredentialStatusService({
       now: () => new Date("2026-05-23T00:00:00.000Z"),

--- a/tests/gateway/agent-credential-status.test.ts
+++ b/tests/gateway/agent-credential-status.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { createAgentCredentialRoutes } from "../../packages/gateway/src/onboarding/agent-credential-routes.js";
+import { createAgentCredentialStatusService } from "../../packages/gateway/src/onboarding/agent-credential-status.js";
+import { testPrincipal } from "../helpers/activation-readiness.js";
+
+function post(path: string, body: unknown = {}): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("agent credential status routes", () => {
+  it("keeps Hermes active when Claude and Codex are missing", async () => {
+    const service = createAgentCredentialStatusService();
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request("/credentials/status");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.systemAgent).toBe("hermes");
+    expect(body.activeAgents).toEqual(["hermes"]);
+    expect(body.agents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ agent: "hermes", status: "available", coordinationRole: "system_agent" }),
+      expect.objectContaining({ agent: "claude", status: "missing", coordinationRole: "core_agent" }),
+      expect.objectContaining({ agent: "codex", status: "missing", coordinationRole: "coding_specialist" }),
+    ]));
+    expect(JSON.stringify(body)).not.toMatch(/secret|token|anthropic|\/home\//i);
+  });
+
+  it("upgrades connected Claude or Codex without removing Hermes", async () => {
+    const service = createAgentCredentialStatusService({
+      now: () => new Date("2026-05-23T00:00:00.000Z"),
+    });
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const verified = await app.request(post("/credentials/codex/verify"));
+    expect(verified.status).toBe(200);
+    await expect(verified.json()).resolves.toMatchObject({
+      agent: "codex",
+      status: "available",
+      verifiedAt: "2026-05-23T00:00:00.000Z",
+    });
+
+    const body = await (await app.request("/credentials/status")).json();
+    expect(body.systemAgent).toBe("hermes");
+    expect(body.activeAgents).toEqual(["codex", "hermes"]);
+    expect(body.routingExplanation).toContain("Hermes remains");
+  });
+
+  it("accepts bodyless verify requests because no payload is required", async () => {
+    const service = createAgentCredentialStatusService({
+      now: () => new Date("2026-05-23T00:00:00.000Z"),
+    });
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const verified = await app.request(new Request("http://localhost/credentials/claude/verify", {
+      method: "POST",
+    }));
+
+    expect(verified.status).toBe(200);
+    await expect(verified.json()).resolves.toMatchObject({
+      agent: "claude",
+      status: "available",
+      verifiedAt: "2026-05-23T00:00:00.000Z",
+    });
+  });
+
+  it("rejects invalid agent identifiers with a generic error", async () => {
+    const service = createAgentCredentialStatusService();
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/credentials/not-a-real-agent/verify"));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "invalid_request",
+      message: "Request is invalid",
+      retryable: false,
+    });
+  });
+
+  it("does not verify Hermes because it is already the system agent", async () => {
+    const service = createAgentCredentialStatusService();
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/credentials/hermes/verify"));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: "invalid_request",
+      retryable: false,
+    });
+  });
+
+  it("rejects oversized verify bodies before credential updates", async () => {
+    const service = createAgentCredentialStatusService();
+    const app = createAgentCredentialRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(new Request("http://localhost/credentials/claude/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: "x".repeat(2048) }),
+    }));
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({
+      error: "payload_too_large",
+      message: "Request body is too large",
+      retryable: false,
+    });
+    await expect((await app.request("/credentials/status")).json()).resolves.toMatchObject({
+      activeAgents: ["hermes"],
+    });
+  });
+});

--- a/tests/gateway/coding-setup.test.ts
+++ b/tests/gateway/coding-setup.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCodingSetupProvider } from "../../packages/gateway/src/onboarding/coding-setup.js";
+
+describe("coding setup aggregation", () => {
+  it("uses the selected project to derive GitHub readiness without listing projects twice", async () => {
+    const listMatrixProjects = vi.fn(async () => [{
+      slug: "matrix-os",
+      name: "Matrix OS",
+      repositoryUrl: "https://github.com/hamedmp/matrix-os",
+    }]);
+    const hasGitHubConnection = vi.fn(async (_ownerId, selectedProject) =>
+      selectedProject?.repositoryUrl?.startsWith("https://github.com/") ?? false
+    );
+    const provider = createCodingSetupProvider({
+      hasGitHubConnection,
+      listMatrixProjects,
+      getSelectedProjectSlug: async () => "matrix-os",
+      hasIssueSource: async () => true,
+      getSymphonyStatus: async () => ({
+        ready: true,
+        runStatuses: ["running"],
+        activeAgents: ["codex"],
+      }),
+      hasTerminalContext: async () => true,
+    });
+
+    const status = await provider.getCodingSetup("owner_123");
+
+    expect(status.githubConnected).toBe(true);
+    expect(listMatrixProjects).toHaveBeenCalledTimes(1);
+    expect(hasGitHubConnection).toHaveBeenCalledWith("owner_123", expect.objectContaining({
+      slug: "matrix-os",
+      repositoryUrl: "https://github.com/hamedmp/matrix-os",
+    }));
+  });
+});

--- a/tests/gateway/onboarding-activation.test.ts
+++ b/tests/gateway/onboarding-activation.test.ts
@@ -36,7 +36,7 @@ describe("activation readiness contracts", () => {
   it("validates goal request boundaries", () => {
     expect(() => SelectGoalsRequestSchema.parse({ goalIds: ["coding"] })).not.toThrow();
     expect(() => SelectGoalsRequestSchema.parse({ goalIds: [] })).toThrow();
-    expect(() => SelectGoalsRequestSchema.parse({ goalIds: ["paid-beta-readiness"] })).toThrow();
+    expect(() => SelectGoalsRequestSchema.parse({ goalIds: ["unknown-launch-slug"] })).toThrow();
   });
 
   it("merges shared setup step unlocks across selected goals", () => {

--- a/tests/gateway/onboarding-activation.test.ts
+++ b/tests/gateway/onboarding-activation.test.ts
@@ -92,7 +92,7 @@ describe("activation readiness contracts", () => {
   });
 
   it("merges shared setup step unlocks across selected goals", () => {
-    const hermesStep = stepsForGoals(["app_building", "assistant"]).find((step) => step.id === "hermes.available");
+    const hermesStep = stepsForGoals(["app_building", "assistant"]).find((step) => step.id === "hermes.continuity");
 
     expect(hermesStep).toMatchObject({
       required: true,

--- a/tests/gateway/onboarding-activation.test.ts
+++ b/tests/gateway/onboarding-activation.test.ts
@@ -24,6 +24,58 @@ describe("activation readiness contracts", () => {
     });
   });
 
+  it("keeps Hermes additive when Claude or Codex credentials are connected later", async () => {
+    const { service } = createTestReadinessService(undefined, {
+      agentCredentials: {
+        systemAgent: "hermes",
+        activeAgents: ["claude", "codex", "hermes"],
+        routingExplanation: "Hermes remains the Matrix system agent while Claude and Codex add specialist paths.",
+        agents: [
+          {
+            agent: "claude",
+            status: "available",
+            coordinationRole: "core_agent",
+            workflows: ["core_agent"],
+            degradedWorkflows: [],
+            verifiedAt: "2026-05-23T00:00:00.000Z",
+            nextAction: null,
+          },
+          {
+            agent: "codex",
+            status: "available",
+            coordinationRole: "coding_specialist",
+            workflows: ["coding"],
+            degradedWorkflows: [],
+            verifiedAt: "2026-05-23T00:00:00.000Z",
+            nextAction: null,
+          },
+          {
+            agent: "hermes",
+            status: "available",
+            coordinationRole: "system_agent",
+            workflows: ["app_building", "assistant", "integrations", "company_brain"],
+            degradedWorkflows: [],
+            verifiedAt: null,
+            nextAction: null,
+          },
+        ],
+      },
+    });
+
+    const readiness = await service.getReadiness(testPrincipal.userId);
+
+    expect(readiness.systemAgent).toBe("hermes");
+    expect(readiness.activeAgents).toEqual(["claude", "codex", "hermes"]);
+    expect(readiness.agents.find((agent) => agent.agent === "hermes")).toMatchObject({
+      status: "available",
+      coordinationRole: "system_agent",
+    });
+    expect(readiness.gates.find((gate) => gate.id === "hermes.continuity")).toMatchObject({
+      status: "pass",
+      message: "Hermes remains available as the Matrix system agent",
+    });
+  });
+
   it("derives degraded status until release-critical gates pass", async () => {
     const { service } = createTestReadinessService();
 

--- a/tests/gateway/symphony-routes.test.ts
+++ b/tests/gateway/symphony-routes.test.ts
@@ -212,6 +212,89 @@ describe("Matrix Symphony routes", () => {
     expect(JSON.stringify(body)).not.toContain("/home/matrix");
   });
 
+  it("only exposes onboarding-supported active agents in status", async () => {
+    const snapshot = structuredClone(baseSnapshot);
+    snapshot.runs = [
+      ...snapshot.runs,
+      {
+        ...snapshot.runs[0]!,
+        id: "run_opencode",
+        agent: "opencode",
+        status: "running",
+      },
+      {
+        ...snapshot.runs[0]!,
+        id: "run_pi",
+        agent: "pi",
+        status: "handoff",
+      },
+    ];
+    const { app } = deps(snapshot);
+
+    const res = await app.request("/status");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.activeAgents).toEqual(["codex"]);
+  });
+
+  it("reports failed when the latest handoff-relevant run failed", async () => {
+    const snapshot = structuredClone(baseSnapshot);
+    snapshot.runs = [{
+      ...snapshot.runs[0]!,
+      status: "failed",
+      lastEvent: "Agent failed",
+      updatedAt: "2026-05-14T00:00:00.000Z",
+    }, {
+      ...snapshot.runs[0]!,
+      id: "run_done",
+      status: "completed",
+      lastEvent: "Older handoff",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    }];
+    const { app } = deps(snapshot);
+
+    const res = await app.request("/status");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      handoff: {
+        status: "failed",
+        failedCount: 1,
+        nextAction: "Review the failure summary and retry when ready",
+      },
+    });
+  });
+
+  it("prioritizes blocked handoffs over ready handoffs", async () => {
+    const snapshot = structuredClone(baseSnapshot);
+    snapshot.runs = [{
+      ...snapshot.runs[0]!,
+      status: "handoff",
+      lastEvent: "Ready for review",
+      updatedAt: "2026-05-14T00:00:00.000Z",
+    }, {
+      ...snapshot.runs[0]!,
+      id: "run_blocked",
+      status: "blocked",
+      lastEvent: "Needs input",
+      updatedAt: "2026-05-14T00:01:00.000Z",
+    }];
+    const { app } = deps(snapshot);
+
+    const res = await app.request("/status");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      handoff: {
+        status: "needs_input",
+        readyCount: 1,
+        needsInputCount: 1,
+        nextAction: "Open the blocked run and provide input",
+      },
+    });
+  });
+
   it("saves config and never returns the Linear secret", async () => {
     const { app, repository, statusHub } = deps(structuredClone(baseSnapshot));
 

--- a/tests/gateway/symphony-routes.test.ts
+++ b/tests/gateway/symphony-routes.test.ts
@@ -176,6 +176,42 @@ describe("Matrix Symphony routes", () => {
     expect(JSON.stringify(body)).not.toContain("lin_api");
   });
 
+  it("returns active agent and current handoff summaries without worktree paths", async () => {
+    const snapshot = structuredClone(baseSnapshot);
+    snapshot.runs = [
+      ...snapshot.runs,
+      {
+        id: "run_done",
+        installationId: "sym_user_123",
+        ticketExternalId: "issue_2",
+        ticketIdentifier: "MAT-2",
+        ticketTitle: "Ship setup",
+        status: "completed",
+        attempt: 1,
+        agent: "claude",
+        projectSlug: "matrix-os",
+        claimKey: "linear:issue_2",
+        worktreePath: "/home/matrix/home/projects/matrix-os/.worktrees/wt_done",
+        lastEvent: "Pull request ready",
+        updatedAt: "2026-05-13T00:00:00.000Z",
+        finishedAt: "2026-05-13T00:05:00.000Z",
+      },
+    ];
+    const { app } = deps(snapshot);
+
+    const res = await app.request("/status");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.activeAgents).toEqual(expect.arrayContaining(["codex", "claude"]));
+    expect(body.handoff).toMatchObject({
+      status: "running",
+      runningCount: 1,
+      nextAction: "Monitor the active Symphony run",
+    });
+    expect(JSON.stringify(body)).not.toContain("/home/matrix");
+  });
+
   it("saves config and never returns the Linear secret", async () => {
     const { app, repository, statusHub } = deps(structuredClone(baseSnapshot));
 

--- a/tests/gateway/symphony-workflow.test.ts
+++ b/tests/gateway/symphony-workflow.test.ts
@@ -153,7 +153,12 @@ describe("Symphony workflow", () => {
         ) ?? null,
       listRuns: async (_ownerId, input) =>
         Array.from(runs.values()).filter((run) => !input?.status || run.status === input.status),
-      appendEvent: async (_ownerId, event) => ({ id: "evt_1", createdAt: "2026-05-23T00:00:00.000Z", ...event }),
+      appendEvent: async (_ownerId, event) => {
+        if (event.type === "symphony.run.reused") {
+          throw new Error("event log unavailable");
+        }
+        return { id: "evt_1", createdAt: "2026-05-23T00:00:00.000Z", ...event };
+      },
       recordPoll: async (_ownerId, at) => {
         snapshot.lastPollAt = at;
       },

--- a/tests/gateway/symphony-workflow.test.ts
+++ b/tests/gateway/symphony-workflow.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { atomicWriteJson } from "../../packages/gateway/src/state-ops.js";
 import { composeSymphonyPrompt, loadWorkflowContract, SymphonyWorkflowError } from "../../packages/gateway/src/symphony/prompt.js";
+import { createMatrixSymphonyOrchestrator } from "../../packages/gateway/src/symphony/orchestrator.js";
+import type { SymphonyRepository } from "../../packages/gateway/src/symphony/repository.js";
+import type { SymphonyRun, SymphonySnapshot } from "../../packages/gateway/src/symphony/contracts.js";
 
 describe("Symphony workflow", () => {
   let homePath: string;
@@ -82,5 +85,99 @@ describe("Symphony workflow", () => {
     expect(prompt).toContain("MAT-1");
     expect(prompt).toContain("Build Matrix Symphony");
     expect(prompt).not.toContain("lin_api");
+  });
+
+  it("reuses an active claim when a duplicate run appears before dispatch starts", async () => {
+    const snapshot: SymphonySnapshot = {
+      installation: {
+        id: "sym_user_123",
+        ownerId: "user_123",
+        enabled: true,
+        projectSlug: "matrix-os",
+        credentialConfigured: true,
+        pollIntervalMs: 30_000,
+        maxConcurrentAgents: 1,
+        defaultAgent: "codex",
+        authorizedOperators: [],
+        createdAt: "2026-05-23T00:00:00.000Z",
+        updatedAt: "2026-05-23T00:00:00.000Z",
+      },
+      rule: {
+        installationId: "sym_user_123",
+        teamId: "team_1",
+        teamKey: "MAT",
+        requiredLabels: ["symphony"],
+        activeStates: ["Todo"],
+        terminalStates: ["Done"],
+        assigneeIds: [],
+        updatedAt: "2026-05-23T00:00:00.000Z",
+      },
+      runs: [],
+      events: [],
+      lastPollAt: null,
+    };
+    const runs = new Map<string, SymphonyRun>();
+    const repository: SymphonyRepository = {
+      bootstrap: async () => undefined,
+      resolveOwnerIdForOperator: async (userId) => userId,
+      listEnabledOwnerIds: async () => ["user_123"],
+      getSnapshot: async () => ({ ...snapshot, runs: Array.from(runs.values()) }),
+      saveConfig: async () => {
+        throw new Error("not used");
+      },
+      setCredentialConfigured: async () => undefined,
+      setEnabled: async () => snapshot.installation!,
+      upsertRun: async (_ownerId, run) => {
+        const duplicate: SymphonyRun = {
+          ...run,
+          id: "run_existing",
+          status: "running",
+          sessionId: "sess_existing",
+          worktreeId: "wt_existing",
+          lastEvent: "Agent session started elsewhere",
+        };
+        runs.set(duplicate.id, duplicate);
+        throw new Error("duplicate claim");
+      },
+      updateRun: async (_ownerId, runId, patch) => {
+        const current = runs.get(runId);
+        if (!current) return null;
+        const next = { ...current, ...patch };
+        runs.set(runId, next);
+        return next;
+      },
+      getRun: async (_ownerId, runId) => runs.get(runId) ?? null,
+      findActiveRunByClaim: async (_ownerId, claimKey) =>
+        Array.from(runs.values()).find((run) =>
+          run.claimKey === claimKey && ["queued", "running", "retrying", "blocked"].includes(run.status)
+        ) ?? null,
+      listRuns: async (_ownerId, input) =>
+        Array.from(runs.values()).filter((run) => !input?.status || run.status === input.status),
+      appendEvent: async (_ownerId, event) => ({ id: "evt_1", createdAt: "2026-05-23T00:00:00.000Z", ...event }),
+      recordPoll: async (_ownerId, at) => {
+        snapshot.lastPollAt = at;
+      },
+    };
+    const worktreeManager = { createWorktree: vi.fn() };
+    const agentSessionManager = { startSession: vi.fn(), killSession: vi.fn() };
+    const orchestrator = createMatrixSymphonyOrchestrator({
+      homePath,
+      repository,
+      credentialStore: { readLinearCredential: vi.fn(async () => "lin_api_secret"), hasLinearCredential: vi.fn(), writeLinearCredential: vi.fn(), deleteLinearCredential: vi.fn() },
+      linearSource: {
+        previewTickets: vi.fn(async () => ({
+          truncated: false,
+          tickets: [{ externalId: "issue_1", identifier: "MAT-1", title: "Build", stateName: "Todo", labels: ["symphony"] }],
+        })),
+      },
+      worktreeManager,
+      agentSessionManager,
+    });
+
+    await expect(orchestrator.poll("user_123")).resolves.toMatchObject({ dispatched: 1, skipped: 0 });
+
+    expect(worktreeManager.createWorktree).not.toHaveBeenCalled();
+    expect(agentSessionManager.startSession).not.toHaveBeenCalled();
+    expect(Array.from(runs.values())).toHaveLength(1);
   });
 });

--- a/tests/helpers/activation-readiness.ts
+++ b/tests/helpers/activation-readiness.ts
@@ -1,15 +1,23 @@
 import { createReadinessService } from "../../packages/gateway/src/onboarding/readiness-service.js";
 import { InMemoryReadinessRepository } from "../../packages/gateway/src/onboarding/readiness-repository.js";
+import type { CodingSetupProvider, CodingSetupStatus } from "../../packages/gateway/src/onboarding/coding-setup.js";
 
 export const testPrincipal = {
   userId: "user_activation_test",
   source: "dev-default" as const,
 };
 
-export function createTestReadinessService(now: Date = new Date("2026-05-23T00:00:00.000Z")) {
+export function createTestReadinessService(
+  now: Date = new Date("2026-05-23T00:00:00.000Z"),
+  options: { codingSetup?: CodingSetupStatus } = {},
+) {
   const repository = new InMemoryReadinessRepository();
+  const codingSetup: CodingSetupProvider | undefined = options.codingSetup
+    ? { getCodingSetup: async () => options.codingSetup! }
+    : undefined;
   const service = createReadinessService({
     repository,
+    codingSetup,
     now: () => now,
   });
   return { repository, service };

--- a/tests/helpers/activation-readiness.ts
+++ b/tests/helpers/activation-readiness.ts
@@ -1,6 +1,8 @@
 import { createReadinessService } from "../../packages/gateway/src/onboarding/readiness-service.js";
 import { InMemoryReadinessRepository } from "../../packages/gateway/src/onboarding/readiness-repository.js";
 import type { CodingSetupProvider, CodingSetupStatus } from "../../packages/gateway/src/onboarding/coding-setup.js";
+import type { AgentCredentialStatusResponse } from "../../packages/gateway/src/onboarding/activation-contracts.js";
+import type { AgentCredentialStatusService } from "../../packages/gateway/src/onboarding/agent-credential-status.js";
 
 export const testPrincipal = {
   userId: "user_activation_test",
@@ -9,15 +11,26 @@ export const testPrincipal = {
 
 export function createTestReadinessService(
   now: Date = new Date("2026-05-23T00:00:00.000Z"),
-  options: { codingSetup?: CodingSetupStatus } = {},
+  options: { codingSetup?: CodingSetupStatus; agentCredentials?: AgentCredentialStatusResponse } = {},
 ) {
   const repository = new InMemoryReadinessRepository();
   const codingSetup: CodingSetupProvider | undefined = options.codingSetup
     ? { getCodingSetup: async () => options.codingSetup! }
     : undefined;
+  const agentCredentials: AgentCredentialStatusService | undefined = options.agentCredentials
+    ? {
+      getStatus: async () => options.agentCredentials!,
+      verifyAgent: async (_ownerId, agent) => ({
+        agent,
+        status: "available",
+        verifiedAt: now.toISOString(),
+      }),
+    }
+    : undefined;
   const service = createReadinessService({
     repository,
     codingSetup,
+    agentCredentials,
     now: () => now,
   });
   return { repository, service };

--- a/tests/helpers/activation-readiness.ts
+++ b/tests/helpers/activation-readiness.ts
@@ -3,6 +3,7 @@ import { InMemoryReadinessRepository } from "../../packages/gateway/src/onboardi
 import type { CodingSetupProvider, CodingSetupStatus } from "../../packages/gateway/src/onboarding/coding-setup.js";
 import type { AgentCredentialStatusResponse } from "../../packages/gateway/src/onboarding/activation-contracts.js";
 import type { AgentCredentialStatusService } from "../../packages/gateway/src/onboarding/agent-credential-status.js";
+import type { IntegrationCapabilityService } from "../../packages/gateway/src/onboarding/integration-capabilities.js";
 
 export const testPrincipal = {
   userId: "user_activation_test",
@@ -11,13 +12,18 @@ export const testPrincipal = {
 
 export function createTestReadinessService(
   now: Date = new Date("2026-05-23T00:00:00.000Z"),
-  options: { codingSetup?: CodingSetupStatus; agentCredentials?: AgentCredentialStatusResponse } = {},
+  options: {
+    codingSetup?: CodingSetupStatus;
+    agentCredentials?: AgentCredentialStatusResponse;
+    agentCredentialService?: AgentCredentialStatusService;
+    integrationCapabilityService?: IntegrationCapabilityService;
+  } = {},
 ) {
   const repository = new InMemoryReadinessRepository();
   const codingSetup: CodingSetupProvider | undefined = options.codingSetup
     ? { getCodingSetup: async () => options.codingSetup! }
     : undefined;
-  const agentCredentials: AgentCredentialStatusService | undefined = options.agentCredentials
+  const agentCredentials: AgentCredentialStatusService | undefined = options.agentCredentialService ?? (options.agentCredentials
     ? {
       getStatus: async () => options.agentCredentials!,
       verifyAgent: async (_ownerId, agent) => ({
@@ -26,11 +32,12 @@ export function createTestReadinessService(
         verifiedAt: now.toISOString(),
       }),
     }
-    : undefined;
+    : undefined);
   const service = createReadinessService({
     repository,
     codingSetup,
     agentCredentials,
+    integrationCapabilities: options.integrationCapabilityService,
     now: () => now,
   });
   return { repository, service };

--- a/tests/shell/agent-credential-panel.test.tsx
+++ b/tests/shell/agent-credential-panel.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentCredentialPanel } from "../../shell/src/components/onboarding/AgentCredentialPanel.js";
+
+describe("AgentCredentialPanel", () => {
+  it("shows credential verification errors", () => {
+    render(
+      <AgentCredentialPanel
+        status={null}
+        error="Could not verify agent credential"
+        onVerify={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Could not verify agent credential")).toBeTruthy();
+  });
+});

--- a/tests/shell/app-launch.test.ts
+++ b/tests/shell/app-launch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { canonicalAppLaunchPath, iconUrlForSlug } from "../../shell/src/lib/app-launch.js";
+import { canonicalAppLaunchPath, iconUrlForSlug, terminalContextLaunchPath } from "../../shell/src/lib/app-launch.js";
 
 describe("app launch helpers", () => {
   it("canonicalizes runtime apps to slug routes before iframe rendering", () => {
@@ -30,5 +30,11 @@ describe("app launch helpers", () => {
     expect(iconUrlForSlug("folder")).toBe("/icons/folder.svg");
     expect(iconUrlForSlug("chat")).toBe("/icons/chat.svg");
     expect(iconUrlForSlug("game-center")).toBe("/icons/game-center.png");
+  });
+
+  it("keeps project context for valid project slugs that are not icon slugs", () => {
+    expect(terminalContextLaunchPath("matrix_os")).toBe("__terminal__?project=matrix_os");
+    expect(terminalContextLaunchPath("org/matrix_os")).toBe("__terminal__?project=org%2Fmatrix_os");
+    expect(terminalContextLaunchPath("../matrix")).toBe("__terminal__");
   });
 });

--- a/tests/shell/use-onboarding-readiness.test.ts
+++ b/tests/shell/use-onboarding-readiness.test.ts
@@ -35,6 +35,7 @@ describe("coerceReadinessResponse", () => {
       gates: "bad",
       systemAgent: "claude",
       activeAgents: undefined,
+      codingHandoffStatus: "running",
     });
 
     expect(readiness).toMatchObject({
@@ -43,6 +44,7 @@ describe("coerceReadinessResponse", () => {
       gates: [],
       systemAgent: "hermes",
       activeAgents: ["hermes"],
+      codingHandoffStatus: "running",
     });
   });
 });


### PR DESCRIPTION
Stack: 3/8

## Summary

- Adds coding setup gates for GitHub/project/task source/Symphony/terminal context.
- Adds duplicate Symphony run prevention and safe handoff status.
- Adds Claude/Codex credential status while keeping Hermes as the always-on Matrix system agent.

## Tests

- `bun run typecheck`
- `bun run check:patterns` (0 violations, existing warning-only baseline)
- `bun run test -- --reporter=dot` (459 files passed, 3 skipped; 4,752 tests passed, 20 skipped)
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bWF0cml4b3MudGVzdCQ= pnpm --dir shell build`
- `pnpm --dir shell exec playwright test ../tests/e2e/onboarding-activation.spec.ts ../tests/e2e/onboarding-visual.spec.ts --config ../tests/e2e/playwright.config.ts` (8 passed)

## Review/Monitoring

- Stacked PR base: `082-premium-onboarding`
- Greptile and CI must pass before merging.

## Invariants

- Source of truth: Symphony run state remains canonical for active coding work; credential status is additive readiness metadata.
- Lock/transaction scope: duplicate-run prevention checks and records the active run through the existing Symphony orchestration path.
- Acceptable orphan states: failed or missing Claude/Codex credentials degrade specialist availability but do not disable Hermes.
- Auth source of truth: credential and Symphony setup routes stay behind owner gateway authentication.
- Deferred scope: integration action approvals and company-brain workflows land later.