### PR TITLE
feat(canvas): add pasted image assets

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   screenshots:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,8 +38,8 @@ jobs:
           E2E_TEST_BYPASS: "1"
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY || 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' }}
 
-      - name: Install Playwright Chromium
-        run: cd shell && pnpm exec playwright install chromium
+      - name: Verify Chrome
+        run: google-chrome --version
 
       - name: Run Playwright tests
         run: cd shell && pnpm exec playwright test --update-snapshots

--- a/packages/gateway/src/canvas/assets.ts
+++ b/packages/gateway/src/canvas/assets.ts
@@ -1,0 +1,27 @@
+export const CANVAS_ASSET_MIME_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/avif"] as const;
+
+export type CanvasAssetMimeType = typeof CANVAS_ASSET_MIME_TYPES[number];
+
+const CANVAS_ASSET_EXTENSION_BY_MIME: Record<CanvasAssetMimeType, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/avif": "avif",
+};
+
+const CANVAS_ASSET_MIME_TYPE_SET = new Set<string>(CANVAS_ASSET_MIME_TYPES);
+const CANVAS_ASSET_PATH = /^system\/canvas-assets\/cnv_[A-Za-z0-9_-]+\/asset_[A-Za-z0-9_-]+\.(?:png|jpg|webp|gif|avif)$/;
+
+export function isCanvasAssetMimeType(value: string): value is CanvasAssetMimeType {
+  return CANVAS_ASSET_MIME_TYPE_SET.has(value);
+}
+
+export function canvasAssetExtensionForMimeType(value: string): string | undefined {
+  if (!isCanvasAssetMimeType(value)) return undefined;
+  return CANVAS_ASSET_EXTENSION_BY_MIME[value];
+}
+
+export function isCanvasAssetPath(value: string): boolean {
+  return CANVAS_ASSET_PATH.test(value);
+}

