### PR TITLE
fix(ci): restore main workflow checks

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -74,6 +74,7 @@ jobs:
               build: null
               environment:
                 MATRIX_DOCKER_CHOWN_SOURCE: "true"
+                MATRIX_AUTH_ALLOW_INSECURE_DEV: "1"
           EOF
 
       - name: Create external volumes

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -9,7 +9,7 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { installPostHogHonoErrorTracking } from "@matrix-os/observability";
-import { createDispatcher, type Dispatcher, type BatchEntry, type DispatchContext } from "./dispatcher.js";
+import { createDispatcher, type Dispatcher, type BatchEntry, type DispatchContext, type SpawnFn } from "./dispatcher.js";
 import { createWatcher, type Watcher } from "./watcher.js";
 import { createPtyHandler, type PtyMessage } from "./pty.js";
 import { SessionRegistry, ClientMessageSchema, UUID_REGEX, type SessionHandle, type PtyServerMessage, type SessionInfo } from "./session-registry.js";
@@ -286,6 +286,7 @@ export interface GatewayConfig {
   port?: number;
   model?: string;
   maxTurns?: number;
+  spawnFn?: SpawnFn;
   syncReport?: { added: string[]; updated: string[]; skipped: string[] };
 }
 
@@ -451,6 +452,7 @@ export async function createGateway(config: GatewayConfig) {
     homePath,
     model: config.model,
     maxTurns: config.maxTurns,
+    spawnFn: config.spawnFn,
   });
 
   const watcher: Watcher = createWatcher(homePath);

