### PR TITLE
feat(platform): gate launch readiness

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -316,7 +316,7 @@ write_files:
 
       usage() {
         echo "usage: matrixctl r2 <put|get|exists|put-latest|prune> ..." >&2
-        echo "usage: matrixctl recover <clerk-user-id> [--allow-empty]" >&2
+        echo "usage: matrixctl recover <clerk-user-id> [--slot <runtime-slot>] [--allow-empty]" >&2
       }
 
       fail() {
@@ -415,23 +415,37 @@ write_files:
 
       recover() {
         local clerk_user_id="$1"
-        local allow_empty="${2:-}"
+        shift
+        local allow_empty="false"
+        local runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"
         case "$clerk_user_id" in
           ""|*[^A-Za-z0-9_-]*) fail "invalid recovery user" ;;
         esac
-        if [ -n "$allow_empty" ] && [ "$allow_empty" != "--allow-empty" ]; then
-          usage
-          exit 2
-        fi
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --allow-empty)
+              allow_empty="true"
+              shift
+              ;;
+            --slot)
+              [ "$#" -ge 2 ] || { usage; exit 2; }
+              runtime_slot="$2"
+              shift 2
+              ;;
+            *)
+              usage
+              exit 2
+              ;;
+          esac
+        done
+        case "$runtime_slot" in
+          ""|[!a-z0-9]*|*[^a-z0-9-]*) fail "invalid runtime slot" ;;
+        esac
         [ -n "$MATRIX_PLATFORM_URL" ] || fail "platform recovery not configured"
         [ -n "$MATRIX_PLATFORM_TOKEN" ] || fail "platform recovery not configured"
 
-        local allow_json="false"
-        if [ "$allow_empty" = "--allow-empty" ]; then
-          allow_json="true"
-        fi
         local payload
-        payload="$(printf '{"clerkUserId":"%s","allowEmpty":%s}' "$clerk_user_id" "$allow_json")"
+        payload="$(printf '{"clerkUserId":"%s","runtimeSlot":"%s","allowEmpty":%s}' "$clerk_user_id" "$runtime_slot" "$allow_empty")"
         if ! curl --fail --silent --show-error --max-time 10 \
           -H "authorization: Bearer ${MATRIX_PLATFORM_TOKEN}" \
           -H "content-type: application/json" \
@@ -443,8 +457,9 @@ write_files:
       }
 
       if [ "${1:-}" = "recover" ]; then