--- a/packages/gateway/src/canvas/contracts.ts
+++ b/packages/gateway/src/canvas/contracts.ts
@@ -76,6 +76,7 @@ export const CanvasNodeTypeSchema = z.enum([
   "task",
   "file",
   "preview",
+  "image",
   "note",
   "app_window",
   "issue",

--- a/packages/gateway/src/canvas/contracts.ts
+++ b/packages/gateway/src/canvas/contracts.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { isCanvasAssetPath } from "./assets.js";
 
 export const CANVAS_DOCUMENT_MAX_BYTES = 256 * 1024;
 export const CANVAS_NODE_METADATA_MAX_BYTES = 16 * 1024;
@@ -160,6 +161,9 @@ export const CanvasNodeSchema = z.object({
   }
   if (value.type === "image" && value.sourceRef?.kind !== "file") {
     ctx.addIssue({ code: "custom", message: "Image nodes require a file source", path: ["sourceRef", "kind"] });
+  }
+  if (value.type === "image" && value.sourceRef?.kind === "file" && !isCanvasAssetPath(value.sourceRef.id)) {
+    ctx.addIssue({ code: "custom", message: "Image nodes require a canvas asset path", path: ["sourceRef", "id"] });
   }
 });
 

--- a/packages/gateway/src/canvas/contracts.ts
+++ b/packages/gateway/src/canvas/contracts.ts
@@ -158,6 +158,9 @@ export const CanvasNodeSchema = z.object({
   if (value.type === "preview" && value.sourceRef?.kind === "url" && !safeUrl(value.sourceRef.id)) {
     ctx.addIssue({ code: "custom", message: "Unsafe preview URL", path: ["sourceRef", "id"] });
   }
+  if (value.type === "image" && value.sourceRef?.kind !== "file") {
+    ctx.addIssue({ code: "custom", message: "Image nodes require a file source", path: ["sourceRef", "kind"] });
+  }
 });
 
 export const CanvasEdgeTypeSchema = z.enum(["visual", "depends_on", "implements", "reviews", "opens", "related"]);

--- a/packages/gateway/src/canvas/routes.ts
+++ b/packages/gateway/src/canvas/routes.ts
@@ -14,12 +14,11 @@ import {
   type PatchCanvasNodeUpdates,
   type CreateCanvasRequest,
 } from "./contracts.js";
-import { mapCanvasError } from "./service.js";
+import { CANVAS_ASSET_FILE_LIMIT, mapCanvasError } from "./service.js";
 import { isRequestPrincipalError, mapRequestPrincipalError } from "../request-principal.js";
 
 const CANVAS_WRITE_BODY_LIMIT = 256 * 1024;
 const CANVAS_ACTION_BODY_LIMIT = 64 * 1024;
-const CANVAS_ASSET_FILE_LIMIT = 10 * 1024 * 1024;
 const CANVAS_ASSET_BODY_LIMIT = CANVAS_ASSET_FILE_LIMIT + 256 * 1024;
 const CANVAS_ASSET_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif", "image/avif"]);
 

--- a/packages/gateway/src/canvas/routes.ts
+++ b/packages/gateway/src/canvas/routes.ts
@@ -14,13 +14,13 @@ import {
   type PatchCanvasNodeUpdates,
   type CreateCanvasRequest,
 } from "./contracts.js";
+import { isCanvasAssetMimeType } from "./assets.js";
 import { CANVAS_ASSET_FILE_LIMIT, mapCanvasError } from "./service.js";
 import { isRequestPrincipalError, mapRequestPrincipalError } from "../request-principal.js";
 
 const CANVAS_WRITE_BODY_LIMIT = 256 * 1024;
 const CANVAS_ACTION_BODY_LIMIT = 64 * 1024;
 const CANVAS_ASSET_BODY_LIMIT = CANVAS_ASSET_FILE_LIMIT + 256 * 1024;
-const CANVAS_ASSET_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif", "image/avif"]);
 
 export interface CanvasRouteService {
   listCanvases(userId: string, query?: { scopeType?: string; scopeId?: string; limit?: number; cursor?: string; q?: string }): Promise<unknown>;
@@ -227,7 +227,7 @@ export function createCanvasRoutes(deps: CanvasRouteDeps): Hono {
       const formData = await c.req.formData();
       const file = formData.get("file");
       if (!(file instanceof File)) return validationError(c);
-      if (!CANVAS_ASSET_MIME_TYPES.has(file.type)) return validationError(c);
+      if (!isCanvasAssetMimeType(file.type)) return validationError(c);
       if (file.size <= 0 || file.size > CANVAS_ASSET_FILE_LIMIT) return validationError(c);
       if (file.name && !hasSafeOriginalAssetName(file.name)) return validationError(c);
       if (!deps.service.uploadCanvasAsset) return c.json({ error: "Canvas request failed" }, 500);

--- a/packages/gateway/src/canvas/routes.ts
+++ b/packages/gateway/src/canvas/routes.ts
@@ -19,6 +19,9 @@ import { isRequestPrincipalError, mapRequestPrincipalError } from "../request-pr
 
 const CANVAS_WRITE_BODY_LIMIT = 256 * 1024;
 const CANVAS_ACTION_BODY_LIMIT = 64 * 1024;
+const CANVAS_ASSET_FILE_LIMIT = 10 * 1024 * 1024;
+const CANVAS_ASSET_BODY_LIMIT = CANVAS_ASSET_FILE_LIMIT + 256 * 1024;
+const CANVAS_ASSET_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif", "image/avif"]);
 
 export interface CanvasRouteService {
   listCanvases(userId: string, query?: { scopeType?: string; scopeId?: string; limit?: number; cursor?: string; q?: string }): Promise<unknown>;
@@ -29,6 +32,7 @@ export interface CanvasRouteService {
   deleteCanvas(userId: string, canvasId: string): Promise<unknown>;
   exportCanvas(userId: string, canvasId: string): Promise<unknown>;
   executeAction(userId: string, canvasId: string, action: CanvasAction): Promise<unknown>;
+  uploadCanvasAsset?(userId: string, canvasId: string, file: File): Promise<unknown>;
 }
 
 export interface CanvasRouteDeps {
@@ -82,6 +86,10 @@ function validationError(c: any) {
   return c.json({ error: "Invalid request" }, 400);
 }
 
+function hasSafeOriginalAssetName(name: string): boolean {
+  return name.length <= 160 && !name.includes("/") && !name.includes("\\") && !name.includes("\0");
+}
+
 function handleError(c: any, err: unknown) {
   if (isRequestPrincipalError(err)) {
     const mapped = mapRequestPrincipalError(err, "Canvas request failed");
@@ -127,6 +135,7 @@ export function createCanvasRoutes(deps: CanvasRouteDeps): Hono {
   const writeBodyLimit = bodyLimit({ maxSize: CANVAS_WRITE_BODY_LIMIT, onError: bodyTooLarge });
   const actionBodyLimit = bodyLimit({ maxSize: CANVAS_ACTION_BODY_LIMIT, onError: bodyTooLarge });
   const deleteBodyLimit = bodyLimit({ maxSize: 1024, onError: bodyTooLarge });
+  const assetBodyLimit = bodyLimit({ maxSize: CANVAS_ASSET_BODY_LIMIT, onError: bodyTooLarge });
 
   app.get("/", async (c) => {
     try {
@@ -207,6 +216,23 @@ export function createCanvasRoutes(deps: CanvasRouteDeps): Hono {
       const parsed = CanvasActionSchema.safeParse(await parseJson(c));
       if (!parsed.success) return validationError(c);
       return c.json(await deps.service.executeAction(userId, parseCanvasId(c), parsed.data));
+    } catch (err: unknown) {
+      return handleError(c, err);
+    }
+  });
+
+  app.post("/:canvasId/assets", assetBodyLimit, async (c) => {
+    try {
+      const userId = getUserIdOrThrow(deps, c);
+      const canvasId = parseCanvasId(c);
+      const formData = await c.req.formData();
+      const file = formData.get("file");
+      if (!(file instanceof File)) return validationError(c);
+      if (!CANVAS_ASSET_MIME_TYPES.has(file.type)) return validationError(c);
+      if (file.size <= 0 || file.size > CANVAS_ASSET_FILE_LIMIT) return validationError(c);
+      if (file.name && !hasSafeOriginalAssetName(file.name)) return validationError(c);
+      if (!deps.service.uploadCanvasAsset) return c.json({ error: "Canvas request failed" }, 500);
+      return c.json(await deps.service.uploadCanvasAsset(userId, canvasId, file), 201);
     } catch (err: unknown) {
       return handleError(c, err);
     }

--- a/packages/gateway/src/canvas/service.ts
+++ b/packages/gateway/src/canvas/service.ts
@@ -66,6 +66,13 @@ export class CanvasConfigurationError extends Error {
   }
 }
 
+export class CanvasInvalidRequestError extends Error {
+  constructor(message = "Invalid request") {
+    super(message);
+    this.name = "CanvasInvalidRequestError";
+  }
+}
+
 export interface CanvasTerminalRegistry {
   create(cwd: string, shell?: string): string;
   getSession(sessionId: string): { sessionId: string; state: "running" | "exited"; attachedClients?: number } | null;
@@ -79,7 +86,7 @@ export interface CanvasServiceOptions {
   resolvePreviewHost?: (hostname: string) => Promise<Array<{ address: string; family: number }>>;
 }
 
-const CANVAS_ASSET_FILE_LIMIT = 10 * 1024 * 1024;
+export const CANVAS_ASSET_FILE_LIMIT = 10 * 1024 * 1024;
 const CANVAS_ASSET_EXTENSIONS = new Map([
   ["image/png", "png"],
   ["image/jpeg", "jpg"],
@@ -98,6 +105,9 @@ export function mapCanvasError(err: unknown): CanvasSafeError {
   if (err instanceof CanvasConfigurationError) {
     console.error("[canvas] Configuration error:", err.message);
     return { error: "Canvas service unavailable", status: 503 };
+  }
+  if (err instanceof CanvasInvalidRequestError) {
+    return { error: "Invalid request", status: 400 };
   }
   if (err instanceof SyntaxError) {
     return { error: "Invalid JSON", status: 400 };
@@ -335,7 +345,7 @@ export class CanvasService {
 
     const extension = CANVAS_ASSET_EXTENSIONS.get(file.type);
     if (!extension || file.size <= 0 || file.size > CANVAS_ASSET_FILE_LIMIT) {
-      throw new SyntaxError("Invalid request");
+      throw new CanvasInvalidRequestError();
     }
 
     const assetId = `asset_${randomBytes(12).toString("hex")}`;

--- a/packages/gateway/src/canvas/service.ts
+++ b/packages/gateway/src/canvas/service.ts
@@ -1,5 +1,8 @@
 import { lookup } from "node:dns/promises";
+import { randomBytes } from "node:crypto";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { isIP } from "node:net";
+import { dirname } from "node:path";
 import { resolveWithinHome } from "../path-security.js";
 import {
   CanvasNodeSchema,
@@ -48,6 +51,14 @@ export interface CanvasSafeError {
   latestRevision?: number;
 }
 
+export interface CanvasAssetUploadResult {
+  assetId: string;
+  path: string;
+  mimeType: string;
+  sizeBytes: number;
+  originalName: string;
+}
+
 export class CanvasConfigurationError extends Error {
   constructor(message = "Canvas service is not configured") {
     super(message);
@@ -67,6 +78,15 @@ export interface CanvasServiceOptions {
   fetchImpl?: typeof fetch;
   resolvePreviewHost?: (hostname: string) => Promise<Array<{ address: string; family: number }>>;
 }
+
+const CANVAS_ASSET_FILE_LIMIT = 10 * 1024 * 1024;
+const CANVAS_ASSET_EXTENSIONS = new Map([
+  ["image/png", "png"],
+  ["image/jpeg", "jpg"],
+  ["image/webp", "webp"],
+  ["image/gif", "gif"],
+  ["image/avif", "avif"],
+]);
 
 export function mapCanvasError(err: unknown): CanvasSafeError {
   if (err instanceof CanvasConflictError) {
@@ -108,6 +128,14 @@ function nodeCounts(record: CanvasRecord) {
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function safeOriginalAssetName(name: string, extension: string): string {
+  const fallback = `clipboard-image.${extension}`;
+  if (!name || name.length > 160 || name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    return fallback;
+  }
+  return name;
 }
 
 function baseNode(id: string, type: CanvasNode["type"], x: number, y: number, metadata: Record<string, unknown>, sourceRef: CanvasNode["sourceRef"]): CanvasNode {
@@ -295,6 +323,50 @@ export class CanvasService {
       canvas: record,
       linkedSummaries: this.resolveLinkedState(record),
       exportedAt: nowIso(),
+    };
+  }
+
+  async uploadCanvasAsset(userId: string, canvasId: string, file: File): Promise<CanvasAssetUploadResult> {
+    if (!this.homePath) {
+      throw new CanvasConfigurationError("homePath is required for canvas assets");
+    }
+    const record = await this.repository.get(ownerFromUser(userId), canvasId);
+    if (!record) throw new CanvasNotFoundError(canvasId);
+
+    const extension = CANVAS_ASSET_EXTENSIONS.get(file.type);
+    if (!extension || file.size <= 0 || file.size > CANVAS_ASSET_FILE_LIMIT) {
+      throw new SyntaxError("Invalid request");
+    }
+
+    const assetId = `asset_${randomBytes(12).toString("hex")}`;
+    const relativePath = `system/canvas-assets/${canvasId}/${assetId}.${extension}`;
+    const finalPath = resolveWithinHome(this.homePath, relativePath);
+    if (!finalPath) {
+      throw new CanvasConfigurationError("Invalid canvas asset path");
+    }
+    const tempPath = `${finalPath}.${process.pid}.${Date.now()}.tmp`;
+    await mkdir(dirname(finalPath), { recursive: true });
+
+    try {
+      await writeFile(tempPath, Buffer.from(await file.arrayBuffer()), { flag: "wx" });
+      await rename(tempPath, finalPath);
+    } catch (err: unknown) {
+      try {
+        await unlink(tempPath);
+      } catch (cleanupErr: unknown) {
+        if (!(cleanupErr instanceof Error && (cleanupErr as NodeJS.ErrnoException).code === "ENOENT")) {
+          console.warn("[canvas] Failed to clean up temp asset:", cleanupErr);
+        }
+      }
+      throw err;
+    }
+
+    return {
+      assetId,
+      path: relativePath,
+      mimeType: file.type,
+      sizeBytes: file.size,
+      originalName: safeOriginalAssetName(file.name, extension),
     };
   }
 

--- a/packages/gateway/src/canvas/service.ts
+++ b/packages/gateway/src/canvas/service.ts
@@ -4,6 +4,7 @@ import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { isIP } from "node:net";
 import { dirname } from "node:path";
 import { resolveWithinHome } from "../path-security.js";
+import { canvasAssetExtensionForMimeType } from "./assets.js";
 import {
   CanvasNodeSchema,
   createBlankCanvasDocument,
@@ -87,13 +88,6 @@ export interface CanvasServiceOptions {
 }
 
 export const CANVAS_ASSET_FILE_LIMIT = 10 * 1024 * 1024;
-const CANVAS_ASSET_EXTENSIONS = new Map([
-  ["image/png", "png"],
-  ["image/jpeg", "jpg"],
-  ["image/webp", "webp"],
-  ["image/gif", "gif"],
-  ["image/avif", "avif"],
-]);
 
 export function mapCanvasError(err: unknown): CanvasSafeError {
   if (err instanceof CanvasConflictError) {
@@ -343,7 +337,7 @@ export class CanvasService {
     const record = await this.repository.get(ownerFromUser(userId), canvasId);
     if (!record) throw new CanvasNotFoundError(canvasId);
 
-    const extension = CANVAS_ASSET_EXTENSIONS.get(file.type);
+    const extension = canvasAssetExtensionForMimeType(file.type);
     if (!extension || file.size <= 0 || file.size > CANVAS_ASSET_FILE_LIMIT) {
       throw new CanvasInvalidRequestError();
     }

--- a/packages/gateway/src/file-utils.ts
+++ b/packages/gateway/src/file-utils.ts
@@ -22,6 +22,7 @@ const MIME_MAP: Record<string, string> = {
   ".jpeg": "image/jpeg",
   ".gif": "image/gif",
   ".webp": "image/webp",
+  ".avif": "image/avif",
   ".svg": "image/svg+xml",
   ".pdf": "application/pdf",
   ".mp3": "audio/mpeg",

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -2742,6 +2742,7 @@ export async function createGateway(config: GatewayConfig) {
       jpeg: "image/jpeg",
       gif: "image/gif",
       webp: "image/webp",
+      avif: "image/avif",
       svg: "image/svg+xml",
     };
 

--- a/shell/playwright.config.ts
+++ b/shell/playwright.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     screenshot: "only-on-failure",
     trace: "on-first-retry",
     ...devices["Desktop Chrome"],
+    ...(process.env.CI ? { channel: "chrome" } : {}),
     viewport: { width: 1440, height: 900 },
   },
   webServer: {

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -15,9 +15,9 @@ import { CanvasTextLabel } from "./CanvasTextLabel";
 import { SelectionRect } from "./SelectionRect";
 import { autoArrangeWindows } from "./CanvasToolbar";
 import { CanvasMinimap } from "./CanvasMinimap";
+import { isCanvasAssetMimeType } from "../../../../packages/gateway/src/canvas/assets.js";
 
 const GROUP_COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"];
-const CANVAS_PASTE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif", "image/avif"]);
 const MAX_PASTED_IMAGE_WIDTH = 640;
 const MAX_PASTED_IMAGE_HEIGHT = 480;
 
@@ -42,7 +42,7 @@ function imageFilesFromClipboard(data: DataTransfer | null): File[] {
   const files: File[] = [];
   const seen = new Set<File>();
   for (const item of Array.from(data.items ?? [])) {
-    if (item.kind !== "file" || !CANVAS_PASTE_IMAGE_TYPES.has(item.type)) continue;
+    if (item.kind !== "file" || !isCanvasAssetMimeType(item.type)) continue;
     const file = item.getAsFile();
     if (file && !seen.has(file)) {
       seen.add(file);
@@ -50,7 +50,7 @@ function imageFilesFromClipboard(data: DataTransfer | null): File[] {
     }
   }
   for (const file of Array.from(data.files ?? [])) {
-    if (!CANVAS_PASTE_IMAGE_TYPES.has(file.type) || seen.has(file)) continue;
+    if (!isCanvasAssetMimeType(file.type) || seen.has(file)) continue;
     seen.add(file);
     files.push(file);
   }

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -15,7 +15,7 @@ import { CanvasTextLabel } from "./CanvasTextLabel";
 import { SelectionRect } from "./SelectionRect";
 import { autoArrangeWindows } from "./CanvasToolbar";
 import { CanvasMinimap } from "./CanvasMinimap";
-import { isCanvasAssetMimeType } from "../../../../packages/gateway/src/canvas/assets.js";
+import { isCanvasAssetMimeType } from "../../../../packages/gateway/src/canvas/assets";
 
 const GROUP_COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"];
 const MAX_PASTED_IMAGE_WIDTH = 640;

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -6,9 +6,10 @@ import { useWindowManager } from "@/hooks/useWindowManager";
 import { useCanvasTransform } from "@/hooks/useCanvasTransform";
 import { useCanvasGroups } from "@/stores/canvas-groups";
 import { useCanvasLabels } from "@/stores/canvas-labels";
+import { useWorkspaceCanvasStore } from "@/stores/workspace-canvas-store";
 import { CanvasTransform } from "./CanvasTransform";
 import { CanvasWindow } from "./CanvasWindow";
-import { WorkspaceCanvas } from "./WorkspaceCanvas";
+import { WorkspaceCanvas, WorkspaceCanvasLayer } from "./WorkspaceCanvas";
 import { CanvasGroupRect } from "./CanvasGroup";
 import { CanvasTextLabel } from "./CanvasTextLabel";
 import { SelectionRect } from "./SelectionRect";
@@ -16,6 +17,67 @@ import { autoArrangeWindows } from "./CanvasToolbar";
 import { CanvasMinimap } from "./CanvasMinimap";
 
 const GROUP_COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"];
+const CANVAS_PASTE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif", "image/avif"]);
+const MAX_PASTED_IMAGE_WIDTH = 640;
+const MAX_PASTED_IMAGE_HEIGHT = 480;
+
+function isEditablePasteTarget(target: EventTarget | null): boolean {
+  const active = typeof document !== "undefined" ? document.activeElement : null;
+  const candidates = [target, active].filter(Boolean);
+  for (const candidate of candidates) {
+    if (!(candidate instanceof Element)) continue;
+    const editable = candidate.closest("input, textarea, select, [contenteditable], [data-canvas-window]");
+    if (
+      editable &&
+      (!(editable instanceof HTMLElement) || editable.getAttribute("contenteditable") !== "false")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function imageFilesFromClipboard(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  const files: File[] = [];
+  const seen = new Set<File>();
+  for (const item of Array.from(data.items ?? [])) {
+    if (item.kind !== "file" || !CANVAS_PASTE_IMAGE_TYPES.has(item.type)) continue;
+    const file = item.getAsFile();
+    if (file && !seen.has(file)) {
+      seen.add(file);
+      files.push(file);
+    }
+  }
+  for (const file of Array.from(data.files ?? [])) {
+    if (!CANVAS_PASTE_IMAGE_TYPES.has(file.type) || seen.has(file)) continue;
+    seen.add(file);
+    files.push(file);
+  }
+  return files;
+}
+
+async function getImageDimensions(file: File): Promise<{ width: number; height: number }> {
+  if (typeof createImageBitmap === "function") {
+    try {
+      const bitmap = await createImageBitmap(file);
+      const dimensions = { width: bitmap.width, height: bitmap.height };
+      bitmap.close();
+      return dimensions;
+    } catch (err: unknown) {
+      console.warn("[canvas] Failed to read pasted image dimensions:", err);
+    }
+  }
+  return { width: MAX_PASTED_IMAGE_WIDTH, height: Math.round(MAX_PASTED_IMAGE_WIDTH * 9 / 16) };
+}
+
+function fitImageDimensions(dimensions: { width: number; height: number }): { width: number; height: number } {
+  const scale = Math.min(1, MAX_PASTED_IMAGE_WIDTH / dimensions.width, MAX_PASTED_IMAGE_HEIGHT / dimensions.height);
+  return {
+    width: Math.max(80, Math.round(dimensions.width * scale)),
+    height: Math.max(60, Math.round(dimensions.height * scale)),
+  };
+}
 
 interface CanvasRendererProps {
   children?: ReactNode;
@@ -30,6 +92,8 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
   const createGroup = useCanvasGroups((s) => s.createGroup);
   const addToGroup = useCanvasGroups((s) => s.addToGroup);
   const labels = useCanvasLabels((s) => s.labels);
+  const uploadCanvasAsset = useWorkspaceCanvasStore((s) => s.uploadCanvasAsset);
+  const addImageNode = useWorkspaceCanvasStore((s) => s.addImageNode);
 
   const autoArrange = useCallback(
     (wins: typeof windows) => {
@@ -123,6 +187,31 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [handleFitAll]);
 
+  useEffect(() => {
+    const onPaste = (event: ClipboardEvent) => {
+      if (isEditablePasteTarget(event.target)) return;
+      const files = imageFilesFromClipboard(event.clipboardData);
+      if (files.length === 0) return;
+      event.preventDefault();
+      const rect = useCanvasTransform.getState().containerRect;
+      const center = useCanvasTransform.getState().screenToCanvas(
+        (rect?.left ?? 0) + (rect?.width ?? window.innerWidth) / 2,
+        (rect?.top ?? 0) + (rect?.height ?? window.innerHeight) / 2,
+      );
+      void Promise.all(files.map(async (file) => {
+        const [asset, naturalSize] = await Promise.all([
+          uploadCanvasAsset(file),
+          getImageDimensions(file),
+        ]);
+        if (!asset) return;
+        await addImageNode(asset, fitImageDimensions(naturalSize), center);
+      }));
+    };
+
+    window.addEventListener("paste", onPaste);
+    return () => window.removeEventListener("paste", onPaste);
+  }, [addImageNode, uploadCanvasAsset]);
+
   return (
     <div className="relative w-full h-full">
       <CanvasTransform
@@ -146,6 +235,7 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
           </div>
         )}
         {children}
+        <WorkspaceCanvasLayer />
         {windows.map((win) => (
           <CanvasWindow key={win.id} win={win} hidden={win.minimized} />
         ))}

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -193,6 +193,8 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
       const files = imageFilesFromClipboard(event.clipboardData);
       if (files.length === 0) return;
       event.preventDefault();
+      const canvasId = useWorkspaceCanvasStore.getState().activeCanvasId;
+      if (!canvasId) return;
       const rect = useCanvasTransform.getState().containerRect;
       const center = useCanvasTransform.getState().screenToCanvas(
         (rect?.left ?? 0) + (rect?.width ?? window.innerWidth) / 2,
@@ -204,7 +206,7 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
           getImageDimensions(file),
         ]);
         if (!asset) return;
-        await addImageNode(asset, fitImageDimensions(naturalSize), center);
+        await addImageNode(asset, fitImageDimensions(naturalSize), center, { canvasId });
       }));
     };
 

--- a/shell/src/components/canvas/WorkspaceCanvas.tsx
+++ b/shell/src/components/canvas/WorkspaceCanvas.tsx
@@ -122,9 +122,9 @@ export function WorkspaceCanvasLayer() {
             if (!drag || drag.nodeId !== node.id || drag.pointerId !== event.pointerId) return;
             dragRef.current = null;
             if (drag.mode === "move") {
-              void updateNode(node.id, { position: { x: drag.nextX, y: drag.nextY } });
+              void updateNode(node.id, { position: { x: drag.origX, y: drag.origY } });
             } else {
-              void updateNode(node.id, { size: { width: drag.nextW, height: drag.nextH } });
+              void updateNode(node.id, { size: { width: drag.origW, height: drag.origH } });
             }
             clearImageDragPreview(event.currentTarget);
           }}

--- a/shell/src/components/canvas/WorkspaceCanvas.tsx
+++ b/shell/src/components/canvas/WorkspaceCanvas.tsx
@@ -1,24 +1,122 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Tldraw } from "@tldraw/tldraw";
 import "@tldraw/tldraw/tldraw.css";
+import { useCanvasTransform } from "@/hooks/useCanvasTransform";
 import { selectVisibleWorkspaceCanvasNodes, useWorkspaceCanvasStore } from "@/stores/workspace-canvas-store";
 import { WorkspaceCanvasNode } from "./WorkspaceCanvasNode";
 import { WorkspaceCanvasToolbar } from "./WorkspaceCanvasToolbar";
 import { WorkspaceCanvasInspector } from "./WorkspaceCanvasInspector";
+
+export function WorkspaceCanvasLayer() {
+  const document = useWorkspaceCanvasStore((s) => s.document);
+  const query = useWorkspaceCanvasStore((s) => s.query);
+  const filters = useWorkspaceCanvasStore((s) => s.filters);
+  const setSelectedNode = useWorkspaceCanvasStore((s) => s.setSelectedNode);
+  const updateNode = useWorkspaceCanvasStore((s) => s.updateNode);
+  const zoom = useCanvasTransform((s) => s.zoom);
+  const dragRef = useRef<{
+    nodeId: string;
+    mode: "move" | "resize";
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+    origW: number;
+    origH: number;
+  } | null>(null);
+  const visibleNodes = useMemo(() => selectVisibleWorkspaceCanvasNodes(document, query, filters), [document, filters, query]);
+  const nodeById = useMemo(() => new Map(document?.nodes.map((node) => [node.id, node]) ?? []), [document?.nodes]);
+
+  if (!document) return null;
+
+  return (
+    <>
+      <div className="absolute inset-0" style={{ zIndex: -1 }} />
+      {visibleNodes.map((node) => (
+        <div
+          key={node.id}
+          className="pointer-events-auto absolute touch-none"
+          style={{
+            transform: `translate(${node.position.x}px, ${node.position.y}px)`,
+            width: node.size.width,
+            height: node.size.height,
+            zIndex: 30 + node.zIndex,
+          }}
+          onMouseDown={() => setSelectedNode(node.id)}
+          onPointerDown={(event) => {
+            if (node.type !== "image" || event.button !== 0) return;
+            if (event.target instanceof Element && event.target.closest("button")) return;
+            const mode = event.target instanceof Element && event.target.closest("[data-workspace-canvas-resize]") ? "resize" : "move";
+            event.preventDefault();
+            event.stopPropagation();
+            dragRef.current = {
+              nodeId: node.id,
+              mode,
+              startX: event.clientX,
+              startY: event.clientY,
+              origX: node.position.x,
+              origY: node.position.y,
+              origW: node.size.width,
+              origH: node.size.height,
+            };
+            event.currentTarget.setPointerCapture(event.pointerId);
+          }}
+          onPointerMove={(event) => {
+            const drag = dragRef.current;
+            if (!drag || drag.nodeId !== node.id) return;
+            const dx = (event.clientX - drag.startX) / zoom;
+            const dy = (event.clientY - drag.startY) / zoom;
+            if (drag.mode === "move") {
+              void updateNode(node.id, { position: { x: Math.round(drag.origX + dx), y: Math.round(drag.origY + dy) } });
+              return;
+            }
+            void updateNode(node.id, {
+              size: {
+                width: Math.max(80, Math.round(drag.origW + dx)),
+                height: Math.max(60, Math.round(drag.origH + dy)),
+              },
+            });
+          }}
+          onPointerUp={() => {
+            dragRef.current = null;
+          }}
+          onPointerCancel={() => {
+            dragRef.current = null;
+          }}
+        >
+          <WorkspaceCanvasNode node={node} />
+        </div>
+      ))}
+      <svg className="pointer-events-none absolute inset-0 h-full w-full">
+        {document.edges.map((edge) => {
+          const from = nodeById.get(edge.fromNodeId);
+          const to = nodeById.get(edge.toNodeId);
+          if (!from || !to) return null;
+          return (
+            <line
+              key={edge.id}
+              x1={from.position.x + from.size.width}
+              y1={from.position.y + from.size.height / 2}
+              x2={to.position.x}
+              y2={to.position.y + to.size.height / 2}
+              stroke="rgba(255,255,255,0.35)"
+              strokeWidth={2}
+            />
+          );
+        })}
+      </svg>
+    </>
+  );
+}
 
 export function WorkspaceCanvas() {
   const document = useWorkspaceCanvasStore((s) => s.document);
   const summaries = useWorkspaceCanvasStore((s) => s.summaries);
   const loadSummaries = useWorkspaceCanvasStore((s) => s.loadSummaries);
   const openCanvas = useWorkspaceCanvasStore((s) => s.openCanvas);
-  const query = useWorkspaceCanvasStore((s) => s.query);
-  const filters = useWorkspaceCanvasStore((s) => s.filters);
-  const setSelectedNode = useWorkspaceCanvasStore((s) => s.setSelectedNode);
   const tldrawLayerEnabled = document?.displayOptions.tldrawLayer === true;
-  const visibleNodes = useMemo(() => selectVisibleWorkspaceCanvasNodes(document, query, filters), [document, filters, query]);
-  const nodeById = useMemo(() => new Map(document?.nodes.map((node) => [node.id, node]) ?? []), [document?.nodes]);
 
   useEffect(() => {
     void loadSummaries();
@@ -46,41 +144,6 @@ export function WorkspaceCanvas() {
       </div>
       <div className="absolute right-4 top-4 z-20">
         <WorkspaceCanvasInspector />
-      </div>
-      <div className="absolute inset-0">
-        {visibleNodes.map((node) => (
-          <div
-            key={node.id}
-            className="pointer-events-auto absolute"
-            style={{
-              transform: `translate(${node.position.x}px, ${node.position.y}px)`,
-              width: node.size.width,
-              height: node.size.height,
-              zIndex: 30 + node.zIndex,
-            }}
-            onMouseDown={() => setSelectedNode(node.id)}
-          >
-            <WorkspaceCanvasNode node={node} />
-          </div>
-        ))}
-        <svg className="pointer-events-none absolute inset-0 h-full w-full">
-          {document.edges.map((edge) => {
-            const from = nodeById.get(edge.fromNodeId);
-            const to = nodeById.get(edge.toNodeId);
-            if (!from || !to) return null;
-            return (
-              <line
-                key={edge.id}
-                x1={from.position.x + from.size.width}
-                y1={from.position.y + from.size.height / 2}
-                x2={to.position.x}
-                y2={to.position.y + to.size.height / 2}
-                stroke="rgba(255,255,255,0.35)"
-                strokeWidth={2}
-              />
-            );
-          })}
-        </svg>
       </div>
     </div>
   );

--- a/shell/src/components/canvas/WorkspaceCanvas.tsx
+++ b/shell/src/components/canvas/WorkspaceCanvas.tsx
@@ -9,6 +9,34 @@ import { WorkspaceCanvasNode } from "./WorkspaceCanvasNode";
 import { WorkspaceCanvasToolbar } from "./WorkspaceCanvasToolbar";
 import { WorkspaceCanvasInspector } from "./WorkspaceCanvasInspector";
 
+type ImageDragState = {
+  nodeId: string;
+  mode: "move" | "resize";
+  pointerId: number;
+  startX: number;
+  startY: number;
+  origX: number;
+  origY: number;
+  origW: number;
+  origH: number;
+  nextX: number;
+  nextY: number;
+  nextW: number;
+  nextH: number;
+};
+
+function applyImageDragPreview(element: HTMLElement, drag: ImageDragState) {
+  element.style.transform = `translate(${drag.nextX}px, ${drag.nextY}px)`;
+  element.style.width = `${drag.nextW}px`;
+  element.style.height = `${drag.nextH}px`;
+}
+
+function clearImageDragPreview(element: HTMLElement) {
+  element.style.transform = "";
+  element.style.width = "";
+  element.style.height = "";
+}
+
 export function WorkspaceCanvasLayer() {
   const document = useWorkspaceCanvasStore((s) => s.document);
   const query = useWorkspaceCanvasStore((s) => s.query);
@@ -16,16 +44,7 @@ export function WorkspaceCanvasLayer() {
   const setSelectedNode = useWorkspaceCanvasStore((s) => s.setSelectedNode);
   const updateNode = useWorkspaceCanvasStore((s) => s.updateNode);
   const zoom = useCanvasTransform((s) => s.zoom);
-  const dragRef = useRef<{
-    nodeId: string;
-    mode: "move" | "resize";
-    startX: number;
-    startY: number;
-    origX: number;
-    origY: number;
-    origW: number;
-    origH: number;
-  } | null>(null);
+  const dragRef = useRef<ImageDragState | null>(null);
   const visibleNodes = useMemo(() => selectVisibleWorkspaceCanvasNodes(document, query, filters), [document, filters, query]);
   const nodeById = useMemo(() => new Map(document?.nodes.map((node) => [node.id, node]) ?? []), [document?.nodes]);
 
@@ -54,36 +73,60 @@ export function WorkspaceCanvasLayer() {
             dragRef.current = {
               nodeId: node.id,
               mode,
+              pointerId: event.pointerId,
               startX: event.clientX,
               startY: event.clientY,
               origX: node.position.x,
               origY: node.position.y,
               origW: node.size.width,
               origH: node.size.height,
+              nextX: node.position.x,
+              nextY: node.position.y,
+              nextW: node.size.width,
+              nextH: node.size.height,
             };
-            event.currentTarget.setPointerCapture(event.pointerId);
+            if ("setPointerCapture" in event.currentTarget) {
+              event.currentTarget.setPointerCapture(event.pointerId);
+            }
           }}
           onPointerMove={(event) => {
             const drag = dragRef.current;
-            if (!drag || drag.nodeId !== node.id) return;
+            if (!drag || drag.nodeId !== node.id || drag.pointerId !== event.pointerId) return;
             const dx = (event.clientX - drag.startX) / zoom;
             const dy = (event.clientY - drag.startY) / zoom;
             if (drag.mode === "move") {
-              void updateNode(node.id, { position: { x: Math.round(drag.origX + dx), y: Math.round(drag.origY + dy) } });
-              return;
+              drag.nextX = Math.round(drag.origX + dx);
+              drag.nextY = Math.round(drag.origY + dy);
+            } else {
+              drag.nextW = Math.max(80, Math.round(drag.origW + dx));
+              drag.nextH = Math.max(60, Math.round(drag.origH + dy));
             }
-            void updateNode(node.id, {
-              size: {
-                width: Math.max(80, Math.round(drag.origW + dx)),
-                height: Math.max(60, Math.round(drag.origH + dy)),
-              },
-            });
+            applyImageDragPreview(event.currentTarget, drag);
           }}
-          onPointerUp={() => {
+          onPointerUp={(event) => {
+            const drag = dragRef.current;
+            if (!drag || drag.nodeId !== node.id || drag.pointerId !== event.pointerId) return;
             dragRef.current = null;
+            if ("releasePointerCapture" in event.currentTarget) {
+              event.currentTarget.releasePointerCapture(event.pointerId);
+            }
+            if (drag.mode === "move") {
+              void updateNode(node.id, { position: { x: drag.nextX, y: drag.nextY } });
+            } else {
+              void updateNode(node.id, { size: { width: drag.nextW, height: drag.nextH } });
+            }
+            clearImageDragPreview(event.currentTarget);
           }}
-          onPointerCancel={() => {
+          onPointerCancel={(event) => {
+            const drag = dragRef.current;
+            if (!drag || drag.nodeId !== node.id || drag.pointerId !== event.pointerId) return;
             dragRef.current = null;
+            if (drag.mode === "move") {
+              void updateNode(node.id, { position: { x: drag.nextX, y: drag.nextY } });
+            } else {
+              void updateNode(node.id, { size: { width: drag.nextW, height: drag.nextH } });
+            }
+            clearImageDragPreview(event.currentTarget);
           }}
         >
           <WorkspaceCanvasNode node={node} />

--- a/shell/src/components/canvas/WorkspaceCanvasNode.tsx
+++ b/shell/src/components/canvas/WorkspaceCanvasNode.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Terminal, GitPullRequest, ClipboardCheck, FileText, Eye, AppWindow, CircleDot, AlertTriangle } from "lucide-react";
+import { Terminal, GitPullRequest, ClipboardCheck, FileText, Eye, AppWindow, CircleDot, AlertTriangle, ImageIcon, Trash2 } from "lucide-react";
 import { TerminalPane } from "@/components/terminal/TerminalPane";
+import { getGatewayUrl } from "@/lib/gateway";
 import { useTheme } from "@/hooks/useTheme";
 import type { WorkspaceCanvasNode as WorkspaceCanvasNodeModel } from "@/stores/workspace-canvas-store";
 import { useWorkspaceCanvasStore } from "@/stores/workspace-canvas-store";
@@ -16,6 +17,7 @@ function Icon({ type }: { type: WorkspaceCanvasNodeModel["type"] }) {
   if (type === "pr") return <GitPullRequest size={16} />;
   if (type === "review_loop" || type === "finding") return <ClipboardCheck size={16} />;
   if (type === "file" || type === "note" || type === "task") return <FileText size={16} />;
+  if (type === "image") return <ImageIcon size={16} />;
   if (type === "preview") return <Eye size={16} />;
   if (type === "app_window") return <AppWindow size={16} />;
   if (type === "fallback") return <AlertTriangle size={16} />;
@@ -28,11 +30,43 @@ export function WorkspaceCanvasNode({ node }: { node: WorkspaceCanvasNodeModel }
   const setSelectedNode = useWorkspaceCanvasStore((s) => s.setSelectedNode);
   const setFocusedNode = useWorkspaceCanvasStore((s) => s.setFocusedNode);
   const executeAction = useWorkspaceCanvasStore((s) => s.executeAction);
+  const deleteNode = useWorkspaceCanvasStore((s) => s.deleteNode);
   const isFocused = focusedNodeId === node.id;
   const terminalSessionId = node.type === "terminal" && node.sourceRef?.id !== "unattached" ? node.sourceRef?.id : undefined;
 
   if (node.type === "fallback" || node.displayState === "recoverable" || node.displayState === "missing") {
     return <WorkspaceCanvasFallbackNode node={node} />;
+  }
+
+  if (node.type === "image" && node.sourceRef?.kind === "file") {
+    const imagePath = node.sourceRef.id.split("/").map((part) => encodeURIComponent(part)).join("/");
+    const imageUrl = `${getGatewayUrl()}/files/${imagePath}`;
+    const alt = String(node.metadata.originalName ?? node.metadata.title ?? "Pasted image");
+    return (
+      <div
+        className="group/image relative h-full overflow-hidden rounded-md border border-white/20 bg-black/40 shadow-xl"
+        onClick={() => setSelectedNode(node.id)}
+      >
+        <img src={imageUrl} alt={alt} className="h-full w-full select-none object-contain" draggable={false} />
+        <div className="pointer-events-none absolute inset-0 rounded-md ring-1 ring-white/10" />
+        <button
+          type="button"
+          className="absolute right-2 top-2 flex size-7 items-center justify-center rounded bg-black/65 text-white opacity-0 shadow transition-opacity hover:bg-black/80 group-hover/image:opacity-100"
+          aria-label="Delete pasted image"
+          onClick={(event) => {
+            event.stopPropagation();
+            void deleteNode(node.id);
+          }}
+        >
+          <Trash2 size={14} />
+        </button>
+        <div
+          data-workspace-canvas-resize
+          className="absolute bottom-0 right-0 size-4 cursor-se-resize rounded-tl bg-black/60 opacity-0 transition-opacity group-hover/image:opacity-100"
+          aria-hidden
+        />
+      </div>
+    );
   }
 
   return (

--- a/shell/src/stores/workspace-canvas-store.ts
+++ b/shell/src/stores/workspace-canvas-store.ts
@@ -118,7 +118,7 @@ interface WorkspaceCanvasStore {
   exportCanvas: () => Promise<unknown | null>;
   executeAction: (nodeId: string, type: string, payload?: Record<string, unknown>) => Promise<unknown | null>;
   addNode: (type: WorkspaceCanvasNodeType, metadata?: Record<string, unknown>) => Promise<void>;
-  addImageNode: (asset: CanvasAssetUpload, dimensions: { width: number; height: number }, center: { x: number; y: number }) => Promise<void>;
+  addImageNode: (asset: CanvasAssetUpload, dimensions: { width: number; height: number }, center: { x: number; y: number }, options?: { canvasId?: string }) => Promise<void>;
   uploadCanvasAsset: (file: File) => Promise<CanvasAssetUpload | null>;
   deleteNode: (nodeId: string) => Promise<void>;
   addEdge: (fromNodeId: string, toNodeId: string, type?: WorkspaceCanvasEdge["type"]) => Promise<void>;
@@ -398,9 +398,9 @@ export const useWorkspaceCanvasStore = create<WorkspaceCanvasStore>((set, get) =
     get().scheduleSave(next);
   },
 
-  async addImageNode(asset, dimensions, center) {
+  async addImageNode(asset, dimensions, center, options = {}) {
     const document = get().document;
-    if (!document) return;
+    if (!document || (options.canvasId && document.id !== options.canvasId)) return;
     const nextNode = createImageNode(asset, dimensions, center, document.nodes.length);
     const next = { ...document, nodes: [...document.nodes, nextNode] };
     set({ document: next, selectedNodeId: nextNode.id });

--- a/shell/src/stores/workspace-canvas-store.ts
+++ b/shell/src/stores/workspace-canvas-store.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import { getGatewayUrl } from "@/lib/gateway";
+import { isCanvasAssetMimeType, isCanvasAssetPath } from "../../../packages/gateway/src/canvas/assets.js";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 const SAFE_CANVAS_ERROR_MESSAGES = new Set([
@@ -95,6 +96,23 @@ export interface CanvasAssetUpload {
   mimeType: string;
   sizeBytes: number;
   originalName: string;
+}
+
+function parseCanvasAssetUpload(value: unknown): CanvasAssetUpload | null {
+  if (typeof value !== "object" || value === null) return null;
+  const asset = value as Record<string, unknown>;
+  if (typeof asset.assetId !== "string" || asset.assetId.length < 1 || asset.assetId.length > 120) return null;
+  if (typeof asset.path !== "string" || !isCanvasAssetPath(asset.path)) return null;
+  if (typeof asset.mimeType !== "string" || !isCanvasAssetMimeType(asset.mimeType)) return null;
+  if (typeof asset.sizeBytes !== "number" || !Number.isFinite(asset.sizeBytes) || asset.sizeBytes <= 0) return null;
+  if (typeof asset.originalName !== "string" || asset.originalName.length < 1 || asset.originalName.length > 160) return null;
+  return {
+    assetId: asset.assetId,
+    path: asset.path,
+    mimeType: asset.mimeType,
+    sizeBytes: asset.sizeBytes,
+    originalName: asset.originalName,
+  };
 }
 
 interface WorkspaceCanvasStore {
@@ -429,8 +447,12 @@ export const useWorkspaceCanvasStore = create<WorkspaceCanvasStore>((set, get) =
       if (!response.ok) {
         throw new Error(safeCanvasErrorMessage((body as { error?: unknown }).error));
       }
+      const asset = parseCanvasAssetUpload(body);
+      if (!asset) {
+        throw new Error("Canvas request failed");
+      }
       set({ error: null });
-      return body as CanvasAssetUpload;
+      return asset;
     } catch (err: unknown) {
       set({ error: err instanceof Error ? err.message : "Canvas request failed" });
       return null;

--- a/shell/src/stores/workspace-canvas-store.ts
+++ b/shell/src/stores/workspace-canvas-store.ts
@@ -2,7 +2,7 @@
 
 import { create } from "zustand";
 import { getGatewayUrl } from "@/lib/gateway";
-import { isCanvasAssetMimeType, isCanvasAssetPath } from "../../../packages/gateway/src/canvas/assets.js";
+import { isCanvasAssetMimeType, isCanvasAssetPath } from "../../../packages/gateway/src/canvas/assets";
 
 const REQUEST_TIMEOUT_MS = 10_000;
 const SAFE_CANVAS_ERROR_MESSAGES = new Set([

--- a/shell/src/stores/workspace-canvas-store.ts
+++ b/shell/src/stores/workspace-canvas-store.ts
@@ -34,6 +34,7 @@ export type WorkspaceCanvasNodeType =
   | "task"
   | "file"
   | "preview"
+  | "image"
   | "note"
   | "app_window"
   | "issue"
@@ -88,6 +89,14 @@ export interface WorkspaceCanvasSummary {
 
 type SaveStatus = "idle" | "saving" | "saved" | "conflict" | "error";
 
+export interface CanvasAssetUpload {
+  assetId: string;
+  path: string;
+  mimeType: string;
+  sizeBytes: number;
+  originalName: string;
+}
+
 interface WorkspaceCanvasStore {
   summaries: WorkspaceCanvasSummary[];
   activeCanvasId: string | null;
@@ -109,6 +118,9 @@ interface WorkspaceCanvasStore {
   exportCanvas: () => Promise<unknown | null>;
   executeAction: (nodeId: string, type: string, payload?: Record<string, unknown>) => Promise<unknown | null>;
   addNode: (type: WorkspaceCanvasNodeType, metadata?: Record<string, unknown>) => Promise<void>;
+  addImageNode: (asset: CanvasAssetUpload, dimensions: { width: number; height: number }, center: { x: number; y: number }) => Promise<void>;
+  uploadCanvasAsset: (file: File) => Promise<CanvasAssetUpload | null>;
+  deleteNode: (nodeId: string) => Promise<void>;
   addEdge: (fromNodeId: string, toNodeId: string, type?: WorkspaceCanvasEdge["type"]) => Promise<void>;
   setSelectedNode: (nodeId: string | null) => void;
   setFocusedNode: (nodeId: string | null) => void;
@@ -191,6 +203,34 @@ function createNode(type: WorkspaceCanvasNodeType, metadata: Record<string, unkn
 function createEdgeId(index: number): string {
   const entropy = Math.random().toString(36).slice(2, 10);
   return `edge_${Date.now().toString(36)}_${index}_${entropy}`;
+}
+
+function createImageNode(
+  asset: CanvasAssetUpload,
+  dimensions: { width: number; height: number },
+  center: { x: number; y: number },
+  index: number,
+): WorkspaceCanvasNode {
+  const id = `node_image_${Date.now().toString(36)}_${index}`;
+  const now = new Date().toISOString();
+  return {
+    id,
+    type: "image",
+    position: { x: Math.round(center.x - dimensions.width / 2), y: Math.round(center.y - dimensions.height / 2) },
+    size: { width: Math.round(dimensions.width), height: Math.round(dimensions.height) },
+    zIndex: index,
+    displayState: "normal",
+    sourceRef: { kind: "file", id: asset.path },
+    metadata: {
+      mimeType: asset.mimeType,
+      sizeBytes: asset.sizeBytes,
+      originalName: asset.originalName,
+      width: Math.round(dimensions.width),
+      height: Math.round(dimensions.height),
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 export const useWorkspaceCanvasStore = create<WorkspaceCanvasStore>((set, get) => {
@@ -354,6 +394,61 @@ export const useWorkspaceCanvasStore = create<WorkspaceCanvasStore>((set, get) =
     const nextNode = createNode(type, metadata, document.nodes.length);
     const next = { ...document, nodes: [...document.nodes, nextNode] };
     set({ document: next, selectedNodeId: nextNode.id });
+    get().scheduleSave(next);
+  },
+
+  async addImageNode(asset, dimensions, center) {
+    const document = get().document;
+    if (!document) return;
+    const nextNode = createImageNode(asset, dimensions, center, document.nodes.length);
+    const next = { ...document, nodes: [...document.nodes, nextNode] };
+    set({ document: next, selectedNodeId: nextNode.id });
+    get().scheduleSave(next);
+  },
+
+  async uploadCanvasAsset(file) {
+    const document = get().document;
+    if (!document) return null;
+    const formData = new FormData();
+    formData.append("file", file, file.name || "clipboard-image");
+    try {
+      const response = await fetch(`${getGatewayUrl()}/api/canvases/${encodeURIComponent(document.id)}/assets`, {
+        method: "POST",
+        body: formData,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      let body: unknown = {};
+      try {
+        body = await response.json();
+      } catch (err: unknown) {
+        if (!(err instanceof SyntaxError)) {
+          console.warn("[workspace-canvas] Failed to parse asset upload response:", err);
+        }
+      }
+      if (!response.ok) {
+        throw new Error(safeCanvasErrorMessage((body as { error?: unknown }).error));
+      }
+      set({ error: null });
+      return body as CanvasAssetUpload;
+    } catch (err: unknown) {
+      set({ error: err instanceof Error ? err.message : "Canvas request failed" });
+      return null;
+    }
+  },
+
+  async deleteNode(nodeId) {
+    const document = get().document;
+    if (!document) return;
+    const next = {
+      ...document,
+      nodes: document.nodes.filter((node) => node.id !== nodeId),
+      edges: document.edges.filter((edge) => edge.fromNodeId !== nodeId && edge.toNodeId !== nodeId),
+    };
+    set({
+      document: next,
+      selectedNodeId: get().selectedNodeId === nodeId ? null : get().selectedNodeId,
+      focusedNodeId: get().focusedNodeId === nodeId ? null : get().focusedNodeId,
+    });
     get().scheduleSave(next);
   },
 

--- a/shell/src/stores/workspace-canvas-store.ts
+++ b/shell/src/stores/workspace-canvas-store.ts
@@ -211,7 +211,8 @@ function createImageNode(
   center: { x: number; y: number },
   index: number,
 ): WorkspaceCanvasNode {
-  const id = `node_image_${Date.now().toString(36)}_${index}`;
+  const entropy = Math.random().toString(36).slice(2, 10);
+  const id = `node_image_${Date.now().toString(36)}_${index}_${entropy}`;
   const now = new Date().toISOString();
   return {
     id,

--- a/tests/gateway/canvas-contracts.test.ts
+++ b/tests/gateway/canvas-contracts.test.ts
@@ -109,6 +109,13 @@ describe("canvas contracts", () => {
         sourceRef: { kind: "file", id: "../system/canvas-assets/cnv_0123456789abcdef/asset.png" },
       }),
     ).toThrow();
+
+    expect(() =>
+      CanvasNodeSchema.parse({
+        ...node("node_image", "image"),
+        sourceRef: { kind: "url", id: "https://example.com/image.png" },
+      }),
+    ).toThrow();
   });
 
   it("rejects stale revisions before repository writes", () => {

--- a/tests/gateway/canvas-contracts.test.ts
+++ b/tests/gateway/canvas-contracts.test.ts
@@ -78,6 +78,39 @@ describe("canvas contracts", () => {
     ).toThrow();
   });
 
+  it("accepts image nodes with safe canvas asset file references", () => {
+    const parsed = CanvasNodeSchema.parse({
+      ...node("node_image", "image"),
+      sourceRef: { kind: "file", id: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png" },
+      metadata: {
+        mimeType: "image/png",
+        sizeBytes: 1024,
+        originalName: "Screenshot.png",
+        width: 1280,
+        height: 720,
+      },
+    });
+
+    expect(parsed.type).toBe("image");
+    expect(parsed.sourceRef?.kind).toBe("file");
+  });
+
+  it("rejects image nodes without a safe file source reference", () => {
+    expect(() =>
+      CanvasNodeSchema.parse({
+        ...node("node_image", "image"),
+        sourceRef: null,
+      }),
+    ).toThrow();
+
+    expect(() =>
+      CanvasNodeSchema.parse({
+        ...node("node_image", "image"),
+        sourceRef: { kind: "file", id: "../system/canvas-assets/cnv_0123456789abcdef/asset.png" },
+      }),
+    ).toThrow();
+  });
+
   it("rejects stale revisions before repository writes", () => {
     expect(ReplaceCanvasRequestSchema.parse({
       baseRevision: 1,

--- a/tests/gateway/canvas-contracts.test.ts
+++ b/tests/gateway/canvas-contracts.test.ts
@@ -113,6 +113,20 @@ describe("canvas contracts", () => {
     expect(() =>
       CanvasNodeSchema.parse({
         ...node("node_image", "image"),
+        sourceRef: { kind: "file", id: "system/theme.json" },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      CanvasNodeSchema.parse({
+        ...node("node_image", "image"),
+        sourceRef: { kind: "file", id: "system/canvas-assets/cnv_0123456789abcdef/asset.txt" },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      CanvasNodeSchema.parse({
+        ...node("node_image", "image"),
         sourceRef: { kind: "url", id: "https://example.com/image.png" },
       }),
     ).toThrow();

--- a/tests/gateway/canvas-routes.test.ts
+++ b/tests/gateway/canvas-routes.test.ts
@@ -34,6 +34,13 @@ const service: CanvasRouteService = {
   deleteCanvas: vi.fn().mockResolvedValue({ ok: true }),
   exportCanvas: vi.fn().mockResolvedValue({ canvas: {}, linkedSummaries: {}, exportedAt: "2026-04-27T00:00:00.000Z" }),
   executeAction: vi.fn().mockResolvedValue({ ok: true, result: { kind: "noop" } }),
+  uploadCanvasAsset: vi.fn().mockResolvedValue({
+    assetId: "asset_0123456789abcdef",
+    path: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png",
+    mimeType: "image/png",
+    sizeBytes: 8,
+    originalName: "screenshot.png",
+  }),
 };
 
 describe("canvas routes", () => {
@@ -206,5 +213,84 @@ describe("canvas routes", () => {
     expect(broadcastCanvasUpdate).toHaveBeenNthCalledWith(3, "cnv_0123456789abcdef", {
       type: "canvas:deleted",
     });
+  });
+
+  it("uploads a canvas image asset after authentication and canvas validation", async () => {
+    const uploadCanvasAsset = vi.fn().mockResolvedValue({
+      assetId: "asset_0123456789abcdef",
+      path: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png",
+      mimeType: "image/png",
+      sizeBytes: 8,
+      originalName: "screenshot.png",
+    });
+    const app = createApp({ ...service, uploadCanvasAsset });
+    const form = new FormData();
+    form.append("file", new Blob([Buffer.from("fake-png")], { type: "image/png" }), "screenshot.png");
+
+    const res = await app.request("/api/canvases/cnv_0123456789abcdef/assets", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toMatchObject({
+      path: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png",
+      mimeType: "image/png",
+    });
+    expect(uploadCanvasAsset).toHaveBeenCalledWith("user_a", "cnv_0123456789abcdef", expect.any(File));
+  });
+
+  it("rejects unauthenticated canvas image uploads", async () => {
+    const uploadCanvasAsset = vi.fn();
+    const app = createApp({ ...service, uploadCanvasAsset }, null);
+    const form = new FormData();
+    form.append("file", new Blob([Buffer.from("fake-png")], { type: "image/png" }), "screenshot.png");
+
+    const res = await app.request("/api/canvases/cnv_0123456789abcdef/assets", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(uploadCanvasAsset).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid canvas image upload requests before service calls", async () => {
+    const uploadCanvasAsset = vi.fn();
+    const app = createApp({ ...service, uploadCanvasAsset });
+
+    const missingFile = await app.request("/api/canvases/cnv_0123456789abcdef/assets", {
+      method: "POST",
+      body: new FormData(),
+    });
+    expect(missingFile.status).toBe(400);
+    expect(await missingFile.json()).toEqual({ error: "Invalid request" });
+
+    const badType = new FormData();
+    badType.append("file", new Blob([Buffer.from("<svg/>")], { type: "image/svg+xml" }), "bad.svg");
+    const badTypeRes = await app.request("/api/canvases/cnv_0123456789abcdef/assets", {
+      method: "POST",
+      body: badType,
+    });
+    expect(badTypeRes.status).toBe(400);
+    expect(await badTypeRes.json()).toEqual({ error: "Invalid request" });
+
+    expect(uploadCanvasAsset).not.toHaveBeenCalled();
+  });
+
+  it("applies upload body limits before canvas image upload handling", async () => {
+    const uploadCanvasAsset = vi.fn();
+    const app = createApp({ ...service, uploadCanvasAsset });
+    const form = new FormData();
+    form.append("file", new Blob([Buffer.alloc(11 * 1024 * 1024)], { type: "image/png" }), "large.png");
+
+    const res = await app.request("/api/canvases/cnv_0123456789abcdef/assets", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(res.status).toBe(413);
+    expect(uploadCanvasAsset).not.toHaveBeenCalled();
   });
 });

--- a/tests/gateway/canvas-service.test.ts
+++ b/tests/gateway/canvas-service.test.ts
@@ -157,6 +157,19 @@ describe("CanvasService", () => {
     await expect(service.uploadCanvasAsset("user_a", "cnv_0123456789abcdef", file)).rejects.toBeInstanceOf(CanvasNotFoundError);
   });
 
+  it("maps invalid canvas image asset files to a generic invalid request", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "canvas-home-"));
+    const service = new CanvasService(repository([record()]), { homePath });
+    const file = new File([Buffer.from("<svg/>")], "bad.svg", { type: "image/svg+xml" });
+
+    try {
+      await service.uploadCanvasAsset("user_a", "cnv_0123456789abcdef", file);
+      throw new Error("expected upload to fail");
+    } catch (err: unknown) {
+      expect(mapCanvasError(err)).toEqual({ error: "Invalid request", status: 400 });
+    }
+  });
+
   it("marks stale terminal refs recoverable on the main canvas read path", async () => {
     const service = new CanvasService(repository([record({
       nodes: [{

--- a/tests/gateway/canvas-service.test.ts
+++ b/tests/gateway/canvas-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from "node:fs/promises";
+import { readFile, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -129,6 +129,32 @@ describe("CanvasService", () => {
       updates: { sourceRef: { kind: "file", id: "projects/app/README.md" } },
     })).rejects.toBeInstanceOf(CanvasConfigurationError);
     expect(repo.patchNode).not.toHaveBeenCalled();
+  });
+
+  it("stores canvas image assets under the owner home after confirming canvas access", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "canvas-home-"));
+    const repo = repository([record()]);
+    const service = new CanvasService(repo, { homePath });
+    const file = new File([Buffer.from("fake-png")], "Screenshot.png", { type: "image/png" });
+
+    const result = await service.uploadCanvasAsset("user_a", "cnv_0123456789abcdef", file);
+
+    expect(repo.get).toHaveBeenCalledWith({ ownerScope: "personal", ownerId: "user_a" }, "cnv_0123456789abcdef");
+    expect(result).toMatchObject({
+      mimeType: "image/png",
+      sizeBytes: 8,
+      originalName: "Screenshot.png",
+    });
+    expect(result.path).toMatch(/^system\/canvas-assets\/cnv_0123456789abcdef\/asset_[a-f0-9]{24}\.png$/);
+    await expect(readFile(join(homePath, result.path), "utf-8")).resolves.toBe("fake-png");
+  });
+
+  it("does not store canvas image assets for inaccessible canvases", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "canvas-home-"));
+    const service = new CanvasService(repository([]), { homePath });
+    const file = new File([Buffer.from("fake-png")], "Screenshot.png", { type: "image/png" });
+
+    await expect(service.uploadCanvasAsset("user_a", "cnv_0123456789abcdef", file)).rejects.toBeInstanceOf(CanvasNotFoundError);
   });
 
   it("marks stale terminal refs recoverable on the main canvas read path", async () => {

--- a/tests/gateway/file-utils.test.ts
+++ b/tests/gateway/file-utils.test.ts
@@ -9,6 +9,7 @@ describe("getMimeType", () => {
   it("returns correct MIME for images", () => {
     expect(getMimeType(".png")).toBe("image/png");
     expect(getMimeType(".jpg")).toBe("image/jpeg");
+    expect(getMimeType(".avif")).toBe("image/avif");
     expect(getMimeType(".svg")).toBe("image/svg+xml");
   });
 
@@ -80,6 +81,7 @@ describe("isBinaryFile", () => {
   it("recognizes binary files", () => {
     expect(isBinaryFile("photo.png")).toBe(true);
     expect(isBinaryFile("photo.jpg")).toBe(true);
+    expect(isBinaryFile("photo.avif")).toBe(true);
     expect(isBinaryFile("doc.pdf")).toBe(true);
     expect(isBinaryFile("song.mp3")).toBe(true);
     expect(isBinaryFile("clip.mp4")).toBe(true);

--- a/tests/shell/workspace-canvas-renderer.test.tsx
+++ b/tests/shell/workspace-canvas-renderer.test.tsx
@@ -207,6 +207,71 @@ describe("workspace canvas renderer", () => {
     });
   });
 
+  it("does not finish a pasted image into a different active canvas", async () => {
+    let resolveUpload: (response: Response) => void = () => {};
+    const uploadPromise = new Promise<Response>((resolve) => {
+      resolveUpload = resolve;
+    });
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/assets")) return uploadPromise;
+      if (url.includes("/api/canvases/cnv_0123456789abcdef")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ revision: 2, updatedAt: "2026-05-27T00:00:00.000Z" }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ canvases: [] }) });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<CanvasRenderer />);
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => new File([Buffer.from("fake-png")], "screenshot.png", { type: "image/png" }),
+          },
+        ],
+        files: [],
+      },
+    });
+
+    window.dispatchEvent(event);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/assets"), expect.any(Object)));
+    useWorkspaceCanvasStore.setState({
+      activeCanvasId: "cnv_other123456789",
+      document: {
+        id: "cnv_other123456789",
+        title: "Other Canvas",
+        revision: 1,
+        schemaVersion: 1,
+        scopeType: "global",
+        scopeRef: null,
+        nodes: [],
+        edges: [],
+        viewStates: [],
+        displayOptions: {},
+      } as any,
+    });
+
+    resolveUpload({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve({
+        assetId: "asset_0123456789abcdef",
+        path: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png",
+        mimeType: "image/png",
+        sizeBytes: 8,
+        originalName: "screenshot.png",
+      }),
+    } as Response);
+
+    await waitFor(() => {
+      expect(useWorkspaceCanvasStore.getState().document?.id).toBe("cnv_other123456789");
+      expect(useWorkspaceCanvasStore.getState().document?.nodes).toEqual([]);
+    });
+  });
+
   it("commits image drags once on pointer release instead of every pointer move", () => {
     const updateNode = vi.fn(useWorkspaceCanvasStore.getState().updateNode);
     Object.defineProperty(HTMLElement.prototype, "setPointerCapture", { configurable: true, value: vi.fn() });

--- a/tests/shell/workspace-canvas-renderer.test.tsx
+++ b/tests/shell/workspace-canvas-renderer.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CanvasRenderer } from "../../shell/src/components/canvas/CanvasRenderer.js";
 import { useWorkspaceCanvasStore } from "../../shell/src/stores/workspace-canvas-store.js";
+import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
 import { WorkspaceCanvas } from "../../shell/src/components/canvas/WorkspaceCanvas.js";
 import { WorkspaceCanvasNode } from "../../shell/src/components/canvas/WorkspaceCanvasNode.js";
 
@@ -15,6 +17,12 @@ vi.mock("../../shell/src/components/terminal/TerminalPane.js", () => ({
 vi.mock("../../shell/src/hooks/useTheme.js", () => ({
   useTheme: () => ({ colors: { background: "#000", foreground: "#fff" } }),
 }));
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
 
 function node(type: any, metadata: Record<string, unknown> = {}) {
   return {
@@ -30,6 +38,66 @@ function node(type: any, metadata: Record<string, unknown> = {}) {
 }
 
 describe("workspace canvas renderer", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock as unknown as typeof ResizeObserver);
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue({ width: 1600, height: 900, close: vi.fn() }));
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/assets")) {
+        return Promise.resolve({
+          ok: true,
+          status: 201,
+          json: () => Promise.resolve({
+            assetId: "asset_0123456789abcdef",
+            path: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png",
+            mimeType: "image/png",
+            sizeBytes: 8,
+            originalName: "screenshot.png",
+          }),
+        });
+      }
+      if (url.includes("/api/canvases/cnv_0123456789abcdef")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ revision: 2, updatedAt: "2026-05-27T00:00:00.000Z" }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ canvases: [] }) });
+    }));
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 1000,
+      height: 800,
+      right: 1000,
+      bottom: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    useCanvasTransform.setState({ zoom: 1, panX: 10, panY: 20, containerRect: { left: 0, top: 0, width: 1000, height: 800 }, isAnimating: false, isScrolling: false });
+    useWorkspaceCanvasStore.setState({
+      summaries: [],
+      activeCanvasId: "cnv_0123456789abcdef",
+      document: {
+        id: "cnv_0123456789abcdef",
+        title: "Global Canvas",
+        revision: 1,
+        schemaVersion: 1,
+        scopeType: "global",
+        scopeRef: null,
+        nodes: [],
+        edges: [],
+        viewStates: [],
+        displayOptions: {},
+      } as any,
+      linkedState: null,
+      selectedNodeId: null,
+      focusedNodeId: null,
+      query: "",
+      filters: [],
+      saveStatus: "idle",
+      error: null,
+    });
+  });
+
   it("renders PR, task, review, finding, terminal, custom, and fallback nodes", () => {
     for (const item of [
       node("pr", { number: 57, owner: "acme", repo: "app" }),
@@ -93,5 +161,76 @@ describe("workspace canvas renderer", () => {
     render(<WorkspaceCanvas />);
 
     expect(screen.getByTestId("mock-tldraw")).toBeTruthy();
+  });
+
+  it("renders image nodes from canvas asset file references", () => {
+    render(
+      <WorkspaceCanvasNode
+        node={{
+          ...node("image", { originalName: "Screenshot.png", width: 1280, height: 720 }),
+          sourceRef: { kind: "file", id: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png" },
+        } as any}
+      />,
+    );
+
+    const image = screen.getByAltText("Screenshot.png") as HTMLImageElement;
+    expect(image.src).toContain("/files/system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png");
+  });
+
+  it("pastes clipboard images into the current viewport center as persisted image nodes", async () => {
+    render(<CanvasRenderer />);
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => new File([Buffer.from("fake-png")], "screenshot.png", { type: "image/png" }),
+          },
+        ],
+        files: [],
+      },
+    });
+
+    window.dispatchEvent(event);
+
+    await waitFor(() => {
+      const imageNode = useWorkspaceCanvasStore.getState().document?.nodes.find((item) => item.type === "image");
+      expect(imageNode).toBeTruthy();
+      expect(imageNode?.position).toEqual({ x: 170, y: 200 });
+      expect(imageNode?.size).toEqual({ width: 640, height: 360 });
+      expect(imageNode?.sourceRef).toEqual({
+        kind: "file",
+        id: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png",
+      });
+    });
+  });
+
+  it("does not paste canvas images while an editable element owns focus", async () => {
+    render(
+      <>
+        <textarea aria-label="Editor" />
+        <CanvasRenderer />
+      </>,
+    );
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => new File([Buffer.from("fake-png")], "screenshot.png", { type: "image/png" }),
+          },
+        ],
+        files: [],
+      },
+    });
+
+    fireEvent(screen.getByLabelText("Editor"), event);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(useWorkspaceCanvasStore.getState().document?.nodes).toEqual([]);
   });
 });

--- a/tests/shell/workspace-canvas-renderer.test.tsx
+++ b/tests/shell/workspace-canvas-renderer.test.tsx
@@ -8,6 +8,8 @@ import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js"
 import { WorkspaceCanvas, WorkspaceCanvasLayer } from "../../shell/src/components/canvas/WorkspaceCanvas.js";
 import { WorkspaceCanvasNode } from "../../shell/src/components/canvas/WorkspaceCanvasNode.js";
 
+const originalUpdateNode = useWorkspaceCanvasStore.getState().updateNode;
+
 vi.mock("@tldraw/tldraw", () => ({
   Tldraw: () => <div data-testid="mock-tldraw" />,
 }));
@@ -95,6 +97,7 @@ describe("workspace canvas renderer", () => {
       filters: [],
       saveStatus: "idle",
       error: null,
+      updateNode: originalUpdateNode,
     });
   });
 
@@ -314,6 +317,46 @@ describe("workspace canvas renderer", () => {
 
     expect(updateNode).toHaveBeenCalledTimes(1);
     expect(updateNode).toHaveBeenCalledWith("node_image", { position: { x: 120, y: 210 } });
+  });
+
+  it("reverts image drag previews when the pointer is cancelled", () => {
+    const updateNode = vi.fn(useWorkspaceCanvasStore.getState().updateNode);
+    Object.defineProperty(HTMLElement.prototype, "setPointerCapture", { configurable: true, value: vi.fn() });
+    useCanvasTransform.setState({ zoom: 2 });
+    useWorkspaceCanvasStore.setState({
+      updateNode: updateNode as any,
+      document: {
+        id: "cnv_0123456789abcdef",
+        title: "Global Canvas",
+        revision: 1,
+        schemaVersion: 1,
+        scopeType: "global",
+        scopeRef: null,
+        nodes: [{
+          id: "node_image",
+          type: "image",
+          position: { x: 100, y: 200 },
+          size: { width: 640, height: 360 },
+          zIndex: 0,
+          displayState: "normal",
+          sourceRef: { kind: "file", id: "system/canvas-assets/cnv_0123456789abcdef/asset.png" },
+          metadata: { originalName: "Screenshot.png" },
+        }],
+        edges: [],
+        viewStates: [],
+        displayOptions: {},
+      } as any,
+    });
+
+    render(<WorkspaceCanvasLayer />);
+    const wrapper = screen.getByAltText("Screenshot.png").closest(".pointer-events-auto") as HTMLElement;
+
+    fireEvent.pointerDown(wrapper, { button: 0, pointerId: 1, clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(wrapper, { pointerId: 1, clientX: 140, clientY: 120 });
+    fireEvent.pointerCancel(wrapper, { pointerId: 1 });
+
+    expect(updateNode).toHaveBeenCalledTimes(1);
+    expect(updateNode).toHaveBeenCalledWith("node_image", { position: { x: 100, y: 200 } });
   });
 
   it("does not paste canvas images while an editable element owns focus", async () => {

--- a/tests/shell/workspace-canvas-renderer.test.tsx
+++ b/tests/shell/workspace-canvas-renderer.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CanvasRenderer } from "../../shell/src/components/canvas/CanvasRenderer.js";
 import { useWorkspaceCanvasStore } from "../../shell/src/stores/workspace-canvas-store.js";
 import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
-import { WorkspaceCanvas } from "../../shell/src/components/canvas/WorkspaceCanvas.js";
+import { WorkspaceCanvas, WorkspaceCanvasLayer } from "../../shell/src/components/canvas/WorkspaceCanvas.js";
 import { WorkspaceCanvasNode } from "../../shell/src/components/canvas/WorkspaceCanvasNode.js";
 
 vi.mock("@tldraw/tldraw", () => ({
@@ -205,6 +205,50 @@ describe("workspace canvas renderer", () => {
         id: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png",
       });
     });
+  });
+
+  it("commits image drags once on pointer release instead of every pointer move", () => {
+    const updateNode = vi.fn(useWorkspaceCanvasStore.getState().updateNode);
+    Object.defineProperty(HTMLElement.prototype, "setPointerCapture", { configurable: true, value: vi.fn() });
+    Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", { configurable: true, value: vi.fn() });
+    useCanvasTransform.setState({ zoom: 2 });
+    useWorkspaceCanvasStore.setState({
+      updateNode: updateNode as any,
+      document: {
+        id: "cnv_0123456789abcdef",
+        title: "Global Canvas",
+        revision: 1,
+        schemaVersion: 1,
+        scopeType: "global",
+        scopeRef: null,
+        nodes: [{
+          id: "node_image",
+          type: "image",
+          position: { x: 100, y: 200 },
+          size: { width: 640, height: 360 },
+          zIndex: 0,
+          displayState: "normal",
+          sourceRef: { kind: "file", id: "system/canvas-assets/cnv_0123456789abcdef/asset.png" },
+          metadata: { originalName: "Screenshot.png" },
+        }],
+        edges: [],
+        viewStates: [],
+        displayOptions: {},
+      } as any,
+    });
+
+    render(<WorkspaceCanvasLayer />);
+    const wrapper = screen.getByAltText("Screenshot.png").closest(".pointer-events-auto") as HTMLElement;
+
+    fireEvent.pointerDown(wrapper, { button: 0, pointerId: 1, clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(wrapper, { pointerId: 1, clientX: 140, clientY: 120 });
+
+    expect(updateNode).not.toHaveBeenCalled();
+
+    fireEvent.pointerUp(wrapper, { pointerId: 1 });
+
+    expect(updateNode).toHaveBeenCalledTimes(1);
+    expect(updateNode).toHaveBeenCalledWith("node_image", { position: { x: 120, y: 210 } });
   });
 
   it("does not paste canvas images while an editable element owns focus", async () => {

--- a/tests/shell/workspace-canvas-store.test.ts
+++ b/tests/shell/workspace-canvas-store.test.ts
@@ -216,6 +216,17 @@ describe("workspace canvas store", () => {
     }
   });
 
+  it("rejects malformed canvas asset upload responses", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ assetId: "asset_missing_path" }) });
+    vi.stubGlobal("fetch", fetchMock);
+    useWorkspaceCanvasStore.setState({ document: document as any });
+
+    await expect(useWorkspaceCanvasStore.getState().uploadCanvasAsset(new File(["fake"], "screenshot.png", { type: "image/png" }))).resolves.toBeNull();
+
+    expect(useWorkspaceCanvasStore.getState().error).toBe("Canvas request failed");
+  });
+
   it("does not switch back to a stale canvas after a save conflict", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({ error: "Canvas conflict" }) });

--- a/tests/shell/workspace-canvas-store.test.ts
+++ b/tests/shell/workspace-canvas-store.test.ts
@@ -155,6 +155,38 @@ describe("workspace canvas store", () => {
     expect(useWorkspaceCanvasStore.getState().focusedNodeId).toBe("node_note");
   });
 
+  it("updates and deletes image nodes while keeping canvas coordinates in world units", async () => {
+    useWorkspaceCanvasStore.setState({
+      document: {
+        ...document,
+        nodes: [
+          {
+            id: "node_image",
+            type: "image",
+            position: { x: 100, y: 200 },
+            size: { width: 640, height: 360 },
+            zIndex: 0,
+            displayState: "normal",
+            sourceRef: { kind: "file", id: "system/canvas-assets/cnv_0123456789abcdef/asset.png" },
+            metadata: { originalName: "Screenshot.png" },
+          },
+        ],
+      } as any,
+    });
+
+    await useWorkspaceCanvasStore.getState().updateNode("node_image", {
+      position: { x: 150, y: 225 },
+      size: { width: 800, height: 450 },
+    });
+    expect(useWorkspaceCanvasStore.getState().document?.nodes[0]).toMatchObject({
+      position: { x: 150, y: 225 },
+      size: { width: 800, height: 450 },
+    });
+
+    await useWorkspaceCanvasStore.getState().deleteNode("node_image");
+    expect(useWorkspaceCanvasStore.getState().document?.nodes).toEqual([]);
+  });
+
   it("does not switch back to a stale canvas after a save conflict", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({ error: "Canvas conflict" }) });

--- a/tests/shell/workspace-canvas-store.test.ts
+++ b/tests/shell/workspace-canvas-store.test.ts
@@ -187,6 +187,35 @@ describe("workspace canvas store", () => {
     expect(useWorkspaceCanvasStore.getState().document?.nodes).toEqual([]);
   });
 
+  it("adds random entropy to pasted image node ids", async () => {
+    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(1_776_729_600_000);
+    const randomSpy = vi.spyOn(Math, "random")
+      .mockReturnValueOnce(0.111111111)
+      .mockReturnValueOnce(0.222222222);
+    useWorkspaceCanvasStore.setState({ document: document as any });
+    const asset = {
+      assetId: "asset_0123456789abcdef",
+      path: "system/canvas-assets/cnv_0123456789abcdef/asset_0123456789abcdef.png",
+      mimeType: "image/png",
+      sizeBytes: 8,
+      originalName: "screenshot.png",
+    };
+
+    try {
+      await useWorkspaceCanvasStore.getState().addImageNode(asset, { width: 640, height: 360 }, { x: 320, y: 180 });
+      await useWorkspaceCanvasStore.getState().addImageNode(asset, { width: 640, height: 360 }, { x: 320, y: 180 });
+
+      const ids = useWorkspaceCanvasStore.getState().document?.nodes.map((node) => node.id) ?? [];
+      expect(ids).toHaveLength(2);
+      expect(ids[0]).toMatch(/^node_image_[a-z0-9]+_0_[a-z0-9]+$/);
+      expect(ids[1]).toMatch(/^node_image_[a-z0-9]+_1_[a-z0-9]+$/);
+      expect(new Set(ids).size).toBe(2);
+    } finally {
+      dateSpy.mockRestore();
+      randomSpy.mockRestore();
+    }
+  });
+
   it("does not switch back to a stale canvas after a save conflict", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({ error: "Canvas conflict" }) });


### PR DESCRIPTION
Summary:
- Add image canvas nodes backed by Matrix home asset files.
- Add authenticated canvas asset upload handling and validation.
- Paste clipboard images into Canvas mode at the viewport center.
- Render pasted images as movable, resizable, deletable canvas objects.

Rationale:
- Keep image bytes as owner-controlled files while canvas documents remain
  the source of truth for placement and metadata.
- Preserve world-coordinate anchoring so pan and zoom do not rewrite image
  positions.

Tests:
- flox activate -- bun run typecheck
- flox activate -- bun run check:patterns
- flox activate -- bun run test tests/gateway/canvas-service.test.ts tests/gateway/canvas-contracts.test.ts tests/gateway/canvas-routes.test.ts tests/shell/workspace-canvas-store.test.ts tests/shell/workspace-canvas-renderer.test.tsx
- flox activate -- bun run test (fails on unrelated existing/env issues:
  missing MATRIX_AUTH_TOKEN e2e auth, Telegram voice test timeouts, and a
  platform metrics expectation mismatch)

Invariants:
- Source of truth: canvas documents remain canonical for placement, size,
  z-index, and asset references. Image bytes are owner-controlled files under
  system/canvas-assets and are referenced from nodes via sourceRef.
- Lock/transaction scope: uploads validate ownership before writing files.
  There are no database mutations in the upload path; canvas document changes
  are persisted through the existing debounced canvas save flow.
- Acceptable orphan states: if a node reference is later removed, the file may
  remain until a future sweep-based cleanup removes unreferenced assets. If a
  temp write fails before rename, the temp file is best-effort cleaned up.
- Auth source of truth: upload routes use the existing authenticated gateway
  principal and confirm canvas ownership through the canvas repository before
  storing asset bytes.
- Deferred scope: sticky notes, existing note-node behavior, SVG paste/upload,
  and immediate orphan-asset deletion are intentionally out of scope.

Co-authored-by: Codex <codex@openai.com>