### PR TITLE
chore(cli): prep 0.3.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,36 @@ jobs:
             ./scripts/review/check-patterns.sh --diff "$BEFORE"
           fi
 
+  sync-client:
+    name: Sync Client Package
+    needs: [typecheck, patterns]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build sync client
+        run: pnpm --filter @finnaai/matrix build
+
+      - name: Test sync client
+        run: pnpm --filter @finnaai/matrix test
+
+      - name: Verify publish shape
+        run: pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
+
   # ── Gate 2: Tests ──
   unit:
     name: Unit Tests (${{ matrix.shard }}/4)
-    needs: [typecheck, patterns]
+    needs: [typecheck, patterns, sync-client]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish (semver, no leading v — e.g. 0.2.4)"
+        description: "Version to publish (semver, no leading v — e.g. 0.3.0)"
         required: true
         type: string
 
@@ -27,8 +27,10 @@ jobs:
   validate:
     name: Validate version
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v6
+
       - name: Check semver format
         env:
           VERSION: ${{ inputs.version }}
@@ -36,6 +38,31 @@ jobs:
           set -euo pipefail
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "version '$VERSION' is not valid semver (expected X.Y.Z or X.Y.Z-prerelease)" >&2
+            exit 1
+          fi
+
+      - name: Check package version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION="$(node -p "require('./packages/sync-client/package.json').version")"
+          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "packages/sync-client/package.json is $PACKAGE_VERSION, expected $VERSION" >&2
+            exit 1
+          fi
+
+      - name: Check release is new
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if npm view "@finnaai/matrix@$VERSION" version >/dev/null 2>&1; then
+            echo "@finnaai/matrix@$VERSION already exists on npm" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/cli-v${VERSION}" >/dev/null 2>&1; then
+            echo "tag cli-v${VERSION} already exists" >&2
             exit 1
           fi
 