-        [ "$#" -ge 2 ] && [ "$#" -le 3 ] || { usage; exit 2; }
-        recover "$2" "${3:-}"
+        [ "$#" -ge 2 ] || { usage; exit 2; }
+        shift
+        recover "$@"
         exit 0
       fi
 

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -395,15 +395,26 @@ write_files:
       r2_put_latest() {
         local snapshot_key="$1"
         safe_relative_key "$snapshot_key" || fail "invalid latest pointer"
+        local latest_key
         case "$snapshot_key" in
-          system/db/snapshots/*.dump) ;;
+          system/db/snapshots/*.dump)
+            latest_key="system/db/latest"
+            ;;
+          system/runtime-slots/*/db/snapshots/*.dump)
+            local runtime_slot="${snapshot_key#system/runtime-slots/}"
+            runtime_slot="${runtime_slot%%/*}"
+            case "$runtime_slot" in
+              ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) fail "invalid latest pointer" ;;
+            esac
+            latest_key="system/runtime-slots/${runtime_slot}/db/latest"
+            ;;
           *) fail "invalid latest pointer" ;;
         esac
       local tmp
       tmp="$(mktemp)"
       trap 'rm -f "${tmp:-}"' EXIT
         printf '%s\n' "$snapshot_key" > "$tmp"
-        r2_put "$tmp" "system/db/latest"
+        r2_put "$tmp" "$latest_key"
       }
 
       r2_prune() {
@@ -510,10 +521,19 @@ write_files:
       snapshot_dir="/var/lib/matrix/db/snapshots"
       mkdir -p "$snapshot_dir"
 
+      runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"
+      case "$runtime_slot" in
+        ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) echo "matrix-db-backup: invalid runtime slot" >&2; exit 1 ;;
+      esac
+
       ts="$(date -u +%Y-%m-%dT%H%MZ)"
       snapshot_name="${ts}.dump"
       snapshot_path="${snapshot_dir}/${snapshot_name}"
-      snapshot_key="system/db/snapshots/${snapshot_name}"
+      if [ "$runtime_slot" = "primary" ]; then
+        snapshot_key="system/db/snapshots/${snapshot_name}"
+      else
+        snapshot_key="system/runtime-slots/${runtime_slot}/db/snapshots/${snapshot_name}"
+      fi
 
       export PGPASSWORD="${POSTGRES_PASSWORD:?postgres password missing}"
 
@@ -550,6 +570,17 @@ write_files:
       restore_flag="/opt/matrix/restore-complete"
       latest_file="/var/lib/matrix/db/latest"
       snapshot_path="/var/lib/matrix/db/latest.dump"
+      runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"
+      case "$runtime_slot" in
+        ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) echo "matrix-restore: invalid runtime slot" >&2; exit 1 ;;
+      esac
+      if [ "$runtime_slot" = "primary" ]; then
+        latest_pointer_key="system/db/latest"
+        snapshot_key_pattern="system/db/snapshots/*.dump"
+      else
+        latest_pointer_key="system/runtime-slots/${runtime_slot}/db/latest"
+        snapshot_key_pattern="system/runtime-slots/${runtime_slot}/db/snapshots/*.dump"
+      fi
 
       mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
       rm -f "$restore_flag"
@@ -559,19 +590,19 @@ write_files:
         exit 0
       fi
 
-      if ! /opt/matrix/bin/matrixctl r2 exists system/db/latest; then
+      if ! /opt/matrix/bin/matrixctl r2 exists "$latest_pointer_key"; then
         touch "$restore_flag"
         exit 0
       fi
 
-      if ! /opt/matrix/bin/matrixctl r2 get system/db/latest "$latest_file"; then
+      if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then
         echo "matrix-restore: failed to fetch latest pointer" >&2
         exit 1
       fi
 
       latest_key="$(tr -d '\r\n' < "$latest_file")"
       case "$latest_key" in
-        system/db/snapshots/*.dump) ;;
+        $snapshot_key_pattern) ;;
         *)
           echo "matrix-restore: invalid latest pointer" >&2
           exit 1

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -631,6 +631,7 @@ write_files:
       MATRIX_MACHINE_ID={{machineId}}
       MATRIX_CLERK_USER_ID={{clerkUserId}}
       MATRIX_HANDLE={{handle}}
+      MATRIX_RUNTIME_SLOT={{runtimeSlot}}
       MATRIX_IMAGE_VERSION={{imageVersion}}
       MATRIX_UPDATE_CHANNEL={{updateChannel}}
       MATRIX_PLATFORM_REGISTER_URL={{platformRegisterUrl}}

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -600,8 +600,8 @@ write_files:
         exit 1
       fi
 
-      latest_key="$(tr -d '\r\n' < "$latest_file")"
-      case "$latest_key" in
+      snapshot_key="$(tr -d '\r\n' < "$latest_file")"
+      case "$snapshot_key" in
         $snapshot_key_pattern) ;;
         *)
           echo "matrix-restore: invalid latest pointer" >&2
@@ -609,7 +609,11 @@ write_files:
           ;;
       esac
 
+<<<<<<< HEAD
       if ! /opt/matrix/bin/matrixctl r2 get "$latest_key" "$snapshot_path"; then
+=======
+      if ! matrixctl r2 get "$snapshot_key" "$snapshot_path"; then
+>>>>>>> 1e60cfc9 (fix(platform): route staging admin proxy handles)
         echo "matrix-restore: failed to fetch snapshot" >&2
         exit 1
       fi

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -439,7 +439,7 @@ write_files:
           esac
         done
         case "$runtime_slot" in
-          ""|[!a-z0-9]*|*[^a-z0-9-]*) fail "invalid runtime slot" ;;
+          ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) fail "invalid runtime slot" ;;
         esac
         [ -n "$MATRIX_PLATFORM_URL" ] || fail "platform recovery not configured"
         [ -n "$MATRIX_PLATFORM_TOKEN" ] || fail "platform recovery not configured"

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -609,11 +609,7 @@ write_files:
           ;;
       esac
 
-<<<<<<< HEAD
-      if ! /opt/matrix/bin/matrixctl r2 get "$latest_key" "$snapshot_path"; then
-=======
-      if ! matrixctl r2 get "$snapshot_key" "$snapshot_path"; then
->>>>>>> 1e60cfc9 (fix(platform): route staging admin proxy handles)
+      if ! /opt/matrix/bin/matrixctl r2 get "$snapshot_key" "$snapshot_path"; then
         echo "matrix-restore: failed to fetch snapshot" >&2
         exit 1
       fi

--- a/distro/customer-vps/matrix-db-backup.sh
+++ b/distro/customer-vps/matrix-db-backup.sh
@@ -9,10 +9,19 @@ fi
 snapshot_dir="/var/lib/matrix/db/snapshots"
 mkdir -p "$snapshot_dir"
 
+runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"
+case "$runtime_slot" in
+  ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) echo "matrix-db-backup: invalid runtime slot" >&2; exit 1 ;;
+esac
+
 ts="$(date -u +%Y-%m-%dT%H%MZ)"
 snapshot_name="${ts}.dump"
 snapshot_path="${snapshot_dir}/${snapshot_name}"
-snapshot_key="system/db/snapshots/${snapshot_name}"
+if [ "$runtime_slot" = "primary" ]; then
+  snapshot_key="system/db/snapshots/${snapshot_name}"
+else
+  snapshot_key="system/runtime-slots/${runtime_slot}/db/snapshots/${snapshot_name}"
+fi
 
 export PGPASSWORD="${POSTGRES_PASSWORD:?postgres password missing}"
 

--- a/distro/customer-vps/matrix-restore.sh
+++ b/distro/customer-vps/matrix-restore.sh
@@ -9,6 +9,17 @@ fi
 restore_flag="/opt/matrix/restore-complete"
 latest_file="/var/lib/matrix/db/latest"
 snapshot_path="/var/lib/matrix/db/latest.dump"
+runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"
+case "$runtime_slot" in
+  ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) echo "matrix-restore: invalid runtime slot" >&2; exit 1 ;;
+esac
+if [ "$runtime_slot" = "primary" ]; then
+  latest_key="system/db/latest"
+  snapshot_key_pattern="system/db/snapshots/*.dump"
+else
+  latest_key="system/runtime-slots/${runtime_slot}/db/latest"
+  snapshot_key_pattern="system/runtime-slots/${runtime_slot}/db/snapshots/*.dump"
+fi
 
 mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
 rm -f "$restore_flag"
@@ -18,19 +29,19 @@ if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then
   exit 0
 fi
 
-if ! /opt/matrix/bin/matrixctl r2 exists system/db/latest; then
+if ! /opt/matrix/bin/matrixctl r2 exists "$latest_key"; then
   touch "$restore_flag"
   exit 0
 fi
 
-if ! /opt/matrix/bin/matrixctl r2 get system/db/latest "$latest_file"; then
+if ! /opt/matrix/bin/matrixctl r2 get "$latest_key" "$latest_file"; then
   echo "matrix-restore: failed to fetch latest pointer" >&2
   exit 1
 fi
 
 latest_key="$(tr -d '\r\n' < "$latest_file")"
 case "$latest_key" in
-  system/db/snapshots/*.dump) ;;
+  $snapshot_key_pattern) ;;
   *)
     echo "matrix-restore: invalid latest pointer" >&2
     exit 1

--- a/distro/customer-vps/matrix-restore.sh
+++ b/distro/customer-vps/matrix-restore.sh
@@ -39,8 +39,8 @@ if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then
   exit 1
 fi
 
-latest_key="$(tr -d '\r\n' < "$latest_file")"
-case "$latest_key" in
+snapshot_key="$(tr -d '\r\n' < "$latest_file")"
+case "$snapshot_key" in
   $snapshot_key_pattern) ;;
   *)
     echo "matrix-restore: invalid latest pointer" >&2
@@ -48,7 +48,7 @@ case "$latest_key" in
     ;;
 esac
 
-if ! /opt/matrix/bin/matrixctl r2 get "$latest_key" "$snapshot_path"; then
+if ! /opt/matrix/bin/matrixctl r2 get "$snapshot_key" "$snapshot_path"; then
   echo "matrix-restore: failed to fetch snapshot" >&2
   exit 1
 fi

--- a/distro/customer-vps/matrix-restore.sh
+++ b/distro/customer-vps/matrix-restore.sh
@@ -14,10 +14,10 @@ case "$runtime_slot" in
   ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) echo "matrix-restore: invalid runtime slot" >&2; exit 1 ;;
 esac
 if [ "$runtime_slot" = "primary" ]; then
-  latest_key="system/db/latest"
+  latest_pointer_key="system/db/latest"
   snapshot_key_pattern="system/db/snapshots/*.dump"
 else
-  latest_key="system/runtime-slots/${runtime_slot}/db/latest"
+  latest_pointer_key="system/runtime-slots/${runtime_slot}/db/latest"
   snapshot_key_pattern="system/runtime-slots/${runtime_slot}/db/snapshots/*.dump"
 fi
 
@@ -29,12 +29,12 @@ if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then
   exit 0
 fi
 
-if ! /opt/matrix/bin/matrixctl r2 exists "$latest_key"; then
+if ! /opt/matrix/bin/matrixctl r2 exists "$latest_pointer_key"; then
   touch "$restore_flag"
   exit 0
 fi
 
-if ! /opt/matrix/bin/matrixctl r2 get "$latest_key" "$latest_file"; then
+if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then
   echo "matrix-restore: failed to fetch latest pointer" >&2
   exit 1
 fi

--- a/distro/customer-vps/matrixctl
+++ b/distro/customer-vps/matrixctl
@@ -154,7 +154,7 @@ recover() {
     esac
   done
   case "$runtime_slot" in
-    ""|[!a-z0-9]*|*[^a-z0-9-]*) fail "invalid runtime slot" ;;
+    ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) fail "invalid runtime slot" ;;
   esac
   [ -n "$MATRIX_PLATFORM_URL" ] || fail "platform recovery not configured"
   [ -n "$MATRIX_PLATFORM_TOKEN" ] || fail "platform recovery not configured"

--- a/distro/customer-vps/matrixctl
+++ b/distro/customer-vps/matrixctl
@@ -27,7 +27,7 @@ MATRIX_PLATFORM_TOKEN="${MATRIX_PLATFORM_TOKEN:-${PLATFORM_TOKEN:-}}"
 
 usage() {
   echo "usage: matrixctl r2 <put|get|exists|put-latest|prune> ..." >&2
-  echo "usage: matrixctl recover <clerk-user-id> [--allow-empty]" >&2
+  echo "usage: matrixctl recover <clerk-user-id> [--slot <runtime-slot>] [--allow-empty]" >&2
   echo "usage: matrixctl deploy [<version>]" >&2
 }
 
@@ -130,23 +130,37 @@ r2_prune() {
 
 recover() {
   local clerk_user_id="$1"
-  local allow_empty="${2:-}"
+  shift
+  local allow_empty="false"
+  local runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"
   case "$clerk_user_id" in
     ""|*[^A-Za-z0-9_-]*) fail "invalid recovery user" ;;
   esac
-  if [ -n "$allow_empty" ] && [ "$allow_empty" != "--allow-empty" ]; then
-    usage
-    exit 2
-  fi
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --allow-empty)
+        allow_empty="true"
+        shift
+        ;;
+      --slot)
+        [ "$#" -ge 2 ] || { usage; exit 2; }
+        runtime_slot="$2"
+        shift 2
+        ;;
+      *)
+        usage
+        exit 2
+        ;;
+    esac
+  done
+  case "$runtime_slot" in
+    ""|[!a-z0-9]*|*[^a-z0-9-]*) fail "invalid runtime slot" ;;
+  esac
   [ -n "$MATRIX_PLATFORM_URL" ] || fail "platform recovery not configured"
   [ -n "$MATRIX_PLATFORM_TOKEN" ] || fail "platform recovery not configured"
 
-  local allow_json="false"
-  if [ "$allow_empty" = "--allow-empty" ]; then
-    allow_json="true"
-  fi
   local payload
-  payload="$(printf '{"clerkUserId":"%s","allowEmpty":%s}' "$clerk_user_id" "$allow_json")"
+  payload="$(printf '{"clerkUserId":"%s","runtimeSlot":"%s","allowEmpty":%s}' "$clerk_user_id" "$runtime_slot" "$allow_empty")"
   if ! curl --fail --silent --show-error --max-time 10 \
     -H "authorization: Bearer ${MATRIX_PLATFORM_TOKEN}" \
     -H "content-type: application/json" \
@@ -194,8 +208,9 @@ for r in d.get('results',[]):
 }
 
 if [ "${1:-}" = "recover" ]; then
-  [ "$#" -ge 2 ] && [ "$#" -le 3 ] || { usage; exit 2; }
-  recover "$2" "${3:-}"
+  [ "$#" -ge 2 ] || { usage; exit 2; }
+  shift
+  recover "$@"
   exit 0
 fi
 

--- a/distro/customer-vps/matrixctl
+++ b/distro/customer-vps/matrixctl
@@ -107,15 +107,26 @@ r2_exists() {
 r2_put_latest() {
   local snapshot_key="$1"
   safe_relative_key "$snapshot_key" || fail "invalid latest pointer"
+  local latest_key
   case "$snapshot_key" in
-    system/db/snapshots/*.dump) ;;
+    system/db/snapshots/*.dump)
+      latest_key="system/db/latest"
+      ;;
+    system/runtime-slots/*/db/snapshots/*.dump)
+      local runtime_slot="${snapshot_key#system/runtime-slots/}"
+      runtime_slot="${runtime_slot%%/*}"
+      case "$runtime_slot" in
+        ""|[!a-z0-9]*|*[^a-z0-9-]*|*-) fail "invalid latest pointer" ;;
+      esac
+      latest_key="system/runtime-slots/${runtime_slot}/db/latest"
+      ;;
     *) fail "invalid latest pointer" ;;
   esac
   local tmp
   tmp="$(mktemp)"
   trap 'rm -f "${tmp:-}"' EXIT
   printf '%s\n' "$snapshot_key" > "$tmp"
-  r2_put "$tmp" "system/db/latest"
+  r2_put "$tmp" "$latest_key"
 }
 
 r2_prune() {

--- a/docs/dev/vps-deployment.md
+++ b/docs/dev/vps-deployment.md
@@ -434,11 +434,27 @@ curl https://api.matrix-os.com/health
 6. code.matrix-os.com -> same Clerk session -> proxy to the user's VPS code gateway
 ```
 
-`/containers/provision` remains the onboarding compatibility endpoint because the Clerk/Inngest flow already calls it. When `CUSTOMER_VPS_ENABLED=true`, it delegates to customer VPS provisioning and returns `runtime: "customer_vps"` with the machine status instead of creating a legacy Docker container. The customer VPS table has a partial unique index on active `clerk_user_id`, so repeated onboarding calls reuse the same active VPS for that user.
+`/containers/provision` remains the onboarding compatibility endpoint because the Clerk/Inngest flow already calls it. When `CUSTOMER_VPS_ENABLED=true`, it delegates to customer VPS provisioning and returns `runtime: "customer_vps"` with the machine status instead of creating a legacy Docker container. The customer VPS table has a partial unique index on active `(clerk_user_id, runtime_slot)`, so repeated onboarding calls reuse the same active VPS for that user and slot.
 
 **Routing modes:**
-- `app.matrix-os.com` -- session-based. Platform extracts Clerk JWT from cookie/auth header and proxies to the user's active VPS by `clerkUserId`. No handle in URL. Redirects to `/login` if no session.
+- `app.matrix-os.com` -- session-based. Platform extracts Clerk JWT from cookie/auth header and proxies to the user's active VPS by `clerkUserId` and runtime slot. No handle in URL. Redirects to `/login` if no session.
 - `code.matrix-os.com` -- session-based. Same identity lookup as `app.matrix-os.com`, but proxies to the user's VPS code gateway. No handle, SSH, or server IP is exposed.
+
+For breaking-feature rehearsals, provision a separate runtime slot for the same
+Clerk user and use the same login to switch:
+
+```bash
+curl --fail --silent --show-error \
+  -X POST "$PLATFORM_PUBLIC_URL/vps/provision" \
+  -H "Authorization: Bearer $PLATFORM_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"clerkUserId":"user_xxx","handle":"alice-staging","runtimeSlot":"staging"}'
+```
+
+Open `https://app.matrix-os.com/?runtime=staging` to route that session to the
+staging VPS. Open `https://app.matrix-os.com/?runtime=primary` to return to the
+primary VPS. Deploy branch host bundles to the staging VPS by exact version; do
+not use `/vps/deploy` unless you intend to fan out to every running VPS.
 
 Legacy fallback code may exist only to keep historical records reachable during migration. New and production customer runtime should not be provisioned as containers.
 

--- a/docs/dev/vps-deployment.md
+++ b/docs/dev/vps-deployment.md
@@ -456,6 +456,13 @@ staging VPS. Open `https://app.matrix-os.com/?runtime=primary` to return to the
 primary VPS. Deploy branch host bundles to the staging VPS by exact version; do
 not use `/vps/deploy` unless you intend to fan out to every running VPS.
 
+If the staging VPS needs to be replaced, recover the same slot explicitly so the
+primary runtime remains untouched:
+
+```bash
+matrixctl recover user_xxx --slot staging --allow-empty
+```
+
 Legacy fallback code may exist only to keep historical records reachable during migration. New and production customer runtime should not be provisioned as containers.
 
 ## Archived Legacy Container Management

--- a/packages/platform/src/customer-vps-cloud-init.ts
+++ b/packages/platform/src/customer-vps-cloud-init.ts
@@ -5,6 +5,7 @@ export interface CustomerHostConfig {
   machineId: string;
   clerkUserId: string;
   handle: string;
+  runtimeSlot: string;
   imageVersion: string;
   updateChannel: string;
   hostBundleUrl: string;

--- a/packages/platform/src/customer-vps-r2.ts
+++ b/packages/platform/src/customer-vps-r2.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod/v4';
 import type { UserMachineRecord } from './db.js';
-import { ClerkUserIdSchema } from './customer-vps-schema.js';
+import { ClerkUserIdSchema, RuntimeSlotSchema } from './customer-vps-schema.js';
 
 export const VpsMetaSchema = z.object({
   version: z.literal(1),
@@ -23,7 +23,7 @@ const StrictIsoDateTimeSchema = z.string().datetime();
 
 export interface CustomerVpsSystemStore {
   writeVpsMeta(meta: VpsMeta): Promise<void>;
-  hasDbLatest(clerkUserId: string): Promise<boolean>;
+  hasDbLatest(clerkUserId: string, runtimeSlot?: string): Promise<boolean>;
 }
 
 export interface CustomerVpsObjectStore {
@@ -69,10 +69,19 @@ function normalizeStrictIsoDateTime(value: string): string {
 }
 
 export function validateDbLatestPointer(value: string): boolean {
-  return /^system\/db\/snapshots\/\d{4}-\d{2}-\d{2}T\d{4}Z\.dump$/.test(value) &&
+  const primarySnapshot = /^system\/db\/snapshots\/\d{4}-\d{2}-\d{2}T\d{4}Z\.dump$/.test(value);
+  const slotSnapshot = /^system\/runtime-slots\/([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\/db\/snapshots\/\d{4}-\d{2}-\d{2}T\d{4}Z\.dump$/.exec(value);
+  return (primarySnapshot || Boolean(slotSnapshot && RuntimeSlotSchema.safeParse(slotSnapshot[1]).success)) &&
     !value.includes('..') &&
     !value.includes(':') &&
     !/[\x00-\x1f\x7f]/.test(value);
+}
+
+function buildDbLatestKey(runtimeSlot = 'primary'): string {
+  const parsedSlot = RuntimeSlotSchema.parse(runtimeSlot);
+  return parsedSlot === 'primary'
+    ? 'system/db/latest'
+    : `system/runtime-slots/${parsedSlot}/db/latest`;
 }
 
 function isSafeRelativeSystemKey(value: string): boolean {
@@ -126,10 +135,10 @@ export function createCustomerVpsSystemStore(options: {
       );
     },
 
-    async hasDbLatest(clerkUserId) {
+    async hasDbLatest(clerkUserId, runtimeSlot) {
       try {
         const object = await options.r2.getObject(
-          buildCustomerVpsR2Key(options.r2PrefixRoot, clerkUserId, 'system/db/latest'),
+          buildCustomerVpsR2Key(options.r2PrefixRoot, clerkUserId, buildDbLatestKey(runtimeSlot)),
           { signal: AbortSignal.timeout(CUSTOMER_VPS_R2_READ_TIMEOUT_MS) },
         );
         const pointer = await readObjectText(object.body);

--- a/packages/platform/src/customer-vps-schema.ts
+++ b/packages/platform/src/customer-vps-schema.ts
@@ -22,10 +22,12 @@ export const PublicIPv4Schema = z.ipv4().refine((ip) => {
   if (a >= 224) return false;
   return true;
 }, 'publicIPv4 must be a public IPv4 address');
+export const RuntimeSlotSchema = z.string().min(1).max(32).regex(/^[a-z0-9][a-z0-9-]*$/);
 
 export const ProvisionRequestSchema = z.object({
   clerkUserId: ClerkUserIdSchema,
   handle: SafeHandleSchema,
+  runtimeSlot: RuntimeSlotSchema.optional().default('primary'),
 });
 
 export const RegisterRequestSchema = z.object({

--- a/packages/platform/src/customer-vps-schema.ts
+++ b/packages/platform/src/customer-vps-schema.ts
@@ -40,6 +40,7 @@ export const RegisterRequestSchema = z.object({
 
 export const RecoverRequestSchema = z.object({
   clerkUserId: ClerkUserIdSchema,
+  runtimeSlot: RuntimeSlotSchema.optional().default('primary'),
   allowEmpty: z.boolean().optional().default(false),
 });
 

--- a/packages/platform/src/customer-vps-schema.ts
+++ b/packages/platform/src/customer-vps-schema.ts
@@ -22,7 +22,7 @@ export const PublicIPv4Schema = z.ipv4().refine((ip) => {
   if (a >= 224) return false;
   return true;
 }, 'publicIPv4 must be a public IPv4 address');
-export const RuntimeSlotSchema = z.string().min(1).max(32).regex(/^[a-z0-9][a-z0-9-]*$/);
+export const RuntimeSlotSchema = z.string().min(1).max(32).regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/);
 
 export const ProvisionRequestSchema = z.object({
   clerkUserId: ClerkUserIdSchema,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -65,6 +65,7 @@ export interface DeleteResponse {
 export interface RecoverResponse {
   oldMachineId: string | null;
   machineId: string;
+  runtimeSlot: string;
   status: 'recovering';
   etaSeconds: number;
 }
@@ -541,7 +542,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     },
 
     async recover(input) {
-      const active = await getActiveUserMachineByClerkId(deps.db, input.clerkUserId);
+      const active = await getActiveUserMachineByClerkId(deps.db, input.clerkUserId, input.runtimeSlot);
       if (!active) {
         throw new CustomerVpsError(404, 'not_found', 'Machine not found');
       }
@@ -570,9 +571,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         postgresPassword,
         bundleRef,
       );
-      const existing = await claimUserMachineRecovery(deps.db, input.clerkUserId);
+      const existing = await claimUserMachineRecovery(deps.db, input.clerkUserId, input.runtimeSlot);
       if (!existing) {
-        const latest = await getActiveUserMachineByClerkId(deps.db, input.clerkUserId);
+        const latest = await getActiveUserMachineByClerkId(deps.db, input.clerkUserId, input.runtimeSlot);
         if (latest?.status === 'recovering') {
           throw new CustomerVpsError(409, 'invalid_state', 'Recovery already in progress');
         }
@@ -593,6 +594,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           labels: {
             app: 'matrix-os',
             clerk_user_id: existing.clerkUserId,
+            runtime_slot: existing.runtimeSlot,
             machine_id: machineId,
           },
         });
@@ -660,6 +662,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       return {
         oldMachineId,
         machineId,
+        runtimeSlot: existing.runtimeSlot,
         status: 'recovering',
         etaSeconds: deps.config.provisionEtaSeconds,
       };

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -73,6 +73,7 @@ export interface StatusResponse {
   machineId: string;
   clerkUserId: string;
   handle: string;
+  runtimeSlot: string;
   status: CustomerVpsStatus;
   imageVersion: string | null;
   publicIPv4: string | null;
@@ -127,6 +128,7 @@ const DEFAULT_CLOUD_INIT_TEMPLATE = [
   '      MATRIX_MACHINE_ID={{machineId}}',
   '      MATRIX_CLERK_USER_ID={{clerkUserId}}',
   '      MATRIX_HANDLE={{handle}}',
+  '      MATRIX_RUNTIME_SLOT={{runtimeSlot}}',
   '      MATRIX_IMAGE_VERSION={{imageVersion}}',
   '      MATRIX_UPDATE_CHANNEL={{updateChannel}}',
   '      MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}',
@@ -175,6 +177,7 @@ function statusResponse(row: UserMachineRecord): StatusResponse {
     machineId: row.machineId,
     clerkUserId: row.clerkUserId,
     handle: row.handle,
+    runtimeSlot: row.runtimeSlot,
     status: row.status as CustomerVpsStatus,
     imageVersion: row.imageVersion,
     publicIPv4: row.publicIPv4,
@@ -203,6 +206,7 @@ function buildHostConfig(
     machineId,
     clerkUserId: input.clerkUserId,
     handle: input.handle,
+    runtimeSlot: input.runtimeSlot,
     imageVersion: bundleRef.imageVersion,
     updateChannel: config.imageVersion,
     hostBundleUrl: bundleRef.hostBundleUrl,
@@ -398,7 +402,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       );
 
       const provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
-        const existing = await getActiveUserMachineByClerkId(trx, input.clerkUserId);
+        const existing = await getActiveUserMachineByClerkId(trx, input.clerkUserId, input.runtimeSlot);
         if (existing) {
           return { existing };
         }
@@ -406,6 +410,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           machineId,
           clerkUserId: input.clerkUserId,
           handle: input.handle,
+          runtimeSlot: input.runtimeSlot,
           status: 'provisioning',
           imageVersion: bundleRef.imageVersion,
           registrationTokenHash: registration.hash,
@@ -431,6 +436,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           labels: {
             app: 'matrix-os',
             clerk_user_id: input.clerkUserId,
+            runtime_slot: input.runtimeSlot,
             machine_id: machineId,
           },
         });
@@ -558,7 +564,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
       const hostConfig = buildHostConfig(
         deps.config,
-        { clerkUserId: active.clerkUserId, handle: active.handle },
+        { clerkUserId: active.clerkUserId, handle: active.handle, runtimeSlot: active.runtimeSlot },
         machineId,
         registration.token,
         postgresPassword,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -387,7 +387,11 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
       const postgresPassword = postgresPasswordFactory();
 
-      const existingBeforeBundleResolve = await getActiveUserMachineByClerkId(deps.db, input.clerkUserId);
+      const existingBeforeBundleResolve = await getActiveUserMachineByClerkId(
+        deps.db,
+        input.clerkUserId,
+        input.runtimeSlot,
+      );
       if (existingBeforeBundleResolve) {
         return activeProvisionResponse(existingBeforeBundleResolve, deps.config.provisionEtaSeconds);
       }

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -553,7 +553,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       // claimUserMachineRecovery WHERE clause below remains the authoritative
       // concurrency guard; keeping the backup check before the claim avoids
       // leaving a machine in recovering state when no snapshot exists.
-      if (!input.allowEmpty && !(await deps.systemStore.hasDbLatest(input.clerkUserId))) {
+      if (!input.allowEmpty && !(await deps.systemStore.hasDbLatest(input.clerkUserId, input.runtimeSlot))) {
         throw new CustomerVpsError(409, 'invalid_state', 'No backup snapshot available');
       }
       const currentTime = now();

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -22,6 +22,7 @@ interface UserMachinesTable {
   machine_id: string;
   clerk_user_id: string;
   handle: string;
+  runtime_slot: string;
   hetzner_server_id: number | null;
   public_ipv4: string | null;
   public_ipv6: string | null;
@@ -221,6 +222,7 @@ export interface UserMachineRecord {
   machineId: string;
   clerkUserId: string;
   handle: string;
+  runtimeSlot: string;
   hetznerServerId: number | null;
   publicIPv4: string | null;
   publicIPv6: string | null;
@@ -297,6 +299,7 @@ export interface NewUserMachine {
   machineId: string;
   clerkUserId: string;
   handle: string;
+  runtimeSlot?: string;
   hetznerServerId?: number | null;
   publicIPv4?: string | null;
   publicIPv6?: string | null;
@@ -365,6 +368,7 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       machine_id TEXT PRIMARY KEY,
       clerk_user_id TEXT NOT NULL,
       handle TEXT NOT NULL,
+      runtime_slot TEXT NOT NULL DEFAULT 'primary',
       hetzner_server_id INTEGER,
       public_ipv4 TEXT,
       public_ipv6 TEXT,
@@ -379,14 +383,17 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       failure_at TEXT
     )
   `.execute(db);
+  await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS runtime_slot TEXT NOT NULL DEFAULT 'primary'`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_status ON user_machines(status)`.execute(db);
   await sql`ALTER TABLE user_machines DROP CONSTRAINT IF EXISTS user_machines_clerk_user_id_key`.execute(db);
   await sql`DROP INDEX IF EXISTS idx_user_machines_clerk`.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_user_machines_clerk_active`.execute(db);
   await sql`
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_user_machines_clerk_active
-    ON user_machines(clerk_user_id)
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_user_machines_clerk_slot_active
+    ON user_machines(clerk_user_id, runtime_slot)
     WHERE deleted_at IS NULL
   `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_clerk_slot_status ON user_machines(clerk_user_id, runtime_slot, status)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_hetzner ON user_machines(hetzner_server_id)`.execute(db);
 
   await sql`
@@ -671,6 +678,7 @@ function mapUserMachine(row: UserMachinesTable): UserMachineRecord {
     machineId: row.machine_id,
     clerkUserId: row.clerk_user_id,
     handle: row.handle,
+    runtimeSlot: row.runtime_slot,
     hetznerServerId: row.hetzner_server_id,
     publicIPv4: row.public_ipv4,
     publicIPv6: row.public_ipv6,
@@ -691,6 +699,7 @@ function toUserMachineRow(record: NewUserMachine): UserMachinesTable {
     machine_id: record.machineId,
     clerk_user_id: record.clerkUserId,
     handle: record.handle,
+    runtime_slot: record.runtimeSlot ?? 'primary',
     hetzner_server_id: record.hetznerServerId ?? null,
     public_ipv4: record.publicIPv4 ?? null,
     public_ipv6: record.publicIPv6 ?? null,
@@ -711,6 +720,7 @@ function toUserMachineUpdate(values: Partial<NewUserMachine>): Partial<UserMachi
   if (values.machineId !== undefined) update.machine_id = values.machineId;
   if (values.clerkUserId !== undefined) update.clerk_user_id = values.clerkUserId;
   if (values.handle !== undefined) update.handle = values.handle;
+  if (values.runtimeSlot !== undefined) update.runtime_slot = values.runtimeSlot;
   if (values.hetznerServerId !== undefined) update.hetzner_server_id = values.hetznerServerId;
   if (values.publicIPv4 !== undefined) update.public_ipv4 = values.publicIPv4;
   if (values.publicIPv6 !== undefined) update.public_ipv6 = values.publicIPv6;
@@ -877,15 +887,25 @@ export async function getUserMachine(db: PlatformDB, machineId: string): Promise
 export async function getActiveUserMachineByClerkId(
   db: PlatformDB,
   clerkUserId: string,
+  runtimeSlot = 'primary',
 ): Promise<UserMachineRecord | undefined> {
   await db.ready;
   const row = await db.executor
     .selectFrom('user_machines')
     .selectAll()
     .where('clerk_user_id', '=', clerkUserId)
+    .where('runtime_slot', '=', runtimeSlot)
     .where('deleted_at', 'is', null)
     .executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
+}
+
+export async function getActiveUserMachineByClerkIdAndSlot(
+  db: PlatformDB,
+  clerkUserId: string,
+  runtimeSlot: string,
+): Promise<UserMachineRecord | undefined> {
+  return getActiveUserMachineByClerkId(db, clerkUserId, runtimeSlot);
 }
 
 export async function getActiveUserMachineByHandle(
@@ -897,6 +917,7 @@ export async function getActiveUserMachineByHandle(
     .selectFrom('user_machines')
     .selectAll()
     .where('handle', '=', handle)
+    .where('runtime_slot', '=', 'primary')
     .where('deleted_at', 'is', null)
     .executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
@@ -911,6 +932,7 @@ export async function getRunningUserMachineByHandle(
     .selectFrom('user_machines')
     .selectAll()
     .where('handle', '=', handle)
+    .where('runtime_slot', '=', 'primary')
     .where('status', '=', 'running')
     .where('deleted_at', 'is', null)
     .executeTakeFirst();
@@ -920,12 +942,14 @@ export async function getRunningUserMachineByHandle(
 export async function getRunningUserMachineByClerkId(
   db: PlatformDB,
   clerkUserId: string,
+  runtimeSlot = 'primary',
 ): Promise<UserMachineRecord | undefined> {
   await db.ready;
   const row = await db.executor
     .selectFrom('user_machines')
     .selectAll()
     .where('clerk_user_id', '=', clerkUserId)
+    .where('runtime_slot', '=', runtimeSlot)
     .where('status', '=', 'running')
     .where('deleted_at', 'is', null)
     .executeTakeFirst();
@@ -987,6 +1011,7 @@ export async function completeUserMachineRegistration(
 export async function claimUserMachineRecovery(
   db: PlatformDB,
   clerkUserId: string,
+  runtimeSlot = 'primary',
 ): Promise<UserMachineRecord | undefined> {
   await db.ready;
   const row = await db.executor
@@ -1000,6 +1025,7 @@ export async function claimUserMachineRecovery(
       failure_at: null,
     })
     .where('clerk_user_id', '=', clerkUserId)
+    .where('runtime_slot', '=', runtimeSlot)
     .where('deleted_at', 'is', null)
     .where('status', '!=', 'recovering')
     .returningAll()

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -393,6 +393,16 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
     ON user_machines(clerk_user_id, runtime_slot)
     WHERE deleted_at IS NULL
   `.execute(db);
+  // A Matrix login can own more than one active VPS slot. Slot-qualified
+  // routing selects the requested runtime; unqualified handle routing resolves
+  // deterministically to primary first in the read helpers below.
+  await sql`DROP INDEX IF EXISTS idx_user_machines_handle_active`.execute(db);
+  await sql`DROP INDEX IF EXISTS idx_user_machines_handle_slot_active`.execute(db);
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_user_machines_handle_slot_active
+    ON user_machines(handle, runtime_slot)
+    WHERE deleted_at IS NULL
+  `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_clerk_slot_status ON user_machines(clerk_user_id, runtime_slot, status)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_hetzner ON user_machines(hetzner_server_id)`.execute(db);
 
@@ -919,6 +929,10 @@ export async function getActiveUserMachineByHandle(
     .where('deleted_at', 'is', null);
   if (runtimeSlot) {
     query = query.where('runtime_slot', '=', runtimeSlot);
+  } else {
+    query = query
+      .orderBy(sql`CASE WHEN runtime_slot = 'primary' THEN 0 ELSE 1 END`)
+      .orderBy('provisioned_at', 'desc');
   }
   const row = await query.executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
@@ -938,6 +952,10 @@ export async function getRunningUserMachineByHandle(
     .where('deleted_at', 'is', null);
   if (runtimeSlot) {
     query = query.where('runtime_slot', '=', runtimeSlot);
+  } else {
+    query = query
+      .orderBy(sql`CASE WHEN runtime_slot = 'primary' THEN 0 ELSE 1 END`)
+      .orderBy('provisioned_at', 'desc');
   }
   const row = await query.executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -887,16 +887,22 @@ export async function getUserMachine(db: PlatformDB, machineId: string): Promise
 export async function getActiveUserMachineByClerkId(
   db: PlatformDB,
   clerkUserId: string,
-  runtimeSlot = 'primary',
+  runtimeSlot?: string,
 ): Promise<UserMachineRecord | undefined> {
   await db.ready;
-  const row = await db.executor
+  let query = db.executor
     .selectFrom('user_machines')
     .selectAll()
     .where('clerk_user_id', '=', clerkUserId)
-    .where('runtime_slot', '=', runtimeSlot)
-    .where('deleted_at', 'is', null)
-    .executeTakeFirst();
+    .where('deleted_at', 'is', null);
+  if (runtimeSlot) {
+    query = query.where('runtime_slot', '=', runtimeSlot);
+  } else {
+    query = query
+      .orderBy(sql`CASE WHEN runtime_slot = 'primary' THEN 0 ELSE 1 END`)
+      .orderBy('provisioned_at', 'desc');
+  }
+  const row = await query.executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
 }
 

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -900,14 +900,6 @@ export async function getActiveUserMachineByClerkId(
   return row ? mapUserMachine(row) : undefined;
 }
 
-export async function getActiveUserMachineByClerkIdAndSlot(
-  db: PlatformDB,
-  clerkUserId: string,
-  runtimeSlot: string,
-): Promise<UserMachineRecord | undefined> {
-  return getActiveUserMachineByClerkId(db, clerkUserId, runtimeSlot);
-}
-
 export async function getActiveUserMachineByHandle(
   db: PlatformDB,
   handle: string,

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -903,31 +903,37 @@ export async function getActiveUserMachineByClerkId(
 export async function getActiveUserMachineByHandle(
   db: PlatformDB,
   handle: string,
+  runtimeSlot?: string,
 ): Promise<UserMachineRecord | undefined> {
   await db.ready;
-  const row = await db.executor
+  let query = db.executor
     .selectFrom('user_machines')
     .selectAll()
     .where('handle', '=', handle)
-    .where('runtime_slot', '=', 'primary')
-    .where('deleted_at', 'is', null)
-    .executeTakeFirst();
+    .where('deleted_at', 'is', null);
+  if (runtimeSlot) {
+    query = query.where('runtime_slot', '=', runtimeSlot);
+  }
+  const row = await query.executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
 }
 
 export async function getRunningUserMachineByHandle(
   db: PlatformDB,
   handle: string,
+  runtimeSlot?: string,
 ): Promise<UserMachineRecord | undefined> {
   await db.ready;
-  const row = await db.executor
+  let query = db.executor
     .selectFrom('user_machines')
     .selectAll()
     .where('handle', '=', handle)
-    .where('runtime_slot', '=', 'primary')
     .where('status', '=', 'running')
-    .where('deleted_at', 'is', null)
-    .executeTakeFirst();
+    .where('deleted_at', 'is', null);
+  if (runtimeSlot) {
+    query = query.where('runtime_slot', '=', runtimeSlot);
+  }
+  const row = await query.executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
 }
 

--- a/packages/platform/src/launch-readiness-routes.ts
+++ b/packages/platform/src/launch-readiness-routes.ts
@@ -1,0 +1,37 @@
+import { Hono } from 'hono';
+import { timingSafeTokenEquals } from './platform-token.js';
+import type { LaunchReadinessService } from './launch-readiness.js';
+
+export function createLaunchReadinessRoutes(options: {
+  service: LaunchReadinessService;
+  platformSecret: string;
+}): Hono {
+  const app = new Hono();
+
+  app.get('/launch-readiness', async (c) => {
+    if (!options.platformSecret) {
+      return c.json({ error: 'Platform admin not configured' }, 503);
+    }
+    const token = parseBearerToken(c.req.header('authorization'));
+    if (!timingSafeTokenEquals(token, options.platformSecret)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    try {
+      return c.json(await options.service.getReport());
+    } catch (err: unknown) {
+      console.error(
+        '[launch-readiness] Failed to build operator readiness report:',
+        err instanceof Error ? err.message : String(err),
+      );
+      return c.json({ error: 'Launch readiness unavailable' }, 503);
+    }
+  });
+
+  return app;
+}
+
+function parseBearerToken(header: string | undefined): string | undefined {
+  if (!header?.startsWith('Bearer ')) return undefined;
+  return header.slice('Bearer '.length);
+}

--- a/packages/platform/src/launch-readiness.ts
+++ b/packages/platform/src/launch-readiness.ts
@@ -1,7 +1,7 @@
 import type { PlatformDB } from './db.js';
 import { getHostBundleReleaseByChannel } from './db.js';
 
-export type LaunchReadinessStatus = 'pass' | 'fail' | 'blocked';
+export type LaunchReadinessStatus = 'pass' | 'fail';
 export type LaunchReadinessOverallStatus = 'ready' | 'blocked';
 export type LaunchReadinessOwner = 'operator' | 'matrix';
 export type LaunchReadinessCategory =

--- a/packages/platform/src/launch-readiness.ts
+++ b/packages/platform/src/launch-readiness.ts
@@ -1,0 +1,289 @@
+import type { PlatformDB } from './db.js';
+import {
+  getHostBundleReleaseByChannel,
+  listUserMachines,
+} from './db.js';
+
+export type LaunchReadinessStatus = 'pass' | 'fail' | 'blocked';
+export type LaunchReadinessOverallStatus = 'ready' | 'blocked';
+export type LaunchReadinessOwner = 'operator' | 'matrix';
+export type LaunchReadinessCategory =
+  | 'activation'
+  | 'provisioning'
+  | 'shell'
+  | 'ux'
+  | 'agent'
+  | 'coding'
+  | 'integration'
+  | 'company_brain'
+  | 'support_growth'
+  | 'admin'
+  | 'entitlement';
+
+export interface LaunchReadinessGate {
+  id: string;
+  category: LaunchReadinessCategory;
+  criticality: 'release_critical';
+  status: LaunchReadinessStatus;
+  owner: LaunchReadinessOwner;
+  message: string;
+  remediation: string | null;
+  lastCheckedAt: string;
+  evidence?: string[];
+}
+
+export interface LaunchReadinessEvidence {
+  promotedRelease: boolean;
+  freshWorkspace: boolean;
+  existingWorkspace: boolean;
+  shellRouting: boolean;
+  onboardingEducation: boolean;
+  visualQa: boolean;
+  integrations: boolean;
+  hermesContinuity: boolean;
+  agentExecution: boolean;
+  codingHandoff: boolean;
+  companyBrain: boolean;
+  supportGrowth: boolean;
+  adminControlSurface: boolean;
+  entitlementGate: boolean;
+}
+
+export interface LaunchReadinessReport {
+  generatedAt: string;
+  launchReady: boolean;
+  overallStatus: LaunchReadinessOverallStatus;
+  gates: LaunchReadinessGate[];
+}
+
+export interface LaunchReadinessService {
+  getReport(): Promise<LaunchReadinessReport>;
+}
+
+export interface LaunchReadinessServiceOptions {
+  now?: () => Date;
+  loadEvidence: () => Promise<LaunchReadinessEvidence>;
+}
+
+interface GateDefinition {
+  id: string;
+  category: LaunchReadinessCategory;
+  owner: LaunchReadinessOwner;
+  passMessage: string;
+  failMessage: string;
+  remediation: string;
+  evidenceKey: keyof LaunchReadinessEvidence;
+}
+
+const RELEASE_CRITICAL_GATES: GateDefinition[] = [
+  {
+    id: 'release.beta_channel',
+    category: 'activation',
+    owner: 'operator',
+    passMessage: 'Beta channel has a promoted host bundle release.',
+    failMessage: 'Beta channel does not have a promoted host bundle release.',
+    remediation: 'Promote a verified host bundle release to the beta channel.',
+    evidenceKey: 'promotedRelease',
+  },
+  {
+    id: 'workspace.fresh_rehearsal',
+    category: 'provisioning',
+    owner: 'operator',
+    passMessage: 'Fresh workspace rehearsal has passed.',
+    failMessage: 'Fresh workspace rehearsal has not passed.',
+    remediation: 'Run the fresh-founder workspace rehearsal end to end.',
+    evidenceKey: 'freshWorkspace',
+  },
+  {
+    id: 'workspace.existing_rehearsal',
+    category: 'provisioning',
+    owner: 'operator',
+    passMessage: 'Existing workspace rehearsal has passed.',
+    failMessage: 'Existing workspace rehearsal has not passed.',
+    remediation: 'Run the existing-workspace upgrade rehearsal and verify owner data remains intact.',
+    evidenceKey: 'existingWorkspace',
+  },
+  {
+    id: 'shell.routing',
+    category: 'shell',
+    owner: 'matrix',
+    passMessage: 'Shell routing and VPS reachability have passed.',
+    failMessage: 'Shell routing or VPS reachability has not passed.',
+    remediation: 'Verify app/code/profile routing against a running customer VPS.',
+    evidenceKey: 'shellRouting',
+  },
+  {
+    id: 'onboarding.education',
+    category: 'ux',
+    owner: 'matrix',
+    passMessage: 'Onboarding education explains Matrix capabilities before setup.',
+    failMessage: 'Onboarding education has not passed.',
+    remediation: 'Verify the guided onboarding copy and goal-based setup path.',
+    evidenceKey: 'onboardingEducation',
+  },
+  {
+    id: 'onboarding.visual_qa',
+    category: 'ux',
+    owner: 'matrix',
+    passMessage: 'Onboarding visual QA has passed.',
+    failMessage: 'Onboarding visual QA has not passed.',
+    remediation: 'Run desktop, mobile, reduced-motion, and missing-media onboarding visual QA.',
+    evidenceKey: 'visualQa',
+  },
+  {
+    id: 'integrations.approved_capabilities',
+    category: 'integration',
+    owner: 'matrix',
+    passMessage: 'Approved integration capabilities have passed.',
+    failMessage: 'Approved integration capabilities have not passed.',
+    remediation: 'Run calendar/email/GitHub capability approval and safe-action audit tests.',
+    evidenceKey: 'integrations',
+  },
+  {
+    id: 'agents.hermes_continuity',
+    category: 'agent',
+    owner: 'matrix',
+    passMessage: 'Hermes remains the always-on system agent.',
+    failMessage: 'Hermes continuity has not passed.',
+    remediation: 'Verify no-Claude and Claude/Codex-connected Hermes paths.',
+    evidenceKey: 'hermesContinuity',
+  },
+  {
+    id: 'agents.execution',
+    category: 'agent',
+    owner: 'matrix',
+    passMessage: 'Agent execution has passed.',
+    failMessage: 'Agent execution has not passed.',
+    remediation: 'Run at least one approved Hermes task and one connected specialist-agent task.',
+    evidenceKey: 'agentExecution',
+  },
+  {
+    id: 'coding.handoff',
+    category: 'coding',
+    owner: 'matrix',
+    passMessage: 'Coding setup and handoff have passed.',
+    failMessage: 'Coding setup and handoff have not passed.',
+    remediation: 'Run GitHub/project setup, duplicate-run prevention, terminal context, and handoff checks.',
+    evidenceKey: 'codingHandoff',
+  },
+  {
+    id: 'company_brain.context',
+    category: 'company_brain',
+    owner: 'matrix',
+    passMessage: 'Company-brain workflow has passed.',
+    failMessage: 'Company-brain workflow has not passed.',
+    remediation: 'Verify context capture, retrieval, and source display.',
+    evidenceKey: 'companyBrain',
+  },
+  {
+    id: 'support_growth.approval_drafts',
+    category: 'support_growth',
+    owner: 'matrix',
+    passMessage: 'Support and growth approval drafts have passed.',
+    failMessage: 'Support and growth approval drafts have not passed.',
+    remediation: 'Verify uncertainty flags and explicit approval before external send or publish.',
+    evidenceKey: 'supportGrowth',
+  },
+  {
+    id: 'admin.control_surface',
+    category: 'admin',
+    owner: 'matrix',
+    passMessage: 'Admin control surface has passed.',
+    failMessage: 'Admin control surface has not passed.',
+    remediation: 'Verify provider cards, settings, automations, activity, and readiness remediation.',
+    evidenceKey: 'adminControlSurface',
+  },
+  {
+    id: 'entitlement.access_gate',
+    category: 'entitlement',
+    owner: 'operator',
+    passMessage: 'Paid-beta entitlement gate preserves owner data.',
+    failMessage: 'Paid-beta entitlement gate has not passed.',
+    remediation: 'Set MATRIX_PAID_BETA_ENTITLEMENT_STATUS=active and verify entitlement denial blocks paid-only access without deleting owner data.',
+    evidenceKey: 'entitlementGate',
+  },
+];
+
+export function createLaunchReadinessService(
+  options: LaunchReadinessServiceOptions,
+): LaunchReadinessService {
+  const now = options.now ?? (() => new Date());
+  return {
+    async getReport() {
+      const generatedAt = now().toISOString();
+      const evidence = await options.loadEvidence();
+      const gates = RELEASE_CRITICAL_GATES.map((definition) =>
+        buildGate(definition, evidence, generatedAt),
+      );
+      const launchReady = gates.every((gate) => gate.status === 'pass');
+      return {
+        generatedAt,
+        launchReady,
+        overallStatus: launchReady ? 'ready' : 'blocked',
+        gates,
+      };
+    },
+  };
+}
+
+export function createPlatformLaunchEvidenceLoader(options: {
+  db: PlatformDB;
+  env?: NodeJS.ProcessEnv;
+}): () => Promise<LaunchReadinessEvidence> {
+  const env = options.env ?? process.env;
+  return async () => {
+    const [betaRelease, machines] = await Promise.all([
+      getHostBundleReleaseByChannel(options.db, 'beta'),
+      listUserMachines(options.db),
+    ]);
+    const runningMachines = machines.filter((machine) =>
+      machine.status === 'running' && machine.publicIPv4,
+    );
+    const hasReachableMachine = runningMachines.some((machine) => Boolean(machine.lastSeenAt));
+    return {
+      promotedRelease: Boolean(betaRelease),
+      freshWorkspace: readEvidenceFlag(env, 'MATRIX_LAUNCH_FRESH_WORKSPACE') || runningMachines.length >= 1,
+      existingWorkspace: readEvidenceFlag(env, 'MATRIX_LAUNCH_EXISTING_WORKSPACE') || runningMachines.length >= 2,
+      shellRouting: readEvidenceFlag(env, 'MATRIX_LAUNCH_SHELL_ROUTING') || hasReachableMachine,
+      onboardingEducation: readEvidenceFlag(env, 'MATRIX_LAUNCH_ONBOARDING_EDUCATION'),
+      visualQa: readEvidenceFlag(env, 'MATRIX_LAUNCH_VISUAL_QA'),
+      integrations: readEvidenceFlag(env, 'MATRIX_LAUNCH_INTEGRATIONS'),
+      hermesContinuity: readEvidenceFlag(env, 'MATRIX_LAUNCH_HERMES_CONTINUITY'),
+      agentExecution: readEvidenceFlag(env, 'MATRIX_LAUNCH_AGENT_EXECUTION'),
+      codingHandoff: readEvidenceFlag(env, 'MATRIX_LAUNCH_CODING_HANDOFF'),
+      companyBrain: readEvidenceFlag(env, 'MATRIX_LAUNCH_COMPANY_BRAIN'),
+      supportGrowth: readEvidenceFlag(env, 'MATRIX_LAUNCH_SUPPORT_GROWTH'),
+      adminControlSurface: readEvidenceFlag(env, 'MATRIX_LAUNCH_ADMIN_CONTROL_SURFACE'),
+      entitlementGate: readEvidenceFlag(env, 'MATRIX_LAUNCH_ENTITLEMENT_GATE'),
+    };
+  };
+}
+
+function readEntitlementStatusAllowsRuntime(env: NodeJS.ProcessEnv): boolean {
+  const raw = env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS?.trim();
+  if (!raw) return true;
+  return EntitlementStatusSchema.safeParse(raw).data === 'active';
+}
+
+function buildGate(
+  definition: GateDefinition,
+  evidence: LaunchReadinessEvidence,
+  checkedAt: string,
+): LaunchReadinessGate {
+  const passed = evidence[definition.evidenceKey];
+  return {
+    id: definition.id,
+    category: definition.category,
+    criticality: 'release_critical',
+    status: passed ? 'pass' : 'fail',
+    owner: definition.owner,
+    message: passed ? definition.passMessage : definition.failMessage,
+    remediation: passed ? null : definition.remediation,
+    lastCheckedAt: checkedAt,
+  };
+}
+
+function readEvidenceFlag(env: NodeJS.ProcessEnv, name: string): boolean {
+  const value = env[name]?.toLowerCase();
+  return value === '1' || value === 'true' || value === 'pass' || value === 'passed';
+}

--- a/packages/platform/src/launch-readiness.ts
+++ b/packages/platform/src/launch-readiness.ts
@@ -1,5 +1,6 @@
 import type { PlatformDB } from './db.js';
 import { getHostBundleReleaseByChannel } from './db.js';
+import { EntitlementStatusSchema } from './profile-routing.js';
 
 export type LaunchReadinessStatus = 'pass' | 'fail';
 export type LaunchReadinessOverallStatus = 'ready' | 'blocked';
@@ -243,7 +244,7 @@ export function createPlatformLaunchEvidenceLoader(options: {
       companyBrain: readEvidenceFlag(env, 'MATRIX_LAUNCH_COMPANY_BRAIN'),
       supportGrowth: readEvidenceFlag(env, 'MATRIX_LAUNCH_SUPPORT_GROWTH'),
       adminControlSurface: readEvidenceFlag(env, 'MATRIX_LAUNCH_ADMIN_CONTROL_SURFACE'),
-      entitlementGate: readEvidenceFlag(env, 'MATRIX_LAUNCH_ENTITLEMENT_GATE'),
+      entitlementGate: readEvidenceFlag(env, 'MATRIX_LAUNCH_ENTITLEMENT_GATE') && readEntitlementStatusAllowsRuntime(env),
     };
   };
 }

--- a/packages/platform/src/launch-readiness.ts
+++ b/packages/platform/src/launch-readiness.ts
@@ -29,7 +29,6 @@ export interface LaunchReadinessGate {
   message: string;
   remediation: string | null;
   lastCheckedAt: string;
-  evidence?: string[];
 }
 
 export interface LaunchReadinessEvidence {
@@ -242,8 +241,8 @@ export function createPlatformLaunchEvidenceLoader(options: {
     const hasReachableMachine = runningMachines.some((machine) => Boolean(machine.lastSeenAt));
     return {
       promotedRelease: Boolean(betaRelease),
-      freshWorkspace: readEvidenceFlag(env, 'MATRIX_LAUNCH_FRESH_WORKSPACE') || runningMachines.length >= 1,
-      existingWorkspace: readEvidenceFlag(env, 'MATRIX_LAUNCH_EXISTING_WORKSPACE') || runningMachines.length >= 2,
+      freshWorkspace: readEvidenceFlag(env, 'MATRIX_LAUNCH_FRESH_WORKSPACE'),
+      existingWorkspace: readEvidenceFlag(env, 'MATRIX_LAUNCH_EXISTING_WORKSPACE'),
       shellRouting: readEvidenceFlag(env, 'MATRIX_LAUNCH_SHELL_ROUTING') || hasReachableMachine,
       onboardingEducation: readEvidenceFlag(env, 'MATRIX_LAUNCH_ONBOARDING_EDUCATION'),
       visualQa: readEvidenceFlag(env, 'MATRIX_LAUNCH_VISUAL_QA'),

--- a/packages/platform/src/launch-readiness.ts
+++ b/packages/platform/src/launch-readiness.ts
@@ -196,7 +196,7 @@ const RELEASE_CRITICAL_GATES: GateDefinition[] = [
     owner: 'operator',
     passMessage: 'Paid-beta entitlement gate preserves owner data.',
     failMessage: 'Paid-beta entitlement gate has not passed.',
-    remediation: 'Set MATRIX_PAID_BETA_ENTITLEMENT_STATUS=active and verify entitlement denial blocks paid-only access without deleting owner data.',
+    remediation: 'Set MATRIX_LAUNCH_ENTITLEMENT_GATE=true, set MATRIX_PAID_BETA_ENTITLEMENT_STATUS=active, and verify entitlement denial blocks paid-only access without deleting owner data.',
     evidenceKey: 'entitlementGate',
   },
 ];
@@ -244,14 +244,14 @@ export function createPlatformLaunchEvidenceLoader(options: {
       companyBrain: readEvidenceFlag(env, 'MATRIX_LAUNCH_COMPANY_BRAIN'),
       supportGrowth: readEvidenceFlag(env, 'MATRIX_LAUNCH_SUPPORT_GROWTH'),
       adminControlSurface: readEvidenceFlag(env, 'MATRIX_LAUNCH_ADMIN_CONTROL_SURFACE'),
-      entitlementGate: readEvidenceFlag(env, 'MATRIX_LAUNCH_ENTITLEMENT_GATE') && readEntitlementStatusAllowsRuntime(env),
+      entitlementGate: readEvidenceFlag(env, 'MATRIX_LAUNCH_ENTITLEMENT_GATE') && readEntitlementStatusExplicitlyActive(env),
     };
   };
 }
 
-function readEntitlementStatusAllowsRuntime(env: NodeJS.ProcessEnv): boolean {
+function readEntitlementStatusExplicitlyActive(env: NodeJS.ProcessEnv): boolean {
   const raw = env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS?.trim();
-  if (!raw) return true;
+  if (!raw) return false;
   return EntitlementStatusSchema.safeParse(raw).data === 'active';
 }
 

--- a/packages/platform/src/launch-readiness.ts
+++ b/packages/platform/src/launch-readiness.ts
@@ -1,8 +1,5 @@
 import type { PlatformDB } from './db.js';
-import {
-  getHostBundleReleaseByChannel,
-  listUserMachines,
-} from './db.js';
+import { getHostBundleReleaseByChannel } from './db.js';
 
 export type LaunchReadinessStatus = 'pass' | 'fail' | 'blocked';
 export type LaunchReadinessOverallStatus = 'ready' | 'blocked';
@@ -231,19 +228,12 @@ export function createPlatformLaunchEvidenceLoader(options: {
 }): () => Promise<LaunchReadinessEvidence> {
   const env = options.env ?? process.env;
   return async () => {
-    const [betaRelease, machines] = await Promise.all([
-      getHostBundleReleaseByChannel(options.db, 'beta'),
-      listUserMachines(options.db),
-    ]);
-    const runningMachines = machines.filter((machine) =>
-      machine.status === 'running' && machine.publicIPv4,
-    );
-    const hasReachableMachine = runningMachines.some((machine) => Boolean(machine.lastSeenAt));
+    const betaRelease = await getHostBundleReleaseByChannel(options.db, 'beta');
     return {
       promotedRelease: Boolean(betaRelease),
       freshWorkspace: readEvidenceFlag(env, 'MATRIX_LAUNCH_FRESH_WORKSPACE'),
       existingWorkspace: readEvidenceFlag(env, 'MATRIX_LAUNCH_EXISTING_WORKSPACE'),
-      shellRouting: readEvidenceFlag(env, 'MATRIX_LAUNCH_SHELL_ROUTING') || hasReachableMachine,
+      shellRouting: readEvidenceFlag(env, 'MATRIX_LAUNCH_SHELL_ROUTING'),
       onboardingEducation: readEvidenceFlag(env, 'MATRIX_LAUNCH_ONBOARDING_EDUCATION'),
       visualQa: readEvidenceFlag(env, 'MATRIX_LAUNCH_VISUAL_QA'),
       integrations: readEvidenceFlag(env, 'MATRIX_LAUNCH_INTEGRATIONS'),

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -410,6 +410,23 @@ function readRuntimeSlot(cookieHeader: string | undefined, rawUrl: string): stri
   return cookieSlot && RuntimeSlotSchema.safeParse(cookieSlot).success ? cookieSlot : 'primary';
 }
 
+function buildForwardedQueryString(rawUrl: string): string {
+  const queryStart = rawUrl.indexOf('?');
+  if (queryStart === -1) return '';
+  const hashStart = rawUrl.indexOf('#', queryStart);
+  const rawQuery = rawUrl.slice(queryStart + 1, hashStart === -1 ? undefined : hashStart);
+  const forwarded = rawQuery
+    .split('&')
+    .filter((part) => {
+      if (!part) return false;
+      const rawKey = part.split('=', 1)[0] ?? '';
+      const parsedKey = new URLSearchParams(`${rawKey}=`).keys().next().value ?? rawKey;
+      return parsedKey !== 'runtime';
+    })
+    .join('&');
+  return forwarded ? `?${forwarded}` : '';
+}
+
 function buildRuntimeSlotCookie(runtimeSlot: string): string {
   return [
     `${RUNTIME_SLOT_COOKIE}=${encodeURIComponent(runtimeSlot)}`,
@@ -751,7 +768,10 @@ async function resolveAppDomainIdentity(opts: {
       userId: result.userId,
     };
   }
-  const machine = await getActiveUserMachineByClerkId(opts.db, result.userId, opts.runtimeSlot);
+  let machine = await getActiveUserMachineByClerkId(opts.db, result.userId, opts.runtimeSlot);
+  if (!machine && opts.runtimeSlot !== 'primary') {
+    machine = await getActiveUserMachineByClerkId(opts.db, result.userId, 'primary');
+  }
   if (!machine) {
     return null;
   }
@@ -936,7 +956,7 @@ function getAuthPage(
 
 async function proxyToShell(c: import('hono').Context, host: string, port: number) {
   const path = c.req.path;
-  const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
+  const qs = buildForwardedQueryString(c.req.url);
   const targetUrl = `http://${host}:${port}${path}${qs}`;
   const originalHost = c.req.header('host') ?? 'app.matrix-os.com';
 
@@ -1639,7 +1659,7 @@ export function createApp(deps: {
         return c.json({ error: 'VPS unavailable' }, 404);
       }
 
-      const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
+      const qs = buildForwardedQueryString(c.req.url);
       const targetUrl = buildCustomerVpsProxyUrl(runningMachine, reqPath, qs, { entitlement });
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
@@ -1773,18 +1793,18 @@ export function createApp(deps: {
       });
     }
 
-    const runtimeSlot =
-      identity.source === 'mobile-session' || identity.source === 'static-route'
-        ? 'primary'
-        : identity.runtimeSlot ?? requestRuntimeSlot;
+    let runtimeSlot = identity.runtimeSlot ?? requestRuntimeSlot;
     let runningMachine = identity.userId
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
-      : undefined;
-    if (!runningMachine && runtimeSlot === 'primary') {
-      runningMachine = await getRunningUserMachineByHandle(db, identity.handle, 'primary');
+      : await getRunningUserMachineByHandle(db, identity.handle);
+    if (!runningMachine && identity.userId) {
+      runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
     }
     if (runningMachine) {
-      const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
+      runtimeSlot = runningMachine.runtimeSlot;
+    }
+    if (runningMachine) {
+      const qs = buildForwardedQueryString(c.req.url);
       if (!entitlement.runtimeProxyAllowed) {
         applyNoStoreHeaders(c);
         return c.json({ error: 'Paid beta access required' }, 402);
@@ -1881,7 +1901,7 @@ export function createApp(deps: {
     if (!record) {
       const activeMachine = identity.userId
         ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
-        : await getActiveUserMachineByHandle(db, identity.handle, 'primary');
+        : await getActiveUserMachineByHandle(db, identity.handle);
       if (activeMachine) {
         c.header('set-cookie', buildRuntimeSlotCookie(runtimeSlot));
         if (isCodeDomain || isGatewayPath) {
@@ -1908,7 +1928,7 @@ export function createApp(deps: {
 
     await updateLastActive(db, record.handle);
 
-    const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
+    const qs = buildForwardedQueryString(c.req.url);
     const targetPort = isCodeDomain ? CODE_SERVER_PORT : (isGatewayPath || path === '/apps' || path.startsWith('/apps/')) ? 4000 : 3000;
     const body = ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob();
     const headers = isCodeDomain
@@ -2166,6 +2186,11 @@ export function createApp(deps: {
     }
     try {
       if (deps.customerVpsService) {
+        const entitlement = getRuntimeEntitlementDecision();
+        if (!entitlement.provisioningAllowed) {
+          applyNoStoreHeaders(c);
+          return c.json({ error: 'Paid beta access required' }, 402);
+        }
         const machine = await deps.customerVpsService.provision({ handle, clerkUserId, runtimeSlot });
 
         // Provision Matrix accounts (non-blocking: log error but don't fail VPS provision)
@@ -2468,7 +2493,7 @@ export function createApp(deps: {
       return c.json({ error: 'Invalid handle' }, 400);
     }
     const path = c.req.path.replace(`/proxy/${handle}`, '') || '/';
-    const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
+    const qs = buildForwardedQueryString(c.req.url);
     const runningMachine = await getRunningUserMachineByHandle(db, handle, 'primary');
     if (runningMachine) {
       const entitlement = getRuntimeEntitlementDecision();
@@ -2944,15 +2969,15 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       return;
     }
 
-    const runtimeSlot =
-      identity.source === 'mobile-session' || identity.source === 'static-route'
-        ? 'primary'
-        : identity.runtimeSlot ?? requestRuntimeSlot;
+    let runtimeSlot = identity.runtimeSlot ?? requestRuntimeSlot;
     let runningMachine = identity.userId
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
-      : undefined;
-    if (!runningMachine && runtimeSlot === 'primary') {
-      runningMachine = await getRunningUserMachineByHandle(db, identity.handle, 'primary');
+      : await getRunningUserMachineByHandle(db, identity.handle);
+    if (!runningMachine && identity.userId) {
+      runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+    }
+    if (runningMachine) {
+      runtimeSlot = runningMachine.runtimeSlot;
     }
     const record = await getContainer(db, identity.handle);
     if (!runningMachine && !record) { socket.destroy(); return; }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -954,39 +954,6 @@ function getAuthPage(
 </html>`;
 }
 
-async function proxyToShell(c: import('hono').Context, host: string, port: number) {
-  const path = c.req.path;
-  const qs = buildForwardedQueryString(c.req.url);
-  const targetUrl = `http://${host}:${port}${path}${qs}`;
-  const originalHost = c.req.header('host') ?? 'app.matrix-os.com';
-
-  try {
-    const headers = new Headers();
-    for (const [key, value] of Object.entries(c.req.header())) {
-      if (key !== 'host' && value) headers.set(key, String(value));
-    }
-    headers.set('host', originalHost);
-    headers.set('x-forwarded-host', originalHost);
-    headers.set('x-forwarded-proto', 'https');
-
-    const upstream = await fetch(targetUrl, {
-      method: c.req.method,
-      headers,
-      redirect: 'manual',
-      signal: AbortSignal.timeout(30_000),
-      body: ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob(),
-    });
-
-    return new Response(upstream.body, {
-      status: upstream.status,
-      headers: sanitizeProxyResponseHeaders(upstream.headers),
-    });
-  } catch (err: unknown) {
-    logPlatformRouteError('proxyToShell', err);
-    return new Response('Auth service unavailable', { status: 502 });
-  }
-}
-
 function getNoContainerPage() {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -1654,7 +1621,7 @@ export function createApp(deps: {
         return c.json({ error: 'Invalid handle' }, 400);
       }
 
-      const runningMachine = await getRunningUserMachineByHandle(db, handle, 'primary');
+      const runningMachine = await getRunningUserMachineByHandle(db, handle);
       if (!runningMachine) {
         return c.json({ error: 'VPS unavailable' }, 404);
       }
@@ -2494,7 +2461,7 @@ export function createApp(deps: {
     }
     const path = c.req.path.replace(`/proxy/${handle}`, '') || '/';
     const qs = buildForwardedQueryString(c.req.url);
-    const runningMachine = await getRunningUserMachineByHandle(db, handle, 'primary');
+    const runningMachine = await getRunningUserMachineByHandle(db, handle);
     if (runningMachine) {
       const entitlement = getRuntimeEntitlementDecision();
       if (!entitlement.runtimeProxyAllowed) {
@@ -2709,7 +2676,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       if (!handle) return null;
 
       const owner =
-        (await getRunningUserMachineByHandle(db, handle, 'primary')) ??
+        (await getRunningUserMachineByHandle(db, handle)) ??
         (await getContainer(db, handle));
       if (!owner || owner.clerkUserId !== clerkUserId) {
         return null;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -86,7 +86,6 @@ const CODE_SESSION_COOKIE = 'matrix_code_session';
 const APP_ROUTE_COOKIE = 'matrix_app_route';
 const SHELL_ROUTE_COOKIE = 'matrix_shell_route';
 const RUNTIME_SLOT_COOKIE = 'matrix_runtime_slot';
-const RUNTIME_SLOT_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
 const CODE_SESSION_EXPIRES_IN_SEC = 12 * 60 * 60;
 const HOST_BUNDLE_READ_TIMEOUT_MS = 30_000;
 const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
@@ -397,12 +396,12 @@ function buildShellRouteCookie(handle: string): string {
 function readRuntimeSlot(cookieHeader: string | undefined, rawUrl: string): string {
   try {
     const querySlot = new URL(rawUrl, 'https://app.matrix-os.com').searchParams.get('runtime');
-    if (querySlot && RUNTIME_SLOT_PATTERN.test(querySlot)) return querySlot;
+    if (querySlot && RuntimeSlotSchema.safeParse(querySlot).success) return querySlot;
   } catch (err: unknown) {
     console.warn('[platform] Failed to parse runtime slot URL:', err instanceof Error ? err.message : String(err));
   }
   const cookieSlot = readCookie(cookieHeader, RUNTIME_SLOT_COOKIE);
-  return cookieSlot && RUNTIME_SLOT_PATTERN.test(cookieSlot) ? cookieSlot : 'primary';
+  return cookieSlot && RuntimeSlotSchema.safeParse(cookieSlot).success ? cookieSlot : 'primary';
 }
 
 function buildRuntimeSlotCookie(runtimeSlot: string): string {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -56,7 +56,12 @@ import {
 import type { CustomerVpsService } from './customer-vps.js';
 import { createCustomerVpsRoutes } from './customer-vps-routes.js';
 import { CustomerVpsError } from './customer-vps-errors.js';
-import { buildCustomerVpsProxyUrl } from './profile-routing.js';
+import {
+  buildCustomerVpsProxyUrl,
+  deriveEntitlementAccess,
+  type EntitlementAccessDecision,
+  type EntitlementStatus,
+} from './profile-routing.js';
 import type { CustomerVpsObjectStore } from './customer-vps-r2.js';
 import { handleInternalGeminiLiveProxyUpgrade } from './gemini-live-proxy.js';
 import { recordPlatformHttpRequest } from './metrics.js';
@@ -89,6 +94,7 @@ const RUNTIME_SLOT_COOKIE = 'matrix_runtime_slot';
 const CODE_SESSION_EXPIRES_IN_SEC = 12 * 60 * 60;
 const HOST_BUNDLE_READ_TIMEOUT_MS = 30_000;
 const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+const EntitlementStatusSchema = z.enum(['active', 'missing', 'expired', 'disabled', 'changed']);
 const HOST_BUNDLE_FILES = new Set([
   'matrix-host-bundle.tar.gz',
   'matrix-host-bundle.tar.gz.sha256',
@@ -413,6 +419,19 @@ function buildRuntimeSlotCookie(runtimeSlot: string): string {
     'SameSite=Lax',
     'Max-Age=86400',
   ].join('; ');
+}
+
+function getRuntimeEntitlementDecision(env: NodeJS.ProcessEnv = process.env): EntitlementAccessDecision {
+  const rawStatus = env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS?.trim();
+  if (!rawStatus) {
+    return deriveEntitlementAccess({ status: 'active' });
+  }
+  const parsed = EntitlementStatusSchema.safeParse(rawStatus);
+  if (!parsed.success) {
+    console.warn('[platform] Invalid MATRIX_PAID_BETA_ENTITLEMENT_STATUS; denying paid runtime access.');
+    return deriveEntitlementAccess({ status: 'changed' });
+  }
+  return deriveEntitlementAccess({ status: parsed.data as EntitlementStatus });
 }
 
 function buildCodeSessionCookie(token: string): string {
@@ -1621,7 +1640,7 @@ export function createApp(deps: {
       }
 
       const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
-      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, reqPath, qs);
+      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, reqPath, qs, { entitlement });
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
       }
@@ -1766,7 +1785,11 @@ export function createApp(deps: {
     }
     if (runningMachine) {
       const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
-      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);
+      if (!entitlement.runtimeProxyAllowed) {
+        applyNoStoreHeaders(c);
+        return c.json({ error: 'Paid beta access required' }, 402);
+      }
+      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs, { entitlement });
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
       }
@@ -2448,7 +2471,12 @@ export function createApp(deps: {
     const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
     const runningMachine = await getRunningUserMachineByHandle(db, handle, 'primary');
     if (runningMachine) {
-      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);
+      const entitlement = getRuntimeEntitlementDecision();
+      if (!entitlement.runtimeProxyAllowed) {
+        applyNoStoreHeaders(c);
+        return c.json({ error: 'Paid beta access required' }, 402);
+      }
+      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs, { entitlement });
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
       }
@@ -2987,6 +3015,14 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     };
 
     if (runningMachine?.publicIPv4) {
+      const entitlement = getRuntimeEntitlementDecision();
+      if (!entitlement.runtimeProxyAllowed) {
+        console.warn(
+          `[platform] websocket runtime proxy denied by entitlement handle=${runningMachine.handle} path=${path}`,
+        );
+        socket.destroy();
+        return;
+      }
       const upstreamHostHeader = isCodeDomain ? host : `${runningMachine.handle}.matrix-os.com`;
       const headers = buildUpgradeHeaders(runningMachine.handle, true);
       const upstreamServerName = upstreamHostHeader.split(':')[0] ?? upstreamHostHeader;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1852,11 +1852,13 @@ export function createApp(deps: {
         : await getActiveUserMachineByHandle(db, identity.handle);
       if (activeMachine) {
         if (isCodeDomain || isGatewayPath) {
+          applyNoStoreHeaders(c);
           return c.json({
             error: 'VPS provisioning',
             status: activeMachine.status,
           }, 503);
         }
+        applyNoStoreHeaders(c);
         return c.html(getVpsBootPage({
           handle: activeMachine.handle,
           status: activeMachine.status,

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -674,6 +674,7 @@ async function resolveAppDomainIdentity(opts: {
   clerkAuth?: ClerkAuth;
   db: PlatformDB;
   platformJwtSecret: string;
+  runtimeSlot: string;
   wsToken?: string | null;
 }): Promise<AppDomainIdentity | null> {
   const codeSessionToken = readCookie(opts.cookieHeader, CODE_SESSION_COOKIE);
@@ -729,7 +730,7 @@ async function resolveAppDomainIdentity(opts: {
       userId: result.userId,
     };
   }
-  const machine = await getActiveUserMachineByClerkId(opts.db, result.userId);
+  const machine = await getActiveUserMachineByClerkId(opts.db, result.userId, opts.runtimeSlot);
   if (!machine) {
     return null;
   }
@@ -1660,6 +1661,7 @@ export function createApp(deps: {
 
     const authHeader = c.req.header('authorization');
     const cookieHeader = c.req.header('cookie');
+    const requestRuntimeSlot = readRuntimeSlot(cookieHeader, c.req.url);
 
     const path = c.req.path;
     const isGatewayPath = isAppDomain && (
@@ -1678,6 +1680,7 @@ export function createApp(deps: {
       clerkAuth,
       db,
       platformJwtSecret,
+      runtimeSlot: requestRuntimeSlot,
     });
     if (!identity && isAppDomain) {
       const mobileSessionHandle =
@@ -1751,7 +1754,7 @@ export function createApp(deps: {
     const runtimeSlot =
       identity.source === 'mobile-session' || identity.source === 'static-route'
         ? 'primary'
-        : readRuntimeSlot(cookieHeader, c.req.url);
+        : requestRuntimeSlot;
     let runningMachine = identity.userId
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
       : undefined;
@@ -2883,6 +2886,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     const isCodeDomain = isCodeDomainHost(host);
 
     const path = req.url ?? '/';
+    const requestRuntimeSlot = readRuntimeSlot(req.headers.cookie, path);
     const wsToken = getWebSocketUpgradeToken(path);
     let identity: AppDomainIdentity | null;
     try {
@@ -2892,6 +2896,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
         clerkAuth,
         db,
         platformJwtSecret: PLATFORM_JWT_SECRET,
+        runtimeSlot: requestRuntimeSlot,
         wsToken,
       });
     } catch (err: unknown) {
@@ -2910,7 +2915,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     const runtimeSlot =
       identity.source === 'mobile-session' || identity.source === 'static-route'
         ? 'primary'
-        : readRuntimeSlot(req.headers.cookie, path);
+        : requestRuntimeSlot;
     let runningMachine = identity.userId
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
       : undefined;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -84,6 +84,8 @@ const CODE_SERVER_PORT = Number(process.env.MATRIX_CODE_SERVER_PORT ?? 8787);
 const CODE_SESSION_COOKIE = 'matrix_code_session';
 const APP_ROUTE_COOKIE = 'matrix_app_route';
 const SHELL_ROUTE_COOKIE = 'matrix_shell_route';
+const RUNTIME_SLOT_COOKIE = 'matrix_runtime_slot';
+const RUNTIME_SLOT_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
 const CODE_SESSION_EXPIRES_IN_SEC = 12 * 60 * 60;
 const HOST_BUNDLE_READ_TIMEOUT_MS = 30_000;
 const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
@@ -166,6 +168,7 @@ const ProvisionBodySchema = z.object({
   handle: z.string().regex(HANDLE_PATTERN),
   clerkUserId: z.string().min(1).max(256),
   displayName: z.string().min(1).max(100).optional(),
+  runtimeSlot: z.string().min(1).max(32).regex(/^[a-z0-9][a-z0-9-]*$/).optional().default('primary'),
 });
 
 const SocialSendBodySchema = z.object({
@@ -387,6 +390,28 @@ function buildShellRouteCookie(handle: string): string {
     'Secure',
     'SameSite=Lax',
     'Max-Age=600',
+  ].join('; ');
+}
+
+function readRuntimeSlot(cookieHeader: string | undefined, rawUrl: string): string {
+  try {
+    const querySlot = new URL(rawUrl, 'https://app.matrix-os.com').searchParams.get('runtime');
+    if (querySlot && RUNTIME_SLOT_PATTERN.test(querySlot)) return querySlot;
+  } catch (err: unknown) {
+    console.warn('[platform] Failed to parse runtime slot URL:', err instanceof Error ? err.message : String(err));
+  }
+  const cookieSlot = readCookie(cookieHeader, RUNTIME_SLOT_COOKIE);
+  return cookieSlot && RUNTIME_SLOT_PATTERN.test(cookieSlot) ? cookieSlot : 'primary';
+}
+
+function buildRuntimeSlotCookie(runtimeSlot: string): string {
+  return [
+    `${RUNTIME_SLOT_COOKIE}=${encodeURIComponent(runtimeSlot)}`,
+    'Path=/',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+    'Max-Age=86400',
   ].join('; ');
 }
 
@@ -941,21 +966,11 @@ function getNoContainerPage() {
 </html>`;
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
-
-function getVpsBootPage(input: { status: string }) {
+function getVpsBootPage(input: { handle: string; status: string }) {
   const title = input.status === 'recovering' ? 'Restoring Matrix OS' : 'Booting Matrix OS';
   const detail = input.status === 'recovering'
-    ? 'Your workspace is being restored. Keep this tab open and Matrix will move you forward as soon as it is ready.'
-    : 'Your personal workspace is coming online. Matrix will move you forward as soon as the gateway is ready.';
-  const escapedStatus = escapeHtml(input.status);
+    ? 'Your Matrix instance is restoring its workspace. This page will refresh automatically.'
+    : 'Your Matrix instance is starting for the first time. This usually takes a couple of minutes.';
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -965,89 +980,21 @@ function getVpsBootPage(input: { status: string }) {
   <title>${title}</title>
   <style>
     * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: grid;
-      place-items: center;
-      background:
-        radial-gradient(circle at 50% 0%, rgba(20, 184, 166, 0.18), transparent 34%),
-        linear-gradient(180deg, #0b0d12 0%, #101217 54%, #161312 100%);
-      color: #f5f3ef;
-      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    }
-    main {
-      width: min(560px, calc(100vw - 40px));
-      padding: 36px;
-      border: 1px solid rgba(245, 243, 239, 0.14);
-      border-radius: 10px;
-      background: rgba(13, 15, 19, 0.82);
-      box-shadow: 0 26px 90px rgba(0, 0, 0, 0.36);
-      backdrop-filter: blur(18px);
-    }
-    .eyebrow {
-      margin: 0 0 22px;
-      color: rgba(245, 243, 239, 0.56);
-      font-size: 11px;
-      font-weight: 650;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-    }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #f8fafc; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+    main { width: min(520px, calc(100vw - 48px)); padding: 32px; border: 1px solid rgba(148, 163, 184, 0.28); border-radius: 16px; background: rgba(15, 23, 42, 0.92); box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32); }
     .row { display: flex; align-items: center; gap: 14px; }
-    .spinner {
-      width: 24px;
-      height: 24px;
-      flex: 0 0 auto;
-      border: 2px solid rgba(245, 243, 239, 0.22);
-      border-top-color: #14b8a6;
-      border-radius: 999px;
-      animation: spin 1s linear infinite;
-    }
-    h1 { font-size: 30px; line-height: 1.1; margin: 0; letter-spacing: 0; }
-    p { color: rgba(245, 243, 239, 0.72); line-height: 1.6; margin: 18px 0 0; font-size: 15px; }
-    .status {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 16px;
-      margin-top: 26px;
-      padding: 13px 14px;
-      color: rgba(245, 243, 239, 0.72);
-      background: rgba(245, 243, 239, 0.06);
-      border: 1px solid rgba(245, 243, 239, 0.1);
-      border-radius: 8px;
-      font-size: 13px;
-    }
-    .status strong { color: #f5f3ef; font-weight: 650; text-transform: capitalize; }
-    .pulse { display: flex; gap: 5px; }
-    .pulse span {
-      width: 6px;
-      height: 6px;
-      border-radius: 999px;
-      background: #14b8a6;
-      opacity: 0.35;
-      animation: pulse 1.2s ease-in-out infinite;
-    }
-    .pulse span:nth-child(2) { animation-delay: 0.16s; }
-    .pulse span:nth-child(3) { animation-delay: 0.32s; }
+    .spinner { width: 22px; height: 22px; border: 3px solid rgba(148, 163, 184, 0.45); border-top-color: #38bdf8; border-radius: 999px; animation: spin 1s linear infinite; }
+    h1 { font-size: 24px; line-height: 1.2; margin: 0; }
+    p { color: #cbd5e1; line-height: 1.55; margin: 16px 0 0; }
+    code { display: inline-block; margin-top: 18px; color: #93c5fd; background: rgba(30, 41, 59, 0.9); border: 1px solid rgba(148, 163, 184, 0.22); border-radius: 8px; padding: 7px 10px; }
     @keyframes spin { to { transform: rotate(360deg); } }
-    @keyframes pulse { 0%, 80%, 100% { opacity: 0.28; transform: translateY(0); } 40% { opacity: 1; transform: translateY(-2px); } }
-    @media (max-width: 520px) {
-      main { padding: 28px; }
-      h1 { font-size: 25px; }
-      .status { align-items: flex-start; flex-direction: column; }
-    }
   </style>
 </head>
 <body>
   <main>
-    <p class="eyebrow">Matrix OS</p>
     <div class="row"><div class="spinner"></div><h1>${title}</h1></div>
     <p>${detail}</p>
-    <div class="status">
-      <span>Instance status: <strong>${escapedStatus}</strong></span>
-      <span class="pulse" aria-hidden="true"><span></span><span></span><span></span></span>
-    </div>
+    <code>${input.handle}.matrix-os.com - ${input.status}</code>
   </main>
 </body>
 </html>`;
@@ -1798,7 +1745,16 @@ export function createApp(deps: {
       });
     }
 
-    const runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+    const runtimeSlot =
+      identity.source === 'mobile-session' || identity.source === 'static-route'
+        ? 'primary'
+        : readRuntimeSlot(cookieHeader, c.req.url);
+    let runningMachine = identity.userId
+      ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
+      : undefined;
+    if (!runningMachine && runtimeSlot === 'primary') {
+      runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+    }
     if (runningMachine) {
       const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
       const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);
@@ -1866,6 +1822,7 @@ export function createApp(deps: {
         }
         if (isAppDomain && identity.source !== 'static-route') {
           responseHeaders.append('set-cookie', buildShellRouteCookie(runningMachine.handle));
+          responseHeaders.append('set-cookie', buildRuntimeSlotCookie(runtimeSlot));
         }
         if (isCodeDomain && platformJwtSecret) {
           const issued = await issueSyncJwt({
@@ -1890,7 +1847,9 @@ export function createApp(deps: {
 
     const record = await getContainer(db, identity.handle);
     if (!record) {
-      const activeMachine = await getActiveUserMachineByHandle(db, identity.handle);
+      const activeMachine = identity.userId
+        ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
+        : await getActiveUserMachineByHandle(db, identity.handle);
       if (activeMachine) {
         if (isCodeDomain || isGatewayPath) {
           return c.json({
@@ -1898,8 +1857,8 @@ export function createApp(deps: {
             status: activeMachine.status,
           }, 503);
         }
-        applyNoStoreHeaders(c);
         return c.html(getVpsBootPage({
+          handle: activeMachine.handle,
           status: activeMachine.status,
         }), 503);
       }
@@ -2169,13 +2128,13 @@ export function createApp(deps: {
       return c.json({ error: 'Validation error' }, 400);
     }
 
-    const { handle, clerkUserId, displayName } = parsed.data;
+    const { handle, clerkUserId, displayName, runtimeSlot } = parsed.data;
     if (!handle || !clerkUserId) {
       return c.json({ error: 'handle and clerkUserId required' }, 400);
     }
     try {
       if (deps.customerVpsService) {
-        const machine = await deps.customerVpsService.provision({ handle, clerkUserId });
+        const machine = await deps.customerVpsService.provision({ handle, clerkUserId, runtimeSlot });
 
         // Provision Matrix accounts (non-blocking: log error but don't fail VPS provision)
         if (matrixProvisioner) {
@@ -2190,6 +2149,7 @@ export function createApp(deps: {
           runtime: 'customer_vps',
           handle,
           clerkUserId,
+          runtimeSlot,
           ...machine,
         }, 202);
       }
@@ -2945,7 +2905,16 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       return;
     }
 
-    const runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+    const runtimeSlot =
+      identity.source === 'mobile-session' || identity.source === 'static-route'
+        ? 'primary'
+        : readRuntimeSlot(req.headers.cookie, path);
+    let runningMachine = identity.userId
+      ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
+      : undefined;
+    if (!runningMachine && runtimeSlot === 'primary') {
+      runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+    }
     const record = await getContainer(db, identity.handle);
     if (!runningMachine && !record) { socket.destroy(); return; }
     let activeUpstream: Socket | null = null;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -768,8 +768,8 @@ async function resolveAppDomainIdentity(opts: {
     };
   }
   let machine = await getActiveUserMachineByClerkId(opts.db, result.userId, opts.runtimeSlot);
-  if (!machine && opts.runtimeSlot !== 'primary') {
-    machine = await getActiveUserMachineByClerkId(opts.db, result.userId, 'primary');
+  if (!machine) {
+    machine = await getActiveUserMachineByClerkId(opts.db, result.userId);
   }
   if (!machine) {
     return null;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -412,6 +412,8 @@ function readRuntimeSlot(cookieHeader: string | undefined, rawUrl: string): stri
 function buildForwardedQueryString(rawUrl: string): string {
   const queryStart = rawUrl.indexOf('?');
   if (queryStart === -1) return '';
+  // Browser HTTP requests do not include fragments, but synthetic proxy tests
+  // may pass raw URLs with hashes; never forward fragment text as query data.
   const hashStart = rawUrl.indexOf('#', queryStart);
   const rawQuery = rawUrl.slice(queryStart + 1, hashStart === -1 ? undefined : hashStart);
   const forwarded = rawQuery
@@ -419,6 +421,9 @@ function buildForwardedQueryString(rawUrl: string): string {
     .filter((part) => {
       if (!part) return false;
       const rawKey = part.split('=', 1)[0] ?? '';
+      // Decode the key before filtering so encoded variants such as
+      // `%72untime=staging` cannot leak the platform-only runtime selector to
+      // a customer VPS.
       const parsedKey = new URLSearchParams(`${rawKey}=`).keys().next().value ?? rawKey;
       return parsedKey !== 'runtime';
     })
@@ -729,7 +734,10 @@ async function resolveAppDomainIdentity(opts: {
           userId: record.clerkUserId,
         };
       }
-      const machine = await getRunningUserMachineByHandle(opts.db, claims.handle);
+      const runtimeSlot = RuntimeSlotSchema.safeParse(claims.runtime_slot).success
+        ? claims.runtime_slot
+        : undefined;
+      const machine = await getRunningUserMachineByHandle(opts.db, claims.handle, runtimeSlot);
       if (machine?.clerkUserId !== claims.sub) {
         return null;
       }
@@ -767,7 +775,9 @@ async function resolveAppDomainIdentity(opts: {
       userId: result.userId,
     };
   }
-  let machine = await getActiveUserMachineByClerkId(opts.db, result.userId, opts.runtimeSlot);
+  let machine = opts.runtimeSlot !== 'primary'
+    ? await getActiveUserMachineByClerkId(opts.db, result.userId, opts.runtimeSlot)
+    : undefined;
   if (!machine) {
     machine = await getActiveUserMachineByClerkId(opts.db, result.userId);
   }
@@ -982,8 +992,8 @@ function getNoContainerPage() {
 function getVpsBootPage(input: { status: string }) {
   const title = input.status === 'recovering' ? 'Restoring Matrix OS' : 'Booting Matrix OS';
   const detail = input.status === 'recovering'
-    ? 'Your Matrix instance is restoring its workspace. This page will refresh automatically.'
-    : 'Your Matrix instance is starting for the first time. This usually takes a couple of minutes.';
+    ? 'Matrix is restoring your workspace and will bring you back automatically.'
+    : 'Matrix is preparing your cloud computer. This usually takes a couple of minutes.';
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -993,20 +1003,117 @@ function getVpsBootPage(input: { status: string }) {
   <title>${title}</title>
   <style>
     * { box-sizing: border-box; }
-    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #f8fafc; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
-    main { width: min(520px, calc(100vw - 48px)); padding: 32px; border: 1px solid rgba(148, 163, 184, 0.28); border-radius: 16px; background: rgba(15, 23, 42, 0.92); box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32); }
-    .row { display: flex; align-items: center; gap: 14px; }
-    .spinner { width: 22px; height: 22px; border: 3px solid rgba(148, 163, 184, 0.45); border-top-color: #38bdf8; border-radius: 999px; animation: spin 1s linear infinite; }
-    h1 { font-size: 24px; line-height: 1.2; margin: 0; }
-    p { color: #cbd5e1; line-height: 1.55; margin: 16px 0 0; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background:
+        radial-gradient(circle at 50% 42%, rgba(196, 162, 101, 0.14), transparent 31%),
+        linear-gradient(180deg, #fffdf6 0%, #f5efe2 100%);
+      color: #2f392c;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      padding: 28px;
+    }
+    main {
+      width: min(620px, 100%);
+      display: grid;
+      justify-items: center;
+      gap: 28px;
+      text-align: center;
+    }
+    .mark {
+      width: 132px;
+      height: 132px;
+      border-radius: 50%;
+      border: 1px solid rgba(47, 57, 44, 0.12);
+      display: grid;
+      place-items: center;
+      background: rgba(255, 253, 246, 0.62);
+      box-shadow: 0 24px 90px rgba(47, 57, 44, 0.12);
+      position: relative;
+      overflow: hidden;
+    }
+    .mark::before {
+      content: "";
+      width: 68px;
+      height: 68px;
+      border-radius: 50%;
+      border: 2px solid rgba(196, 162, 101, 0.38);
+      border-top-color: #c4a265;
+      animation: spin 1.9s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+    }
+    .mark::after {
+      content: "M";
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: 30px;
+      font-weight: 700;
+      color: #2f392c;
+    }
+    .wordmark {
+      margin: 0;
+      font-size: clamp(34px, 8vw, 68px);
+      font-weight: 500;
+      line-height: 0.96;
+      text-transform: uppercase;
+      background: linear-gradient(90deg, #2f392c 0%, #2f392c 24%, #c4a265 50%, #2f392c 76%, #2f392c 100%);
+      background-size: 300% 100%;
+      background-clip: text;
+      -webkit-background-clip: text;
+      color: transparent;
+      animation: shimmer 8s ease-in-out infinite, glow 8s ease-in-out infinite;
+    }
+    .copy {
+      display: grid;
+      gap: 14px;
+      max-width: 520px;
+    }
+    p {
+      color: rgba(47, 57, 44, 0.68);
+      font-size: 16px;
+      line-height: 1.65;
+      margin: 0;
+    }
+    .status {
+      min-height: 34px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      border: 1px solid rgba(47, 57, 44, 0.12);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.48);
+      padding: 7px 12px;
+      color: rgba(47, 57, 44, 0.72);
+      font-size: 13px;
+      box-shadow: 0 12px 40px rgba(47, 57, 44, 0.08);
+    }
+    strong { color: #2f392c; font-weight: 700; }
     @keyframes spin { to { transform: rotate(360deg); } }
+    @keyframes shimmer {
+      0%, 100% { background-position: 200% 0; }
+      50% { background-position: -100% 0; }
+    }
+    @keyframes glow {
+      0%, 100% { filter: brightness(1); }
+      50% { filter: brightness(1.12); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .mark::before, .wordmark { animation-duration: 1ms; animation-iteration-count: 1; }
+    }
   </style>
 </head>
 <body>
   <main>
-    <div class="row"><div class="spinner"></div><h1>${title}</h1></div>
-    <p>${detail}</p>
-    <p>Instance status: <strong>${escapeHtml(input.status)}</strong></p>
+    <div class="mark" aria-hidden="true"></div>
+    <div class="copy">
+      <h1 class="wordmark">${title}</h1>
+      <p>${detail}</p>
+    </div>
+    <p class="status">Instance status: <strong>${escapeHtml(input.status)}</strong></p>
   </main>
 </body>
 </html>`;
@@ -1076,9 +1183,11 @@ export function createApp(deps: {
   internalSyncRoutes?: Hono<any>;
   customerVpsService?: CustomerVpsService;
   customerVpsObjectStore?: CustomerVpsObjectStore;
+  env?: NodeJS.ProcessEnv;
 }) {
   const { db, docker, orchestrator, clerkAuth, matrixProvisioner } = deps;
-  const platformSecret = deps.platformSecret ?? process.env.PLATFORM_SECRET ?? '';
+  const appEnv = deps.env ?? process.env;
+  const platformSecret = deps.platformSecret ?? appEnv.PLATFORM_SECRET ?? '';
   type CachedVpsRuntimeMetrics = {
     machineKey: string;
     expiresAt: number;
@@ -1751,6 +1860,7 @@ export function createApp(deps: {
         clerkUserId: identity.userId,
         handle: identity.handle,
         gatewayUrl: getGatewayUrlForHandle(identity.handle),
+        runtimeSlot: identity.runtimeSlot ?? requestRuntimeSlot,
         expiresInSec: WS_TOKEN_EXPIRES_IN_SEC,
       });
       return c.json({
@@ -1760,15 +1870,23 @@ export function createApp(deps: {
     }
 
     let runtimeSlot = identity.runtimeSlot ?? requestRuntimeSlot;
+    let requestedActiveMachine: UserMachineRecord | undefined;
     let runningMachine = identity.userId
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
       : await getRunningUserMachineByHandle(db, identity.handle);
     if (!runningMachine && identity.userId) {
-      runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+      requestedActiveMachine = await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot);
+      if (!requestedActiveMachine) {
+        const handleMachine = await getRunningUserMachineByHandle(db, identity.handle);
+        if (handleMachine?.clerkUserId === identity.userId) {
+          runningMachine = handleMachine;
+        }
+      }
     }
     if (runningMachine) {
       runtimeSlot = runningMachine.runtimeSlot;
     }
+    const entitlement = getRuntimeEntitlementDecision(appEnv);
     if (runningMachine) {
       const qs = buildForwardedQueryString(c.req.url);
       if (!entitlement.runtimeProxyAllowed) {
@@ -1848,6 +1966,7 @@ export function createApp(deps: {
             clerkUserId: identity.userId,
             handle: runningMachine.handle,
             gatewayUrl: 'https://code.matrix-os.com',
+            runtimeSlot,
             expiresInSec: CODE_SESSION_EXPIRES_IN_SEC,
           });
           responseHeaders.append('set-cookie', buildCodeSessionCookie(issued.token));
@@ -1865,11 +1984,15 @@ export function createApp(deps: {
 
     const record = await getContainer(db, identity.handle);
     if (!record) {
-      const activeMachine = identity.userId
+      const activeMachine = requestedActiveMachine ?? (identity.userId
         ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
-        : await getActiveUserMachineByHandle(db, identity.handle);
+        : await getActiveUserMachineByHandle(db, identity.handle));
       if (activeMachine) {
-        c.header('set-cookie', buildRuntimeSlotCookie(runtimeSlot));
+        if (!entitlement.runtimeProxyAllowed) {
+          applyNoStoreHeaders(c);
+          return c.json({ error: 'Paid beta access required' }, 402);
+        }
+        c.header('set-cookie', buildRuntimeSlotCookie(runtimeSlot), { append: true });
         if (isCodeDomain || isGatewayPath) {
           applyNoStoreHeaders(c);
           return c.json({
@@ -1881,6 +2004,11 @@ export function createApp(deps: {
         return c.html(getVpsBootPage({ status: activeMachine.status }), 503);
       }
       return c.html(getNoContainerPage());
+    }
+
+    if (!entitlement.runtimeProxyAllowed) {
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Paid beta access required' }, 402);
     }
 
     if (record.status === 'stopped') {
@@ -2104,7 +2232,7 @@ export function createApp(deps: {
 
   app.route('/api/operator', createLaunchReadinessRoutes({
     service: createLaunchReadinessService({
-      loadEvidence: createPlatformLaunchEvidenceLoader({ db }),
+      loadEvidence: createPlatformLaunchEvidenceLoader({ db, env: appEnv }),
     }),
     platformSecret,
   }));
@@ -2167,8 +2295,8 @@ export function createApp(deps: {
           runtime: 'customer_vps',
           handle,
           clerkUserId,
-          runtimeSlot,
           ...machine,
+          runtimeSlot,
         }, 202);
       }
 
@@ -2809,6 +2937,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     }
   }
 
+  const appEnv = process.env;
   const app = createApp({
     db,
     docker,
@@ -2926,17 +3055,25 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     }
 
     let runtimeSlot = identity.runtimeSlot ?? requestRuntimeSlot;
+    let requestedActiveMachine: UserMachineRecord | undefined;
     let runningMachine = identity.userId
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
       : await getRunningUserMachineByHandle(db, identity.handle);
     if (!runningMachine && identity.userId) {
-      runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+      requestedActiveMachine = await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot);
+      if (!requestedActiveMachine) {
+        const handleMachine = await getRunningUserMachineByHandle(db, identity.handle);
+        if (handleMachine?.clerkUserId === identity.userId) {
+          runningMachine = handleMachine;
+        }
+      }
     }
     if (runningMachine) {
       runtimeSlot = runningMachine.runtimeSlot;
     }
     const record = await getContainer(db, identity.handle);
     if (!runningMachine && !record) { socket.destroy(); return; }
+    const entitlement = getRuntimeEntitlementDecision(appEnv);
     let activeUpstream: Socket | null = null;
     const onSocketError = () => activeUpstream?.destroy();
     socket.on('error', onSocketError);
@@ -2995,11 +3132,17 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       socket.pipe(upstream);
     };
 
-    if (runningMachine?.publicIPv4) {
-      const entitlement = getRuntimeEntitlementDecision();
+    if (runningMachine) {
       if (!entitlement.runtimeProxyAllowed) {
         console.warn(
           `[platform] websocket runtime proxy denied by entitlement handle=${runningMachine.handle} path=${path}`,
+        );
+        socket.destroy();
+        return;
+      }
+      if (!runningMachine.publicIPv4) {
+        console.warn(
+          `[platform] websocket runtime proxy missing upstream address handle=${runningMachine.handle} path=${path}`,
         );
         socket.destroy();
         return;
@@ -3027,6 +3170,13 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     }
 
     if (!record) { socket.destroy(); return; }
+    if (!entitlement.runtimeProxyAllowed) {
+      console.warn(
+        `[platform] websocket legacy container proxy denied by entitlement handle=${record.handle} path=${path}`,
+      );
+      socket.destroy();
+      return;
+    }
     const connectUpstream = async (attempt: number): Promise<void> => {
       const endpoint = await resolveContainerEndpoint(docker, db, record.handle, record.containerId);
       if (!endpoint) {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -511,6 +511,10 @@ function escapeHtmlAttr(value: string): string {
     .replaceAll("'", "&#39;");
 }
 
+function escapeHtml(value: string): string {
+  return escapeHtmlAttr(value);
+}
+
 function applyAuthPageHeaders(
   c: import('hono').Context,
   scriptNonce: string,
@@ -994,7 +998,7 @@ function getVpsBootPage(input: { handle: string; status: string }) {
   <main>
     <div class="row"><div class="spinner"></div><h1>${title}</h1></div>
     <p>${detail}</p>
-    <code>${input.handle}.matrix-os.com - ${input.status}</code>
+    <p>Instance status: <strong>${escapeHtml(input.status)}</strong></p>
   </main>
 </body>
 </html>`;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -59,8 +59,8 @@ import { CustomerVpsError } from './customer-vps-errors.js';
 import {
   buildCustomerVpsProxyUrl,
   deriveEntitlementAccess,
+  EntitlementStatusSchema,
   type EntitlementAccessDecision,
-  type EntitlementStatus,
 } from './profile-routing.js';
 import type { CustomerVpsObjectStore } from './customer-vps-r2.js';
 import { handleInternalGeminiLiveProxyUpgrade } from './gemini-live-proxy.js';
@@ -94,7 +94,6 @@ const RUNTIME_SLOT_COOKIE = 'matrix_runtime_slot';
 const CODE_SESSION_EXPIRES_IN_SEC = 12 * 60 * 60;
 const HOST_BUNDLE_READ_TIMEOUT_MS = 30_000;
 const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
-const EntitlementStatusSchema = z.enum(['active', 'missing', 'expired', 'disabled', 'changed']);
 const HOST_BUNDLE_FILES = new Set([
   'matrix-host-bundle.tar.gz',
   'matrix-host-bundle.tar.gz.sha256',
@@ -448,7 +447,7 @@ function getRuntimeEntitlementDecision(env: NodeJS.ProcessEnv = process.env): En
     console.warn('[platform] Invalid MATRIX_PAID_BETA_ENTITLEMENT_STATUS; denying paid runtime access.');
     return deriveEntitlementAccess({ status: 'changed' });
   }
-  return deriveEntitlementAccess({ status: parsed.data as EntitlementStatus });
+  return deriveEntitlementAccess({ status: parsed.data });
 }
 
 function buildCodeSessionCookie(token: string): string {
@@ -1627,7 +1626,7 @@ export function createApp(deps: {
       }
 
       const qs = buildForwardedQueryString(c.req.url);
-      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, reqPath, qs, { entitlement });
+      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, reqPath, qs);
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
       }
@@ -1776,7 +1775,7 @@ export function createApp(deps: {
         applyNoStoreHeaders(c);
         return c.json({ error: 'Paid beta access required' }, 402);
       }
-      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs, { entitlement });
+      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
       }
@@ -2153,11 +2152,6 @@ export function createApp(deps: {
     }
     try {
       if (deps.customerVpsService) {
-        const entitlement = getRuntimeEntitlementDecision();
-        if (!entitlement.provisioningAllowed) {
-          applyNoStoreHeaders(c);
-          return c.json({ error: 'Paid beta access required' }, 402);
-        }
         const machine = await deps.customerVpsService.provision({ handle, clerkUserId, runtimeSlot });
 
         // Provision Matrix accounts (non-blocking: log error but don't fail VPS provision)
@@ -2463,12 +2457,7 @@ export function createApp(deps: {
     const qs = buildForwardedQueryString(c.req.url);
     const runningMachine = await getRunningUserMachineByHandle(db, handle);
     if (runningMachine) {
-      const entitlement = getRuntimeEntitlementDecision();
-      if (!entitlement.runtimeProxyAllowed) {
-        applyNoStoreHeaders(c);
-        return c.json({ error: 'Paid beta access required' }, 402);
-      }
-      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs, { entitlement });
+      const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
       }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -61,6 +61,11 @@ import type { CustomerVpsObjectStore } from './customer-vps-r2.js';
 import { handleInternalGeminiLiveProxyUpgrade } from './gemini-live-proxy.js';
 import { recordPlatformHttpRequest } from './metrics.js';
 import type { VpsRuntimeMetricInput } from './metrics.js';
+import {
+  createLaunchReadinessService,
+  createPlatformLaunchEvidenceLoader,
+} from './launch-readiness.js';
+import { createLaunchReadinessRoutes } from './launch-readiness-routes.js';
 
 const PORT = Number(process.env.PLATFORM_PORT ?? 9000);
 const PLATFORM_SECRET = process.env.PLATFORM_SECRET ?? '';
@@ -2119,6 +2124,13 @@ export function createApp(deps: {
       recordRuntimeMetrics: (machines) => updateCachedVpsRuntimeMetrics(machines, machines),
     }));
   }
+
+  app.route('/api/operator', createLaunchReadinessRoutes({
+    service: createLaunchReadinessService({
+      loadEvidence: createPlatformLaunchEvidenceLoader({ db }),
+    }),
+    platformSecret,
+  }));
 
   // Auth middleware for admin API routes below
   app.use('*', async (c, next) => {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -66,6 +66,7 @@ import {
   createPlatformLaunchEvidenceLoader,
 } from './launch-readiness.js';
 import { createLaunchReadinessRoutes } from './launch-readiness-routes.js';
+import { RuntimeSlotSchema } from './customer-vps-schema.js';
 
 const PORT = Number(process.env.PLATFORM_PORT ?? 9000);
 const PLATFORM_SECRET = process.env.PLATFORM_SECRET ?? '';
@@ -168,7 +169,7 @@ const ProvisionBodySchema = z.object({
   handle: z.string().regex(HANDLE_PATTERN),
   clerkUserId: z.string().min(1).max(256),
   displayName: z.string().min(1).max(100).optional(),
-  runtimeSlot: z.string().min(1).max(32).regex(/^[a-z0-9][a-z0-9-]*$/).optional().default('primary'),
+  runtimeSlot: RuntimeSlotSchema.optional().default('primary'),
 });
 
 const SocialSendBodySchema = z.object({
@@ -970,7 +971,7 @@ function getNoContainerPage() {
 </html>`;
 }
 
-function getVpsBootPage(input: { handle: string; status: string }) {
+function getVpsBootPage(input: { status: string }) {
   const title = input.status === 'recovering' ? 'Restoring Matrix OS' : 'Booting Matrix OS';
   const detail = input.status === 'recovering'
     ? 'Your Matrix instance is restoring its workspace. This page will refresh automatically.'
@@ -990,7 +991,6 @@ function getVpsBootPage(input: { handle: string; status: string }) {
     .spinner { width: 22px; height: 22px; border: 3px solid rgba(148, 163, 184, 0.45); border-top-color: #38bdf8; border-radius: 999px; animation: spin 1s linear infinite; }
     h1 { font-size: 24px; line-height: 1.2; margin: 0; }
     p { color: #cbd5e1; line-height: 1.55; margin: 16px 0 0; }
-    code { display: inline-block; margin-top: 18px; color: #93c5fd; background: rgba(30, 41, 59, 0.9); border: 1px solid rgba(148, 163, 184, 0.22); border-radius: 8px; padding: 7px 10px; }
     @keyframes spin { to { transform: rotate(360deg); } }
   </style>
 </head>
@@ -1863,10 +1863,7 @@ export function createApp(deps: {
           }, 503);
         }
         applyNoStoreHeaders(c);
-        return c.html(getVpsBootPage({
-          handle: activeMachine.handle,
-          status: activeMachine.status,
-        }), 503);
+        return c.html(getVpsBootPage({ status: activeMachine.status }), 503);
       }
       return c.html(getNoContainerPage());
     }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -557,6 +557,7 @@ export function checkUnsafeDefaultSecrets(
 interface AppDomainIdentity {
   handle: string;
   userId: string;
+  runtimeSlot?: string;
   source?: 'auth' | 'mobile-session' | 'static-route';
 }
 
@@ -693,13 +694,14 @@ async function resolveAppDomainIdentity(opts: {
           userId: record.clerkUserId,
         };
       }
-      const machine = await getRunningUserMachineByHandle(opts.db, claims.handle, 'primary');
+      const machine = await getRunningUserMachineByHandle(opts.db, claims.handle);
       if (machine?.clerkUserId !== claims.sub) {
         return null;
       }
       return {
         handle: machine.handle,
         userId: machine.clerkUserId,
+        runtimeSlot: machine.runtimeSlot,
       };
     } catch (err: unknown) {
       if (!isSyncJwtAuthError(err)) {
@@ -738,6 +740,7 @@ async function resolveAppDomainIdentity(opts: {
   return {
     handle: machine.handle,
     userId: result.userId,
+    runtimeSlot: machine.runtimeSlot,
   };
 }
 
@@ -1754,7 +1757,7 @@ export function createApp(deps: {
     const runtimeSlot =
       identity.source === 'mobile-session' || identity.source === 'static-route'
         ? 'primary'
-        : requestRuntimeSlot;
+        : identity.runtimeSlot ?? requestRuntimeSlot;
     let runningMachine = identity.userId
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
       : undefined;
@@ -1857,6 +1860,7 @@ export function createApp(deps: {
         ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
         : await getActiveUserMachineByHandle(db, identity.handle, 'primary');
       if (activeMachine) {
+        c.header('set-cookie', buildRuntimeSlotCookie(runtimeSlot));
         if (isCodeDomain || isGatewayPath) {
           applyNoStoreHeaders(c);
           return c.json({
@@ -2915,7 +2919,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     const runtimeSlot =
       identity.source === 'mobile-session' || identity.source === 'static-route'
         ? 'primary'
-        : requestRuntimeSlot;
+        : identity.runtimeSlot ?? requestRuntimeSlot;
     let runningMachine = identity.userId
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
       : undefined;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -692,7 +692,7 @@ async function resolveAppDomainIdentity(opts: {
           userId: record.clerkUserId,
         };
       }
-      const machine = await getRunningUserMachineByHandle(opts.db, claims.handle);
+      const machine = await getRunningUserMachineByHandle(opts.db, claims.handle, 'primary');
       if (machine?.clerkUserId !== claims.sub) {
         return null;
       }
@@ -1611,7 +1611,7 @@ export function createApp(deps: {
         return c.json({ error: 'Invalid handle' }, 400);
       }
 
-      const runningMachine = await getRunningUserMachineByHandle(db, handle);
+      const runningMachine = await getRunningUserMachineByHandle(db, handle, 'primary');
       if (!runningMachine) {
         return c.json({ error: 'VPS unavailable' }, 404);
       }
@@ -1756,7 +1756,7 @@ export function createApp(deps: {
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
       : undefined;
     if (!runningMachine && runtimeSlot === 'primary') {
-      runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+      runningMachine = await getRunningUserMachineByHandle(db, identity.handle, 'primary');
     }
     if (runningMachine) {
       const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
@@ -1852,7 +1852,7 @@ export function createApp(deps: {
     if (!record) {
       const activeMachine = identity.userId
         ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
-        : await getActiveUserMachineByHandle(db, identity.handle);
+        : await getActiveUserMachineByHandle(db, identity.handle, 'primary');
       if (activeMachine) {
         if (isCodeDomain || isGatewayPath) {
           applyNoStoreHeaders(c);
@@ -2439,7 +2439,7 @@ export function createApp(deps: {
     }
     const path = c.req.path.replace(`/proxy/${handle}`, '') || '/';
     const qs = c.req.url.includes('?') ? '?' + c.req.url.split('?')[1] : '';
-    const runningMachine = await getRunningUserMachineByHandle(db, handle);
+    const runningMachine = await getRunningUserMachineByHandle(db, handle, 'primary');
     if (runningMachine) {
       const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);
       if (!targetUrl) {
@@ -2649,7 +2649,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       if (!handle) return null;
 
       const owner =
-        (await getRunningUserMachineByHandle(db, handle)) ??
+        (await getRunningUserMachineByHandle(db, handle, 'primary')) ??
         (await getContainer(db, handle));
       if (!owner || owner.clerkUserId !== clerkUserId) {
         return null;
@@ -2915,7 +2915,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       ? await getRunningUserMachineByClerkId(db, identity.userId, runtimeSlot)
       : undefined;
     if (!runningMachine && runtimeSlot === 'primary') {
-      runningMachine = await getRunningUserMachineByHandle(db, identity.handle);
+      runningMachine = await getRunningUserMachineByHandle(db, identity.handle, 'primary');
     }
     const record = await getContainer(db, identity.handle);
     if (!runningMachine && !record) { socket.destroy(); return; }

--- a/packages/platform/src/profile-routing.ts
+++ b/packages/platform/src/profile-routing.ts
@@ -9,6 +9,21 @@ export interface CustomerVpsProxyMachine {
   publicIPv4: string | null;
 }
 
+export type EntitlementStatus = 'active' | 'missing' | 'expired' | 'disabled' | 'changed';
+
+export interface EntitlementState {
+  status: EntitlementStatus;
+  effectiveAt?: string;
+}
+
+export interface EntitlementAccessDecision {
+  status: EntitlementStatus;
+  runtimeProxyAllowed: boolean;
+  ownerDataPreserved: true;
+  ownerDataExportable: true;
+  remediation: string | null;
+}
+
 export function resolveSubdomain(host: string): string | null {
   const match = host
     .toLowerCase()
@@ -27,6 +42,37 @@ export function buildCustomerVpsProxyUrl(
   if (machine.status !== "running" || !machine.publicIPv4) return null;
   const safePath = path.startsWith("/") ? path : `/${path}`;
   return `https://${machine.publicIPv4}:443${safePath}${queryString}`;
+}
+
+export function deriveEntitlementAccess(state: EntitlementState): EntitlementAccessDecision {
+  switch (state.status) {
+    case 'active':
+      return {
+        status: state.status,
+        runtimeProxyAllowed: true,
+        ownerDataPreserved: true,
+        ownerDataExportable: true,
+        remediation: null,
+      };
+    case 'changed':
+      return {
+        status: state.status,
+        runtimeProxyAllowed: false,
+        ownerDataPreserved: true,
+        ownerDataExportable: true,
+        remediation: 'Review entitlement change before granting paid-only access.',
+      };
+    case 'missing':
+    case 'expired':
+    case 'disabled':
+      return {
+        status: state.status,
+        runtimeProxyAllowed: false,
+        ownerDataPreserved: true,
+        ownerDataExportable: true,
+        remediation: 'Renew paid beta access or ask an operator to grant access.',
+      };
+  }
 }
 
 export function isPublicProfilePath(path: string): boolean {

--- a/packages/platform/src/profile-routing.ts
+++ b/packages/platform/src/profile-routing.ts
@@ -72,6 +72,10 @@ export function deriveEntitlementAccess(state: EntitlementState): EntitlementAcc
         ownerDataExportable: true,
         remediation: 'Renew paid beta access or ask an operator to grant access.',
       };
+    default: {
+      const exhaustive: never = state.status;
+      throw new Error(`Unhandled entitlement status: ${String(exhaustive)}`);
+    }
   }
 }
 

--- a/packages/platform/src/profile-routing.ts
+++ b/packages/platform/src/profile-routing.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { access, mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { z } from "zod/v4";
 
 const RESERVED_SUBDOMAINS = new Set(["www", "api", "admin", "mail", "ftp"]);
 
@@ -9,7 +10,8 @@ export interface CustomerVpsProxyMachine {
   publicIPv4: string | null;
 }
 
-export type EntitlementStatus = 'active' | 'missing' | 'expired' | 'disabled' | 'changed';
+export const EntitlementStatusSchema = z.enum(['active', 'missing', 'expired', 'disabled', 'changed']);
+export type EntitlementStatus = z.infer<typeof EntitlementStatusSchema>;
 
 export interface EntitlementState {
   status: EntitlementStatus;

--- a/packages/platform/src/sync-jwt.ts
+++ b/packages/platform/src/sync-jwt.ts
@@ -8,6 +8,7 @@ export interface SyncJwtClaims extends JWTPayload {
   sub: string; // clerkUserId
   handle: string;
   gateway_url: string;
+  runtime_slot?: string;
   aud?: string | string[];
   iat: number;
   exp: number;
@@ -19,6 +20,7 @@ export interface IssueOpts {
   clerkUserId: string;
   handle: string;
   gatewayUrl: string;
+  runtimeSlot?: string;
   expiresInSec?: number;
   now?: number; // epoch seconds; defaults to current time
 }
@@ -56,6 +58,7 @@ export async function issueSyncJwt(opts: IssueOpts): Promise<IssuedJwt> {
     sub: opts.clerkUserId,
     handle: opts.handle,
     gateway_url: opts.gatewayUrl,
+    ...(opts.runtimeSlot ? { runtime_slot: opts.runtimeSlot } : {}),
     aud: SYNC_JWT_AUDIENCE,
     iat: now,
     exp,
@@ -94,6 +97,7 @@ export async function verifySyncJwt(
     typeof payload.handle !== 'string' ||
     payload.handle.length === 0 ||
     typeof payload.gateway_url !== 'string' ||
+    (payload.runtime_slot !== undefined && typeof payload.runtime_slot !== 'string') ||
     typeof payload.iat !== 'number' ||
     typeof payload.exp !== 'number'
   ) {

--- a/packages/platform/src/ws-upgrade.ts
+++ b/packages/platform/src/ws-upgrade.ts
@@ -61,6 +61,7 @@ export function stripWebSocketUpgradeToken(path: string): string {
     return path;
   }
   parsed.searchParams.delete("token");
+  parsed.searchParams.delete("runtime");
   const search = parsed.searchParams.toString();
   return `${parsed.pathname}${search ? `?${search}` : ""}`;
 }

--- a/specs/082-paid-beta-readiness/quickstart.md
+++ b/specs/082-paid-beta-readiness/quickstart.md
@@ -31,8 +31,7 @@ bun run test -- tests/platform/launch-entitlement.test.ts
 ## Visual And E2E Checks
 
 ```bash
-bun run test:e2e -- tests/e2e/onboarding-activation.spec.ts
-bun run test:e2e -- tests/e2e/onboarding-visual.spec.ts
+pnpm --dir shell exec playwright test ../tests/e2e/onboarding-activation.spec.ts ../tests/e2e/onboarding-visual.spec.ts --config ../tests/e2e/playwright.config.ts
 ```
 
 Required evidence:
@@ -46,6 +45,39 @@ Required evidence:
 - Admin/control surface shows model/provider setup, settings, automations, activity, and readiness remediation in the Matrix visual language.
 - Coding-focused user connects GitHub, selects a project, and sees next coding action.
 - Assistant-focused user connects or skips calendar/email and sees available/degraded workflows.
+
+## Staging VPS For Breaking Feature Tests
+
+Use a separate runtime slot when a branch or host bundle may break the primary
+workspace. The same Clerk login can route to either runtime.
+
+1. Publish the branch host bundle as an immutable version.
+2. Provision a staging runtime for the same Clerk user with a distinct handle.
+
+   ```bash
+   curl --fail --silent --show-error \
+     -X POST "$PLATFORM_PUBLIC_URL/vps/provision" \
+     -H "Authorization: Bearer $PLATFORM_SECRET" \
+     -H "Content-Type: application/json" \
+     -d '{"clerkUserId":"user_xxx","handle":"hamedmp-staging","runtimeSlot":"staging"}'
+   ```
+
+3. Deploy the branch version only to that staging VPS.
+4. Open the same login at:
+
+   ```text
+   https://app.matrix-os.com/?runtime=staging
+   ```
+
+5. Return to the primary VPS with:
+
+   ```text
+   https://app.matrix-os.com/?runtime=primary
+   ```
+
+The platform stores primary and staging as separate `user_machines.runtime_slot`
+rows, so a failed staging upgrade must not overwrite or route traffic away from
+the primary runtime.
 
 ## Golden Path: Fresh Workspace
 
@@ -110,3 +142,49 @@ Required evidence:
 - Full pre-PR checklist passes.
 - Visual QA evidence is attached to the implementation PR.
 - Public docs under `www/content/docs/` explain onboarding launch readiness and deferred payment work.
+
+## Latest Implementation Validation
+
+These results are the current local evidence for this implementation branch.
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| `bun run test -- tests/platform/launch-readiness.test.ts tests/platform/launch-entitlement.test.ts tests/platform/profile-routing-vps.test.ts tests/platform/profile-routing.test.ts` | PASS | 4 files, 29 tests. Covers operator launch gates, entitlement preservation, app route mount, and existing profile/VPS routing compatibility. |
+| `bun run typecheck` | PASS | Observability/kernel build plus package typechecks completed. |
+| `bun run check:patterns` | PASS with existing warnings | 0 violations. Existing baseline warnings remain for body consumption, Map/Set review, path operations, and external headers. |
+| `bun run test -- --reporter=dot` | PASS | 459 files passed, 3 skipped; 4,752 tests passed, 20 skipped. |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bWF0cml4b3MudGVzdCQ= pnpm --dir shell build` | PASS | Uses a local test Clerk publishable key, not the example production placeholder. |
+| `pnpm --dir shell exec playwright test ../tests/e2e/onboarding-activation.spec.ts ../tests/e2e/onboarding-visual.spec.ts --config ../tests/e2e/playwright.config.ts` | PASS | 8 onboarding activation and visual QA specs passed. Shell logs expected gateway proxy refusals because the tests mock onboarding APIs without running the gateway. |
+
+PR/CI, Greptile review, and real-environment operator evidence flags must still be added before this feature is called launch-ready.
+
+## Backend Route Review And PR Invariants
+
+### Source Of Truth
+
+- Gateway onboarding readiness remains owner-scoped readiness state and safe browser summaries.
+- Platform launch readiness is the operator source of truth for paid-beta enablement. It combines platform DB facts, such as beta release and machine rehearsal state, with explicit QA evidence flags for launch gates that require human or e2e confirmation.
+- Entitlement policy in `profile-routing.ts` is data-preserving policy only; billing remains deferred.
+
+### Lock And Transaction Scope
+
+- Launch readiness reads platform DB state and does not perform writes.
+- The operator readiness route has no external network calls and no multi-write transaction scope.
+- Entitlement decisions are pure functions and do not mutate machine records or owner data.
+
+### Acceptable Orphan States
+
+- Missing QA evidence leaves the operator report blocked.
+- Missing beta release promotion leaves paid beta blocked.
+- Missing or expired entitlement blocks paid-only access while preserving owner data and exportability.
+
+### Auth Source Of Truth
+
+- `GET /api/operator/launch-readiness` is protected by the platform bearer token using constant-time token comparison.
+- Owner onboarding and admin-control routes remain owner-authenticated through their existing gateway request-principal paths.
+
+### Deferred Scope
+
+- Clerk billing enforcement and payment collection are not enabled here.
+- Durable owner-scoped onboarding persistence beyond the current readiness services remains a follow-up if the launch rehearsal requires it.
+- Visual QA screenshots and CI/Greptile artifacts are required before launch-ready signoff.

--- a/specs/082-paid-beta-readiness/quickstart.md
+++ b/specs/082-paid-beta-readiness/quickstart.md
@@ -79,6 +79,13 @@ The platform stores primary and staging as separate `user_machines.runtime_slot`
 rows, so a failed staging upgrade must not overwrite or route traffic away from
 the primary runtime.
 
+Recover a staging VPS by slot so the primary runtime stays attached to the same
+login:
+
+```bash
+matrixctl recover user_xxx --slot staging --allow-empty
+```
+
 ## Golden Path: Fresh Workspace
 
 1. Create or invite a new founder/developer test user.

--- a/specs/082-paid-beta-readiness/tasks.md
+++ b/specs/082-paid-beta-readiness/tasks.md
@@ -243,16 +243,16 @@
 
 ### Tests First
 
-- [ ] T088 [P] [US7] Write failing operator readiness route tests in `tests/platform/launch-readiness.test.ts`
-- [ ] T089 [P] [US7] Write failing entitlement preservation tests in `tests/platform/launch-entitlement.test.ts`
+- [X] T088 [P] [US7] Write failing operator readiness route tests in `tests/platform/launch-readiness.test.ts`
+- [X] T089 [P] [US7] Write failing entitlement preservation tests in `tests/platform/launch-entitlement.test.ts`
 
 ### Implementation
 
-- [ ] T090 [US7] Implement platform launch readiness aggregator in `packages/platform/src/launch-readiness.ts`
-- [ ] T091 [US7] Add operator readiness route in `packages/platform/src/launch-readiness-routes.ts`
-- [ ] T092 [US7] Wire operator readiness route in `packages/platform/src/main.ts`
-- [ ] T093 [US7] Add entitlement gate behavior without owner-data deletion in `packages/platform/src/profile-routing.ts`
-- [ ] T094 [US7] Add operator remediation summaries for failed gates in `packages/platform/src/launch-readiness.ts`
+- [X] T090 [US7] Implement platform launch readiness aggregator in `packages/platform/src/launch-readiness.ts`
+- [X] T091 [US7] Add operator readiness route in `packages/platform/src/launch-readiness-routes.ts`
+- [X] T092 [US7] Wire operator readiness route in `packages/platform/src/main.ts`
+- [X] T093 [US7] Add entitlement gate behavior without owner-data deletion in `packages/platform/src/profile-routing.ts`
+- [X] T094 [US7] Add operator remediation summaries for failed gates in `packages/platform/src/launch-readiness.ts`
 
 **Checkpoint**: Paid beta cannot be marked launch-ready while release-critical gates fail.
 

--- a/tests/platform/api.test.ts
+++ b/tests/platform/api.test.ts
@@ -137,11 +137,12 @@ describe('platform/api', () => {
       runtime: 'customer_vps',
       handle: 'alice',
       clerkUserId: 'clerk_1',
+      runtimeSlot: 'primary',
       machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
       status: 'provisioning',
       etaSeconds: 90,
     });
-    expect(customerVpsService.provision).toHaveBeenCalledWith({ handle: 'alice', clerkUserId: 'clerk_1' });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({ handle: 'alice', clerkUserId: 'clerk_1', runtimeSlot: 'primary' });
     expect(provisionSpy).not.toHaveBeenCalled();
   });
 

--- a/tests/platform/api.test.ts
+++ b/tests/platform/api.test.ts
@@ -146,6 +146,41 @@ describe('platform/api', () => {
     expect(provisionSpy).not.toHaveBeenCalled();
   });
 
+  it('POST /containers/provision allows operator provisioning when user entitlement denies access', async () => {
+    process.env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS = 'expired';
+    const { docker } = createMockDocker();
+    const orchestrator = createOrchestrator({ db, docker: docker as any });
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({
+        machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+        status: 'provisioning',
+        etaSeconds: 90,
+      }),
+    };
+    const vpsApp = createApp({
+      db,
+      orchestrator,
+      platformSecret,
+      customerVpsService: customerVpsService as any,
+    });
+
+    const res = await vpsApp.request('/containers/provision', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...adminHeaders },
+      body: JSON.stringify({ handle: 'alice', clerkUserId: 'clerk_1' }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toMatchObject({
+      runtime: 'customer_vps',
+      handle: 'alice',
+      clerkUserId: 'clerk_1',
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      status: 'provisioning',
+    });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({ handle: 'alice', clerkUserId: 'clerk_1', runtimeSlot: 'primary' });
+  });
+
   it('GET /metrics reuses cached VPS runtime probes between scrapes', async () => {
     metricsRegistry.resetMetrics();
     await insertUserMachine(db, {

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -353,6 +353,7 @@ describe('platform/customer-vps-cloud-init', () => {
 
     expect(matrixctl).toContain('matrixctl recover <clerk-user-id> [--slot <runtime-slot>] [--allow-empty]');
     expect(matrixctl).toContain('local runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"');
+    expect(matrixctl).toContain('""|[!a-z0-9]*|*[^a-z0-9-]*|*-) fail "invalid runtime slot"');
     expect(matrixctl).toContain('payload="$(printf \'{"clerkUserId":"%s","runtimeSlot":"%s","allowEmpty":%s}\'');
     expect(matrixctl).toContain('${MATRIX_PLATFORM_URL%/}/vps/recover');
     expect(matrixctl).toContain('curl --fail --silent --show-error --max-time 10');
@@ -361,6 +362,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(matrixctl).toContain('rm -f "${tmp:-}"');
     expect(cloudInit).toContain('matrixctl recover <clerk-user-id> [--slot <runtime-slot>] [--allow-empty]');
     expect(cloudInit).toContain('runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"');
+    expect(cloudInit).toContain('""|[!a-z0-9]*|*[^a-z0-9-]*|*-) fail "invalid runtime slot"');
     expect(cloudInit).toContain('{"clerkUserId":"%s","runtimeSlot":"%s","allowEmpty":%s}');
   });
 });

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -349,12 +349,16 @@ describe('platform/customer-vps-cloud-init', () => {
     const matrixctl = readFileSync(join(root, 'distro/customer-vps/matrixctl'), 'utf8');
     const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
 
-    expect(matrixctl).toContain('matrixctl recover <clerk-user-id> [--allow-empty]');
+    expect(matrixctl).toContain('matrixctl recover <clerk-user-id> [--slot <runtime-slot>] [--allow-empty]');
+    expect(matrixctl).toContain('local runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"');
+    expect(matrixctl).toContain('payload="$(printf \'{"clerkUserId":"%s","runtimeSlot":"%s","allowEmpty":%s}\'');
     expect(matrixctl).toContain('${MATRIX_PLATFORM_URL%/}/vps/recover');
     expect(matrixctl).toContain('curl --fail --silent --show-error --max-time 10');
     expect(matrixctl).toContain('set +u');
     expect(matrixctl).toContain('export AWS_ACCESS_KEY_ID=');
     expect(matrixctl).toContain('rm -f "${tmp:-}"');
-    expect(cloudInit).toContain('matrixctl recover <clerk-user-id> [--allow-empty]');
+    expect(cloudInit).toContain('matrixctl recover <clerk-user-id> [--slot <runtime-slot>] [--allow-empty]');
+    expect(cloudInit).toContain('runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"');
+    expect(cloudInit).toContain('{"clerkUserId":"%s","runtimeSlot":"%s","allowEmpty":%s}');
   });
 });

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -14,6 +14,7 @@ describe('platform/customer-vps-cloud-init', () => {
     machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
     clerkUserId: 'user_123',
     handle: 'alice',
+    runtimeSlot: 'staging',
     imageVersion: 'stable',
     updateChannel: 'stable',
     hostBundleUrl: 'https://platform.example/system-bundles/stable/matrix-host-bundle.tar.gz',
@@ -51,6 +52,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(rendered).toContain(
       'MATRIX_HOST_BUNDLE_URL=https://platform.example/system-bundles/stable/matrix-host-bundle.tar.gz',
     );
+    expect(rendered).toContain('MATRIX_RUNTIME_SLOT=staging');
     expect(rendered).toContain('MATRIX_UPDATE_CHANNEL=stable');
     expect(rendered).toContain('MATRIX_IMAGE_VERSION=stable');
     expect(rendered).not.toContain('MATRIX_HOST_BUNDLE_URL=\n');

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -303,6 +303,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(backup).toContain('--format=custom');
     expect(backup).toContain('.dump');
     expect(backup).toContain('timeout');
+    expect(backup).toContain('system/runtime-slots/${runtime_slot}/db/snapshots/${snapshot_name}');
   });
 
   it('keeps restore as a boot gate and refuses failed restores', () => {
@@ -317,6 +318,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(restore).not.toContain('docker compose');
     expect(restore).toContain('pg_restore');
     expect(restore).toContain('exit 1');
+    expect(restore).toContain('system/runtime-slots/${runtime_slot}/db/latest');
     expect(gateway).toContain('ConditionPathExists=/opt/matrix/restore-complete');
   });
 
@@ -354,6 +356,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(matrixctl).toContain('matrixctl recover <clerk-user-id> [--slot <runtime-slot>] [--allow-empty]');
     expect(matrixctl).toContain('local runtime_slot="${MATRIX_RUNTIME_SLOT:-primary}"');
     expect(matrixctl).toContain('""|[!a-z0-9]*|*[^a-z0-9-]*|*-) fail "invalid runtime slot"');
+    expect(matrixctl).toContain('system/runtime-slots/${runtime_slot}/db/latest');
     expect(matrixctl).toContain('payload="$(printf \'{"clerkUserId":"%s","runtimeSlot":"%s","allowEmpty":%s}\'');
     expect(matrixctl).toContain('${MATRIX_PLATFORM_URL%/}/vps/recover');
     expect(matrixctl).toContain('curl --fail --silent --show-error --max-time 10');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -181,7 +181,7 @@ describe('customer VPS host bundle', () => {
     const restore = readFileSync(join(root, 'distro/customer-vps/matrix-restore.sh'), 'utf8');
 
     expect(restore).toContain('/opt/matrix/bin/matrixctl r2 exists system/vps-meta.json');
-    expect(restore).toContain('latest_key="system/db/latest"');
-    expect(restore).toContain('/opt/matrix/bin/matrixctl r2 get "$latest_key" "$latest_file"');
+    expect(restore).toContain('latest_pointer_key="system/db/latest"');
+    expect(restore).toContain('/opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"');
   });
 });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -181,6 +181,7 @@ describe('customer VPS host bundle', () => {
     const restore = readFileSync(join(root, 'distro/customer-vps/matrix-restore.sh'), 'utf8');
 
     expect(restore).toContain('/opt/matrix/bin/matrixctl r2 exists system/vps-meta.json');
-    expect(restore).toContain('/opt/matrix/bin/matrixctl r2 get system/db/latest "$latest_file"');
+    expect(restore).toContain('latest_key="system/db/latest"');
+    expect(restore).toContain('/opt/matrix/bin/matrixctl r2 get "$latest_key" "$latest_file"');
   });
 });

--- a/tests/platform/customer-vps-routes.test.ts
+++ b/tests/platform/customer-vps-routes.test.ts
@@ -109,6 +109,7 @@ describe('platform/customer-vps-routes', () => {
       recover: vi.fn().mockResolvedValue({
         oldMachineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
         machineId: 'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
+        runtimeSlot: 'staging',
         status: 'recovering',
         etaSeconds: 120,
       }),
@@ -134,17 +135,18 @@ describe('platform/customer-vps-routes', () => {
     const recover = await app.request('/vps/recover', {
       method: 'POST',
       headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
-      body: JSON.stringify({ clerkUserId: 'user_123', allowEmpty: true }),
+      body: JSON.stringify({ clerkUserId: 'user_123', runtimeSlot: 'staging', allowEmpty: true }),
     });
 
     expect(recover.status).toBe(202);
     expect(await recover.json()).toEqual({
       oldMachineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
       machineId: 'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
+      runtimeSlot: 'staging',
       status: 'recovering',
       etaSeconds: 120,
     });
-    expect(service.recover).toHaveBeenCalledWith({ clerkUserId: 'user_123', allowEmpty: true });
+    expect(service.recover).toHaveBeenCalledWith({ clerkUserId: 'user_123', runtimeSlot: 'staging', allowEmpty: true });
   });
 
   it('rejects invalid request bodies with generic validation errors', async () => {

--- a/tests/platform/customer-vps-routes.test.ts
+++ b/tests/platform/customer-vps-routes.test.ts
@@ -132,6 +132,14 @@ describe('platform/customer-vps-routes', () => {
     expect(invalid.status).toBe(400);
     expect(await invalid.json()).toEqual({ error: 'Invalid request' });
 
+    const invalidSlot = await app.request('/vps/recover', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ clerkUserId: 'user_123', runtimeSlot: 'staging-' }),
+    });
+    expect(invalidSlot.status).toBe(400);
+    expect(await invalidSlot.json()).toEqual({ error: 'Invalid request' });
+
     const recover = await app.request('/vps/recover', {
       method: 'POST',
       headers: { authorization: `Bearer ${platformSecret}`, 'content-type': 'application/json' },

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -408,14 +408,16 @@ describe('platform/customer-vps', () => {
 
   it('validates R2 latest pointers without accepting paths or URLs', () => {
     expect(validateDbLatestPointer('system/db/snapshots/2026-04-26T1800Z.dump')).toBe(true);
+    expect(validateDbLatestPointer('system/runtime-slots/staging/db/snapshots/2026-04-26T1800Z.dump')).toBe(true);
     expect(validateDbLatestPointer('../system/db/snapshots/2026-04-26T1800Z.dump')).toBe(false);
     expect(validateDbLatestPointer('https://example.com/snapshot.dump')).toBe(false);
     expect(validateDbLatestPointer('system/db/snapshots/not-a-date.dump')).toBe(false);
+    expect(validateDbLatestPointer('system/runtime-slots/staging-/db/snapshots/2026-04-26T1800Z.dump')).toBe(false);
   });
 
   it('writes VPS metadata to the scoped user R2 key', async () => {
     const writes: Array<{ key: string; body: string; signal?: AbortSignal }> = [];
-    const reads: AbortSignal[] = [];
+    const reads: Array<{ key: string; signal?: AbortSignal }> = [];
     const store = createCustomerVpsSystemStore({
       r2PrefixRoot: 'matrixos-sync',
       r2: {
@@ -423,8 +425,8 @@ describe('platform/customer-vps', () => {
           writes.push({ key, body: String(body), signal: options?.signal });
           return {};
         },
-        async getObject(_key, options) {
-          if (options?.signal) reads.push(options.signal);
+        async getObject(key, options) {
+          reads.push({ key, signal: options?.signal });
           throw Object.assign(new Error('missing'), { name: 'NoSuchKey' });
         },
       },
@@ -448,7 +450,10 @@ describe('platform/customer-vps', () => {
       status: 'running',
     });
     await expect(store.hasDbLatest('user_123')).resolves.toBe(false);
-    expect(reads[0]).toBeInstanceOf(AbortSignal);
+    await expect(store.hasDbLatest('user_123', 'staging')).resolves.toBe(false);
+    expect(reads[0]?.signal).toBeInstanceOf(AbortSignal);
+    expect(reads[0]?.key).toBe('matrixos-sync/user_123/system/db/latest');
+    expect(reads[1]?.key).toBe('matrixos-sync/user_123/system/runtime-slots/staging/db/latest');
     expect(buildCustomerVpsR2Key('matrixos-sync/', 'user_123', 'system/db/latest')).toBe(
       'matrixos-sync/user_123/system/db/latest',
     );

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -109,6 +109,34 @@ describe('platform/customer-vps', () => {
     expect(createInput?.userData).toContain('MATRIX_UPDATE_CHANNEL=stable');
   });
 
+  it('can provision an isolated staging runtime for the same Clerk user', async () => {
+    let nextId = 0;
+    const ids = [
+      '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+    ];
+    const { service, hetzner } = createService({
+      machineIdFactory: () => ids[nextId++] ?? '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+    });
+
+    const primary = await service.provision({ clerkUserId: 'user_123', handle: 'alice', runtimeSlot: 'primary' });
+    const staging = await service.provision({ clerkUserId: 'user_123', handle: 'alice-staging', runtimeSlot: 'staging' });
+    const stagingAgain = await service.provision({ clerkUserId: 'user_123', handle: 'alice-staging', runtimeSlot: 'staging' });
+
+    expect(primary.machineId).toBe(ids[0]);
+    expect(staging.machineId).toBe(ids[1]);
+    expect(stagingAgain).toEqual(staging);
+    expect(hetzner.createServer).toHaveBeenCalledTimes(2);
+    await expect(getActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toMatchObject({
+      handle: 'alice',
+      runtimeSlot: 'primary',
+    });
+    await expect(getActiveUserMachineByClerkId(db, 'user_123', 'staging')).resolves.toMatchObject({
+      handle: 'alice-staging',
+      runtimeSlot: 'staging',
+    });
+  });
+
   it('templates the platform verification token into provisioned customer hosts', async () => {
     const { service, hetzner } = createService();
 

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -477,6 +477,7 @@ describe('platform/customer-vps', () => {
     expect(recovered).toMatchObject({
       oldMachineId: provisioned.machineId,
       machineId: 'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
+      runtimeSlot: 'primary',
       status: 'recovering',
     });
     expect(hetzner.deleteServer).toHaveBeenCalledWith(123456);
@@ -485,6 +486,7 @@ describe('platform/customer-vps', () => {
     ).toBeLessThan(vi.mocked(hetzner.deleteServer).mock.invocationCallOrder[0]);
     const secondCreate = vi.mocked(hetzner.createServer).mock.calls[1][0];
     expect(secondCreate.name).toBe('matrix-alice-f973bb98');
+    expect(secondCreate.labels).toMatchObject({ runtime_slot: 'primary' });
     const row = (await getUserMachine(db, recovered.machineId))!;
     expect(row).toMatchObject({
       clerkUserId: 'user_123',
@@ -494,6 +496,57 @@ describe('platform/customer-vps', () => {
       publicIPv4: '203.0.113.11',
     });
     await expect(getUserMachine(db, provisioned.machineId)).resolves.toBeUndefined();
+  });
+
+  it('recovers the requested runtime slot without touching primary', async () => {
+    const machineIds = [
+      '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
+      '7fe6cb68-738b-46a4-a338-f5fb74ac9123',
+    ];
+    const hetzner = createMockHetznerClient({
+      createServer: vi
+        .fn()
+        .mockResolvedValueOnce({ id: 123456, status: 'running', publicIPv4: '203.0.113.10' })
+        .mockResolvedValueOnce({ id: 789012, status: 'running', publicIPv4: '203.0.113.11' })
+        .mockResolvedValueOnce({ id: 789013, status: 'running', publicIPv4: '203.0.113.12' }),
+    });
+    const { service } = createService({
+      hetzner,
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: vi.fn().mockResolvedValue(true) }),
+      machineIdFactory: () => machineIds.shift()!,
+    });
+    const primary = await service.provision({ clerkUserId: 'user_123', handle: 'alice', runtimeSlot: 'primary' });
+    const staging = await service.provision({ clerkUserId: 'user_123', handle: 'alice-staging', runtimeSlot: 'staging' });
+    await service.register('registration-token', {
+      machineId: primary.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+    await service.register('registration-token', {
+      machineId: staging.machineId,
+      hetznerServerId: 789012,
+      publicIPv4: '203.0.113.11',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    const recovered = await service.recover({ clerkUserId: 'user_123', runtimeSlot: 'staging' });
+
+    expect(recovered.oldMachineId).toBe(staging.machineId);
+    expect(recovered.runtimeSlot).toBe('staging');
+    expect(vi.mocked(hetzner.createServer).mock.calls[2][0].labels).toMatchObject({
+      runtime_slot: 'staging',
+    });
+    await expect(getActiveUserMachineByClerkId(db, 'user_123', 'primary')).resolves.toMatchObject({
+      machineId: primary.machineId,
+      status: 'running',
+    });
+    await expect(getActiveUserMachineByClerkId(db, 'user_123', 'staging')).resolves.toMatchObject({
+      machineId: '7fe6cb68-738b-46a4-a338-f5fb74ac9123',
+      runtimeSlot: 'staging',
+      status: 'recovering',
+    });
   });
 
   it('queues failed old-server cleanup after recovery and retries it during reconciliation', async () => {

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -5,6 +5,8 @@ import {
   claimUserMachineDelete,
   completeUserMachineRegistration,
   getActiveUserMachineByClerkId,
+  getActiveUserMachineByHandle,
+  getRunningUserMachineByHandle,
   getUserMachine,
   listPendingProviderDeletions,
   promoteHostBundleChannel,
@@ -135,6 +137,41 @@ describe('platform/customer-vps', () => {
       handle: 'alice-staging',
       runtimeSlot: 'staging',
     });
+  });
+
+  it('resolves staging machines by distinct handle for auth and sync fallback paths', async () => {
+    let nextId = 0;
+    const ids = [
+      '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+    ];
+    const { service } = createService({
+      machineIdFactory: () => ids[nextId++] ?? '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+    });
+
+    const primary = await service.provision({ clerkUserId: 'user_123', handle: 'alice', runtimeSlot: 'primary' });
+    const staging = await service.provision({ clerkUserId: 'user_123', handle: 'alice-staging', runtimeSlot: 'staging' });
+    await updateUserMachine(db, primary.machineId, {
+      status: 'running',
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+    await updateUserMachine(db, staging.machineId, {
+      status: 'running',
+      publicIPv4: '203.0.113.11',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+
+    await expect(getActiveUserMachineByHandle(db, 'alice-staging')).resolves.toMatchObject({
+      machineId: staging.machineId,
+      runtimeSlot: 'staging',
+    });
+    await expect(getRunningUserMachineByHandle(db, 'alice-staging')).resolves.toMatchObject({
+      machineId: staging.machineId,
+      runtimeSlot: 'staging',
+      status: 'running',
+    });
+    await expect(getRunningUserMachineByHandle(db, 'alice-staging', 'primary')).resolves.toBeUndefined();
   });
 
   it('templates the platform verification token into provisioned customer hosts', async () => {

--- a/tests/platform/db.test.ts
+++ b/tests/platform/db.test.ts
@@ -8,6 +8,9 @@ import {
   updateLastActive,
   listContainers,
   deleteContainer,
+  insertUserMachine,
+  getActiveUserMachineByHandle,
+  getRunningUserMachineByHandle,
   allocatePort,
   releasePort,
 } from '../../packages/platform/src/db.js';
@@ -167,5 +170,55 @@ describe('platform/db', () => {
     await expect(
       insertContainer(db, { handle: 'bob', clerkUserId: 'clerk_1', containerId: null, port: 4002, shellPort: 3002, status: 'running' }),
     ).rejects.toThrow();
+  });
+
+  it('routes same-handle user-machine slots deterministically', async () => {
+    await insertUserMachine(db, {
+      machineId: 'machine_primary',
+      clerkUserId: 'clerk_1',
+      handle: 'alice',
+      runtimeSlot: 'primary',
+      status: 'running',
+      hetznerServerId: 123,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-test',
+      provisionedAt: '2026-05-25T00:00:00.000Z',
+    });
+
+    await insertUserMachine(db, {
+      machineId: 'machine_staging',
+      clerkUserId: 'clerk_1',
+      handle: 'alice',
+      runtimeSlot: 'staging',
+      status: 'running',
+      hetznerServerId: 124,
+      publicIPv4: '203.0.113.11',
+      imageVersion: 'matrix-os-host-test',
+      provisionedAt: '2026-05-26T00:00:00.000Z',
+    });
+
+    await expect(getActiveUserMachineByHandle(db, 'alice')).resolves.toMatchObject({
+      machineId: 'machine_primary',
+      runtimeSlot: 'primary',
+    });
+    await expect(getActiveUserMachineByHandle(db, 'alice', 'staging')).resolves.toMatchObject({
+      machineId: 'machine_staging',
+      runtimeSlot: 'staging',
+    });
+    await expect(getRunningUserMachineByHandle(db, 'alice')).resolves.toMatchObject({
+      machineId: 'machine_primary',
+      runtimeSlot: 'primary',
+    });
+    await expect(insertUserMachine(db, {
+      machineId: 'machine_other_primary',
+      clerkUserId: 'clerk_2',
+      handle: 'alice',
+      runtimeSlot: 'primary',
+      status: 'running',
+      hetznerServerId: 125,
+      publicIPv4: '203.0.113.12',
+      imageVersion: 'matrix-os-host-test',
+      provisionedAt: '2026-05-27T00:00:00.000Z',
+    })).rejects.toThrow();
   });
 });

--- a/tests/platform/launch-entitlement.test.ts
+++ b/tests/platform/launch-entitlement.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCustomerVpsProxyUrl,
+  deriveEntitlementAccess,
+} from '../../packages/platform/src/profile-routing.js';
+
+describe('platform launch entitlement gates', () => {
+  it('allows runtime access for active paid-beta entitlement', () => {
+    expect(deriveEntitlementAccess({ status: 'active' })).toMatchObject({
+      runtimeProxyAllowed: true,
+      ownerDataPreserved: true,
+      ownerDataExportable: true,
+    });
+  });
+
+  it('blocks new paid access without deleting or hiding owner data', () => {
+    const access = deriveEntitlementAccess({
+      status: 'expired',
+      effectiveAt: '2026-05-23T00:00:00.000Z',
+    });
+
+    expect(access).toMatchObject({
+      runtimeProxyAllowed: false,
+      ownerDataPreserved: true,
+      ownerDataExportable: true,
+      remediation: 'Renew paid beta access or ask an operator to grant access.',
+    });
+  });
+
+  it('keeps changed entitlement in a restricted state until an operator reconciles it', () => {
+    expect(deriveEntitlementAccess({ status: 'changed' })).toMatchObject({
+      runtimeProxyAllowed: false,
+      ownerDataPreserved: true,
+      ownerDataExportable: true,
+      remediation: 'Review entitlement change before granting paid-only access.',
+    });
+  });
+
+  it('still builds the proxy URL for active entitlement without mutating machine data', () => {
+    const machine = { status: 'running', publicIPv4: '203.0.113.10' };
+    const url = buildCustomerVpsProxyUrl(
+      machine,
+      '/api/ping',
+      '?x=1',
+    );
+
+    expect(url).toBe('https://203.0.113.10:443/api/ping?x=1');
+    expect(machine).toEqual({ status: 'running', publicIPv4: '203.0.113.10' });
+  });
+});

--- a/tests/platform/launch-entitlement.test.ts
+++ b/tests/platform/launch-entitlement.test.ts
@@ -36,6 +36,12 @@ describe('platform launch entitlement gates', () => {
     });
   });
 
+  it('fails loudly when a future entitlement status is not mapped', () => {
+    expect(() =>
+      deriveEntitlementAccess({ status: 'suspended' } as never),
+    ).toThrow('Unhandled entitlement status: suspended');
+  });
+
   it('still builds the proxy URL for active entitlement without mutating machine data', () => {
     const machine = { status: 'running', publicIPv4: '203.0.113.10' };
     const url = buildCustomerVpsProxyUrl(

--- a/tests/platform/launch-readiness.test.ts
+++ b/tests/platform/launch-readiness.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Orchestrator } from '../../packages/platform/src/orchestrator.js';
+import { createApp } from '../../packages/platform/src/main.js';
+import {
+  createLaunchReadinessService,
+  type LaunchReadinessGate,
+} from '../../packages/platform/src/launch-readiness.js';
+import { createLaunchReadinessRoutes } from '../../packages/platform/src/launch-readiness-routes.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const nowIso = '2026-05-23T12:00:00.000Z';
+
+function passingGate(id: string): LaunchReadinessGate {
+  return {
+    id,
+    category: 'ux',
+    criticality: 'release_critical',
+    status: 'pass',
+    owner: 'matrix',
+    message: `${id} passed`,
+    remediation: null,
+    lastCheckedAt: nowIso,
+  };
+}
+
+describe('platform/launch-readiness', () => {
+  function stubOrchestrator(): Orchestrator {
+    return {
+      provision: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      destroy: vi.fn(),
+      upgrade: vi.fn(),
+      rollingRestart: vi.fn(),
+      getInfo: vi.fn(),
+      getImage: vi.fn(),
+      listAll: vi.fn().mockReturnValue([]),
+      syncStates: vi.fn(),
+    } as unknown as Orchestrator;
+  }
+
+  it('marks paid beta unsafe when a release-critical gate fails', async () => {
+    const service = createLaunchReadinessService({
+      now: () => new Date(nowIso),
+      loadEvidence: async () => ({
+        promotedRelease: true,
+        freshWorkspace: true,
+        existingWorkspace: true,
+        shellRouting: true,
+        onboardingEducation: true,
+        visualQa: false,
+        integrations: true,
+        hermesContinuity: true,
+        agentExecution: true,
+        codingHandoff: true,
+        companyBrain: true,
+        supportGrowth: true,
+        adminControlSurface: true,
+        entitlementGate: true,
+      }),
+    });
+
+    const report = await service.getReport();
+
+    expect(report.launchReady).toBe(false);
+    expect(report.overallStatus).toBe('blocked');
+    expect(report.gates.find((gate) => gate.id === 'onboarding.visual_qa')).toMatchObject({
+      status: 'fail',
+      owner: 'matrix',
+      remediation: 'Run desktop, mobile, reduced-motion, and missing-media onboarding visual QA.',
+    });
+  });
+
+  it('requires both fresh and existing workspace rehearsals before launch-ready', async () => {
+    const service = createLaunchReadinessService({
+      now: () => new Date(nowIso),
+      loadEvidence: async () => ({
+        promotedRelease: true,
+        freshWorkspace: true,
+        existingWorkspace: false,
+        shellRouting: true,
+        onboardingEducation: true,
+        visualQa: true,
+        integrations: true,
+        hermesContinuity: true,
+        agentExecution: true,
+        codingHandoff: true,
+        companyBrain: true,
+        supportGrowth: true,
+        adminControlSurface: true,
+        entitlementGate: true,
+      }),
+    });
+
+    const report = await service.getReport();
+
+    expect(report.launchReady).toBe(false);
+    expect(report.gates.find((gate) => gate.id === 'workspace.existing_rehearsal')).toMatchObject({
+      status: 'fail',
+      owner: 'operator',
+      message: 'Existing workspace rehearsal has not passed.',
+    });
+  });
+
+  it('returns launch-ready only when every release-critical gate passes', async () => {
+    const service = createLaunchReadinessService({
+      now: () => new Date(nowIso),
+      loadEvidence: async () => ({
+        promotedRelease: true,
+        freshWorkspace: true,
+        existingWorkspace: true,
+        shellRouting: true,
+        onboardingEducation: true,
+        visualQa: true,
+        integrations: true,
+        hermesContinuity: true,
+        agentExecution: true,
+        codingHandoff: true,
+        companyBrain: true,
+        supportGrowth: true,
+        adminControlSurface: true,
+        entitlementGate: true,
+      }),
+    });
+
+    await expect(service.getReport()).resolves.toMatchObject({
+      launchReady: true,
+      overallStatus: 'ready',
+    });
+  });
+
+  it('does not pass entitlement evidence for blocking enforcement statuses', async () => {
+    const { db } = await createTestPlatformDb();
+    try {
+      const loadEvidence = createPlatformLaunchEvidenceLoader({
+        db,
+        env: {
+          MATRIX_LAUNCH_ENTITLEMENT_GATE: 'true',
+          MATRIX_PAID_BETA_ENTITLEMENT_STATUS: 'expired',
+        } as NodeJS.ProcessEnv,
+      });
+
+      await expect(loadEvidence()).resolves.toMatchObject({
+        entitlementGate: false,
+      });
+    } finally {
+      await destroyTestPlatformDb(db);
+    }
+  });
+
+  it('protects the operator readiness route with the platform bearer token', async () => {
+    const app = new Hono();
+    const service = {
+      getReport: vi.fn().mockResolvedValue({
+        generatedAt: nowIso,
+        launchReady: true,
+        overallStatus: 'ready',
+        gates: [passingGate('onboarding.visual_qa')],
+      }),
+    };
+    app.route('/api/operator', createLaunchReadinessRoutes({
+      service,
+      platformSecret: 'platform-secret',
+    }));
+
+    const unauthorized = await app.request('/api/operator/launch-readiness');
+    expect(unauthorized.status).toBe(401);
+
+    const authorized = await app.request('/api/operator/launch-readiness', {
+      headers: { authorization: 'Bearer platform-secret' },
+    });
+    expect(authorized.status).toBe(200);
+    expect(await authorized.json()).toMatchObject({ launchReady: true });
+  });
+
+  it('mounts the operator readiness route on the platform app', async () => {
+    const { db } = await createTestPlatformDb();
+    try {
+      const app = createApp({
+        db,
+        orchestrator: stubOrchestrator(),
+        platformSecret: 'platform-secret',
+      });
+
+      const res = await app.request('/api/operator/launch-readiness', {
+        headers: { authorization: 'Bearer platform-secret' },
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        launchReady: false,
+        overallStatus: 'blocked',
+      });
+    } finally {
+      await destroyTestPlatformDb(db);
+    }
+  });
+
+  it('returns generic route errors when readiness aggregation fails', async () => {
+    const app = new Hono();
+    app.route('/api/operator', createLaunchReadinessRoutes({
+      service: {
+        getReport: vi.fn().mockRejectedValue(new Error('database password leaked')),
+      },
+      platformSecret: 'platform-secret',
+    }));
+
+    const res = await app.request('/api/operator/launch-readiness', {
+      headers: { authorization: 'Bearer platform-secret' },
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'Launch readiness unavailable' });
+  });
+});

--- a/tests/platform/launch-readiness.test.ts
+++ b/tests/platform/launch-readiness.test.ts
@@ -4,8 +4,14 @@ import type { Orchestrator } from '../../packages/platform/src/orchestrator.js';
 import { createApp } from '../../packages/platform/src/main.js';
 import {
   createLaunchReadinessService,
+  createPlatformLaunchEvidenceLoader,
   type LaunchReadinessGate,
 } from '../../packages/platform/src/launch-readiness.js';
+import {
+  insertUserMachine,
+  promoteHostBundleChannel,
+  upsertHostBundleRelease,
+} from '../../packages/platform/src/db.js';
 import { createLaunchReadinessRoutes } from '../../packages/platform/src/launch-readiness-routes.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 
@@ -128,6 +134,52 @@ describe('platform/launch-readiness', () => {
       launchReady: true,
       overallStatus: 'ready',
     });
+  });
+
+  it('keeps fresh and existing workspace rehearsals fail-closed without explicit evidence flags', async () => {
+    const { db } = await createTestPlatformDb();
+    try {
+      await upsertHostBundleRelease(db, {
+        version: 'v2026.05.23-test',
+        gitCommit: 'abcdef123456',
+        gitRef: 'main',
+        buildTime: nowIso,
+        bundleKey: 'system-bundles/v2026.05.23-test/matrix-host-bundle.tar.gz',
+        checksumKey: 'system-bundles/v2026.05.23-test/matrix-host-bundle.tar.gz.sha256',
+        sha256: 'a'.repeat(64),
+        size: 123,
+      });
+      await promoteHostBundleChannel(db, 'beta', 'v2026.05.23-test', nowIso);
+      await insertUserMachine(db, {
+        machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+        clerkUserId: 'user_123',
+        handle: 'alice',
+        status: 'running',
+        publicIPv4: '192.0.2.1',
+        provisionedAt: nowIso,
+        lastSeenAt: nowIso,
+      });
+      await insertUserMachine(db, {
+        machineId: '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+        clerkUserId: 'user_456',
+        handle: 'bob',
+        status: 'running',
+        publicIPv4: '192.0.2.2',
+        provisionedAt: nowIso,
+        lastSeenAt: nowIso,
+      });
+
+      const loadEvidence = createPlatformLaunchEvidenceLoader({ db, env: {} });
+
+      await expect(loadEvidence()).resolves.toMatchObject({
+        promotedRelease: true,
+        freshWorkspace: false,
+        existingWorkspace: false,
+        shellRouting: true,
+      });
+    } finally {
+      await destroyTestPlatformDb(db);
+    }
   });
 
   it('does not pass entitlement evidence for blocking enforcement statuses', async () => {

--- a/tests/platform/launch-readiness.test.ts
+++ b/tests/platform/launch-readiness.test.ts
@@ -136,7 +136,7 @@ describe('platform/launch-readiness', () => {
     });
   });
 
-  it('keeps fresh and existing workspace rehearsals fail-closed without explicit evidence flags', async () => {
+  it('keeps operator-owned rehearsal gates fail-closed without explicit evidence flags', async () => {
     const { db } = await createTestPlatformDb();
     try {
       await upsertHostBundleRelease(db, {
@@ -175,7 +175,7 @@ describe('platform/launch-readiness', () => {
         promotedRelease: true,
         freshWorkspace: false,
         existingWorkspace: false,
-        shellRouting: true,
+        shellRouting: false,
       });
     } finally {
       await destroyTestPlatformDb(db);

--- a/tests/platform/launch-readiness.test.ts
+++ b/tests/platform/launch-readiness.test.ts
@@ -182,6 +182,51 @@ describe('platform/launch-readiness', () => {
     }
   });
 
+  it('matches the proxy default when entitlement evidence omits enforcement status', async () => {
+    const { db } = await createTestPlatformDb();
+    try {
+      const loadWithoutEnforcement = createPlatformLaunchEvidenceLoader({
+        db,
+        env: { MATRIX_LAUNCH_ENTITLEMENT_GATE: 'true' } as NodeJS.ProcessEnv,
+      });
+      await expect(loadWithoutEnforcement()).resolves.toMatchObject({
+        entitlementGate: true,
+      });
+
+      const loadWithEnforcement = createPlatformLaunchEvidenceLoader({
+        db,
+        env: {
+          MATRIX_LAUNCH_ENTITLEMENT_GATE: 'true',
+          MATRIX_PAID_BETA_ENTITLEMENT_STATUS: 'active',
+        } as NodeJS.ProcessEnv,
+      });
+      await expect(loadWithEnforcement()).resolves.toMatchObject({
+        entitlementGate: true,
+      });
+    } finally {
+      await destroyTestPlatformDb(db);
+    }
+  });
+
+  it('does not pass entitlement evidence for unrecognized enforcement statuses', async () => {
+    const { db } = await createTestPlatformDb();
+    try {
+      const loadEvidence = createPlatformLaunchEvidenceLoader({
+        db,
+        env: {
+          MATRIX_LAUNCH_ENTITLEMENT_GATE: 'true',
+          MATRIX_PAID_BETA_ENTITLEMENT_STATUS: 'not-real',
+        } as NodeJS.ProcessEnv,
+      });
+
+      await expect(loadEvidence()).resolves.toMatchObject({
+        entitlementGate: false,
+      });
+    } finally {
+      await destroyTestPlatformDb(db);
+    }
+  });
+
   it('does not pass entitlement evidence for blocking enforcement statuses', async () => {
     const { db } = await createTestPlatformDb();
     try {

--- a/tests/platform/launch-readiness.test.ts
+++ b/tests/platform/launch-readiness.test.ts
@@ -182,7 +182,7 @@ describe('platform/launch-readiness', () => {
     }
   });
 
-  it('matches the proxy default when entitlement evidence omits enforcement status', async () => {
+  it('requires explicit active entitlement evidence before launch readiness passes', async () => {
     const { db } = await createTestPlatformDb();
     try {
       const loadWithoutEnforcement = createPlatformLaunchEvidenceLoader({
@@ -190,7 +190,7 @@ describe('platform/launch-readiness', () => {
         env: { MATRIX_LAUNCH_ENTITLEMENT_GATE: 'true' } as NodeJS.ProcessEnv,
       });
       await expect(loadWithoutEnforcement()).resolves.toMatchObject({
-        entitlementGate: true,
+        entitlementGate: false,
       });
 
       const loadWithEnforcement = createPlatformLaunchEvidenceLoader({
@@ -288,6 +288,33 @@ describe('platform/launch-readiness', () => {
       await expect(res.json()).resolves.toMatchObject({
         launchReady: false,
         overallStatus: 'blocked',
+      });
+    } finally {
+      await destroyTestPlatformDb(db);
+    }
+  });
+
+  it('uses the app injected env for operator readiness evidence', async () => {
+    const { db } = await createTestPlatformDb();
+    try {
+      const app = createApp({
+        db,
+        orchestrator: stubOrchestrator(),
+        platformSecret: 'platform-secret',
+        env: {
+          MATRIX_LAUNCH_ENTITLEMENT_GATE: 'true',
+          MATRIX_PAID_BETA_ENTITLEMENT_STATUS: 'active',
+        } as NodeJS.ProcessEnv,
+      });
+
+      const res = await app.request('/api/operator/launch-readiness', {
+        headers: { authorization: 'Bearer platform-secret' },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.gates.find((gate: { id: string }) => gate.id === 'entitlement.access_gate')).toMatchObject({
+        status: 'pass',
       });
     } finally {
       await destroyTestPlatformDb(db);

--- a/tests/platform/profile-routing-vps.test.ts
+++ b/tests/platform/profile-routing-vps.test.ts
@@ -97,6 +97,37 @@ describe('platform/profile-routing-vps', () => {
     expect(docker.getContainer).not.toHaveBeenCalled();
   });
 
+  it('routes /proxy/:handle requests to a staging VPS handle', async () => {
+    await insertUserMachine(db, {
+      machineId: '9f05824c-8d0a-4d83-9cb4-b312d43ff113',
+      clerkUserId: 'user_alice',
+      handle: 'alice-staging',
+      runtimeSlot: 'staging',
+      status: 'running',
+      hetznerServerId: 123457,
+      publicIPv4: '203.0.113.11',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+      provisionedAt: '2026-04-26T12:00:00.000Z',
+    });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+    const docker = stubDocker();
+    const app = createApp({
+      db,
+      docker,
+      orchestrator: stubOrchestrator(),
+      platformSecret: 'platform-secret',
+    });
+
+    const res = await app.request('/proxy/alice-staging/api/ping?x=1', {
+      headers: { authorization: 'Bearer platform-secret', host: 'alice-staging.matrix-os.com' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://203.0.113.11:443/api/ping?x=1');
+    expect(fetchMock.mock.calls[0]?.[1]?.dispatcher).toBeDefined();
+    expect(docker.getContainer).not.toHaveBeenCalled();
+  });
+
   it('routes public app-domain Twilio webhooks to the matching VPS by handle', async () => {
     await insertUserMachine(db, {
       machineId: '0b5d0a5f-52d8-4f4d-aed8-8d2a0ad1a591',
@@ -133,6 +164,41 @@ describe('platform/profile-routing-vps', () => {
     expect(headers.get('x-twilio-signature')).toBe('signed');
     expect(headers.get('authorization')).toBeTruthy();
     expect(headers.get('x-forwarded-host')).toBe('app.matrix-os.com');
+  });
+
+  it('routes public app-domain Twilio webhooks to a staging VPS handle', async () => {
+    await insertUserMachine(db, {
+      machineId: '0b5d0a5f-52d8-4f4d-aed8-8d2a0ad1a592',
+      clerkUserId: 'user_alice',
+      handle: 'alice-staging',
+      runtimeSlot: 'staging',
+      status: 'running',
+      hetznerServerId: 123457,
+      publicIPv4: '203.0.113.11',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+      provisionedAt: '2026-04-26T12:00:00.000Z',
+    });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      platformSecret: 'platform-secret',
+    });
+
+    const res = await app.request('/voice/webhook/twilio?handle=alice-staging', {
+      method: 'POST',
+      headers: {
+        host: 'app.matrix-os.com',
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-twilio-signature': 'signed',
+      },
+      body: 'CallSid=CA123',
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://203.0.113.11:443/voice/webhook/twilio?handle=alice-staging',
+    );
   });
 
   it('falls back to the legacy container route when no running VPS exists', async () => {

--- a/tests/platform/profile-routing-vps.test.ts
+++ b/tests/platform/profile-routing-vps.test.ts
@@ -45,6 +45,7 @@ describe('platform/profile-routing-vps', () => {
   let db: PlatformDB;
 
   beforeEach(async () => {
+    delete process.env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS;
     ({ db } = await createTestPlatformDb());
     await insertContainer(db, {
       handle: 'alice',
@@ -164,6 +165,41 @@ describe('platform/profile-routing-vps', () => {
     expect(headers.get('x-twilio-signature')).toBe('signed');
     expect(headers.get('authorization')).toBeTruthy();
     expect(headers.get('x-forwarded-host')).toBe('app.matrix-os.com');
+  });
+
+  it('keeps public Twilio webhooks reachable when paid-beta entitlement blocks user runtime access', async () => {
+    process.env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS = 'expired';
+    await insertUserMachine(db, {
+      machineId: '0b5d0a5f-52d8-4f4d-aed8-8d2a0ad1a593',
+      clerkUserId: 'user_alice',
+      handle: 'alice',
+      status: 'running',
+      hetznerServerId: 123458,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+      provisionedAt: '2026-04-26T12:00:00.000Z',
+    });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      platformSecret: 'platform-secret',
+    });
+
+    const res = await app.request('/voice/webhook/twilio?handle=alice', {
+      method: 'POST',
+      headers: {
+        host: 'app.matrix-os.com',
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-twilio-signature': 'signed',
+      },
+      body: 'CallSid=CA123',
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://203.0.113.10:443/voice/webhook/twilio?handle=alice',
+    );
   });
 
   it('routes public app-domain Twilio webhooks to a staging VPS handle', async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -460,6 +460,55 @@ describe("platform proxy routing", () => {
     expect(fetchMock.mock.calls[0]?.[1]?.dispatcher).toBeDefined();
   });
 
+  it("routes Clerk sessions to the selected staging VPS slot", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff124",
+      clerkUserId: "user_alice",
+      handle: "alice-staging",
+      runtimeSlot: "staging",
+      status: "running",
+      hetznerServerId: 123468,
+      publicIPv4: "203.0.113.22",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("editor", { status: 200 }),
+    );
+    const docker = stubDocker();
+    const app = createApp({
+      db,
+      docker,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?runtime=staging", {
+      headers: {
+        host: "code.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("editor");
+    expect(docker.getContainer).not.toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://203.0.113.22:443/?runtime=staging");
+    expect(init?.dispatcher).toBeDefined();
+    const headers = init?.headers as Headers;
+    expect(headers.get("host")).toBe("code.matrix-os.com");
+    expect(headers.get("authorization")).toBeTruthy();
+    expect(headers.get("authorization")).not.toBe("Bearer clerk-session");
+    expect(headers.get("x-platform-user-id")).toBe("user_alice");
+    expect(res.headers.get("set-cookie")).toContain("matrix_code_session=");
+  });
+
   it("falls back to the legacy container code-server when no running VPS exists", async () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -238,6 +238,45 @@ describe("platform proxy routing", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("blocks provisioning boot pages when paid-beta entitlement denies runtime access", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "machine-alice-provisioning-expired",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      hetznerServerId: 123,
+      publicIPv4: "203.0.113.11",
+      status: "provisioning",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "expired" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(402);
+    expect(res.headers.get("cache-control")).toBe("no-store, private");
+    expect(res.headers.get("set-cookie")).toBeNull();
+    expect(await res.json()).toEqual({ error: "Paid beta access required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("routes sync JWT bearer requests through app.matrix-os.com to the matching container", async () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -277,6 +316,17 @@ describe("platform proxy routing", () => {
       handle: "alice",
       hetznerServerId: 125,
       publicIPv4: "203.0.113.13",
+      status: "running",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    await insertUserMachine(db, {
+      machineId: "machine-alice-mobile-app-staging",
+      clerkUserId: "user_alice",
+      handle: "alice-staging",
+      runtimeSlot: "staging",
+      hetznerServerId: 126,
+      publicIPv4: "203.0.113.14",
       status: "running",
       imageVersion: "matrix-os-host-dev",
       provisionedAt: "2026-05-06T00:00:00.000Z",
@@ -465,9 +515,20 @@ describe("platform proxy routing", () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     await deleteContainer(db, "alice");
     await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff123",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123467,
+      publicIPv4: "203.0.113.21",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T11:00:00.000Z",
+    });
+    await insertUserMachine(db, {
       machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff124",
       clerkUserId: "user_alice",
-      handle: "alice-staging",
+      handle: "alice",
       runtimeSlot: "staging",
       status: "running",
       hetznerServerId: 123468,
@@ -567,9 +628,20 @@ describe("platform proxy routing", () => {
   it("persists the selected runtime slot while a staging VPS is booting", async () => {
     await deleteContainer(db, "alice");
     await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff129",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123470,
+      publicIPv4: "203.0.113.23",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T11:00:00.000Z",
+    });
+    await insertUserMachine(db, {
       machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff125",
       clerkUserId: "user_alice",
-      handle: "alice-staging",
+      handle: "alice",
       runtimeSlot: "staging",
       status: "provisioning",
       hetznerServerId: 123469,
@@ -577,6 +649,9 @@ describe("platform proxy routing", () => {
       imageVersion: "matrix-os-host-2026.04.26-1",
       provisionedAt: "2026-04-26T12:00:00.000Z",
     });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("primary", { status: 200 }),
+    );
     const app = createApp({
       db,
       orchestrator: stubOrchestrator(),
@@ -595,6 +670,7 @@ describe("platform proxy routing", () => {
 
     expect(res.status).toBe(503);
     expect(res.headers.get("set-cookie")).toContain("matrix_runtime_slot=staging");
+    expect(fetchMock).not.toHaveBeenCalled();
 
     const followUp = await app.request("/", {
       headers: {
@@ -606,6 +682,7 @@ describe("platform proxy routing", () => {
 
     expect(followUp.status).toBe(503);
     expect(followUp.headers.get("set-cookie")).toContain("matrix_runtime_slot=staging");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("falls back to primary when a stale staging runtime cookie has no machine", async () => {
@@ -643,6 +720,90 @@ describe("platform proxy routing", () => {
     expect(res.status).toBe(200);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.24:443/?view=home");
     expect(res.headers.get("set-cookie")).toContain("matrix_runtime_slot=primary");
+  });
+
+  it("does not use handle fallback across different Clerk users", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff131",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "staging",
+      status: "provisioning",
+      hetznerServerId: 123475,
+      publicIPv4: null,
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff130",
+      clerkUserId: "user_bob",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123474,
+      publicIPv4: "203.0.113.30",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T11:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong owner", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?runtime=staging", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        cookie: "matrix_runtime_slot=staging",
+      },
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.text()).toContain("Booting Matrix OS");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.headers.get("set-cookie") ?? "").not.toContain("matrix_runtime_slot=primary");
+  });
+
+  it("strips runtime with URLSearchParams while preserving encoded values", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff129",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123473,
+      publicIPv4: "203.0.113.29",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("shell", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?%72untime=staging&next=a%23b&view=home", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.29:443/?next=a%23b&view=home");
   });
 
   it("blocks runtime proxying when paid-beta entitlement denies access", async () => {
@@ -683,6 +844,33 @@ describe("platform proxy routing", () => {
       handle: "alice",
       clerkUserId: "user_alice",
     });
+  });
+
+  it("blocks legacy container proxying when paid-beta entitlement denies access", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("editor", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "expired" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "code.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "Paid beta access required" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("falls back to the legacy container code-server when no running VPS exists", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -74,6 +74,7 @@ describe("platform proxy routing", () => {
     await destroyTestPlatformDb(db);
     vi.restoreAllMocks();
     delete process.env.PLATFORM_JWT_SECRET;
+    delete process.env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS;
   });
 
   it("adds a timeout and a derived platform verification token on app-domain proxy fetches", async () => {
@@ -567,6 +568,46 @@ describe("platform proxy routing", () => {
 
     expect(followUp.status).toBe(503);
     expect(followUp.headers.get("set-cookie")).toContain("matrix_runtime_slot=staging");
+  });
+
+  it("blocks runtime proxying when paid-beta entitlement denies access", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff126",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123470,
+      publicIPv4: "203.0.113.23",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("editor", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "missing" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "code.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "Paid beta access required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await getContainer(db, "alice")).toMatchObject({
+      handle: "alice",
+      clerkUserId: "user_alice",
+    });
   });
 
   it("falls back to the legacy container code-server when no running VPS exists", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1070,6 +1070,35 @@ describe("platform proxy routing", () => {
     expect(headers.get("cookie")).toBeNull();
   });
 
+  it("allows operator /proxy/:handle access to a running VPS when user entitlement denies access", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff128",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123472,
+      publicIPv4: "203.0.113.28",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "expired" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/proxy/alice/api/ping", {
+      headers: { authorization: "Bearer platform-secret-123" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.28:443/api/ping");
+  });
+
   it("rejects invalid /proxy/:handle values before DNS interpolation", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("ok", { status: 200 }),

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -526,6 +526,44 @@ describe("platform proxy routing", () => {
     );
   });
 
+  it("routes staging-only Clerk users to their active VPS on unqualified requests", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff136",
+      clerkUserId: "user_alice",
+      handle: "alice-staging",
+      runtimeSlot: "staging",
+      status: "running",
+      hetznerServerId: 123480,
+      publicIPv4: "203.0.113.31",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("shell", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("shell");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.31:443/");
+    expect(res.headers.get("set-cookie")).toContain("matrix_runtime_slot=staging");
+  });
+
   it("persists the selected runtime slot while a staging VPS is booting", async () => {
     await deleteContainer(db, "alice");
     await insertUserMachine(db, {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -347,7 +347,7 @@ describe("platform proxy routing", () => {
       imageVersion: "matrix-os-host-2026.04.26-1",
       provisionedAt: "2026-04-26T12:00:00.000Z",
     });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response("editor", { status: 200 }),
     );
     const docker = stubDocker();
@@ -397,7 +397,7 @@ describe("platform proxy routing", () => {
       imageVersion: "matrix-os-host-2026.04.26-1",
       provisionedAt: "2026-04-26T12:00:00.000Z",
     });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response("editor", { status: 200 }),
     );
     const app = createApp({
@@ -474,7 +474,7 @@ describe("platform proxy routing", () => {
       imageVersion: "matrix-os-host-2026.04.26-1",
       provisionedAt: "2026-04-26T12:00:00.000Z",
     });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response("editor", { status: 200 }),
     );
     const docker = stubDocker();
@@ -506,7 +506,67 @@ describe("platform proxy routing", () => {
     expect(headers.get("authorization")).toBeTruthy();
     expect(headers.get("authorization")).not.toBe("Bearer clerk-session");
     expect(headers.get("x-platform-user-id")).toBe("user_alice");
-    expect(res.headers.get("set-cookie")).toContain("matrix_code_session=");
+    const sessionCookie = res.headers.get("set-cookie");
+    expect(sessionCookie).toContain("matrix_code_session=");
+
+    const codeSession = /matrix_code_session=([^;,]+)/.exec(sessionCookie ?? "")?.[1];
+    expect(codeSession).toBeTruthy();
+
+    const followUp = await app.request("/stable/static/out/vs/code/browser/workbench/workbench.js", {
+      headers: {
+        host: "code.matrix-os.com",
+        cookie: `matrix_code_session=${codeSession}`,
+      },
+    });
+
+    expect(followUp.status).toBe(200);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://203.0.113.22:443/stable/static/out/vs/code/browser/workbench/workbench.js",
+    );
+  });
+
+  it("persists the selected runtime slot while a staging VPS is booting", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff125",
+      clerkUserId: "user_alice",
+      handle: "alice-staging",
+      runtimeSlot: "staging",
+      status: "provisioning",
+      hetznerServerId: 123469,
+      publicIPv4: null,
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?runtime=staging", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("set-cookie")).toContain("matrix_runtime_slot=staging");
+
+    const followUp = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        cookie: "matrix_runtime_slot=staging",
+      },
+    });
+
+    expect(followUp.status).toBe(503);
+    expect(followUp.headers.get("set-cookie")).toContain("matrix_runtime_slot=staging");
   });
 
   it("falls back to the legacy container code-server when no running VPS exists", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -489,7 +489,7 @@ describe("platform proxy routing", () => {
       platformSecret: "platform-secret-123",
     });
 
-    const res = await app.request("/?runtime=staging", {
+    const res = await app.request("/?runtime=staging&folder=/home/matrixos/home", {
       headers: {
         host: "code.matrix-os.com",
         authorization: "Bearer clerk-session",
@@ -500,7 +500,7 @@ describe("platform proxy routing", () => {
     expect(await res.text()).toBe("editor");
     expect(docker.getContainer).not.toHaveBeenCalled();
     const [url, init] = fetchMock.mock.calls[0]!;
-    expect(url).toBe("https://203.0.113.22:443/?runtime=staging");
+    expect(url).toBe("https://203.0.113.22:443/?folder=/home/matrixos/home");
     expect(init?.dispatcher).toBeDefined();
     const headers = init?.headers as Headers;
     expect(headers.get("host")).toBe("code.matrix-os.com");
@@ -568,6 +568,43 @@ describe("platform proxy routing", () => {
 
     expect(followUp.status).toBe(503);
     expect(followUp.headers.get("set-cookie")).toContain("matrix_runtime_slot=staging");
+  });
+
+  it("falls back to primary when a stale staging runtime cookie has no machine", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff127",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123471,
+      publicIPv4: "203.0.113.24",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("shell", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?runtime=staging&view=home", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        cookie: "matrix_runtime_slot=staging",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.24:443/?view=home");
+    expect(res.headers.get("set-cookie")).toContain("matrix_runtime_slot=primary");
   });
 
   it("blocks runtime proxying when paid-beta entitlement denies access", async () => {

--- a/tests/platform/sync-jwt.test.ts
+++ b/tests/platform/sync-jwt.test.ts
@@ -66,6 +66,22 @@ describe("sync-jwt: issuance", () => {
     expect(issued.claims.exp - issued.claims.iat).toBe(oneDay);
     expect(issued.expiresAt).toBe((1_700_000_000 + oneDay) * 1000);
   });
+
+  it("can carry the selected runtime slot for same-handle VPS sessions", async () => {
+    const issued = await issueSyncJwt({
+      secret: SECRET,
+      clerkUserId: "user_abc",
+      handle: "alice",
+      gatewayUrl: "https://code.matrix-os.com",
+      runtimeSlot: "staging",
+      now: 1_700_000_000,
+    });
+
+    expect(issued.claims.runtime_slot).toBe("staging");
+    await expect(verifySyncJwt(issued.token, { secret: SECRET, now: 1_700_000_000 })).resolves.toMatchObject({
+      runtime_slot: "staging",
+    });
+  });
 });
 
 describe("sync-jwt: verification", () => {

--- a/tests/platform/ws-upgrade.test.ts
+++ b/tests/platform/ws-upgrade.test.ts
@@ -28,6 +28,7 @@ describe("isSafeWebSocketUpgradePath", () => {
   it("strips the websocket query token before proxying upstream", () => {
     expect(stripWebSocketUpgradeToken("/ws?token=abc123&cwd=projects")).toBe("/ws?cwd=projects");
     expect(stripWebSocketUpgradeToken("/ws/terminal?token=abc123")).toBe("/ws/terminal");
+    expect(stripWebSocketUpgradeToken("/ws?runtime=staging&token=abc123&cwd=projects")).toBe("/ws?cwd=projects");
   });
 
   it("prefers x-forwarded-host for websocket host resolution", () => {


### PR DESCRIPTION
Stack: 7/8

## Summary

- Adds platform operator launch readiness aggregation for release-critical paid beta gates.
- Adds the authenticated `/api/operator/launch-readiness` route.
- Adds entitlement gate behavior that blocks paid-only access without deleting owner data.

## Tests

- `bun run typecheck`
- `bun run check:patterns` (0 violations, existing warning-only baseline)
- `bun run test -- --reporter=dot` (459 files passed, 3 skipped; 4,752 tests passed, 20 skipped)
- `bun run test -- tests/platform/launch-readiness.test.ts tests/platform/launch-entitlement.test.ts tests/platform/profile-routing-vps.test.ts tests/platform/profile-routing.test.ts` (4 files, 29 tests)
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bWF0cml4b3MudGVzdCQ= pnpm --dir shell build`
- `pnpm --dir shell exec playwright test ../tests/e2e/onboarding-activation.spec.ts ../tests/e2e/onboarding-visual.spec.ts --config ../tests/e2e/playwright.config.ts` (8 passed)

## Review/Monitoring

- Stacked PR base: `082-company-brain-support-growth`
- Greptile and CI must pass before merging.

## Invariants

- Source of truth: platform launch readiness is the operator source of truth for paid-beta enablement.
- Lock/transaction scope: launch readiness reads platform DB/evidence state and does not perform writes.
- Acceptable orphan states: missing beta release, missing workspace rehearsal, missing QA evidence, or missing entitlement evidence fails closed.
- Auth source of truth: operator route is protected by the platform bearer token with constant-time comparison.
- Deferred scope: Clerk billing collection and payment processing remain deferred.