### PR TITLE
fix(platform): harden customer VPS onboarding

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -683,15 +683,21 @@ runcmd:
     install -d -o matrix -g matrix -m 0755 /home/matrix/home/.config /home/matrix/home/.config/systemd /home/matrix/home/.config/systemd/user
     install -d -o matrix -g matrix -m 0700 /home/matrix/home/.config/gh
     if [ -d /home/matrix/.config/gh ] && [ ! -L /home/matrix/.config/gh ]; then
-      cp -an /home/matrix/.config/gh/. /home/matrix/home/.config/gh/ || true
-      rm -rf /home/matrix/.config/gh
+      if cp -an /home/matrix/.config/gh/. /home/matrix/home/.config/gh/; then
+        rm -rf /home/matrix/.config/gh
+      else
+        echo "matrix-host: failed to migrate .config/gh; skipping removal" >&2
+      fi
     fi
     ln -sfn /home/matrix/home/.config/gh /home/matrix/.config/gh
     chown -h matrix:matrix /home/matrix/.config/gh
     install -d -o matrix -g matrix -m 0700 /home/matrix/home/.ssh
     if [ -d /home/matrix/.ssh ] && [ ! -L /home/matrix/.ssh ]; then
-      cp -an /home/matrix/.ssh/. /home/matrix/home/.ssh/ || true
-      rm -rf /home/matrix/.ssh
+      if cp -an /home/matrix/.ssh/. /home/matrix/home/.ssh/; then
+        rm -rf /home/matrix/.ssh
+      else
+        echo "matrix-host: failed to migrate .ssh; skipping removal" >&2
+      fi
     fi
     ln -sfn /home/matrix/home/.ssh /home/matrix/.ssh
     chown -h matrix:matrix /home/matrix/.ssh

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -519,8 +519,8 @@ write_files:
         exit 1
       fi
 
-      matrixctl r2 put "$snapshot_path" "$snapshot_key"
-      matrixctl r2 put-latest "$snapshot_key"
+      /opt/matrix/bin/matrixctl r2 put "$snapshot_path" "$snapshot_key"
+      /opt/matrix/bin/matrixctl r2 put-latest "$snapshot_key"
   - path: /opt/matrix/bin/matrix-restore.sh
     owner: root:root
     permissions: "0750"
@@ -539,17 +539,17 @@ write_files:
       mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
       rm -f "$restore_flag"
 
-      if ! matrixctl r2 exists system/vps-meta.json; then
+      if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then
         touch "$restore_flag"
         exit 0
       fi
 
-      if ! matrixctl r2 exists system/db/latest; then
+      if ! /opt/matrix/bin/matrixctl r2 exists system/db/latest; then
         touch "$restore_flag"
         exit 0
       fi
 
-      if ! matrixctl r2 get system/db/latest "$latest_file"; then
+      if ! /opt/matrix/bin/matrixctl r2 get system/db/latest "$latest_file"; then
         echo "matrix-restore: failed to fetch latest pointer" >&2
         exit 1
       fi
@@ -563,7 +563,7 @@ write_files:
           ;;
       esac
 
-      if ! matrixctl r2 get "$latest_key" "$snapshot_path"; then
+      if ! /opt/matrix/bin/matrixctl r2 get "$latest_key" "$snapshot_path"; then
         echo "matrix-restore: failed to fetch snapshot" >&2
         exit 1
       fi
@@ -617,7 +617,7 @@ write_files:
       MATRIX_CLERK_USER_ID={{clerkUserId}}
       MATRIX_HANDLE={{handle}}
       MATRIX_IMAGE_VERSION={{imageVersion}}
-      MATRIX_UPDATE_CHANNEL={{imageVersion}}
+      MATRIX_UPDATE_CHANNEL={{updateChannel}}
       MATRIX_PLATFORM_REGISTER_URL={{platformRegisterUrl}}
       PLATFORM_INTERNAL_URL={{platformInternalUrl}}
       UPGRADE_TOKEN={{platformVerificationToken}}
@@ -674,12 +674,27 @@ runcmd:
     install -d -o root -g matrix -m 0750 /opt/matrix/env /opt/matrix/bin /opt/matrix/tls
     install -d -o matrix -g matrix -m 0755 /opt/matrix/messaging /opt/matrix/messaging/bin
     install -d -o matrix -g matrix -m 0755 /home/matrix /home/matrix/.local /home/matrix/.cache /home/matrix/.config
-    install -d -o matrix -g matrix -m 0755 /home/matrix/.config/systemd /home/matrix/home/.config/systemd/user
+    install -d -o matrix -g matrix -m 0755 /home/matrix/.config/systemd
     install -d -o root -g root -m 0750 /etc/sudoers.d
     printf 'matrix ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/matrix
     chmod 0440 /etc/sudoers.d/matrix
     visudo -cf /etc/sudoers.d/matrix
     install -d -o matrix -g matrix -m 0750 /home/matrix/home /home/matrix/projects /var/lib/matrix/db/snapshots /var/lib/matrix/logs
