### PR TITLE
feat(symphony): specify elixir runtime service

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/082-paid-beta-readiness"
+  "feature_directory": "specs/083-elixir-symphony"
 }

--- a/distro/customer-vps/host-bin/matrix-symphony
+++ b/distro/customer-vps/host-bin/matrix-symphony
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /opt/matrix/env/host.env
+if [ -f /opt/matrix/env/registration.env ]; then
+  source /opt/matrix/env/registration.env
+fi
+
+APP_DIR="${MATRIX_APP_DIR:-/opt/matrix/app}"
+SYMPHONY_BIN="${SYMPHONY_BIN:-$APP_DIR/packages/symphony-elixir/bin/symphony}"
+WORKFLOW_FILE="${SYMPHONY_WORKFLOW_FILE:-$APP_DIR/packages/symphony-elixir/WORKFLOW.md}"
+
+export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+export SYMPHONY_HOST="${SYMPHONY_HOST:-127.0.0.1}"
+export SYMPHONY_PORT="${SYMPHONY_PORT:-4766}"
+export SYMPHONY_WORKSPACE_ROOT="${SYMPHONY_WORKSPACE_ROOT:-$MATRIX_HOME/projects/matrix-os/symphony-workspaces}"
+export SYMPHONY_CODEX_COMMAND="${SYMPHONY_CODEX_COMMAND:-codex app-server}"
+export PATH="/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+
+mkdir -p "$SYMPHONY_WORKSPACE_ROOT"
+exec "$SYMPHONY_BIN" "$WORKFLOW_FILE"

--- a/distro/customer-vps/systemd/matrix-symphony.service
+++ b/distro/customer-vps/systemd/matrix-symphony.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Matrix OS customer Symphony
+After=network-online.target matrix-restore.service
+Wants=network-online.target
+Requires=matrix-restore.service
+ConditionPathExists=/opt/matrix/restore-complete
+ConditionPathExists=/opt/matrix/bin/matrix-symphony
+ConditionPathExists=/opt/matrix/app/packages/symphony-elixir/bin/symphony
+
+[Service]
+User=matrix
+Group=matrix
+Environment=MATRIX_HOME=/home/matrix/home
+Environment=SYMPHONY_HOST=127.0.0.1
+Environment=SYMPHONY_PORT=4766
+Environment=SYMPHONY_WORKSPACE_ROOT=/home/matrix/home/projects/matrix-os/symphony-workspaces
+WorkingDirectory=/opt/matrix
+ExecStart=/opt/matrix/bin/matrix-symphony
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=30
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/symphony-elixir/LICENSE
+++ b/packages/symphony-elixir/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/symphony-elixir/NOTICE
+++ b/packages/symphony-elixir/NOTICE
@@ -1,0 +1,6 @@
+Matrix-adapted Elixir Symphony
+Copyright 2026 Matrix OS contributors
+
+This package adapts Symphony runtime concepts for Matrix OS customer VPS
+services. The adapted source is distributed under the Apache License, Version
+2.0, and keeps third-party license boundaries explicit for later vendored code.

--- a/packages/symphony-elixir/NOTICE.md
+++ b/packages/symphony-elixir/NOTICE.md
@@ -1,0 +1,8 @@
+# Matrix OS Symphony Notice
+
+This package adapts the Elixir implementation from upstream Symphony:
+
+- Source: `https://github.com/odysseus0/symphony`
+- License: Apache License, Version 2.0
+
+Preserve upstream license and notices when importing or updating source. Matrix-specific changes should stay documented here or in nearby adapter files so future upstream rebases remain auditable.

--- a/packages/symphony-elixir/README.md
+++ b/packages/symphony-elixir/README.md
@@ -1,0 +1,7 @@
+# Matrix-adapted Elixir Symphony
+
+This package is the Matrix OS adaptation point for the upstream Elixir Symphony runtime from `https://github.com/odysseus0/symphony`.
+
+The runtime is packaged into customer VPS host bundles and started by `matrix-symphony.service` as the `matrix` user with `MATRIX_HOME=/home/matrix/home`. Matrix gateway remains the browser-facing control plane and proxies `/api/symphony/*` to the loopback Elixir API.
+
+The full adapted source is added in the runtime packaging stack. This scaffold pins the package location, service contract, and license boundary so stack layers can stay reviewable.

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -89,7 +89,7 @@ cp -a "$ROOT_DIR/distro/customer-vps/host-bin/." "$STAGE_DIR/bin/"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"
 # The bundle is usually extracted as root:root during in-place upgrades, while
 # the systemd units execute these wrappers as the matrix user.
-chmod 0755 "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
+chmod 0755 "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
 
 cp -a "$ROOT_DIR/node_modules" "$STAGE_DIR/app/node_modules"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"

--- a/specs/083-elixir-symphony/contracts/gateway-symphony-api.md
+++ b/specs/083-elixir-symphony/contracts/gateway-symphony-api.md
@@ -1,0 +1,46 @@
+# Contract: Matrix Gateway Symphony API
+
+All routes are browser-facing Matrix gateway routes. The upstream Elixir service remains loopback-only.
+
+## GET `/api/symphony/state`
+
+Returns normalized Elixir service state.
+
+```json
+{
+  "service": {
+    "status": "ready",
+    "version": "0.1.0-matrix",
+    "workspaceRoot": "/home/matrix/home/projects/matrix-os/symphony-workspaces",
+    "credentialStatus": "connected",
+    "lastHeartbeatAt": "2026-05-25T00:00:00.000Z"
+  },
+  "groups": {
+    "queue": [],
+    "running": [],
+    "needsAttention": [],
+    "done": []
+  }
+}
+```
+
+Errors use coarse codes: `unauthorized`, `forbidden`, `service_unavailable`, `timeout`, `invalid_response`.
+
+## GET `/api/symphony/issues/:issueIdentifier`
+
+Returns detail for one issue/run. `issueIdentifier` must match the gateway-safe issue identifier schema before proxying.
+
+## POST `/api/symphony/refresh`
+
+Triggers an Elixir refresh/poll cycle. Request body must be empty or `{}` and is body-limited before parsing.
+
+## POST `/api/symphony/runs/:runId/stop`
+
+Stops an active run when the Elixir runtime exposes the action. `runId` must match the safe run ID schema. Response returns updated normalized state or detail.
+
+## Proxy Rules
+
+- Only allowlisted upstream route templates may be called.
+- Upstream origin is configured server-side and must be loopback.
+- Every upstream call uses `AbortSignal.timeout(10000)`.
+- Raw upstream errors are logged server-side and mapped to coarse client errors.

