### PR TITLE
feat(onboarding): add admin control surface

### DIFF
--- a/packages/gateway/src/onboarding/admin-control-routes.ts
+++ b/packages/gateway/src/onboarding/admin-control-routes.ts
@@ -1,0 +1,80 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { z } from "zod/v4";
+import { mapActivationError } from "./activation-errors.js";
+import type { AdminControlService } from "./admin-control-service.js";
+import {
+  requireRequestPrincipal,
+  type RequestPrincipal,
+} from "../request-principal.js";
+
+const ADMIN_CONTROL_BODY_LIMIT = 4096;
+
+const SetupSessionRequestSchema = z.union([z.object({
+  target: z.string().trim().min(3).max(120).regex(/^[a-z]+:[a-z0-9_.:-]+$/),
+  intent: z.enum(["connect", "configure", "resume"]),
+}).strict(), z.object({
+  section: z.enum(["models", "agents", "integrations", "settings", "automations", "activity", "readiness"]),
+  resume: z.boolean().default(true),
+}).strict()]);
+
+function normalizeSetupSessionRequest(body: z.infer<typeof SetupSessionRequestSchema>) {
+  if ("target" in body) return body;
+  const targetBySection: Record<typeof body.section, string> = {
+    models: "agent:claude",
+    agents: "agent:claude",
+    integrations: "integration:default",
+    settings: "setting:general",
+    automations: "setting:automations",
+    activity: "setting:activity",
+    readiness: "setting:readiness",
+  };
+  return {
+    target: targetBySection[body.section],
+    intent: body.resume ? "resume" as const : "configure" as const,
+  };
+}
+
+export interface AdminControlRouteDeps {
+  service: AdminControlService;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+function jsonError(c: Context, err: unknown) {
+  const mapped = mapActivationError(err);
+  return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+}
+
+export function createAdminControlRoutes(deps: AdminControlRouteDeps): Hono {
+  const app = new Hono();
+  const limited = bodyLimit({ maxSize: ADMIN_CONTROL_BODY_LIMIT });
+  const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
+
+  app.get("/control-surface", async (c) => {
+    try {
+      const principal = principalFor(c);
+      return c.json(await deps.service.getSurface(principal.userId));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/control-surface/setup-session", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      const body = normalizeSetupSessionRequest(SetupSessionRequestSchema.parse(await c.req.json()));
+      const result = await deps.service.createOrResumeSetupSession(principal.userId, body);
+      return c.json({
+        ...result,
+        sessionId: result.session.id,
+        status: result.session.status,
+        currentStepId: result.session.target,
+      });
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/onboarding/admin-control-service.ts
+++ b/packages/gateway/src/onboarding/admin-control-service.ts
@@ -4,6 +4,7 @@ import type { ReadinessService } from "./readiness-service.js";
 
 const MAX_SETUP_SESSIONS = 512;
 const MAX_SETUP_SESSIONS_PER_OWNER = 16;
+const SETUP_SESSION_TTL_MS = 1000 * 60 * 60 * 24;
 
 export interface AdminProviderCard {
   id: "hermes" | "claude" | "codex" | string;
@@ -94,8 +95,19 @@ export function createAdminControlService(options: {
     return key.startsWith(`${encodeURIComponent(ownerId)}:`);
   }
 
+  function sweepSetupSessions(timestampMs = now().getTime()): void {
+    for (const [key, session] of setupSessions) {
+      const updatedAt = Date.parse(session.updatedAt);
+      if (!Number.isFinite(updatedAt) || timestampMs - updatedAt > SETUP_SESSION_TTL_MS) {
+        setupSessions.delete(key);
+      }
+    }
+  }
+
   async function getSurface(ownerId: string): Promise<AdminControlSurface> {
-    const timestamp = now().toISOString();
+    const currentTime = now();
+    const timestamp = currentTime.toISOString();
+    sweepSetupSessions(currentTime.getTime());
     const [agentStatus, integrationStatus, readiness] = await Promise.all([
       options.agentCredentials.getStatus(ownerId),
       options.integrations.listCapabilities(ownerId),
@@ -149,7 +161,9 @@ export function createAdminControlService(options: {
         createdAt: timestamp,
       },
     ];
-    const latestSession = Array.from(setupSessions.values()).find((session) => session.id.startsWith(`setup.${ownerId}.`)) ?? null;
+    const latestSession = Array.from(setupSessions.values())
+      .filter((session) => session.id.startsWith(`setup.${ownerId}.`))
+      .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))[0] ?? null;
 
     return {
       sections: ["models", "agents", "integrations", "settings", "automations", "activity", "readiness"],
@@ -160,7 +174,7 @@ export function createAdminControlService(options: {
         { id: "readiness-gates", label: "Readiness gates", status: failed || blocked ? "needs_review" : "saved", updatedAt: timestamp },
       ],
       automationSummary: {
-        active: connected,
+        active: 0,
         needsApproval: 0,
         lastActivityAt: null,
       },
@@ -172,10 +186,12 @@ export function createAdminControlService(options: {
   }
 
   async function createOrResumeSetupSession(ownerId: string, input: { target: string; intent: "connect" | "configure" | "resume" }) {
+    const currentTime = now();
+    sweepSetupSessions(currentTime.getTime());
     const key = sessionKey(ownerId, input.target);
     const existing = setupSessions.get(key);
     if (existing) {
-      const resumed = { ...existing, status: "resumable" as const, updatedAt: now().toISOString() };
+      const resumed = { ...existing, status: "resumable" as const, updatedAt: currentTime.toISOString() };
       setupSessions.delete(key);
       setupSessions.set(key, resumed);
       return { session: resumed };
@@ -194,7 +210,7 @@ export function createAdminControlService(options: {
       target: input.target,
       status: "new",
       title: labelForTarget(input.target),
-      updatedAt: now().toISOString(),
+      updatedAt: currentTime.toISOString(),
     };
     setupSessions.set(key, session);
     return { session };

--- a/packages/gateway/src/onboarding/admin-control-service.ts
+++ b/packages/gateway/src/onboarding/admin-control-service.ts
@@ -1,0 +1,204 @@
+import type { AgentCredentialStatusService } from "./agent-credential-status.js";
+import type { IntegrationCapabilityService } from "./integration-capabilities.js";
+import type { ReadinessService } from "./readiness-service.js";
+
+const MAX_SETUP_SESSIONS = 512;
+const MAX_SETUP_SESSIONS_PER_OWNER = 16;
+
+export interface AdminProviderCard {
+  id: "hermes" | "claude" | "codex" | string;
+  label: string;
+  status: "available" | "missing" | "expired" | "revoked" | "failed" | "not_applicable" | "connected" | "approved" | "unavailable";
+  mode: "matrix_system_agent" | "bring_your_own" | "integration";
+  nextAction: string | null;
+}
+
+export interface AdminSettingSummary {
+  id: string;
+  label: string;
+  status: "saved" | "needs_review" | "failed";
+  updatedAt: string;
+}
+
+export interface AdminSetupSession {
+  id: string;
+  target: string;
+  status: "new" | "resumable";
+  title: string;
+  updatedAt: string;
+}
+
+export interface AdminControlSurface {
+  sections: string[];
+  providers: AdminProviderCard[];
+  settings: AdminSettingSummary[];
+  automationSummary: {
+    active: number;
+    needsApproval: number;
+    lastActivityAt: string | null;
+  };
+  integrationSummary: {
+    connected: number;
+    approved: number;
+    needsConnection: number;
+  };
+  readiness: {
+    overallStatus: string;
+    blocked: number;
+    failed: number;
+    ready: number;
+  };
+  activity: Array<{
+    id: string;
+    kind: "readiness" | "integration" | "automation" | "setting";
+    summary: string;
+    createdAt: string;
+  }>;
+  setupSession: AdminSetupSession | null;
+}
+
+export interface AdminControlService {
+  getSurface(ownerId: string): Promise<AdminControlSurface>;
+  createOrResumeSetupSession(ownerId: string, input: { target: string; intent: "connect" | "configure" | "resume" }): Promise<{ session: AdminSetupSession }>;
+}
+
+function labelForTarget(target: string): string {
+  if (target === "agent:claude") return "Connect Claude";
+  if (target === "agent:codex") return "Connect Codex";
+  if (target.startsWith("integration:")) return "Connect integration";
+  if (target.startsWith("setting:")) return "Configure setting";
+  return "Resume setup";
+}
+
+function labelForIntegrationProvider(provider: string): string {
+  if (provider === "github") return "GitHub";
+  if (provider === "calendar") return "Calendar";
+  if (provider === "email") return "Email";
+  return provider.charAt(0).toUpperCase() + provider.slice(1).replace(/_/g, " ");
+}
+
+export function createAdminControlService(options: {
+  agentCredentials: AgentCredentialStatusService;
+  integrations: IntegrationCapabilityService;
+  readiness: ReadinessService;
+  now?: () => Date;
+}): AdminControlService {
+  const now = options.now ?? (() => new Date());
+  const setupSessions = new Map<string, AdminSetupSession>();
+
+  function sessionKey(ownerId: string, target: string): string {
+    return `${encodeURIComponent(ownerId)}:${target}`;
+  }
+
+  function sessionBelongsToOwner(key: string, ownerId: string): boolean {
+    return key.startsWith(`${encodeURIComponent(ownerId)}:`);
+  }
+
+  async function getSurface(ownerId: string): Promise<AdminControlSurface> {
+    const timestamp = now().toISOString();
+    const [agentStatus, integrationStatus, readiness] = await Promise.all([
+      options.agentCredentials.getStatus(ownerId),
+      options.integrations.listCapabilities(ownerId),
+      options.readiness.getReadiness(ownerId),
+    ]);
+    const providers: AdminProviderCard[] = [
+      ...agentStatus.agents.map((agent) => ({
+        id: agent.agent,
+        label: agent.agent === "hermes" ? "Hermes" : agent.agent === "claude" ? "Claude" : "Codex",
+        status: agent.status,
+        mode: agent.agent === "hermes" ? "matrix_system_agent" as const : "bring_your_own" as const,
+        nextAction: agent.nextAction,
+      })),
+      ...integrationStatus.capabilities.slice(0, 4).map((capability) => ({
+        id: capability.id,
+        label: labelForIntegrationProvider(capability.provider),
+        status: capability.status === "connect_required" ? "missing" as const : capability.status,
+        mode: "integration" as const,
+        nextAction: capability.status === "approved"
+          ? null
+          : capability.status === "connect_required"
+            ? `Connect ${capability.provider}`
+            : `Approve ${capability.provider}`,
+      })),
+    ];
+    const approved = integrationStatus.capabilities.filter((capability) => capability.status === "approved").length;
+    const connected = integrationStatus.capabilities.filter((capability) => capability.status === "connected" || capability.status === "approved").length;
+    const needsConnection = integrationStatus.capabilities.filter((capability) => capability.status === "connect_required").length;
+    let integrationApprovalStatus: "saved" | "needs_review" = "needs_review";
+    if (connected === 0 && needsConnection === 0) {
+      integrationApprovalStatus = "saved";
+    } else if (connected > approved) {
+      integrationApprovalStatus = "needs_review";
+    } else if (approved > 0) {
+      integrationApprovalStatus = "saved";
+    }
+    const failed = readiness.gates.filter((gate) => gate.status === "fail").length;
+    const blocked = readiness.gates.filter((gate) => gate.status === "blocked").length;
+    const ready = readiness.gates.filter((gate) => gate.status === "pass").length;
+    const activity = [
+      {
+        id: "activity.readiness",
+        kind: "readiness" as const,
+        summary: readiness.overallStatus === "ready" ? "Readiness is green" : "Readiness needs review",
+        createdAt: timestamp,
+      },
+      {
+        id: "activity.integrations",
+        kind: "integration" as const,
+        summary: approved > 0 ? "Hermes has approved capabilities" : "Integration approval is pending",
+        createdAt: timestamp,
+      },
+    ];
+    const latestSession = Array.from(setupSessions.values()).find((session) => session.id.startsWith(`setup.${ownerId}.`)) ?? null;
+
+    return {
+      sections: ["models", "agents", "integrations", "settings", "automations", "activity", "readiness"],
+      providers,
+      settings: [
+        { id: "agent-routing", label: "Agent routing", status: "saved", updatedAt: timestamp },
+        { id: "integration-approvals", label: "Integration approvals", status: integrationApprovalStatus, updatedAt: timestamp },
+        { id: "readiness-gates", label: "Readiness gates", status: failed || blocked ? "needs_review" : "saved", updatedAt: timestamp },
+      ],
+      automationSummary: {
+        active: connected,
+        needsApproval: 0,
+        lastActivityAt: null,
+      },
+      integrationSummary: { connected, approved, needsConnection },
+      readiness: { overallStatus: readiness.overallStatus, blocked, failed, ready },
+      activity,
+      setupSession: latestSession,
+    };
+  }
+
+  async function createOrResumeSetupSession(ownerId: string, input: { target: string; intent: "connect" | "configure" | "resume" }) {
+    const key = sessionKey(ownerId, input.target);
+    const existing = setupSessions.get(key);
+    if (existing) {
+      const resumed = { ...existing, status: "resumable" as const, updatedAt: now().toISOString() };
+      setupSessions.delete(key);
+      setupSessions.set(key, resumed);
+      return { session: resumed };
+    }
+    const ownerSessions = Array.from(setupSessions.entries())
+      .filter(([, session]) => session.id.startsWith(`setup.${ownerId}.`))
+      .sort((left, right) => Date.parse(left[1].updatedAt) - Date.parse(right[1].updatedAt));
+    if (ownerSessions.length >= MAX_SETUP_SESSIONS_PER_OWNER) {
+      setupSessions.delete(ownerSessions[0][0]);
+    } else if (setupSessions.size >= MAX_SETUP_SESSIONS) {
+      const oldestKey = setupSessions.keys().next().value as string | undefined;
+      if (oldestKey) setupSessions.delete(oldestKey);
+    }
+    const session: AdminSetupSession = {
+      id: `setup.${ownerId}.${input.target.replace(/[^a-zA-Z0-9_.:-]/g, "_")}`,
+      target: input.target,
+      status: "new",
+      title: labelForTarget(input.target),
+      updatedAt: now().toISOString(),
+    };
+    setupSessions.set(key, session);
+    return { session };
+  }
+
+  return { getSurface, createOrResumeSetupSession };
+}

--- a/packages/gateway/src/onboarding/admin-control-service.ts
+++ b/packages/gateway/src/onboarding/admin-control-service.ts
@@ -126,18 +126,20 @@ export function createAdminControlService(options: {
         label: labelForIntegrationProvider(capability.provider),
         status: capability.status === "connect_required" ? "missing" as const : capability.status,
         mode: "integration" as const,
-        nextAction: capability.status === "approved"
+        nextAction: capability.status === "approved" || capability.status === "unavailable"
           ? null
           : capability.status === "connect_required"
-            ? `Connect ${capability.provider}`
-            : `Approve ${capability.provider}`,
+            ? `Connect ${labelForIntegrationProvider(capability.provider)}`
+            : `Approve ${labelForIntegrationProvider(capability.provider)}`,
       })),
     ];
     const approved = integrationStatus.capabilities.filter((capability) => capability.status === "approved").length;
     const connected = integrationStatus.capabilities.filter((capability) => capability.status === "connected" || capability.status === "approved").length;
     const needsConnection = integrationStatus.capabilities.filter((capability) => capability.status === "connect_required").length;
     let integrationApprovalStatus: "saved" | "needs_review" = "needs_review";
-    if (connected === 0 && needsConnection === 0) {
+    if (needsConnection > 0) {
+      integrationApprovalStatus = "needs_review";
+    } else if (connected === 0) {
       integrationApprovalStatus = "saved";
     } else if (connected > approved) {
       integrationApprovalStatus = "needs_review";
@@ -161,8 +163,9 @@ export function createAdminControlService(options: {
         createdAt: timestamp,
       },
     ];
-    const latestSession = Array.from(setupSessions.values())
-      .filter((session) => session.id.startsWith(`setup.${ownerId}.`))
+    const latestSession = Array.from(setupSessions.entries())
+      .filter(([key]) => sessionBelongsToOwner(key, ownerId))
+      .map(([, session]) => session)
       .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))[0] ?? null;
 
     return {
@@ -190,14 +193,15 @@ export function createAdminControlService(options: {
     sweepSetupSessions(currentTime.getTime());
     const key = sessionKey(ownerId, input.target);
     const existing = setupSessions.get(key);
-    if (existing) {
+    if (existing && input.intent === "resume") {
       const resumed = { ...existing, status: "resumable" as const, updatedAt: currentTime.toISOString() };
       setupSessions.delete(key);
       setupSessions.set(key, resumed);
       return { session: resumed };
     }
+    if (existing) setupSessions.delete(key);
     const ownerSessions = Array.from(setupSessions.entries())
-      .filter(([, session]) => session.id.startsWith(`setup.${ownerId}.`))
+      .filter(([entryKey]) => sessionBelongsToOwner(entryKey, ownerId))
       .sort((left, right) => Date.parse(left[1].updatedAt) - Date.parse(right[1].updatedAt));
     if (ownerSessions.length >= MAX_SETUP_SESSIONS_PER_OWNER) {
       setupSessions.delete(ownerSessions[0][0]);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -87,6 +87,8 @@ import { createAgentCredentialRoutes } from "./onboarding/agent-credential-route
 import { createAgentActionAuditService } from "./onboarding/agent-action-audit.js";
 import { capabilityIdsForConnectedServices, createIntegrationCapabilityService } from "./onboarding/integration-capabilities.js";
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
+import { createAdminControlService } from "./onboarding/admin-control-service.js";
+import { createAdminControlRoutes } from "./onboarding/admin-control-routes.js";
 import { createVocalHandler } from "./vocal/ws-handler.js";
 import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
 import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
@@ -552,6 +554,11 @@ export async function createGateway(config: GatewayConfig) {
     codingSetup: {
       getCodingSetup: async (ownerId) => codingSetupProvider?.getCodingSetup(ownerId) ?? unavailableCodingSetup,
     },
+  });
+  const adminControlService = createAdminControlService({
+    agentCredentials: agentCredentialService,
+    integrations: integrationCapabilityService,
+    readiness: readinessService,
   });
 
   // App data layer (Postgres-backed when DATABASE_URL is set)
@@ -1444,6 +1451,7 @@ export async function createGateway(config: GatewayConfig) {
     service: integrationCapabilityService,
     audit: agentActionAuditService,
   }));
+  app.route("/api/admin", createAdminControlRoutes({ service: adminControlService }));
   app.route("/api", createShellRoutes({
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -15,6 +15,7 @@ import { CodingSetupPanel } from "./onboarding/CodingSetupPanel";
 import { CodingHandoffSummary } from "./onboarding/CodingHandoffSummary";
 import { AgentCredentialPanel } from "./onboarding/AgentCredentialPanel";
 import { AssistantSetupPanel } from "./onboarding/AssistantSetupPanel";
+import { AdminControlPanel, type AdminControlSurface } from "./onboarding/AdminControlPanel";
 import { MicPermissionDialog } from "./MicPermissionDialog";
 import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
@@ -43,6 +44,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
   const [continueExiting, setContinueExiting] = useState(false);
   const [entranceStage, setEntranceStage] = useState<"hidden" | "center" | "settled">("hidden");
   const [logoMediaAvailable, setLogoMediaAvailable] = useState(true);
+  const [adminSurface, setAdminSurface] = useState<AdminControlSurface | null>(null);
   const ambientRef = useRef<HTMLAudioElement | null>(null);
   const gainNodeRef = useRef<GainNode | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
@@ -105,6 +107,29 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
       }
       ambientRef.current?.pause();
       audioCtxRef.current?.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/admin/control-surface", {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("admin control request failed");
+        return await res.json() as AdminControlSurface;
+      })
+      .then((surface) => {
+        if (!cancelled) setAdminSurface(surface);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          console.warn("[onboarding] admin control load failed:", err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
     };
   }, []);
 
@@ -262,6 +287,8 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
                   onApprove={integrationCapabilities.approveForHermes}
                 />
               )}
+
+              <AdminControlPanel surface={adminSurface} />
 
               <div className="flex flex-col gap-2 sm:flex-row">
                 <button

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -50,6 +50,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
   const audioCtxRef = useRef<AudioContext | null>(null);
   const continueTimerRef = useRef<number | null>(null);
   const continueFrameRef = useRef<number | null>(null);
+  const adminActionControllerRef = useRef<AbortController | null>(null);
 
   // Live subtitle — accumulated AI transcript fragments, synced with voice
   const subtitle = ob.currentSubtitle;
@@ -105,6 +106,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
       if (continueFrameRef.current !== null) {
         window.cancelAnimationFrame(continueFrameRef.current);
       }
+      adminActionControllerRef.current?.abort();
       ambientRef.current?.pause();
       audioCtxRef.current?.close();
     };

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -110,28 +110,55 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
     };
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
+  const refreshAdminSurface = useCallback((signal?: AbortSignal) => {
+    const requestSignal = signal ? AbortSignal.any([signal, AbortSignal.timeout(10_000)]) : AbortSignal.timeout(10_000);
     void fetch("/api/admin/control-surface", {
       headers: { Accept: "application/json" },
-      signal: AbortSignal.timeout(10_000),
+      signal: requestSignal,
     })
       .then(async (res) => {
         if (!res.ok) throw new Error("admin control request failed");
         return await res.json() as AdminControlSurface;
       })
       .then((surface) => {
-        if (!cancelled) setAdminSurface(surface);
+        setAdminSurface(surface);
       })
       .catch((err: unknown) => {
-        if (!cancelled) {
-          console.warn("[onboarding] admin control load failed:", err instanceof Error ? err.message : String(err));
-        }
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.warn("[onboarding] admin control load failed:", err instanceof Error ? err.message : String(err));
       });
-    return () => {
-      cancelled = true;
-    };
   }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    refreshAdminSurface(controller.signal);
+    return () => controller.abort();
+  }, [refreshAdminSurface]);
+
+  const resumeAdminSetup = useCallback((target: string) => {
+    adminActionControllerRef.current?.abort();
+    const controller = new AbortController();
+    adminActionControllerRef.current = controller;
+    const requestSignal = AbortSignal.any([controller.signal, AbortSignal.timeout(10_000)]);
+    void fetch("/api/admin/control-surface/setup-session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ target, intent: "resume" }),
+      signal: requestSignal,
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("admin setup request failed");
+        return await res.json();
+      })
+      .then(() => refreshAdminSurface(controller.signal))
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.warn("[onboarding] admin setup failed:", err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (adminActionControllerRef.current === controller) adminActionControllerRef.current = null;
+      });
+  }, [refreshAdminSurface]);
 
   function startAmbientAudio() {
     const audio = new Audio("/onboarding-ambient.wav");
@@ -288,7 +315,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
                 />
               )}
 
-              <AdminControlPanel surface={adminSurface} />
+              <AdminControlPanel surface={adminSurface} onResumeSetup={resumeAdminSetup} />
 
               <div className="flex flex-col gap-2 sm:flex-row">
                 <button

--- a/shell/src/components/onboarding/AdminControlPanel.tsx
+++ b/shell/src/components/onboarding/AdminControlPanel.tsx
@@ -34,6 +34,12 @@ export function AdminControlPanel({
   onResumeSetup: (target: string) => void;
 }) {
   if (!surface) return null;
+  const setupSession = surface.setupSession;
+  const settingsLabel = surface.settings.some((setting) => setting.status === "failed")
+    ? "attention needed"
+    : surface.settings.some((setting) => setting.status === "needs_review")
+      ? "review before launch"
+      : "saved and reloadable";
 
   return (
     <section className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/80 p-4 shadow-[0_16px_45px_rgba(23,40,31,0.08)]">
@@ -60,7 +66,7 @@ export function AdminControlPanel({
                 <BotIcon className="h-4 w-4" aria-hidden="true" />
                 <p className="text-xs font-semibold">{provider.label}</p>
               </div>
-              {(provider.status === "available" || provider.status === "approved") && <CheckCircle2Icon className="h-4 w-4" aria-hidden="true" />}
+              {(provider.status === "available" || provider.status === "approved" || provider.status === "connected") && <CheckCircle2Icon className="h-4 w-4" aria-hidden="true" />}
             </div>
             <p className="mt-1 text-xs capitalize opacity-75">{provider.mode.replaceAll("_", " ")}</p>
             <p className="mt-1 text-xs capitalize opacity-75">{provider.status.replaceAll("_", " ")}</p>
@@ -70,8 +76,8 @@ export function AdminControlPanel({
 
       <div className="mt-3 grid gap-2 lg:grid-cols-[0.9fr_1.1fr]">
         <AdminSetupWizard
-          session={surface.setupSession}
-          onResume={surface.setupSession ? () => onResumeSetup(surface.setupSession.target) : undefined}
+          session={setupSession}
+          onResume={setupSession ? () => onResumeSetup(setupSession.target) : undefined}
         />
         <div className="grid gap-2 sm:grid-cols-3">
           <div className="rounded-md border border-[#17281f]/10 bg-white/55 p-3">
@@ -88,7 +94,7 @@ export function AdminControlPanel({
               Settings
             </p>
             <p className="mt-2 text-xl font-semibold text-[#17281f]">{surface.settings.length}</p>
-            <p className="text-xs text-[#17281f]/55">saved and reloadable</p>
+            <p className="text-xs text-[#17281f]/55">{settingsLabel}</p>
           </div>
           <div className="rounded-md border border-[#17281f]/10 bg-white/55 p-3">
             <p className="flex items-center gap-1.5 text-xs font-semibold text-[#111612]">

--- a/shell/src/components/onboarding/AdminControlPanel.tsx
+++ b/shell/src/components/onboarding/AdminControlPanel.tsx
@@ -26,7 +26,13 @@ function providerTone(status: string) {
   return "text-[#17281f]/65 bg-white/55 border-[#17281f]/10";
 }
 
-export function AdminControlPanel({ surface }: { surface: AdminControlSurface | null }) {
+export function AdminControlPanel({
+  surface,
+  onResumeSetup,
+}: {
+  surface: AdminControlSurface | null;
+  onResumeSetup: (target: string) => void;
+}) {
   if (!surface) return null;
 
   return (
@@ -63,7 +69,10 @@ export function AdminControlPanel({ surface }: { surface: AdminControlSurface | 
       </div>
 
       <div className="mt-3 grid gap-2 lg:grid-cols-[0.9fr_1.1fr]">
-        <AdminSetupWizard session={surface.setupSession} />
+        <AdminSetupWizard
+          session={surface.setupSession}
+          onResume={surface.setupSession ? () => onResumeSetup(surface.setupSession.target) : undefined}
+        />
         <div className="grid gap-2 sm:grid-cols-3">
           <div className="rounded-md border border-[#17281f]/10 bg-white/55 p-3">
             <p className="flex items-center gap-1.5 text-xs font-semibold text-[#111612]">

--- a/shell/src/components/onboarding/AdminControlPanel.tsx
+++ b/shell/src/components/onboarding/AdminControlPanel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { ActivityIcon, BotIcon, CheckCircle2Icon, GaugeIcon, Settings2Icon, WorkflowIcon } from "lucide-react";
+import { AdminSetupWizard, type AdminSetupSessionSummary } from "./AdminSetupWizard";
+
+export interface AdminControlSurface {
+  sections: string[];
+  providers: Array<{
+    id: string;
+    label: string;
+    status: string;
+    mode: "matrix_system_agent" | "bring_your_own" | "integration";
+    nextAction: string | null;
+  }>;
+  settings: Array<{ id: string; label: string; status: string; updatedAt: string }>;
+  automationSummary: { active: number; needsApproval: number; lastActivityAt: string | null };
+  integrationSummary: { connected: number; approved: number; needsConnection: number };
+  readiness: { overallStatus: string; blocked: number; failed: number; ready: number };
+  activity: Array<{ id: string; kind: string; summary: string; createdAt: string }>;
+  setupSession: AdminSetupSessionSummary | null;
+}
+
+function providerTone(status: string) {
+  if (status === "available" || status === "approved" || status === "connected") return "text-[#213829] bg-[#4f7f5c]/10 border-[#4f7f5c]/20";
+  if (status === "failed" || status === "revoked" || status === "expired") return "text-[#5f2b1e] bg-[#b4532f]/10 border-[#b4532f]/20";
+  return "text-[#17281f]/65 bg-white/55 border-[#17281f]/10";
+}
+
+export function AdminControlPanel({ surface }: { surface: AdminControlSurface | null }) {
+  if (!surface) return null;
+
+  return (
+    <section className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/80 p-4 shadow-[0_16px_45px_rgba(23,40,31,0.08)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-[#111612]">
+            <GaugeIcon className="h-4 w-4 text-[#a6542f]" aria-hidden="true" />
+            Matrix control
+          </h2>
+          <p className="mt-1 max-w-xl text-xs leading-5 text-[#17281f]/62">
+            Models, agents, integrations, settings, automations, activity, and readiness stay inspectable from one operational surface.
+          </p>
+        </div>
+        <div className="rounded-full border border-[#17281f]/10 bg-white/60 px-2.5 py-1 text-xs font-medium capitalize text-[#17281f]/70">
+          {surface.readiness.overallStatus}
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-3">
+        {surface.providers.map((provider) => (
+          <div key={provider.id} className={`rounded-md border p-3 ${providerTone(provider.status)}`}>
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <BotIcon className="h-4 w-4" aria-hidden="true" />
+                <p className="text-xs font-semibold">{provider.label}</p>
+              </div>
+              {(provider.status === "available" || provider.status === "approved") && <CheckCircle2Icon className="h-4 w-4" aria-hidden="true" />}
+            </div>
+            <p className="mt-1 text-xs capitalize opacity-75">{provider.mode.replaceAll("_", " ")}</p>
+            <p className="mt-1 text-xs capitalize opacity-75">{provider.status.replaceAll("_", " ")}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-2 lg:grid-cols-[0.9fr_1.1fr]">
+        <AdminSetupWizard session={surface.setupSession} />
+        <div className="grid gap-2 sm:grid-cols-3">
+          <div className="rounded-md border border-[#17281f]/10 bg-white/55 p-3">
+            <p className="flex items-center gap-1.5 text-xs font-semibold text-[#111612]">
+              <WorkflowIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              Automations
+            </p>
+            <p className="mt-2 text-xl font-semibold text-[#17281f]">{surface.automationSummary.active}</p>
+            <p className="text-xs text-[#17281f]/55">{surface.automationSummary.needsApproval} need approval</p>
+          </div>
+          <div className="rounded-md border border-[#17281f]/10 bg-white/55 p-3">
+            <p className="flex items-center gap-1.5 text-xs font-semibold text-[#111612]">
+              <Settings2Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              Settings
+            </p>
+            <p className="mt-2 text-xl font-semibold text-[#17281f]">{surface.settings.length}</p>
+            <p className="text-xs text-[#17281f]/55">saved and reloadable</p>
+          </div>
+          <div className="rounded-md border border-[#17281f]/10 bg-white/55 p-3">
+            <p className="flex items-center gap-1.5 text-xs font-semibold text-[#111612]">
+              <ActivityIcon className="h-3.5 w-3.5" aria-hidden="true" />
+              Activity
+            </p>
+            <p className="mt-2 text-xl font-semibold text-[#17281f]">{surface.activity.length}</p>
+            <p className="text-xs text-[#17281f]/55">{surface.activity[0]?.summary ?? "No recent activity"}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/shell/src/components/onboarding/AdminSetupWizard.tsx
+++ b/shell/src/components/onboarding/AdminSetupWizard.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { RotateCcwIcon } from "lucide-react";
+
+export interface AdminSetupSessionSummary {
+  id: string;
+  target: string;
+  status: "new" | "resumable";
+  title: string;
+  updatedAt: string;
+}
+
+export function AdminSetupWizard({ session }: { session: AdminSetupSessionSummary | null }) {
+  return (
+    <div className="rounded-md border border-[#17281f]/10 bg-white/55 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold text-[#111612]">Setup wizard</p>
+          <p className="mt-1 text-xs leading-5 text-[#17281f]/60">
+            {session ? session.title : "Start or resume model, integration, settings, or automation setup from one place."}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[#17281f]/12 bg-[#f8f5ee]/85 px-2.5 text-xs font-medium text-[#17281f]"
+        >
+          <RotateCcwIcon className="h-3.5 w-3.5" aria-hidden="true" />
+          Resume setup
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/shell/src/components/onboarding/AdminSetupWizard.tsx
+++ b/shell/src/components/onboarding/AdminSetupWizard.tsx
@@ -10,7 +10,13 @@ export interface AdminSetupSessionSummary {
   updatedAt: string;
 }
 
-export function AdminSetupWizard({ session }: { session: AdminSetupSessionSummary | null }) {
+export function AdminSetupWizard({
+  session,
+  onResume,
+}: {
+  session: AdminSetupSessionSummary | null;
+  onResume?: () => void;
+}) {
   return (
     <div className="rounded-md border border-[#17281f]/10 bg-white/55 p-3">
       <div className="flex items-center justify-between gap-3">
@@ -20,13 +26,16 @@ export function AdminSetupWizard({ session }: { session: AdminSetupSessionSummar
             {session ? session.title : "Start or resume model, integration, settings, or automation setup from one place."}
           </p>
         </div>
-        <button
-          type="button"
-          className="inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[#17281f]/12 bg-[#f8f5ee]/85 px-2.5 text-xs font-medium text-[#17281f]"
-        >
-          <RotateCcwIcon className="h-3.5 w-3.5" aria-hidden="true" />
-          Resume setup
-        </button>
+        {session && onResume ? (
+          <button
+            type="button"
+            onClick={onResume}
+            className="inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[#17281f]/12 bg-[#f8f5ee]/85 px-2.5 text-xs font-medium text-[#17281f]"
+          >
+            <RotateCcwIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            Resume setup
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/specs/082-paid-beta-readiness/tasks.md
+++ b/specs/082-paid-beta-readiness/tasks.md
@@ -170,18 +170,18 @@
 
 ### Tests First
 
-- [ ] T063 [P] [ADMIN] Write failing admin control contract tests in `tests/gateway/admin-control-routes.test.ts`
-- [ ] T064 [P] [ADMIN] Write failing admin control surface state tests in `tests/gateway/onboarding-activation.test.ts`
-- [ ] T065 [P] [ADMIN] Write failing admin control e2e visual path in `tests/e2e/onboarding-activation.spec.ts`
+- [X] T063 [P] [ADMIN] Write failing admin control contract tests in `tests/gateway/admin-control-routes.test.ts`
+- [X] T064 [P] [ADMIN] Write failing admin control surface state tests in `tests/gateway/onboarding-activation.test.ts`
+- [X] T065 [P] [ADMIN] Write failing admin control e2e visual path in `tests/e2e/onboarding-activation.spec.ts`
 
 ### Implementation
 
-- [ ] T066 [ADMIN] Implement admin control surface summaries in `packages/gateway/src/onboarding/admin-control-service.ts`
-- [ ] T067 [ADMIN] Add admin control routes for provider cards, setup sessions, settings, automations, activity, and readiness in `packages/gateway/src/onboarding/admin-control-routes.ts`
-- [ ] T068 [ADMIN] Wire admin control routes in `packages/gateway/src/server.ts`
-- [ ] T069 [P] [ADMIN] Create Finna-inspired provider/model cards in `shell/src/components/onboarding/AdminControlPanel.tsx`
-- [ ] T070 [P] [ADMIN] Create setup wizard resume/reconnect states in `shell/src/components/onboarding/AdminSetupWizard.tsx`
-- [ ] T071 [ADMIN] Wire admin control panel into onboarding and settings entry points in `shell/src/components/OnboardingScreen.tsx`
+- [X] T066 [ADMIN] Implement admin control surface summaries in `packages/gateway/src/onboarding/admin-control-service.ts`
+- [X] T067 [ADMIN] Add admin control routes for provider cards, setup sessions, settings, automations, activity, and readiness in `packages/gateway/src/onboarding/admin-control-routes.ts`
+- [X] T068 [ADMIN] Wire admin control routes in `packages/gateway/src/server.ts`
+- [X] T069 [P] [ADMIN] Create Finna-inspired provider/model cards in `shell/src/components/onboarding/AdminControlPanel.tsx`
+- [X] T070 [P] [ADMIN] Create setup wizard resume/reconnect states in `shell/src/components/onboarding/AdminSetupWizard.tsx`
+- [X] T071 [ADMIN] Wire admin control panel into onboarding and settings entry points in `shell/src/components/OnboardingScreen.tsx`
 
 **Checkpoint**: Admin/control setup is inspectable, resumable, and visually aligned with Matrix branding.
 

--- a/tests/e2e/onboarding-activation.spec.ts
+++ b/tests/e2e/onboarding-activation.spec.ts
@@ -248,4 +248,62 @@ test.describe("onboarding activation", () => {
     await expect(page.getByText("Email summaries")).toBeVisible();
     await expect(page.getByRole("button", { name: /Approve Hermes/i })).toBeVisible();
   });
+
+  test("shows the Matrix admin control surface during onboarding", async ({ page }) => {
+    await page.route("**/api/onboarding/readiness", async (route) => {
+      await route.fulfill({
+        json: {
+          overallStatus: "degraded",
+          goals: [],
+          gates: [],
+          systemAgent: "hermes",
+          activeAgents: ["hermes"],
+          agents: [],
+        },
+      });
+    });
+    await page.route("**/api/agents/credentials/status", async (route) => {
+      await route.fulfill({
+        json: {
+          systemAgent: "hermes",
+          activeAgents: ["hermes"],
+          routingExplanation: "Hermes remains the Matrix system agent.",
+          agents: [],
+        },
+      });
+    });
+    await page.route("**/api/integrations/capabilities", async (route) => {
+      await route.fulfill({ json: { capabilities: [] } });
+    });
+    await page.route("**/api/admin/control-surface", async (route) => {
+      await route.fulfill({
+        json: {
+          sections: ["models", "agents", "integrations", "settings", "automations", "activity", "readiness"],
+          providers: [
+            { id: "hermes", label: "Hermes", status: "available", mode: "matrix_system_agent", nextAction: null },
+            { id: "claude", label: "Claude", status: "missing", mode: "bring_your_own", nextAction: "Connect Claude" },
+            { id: "codex", label: "Codex", status: "missing", mode: "bring_your_own", nextAction: "Connect Codex" },
+          ],
+          settings: [
+            { id: "agent-routing", label: "Agent routing", status: "saved", updatedAt: "2026-05-23T00:00:00.000Z" },
+          ],
+          automationSummary: { active: 2, needsApproval: 1, lastActivityAt: "2026-05-23T00:00:00.000Z" },
+          integrationSummary: { connected: 1, approved: 1, needsConnection: 2 },
+          readiness: { overallStatus: "degraded", blocked: 0, failed: 1, ready: 3 },
+          activity: [
+            { id: "activity.readiness", kind: "readiness", summary: "Readiness needs review", createdAt: "2026-05-23T00:00:00.000Z" },
+          ],
+          setupSession: { id: "setup.agent.claude", target: "agent:claude", status: "resumable", title: "Connect Claude", updatedAt: "2026-05-23T00:00:00.000Z" },
+        },
+      });
+    });
+
+    await page.goto("/");
+
+    await expect(page.getByText("Matrix control")).toBeVisible();
+    await expect(page.getByText("Hermes")).toBeVisible();
+    await expect(page.getByText("Automations")).toBeVisible();
+    await expect(page.getByText("Resume setup")).toBeVisible();
+    await expect(page.getByText("Readiness needs review")).toBeVisible();
+  });
 });

--- a/tests/gateway/admin-control-routes.test.ts
+++ b/tests/gateway/admin-control-routes.test.ts
@@ -33,7 +33,7 @@ describe("admin control routes", () => {
       expect.objectContaining({ id: "codex", label: "Codex", mode: "bring_your_own" }),
     ]));
     expect(body.integrationSummary).toMatchObject({ approved: 1 });
-    expect(body.automationSummary).toEqual(expect.objectContaining({ active: expect.any(Number), needsApproval: expect.any(Number) }));
+    expect(body.automationSummary).toEqual(expect.objectContaining({ active: 0, needsApproval: 0, lastActivityAt: null }));
     expect(JSON.stringify(body)).not.toMatch(/secret|token|postgres|\/home\//i);
   });
 
@@ -198,6 +198,28 @@ describe("admin control routes", () => {
       session: expect.objectContaining({ target: "integration:default" }),
       currentStepId: "integration:default",
     });
+  });
+
+  it("returns the most recently resumed setup session on the control surface", async () => {
+    let current = Date.parse("2026-05-23T00:00:00.000Z");
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService();
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({
+      agentCredentials,
+      integrations,
+      readiness,
+      now: () => new Date(current),
+    });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(post("/control-surface/setup-session", { target: "agent:claude", intent: "connect" }));
+    current += 1000;
+    await app.request(post("/control-surface/setup-session", { target: "agent:codex", intent: "connect" }));
+
+    const body = await (await app.request("/control-surface")).json();
+
+    expect(body.setupSession).toMatchObject({ target: "agent:codex" });
   });
 
   it("does not leak setup sessions between owner id prefixes", async () => {

--- a/tests/gateway/admin-control-routes.test.ts
+++ b/tests/gateway/admin-control-routes.test.ts
@@ -72,6 +72,62 @@ describe("admin control routes", () => {
     expect(body.providers).not.toEqual(expect.arrayContaining([
       expect.objectContaining({ id: "messaging.post_message", label: "GitHub" }),
     ]));
+    expect(body.providers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "messaging.post_message", nextAction: "Approve Messaging" }),
+    ]));
+  });
+
+  it("keeps pending connection requirements visible after another capability is approved", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = {
+      listCapabilities: async () => ({
+        capabilities: [
+          {
+            id: "calendar.create_event",
+            provider: "calendar" as const,
+            capability: "create_calendar_event",
+            status: "approved" as const,
+            approvedAgents: ["hermes" as const],
+            requiresApprovalPerAction: true,
+          },
+          {
+            id: "email.read_email",
+            provider: "email" as const,
+            capability: "read_email",
+            status: "connect_required" as const,
+            approvedAgents: [],
+            requiresApprovalPerAction: true,
+          },
+          {
+            id: "github.read_repository",
+            provider: "github" as const,
+            capability: "read_repository",
+            status: "unavailable" as const,
+            approvedAgents: [],
+            requiresApprovalPerAction: true,
+          },
+        ],
+      }),
+      getCapabilityApproval: async () => null,
+      setApproval: async () => ({
+        capabilityId: "calendar.create_event",
+        agent: "hermes" as const,
+        status: "approved" as const,
+      }),
+    };
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const body = await (await app.request("/control-surface")).json();
+
+    expect(body.settings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "integration-approvals", status: "needs_review" }),
+    ]));
+    expect(body.providers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "email.read_email", nextAction: "Connect Email" }),
+      expect.objectContaining({ id: "github.read_repository", nextAction: null }),
+    ]));
   });
 
   it("does not require integration approval review when no integrations are available", async () => {
@@ -114,7 +170,7 @@ describe("admin control routes", () => {
     ]));
   });
 
-  it("creates and resumes setup wizard sessions without duplicate destructive work", async () => {
+  it("creates fresh setup wizard sessions for connect and resumes only on resume intent", async () => {
     const agentCredentials = createAgentCredentialStatusService({ now: () => new Date("2026-05-23T00:00:00.000Z") });
     const integrations = createIntegrationCapabilityService();
     const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
@@ -127,7 +183,7 @@ describe("admin control routes", () => {
     }));
     const resumed = await app.request(post("/control-surface/setup-session", {
       target: "agent:claude",
-      intent: "connect",
+      intent: "resume",
     }));
 
     expect(created.status).toBe(200);
@@ -136,6 +192,22 @@ describe("admin control routes", () => {
     const second = await resumed.json();
     expect(second.session.id).toBe(first.session.id);
     expect(second.session.status).toBe("resumable");
+  });
+
+  it("does not resume stale setup state when the operator asks to connect", async () => {
+    const agentCredentials = createAgentCredentialStatusService({ now: () => new Date("2026-05-23T00:00:00.000Z") });
+    const integrations = createIntegrationCapabilityService();
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness, now: () => new Date("2026-05-23T00:00:00.000Z") });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(post("/control-surface/setup-session", { target: "agent:claude", intent: "connect" }));
+    const restarted = await app.request(post("/control-surface/setup-session", { target: "agent:claude", intent: "connect" }));
+
+    expect(restarted.status).toBe(200);
+    await expect(restarted.json()).resolves.toMatchObject({
+      session: expect.objectContaining({ status: "new" }),
+    });
   });
 
   it("starts a fresh setup session when the operator asks to configure", async () => {

--- a/tests/gateway/admin-control-routes.test.ts
+++ b/tests/gateway/admin-control-routes.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { createAdminControlRoutes } from "../../packages/gateway/src/onboarding/admin-control-routes.js";
+import { createAdminControlService } from "../../packages/gateway/src/onboarding/admin-control-service.js";
+import { createAgentCredentialStatusService } from "../../packages/gateway/src/onboarding/agent-credential-status.js";
+import { createIntegrationCapabilityService } from "../../packages/gateway/src/onboarding/integration-capabilities.js";
+import { createTestReadinessService, testPrincipal } from "../helpers/activation-readiness.js";
+
+function post(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("admin control routes", () => {
+  it("returns provider cards, setup state, settings, automations, activity, and readiness safely", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService({ connectedCapabilityIds: ["calendar.create_event"] });
+    await integrations.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true);
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request("/control-surface");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sections).toEqual(["models", "agents", "integrations", "settings", "automations", "activity", "readiness"]);
+    expect(body.providers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "hermes", label: "Hermes", status: "available", mode: "matrix_system_agent" }),
+      expect.objectContaining({ id: "claude", label: "Claude", mode: "bring_your_own" }),
+      expect.objectContaining({ id: "codex", label: "Codex", mode: "bring_your_own" }),
+    ]));
+    expect(body.integrationSummary).toMatchObject({ approved: 1 });
+    expect(body.automationSummary).toEqual(expect.objectContaining({ active: expect.any(Number), needsApproval: expect.any(Number) }));
+    expect(JSON.stringify(body)).not.toMatch(/secret|token|postgres|\/home\//i);
+  });
+
+  it("labels non-GitHub integration providers by their actual provider", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = {
+      listCapabilities: async () => ({
+        capabilities: [{
+          id: "messaging.post_message",
+          provider: "messaging" as const,
+          capability: "post_message",
+          status: "connected" as const,
+          approvedAgents: [],
+          requiresApprovalPerAction: true,
+        }],
+      }),
+      getCapabilityApproval: async () => ({
+        capabilityId: "messaging.post_message",
+        approvedAgents: [],
+      }),
+      setApproval: async () => ({
+        capabilityId: "messaging.post_message",
+        agent: "hermes" as const,
+        status: "connected" as const,
+      }),
+    };
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const body = await (await app.request("/control-surface")).json();
+
+    expect(body.providers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "messaging.post_message", label: "Messaging", mode: "integration" }),
+    ]));
+    expect(body.providers).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "messaging.post_message", label: "GitHub" }),
+    ]));
+  });
+
+  it("does not require integration approval review when no integrations are available", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = {
+      listCapabilities: async () => ({ capabilities: [] }),
+      getCapabilityApproval: async () => null,
+      setApproval: async () => ({
+        capabilityId: "calendar.create_event",
+        agent: "hermes" as const,
+        status: "unavailable" as const,
+      }),
+    };
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const body = await (await app.request("/control-surface")).json();
+
+    expect(body.settings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "integration-approvals", status: "saved" }),
+    ]));
+  });
+
+  it("keeps integration approvals in review when connected capabilities are only partially approved", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService({
+      connectedCapabilityIds: ["calendar.create_event", "email.read_email"],
+    });
+    await integrations.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true);
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const body = await (await app.request("/control-surface")).json();
+
+    expect(body.integrationSummary).toMatchObject({ connected: 2, approved: 1 });
+    expect(body.settings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "integration-approvals", status: "needs_review" }),
+    ]));
+  });
+
+  it("creates and resumes setup wizard sessions without duplicate destructive work", async () => {
+    const agentCredentials = createAgentCredentialStatusService({ now: () => new Date("2026-05-23T00:00:00.000Z") });
+    const integrations = createIntegrationCapabilityService();
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness, now: () => new Date("2026-05-23T00:00:00.000Z") });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/control-surface/setup-session", {
+      target: "agent:claude",
+      intent: "connect",
+    }));
+    const resumed = await app.request(post("/control-surface/setup-session", {
+      target: "agent:claude",
+      intent: "connect",
+    }));
+
+    expect(created.status).toBe(200);
+    expect(resumed.status).toBe(200);
+    const first = await created.json();
+    const second = await resumed.json();
+    expect(second.session.id).toBe(first.session.id);
+    expect(second.session.status).toBe("resumable");
+  });
+
+  it("starts a fresh setup session when the operator asks to configure", async () => {
+    let current = Date.parse("2026-05-23T00:00:00.000Z");
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService();
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({
+      agentCredentials,
+      integrations,
+      readiness,
+      now: () => new Date(current),
+    });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(post("/control-surface/setup-session", { target: "setting:general", intent: "connect" }));
+    current += 1000;
+    const configured = await app.request(post("/control-surface/setup-session", { target: "setting:general", intent: "configure" }));
+
+    expect(configured.status).toBe(200);
+    await expect(configured.json()).resolves.toMatchObject({
+      session: expect.objectContaining({ status: "new", updatedAt: "2026-05-23T00:00:01.000Z" }),
+    });
+  });
+
+  it("accepts the documented section/resume setup session payload", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService();
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/control-surface/setup-session", {
+      section: "models",
+      resume: true,
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      session: expect.objectContaining({ target: "agent:claude" }),
+      sessionId: expect.stringContaining("setup."),
+      currentStepId: "agent:claude",
+    });
+  });
+
+  it("maps integration section setup to a generic integration target", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService();
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/control-surface/setup-session", {
+      section: "integrations",
+      resume: true,
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      session: expect.objectContaining({ target: "integration:default" }),
+      currentStepId: "integration:default",
+    });
+  });
+
+  it("does not leak setup sessions between owner id prefixes", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService();
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+
+    await service.createOrResumeSetupSession("owner:one:extra", { target: "agent:codex", intent: "connect" });
+    const surface = await service.getSurface("owner:one");
+
+    expect(surface.setupSession).toBeNull();
+  });
+
+  it("rejects invalid setup targets with a generic client-safe error", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService();
+    const { service: readiness } = createTestReadinessService(undefined, { agentCredentialService: agentCredentials, integrationCapabilityService: integrations });
+    const service = createAdminControlService({ agentCredentials, integrations, readiness });
+    const app = createAdminControlRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/control-surface/setup-session", {
+      target: "../../secret",
+      intent: "connect",
+    }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "invalid_request",
+      message: "Request is invalid",
+      retryable: false,
+    });
+  });
+});

