### PR TITLE
feat(symphony): bridge elixir controls to matrix

### DIFF
--- a/packages/gateway/src/symphony/proxy-contracts.ts
+++ b/packages/gateway/src/symphony/proxy-contracts.ts
@@ -55,6 +55,11 @@ export const ElixirRefreshSchema = z.object({
   requested_at: z.string().optional(),
 }).passthrough();
 
+export const ElixirStopSchema = z.object({
+  stopped: z.literal(true).optional(),
+  stopped_at: z.string().optional(),
+}).passthrough();
+
 export function genericProxyError(code: string, message: string) {
   return { error: { code, message } };
 }

--- a/packages/gateway/src/symphony/proxy.ts
+++ b/packages/gateway/src/symphony/proxy.ts
@@ -6,6 +6,7 @@ import { isRequestPrincipalError, mapRequestPrincipalError, requireRequestPrinci
 import {
   ElixirIssueSchema,
   ElixirRefreshSchema,
+  ElixirStopSchema,
   ElixirStateSchema,
   EmptyProxyBodySchema,
   genericProxyError,
@@ -149,7 +150,7 @@ function normalizeRunning(entry: Record<string, unknown>) {
     latestMessage: scrubText(entry.last_message),
     startedAt: safeText(entry.started_at),
     updatedAt: safeText(entry.last_event_at),
-    allowedActions: ["refresh", "open_workspace"],
+    allowedActions: ["refresh", "open_workspace", "stop"],
   };
 }
 
@@ -161,7 +162,7 @@ function normalizeRetry(entry: Record<string, unknown>) {
     attempt: typeof entry.attempt === "number" ? entry.attempt : 0,
     dueAt: safeText(entry.due_at),
     latestEvent: "retrying",
-    allowedActions: ["refresh"],
+    allowedActions: ["refresh", "stop"],
   };
 }
 
@@ -196,7 +197,7 @@ function normalizeIssue(body: unknown) {
     logs: normalizeLogs(parsed.logs),
     recentEvents: normalizeRecentEvents(parsed.recent_events),
     retry: parsed.retry ? { attempt: parsed.retry.attempt ?? 0, dueAt: parsed.retry.due_at ?? null } : null,
-    allowedActions: ["refresh", "open_workspace"],
+    allowedActions: ["refresh", "open_workspace", "stop"],
   };
 }
 
@@ -256,7 +257,13 @@ export function createElixirSymphonyProxyRoutes(deps: ElixirSymphonyProxyDeps = 
     if (!parsed.ok) return parsed.response;
     const upstream = await fetchJson(proxyDeps, upstreamUrl(origin, `/api/v1/runs/${encodeURIComponent(parsedRunId.data)}/stop`), { method: "POST" });
     if (!upstream.ok) return c.json(upstream.body, status(upstream.status));
-    return c.json({ stopped: true });
+    try {
+      const body = ElixirStopSchema.parse(upstream.body);
+      return c.json({ stopped: body.stopped ?? true, stoppedAt: body.stopped_at ?? null });
+    } catch (err: unknown) {
+      console.warn("[symphony] Failed to normalize Elixir stop:", err instanceof Error ? err.message : String(err));
+      return c.json(genericProxyError("invalid_response", "Symphony returned an invalid response"), status(502));
+    }
   }));
 
   return app;

--- a/packages/symphony-elixir/lib/symphony_elixir/linear/bridge.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/linear/bridge.ex
@@ -1,0 +1,8 @@
+defmodule SymphonyElixir.Linear.Bridge do
+  @moduledoc false
+
+  @credential "matrixos:integration:linear"
+
+  @spec credential() :: String.t()
+  def credential, do: @credential
+end