--- a/specs/083-elixir-symphony/data-model.md
+++ b/specs/083-elixir-symphony/data-model.md
@@ -1,0 +1,50 @@
+# Data Model: Elixir Symphony Runtime
+
+## SymphonyServiceState
+
+- `status`: `starting | ready | unavailable | degraded`
+- `version`: adapted runtime version
+- `boundOrigin`: loopback origin used by the gateway, never browser-visible as a direct target
+- `matrixHome`: owner home root, expected `/home/matrix/home`
+- `workspaceRoot`: Matrix-managed Symphony workspace root
+- `credentialStatus`: `connected | setup_required | unavailable`
+- `lastHeartbeatAt`: service heartbeat timestamp
+- `runs`: bounded list of `SymphonyRunSummary`
+- `limits`: log/run/event caps applied by the service
+
+## SymphonyRunSummary
+
+- `runId`: Matrix/Elixir stable run identifier
+- `issueIdentifier`: external issue key such as `MAT-32`
+- `issueTitle`: browser-safe title
+- `status`: `queued | running | needs_attention | done | stopped | failed`
+- `sessionId`: Codex app-server session identifier
+- `threadId`: Codex thread identifier
+- `turnCount`: number of observed turns
+- `latestEvent`: coarse status event
+- `workspacePath`: Matrix-owned path under `workspaceRoot`
+- `workpadUrl`: Matrix or Linear workpad URL when available
+- `allowedActions`: action list such as `refresh`, `stop`, `open_workspace`, `open_workpad`
+- `updatedAt`: timestamp
+
+## SymphonyIssueDetail
+
+- Extends `SymphonyRunSummary`
+- `logs`: bounded event/log entries with redacted text
+- `attempts`: retry count
+- `attentionReason`: coarse reason for setup/action required
+- `links`: issue/workspace/workpad links safe for the Matrix app
+
+## CredentialBridgeState
+
+- `provider`: `linear`
+- `status`: `connected | setup_required | unavailable`
+- `source`: `matrix_platform | pipedream | local_fallback`
+- `lastCheckedAt`: timestamp
+- `clientMessage`: generic setup or unavailable text
+
+## LegacyRunnerMigrationState
+
+- `legacyConfigFound`: boolean
+- `migrationAction`: `ignored | migrated_non_secret_config | blocked`
+- `notes`: bounded operator-safe notes

--- a/specs/083-elixir-symphony/plan.md
+++ b/specs/083-elixir-symphony/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Elixir Symphony Runtime
+
+**Branch**: `083-elixir-symphony` | **Date**: 2026-05-25 | **Spec**: `specs/083-elixir-symphony/spec.md`  
+**Input**: Feature specification from `/specs/083-elixir-symphony/spec.md`
+
+## Summary
+
+Replace Matrix's duplicate TypeScript Symphony orchestration path with an adapted Elixir Symphony runtime packaged into the customer VPS host bundle. The Elixir runtime runs as `matrix-symphony.service`, uses Matrix-owned workspace roots and Linear credential bridging, executes agents through `codex app-server`, and exposes loopback HTTP state/control. Matrix gateway proxies `/api/symphony/*` with auth, validation, timeouts, and generic error mapping. The Matrix Symphony app becomes a responsive UI shell over normalized Elixir state.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.5+ strict, Node.js 24+, React 19, Hono gateway, Elixir `~> 1.19` for adapted Symphony runtime  
+**Primary Dependencies**: Existing Matrix gateway/app stack, upstream Elixir Symphony Phoenix/Bandit/Req/Jason runtime, systemd host services, Codex `app-server`  
+**Storage**: Owner-controlled Matrix home files for runtime config and workspaces; Matrix platform/Pipedream integration storage for Linear secrets; no new embedded database  
+**Testing**: Vitest for gateway/app/systemd; Elixir `mix test` for adapted runtime when toolchain is available; host-bundle smoke tests  
+**Target Platform**: Customer VPS Linux host services, Matrix web app, Matrix gateway  
+**Project Type**: Multi-surface runtime: host service + gateway API + Vite app + docs  
+**Performance Goals**: Gateway proxy state/control responses timeout within 10 seconds; browser-visible logs bounded; no duplicate active ticket state between TS and Elixir runtimes  
+**Constraints**: Loopback-only Elixir API; no browser-visible secrets; Matrix auth gates all browser calls; workspaces remain under owner home; Codex execution uses app-server  
+**Scale/Scope**: One Symphony service per customer VPS, bounded active/completed runs, one workspace per active issue
+
+## Constitution Check
+
+- **Data Belongs to Its Owner**: PASS. Runtime config/workspaces live under owner home; provider secrets stay in Matrix integration storage.
+- **AI Is the Kernel**: PASS WITH ADAPTER. Codex app-server becomes the execution protocol for coding agents; this is compatible with Matrix kernel direction.
+- **Headless Core, Multi-Shell**: PASS. Symphony runs headlessly as a service; Matrix app is one shell.
+- **Defense in Depth**: PASS REQUIRED. Spec includes auth matrix, route validation, loopback proxy constraint, timeout policy, generic error policy, and resource caps.
+- **TDD**: PASS REQUIRED. Tasks require tests before implementation for service packaging, gateway proxy, credential bridge, and app UI.
+- **Documentation-Driven Development**: PASS REQUIRED. Public docs update is part of the stack.
+
+## Project Structure
+
+```text
+specs/083-elixir-symphony/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── gateway-symphony-api.md
+└── tasks.md
+
+distro/customer-vps/systemd/
+└── matrix-symphony.service
+
+packages/gateway/src/symphony/
+├── proxy.ts
+├── proxy-contracts.ts
+└── credential-bridge.ts
+
+packages/gateway/src/symphony-routes.ts
+home/apps/symphony/src/App.tsx
+home/apps/symphony/src/*
+tests/gateway/*
+tests/deploy/customer-vps/*
+tests/default-apps/*
+www/content/docs/symphony.mdx
+```
+
+**Structure Decision**: Keep Matrix-owned browser/API integration in TypeScript and host-runtime orchestration in an adapted Elixir source tree. The exact Elixir source location will be selected during implementation after checking host-bundle packaging constraints; likely candidates are `packages/symphony-elixir/` or `distro/customer-vps/symphony/`.
+
+## Stack Plan
+
+- **Stack 1 - Spec and packaging contract**: Add this spec/plan/tasks/contracts, choose Elixir source location, add license/notice handling, and add failing host-bundle/systemd tests.
+- **Stack 2 - Elixir runtime packaging**: Vendor/adapt Elixir Symphony runtime, add `matrix-symphony.service`, host-bundle packaging, loopback config, owner-home workspace defaults, and runtime tests.
+- **Stack 3 - Gateway proxy and credential bridge**: Replace `/api/symphony/*` with Matrix-authenticated proxy routes, Zod contracts, timeout/error mapping, and Matrix Linear credential bridge.
+- **Stack 4 - Matrix app shell**: Update `home/apps/symphony` to render Elixir state/session/turn/log/workpad/workspace/actions responsively.
+- **Stack 5 - Retirement and docs**: Disable/remove TypeScript orchestrator/run table, update public docs, run full validation, and monitor stacked PR CI/reviews/Greptile until 5/5.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --- | --- | --- |
+| Second runtime language in customer host bundle | User explicitly wants the Elixir Symphony implementation for app-server lifecycle semantics | Reimplementing app-server orchestration in TypeScript repeats the confusing current direction and loses upstream alignment |