--- a/tests/e2e/api/channel-routing.e2e.test.ts
+++ b/tests/e2e/api/channel-routing.e2e.test.ts
@@ -5,7 +5,14 @@ describe("E2E: Channel status + Message API", () => {
   let gw: TestGateway;
 
   beforeAll(async () => {
-    gw = await startTestGateway();
+    gw = await startTestGateway({
+      spawnFn: async function* () {
+        yield {
+          type: "result",
+          data: { sessionId: "test-session", cost: 0, tokensIn: 0, tokensOut: 0 },
+        };
+      },
+    });
   });
 
   afterAll(async () => {
@@ -44,18 +51,17 @@ describe("E2E: Channel status + Message API", () => {
     }
   });
 
-  it("POST /api/message dispatches and returns error without API key", async () => {
+  it("POST /api/message dispatches through the gateway", async () => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3000);
     try {
-      const res = await fetch(`${gw.url}/api/message`, {
+      const res = await gw.request("/api/message", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: "hello" }),
         signal: controller.signal,
       });
-      // Without ANTHROPIC_API_KEY the SDK throws, Hono returns 500
-      expect([200, 500]).toContain(res.status);
+      expect(res.status).toBe(200);
     } catch (e: unknown) {
       // AbortError is acceptable - means the request was accepted but SDK is slow to fail
       if (e instanceof Error && e.name === "AbortError") {
@@ -101,7 +107,7 @@ describe("E2E: Channel status + Message API", () => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3000);
     try {
-      const res = await fetch(`${gw.url}/api/message`, {
+      const res = await gw.request("/api/message", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -110,7 +116,7 @@ describe("E2E: Channel status + Message API", () => {
         }),
         signal: controller.signal,
       });
-      expect([200, 500]).toContain(res.status);
+      expect(res.status).toBe(200);
     } catch (e: unknown) {
       if (e instanceof Error && e.name === "AbortError") {
         expect(true).toBe(true);
@@ -126,7 +132,7 @@ describe("E2E: Channel status + Message API", () => {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3000);
     try {
-      const res = await fetch(`${gw.url}/api/message`, {
+      const res = await gw.request("/api/message", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -135,7 +141,7 @@ describe("E2E: Channel status + Message API", () => {
         }),
         signal: controller.signal,
       });
-      expect([200, 500]).toContain(res.status);
+      expect(res.status).toBe(200);
     } catch (e: unknown) {
       if (e instanceof Error && e.name === "AbortError") {
         expect(true).toBe(true);

--- a/tests/e2e/api/channel-routing.e2e.test.ts
+++ b/tests/e2e/api/channel-routing.e2e.test.ts
@@ -52,27 +52,13 @@ describe("E2E: Channel status + Message API", () => {
   });
 
   it("POST /api/message dispatches through the gateway", async () => {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
-    try {
-      const res = await gw.request("/api/message", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: "hello" }),
-        signal: controller.signal,
-      });
-      expect(res.status).toBe(200);
-    } catch (e: unknown) {
-      // AbortError is acceptable - means the request was accepted but SDK is slow to fail
-      if (e instanceof Error && e.name === "AbortError") {
-        expect(true).toBe(true);
-      } else {
-        throw e;
-      }
-    } finally {
-      clearTimeout(timeout);
-    }
-  }, 5_000);
+    const res = await gw.request("/api/message", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello" }),
+    });
+    expect(res.status).toBe(200);
+  });
 
   it("POST /api/message rejects malformed JSON before dispatch", async () => {
     const res = await fetch(`${gw.url}/api/message`, {
@@ -104,54 +90,28 @@ describe("E2E: Channel status + Message API", () => {
   });
 
   it("POST /api/message with sessionId is accepted", async () => {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
-    try {
-      const res = await gw.request("/api/message", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          text: "with session",
-          sessionId: "test-session-456",
-        }),
-        signal: controller.signal,
-      });
-      expect(res.status).toBe(200);
-    } catch (e: unknown) {
-      if (e instanceof Error && e.name === "AbortError") {
-        expect(true).toBe(true);
-      } else {
-        throw e;
-      }
-    } finally {
-      clearTimeout(timeout);
-    }
-  }, 5_000);
+    const res = await gw.request("/api/message", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "with session",
+        sessionId: "test-session-456",
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
 
   it("POST /api/message with from field is accepted", async () => {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
-    try {
-      const res = await gw.request("/api/message", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          text: "from external",
-          from: { handle: "@test:matrix.org", displayName: "Test User" },
-        }),
-        signal: controller.signal,
-      });
-      expect(res.status).toBe(200);
-    } catch (e: unknown) {
-      if (e instanceof Error && e.name === "AbortError") {
-        expect(true).toBe(true);
-      } else {
-        throw e;
-      }
-    } finally {
-      clearTimeout(timeout);
-    }
-  }, 5_000);
+    const res = await gw.request("/api/message", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: "from external",
+        from: { handle: "@test:matrix.org", displayName: "Test User" },
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
 
   it("GET /health returns channel status in response", async () => {
     const res = await fetch(`${gw.url}/health`);

--- a/tests/e2e/fixtures/gateway.ts
+++ b/tests/e2e/fixtures/gateway.ts
@@ -3,16 +3,20 @@ import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { createGateway } from "../../../packages/gateway/src/server.js";
+import type { SpawnFn } from "../../../packages/gateway/src/dispatcher.js";
 
 const TEMPLATE_DIR = resolve(__dirname, "../../../home");
 
 export interface TestGateway {
   url: string;
   homePath: string;
+  request: (path: string, init?: RequestInit) => ReturnType<Awaited<ReturnType<typeof createGateway>>["app"]["request"]>;
   close: () => Promise<void>;
 }
 
 let nextPort = 14_000 + Math.floor(Math.random() * 10_000);
+let insecureDevGatewayCount = 0;
+let previousInsecureDevValue: string | undefined;
 
 function getPort(): number {
   return nextPort++;
@@ -21,6 +25,7 @@ function getPort(): number {
 export interface TestGatewayOptions {
   authToken?: string;
   config?: Record<string, unknown>;
+  spawnFn?: SpawnFn;
 }
 
 export async function startTestGateway(
@@ -58,13 +63,19 @@ export async function startTestGateway(
 
   // Set auth token if provided
   const prevToken = process.env.MATRIX_AUTH_TOKEN;
+  const usesInsecureDevAuth = !options.authToken;
   if (options.authToken) {
     process.env.MATRIX_AUTH_TOKEN = options.authToken;
   } else {
     delete process.env.MATRIX_AUTH_TOKEN;
+    if (insecureDevGatewayCount === 0) {
+      previousInsecureDevValue = process.env.MATRIX_AUTH_ALLOW_INSECURE_DEV;
+      process.env.MATRIX_AUTH_ALLOW_INSECURE_DEV = "1";
+    }
+    insecureDevGatewayCount += 1;
   }
 
-  const gateway = await createGateway({ homePath, port });
+  const gateway = await createGateway({ homePath, port, spawnFn: options.spawnFn });
 
   // Restore env
   if (prevToken !== undefined) {
@@ -76,8 +87,25 @@ export async function startTestGateway(
   return {
     url: `http://localhost:${port}`,
     homePath,
+    request(path, init) {
+      return gateway.app.request(path, init);
+    },
     async close() {
-      await gateway.close();
+      try {
+        await gateway.close();
+      } finally {
+        if (usesInsecureDevAuth) {
+          insecureDevGatewayCount = Math.max(0, insecureDevGatewayCount - 1);
+          if (insecureDevGatewayCount === 0) {
+            if (previousInsecureDevValue !== undefined) {
+              process.env.MATRIX_AUTH_ALLOW_INSECURE_DEV = previousInsecureDevValue;
+            } else {
+              delete process.env.MATRIX_AUTH_ALLOW_INSECURE_DEV;
+            }
+            previousInsecureDevValue = undefined;
+          }
+        }
+      }
     },
   };
 }

--- a/tests/e2e/fixtures/gateway.ts
+++ b/tests/e2e/fixtures/gateway.ts
@@ -22,6 +22,18 @@ function getPort(): number {
   return nextPort++;
 }
 
+function releaseInsecureDevAuth(): void {
+  insecureDevGatewayCount = Math.max(0, insecureDevGatewayCount - 1);
+  if (insecureDevGatewayCount === 0) {
+    if (previousInsecureDevValue !== undefined) {
+      process.env.MATRIX_AUTH_ALLOW_INSECURE_DEV = previousInsecureDevValue;
+    } else {
+      delete process.env.MATRIX_AUTH_ALLOW_INSECURE_DEV;
+    }
+    previousInsecureDevValue = undefined;
+  }
+}
+
 export interface TestGatewayOptions {
   authToken?: string;
   config?: Record<string, unknown>;
@@ -75,7 +87,20 @@ export async function startTestGateway(
     insecureDevGatewayCount += 1;
   }
 
-  const gateway = await createGateway({ homePath, port, spawnFn: options.spawnFn });
+  let gateway: Awaited<ReturnType<typeof createGateway>>;
+  try {
+    gateway = await createGateway({ homePath, port, spawnFn: options.spawnFn });
+  } catch (error) {
+    if (usesInsecureDevAuth) {
+      releaseInsecureDevAuth();
+    }
+    if (prevToken !== undefined) {
+      process.env.MATRIX_AUTH_TOKEN = prevToken;
+    } else {
+      delete process.env.MATRIX_AUTH_TOKEN;
+    }
+    throw error;
+  }
 
   // Restore env
   if (prevToken !== undefined) {
@@ -95,15 +120,7 @@ export async function startTestGateway(
         await gateway.close();
       } finally {
         if (usesInsecureDevAuth) {
-          insecureDevGatewayCount = Math.max(0, insecureDevGatewayCount - 1);
-          if (insecureDevGatewayCount === 0) {
-            if (previousInsecureDevValue !== undefined) {
-              process.env.MATRIX_AUTH_ALLOW_INSECURE_DEV = previousInsecureDevValue;
-            } else {
-              delete process.env.MATRIX_AUTH_ALLOW_INSECURE_DEV;
-            }
-            previousInsecureDevValue = undefined;
-          }
+          releaseInsecureDevAuth();
         }
       }
     },

--- a/tests/gateway/voice/telegram-voice.test.ts
+++ b/tests/gateway/voice/telegram-voice.test.ts
@@ -100,7 +100,7 @@ describe("Telegram voice note handling", () => {
     adapter.onMessage = (msg) => messages.push(msg);
 
     adapter.setVoiceContext({ homePath, stt });
-    await adapter.start({ enabled: true, token: "test-token-123" });
+    await adapter.start({ enabled: true, token: "test-token-123", allowFrom: ["123"] });
 
     mockBot.triggerMessage({
       voice: { file_id: "voice_file_abc", duration: 5 },
@@ -132,7 +132,7 @@ describe("Telegram voice note handling", () => {
     adapter.onMessage = () => {};
 
     adapter.setVoiceContext({ homePath, stt });
-    await adapter.start({ enabled: true, token: "test-token-123" });
+    await adapter.start({ enabled: true, token: "test-token-123", allowFrom: ["123"] });
 
     mockBot.triggerMessage({
       voice: { file_id: "voice_file_abc", duration: 5 },
@@ -170,7 +170,7 @@ describe("Telegram voice note handling", () => {
     adapter.onMessage = (msg) => messages.push(msg);
 
     adapter.setVoiceContext({ homePath, stt });
-    await adapter.start({ enabled: true, token: "test-token-123" });
+    await adapter.start({ enabled: true, token: "test-token-123", allowFrom: ["123"] });
 
     mockBot.triggerMessage({
       voice: { file_id: "voice_abc", duration: 3 },
@@ -210,7 +210,7 @@ describe("Telegram voice note handling", () => {
     adapter.onMessage = (msg) => messages.push(msg);
 
     adapter.setVoiceContext({ homePath, stt });
-    await adapter.start({ enabled: true, token: "test-token-123" });
+    await adapter.start({ enabled: true, token: "test-token-123", allowFrom: ["123"] });
 
     mockBot.triggerMessage({
       voice: { file_id: "voice_abc", duration: 3 },
@@ -252,7 +252,7 @@ describe("Telegram voice note handling", () => {
     adapter.onMessage = (msg) => messages.push(msg);
 
     adapter.setVoiceContext({ homePath, stt });
-    await adapter.start({ enabled: true, token: "test-token-123" });
+    await adapter.start({ enabled: true, token: "test-token-123", allowFrom: ["123"] });
 
     mockBot.triggerMessage({
       voice: { file_id: "voice_abc", duration: 3 },
@@ -293,7 +293,7 @@ describe("Telegram voice note handling", () => {
     adapter.onMessage = (msg) => messages.push(msg);
 
     adapter.setVoiceContext({ homePath, stt });
-    await adapter.start({ enabled: true, token: "test-token-123" });
+    await adapter.start({ enabled: true, token: "test-token-123", allowFrom: ["123"] });
 
     mockBot.triggerMessage({
       audio: { file_id: "audio_file_xyz", duration: 10 },
@@ -312,7 +312,7 @@ describe("Telegram voice note handling", () => {
     adapter.onMessage = (msg) => messages.push(msg);
 
     // Do NOT set voice context
-    await adapter.start({ enabled: true, token: "test-token-123" });
+    await adapter.start({ enabled: true, token: "test-token-123", allowFrom: ["123"] });
 
     mockBot.triggerMessage({
       voice: { file_id: "voice_abc", duration: 3 },

--- a/tests/platform/api.test.ts
+++ b/tests/platform/api.test.ts
@@ -93,7 +93,7 @@ describe('platform/api', () => {
     }
 
     const output = await metricsRegistry.metrics();
-    expect(output).toContain('platform_http_requests_total{method="GET",path="/boom",status="500"} 1');
+    expect(output).toContain('platform_http_requests_total{method="GET",path="/:path",status="500"} 1');
   });
 
   it('POST /containers/provision creates a container', async () => {


### PR DESCRIPTION
## Summary
- make unauthenticated e2e gateway fixtures opt into explicit insecure dev auth for no-token tests
- keep /api/message e2e coverage on the Hono route with a fake kernel spawn instead of the real SDK/socket path
- align Telegram voice tests and platform metrics assertions with current security/metrics behavior
- set Docker CI scenarios to explicit insecure dev auth so bridge/social smoke scripts can hit protected dev routes

## Invariants
- Source of truth: production gateway auth remains MATRIX_AUTH_TOKEN/JWT; insecure auth is only enabled by explicit MATRIX_AUTH_ALLOW_INSECURE_DEV in test/dev paths.
- Lock/transaction scope: no database write flow changes.
- Acceptable orphan states: no runtime persistence changes; test gateways still clean up their isolated temp homes on close.
- Auth source of truth: protected production routes still reject without configured auth; tests that expect no-token dev behavior now opt in explicitly.
- Deferred scope: this does not publish CLI 0.3.0; it restores green checks needed before a main-branch release.

## Validation
- bun run typecheck
- bun run check:patterns
- git diff --check
- bun run test tests/e2e/api/file-management.e2e.test.ts tests/e2e/api/settings-persistence.e2e.test.ts tests/e2e/api/bridge-data.e2e.test.ts tests/e2e/api/auth-gates.e2e.test.ts
- bun run test tests/platform/api.test.ts tests/gateway/voice/telegram-voice.test.ts
- bun run test tests/e2e/api/channel-routing.e2e.test.ts
- bun run test -- --shard=1/4
- bun run test -- --shard=2/4
- bun run test -- --shard=3/4
- bun run test -- --shard=4/4