+    install -d -o matrix -g matrix -m 0755 /home/matrix/home/.config /home/matrix/home/.config/systemd /home/matrix/home/.config/systemd/user
+    install -d -o matrix -g matrix -m 0700 /home/matrix/home/.config/gh
+    if [ -d /home/matrix/.config/gh ] && [ ! -L /home/matrix/.config/gh ]; then
+      cp -an /home/matrix/.config/gh/. /home/matrix/home/.config/gh/ || true
+      rm -rf /home/matrix/.config/gh
+    fi
+    ln -sfn /home/matrix/home/.config/gh /home/matrix/.config/gh
+    chown -h matrix:matrix /home/matrix/.config/gh
+    install -d -o matrix -g matrix -m 0700 /home/matrix/home/.ssh
+    if [ -d /home/matrix/.ssh ] && [ ! -L /home/matrix/.ssh ]; then
+      cp -an /home/matrix/.ssh/. /home/matrix/home/.ssh/ || true
+      rm -rf /home/matrix/.ssh
+    fi
+    ln -sfn /home/matrix/home/.ssh /home/matrix/.ssh
+    chown -h matrix:matrix /home/matrix/.ssh
     ln -sfn /home/matrix/home/.config/systemd/user /home/matrix/.config/systemd/user
     chown -h matrix:matrix /home/matrix/.config/systemd/user
     install -d -o root -g root -m 0755 /home/matrixos
@@ -695,6 +710,9 @@ runcmd:
     [ "$expected" = "$actual" ] || { echo "matrix-host: bundle sha256 mismatch" >&2; exit 1; }
     tar -xzf /tmp/matrix-host.tgz -C /opt/matrix
     chown -R root:matrix /opt/matrix/bin /opt/matrix/app /opt/matrix/runtime
