### PR TITLE
fix(gateway): allow shell startup with no zellij sessions

### DIFF
--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -88,6 +88,14 @@ export function classifyZellijFailure(err: unknown, stderr: string): ZellijFailu
   return diagnostic;
 }
 
+function isNoActiveSessionsFailure(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const stderr = (err as { stderr?: unknown }).stderr;
+  return typeof stderr === "string" && /no active zellij sessions found/i.test(stderr);
+}
+
 export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter {
   const execFile = deps.execFile ?? nodeExecFile;
   const spawn = deps.spawn ?? nodeSpawn;
@@ -121,7 +129,15 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
 
   return {
     async listSessions() {
-      const stdout = await run(["list-sessions", "--no-formatting"]);
+      let stdout: string;
+      try {
+        stdout = await run(["list-sessions", "--no-formatting"]);
+      } catch (err) {
+        if (isNoActiveSessionsFailure(err)) {
+          return [];
+        }
+        throw err;
+      }
       return stdout
         .split(/\r?\n/)
         .map((line) => line.trim().split(/\s+/)[0])

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -32,6 +32,16 @@ describe("zellij adapter", () => {
     );
   });
 
+  it("treats zellij's no-active-sessions response as an empty session list", async () => {
+    const execFile = vi.fn((_file, _args, _opts, cb) => {
+      cb(Object.assign(new Error("zellij exited"), { code: 1 }), "", "NO ACTIVE ZELLIJ SESSIONS FOUND\n");
+      return childProcess();
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.listSessions()).resolves.toEqual([]);
+  });
+
   it("sanitizes stderr before surfacing errors", async () => {
     const execFile = vi.fn((_file, _args, _opts, cb) => {
       cb(new Error("boom"), "", "failed in /home/alice/.ssh with zellij internals");


### PR DESCRIPTION
Summary:
- Treat Zellij's no-active-sessions list response as an empty session list instead of a fatal shell error.
- Add regression coverage for fresh VPS shell startup where no Zellij sessions exist yet.

Tests:
- flox activate -- pnpm exec vitest run tests/gateway/shell-zellij.test.ts tests/gateway/shell-registry.test.ts
- flox activate -- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- flox activate -- bun run check:patterns (0 violations; existing broad warnings only)

Review/Monitoring:
- Watch CI and automated reviews after publish.
- After host-bundle deploy, verify GET /api/sessions returns an empty list on a fresh VPS and mos shell new can create the first session.

Invariants:
- Source of truth: Zellij remains canonical for live shell sessions; registry metadata reconciles against live sessions.
- Lock/transaction scope: ShellRegistry mutation queue still serializes list/create reconciliation; no DB transaction involved.
- Acceptable orphan states: Existing rollback path remains responsible for deleting a Zellij session if metadata persistence fails after create.
- Auth source of truth: Gateway auth/request principal behavior is unchanged.
- Deferred scope: This does not change host-bundle publish/deploy automation or client-visible error wording.