### PR TITLE
fix(gateway): attach zellij shells through a PTY

### DIFF
--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -1,8 +1,8 @@
-import type { ChildProcess } from "node:child_process";
 import { z } from "zod/v4";
 import { ShellReplayBuffer } from "./replay-buffer.js";
 import type { ScrollbackStore } from "./scrollback-store.js";
 import { validateSessionName } from "./names.js";
+import type { ShellAttachProcess } from "./zellij.js";
 
 const ShellWsInputSchema = z.object({
   type: z.literal("input"),
@@ -35,7 +35,7 @@ interface ShellWsRegistry {
 }
 
 interface ShellWsAdapter {
-  attachSession(name: string, options?: { signal?: AbortSignal }): ChildProcess;
+  attachSession(name: string, options?: { signal?: AbortSignal }): ShellAttachProcess;
 }
 
 export interface ShellWsHandlerOptions {
@@ -119,15 +119,29 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
 
     const abortController = new AbortController();
     const replayBuffer = buffers.get(safeName);
-    const child = options.adapter.attachSession(safeName, {
-      signal: abortController.signal,
-    });
+    let child: ShellAttachProcess;
+    try {
+      child = options.adapter.attachSession(safeName, {
+        signal: abortController.signal,
+      });
+    } catch (err: unknown) {
+      console.warn("[shell] zellij attach process failed:", err instanceof Error ? err.message : String(err));
+      sendJson(ws, {
+        type: "error",
+        code: "attach_failed",
+        message: "Shell attach failed",
+      });
+      ws.close?.();
+      return { onMessage: () => undefined, onClose: () => undefined };
+    }
     let closed = false;
+    let dataDisposable: { dispose(): void } | null = null;
+    let exitDisposable: { dispose(): void } | null = null;
     const cleanupProcessListeners = () => {
-      child.stdout?.off("data", onStdout);
-      child.stderr?.off("data", onStderr);
-      child.off("close", onChildClose);
-      child.off("error", onChildError);
+      dataDisposable?.dispose();
+      exitDisposable?.dispose();
+      dataDisposable = null;
+      exitDisposable = null;
     };
 
     sendJson(ws, {
@@ -144,8 +158,7 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
       sendJson(ws, event);
     }
 
-    const onStdout = (chunk: Buffer | string) => {
-      const data = Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : String(chunk);
+    const onData = (data: string) => {
       void replayBuffer.writePersistent(data)
         .then((result) => {
           if (result.seq !== null) {
@@ -156,35 +169,16 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           console.warn("[shell] failed to persist terminal output:", err instanceof Error ? err.message : String(err));
         });
     };
-    const onStderr = (chunk: Buffer | string) => {
-      // zellij stderr may contain paths or implementation details; keep it server-side only.
-      const length = Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(String(chunk));
-      if (length > 0) {
-        console.warn("[shell] zellij attach emitted stderr");
-      }
-    };
-    const onChildClose = (code: number | null) => {
+    const onExit = (event: { exitCode: number }) => {
       if (closed) {
         return;
       }
       closed = true;
       cleanupProcessListeners();
-      sendJson(ws, { type: "exit", code: code ?? null });
+      sendJson(ws, { type: "exit", code: event.exitCode });
     };
-    const onChildError = (err: unknown) => {
-      console.warn("[shell] zellij attach process failed:", err instanceof Error ? err.message : String(err));
-      if (!closed) {
-        sendJson(ws, {
-          type: "error",
-          code: "attach_failed",
-          message: "Shell attach failed",
-        });
-      }
-    };
-    child.stdout?.on("data", onStdout);
-    child.stderr?.on("data", onStderr);
-    child.once("close", onChildClose);
-    child.once("error", onChildError);
+    dataDisposable = child.onData(onData);
+    exitDisposable = child.onExit(onExit);
 
     const closeSession = () => {
       if (closed) {
@@ -220,10 +214,12 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
           return;
         }
         if (msg.type === "input") {
-          child.stdin?.write(msg.data);
+          child.write(msg.data);
+          return;
         }
-        // child_process does not expose PTY resize. The message is validated
-        // and accepted so clients can use the same protocol as PTY-backed paths.
+        if (msg.type === "resize") {
+          child.resize(msg.cols, msg.rows);
+        }
       },
       onClose: closeSession,
     };

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -1,12 +1,36 @@
 import {
   execFile as nodeExecFile,
-  spawn as nodeSpawn,
-  type ChildProcess,
 } from "node:child_process";
+import { createRequire } from "node:module";
 import { shellError, type ShellSafeError } from "./errors.js";
 
 type ExecFile = typeof nodeExecFile;
-type Spawn = typeof nodeSpawn;
+type Disposable = { dispose(): void };
+type PtyExitEvent = { exitCode: number; signal?: number };
+export interface ShellAttachProcess {
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(): void;
+  onData(listener: (data: string) => void): Disposable;
+  onExit(listener: (event: PtyExitEvent) => void): Disposable;
+}
+type PtySpawn = (
+  command: string,
+  args: string[],
+  options: {
+    name: string;
+    cols: number;
+    rows: number;
+    cwd: string;
+    env: Record<string, string>;
+  },
+) => ShellAttachProcess;
+
+const esmRequire = createRequire(import.meta.url);
+
+function defaultPtySpawn(): PtySpawn {
+  return (esmRequire("node-pty") as { spawn: PtySpawn }).spawn;
+}
 
 export interface ZellijFailureDiagnostic {
   binary: "zellij";
@@ -19,8 +43,10 @@ export interface ZellijFailureDiagnostic {
 
 export interface ZellijAdapterDeps {
   execFile?: ExecFile;
-  spawn?: Spawn;
+  spawnPty?: PtySpawn;
   timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface CreateSessionOptions {
@@ -39,7 +65,7 @@ export interface ZellijAdapter {
   createSession(options: CreateSessionOptions): Promise<void>;
   deleteSession(name: string, options?: { force?: boolean }): Promise<void>;
   validateLayout(path: string): Promise<void>;
-  attachSession(name: string, options?: AttachOptions): ChildProcess;
+  attachSession(name: string, options?: AttachOptions): ShellAttachProcess;
   listTabs(name: string): Promise<unknown[]>;
   createTab(name: string, input: { name?: string; cwd?: string; cmd?: string }): Promise<unknown>;
   switchTab(name: string, tab: number): Promise<unknown>;
@@ -48,6 +74,40 @@ export interface ZellijAdapter {
   closePane(name: string, pane: string): Promise<unknown>;
   applyLayout(name: string, layout: string): Promise<unknown>;
   dumpLayout(name: string): Promise<unknown>;
+}
+
+const SAFE_ATTACH_ENV_KEYS = new Set([
+  "COLORTERM",
+  "DISPLAY",
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TMPDIR",
+  "USER",
+  "WAYLAND_DISPLAY",
+  "XAUTHORITY",
+  "XDG_RUNTIME_DIR",
+]);
+
+const ZELLIJ_CONTEXT_ENV_KEYS = new Set([
+  "ZELLIJ",
+  "ZELLIJ_SESSION_NAME",
+  "ZELLIJ_PANE_ID",
+]);
+
+function attachEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value !== "string") continue;
+    if (ZELLIJ_CONTEXT_ENV_KEYS.has(key)) continue;
+    if (SAFE_ATTACH_ENV_KEYS.has(key) || key.startsWith("LC_") || key.startsWith("ZELLIJ_")) {
+      env[key] = value;
+    }
+  }
+  env.TERM = "xterm-256color";
+  return env;
 }
 
 export function sanitizeZellijError(stderr: string): string {
@@ -90,16 +150,17 @@ export function classifyZellijFailure(err: unknown, stderr: string): ZellijFailu
 
 export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter {
   const execFile = deps.execFile ?? nodeExecFile;
-  const spawn = deps.spawn ?? nodeSpawn;
   const timeoutMs = deps.timeoutMs ?? 10_000;
+  const cwd = deps.cwd ?? process.cwd();
+  const spawnPty = deps.spawnPty ?? defaultPtySpawn();
 
-  function run(args: string[], timeout = timeoutMs, cwd?: string): Promise<string> {
+  function run(args: string[], timeout = timeoutMs, runCwd?: string): Promise<string> {
     const controller = new AbortController();
     return new Promise((resolve, reject) => {
       const child = execFile(
         "zellij",
         args,
-        { timeout, signal: controller.signal, cwd },
+        { timeout, signal: controller.signal, cwd: runCwd },
         (err, stdout, stderr) => {
           if (err) {
             const safe = shellError("zellij_failed", "Shell operation failed", 500);
@@ -148,18 +209,26 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       await run(["setup", "--check", "--layout", path], 5_000);
     },
     attachSession(name, options = {}) {
-      const child = spawn("zellij", ["attach", name], { stdio: "pipe" });
+      const pty = spawnPty("zellij", ["attach", name], {
+        name: "xterm-256color",
+        cols: 120,
+        rows: 40,
+        cwd,
+        env: attachEnv(deps.env),
+      });
       const abort = () => {
-        child.kill();
+        pty.kill();
       };
+      const exitDisposable = pty.onExit(() => {
+        options.signal?.removeEventListener("abort", abort);
+        exitDisposable.dispose();
+      });
       if (options.signal?.aborted) {
         abort();
       } else {
         options.signal?.addEventListener("abort", abort, { once: true });
       }
-      child.once?.("close", () => options.signal?.removeEventListener("abort", abort));
-      child.once?.("error", () => options.signal?.removeEventListener("abort", abort));
-      return child;
+      return pty;
     },
     async listTabs(name) {
       const stdout = await run(["--session", name, "action", "query-tab-names"]);

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -14,6 +14,16 @@ function childProcess() {
   });
 }
 
+function ptyProcess() {
+  return {
+    kill: vi.fn(),
+    resize: vi.fn(),
+    write: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onExit: vi.fn(() => ({ dispose: vi.fn() })),
+  };
+}
+
 describe("zellij adapter", () => {
   it("uses execFile with argument arrays and bounded timeouts", async () => {
     const child = childProcess();
@@ -100,21 +110,68 @@ describe("zellij adapter", () => {
     });
   });
 
-  it("kills attach processes when the caller aborts", () => {
-    const child = childProcess();
-    const spawn = vi.fn(() => child);
+  it("starts attach through a PTY with a scrubbed zellij environment", () => {
+    const pty = ptyProcess();
+    const spawnPty = vi.fn(() => pty);
     const controller = new AbortController();
-    const adapter = createZellijAdapter({ execFile: vi.fn(), spawn, timeoutMs: 25 });
+    const adapter = createZellijAdapter({
+      execFile: vi.fn(),
+      spawnPty,
+      timeoutMs: 25,
+      env: {
+        HOME: "/home/matrix",
+        PATH: "/opt/matrix/bin",
+        TERM: "screen-256color",
+        XDG_RUNTIME_DIR: "/run/user/999",
+        ZELLIJ: "0",
+        ZELLIJ_CONFIG_DIR: "/home/matrix/.config/zellij",
+        ZELLIJ_CONFIG_FILE: "/home/matrix/.config/zellij/config.kdl",
+        ZELLIJ_SESSION_NAME: "main",
+        ZELLIJ_PANE_ID: "1",
+        ZELLIJ_SOCKET_DIR: "/run/user/999/zellij",
+        SECRET_TOKEN: "nope",
+      },
+      cwd: "/opt/matrix/app",
+    });
+
+    adapter.attachSession("main", { signal: controller.signal });
+
+    expect(spawnPty).toHaveBeenCalledWith(
+      "zellij",
+      ["attach", "main"],
+      expect.objectContaining({
+        cols: 120,
+        rows: 40,
+        name: "xterm-256color",
+        cwd: "/opt/matrix/app",
+        env: expect.objectContaining({
+          HOME: "/home/matrix",
+          PATH: "/opt/matrix/bin",
+          TERM: "xterm-256color",
+          XDG_RUNTIME_DIR: "/run/user/999",
+          ZELLIJ_CONFIG_DIR: "/home/matrix/.config/zellij",
+          ZELLIJ_CONFIG_FILE: "/home/matrix/.config/zellij/config.kdl",
+          ZELLIJ_SOCKET_DIR: "/run/user/999/zellij",
+        }),
+      }),
+    );
+    const env = spawnPty.mock.calls[0]?.[2].env;
+    expect(env).not.toHaveProperty("ZELLIJ");
+    expect(env).not.toHaveProperty("ZELLIJ_SESSION_NAME");
+    expect(env).not.toHaveProperty("ZELLIJ_PANE_ID");
+    expect(env).not.toHaveProperty("SECRET_TOKEN");
+  });
+
+  it("kills attach PTYs when the caller aborts", () => {
+    const pty = ptyProcess();
+    const spawnPty = vi.fn(() => pty);
+    const controller = new AbortController();
+    const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25 });
 
     adapter.attachSession("main", { signal: controller.signal });
     controller.abort();
 
-    expect(spawn).toHaveBeenCalledWith(
-      "zellij",
-      ["attach", "main"],
-      expect.objectContaining({ stdio: "pipe" }),
-    );
-    expect(child.kill).toHaveBeenCalled();
+    expect(pty.kill).toHaveBeenCalled();
   });
 
   it("creates sessions in the requested cwd using headless attach", async () => {

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { authMiddleware } from "../../packages/gateway/src/auth.js";
 import {
@@ -6,25 +5,46 @@ import {
   type ShellWsSocket,
 } from "../../packages/gateway/src/shell/ws.js";
 
-class FakeStream extends EventEmitter {
+class FakePty {
   writes: string[] = [];
-
-  write(data: string): boolean {
-    this.writes.push(data);
-    return true;
-  }
-}
-
-class FakeChild extends EventEmitter {
-  stdout = new FakeStream();
-  stderr = new FakeStream();
-  stdin = new FakeStream();
+  resizes: Array<{ cols: number; rows: number }> = [];
   killed = false;
+  private dataListeners = new Set<(data: string) => void>();
+  private exitListeners = new Set<(event: { exitCode: number; signal?: number }) => void>();
 
-  kill(): boolean {
+  write(data: string): void {
+    this.writes.push(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.resizes.push({ cols, rows });
+  }
+
+  kill(): void {
     this.killed = true;
-    this.emit("close", 0);
-    return true;
+    this.emitExit({ exitCode: 0 });
+  }
+
+  onData(listener: (data: string) => void) {
+    this.dataListeners.add(listener);
+    return { dispose: () => this.dataListeners.delete(listener) };
+  }
+
+  onExit(listener: (event: { exitCode: number; signal?: number }) => void) {
+    this.exitListeners.add(listener);
+    return { dispose: () => this.exitListeners.delete(listener) };
+  }
+
+  emitData(data: string): void {
+    for (const listener of this.dataListeners) {
+      listener(data);
+    }
+  }
+
+  emitExit(event: { exitCode: number; signal?: number }): void {
+    for (const listener of this.exitListeners) {
+      listener(event);
+    }
   }
 }
 
@@ -43,14 +63,14 @@ function socket(): ShellWsSocket & { sent: unknown[]; closed: boolean } {
 
 describe("zellij terminal WebSocket", () => {
   it("attaches to a named session, replays from seq, forwards input, and cleans up", async () => {
-    const child = new FakeChild();
+    const pty = new FakePty();
     const ws = socket();
     const handler = createShellWsHandler({
       registry: {
         list: vi.fn(async () => [{ name: "main", status: "active" }]),
       },
       adapter: {
-        attachSession: vi.fn(() => child as never),
+        attachSession: vi.fn(() => pty),
       },
       maxReplayBytes: 4096,
     });
@@ -61,15 +81,56 @@ describe("zellij terminal WebSocket", () => {
       fromSeq: 0,
     });
 
-    child.stdout.emit("data", Buffer.from("hello"));
+    pty.emitData("hello");
     await new Promise((resolve) => setTimeout(resolve, 0));
     session.onMessage(JSON.stringify({ type: "input", data: "pwd\r" }));
+    session.onMessage(JSON.stringify({ type: "resize", cols: 100, rows: 30 }));
     session.onClose();
 
     expect(ws.sent).toContainEqual({ type: "attached", session: "main", state: "running", fromSeq: 0 });
     expect(ws.sent).toContainEqual({ type: "output", seq: 0, data: "hello" });
-    expect(child.stdin.writes).toEqual(["pwd\r"]);
-    expect(child.killed).toBe(true);
+    expect(pty.writes).toEqual(["pwd\r"]);
+    expect(pty.resizes).toEqual([{ cols: 100, rows: 30 }]);
+    expect(pty.killed).toBe(true);
+  });
+
+  it("sends the existing exit frame when the PTY exits", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+    });
+
+    await handler.open({ ws, session: "main", fromSeq: 0 });
+    pty.emitExit({ exitCode: 101 });
+
+    expect(ws.sent).toContainEqual({ type: "exit", code: 101 });
+  });
+
+  it("returns a stable error frame if PTY attach throws before listeners are registered", async () => {
+    const ws = socket();
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => {
+          throw new Error("spawn failed");
+        }),
+      },
+    });
+
+    await handler.open({ ws, session: "main", fromSeq: 0 });
+
+    expect(ws.sent).toEqual([
+      { type: "error", code: "attach_failed", message: "Shell attach failed" },
+    ]);
+    expect(ws.closed).toBe(true);
   });
 
   it("rejects missing sessions with a stable error", async () => {


### PR DESCRIPTION
Summary
- Replace server-side zellij attach pipes with node-pty so systemd-hosted gateways provide a real terminal device.
- Forward shell WebSocket input, resize, output, and exit through the PTY-backed attach interface.
- Scrub inherited ZELLIJ context variables from attach env and force TERM=xterm-256color.

Tests
- flox activate -- bun run test tests/gateway/shell-zellij.test.ts tests/gateway/terminal-zellij-ws.test.ts
- flox activate -- pnpm --filter @matrix-os/gateway build
- flox activate -- bun run check:patterns (0 violations; existing scanner warnings only)
- flox activate -- bun run typecheck
- flox activate -- bun run test was started but stopped after it spent several minutes in unrelated broad tests; focused coverage and typecheck passed.

Review/Monitoring
- Open PR and monitor CI plus trusted Greptile review to 5/5 before marking complete.

Invariants
- Source of truth: zellij remains the live shell/session runtime; WebSocket replay remains the output transcript path.
- Lock/transaction scope: no database or multi-write transaction changes; attach is a runtime process bridge only.
- Acceptable orphan states: if WebSocket close or abort happens, the attach PTY is killed; the underlying zellij session remains reusable.
- Auth source of truth: existing /ws/terminal auth and session validation remain unchanged.
- Deferred scope: CLI raw-mode and attach messaging cleanup are intentionally left for a follow-up PR.