### PR TITLE
docs(symphony): document elixir service runtime

### DIFF
--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -23,6 +23,7 @@ interface SymphonyRun {
 interface SymphonyState {
   service: {
     status: "ready" | "degraded" | "unavailable";
+    credentialStatus?: "connected" | "setup_required" | "unavailable" | "not_required";
     generatedAt: string | null;
   };
   groups: Record<RunGroup, SymphonyRun[]>;
@@ -144,6 +145,7 @@ export default function App() {
   const [selectedIssue, setSelectedIssue] = useState<string | null>(null);
   const [detail, setDetail] = useState<SymphonyIssueDetail | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const selectedIssueRef = useRef<string | null>(null);
   const detailAbortRef = useRef<AbortController | null>(null);
@@ -182,6 +184,7 @@ export default function App() {
     setState(next);
     const nextActive = chooseActiveIssue(next, selectedIssueRef.current, preferredIssue);
     setActiveIssue(nextActive);
+    setLoading(false);
     if (nextActive) {
       try {
         await loadIssueDetail(nextActive);
@@ -200,6 +203,7 @@ export default function App() {
     void loadState().catch((err: unknown) => {
       console.warn("[symphony] state load failed:", err instanceof Error ? err.message : String(err));
       setError("Symphony is unavailable.");
+      setLoading(false);
     });
   }, [loadState]);
 
@@ -286,6 +290,18 @@ export default function App() {
         <Metric label="Done / Handoff" value={state.groups.done.length} />
       </section>
 
+      {loading && (
+        <div className="mx-5 mb-4 border bg-white px-4 py-3 text-sm text-muted-foreground">
+          Loading Symphony state...
+        </div>
+      )}
+
+      {state.service.credentialStatus === "setup_required" && (
+        <div className="mx-5 mb-4 border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          Connect Linear in Matrix Integrations to let Symphony poll assigned work.
+        </div>
+      )}
+
       <section className="grid gap-5 px-5 pb-5 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
         <div className="space-y-4">
           {RUN_GROUPS.map((group) => (
@@ -323,6 +339,7 @@ export default function App() {
             <div className="min-w-0">
               <h2 className="truncate text-base font-semibold">{detail?.issueIdentifier ?? activeIssue ?? "No active issue"}</h2>
               <p className="text-sm text-muted-foreground">Service: {state.service.status}</p>
+              <p className="text-sm text-muted-foreground">Linear: {state.service.credentialStatus ?? "unavailable"}</p>
             </div>
             {detail?.workpadUrl && (
               <Button variant="outline" size="sm" onClick={() => window.open(detail.workpadUrl!, "_blank", "noopener,noreferrer")}>

--- a/packages/gateway/src/symphony/proxy-contracts.ts
+++ b/packages/gateway/src/symphony/proxy-contracts.ts
@@ -26,6 +26,7 @@ const ElixirRetryEntrySchema = z.object({
 
 export const ElixirStateSchema = z.object({
   generated_at: z.string().optional(),
+  credential_status: z.enum(["connected", "setup_required", "unavailable", "not_required"]).optional(),
   error: z.object({ code: z.string().optional(), message: z.string().optional() }).optional(),
   running: z.array(ElixirRunningEntrySchema).optional(),
   retrying: z.array(ElixirRetryEntrySchema).optional(),

--- a/packages/gateway/src/symphony/proxy.ts
+++ b/packages/gateway/src/symphony/proxy.ts
@@ -172,6 +172,7 @@ function normalizeState(body: unknown) {
     service: {
       status: parsed.error ? "degraded" : "ready",
       generatedAt: parsed.generated_at ?? null,
+      credentialStatus: parsed.credential_status ?? "unavailable",
     },
     groups: {
       queue: [],

--- a/packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex
@@ -3,7 +3,7 @@ defmodule SymphonyElixirWeb.Presenter do
   Shared projections for the observability API and dashboard.
   """
 
-  alias SymphonyElixir.{Config, Orchestrator, StatusDashboard}
+  alias SymphonyElixir.{Config, Linear.Bridge, Orchestrator, StatusDashboard}
 
   @spec state_payload(GenServer.name(), timeout()) :: map()
   def state_payload(orchestrator, snapshot_timeout_ms) do
@@ -13,6 +13,7 @@ defmodule SymphonyElixirWeb.Presenter do
       %{} = snapshot ->
         %{
           generated_at: generated_at,
+          credential_status: credential_status(),
           counts: %{
             running: length(snapshot.running),
             retrying: length(snapshot.retrying)
@@ -24,10 +25,18 @@ defmodule SymphonyElixirWeb.Presenter do
         }
 
       :timeout ->
-        %{generated_at: generated_at, error: %{code: "snapshot_timeout", message: "Snapshot timed out"}}
+        %{
+          generated_at: generated_at,
+          credential_status: credential_status(),
+          error: %{code: "snapshot_timeout", message: "Snapshot timed out"}
+        }
 
       :unavailable ->
-        %{generated_at: generated_at, error: %{code: "snapshot_unavailable", message: "Snapshot unavailable"}}
+        %{
+          generated_at: generated_at,
+          credential_status: credential_status(),
+          error: %{code: "snapshot_unavailable", message: "Snapshot unavailable"}
+        }
     end
   end
 
@@ -180,6 +189,37 @@ defmodule SymphonyElixirWeb.Presenter do
 
   defp summarize_message(nil), do: nil
   defp summarize_message(message), do: StatusDashboard.humanize_codex_message(message)
+
+  defp credential_status do
+    case Config.settings() do
+      {:ok, settings} ->
+        cond do
+          settings.tracker.kind != "linear" ->
+            "not_required"
+
+          is_binary(settings.tracker.api_key) and settings.tracker.api_key == Bridge.credential() ->
+            if matrix_linear_bridge_configured?(), do: "connected", else: "setup_required"
+
+          is_binary(settings.tracker.api_key) ->
+            "connected"
+
+          true ->
+            "setup_required"
+        end
+
+      {:error, _reason} ->
+        "unavailable"
+    end
+  end
+
+  defp matrix_linear_bridge_configured? do
+    Enum.all?(["PLATFORM_INTERNAL_URL", "UPGRADE_TOKEN", "MATRIX_HANDLE"], fn name ->
+      case System.get_env(name) do
+        value when is_binary(value) and value != "" -> true
+        _ -> false
+      end
+    end)
+  end
 
   defp due_at_iso8601(due_in_ms) when is_integer(due_in_ms) do
     DateTime.utc_now()

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -23,7 +23,7 @@ function json(body: unknown, init?: ResponseInit): Response {
 
 function symphonyState() {
   return {
-    service: { status: "ready", generatedAt: "2026-05-25T00:00:00Z" },
+    service: { status: "ready", credentialStatus: "connected", generatedAt: "2026-05-25T00:00:00Z" },
     groups: {
       queue: [{ issueIdentifier: "MAT-31", status: "queued", latestEvent: "Queued" }],
       running: [{ issueIdentifier: "MAT-32", status: "running", sessionId: "thread-1-turn-2", turnCount: 2, latestEvent: "session_started" }],
@@ -109,6 +109,7 @@ describe("Symphony app", () => {
     expect(screen.getAllByText("Needs Attention").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Done / Handoff").length).toBeGreaterThan(0);
     expect(screen.getAllByText("thread-1-turn-2").length).toBeGreaterThan(0);
+    expect(screen.getByText("Linear: connected")).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();
     expect(screen.getAllByText("session_started").length).toBeGreaterThan(0);
     expect(screen.getByText("/home/matrix/home/projects/matrix-os/symphony-workspaces/MAT-32")).toBeTruthy();
@@ -223,6 +224,47 @@ describe("Symphony app", () => {
     await waitFor(() => expect(screen.getAllByText("Queue").length).toBeGreaterThan(0));
     expect(screen.queryByText("Symphony is unavailable.")).toBeNull();
     expect(screen.getByText("Issue detail could not be loaded.")).toBeTruthy();
+  });
+
+  it("clears initial loading once state is ready before issue detail resolves", async () => {
+    let resolveDetail: (response: Response) => void = () => {};
+    const detailResponse = new Promise<Response>((resolve) => {
+      resolveDetail = resolve;
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/symphony/state") {
+        return json({
+          service: { status: "ready", credentialStatus: "setup_required", generatedAt: "2026-05-25T00:00:00Z" },
+          groups: {
+            queue: [],
+            running: [{ issueIdentifier: "MAT-32", status: "running" }],
+            needsAttention: [],
+            done: [],
+          },
+        });
+      }
+      if (url === "/api/symphony/issues/MAT-32") {
+        return detailResponse;
+      }
+      return json({ ok: true });
+    }));
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect Linear in Matrix Integrations to let Symphony poll assigned work.")).toBeTruthy();
+    });
+    expect(screen.queryByText("Loading Symphony state...")).toBeNull();
+
+    resolveDetail(json({
+      issueIdentifier: "MAT-32",
+      status: "running",
+      allowedActions: ["refresh"],
+      logs: { codexSessionLogs: [] },
+      recentEvents: [],
+    }));
   });
 
   it("keeps long session and workspace text visible for mobile-friendly layouts", async () => {

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -207,8 +207,10 @@ describe("customer VPS Symphony systemd unit", () => {
 
   it("routes Linear through the Matrix-owned integration bridge by default", async () => {
     const linearClient = await readFile("packages/symphony-elixir/lib/symphony_elixir/linear/client.ex", "utf8");
+    const presenter = await readFile("packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex", "utf8");
 
     expect(linearClient).toContain("Bridge.credential()");
+    expect(presenter).toContain("is_binary(settings.tracker.api_key) and settings.tracker.api_key == Bridge.credential()");
     expect(linearClient).toContain("PLATFORM_INTERNAL_URL");
     expect(linearClient).toContain("UPGRADE_TOKEN");
     expect(linearClient).toContain("MATRIX_HANDLE");

--- a/tests/gateway/symphony-proxy.test.ts
+++ b/tests/gateway/symphony-proxy.test.ts
@@ -28,6 +28,7 @@ describe("Elixir Symphony proxy routes", () => {
   it("normalizes loopback Elixir state without exposing raw upstream errors", async () => {
     const fetchImpl = vi.fn(async () => json({
       generated_at: "2026-05-25T00:00:00Z",
+      credential_status: "connected",
       counts: { running: 1, retrying: 1 },
       running: [{
         issue_identifier: "MAT-32",
@@ -53,7 +54,7 @@ describe("Elixir Symphony proxy routes", () => {
     }));
     const body = await res.json();
     expect(body).toMatchObject({
-      service: { status: "ready", generatedAt: "2026-05-25T00:00:00Z" },
+      service: { status: "ready", generatedAt: "2026-05-25T00:00:00Z", credentialStatus: "connected" },
       groups: {
         running: [{ issueIdentifier: "MAT-32", sessionId: "thread-1-turn-2", turnCount: 2, latestEvent: "[redacted]", latestMessage: "session completed with [redacted] [redacted]" }],
         needsAttention: [{ issueIdentifier: "MAT-33", attempt: 2 }],

--- a/www/content/docs/symphony.mdx
+++ b/www/content/docs/symphony.mdx
@@ -1,51 +1,80 @@
 ---
 title: Symphony
-description: Run assigned Linear tickets with Matrix-owned coding agents and worktrees.
+description: Run Linear tickets through the Matrix-owned Elixir Symphony service.
 ---
 
 # Symphony
 
-Symphony turns selected Linear tickets into Matrix-owned coding-agent runs. You
-choose which team, labels, states, and assignees Symphony can react to. Matrix
-creates the worktree, starts the agent session, and shows the status in one
-dashboard.
+Symphony is the Matrix coding-agent operator for Linear work. On each customer
+VPS it runs as `matrix-symphony.service`, owned by the `matrix` user with
+`MATRIX_HOME=/home/matrix/home`.
 
-## Set Up Linear
+The service is an adapted Elixir runtime. It polls eligible Linear issues,
+creates Matrix-owned workspaces, starts agents through `codex app-server`, and
+exposes loopback state to the Matrix gateway. The browser never talks to the
+Elixir service directly.
 
-Open Symphony from Matrix and use **Setup**.
+## Linear Access
 
-Add a Linear API secret server-side, then choose:
+Connect Linear from Matrix settings or the Integrations app. Symphony uses that
+Matrix-owned connection through the platform integration bridge.
 
-- Matrix project
-- Linear team
-- Required labels
-- Active and terminal states
-- Optional assignee IDs
-- Agent and concurrency
+You do not need to put `LINEAR_API_KEY` on the VPS. The Elixir runtime defaults
+to the Matrix credential bridge, which calls the platform internal integrations
+route using the VPS internal token. The UI only receives coarse setup or
+availability status, not provider tokens or raw provider errors.
 
-The browser only sees whether a credential exists. It never receives your
-Linear token.
+For local development, an explicit `SYMPHONY_LINEAR_API_KEY` or
+`SYMPHONY_LINEAR_CREDENTIAL` can still override the bridge.
 
-## Run Tickets
+## Runtime Paths
 
-After setup, Symphony previews eligible tickets. Press **Start** to let Symphony
-poll Linear and claim work.
+Symphony workspaces live under the owner home:
 
-For every eligible ticket, Symphony creates or reuses one Matrix worktree,
-acquires the worktree lease, starts one agent session, and records the run in
-the dashboard. Duplicate active claims for the same ticket are rejected.
+```txt
+/home/matrix/home/projects/matrix-os/symphony-workspaces/<issue>
+```
 
-## Operate Runs
+Runtime logs live under:
 
-The dashboard groups work by Queue, Running, Needs Attention, and Done/Handoff.
-Each run shows the ticket, agent, worktree, session, latest event, and actions to
-stop, retry, open the Matrix workspace, or open the Linear ticket.
+```txt
+/home/matrix/home/system/symphony/logs
+```
 
-If Linear, workflow loading, worktree creation, or agent startup fails, Symphony
-shows a generic attention state while detailed errors stay in server logs.
+Updates replace `/opt/matrix/app` only. They must not overwrite owner data under
+`/home/matrix/home`.
 
-## Workflow Policy
+## Matrix App
 
-Repository instructions stay in `WORKFLOW.md` inside the selected Matrix
-project. Matrix stores runtime rules and credentials separately so teams can
-version coding policy without putting secrets in the repo.
+Open Symphony from Matrix to see the Elixir runtime state. The app shows:
+
+- Queue, Running, Needs Attention, and Done/Handoff groups
+- active issue identifier
+- Codex app-server session ID and turn count
+- latest event and message
+- workspace path
+- workpad link when available
+- recent logs
+
+Use **Refresh** to ask the Elixir runtime to poll and reconcile now. Use
+**Stop** to terminate the active issue session through the gateway proxy.
+
+## Service Operations
+
+The host bundle installs and starts:
+
+```bash
+systemctl status matrix-symphony.service
+journalctl -u matrix-symphony.service -f
+```
+
+The service binds to `127.0.0.1:4766`. Matrix gateway proxies authenticated
+requests from `/api/symphony/*` to that loopback API with validation, body
+limits, timeouts, and generic error mapping.
+
+## Migration Notes
+
+The old in-gateway TypeScript Symphony runner is no longer the runtime source of
+truth for the Matrix app. Gateway routes now proxy the Elixir service instead of
+maintaining a separate run table. Existing docs or workflows that mention
+manual Symphony API-key setup should be moved to Matrix Integrations.


### PR DESCRIPTION
Summary
- Updates public Symphony docs for the Elixir host service, Matrix-owned Linear setup, workspace/log paths, app-server state, and migration notes.
- Adds visible credential status to the app/proxy projection so setup-required states are coarse and token-free.

Tests
- pnpm exec vitest run tests/gateway/symphony-proxy.test.ts tests/default-apps/symphony-app.test.tsx
- node scripts/build-default-apps.mjs home/apps/symphony
- bun run test

Review/Monitoring
- Part of Graphite stack #183-#195.

Invariants
- Source of truth: docs describe Elixir service plus Matrix gateway proxy boundary.
- Lock/transaction scope: no persistence.
- Acceptable orphan states: setup-required status remains coarse.
- Auth source of truth: Matrix integrations, not browser-provided provider secrets.
- Deferred scope: deeper troubleshooting screenshots can follow after live deployment.