--- a/tests/gateway/onboarding-activation.test.ts
+++ b/tests/gateway/onboarding-activation.test.ts
@@ -186,7 +186,7 @@ describe("activation readiness contracts", () => {
     expect(surface.providers.map((provider) => provider.id)).toEqual(expect.arrayContaining(["hermes", "claude", "codex"]));
     expect(surface.settings).toEqual(expect.arrayContaining([
       expect.objectContaining({ id: "agent-routing", status: "saved" }),
-      expect.objectContaining({ id: "integration-approvals", status: "saved" }),
+      expect.objectContaining({ id: "integration-approvals", status: "needs_review" }),
     ]));
     expect(surface.readiness.overallStatus).toBe("degraded");
     expect(surface.activity).toEqual(expect.arrayContaining([

--- a/tests/gateway/onboarding-activation.test.ts
+++ b/tests/gateway/onboarding-activation.test.ts
@@ -8,6 +8,9 @@ import { stepsForGoals } from "../../packages/gateway/src/onboarding/readiness-s
 import { mapActivationError, safeClientMessage } from "../../packages/gateway/src/onboarding/activation-errors.js";
 import { ReadinessStatusCache } from "../../packages/gateway/src/onboarding/readiness-cache.js";
 import { createAgentActionAuditService } from "../../packages/gateway/src/onboarding/agent-action-audit.js";
+import { createAdminControlService } from "../../packages/gateway/src/onboarding/admin-control-service.js";
+import { createAgentCredentialStatusService } from "../../packages/gateway/src/onboarding/agent-credential-status.js";
+import { createIntegrationCapabilityService } from "../../packages/gateway/src/onboarding/integration-capabilities.js";
 import { createTestReadinessService, testPrincipal } from "../helpers/activation-readiness.js";
 
 describe("activation readiness contracts", () => {
@@ -166,5 +169,28 @@ describe("activation readiness contracts", () => {
     });
     expect(action.summary).toBe("Agent action completed");
     expect(JSON.stringify(action)).not.toMatch(/sk_live|\/home|token/i);
+  });
+
+  it("derives admin control surface state from agents, integrations, and readiness", async () => {
+    const agentCredentials = createAgentCredentialStatusService();
+    const integrations = createIntegrationCapabilityService({ connectedCapabilityIds: ["calendar.create_event"] });
+    await integrations.setApproval(testPrincipal.userId, "calendar.create_event", "hermes", true);
+    const { service: readiness } = createTestReadinessService(undefined, {
+      agentCredentialService: agentCredentials,
+      integrationCapabilityService: integrations,
+    });
+    const admin = createAdminControlService({ agentCredentials, integrations, readiness });
+
+    const surface = await admin.getSurface(testPrincipal.userId);
+
+    expect(surface.providers.map((provider) => provider.id)).toEqual(expect.arrayContaining(["hermes", "claude", "codex"]));
+    expect(surface.settings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "agent-routing", status: "saved" }),
+      expect.objectContaining({ id: "integration-approvals", status: "saved" }),
+    ]));
+    expect(surface.readiness.overallStatus).toBe("degraded");
+    expect(surface.activity).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "readiness", summary: "Readiness needs review" }),
+    ]));
   });
 });

