### PR TITLE
fix(platform): accept tunnel websocket upgrades

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -42,7 +42,7 @@ import type { MatrixProvisioner } from './matrix-provisioning.js';
 import { createAuthRoutes } from './auth-routes.js';
 import { issueSyncJwt, verifySyncJwt } from './sync-jwt.js';
 import {
-  getWebSocketUpgradeHost,
+  getSessionRoutedWebSocketHost,
   getWebSocketUpgradeToken,
   isAppDomainHost,
   isCodeDomainHost,
@@ -3463,14 +3463,14 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       return;
     }
 
-    const host = getWebSocketUpgradeHost(req.headers.host, req.headers['x-forwarded-host']);
+    const path = req.url ?? '/';
+    const host = getSessionRoutedWebSocketHost(req.headers.host, req.headers['x-forwarded-host'], path);
     if (!isSessionRoutedHost(host)) {
       socket.destroy();
       return;
     }
     const isCodeDomain = isCodeDomainHost(host);
 
-    const path = req.url ?? '/';
     const requestRuntimeSlot = readRuntimeSlot(path);
     const wsToken = getWebSocketUpgradeToken(path);
     let identity: AppDomainIdentity | null;
@@ -3590,7 +3590,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
         socket.destroy();
         return;
       }
-      const upstreamHostHeader = isCodeDomain ? host : `${runningMachine.handle}.matrix-os.com`;
+      const upstreamHostHeader = isCodeDomain ? host : 'app.matrix-os.com';
       const headers = buildUpgradeHeaders(runningMachine.handle, true);
       const upstreamServerName = upstreamHostHeader.split(':')[0] ?? upstreamHostHeader;
       const upstream = createTlsConnection({

--- a/packages/platform/src/ws-upgrade.ts
+++ b/packages/platform/src/ws-upgrade.ts
@@ -39,6 +39,25 @@ export function isSessionRoutedHost(host: string): boolean {
   return isAppDomainHost(host) || isCodeDomainHost(host);
 }
 
+export function isInternalWebSocketOriginHost(host: string): boolean {
+  return /^(platform|distro-platform-1|matrixos-platform|localhost|127\.0\.0\.1)(?::\d+)?$/i.test(host);
+}
+
+export function getSessionRoutedWebSocketHost(
+  hostHeader: string | string[] | undefined,
+  forwardedHostHeader: string | string[] | undefined,
+  path: string,
+): string {
+  const host = getWebSocketUpgradeHost(hostHeader, forwardedHostHeader);
+  if (isSessionRoutedHost(host)) {
+    return host;
+  }
+  if (isInternalWebSocketOriginHost(host) && getWebSocketUpgradeToken(path)) {
+    return "app.matrix-os.com";
+  }
+  return host;
+}
+
 function parseWebSocketUpgradeUrl(path: string): URL | null {
   try {
     return new URL(path, "http://platform.invalid");

--- a/tests/platform/ws-upgrade.test.ts
+++ b/tests/platform/ws-upgrade.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 import {
   getWebSocketUpgradeHost,
   getWebSocketUpgradeToken,
+  getSessionRoutedWebSocketHost,
   isAppDomainHost,
   isCodeDomainHost,
+  isInternalWebSocketOriginHost,
   isSessionRoutedHost,
   isSafeWebSocketUpgradePath,
   stripWebSocketUpgradeToken,
@@ -53,5 +55,19 @@ describe("isSafeWebSocketUpgradePath", () => {
     expect(isSessionRoutedHost("app.matrix-os.com")).toBe(true);
     expect(isSessionRoutedHost("code.matrix-os.com")).toBe(true);
     expect(isSessionRoutedHost("legacy.matrix-os.com")).toBe(false);
+  });
+
+  it("recognizes internal tunnel origin hosts", () => {
+    expect(isInternalWebSocketOriginHost("platform:9000")).toBe(true);
+    expect(isInternalWebSocketOriginHost("distro-platform-1:9000")).toBe(true);
+    expect(isInternalWebSocketOriginHost("127.0.0.1:9000")).toBe(true);
+    expect(isInternalWebSocketOriginHost("evil.matrix-os.com")).toBe(false);
+  });
+
+  it("falls back to app domain for token-authenticated tunnel websocket upgrades", () => {
+    expect(getSessionRoutedWebSocketHost("platform:9000", undefined, "/ws?token=abc")).toBe("app.matrix-os.com");
+    expect(getSessionRoutedWebSocketHost("platform:9000", undefined, "/ws")).toBe("platform:9000");
+    expect(getSessionRoutedWebSocketHost("evil.example.com", undefined, "/ws?token=abc")).toBe("evil.example.com");
+    expect(getSessionRoutedWebSocketHost("platform:9000", "code.matrix-os.com", "/ws?token=abc")).toBe("code.matrix-os.com");
   });
 });


### PR DESCRIPTION
## Summary
- Accept token-authenticated WebSocket upgrades that arrive from the Cloudflare tunnel with an internal origin Host such as `platform:9000`.
- Keep the public app-domain routing model for browser WebSockets and stop forwarding app-domain WS upstreams with legacy `{handle}.matrix-os.com` Host headers.
- Add regression coverage for internal tunnel host fallback and unsafe host rejection.

## Tests
- `bun run test -- tests/platform/ws-upgrade.test.ts`
- `bun run test -- tests/platform/proxy-routing.test.ts`
- `bun run test -- tests/platform/ws-upgrade.test.ts tests/platform/proxy-routing.test.ts`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warning-only baseline)
- `bun run test` attempted, but the host filesystem is full: `/dev/sda1` is 100% used and the run failed with `ENOSPC: no space left on device` while creating/writing `/tmp` test files.

## Invariants
- Source of truth: app-domain browser WebSocket routing remains keyed by platform-issued sync JWTs plus platform DB machine records.
- Lock/transaction scope: no DB writes or transactions are introduced; this only changes upgrade host classification and upstream Host/SNI selection.
- Acceptable orphan states: invalid/non-token internal-host upgrades still close fail-closed; external unrecognized hosts are not treated as app-domain sessions.
- Auth source of truth: browser WS auth remains the platform sync JWT query-token path; this does not add unauthenticated tunnel access.
- Deferred scope: broader platform Docker distribution/release automation is intentionally deferred from this hotfix PR.