### PR TITLE
docs(constitution): require manual worktree, PR, and Greptile 5/5 for every change

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -169,6 +169,17 @@ The OS is complex and self-modifying. TDD is mandatory to prevent regressions as
 - **Coverage target**: 99-100% for kernel and gateway packages. Measure with `vitest --coverage`.
 - **No implementation without a failing test**: If a test can't be written for it, question whether it's needed
 
+### X. Worktree, PR, and Greptile 5/5 (NON-NEGOTIABLE)
+
+Every change to Matrix OS — code, docs, specs, configuration — ships via pull request from a **manual git worktree**. Direct commits to `main` are prohibited.
+
+- **Manual worktree, always**: start with `git worktree add -b <kebab-branch> ../<dir-name> origin/main`. Do all work in the worktree. This is distinct from the banned Agent-tool `isolation: "worktree"` parameter, which discards uncommitted changes; manual worktrees are persistent and safe.
+- **PR required**: open via `gh pr create` with a Conventional Commit title and the mandatory invariants section (source of truth, lock/transaction scope, acceptable orphan states, auth source of truth, deferred scope).
+- **Greptile 5/5 before merge**: every finding must be fixed in the diff or explicitly deferred in the PR body with a linked follow-up issue. No exceptions, including docs-only PRs. The only acceptable bypass is when CI is itself broken in a way that prevents Greptile from running — in which case flag it to the human owner and do not merge.
+- **Constitution re-read every session**: re-read this file at the start of every session and after compaction. The CLAUDE.md / AGENTS.md files point here as the source of truth; do not rely on memory.
+
+This principle exists because PR review discipline plus an automated quality floor (Greptile) is the only scalable way to keep ~317-PR-review-comment defect classes from re-entering the codebase as the team scales. It also makes the same workflow available to every external developer using Matrix OS once we expose it.
+
 ### Other Workflow Rules
 
 - Verify every SDK assumption against actual docs before implementing
@@ -181,7 +192,7 @@ The OS is complex and self-modifying. TDD is mandatory to prevent regressions as
 
 This constitution supersedes all other development practices for Matrix OS. Amendments require updating this file with rationale. If a principle conflicts with implementation reality (e.g., SDK limitation), document the deviation in SDK-VERIFICATION.md and propose the simplest workaround.
 
-**Version**: 2.0.0 | **Ratified**: 2026-02-11 | **Last Amended**: 2026-04-03
+**Version**: 2.2.0 | **Ratified**: 2026-02-11 | **Last Amended**: 2026-05-27
 
 ### Amendment Log
 
@@ -201,3 +212,4 @@ This constitution supersedes all other development practices for Matrix OS. Amen
   - **Principle IX** (was VIII): TDD renumbered.
   - **Tech constraints**: AI kernel marked model-agnostic, container-per-user flagged as current implementation (not principle), Postgres selected as the standard persistence layer.
 - **2.1.0** (2026-04-27): Database standard hardened. PostgreSQL via Kysely is the required persistence layer for platform, kernel durable state, per-user, app, social, and control-plane data. SQLite, Drizzle ORM, and better-sqlite3 are no longer accepted for new Matrix OS persistence.