--- a/specs/083-elixir-symphony/quickstart.md
+++ b/specs/083-elixir-symphony/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart: Elixir Symphony Runtime
+
+## Local Validation
+
+1. Build and test the adapted Elixir runtime.
+
+   ```bash
+   cd packages/symphony-elixir
+   mix test
+   ```
+
+2. Start the runtime in Matrix mode.
+
+   ```bash
+   MATRIX_HOME=/home/matrix/home \
+   SYMPHONY_HOST=127.0.0.1 \
+   SYMPHONY_PORT=4766 \
+   SYMPHONY_WORKSPACE_ROOT=/home/matrix/home/projects/matrix-os/symphony-workspaces \
+   ./bin/symphony ./WORKFLOW.md
+   ```
+
+3. Run focused Matrix tests.
+
+   ```bash
+   pnpm exec vitest run tests/gateway/symphony-proxy.test.ts tests/default-apps/symphony-app.test.tsx
+   pnpm exec vitest run tests/deploy/customer-vps/symphony-systemd.test.ts
+   ```
+
+4. Build the host bundle and verify `matrix-symphony.service` is included.
+
+   ```bash
+   set -a; source .env; set +a
+   ./scripts/build-host-bundle.sh
+   ```
+
+## VPS Verification
+
+1. Confirm the service is installed and loopback-bound.
+
+   ```bash
+   systemctl status matrix-symphony.service
+   curl -fsS http://127.0.0.1:4766/api/v1/state
+   ```
+
+2. Confirm Matrix gateway proxy works.
+
+   ```bash
+   curl -fsS http://127.0.0.1:3001/api/symphony/state
+   ```
+
+3. Open the Matrix Symphony app and verify the active issue, session ID, turn count, logs, workpad link, workspace path, refresh, and stop actions.