--- a/packages/symphony-elixir/lib/symphony_elixir/linear/client.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/linear/client.ex
@@ -4,7 +4,7 @@ defmodule SymphonyElixir.Linear.Client do
   """
 
   require Logger
-  alias SymphonyElixir.{Config, Linear.Issue}
+  alias SymphonyElixir.{Config, Linear.Bridge, Linear.Issue}
 
   @issue_page_size 50
   @max_pages 200
@@ -165,7 +165,7 @@ defmodule SymphonyElixir.Linear.Client do
   def graphql(query, variables \\ %{}, opts \\ [])
       when is_binary(query) and is_map(variables) and is_list(opts) do
     payload = build_graphql_payload(query, variables, Keyword.get(opts, :operation_name))
-    request_fun = Keyword.get(opts, :request_fun, &post_graphql_request/2)
+    request_fun = Keyword.get(opts, :request_fun) || graphql_request_fun()
 
     with {:ok, headers} <- graphql_headers(),
          {:ok, %{status: 200, body: body}} <- request_fun.(payload, headers) do
@@ -391,12 +391,25 @@ defmodule SymphonyElixir.Linear.Client do
       nil ->
         {:error, :missing_linear_api_token}
 
+      token when token == Bridge.credential() ->
+        {:ok,
+         [
+           {"Content-Type", "application/json"}
+         ]}
+
       token ->
         {:ok,
          [
            {"Authorization", token},
            {"Content-Type", "application/json"}
          ]}
+    end
+  end
+
+  defp graphql_request_fun do
+    case Config.settings!().tracker.api_key do
+      token when token == Bridge.credential() -> &post_matrix_linear_bridge_request/2
+      _ -> &post_graphql_request/2
     end
   end
 
@@ -408,6 +421,59 @@ defmodule SymphonyElixir.Linear.Client do
       receive_timeout: 30_000
     )
   end
+
+  defp post_matrix_linear_bridge_request(payload, _headers) do
+    with {:ok, url} <- matrix_linear_bridge_url(),
+         {:ok, token} <- matrix_linear_bridge_token() do
+      Req.post(url,
+        headers: [
+          {"Authorization", "Bearer " <> token},
+          {"Content-Type", "application/json"}
+        ],
+        json: %{
+          service: "linear",
+          action: "graphql",
+          params: %{
+            query: payload["query"],
+            variables: payload["variables"] || %{}
+          }
+        },
+        connect_options: [timeout: 30_000],
+        receive_timeout: 30_000
+      )
+      |> unwrap_matrix_linear_bridge_response()
+    end
+  end
+
+  defp matrix_linear_bridge_url do
+    with {:ok, base_url} <- required_env("PLATFORM_INTERNAL_URL", :missing_platform_internal_url),
+         {:ok, handle} <- required_env("MATRIX_HANDLE", :missing_matrix_handle) do
+      encoded_handle = URI.encode(handle, &URI.char_unreserved?/1)
+      {:ok, String.trim_trailing(base_url, "/") <> "/internal/containers/" <> encoded_handle <> "/integrations/call"}
+    end
+  end
+
+  defp matrix_linear_bridge_token do
+    required_env("UPGRADE_TOKEN", :missing_upgrade_token)
+  end
+
+  defp required_env(name, reason) do
+    case System.get_env(name) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, reason}
+    end
+  end
+
+  defp unwrap_matrix_linear_bridge_response({:ok, %{body: %{"data" => data}} = response}) when is_map(data) do
+    {:ok, %{response | body: data}}
+  end
+
+  defp unwrap_matrix_linear_bridge_response({:ok, %{body: %{"error" => _error}}}) do
+    Logger.warning("Matrix Linear bridge returned an error response")
+    {:error, :matrix_linear_bridge_error}
+  end
+
+  defp unwrap_matrix_linear_bridge_response(other), do: other
 
   defp decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter) do
     issues =

--- a/packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/orchestrator.ex
@@ -964,6 +964,18 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
+  @spec stop_issue(String.t()) :: {:ok, map()} | {:error, :issue_not_found} | :unavailable
+  def stop_issue(issue_identifier), do: stop_issue(__MODULE__, issue_identifier)
+
+  @spec stop_issue(GenServer.server(), String.t()) :: {:ok, map()} | {:error, :issue_not_found} | :unavailable
+  def stop_issue(server, issue_identifier) when is_binary(issue_identifier) do
+    if Process.whereis(server) do
+      GenServer.call(server, {:stop_issue, issue_identifier})
+    else
+      :unavailable
+    end
+  end
+
   @spec snapshot() :: map() | :timeout | :unavailable
   def snapshot, do: snapshot(__MODULE__, 15_000)
 
@@ -1048,6 +1060,69 @@ defmodule SymphonyElixir.Orchestrator do
        requested_at: DateTime.utc_now(),
        operations: ["poll", "reconcile"]
      }, state}
+  end
+
+  def handle_call({:stop_issue, issue_identifier}, _from, state) when is_binary(issue_identifier) do
+    case stop_issue_in_state(state, issue_identifier) do
+      {:ok, stopped, state} ->
+        notify_dashboard()
+        {:reply, {:ok, stopped}, state}
+
+      {:error, :issue_not_found} ->
+        {:reply, {:error, :issue_not_found}, state}
+    end
+  end
+
+  defp stop_issue_in_state(%State{} = state, issue_identifier) do
+    cond do
+      match = find_running_issue_match(state.running, issue_identifier) ->
+        {issue_id, running_entry} = match
+        stopped = stop_payload(issue_identifier, issue_id, Map.get(running_entry, :identifier), "running")
+        {:ok, stopped, terminate_running_issue(state, issue_id, false)}
+
+      match = find_retry_issue_match(state.retry_attempts, issue_identifier) ->
+        {issue_id, retry_entry} = match
+        stopped = stop_payload(issue_identifier, issue_id, Map.get(retry_entry, :identifier), "retrying")
+        {:ok, stopped, cancel_retry_issue(state, issue_id, retry_entry)}
+
+      true ->
+        {:error, :issue_not_found}
+    end
+  end
+
+  defp find_running_issue_match(running, issue_identifier) when is_map(running) do
+    Enum.find(running, fn {issue_id, running_entry} ->
+      issue_id == issue_identifier || Map.get(running_entry, :identifier) == issue_identifier
+    end)
+  end
+
+  defp find_retry_issue_match(retry_attempts, issue_identifier) when is_map(retry_attempts) do
+    Enum.find(retry_attempts, fn {issue_id, retry_entry} ->
+      issue_id == issue_identifier || Map.get(retry_entry, :identifier) == issue_identifier
+    end)
+  end
+
+  defp cancel_retry_issue(%State{} = state, issue_id, retry_entry) when is_map(retry_entry) do
+    case Map.get(retry_entry, :timer_ref) do
+      timer_ref when is_reference(timer_ref) -> Process.cancel_timer(timer_ref)
+      _ -> :ok
+    end
+
+    %{
+      state
+      | claimed: MapSet.delete(state.claimed, issue_id),
+        retry_attempts: Map.delete(state.retry_attempts, issue_id)
+    }
+  end
+
+  defp stop_payload(requested_identifier, issue_id, known_identifier, previous_status) do
+    %{
+      stopped: true,
+      issue_id: issue_id,
+      issue_identifier: known_identifier || requested_identifier,
+      previous_status: previous_status,
+      stopped_at: DateTime.utc_now()
+    }
   end
 
   defp integrate_codex_update(running_entry, %{event: event, timestamp: timestamp} = update) do

--- a/packages/symphony-elixir/lib/symphony_elixir_web/controllers/observability_api_controller.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir_web/controllers/observability_api_controller.ex
@@ -56,6 +56,20 @@ defmodule SymphonyElixirWeb.ObservabilityApiController do
     end
   end
 
+  @spec stop(Conn.t(), map()) :: Conn.t()
+  def stop(conn, %{"issue_identifier" => issue_identifier}) do
+    case Presenter.stop_payload(issue_identifier, orchestrator()) do
+      {:ok, payload} ->
+        json(conn, payload)
+
+      {:error, :issue_not_found} ->
+        error_response(conn, 404, "issue_not_found", "Issue not found")
+
+      {:error, :unavailable} ->
+        error_response(conn, 503, "orchestrator_unavailable", "Orchestrator is unavailable")
+    end
+  end
+
   @spec method_not_allowed(Conn.t(), map()) :: Conn.t()
   def method_not_allowed(conn, _params) do
     error_response(conn, 405, "method_not_allowed", "Method not allowed")

--- a/packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex
@@ -64,6 +64,21 @@ defmodule SymphonyElixirWeb.Presenter do
     end
   end
 
+  @spec stop_payload(String.t(), GenServer.name()) ::
+          {:ok, map()} | {:error, :issue_not_found | :unavailable}
+  def stop_payload(issue_identifier, orchestrator) when is_binary(issue_identifier) do
+    case Orchestrator.stop_issue(orchestrator, issue_identifier) do
+      {:ok, payload} ->
+        {:ok, Map.update!(payload, :stopped_at, &DateTime.to_iso8601/1)}
+
+      {:error, :issue_not_found} ->
+        {:error, :issue_not_found}
+
+      :unavailable ->
+        {:error, :unavailable}
+    end
+  end
+
   defp issue_payload_body(issue_identifier, running, retry) do
     %{
       issue_identifier: issue_identifier,

--- a/packages/symphony-elixir/lib/symphony_elixir_web/router.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir_web/router.ex
@@ -34,6 +34,8 @@ defmodule SymphonyElixirWeb.Router do
     match(:*, "/api/v1/state", ObservabilityApiController, :method_not_allowed)
     post("/api/v1/refresh", ObservabilityApiController, :refresh)
     match(:*, "/api/v1/refresh", ObservabilityApiController, :method_not_allowed)
+    post("/api/v1/runs/:issue_identifier/stop", ObservabilityApiController, :stop)
+    match(:*, "/api/v1/runs/:issue_identifier/stop", ObservabilityApiController, :method_not_allowed)
     get("/api/v1/:issue_identifier", ObservabilityApiController, :issue)
     match(:*, "/api/v1/:issue_identifier", ObservabilityApiController, :method_not_allowed)
     match(:*, "/*path", ObservabilityApiController, :not_found)

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -51,6 +51,7 @@ describe("customer VPS Symphony systemd unit", () => {
     const mix = await readFile("packages/symphony-elixir/mix.exs", "utf8");
     const workflow = await readFile("packages/symphony-elixir/WORKFLOW.md", "utf8");
     const configSchema = await readFile("packages/symphony-elixir/lib/symphony_elixir/config/schema.ex", "utf8");
+    const linearBridge = await readFile("packages/symphony-elixir/lib/symphony_elixir/linear/bridge.ex", "utf8");
     const buildScript = await readFile("scripts/build-host-bundle.sh", "utf8");
 
     expect(license).toContain("Apache License");
@@ -63,6 +64,9 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(workflow).toContain('host: "127.0.0.1"');
     expect(configSchema).toContain("SYMPHONY_WORKSPACE_ROOT");
     expect(configSchema).toContain("MATRIX_HOME");
+    expect(configSchema).toContain("SYMPHONY_LINEAR_CREDENTIAL");
+    expect(configSchema).toContain("Bridge.credential()");
+    expect(linearBridge).toContain("matrixos:integration:linear");
     expect(configSchema).toContain("SYMPHONY_LINEAR_API_KEY");
     expect(configSchema).toContain("SYMPHONY_LINEAR_PROJECT_SLUG");
     expect(buildScript).toContain("cp -a \"$ROOT_DIR/packages\" \"$STAGE_DIR/app/packages\"");
@@ -71,6 +75,7 @@ describe("customer VPS Symphony systemd unit", () => {
   it("keeps observability failures distinct from missing issues", async () => {
     const presenter = await readFile("packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex", "utf8");
     const controller = await readFile("packages/symphony-elixir/lib/symphony_elixir_web/controllers/observability_api_controller.ex", "utf8");
+    const router = await readFile("packages/symphony-elixir/lib/symphony_elixir_web/router.ex", "utf8");
     const pubsub = await readFile("packages/symphony-elixir/lib/symphony_elixir_web/observability_pubsub.ex", "utf8");
     const staticAssets = await readFile(
       "packages/symphony-elixir/lib/symphony_elixir_web/controllers/static_asset_controller.ex",
@@ -84,6 +89,8 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(controller).toContain("orchestrator_unavailable");
     expect(controller).toContain('code: "snapshot_timeout"');
     expect(controller).toContain("put_status(503)");
+    expect(router).toContain('post("/api/v1/runs/:issue_identifier/stop"');
+    expect(router).not.toContain('post("/api/v1/:issue_identifier/stop"');
     expect(pubsub).toContain("_ = Phoenix.PubSub.broadcast");
     expect(pubsub).toContain(":ok");
     const dashboardLive = await readFile("packages/symphony-elixir/lib/symphony_elixir_web/live/dashboard_live.ex", "utf8");
@@ -196,5 +203,21 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(prBodyCheck).toContain("|> Enum.drop_while(&(&1 != current_heading))");
     expect(prBodyCheck).toContain("|> Enum.drop(1)");
     expect(prBodyCheck).not.toContain('"\n\n" <- binary_part(doc, section_start, 2)');
+  });
+
+  it("routes Linear through the Matrix-owned integration bridge by default", async () => {
+    const linearClient = await readFile("packages/symphony-elixir/lib/symphony_elixir/linear/client.ex", "utf8");
+
+    expect(linearClient).toContain("Bridge.credential()");
+    expect(linearClient).toContain("PLATFORM_INTERNAL_URL");
+    expect(linearClient).toContain("UPGRADE_TOKEN");
+    expect(linearClient).toContain("MATRIX_HANDLE");
+    expect(linearClient).toContain("/internal/containers/");
+    expect(linearClient).toContain("/integrations/call");
+    expect(linearClient).toContain("URI.encode(handle, &URI.char_unreserved?/1)");
+    expect(linearClient).not.toContain("URI.encode_www_form(handle)");
+    expect(linearClient).toContain('service: "linear"');
+    expect(linearClient).toContain('action: "graphql"');
+    expect(linearClient).toContain(":matrix_linear_bridge_error");
   });
 });

--- a/tests/gateway/symphony-proxy.test.ts
+++ b/tests/gateway/symphony-proxy.test.ts
@@ -60,6 +60,7 @@ describe("Elixir Symphony proxy routes", () => {
       },
     });
     expect(JSON.stringify(body)).not.toContain("lin_secret");
+    expect(body.groups.needsAttention[0].allowedActions).toContain("stop");
   });
 
   it("rejects unauthenticated callers before contacting Elixir", async () => {
@@ -107,6 +108,44 @@ describe("Elixir Symphony proxy routes", () => {
     });
 
     const res = await app.request("/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: { code: "invalid_response", message: "Symphony returned an invalid response" } });
+  });
+
+  it("proxies stop actions to the Elixir issue stop endpoint", async () => {
+    const fetchImpl = vi.fn(async () => json({ stopped: true, stopped_at: "2026-05-25T00:00:01Z" }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/runs/MAT-32/stop", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:4766/api/v1/runs/MAT-32/stop", expect.objectContaining({
+      method: "POST",
+      signal: expect.any(AbortSignal),
+    }));
+    expect(await res.json()).toEqual({ stopped: true, stoppedAt: "2026-05-25T00:00:01Z" });
+  });
+
+  it("maps malformed stop responses to generic invalid-response errors", async () => {
+    const fetchImpl = vi.fn(async () => json({ stopped: false }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/runs/MAT-32/stop", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: "{}",
@@ -219,6 +258,6 @@ describe("Elixir Symphony proxy routes", () => {
       method: "POST",
       signal: expect.any(AbortSignal),
     }));
-    expect(await res.json()).toEqual({ stopped: true });
+    expect(await res.json()).toEqual({ stopped: true, stoppedAt: null });
   });
 });


### PR DESCRIPTION
Summary
- Adds Elixir stop controls and Matrix-owned Linear bridge behavior.
- The Elixir Linear client defaults to the platform internal integrations route via PLATFORM_INTERNAL_URL, UPGRADE_TOKEN, and MATRIX_HANDLE.

Tests
- pnpm exec vitest run tests/gateway/symphony-proxy.test.ts tests/deploy/customer-vps/symphony-systemd.test.ts tests/default-apps/symphony-app.test.tsx
- bun run check:patterns
- bun run typecheck
- bun run test

Review/Monitoring
- Part of Graphite stack #183-#195.

Invariants
- Source of truth: Elixir orchestrator owns running/retry state and termination.
- Lock/transaction scope: stop mutates only in-memory Elixir state and cancels task/timer refs atomically within GenServer call handling.
- Acceptable orphan states: stopped workspace is preserved; missing issue returns generic not found.
- Auth source of truth: browser calls gateway; Elixir calls platform internal integrations with VPS token.
- Deferred scope: richer Linear connection diagnostics can be added later.