### PR TITLE
feat(www): pitch developers on the landing page

### DIFF
--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -148,8 +148,16 @@ function approvalPage(
       var button = document.getElementById('confirm-button');
       if (button) {
         button.disabled = isBusy;
-        button.textContent = isBusy ? 'Authorizing...' : 'Confirm';
+        button.textContent = isBusy ? 'authorizing...' : 'approve login';
       }
+    }
+
+    function updateSignedInInstance() {
+      var instance = document.getElementById('instance-line');
+      if (!instance || !window.Clerk || !window.Clerk.user) return;
+      var user = window.Clerk.user;
+      var handle = user.username || user.primaryEmailAddress?.emailAddress || user.id;
+      instance.textContent = 'signed in: @' + handle + ' on app.matrix-os.com';
     }
 
     async function submitApproval(event) {
@@ -225,6 +233,7 @@ function approvalPage(
 
     function initClerk() {
       window.Clerk.load().then(function() {
+        updateSignedInInstance();
         if (window.Clerk.user && window.Clerk.session) {
           showConfirm();
         } else {
@@ -266,28 +275,128 @@ function approvalPage(
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Authorize device -- Matrix OS</title>
   <style>
-    body { font-family: -apple-system, sans-serif; background: #0a0a0a; color: #eee; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
-    .card { max-width: 420px; padding: 2rem; background: #141414; border: 1px solid #222; border-radius: 8px; text-align: center; }
-    h1 { margin: 0 0 1rem; font-size: 1.25rem; }
-    .code { font-family: monospace; font-size: 1.5rem; letter-spacing: 0.1em; padding: 0.5rem 1rem; background: #1f1f1f; border-radius: 6px; margin: 1rem 0; }
-    button { background: #3b82f6; color: white; border: 0; padding: 0.6rem 1.2rem; font-size: 1rem; border-radius: 6px; cursor: pointer; }
-    button:disabled { opacity: 0.6; cursor: wait; }
-    .status { min-height: 1.25rem; margin: 1rem 0 0; color: #fca5a5; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #101312;
+      color: #e8efe7;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      padding: 24px;
+    }
+    main {
+      width: min(920px, 100%);
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 280px;
+      gap: 20px;
+      align-items: stretch;
+    }
+    .terminal {
+      min-height: 480px;
+      background: #070908;
+      border: 1px solid #2b3a34;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 24px 80px rgba(0,0,0,0.38);
+    }
+    .bar {
+      height: 38px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 14px;
+      background: #151a18;
+      border-bottom: 1px solid #2b3a34;
+      color: #9aa8a1;
+      font-size: 13px;
+    }
+    .dot { width: 10px; height: 10px; border-radius: 999px; background: #5f6b65; }
+    .dot.ok { background: #66d19e; }
+    .screen {
+      padding: 28px;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 14px;
+      line-height: 1.7;
+    }
+    .prompt { color: #8fbfa3; }
+    .muted { color: #8a968f; }
+    .code {
+      display: inline-block;
+      margin: 12px 0 18px;
+      padding: 10px 14px;
+      border: 1px solid #385247;
+      border-radius: 6px;
+      background: #101714;
+      color: #f4f7f1;
+      font-size: 24px;
+      letter-spacing: 0.08em;
+    }
+    .panel {
+      background: #f6f2e8;
+      color: #25332d;
+      border: 1px solid #ddd4c3;
+      border-radius: 8px;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    h1 { margin: 0; font-size: 20px; line-height: 1.2; }
+    p { margin: 0; color: #516158; line-height: 1.5; }
+    button {
+      width: 100%;
+      background: #25332d;
+      color: #fffdf6;
+      border: 0;
+      padding: 0.75rem 1rem;
+      font-size: 0.95rem;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+    button:disabled { opacity: 0.65; cursor: wait; }
+    .status { min-height: 1.25rem; color: #9f2d2d; }
+    #signin-area { min-width: 0; }
+    @media (max-width: 760px) {
+      main { grid-template-columns: 1fr; }
+      .terminal { min-height: 360px; }
+      .screen { padding: 20px; }
+    }
   </style>
 </head>
 <body>
-  <div class="card">
-    <h1>Authorize this device</h1>
-    <p>You're approving:</p>
-    <div class="code">${escapedCode}</div>
-    <div id="signin-area" style="display:none"></div>
-    <form id="confirm-area" method="POST" action="/auth/device/approve" style="display:block">
-      <input type="hidden" name="userCode" value="${escapedCode}">
-      <input type="hidden" name="csrf" value="${escapedCsrf}">
-      <button id="confirm-button" type="submit">Confirm</button>
-    </form>
-    <p id="status" class="status" role="status" aria-live="polite">${publishableKey ? '' : 'Sign-in is unavailable. Refresh and try again.'}</p>
-  </div>
+  <main>
+    <section class="terminal" aria-label="Matrix CLI login preview">
+      <div class="bar"><span class="dot ok"></span><span class="dot"></span><span class="dot"></span><span>matrix login</span></div>
+      <div class="screen">
+        <div><span class="prompt">matrix</span> login</div>
+        <div class="muted">open app.matrix-os.com/auth/device</div>
+        <div>verification code</div>
+        <div class="code">${escapedCode}</div>
+        <div id="instance-line" class="muted">waiting for signed-in Matrix instance...</div>
+        <br>
+        <div><span class="prompt">matrix</span> whoami</div>
+        <div class="muted">@handle on app.matrix-os.com</div>
+        <div><span class="prompt">matrix</span> shell connect -c main</div>
+        <div><span class="prompt">matrix</span> run -it -- claude</div>
+        <div><span class="prompt">matrix</span> doctor</div>
+      </div>
+    </section>
+    <section class="panel">
+      <div>
+        <h1>Approve Matrix CLI</h1>
+        <p>Authorize this terminal to connect to your Matrix OS cloud computer.</p>
+      </div>
+      <div id="signin-area" style="display:none"></div>
+      <form id="confirm-area" method="POST" action="/auth/device/approve" style="display:block">
+        <input type="hidden" name="userCode" value="${escapedCode}">
+        <input type="hidden" name="csrf" value="${escapedCsrf}">
+        <button id="confirm-button" type="submit">approve login</button>
+      </form>
+      <p id="status" class="status" role="status" aria-live="polite">${publishableKey ? '' : 'Sign-in is unavailable. Refresh and try again.'}</p>
+    </section>
+  </main>
   ${clerkLoader}
   ${clerkScript}
 </body>

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -478,6 +478,10 @@ describe("device routes", () => {
       const cookie = res.headers.get("set-cookie") ?? "";
       expect(cookie).toMatch(/device_csrf=[A-Fa-f0-9]+/);
       expect(cookie).toMatch(/HttpOnly/);
+      const html = await res.text();
+      expect(html).toContain("shell connect -c main");
+      expect(html).toContain("run -it -- claude");
+      expect(html).toContain('id="instance-line"');
     });
 
     it("submits approval with an explicit Clerk bearer token", async () => {

--- a/www/content/docs/guide/developer-workflow.mdx
+++ b/www/content/docs/guide/developer-workflow.mdx
@@ -1,0 +1,315 @@
+---
+title: Developer Workflow
+description: Use Matrix OS as the persistent workspace for Claude Code, Codex, Cursor, Copilot, Gemini CLI, Cline, Jules, Devin, and other coding agents.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+
+AI coding has moved from autocomplete to agents that can read repositories, edit files, run tests, open pull requests, and work in the background. Matrix OS gives those agents a persistent place to work: your own cloud computer, your files, your shell sessions, your project context, and your review history.
+
+Use Matrix when you want the speed of Claude Code, Codex, Cursor, Copilot, Gemini CLI, Cline, Jules, Devin, or another agent without rebuilding your setup for every tool.
+
+<Callout type="info" title="The simple version">
+  Matrix is the shared development workspace. Your AI tools are interchangeable workers that can attach to it.
+</Callout>
+
+## Quick Agent Setup
+
+Paste this into Claude, Codex, Cursor, Cline, or another coding agent:
+
+````md
+# Set Up Matrix OS For My Dev Workflow
+
+Set up Matrix OS so I can use my own cloud computer for coding agents,
+terminal sessions, and project work.
+
+First, read the official Matrix agent skill:
+
+```text
+https://matrix-os.com/skills.md
+```
+
+If your runtime supports file skills, install it:
+
+```bash
+npx skills add HamedMP/matrix-os --skill matrix-os
+```
+
+Then show me this checklist:
+
+1. Install or update the Matrix CLI
+2. Run `matrix login` and wait for my Matrix instance to be ready
+3. Start my preferred coding agent on Matrix with `matrix run`
+4. Explain the reconnect and recovery commands only after the main path works
+
+Then proceed step by step. Keep the happy path to two Matrix commands:
+
+```bash
+matrix login
+matrix run -it -- claude
+```
+
+Use `codex`, `gemini`, or another terminal agent instead of `claude` if I ask for it.
+
+## Step 1: Install or update the Matrix CLI
+
+From the current project root, check whether the Matrix CLI is available:
+
+```bash
+command -v matrix && matrix --version
+```
+
+If `matrix` is missing, install it:
+
+```bash
+npm install -g @finnaai/matrix
+```
+
+If the user prefers another package manager, use the equivalent global
+install command from `skills.md`.
+
+## Step 2: Sign in to Matrix
+
+Run:
+
+```bash
+matrix login
+```
+
+Pause while I complete the browser login flow. If Matrix says no instance
+exists yet, send me to:
+
+```text
+https://app.matrix-os.com
+```
+
+Wait for provisioning, then run `matrix login` again.
+
+## Step 3: Run agents inside Matrix
+
+For a remote agent session, run one command at a time:
+
+```bash
+matrix run -it -- claude
+```
+
+or:
+
+```bash
+matrix run -it -- codex
+```
+
+Do not pre-create a named session and then run `matrix run --session` for
+the first command. If a named session already exists, `matrix run --session`
+may attach to it instead of launching the requested command.
+
+## Step 4: Verify or recover only if needed
+
+If setup fails, use:
+
+```bash
+matrix status
+matrix doctor
+matrix instance info
+matrix shell ls
+```
+
+If I detach from a named setup session later, reconnect with:
+
+```bash
+matrix shell attach setup
+```
+
+## Step 5: Finish
+
+Summarize:
+
+- whether `matrix login` succeeded;
+- whether the Matrix instance is ready;
+- the exact command to start Claude, Codex, or my preferred agent in Matrix.
+````
+
+This pattern keeps the human in the login loop while still letting the coding agent do the install, verification, and setup work.
+
+## Why Matrix Helps
+
+Most AI coding tools are optimized around one surface:
+
+- an editor agent that edits the open project;
+- a terminal agent that runs commands where you start it;
+- a cloud task agent that clones a repository into a temporary environment;
+- a pull request agent that works through GitHub issues or PRs.
+
+Those surfaces are useful, but they fragment your workflow. Setup scripts, secrets, terminals, task notes, screenshots, logs, and review findings spread across machines and products.
+
+Matrix gives you a stable home for the work:
+
+- **One always-on development machine** - your Matrix instance keeps projects, terminals, files, and tools available after you close your laptop.
+- **Shared shell sessions** - open a zellij session once, then reconnect from the web workspace, CLI, or an agent.
+- **Agent choice** - run Claude Code, Codex CLI, Gemini CLI, Cline, or another terminal agent in the same environment.
+- **Durable context** - keep repository notes, AGENTS.md, skills, task plans, transcripts, and review results where future agents can find them.
+- **Human control** - agents can do the repetitive work, but you keep review, merge, deployment, and account decisions explicit.
+
+## Common AI Coding Workflows
+
+### Editor Pairing
+
+Use this when you are actively reading code and want fast local edits.
+
+Examples include Cursor Agent, GitHub Copilot agent mode, Windsurf Cascade, Cline in VS Code or JetBrains, and similar IDE agents. These tools are best for targeted refactors, UI iteration, "explain this code", and changing files while you stay in the editor.
+
+Matrix adds value by keeping the remote shell, running services, test commands, and project state available even when the editor changes.
+
+### Terminal Agent Sessions
+
+Use this when the agent needs to run commands, inspect the repo, install tools, execute tests, or drive a local browser.
+
+Examples include Claude Code, Codex CLI, Gemini CLI, Cline CLI, and Devin for Terminal. Terminal agents pair naturally with Matrix because `matrix run` starts them on your Matrix instance from your local terminal.
+
+```bash
+npm i -g @finnaai/matrix
+matrix login
+matrix run -it -- claude
+```
+
+Use the agent you prefer:
+
+```bash
+matrix run -it -- codex
+matrix run -it -- gemini
+```
+
+### Async Cloud Tasks
+
+Use this when the work is well-scoped and can run while you do something else.
+
+Examples include Codex cloud tasks, GitHub Copilot coding agent, Google Jules, Devin cloud sessions, and other agents that open a draft pull request for review. These are good for dependency upgrades, documentation passes, test additions, simple bug fixes, and isolated feature slices.
+
+Matrix adds value before and after the async work:
+
+- prepare a clear task brief from your project context;
+- keep setup commands and repository instructions in files;
+- compare the agent PR against your local Matrix workspace;
+- run follow-up checks in your persistent shell;
+- hand the next round to another agent if the first one stalls.
+
+### Review And Repair Loops
+
+Use this when code exists but needs hardening.
+
+A strong loop is:
+
+1. Ask one agent to implement the slice.
+2. Run tests and pattern checks in Matrix.
+3. Ask another agent or reviewer to inspect the diff.
+4. Fix only actionable findings.
+5. Repeat until the PR is boring.
+
+This works especially well when Matrix keeps the terminal output, review notes, and source tree in one workspace instead of scattering them across separate browser tabs.
+
+## Recommended Matrix Setup
+
+<Steps>
+  <Step>
+    ### Sign in
+
+    Create your Matrix account in the browser, then authenticate the CLI:
+
+    ```bash
+    npm i -g @finnaai/matrix
+    matrix login
+    matrix whoami
+    ```
+  </Step>
+  <Step>
+    ### Install your preferred agents
+
+    Install the coding agents you use on the Matrix instance, then start them with `matrix run -it -- <agent>`. Keep each agent's project instructions in repository files so the next tool gets the same context.
+  </Step>
+  <Step>
+    ### Keep project context in files
+
+    Store working notes, command recipes, setup steps, and review criteria in the repository. Agents are much more useful when the expected architecture, test commands, and safety rules are written down.
+  </Step>
+  <Step>
+    ### Use PRs as the boundary
+
+    Let agents edit, test, and propose. Keep merge authority with a human review path. Matrix is the workspace; Git remains the audit trail.
+  </Step>
+</Steps>
+
+## What To Delegate
+
+<Cards>
+  <Card title="Good First Tasks">
+    Update docs, add tests, fix small bugs, rename APIs, improve empty states, clean up types, and explain unfamiliar code.
+  </Card>
+  <Card title="Good Agent Tasks">
+    Implement a narrow feature behind tests, refactor one subsystem, build a prototype branch, reproduce a bug, or prepare a PR summary.
+  </Card>
+  <Card title="Keep Human-Owned">
+    Product direction, schema migrations with data risk, auth design, secrets, billing, destructive production actions, and final merge decisions.
+  </Card>
+</Cards>
+
+## Prompt Pattern
+
+Give agents the same shape of request each time:
+
+```md
+Goal:
+Fix the bug where ...
+
+Context:
+- The relevant files are ...
+- The expected behavior is ...
+- The current behavior is ...
+
+Constraints:
+- Do not change ...
+- Keep data migration safe ...
+- Use the existing pattern in ...
+
+Verification:
+- Run ...
+- Add or update tests for ...
+- Summarize remaining risk.
+```
+
+For bigger work, ask Matrix to turn a rough idea into a task brief first. Then give that brief to the agent that is best for the job.
+
+## How Matrix Fits With Popular Agents
+
+| Tool | Best at | Matrix role |
+| ---- | ------- | ----------- |
+| Claude Code | Deep terminal work, multi-file edits, debugging, command-driven workflows | Start it with `matrix run -it -- claude` and keep repo instructions available in Matrix |
+| OpenAI Codex | Local and cloud coding tasks, refactors, tests, PR-sized changes | Use Matrix for setup, validation, handoff, and follow-up iteration |
+| Cursor | Editor-native agent work and fast multi-file changes | Keep services, tests, and terminal state running in Matrix while editing in Cursor |
+| GitHub Copilot | IDE agent mode and GitHub PR/issue workflows | Use Matrix to prepare issue briefs, reproduce results, and validate PRs |
+| Windsurf Cascade | Agentic IDE workflows with chat, code mode, terminal, and checkpoints | Use Matrix as the persistent backend workspace behind editor sessions |
+| Gemini CLI | Terminal agent work with Gemini from a shell | Start it with `matrix run -it -- gemini` and keep outputs with the project |
+| Cline | Editor or CLI agent with browser, terminal, and MCP-style tool workflows | Use Matrix for shared remote runtime, services, and long-lived project state |
+| Jules or Devin | Async tasks on separate managed environments | Use Matrix to write better briefs, compare results, and continue work after handoff |
+
+## Practical Weekly Workflow
+
+1. Start the week in Matrix and ask for a project status summary.
+2. Pick two or three small tasks that can become PRs.
+3. Start the right agent with `matrix run -it -- <agent>`.
+4. Let one agent implement while you use another for review or documentation.
+5. Run tests and checks in Matrix before pushing.
+6. Keep useful prompts, failures, and commands in the project so the next agent has better context.
+
+## Further Reading
+
+- [Claude Code docs](https://code.claude.com/docs/en)
+- [OpenAI Codex docs](https://platform.openai.com/docs/codex/overview)
+- [Cursor docs](https://docs.cursor.com/)
+- [GitHub Copilot coding agent docs](https://docs.github.com/en/copilot/using-github-copilot/coding-agent/about-assigning-tasks-to-copilot)
+- [Windsurf Cascade docs](https://docs.windsurf.com/windsurf/cascade)
+- [Gemini CLI docs](https://developers.google.com/gemini-code-assist/docs/gemini-cli)
+- [Cline docs](https://docs.cline.bot/introduction/overview)
+- [Jules docs](https://jules.google/docs/)
+- [Devin docs](https://docs.devin.ai/)

--- a/www/content/docs/guide/index.mdx
+++ b/www/content/docs/guide/index.mdx
@@ -37,6 +37,9 @@ You do not use Matrix by configuring infrastructure. You use it by asking for ou
   <Card title="Memory And Data" href="/docs/guide/storage">
     Keep files, app data, memories, and workspace state in your own Matrix environment.
   </Card>
+  <Card title="Developer Workflow" href="/docs/guide/developer-workflow">
+    Give Claude, Codex, Cursor, Cline, or another coding agent a persistent Matrix computer to work from.
+  </Card>
 </Cards>
 
 ## Example Workflows

--- a/www/content/docs/guide/meta.json
+++ b/www/content/docs/guide/meta.json
@@ -3,5 +3,5 @@
   "title": "Guide",
   "description": "Learn how to use Matrix OS",
   "icon": "BookOpen",
-  "pages": ["index", "getting-started", "mobile", "integrations", "apps", "app-store", "channels", "social", "storage", "agents", "file-system", "cloud-coding"]
+  "pages": ["index", "getting-started", "mobile", "integrations", "apps", "app-store", "channels", "social", "storage", "agents", "file-system", "cloud-coding", "developer-workflow"]
 }

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -432,36 +432,30 @@ export default function LandingPage() {
         <div className="mx-auto max-w-[1100px] px-8">
           <div className="grid gap-10 md:grid-cols-[0.9fr_1.1fr] md:items-center">
             <div>
-              <p className="text-[11px] tracking-[0.3em] uppercase mb-6" style={{ color: c.subtle }}>For developers</p>
+              <p className="text-[11px] tracking-[0.3em] uppercase mb-6" style={{ color: c.subtle }}>For coding agents</p>
               <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-semibold leading-[1.15] mb-6" style={{ color: c.forest }}>
-                A compound-engineering workspace for you and your agents.
+                Give your agent the setup file.
               </h2>
-              <p className="text-[15px] leading-[1.9] mb-4" style={{ color: c.mutedFg }}>
-                Matrix is built developer-first. One CLI, one cloud VPS per engineer, shared zellij sessions you and your coding agent both attach to, Linear-driven Symphony orchestration, and a slash-command workflow (plan → work → review → compound) that captures what worked so the next change is easier.
-              </p>
               <p className="text-[15px] leading-[1.9]" style={{ color: c.mutedFg }}>
-                Read the <a href="/docs/handbook" className="underline" style={{ color: c.forest }}>engineering handbook</a> for the full workflow, or browse <a href="/skills.md" className="underline" style={{ color: c.forest }}>skills.md</a> if you want your coding agent to set everything up for you.
+                Matrix publishes an agent-readable skill at <code>matrix-os.com/skills.md</code>. Claude, Codex, Cursor, Cline, or another coding agent can read it, install the CLI, help you sign up with <code>matrix login</code>, and start working on your cloud computer with <code>matrix run</code>.
               </p>
             </div>
             <div className="rounded-[16px] p-6 md:p-8" style={{ backgroundColor: "rgba(67,78,63,0.06)", border: `1px solid ${c.border}` }}>
               <pre className="overflow-x-auto text-left text-[12px] leading-[1.8]" style={{ color: c.forest }}>
-                <code>{`# Install + claim your cloud VPS
-npm i -g @finnaai/matrix
-matrix login
+                <code>{`Read https://matrix-os.com/skills.md
 
-# Open a shared zellij session you and your agent both attach to
-matrix shell new setup
-matrix run -it --session setup -- claude
-matrix shell connect setup`}</code>
+npx skills add HamedMP/matrix-os --skill matrix-os
+matrix login
+matrix run -it -- claude`}</code>
               </pre>
               <div className="mt-6 flex flex-wrap gap-3">
-                <a href="/docs/handbook" className="inline-flex items-center gap-2 rounded-full px-6 py-3 text-[12px] tracking-[0.12em] uppercase font-medium transition-opacity duration-300 hover:opacity-80"
-                  style={{ backgroundColor: c.forest, color: c.pageBg }}>
-                  Engineering handbook <ArrowRightIcon className="size-3.5" />
-                </a>
                 <a href="/skills.md" className="inline-flex items-center gap-2 rounded-full px-6 py-3 text-[12px] tracking-[0.12em] uppercase font-medium transition-opacity duration-300 hover:opacity-80"
+                  style={{ backgroundColor: c.forest, color: c.pageBg }}>
+                  Open skills.md <ArrowRightIcon className="size-3.5" />
+                </a>
+                <a href="/docs/guide/developer-workflow" className="inline-flex items-center gap-2 rounded-full px-6 py-3 text-[12px] tracking-[0.12em] uppercase font-medium transition-opacity duration-300 hover:opacity-80"
                   style={{ border: `1px solid ${c.border}`, color: c.forest }}>
-                  skills.md for agents
+                  Developer workflow
                 </a>
               </div>
             </div>

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -43,6 +43,7 @@ const c = {
 const navLinks = [
   { label: "about", href: "#about" },
   { label: "features", href: "#features" },
+  { label: "developers", href: "#developers" },
   { label: "agents", href: "/skills.md" },
 ] as const;
 
@@ -427,36 +428,40 @@ export default function LandingPage() {
         </div>
       </section>
 
-      <section className="py-28 md:py-36" style={{ backgroundColor: c.pageBg }}>
+      <section id="developers" className="py-28 md:py-36" style={{ backgroundColor: c.pageBg }}>
         <div className="mx-auto max-w-[1100px] px-8">
           <div className="grid gap-10 md:grid-cols-[0.9fr_1.1fr] md:items-center">
             <div>
-              <p className="text-[11px] tracking-[0.3em] uppercase mb-6" style={{ color: c.subtle }}>For coding agents</p>
+              <p className="text-[11px] tracking-[0.3em] uppercase mb-6" style={{ color: c.subtle }}>For developers</p>
               <h2 className="text-[clamp(1.75rem,4vw,3rem)] font-semibold leading-[1.15] mb-6" style={{ color: c.forest }}>
-                Give your agent the setup file.
+                A compound-engineering workspace for you and your agents.
               </h2>
+              <p className="text-[15px] leading-[1.9] mb-4" style={{ color: c.mutedFg }}>
+                Matrix is built developer-first. One CLI, one cloud VPS per engineer, shared zellij sessions you and your coding agent both attach to, Linear-driven Symphony orchestration, and a slash-command workflow (plan → work → review → compound) that captures what worked so the next change is easier.
+              </p>
               <p className="text-[15px] leading-[1.9]" style={{ color: c.mutedFg }}>
-                Matrix publishes an agent-readable skill at <code>matrix-os.com/skills.md</code>. Claude, Codex, or another coding agent can read it, install the CLI, help you claim your account, and attach to the same VPS shell session you see in Matrix.
+                Read the <a href="/docs/handbook" className="underline" style={{ color: c.forest }}>engineering handbook</a> for the full workflow, or browse <a href="/skills.md" className="underline" style={{ color: c.forest }}>skills.md</a> if you want your coding agent to set everything up for you.
               </p>
             </div>
             <div className="rounded-[16px] p-6 md:p-8" style={{ backgroundColor: "rgba(67,78,63,0.06)", border: `1px solid ${c.border}` }}>
               <pre className="overflow-x-auto text-left text-[12px] leading-[1.8]" style={{ color: c.forest }}>
-                <code>{`Read https://matrix-os.com/skills.md
-
-npx skills add HamedMP/matrix-os --skill matrix-os
+                <code>{`# Install + claim your cloud VPS
+npm i -g @finnaai/matrix
 matrix login
-matrix run -it --session setup -- gh auth login
+
+# Open a shared zellij session you and your agent both attach to
+matrix shell new setup
 matrix run -it --session setup -- claude
-matrix shell attach setup`}</code>
+matrix shell connect setup`}</code>
               </pre>
               <div className="mt-6 flex flex-wrap gap-3">
-                <a href="/skills.md" className="inline-flex items-center gap-2 rounded-full px-6 py-3 text-[12px] tracking-[0.12em] uppercase font-medium transition-opacity duration-300 hover:opacity-80"
+                <a href="/docs/handbook" className="inline-flex items-center gap-2 rounded-full px-6 py-3 text-[12px] tracking-[0.12em] uppercase font-medium transition-opacity duration-300 hover:opacity-80"
                   style={{ backgroundColor: c.forest, color: c.pageBg }}>
-                  Open skills.md <ArrowRightIcon className="size-3.5" />
+                  Engineering handbook <ArrowRightIcon className="size-3.5" />
                 </a>
-                <a href="https://skills.sh/HamedMP/matrix-os" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 rounded-full px-6 py-3 text-[12px] tracking-[0.12em] uppercase font-medium transition-opacity duration-300 hover:opacity-80"
+                <a href="/skills.md" className="inline-flex items-center gap-2 rounded-full px-6 py-3 text-[12px] tracking-[0.12em] uppercase font-medium transition-opacity duration-300 hover:opacity-80"
                   style={{ border: `1px solid ${c.border}`, color: c.forest }}>
-                  skills.sh
+                  skills.md for agents
                 </a>
               </div>
             </div>


### PR DESCRIPTION
Updates the landing-page coding-agent section to point developers at the live Matrix agent setup path instead of an internal engineering handbook. The section now keeps the simple model from `skills.md`: give the agent the setup file, run `matrix login`, then start work on the Matrix computer with `matrix run`.

- Keeps the `developers` nav anchor for direct access to the section.
- Restores the primary CTA to `/skills.md`, which exists in this PR and is the source of truth for agent setup.
- Removes the dead `/docs/handbook` dependency and the unsafe `matrix shell new setup` before `matrix run` snippet.
- Adds a user-facing `/docs/guide/developer-workflow` guide covering Matrix benefits across Claude Code, Codex, Cursor, Copilot, Gemini CLI, Cline, Jules, Devin, and similar agent workflows.
- Links the new guide from the guide index and docs nav metadata.

## Invariants

- Source of truth: `/skills.md` remains the canonical agent-readable Matrix setup file. The new developer workflow guide explains the benefits and points back to that setup flow instead of replacing it.
- Acceptable orphan states: none. Landing-page CTAs now point only to routes/files present in this PR: `/skills.md` and `/docs/guide/developer-workflow`.
- Auth source of truth: unchanged. Website auth remains Clerk SignedIn/SignedOut; CLI onboarding still starts with `matrix login`.
- Deferred scope: no CLI behavior changes, no new `/docs/handbook` route, and no changes to `skills.md` itself.

## Test plan

- [x] `pnpm --dir www exec tsc --noEmit`
- [x] `bun run check:patterns`
- [x] `pnpm --dir www build` reached MDX compile and TypeScript successfully; full prerender is blocked in this environment without a valid Clerk publishable key.