+    chmod -R g+rwX /opt/matrix/app
+    printf '%s\n' "$MATRIX_IMAGE_VERSION" >/opt/matrix/app/BUNDLE_VERSION
+    chown matrix:matrix /opt/matrix/app/BUNDLE_VERSION
     if [ -d /opt/matrix/systemd ]; then
       install -d -o root -g root -m 0755 /etc/systemd/system
       install -o root -g root -m 0644 /opt/matrix/systemd/*.service /etc/systemd/system/
@@ -703,7 +721,14 @@ runcmd:
       chown root:matrix /opt/matrix/release.json
       chmod 0644 /opt/matrix/release.json
     fi
-    chmod 0750 /opt/matrix/bin/matrixctl /opt/matrix/bin/matrix-db-backup.sh /opt/matrix/bin/matrix-restore.sh /opt/matrix/bin/matrix-gateway /opt/matrix/bin/matrix-shell /opt/matrix/bin/matrix-code /opt/matrix/bin/matrix-sync-agent /opt/matrix/bin/matrix-install-hermes /opt/matrix/bin/matrix-install-linux-tools /opt/matrix/bin/matrix-messaging-health /opt/matrix/bin/matrix-messaging-backup /opt/matrix/bin/matrix-messaging-restore
+    for required_bin in matrixctl matrix-db-backup.sh matrix-restore.sh matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-install-hermes; do
+      chmod 0750 "/opt/matrix/bin/${required_bin}"
+    done
+    for optional_bin in matrix-install-linux-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do
+      if [ -e "/opt/matrix/bin/${optional_bin}" ]; then
+        chmod 0750 "/opt/matrix/bin/${optional_bin}"
+      fi
+    done
     for cli in node npm npx claude codex opencode pi code-server uv uvx; do
       if [ -x "/opt/matrix/runtime/node/bin/${cli}" ]; then
         ln -sf "/opt/matrix/runtime/node/bin/${cli}" "/usr/local/bin/${cli}"

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -725,8 +725,19 @@ runcmd:
     tar -xzf /tmp/matrix-host.tgz -C /opt/matrix
     chown -R root:matrix /opt/matrix/bin /opt/matrix/app /opt/matrix/runtime
     chmod -R g+rwX /opt/matrix/app
-    printf '%s\n' "$MATRIX_IMAGE_VERSION" >/opt/matrix/app/BUNDLE_VERSION
-    chown matrix:matrix /opt/matrix/app/BUNDLE_VERSION
+    if [ -f /opt/matrix/release.json ]; then
+      bundle_version="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]\+\)".*/\1/p' /opt/matrix/release.json | head -n 1)"
+      if [ -n "$bundle_version" ]; then
+        printf '%s\n' "$bundle_version" >/opt/matrix/app/BUNDLE_VERSION
+        chown matrix:matrix /opt/matrix/app/BUNDLE_VERSION
+      else
+        echo "matrix-host: release metadata has no version; leaving BUNDLE_VERSION unchanged" >&2
+      fi
+    elif [ -f /opt/matrix/app/BUNDLE_VERSION ]; then
+      chown matrix:matrix /opt/matrix/app/BUNDLE_VERSION
+    else
+      echo "matrix-host: release metadata missing; leaving BUNDLE_VERSION absent" >&2
+    fi
     if [ -d /opt/matrix/systemd ]; then
       install -d -o root -g root -m 0755 /etc/systemd/system
       install -o root -g root -m 0644 /opt/matrix/systemd/*.service /etc/systemd/system/

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -689,8 +689,12 @@ runcmd:
         echo "matrix-host: failed to migrate .config/gh; skipping removal" >&2
       fi
     fi
-    ln -sfn /home/matrix/home/.config/gh /home/matrix/.config/gh
-    chown -h matrix:matrix /home/matrix/.config/gh
+    if [ ! -e /home/matrix/.config/gh ] || [ -L /home/matrix/.config/gh ]; then
+      ln -sfn /home/matrix/home/.config/gh /home/matrix/.config/gh
+      chown -h matrix:matrix /home/matrix/.config/gh
+    else
+      echo "matrix-host: .config/gh remains a real directory; skipping symlink" >&2
+    fi
     install -d -o matrix -g matrix -m 0700 /home/matrix/home/.ssh
     if [ -d /home/matrix/.ssh ] && [ ! -L /home/matrix/.ssh ]; then
       if cp -an /home/matrix/.ssh/. /home/matrix/home/.ssh/; then
@@ -699,8 +703,12 @@ runcmd:
         echo "matrix-host: failed to migrate .ssh; skipping removal" >&2
       fi
     fi
-    ln -sfn /home/matrix/home/.ssh /home/matrix/.ssh
-    chown -h matrix:matrix /home/matrix/.ssh
+    if [ ! -e /home/matrix/.ssh ] || [ -L /home/matrix/.ssh ]; then
+      ln -sfn /home/matrix/home/.ssh /home/matrix/.ssh
+      chown -h matrix:matrix /home/matrix/.ssh
+    else
+      echo "matrix-host: .ssh remains a real directory; skipping symlink" >&2
+    fi
     ln -sfn /home/matrix/home/.config/systemd/user /home/matrix/.config/systemd/user
     chown -h matrix:matrix /home/matrix/.config/systemd/user
     install -d -o root -g root -m 0755 /home/matrixos

--- a/distro/customer-vps/host-bin/matrix-install-linux-tools
+++ b/distro/customer-vps/host-bin/matrix-install-linux-tools
@@ -29,6 +29,8 @@ if command -v apt-get >/dev/null 2>&1; then
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential procps curl file git
 fi
 
+cd "${HOME:-/home/matrix}"
+
 if [ ! -x "$BREW_BIN" ]; then
   tmp_installer="$(mktemp)"
   trap 'rm -f "${tmp_installer:-}"' EXIT
@@ -44,9 +46,16 @@ if ! "$BREW_BIN" list --versions graphite >/dev/null 2>&1; then
   retry 3 30 timeout 600 "$BREW_BIN" install withgraphite/tap/graphite
 fi
 
+if ! "$BREW_BIN" list --versions gh >/dev/null 2>&1; then
+  retry 3 30 timeout 600 "$BREW_BIN" install gh
+fi
+
 sudo install -d -o root -g root -m 0755 /etc/profile.d
 printf '%s\n' \
   '# Homebrew on Linux' \
+  'if [ -n "${PWD:-}" ] && [ ! -r "${PWD}" ]; then' \
+  '  cd "${HOME:-/home/matrix}" || true' \
+  'fi' \
   "eval \"\$(${BREW_BIN} shellenv bash)\"" \
   | sudo tee /etc/profile.d/homebrew.sh >/dev/null
 sudo chmod 0644 /etc/profile.d/homebrew.sh
@@ -55,6 +64,10 @@ sudo ln -sf "$BREW_BIN" /usr/local/bin/brew
 if [ -x "$BREW_PREFIX/bin/gt" ]; then
   sudo ln -sf "$BREW_PREFIX/bin/gt" /usr/local/bin/gt
 fi
+if [ -x "$BREW_PREFIX/bin/gh" ]; then
+  sudo ln -sf "$BREW_PREFIX/bin/gh" /usr/local/bin/gh
+fi
 
 "$BREW_BIN" --version
 "$BREW_PREFIX/bin/gt" --version
+"$BREW_PREFIX/bin/gh" --version

--- a/distro/customer-vps/host-bin/matrix-install-linux-tools
+++ b/distro/customer-vps/host-bin/matrix-install-linux-tools
@@ -69,5 +69,9 @@ if [ -x "$BREW_PREFIX/bin/gh" ]; then
 fi
 
 "$BREW_BIN" --version
-"$BREW_PREFIX/bin/gt" --version
-"$BREW_PREFIX/bin/gh" --version
+if [ -x "$BREW_PREFIX/bin/gt" ]; then
+  "$BREW_PREFIX/bin/gt" --version
+fi
+if [ -x "$BREW_PREFIX/bin/gh" ]; then
+  "$BREW_PREFIX/bin/gh" --version
+fi

--- a/packages/platform/src/customer-vps-cloud-init.ts
+++ b/packages/platform/src/customer-vps-cloud-init.ts
@@ -6,6 +6,7 @@ export interface CustomerHostConfig {
   clerkUserId: string;
   handle: string;
   imageVersion: string;
+  updateChannel: string;
   hostBundleUrl: string;
   platformRegisterUrl: string;
   platformInternalUrl: string;

--- a/packages/platform/src/customer-vps-config.ts
+++ b/packages/platform/src/customer-vps-config.ts
@@ -6,6 +6,7 @@ export interface CustomerVpsConfig {
   sshKeyName?: string;
   imageVersion: string;
   hostBundleUrl: string;
+  hostBundleUrlOverride?: boolean;
   platformRegisterUrl: string;
   platformSecret: string;
   r2AccessKeyId: string;
@@ -40,6 +41,7 @@ export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): Cus
     hostBundleUrl:
       env.MATRIX_HOST_BUNDLE_URL ??
       `${bundleBaseUrl}/system-bundles/${encodeURIComponent(imageVersion)}/matrix-host-bundle.tar.gz`,
+    hostBundleUrlOverride: Boolean(env.MATRIX_HOST_BUNDLE_URL),
     platformRegisterUrl: `${platformUrl.replace(/\/$/, '')}/vps/register`,
     platformSecret: env.PLATFORM_SECRET ?? '',
     r2AccessKeyId: env.S3_ACCESS_KEY_ID ?? env.R2_ACCESS_KEY_ID ?? '',

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -245,6 +245,10 @@ async function resolveHostBundleRef(db: PlatformDB, config: CustomerVpsConfig): 
 
   const release = await getHostBundleReleaseByChannel(db, config.imageVersion);
   if (!release) {
+    logCustomerVpsError(
+      `host bundle channel missing release channel=${config.imageVersion}`,
+      new Error('falling back to configured host bundle URL without immutable version pin'),
+    );
     return { imageVersion: config.imageVersion, hostBundleUrl: config.hostBundleUrl };
   }
 
@@ -375,6 +379,12 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const machineId = machineIdFactory();
       const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
       const postgresPassword = postgresPasswordFactory();
+
+      const existingBeforeBundleResolve = await getActiveUserMachineByClerkId(deps.db, input.clerkUserId);
+      if (existingBeforeBundleResolve) {
+        return activeProvisionResponse(existingBeforeBundleResolve, deps.config.provisionEtaSeconds);
+      }
+
       const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
       const hostConfig = buildHostConfig(
         deps.config,
@@ -551,18 +561,18 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const machineId = machineIdFactory();
       const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
       const postgresPassword = postgresPasswordFactory();
-      const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
-      const hostConfig = buildHostConfig(
-        deps.config,
-        { clerkUserId: existing.clerkUserId, handle: existing.handle },
-        machineId,
-        registration.token,
-        postgresPassword,
-        bundleRef,
-      );
 
       let newServerId: number | null = null;
       try {
+        const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
+        const hostConfig = buildHostConfig(
+          deps.config,
+          { clerkUserId: existing.clerkUserId, handle: existing.handle },
+          machineId,
+          registration.token,
+          postgresPassword,
+          bundleRef,
+        );
         const userData = renderCloudInitTemplate(
           deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
           hostConfig,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -547,6 +547,19 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       if (!input.allowEmpty && !(await deps.systemStore.hasDbLatest(input.clerkUserId))) {
         throw new CustomerVpsError(409, 'invalid_state', 'No backup snapshot available');
       }
+      const currentTime = now();
+      const machineId = machineIdFactory();
+      const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
+      const postgresPassword = postgresPasswordFactory();
+      const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
+      const hostConfig = buildHostConfig(
+        deps.config,
+        { clerkUserId: active.clerkUserId, handle: active.handle },
+        machineId,
+        registration.token,
+        postgresPassword,
+        bundleRef,
+      );
       const existing = await claimUserMachineRecovery(deps.db, input.clerkUserId);
       if (!existing) {
         const latest = await getActiveUserMachineByClerkId(deps.db, input.clerkUserId);
@@ -557,22 +570,9 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       }
       const oldMachineId = existing.machineId;
       const oldServerId = active.hetznerServerId;
-      const currentTime = now();
-      const machineId = machineIdFactory();
-      const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
-      const postgresPassword = postgresPasswordFactory();
 
       let newServerId: number | null = null;
       try {
-        const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
-        const hostConfig = buildHostConfig(
-          deps.config,
-          { clerkUserId: existing.clerkUserId, handle: existing.handle },
-          machineId,
-          registration.token,
-          postgresPassword,
-          bundleRef,
-        );
         const userData = renderCloudInitTemplate(
           deps.cloudInitTemplate ?? DEFAULT_CLOUD_INIT_TEMPLATE,
           hostConfig,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -233,6 +233,8 @@ function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: s
   if (config.hostBundleUrl.includes(currentSegment)) {
     return config.hostBundleUrl.replaceAll(currentSegment, pinnedSegment);
   }
+  // Defensive fallback for future URL-template changes. The current generated
+  // URL always contains the encoded image-version segment above.
   const url = new URL(config.hostBundleUrl);
   url.pathname = `/system-bundles/${encodeURIComponent(imageVersion)}/matrix-host-bundle.tar.gz`;
   return url.toString();
@@ -551,6 +553,8 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const machineId = machineIdFactory();
       const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
       const postgresPassword = postgresPasswordFactory();
+      // Resolve before claiming recovery so bundle lookup failures do not clear
+      // the old provider server id and leave a billable VPS untracked.
       const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
       const hostConfig = buildHostConfig(
         deps.config,

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -231,7 +231,7 @@ function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: s
   const currentSegment = `/system-bundles/${encodeURIComponent(config.imageVersion)}/`;
   const pinnedSegment = `/system-bundles/${encodeURIComponent(imageVersion)}/`;
   if (config.hostBundleUrl.includes(currentSegment)) {
-    return config.hostBundleUrl.replace(currentSegment, pinnedSegment);
+    return config.hostBundleUrl.replaceAll(currentSegment, pinnedSegment);
   }
   const url = new URL(config.hostBundleUrl);
   url.pathname = `/system-bundles/${encodeURIComponent(imageVersion)}/matrix-host-bundle.tar.gz`;

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -5,6 +5,7 @@ import {
   claimUserMachineRecovery,
   completeUserMachineRegistration,
   getActiveUserMachineByClerkId,
+  getHostBundleReleaseByChannel,
   getUserMachine,
   insertUserMachine,
   insertProviderDeletion,
@@ -127,6 +128,7 @@ const DEFAULT_CLOUD_INIT_TEMPLATE = [
   '      MATRIX_CLERK_USER_ID={{clerkUserId}}',
   '      MATRIX_HANDLE={{handle}}',
   '      MATRIX_IMAGE_VERSION={{imageVersion}}',
+  '      MATRIX_UPDATE_CHANNEL={{updateChannel}}',
   '      MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}',
   '      MATRIX_PLATFORM_REGISTER_URL={{platformRegisterUrl}}',
   '      PLATFORM_INTERNAL_URL={{platformInternalUrl}}',
@@ -195,13 +197,15 @@ function buildHostConfig(
   machineId: string,
   registrationToken: string,
   postgresPassword: string,
+  bundleRef: HostBundleRef,
 ): CustomerHostConfig {
   return {
     machineId,
     clerkUserId: input.clerkUserId,
     handle: input.handle,
-    imageVersion: config.imageVersion,
-    hostBundleUrl: config.hostBundleUrl,
+    imageVersion: bundleRef.imageVersion,
+    updateChannel: config.imageVersion,
+    hostBundleUrl: bundleRef.hostBundleUrl,
     platformRegisterUrl: config.platformRegisterUrl,
     platformInternalUrl: new URL(config.platformRegisterUrl).origin,
     platformVerificationToken: buildPlatformVerificationToken(input.handle, config.platformSecret),
@@ -213,6 +217,40 @@ function buildHostConfig(
     r2Bucket: config.r2Bucket,
     r2Prefix: `${config.r2PrefixRoot}/${input.clerkUserId}/` as `matrixos-sync/${string}/`,
     postgresPassword,
+  };
+}
+
+const HOST_BUNDLE_CHANNELS = new Set(['stable', 'canary', 'beta', 'dev']);
+
+interface HostBundleRef {
+  imageVersion: string;
+  hostBundleUrl: string;
+}
+
+function hostBundleUrlForImageVersion(config: CustomerVpsConfig, imageVersion: string): string {
+  const currentSegment = `/system-bundles/${encodeURIComponent(config.imageVersion)}/`;
+  const pinnedSegment = `/system-bundles/${encodeURIComponent(imageVersion)}/`;
+  if (config.hostBundleUrl.includes(currentSegment)) {
+    return config.hostBundleUrl.replace(currentSegment, pinnedSegment);
+  }
+  const url = new URL(config.hostBundleUrl);
+  url.pathname = `/system-bundles/${encodeURIComponent(imageVersion)}/matrix-host-bundle.tar.gz`;
+  return url.toString();
+}
+
+async function resolveHostBundleRef(db: PlatformDB, config: CustomerVpsConfig): Promise<HostBundleRef> {
+  if (config.hostBundleUrlOverride || !HOST_BUNDLE_CHANNELS.has(config.imageVersion)) {
+    return { imageVersion: config.imageVersion, hostBundleUrl: config.hostBundleUrl };
+  }
+
+  const release = await getHostBundleReleaseByChannel(db, config.imageVersion);
+  if (!release) {
+    return { imageVersion: config.imageVersion, hostBundleUrl: config.hostBundleUrl };
+  }
+
+  return {
+    imageVersion: release.version,
+    hostBundleUrl: hostBundleUrlForImageVersion(config, release.version),
   };
 }
 
@@ -337,12 +375,14 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const machineId = machineIdFactory();
       const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
       const postgresPassword = postgresPasswordFactory();
+      const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
       const hostConfig = buildHostConfig(
         deps.config,
         input,
         machineId,
         registration.token,
         postgresPassword,
+        bundleRef,
       );
 
       const provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
@@ -355,7 +395,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           clerkUserId: input.clerkUserId,
           handle: input.handle,
           status: 'provisioning',
-          imageVersion: deps.config.imageVersion,
+          imageVersion: bundleRef.imageVersion,
           registrationTokenHash: registration.hash,
           registrationTokenExpiresAt: registration.expiresAt,
           provisionedAt: currentTime.toISOString(),
@@ -511,12 +551,14 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const machineId = machineIdFactory();
       const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
       const postgresPassword = postgresPasswordFactory();
+      const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
       const hostConfig = buildHostConfig(
         deps.config,
         { clerkUserId: existing.clerkUserId, handle: existing.handle },
         machineId,
         registration.token,
         postgresPassword,
+        bundleRef,
       );
 
       let newServerId: number | null = null;
@@ -542,7 +584,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             hetznerServerId: server.id,
             publicIPv4: server.publicIPv4,
             publicIPv6: server.publicIPv6,
-            imageVersion: deps.config.imageVersion,
+            imageVersion: bundleRef.imageVersion,
             registrationTokenHash: registration.hash,
             registrationTokenExpiresAt: registration.expiresAt,
             provisionedAt: currentTime.toISOString(),

--- a/specs/066-file-sync/deployment-plan.md
+++ b/specs/066-file-sync/deployment-plan.md
@@ -17,7 +17,7 @@ Incremental rollout of the three-way file sync system (Phase 9 OAuth + Phase 10 
                         |
                    matrix-os.com
                    app.matrix-os.com
-                   <handle>.matrix-os.com   (legacy; still routed)
+                   code.matrix-os.com
                         |
                         v
              +-------------------------+
@@ -416,7 +416,7 @@ Once PRs 1–3 are shipped, the next highest-value work lives in `specs/066-file
 ### Architecture-level
 
 - **PR 4 — Signup from CLI** (above).
-- **Clerk cookie cross-subdomain config** (referenced as TODO in `main.ts:290-306`). Unblocks the previously-disabled `<handle>.matrix-os.com` auth check. Only needed if the handle-subdomain routing is kept alive for backwards compat; can be deleted if not.
+- **Shared router session hardening**. Keep CLI, shell, and code access on `app.matrix-os.com` / `code.matrix-os.com`; do not reintroduce username subdomain routing.
 - **Gateway HA**. Currently one container = one gateway = one daemon. A restart drops WS connections. Moving to a per-user queue (NATS, Redis Streams) between home-mirror and the WS fan-out decouples availability from daemon liveness.
 
 ---

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -15,6 +15,7 @@ describe('platform/customer-vps-cloud-init', () => {
     clerkUserId: 'user_123',
     handle: 'alice',
     imageVersion: 'stable',
+    updateChannel: 'stable',
     hostBundleUrl: 'https://platform.example/system-bundles/stable/matrix-host-bundle.tar.gz',
     platformRegisterUrl: 'https://platform.example/vps/register',
     platformInternalUrl: 'https://platform.example',
@@ -51,6 +52,7 @@ describe('platform/customer-vps-cloud-init', () => {
       'MATRIX_HOST_BUNDLE_URL=https://platform.example/system-bundles/stable/matrix-host-bundle.tar.gz',
     );
     expect(rendered).toContain('MATRIX_UPDATE_CHANNEL=stable');
+    expect(rendered).toContain('MATRIX_IMAGE_VERSION=stable');
     expect(rendered).not.toContain('MATRIX_HOST_BUNDLE_URL=\n');
   });
 
@@ -116,9 +118,10 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then');
     expect(cloudInit).toContain('systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service');
     expect(cloudInit).toContain('messaging runtimes not installed; units installed but not enabled');
-    expect(cloudInit).toContain('matrix-messaging-health /opt/matrix/bin/matrix-messaging-backup /opt/matrix/bin/matrix-messaging-restore');
+    expect(cloudInit).toContain('for optional_bin in matrix-install-linux-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do');
     expect(cloudInit).toContain('MATRIX_HOST_BUNDLE_URL={{hostBundleUrl}}');
-    expect(cloudInit).toContain('MATRIX_UPDATE_CHANNEL={{imageVersion}}');
+    expect(cloudInit).toContain('MATRIX_IMAGE_VERSION={{imageVersion}}');
+    expect(cloudInit).toContain('MATRIX_UPDATE_CHANNEL={{updateChannel}}');
     expect(cloudInit).toContain('UPGRADE_TOKEN={{platformVerificationToken}}');
     expect(cloudInit).toContain('MATRIX_CODE_PROXY_TOKEN={{platformVerificationToken}}');
     expect(cloudInit).toContain('PLATFORM_INTERNAL_URL={{platformInternalUrl}}');
@@ -181,6 +184,11 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(buildScript).toContain('/opt/matrix/runtime/code-server/bin/code-server "$@"');
     expect(cloudInit).toContain('path: /etc/profile.d/matrix-runtime.sh');
     expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0755 /home/matrix /home/matrix/.local /home/matrix/.cache /home/matrix/.config');
+    expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0755 /home/matrix/home/.config /home/matrix/home/.config/systemd /home/matrix/home/.config/systemd/user');
+    expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0700 /home/matrix/home/.config/gh');
+    expect(cloudInit).toContain('ln -sfn /home/matrix/home/.config/gh /home/matrix/.config/gh');
+    expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0700 /home/matrix/home/.ssh');
+    expect(cloudInit).toContain('ln -sfn /home/matrix/home/.ssh /home/matrix/.ssh');
     expect(cloudInit).toContain('ln -sfn /home/matrix/home /home/matrixos/home');
     expect(cloudInit).toContain('DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential ca-certificates curl docker.io file git postgresql-client procps nginx openssl sudo unzip');
     expect(cloudInit).toContain('for cli in node npm npx claude codex opencode pi code-server uv uvx; do');
@@ -197,6 +205,8 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(gateway).toContain('MATRIX_SKILL_TARGETS=matrix,claude,codex');
     expect(cloudInit).toContain('DATABASE_URL=postgresql://matrix:{{postgresPassword}}@127.0.0.1:5432/matrix');
     expect(cloudInit).not.toContain('owner: root:matrix');
+    expect(cloudInit).toContain("printf '%s\\n' \"$MATRIX_IMAGE_VERSION\" >/opt/matrix/app/BUNDLE_VERSION");
+    expect(cloudInit).toContain('chmod -R g+rwX /opt/matrix/app');
   });
 
   it('grants the customer matrix user passwordless sudo for host installers', () => {
@@ -214,18 +224,22 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('ln -sfn /home/matrix/home/.config/systemd/user /home/matrix/.config/systemd/user');
   });
 
-  it('installs Homebrew and Graphite CLI on customer Linux hosts', () => {
+  it('installs Homebrew, Graphite CLI, and GitHub CLI on customer Linux hosts', () => {
     const root = process.cwd();
     const installer = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-linux-tools'), 'utf8');
     const bundleScript = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
 
     expect(installer).toContain('https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh');
     expect(installer).toContain('retry 2 30 env NONINTERACTIVE=1 timeout 600 /bin/bash "$tmp_installer"');
+    expect(installer).toContain('cd "${HOME:-/home/matrix}"');
     expect(installer).toContain('retry 3 30 timeout 600 "$BREW_BIN" install withgraphite/tap/graphite');
+    expect(installer).toContain('retry 3 30 timeout 600 "$BREW_BIN" install gh');
     expect(installer).toContain('/etc/profile.d/homebrew.sh');
+    expect(installer).toContain('if [ -n "${PWD:-}" ] && [ ! -r "${PWD}" ]; then');
     expect(installer).toContain('"eval \\"\\$(${BREW_BIN} shellenv bash)\\""');
     expect(installer).toContain('sudo ln -sf "$BREW_BIN" /usr/local/bin/brew');
     expect(installer).toContain('sudo ln -sf "$BREW_PREFIX/bin/gt" /usr/local/bin/gt');
+    expect(installer).toContain('sudo ln -sf "$BREW_PREFIX/bin/gh" /usr/local/bin/gh');
     expect(bundleScript).toContain('matrix-install-linux-tools');
   });
 

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -205,7 +205,9 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(gateway).toContain('MATRIX_SKILL_TARGETS=matrix,claude,codex');
     expect(cloudInit).toContain('DATABASE_URL=postgresql://matrix:{{postgresPassword}}@127.0.0.1:5432/matrix');
     expect(cloudInit).not.toContain('owner: root:matrix');
-    expect(cloudInit).toContain("printf '%s\\n' \"$MATRIX_IMAGE_VERSION\" >/opt/matrix/app/BUNDLE_VERSION");
+    expect(cloudInit).not.toContain("printf '%s\\n' \"$MATRIX_IMAGE_VERSION\" >/opt/matrix/app/BUNDLE_VERSION");
+    expect(cloudInit).toContain('bundle_version="$(sed -n');
+    expect(cloudInit).toContain("printf '%s\\n' \"$bundle_version\" >/opt/matrix/app/BUNDLE_VERSION");
     expect(cloudInit).toContain('chmod -R g+rwX /opt/matrix/app');
   });
 

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -7,7 +7,9 @@ import {
   getActiveUserMachineByClerkId,
   getUserMachine,
   listPendingProviderDeletions,
+  promoteHostBundleChannel,
   updateUserMachine,
+  upsertHostBundleRelease,
   type PlatformDB,
 } from '../../packages/platform/src/db.js';
 import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
@@ -75,6 +77,36 @@ describe('platform/customer-vps', () => {
     const row = await getActiveUserMachineByClerkId(db, 'user_123');
     expect(row?.hetznerServerId).toBe(123456);
     expect(row?.registrationTokenHash).toBe(hashRegistrationToken('registration-token'));
+  });
+
+  it('pins channel image versions to the current immutable host bundle release at provision time', async () => {
+    await upsertHostBundleRelease(db, {
+      version: 'v2026.05.25-80',
+      channel: 'stable',
+      gitCommit: 'adb12c560b8e6253fd0047eb2375b379e7659cbe',
+      gitRef: 'main',
+      buildTime: '2026-05-25T11:58:42.274Z',
+      bundleKey: 'system-bundles/v2026.05.25-80/matrix-host-bundle.tar.gz',
+      checksumKey: 'system-bundles/v2026.05.25-80/matrix-host-bundle.tar.gz.sha256',
+      sha256: 'a'.repeat(64),
+      size: 1_257_725_742,
+      severity: 'normal',
+      updateType: 'manual',
+      changelog: 'Release latest main host bundle',
+      createdAt: '2026-05-25T12:14:58.275Z',
+    });
+    await promoteHostBundleChannel(db, 'stable', 'v2026.05.25-80');
+    const { service, hetzner } = createService();
+
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    expect((await getUserMachine(db, provisioned.machineId))?.imageVersion).toBe('v2026.05.25-80');
+    const createInput = vi.mocked(hetzner.createServer).mock.calls[0]?.[0];
+    expect(createInput?.userData).toContain(
+      'MATRIX_HOST_BUNDLE_URL=http://localhost:9000/system-bundles/v2026.05.25-80/matrix-host-bundle.tar.gz',
+    );
+    expect(createInput?.userData).toContain('MATRIX_IMAGE_VERSION=v2026.05.25-80');
+    expect(createInput?.userData).toContain('MATRIX_UPDATE_CHANNEL=stable');
   });
 
   it('templates the platform verification token into provisioned customer hosts', async () => {

--- a/www/content/docs/guide/cloud-coding.mdx
+++ b/www/content/docs/guide/cloud-coding.mdx
@@ -16,6 +16,24 @@ matrixos project add github.com/owner/repo
 
 Project import validates repository URLs, stages clones safely, and creates a durable project record before worktrees, sessions, or reviews attach to it.
 
+## Installing tools
+
+Your Matrix VPS is your own Linux machine. The `matrix` user has passwordless `sudo`, so you can install operating-system packages directly:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y jq ripgrep
+```
+
+Developer CLIs that are not available from Ubuntu's default package repositories are installed with Homebrew on Linux:
+
+```bash
+brew install gh
+brew install withgraphite/tap/graphite
+```
+
+Baseline developer tools such as Git, Homebrew, Graphite CLI, and GitHub CLI are installed automatically on new Matrix VPSes.
+
 ## Data ownership
 
 Your workspace data belongs to you. Source repositories live under `~/projects`, session records live under `~/system/sessions`, transcripts live under `~/system/session-output`, and review state lives under `~/system/reviews`.

--- a/www/content/docs/guide/cloud-coding.mdx
+++ b/www/content/docs/guide/cloud-coding.mdx
@@ -28,8 +28,8 @@ sudo apt-get install -y jq ripgrep
 Developer CLIs that are not available from Ubuntu's default package repositories are installed with Homebrew on Linux:
 
 ```bash
-brew install gh
-brew install withgraphite/tap/graphite
+brew install yq
+brew install charmbracelet/tap/glow
 ```
 
 Baseline developer tools such as Git, Homebrew, Graphite CLI, and GitHub CLI are installed automatically on new Matrix VPSes.


### PR DESCRIPTION
## Summary

- pin channel-based customer VPS provisioning to the resolved immutable host-bundle release while preserving the update channel
- harden cloud-init so optional bundle scripts do not abort old bundles, app files remain group-writable, and owner-home `.config`/`.ssh` paths are correctly owned and linked
- install GitHub CLI with the baseline Linux developer tools and document how users install packages with `sudo apt-get` or Homebrew

## Tests

- `bun run typecheck`
- `bun run check:patterns`
- `pnpm exec vitest run tests/platform/customer-vps.test.ts tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts`

`bun run test` was started, but the runner stopped producing output after Vitest started and no matching Vitest process remained visible; I stopped the stale runner and kept the completed gates above.

## Invariants

- Source of truth: platform DB release/channel metadata remains canonical for resolving channel provisioning; each VPS records the immutable installed `imageVersion` while retaining `MATRIX_UPDATE_CHANNEL` for future updates.
- Lock/transaction scope: machine rows are still inserted or updated inside the existing platform transaction; external Hetzner provisioning stays outside the DB critical section.
- Acceptable orphan states: if a VPS is created but registration fails, the existing recovery/reconciliation flow still uses the registration token and machine row state; cloud-init no longer aborts just because optional tools are missing from an older bundle.
- Auth source of truth: GitHub auth remains user-owned under the Matrix home; `/home/matrix/.config/gh` and `/home/matrix/.ssh` point at the owner home so `gh`, `ssh`, and `git` see the same credentials.
- Deferred scope: this does not change release promotion policy, GitHub org permissions, or SSO authorization requirements for external private org repositories.