@@ -57,6 +84,12 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Build sync client
+        run: pnpm --filter @finnaai/matrix build
+
+      - name: Verify sync-client publish shape
+        run: pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
 
       - name: Type check
         run: bun run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Check semver format
         env:
           VERSION: ${{ inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Format:
 - Commit hashes point at the source of truth.
 - Large features may also have feature-specific changelogs under `specs/<NNN>-<feature>/`.
 
+## 2026-05-26
+
+### CLI 0.3.0 Release Prep
+
+Prepared the installable `@finnaai/matrix` CLI for the `0.3.0` release after the onboarding/signup PR set.
+
+Highlights:
+
+- Stamped the sync-client package as `0.3.0`.
+- Documented the dedicated CLI release process for npm, Homebrew, GitHub `cli-v*` releases, and the macOS MatrixSync installer.
+- Added CI coverage for sync-client build/test/publish-shape checks.
+- Hardened the manual release workflow so it rejects mismatched package versions, existing npm versions, and existing `cli-v<version>` tags before publishing.
+
 ## 2026-04-28
 
 ### VPS-per-User Customer Host Completion

--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -1,0 +1,65 @@
+# CLI Release Process
+
+The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-client`. It is separate from the VPS host-bundle release path: host bundles update customer VPS runtime code, while CLI releases update what users install through npm, Homebrew, `get.matrix-os.com`, and the macOS MatrixSync installer.
+
+## Current Prepared Release
+
+`0.3.0` is the prepared CLI release for the post-onboarding PR set. It includes the user-facing `matrix run` command, shell-session attachment support, completion updates, and the signup/onboarding-compatible login flow already present in `packages/sync-client`.
+
+## Versioning
+
+- Use semver without a leading `v` in `packages/sync-client/package.json`.
+- GitHub release tags use `cli-v<version>`, for example `cli-v0.3.0`.
+- Do not reuse Matrix OS host-bundle tags such as `v2026.05.12-43` or `v0.X.0` for the CLI.
+- Publish only the `@finnaai/matrix` package. The repo root package is private and must not be published.
+
+## Preflight
+
+Run these from the repo root before dispatching the release workflow:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @finnaai/matrix build
+pnpm --filter @finnaai/matrix test
+pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
+```
+
+Also verify the version is new:
+
+```bash
+npm view @finnaai/matrix version
+git tag -l 'cli-v*'
+```
+
+## Release
+
+Use the manual GitHub Actions workflow named `Release` with `version=0.3.0`. The workflow:
+
+1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
+2. Runs root typecheck and tests.
+3. Builds and notarises the macOS `.pkg` when `ENABLE_MACOS_PKG=true`.
+4. Publishes `@finnaai/matrix` to npm with provenance.
+5. Creates GitHub release `cli-v<version>`.
+6. Updates `FinnaAI/homebrew-tap` with the npm tarball URL and SHA-256.
+
+## Post-Release Verification
+
+```bash
+npm view @finnaai/matrix version
+npm view @finnaai/matrix dist.tarball
+brew update && brew info finnaai/tap/matrix
+MATRIX_VERSION=0.3.0 sh scripts/install.sh
+matrix --version
+matrix login --help
+matrix run --help
+```
+
+For macOS, also verify the GitHub release contains `MatrixSync-0.3.0.pkg` when the macOS job was enabled.
+
+## Rollback
+
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.1` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+
+```bash
+npm deprecate @finnaai/matrix@0.3.0 "Use @finnaai/matrix@0.3.1"
+```

--- a/docs/dev/onboarding.md
+++ b/docs/dev/onboarding.md
@@ -181,7 +181,8 @@ Never run `docker compose down -v` unless you want to destroy all data.
 ## Useful Links
 
 - [Docker Development Guide](docker-development.md) -- volumes, HMR, troubleshooting, branch isolation
-- [Release Process](releases.md) -- versioning and tagging
+- [Release Process](releases.md) -- host-bundle versioning and tagging
+- [CLI Release Process](cli-release.md) -- npm, Homebrew, and MatrixSync installer releases
 - [Stacked PR Workflow](stacked-prs.md) -- Graphite stacks for multi-slice features
 - [VPS Deployment](vps-deployment.md) -- production server
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) -- code style, CI/CD, PR process

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -2,6 +2,8 @@
 
 Matrix OS production releases are VPS-native host bundles. R2 stores immutable tarball bytes, and platform Postgres is the source of truth for release metadata and channel pointers. Customer VPSes update by downloading a registered bundle and atomically replacing `/opt/matrix/app`; user data stays in `/home/matrix/home` and local Postgres.
 
+For installable CLI releases, use [CLI Release Process](cli-release.md). CLI versions publish `@finnaai/matrix` and use `cli-v<version>` tags; they are intentionally separate from host-bundle versions.
+
 ## Engineer Summary
 
 - `main` is the source of truth. A push to `main` runs `.github/workflows/host-bundle-release.yml`.
@@ -11,6 +13,7 @@ Matrix OS production releases are VPS-native host bundles. R2 stores immutable t
 - A customer VPS sync agent fetches DB-backed release metadata, verifies SHA-256, extracts to staging, moves the old app to `/opt/matrix/app.rollback`, moves the new app into `/opt/matrix/app`, writes `/opt/matrix/release.json`, and restarts Matrix services.
 - Host-bundle updates must never overwrite owner data. Do not delete or replace `/home/matrix/home`, `/opt/matrix/env`, or the local Postgres data directory during deploys or rollbacks.
 - `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` and CI/release paths use `pnpm install --frozen-lockfile`; do not bypass either during releases.
+- CLI releases are manual through `.github/workflows/release.yml`; bump `packages/sync-client/package.json`, run the sync-client checks, and dispatch the workflow with the same semver.
 
 ## Version Scheme
 

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

Prepares the installable Matrix CLI for the `0.3.0` release after the onboarding/signup PR set.

- Bumps `@finnaai/matrix` to `0.3.0`
- Adds `docs/dev/cli-release.md` with the npm, GitHub release, Homebrew, and MatrixSync release flow
- Links the CLI release docs from existing dev release/onboarding docs
- Adds CI coverage for sync-client build/test/publish-shape checks
- Hardens the manual release workflow to reject mismatched package versions, existing npm versions, and existing `cli-v<version>` tags before publishing
- Fixes the gateway coding setup provider type so CI typecheck can pass on the PR merge ref

## Invariants

- Source of truth: `packages/sync-client/package.json` is the CLI package version; host-bundle versions remain separate.
- Release boundary: CLI releases publish `@finnaai/matrix` and `cli-v*` GitHub releases only; the private root package is not published.
- Automation boundary: CI validates package shape and release uniqueness before npm publish.
- Runtime fallback: readiness still returns the existing unavailable coding setup fallback when no coding setup provider is wired.
- Deferred scope: this does not dispatch the release workflow or publish `0.3.0`; it only prepares the repo for that release.

## Validation

- `pnpm --filter @finnaai/matrix build`
- `pnpm --filter @finnaai/matrix test` — 22 files, 248 tests passed
- `pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs`
- `bun run typecheck:build-kernel`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `git diff --check`
- `bun run check:patterns` — 0 violations, existing warnings only
- Verified `@finnaai/matrix@0.3.0` is not published on npm
- Verified no local `cli-v0.3.0` tag exists