+- **2.2.0** (2026-05-27): Added Principle X — Worktree, PR, and Greptile 5/5 (NON-NEGOTIABLE). Codifies the canonical compound-engineering loop: manual `git worktree` + PR + Greptile 5/5 gate. Constitution must be re-read at the start of every session. Distinguished required manual `git worktree` from the banned Agent-tool `isolation: "worktree"` parameter. Motivated by positioning developers as the first ICP and the need for a scalable review discipline as the team and external developer community grow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Matrix OS is **Web 4**: a unified AI operating system (OS + messaging + social +
 
 ## Constitution
 
-Read `.specify/memory/constitution.md`: the 9 core principles. Re-read after compaction.
+Read `.specify/memory/constitution.md`: the 10 core principles. **Re-read at the start of every session and after compaction** — the constitution is the source of truth for non-negotiable rules.
 
 Key principles:
 
@@ -284,6 +284,8 @@ Do not request review while still pushing commits. Either declare a review commi
 
 ### Hard Rules (never violate)
 
+- **All changes ship via PR from a manual `git worktree`** -- no direct commits to `main`, no exceptions. Create the worktree with `git worktree add -b <kebab-branch> ../<dir-name> origin/main` and do all work there. Applies to code AND docs.
+- **No PR merge until Greptile reports 5/5** -- every finding must be fixed in the diff or explicitly deferred in the PR body with a linked follow-up issue.
 - No bare `catch {}` or `.catch(() => {})` -- every catch must check error type and log
 - No `fetch()` without `signal: AbortSignal.timeout()` -- 10s APIs, 30s downloads
 - No `writeFileSync`/`appendFileSync` in request handlers -- use `fs/promises`
@@ -305,14 +307,14 @@ Read these on demand, not every session:
 - `docs/dev/releases.md` -- when tagging a release or managing versions
 - `specs/quality-gates.md` -- when writing a new spec or reviewing a PR
 - `specs/ux-guide.md` -- when working on shell/frontend UI
-- `.specify/memory/constitution.md` -- when making architectural decisions (re-read after compaction)
+- `.specify/memory/constitution.md` -- re-read at the start of every session and after compaction (10 core principles, source of truth for non-negotiable rules)
 
 ## Swarm / Multi-Agent Rules
 
-- **NEVER use worktree isolation** (`isolation: "worktree"` is BANNED) -- worktrees lose uncommitted changes
+- **NEVER use Agent-tool `isolation: "worktree"`** -- that parameter creates an ephemeral worktree that discards uncommitted changes. This is distinct from the required **manual `git worktree add`** workflow (see Hard Rules), which is the canonical way every change ships.
 - **Agents MUST commit progress** after each phase/feature
 - **NEVER call TeamDelete** -- team files are cheap, lost work is expensive
-- Agents work on current branch in parallel, no feature branches
+- Sub-agents spawned for parallel exploration share the parent's worktree; they must commit before exiting.
 
 ## Active Technologies
 - TypeScript 5.5+ strict, ES modules, Node.js 24+, React 19, Next.js 16 + Hono, Zod 4 via `zod/v4`, Kysely/Postgres for user app/workspace data, existing terminal stack (`node-pty`, `@xterm/xterm`), `@tldraw/tldraw` for the shell canvas renderer (071-tldraw-workspace-canvas)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Matrix OS is **Web 4**: a unified AI operating system (OS + messaging + social +
 
 ## Constitution
 
-Read `.specify/memory/constitution.md`: the 9 core principles. Re-read after compaction.
+Read `.specify/memory/constitution.md`: the 10 core principles. **Re-read at the start of every session and after compaction** — the constitution is the source of truth for non-negotiable rules.
 
 Key principles:
 
@@ -206,6 +206,8 @@ Do not request review while still pushing commits. Either declare a review commi
 
 ### Hard Rules (never violate)
 
+- **All changes ship via PR from a manual `git worktree`** -- no direct commits to `main`, no exceptions. Create the worktree with `git worktree add -b <kebab-branch> ../<dir-name> origin/main` and do all work there. Applies to code AND docs.
+- **No PR merge until Greptile reports 5/5** -- every finding must be fixed in the diff or explicitly deferred in the PR body with a linked follow-up issue.
 - No bare `catch {}` or `.catch(() => {})` -- every catch must check error type and log
 - No `fetch()` without `signal: AbortSignal.timeout()` -- 10s APIs, 30s downloads
 - No `writeFileSync`/`appendFileSync` in request handlers -- use `fs/promises`
@@ -225,14 +227,14 @@ Read these on demand, not every session:
 - `docs/dev/releases.md` -- when tagging a release or managing versions
 - `specs/quality-gates.md` -- when writing a new spec or reviewing a PR
 - `specs/ux-guide.md` -- when working on shell/frontend UI
-- `.specify/memory/constitution.md` -- when making architectural decisions (re-read after compaction)
+- `.specify/memory/constitution.md` -- re-read at the start of every session and after compaction (10 core principles, source of truth for non-negotiable rules)
 
 ## Swarm / Multi-Agent Rules
 
-- **NEVER use worktree isolation** (`isolation: "worktree"` is BANNED) -- worktrees lose uncommitted changes
+- **NEVER use Agent-tool `isolation: "worktree"`** -- that parameter creates an ephemeral worktree that discards uncommitted changes. This is distinct from the required **manual `git worktree add`** workflow (see Hard Rules), which is the canonical way every change ships.
 - **Agents MUST commit progress** after each phase/feature
 - **NEVER call TeamDelete** -- team files are cheap, lost work is expensive
-- Agents work on current branch in parallel, no feature branches
+- Sub-agents spawned for parallel exploration share the parent's worktree; they must commit before exiting.
 
 ## Active Technologies
 


### PR DESCRIPTION
## Summary

- Adds **Principle X — Worktree, PR, and Greptile 5/5 (NON-NEGOTIABLE)** to `.specify/memory/constitution.md`.
- Mirrors the rule in `CLAUDE.md` and `AGENTS.md` as a Hard Rule so every agent session picks it up.
- Strengthens the existing constitution pointer: re-read at the **start of every session**, not only after compaction.
- Clarifies the long-standing ban on the Agent-tool `isolation: "worktree"` parameter vs the required manual `git worktree add` workflow — they are different things and the second is now mandatory.

## Why

Developers are Matrix's first ICP (announced 2026-05-27). The internal engineering team is the dogfood loop for the same compound-engineering workflow we'll eventually expose to every external developer. Locking in the discipline now keeps the bar high as the team scales and gives external devs a workflow worth copying.

## Invariants

- **Source of truth**: `.specify/memory/constitution.md` Principle X. `CLAUDE.md` and `AGENTS.md` link back to it.
- **Lock/transaction scope**: docs-only change; no runtime impact.
- **Acceptable orphan states**: none — the three files are updated atomically in a single commit.
- **Auth source of truth**: n/a (no endpoints touched).
- **Deferred scope**: enforcement automation (a pre-receive hook or branch protection rule blocking direct main pushes, plus a merge-queue check requiring Greptile 5/5) is intentionally out of scope here and will land in a follow-up PR.

## Test plan

- [ ] Pre-PR sweep — n/a, docs only.
- [ ] Greptile reports 5/5 on this PR (per the new rule, applied to itself).
- [ ] Manual: read the three changed files and confirm wording is consistent and unambiguous.