--- a/specs/083-elixir-symphony/research.md
+++ b/specs/083-elixir-symphony/research.md
@@ -1,0 +1,73 @@
+# Research: Elixir Symphony Runtime
+
+## Decision: Use Elixir Symphony As The Runtime Source Of Truth
+
+The Matrix `078-matrix-symphony` spec intentionally moved Symphony into the gateway as a Matrix-native TypeScript orchestrator. The user has now reversed that direction for this feature: the Elixir implementation should become the per-VPS runtime because it already models Codex app-server sessions and exposes lifecycle observability that the current Matrix app lacks.
+
+**Rationale**:
+
+- Elixir Symphony already starts `codex app-server` and tracks thread/turn/session identifiers.
+- It exposes an HTTP/LiveView observability surface that can be adapted behind Matrix gateway auth.
+- It keeps the orchestration process independent from gateway restarts.
+- Matrix can still own auth, workspace roots, host-bundle packaging, and app UX through adapter layers.
+
+**Rejected alternative**: Continue extending the TypeScript gateway orchestrator from `078-matrix-symphony`. That keeps everything in one language, but recreates app-server lifecycle tracking and continues to split user expectations between terminal auth state, gateway run state, and actual Codex progress.
+
+## Decision: Gateway Proxy, Not Browser Direct-To-Elixir
+
+Matrix gateway remains the browser-facing control plane. `/api/symphony/*` routes authenticate the Matrix user, validate and bound requests, call the loopback Elixir API with timeouts, and return a Matrix-normalized response.
+
+**Rationale**:
+
+- Preserves existing Matrix auth and browser security model.
+- Keeps the Elixir API loopback-only.
+- Lets Matrix map errors and shape payloads without forking every Elixir dashboard detail into the browser contract.
+
+**Rejected alternative**: Expose the Elixir Phoenix endpoint directly to the browser. That would create a second auth/session surface and make CORS, CSRF, and service reachability harder to reason about.
+
+## Decision: Matrix-Owned Linear Credential Bridge
+
+Symphony should prefer Matrix/Pipedream/platform integration state and avoid requiring `LINEAR_API_KEY` in customer VPS shell environments. The bridge may start as a gateway/platform endpoint that returns a scoped capability to the local service, then evolve into a first-class integration token exchange.
+
+**Rationale**:
+
+- Users already connect integrations through Matrix.
+- Secrets remain in Matrix-managed storage instead of copied into VPS dotfiles.
+- It aligns with the owner-data model: browser sees setup state, not provider credentials.
+
+**Open implementation detail**: The first implementation can proxy Linear calls through the gateway/platform rather than minting a local token, if that is smaller and easier to audit.
+
+## Decision: Matrix-Managed Workspace Root
+
+Default workspace root should be under owner home, using a deterministic Matrix project path such as `/home/matrix/home/projects/matrix-os/symphony-workspaces/<issue>`.
+
+**Rationale**:
+
+- Workspaces are inspectable user-owned files.
+- Matrix can open them in Workspace/Code surfaces.
+- Path validation can be centralized around a single configured root.
+
+## Decision: Preserve Upstream License And Keep Fork Boundary Explicit
+
+The upstream Symphony repository is Apache-2.0. Matrix can adapt and redistribute it, but the host-bundle source should retain license/notice material and document local Matrix changes.
+
+**Rationale**:
+
+- Keeps license compliance straightforward.
+- Makes future upstream rebases possible.
+- Helps reviewers separate upstream code from Matrix adapters.
+
+## Spike Findings From Local Upstream Clone
+
+- Elixir package app: `symphony_elixir`, version `0.1.0`, Elixir `~> 1.19`.
+- Runtime HTTP API includes `GET /api/v1/state`, `GET /api/v1/:issue_identifier`, and `POST /api/v1/refresh`.
+- Codex app-server client starts a `codex app-server` process over stdio, starts a thread, then starts turns and emits `session_id=<thread_id>-<turn_id>`.
+- Dynamic tools include `linear_graphql` and `sync_workpad` in the local clone.
+- The Phoenix endpoint can bind to a configured host/port; Matrix must force loopback in customer runtime.
+
+## Risks
+
+- Elixir runtime toolchain may not exist in current host-bundle build/runtime images.
+- The upstream API does not yet expose every Matrix action needed by the app, especially stop controls; we may need small Elixir API additions.
+- Matrix-owned Linear credentials require a service-to-service bridge that does not leak secrets and does not couple customer VPSes to platform internals.
+- Retiring TypeScript Symphony too early could break existing app tests before the Elixir proxy/app contract is complete.

