### PR TITLE
feat(symphony): proxy elixir runtime state

### DIFF
--- a/packages/gateway/src/symphony/index.ts
+++ b/packages/gateway/src/symphony/index.ts
@@ -1,4 +1,6 @@
 export * from "./contracts.js";
+export * from "./proxy.js";
+export * from "./proxy-contracts.js";
 export * from "./auth.js";
 export * from "./credential-store.js";
 export * from "./linear-source.js";

--- a/packages/gateway/src/symphony/proxy-contracts.ts
+++ b/packages/gateway/src/symphony/proxy-contracts.ts
@@ -1,0 +1,60 @@
+import { z } from "zod/v4";
+
+export const SymphonyIssueIdentifierSchema = z.string().min(1).max(80).regex(/^[A-Z][A-Z0-9]{1,12}-[0-9]{1,10}$/);
+export const SymphonyRunIdSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9_-]+$/);
+export const EmptyProxyBodySchema = z.object({}).strict();
+
+const ElixirRunningEntrySchema = z.object({
+  issue_identifier: z.string().optional(),
+  issue_id: z.string().optional(),
+  state: z.string().optional(),
+  session_id: z.string().optional().nullable(),
+  turn_count: z.number().int().nonnegative().optional(),
+  last_event: z.string().optional().nullable(),
+  last_message: z.string().optional().nullable(),
+  started_at: z.string().optional().nullable(),
+  last_event_at: z.string().optional().nullable(),
+}).passthrough();
+
+const ElixirRetryEntrySchema = z.object({
+  issue_identifier: z.string().optional(),
+  issue_id: z.string().optional(),
+  attempt: z.number().int().nonnegative().optional(),
+  due_at: z.string().optional().nullable(),
+  error: z.unknown().optional(),
+}).passthrough();
+
+export const ElixirStateSchema = z.object({
+  generated_at: z.string().optional(),
+  error: z.object({ code: z.string().optional(), message: z.string().optional() }).optional(),
+  running: z.array(ElixirRunningEntrySchema).optional(),
+  retrying: z.array(ElixirRetryEntrySchema).optional(),
+}).passthrough();
+
+export const ElixirIssueSchema = z.object({
+  issue_identifier: z.string().optional(),
+  issue_id: z.string().optional().nullable(),
+  status: z.string().optional(),
+  workspace: z.object({ path: z.string().optional() }).passthrough().optional(),
+  running: z.object({
+    session_id: z.string().optional().nullable(),
+    turn_count: z.number().int().nonnegative().optional(),
+    last_event: z.string().optional().nullable(),
+    last_message: z.string().optional().nullable(),
+  }).passthrough().optional().nullable(),
+  retry: z.object({
+    attempt: z.number().int().nonnegative().optional(),
+    due_at: z.string().optional().nullable(),
+    error: z.unknown().optional(),
+  }).passthrough().optional().nullable(),
+  logs: z.unknown().optional(),
+  recent_events: z.array(z.unknown()).optional(),
+}).passthrough();
+
+export const ElixirRefreshSchema = z.object({
+  requested_at: z.string().optional(),
+}).passthrough();
+
+export function genericProxyError(code: string, message: string) {
+  return { error: { code, message } };
+}

