### PR TITLE
feat(www): add early access Tally form page

### DIFF
--- a/www/src/app/early-access/page.tsx
+++ b/www/src/app/early-access/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next";
+import Script from "next/script";
+
+const TALLY_FORM_ID = "2ED9lb";
+const DISCORD_URL = "https://discord.gg/cSBBQWtPwV";
+const TALLY_QUERY_KEYS = [
+  "email",
+  "userId",
+  "source",
+  "userGroup",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+] as const;
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export const metadata: Metadata = {
+  title: "Matrix Early Access",
+  description: "Request priority access to Matrix OS, the AI operating system for builders.",
+  openGraph: {
+    title: "Matrix Early Access",
+    description: "Request priority access to Matrix OS, the AI operating system for builders.",
+    url: "https://matrix-os.com/early-access",
+    siteName: "Matrix OS",
+    type: "website",
+  },
+};
+
+export default async function EarlyAccessPage({ searchParams }: { searchParams: SearchParams }) {
+  const tallyUrl = buildTallyEmbedUrl(await searchParams);
+
+  return (
+    <main className="min-h-screen bg-[var(--stone)] text-[var(--ink)]">
+      <div className="mx-auto grid min-h-screen w-full max-w-6xl grid-cols-1 gap-10 px-5 py-6 md:grid-cols-[0.82fr_1.18fr] md:px-8 md:py-10">
+        <section className="flex flex-col justify-between gap-10 border-b border-[var(--pebble)] pb-8 md:border-b-0 md:border-r md:pb-0 md:pr-10">
+          <div>
+            <a href="/" className="inline-flex items-center gap-3 text-sm font-medium tracking-[0.12em] uppercase">
+              <img src="/rabbit.svg" alt="Matrix OS" className="size-7 rounded-md" />
+              Matrix OS
+            </a>
+
+            <div className="mt-16 max-w-xl md:mt-24">
+              <p className="text-sm font-medium uppercase tracking-[0.18em] text-[var(--moss)]">
+                Early Access
+              </p>
+              <h1
+                className="mt-5 text-4xl font-light leading-[1.05] tracking-tight sm:text-5xl lg:text-6xl"
+                style={{ fontFamily: "var(--font-serif), Georgia, serif" }}
+              >
+                Tell me what you want Matrix to do first.
+              </h1>
+              <p className="mt-6 text-base leading-7 text-[var(--ink)]/65 sm:text-lg">
+                I&apos;m opening early-access batches for builders who can try Matrix this week. Your answers help me prioritize engineers, technical founders, and concrete workflows.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 text-sm text-[var(--ink)]/65">
+            <a
+              href={DISCORD_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-fit items-center rounded-full border border-[var(--pebble)] px-4 py-2 text-[var(--ink)] transition-colors hover:border-[var(--forest)] hover:text-[var(--forest)]"
+            >
+              Join the Discord
+            </a>
+            <p>Priority goes to people with a clear first workflow and time to test soon.</p>
+          </div>
+        </section>
+
+        <section className="flex min-h-[760px] flex-col">
+          <iframe
+            src={tallyUrl}
+            data-tally-src={tallyUrl}
+            loading="lazy"
+            width="100%"
+            height="760"
+            frameBorder="0"
+            marginHeight={0}
+            marginWidth={0}
+            title="Matrix Early Access Request"
+            className="min-h-[760px] w-full flex-1"
+          />
+        </section>
+      </div>
+      <Script src="https://tally.so/widgets/embed.js" strategy="afterInteractive" />
+    </main>
+  );
+}
+
+function buildTallyEmbedUrl(searchParams: Awaited<SearchParams>) {
+  const params = new URLSearchParams({
+    alignLeft: "1",
+    hideTitle: "1",
+    transparentBackground: "1",
+    dynamicHeight: "1",
+  });
+
+  for (const key of TALLY_QUERY_KEYS) {
+    const value = searchParams[key];
+    const text = Array.isArray(value) ? value[0] : value;
+    if (text) params.set(key, text);
+  }
+
+  return `https://tally.so/embed/${TALLY_FORM_ID}?${params.toString()}`;
+}

--- a/www/src/app/early-access/page.tsx
+++ b/www/src/app/early-access/page.tsx
@@ -4,8 +4,7 @@ import Script from "next/script";
 const TALLY_FORM_ID = "2ED9lb";
 const DISCORD_URL = "https://discord.gg/cSBBQWtPwV";
 const TALLY_QUERY_KEYS = [
-  "email",
-  "userId",
+  "invite",
   "source",
   "userGroup",
   "utm_source",
@@ -71,7 +70,6 @@ export default async function EarlyAccessPage({ searchParams }: { searchParams: 
 
         <section className="flex min-h-[760px] flex-col">
           <iframe
-            src={tallyUrl}
             data-tally-src={tallyUrl}
             loading="lazy"
             width="100%"
@@ -79,6 +77,8 @@ export default async function EarlyAccessPage({ searchParams }: { searchParams: 
             frameBorder="0"
             marginHeight={0}
             marginWidth={0}
+            sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
+            referrerPolicy="strict-origin-when-cross-origin"
             title="Matrix Early Access Request"
             className="min-h-[760px] w-full flex-1"
           />


### PR DESCRIPTION
Summary
- Add /early-access as a Matrix-branded wrapper around the published Tally form.
- Forward email, userId, source, userGroup, and UTM query params into Tally hidden fields.
- Include Discord CTA and route metadata for sharing.

Tests
- pnpm --dir www exec tsc --noEmit
- Local dev server GET/HEAD /early-access returned HTTP 200

Notes
- pnpm --dir www build was attempted but stalled during the Turbopack production build step and was stopped.