### PR TITLE
fix(gateway): check agent auth in Matrix home

### DIFF
--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -183,7 +183,7 @@ export function createWorkspaceRoutes(options: {
   const app = new Hono();
   const projectManager = options.projectManager ?? createProjectManager({ homePath: options.homePath });
   const worktreeManager = options.worktreeManager ?? createWorktreeManager({ homePath: options.homePath });
-  const agentLauncher = options.agentLauncher ?? createAgentLauncher({ cwd: options.homePath });
+  const agentLauncher = options.agentLauncher ?? createAgentLauncher({ cwd: options.homePath, runtimeHome: options.homePath });
   const zellijRuntime = options.zellijRuntime ?? createZellijRuntime({ homePath: options.homePath });
   const agentSessionManager = options.agentSessionManager ?? createAgentSessionManager({
     homePath: options.homePath,

--- a/tests/gateway/workspace-routes.test.ts
+++ b/tests/gateway/workspace-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdir, mkdtemp, stat } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -348,6 +348,53 @@ describe("workspace API routes", () => {
       available: true,
       enforced: true,
     });
+  });
+
+  it("checks default agent auth with the Matrix home", async () => {
+    const binPath = join(homePath, "bin");
+    await mkdir(binPath, { recursive: true });
+    const script = `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "--version" ]; then
+  printf '%s 1.0.0\\n' "$(basename "$0")"
+  exit 0
+fi
+if [ "\${1:-}" = "login" ] && [ "\${2:-}" = "status" ]; then
+  [ "\${HOME:-}" = "\${EXPECTED_MATRIX_HOME:-}" ]
+  exit $?
+fi
+if [ "\${1:-}" = "auth" ] && [ "\${2:-}" = "status" ]; then
+  exit 0
+fi
+exit 1
+`;
+    for (const command of ["claude", "codex", "opencode", "pi"]) {
+      const commandPath = join(binPath, command);
+      await writeFile(commandPath, script);
+      await chmod(commandPath, 0o755);
+    }
+    const originalPath = process.env.PATH;
+    const originalExpectedHome = process.env.EXPECTED_MATRIX_HOME;
+    process.env.PATH = `${binPath}:${originalPath ?? ""}`;
+    process.env.EXPECTED_MATRIX_HOME = homePath;
+    try {
+      const app = createWorkspaceRoutes({ homePath });
+
+      const res = await app.request("/api/agents");
+      const body = await res.json() as { agents: Array<{ id: string; authState: string; errorCode: string | null }> };
+
+      expect(body.agents.find((agent) => agent.id === "codex")).toMatchObject({
+        authState: "ok",
+        errorCode: null,
+      });
+    } finally {
+      process.env.PATH = originalPath;
+      if (originalExpectedHome === undefined) {
+        delete process.env.EXPECTED_MATRIX_HOME;
+      } else {
+        process.env.EXPECTED_MATRIX_HOME = originalExpectedHome;
+      }
+    }
   });
 
   it("routes review start, status, next, approve, and stop through review records", async () => {

--- a/tests/gateway/workspace-routes.test.ts
+++ b/tests/gateway/workspace-routes.test.ts
@@ -388,7 +388,11 @@ exit 1
         errorCode: null,
       });
     } finally {
-      process.env.PATH = originalPath;
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
       if (originalExpectedHome === undefined) {
         delete process.env.EXPECTED_MATRIX_HOME;
       } else {


### PR DESCRIPTION
## Summary
- make the default workspace /api/agents route check CLI auth with the Matrix home as HOME/MATRIX_HOME
- add a regression test that catches the Symphony banner mismatch where Codex auth works in the Matrix terminal but /api/agents reports auth_required

## Tests
- pnpm exec vitest run tests/gateway/workspace-routes.test.ts --testNamePattern "checks default agent auth"
- pnpm exec vitest run tests/gateway/workspace-routes.test.ts tests/default-apps/symphony-app.test.tsx tests/gateway/agent-launcher.test.ts