### PR TITLE
fix(gateway): expose bundled zellij to customer VPS shell sessions

### DIFF
--- a/distro/customer-vps/host-bin/matrix-gateway
+++ b/distro/customer-vps/host-bin/matrix-gateway
@@ -27,7 +27,7 @@ export PORT="$GATEWAY_PORT"
 export GATEWAY_URL="${GATEWAY_URL:-http://127.0.0.1:${GATEWAY_PORT}}"
 export NEXT_PUBLIC_GATEWAY_URL="${NEXT_PUBLIC_GATEWAY_URL:-http://127.0.0.1:${GATEWAY_PORT}}"
 export NEXT_PUBLIC_GATEWAY_WS="${NEXT_PUBLIC_GATEWAY_WS:-wss://code.matrix-os.com/ws}"
-export PATH="/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+export PATH="/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
 
 sync_bundled_home_assets() {
   local bundled_home="$APP_DIR/home"

--- a/packages/gateway/src/shell/errors.ts
+++ b/packages/gateway/src/shell/errors.ts
@@ -2,6 +2,7 @@ export interface ShellSafeError extends Error {
   code: string;
   safeMessage: string;
   status?: number;
+  diagnostic?: unknown;
 }
 
 export function shellError(

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -280,9 +280,45 @@ function safeError(c: Context, err: unknown) {
     );
   }
   const shellErr = toShellError(err);
-  console.warn("[shell] route failed:", err instanceof Error ? err.message : String(err));
+  if (shellErr.diagnostic) {
+    console.warn("[shell] route failed:", {
+      code: shellErr.code,
+      diagnostic: shellErr.diagnostic,
+      ...describeErrorForLog(shellErr),
+    });
+  } else {
+    console.warn("[shell] route failed:", err instanceof Error ? err.message : String(err));
+  }
   return c.json(
     { error: { code: shellErr.code, message: shellErr.safeMessage } },
     (shellErr.status ?? 500) as 500,
   );
+}
+
+function describeErrorForLog(err: unknown) {
+  if (!(err instanceof Error)) {
+    return { message: String(err) };
+  }
+  const context: {
+    message: string;
+    cause?: string | { message: string; code?: string | number; signal?: string };
+  } = { message: err.message };
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    const causeContext: { message: string; code?: string | number; signal?: string } = {
+      message: cause.message,
+    };
+    const code = (cause as NodeJS.ErrnoException).code;
+    const signal = (cause as { signal?: unknown }).signal;
+    if (typeof code === "string" || typeof code === "number") {
+      causeContext.code = code;
+    }
+    if (typeof signal === "string") {
+      causeContext.signal = signal;
+    }
+    context.cause = causeContext;
+  } else if (cause !== undefined) {
+    context.cause = String(cause);
+  }
+  return context;
 }

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -8,6 +8,15 @@ import { shellError, type ShellSafeError } from "./errors.js";
 type ExecFile = typeof nodeExecFile;
 type Spawn = typeof nodeSpawn;
 
