### PR TITLE
test(apps): pin vite app package manager

### DIFF
--- a/home/apps/_template-vite/package.json
+++ b/home/apps/_template-vite/package.json
@@ -2,6 +2,7 @@
   "name": "template-vite",
   "private": true,
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "packageManager": "pnpm@10.33.4",
   "scripts": {

--- a/home/apps/messages/package.json
+++ b/home/apps/messages/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@10.33.4",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3105",
     "build": "tsc --noEmit && vite build",

--- a/home/apps/notes/package.json
+++ b/home/apps/notes/package.json
@@ -2,6 +2,7 @@
   "name": "@matrixos/notes",
   "private": true,
   "version": "3.0.0",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3101",

--- a/home/apps/symphony/package.json
+++ b/home/apps/symphony/package.json
@@ -2,6 +2,7 @@
   "name": "@matrixos/symphony",
   "private": true,
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3106",

--- a/home/apps/task-manager/package.json
+++ b/home/apps/task-manager/package.json
@@ -2,6 +2,7 @@
   "name": "@matrixos/task-manager",
   "private": true,
   "version": "2.0.0",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3102",

--- a/home/apps/whiteboard/package.json
+++ b/home/apps/whiteboard/package.json
@@ -2,6 +2,7 @@
   "name": "@matrixos/whiteboard",
   "private": true,
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3100",

--- a/tests/fixtures/apps/hello-vite/package.json
+++ b/tests/fixtures/apps/hello-vite/package.json
@@ -2,6 +2,7 @@
   "name": "hello-vite",
   "private": true,
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "packageManager": "pnpm@10.33.4",
   "scripts": {


### PR DESCRIPTION
Summary
- Pins Vite app fixtures/templates to pnpm 10.33.4 so app-runtime tests do not drift to pnpm 11 outside the workspace.
- Updates cloud-init assertions for matrix-symphony.service and Erlang runtime packages.

Tests
- pnpm exec vitest run tests/platform/customer-vps-cloud-init.test.ts tests/gateway/app-runtime/build-orchestrator.test.ts tests/gateway/app-runtime/install-flow.test.ts tests/gateway/app-runtime-phase1.test.ts tests/gateway/app-manifest-api.test.ts tests/gateway/template-builds.test.ts
- bun run check:patterns
- bun run typecheck
- bun run test

Review/Monitoring
- Top of Graphite stack #183-#195.

Invariants
- Source of truth: package manager version follows repo packageManager.
- Lock/transaction scope: no runtime persistence.
- Acceptable orphan states: none.
- Auth source of truth: unchanged.
- Deferred scope: no app dependency upgrades in this PR.