--- a/tests/shell/admin-setup-wizard.test.tsx
+++ b/tests/shell/admin-setup-wizard.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AdminSetupWizard } from "../../shell/src/components/onboarding/AdminSetupWizard.js";
+
+describe("AdminSetupWizard", () => {
+  it("hides resume action until a setup session exists", () => {
+    const onResume = vi.fn();
+
+    render(<AdminSetupWizard session={null} onResume={onResume} />);
+
+    expect(screen.queryByRole("button", { name: /resume setup/i })).toBeNull();
+  });
+
+  it("resumes the existing setup session when present", () => {
+    const onResume = vi.fn();
+
+    render(
+      <AdminSetupWizard
+        session={{
+          id: "setup.agent.claude",
+          target: "agent:claude",
+          status: "resumable",
+          title: "Connect Claude",
+          updatedAt: "2026-05-23T00:00:00.000Z",
+        }}
+        onResume={onResume}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /resume setup/i }));
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Stack: 5/8

## Summary

- Adds the Matrix admin/control surface for models, agents, integrations, settings, automations, activity, setup resume, and readiness.
- Builds Finna-inspired provider cards and resumable setup wizard states in the Matrix visual language.

## Tests

- `bun run typecheck`
- `bun run check:patterns` (0 violations, existing warning-only baseline)
- `bun run test -- --reporter=dot` (459 files passed, 3 skipped; 4,752 tests passed, 20 skipped)
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bWF0cml4b3MudGVzdCQ= pnpm --dir shell build`
- `pnpm --dir shell exec playwright test ../tests/e2e/onboarding-activation.spec.ts ../tests/e2e/onboarding-visual.spec.ts --config ../tests/e2e/playwright.config.ts` (8 passed)

## Review/Monitoring

- Stacked PR base: `082-assistant-capabilities`
- Greptile and CI must pass before merging.

## Invariants

- Source of truth: admin/control summaries aggregate existing readiness, provider, integration, setting, automation, and activity state.
- Lock/transaction scope: this layer exposes summary/control routes and setup session state without cross-provider transactional writes.
- Acceptable orphan states: interrupted setup sessions are resumable; failed provider cards show remediation instead of duplicate actions.
- Auth source of truth: admin/control routes require owner gateway authentication.
- Deferred scope: paid-beta operator readiness remains a platform concern in a later layer.