--- a/packages/gateway/src/symphony/proxy.ts
+++ b/packages/gateway/src/symphony/proxy.ts
@@ -1,0 +1,263 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { requestHasBody } from "../http-body.js";
+import { isRequestPrincipalError, mapRequestPrincipalError, requireRequestPrincipal, type RequestPrincipal } from "../request-principal.js";
+import {
+  ElixirIssueSchema,
+  ElixirRefreshSchema,
+  ElixirStateSchema,
+  EmptyProxyBodySchema,
+  genericProxyError,
+  SymphonyIssueIdentifierSchema,
+  SymphonyRunIdSchema,
+} from "./proxy-contracts.js";
+
+const DEFAULT_UPSTREAM_ORIGIN = "http://127.0.0.1:4766";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const BODY_LIMIT_BYTES = 1024;
+
+export interface ElixirSymphonyProxyDeps {
+  upstreamOrigin?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+function status(code: number): ContentfulStatusCode {
+  return code as ContentfulStatusCode;
+}
+
+function normalizeLoopbackOrigin(rawOrigin = DEFAULT_UPSTREAM_ORIGIN): string {
+  const url = new URL(rawOrigin);
+  if (url.protocol !== "http:" || !["127.0.0.1", "localhost", "[::1]"].includes(url.hostname)) {
+    throw new Error("Symphony upstream origin must be loopback HTTP");
+  }
+  return url.origin;
+}
+
+function upstreamUrl(origin: string, path: string): string {
+  return new URL(path, `${origin}/`).toString();
+}
+
+async function withPrincipal(c: Context, deps: ElixirSymphonyProxyDeps, fn: (principal: RequestPrincipal) => Promise<Response>): Promise<Response> {
+  try {
+    const principal = deps.getPrincipal?.(c) ?? requireRequestPrincipal(c, { requireAuthContextReady: false });
+    return await fn(principal);
+  } catch (err: unknown) {
+    if (!isRequestPrincipalError(err)) throw err;
+    const mapped = mapRequestPrincipalError(err, "Symphony request failed");
+    if (mapped.log) console.error("[symphony] Principal resolution failed:", err);
+    return c.json(genericProxyError("unauthorized", mapped.body.error), status(mapped.status));
+  }
+}
+
+async function parseEmptyJson(c: Context): Promise<{ ok: true } | { ok: false; response: Response }> {
+  let raw: unknown = {};
+  if (requestHasBody(c)) {
+    try {
+      raw = await c.req.json();
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "BodyLimitError") {
+        return { ok: false, response: c.json(genericProxyError("payload_too_large", "Request body is too large"), status(413)) };
+      }
+      return { ok: false, response: c.json(genericProxyError("invalid_json", "Request body must be valid JSON"), status(400)) };
+    }
+  }
+  const parsed = EmptyProxyBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, response: c.json(genericProxyError("invalid_request", "Request body is invalid"), status(400)) };
+  }
+  return { ok: true };
+}
+
+async function fetchJson(deps: Required<Pick<ElixirSymphonyProxyDeps, "fetchImpl" | "timeoutMs">>, url: string, init: RequestInit): Promise<
+  { ok: true; status: number; body: unknown } | { ok: false; status: number; body: ReturnType<typeof genericProxyError> }
+> {
+  try {
+    const res = await deps.fetchImpl(url, { ...init, signal: AbortSignal.timeout(deps.timeoutMs) });
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch (err: unknown) {
+      console.warn("[symphony] Elixir response was not JSON:", err instanceof Error ? err.message : String(err));
+      return { ok: false, status: 502, body: genericProxyError("invalid_response", "Symphony returned an invalid response") };
+    }
+    if (!res.ok) {
+      if (res.status === 404) {
+        return { ok: false, status: 404, body: genericProxyError("not_found", "Symphony resource not found") };
+      }
+      return { ok: false, status: 503, body: genericProxyError("service_unavailable", "Symphony is unavailable") };
+    }
+    return { ok: true, status: res.status, body };
+  } catch (err: unknown) {
+    console.warn("[symphony] Elixir proxy request failed:", err instanceof Error ? err.message : String(err));
+    return { ok: false, status: 503, body: genericProxyError("service_unavailable", "Symphony is unavailable") };
+  }
+}
+
+function safeText(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value.slice(0, 500) : null;
+}
+
+function scrubText(value: unknown): string | null {
+  const text = safeText(value);
+  if (!text) return null;
+  return text.replace(/\b[A-Za-z0-9_]*(?:secret|token|key)[A-Za-z0-9_]*\b/gi, "[redacted]");
+}
+
+function normalizeLogLines(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => scrubText(typeof entry === "string" ? entry : JSON.stringify(entry)))
+    .filter((entry): entry is string => Boolean(entry))
+    .slice(0, 20);
+}
+
+function normalizeLogs(value: unknown) {
+  if (!value || typeof value !== "object") return { codexSessionLogs: [] };
+  const record = value as Record<string, unknown>;
+  return {
+    codexSessionLogs: normalizeLogLines(record.codex_session_logs ?? record.codexSessionLogs),
+  };
+}
+
+function normalizeRecentEvents(value: unknown): Array<{ at: string | null; event: string | null; message: string | null }> {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 20).map((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return { at: null, event: "event", message: scrubText(entry) };
+    }
+    const record = entry as Record<string, unknown>;
+    return {
+      at: safeText(record.at),
+      event: safeText(record.event),
+      message: scrubText(record.message),
+    };
+  });
+}
+
+function normalizeRunning(entry: Record<string, unknown>) {
+  return {
+    issueIdentifier: safeText(entry.issue_identifier),
+    issueId: safeText(entry.issue_id),
+    status: "running",
+    state: safeText(entry.state),
+    sessionId: safeText(entry.session_id),
+    turnCount: typeof entry.turn_count === "number" ? entry.turn_count : 0,
+    latestEvent: scrubText(entry.last_event),
+    latestMessage: scrubText(entry.last_message),
+    startedAt: safeText(entry.started_at),
+    updatedAt: safeText(entry.last_event_at),
+    allowedActions: ["refresh", "open_workspace"],
+  };
+}
+
+function normalizeRetry(entry: Record<string, unknown>) {
+  return {
+    issueIdentifier: safeText(entry.issue_identifier),
+    issueId: safeText(entry.issue_id),
+    status: "needs_attention",
+    attempt: typeof entry.attempt === "number" ? entry.attempt : 0,
+    dueAt: safeText(entry.due_at),
+    latestEvent: "retrying",
+    allowedActions: ["refresh"],
+  };
+}
+
+function normalizeState(body: unknown) {
+  const parsed = ElixirStateSchema.parse(body);
+  return {
+    service: {
+      status: parsed.error ? "degraded" : "ready",
+      generatedAt: parsed.generated_at ?? null,
+    },
+    groups: {
+      queue: [],
+      running: (parsed.running ?? []).map(normalizeRunning),
+      needsAttention: (parsed.retrying ?? []).map(normalizeRetry),
+      done: [],
+    },
+  };
+}
+
+function normalizeIssue(body: unknown) {
+  const parsed = ElixirIssueSchema.parse(body);
+  return {
+    issueIdentifier: parsed.issue_identifier ?? null,
+    issueId: parsed.issue_id ?? null,
+    status: parsed.status ?? "unknown",
+    sessionId: parsed.running?.session_id ?? null,
+    turnCount: parsed.running?.turn_count ?? 0,
+    latestEvent: scrubText(parsed.running?.last_event),
+    latestMessage: scrubText(parsed.running?.last_message),
+    workspacePath: safeText(parsed.workspace?.path) ?? null,
+    workpadUrl: null,
+    logs: normalizeLogs(parsed.logs),
+    recentEvents: normalizeRecentEvents(parsed.recent_events),
+    retry: parsed.retry ? { attempt: parsed.retry.attempt ?? 0, dueAt: parsed.retry.due_at ?? null } : null,
+    allowedActions: ["refresh", "open_workspace"],
+  };
+}
+
+export function createElixirSymphonyProxyRoutes(deps: ElixirSymphonyProxyDeps = {}) {
+  const origin = normalizeLoopbackOrigin(deps.upstreamOrigin ?? process.env.SYMPHONY_UPSTREAM_ORIGIN);
+  const proxyDeps = {
+    fetchImpl: deps.fetchImpl ?? fetch,
+    timeoutMs: deps.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+  const app = new Hono();
+  const emptyLimited = bodyLimit({ maxSize: BODY_LIMIT_BYTES });
+
+  app.get("/state", (c) => withPrincipal(c, deps, async () => {
+    const upstream = await fetchJson(proxyDeps, upstreamUrl(origin, "/api/v1/state"), { method: "GET" });
+    if (!upstream.ok) return c.json(upstream.body, status(upstream.status));
+    try {
+      return c.json(normalizeState(upstream.body));
+    } catch (err: unknown) {
+      console.warn("[symphony] Failed to normalize Elixir state:", err instanceof Error ? err.message : String(err));
+      return c.json(genericProxyError("invalid_response", "Symphony returned an invalid response"), status(502));
+    }
+  }));
+
+  app.get("/issues/:issueIdentifier", (c) => withPrincipal(c, deps, async () => {
+    const issueIdentifier = c.req.param("issueIdentifier");
+    const parsed = SymphonyIssueIdentifierSchema.safeParse(issueIdentifier);
+    if (!parsed.success) return c.json(genericProxyError("invalid_request", "Issue identifier is invalid"), status(400));
+    const upstream = await fetchJson(proxyDeps, upstreamUrl(origin, `/api/v1/issues/${encodeURIComponent(parsed.data)}`), { method: "GET" });
+    if (!upstream.ok) return c.json(upstream.body, status(upstream.status));
+    try {
+      return c.json(normalizeIssue(upstream.body));
+    } catch (err: unknown) {
+      console.warn("[symphony] Failed to normalize Elixir issue:", err instanceof Error ? err.message : String(err));
+      return c.json(genericProxyError("invalid_response", "Symphony returned an invalid response"), status(502));
+    }
+  }));
+
+  app.post("/refresh", emptyLimited, (c) => withPrincipal(c, deps, async () => {
+    const parsed = await parseEmptyJson(c);
+    if (!parsed.ok) return parsed.response;
+    const upstream = await fetchJson(proxyDeps, upstreamUrl(origin, "/api/v1/refresh"), { method: "POST" });
+    if (!upstream.ok) return c.json(upstream.body, status(upstream.status));
+    try {
+      const body = ElixirRefreshSchema.parse(upstream.body);
+      return c.json({ requested: true, requestedAt: body.requested_at ?? null }, status(upstream.status === 202 ? 202 : 200));
+    } catch (err: unknown) {
+      console.warn("[symphony] Failed to normalize Elixir refresh:", err instanceof Error ? err.message : String(err));
+      return c.json(genericProxyError("invalid_response", "Symphony returned an invalid response"), status(502));
+    }
+  }));
+
+  app.post("/runs/:runId/stop", emptyLimited, (c) => withPrincipal(c, deps, async () => {
+    const runId = c.req.param("runId");
+    const parsedRunId = SymphonyRunIdSchema.safeParse(runId);
+    if (!parsedRunId.success) return c.json(genericProxyError("invalid_request", "Run identifier is invalid"), status(400));
+    const parsed = await parseEmptyJson(c);
+    if (!parsed.ok) return parsed.response;
+    const upstream = await fetchJson(proxyDeps, upstreamUrl(origin, `/api/v1/runs/${encodeURIComponent(parsedRunId.data)}/stop`), { method: "POST" });
+    if (!upstream.ok) return c.json(upstream.body, status(upstream.status));
+    return c.json({ stopped: true });
+  }));
+
+  return app;
+}

--- a/tests/gateway/symphony-proxy.test.ts
+++ b/tests/gateway/symphony-proxy.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+import { createElixirSymphonyProxyRoutes } from "../../packages/gateway/src/symphony/proxy.js";
+import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Elixir Symphony proxy routes", () => {
+  it("normalizes loopback Elixir state without exposing raw upstream errors", async () => {
+    const fetchImpl = vi.fn(async () => json({
+      generated_at: "2026-05-25T00:00:00Z",
+      counts: { running: 1, retrying: 1 },
+      running: [{
+        issue_identifier: "MAT-32",
+        state: "In Progress",
+        session_id: "thread-1-turn-2",
+        turn_count: 2,
+        last_event: "session_token_event",
+        last_message: "session completed with token lin_secret123",
+      }],
+      retrying: [{ issue_identifier: "MAT-33", attempt: 2, error: "linear exploded with token lin_secret" }],
+    }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/state");
+
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:4766/api/v1/state", expect.objectContaining({
+      method: "GET",
+      signal: expect.any(AbortSignal),
+    }));
+    const body = await res.json();
+    expect(body).toMatchObject({
+      service: { status: "ready", generatedAt: "2026-05-25T00:00:00Z" },
+      groups: {
+        running: [{ issueIdentifier: "MAT-32", sessionId: "thread-1-turn-2", turnCount: 2, latestEvent: "[redacted]", latestMessage: "session completed with [redacted] [redacted]" }],
+        needsAttention: [{ issueIdentifier: "MAT-33", attempt: 2 }],
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain("lin_secret");
+  });
+
+  it("rejects unauthenticated callers before contacting Elixir", async () => {
+    const fetchImpl = vi.fn();
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => {
+        throw new MissingRequestPrincipalError();
+      },
+    });
+
+    const res = await app.request("/state");
+
+    expect(res.status).toBe(401);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("proxies refresh with body limits and an upstream timeout", async () => {
+    const fetchImpl = vi.fn(async () => json({ requested_at: "2026-05-25T00:00:00Z" }, { status: 202 }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+      timeoutMs: 1234,
+    });
+
+    const res = await app.request("/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(202);
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:4766/api/v1/refresh", expect.objectContaining({
+      method: "POST",
+      signal: expect.any(AbortSignal),
+    }));
+    expect(await res.json()).toEqual({ requested: true, requestedAt: "2026-05-25T00:00:00Z" });
+  });
+
+  it("maps malformed refresh responses to generic invalid-response errors", async () => {
+    const fetchImpl = vi.fn(async () => json({ requested_at: 123 }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: { code: "invalid_response", message: "Symphony returned an invalid response" } });
+  });
+
+  it("maps offline or invalid upstream responses to generic unavailable errors", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:4766");
+    });
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/state");
+
+    expect(res.status).toBe(503);
+    expect(JSON.stringify(await res.json())).not.toContain("ECONNREFUSED");
+  });
+
+  it("validates issue identifiers before proxying detail requests", async () => {
+    const fetchImpl = vi.fn();
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/issues/not-a-linear-key");
+
+    expect(res.status).toBe(400);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("preserves upstream missing-resource errors as not found", async () => {
+    const fetchImpl = vi.fn(async () => json({ error: { code: "issue_not_found" } }, { status: 404 }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/issues/MAT-404");
+
+    expect(res.status).toBe(404);
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:4766/api/v1/issues/MAT-404", expect.objectContaining({
+      method: "GET",
+      signal: expect.any(AbortSignal),
+    }));
+    expect(await res.json()).toEqual({ error: { code: "not_found", message: "Symphony resource not found" } });
+  });
+
+  it("scrubs issue logs and recent events before returning detail payloads", async () => {
+    const longWorkspacePath = `/tmp/${"workspace-".repeat(80)}`;
+    const fetchImpl = vi.fn(async () => json({
+      issue_identifier: "MAT-32",
+      status: "running",
+      workspace: {
+        path: longWorkspacePath,
+      },
+      running: {
+        last_event: "session_token_event",
+        last_message: "raw lin_secret token leaked",
+      },
+      logs: {
+        codex_session_logs: ["session started", "raw lin_secret token leaked"],
+      },
+      recent_events: [{ at: "2026-05-25T00:00:00Z", event: "token_usage", message: "gho_token should not leak" }],
+    }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/issues/MAT-32");
+
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:4766/api/v1/issues/MAT-32", expect.objectContaining({
+      method: "GET",
+      signal: expect.any(AbortSignal),
+    }));
+    const body = await res.json();
+    expect(body.latestEvent).toBe("[redacted]");
+    expect(body.latestMessage).toBe("raw [redacted] [redacted] leaked");
+    expect(body.workspacePath).toBe(longWorkspacePath.slice(0, 500));
+    expect(body.logs.codexSessionLogs).toEqual(["session started", "raw [redacted] [redacted] leaked"]);
+    expect(body.recentEvents[0].event).toBe("token_usage");
+    expect(body.recentEvents[0].message).toBe("[redacted] should not leak");
+    expect(JSON.stringify(body)).not.toContain("lin_secret");
+    expect(JSON.stringify(body)).not.toContain("gho_token");
+  });
+
+  it("proxies stop requests to the Elixir run endpoint", async () => {
+    const fetchImpl = vi.fn(async () => json({ stopped: true }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/runs/MAT-32/stop", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:4766/api/v1/runs/MAT-32/stop", expect.objectContaining({
+      method: "POST",
+      signal: expect.any(AbortSignal),
+    }));
+    expect(await res.json()).toEqual({ stopped: true });
+  });
+});


### PR DESCRIPTION
Summary
- Adds Matrix-authenticated /api/symphony proxy routes for Elixir state, issue details, refresh, and stop.
- Normalizes Elixir payloads into browser-safe response shapes with validation, loopback-only upstreams, body limits, and timeouts.

Tests
- pnpm exec vitest run tests/gateway/symphony-proxy.test.ts
- bun run check:patterns
- bun run typecheck
- bun run test

Review/Monitoring
- Part of Graphite stack #183-#195.

Invariants
- Source of truth: Elixir loopback API is canonical for Symphony state.
- Lock/transaction scope: no DB writes; proxy calls are single upstream requests with AbortSignal.timeout.
- Acceptable orphan states: upstream offline maps to generic unavailable without leaking provider or network details.
- Auth source of truth: Matrix request principal before contacting Elixir.
- Deferred scope: server route replacement is upstack.