--- a/specs/083-elixir-symphony/spec.md
+++ b/specs/083-elixir-symphony/spec.md
@@ -1,0 +1,193 @@
+# Feature Specification: Elixir Symphony Runtime
+
+**Feature Branch**: `083-elixir-symphony`  
+**Created**: 2026-05-25  
+**Status**: Draft  
+**Input**: User description: "Use the Elixir Symphony implementation, adapt it for Matrix, replace the current TypeScript Symphony runner, keep it as a per-VPS service, proxy it through the gateway, show its Codex app-server state in the Matrix app, use Matrix-owned Linear auth, and use Matrix workspace conventions."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run Symphony As A Matrix VPS Service (Priority: P1)
+
+A Matrix owner signs in to their VPS-backed OS and Symphony is available as a host service named `matrix-symphony.service`, running as the `matrix` user with `MATRIX_HOME=/home/matrix/home`. The service uses Matrix-owned workspace paths and runs the adapted Elixir Symphony orchestrator instead of the in-gateway TypeScript run table.
+
+**Why this priority**: The replacement only works if Symphony is part of the normal customer VPS runtime and survives shell/gateway restarts.
+
+**Independent Test**: Build a host bundle, install it into a VPS-like fixture, start `matrix-symphony.service`, and verify the service reads `MATRIX_HOME`, binds only to loopback, reports health/state, and uses a workspace root under the owner home.
+
+**Acceptance Scenarios**:
+
+1. **Given** a customer VPS has the latest host bundle installed, **When** systemd starts Matrix services, **Then** `matrix-symphony.service` runs as `matrix`, receives `MATRIX_HOME=/home/matrix/home`, and binds its HTTP API to `127.0.0.1`.
+2. **Given** the gateway restarts while Symphony is running, **When** the gateway comes back, **Then** it can read the current Symphony state from the local Elixir service without reconstructing a separate TypeScript run table.
+3. **Given** the Elixir service fails to start, **When** the app requests Symphony state, **Then** the gateway returns a generic unavailable response and logs the service failure server-side.
+4. **Given** Symphony creates a workspace for a ticket, **When** the workspace path is inspected, **Then** it lives under the configured owner-home project/worktree root and not under a temporary global path.
+
+---
+
+### User Story 2 - Proxy Symphony Through Matrix Gateway Control (Priority: P1)
+
+The Matrix gateway exposes `/api/symphony/*` as the authenticated control plane for the local Elixir API. Browser apps never call the Elixir service directly, and the gateway owns auth, body limits, request validation, timeout behavior, and client-safe error mapping.
+
+**Why this priority**: Matrix users need one authenticated API surface, and the Elixir service should not become a second browser-visible trust boundary.
+
+**Independent Test**: With a fake loopback Symphony service, call `/api/symphony/state`, `/api/symphony/issues/:issueIdentifier`, `/api/symphony/refresh`, and stop/control routes through the gateway as authorized and unauthorized users; verify proxying, timeouts, body limits, and generic errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authorized Matrix user requests Symphony state, **When** the Elixir service responds, **Then** the gateway returns the normalized state payload with no provider secrets or internal paths beyond allowed workspace/workpad paths.
+2. **Given** an unauthorized user requests Symphony state or controls, **When** the request reaches the gateway, **Then** the gateway rejects it before contacting the Elixir service.
+3. **Given** the Elixir service hangs or is offline, **When** the gateway proxies a request, **Then** the request times out within the configured service timeout and returns a generic unavailable response.
+4. **Given** a client sends a mutating Symphony request, **When** the gateway handles it, **Then** `bodyLimit` applies before buffering and the payload is validated at the route boundary.
+
+---
+
+### User Story 3 - Use Matrix-Owned Linear Auth And Project Roots (Priority: P1)
+
+A Matrix owner connects Linear through the existing Matrix integration path, and Symphony receives a short-lived or locally bridged credential from Matrix instead of requiring users to manually put `LINEAR_API_KEY` on the VPS. Symphony workspaces are created under Matrix-managed project roots, such as `~/projects/matrix-os/symphony-workspaces/<issue>`, and can be opened from Matrix workspace UI.
+
+**Why this priority**: The current separate credential and workspace setup is the source of confusion; Matrix must remain the owner of integrations and project state.
+
+**Independent Test**: Configure a Matrix Linear integration without `LINEAR_API_KEY` in the VPS environment, start Symphony, and verify issue polling/comments work through the Matrix credential bridge while workspace paths remain under the Matrix owner home.
+
+**Acceptance Scenarios**:
+
+1. **Given** Linear is connected in Matrix/Pipedream/platform integrations, **When** Symphony polls Linear, **Then** it uses a Matrix-provided credential bridge rather than requiring `LINEAR_API_KEY` in the shell environment.
+2. **Given** no Matrix-owned Linear credential is available, **When** Symphony starts, **Then** it reports a setup-required state without exposing provider details.
+3. **Given** Symphony creates or reuses a worktree, **When** the path is serialized to the UI, **Then** it is under the configured Matrix workspace root and can be opened by Matrix workspace links.
+4. **Given** an issue identifier contains unexpected characters, **When** Symphony derives a workspace path, **Then** it validates and sanitizes the identifier before using it in filesystem paths.
+
+---
+
+### User Story 4 - Operate Codex App-Server Sessions From The Matrix App (Priority: P2)
+
+The Matrix Symphony app is a UI shell over the Elixir service. It shows queue/running/attention/done state, active issue, Codex session ID, thread/turn count, latest lifecycle event, bounded logs, workpad URL, workspace path, and refresh/stop actions.
+
+**Why this priority**: The Elixir implementation exposes useful Codex lifecycle state; Matrix should surface that instead of showing an ambiguous terminal-or-auth status.
+
+**Independent Test**: Run the app against seeded Symphony state payloads and verify each status group, issue detail, session ID, turn count, workpad link, workspace link, refresh action, stop action, loading state, and unavailable state renders correctly on desktop and mobile widths.
+
+**Acceptance Scenarios**:
+
+1. **Given** Symphony has a running ticket, **When** the app loads, **Then** it shows the issue identifier/title, session ID, turn count, workspace path, workpad URL, latest event, and bounded logs.
+2. **Given** Symphony has queued, running, needs-attention, and done items, **When** the app loads, **Then** the items are grouped into those operational states without crowding the first screen.
+3. **Given** the user taps refresh or stop, **When** the gateway action succeeds, **Then** the app updates from the returned Elixir state and does not clear unrelated run details.
+4. **Given** the app is used on a narrow viewport, **When** state includes long issue titles, session IDs, or paths, **Then** controls remain visible, text wraps or truncates intentionally, and no controls overlap.
+
+---
+
+### User Story 5 - Retire The Duplicate TypeScript Symphony Runner (Priority: P3)
+
+Matrix removes or disables the existing in-gateway TypeScript Symphony orchestrator/run table once the Elixir service is the source of truth. Documentation and tests describe the new ownership boundary and migration behavior.
+
+**Why this priority**: Keeping two orchestrators creates conflicting run state, credentials, logs, and operator semantics.
+
+**Independent Test**: Search for TypeScript Symphony runner entrypoints, start the gateway with the Elixir service configured, and verify `/api/symphony/*` uses the proxy path while legacy runner state is not created or mutated.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new Elixir service path is enabled, **When** a user starts or refreshes Symphony, **Then** no TypeScript Symphony run table or TypeScript ticket runner is used.
+2. **Given** old local Symphony config files exist, **When** the gateway starts, **Then** it either ignores them safely or migrates only non-secret settings to the new service config.
+3. **Given** docs mention Symphony setup, **When** users follow the docs, **Then** they configure Matrix integrations and host service controls rather than manual `LINEAR_API_KEY` runner setup.
+
+### Edge Cases
+
+- The Elixir service is installed but not running.
+- The Elixir service is running but bound to the wrong host or port.
+- The gateway receives a slow or malformed loopback response.
+- Matrix Linear integration exists in the platform but the VPS cannot reach the credential bridge.
+- The Linear credential is revoked during an active run.
+- A ticket becomes ineligible while Codex app-server is mid-turn.
+- Codex app-server emits malformed JSON, exits unexpectedly, or requests unsupported dynamic tools.
+- Workpad sync succeeds but Linear comment update fails, or vice versa.
+- Workspace creation succeeds but Codex session startup fails.
+- A service restart happens while a worktree lease or Codex turn is active.
+- A user-controlled issue identifier, repo slug, branch name, or workpad path attempts traversal.
+- Log payloads exceed browser-safe display limits.
+- Mobile viewport receives long paths, issue titles, or session identifiers.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Matrix MUST package an adapted Elixir Symphony runtime in the host bundle with its upstream Apache-2.0 license/notice preserved.
+- **FR-002**: Matrix MUST install a `matrix-symphony.service` systemd unit for customer VPS runtime, running as `matrix`, using `MATRIX_HOME=/home/matrix/home`, and binding its HTTP API to loopback only.
+- **FR-003**: Matrix MUST expose `/api/symphony/*` through the gateway as the browser-facing API and MUST NOT require browser clients to call the Elixir service directly.
+- **FR-004**: The gateway MUST enforce Matrix auth/authorization before proxying any Symphony state or control request.
+- **FR-005**: Every mutating `/api/symphony/*` route MUST use Hono `bodyLimit` before body parsing and validate payloads with Zod at the route boundary.
+- **FR-006**: Every gateway fetch to the Elixir service MUST use `AbortSignal.timeout()` and map loopback/network/internal failures to generic client-facing errors.
+- **FR-007**: Gateway proxying MUST only target a configured loopback origin; it MUST NOT proxy arbitrary user-controlled URLs.
+- **FR-008**: Matrix MUST normalize Elixir state into a stable browser contract that includes service status, issue identifier/title, run status, session ID, thread ID, turn count, latest event, bounded logs, workspace path, workpad URL, and allowed actions.
+- **FR-009**: The Matrix Symphony app MUST show queue, running, needs-attention, and done/handoff groups from Elixir state.
+- **FR-010**: The Matrix Symphony app MUST render active issue details, Codex app-server session ID, turn count, bounded logs, workpad URL, workspace path, refresh, and stop actions.
+- **FR-011**: The Matrix Symphony app MUST remain usable on mobile widths without overlapping controls or hiding essential links/actions.
+- **FR-012**: Symphony MUST use `codex app-server` for agent execution, not terminal-session spawning as the primary run mechanism.
+- **FR-013**: Symphony MUST serve or proxy Codex lifecycle state from Elixir as the source of truth for active runs.
+- **FR-014**: Symphony MUST create/reuse workspaces under a Matrix-managed owner-home root, with safe path validation for all issue-derived segments.
+- **FR-015**: Symphony MUST prefer Matrix-owned Linear credentials from platform/Pipedream/integration state over requiring `LINEAR_API_KEY` in a user VPS environment.
+- **FR-016**: If Matrix-owned Linear credentials are unavailable, Symphony MUST report setup-required status without exposing provider tokens or raw provider errors.
+- **FR-017**: Symphony MUST preserve workpad and Linear comment functionality through Matrix-approved dynamic tools or credential bridging.
+- **FR-018**: Matrix MUST retire, disable, or bypass the duplicate TypeScript Symphony orchestrator/run table once the Elixir service is enabled.
+- **FR-019**: Runtime config and non-secret state MUST live under owner-controlled Matrix home files; provider credentials MUST remain in Matrix secret/integration storage.
+- **FR-020**: In-memory state for logs, recent events, runs, and subscribers MUST be capped with explicit eviction or retention rules.
+- **FR-021**: Shutdown of the Elixir service MUST drain or mark active runs consistently so gateway/app state does not show stale progress as healthy.
+- **FR-022**: Tests MUST cover service packaging, systemd unit rendering, gateway proxy auth, timeout/error mapping, credential bridge behavior, path validation, app rendering, and mobile layout.
+- **FR-023**: Public docs MUST describe the Matrix-owned Symphony service, gateway proxy, Linear setup, workspace root convention, troubleshooting, and migration away from legacy TypeScript runner behavior.
+
+### Security Architecture
+
+#### Auth Matrix
+
+| Route/Surface | Caller | Auth Method | Public? | Notes |
+| --- | --- | --- | --- | --- |
+| `matrix-symphony.service` loopback HTTP | Local gateway only | Loopback binding plus optional internal token | No | Must bind to `127.0.0.1`; browser never calls it directly. |
+| `GET /api/symphony/state` | Matrix app/user | Existing Matrix gateway auth | No | Returns normalized, secret-free state. |
+| `GET /api/symphony/issues/:issueIdentifier` | Matrix app/user | Existing Matrix gateway auth | No | Validates identifier and maps not-found generically. |
+| `POST /api/symphony/refresh` | Matrix app/user | Existing Matrix gateway auth + bodyLimit | No | Proxies refresh with timeout. |
+| `POST /api/symphony/runs/:runId/stop` | Matrix app/user | Existing Matrix gateway auth + bodyLimit | No | Stops through Elixir API when supported; returns normalized state. |
+| Matrix Linear credential bridge | Elixir service/gateway | Matrix internal service auth | No | Must not expose raw tokens in browser responses or local logs. |
+| Workpad/workspace links | Matrix app/user | Existing Matrix file/workspace auth | No | Only exposes owner-home paths that Matrix can open. |
+
+#### Input Validation
+
+- Issue identifiers, run IDs, workspace roots, workpad paths, repo slugs, action payloads, and query params MUST be validated at the gateway boundary.
+- Issue-derived path segments MUST use a strict safe-slug mapping and resolved paths MUST stay under the configured workspace root.
+- Gateway proxy routes MUST construct upstream paths from allowlisted route patterns, not from raw client URLs.
+- Elixir dynamic tool payloads for Linear/workpad operations MUST use bounded schemas and generic error mapping.
+
+#### Error Policy
+
+- Browser responses MUST never include raw Elixir exceptions, provider errors, filesystem paths outside allowed owner-home display paths, Postgres errors, stack traces, tokens, or raw Codex stderr.
+- Gateway logs and Elixir logs MAY include internal details required for debugging, but secrets must be redacted.
+- Service-unavailable, timeout, credential-missing, and validation-failed states MUST be distinguishable to the UI using coarse codes.
+
+#### Resource Management
+
+- Gateway proxy timeout default: 10 seconds for state/control APIs.
+- Elixir Codex app-server line length and stream logs MUST be bounded.
+- Browser-visible logs MUST be capped by count and byte length.
+- Run/event registries MUST define max active/completed records and eviction semantics.
+- Workspace roots MUST have cleanup/recovery policy for abandoned failed workspaces; active user data must not be deleted automatically.
+- Service shutdown MUST stop accepting new dispatch, mark in-flight state consistently, and close Codex app-server ports/processes.
+
+### Key Entities *(include if feature involves data)*
+
+- **Symphony Service Instance**: Per-VPS Elixir runtime process with loopback API, service status, version, owner home, workspace root, and configuration.
+- **Gateway Proxy Contract**: Stable Matrix API shape for normalized Symphony state and actions.
+- **Credential Bridge**: Matrix-owned path for giving the local service the minimum Linear capability without exposing provider tokens to browser or shell setup.
+- **Symphony Issue Run**: A ticket lifecycle owned by the Elixir service, including status, issue metadata, workspace, workpad, session ID, thread ID, turn count, latest event, timestamps, and allowed actions.
+- **Codex App-Server Session**: Elixir-managed Codex lifecycle with thread/turn/session IDs and bounded lifecycle events.
+- **Matrix Symphony App View Model**: Browser-safe projection rendered by the Matrix app.
+- **Legacy TypeScript Symphony Runner**: Existing in-gateway orchestration path to be bypassed or removed after the Elixir runtime is active.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A fresh customer VPS host bundle starts `matrix-symphony.service` as `matrix` with `MATRIX_HOME=/home/matrix/home`, loopback API binding, and a Matrix-managed workspace root.
+- **SC-002**: Authorized Matrix app calls to `/api/symphony/state` return Elixir-backed state within 10 seconds and contain zero provider secrets or raw internal errors.
+- **SC-003**: Unauthorized calls to all `/api/symphony/*` routes are rejected before the gateway contacts the Elixir service.
+- **SC-004**: A Linear-connected Matrix owner can run an eligible ticket without manually setting `LINEAR_API_KEY` on the VPS.
+- **SC-005**: A running ticket exposes Codex app-server `session_id`, `thread_id`, turn count, latest lifecycle event, bounded logs, workpad URL, and workspace path in the Matrix app.
+- **SC-006**: Mobile and desktop app views show refresh/stop/open-workspace/open-workpad actions without overlap for long issue titles and paths.
+- **SC-007**: With the Elixir service enabled, no TypeScript Symphony run table entries are created or mutated by normal `/api/symphony/*` use.
+- **SC-008**: CI passes `bun run typecheck`, `bun run check:patterns`, focused gateway/app tests, host-bundle/systemd tests, and Elixir runtime tests or a documented CI-equivalent fallback.

