### PR TITLE
feat(onboarding): add company brain and draft workflows

### DIFF
--- a/packages/gateway/src/onboarding/company-brain-readiness.ts
+++ b/packages/gateway/src/onboarding/company-brain-readiness.ts
@@ -54,7 +54,7 @@ function safeDisplay(value: string, fallback: string, max = 220): string {
 function flagsFor(item: CompanyContextItem): CompanyBrainReadiness["reviewFlags"] {
   const text = `${item.title} ${item.summary}`.toLowerCase();
   const flags: CompanyBrainReadiness["reviewFlags"] = [];
-  if (text.includes("stale")) {
+  if (/\bstale\b/.test(text)) {
     flags.push({ itemId: item.id, kind: "stale", message: "Check whether this context is still current." });
   }
   if (/(^|[^a-z0-9-])contradict(?:ion|ions|ory|s|ed)?\b/.test(text)) {

--- a/packages/gateway/src/onboarding/company-brain-readiness.ts
+++ b/packages/gateway/src/onboarding/company-brain-readiness.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from "node:crypto";
+
+const MAX_OWNERS = 512;
+const MAX_ITEMS_PER_OWNER = 200;
+const UNSAFE_DISPLAY = /(secret|token|postgres|\/home\/|database)/i;
+
+export type CompanyContextType =
+  | "product_decision"
+  | "customer_note"
+  | "support_thread"
+  | "growth_idea"
+  | "social_draft"
+  | "task"
+  | "project_record";
+
+export interface CompanyContextItem {
+  id: string;
+  type: CompanyContextType;
+  title: string;
+  summary: string;
+  source: string;
+  visibility: "owner_only" | "authorized_teammates";
+  updatedAt: string;
+}
+
+export interface CompanyBrainReadiness {
+  status: "needs_context" | "ready" | "needs_review";
+  guidance: string;
+  items: CompanyContextItem[];
+  sourceLinks: string[];
+  reviewFlags: Array<{
+    itemId: string;
+    kind: "stale" | "contradiction";
+    message: string;
+  }>;
+}
+
+export interface CompanyBrainReadinessService {
+  getReadiness(ownerId: string): Promise<CompanyBrainReadiness>;
+  addContext(ownerId: string, input: Omit<CompanyContextItem, "id" | "updatedAt">): Promise<CompanyContextItem>;
+}
+
+function safeDisplay(value: string, fallback: string): string {
+  const trimmed = value.trim().slice(0, 220);
+  if (!trimmed || UNSAFE_DISPLAY.test(trimmed)) return fallback;
+  return trimmed;
+}
+
+function flagsFor(item: CompanyContextItem): CompanyBrainReadiness["reviewFlags"] {
+  const text = `${item.title} ${item.summary}`.toLowerCase();
+  const flags: CompanyBrainReadiness["reviewFlags"] = [];
+  if (text.includes("stale")) {
+    flags.push({ itemId: item.id, kind: "stale", message: "Check whether this context is still current." });
+  }
+  if (/(^|[^a-z0-9-])contradict(?:ion|ions|ory|s|ed)?\b/.test(text)) {
+    flags.push({ itemId: item.id, kind: "contradiction", message: "Resolve contradictory context before agents rely on it." });
+  }
+  return flags;
+}
+
+export function createCompanyBrainReadinessService(options: {
+  now?: () => Date;
+} = {}): CompanyBrainReadinessService {
+  const now = options.now ?? (() => new Date());
+  const ownerItems = new Map<string, CompanyContextItem[]>();
+
+  function getItems(ownerId: string): CompanyContextItem[] {
+    const existing = ownerItems.get(ownerId);
+    if (existing) {
+      ownerItems.delete(ownerId);
+      ownerItems.set(ownerId, existing);
+      return existing;
+    }
+    if (ownerItems.size >= MAX_OWNERS) {
+      const oldestKey = ownerItems.keys().next().value as string | undefined;
+      if (oldestKey) ownerItems.delete(oldestKey);
+    }
+    const next: CompanyContextItem[] = [];
+    ownerItems.set(ownerId, next);
+    return next;
+  }
+
+  async function getReadiness(ownerId: string): Promise<CompanyBrainReadiness> {
+    const items = getItems(ownerId);
+    const reviewFlags = items.flatMap(flagsFor);
+    const status = items.length === 0 ? "needs_context" : reviewFlags.length > 0 ? "needs_review" : "ready";
+    return {
+      status,
+      guidance: status === "needs_context"
+        ? "Add a product decision, customer note, or project record so Matrix can ground company answers."
+        : status === "needs_review"
+          ? "Review stale or contradictory context before agents rely on it."
+          : "Company context is ready for Matrix answers and drafts.",
+      items: [...items],
+      sourceLinks: Array.from(new Set(items.map((item) => item.source))).slice(0, 20),
+      reviewFlags,
+    };
+  }
+
+  async function addContext(ownerId: string, input: Omit<CompanyContextItem, "id" | "updatedAt">): Promise<CompanyContextItem> {
+    const items = getItems(ownerId);
+    const item: CompanyContextItem = {
+      ...input,
+      id: `ctx.${randomUUID()}`,
+      title: safeDisplay(input.title, "Company context"),
+      summary: safeDisplay(input.summary, "Company context captured"),
+      source: safeDisplay(input.source, "Manual note"),
+      updatedAt: now().toISOString(),
+    };
+    items.push(item);
+    while (items.length > MAX_ITEMS_PER_OWNER) items.shift();
+    return item;
+  }
+
+  return { getReadiness, addContext };
+}

--- a/packages/gateway/src/onboarding/company-brain-readiness.ts
+++ b/packages/gateway/src/onboarding/company-brain-readiness.ts
@@ -2,7 +2,8 @@ import { randomUUID } from "node:crypto";
 
 const MAX_OWNERS = 512;
 const MAX_ITEMS_PER_OWNER = 200;
-const UNSAFE_DISPLAY = /(secret|token|postgres|\/home\/|database)/i;
+const UNSAFE_DISPLAY = /(sk_[a-z0-9][a-z0-9_-]*|\/home\/[^\s,;]+|[A-Za-z0-9_.-]*(?:secret|token)[A-Za-z0-9_.-]*\s*[:=]\s*[^\s,;]+)/gi;
+const SENSITIVE_TERMS = /\b(secret|token|postgres|database)\b/gi;
 
 export type CompanyContextType =
   | "product_decision"
@@ -42,8 +43,12 @@ export interface CompanyBrainReadinessService {
 
 function safeDisplay(value: string, fallback: string, max = 220): string {
   const trimmed = value.trim().slice(0, max);
-  if (!trimmed || UNSAFE_DISPLAY.test(trimmed)) return fallback;
-  return trimmed;
+  if (!trimmed) return fallback;
+  const redacted = trimmed
+    .replace(UNSAFE_DISPLAY, "[redacted]")
+    .replace(SENSITIVE_TERMS, "[redacted]")
+    .trim();
+  return redacted || fallback;
 }
 
 function flagsFor(item: CompanyContextItem): CompanyBrainReadiness["reviewFlags"] {

--- a/packages/gateway/src/onboarding/company-brain-readiness.ts
+++ b/packages/gateway/src/onboarding/company-brain-readiness.ts
@@ -40,8 +40,8 @@ export interface CompanyBrainReadinessService {
   addContext(ownerId: string, input: Omit<CompanyContextItem, "id" | "updatedAt">): Promise<CompanyContextItem>;
 }
 
-function safeDisplay(value: string, fallback: string): string {
-  const trimmed = value.trim().slice(0, 220);
+function safeDisplay(value: string, fallback: string, max = 220): string {
+  const trimmed = value.trim().slice(0, max);
   if (!trimmed || UNSAFE_DISPLAY.test(trimmed)) return fallback;
   return trimmed;
 }
@@ -103,7 +103,7 @@ export function createCompanyBrainReadinessService(options: {
       ...input,
       id: `ctx.${randomUUID()}`,
       title: safeDisplay(input.title, "Company context"),
-      summary: safeDisplay(input.summary, "Company context captured"),
+      summary: safeDisplay(input.summary, "Company context captured", 800),
       source: safeDisplay(input.source, "Manual note"),
       updatedAt: now().toISOString(),
     };

--- a/packages/gateway/src/onboarding/company-brain-readiness.ts
+++ b/packages/gateway/src/onboarding/company-brain-readiness.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 const MAX_OWNERS = 512;
 const MAX_ITEMS_PER_OWNER = 200;
-const UNSAFE_DISPLAY = /(sk_[a-z0-9][a-z0-9_-]*|\/home\/[^\s,;]+|[A-Za-z0-9_.-]*(?:secret|token)[A-Za-z0-9_.-]*\s*[:=]\s*[^\s,;]+)/gi;
+const UNSAFE_DISPLAY = /(sk[_-][a-z0-9][a-z0-9_-]*|\/home\/[^\s,;]+|[A-Za-z0-9_.-]*(?:secret|token)[A-Za-z0-9_.-]*\s*[:=]\s*[^\s,;]+)/gi;
 const SENSITIVE_TERMS = /\b(secret|token|postgres|database)\b/gi;
 
 export type CompanyContextType =
@@ -57,7 +57,7 @@ function flagsFor(item: CompanyContextItem): CompanyBrainReadiness["reviewFlags"
   if (/\bstale\b/.test(text)) {
     flags.push({ itemId: item.id, kind: "stale", message: "Check whether this context is still current." });
   }
-  if (/(^|[^a-z0-9-])contradict(?:ion|ions|ory|s|ed)?\b/.test(text)) {
+  if (/(^|[^a-z0-9-]|self-)contradict(?:ion|ions|ory|s|ed|ing)?\b/.test(text)) {
     flags.push({ itemId: item.id, kind: "contradiction", message: "Resolve contradictory context before agents rely on it." });
   }
   return flags;
@@ -86,7 +86,7 @@ export function createCompanyBrainReadinessService(options: {
   }
 
   async function getReadiness(ownerId: string): Promise<CompanyBrainReadiness> {
-    const items = getItems(ownerId);
+    const items = ownerItems.get(ownerId) ?? [];
     const reviewFlags = items.flatMap(flagsFor);
     const status = items.length === 0 ? "needs_context" : reviewFlags.length > 0 ? "needs_review" : "ready";
     return {

--- a/packages/gateway/src/onboarding/company-brain-routes.ts
+++ b/packages/gateway/src/onboarding/company-brain-routes.ts
@@ -1,0 +1,57 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { z } from "zod/v4";
+import { mapActivationError } from "./activation-errors.js";
+import type { CompanyBrainReadinessService } from "./company-brain-readiness.js";
+import {
+  requireRequestPrincipal,
+  type RequestPrincipal,
+} from "../request-principal.js";
+
+const COMPANY_BRAIN_BODY_LIMIT = 8192;
+
+const CompanyContextRequestSchema = z.object({
+  type: z.enum(["product_decision", "customer_note", "support_thread", "growth_idea", "social_draft", "task", "project_record"]),
+  title: z.string().trim().min(1).max(120),
+  summary: z.string().trim().min(1).max(800),
+  source: z.string().trim().min(1).max(220),
+  visibility: z.enum(["owner_only", "authorized_teammates"]),
+}).strict();
+
+export interface CompanyBrainRouteDeps {
+  service: CompanyBrainReadinessService;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+function jsonError(c: Context, err: unknown) {
+  const mapped = mapActivationError(err);
+  return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+}
+
+export function createCompanyBrainRoutes(deps: CompanyBrainRouteDeps): Hono {
+  const app = new Hono();
+  const limited = bodyLimit({ maxSize: COMPANY_BRAIN_BODY_LIMIT });
+  const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
+
+  app.get("/readiness", async (c) => {
+    try {
+      const principal = principalFor(c);
+      return c.json(await deps.service.getReadiness(principal.userId));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/context", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      const body = CompanyContextRequestSchema.parse(await c.req.json());
+      return c.json(await deps.service.addContext(principal.userId, body));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/onboarding/draft-action-readiness.ts
+++ b/packages/gateway/src/onboarding/draft-action-readiness.ts
@@ -5,7 +5,6 @@ import { ActivationRouteError } from "./activation-errors.js";
 const MAX_OWNERS = 512;
 const MAX_DRAFTS_PER_OWNER = 200;
 const UNSAFE_DISPLAY = /(sk_[a-z0-9][a-z0-9_-]*|\/home\/[^\s,;]+|[A-Za-z0-9_.-]*(?:secret|token)[A-Za-z0-9_.-]*\s*[:=]\s*[^\s,;]+)/gi;
-const SENSITIVE_TERMS = /\b(secret|token|postgres|database)\b/gi;
 
 export type DraftActionType = "support_reply" | "social_post" | "acquisition_message" | "customer_follow_up";
 export type DraftActionStatus = "draft" | "needs_review" | "approved" | "sent" | "rejected";
@@ -51,7 +50,6 @@ function safeDisplay(value: string, fallback: string, max = 5000): string {
   if (!trimmed) return fallback;
   const redacted = trimmed
     .replace(UNSAFE_DISPLAY, "[redacted]")
-    .replace(SENSITIVE_TERMS, "[redacted]")
     .trim();
   return redacted || fallback;
 }

--- a/packages/gateway/src/onboarding/draft-action-readiness.ts
+++ b/packages/gateway/src/onboarding/draft-action-readiness.ts
@@ -45,7 +45,7 @@ export interface DraftActionReadinessService {
   approveDraft(ownerId: string, draftId: string, approved: boolean): Promise<DraftAction>;
 }
 
-function safeDisplay(value: string, fallback: string, max = 1200): string {
+function safeDisplay(value: string, fallback: string, max = 5000): string {
   const trimmed = value.trim().slice(0, max);
   if (!trimmed || UNSAFE_DISPLAY.test(trimmed)) return fallback;
   return trimmed;
@@ -127,6 +127,9 @@ export function createDraftActionReadinessService(options: {
     const draft = draftsFor(ownerId).find((candidate) => candidate.id === draftId);
     if (!draft) {
       throw new ActivationRouteError("draft_not_found", "Draft was not found", { status: 404 });
+    }
+    if (draft.status === "approved" || draft.status === "sent" || draft.status === "rejected") {
+      throw new ActivationRouteError("draft_already_decided", "Draft has already been decided", { status: 409 });
     }
     draft.status = approved ? "approved" : "rejected";
     draft.approvalSummary = approved ? "Draft approved for external action" : "Draft rejected";

--- a/packages/gateway/src/onboarding/draft-action-readiness.ts
+++ b/packages/gateway/src/onboarding/draft-action-readiness.ts
@@ -4,7 +4,7 @@ import { ActivationRouteError } from "./activation-errors.js";
 
 const MAX_OWNERS = 512;
 const MAX_DRAFTS_PER_OWNER = 200;
-const UNSAFE_DISPLAY = /(sk_[a-z0-9][a-z0-9_-]*|\/home\/[^\s,;]+|[A-Za-z0-9_.-]*(?:secret|token)[A-Za-z0-9_.-]*\s*[:=]\s*[^\s,;]+)/gi;
+const UNSAFE_DISPLAY = /(sk[_-][a-z0-9][a-z0-9_-]*|\/home\/[^\s,;]+|[A-Za-z0-9_.-]*(?:secret|token)[A-Za-z0-9_.-]*\s*[:=]\s*[^\s,;]+)/gi;
 
 export type DraftActionType = "support_reply" | "social_post" | "acquisition_message" | "customer_follow_up";
 export type DraftActionStatus = "draft" | "needs_review" | "approved" | "sent" | "rejected";
@@ -57,7 +57,7 @@ function safeDisplay(value: string, fallback: string, max = 5000): string {
 function uncertaintyFlags(content: string): DraftUncertainty[] {
   const lower = content.toLowerCase();
   const flags: DraftUncertainty[] = [];
-  if (lower.includes("unsure") || lower.includes("unknown") || lower.includes("may ") || lower.includes("might ")) {
+  if (lower.includes("unsure") || lower.includes("unknown") || /\bmay (?!i\b|we\b|\d)/.test(lower) || /\bmight\b/.test(lower)) {
     flags.push({ kind: "uncertainty", message: "Confirm timing, facts, or missing context before sending." });
   }
   if (lower.includes("guarantee") || lower.includes("99.999") || /\b(?:always|never)\b/.test(lower)) {
@@ -89,7 +89,7 @@ export function createDraftActionReadinessService(options: {
   }
 
   async function getReadiness(ownerId: string): Promise<DraftActionReadiness> {
-    const drafts = draftsFor(ownerId);
+    const drafts = ownerDrafts.get(ownerId) ?? [];
     const pendingReview = drafts.filter((draft) => draft.status === "needs_review").length;
     const approved = drafts.filter((draft) => draft.status === "approved").length;
     return {
@@ -127,10 +127,11 @@ export function createDraftActionReadinessService(options: {
   }
 
   async function approveDraft(ownerId: string, draftId: string, approved: boolean): Promise<DraftAction> {
-    const draft = draftsFor(ownerId).find((candidate) => candidate.id === draftId);
+    const draft = ownerDrafts.get(ownerId)?.find((candidate) => candidate.id === draftId);
     if (!draft) {
       throw new ActivationRouteError("draft_not_found", "Draft was not found", { status: 404 });
     }
+    draftsFor(ownerId);
     if (draft.status === "approved" || draft.status === "sent" || draft.status === "rejected") {
       throw new ActivationRouteError("draft_already_decided", "Draft has already been decided", { status: 409 });
     }

--- a/packages/gateway/src/onboarding/draft-action-readiness.ts
+++ b/packages/gateway/src/onboarding/draft-action-readiness.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import type { AgentId } from "./activation-contracts.js";
+import { ActivationRouteError } from "./activation-errors.js";
+
+const MAX_OWNERS = 512;
+const MAX_DRAFTS_PER_OWNER = 200;
+const UNSAFE_DISPLAY = /(secret|token|postgres|\/home\/|database|sk_[a-z0-9])/i;
+
+export type DraftActionType = "support_reply" | "social_post" | "acquisition_message" | "customer_follow_up";
+export type DraftActionStatus = "draft" | "needs_review" | "approved" | "sent" | "rejected";
+
+export interface DraftUncertainty {
+  kind: "uncertainty" | "sensitive_claim";
+  message: string;
+}
+
+export interface DraftAction {
+  id: string;
+  type: DraftActionType;
+  status: DraftActionStatus;
+  content: string;
+  destination: string;
+  uncertainties: DraftUncertainty[];
+  createdByAgent: AgentId;
+  createdAt: string;
+  approvalSummary?: string;
+}
+
+export interface DraftActionReadiness {
+  status: "ready" | "needs_review";
+  pendingReview: number;
+  approved: number;
+  guidance: string;
+  drafts: DraftAction[];
+}
+
+export interface DraftActionReadinessService {
+  getReadiness(ownerId: string): Promise<DraftActionReadiness>;
+  createDraft(ownerId: string, input: {
+    type: DraftActionType;
+    content: string;
+    destination: string;
+    createdByAgent: AgentId;
+  }): Promise<DraftAction>;
+  approveDraft(ownerId: string, draftId: string, approved: boolean): Promise<DraftAction>;
+}
+
+function safeDisplay(value: string, fallback: string, max = 1200): string {
+  const trimmed = value.trim().slice(0, max);
+  if (!trimmed || UNSAFE_DISPLAY.test(trimmed)) return fallback;
+  return trimmed;
+}
+
+function uncertaintyFlags(content: string): DraftUncertainty[] {
+  const lower = content.toLowerCase();
+  const flags: DraftUncertainty[] = [];
+  if (lower.includes("unsure") || lower.includes("unknown") || lower.includes("may ") || lower.includes("might ")) {
+    flags.push({ kind: "uncertainty", message: "Confirm timing, facts, or missing context before sending." });
+  }
+  if (lower.includes("guarantee") || lower.includes("99.999") || /\b(?:always|never)\b/.test(lower)) {
+    flags.push({ kind: "sensitive_claim", message: "Review sensitive or absolute claims before approval." });
+  }
+  return flags;
+}
+
+export function createDraftActionReadinessService(options: {
+  now?: () => Date;
+} = {}): DraftActionReadinessService {
+  const now = options.now ?? (() => new Date());
+  const ownerDrafts = new Map<string, DraftAction[]>();
+
+  function draftsFor(ownerId: string): DraftAction[] {
+    const existing = ownerDrafts.get(ownerId);
+    if (existing) {
+      ownerDrafts.delete(ownerId);
+      ownerDrafts.set(ownerId, existing);
+      return existing;
+    }
+    if (ownerDrafts.size >= MAX_OWNERS) {
+      const oldestKey = ownerDrafts.keys().next().value as string | undefined;
+      if (oldestKey) ownerDrafts.delete(oldestKey);
+    }
+    const next: DraftAction[] = [];
+    ownerDrafts.set(ownerId, next);
+    return next;
+  }
+
+  async function getReadiness(ownerId: string): Promise<DraftActionReadiness> {
+    const drafts = draftsFor(ownerId);
+    const pendingReview = drafts.filter((draft) => draft.status === "needs_review").length;
+    const approved = drafts.filter((draft) => draft.status === "approved").length;
+    return {
+      status: pendingReview > 0 ? "needs_review" : "ready",
+      pendingReview,
+      approved,
+      guidance: pendingReview > 0
+        ? "Review drafts before any external send or publish action."
+        : "Support and growth drafts are approval-first.",
+      drafts: [...drafts],
+    };
+  }
+
+  async function createDraft(ownerId: string, input: {
+    type: DraftActionType;
+    content: string;
+    destination: string;
+    createdByAgent: AgentId;
+  }): Promise<DraftAction> {
+    const drafts = draftsFor(ownerId);
+    const safeContent = safeDisplay(input.content, "Draft needs review");
+    const draft: DraftAction = {
+      id: `draft.${randomUUID()}`,
+      type: input.type,
+      status: "needs_review",
+      content: safeContent,
+      destination: safeDisplay(input.destination, "External destination", 220),
+      uncertainties: uncertaintyFlags(safeContent),
+      createdByAgent: input.createdByAgent,
+      createdAt: now().toISOString(),
+    };
+    drafts.push(draft);
+    while (drafts.length > MAX_DRAFTS_PER_OWNER) drafts.shift();
+    return draft;
+  }
+
+  async function approveDraft(ownerId: string, draftId: string, approved: boolean): Promise<DraftAction> {
+    const draft = draftsFor(ownerId).find((candidate) => candidate.id === draftId);
+    if (!draft) {
+      throw new ActivationRouteError("draft_not_found", "Draft was not found", { status: 404 });
+    }
+    draft.status = approved ? "approved" : "rejected";
+    draft.approvalSummary = approved ? "Draft approved for external action" : "Draft rejected";
+    return draft;
+  }
+
+  return { getReadiness, createDraft, approveDraft };
+}

--- a/packages/gateway/src/onboarding/draft-action-readiness.ts
+++ b/packages/gateway/src/onboarding/draft-action-readiness.ts
@@ -4,7 +4,8 @@ import { ActivationRouteError } from "./activation-errors.js";
 
 const MAX_OWNERS = 512;
 const MAX_DRAFTS_PER_OWNER = 200;
-const UNSAFE_DISPLAY = /(secret|token|postgres|\/home\/|database|sk_[a-z0-9])/i;
+const UNSAFE_DISPLAY = /(sk_[a-z0-9][a-z0-9_-]*|\/home\/[^\s,;]+|[A-Za-z0-9_.-]*(?:secret|token)[A-Za-z0-9_.-]*\s*[:=]\s*[^\s,;]+)/gi;
+const SENSITIVE_TERMS = /\b(secret|token|postgres|database)\b/gi;
 
 export type DraftActionType = "support_reply" | "social_post" | "acquisition_message" | "customer_follow_up";
 export type DraftActionStatus = "draft" | "needs_review" | "approved" | "sent" | "rejected";
@@ -47,8 +48,12 @@ export interface DraftActionReadinessService {
 
 function safeDisplay(value: string, fallback: string, max = 5000): string {
   const trimmed = value.trim().slice(0, max);
-  if (!trimmed || UNSAFE_DISPLAY.test(trimmed)) return fallback;
-  return trimmed;
+  if (!trimmed) return fallback;
+  const redacted = trimmed
+    .replace(UNSAFE_DISPLAY, "[redacted]")
+    .replace(SENSITIVE_TERMS, "[redacted]")
+    .trim();
+  return redacted || fallback;
 }
 
 function uncertaintyFlags(content: string): DraftUncertainty[] {
@@ -114,7 +119,7 @@ export function createDraftActionReadinessService(options: {
       status: "needs_review",
       content: safeContent,
       destination: safeDisplay(input.destination, "External destination", 220),
-      uncertainties: uncertaintyFlags(safeContent),
+      uncertainties: uncertaintyFlags(input.content),
       createdByAgent: input.createdByAgent,
       createdAt: now().toISOString(),
     };

--- a/packages/gateway/src/onboarding/draft-action-routes.ts
+++ b/packages/gateway/src/onboarding/draft-action-routes.ts
@@ -1,0 +1,75 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { z } from "zod/v4";
+import { mapActivationError } from "./activation-errors.js";
+import type { DraftActionReadinessService } from "./draft-action-readiness.js";
+import {
+  requireRequestPrincipal,
+  type RequestPrincipal,
+} from "../request-principal.js";
+
+const DRAFT_ACTION_BODY_LIMIT = 16 * 1024;
+
+const DraftCreateRequestSchema = z.object({
+  type: z.enum(["support_reply", "social_post", "acquisition_message", "customer_follow_up"]),
+  content: z.string().trim().min(1).max(5000),
+  destination: z.string().trim().min(1).max(220),
+  createdByAgent: z.enum(["claude", "codex", "hermes"]),
+}).strict();
+
+const DraftApprovalRequestSchema = z.object({
+  approved: z.boolean(),
+}).strict();
+
+const DraftParamsSchema = z.object({
+  draftId: z.string().trim().min(2).max(120).regex(/^draft\.[a-z0-9-]+$/),
+});
+
+export interface DraftActionRouteDeps {
+  service: DraftActionReadinessService;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+function jsonError(c: Context, err: unknown) {
+  const mapped = mapActivationError(err);
+  return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+}
+
+export function createDraftActionRoutes(deps: DraftActionRouteDeps): Hono {
+  const app = new Hono();
+  const limited = bodyLimit({ maxSize: DRAFT_ACTION_BODY_LIMIT });
+  const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
+
+  app.get("/readiness", async (c) => {
+    try {
+      const principal = principalFor(c);
+      return c.json(await deps.service.getReadiness(principal.userId));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/drafts", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      const body = DraftCreateRequestSchema.parse(await c.req.json());
+      return c.json(await deps.service.createDraft(principal.userId, body));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/drafts/:draftId/approval", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      const { draftId } = DraftParamsSchema.parse({ draftId: c.req.param("draftId") });
+      const body = DraftApprovalRequestSchema.parse(await c.req.json());
+      return c.json(await deps.service.approveDraft(principal.userId, draftId, body.approved));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -91,6 +91,8 @@ import { createAdminControlService } from "./onboarding/admin-control-service.js
 import { createAdminControlRoutes } from "./onboarding/admin-control-routes.js";
 import { createCompanyBrainReadinessService } from "./onboarding/company-brain-readiness.js";
 import { createCompanyBrainRoutes } from "./onboarding/company-brain-routes.js";
+import { createDraftActionReadinessService } from "./onboarding/draft-action-readiness.js";
+import { createDraftActionRoutes } from "./onboarding/draft-action-routes.js";
 import { createVocalHandler } from "./vocal/ws-handler.js";
 import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
 import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
@@ -539,6 +541,7 @@ export async function createGateway(config: GatewayConfig) {
   });
   const agentActionAuditService = createAgentActionAuditService();
   const companyBrainService = createCompanyBrainReadinessService();
+  const draftActionService = createDraftActionReadinessService();
   let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;
   const unavailableCodingSetup: CodingSetupStatus = {
     githubConnected: false,
@@ -1456,6 +1459,7 @@ export async function createGateway(config: GatewayConfig) {
   }));
   app.route("/api/admin", createAdminControlRoutes({ service: adminControlService }));
   app.route("/api/company-brain", createCompanyBrainRoutes({ service: companyBrainService }));
+  app.route("/api/support-growth", createDraftActionRoutes({ service: draftActionService }));
   app.route("/api", createShellRoutes({
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -89,6 +89,8 @@ import { capabilityIdsForConnectedServices, createIntegrationCapabilityService }
 import { createIntegrationCapabilityRoutes } from "./onboarding/integration-capability-routes.js";
 import { createAdminControlService } from "./onboarding/admin-control-service.js";
 import { createAdminControlRoutes } from "./onboarding/admin-control-routes.js";
+import { createCompanyBrainReadinessService } from "./onboarding/company-brain-readiness.js";
+import { createCompanyBrainRoutes } from "./onboarding/company-brain-routes.js";
 import { createVocalHandler } from "./vocal/ws-handler.js";
 import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
 import { resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
@@ -536,6 +538,7 @@ export async function createGateway(config: GatewayConfig) {
     storagePath: join(homePath, "system", "integration-capabilities.json"),
   });
   const agentActionAuditService = createAgentActionAuditService();
+  const companyBrainService = createCompanyBrainReadinessService();
   let codingSetupProvider: ReturnType<typeof createCodingSetupProvider> | null = null;
   const unavailableCodingSetup: CodingSetupStatus = {
     githubConnected: false,
@@ -1452,6 +1455,7 @@ export async function createGateway(config: GatewayConfig) {
     audit: agentActionAuditService,
   }));
   app.route("/api/admin", createAdminControlRoutes({ service: adminControlService }));
+  app.route("/api/company-brain", createCompanyBrainRoutes({ service: companyBrainService }));
   app.route("/api", createShellRoutes({
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -16,6 +16,7 @@ import { CodingHandoffSummary } from "./onboarding/CodingHandoffSummary";
 import { AgentCredentialPanel } from "./onboarding/AgentCredentialPanel";
 import { AssistantSetupPanel } from "./onboarding/AssistantSetupPanel";
 import { AdminControlPanel, type AdminControlSurface } from "./onboarding/AdminControlPanel";
+import { CompanyBrainPanel, type CompanyBrainReadiness } from "./onboarding/CompanyBrainPanel";
 import { MicPermissionDialog } from "./MicPermissionDialog";
 import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
@@ -45,6 +46,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
   const [entranceStage, setEntranceStage] = useState<"hidden" | "center" | "settled">("hidden");
   const [logoMediaAvailable, setLogoMediaAvailable] = useState(true);
   const [adminSurface, setAdminSurface] = useState<AdminControlSurface | null>(null);
+  const [companyBrain, setCompanyBrain] = useState<CompanyBrainReadiness | null>(null);
   const ambientRef = useRef<HTMLAudioElement | null>(null);
   const gainNodeRef = useRef<GainNode | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
@@ -162,6 +164,29 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
       });
   }, [refreshAdminSurface]);
 
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/company-brain/readiness", {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("company brain request failed");
+        return await res.json() as CompanyBrainReadiness;
+      })
+      .then((readiness) => {
+        if (!cancelled) setCompanyBrain(readiness);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          console.warn("[onboarding] company brain load failed:", err instanceof Error ? err.message : String(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   function startAmbientAudio() {
     const audio = new Audio("/onboarding-ambient.wav");
     audio.loop = true;
@@ -243,6 +268,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
   const isConversing = ob.stage === "greeting" || ob.stage === "interview" || ob.stage === "connecting";
   const codingSelected = ob.selectedGoalIds.includes("coding");
   const assistantSelected = ob.selectedGoalIds.includes("assistant");
+  const companyBrainSelected = ob.selectedGoalIds.includes("company_brain");
 
   // Render nothing for the one frame between "alreadyComplete" becoming
   // true and the parent unmounting us via the effect above. Placing this
@@ -318,6 +344,8 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
               )}
 
               <AdminControlPanel surface={adminSurface} onResumeSetup={resumeAdminSetup} />
+
+              {companyBrainSelected && <CompanyBrainPanel readiness={companyBrain} />}
 
               <div className="flex flex-col gap-2 sm:flex-row">
                 <button

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -55,6 +55,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
   const continueTimerRef = useRef<number | null>(null);
   const continueFrameRef = useRef<number | null>(null);
   const adminActionControllerRef = useRef<AbortController | null>(null);
+  const supportActionControllerRef = useRef<AbortController | null>(null);
 
   // Live subtitle — accumulated AI transcript fragments, synced with voice
   const subtitle = ob.currentSubtitle;
@@ -111,6 +112,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
         window.cancelAnimationFrame(continueFrameRef.current);
       }
       adminActionControllerRef.current?.abort();
+      supportActionControllerRef.current?.abort();
       ambientRef.current?.pause();
       audioCtxRef.current?.close();
     };

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -261,7 +261,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
     });
   }
 
-  function handleStart(useVoice: boolean) {
+  const handleStart = useCallback((useVoice: boolean) => {
     // Phase 1: dim into light (text glows and screen fades to white/black)
     setPhase("dimming");
     setTimeout(() => {
@@ -275,7 +275,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
         setPhase("revealing");
       }, 400);
     }, 1200);
-  }
+  }, [ob.start]);
 
   const handleTalkToMe = useCallback(async () => {
     if (mic.state === "granted") {
@@ -290,7 +290,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
     const granted = await mic.requestAccess();
     if (granted) handleStart(true);
     else setShowMicDialog(true);
-  }, [mic.state, mic.requestAccess]);
+  }, [handleStart, mic.state, mic.requestAccess]);
 
   const handleMicAllow = useCallback(async () => {
     const granted = await mic.requestAccess();
@@ -298,7 +298,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
     if (granted) {
       handleStart(true);
     }
-  }, [mic.requestAccess]);
+  }, [handleStart, mic.requestAccess]);
 
   const handleContinue = useCallback(() => {
     setContinueExiting(true);

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -17,6 +17,7 @@ import { AgentCredentialPanel } from "./onboarding/AgentCredentialPanel";
 import { AssistantSetupPanel } from "./onboarding/AssistantSetupPanel";
 import { AdminControlPanel, type AdminControlSurface } from "./onboarding/AdminControlPanel";
 import { CompanyBrainPanel, type CompanyBrainReadiness } from "./onboarding/CompanyBrainPanel";
+import { SupportGrowthPanel, type DraftActionReadiness } from "./onboarding/SupportGrowthPanel";
 import { MicPermissionDialog } from "./MicPermissionDialog";
 import { KeyboardIcon, MicIcon, SparklesIcon } from "lucide-react";
 import { MATRIX_ONBOARDING_BRAND_VERSION } from "@/lib/onboarding-brand";
@@ -47,6 +48,7 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
   const [logoMediaAvailable, setLogoMediaAvailable] = useState(true);
   const [adminSurface, setAdminSurface] = useState<AdminControlSurface | null>(null);
   const [companyBrain, setCompanyBrain] = useState<CompanyBrainReadiness | null>(null);
+  const [supportGrowth, setSupportGrowth] = useState<DraftActionReadiness | null>(null);
   const ambientRef = useRef<HTMLAudioElement | null>(null);
   const gainNodeRef = useRef<GainNode | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
@@ -163,6 +165,57 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
         if (adminActionControllerRef.current === controller) adminActionControllerRef.current = null;
       });
   }, [refreshAdminSurface]);
+
+  const refreshSupportGrowth = useCallback((signal?: AbortSignal) => {
+    const requestSignal = signal ? AbortSignal.any([signal, AbortSignal.timeout(10_000)]) : AbortSignal.timeout(10_000);
+    void fetch("/api/support-growth/readiness", {
+      headers: { Accept: "application/json" },
+      signal: requestSignal,
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("support growth request failed");
+        return await res.json() as DraftActionReadiness;
+      })
+      .then(setSupportGrowth)
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.warn("[onboarding] support growth load failed:", err instanceof Error ? err.message : String(err));
+      });
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    refreshSupportGrowth(controller.signal);
+    return () => controller.abort();
+  }, [refreshSupportGrowth]);
+
+  const approveDraft = useCallback((draftId: string) => {
+    supportActionControllerRef.current?.abort();
+    const controller = new AbortController();
+    supportActionControllerRef.current = controller;
+    const requestSignal = AbortSignal.any([controller.signal, AbortSignal.timeout(10_000)]);
+    void fetch(`/api/support-growth/drafts/${encodeURIComponent(draftId)}/approval`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ approved: true }),
+      signal: requestSignal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          refreshSupportGrowth(controller.signal);
+          throw new Error("draft approval failed");
+        }
+        return await res.json();
+      })
+      .then(() => refreshSupportGrowth(controller.signal))
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.warn("[onboarding] draft approval failed:", err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (supportActionControllerRef.current === controller) supportActionControllerRef.current = null;
+      });
+  }, [refreshSupportGrowth]);
 
   useEffect(() => {
     let cancelled = false;
@@ -346,6 +399,10 @@ export function OnboardingScreen({ onComplete, onOpenTerminal }: OnboardingScree
               <AdminControlPanel surface={adminSurface} onResumeSetup={resumeAdminSetup} />
 
               {companyBrainSelected && <CompanyBrainPanel readiness={companyBrain} />}
+
+              {supportGrowth && supportGrowth.drafts.length > 0 && (
+                <SupportGrowthPanel readiness={supportGrowth} onApprove={approveDraft} />
+              )}
 
               <div className="flex flex-col gap-2 sm:flex-row">
                 <button

--- a/shell/src/components/onboarding/BrandFrame.tsx
+++ b/shell/src/components/onboarding/BrandFrame.tsx
@@ -12,7 +12,7 @@ export function BrandFrame({ children, mediaAvailable = true }: BrandFrameProps)
   return (
     <section
       data-onboarding-brand={MATRIX_ONBOARDING_BRAND_VERSION}
-      className="relative min-h-full overflow-hidden bg-[#f4f0e8] text-[#111612]"
+      className="relative min-h-full overflow-x-hidden overflow-y-auto bg-[#f4f0e8] text-[#111612]"
     >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(154,168,137,0.22),transparent_28%),linear-gradient(145deg,rgba(231,224,212,0.96),rgba(244,240,232,0.9)_48%,rgba(23,40,31,0.12))]" />
       <div className="absolute inset-x-0 top-0 h-px bg-[#17281f]/10" />
@@ -26,15 +26,15 @@ export function BrandFrame({ children, mediaAvailable = true }: BrandFrameProps)
           </div>
         </header>
 
-        <div className="grid flex-1 items-center gap-8 py-8 lg:grid-cols-[minmax(0,0.95fr)_minmax(440px,1.05fr)]">
+        <div className="grid flex-1 items-start gap-5 py-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(440px,1.05fr)] lg:items-center lg:gap-8 lg:py-8">
           <div className="max-w-2xl">
             <p className="mb-4 text-xs font-medium uppercase tracking-[0.22em] text-[#d6653b]">
               Guided activation
             </p>
-            <h1 className="text-balance text-4xl font-medium leading-[1.05] text-[#111612] sm:text-5xl lg:text-6xl">
+            <h1 className="text-balance text-3xl font-medium leading-[1.05] text-[#111612] sm:text-5xl lg:text-6xl">
               Set up Matrix around the work you want done first.
             </h1>
-            <p className="mt-5 max-w-xl text-base leading-7 text-[#17281f]/70">
+            <p className="mt-4 max-w-xl text-sm leading-6 text-[#17281f]/70 sm:mt-5 sm:text-base sm:leading-7">
               Connect only the services that matter, learn what Matrix can do, and reach a clear ready-to-work state.
             </p>
             {!mediaAvailable && (
@@ -44,7 +44,7 @@ export function BrandFrame({ children, mediaAvailable = true }: BrandFrameProps)
             )}
           </div>
 
-          <div className="relative rounded-lg border border-[#17281f]/12 bg-white/58 p-4 shadow-[0_24px_80px_rgba(17,22,18,0.12)] backdrop-blur-xl sm:p-5">
+          <div className="relative overflow-hidden rounded-lg border border-[#17281f]/12 bg-white/58 p-4 shadow-[0_24px_80px_rgba(17,22,18,0.12)] backdrop-blur-xl sm:p-5">
             {children}
           </div>
         </div>
@@ -52,4 +52,3 @@ export function BrandFrame({ children, mediaAvailable = true }: BrandFrameProps)
     </section>
   );
 }
-

--- a/shell/src/components/onboarding/CompanyBrainPanel.tsx
+++ b/shell/src/components/onboarding/CompanyBrainPanel.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { AlertTriangleIcon, BookOpenTextIcon, LinkIcon } from "lucide-react";
+
+export interface CompanyBrainReadiness {
+  status: "needs_context" | "ready" | "needs_review";
+  guidance: string;
+  items: Array<{
+    id: string;
+    type: string;
+    title: string;
+    summary: string;
+    source: string;
+    visibility: "owner_only" | "authorized_teammates";
+    updatedAt: string;
+  }>;
+  sourceLinks: string[];
+  reviewFlags: Array<{ itemId: string; kind: "stale" | "contradiction"; message: string }>;
+}
+
+export function CompanyBrainPanel({ readiness }: { readiness: CompanyBrainReadiness | null }) {
+  if (!readiness) return null;
+
+  return (
+    <section className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/80 p-4 shadow-[0_16px_45px_rgba(23,40,31,0.08)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-[#111612]">
+            <BookOpenTextIcon className="h-4 w-4 text-[#a6542f]" aria-hidden="true" />
+            Company brain
+          </h2>
+          <p className="mt-1 max-w-xl text-xs leading-5 text-[#17281f]/62">{readiness.guidance}</p>
+        </div>
+        <span className="rounded-full border border-[#17281f]/10 bg-white/60 px-2.5 py-1 text-xs font-medium capitalize text-[#17281f]/70">
+          {readiness.status.replaceAll("_", " ")}
+        </span>
+      </div>
+
+      {readiness.items.length > 0 ? (
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          {readiness.items.slice(0, 4).map((item) => (
+            <div key={item.id} className="rounded-md border border-[#17281f]/10 bg-white/60 p-3">
+              <p className="text-xs font-semibold text-[#111612]">{item.title}</p>
+              <p className="mt-1 line-clamp-2 text-xs leading-5 text-[#17281f]/62">{item.summary}</p>
+              <p className="mt-2 inline-flex items-center gap-1 text-xs text-[#17281f]/55">
+                <LinkIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                {item.source}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-3 rounded-md border border-dashed border-[#17281f]/15 bg-white/45 p-3 text-xs text-[#17281f]/60">
+          Add a decision, customer note, support thread, or project record to make Matrix answers source-aware.
+        </div>
+      )}
+
+      {readiness.reviewFlags.length > 0 && (
+        <div className="mt-3 rounded-md border border-[#b4532f]/20 bg-[#b4532f]/10 p-3">
+          <p className="flex items-center gap-2 text-xs font-semibold text-[#5f2b1e]">
+            <AlertTriangleIcon className="h-4 w-4" aria-hidden="true" />
+            Review context
+          </p>
+          <div className="mt-2 space-y-1">
+            {readiness.reviewFlags.slice(0, 3).map((flag) => (
+              <p key={`${flag.itemId}-${flag.kind}`} className="text-xs leading-5 text-[#5f2b1e]/80">
+                {flag.message}
+              </p>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {readiness.sourceLinks.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {readiness.sourceLinks.slice(0, 6).map((source) => (
+            <span key={source} className="rounded-full border border-[#17281f]/10 bg-white/60 px-2.5 py-1 text-xs text-[#17281f]/60">
+              {source}
+            </span>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/shell/src/components/onboarding/SupportGrowthPanel.tsx
+++ b/shell/src/components/onboarding/SupportGrowthPanel.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { AlertTriangleIcon, MegaphoneIcon, SendIcon } from "lucide-react";
+
+export interface DraftActionReadiness {
+  status: "ready" | "needs_review";
+  pendingReview: number;
+  approved: number;
+  guidance: string;
+  drafts: Array<{
+    id: string;
+    type: string;
+    status: string;
+    content: string;
+    destination: string;
+    uncertainties: Array<{ kind: "uncertainty" | "sensitive_claim"; message: string }>;
+    createdByAgent: "claude" | "codex" | "hermes";
+    createdAt: string;
+  }>;
+}
+
+export function SupportGrowthPanel({
+  readiness,
+  onApprove,
+}: {
+  readiness: DraftActionReadiness | null;
+  onApprove: (draftId: string) => void;
+}) {
+  if (!readiness || readiness.drafts.length === 0) return null;
+  const visibleDrafts = [
+    ...readiness.drafts.filter((draft) => draft.status === "needs_review"),
+    ...readiness.drafts.filter((draft) => draft.status !== "needs_review"),
+  ].slice(0, 3);
+
+  return (
+    <section className="rounded-md border border-[#17281f]/10 bg-[#f8f5ee]/80 p-4 shadow-[0_16px_45px_rgba(23,40,31,0.08)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold text-[#111612]">
+            <MegaphoneIcon className="h-4 w-4 text-[#a6542f]" aria-hidden="true" />
+            Support and growth
+          </h2>
+          <p className="mt-1 max-w-xl text-xs leading-5 text-[#17281f]/62">{readiness.guidance}</p>
+        </div>
+        <span className="rounded-full border border-[#17281f]/10 bg-white/60 px-2.5 py-1 text-xs font-medium capitalize text-[#17281f]/70">
+          {readiness.pendingReview} pending
+        </span>
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {visibleDrafts.map((draft) => (
+          <div key={draft.id} className="rounded-md border border-[#17281f]/10 bg-white/60 p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold capitalize text-[#111612]">{draft.type.replaceAll("_", " ")}</p>
+                <p className="mt-1 text-xs text-[#17281f]/55">{draft.destination}</p>
+              </div>
+              {draft.status === "needs_review" ? (
+                <button
+                  type="button"
+                  onClick={() => onApprove(draft.id)}
+                  className="inline-flex min-h-8 items-center gap-1.5 rounded-md border border-[#17281f]/12 bg-[#f8f5ee]/85 px-2.5 text-xs font-medium text-[#17281f]"
+                >
+                  <SendIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                  Approve draft
+                </button>
+              ) : (
+                <span className="rounded-full border border-[#17281f]/10 bg-[#f8f5ee]/75 px-2.5 py-1 text-xs font-medium capitalize text-[#17281f]/70">
+                  {draft.status.replaceAll("_", " ")}
+                </span>
+              )}
+            </div>
+            <p className="mt-2 text-xs leading-5 text-[#17281f]/68">{draft.content}</p>
+            {draft.uncertainties.length > 0 && (
+              <div className="mt-2 rounded-md border border-[#b4532f]/20 bg-[#b4532f]/10 p-2">
+                {draft.uncertainties.map((uncertainty) => (
+                  <p key={`${draft.id}-${uncertainty.kind}-${uncertainty.message}`} className="flex items-center gap-1.5 text-xs leading-5 text-[#5f2b1e]">
+                    <AlertTriangleIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    {uncertainty.message}
+                  </p>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/shell/src/components/onboarding/SupportGrowthPanel.tsx
+++ b/shell/src/components/onboarding/SupportGrowthPanel.tsx
@@ -56,6 +56,8 @@ export function SupportGrowthPanel({
                 <p className="mt-1 text-xs text-[#17281f]/55">{draft.destination}</p>
               </div>
               {draft.status === "needs_review" ? (
+                // Rejection is supported by the service but intentionally deferred
+                // from this compact beta panel until the review workflow has room.
                 <button
                   type="button"
                   onClick={() => onApprove(draft.id)}

--- a/specs/082-paid-beta-readiness/tasks.md
+++ b/specs/082-paid-beta-readiness/tasks.md
@@ -195,17 +195,17 @@
 
 ### Tests First
 
-- [ ] T072 [P] [US5] Write failing company context access tests in `tests/gateway/company-brain-readiness.test.ts`
-- [ ] T073 [P] [US5] Write failing company-brain onboarding e2e path in `tests/e2e/onboarding-activation.spec.ts`
+- [X] T072 [P] [US5] Write failing company context access tests in `tests/gateway/company-brain-readiness.test.ts`
+- [X] T073 [P] [US5] Write failing company-brain onboarding e2e path in `tests/e2e/onboarding-activation.spec.ts`
 
 ### Implementation
 
-- [ ] T074 [US5] Implement company context readiness service in `packages/gateway/src/onboarding/company-brain-readiness.ts`
-- [ ] T075 [US5] Add company-brain setup routes in `packages/gateway/src/onboarding/company-brain-routes.ts`
-- [ ] T076 [US5] Wire company-brain routes in `packages/gateway/src/server.ts`
-- [ ] T077 [P] [US5] Create company-brain onboarding panel in `shell/src/components/onboarding/CompanyBrainPanel.tsx`
-- [ ] T078 [US5] Wire company-brain panel into onboarding goal flow in `shell/src/components/OnboardingScreen.tsx`
-- [ ] T079 [US5] Add source-link display and stale/contradictory context copy in `shell/src/components/onboarding/CompanyBrainPanel.tsx`
+- [X] T074 [US5] Implement company context readiness service in `packages/gateway/src/onboarding/company-brain-readiness.ts`
+- [X] T075 [US5] Add company-brain setup routes in `packages/gateway/src/onboarding/company-brain-routes.ts`
+- [X] T076 [US5] Wire company-brain routes in `packages/gateway/src/server.ts`
+- [X] T077 [P] [US5] Create company-brain onboarding panel in `shell/src/components/onboarding/CompanyBrainPanel.tsx`
+- [X] T078 [US5] Wire company-brain panel into onboarding goal flow in `shell/src/components/OnboardingScreen.tsx`
+- [X] T079 [US5] Add source-link display and stale/contradictory context copy in `shell/src/components/onboarding/CompanyBrainPanel.tsx`
 
 **Checkpoint**: US5 can run after foundation without support/growth publishing.
 

--- a/specs/082-paid-beta-readiness/tasks.md
+++ b/specs/082-paid-beta-readiness/tasks.md
@@ -219,17 +219,17 @@
 
 ### Tests First
 
-- [ ] T080 [P] [US6] Write failing draft action approval tests in `tests/gateway/support-growth-readiness.test.ts`
-- [ ] T081 [P] [US6] Write failing support/growth e2e path in `tests/e2e/onboarding-activation.spec.ts`
+- [X] T080 [P] [US6] Write failing draft action approval tests in `tests/gateway/support-growth-readiness.test.ts`
+- [X] T081 [P] [US6] Write failing support/growth e2e path in `tests/e2e/onboarding-activation.spec.ts`
 
 ### Implementation
 
-- [ ] T082 [US6] Implement draft action readiness and approval service in `packages/gateway/src/onboarding/draft-action-readiness.ts`
-- [ ] T083 [US6] Add draft action routes in `packages/gateway/src/onboarding/draft-action-routes.ts`
-- [ ] T084 [US6] Wire draft action routes in `packages/gateway/src/server.ts`
-- [ ] T085 [P] [US6] Create support/growth onboarding panel in `shell/src/components/onboarding/SupportGrowthPanel.tsx`
-- [ ] T086 [US6] Wire support/growth panel into onboarding goal flow in `shell/src/components/OnboardingScreen.tsx`
-- [ ] T087 [US6] Add uncertainty and sensitive-claim display states in `shell/src/components/onboarding/SupportGrowthPanel.tsx`
+- [X] T082 [US6] Implement draft action readiness and approval service in `packages/gateway/src/onboarding/draft-action-readiness.ts`
+- [X] T083 [US6] Add draft action routes in `packages/gateway/src/onboarding/draft-action-routes.ts`
+- [X] T084 [US6] Wire draft action routes in `packages/gateway/src/server.ts`
+- [X] T085 [P] [US6] Create support/growth onboarding panel in `shell/src/components/onboarding/SupportGrowthPanel.tsx`
+- [X] T086 [US6] Wire support/growth panel into onboarding goal flow in `shell/src/components/OnboardingScreen.tsx`
+- [X] T087 [US6] Add uncertainty and sensitive-claim display states in `shell/src/components/onboarding/SupportGrowthPanel.tsx`
 
 **Checkpoint**: US6 drafts remain review-first and safe.
 

--- a/tests/e2e/onboarding-activation.spec.ts
+++ b/tests/e2e/onboarding-activation.spec.ts
@@ -306,4 +306,52 @@ test.describe("onboarding activation", () => {
     await expect(page.getByText("Resume setup")).toBeVisible();
     await expect(page.getByText("Readiness needs review")).toBeVisible();
   });
+
+  test("shows company brain context sources and review flags", async ({ page }) => {
+    await page.route("**/api/onboarding/readiness", async (route) => {
+      await route.fulfill({
+        json: {
+          overallStatus: "degraded",
+          goals: [
+            { id: "company_brain", selected: true, label: "Run my company brain", description: "Use company context" },
+          ],
+          gates: [
+            { id: "company_brain.ready", category: "company_brain", criticality: "recommended", status: "pass", message: "Company context is ready", remediation: null, owner: "user", lastCheckedAt: "2026-05-23T00:00:00.000Z" },
+          ],
+          systemAgent: "hermes",
+          activeAgents: ["hermes"],
+          agents: [],
+        },
+      });
+    });
+    await page.route("**/api/agents/credentials/status", async (route) => {
+      await route.fulfill({ json: { systemAgent: "hermes", activeAgents: ["hermes"], routingExplanation: "Hermes remains the Matrix system agent.", agents: [] } });
+    });
+    await page.route("**/api/integrations/capabilities", async (route) => {
+      await route.fulfill({ json: { capabilities: [] } });
+    });
+    await page.route("**/api/admin/control-surface", async (route) => {
+      await route.fulfill({ json: null, status: 204 });
+    });
+    await page.route("**/api/company-brain/readiness", async (route) => {
+      await route.fulfill({
+        json: {
+          status: "needs_review",
+          guidance: "Review stale or contradictory context before agents rely on it.",
+          items: [
+            { id: "ctx_launch", type: "product_decision", title: "Launch ICP", summary: "Technical founders and developers.", source: "specs/launch-readiness", visibility: "owner_only", updatedAt: "2026-05-23T00:00:00.000Z" },
+          ],
+          sourceLinks: ["specs/launch-readiness"],
+          reviewFlags: [{ itemId: "ctx_launch", kind: "stale", message: "Check whether this context is still current." }],
+        },
+      });
+    });
+
+    await page.goto("/");
+
+    await expect(page.getByText("Company brain")).toBeVisible();
+    await expect(page.getByText("Launch ICP")).toBeVisible();
+    await expect(page.getByText("specs/launch-readiness")).toBeVisible();
+    await expect(page.getByText("Review stale or contradictory context before agents rely on it.")).toBeVisible();
+  });
 });

--- a/tests/e2e/onboarding-activation.spec.ts
+++ b/tests/e2e/onboarding-activation.spec.ts
@@ -52,7 +52,7 @@ test.describe("onboarding activation", () => {
     await openManualSetup(page);
     await expect(page.getByText("Set up Matrix around the work you want done first.")).toBeVisible();
     await page.getByRole("button", { name: /Code with Matrix/i }).click();
-    await expect(page.getByText("Required · Connect GitHub")).toBeVisible();
+    await expect(page.getByText("Connect GitHub")).toBeVisible();
     await expect(page.getByText("Hermes is available as the Matrix system agent")).toBeVisible();
   });
 
@@ -138,7 +138,6 @@ test.describe("onboarding activation", () => {
     });
 
     await openManualSetup(page);
-
     await expect(page.getByText("Coding setup")).toBeVisible();
     await expect(page.getByText("GitHub connected")).toBeVisible();
     await expect(page.getByText("Choose task source")).toBeVisible();
@@ -187,7 +186,6 @@ test.describe("onboarding activation", () => {
     });
 
     await openManualSetup(page);
-
     await expect(page.getByText("Agent setup")).toBeVisible();
     await expect(page.getByText("Hermes is the Matrix system agent")).toBeVisible();
     await expect(page.getByText("Claude is not connected")).toBeVisible();
@@ -241,8 +239,7 @@ test.describe("onboarding activation", () => {
       });
     });
 
-    await page.goto("/");
-
+    await openManualSetup(page);
     await expect(page.getByText("Assistant integrations")).toBeVisible();
     await expect(page.getByText("Calendar event")).toBeVisible();
     await expect(page.getByText("Email summaries")).toBeVisible();
@@ -298,11 +295,10 @@ test.describe("onboarding activation", () => {
       });
     });
 
-    await page.goto("/");
-
+    await openManualSetup(page);
     await expect(page.getByText("Matrix control")).toBeVisible();
-    await expect(page.getByText("Hermes")).toBeVisible();
-    await expect(page.getByText("Automations")).toBeVisible();
+    await expect(page.getByText("Hermes", { exact: true })).toBeVisible();
+    await expect(page.getByText("Automations", { exact: true })).toBeVisible();
     await expect(page.getByText("Resume setup")).toBeVisible();
     await expect(page.getByText("Readiness needs review")).toBeVisible();
   });
@@ -347,11 +343,64 @@ test.describe("onboarding activation", () => {
       });
     });
 
-    await page.goto("/");
-
-    await expect(page.getByText("Company brain")).toBeVisible();
+    await openManualSetup(page);
+    await expect(page.getByRole("heading", { name: "Company brain" })).toBeVisible();
     await expect(page.getByText("Launch ICP")).toBeVisible();
-    await expect(page.getByText("specs/launch-readiness")).toBeVisible();
+    await expect(page.locator("span").filter({ hasText: "specs/launch-readiness" }).first()).toBeVisible();
     await expect(page.getByText("Review stale or contradictory context before agents rely on it.")).toBeVisible();
+  });
+
+  test("shows support and growth drafts as approval-first", async ({ page }) => {
+    await page.route("**/api/onboarding/readiness", async (route) => {
+      await route.fulfill({
+        json: {
+          overallStatus: "degraded",
+          goals: [],
+          gates: [
+            { id: "support_growth.ready", category: "support_growth", criticality: "optional", status: "fail", message: "Drafts need review", remediation: "Review support and growth drafts", owner: "user", lastCheckedAt: "2026-05-23T00:00:00.000Z" },
+          ],
+          systemAgent: "hermes",
+          activeAgents: ["hermes"],
+          agents: [],
+        },
+      });
+    });
+    await page.route("**/api/agents/credentials/status", async (route) => {
+      await route.fulfill({ json: { systemAgent: "hermes", activeAgents: ["hermes"], routingExplanation: "Hermes remains the Matrix system agent.", agents: [] } });
+    });
+    await page.route("**/api/integrations/capabilities", async (route) => {
+      await route.fulfill({ json: { capabilities: [] } });
+    });
+    await page.route("**/api/company-brain/readiness", async (route) => {
+      await route.fulfill({ json: { status: "needs_context", guidance: "Add context.", items: [], sourceLinks: [], reviewFlags: [] } });
+    });
+    await page.route("**/api/support-growth/readiness", async (route) => {
+      await route.fulfill({
+        json: {
+          status: "needs_review",
+          pendingReview: 1,
+          approved: 0,
+          guidance: "Review drafts before any external send or publish action.",
+          drafts: [
+            {
+              id: "draft.launch",
+              type: "support_reply",
+              status: "needs_review",
+              content: "We may support this workflow next week.",
+              destination: "Customer ticket #42",
+              uncertainties: [{ kind: "uncertainty", message: "Confirm timing before sending." }],
+              createdByAgent: "hermes",
+              createdAt: "2026-05-23T00:00:00.000Z",
+            },
+          ],
+        },
+      });
+    });
+
+    await openManualSetup(page);
+    await expect(page.getByRole("heading", { name: "Support and growth" })).toBeVisible();
+    await expect(page.getByText("Customer ticket #42")).toBeVisible();
+    await expect(page.getByText("Confirm timing before sending.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Approve draft", exact: true })).toBeVisible();
   });
 });

--- a/tests/gateway/company-brain-readiness.test.ts
+++ b/tests/gateway/company-brain-readiness.test.ts
@@ -113,6 +113,23 @@ describe("company brain readiness", () => {
     ]));
   });
 
+  it("does not mark longer words containing stale as stale context", async () => {
+    const service = createCompanyBrainReadinessService();
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(post("/context", {
+      type: "product_decision",
+      title: "Roadmap stalemate",
+      summary: "The team is resolving a stalemate over packaging.",
+      source: "notes/roadmap",
+      visibility: "owner_only",
+    }));
+    const body = await (await app.request("/readiness")).json();
+
+    expect(body.status).toBe("ready");
+    expect(body.reviewFlags).toEqual([]);
+  });
+
   it("does not mark non-contradictory context as a contradiction", async () => {
     const service = createCompanyBrainReadinessService();
     const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });

--- a/tests/gateway/company-brain-readiness.test.ts
+++ b/tests/gateway/company-brain-readiness.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { createCompanyBrainRoutes } from "../../packages/gateway/src/onboarding/company-brain-routes.js";
+import { createCompanyBrainReadinessService } from "../../packages/gateway/src/onboarding/company-brain-readiness.js";
+import { testPrincipal } from "../helpers/activation-readiness.js";
+
+function post(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("company brain readiness", () => {
+  it("starts with a safe needs-context state", async () => {
+    const service = createCompanyBrainReadinessService();
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request("/readiness");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("needs_context");
+    expect(body.items).toEqual([]);
+    expect(body.guidance).toContain("Add a product decision");
+    expect(JSON.stringify(body)).not.toMatch(/secret|token|postgres|\/home\//i);
+  });
+
+  it("captures owner-scoped company context with source references", async () => {
+    const service = createCompanyBrainReadinessService({
+      now: () => new Date("2026-05-23T00:00:00.000Z"),
+    });
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/context", {
+      type: "product_decision",
+      title: "Launch ICP",
+      summary: "Paid beta targets technical founders and developers.",
+      source: "specs/launch-readiness",
+      visibility: "owner_only",
+    }));
+
+    expect(created.status).toBe(200);
+    const readiness = await (await app.request("/readiness")).json();
+    expect(readiness.status).toBe("ready");
+    expect(readiness.items).toEqual([
+      expect.objectContaining({
+        title: "Launch ICP",
+        source: "specs/launch-readiness",
+        visibility: "owner_only",
+      }),
+    ]);
+    expect(readiness.sourceLinks).toEqual(["specs/launch-readiness"]);
+  });
+
+  it("marks stale and contradictory context for review", async () => {
+    const service = createCompanyBrainReadinessService();
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(post("/context", {
+      type: "product_decision",
+      title: "Old pricing",
+      summary: "stale contradiction: launch price is unknown",
+      source: "notes/pricing",
+      visibility: "owner_only",
+    }));
+    const body = await (await app.request("/readiness")).json();
+
+    expect(body.status).toBe("needs_review");
+    expect(body.reviewFlags).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "stale" }),
+      expect.objectContaining({ kind: "contradiction" }),
+    ]));
+  });
+
+  it("does not mark non-contradictory context as a contradiction", async () => {
+    const service = createCompanyBrainReadinessService();
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(post("/context", {
+      type: "product_decision",
+      title: "Pricing alignment",
+      summary: "The new offer is non-contradictory with the free tier.",
+      source: "notes/pricing",
+      visibility: "owner_only",
+    }));
+    const body = await (await app.request("/readiness")).json();
+
+    expect(body.status).toBe("ready");
+    expect(body.reviewFlags).toEqual([]);
+  });
+
+  it("marks contradict and contradictions wording for review", async () => {
+    const service = createCompanyBrainReadinessService();
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(post("/context", {
+      type: "product_decision",
+      title: "Pricing mismatch",
+      summary: "These entries contradict each other and create contradictions in the pricing docs.",
+      source: "notes/pricing",
+      visibility: "owner_only",
+    }));
+    const body = await (await app.request("/readiness")).json();
+
+    expect(body.status).toBe("needs_review");
+    expect(body.reviewFlags).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "contradiction" }),
+    ]));
+  });
+});

--- a/tests/gateway/company-brain-readiness.test.ts
+++ b/tests/gateway/company-brain-readiness.test.ts
@@ -72,6 +72,27 @@ describe("company brain readiness", () => {
     await expect(res.json()).resolves.toMatchObject({ summary });
   });
 
+  it("redacts unsafe fragments without replacing company context", async () => {
+    const service = createCompanyBrainReadinessService();
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(post("/context", {
+      type: "customer_note",
+      title: "Customer database migration",
+      summary: "Customer asked about database status; token=sk_test_secret must not be shown.",
+      source: "/home/matrix/notes/customer.md",
+      visibility: "owner_only",
+    }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.title).toContain("Customer");
+    expect(body.summary).toContain("Customer asked");
+    expect(body.summary).toContain("[redacted]");
+    expect(body.source).toBe("[redacted]");
+    expect(JSON.stringify(body)).not.toMatch(/database|token|secret|sk_test|\/home\//i);
+  });
+
   it("marks stale and contradictory context for review", async () => {
     const service = createCompanyBrainReadinessService();
     const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });

--- a/tests/gateway/company-brain-readiness.test.ts
+++ b/tests/gateway/company-brain-readiness.test.ts
@@ -79,7 +79,7 @@ describe("company brain readiness", () => {
     const res = await app.request(post("/context", {
       type: "customer_note",
       title: "Customer database migration",
-      summary: "Customer asked about database status; token=sk_test_secret must not be shown.",
+      summary: "Customer asked about database status; token=sk_test_secret and sk-ant-abc123 must not be shown.",
       source: "/home/matrix/notes/customer.md",
       visibility: "owner_only",
     }));
@@ -90,7 +90,7 @@ describe("company brain readiness", () => {
     expect(body.summary).toContain("Customer asked");
     expect(body.summary).toContain("[redacted]");
     expect(body.source).toBe("[redacted]");
-    expect(JSON.stringify(body)).not.toMatch(/database|token|secret|sk_test|\/home\//i);
+    expect(JSON.stringify(body)).not.toMatch(/database|token|secret|sk_test|sk-ant|\/home\//i);
   });
 
   it("marks stale and contradictory context for review", async () => {
@@ -147,14 +147,33 @@ describe("company brain readiness", () => {
     expect(body.reviewFlags).toEqual([]);
   });
 
-  it("marks contradict and contradictions wording for review", async () => {
+  it("marks contradicting wording for review", async () => {
     const service = createCompanyBrainReadinessService();
     const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
 
     await app.request(post("/context", {
       type: "product_decision",
       title: "Pricing mismatch",
-      summary: "These entries contradict each other and create contradictions in the pricing docs.",
+      summary: "These entries are contradicting the offer page in the pricing docs.",
+      source: "notes/pricing",
+      visibility: "owner_only",
+    }));
+    const body = await (await app.request("/readiness")).json();
+
+    expect(body.status).toBe("needs_review");
+    expect(body.reviewFlags).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "contradiction" }),
+    ]));
+  });
+
+  it("marks self-contradictory wording for review", async () => {
+    const service = createCompanyBrainReadinessService();
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+
+    await app.request(post("/context", {
+      type: "product_decision",
+      title: "Pricing mismatch",
+      summary: "The launch guidance is self-contradictory across pricing notes.",
       source: "notes/pricing",
       visibility: "owner_only",
     }));

--- a/tests/gateway/company-brain-readiness.test.ts
+++ b/tests/gateway/company-brain-readiness.test.ts
@@ -53,6 +53,25 @@ describe("company brain readiness", () => {
     expect(readiness.sourceLinks).toEqual(["specs/launch-readiness"]);
   });
 
+  it("preserves safe summaries up to the route schema limit", async () => {
+    const service = createCompanyBrainReadinessService({
+      now: () => new Date("2026-05-23T00:00:00.000Z"),
+    });
+    const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });
+    const summary = "a".repeat(780);
+
+    const res = await app.request(post("/context", {
+      type: "product_decision",
+      title: "Launch ICP",
+      summary,
+      source: "specs/launch-readiness",
+      visibility: "owner_only",
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ summary });
+  });
+
   it("marks stale and contradictory context for review", async () => {
     const service = createCompanyBrainReadinessService();
     const app = createCompanyBrainRoutes({ service, getPrincipal: () => testPrincipal });

--- a/tests/gateway/support-growth-readiness.test.ts
+++ b/tests/gateway/support-growth-readiness.test.ts
@@ -98,7 +98,7 @@ describe("support and growth draft readiness", () => {
 
     const created = await app.request(post("/drafts", {
       type: "support_reply",
-      content: "Tell the customer the database migration is done; token=sk_test_secret is not needed.",
+      content: "Tell the customer the database migration is done; token=sk_test_secret and sk-ant-abc123 are not needed.",
       destination: "Customer ticket #42",
       createdByAgent: "hermes",
     }));
@@ -107,7 +107,7 @@ describe("support and growth draft readiness", () => {
     expect(draft.content).toContain("Tell the customer");
     expect(draft.content).toContain("database migration is done");
     expect(draft.content).toContain("[redacted]");
-    expect(draft.content).not.toMatch(/token=|secret|sk_test/i);
+    expect(draft.content).not.toMatch(/token=|secret|sk_test|sk-ant/i);
   });
 
   it("preserves legitimate support language that contains sensitive-domain words", async () => {
@@ -124,6 +124,21 @@ describe("support and growth draft readiness", () => {
     const draft = await created.json();
     expect(draft.content).toBe("Tell the customer the database backup and token lifecycle docs are ready.");
     expect(draft.content).not.toContain("[redacted]");
+  });
+
+  it("does not flag May calendar dates as uncertain language", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/drafts", {
+      type: "support_reply",
+      content: "Fix scheduled for May 15th after the rollout window.",
+      destination: "Customer ticket #44",
+      createdByAgent: "hermes",
+    }));
+
+    const draft = await created.json();
+    expect(draft.uncertainties).toEqual([]);
   });
 
   it("does not flag polite May support openers as uncertain language", async () => {

--- a/tests/gateway/support-growth-readiness.test.ts
+++ b/tests/gateway/support-growth-readiness.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { createDraftActionRoutes } from "../../packages/gateway/src/onboarding/draft-action-routes.js";
+import { createDraftActionReadinessService } from "../../packages/gateway/src/onboarding/draft-action-readiness.js";
+import { testPrincipal } from "../helpers/activation-readiness.js";
+
+function post(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("support and growth draft readiness", () => {
+  it("creates review-first drafts with uncertainty and sensitive claim flags", async () => {
+    const service = createDraftActionReadinessService({
+      now: () => new Date("2026-05-23T00:00:00.000Z"),
+    });
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/drafts", {
+      type: "support_reply",
+      content: "We can guarantee 99.999% uptime, but I am unsure about the current SLA.",
+      destination: "Customer ticket #42",
+      createdByAgent: "hermes",
+    }));
+
+    expect(created.status).toBe(200);
+    const draft = await created.json();
+    expect(draft.status).toBe("needs_review");
+    expect(draft.uncertainties).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "uncertainty" }),
+      expect.objectContaining({ kind: "sensitive_claim" }),
+    ]));
+    expect(JSON.stringify(draft)).not.toMatch(/secret|token|\/home\//i);
+  });
+
+  it("requires explicit approval before a draft can be marked approved", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+    const draft = await (await app.request(post("/drafts", {
+      type: "social_post",
+      content: "Matrix helps founders ship code and operate support.",
+      destination: "LinkedIn",
+      createdByAgent: "hermes",
+    }))).json();
+
+    const approved = await app.request(post(`/drafts/${draft.id}/approval`, { approved: true }));
+
+    expect(approved.status).toBe(200);
+    await expect(approved.json()).resolves.toMatchObject({
+      id: draft.id,
+      status: "approved",
+      approvalSummary: "Draft approved for external action",
+    });
+  });
+
+  it("returns safe readiness summaries for pending drafts", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+    await app.request(post("/drafts", {
+      type: "acquisition_message",
+      content: "Draft for an early founder lead.",
+      destination: "Outbound queue",
+      createdByAgent: "hermes",
+    }));
+
+    const body = await (await app.request("/readiness")).json();
+
+    expect(body.status).toBe("needs_review");
+    expect(body.pendingReview).toBe(1);
+    expect(body.guidance).toContain("Review drafts");
+  });
+
+  it("does not flag polite May support openers as uncertain language", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/drafts", {
+      type: "support_reply",
+      content: "May I clarify which plan you're on before I send the setup steps?",
+      destination: "Customer ticket #45",
+      createdByAgent: "hermes",
+    }));
+
+    const draft = await created.json();
+    expect(draft.uncertainties).toEqual([]);
+  });
+
+  it("does not flag words that contain never as sensitive claims", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/drafts", {
+      type: "support_reply",
+      content: "Nevertheless, the setup steps are ready for your team.",
+      destination: "Customer ticket #46",
+      createdByAgent: "hermes",
+    }));
+
+    const draft = await created.json();
+    expect(draft.uncertainties).toEqual([]);
+  });
+
+  it("flags might before punctuation as uncertain language", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/drafts", {
+      type: "support_reply",
+      content: "The timeline might?",
+      destination: "Customer ticket #47",
+      createdByAgent: "hermes",
+    }));
+
+    const draft = await created.json();
+    expect(draft.uncertainties).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "uncertainty" }),
+    ]));
+  });
+});

--- a/tests/gateway/support-growth-readiness.test.ts
+++ b/tests/gateway/support-growth-readiness.test.ts
@@ -105,8 +105,25 @@ describe("support and growth draft readiness", () => {
 
     const draft = await created.json();
     expect(draft.content).toContain("Tell the customer");
+    expect(draft.content).toContain("database migration is done");
     expect(draft.content).toContain("[redacted]");
-    expect(draft.content).not.toMatch(/database|token|secret|sk_test/i);
+    expect(draft.content).not.toMatch(/token=|secret|sk_test/i);
+  });
+
+  it("preserves legitimate support language that contains sensitive-domain words", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/drafts", {
+      type: "support_reply",
+      content: "Tell the customer the database backup and token lifecycle docs are ready.",
+      destination: "Customer ticket #43",
+      createdByAgent: "hermes",
+    }));
+
+    const draft = await created.json();
+    expect(draft.content).toBe("Tell the customer the database backup and token lifecycle docs are ready.");
+    expect(draft.content).not.toContain("[redacted]");
   });
 
   it("does not flag polite May support openers as uncertain language", async () => {

--- a/tests/gateway/support-growth-readiness.test.ts
+++ b/tests/gateway/support-growth-readiness.test.ts
@@ -92,6 +92,23 @@ describe("support and growth draft readiness", () => {
     expect(body.guidance).toContain("Review drafts");
   });
 
+  it("redacts unsafe fragments without replacing the reviewable draft", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const created = await app.request(post("/drafts", {
+      type: "support_reply",
+      content: "Tell the customer the database migration is done; token=sk_test_secret is not needed.",
+      destination: "Customer ticket #42",
+      createdByAgent: "hermes",
+    }));
+
+    const draft = await created.json();
+    expect(draft.content).toContain("Tell the customer");
+    expect(draft.content).toContain("[redacted]");
+    expect(draft.content).not.toMatch(/database|token|secret|sk_test/i);
+  });
+
   it("does not flag polite May support openers as uncertain language", async () => {
     const service = createDraftActionReadinessService();
     const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });

--- a/tests/gateway/support-growth-readiness.test.ts
+++ b/tests/gateway/support-growth-readiness.test.ts
@@ -55,6 +55,26 @@ describe("support and growth draft readiness", () => {
     });
   });
 
+  it("rejects approval changes after a draft is already decided", async () => {
+    const service = createDraftActionReadinessService();
+    const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });
+    const draft = await (await app.request(post("/drafts", {
+      type: "social_post",
+      content: "Matrix helps founders ship code and operate support.",
+      destination: "LinkedIn",
+      createdByAgent: "hermes",
+    }))).json();
+
+    await app.request(post(`/drafts/${draft.id}/approval`, { approved: true }));
+    const repeat = await app.request(post(`/drafts/${draft.id}/approval`, { approved: false }));
+
+    expect(repeat.status).toBe(409);
+    await expect(repeat.json()).resolves.toMatchObject({
+      error: "draft_already_decided",
+      message: "Draft has already been decided",
+    });
+  });
+
   it("returns safe readiness summaries for pending drafts", async () => {
     const service = createDraftActionReadinessService();
     const app = createDraftActionRoutes({ service, getPrincipal: () => testPrincipal });


### PR DESCRIPTION
Stack: 6/8

## Summary

- Adds company-brain readiness for owner/team context sources with stale/contradictory review flags.
- Adds support and growth draft workflows that require explicit approval before external send/publish.

## Tests

- `bun run typecheck`
- `bun run check:patterns` (0 violations, existing warning-only baseline)
- `bun run test -- --reporter=dot` (459 files passed, 3 skipped; 4,752 tests passed, 20 skipped)
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bWF0cml4b3MudGVzdCQ= pnpm --dir shell build`
- `pnpm --dir shell exec playwright test ../tests/e2e/onboarding-activation.spec.ts ../tests/e2e/onboarding-visual.spec.ts --config ../tests/e2e/playwright.config.ts` (8 passed)

## Review/Monitoring

- Stacked PR base: `082-admin-control-surface`
- Greptile and CI must pass before merging.

## Invariants

- Source of truth: company context readiness and draft-action services own their launch setup state.
- Lock/transaction scope: draft approval remains explicit and local; no external send/publish is performed by this layer without approval.
- Acceptable orphan states: stale/contradictory context and uncertain support claims block or warn before agent use.
- Auth source of truth: company-brain and support/growth routes require owner gateway authentication.
- Deferred scope: billing gates and platform launch reporting land in the next stack layer.