+export interface ZellijFailureDiagnostic {
+  binary: "zellij";
+  kind: "binary_not_found" | "timeout" | "process_failed";
+  stderr?: string;
+  errorCode?: string;
+  exitCode?: number;
+  signal?: string;
+}
+
 export interface ZellijAdapterDeps {
   execFile?: ExecFile;
   spawn?: Spawn;
@@ -48,6 +57,37 @@ export function sanitizeZellijError(stderr: string): string {
     .trim();
 }
 
+export function classifyZellijFailure(err: unknown, stderr: string): ZellijFailureDiagnostic {
+  const safeStderr = sanitizeZellijError(stderr);
+  const diagnostic: ZellijFailureDiagnostic = {
+    binary: "zellij",
+    kind: "process_failed",
+  };
+
+  if (err instanceof Error) {
+    const code = (err as NodeJS.ErrnoException & { code?: string | number | null }).code;
+    const signal = (err as { signal?: unknown }).signal;
+    const killed = (err as { killed?: unknown }).killed === true;
+    if (code === "ENOENT") {
+      diagnostic.kind = "binary_not_found";
+    } else if (code === "ETIMEDOUT" || (code == null && killed && signal === "SIGTERM")) {
+      diagnostic.kind = "timeout";
+    }
+    if (typeof code === "number") {
+      diagnostic.exitCode = code;
+    } else if (typeof code === "string") {
+      diagnostic.errorCode = code;
+    }
+    if (typeof signal === "string") {
+      diagnostic.signal = signal;
+    }
+  }
+  if (safeStderr) {
+    diagnostic.stderr = safeStderr;
+  }
+  return diagnostic;
+}
+
 export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter {
   const execFile = deps.execFile ?? nodeExecFile;
   const spawn = deps.spawn ?? nodeSpawn;
@@ -67,6 +107,8 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
             (safe as ShellSafeError & { stderr?: string }).stderr = sanitizeZellijError(
               typeof stderr === "string" ? stderr : String(stderr ?? ""),
             );
+            (safe as ShellSafeError & { diagnostic?: ZellijFailureDiagnostic }).diagnostic =
+              classifyZellijFailure(err, typeof stderr === "string" ? stderr : String(stderr ?? ""));
             reject(safe);
             return;
           }

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import {
+  classifyZellijFailure,
   createZellijAdapter,
   sanitizeZellijError,
 } from "../../packages/gateway/src/shell/zellij.js";
@@ -41,6 +42,61 @@ describe("zellij adapter", () => {
     await expect(adapter.createSession({ name: "main" })).rejects.toMatchObject({
       code: "zellij_failed",
       safeMessage: "Shell operation failed",
+    });
+  });
+
+  it("classifies a missing zellij binary for server diagnostics", async () => {
+    const missing = Object.assign(new Error("spawn zellij ENOENT"), {
+      code: "ENOENT",
+      syscall: "spawn zellij",
+    });
+    const execFile = vi.fn((_file, _args, _opts, cb) => {
+      cb(missing, "", "");
+      return childProcess();
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.createSession({ name: "main" })).rejects.toMatchObject({
+      code: "zellij_failed",
+      diagnostic: {
+        binary: "zellij",
+        kind: "binary_not_found",
+      },
+    });
+  });
+
+  it("classifies zellij timeouts without exposing stderr", () => {
+    const timedOut = Object.assign(new Error("Command timed out"), {
+      code: null,
+      killed: true,
+      signal: "SIGTERM",
+    });
+
+    expect(classifyZellijFailure(timedOut, "details from /home/alice/project")).toEqual({
+      binary: "zellij",
+      kind: "timeout",
+      signal: "SIGTERM",
+      stderr: "details from [path]",
+    });
+  });
+
+  it("keeps errno strings separate from process exit codes", () => {
+    const missing = Object.assign(new Error("spawn zellij ENOENT"), {
+      code: "ENOENT",
+    });
+    const failed = Object.assign(new Error("zellij exited"), {
+      code: 1,
+    });
+
+    expect(classifyZellijFailure(missing, "")).toEqual({
+      binary: "zellij",
+      errorCode: "ENOENT",
+      kind: "binary_not_found",
+    });
+    expect(classifyZellijFailure(failed, "")).toEqual({
+      binary: "zellij",
+      exitCode: 1,
+      kind: "process_failed",
     });
   });
 

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -193,7 +193,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('systemctl start --no-block matrix-linux-tools.service || echo "matrix-host: optional Linux tools install will retry via systemd" >&2');
     expect(cloudInit).not.toContain('sudo -H -u matrix /opt/matrix/bin/matrix-install-linux-tools');
     expect(cloudInit).toContain('test -x /home/linuxbrew/.linuxbrew/bin/brew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"');
-    expect(gateway).toContain('export PATH="/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
+    expect(gateway).toContain('export PATH="/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
     expect(gateway).toContain('MATRIX_SKILL_TARGETS=matrix,claude,codex');
     expect(cloudInit).toContain('DATABASE_URL=postgresql://matrix:{{postgresPassword}}@127.0.0.1:5432/matrix');
     expect(cloudInit).not.toContain('owner: root:matrix');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -160,6 +160,7 @@ describe('customer VPS host bundle', () => {
     expect(launcher).toContain('curl --fail --silent --show-error --max-time 10');
     expect(launcher).toContain('MATRIX_REGISTRATION_TOKEN');
     expect(launcher).toContain('/opt/matrix/app/node_modules/.bin');
+    expect(launcher).toContain('export PATH="/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
     expect(launcher).toContain('export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}"');
     expect(launcher).toContain('sync_bundled_home_assets');
     expect(launcher).toContain('sync-matrix-agent-skills.sh');


### PR DESCRIPTION
Summary
- Add /opt/matrix/bin to the customer VPS gateway PATH so the bundled zellij binary is discoverable by shell session control paths.
- Classify zellij control-process failures as binary_not_found, timeout, or process_failed for server-side diagnostics while keeping client responses generic.
- Add regression coverage for zellij diagnostics and host bundle gateway PATH wiring.

Tests
- flox activate -- pnpm exec vitest run tests/gateway/shell-zellij.test.ts tests/platform/customer-vps-host-bundle.test.ts tests/platform/customer-vps-cloud-init.test.ts
- flox activate -- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- flox activate -- bun run check:patterns (0 violations; existing broad warnings only)

Review/Monitoring
- After host bundle deployment, monitor matrix-gateway.service logs for [shell] route failed diagnostics. A remaining failure should identify binary_not_found, timeout, or process_failed.
- Greptile monitoring pending after PR creation.

Invariants
- Source of truth: zellij remains the source of truth for live shell sessions; the shell registry keeps Matrix-owned metadata and reconciles against live zellij sessions.
- Lock/transaction scope: ShellRegistry still serializes mutations through its existing mutation queue; no database transaction is introduced.
- Acceptable orphan states: If metadata persistence fails after zellij creation, the existing rollback path still deletes the zellij session with force.
- Auth source of truth: Existing gateway auth middleware and request principal behavior are unchanged.
- Deferred scope: This PR does not publish/deploy the host bundle and does not change npm CLI user-facing error wording.