--- a/specs/083-elixir-symphony/tasks.md
+++ b/specs/083-elixir-symphony/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: Elixir Symphony Runtime
+
+**Input**: Design documents from `/specs/083-elixir-symphony/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/gateway-symphony-api.md`
+
+**Tests**: Required. This feature touches host services, auth boundaries, external credentials, filesystem paths, and UI state.
+
+## Phase 1: Setup And Spec Stack
+
+- [ ] T001 Update `.specify/feature.json` to point at `specs/083-elixir-symphony`.
+- [ ] T002 Commit spec, plan, research, data model, contracts, quickstart, and tasks as the first stack layer.
+- [ ] T003 [P] Record upstream Symphony Apache-2.0 license/notice handling in the chosen source location.
+- [ ] T004 [P] Decide and document the adapted Elixir source location after checking host-bundle packaging constraints.
+
+---
+
+## Phase 2: Host Runtime Foundation
+
+**Purpose**: Package and run the Elixir service before gateway/app replacement.
+
+- [ ] T005 [P] Add failing systemd/host-bundle test for `distro/customer-vps/systemd/matrix-symphony.service` in `tests/deploy/customer-vps/symphony-systemd.test.ts`.
+- [ ] T006 [P] Add failing host-bundle packaging test that asserts the adapted Elixir runtime and license/notice files are included.
+- [ ] T007 Vendor or import adapted Elixir Symphony source into the chosen Matrix path without committed `deps/` or build artifacts.
+- [ ] T008 Add Matrix runtime config defaults for `MATRIX_HOME`, loopback host/port, workspace root, and Codex command.
+- [ ] T009 Implement `matrix-symphony.service` running as `matrix` with `MATRIX_HOME=/home/matrix/home`.
+- [ ] T010 Update `scripts/build-host-bundle.sh` to include the service and runtime.
+- [ ] T011 Run host-bundle/systemd focused tests and Elixir tests or document unavailable toolchain fallback.
+
+---
+
+## Phase 3: Gateway Proxy And Credential Bridge (US1, US2, US3)
+
+**Goal**: Make `/api/symphony/*` the Matrix-authenticated proxy/control plane for Elixir state.
+
+**Independent Test**: Fake loopback Elixir service plus gateway tests verify auth, validation, timeout, bodyLimit, normalized payloads, and credential setup states.
+
+- [ ] T012 [P] Add failing gateway proxy tests for authorized state/detail/refresh requests in `tests/gateway/symphony-proxy.test.ts`.
+- [ ] T013 [P] Add failing gateway tests for unauthorized requests not contacting upstream.
+- [ ] T014 [P] Add failing gateway tests for timeout/offline/malformed upstream responses returning generic errors.
+- [ ] T015 [P] Add failing validation tests for issue identifiers, run IDs, mutating body limits, and unsafe upstream paths.
+- [ ] T016 Implement `packages/gateway/src/symphony/proxy-contracts.ts` with Zod schemas and browser-safe response types.
+- [ ] T017 Implement `packages/gateway/src/symphony/proxy.ts` with allowlisted loopback route templates and `AbortSignal.timeout()`.
+- [ ] T018 Replace `packages/gateway/src/symphony-routes.ts` export path with the proxy-backed route registration while preserving auth behavior.
+- [ ] T019 Implement initial Matrix Linear credential bridge status and setup-required behavior without exposing tokens.
+- [ ] T020 Ensure legacy TypeScript orchestrator/run-table paths are not used by normal `/api/symphony/*` requests when Elixir proxy mode is enabled.
+- [ ] T021 Run focused gateway proxy tests plus `bun run check:patterns`.
+
+---
+
+## Phase 4: Matrix App Shell (US4)
+
+**Goal**: Render Elixir-backed Codex lifecycle state clearly in the Matrix Symphony app.
+
+**Independent Test**: Seed browser-safe payloads and verify desktop/mobile UI states and actions.
+
+- [ ] T022 [P] Add failing app tests for queue/running/needs-attention/done groups in `tests/default-apps/symphony-app.test.tsx`.
+- [ ] T023 [P] Add failing app tests for active issue details: session ID, thread/turn count, logs, workpad URL, workspace path, refresh, stop.
+- [ ] T024 [P] Add failing mobile-width layout regression for long titles, session IDs, and paths.
+- [ ] T025 Update `home/apps/symphony/src/App.tsx` and supporting modules to consume the normalized proxy contract.
+- [ ] T026 Add loading, service unavailable, setup-required, and action-in-flight states.
+- [ ] T027 Run focused app tests and `node scripts/build-default-apps.mjs home/apps/symphony`.
+
+---
+
+## Phase 5: Legacy Retirement, Docs, And Validation (US5)
+
+**Goal**: Remove duplicate runner semantics and document the new Matrix/Elixir boundary.
+
+- [ ] T028 [P] Add tests proving normal Symphony API usage does not mutate TypeScript runner state.
+- [ ] T029 Remove, disable, or quarantine the TypeScript Symphony orchestrator/run table behind the new proxy path.
+- [ ] T030 Update `www/content/docs/symphony.mdx` with Matrix-owned Linear setup, service behavior, workspace root, app-server state, troubleshooting, and migration notes.
+- [ ] T031 Update any host-bundle/release docs that list customer VPS services.
+- [ ] T032 Run `bun run typecheck`.
+- [ ] T033 Run `bun run check:patterns`.
+- [ ] T034 Run `bun run test` or the agreed split of focused suites if full tests exceed CI time.
+- [ ] T035 Build a host bundle and verify `matrix-symphony.service`, release files, and runtime state paths.
+
+---
+
+## Dependencies & Execution Order
+
+- Phase 1 blocks all other work.
+- Phase 2 blocks gateway proxy rollout because the proxy needs a stable local service contract.
+- Phase 3 blocks app replacement because the app should not call Elixir directly.
+- Phase 4 can proceed against mocked contracts once Phase 3 schemas exist.
+- Phase 5 is final cleanup after service/proxy/app paths pass focused validation.
+
+## Graphite Stack Plan
+
+- **Stack 1**: Spec, contracts, tasks, source-location/license decision, first failing packaging tests.
+- **Stack 2**: Elixir runtime packaging and `matrix-symphony.service`.
+- **Stack 3**: Gateway proxy and credential bridge.
+- **Stack 4**: Matrix Symphony app shell over Elixir state.
+- **Stack 5**: Legacy TypeScript runner retirement, docs, full validation.

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("customer VPS Symphony systemd unit", () => {
+  it("runs Elixir Symphony as a Matrix-owned loopback service", async () => {
+    const unit = await readFile("distro/customer-vps/systemd/matrix-symphony.service", "utf8");
+    const wrapper = await readFile("distro/customer-vps/host-bin/matrix-symphony", "utf8");
+    const buildScript = await readFile("scripts/build-host-bundle.sh", "utf8");
+
+    expect(unit).toContain("Description=Matrix OS customer Symphony");
+    expect(unit).toContain("User=matrix");
+    expect(unit).toContain("Group=matrix");
+    expect(unit).toContain("Environment=MATRIX_HOME=/home/matrix/home");
+    expect(unit).toContain("Environment=SYMPHONY_HOST=127.0.0.1");
+    expect(unit).toContain("Environment=SYMPHONY_PORT=4766");
+    expect(unit).toContain("Environment=SYMPHONY_WORKSPACE_ROOT=/home/matrix/home/projects/matrix-os/symphony-workspaces");
+    expect(unit).toContain("ExecStart=/opt/matrix/bin/matrix-symphony");
+    expect(unit).not.toContain("EnvironmentFile=/opt/matrix/env/host.env");
+    expect(unit).toContain("KillMode=mixed");
+    expect(unit).toContain("KillSignal=SIGTERM");
+    expect(unit).toContain("TimeoutStopSec=30");
+    expect(unit).toContain("ConditionPathExists=/opt/matrix/app/packages/symphony-elixir/bin/symphony");
+
+    expect(wrapper).toContain("source /opt/matrix/env/host.env");
+    expect(wrapper).toContain("export MATRIX_HOME=\"${MATRIX_HOME:-/home/matrix/home}\"");
+    expect(wrapper).toContain("export SYMPHONY_HOST=\"${SYMPHONY_HOST:-127.0.0.1}\"");
+    expect(wrapper).toContain("export SYMPHONY_PORT=\"${SYMPHONY_PORT:-4766}\"");
+    expect(wrapper).toContain("export SYMPHONY_WORKSPACE_ROOT=\"${SYMPHONY_WORKSPACE_ROOT:-$MATRIX_HOME/projects/matrix-os/symphony-workspaces}\"");
+    expect(wrapper).toContain("exec \"$SYMPHONY_BIN\" \"$WORKFLOW_FILE\"");
+
+    expect(buildScript).toContain("\"$STAGE_DIR/bin/matrix-symphony\"");
+  });
+
+  it("packages the adapted Elixir Symphony source and license in the host bundle app tree", async () => {
+    const license = await readFile("packages/symphony-elixir/LICENSE", "utf8");
+    const notice = await readFile("packages/symphony-elixir/NOTICE", "utf8");
+    const readme = await readFile("packages/symphony-elixir/README.md", "utf8");
+    const buildScript = await readFile("scripts/build-host-bundle.sh", "utf8");
+
+    expect(license).toContain("Apache License");
+    expect(notice).toContain("Matrix-adapted Elixir Symphony");
+    expect(notice).toContain("Copyright 2026 Matrix OS contributors");
+    expect(readme).toContain("Matrix-adapted Elixir Symphony");
+    expect(buildScript).toContain("cp -a \"$ROOT_DIR/packages\" \"$STAGE_DIR/app/packages\"");
+  });
+});


### PR DESCRIPTION
Summary
- Adds spec 083 for replacing the gateway TypeScript Symphony runtime with the Matrix-adapted Elixir service.
- Documents contracts, data model, quickstart, tasks, and host-service packaging scope.

Tests
- bun run check:patterns
- bun run typecheck
- bun run test

Review/Monitoring
- Stack root for PRs #183-#195.

Invariants
- Source of truth: spec artifacts only; no runtime behavior changes in this layer.
- Lock/transaction scope: none.
- Acceptable orphan states: none.
- Auth source of truth: Matrix-owned gateway/platform auth as specified.
- Deferred scope: implementation follows in upstack PRs.