### PR TITLE
feat(onboarding): approve assistant integration capabilities

### DIFF
--- a/packages/gateway/src/onboarding/activation-contracts.ts
+++ b/packages/gateway/src/onboarding/activation-contracts.ts
@@ -148,6 +148,79 @@ export const VerifyAgentCredentialResponseSchema = z.object({
 });
 export type VerifyAgentCredentialResponse = z.infer<typeof VerifyAgentCredentialResponseSchema>;
 
+export const IntegrationCapabilityStatusSchema = z.enum([
+  "connect_required",
+  "connected",
+  "approved",
+  "revoked",
+  "failed",
+  "unavailable",
+]);
+export type IntegrationCapabilityStatus = z.infer<typeof IntegrationCapabilityStatusSchema>;
+
+export const IntegrationProviderSchema = z.enum([
+  "github",
+  "calendar",
+  "email",
+  "messaging",
+  "publishing",
+]);
+export type IntegrationProvider = z.infer<typeof IntegrationProviderSchema>;
+
+export const IntegrationCapabilitySummarySchema = z.object({
+  id: ReadinessGateIdSchema,
+  provider: IntegrationProviderSchema,
+  capability: z.string().trim().min(1).max(80),
+  status: IntegrationCapabilityStatusSchema,
+  approvedAgents: z.array(AgentIdSchema).max(3),
+  requiresApprovalPerAction: z.boolean(),
+});
+export type IntegrationCapabilitySummary = z.infer<typeof IntegrationCapabilitySummarySchema>;
+
+export const IntegrationCapabilitiesResponseSchema = z.object({
+  capabilities: z.array(IntegrationCapabilitySummarySchema),
+});
+export type IntegrationCapabilitiesResponse = z.infer<typeof IntegrationCapabilitiesResponseSchema>;
+
+export const ApproveCapabilityRequestSchema = z.object({
+  agent: AgentIdSchema,
+  approved: z.boolean(),
+});
+export type ApproveCapabilityRequest = z.infer<typeof ApproveCapabilityRequestSchema>;
+
+export const CapabilityParamsSchema = z.object({
+  capabilityId: ReadinessGateIdSchema,
+});
+export type CapabilityParams = z.infer<typeof CapabilityParamsSchema>;
+
+export const ApproveCapabilityResponseSchema = z.object({
+  capabilityId: ReadinessGateIdSchema,
+  agent: AgentIdSchema,
+  status: IntegrationCapabilityStatusSchema,
+});
+export type ApproveCapabilityResponse = z.infer<typeof ApproveCapabilityResponseSchema>;
+
+export const AgentActionStatusSchema = z.enum([
+  "requested",
+  "approved",
+  "completed",
+  "failed",
+  "denied",
+]);
+export type AgentActionStatus = z.infer<typeof AgentActionStatusSchema>;
+
+export const AgentActionSummarySchema = z.object({
+  id: ReadinessGateIdSchema,
+  agent: AgentIdSchema,
+  capability: ReadinessGateIdSchema,
+  status: AgentActionStatusSchema,
+  summary: SafeDisplayTextSchema,
+  target: SafeDisplayTextSchema,
+  createdAt: ActivationDateSchema,
+  completedAt: ActivationDateSchema.nullable(),
+});
+export type AgentActionSummary = z.infer<typeof AgentActionSummarySchema>;
+
 export const ReadinessOverallStatusSchema = z.enum([
   "ready",
   "degraded",

--- a/packages/gateway/src/onboarding/activation-contracts.ts
+++ b/packages/gateway/src/onboarding/activation-contracts.ts
@@ -225,8 +225,8 @@ export const RecordAgentActionRequestSchema = z.object({
   agent: AgentIdSchema,
   capability: ReadinessGateIdSchema,
   status: AgentActionStatusSchema,
-  summary: z.string().trim().min(1).max(500),
-  target: z.string().trim().min(1).max(240),
+  summary: SafeDisplayTextSchema,
+  target: SafeDisplayTextSchema,
 });
 export type RecordAgentActionRequest = z.infer<typeof RecordAgentActionRequestSchema>;
 

--- a/packages/gateway/src/onboarding/activation-contracts.ts
+++ b/packages/gateway/src/onboarding/activation-contracts.ts
@@ -221,6 +221,20 @@ export const AgentActionSummarySchema = z.object({
 });
 export type AgentActionSummary = z.infer<typeof AgentActionSummarySchema>;
 
+export const RecordAgentActionRequestSchema = z.object({
+  agent: AgentIdSchema,
+  capability: ReadinessGateIdSchema,
+  status: AgentActionStatusSchema,
+  summary: z.string().trim().min(1).max(500),
+  target: z.string().trim().min(1).max(240),
+});
+export type RecordAgentActionRequest = z.infer<typeof RecordAgentActionRequestSchema>;
+
+export const AgentActionsResponseSchema = z.object({
+  actions: z.array(AgentActionSummarySchema).max(500),
+});
+export type AgentActionsResponse = z.infer<typeof AgentActionsResponseSchema>;
+
 export const ReadinessOverallStatusSchema = z.enum([
   "ready",
   "degraded",

--- a/packages/gateway/src/onboarding/agent-action-audit.ts
+++ b/packages/gateway/src/onboarding/agent-action-audit.ts
@@ -32,13 +32,20 @@ export function createAgentActionAuditService(options: {
   const now = options.now ?? (() => new Date());
   const actions = new Map<string, AgentActionSummary[]>();
 
-  function actionsFor(ownerId: string): AgentActionSummary[] {
+  function touchActions(ownerId: string, ownerActions: AgentActionSummary[]): AgentActionSummary[] {
+    actions.delete(ownerId);
+    actions.set(ownerId, ownerActions);
+    return ownerActions;
+  }
+
+  function findActions(ownerId: string): AgentActionSummary[] | null {
     const existing = actions.get(ownerId);
-    if (existing) {
-      actions.delete(ownerId);
-      actions.set(ownerId, existing);
-      return existing;
-    }
+    return existing ? touchActions(ownerId, existing) : null;
+  }
+
+  function ensureActions(ownerId: string): AgentActionSummary[] {
+    const existing = actions.get(ownerId);
+    if (existing) return touchActions(ownerId, existing);
     if (actions.size >= MAX_ACTION_OWNERS) {
       const oldestKey = actions.keys().next().value as string | undefined;
       if (oldestKey) actions.delete(oldestKey);
@@ -66,14 +73,14 @@ export function createAgentActionAuditService(options: {
       createdAt: timestamp,
       completedAt: ["completed", "failed", "denied"].includes(input.status) ? timestamp : null,
     };
-    const ownerActions = actionsFor(ownerId);
+    const ownerActions = ensureActions(ownerId);
     ownerActions.push(action);
     while (ownerActions.length > MAX_ACTIONS) ownerActions.shift();
     return action;
   }
 
   async function listActions(ownerId: string): Promise<AgentActionSummary[]> {
-    return [...actionsFor(ownerId)];
+    return [...(findActions(ownerId) ?? [])];
   }
 
   return { recordAction, listActions };

--- a/packages/gateway/src/onboarding/agent-action-audit.ts
+++ b/packages/gateway/src/onboarding/agent-action-audit.ts
@@ -7,7 +7,7 @@ import type {
 
 const MAX_ACTIONS = 500;
 const MAX_ACTION_OWNERS = 512;
-const UNSAFE_DISPLAY = /(secret|token|postgres|pipedream|anthropic|\bsk[-_][a-z0-9]+|\/home\/|\/tmp\/|database)/i;
+const UNSAFE_DISPLAY = /(secret|token|password|bearer\s+[a-z0-9._~+/=-]+|postgres|pipedream|anthropic|\bsk[-_][a-z0-9]+|\/home\/|\/tmp\/)/i;
 
 export interface AgentActionAuditService {
   recordAction(ownerId: string, input: {
@@ -21,7 +21,7 @@ export interface AgentActionAuditService {
 }
 
 function safeDisplay(value: string, fallback: string): string {
-  const trimmed = value.trim().slice(0, 220);
+  const trimmed = value.trim().slice(0, 240);
   if (!trimmed || UNSAFE_DISPLAY.test(trimmed)) return fallback;
   return trimmed;
 }

--- a/packages/gateway/src/onboarding/agent-action-audit.ts
+++ b/packages/gateway/src/onboarding/agent-action-audit.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AgentActionStatus,
+  AgentActionSummary,
+  AgentId,
+} from "./activation-contracts.js";
+
+const MAX_ACTIONS = 500;
+const UNSAFE_DISPLAY = /(secret|token|postgres|pipedream|anthropic|\bsk[-_][a-z0-9]+|\/home\/|\/tmp\/|database)/i;
+
+export interface AgentActionAuditService {
+  recordAction(ownerId: string, input: {
+    agent: AgentId;
+    capability: string;
+    status: AgentActionStatus;
+    summary: string;
+    target: string;
+  }): Promise<AgentActionSummary>;
+  listActions(ownerId: string): Promise<AgentActionSummary[]>;
+}
+
+function safeDisplay(value: string, fallback: string): string {
+  const trimmed = value.trim().slice(0, 220);
+  if (!trimmed || UNSAFE_DISPLAY.test(trimmed)) return fallback;
+  return trimmed;
+}
+
+export function createAgentActionAuditService(options: {
+  now?: () => Date;
+} = {}): AgentActionAuditService {
+  const now = options.now ?? (() => new Date());
+  const actions = new Map<string, AgentActionSummary[]>();
+
+  async function recordAction(ownerId: string, input: {
+    agent: AgentId;
+    capability: string;
+    status: AgentActionStatus;
+    summary: string;
+    target: string;
+  }): Promise<AgentActionSummary> {
+    const timestamp = now().toISOString();
+    const action: AgentActionSummary = {
+      id: `action.${randomUUID()}`,
+      agent: input.agent,
+      capability: input.capability,
+      status: input.status,
+      summary: safeDisplay(input.summary, "Agent action completed"),
+      target: safeDisplay(input.target, "Connected service"),
+      createdAt: timestamp,
+      completedAt: ["completed", "failed", "denied"].includes(input.status) ? timestamp : null,
+    };
+    const ownerActions = actions.get(ownerId) ?? [];
+    ownerActions.push(action);
+    while (ownerActions.length > MAX_ACTIONS) ownerActions.shift();
+    actions.set(ownerId, ownerActions);
+    return action;
+  }
+
+  async function listActions(ownerId: string): Promise<AgentActionSummary[]> {
+    return [...(actions.get(ownerId) ?? [])];
+  }
+
+  return { recordAction, listActions };
+}

--- a/packages/gateway/src/onboarding/agent-action-audit.ts
+++ b/packages/gateway/src/onboarding/agent-action-audit.ts
@@ -6,6 +6,7 @@ import type {
 } from "./activation-contracts.js";
 
 const MAX_ACTIONS = 500;
+const MAX_ACTION_OWNERS = 512;
 const UNSAFE_DISPLAY = /(secret|token|postgres|pipedream|anthropic|\bsk[-_][a-z0-9]+|\/home\/|\/tmp\/|database)/i;
 
 export interface AgentActionAuditService {
@@ -31,6 +32,22 @@ export function createAgentActionAuditService(options: {
   const now = options.now ?? (() => new Date());
   const actions = new Map<string, AgentActionSummary[]>();
 
+  function actionsFor(ownerId: string): AgentActionSummary[] {
+    const existing = actions.get(ownerId);
+    if (existing) {
+      actions.delete(ownerId);
+      actions.set(ownerId, existing);
+      return existing;
+    }
+    if (actions.size >= MAX_ACTION_OWNERS) {
+      const oldestKey = actions.keys().next().value as string | undefined;
+      if (oldestKey) actions.delete(oldestKey);
+    }
+    const next: AgentActionSummary[] = [];
+    actions.set(ownerId, next);
+    return next;
+  }
+
   async function recordAction(ownerId: string, input: {
     agent: AgentId;
     capability: string;
@@ -49,15 +66,14 @@ export function createAgentActionAuditService(options: {
       createdAt: timestamp,
       completedAt: ["completed", "failed", "denied"].includes(input.status) ? timestamp : null,
     };
-    const ownerActions = actions.get(ownerId) ?? [];
+    const ownerActions = actionsFor(ownerId);
     ownerActions.push(action);
     while (ownerActions.length > MAX_ACTIONS) ownerActions.shift();
-    actions.set(ownerId, ownerActions);
     return action;
   }
 
   async function listActions(ownerId: string): Promise<AgentActionSummary[]> {
-    return [...(actions.get(ownerId) ?? [])];
+    return [...actionsFor(ownerId)];
   }
 
   return { recordAction, listActions };

--- a/packages/gateway/src/onboarding/integration-capabilities.ts
+++ b/packages/gateway/src/onboarding/integration-capabilities.ts
@@ -90,22 +90,57 @@ export function createIntegrationCapabilityService(options: {
     return connected;
   }
 
-  function getState(ownerId: string): OwnerCapabilityState {
-    const existing = states.get(ownerId);
-    if (existing) {
-      states.delete(ownerId);
-      states.set(ownerId, existing);
-      return existing;
+  function touchState(ownerId: string, state: OwnerCapabilityState): OwnerCapabilityState {
+    states.delete(ownerId);
+    if (states.size >= MAX_OWNERS) {
+      const oldestKey = states.keys().next().value as string | undefined;
+      if (oldestKey) states.delete(oldestKey);
     }
+    states.set(ownerId, state);
+    return state;
+  }
+
+  async function withOwnerMutation<T>(ownerId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = ownerMutationQueues.get(ownerId) ?? Promise.resolve();
+    const next = previous.catch((err: unknown) => {
+      console.warn("[integrations] previous capability approval mutation failed:", err instanceof Error ? err.message : String(err));
+    }).then(operation);
+    const tracked = next.catch((err: unknown) => {
+      console.warn("[integrations] capability approval mutation failed:", err instanceof Error ? err.message : String(err));
+    });
+    ownerMutationQueues.delete(ownerId);
+    if (ownerMutationQueues.size >= MAX_OWNERS) {
+      const oldestKey = ownerMutationQueues.keys().next().value as string | undefined;
+      if (oldestKey) ownerMutationQueues.delete(oldestKey);
+    }
+    ownerMutationQueues.set(ownerId, tracked);
+    try {
+      return await next;
+    } finally {
+      if (ownerMutationQueues.get(ownerId) === tracked) ownerMutationQueues.delete(ownerId);
+    }
+  }
+
+  function findState(ownerId: string): OwnerCapabilityState | null {
+    const existing = states.get(ownerId);
+    return existing ? touchState(ownerId, existing) : null;
+  }
+
+  function ensureState(ownerId: string): OwnerCapabilityState {
+    const existing = states.get(ownerId);
+    if (existing) return touchState(ownerId, existing);
     const next = { approved: {} };
     return touchState(ownerId, next);
   }
 
   async function listCapabilities(ownerId: string): Promise<IntegrationCapabilitiesResponse> {
-    const state = getState(ownerId);
+    const state = findState(ownerId);
     const connected = await connectedCapabilitiesFor(ownerId);
     const capabilities = registryBackedCapabilities(connected).map((capability) => {
-      const approvedAgents = state.approved[capability.id] ?? [];
+      const approvedAgents = capability.status === "connected" ? state?.approved[capability.id] ?? [] : [];
+      if (state && capability.status !== "connected" && state.approved[capability.id]?.length) {
+        state.approved[capability.id] = [];
+      }
       return {
         ...capability,
         status: approvedAgents.length > 0 ? "approved" as const : capability.status,
@@ -136,12 +171,12 @@ export function createIntegrationCapabilityService(options: {
     if (approved && capability.status === "connect_required") {
       throw new ActivationRouteError("capability_not_connected", "Connect the integration before approving agent access", { status: 409 });
     }
-    const state = getState(ownerId);
+    const state = ensureState(ownerId);
     const current = new Set(state.approved[capabilityId] ?? []);
     if (approved) current.add(agent);
     else current.delete(agent);
     state.approved[capabilityId] = Array.from(current);
-    const nextStatus = current.size > 0 ? "approved" : capability.status;
+    const nextStatus = current.size > 0 && capability.status === "connected" ? "approved" : capability.status;
     options.onChange?.(ownerId);
     return {
       capabilityId,

--- a/packages/gateway/src/onboarding/integration-capabilities.ts
+++ b/packages/gateway/src/onboarding/integration-capabilities.ts
@@ -165,6 +165,9 @@ export function createIntegrationCapabilityService(options: {
   }
 
   async function withOwnerMutation<T>(ownerId: string, operation: () => Promise<T>): Promise<T> {
+    if (!ownerMutationQueues.has(ownerId) && ownerMutationQueues.size >= MAX_OWNERS) {
+      throw new ActivationRouteError("capability_queue_busy", "Capability approvals are busy; try again", { status: 503, retryable: true });
+    }
     const previous = ownerMutationQueues.get(ownerId) ?? Promise.resolve();
     const next = previous.catch((err: unknown) => {
       console.warn("[integrations] previous capability approval mutation failed:", err instanceof Error ? err.message : String(err));
@@ -172,11 +175,6 @@ export function createIntegrationCapabilityService(options: {
     const tracked = next.catch((err: unknown) => {
       console.warn("[integrations] capability approval mutation failed:", err instanceof Error ? err.message : String(err));
     });
-    ownerMutationQueues.delete(ownerId);
-    if (ownerMutationQueues.size >= MAX_OWNERS) {
-      const oldestKey = ownerMutationQueues.keys().next().value as string | undefined;
-      if (oldestKey) ownerMutationQueues.delete(oldestKey);
-    }
     ownerMutationQueues.set(ownerId, tracked);
     try {
       return await next;
@@ -217,10 +215,13 @@ export function createIntegrationCapabilityService(options: {
     const connected = await connectedCapabilitiesFor(ownerId);
     const capability = registryBackedCapabilities(connected).find((candidate) => candidate.id === capabilityId);
     if (!capability) return null;
+    if (!connected.has(capabilityId)) {
+      return { capabilityId, approvedAgents: [] };
+    }
     const state = await findState(ownerId);
     return {
       capabilityId,
-      approvedAgents: capability.status === "connected" ? state?.approved[capabilityId] ?? [] : [],
+      approvedAgents: state?.approved[capabilityId] ?? [],
     };
   }
 

--- a/packages/gateway/src/onboarding/integration-capabilities.ts
+++ b/packages/gateway/src/onboarding/integration-capabilities.ts
@@ -1,0 +1,150 @@
+import type {
+  AgentId,
+  ApproveCapabilityResponse,
+  IntegrationCapabilitySummary,
+  IntegrationCapabilitiesResponse,
+} from "./activation-contracts.js";
+import { ActivationRouteError } from "./activation-errors.js";
+import { SERVICE_REGISTRY } from "../integrations/registry.js";
+
+const MAX_OWNERS = 512;
+
+const LAUNCH_CAPABILITIES: IntegrationCapabilitySummary[] = [
+  {
+    id: "github.read_repository",
+    provider: "github",
+    capability: "read_repository",
+    status: "connect_required",
+    approvedAgents: [],
+    requiresApprovalPerAction: true,
+  },
+  {
+    id: "calendar.create_event",
+    provider: "calendar",
+    capability: "create_calendar_event",
+    status: "connect_required",
+    approvedAgents: [],
+    requiresApprovalPerAction: true,
+  },
+  {
+    id: "email.read_email",
+    provider: "email",
+    capability: "read_email",
+    status: "connect_required",
+    approvedAgents: [],
+    requiresApprovalPerAction: true,
+  },
+];
+
+export interface IntegrationCapabilityService {
+  listCapabilities(ownerId: string): Promise<IntegrationCapabilitiesResponse>;
+  getCapabilityApproval(ownerId: string, capabilityId: string): Promise<{ capabilityId: string; approvedAgents: AgentId[] } | null>;
+  setApproval(ownerId: string, capabilityId: string, agent: AgentId, approved: boolean): Promise<ApproveCapabilityResponse>;
+}
+
+interface OwnerCapabilityState {
+  approved: Record<string, AgentId[]>;
+}
+
+function registryBackedCapabilities(connectedCapabilityIds: Set<string>): IntegrationCapabilitySummary[] {
+  const registryHasGitHub = Boolean(SERVICE_REGISTRY.github);
+  const registryHasCalendar = Boolean(SERVICE_REGISTRY.google_calendar);
+  const registryHasEmail = Boolean(SERVICE_REGISTRY.gmail);
+  return LAUNCH_CAPABILITIES
+    .filter((capability) => {
+      if (capability.provider === "github") return registryHasGitHub;
+      if (capability.provider === "calendar") return registryHasCalendar;
+      if (capability.provider === "email") return registryHasEmail;
+      return true;
+    })
+    .map((capability) => ({
+      ...capability,
+      status: connectedCapabilityIds.has(capability.id) ? "connected" : capability.status,
+      approvedAgents: [],
+    }));
+}
+
+export function capabilityIdsForConnectedServices(serviceIds: Iterable<string>): string[] {
+  const capabilities = new Set<string>();
+  for (const serviceId of serviceIds) {
+    if (serviceId === "github") capabilities.add("github.read_repository");
+    if (serviceId === "google_calendar") capabilities.add("calendar.create_event");
+    if (serviceId === "gmail") capabilities.add("email.read_email");
+  }
+  return Array.from(capabilities);
+}
+
+export function createIntegrationCapabilityService(options: {
+  connectedCapabilityIds?: string[];
+  getConnectedCapabilityIds?: (ownerId: string) => Promise<string[]>;
+} = {}): IntegrationCapabilityService {
+  const states = new Map<string, OwnerCapabilityState>();
+  const ownerMutationQueues = new Map<string, Promise<unknown>>();
+  const connectedCapabilityIds = new Set(options.connectedCapabilityIds ?? []);
+
+  async function connectedCapabilitiesFor(ownerId: string): Promise<Set<string>> {
+    const connected = new Set(connectedCapabilityIds);
+    const dynamicConnected = await options.getConnectedCapabilityIds?.(ownerId);
+    for (const capabilityId of dynamicConnected ?? []) connected.add(capabilityId);
+    return connected;
+  }
+
+  function getState(ownerId: string): OwnerCapabilityState {
+    const existing = states.get(ownerId);
+    if (existing) {
+      states.delete(ownerId);
+      states.set(ownerId, existing);
+      return existing;
+    }
+    const next = { approved: {} };
+    return touchState(ownerId, next);
+  }
+
+  async function listCapabilities(ownerId: string): Promise<IntegrationCapabilitiesResponse> {
+    const state = getState(ownerId);
+    const connected = await connectedCapabilitiesFor(ownerId);
+    const capabilities = registryBackedCapabilities(connected).map((capability) => {
+      const approvedAgents = state.approved[capability.id] ?? [];
+      return {
+        ...capability,
+        status: approvedAgents.length > 0 ? "approved" as const : capability.status,
+        approvedAgents,
+      };
+    });
+    return { capabilities };
+  }
+
+  async function getCapabilityApproval(ownerId: string, capabilityId: string): Promise<{ capabilityId: string; approvedAgents: AgentId[] } | null> {
+    const connected = await connectedCapabilitiesFor(ownerId);
+    const capability = registryBackedCapabilities(connected).find((candidate) => candidate.id === capabilityId);
+    if (!capability) return null;
+    const state = await findState(ownerId);
+    return {
+      capabilityId,
+      approvedAgents: capability.status === "connected" ? state?.approved[capabilityId] ?? [] : [],
+    };
+  }
+
+  async function setApproval(ownerId: string, capabilityId: string, agent: AgentId, approved: boolean): Promise<ApproveCapabilityResponse> {
+    const connected = await connectedCapabilitiesFor(ownerId);
+    const capabilities = registryBackedCapabilities(connected);
+    if (!capabilities.some((capability) => capability.id === capabilityId)) {
+      throw new ActivationRouteError("capability_not_found", "Integration capability was not found", { status: 404 });
+    }
+    if (approved && capability.status === "connect_required") {
+      throw new ActivationRouteError("capability_not_connected", "Connect the integration before approving agent access", { status: 409 });
+    }
+    const state = getState(ownerId);
+    const current = new Set(state.approved[capabilityId] ?? []);
+    if (approved) current.add(agent);
+    else current.delete(agent);
+    state.approved[capabilityId] = Array.from(current);
+    return {
+      capabilityId,
+      agent,
+      status: approved ? "approved" : "connected",
+    };
+  }
+
+  return { listCapabilities, getCapabilityApproval, setApproval };
+}

--- a/packages/gateway/src/onboarding/integration-capabilities.ts
+++ b/packages/gateway/src/onboarding/integration-capabilities.ts
@@ -77,6 +77,7 @@ export function capabilityIdsForConnectedServices(serviceIds: Iterable<string>):
 export function createIntegrationCapabilityService(options: {
   connectedCapabilityIds?: string[];
   getConnectedCapabilityIds?: (ownerId: string) => Promise<string[]>;
+  onChange?: (ownerId: string) => void;
 } = {}): IntegrationCapabilityService {
   const states = new Map<string, OwnerCapabilityState>();
   const ownerMutationQueues = new Map<string, Promise<unknown>>();
@@ -128,7 +129,8 @@ export function createIntegrationCapabilityService(options: {
   async function setApproval(ownerId: string, capabilityId: string, agent: AgentId, approved: boolean): Promise<ApproveCapabilityResponse> {
     const connected = await connectedCapabilitiesFor(ownerId);
     const capabilities = registryBackedCapabilities(connected);
-    if (!capabilities.some((capability) => capability.id === capabilityId)) {
+    const capability = capabilities.find((candidate) => candidate.id === capabilityId);
+    if (!capability) {
       throw new ActivationRouteError("capability_not_found", "Integration capability was not found", { status: 404 });
     }
     if (approved && capability.status === "connect_required") {
@@ -139,10 +141,12 @@ export function createIntegrationCapabilityService(options: {
     if (approved) current.add(agent);
     else current.delete(agent);
     state.approved[capabilityId] = Array.from(current);
+    const nextStatus = current.size > 0 ? "approved" : capability.status;
+    options.onChange?.(ownerId);
     return {
       capabilityId,
       agent,
-      status: approved ? "approved" : "connected",
+      status: nextStatus,
     };
   }
 

--- a/packages/gateway/src/onboarding/integration-capabilities.ts
+++ b/packages/gateway/src/onboarding/integration-capabilities.ts
@@ -6,8 +6,10 @@ import type {
 } from "./activation-contracts.js";
 import { ActivationRouteError } from "./activation-errors.js";
 import { SERVICE_REGISTRY } from "../integrations/registry.js";
+import { atomicWriteJson, readJsonFile } from "../state-ops.js";
 
 const MAX_OWNERS = 512;
+const VALID_AGENTS = new Set<AgentId>(["claude", "codex", "hermes"]);
 
 const LAUNCH_CAPABILITIES: IntegrationCapabilitySummary[] = [
   {
@@ -46,6 +48,11 @@ interface OwnerCapabilityState {
   approved: Record<string, AgentId[]>;
 }
 
+interface StoredIntegrationCapabilityState {
+  version: 1;
+  owners: Record<string, OwnerCapabilityState>;
+}
+
 function registryBackedCapabilities(connectedCapabilityIds: Set<string>): IntegrationCapabilitySummary[] {
   const registryHasGitHub = Boolean(SERVICE_REGISTRY.github);
   const registryHasCalendar = Boolean(SERVICE_REGISTRY.google_calendar);
@@ -78,16 +85,73 @@ export function createIntegrationCapabilityService(options: {
   connectedCapabilityIds?: string[];
   getConnectedCapabilityIds?: (ownerId: string) => Promise<string[]>;
   onChange?: (ownerId: string) => void;
+  storagePath?: string;
 } = {}): IntegrationCapabilityService {
   const states = new Map<string, OwnerCapabilityState>();
   const ownerMutationQueues = new Map<string, Promise<unknown>>();
   const connectedCapabilityIds = new Set(options.connectedCapabilityIds ?? []);
+  let persistQueue: Promise<void> = Promise.resolve();
 
   async function connectedCapabilitiesFor(ownerId: string): Promise<Set<string>> {
     const connected = new Set(connectedCapabilityIds);
     const dynamicConnected = await options.getConnectedCapabilityIds?.(ownerId);
     for (const capabilityId of dynamicConnected ?? []) connected.add(capabilityId);
     return connected;
+  }
+
+  function normalizeState(value: unknown): OwnerCapabilityState | null {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const approved = (value as { approved?: unknown }).approved;
+    if (!approved || typeof approved !== "object" || Array.isArray(approved)) return null;
+    const next: OwnerCapabilityState = { approved: {} };
+    for (const [capabilityId, agents] of Object.entries(approved)) {
+      if (!LAUNCH_CAPABILITIES.some((capability) => capability.id === capabilityId) || !Array.isArray(agents)) continue;
+      next.approved[capabilityId] = agents.filter((agent): agent is AgentId =>
+        typeof agent === "string" && VALID_AGENTS.has(agent as AgentId)
+      );
+    }
+    return next;
+  }
+
+  async function readStoredOwners(): Promise<Record<string, OwnerCapabilityState>> {
+    if (!options.storagePath) return {};
+    try {
+      const stored = await readJsonFile<unknown>(options.storagePath);
+      if (!stored || typeof stored !== "object" || Array.isArray(stored)) return {};
+      const owners = (stored as { owners?: unknown }).owners;
+      if (!owners || typeof owners !== "object" || Array.isArray(owners)) return {};
+      const next: Record<string, OwnerCapabilityState> = {};
+      for (const [ownerId, value] of Object.entries(owners)) {
+        const state = normalizeState(value);
+        if (state) next[ownerId] = state;
+      }
+      return next;
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") return {};
+      console.warn("[integrations] capability approval load failed:", err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }
+
+  async function persistOwner(ownerId: string, state: OwnerCapabilityState | null): Promise<void> {
+    if (!options.storagePath) return;
+    const previousWrite = persistQueue.catch((err: unknown) => {
+      console.warn("[integrations] previous capability approval persist failed:", err instanceof Error ? err.message : String(err));
+    });
+    const write = previousWrite.then(async () => {
+      const owners = await readStoredOwners();
+      if (state && Object.values(state.approved).some((agents) => agents.length > 0)) {
+        owners[ownerId] = structuredClone(state);
+      } else {
+        delete owners[ownerId];
+      }
+      const stored: StoredIntegrationCapabilityState = { version: 1, owners };
+      await atomicWriteJson(options.storagePath!, stored);
+    });
+    persistQueue = write.catch((err: unknown) => {
+      console.warn("[integrations] capability approval persist failed:", err instanceof Error ? err.message : String(err));
+    });
+    await write;
   }
 
   function touchState(ownerId: string, state: OwnerCapabilityState): OwnerCapabilityState {
@@ -121,26 +185,25 @@ export function createIntegrationCapabilityService(options: {
     }
   }
 
-  function findState(ownerId: string): OwnerCapabilityState | null {
-    const existing = states.get(ownerId);
-    return existing ? touchState(ownerId, existing) : null;
-  }
-
-  function ensureState(ownerId: string): OwnerCapabilityState {
+  async function findState(ownerId: string): Promise<OwnerCapabilityState | null> {
     const existing = states.get(ownerId);
     if (existing) return touchState(ownerId, existing);
-    const next = { approved: {} };
+    const stored = (await readStoredOwners())[ownerId];
+    return stored ? ensureState(ownerId, stored) : null;
+  }
+
+  function ensureState(ownerId: string, initial?: OwnerCapabilityState): OwnerCapabilityState {
+    const existing = states.get(ownerId);
+    if (existing) return touchState(ownerId, existing);
+    const next = initial ?? { approved: {} };
     return touchState(ownerId, next);
   }
 
   async function listCapabilities(ownerId: string): Promise<IntegrationCapabilitiesResponse> {
-    const state = findState(ownerId);
+    const state = await findState(ownerId);
     const connected = await connectedCapabilitiesFor(ownerId);
     const capabilities = registryBackedCapabilities(connected).map((capability) => {
       const approvedAgents = capability.status === "connected" ? state?.approved[capability.id] ?? [] : [];
-      if (state && capability.status !== "connected" && state.approved[capability.id]?.length) {
-        state.approved[capability.id] = [];
-      }
       return {
         ...capability,
         status: approvedAgents.length > 0 ? "approved" as const : capability.status,
@@ -171,18 +234,34 @@ export function createIntegrationCapabilityService(options: {
     if (approved && capability.status === "connect_required") {
       throw new ActivationRouteError("capability_not_connected", "Connect the integration before approving agent access", { status: 409 });
     }
-    const state = ensureState(ownerId);
-    const current = new Set(state.approved[capabilityId] ?? []);
-    if (approved) current.add(agent);
-    else current.delete(agent);
-    state.approved[capabilityId] = Array.from(current);
-    const nextStatus = current.size > 0 && capability.status === "connected" ? "approved" : capability.status;
-    options.onChange?.(ownerId);
-    return {
-      capabilityId,
-      agent,
-      status: nextStatus,
-    };
+    return await withOwnerMutation(ownerId, async () => {
+      // Keep the read -> clone -> persist -> touch sequence inside the per-owner
+      // queue so concurrent approvals observe earlier writes before building nextState.
+      const existing = await findState(ownerId);
+      if (!approved && !existing) {
+        return {
+          capabilityId,
+          agent,
+          status: capability.status,
+        };
+      }
+      const nextState: OwnerCapabilityState = { approved: { ...(existing?.approved ?? {}) } };
+      const current = new Set(nextState.approved[capabilityId] ?? []);
+      if (approved) current.add(agent);
+      else current.delete(agent);
+      const nextAgents = Array.from(current);
+      if (nextAgents.length > 0) nextState.approved[capabilityId] = nextAgents;
+      else delete nextState.approved[capabilityId];
+      await persistOwner(ownerId, nextState);
+      touchState(ownerId, nextState);
+      const nextStatus = current.size > 0 && capability.status === "connected" ? "approved" : capability.status;
+      options.onChange?.(ownerId);
+      return {
+        capabilityId,
+        agent,
+        status: nextStatus,
+      };
+    });
   }
 
   return { listCapabilities, getCapabilityApproval, setApproval };

--- a/packages/gateway/src/onboarding/integration-capability-routes.ts
+++ b/packages/gateway/src/onboarding/integration-capability-routes.ts
@@ -1,0 +1,53 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import {
+  ApproveCapabilityRequestSchema,
+  CapabilityParamsSchema,
+} from "./activation-contracts.js";
+import { mapActivationError } from "./activation-errors.js";
+import type { IntegrationCapabilityService } from "./integration-capabilities.js";
+import {
+  requireRequestPrincipal,
+  type RequestPrincipal,
+} from "../request-principal.js";
+
+const INTEGRATION_CAPABILITY_BODY_LIMIT = 2048;
+
+export interface IntegrationCapabilityRouteDeps {
+  service: IntegrationCapabilityService;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+function jsonError(c: Context, err: unknown) {
+  const mapped = mapActivationError(err);
+  return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+}
+
+export function createIntegrationCapabilityRoutes(deps: IntegrationCapabilityRouteDeps): Hono {
+  const app = new Hono();
+  const limited = bodyLimit({ maxSize: INTEGRATION_CAPABILITY_BODY_LIMIT });
+  const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
+
+  app.get("/capabilities", async (c) => {
+    try {
+      const principal = principalFor(c);
+      return c.json(await deps.service.listCapabilities(principal.userId));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/capabilities/:capabilityId/approval", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      const { capabilityId } = CapabilityParamsSchema.parse({ capabilityId: c.req.param("capabilityId") });
+      const body = ApproveCapabilityRequestSchema.parse(await c.req.json());
+      return c.json(await deps.service.setApproval(principal.userId, capabilityId, body.agent, body.approved));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/onboarding/integration-capability-routes.ts
+++ b/packages/gateway/src/onboarding/integration-capability-routes.ts
@@ -4,8 +4,10 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
   ApproveCapabilityRequestSchema,
   CapabilityParamsSchema,
+  RecordAgentActionRequestSchema,
 } from "./activation-contracts.js";
 import { mapActivationError } from "./activation-errors.js";
+import type { AgentActionAuditService } from "./agent-action-audit.js";
 import type { IntegrationCapabilityService } from "./integration-capabilities.js";
 import {
   requireRequestPrincipal,
@@ -16,6 +18,7 @@ const INTEGRATION_CAPABILITY_BODY_LIMIT = 2048;
 
 export interface IntegrationCapabilityRouteDeps {
   service: IntegrationCapabilityService;
+  audit?: AgentActionAuditService;
   getPrincipal?: (c: Context) => RequestPrincipal;
 }
 
@@ -33,6 +36,34 @@ export function createIntegrationCapabilityRoutes(deps: IntegrationCapabilityRou
     try {
       const principal = principalFor(c);
       return c.json(await deps.service.listCapabilities(principal.userId));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.get("/actions", async (c) => {
+    try {
+      const principal = principalFor(c);
+      return c.json({ actions: await deps.audit?.listActions(principal.userId) ?? [] });
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/actions", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      if (!deps.audit) {
+        return c.json({ error: "audit_unavailable", message: "Request failed", retryable: true }, 503);
+      }
+      const body = RecordAgentActionRequestSchema.parse(await c.req.json());
+      if (!capabilityApproval.approvedAgents.includes(body.agent)) {
+        throw new ActivationRouteError("capability_not_approved", "Approve the capability before recording agent actions", {
+          status: 403,
+        });
+      }
+      const action = await deps.audit.recordAction(principal.userId, body);
+      return c.json({ action }, 201);
     } catch (err) {
       return jsonError(c, err);
     }

--- a/packages/gateway/src/onboarding/integration-capability-routes.ts
+++ b/packages/gateway/src/onboarding/integration-capability-routes.ts
@@ -6,7 +6,7 @@ import {
   CapabilityParamsSchema,
   RecordAgentActionRequestSchema,
 } from "./activation-contracts.js";
-import { mapActivationError } from "./activation-errors.js";
+import { ActivationRouteError, mapActivationError } from "./activation-errors.js";
 import type { AgentActionAuditService } from "./agent-action-audit.js";
 import type { IntegrationCapabilityService } from "./integration-capabilities.js";
 import {
@@ -57,6 +57,12 @@ export function createIntegrationCapabilityRoutes(deps: IntegrationCapabilityRou
         return c.json({ error: "audit_unavailable", message: "Request failed", retryable: true }, 503);
       }
       const body = RecordAgentActionRequestSchema.parse(await c.req.json());
+      const capabilityApproval = await deps.service.getCapabilityApproval(principal.userId, body.capability);
+      if (!capabilityApproval) {
+        throw new ActivationRouteError("capability_not_found", "Integration capability was not found", {
+          status: 422,
+        });
+      }
       if (!capabilityApproval.approvedAgents.includes(body.agent)) {
         throw new ActivationRouteError("capability_not_approved", "Approve the capability before recording agent actions", {
           status: 403,

--- a/packages/gateway/src/onboarding/readiness-service.ts
+++ b/packages/gateway/src/onboarding/readiness-service.ts
@@ -16,6 +16,7 @@ import { ReadinessStatusCache } from "./readiness-cache.js";
 import { ActivationRouteError } from "./activation-errors.js";
 import type { CodingSetupProvider, CodingSetupStatus } from "./coding-setup.js";
 import type { AgentCredentialStatusService } from "./agent-credential-status.js";
+import type { IntegrationCapabilityService } from "./integration-capabilities.js";
 
 const GOALS: Record<OnboardingGoalId, Omit<OnboardingGoalSummary, "selected">> = {
   coding: {
@@ -140,6 +141,7 @@ export function createReadinessService(options: {
   cache?: ReadinessStatusCache<ReadinessResponse>;
   codingSetup?: CodingSetupProvider;
   agentCredentials?: AgentCredentialStatusService;
+  integrationCapabilities?: IntegrationCapabilityService;
   now?: () => Date;
 }): ReadinessService {
   const now = options.now ?? (() => new Date());
@@ -190,12 +192,21 @@ export function createReadinessService(options: {
     }
   }
 
-  function deriveGates(record: OnboardingReadinessRecord, codingSetup: CodingSetupStatus | null): ReadinessGateSummary[] {
+  function deriveGates(
+    record: OnboardingReadinessRecord,
+    codingSetup: CodingSetupStatus | null,
+    integrationApproved: boolean | null,
+  ): ReadinessGateSummary[] {
     const checkedAt = now().toISOString();
     return BASE_GATES.map((gate) => {
       const codingPatch = codingGatePatch(gate, codingSetup, checkedAt);
+      const integrationPatch = gate.id === "integrations.capabilities" && integrationApproved !== null
+        ? integrationApproved
+          ? { status: "pass" as const, message: "Hermes has approved integration capabilities", remediation: null, lastCheckedAt: checkedAt }
+          : { status: "fail" as const, message: "Approve one assistant capability for Hermes", remediation: "Approve calendar, email, or summary capabilities", lastCheckedAt: checkedAt }
+        : null;
       const override = record.gateOverrides[gate.id];
-      const base = { ...gate, ...codingPatch };
+      const base = { ...gate, ...codingPatch, ...integrationPatch };
       if (!override) return base;
       return {
         ...base,
@@ -222,13 +233,25 @@ export function createReadinessService(options: {
     const cached = cache.get(ownerId);
     if (cached) return cached;
     const record = await ensureRecord(ownerId);
-    const [codingSetup, credentialStatus] = await Promise.all([
+    const [codingSetup, credentialStatus, integrationStatus] = await Promise.all([
       record.selectedGoalIds.includes("coding") && options.codingSetup
         ? options.codingSetup.getCodingSetup(ownerId)
         : Promise.resolve(null),
       options.agentCredentials ? options.agentCredentials.getStatus(ownerId) : Promise.resolve(null),
+      record.selectedGoalIds.includes("assistant") && options.integrationCapabilities
+        ? options.integrationCapabilities.listCapabilities(ownerId)
+        : Promise.resolve(null),
     ]);
-    const gates = deriveGates(record, codingSetup);
+    const integrationApproved = integrationStatus && integrationStatus.capabilities.length > 0
+      ? integrationStatus.capabilities.some((capability) =>
+        capability.status === "connected" || capability.status === "approved"
+      )
+        ? integrationStatus.capabilities.some((capability) =>
+          capability.status === "approved" && capability.approvedAgents.includes("hermes")
+        )
+        : null
+      : null;
+    const gates = deriveGates(record, codingSetup, integrationApproved);
     const goals = Object.values(GOALS).map((goal) => ({
       ...goal,
       selected: record.selectedGoalIds.includes(goal.id),

--- a/packages/gateway/src/onboarding/readiness-service.ts
+++ b/packages/gateway/src/onboarding/readiness-service.ts
@@ -229,6 +229,16 @@ export function createReadinessService(options: {
     return "degraded" as const;
   }
 
+  async function getIntegrationCapabilityStatus(ownerId: string, record: OnboardingReadinessRecord) {
+    if (!record.selectedGoalIds.includes("assistant") || !options.integrationCapabilities) return null;
+    try {
+      return await options.integrationCapabilities.listCapabilities(ownerId);
+    } catch (err: unknown) {
+      console.warn("[onboarding] integration capability readiness lookup failed:", err instanceof Error ? err.message : String(err));
+      return null;
+    }
+  }
+
   async function getReadiness(ownerId: string): Promise<ReadinessResponse> {
     const cached = cache.get(ownerId);
     if (cached) return cached;
@@ -238,9 +248,7 @@ export function createReadinessService(options: {
         ? options.codingSetup.getCodingSetup(ownerId)
         : Promise.resolve(null),
       options.agentCredentials ? options.agentCredentials.getStatus(ownerId) : Promise.resolve(null),
-      record.selectedGoalIds.includes("assistant") && options.integrationCapabilities
-        ? options.integrationCapabilities.listCapabilities(ownerId)
-        : Promise.resolve(null),
+      getIntegrationCapabilityStatus(ownerId, record),
     ]);
     const integrationApproved = integrationStatus && integrationStatus.capabilities.length > 0
       ? integrationStatus.capabilities.some((capability) =>

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -458,14 +458,30 @@ export async function createGateway(config: GatewayConfig) {
   let agentDetectionInFlight: Promise<Awaited<ReturnType<typeof agentCredentialLauncher.detectAgents>>> | null = null;
   let internalIntegrationBaseUrl: string | null = null;
   const PLATFORM_USER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const CAPABILITY_LOOKUP_TIMEOUT_MS = 10_000;
+  async function withCapabilityLookupTimeout<T>(operation: () => Promise<T>): Promise<T> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => reject(new Error("capability lookup timed out")), CAPABILITY_LOOKUP_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
   async function getConnectedCapabilityIds(ownerId: string): Promise<string[]> {
     if (platformDb) {
       try {
         const dbForLookup = platformDb;
-        const user = await platformDb.getUserByClerkId(ownerId);
-        const platformUserId = user?.id ?? (PLATFORM_USER_ID_PATTERN.test(ownerId) ? ownerId : null);
-        if (!platformUserId) return [];
-        const services = await platformDb.listConnectedServices(platformUserId);
+        const services = await withCapabilityLookupTimeout(async () => {
+          const user = await dbForLookup.getUserByClerkId(ownerId);
+          const platformUserId = user?.id ?? (PLATFORM_USER_ID_PATTERN.test(ownerId) ? ownerId : null);
+          if (!platformUserId) return [];
+          return dbForLookup.listConnectedServices(platformUserId);
+        });
         return capabilityIdsForConnectedServices(services.map((service) => service.service));
       } catch (err: unknown) {
         console.warn("[integrations] platform capability lookup failed:", err instanceof Error ? err.message : String(err));

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -457,10 +457,20 @@ export async function createGateway(config: GatewayConfig) {
   const agentCredentialLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
   let agentDetectionInFlight: Promise<Awaited<ReturnType<typeof agentCredentialLauncher.detectAgents>>> | null = null;
   let internalIntegrationBaseUrl: string | null = null;
+  const PLATFORM_USER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   async function getConnectedCapabilityIds(ownerId: string): Promise<string[]> {
     if (platformDb) {
-      const services = await platformDb.listConnectedServices(ownerId);
-      return capabilityIdsForConnectedServices(services.map((service) => service.service));
+      try {
+        const dbForLookup = platformDb;
+        const user = await platformDb.getUserByClerkId(ownerId);
+        const platformUserId = user?.id ?? (PLATFORM_USER_ID_PATTERN.test(ownerId) ? ownerId : null);
+        if (!platformUserId) return [];
+        const services = await platformDb.listConnectedServices(platformUserId);
+        return capabilityIdsForConnectedServices(services.map((service) => service.service));
+      } catch (err: unknown) {
+        console.warn("[integrations] platform capability lookup failed:", err instanceof Error ? err.message : String(err));
+        return [];
+      }
     }
     if (!internalIntegrationBaseUrl) return [];
     try {
@@ -505,6 +515,7 @@ export async function createGateway(config: GatewayConfig) {
   const integrationCapabilityService = createIntegrationCapabilityService({
     getConnectedCapabilityIds,
     onChange: (ownerId) => readinessCache.delete(ownerId),
+    storagePath: join(homePath, "system", "integration-capabilities.json"),
   });
   const agentActionAuditService = createAgentActionAuditService();
   let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -450,9 +450,44 @@ export async function createGateway(config: GatewayConfig) {
   const clients = new Set<WSContext>();
   const readinessRepository = new InMemoryReadinessRepository();
   const readinessCache = new ReadinessStatusCache<ReadinessResponse>({ maxEntries: 512, ttlMs: 10_000 });
+  const internalPlatformUrl = process.env.PLATFORM_INTERNAL_URL;
+  const internalPlatformToken = process.env.UPGRADE_TOKEN;
+  const internalHandle = process.env.MATRIX_HANDLE;
   let platformDb: PlatformDb | null = null;
   const agentCredentialLauncher = createAgentLauncher({ cwd: homePath, runtimeHome: homePath });
   let agentDetectionInFlight: Promise<Awaited<ReturnType<typeof agentCredentialLauncher.detectAgents>>> | null = null;
+  let internalIntegrationBaseUrl: string | null = null;
+  async function getConnectedCapabilityIds(ownerId: string): Promise<string[]> {
+    if (platformDb) {
+      const services = await platformDb.listConnectedServices(ownerId);
+      return capabilityIdsForConnectedServices(services.map((service) => service.service));
+    }
+    if (!internalIntegrationBaseUrl) return [];
+    try {
+      const headers = new Headers({ Accept: "application/json" });
+      if (internalPlatformToken) headers.set("authorization", `Bearer ${internalPlatformToken}`);
+      const response = await fetch(internalIntegrationBaseUrl, {
+        headers,
+        redirect: "error",
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) return [];
+      const body = await response.json() as unknown;
+      const connections = Array.isArray(body)
+        ? body
+        : body && typeof body === "object" && Array.isArray((body as { connections?: unknown }).connections)
+          ? (body as { connections: unknown[] }).connections
+          : [];
+      return capabilityIdsForConnectedServices(connections.flatMap((connection) =>
+        connection && typeof connection === "object" && typeof (connection as { service?: unknown }).service === "string"
+          ? [(connection as { service: string }).service]
+          : [],
+      ));
+    } catch (err: unknown) {
+      console.warn("[integrations] capability connection lookup failed:", err instanceof Error ? err.message : String(err));
+      return [];
+    }
+  }
   const agentCredentialService = createAgentCredentialStatusService({
     onChange: (ownerId) => readinessCache.delete(ownerId),
     probeAgent: async (_ownerId, agent) => {
@@ -468,11 +503,7 @@ export async function createGateway(config: GatewayConfig) {
     },
   });
   const integrationCapabilityService = createIntegrationCapabilityService({
-    getConnectedCapabilityIds: async (ownerId) => {
-      if (!platformDb) return [];
-      const services = await platformDb.listConnectedServices(ownerId);
-      return capabilityIdsForConnectedServices(services.map((service) => service.service));
-    },
+    getConnectedCapabilityIds,
     onChange: (ownerId) => readinessCache.delete(ownerId),
   });
   const agentActionAuditService = createAgentActionAuditService();
@@ -634,9 +665,6 @@ export async function createGateway(config: GatewayConfig) {
   const s3Bucket = process.env.S3_BUCKET ?? process.env.R2_BUCKET ?? "matrixos-sync";
   const s3ForcePathStyle = process.env.S3_FORCE_PATH_STYLE === "true";
 
-  const internalPlatformUrl = process.env.PLATFORM_INTERNAL_URL;
-  const internalPlatformToken = process.env.UPGRADE_TOKEN;
-  const internalHandle = process.env.MATRIX_HANDLE;
   const geminiLiveConnection: GeminiLiveConnection =
     internalPlatformUrl && internalPlatformToken && internalHandle
       ? { proxy: { platformUrl: internalPlatformUrl, token: internalPlatformToken, handle: internalHandle } }
@@ -756,7 +784,7 @@ export async function createGateway(config: GatewayConfig) {
     }
   }
 
-  const internalIntegrationBaseUrl =
+  internalIntegrationBaseUrl =
     internalPlatformUrl && internalHandle
       ? `${internalPlatformUrl}/internal/containers/${internalHandle}/integrations`
       : null;

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -84,6 +84,7 @@ import { createReadinessRoutes } from "./onboarding/readiness-routes.js";
 import { createCodingSetupProvider, type CodingSetupStatus } from "./onboarding/coding-setup.js";
 import { createAgentCredentialStatusService } from "./onboarding/agent-credential-status.js";
 import { createAgentCredentialRoutes } from "./onboarding/agent-credential-routes.js";
+import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
 import { createVocalHandler } from "./vocal/ws-handler.js";
@@ -474,6 +475,7 @@ export async function createGateway(config: GatewayConfig) {
     },
     onChange: (ownerId) => readinessCache.delete(ownerId),
   });
+  const agentActionAuditService = createAgentActionAuditService();
   let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;
   const unavailableCodingSetup: CodingSetupStatus = {
     githubConnected: false,
@@ -1383,7 +1385,10 @@ export async function createGateway(config: GatewayConfig) {
   app.use("*", authMiddleware(process.env.MATRIX_AUTH_TOKEN));
   app.route("/api/onboarding", createReadinessRoutes({ service: readinessService }));
   app.route("/api/agents", createAgentCredentialRoutes({ service: agentCredentialService }));
-  app.route("/api/integrations", createIntegrationCapabilityRoutes({ service: integrationCapabilityService }));
+  app.route("/api/integrations", createIntegrationCapabilityRoutes({
+    service: integrationCapabilityService,
+    audit: agentActionAuditService,
+  }));
   app.route("/api", createShellRoutes({
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -84,6 +84,8 @@ import { createReadinessRoutes } from "./onboarding/readiness-routes.js";
 import { createCodingSetupProvider, type CodingSetupStatus } from "./onboarding/coding-setup.js";
 import { createAgentCredentialStatusService } from "./onboarding/agent-credential-status.js";
 import { createAgentCredentialRoutes } from "./onboarding/agent-credential-routes.js";
+import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
+import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
 import { createVocalHandler } from "./vocal/ws-handler.js";
 import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
 import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
@@ -464,6 +466,14 @@ export async function createGateway(config: GatewayConfig) {
       };
     },
   });
+  const integrationCapabilityService = createIntegrationCapabilityService({
+    getConnectedCapabilityIds: async (ownerId) => {
+      if (!platformDb) return [];
+      const services = await platformDb.listConnectedServices(ownerId);
+      return capabilityIdsForConnectedServices(services.map((service) => service.service));
+    },
+    onChange: (ownerId) => readinessCache.delete(ownerId),
+  });
   let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;
   const unavailableCodingSetup: CodingSetupStatus = {
     githubConnected: false,
@@ -478,6 +488,7 @@ export async function createGateway(config: GatewayConfig) {
     repository: readinessRepository,
     cache: readinessCache,
     agentCredentials: agentCredentialService,
+    integrationCapabilities: integrationCapabilityService,
     codingSetup: {
       getCodingSetup: async (ownerId) => codingSetupProvider?.getCodingSetup(ownerId) ?? unavailableCodingSetup,
     },
@@ -1372,6 +1383,7 @@ export async function createGateway(config: GatewayConfig) {
   app.use("*", authMiddleware(process.env.MATRIX_AUTH_TOKEN));
   app.route("/api/onboarding", createReadinessRoutes({ service: readinessService }));
   app.route("/api/agents", createAgentCredentialRoutes({ service: agentCredentialService }));
+  app.route("/api/integrations", createIntegrationCapabilityRoutes({ service: integrationCapabilityService }));
   app.route("/api", createShellRoutes({
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useOnboarding } from "@/hooks/useOnboarding";
 import { useAgentCredentialStatus } from "@/hooks/useAgentCredentialStatus";
+import { useIntegrationCapabilities } from "@/hooks/useIntegrationCapabilities";
 import { useMicPermission } from "@/hooks/useMicPermission";
 import { VoiceWave } from "./onboarding/VoiceWave";
 import { ApiKeyInput } from "./onboarding/ApiKeyInput";
@@ -13,6 +14,7 @@ import { ReadinessChecklist } from "./onboarding/ReadinessChecklist";
 import { CodingSetupPanel } from "./onboarding/CodingSetupPanel";
 import { CodingHandoffSummary } from "./onboarding/CodingHandoffSummary";
 import { AgentCredentialPanel } from "./onboarding/AgentCredentialPanel";
+import { AssistantSetupPanel } from "./onboarding/AssistantSetupPanel";
 import { MicPermissionDialog } from "./MicPermissionDialog";
 import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
@@ -30,6 +32,7 @@ interface OnboardingScreenProps {
 export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScreenProps) {
   const ob = useOnboarding();
   const agentCredentials = useAgentCredentialStatus();
+  const integrationCapabilities = useIntegrationCapabilities();
   const mic = useMicPermission();
   const [started, setStarted] = useState(false);
   const [phase, setPhase] = useState<"idle" | "dimming" | "black" | "revealing">("idle");
@@ -185,6 +188,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
   // ── Voice conversation screen (editorial style) ─────────────
   const isConversing = ob.stage === "greeting" || ob.stage === "interview" || ob.stage === "connecting";
   const codingSelected = ob.selectedGoalIds.includes("coding");
+  const assistantSelected = ob.selectedGoalIds.includes("assistant");
 
   // Render nothing for the one frame between "alreadyComplete" becoming
   // true and the parent unmounting us via the effect above. Placing this
@@ -250,6 +254,13 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
               )}
 
               <AgentCredentialPanel status={agentCredentials.status} error={agentCredentials.error} onVerify={agentCredentials.verify} />
+
+              {assistantSelected && (
+                <AssistantSetupPanel
+                  capabilities={integrationCapabilities.capabilities}
+                  onApprove={integrationCapabilities.approveForHermes}
+                />
+              )}
 
               <div className="flex flex-col gap-2 sm:flex-row">
                 <button

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -258,6 +258,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
               {assistantSelected && (
                 <AssistantSetupPanel
                   capabilities={integrationCapabilities.capabilities}
+                  error={integrationCapabilities.error}
                   onApprove={integrationCapabilities.approveForHermes}
                 />
               )}

--- a/shell/src/components/onboarding/AssistantSetupPanel.tsx
+++ b/shell/src/components/onboarding/AssistantSetupPanel.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { CalendarPlusIcon, CheckCircle2Icon, MailIcon, ShieldCheckIcon } from "lucide-react";
+import type { IntegrationCapabilitySummary } from "@/hooks/useIntegrationCapabilities";
+
+function labelForCapability(capability: IntegrationCapabilitySummary) {
+  if (capability.id === "calendar.create_event") return "Calendar event";
+  if (capability.id === "email.read_email") return "Email summaries";
+  if (capability.id === "github.read_repository") return "Repository context";
+  return capability.capability.replaceAll("_", " ");
+}
+
+function iconForCapability(capability: IntegrationCapabilitySummary) {
+  if (capability.provider === "calendar") return CalendarPlusIcon;
+  if (capability.provider === "email") return MailIcon;
+  return ShieldCheckIcon;
+}
+
+export function AssistantSetupPanel({
+  capabilities,
+  onApprove,
+}: {
+  capabilities: IntegrationCapabilitySummary[];
+  onApprove: (capabilityId: string) => void;
+}) {
+  if (capabilities.length === 0) return null;
+
+  return (
+    <section className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/80 p-4 shadow-[0_16px_45px_rgba(23,40,31,0.08)]">
+      <div>
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-[#111612]">
+          <ShieldCheckIcon className="h-4 w-4 text-[#a6542f]" aria-hidden="true" />
+          Assistant integrations
+        </h2>
+        <p className="mt-1 max-w-xl text-xs leading-5 text-[#17281f]/62">
+          Hermes can use approved skills for calendar, email, and work context. Externally visible actions still require approval by default.
+        </p>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-3">
+        {capabilities.map((capability) => {
+          const Icon = iconForCapability(capability);
+          const approved = capability.approvedAgents.includes("hermes");
+          return (
+            <div key={capability.id} className="rounded-md border border-[#17281f]/10 bg-white/60 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Icon className="h-4 w-4 text-[#17281f]/70" aria-hidden="true" />
+                  <p className="text-xs font-semibold text-[#111612]">{labelForCapability(capability)}</p>
+                </div>
+                {approved && <CheckCircle2Icon className="h-4 w-4 text-[#4f7f5c]" aria-hidden="true" />}
+              </div>
+              <p className="mt-2 text-xs capitalize text-[#17281f]/60">{capability.status.replaceAll("_", " ")}</p>
+              {!approved && capability.status !== "connect_required" && (
+                <button
+                  type="button"
+                  onClick={() => onApprove(capability.id)}
+                  className="mt-3 inline-flex min-h-8 items-center rounded-md border border-[#17281f]/12 bg-white/75 px-2.5 text-xs font-medium text-[#17281f] transition hover:border-[#17281f]/28"
+                >
+                  Approve Hermes
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/shell/src/components/onboarding/AssistantSetupPanel.tsx
+++ b/shell/src/components/onboarding/AssistantSetupPanel.tsx
@@ -18,12 +18,14 @@ function iconForCapability(capability: IntegrationCapabilitySummary) {
 
 export function AssistantSetupPanel({
   capabilities,
+  error,
   onApprove,
 }: {
   capabilities: IntegrationCapabilitySummary[];
+  error?: string | null;
   onApprove: (capabilityId: string) => void;
 }) {
-  if (capabilities.length === 0) return null;
+  if (capabilities.length === 0 && !error) return null;
 
   return (
     <section className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/80 p-4 shadow-[0_16px_45px_rgba(23,40,31,0.08)]">
@@ -37,33 +39,44 @@ export function AssistantSetupPanel({
         </p>
       </div>
 
-      <div className="mt-3 grid gap-2 sm:grid-cols-3">
-        {capabilities.map((capability) => {
-          const Icon = iconForCapability(capability);
-          const approved = capability.approvedAgents.includes("hermes");
-          return (
-            <div key={capability.id} className="rounded-md border border-[#17281f]/10 bg-white/60 p-3">
-              <div className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2">
-                  <Icon className="h-4 w-4 text-[#17281f]/70" aria-hidden="true" />
-                  <p className="text-xs font-semibold text-[#111612]">{labelForCapability(capability)}</p>
+      {error && (
+        <p
+          role="status"
+          className="mt-3 rounded-md border border-[#a6542f]/25 bg-[#fff8f2] px-3 py-2 text-xs font-medium text-[#7a351f]"
+        >
+          {error}
+        </p>
+      )}
+
+      {capabilities.length > 0 && (
+        <div className="mt-3 grid gap-2 sm:grid-cols-3">
+          {capabilities.map((capability) => {
+            const Icon = iconForCapability(capability);
+            const approved = capability.approvedAgents.includes("hermes");
+            return (
+              <div key={capability.id} className="rounded-md border border-[#17281f]/10 bg-white/60 p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Icon className="h-4 w-4 text-[#17281f]/70" aria-hidden="true" />
+                    <p className="text-xs font-semibold text-[#111612]">{labelForCapability(capability)}</p>
+                  </div>
+                  {approved && <CheckCircle2Icon className="h-4 w-4 text-[#4f7f5c]" aria-hidden="true" />}
                 </div>
-                {approved && <CheckCircle2Icon className="h-4 w-4 text-[#4f7f5c]" aria-hidden="true" />}
+                <p className="mt-2 text-xs capitalize text-[#17281f]/60">{capability.status.replaceAll("_", " ")}</p>
+                {!approved && capability.status !== "connect_required" && (
+                  <button
+                    type="button"
+                    onClick={() => onApprove(capability.id)}
+                    className="mt-3 inline-flex min-h-8 items-center rounded-md border border-[#17281f]/12 bg-white/75 px-2.5 text-xs font-medium text-[#17281f] transition hover:border-[#17281f]/28"
+                  >
+                    Approve Hermes
+                  </button>
+                )}
               </div>
-              <p className="mt-2 text-xs capitalize text-[#17281f]/60">{capability.status.replaceAll("_", " ")}</p>
-              {!approved && capability.status !== "connect_required" && (
-                <button
-                  type="button"
-                  onClick={() => onApprove(capability.id)}
-                  className="mt-3 inline-flex min-h-8 items-center rounded-md border border-[#17281f]/12 bg-white/75 px-2.5 text-xs font-medium text-[#17281f] transition hover:border-[#17281f]/28"
-                >
-                  Approve Hermes
-                </button>
-              )}
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      )}
     </section>
   );
 }

--- a/shell/src/hooks/useIntegrationCapabilities.ts
+++ b/shell/src/hooks/useIntegrationCapabilities.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface IntegrationCapabilitySummary {
+  id: string;
+  provider: "github" | "calendar" | "email" | "messaging" | "publishing";
+  capability: string;
+  status: "connect_required" | "connected" | "approved" | "revoked" | "failed" | "unavailable";
+  approvedAgents: Array<"claude" | "codex" | "hermes">;
+  requiresApprovalPerAction: boolean;
+}
+
+export function useIntegrationCapabilities() {
+  const mountedRef = useRef(false);
+  const [capabilities, setCapabilities] = useState<IntegrationCapabilitySummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    void fetch("/api/integrations/capabilities", {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("integration capabilities request failed");
+        return await res.json() as { capabilities: IntegrationCapabilitySummary[] };
+      })
+      .then((body) => {
+        if (!mountedRef.current) return;
+        setCapabilities(body.capabilities);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        console.warn("[onboarding] integration capabilities failed:", err instanceof Error ? err.message : String(err));
+        if (mountedRef.current) setError("Could not load integration capabilities");
+      });
+  }, []);
+
+  const approveForHermes = useCallback((capabilityId: string) => {
+    void fetch(`/api/integrations/capabilities/${encodeURIComponent(capabilityId)}/approval`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ agent: "hermes", approved: true }),
+      signal: AbortSignal.timeout(10_000),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("integration capability approval failed");
+        return await res.json();
+      })
+      .then(() => {
+        if (!mountedRef.current) return;
+        refresh();
+      })
+      .catch((err: unknown) => {
+        console.warn("[onboarding] integration approval failed:", err instanceof Error ? err.message : String(err));
+        if (mountedRef.current) setError("Could not approve capability");
+      });
+  }, [refresh]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    refresh();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [refresh]);
+
+  return { capabilities, error, refresh, approveForHermes };
+}

--- a/specs/082-paid-beta-readiness/tasks.md
+++ b/specs/082-paid-beta-readiness/tasks.md
@@ -143,20 +143,20 @@
 
 ### Tests First
 
-- [ ] T052 [P] [US4] Write failing integration capability approval tests in `tests/gateway/integrations-routes.test.ts`
-- [ ] T053 [P] [US4] Write failing safe action audit tests in `tests/gateway/onboarding-activation.test.ts`
-- [ ] T054 [P] [US4] Write failing assistant integration e2e path in `tests/e2e/onboarding-activation.spec.ts`
+- [X] T052 [P] [US4] Write failing integration capability approval tests in `tests/gateway/integrations-routes.test.ts`
+- [X] T053 [P] [US4] Write failing safe action audit tests in `tests/gateway/onboarding-activation.test.ts`
+- [X] T054 [P] [US4] Write failing assistant integration e2e path in `tests/e2e/onboarding-activation.spec.ts`
 
 ### Implementation
 
-- [ ] T055 [US4] Implement integration capability service in `packages/gateway/src/onboarding/integration-capabilities.ts`
-- [ ] T056 [US4] Add capability approval routes in `packages/gateway/src/onboarding/integration-capability-routes.ts`
-- [ ] T057 [US4] Wire capability routes in `packages/gateway/src/server.ts`
-- [ ] T058 [US4] Implement safe agent action audit summaries in `packages/gateway/src/onboarding/agent-action-audit.ts`
-- [ ] T059 [US4] Connect capability status to existing integrations registry in `packages/gateway/src/integrations/registry.ts`
-- [ ] T060 [P] [US4] Create assistant integration setup panel in `shell/src/components/onboarding/AssistantSetupPanel.tsx`
-- [ ] T061 [US4] Add integration capabilities hook in `shell/src/hooks/useIntegrationCapabilities.ts`
-- [ ] T062 [US4] Wire assistant setup panel into onboarding goal flow in `shell/src/components/OnboardingScreen.tsx`
+- [X] T055 [US4] Implement integration capability service in `packages/gateway/src/onboarding/integration-capabilities.ts`
+- [X] T056 [US4] Add capability approval routes in `packages/gateway/src/onboarding/integration-capability-routes.ts`
+- [X] T057 [US4] Wire capability routes in `packages/gateway/src/server.ts`
+- [X] T058 [US4] Implement safe agent action audit summaries in `packages/gateway/src/onboarding/agent-action-audit.ts`
+- [X] T059 [US4] Connect capability status to existing integrations registry in `packages/gateway/src/integrations/registry.ts`
+- [X] T060 [P] [US4] Create assistant integration setup panel in `shell/src/components/onboarding/AssistantSetupPanel.tsx`
+- [X] T061 [US4] Add integration capabilities hook in `shell/src/hooks/useIntegrationCapabilities.ts`
+- [X] T062 [US4] Wire assistant setup panel into onboarding goal flow in `shell/src/components/OnboardingScreen.tsx`
 
 **Checkpoint**: US4 works with mocked or connected capabilities and safe summaries.
 

--- a/tests/e2e/onboarding-activation.spec.ts
+++ b/tests/e2e/onboarding-activation.spec.ts
@@ -193,4 +193,59 @@ test.describe("onboarding activation", () => {
     await expect(page.getByText("Claude is not connected")).toBeVisible();
     await expect(page.getByText("Hermes remains the Matrix system agent even when Claude and Codex are not connected.")).toBeVisible();
   });
+
+  test("shows assistant integration approvals for calendar and email", async ({ page }) => {
+    await page.route("**/api/onboarding/readiness", async (route) => {
+      await route.fulfill({
+        json: {
+          overallStatus: "degraded",
+          goals: [
+            { id: "assistant", selected: true, label: "Use Matrix as an assistant", description: "Operate tasks" },
+          ],
+          gates: [
+            {
+              id: "integrations.capabilities",
+              category: "integration",
+              criticality: "goal_required",
+              status: "fail",
+              message: "Approve one assistant capability for Hermes",
+              remediation: "Approve calendar, email, or summary capabilities",
+              owner: "user",
+              lastCheckedAt: "2026-05-23T00:00:00.000Z",
+            },
+          ],
+          systemAgent: "hermes",
+          activeAgents: ["hermes"],
+          agents: [],
+        },
+      });
+    });
+    await page.route("**/api/agents/credentials/status", async (route) => {
+      await route.fulfill({
+        json: {
+          systemAgent: "hermes",
+          activeAgents: ["hermes"],
+          routingExplanation: "Hermes remains the Matrix system agent.",
+          agents: [],
+        },
+      });
+    });
+    await page.route("**/api/integrations/capabilities", async (route) => {
+      await route.fulfill({
+        json: {
+          capabilities: [
+            { id: "calendar.create_event", provider: "calendar", capability: "create_calendar_event", status: "connected", approvedAgents: [], requiresApprovalPerAction: true },
+            { id: "email.read_email", provider: "email", capability: "read_email", status: "connect_required", approvedAgents: [], requiresApprovalPerAction: true },
+          ],
+        },
+      });
+    });
+
+    await page.goto("/");
+
+    await expect(page.getByText("Assistant integrations")).toBeVisible();
+    await expect(page.getByText("Calendar event")).toBeVisible();
+    await expect(page.getByText("Email summaries")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Approve Hermes/i })).toBeVisible();
+  });
 });

--- a/tests/gateway/activation-readiness-routes.test.ts
+++ b/tests/gateway/activation-readiness-routes.test.ts
@@ -153,6 +153,34 @@ describe("activation readiness routes", () => {
     });
   });
 
+  it("keeps readiness available when assistant capability storage cannot be read", async () => {
+    const { service } = createTestReadinessService(undefined, {
+      integrationCapabilityService: {
+        listCapabilities: async () => {
+          throw new Error("corrupted storage json");
+        },
+        getCapabilityApproval: async () => null,
+        setApproval: async () => ({
+          capabilityId: "calendar.create_event",
+          agent: "hermes",
+          status: "connect_required",
+        }),
+      },
+    });
+    const app = createReadinessRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(jsonRequest("/goals", { goalIds: ["assistant"] }));
+    const res = await app.request("/readiness");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const gatesById = new Map(body.gates.map((gate: { id: string }) => [gate.id, gate]));
+    expect(gatesById.get("integrations.capabilities")).toMatchObject({
+      status: "unknown",
+      message: "Assistant capabilities have not been approved",
+    });
+  });
+
   it("rejects invalid goals with a generic client-safe error", async () => {
     const { service } = createTestReadinessService();
     const app = createReadinessRoutes({ service, getPrincipal: () => testPrincipal });

--- a/tests/gateway/integrations-routes.test.ts
+++ b/tests/gateway/integrations-routes.test.ts
@@ -301,6 +301,27 @@ describe("integration capability routes", () => {
     });
   });
 
+  it("rejects audit summaries longer than the safe display field", async () => {
+    const service = createIntegrationCapabilityService();
+    const audit = createAgentActionAuditService();
+    const app = createIntegrationCapabilityRoutes({ service, audit, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/actions", {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "a".repeat(241),
+      target: "Primary calendar",
+    }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "invalid_request",
+      message: "Request is invalid",
+      retryable: false,
+    });
+  });
+
   it("keeps normal task identifiers in audit summaries", async () => {
     const audit = createAgentActionAuditService({
       now: () => new Date("2026-05-24T00:00:00.000Z"),
@@ -315,6 +336,39 @@ describe("integration capability routes", () => {
     });
 
     expect(action.summary).toBe("Completed task_123 for launch prep");
+  });
+
+  it("keeps normal database wording in audit summaries", async () => {
+    const audit = createAgentActionAuditService({
+      now: () => new Date("2026-05-24T00:00:00.000Z"),
+    });
+
+    const action = await audit.recordAction(testPrincipal.userId, {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "Updated task in project database",
+      target: "Primary calendar",
+    });
+
+    expect(action.summary).toBe("Updated task in project database");
+  });
+
+  it("scrubs password and bearer-shaped audit displays", async () => {
+    const audit = createAgentActionAuditService({
+      now: () => new Date("2026-05-24T00:00:00.000Z"),
+    });
+
+    const action = await audit.recordAction(testPrincipal.userId, {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "Created event with password=hunter2",
+      target: "Bearer abc.def.ghi",
+    });
+
+    expect(action.summary).toBe("Agent action completed");
+    expect(action.target).toBe("Connected service");
   });
 
   it("does not evict audit events when read-only action checks see unknown owners", async () => {

--- a/tests/gateway/integrations-routes.test.ts
+++ b/tests/gateway/integrations-routes.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { createIntegrationCapabilityRoutes } from "../../packages/gateway/src/onboarding/integration-capability-routes.js";
+import {
+  capabilityIdsForConnectedServices,
+  createIntegrationCapabilityService,
+} from "../../packages/gateway/src/onboarding/integration-capabilities.js";
+import { testPrincipal } from "../helpers/activation-readiness.js";
+
+function post(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("integration capability routes", () => {
+  it("maps connected integration services to assistant capabilities", () => {
+    expect(capabilityIdsForConnectedServices(["google_calendar", "gmail", "github", "linear"])).toEqual([
+      "calendar.create_event",
+      "email.read_email",
+      "github.read_repository",
+    ]);
+  });
+
+  it("lists launch capabilities without provider secrets", async () => {
+    const service = createIntegrationCapabilityService();
+    const app = createIntegrationCapabilityRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request("/capabilities");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.capabilities).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "calendar.create_event", provider: "calendar", capability: "create_calendar_event" }),
+      expect.objectContaining({ id: "email.read_email", provider: "email", capability: "read_email" }),
+      expect.objectContaining({ id: "github.read_repository", provider: "github", capability: "read_repository" }),
+    ]));
+    expect(JSON.stringify(body)).not.toMatch(/secret|token|pipedream|\/home\//i);
+  });
+
+  it("approves and revokes Hermes capability use", async () => {
+    const service = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+    });
+    const app = createIntegrationCapabilityRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const approved = await app.request(post("/capabilities/calendar.create_event/approval", {
+      agent: "hermes",
+      approved: true,
+    }));
+
+    expect(approved.status).toBe(200);
+    await expect(approved.json()).resolves.toEqual({
+      capabilityId: "calendar.create_event",
+      agent: "hermes",
+      status: "approved",
+    });
+    const body = await (await app.request("/capabilities")).json();
+    expect(body.capabilities.find((capability: { id: string }) => capability.id === "calendar.create_event")).toMatchObject({
+      status: "approved",
+      approvedAgents: ["hermes"],
+      requiresApprovalPerAction: true,
+    });
+  });
+
+  it("uses owner-scoped connected integrations before approval", async () => {
+    const service = createIntegrationCapabilityService({
+      getConnectedCapabilityIds: async (ownerId) => ownerId === testPrincipal.userId
+        ? capabilityIdsForConnectedServices(["google_calendar"])
+        : [],
+    });
+    const app = createIntegrationCapabilityRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const listed = await app.request("/capabilities");
+    const body = await listed.json();
+    expect(body.capabilities.find((capability: { id: string }) => capability.id === "calendar.create_event")).toMatchObject({
+      status: "connected",
+      approvedAgents: [],
+    });
+
+    const approved = await app.request(post("/capabilities/calendar.create_event/approval", {
+      agent: "hermes",
+      approved: true,
+    }));
+    expect(approved.status).toBe(200);
+  });
+
+  it("requires a connected integration before approving capability use", async () => {
+    const service = createIntegrationCapabilityService();
+    const app = createIntegrationCapabilityRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/capabilities/calendar.create_event/approval", {
+      agent: "hermes",
+      approved: true,
+    }));
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "capability_not_connected",
+      message: "Connect the integration before approving agent access",
+      retryable: false,
+    });
+  });
+
+  it("does not overwrite stored approvals when the persisted file is unreadable", async () => {
+    const home = await mkdtemp(join(tmpdir(), "matrix-capabilities-"));
+    const storagePath = join(home, "system", "integration-capabilities.json");
+    await mkdir(join(home, "system"), { recursive: true });
+    await writeFile(storagePath, "{not-json", "utf8");
+    const service = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+      storagePath,
+    });
+
+    await expect(
+      service.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true),
+    ).rejects.toThrow();
+    await expect(readFile(storagePath, "utf8")).resolves.toBe("{not-json");
+  });
+
+  it("rejects audit actions when a previously approved capability disconnects", async () => {
+    let connected = true;
+    const service = createIntegrationCapabilityService({
+      getConnectedCapabilityIds: async () => {
+        return connected ? ["calendar.create_event"] : [];
+      },
+    });
+    await service.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true);
+    connected = false;
+    const audit = createAgentActionAuditService();
+    const app = createIntegrationCapabilityRoutes({ service, audit, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/actions", {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "Created launch event",
+      target: "Primary calendar",
+    }));
+
+    expect(res.status).toBe(403);
+    expect(await audit.listActions(testPrincipal.userId)).toEqual([]);
+  });
+
+  it("rejects audit records when the agent is not approved for the capability", async () => {
+    const service = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+    });
+    const audit = createAgentActionAuditService();
+    const app = createIntegrationCapabilityRoutes({ service, audit, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/actions", {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "Created launch event",
+      target: "Primary calendar",
+    }));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: "capability_not_approved",
+      message: "Approve the capability before recording agent actions",
+      retryable: false,
+    });
+    expect(await audit.listActions(testPrincipal.userId)).toEqual([]);
+  });
+
+  it("keeps normal task identifiers in audit summaries", async () => {
+    const audit = createAgentActionAuditService({
+      now: () => new Date("2026-05-24T00:00:00.000Z"),
+    });
+
+    const action = await audit.recordAction(testPrincipal.userId, {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "Completed task_123 for launch prep",
+      target: "Primary calendar",
+    });
+
+    expect(action.summary).toBe("Completed task_123 for launch prep");
+  });
+
+  it("rejects unknown capabilities with a generic error", async () => {
+    const service = createIntegrationCapabilityService();
+    const app = createIntegrationCapabilityRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/capabilities/not_real/approval", {
+      agent: "hermes",
+      approved: true,
+    }));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({
+      error: "capability_not_found",
+      message: "Integration capability was not found",
+      retryable: false,
+    });
+  });
+
+  it("does not keep approvals in memory when persistence fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-capabilities-readonly-"));
+    const storagePath = join(root, "state.json");
+    await chmod(root, 0o500);
+    const service = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+      storagePath,
+    });
+
+    try {
+      await expect(service.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true))
+        .rejects.toThrow();
+      await expect(service.getCapabilityApproval(testPrincipal.userId, "calendar.create_event"))
+        .resolves.toEqual({ capabilityId: "calendar.create_event", approvedAgents: [] });
+    } finally {
+      await chmod(root, 0o700);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps concurrent approvals for the same owner", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-capabilities-concurrent-"));
+    const storagePath = join(root, "state.json");
+    const service = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event", "email.read_email"],
+      storagePath,
+    });
+
+    try {
+      await Promise.all([
+        service.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true),
+        service.setApproval(testPrincipal.userId, "email.read_email", "hermes", true),
+      ]);
+
+      await expect(service.getCapabilityApproval(testPrincipal.userId, "calendar.create_event"))
+        .resolves.toEqual({ capabilityId: "calendar.create_event", approvedAgents: ["hermes"] });
+      await expect(service.getCapabilityApproval(testPrincipal.userId, "email.read_email"))
+        .resolves.toEqual({ capabilityId: "email.read_email", approvedAgents: ["hermes"] });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/integrations-routes.test.ts
+++ b/tests/gateway/integrations-routes.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createAgentActionAuditService } from "../../packages/gateway/src/onboarding/agent-action-audit.js";
 import { createIntegrationCapabilityRoutes } from "../../packages/gateway/src/onboarding/integration-capability-routes.js";
 import {
@@ -137,6 +140,44 @@ describe("integration capability routes", () => {
     });
   });
 
+  it("does not evict approvals when revoke checks see unknown owners", async () => {
+    const service = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+    });
+
+    await service.setApproval("owner_0", "calendar.create_event", "hermes", true);
+    for (let index = 1; index <= 512; index += 1) {
+      await service.setApproval(`owner_${index}`, "calendar.create_event", "hermes", false);
+    }
+
+    const ownerZero = await service.listCapabilities("owner_0");
+    expect(ownerZero.capabilities.find((capability) => capability.id === "calendar.create_event")).toMatchObject({
+      status: "approved",
+      approvedAgents: ["hermes"],
+    });
+  });
+
+  it("persists capability approvals across service restarts", async () => {
+    const home = await mkdtemp(join(tmpdir(), "matrix-capabilities-"));
+    const storagePath = join(home, "system", "integration-capabilities.json");
+    const first = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+      storagePath,
+    });
+
+    await first.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true);
+
+    const restarted = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+      storagePath,
+    });
+    const body = await restarted.listCapabilities(testPrincipal.userId);
+    expect(body.capabilities.find((capability) => capability.id === "calendar.create_event")).toMatchObject({
+      status: "approved",
+      approvedAgents: ["hermes"],
+    });
+  });
+
   it("does not overwrite stored approvals when the persisted file is unreadable", async () => {
     const home = await mkdtemp(join(tmpdir(), "matrix-capabilities-"));
     const storagePath = join(home, "system", "integration-capabilities.json");
@@ -237,6 +278,27 @@ describe("integration capability routes", () => {
       retryable: false,
     });
     expect(await audit.listActions(testPrincipal.userId)).toEqual([]);
+  });
+
+  it("rejects audit records for unknown capabilities", async () => {
+    const service = createIntegrationCapabilityService();
+    const audit = createAgentActionAuditService();
+    const app = createIntegrationCapabilityRoutes({ service, audit, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/actions", {
+      agent: "hermes",
+      capability: "calendar.delete_event",
+      status: "completed",
+      summary: "Completed task",
+      target: "Primary calendar",
+    }));
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({
+      error: "capability_not_found",
+      message: "Integration capability was not found",
+      retryable: false,
+    });
   });
 
   it("keeps normal task identifiers in audit summaries", async () => {

--- a/tests/gateway/integrations-routes.test.ts
+++ b/tests/gateway/integrations-routes.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createAgentActionAuditService } from "../../packages/gateway/src/onboarding/agent-action-audit.js";
 import { createIntegrationCapabilityRoutes } from "../../packages/gateway/src/onboarding/integration-capability-routes.js";
 import {
   capabilityIdsForConnectedServices,
@@ -117,6 +118,44 @@ describe("integration capability routes", () => {
       service.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true),
     ).rejects.toThrow();
     await expect(readFile(storagePath, "utf8")).resolves.toBe("{not-json");
+  });
+
+  it("records and lists scrubbed agent action audit events", async () => {
+    const service = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+    });
+    await service.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true);
+    const audit = createAgentActionAuditService({
+      now: () => new Date("2026-05-24T00:00:00.000Z"),
+    });
+    const app = createIntegrationCapabilityRoutes({ service, audit, getPrincipal: () => testPrincipal });
+
+    const recorded = await app.request(post("/actions", {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "Created launch event but raw provider token sk-live-secret appeared in provider logs",
+      target: "Primary calendar",
+    }));
+
+    expect(recorded.status).toBe(201);
+    await expect(recorded.json()).resolves.toMatchObject({
+      action: {
+        agent: "hermes",
+        capability: "calendar.create_event",
+        status: "completed",
+        summary: "Agent action completed",
+        target: "Primary calendar",
+        createdAt: "2026-05-24T00:00:00.000Z",
+        completedAt: "2026-05-24T00:00:00.000Z",
+      },
+    });
+
+    const listed = await app.request("/actions");
+    expect(listed.status).toBe(200);
+    const body = await listed.json();
+    expect(body.actions).toHaveLength(1);
+    expect(JSON.stringify(body)).not.toMatch(/sk-live|secret|token|\/home/i);
   });
 
   it("rejects audit actions when a previously approved capability disconnects", async () => {

--- a/tests/gateway/integrations-routes.test.ts
+++ b/tests/gateway/integrations-routes.test.ts
@@ -87,6 +87,22 @@ describe("integration capability routes", () => {
     expect(approved.status).toBe(200);
   });
 
+  it("clears visible approval when the backing integration disconnects", async () => {
+    let connected = true;
+    const service = createIntegrationCapabilityService({
+      getConnectedCapabilityIds: async () => connected ? capabilityIdsForConnectedServices(["google_calendar"]) : [],
+    });
+
+    await service.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true);
+    connected = false;
+
+    const body = await service.listCapabilities(testPrincipal.userId);
+    expect(body.capabilities.find((capability) => capability.id === "calendar.create_event")).toMatchObject({
+      status: "connect_required",
+      approvedAgents: [],
+    });
+  });
+
   it("requires a connected integration before approving capability use", async () => {
     const service = createIntegrationCapabilityService();
     const app = createIntegrationCapabilityRoutes({ service, getPrincipal: () => testPrincipal });
@@ -101,6 +117,23 @@ describe("integration capability routes", () => {
       error: "capability_not_connected",
       message: "Connect the integration before approving agent access",
       retryable: false,
+    });
+  });
+
+  it("does not evict approvals when read-only capability checks see unknown owners", async () => {
+    const service = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event"],
+    });
+
+    await service.setApproval("owner_0", "calendar.create_event", "hermes", true);
+    for (let index = 1; index <= 512; index += 1) {
+      await service.listCapabilities(`owner_${index}`);
+    }
+
+    const ownerZero = await service.listCapabilities("owner_0");
+    expect(ownerZero.capabilities.find((capability) => capability.id === "calendar.create_event")).toMatchObject({
+      status: "approved",
+      approvedAgents: ["hermes"],
     });
   });
 
@@ -220,6 +253,31 @@ describe("integration capability routes", () => {
     });
 
     expect(action.summary).toBe("Completed task_123 for launch prep");
+  });
+
+  it("does not evict audit events when read-only action checks see unknown owners", async () => {
+    const audit = createAgentActionAuditService({
+      now: () => new Date("2026-05-24T00:00:00.000Z"),
+    });
+
+    await audit.recordAction("owner_0", {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "Created launch event",
+      target: "Primary calendar",
+    });
+    for (let index = 1; index <= 512; index += 1) {
+      await audit.listActions(`owner_${index}`);
+    }
+
+    const ownerZero = await audit.listActions("owner_0");
+    expect(ownerZero).toHaveLength(1);
+    expect(ownerZero[0]).toMatchObject({
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+    });
   });
 
   it("rejects unknown capabilities with a generic error", async () => {

--- a/tests/gateway/onboarding-activation.test.ts
+++ b/tests/gateway/onboarding-activation.test.ts
@@ -7,6 +7,7 @@ import {
 import { stepsForGoals } from "../../packages/gateway/src/onboarding/readiness-service.js";
 import { mapActivationError, safeClientMessage } from "../../packages/gateway/src/onboarding/activation-errors.js";
 import { ReadinessStatusCache } from "../../packages/gateway/src/onboarding/readiness-cache.js";
+import { createAgentActionAuditService } from "../../packages/gateway/src/onboarding/agent-action-audit.js";
 import { createTestReadinessService, testPrincipal } from "../helpers/activation-readiness.js";
 
 describe("activation readiness contracts", () => {
@@ -124,5 +125,30 @@ describe("activation readiness contracts", () => {
     expect(cache.get("a")).toEqual({ value: "A" });
     now = 1100;
     expect(cache.get("a")).toBeNull();
+  });
+
+  it("records safe agent action summaries without raw provider details", async () => {
+    const audit = createAgentActionAuditService({
+      now: () => new Date("2026-05-23T00:00:00.000Z"),
+    });
+
+    const action = await audit.recordAction(testPrincipal.userId, {
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      summary: "Created launch rehearsal event; raw provider token sk_live at /home/matrix/secret failed before retry",
+      target: "Primary calendar",
+    });
+
+    expect(action).toMatchObject({
+      agent: "hermes",
+      capability: "calendar.create_event",
+      status: "completed",
+      target: "Primary calendar",
+      createdAt: "2026-05-23T00:00:00.000Z",
+      completedAt: "2026-05-23T00:00:00.000Z",
+    });
+    expect(action.summary).toBe("Agent action completed");
+    expect(JSON.stringify(action)).not.toMatch(/sk_live|\/home|token/i);
   });
 });

--- a/tests/gateway/onboarding-activation.test.ts
+++ b/tests/gateway/onboarding-activation.test.ts
@@ -101,6 +101,22 @@ describe("activation readiness contracts", () => {
     });
   });
 
+  it("keeps assistant integration gate unknown when no capabilities are connected yet", async () => {
+    const integrations = {
+      listCapabilities: async () => ({ capabilities: [] }),
+      getCapabilityApproval: async () => null,
+      setApproval: async () => ({ capabilityId: "calendar.create_event" as const, agent: "hermes" as const, status: "unavailable" as const }),
+    };
+    const { service } = createTestReadinessService(undefined, { integrationCapabilityService: integrations });
+
+    await service.selectGoals(testPrincipal.userId, ["assistant"]);
+    const readiness = await service.getReadiness(testPrincipal.userId);
+
+    expect(readiness.gates.find((gate) => gate.id === "integrations.capabilities")).toMatchObject({
+      status: "unknown",
+    });
+  });
+
   it("sanitizes unsafe error strings before sending them to clients", () => {
     expect(safeClientMessage("postgres constraint failed at /home/matrix/secret")).toBe("Request failed");
     expect(safeClientMessage("Connect GitHub to continue")).toBe("Connect GitHub to continue");


### PR DESCRIPTION
Stack: 4/8

## Summary

- Adds integration capability approval for assistant workflows across calendar, email, messaging, GitHub, and work updates.
- Adds safe agent action audit summaries and onboarding UI for approved/degraded assistant capabilities.

## Tests

- `bun run typecheck`
- `bun run check:patterns` (0 violations, existing warning-only baseline)
- `bun run test -- --reporter=dot` (459 files passed, 3 skipped; 4,752 tests passed, 20 skipped)
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bWF0cml4b3MudGVzdCQ= pnpm --dir shell build`
- `pnpm --dir shell exec playwright test ../tests/e2e/onboarding-activation.spec.ts ../tests/e2e/onboarding-visual.spec.ts --config ../tests/e2e/playwright.config.ts` (8 passed)

## Review/Monitoring

- Stacked PR base: `082-coding-hermes-continuity`
- Greptile and CI must pass before merging.

## Invariants

- Source of truth: integration registry and capability approval service define what agents may use.
- Lock/transaction scope: approval and audit updates stay in the gateway capability/audit services; no provider network call is trusted as local state until summarized safely.
- Acceptable orphan states: provider failures leave capabilities degraded and return safe summaries without raw provider errors.
- Auth source of truth: capability approval routes require owner gateway authentication.
- Deferred scope: support/growth publish flows remain approval-first and land later.