### PR TITLE
fix(symphony): address agent readiness review

### DIFF
--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -266,7 +266,7 @@ export default function App() {
   const grouped = useMemo(() => groupRuns(runs), [runs]);
   const selectedAgent = config?.installation?.defaultAgent ?? form.defaultAgent;
   const selectedAgentStatus = agents.find((agent) => agent.id === selectedAgent);
-  const agentAuthIssue = selectedAgentStatus && (
+  const agentAuthIssue = config?.installation && selectedAgentStatus && (
     !selectedAgentStatus.installed ||
     selectedAgentStatus.authState === "required" ||
     selectedAgentStatus.authState === "error"

--- a/packages/gateway/src/symphony/orchestrator.ts
+++ b/packages/gateway/src/symphony/orchestrator.ts
@@ -228,6 +228,7 @@ export function createMatrixSymphonyOrchestrator(options: {
     rule: TicketSourceRule,
     ticket: TrackedTicket,
     existing?: SymphonyRun | null,
+    readinessFailure?: { code: string; message: string } | null,
   ): Promise<SymphonyRun> {
     const id = runIdFor(ownerId, ticket);
     const active = existing ?? await options.repository.findActiveRunByClaim(ownerId, claimKey(ticket));
@@ -253,7 +254,6 @@ export function createMatrixSymphonyOrchestrator(options: {
     };
     if (!active) await options.repository.upsertRun(ownerId, run);
     try {
-      const readinessFailure = await agentReadinessFailure(installation.defaultAgent);
       if (readinessFailure) {
         const updated = await options.repository.updateRun(ownerId, run.id, {
           status: "blocked",
@@ -393,13 +393,16 @@ export function createMatrixSymphonyOrchestrator(options: {
       ? activeRuns.length
       : activeRuns.filter((run) => eligibleClaimKeys.has(run.claimKey)).length;
     const capacity = Math.max(0, (snapshot.installation.maxConcurrentAgents ?? DEFAULT_MAX_CONCURRENT_AGENTS) - countedRunning - blockedLiveRuns.length);
+    const readinessFailure = capacity > 0 && eligibleTickets.length > 0
+      ? await agentReadinessFailure(installation.defaultAgent)
+      : null;
     let dispatched = 0;
     for (const ticket of eligibleTickets) {
       if (dispatched >= capacity) break;
       const existing = await options.repository.findActiveRunByClaim(ownerId, claimKey(ticket));
       if (existing && isRetryBackoffActive(existing)) continue;
       if (existing && existing.status !== "queued" && existing.status !== "retrying") continue;
-      const run = await dispatchTicket(ownerId, installation, rule, ticket, existing);
+      const run = await dispatchTicket(ownerId, installation, rule, ticket, existing, readinessFailure);
       if (run.status === "running" || run.status === "queued" || run.status === "retrying") dispatched += 1;
     }
     const at = nowIso();

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -247,6 +247,43 @@ describe("Symphony app", () => {
     expect(screen.getByText("Agent authentication required")).toBeTruthy();
   });
 
+  it("does not show an agent auth notice before Symphony is configured", async () => {
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url === "/api/agents") {
+        return json({
+          agents: [
+            { id: "codex", command: "codex", displayName: "Codex", installed: true, authState: "required", errorCode: "agent_auth_required" },
+          ],
+        });
+      }
+      if (url === "/api/symphony/status") {
+        return json({
+          running: false,
+          installationId: null,
+          credentialConfigured: false,
+          pollIntervalMs: null,
+          maxConcurrentAgents: null,
+          counts: { queued: 0, running: 0, needsAttention: 0, handoff: 0 },
+          lastPollAt: null,
+        });
+      }
+      if (url === "/api/symphony/config") {
+        return json({ installation: null, rule: null });
+      }
+      if (url === "/api/symphony/runs") {
+        return json({ runs: [] });
+      }
+      return json({ ok: true });
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(calls.some((call) => call.url === "/api/agents")).toBe(true));
+    expect(screen.queryByText("Codex needs authentication in this Matrix runtime.")).toBeNull();
+  });
+
   it("saves a server-side Linear secret and non-secret rule set", async () => {
     render(<App />);
     await waitFor(() => expect(screen.getByText("Build Symphony")).toBeTruthy());

--- a/tests/gateway/agent-launcher.test.ts
+++ b/tests/gateway/agent-launcher.test.ts
@@ -50,7 +50,7 @@ describe("agent-launcher", () => {
 
     await launcher.detectAgents();
 
-    expect(runCommand).toHaveBeenCalledWith("codex", ["auth", "status"], expect.objectContaining({
+    expect(runCommand).toHaveBeenCalledWith("codex", ["login", "status"], expect.objectContaining({
       cwd: "/home/matrix/home",
       env: expect.objectContaining({
         HOME: "/home/matrix/home",

--- a/tests/gateway/symphony-orchestrator.test.ts
+++ b/tests/gateway/symphony-orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -178,6 +178,46 @@ describe("Matrix Symphony orchestrator", () => {
       lastErrorCode: "agent_auth_required",
       lastEvent: "Agent authentication required",
     });
+  });
+
+  it("reuses one agent readiness check across all tickets in a poll", async () => {
+    const snapshot = structuredClone(baseSnapshot);
+    snapshot.installation = { ...snapshot.installation!, maxConcurrentAgents: 3 };
+    const repository = memoryRepo(snapshot);
+    const worktreeManager = {
+      createWorktree: vi.fn(async () => ({ ok: true as const, status: 201 as const, worktree: { id: `wt_${randomUUID()}`, path: "/repo/wt", projectSlug: "matrix-os" } })),
+    };
+    const agentSessionManager = {
+      startSession: vi.fn(async () => ({ ok: true as const, status: 201 as const, session: { id: `sess_${randomUUID()}`, runtime: { status: "running" } } })),
+      killSession: vi.fn(),
+    };
+    const detectAgents = vi.fn(async () => ({
+      agents: [{ id: "codex" as const, installed: true, authState: "ok" as const, errorCode: null }],
+    }));
+    const orchestrator = createMatrixSymphonyOrchestrator({
+      homePath,
+      repository,
+      credentialStore: { readLinearCredential: vi.fn(async () => "lin_api_secret"), hasLinearCredential: vi.fn(), writeLinearCredential: vi.fn(), deleteLinearCredential: vi.fn() },
+      linearSource: {
+        previewTickets: vi.fn(async () => ({
+          truncated: false,
+          tickets: [
+            { externalId: "issue_1", identifier: "MAT-1", title: "One", stateName: "Todo", assigneeId: "assignee_1", labels: ["symphony"] },
+            { externalId: "issue_2", identifier: "MAT-2", title: "Two", stateName: "Todo", assigneeId: "assignee_1", labels: ["symphony"] },
+            { externalId: "issue_3", identifier: "MAT-3", title: "Three", stateName: "Todo", assigneeId: "assignee_1", labels: ["symphony"] },
+          ],
+        })),
+      },
+      worktreeManager,
+      agentSessionManager,
+      agentStatusProvider: { detectAgents },
+    });
+
+    await orchestrator.poll("user_123");
+
+    expect(detectAgents).toHaveBeenCalledTimes(1);
+    expect(worktreeManager.createWorktree).toHaveBeenCalledTimes(3);
+    expect(agentSessionManager.startSession).toHaveBeenCalledTimes(3);
   });
 
   it("scopes generated run IDs by Matrix owner for shared Linear tickets", async () => {


### PR DESCRIPTION
What’s fixed there:

  - Greptile issue 1: detectAgents() is now called once per poll, not once per dispatched ticket.
  - Greptile issue 2: the Symphony auth banner no longer appears before Symphony is configured.
  - CI failure from merged main: fixed stale agent-launcher.test.ts expectation from codex auth status to codex login status.

  Validation:

  - bun run test tests/gateway/symphony-orchestrator.test.ts tests/default-apps/symphony-app.test.tsx passed.
  - bun run test tests/gateway/agent-launcher.test.ts passed.
  - bun run test -- --shard=3/4 passed locally: 112 files passed, 1 skipped.
  - bun run typecheck passed.
  - bun run check:patterns passed with 0 violations.

  Live CI on merged PR #159:

  - Docker Tests: passed.
  - Host Bundle Release: passed.
  - CI: failed only on Unit Tests (3/4) due the stale agent-launcher test fixed in the follow-up branch.
