### PR TITLE
feat(releases): add release visibility and fleet dashboards

### DIFF
--- a/distro/observability/dashboards/release-channels.json
+++ b/distro/observability/dashboards/release-channels.json
@@ -32,7 +32,7 @@
       "gridPos": { "h": 4, "w": 12, "x": 12, "y": 0 },
       "id": 3,
       "options": {
-        "content": "Upgrade actions are still intentionally outside Grafana. Use the platform release endpoints for now; this dashboard shows the exact channel target and version drift data needed for a future controlled action panel.",
+        "content": "Operator flow: publish host bundle, promote a channel, deploy by channel/version, then verify runtime drift here. Grafana remains read-only; upgrade actions stay in platform APIs or the shell settings update flow.",
         "mode": "markdown"
       },
       "title": "Upgrade Action Boundary",
@@ -63,8 +63,8 @@
       "gridPos": { "h": 7, "w": 12, "x": 0, "y": 13 },
       "id": 5,
       "options": { "legend": { "displayMode": "table", "placement": "right" }, "pieType": "pie", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "count by (version) (matrix_vps_info)", "legendFormat": "{{version}}", "refId": "A" }],
-      "title": "Installed VPS Versions",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "count by (version) (matrix_vps_runtime_info)", "legendFormat": "{{version}}", "refId": "A" }],
+      "title": "Reported Runtime Versions",
       "type": "piechart"
     },
     {
@@ -76,6 +76,25 @@
       "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "matrix_release_channel_bundle_bytes", "legendFormat": "{{channel}} {{version}}", "refId": "A" }],
       "title": "Bundle Size by Channel",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "custom": { "filterable": true } }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 20 },
+      "id": 7,
+      "options": { "showHeader": true, "sortBy": [{ "displayName": "handle" }] },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "matrix_vps_runtime_info unless on(version) matrix_release_channel_info{channel=\"stable\"}", "format": "table", "instant": true, "refId": "A" }],
+      "title": "Reachable VPSes Not on Stable",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "Value": true, "__name__": true, "instance": true, "job": true },
+            "indexByName": { "handle": 0, "version": 1 }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "schemaVersion": 39,
@@ -86,5 +105,5 @@
   "timezone": "browser",
   "title": "Release Channels",
   "uid": "matrix-release-channels",
-  "version": 1
+  "version": 2
 }

--- a/distro/observability/dashboards/vps-fleet-overview.json
+++ b/distro/observability/dashboards/vps-fleet-overview.json
@@ -36,7 +36,7 @@
       "id": 2,
       "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
       "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "count(matrix_vps_healthy == 1)", "refId": "A" }],
-      "title": "Healthy",
+      "title": "Control Reachable",
       "type": "stat"
     },
     {
@@ -75,8 +75,8 @@
       "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
       "id": 6,
       "options": { "legend": { "displayMode": "table", "placement": "right" }, "pieType": "pie", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "count by (version) (matrix_vps_info)", "legendFormat": "{{version}}", "refId": "A" }],
-      "title": "Version Distribution",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "count by (version) (matrix_vps_runtime_info)", "legendFormat": "{{version}}", "refId": "A" }],
+      "title": "Runtime Release Distribution",
       "type": "piechart"
     },
     {
@@ -99,11 +99,11 @@
           }
         ]
       },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 4 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 4 },
       "id": 7,
       "options": { "showHeader": true, "sortBy": [{ "displayName": "handle" }] },
       "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "matrix_vps_info", "format": "table", "instant": true, "refId": "A" }],
-      "title": "VPS Inventory",
+      "title": "Provisioned VPS Inventory",
       "transformations": [
         {
           "id": "organize",
@@ -118,8 +118,27 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "custom": { "filterable": true } }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 12 },
+      "id": 10,
+      "options": { "showHeader": true, "sortBy": [{ "displayName": "handle" }] },
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "matrix_vps_runtime_info", "format": "table", "instant": true, "refId": "A" }],
+      "title": "Runtime Releases Reported by Reachable VPSes",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "Value": true, "__name__": true, "instance": true, "job": true },
+            "indexByName": { "handle": 0, "version": 1 }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never", "spanNulls": false, "stacking": { "mode": "none" } } }, "overrides": [] },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
       "id": 8,
       "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "matrix_vps_load1{handle=\"$handle\"}", "legendFormat": "$handle", "refId": "A" }],
@@ -129,7 +148,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "smooth", "lineWidth": 2, "showPoints": "never", "spanNulls": false, "stacking": { "mode": "none" } }, "unit": "s" }, "overrides": [] },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
       "id": 9,
       "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
       "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "matrix_vps_probe_latency_seconds{handle=\"$handle\"}", "legendFormat": "$handle", "refId": "A" }],
@@ -164,5 +183,5 @@
   "timezone": "browser",
   "title": "VPS Fleet Overview",
   "uid": "matrix-vps-fleet",
-  "version": 5
+  "version": 6
 }

--- a/docs/dev/fleet-upgrade-operations.md
+++ b/docs/dev/fleet-upgrade-operations.md
@@ -1,0 +1,127 @@
+# Fleet Upgrade Operations
+
+Production customer runtime is VPS-native. Platform containers are not the
+customer rollout path; customer VPSes upgrade by downloading a registered host
+bundle and swapping `/opt/matrix/app`.
+
+## Target Setup
+
+Use three independent control paths so a single stale token cannot strand a VPS:
+
+1. **Outbound control agent**: each VPS runs a small systemd service/timer that
+   polls platform for signed commands over HTTPS. Upgrade commands carry either
+   `{ "channel": "stable" }` or `{ "version": "vYYYY.MM.DD-N" }`; the agent runs
+   `/opt/matrix/bin/matrix-update <target>` locally and posts status back.
+2. **Inbound fast path**: platform may still call `/api/internal/upgrade` for
+   immediate fan-out, but this is an optimization only. It must not be the only
+   way to reach old machines.
+3. **Break-glass SSH**: every provisioned VPS must install a platform operator
+   SSH key for the `matrix` user with a forced command wrapper that only allows
+   safe operations such as `matrix-update`, service status, and journal tails.
+
+The current inbound path uses `UPGRADE_TOKEN=HMAC_SHA256(PLATFORM_SECRET,
+handle)`. That is fail-closed, but old VPSes can drift if they were provisioned
+with a previous secret or token format. The outbound agent fixes this by letting
+the VPS initiate trust refreshes and receive token-rotation commands.
+
+## Standard Release Flow
+
+1. Merge to `main` and wait for the `Host Bundle Release` workflow.
+2. Confirm the published version and changelog:
+
+   ```bash
+   curl --fail --silent --show-error \
+     -H "Authorization: Bearer $PLATFORM_SECRET" \
+     https://app.matrix-os.com/system-bundles/releases/<version>.json
+   ```
+
+3. Promote the tested version:
+
+   ```bash
+   curl --fail --silent --show-error \
+     -X POST https://app.matrix-os.com/system-bundles/channels/stable \
+     -H "Authorization: Bearer $PLATFORM_SECRET" \
+     -H "Content-Type: application/json" \
+     -d '{"version":"<version>"}'
+   ```
+
+4. Deploy by channel:
+
+   ```bash
+   curl --fail --silent --show-error \
+     -X POST https://app.matrix-os.com/vps/deploy \
+     -H "Authorization: Bearer $PLATFORM_SECRET" \
+     -H "Content-Type: application/json" \
+     -d '{"channel":"stable"}'
+   ```
+
+5. Verify with `/vps/releases` and Grafana:
+
+   ```bash
+   curl --fail --silent --show-error \
+     -H "Authorization: Bearer $PLATFORM_SECRET" \
+     https://app.matrix-os.com/vps/releases
+   ```
+
+Grafana dashboards to check:
+
+- **Release Channels**: channel pointers, reported runtime version distribution,
+  and reachable VPSes not on `stable`.
+- **VPS Fleet Overview**: provisioned machine inventory, control reachability,
+  runtime release reports, load, memory, disk, and probe latency.
+
+## Handling Blocked Machines
+
+A blocked machine is one that is `running` in platform DB but rejects both
+release probes and upgrade triggers with `401`, or times out entirely.
+
+1. Try the inbound deploy once:
+
+   ```bash
+   curl --fail --silent --show-error \
+     -X POST https://app.matrix-os.com/vps/deploy \
+     -H "Authorization: Bearer $PLATFORM_SECRET" \
+     -H "Content-Type: application/json" \
+     -d '{"channel":"stable","handle":"<handle>"}'
+   ```
+
+2. If the VPS accepts unauthenticated user update routes, trigger the host-local
+   updater through the gateway:
+
+   ```bash
+   curl --fail --silent --show-error \
+     -X POST https://<vps-ip>/api/system/update \
+     -H "Content-Type: application/json" \
+     -d '{"channel":"stable"}'
+   ```
+
+3. If both fail, use break-glass SSH:
+
+   ```bash
+   ssh matrix@<vps-ip> 'sudo -n /opt/matrix/bin/matrix-update stable'
+   ssh matrix@<vps-ip> 'cat /opt/matrix/release.json'
+   ssh matrix@<vps-ip> 'systemctl is-active matrix-gateway matrix-shell matrix-sync-agent'
+   ```
+
+4. If SSH is unavailable, treat the VPS as unmanaged drift. Repair requires
+   Hetzner console/rescue access or reprovision/recover through backup restore.
+   Do not SSH-copy a bundle as the normal fix.
+
+## Public Release Surface
+
+The platform release DB is the source of truth. Public release pages should read
+from:
+
+- `GET https://app.matrix-os.com/system-bundles/releases?channel=stable`
+- `GET https://app.matrix-os.com/system-bundles/releases/<version>.json`
+
+The website should show:
+
+- release version, channel, date, git commit, bundle checksum
+- changelog/features
+- upgrade command: `matrix-update stable`
+- shell path: Settings -> System -> Updates
+- operator path for fleet upgrades
+
+Do not expose signed R2 URLs on public pages; those are short-lived operational
+links returned for authenticated/download paths.

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -14,6 +14,7 @@ For installable CLI releases, use [CLI Release Process](cli-release.md). CLI ver
 - Host-bundle updates must never overwrite owner data. Do not delete or replace `/home/matrix/home`, `/opt/matrix/env`, or the local Postgres data directory during deploys or rollbacks.
 - `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` and CI/release paths use `pnpm install --frozen-lockfile`; do not bypass either during releases.
 - CLI releases are manual through `.github/workflows/release.yml`; bump `packages/sync-client/package.json`, run the sync-client checks, and dispatch the workflow with the same semver.
+- Fleet upgrade operations, blocked-machine handling, and the durable control-plane setup are documented in [Fleet Upgrade Operations](fleet-upgrade-operations.md).
 
 ## Version Scheme
 

--- a/packages/platform/src/customer-vps-routes.ts
+++ b/packages/platform/src/customer-vps-routes.ts
@@ -41,6 +41,7 @@ export interface CustomerVpsRoutesDeps {
   probeMachineHealth?: (machine: { machineId: string; handle: string; publicIPv4: string | null }) => Promise<boolean>;
   probeMachineRuntime?: (machine: { machineId: string; handle: string; publicIPv4: string | null }) => Promise<{
     healthy: boolean;
+    runtimeVersion?: string | null;
     probeLatencyMs?: number;
     load1?: number | null;
     cpuCount?: number | null;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -943,6 +943,7 @@ async function probeCustomerVpsRuntime(
   platformSecret: string,
 ): Promise<{
   healthy: boolean;
+  runtimeVersion?: string | null;
   probeLatencyMs?: number;
   load1?: number | null;
   cpuCount?: number | null;
@@ -970,6 +971,9 @@ async function probeCustomerVpsRuntime(
     if (!res.ok) return { healthy: false, probeLatencyMs };
 
     const info = await res.json() as {
+      release?: {
+        version?: unknown;
+      };
       resources?: {
         cpuCount?: number;
         loadAverage?: unknown;
@@ -983,6 +987,7 @@ async function probeCustomerVpsRuntime(
     const load1 = typeof loadAverage[0] === 'number' ? loadAverage[0] : null;
     return {
       healthy: true,
+      runtimeVersion: typeof info.release?.version === 'string' ? info.release.version : null,
       probeLatencyMs,
       load1,
       cpuCount: typeof info.resources?.cpuCount === 'number' ? info.resources.cpuCount : null,

--- a/packages/platform/src/metrics.ts
+++ b/packages/platform/src/metrics.ts
@@ -112,6 +112,13 @@ export const vpsHealthy = new Gauge({
   registers: [metricsRegistry],
 });
 
+export const vpsRuntimeInfo = new Gauge({
+  name: 'matrix_vps_runtime_info',
+  help: 'Runtime release info reported by a reachable customer VPS (value is always 1, labels carry metadata)',
+  labelNames: ['handle', 'version'] as const,
+  registers: [metricsRegistry],
+});
+
 export const vpsProbeLatencySeconds = new Gauge({
   name: 'matrix_vps_probe_latency_seconds',
   help: 'Latest VPS system probe latency in seconds',
@@ -306,6 +313,7 @@ export function refreshReleaseChannelMetrics(
 export interface VpsRuntimeMetricInput {
   handle: string;
   healthy?: boolean;
+  runtimeVersion?: string | null;
   probeLatencyMs?: number | null;
   load1?: number | null;
   cpuCount?: number | null;
@@ -317,6 +325,7 @@ export interface VpsRuntimeMetricInput {
 
 export function refreshVpsRuntimeMetrics(machines: VpsRuntimeMetricInput[]): void {
   vpsHealthy.reset();
+  vpsRuntimeInfo.reset();
   vpsProbeLatencySeconds.reset();
   vpsLoad1.reset();
   vpsCpuCount.reset();
@@ -327,6 +336,9 @@ export function refreshVpsRuntimeMetrics(machines: VpsRuntimeMetricInput[]): voi
 
   for (const machine of machines) {
     vpsHealthy.set({ handle: machine.handle }, machine.healthy ? 1 : 0);
+    if (machine.healthy && machine.runtimeVersion) {
+      vpsRuntimeInfo.set({ handle: machine.handle, version: machine.runtimeVersion }, 1);
+    }
     if (typeof machine.probeLatencyMs === 'number') {
       vpsProbeLatencySeconds.set({ handle: machine.handle }, machine.probeLatencyMs / 1000);
     }

--- a/tests/platform/metrics.test.ts
+++ b/tests/platform/metrics.test.ts
@@ -130,6 +130,7 @@ describe('platform/metrics', () => {
       {
         handle: 'alice',
         healthy: true,
+        runtimeVersion: 'v2026.05.27-133',
         probeLatencyMs: 125,
         load1: 0.42,
         cpuCount: 2,
@@ -142,6 +143,7 @@ describe('platform/metrics', () => {
 
     const output = await metricsRegistry.metrics();
     expect(output).toContain('matrix_vps_healthy{handle="alice"} 1');
+    expect(output).toContain('matrix_vps_runtime_info{handle="alice",version="v2026.05.27-133"} 1');
     expect(output).toContain('matrix_vps_probe_latency_seconds{handle="alice"} 0.125');
     expect(output).toContain('matrix_vps_load1{handle="alice"} 0.42');
     expect(output).toContain('matrix_vps_cpu_count{handle="alice"} 2');
@@ -149,6 +151,19 @@ describe('platform/metrics', () => {
     expect(output).toContain('matrix_vps_memory_free_bytes{handle="alice"} 1073741824');
     expect(output).toContain('matrix_vps_disk_total_bytes{handle="alice"} 42949672960');
     expect(output).toContain('matrix_vps_disk_free_bytes{handle="alice"} 32212254720');
+  });
+
+  it('suppresses runtime release info for unhealthy or unversioned VPS probes', async () => {
+    refreshVpsRuntimeMetrics([
+      { handle: 'alice', healthy: false, runtimeVersion: 'v2026.05.27-133' },
+      { handle: 'bob', healthy: true, runtimeVersion: null },
+    ]);
+
+    const output = await metricsRegistry.metrics();
+    expect(output).toContain('matrix_vps_healthy{handle="alice"} 0');
+    expect(output).toContain('matrix_vps_healthy{handle="bob"} 1');
+    expect(output).not.toContain('matrix_vps_runtime_info{handle="alice"');
+    expect(output).not.toContain('matrix_vps_runtime_info{handle="bob"');
   });
 
   it('refreshes platform user and user-to-VPS link metrics', async () => {

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -44,11 +44,13 @@ const navLinks = [
   { label: "about", href: "#about" },
   { label: "features", href: "#features" },
   { label: "developers", href: "#developers" },
+  { label: "releases", href: "/releases" },
   { label: "agents", href: "/skills.md" },
 ] as const;
 
 const communityLinks = [
   { label: "Docs", href: "/docs" },
+  { label: "Releases", href: "/releases" },
   { label: "Agent Skill", href: "/skills.md" },
   { label: "Whitepaper", href: "/whitepaper" },
   { label: "Join Discord", href: "https://discord.gg/cSBBQWtPwV" },

--- a/www/src/app/releases/page.tsx
+++ b/www/src/app/releases/page.tsx
@@ -1,0 +1,174 @@
+import type { Metadata } from "next";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Releases | Matrix OS",
+  description: "Matrix OS host-bundle release notes, upgrade channels, and VPS upgrade commands.",
+};
+
+type Release = {
+  version?: string;
+  channel?: string | null;
+  gitCommit?: string;
+  gitRef?: string | null;
+  buildTime?: string;
+  bundleSha256?: string;
+  sha256?: string;
+  size?: number;
+  severity?: string;
+  updateType?: string;
+  changelog?: string | null;
+  createdAt?: string;
+};
+
+async function fetchReleases(): Promise<{ releases: Release[]; error?: string }> {
+  const platformUrl = process.env.PLATFORM_PUBLIC_URL ?? "https://app.matrix-os.com";
+
+  try {
+    const url = new URL("/system-bundles/releases", platformUrl);
+    url.searchParams.set("channel", "stable");
+    const response = await fetch(url.toString(), {
+      cache: "no-store",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      return { releases: [], error: "Release metadata is temporarily unavailable." };
+    }
+    const data = await response.json() as { releases?: Release[] };
+    return { releases: data.releases ?? [] };
+  } catch (error: unknown) {
+    console.error("Failed to fetch Matrix OS release metadata", error);
+    return { releases: [], error: "Release metadata is temporarily unavailable." };
+  }
+}
+
+function formatDate(value?: string): string {
+  if (!value) return "Unknown date";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("en", { year: "numeric", month: "short", day: "numeric" });
+}
+
+function formatSize(value?: number): string | null {
+  if (typeof value !== "number") return null;
+  return `${(value / 1024 / 1024 / 1024).toFixed(2)} GiB`;
+}
+
+function releaseKey(release: Release, index: number): string {
+  return release.version ?? release.gitCommit ?? `${release.channel ?? "stable"}-${release.createdAt ?? "unknown"}-${index}`;
+}
+
+export default async function ReleasesPage() {
+  const { releases, error } = await fetchReleases();
+  const [latest, ...previous] = releases;
+
+  return (
+    <main className="min-h-screen bg-[#E2E2CF] text-[#32352E]">
+      <nav className="mx-auto flex max-w-5xl items-center justify-between px-6 py-6">
+        <a href="/" className="text-sm font-semibold tracking-[0.18em] uppercase">Matrix OS</a>
+        <div className="flex items-center gap-5 text-xs uppercase tracking-[0.16em] text-[#5C5A4F]">
+          <a href="/docs">Docs</a>
+          <a href="https://github.com/HamedMP/matrix-os">GitHub</a>
+          <a href="https://app.matrix-os.com">Open app</a>
+        </div>
+      </nav>
+
+      <section className="mx-auto max-w-5xl px-6 pb-16 pt-10">
+        <p className="mb-4 text-sm font-medium uppercase tracking-[0.18em] text-[#D06F25]">
+          Host-bundle releases
+        </p>
+        <h1 className="max-w-3xl text-4xl font-light leading-tight sm:text-5xl">
+          Stable Matrix OS runtime updates
+        </h1>
+        <p className="mt-5 max-w-2xl text-base leading-7 text-[#5C5A4F]">
+          These releases update the VPS-native Matrix OS runtime: shell, gateway,
+          bundled apps, update tooling, and system services. Owner data under the
+          Matrix home is preserved during upgrades.
+        </p>
+      </section>
+
+      <section className="mx-auto grid max-w-5xl gap-6 px-6 pb-16 lg:grid-cols-[1.4fr_0.9fr]">
+        <div className="rounded-lg border border-[#D6D3C8] bg-[#ECECDA] p-6">
+          <p className="mb-2 text-xs uppercase tracking-[0.16em] text-[#5C5A4F]">Latest stable</p>
+          {error ? (
+            <p className="text-sm text-[#5C5A4F]">{error}</p>
+          ) : latest ? (
+            <ReleaseSummary release={latest} prominent />
+          ) : (
+            <p className="text-sm text-[#5C5A4F]">No stable releases have been published yet.</p>
+          )}
+        </div>
+
+        <div className="rounded-lg border border-[#D6D3C8] bg-[#ECECDA] p-6">
+          <p className="mb-4 text-xs uppercase tracking-[0.16em] text-[#5C5A4F]">Upgrade</p>
+          <div className="space-y-4 text-sm leading-6 text-[#5C5A4F]">
+            <p>From a customer VPS terminal:</p>
+            <pre className="overflow-x-auto rounded-md bg-[#32352E] p-3 text-xs text-[#E2E2CF]">
+              matrix-update stable
+            </pre>
+            <p>From the web shell, open Settings, then System, then Updates.</p>
+            <p>Operators should promote and deploy through the platform release endpoints.</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl px-6 pb-24">
+        <h2 className="mb-5 text-xl font-medium">Previous stable releases</h2>
+        <div className="divide-y divide-[#D6D3C8] rounded-lg border border-[#D6D3C8] bg-[#ECECDA]">
+          {previous.length === 0 ? (
+            <p className="p-6 text-sm text-[#5C5A4F]">No earlier stable releases are listed.</p>
+          ) : previous.slice(0, 12).map((release, index) => (
+            <div key={releaseKey(release, index)} className="p-5">
+              <ReleaseSummary release={release} />
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function ReleaseSummary({ release, prominent = false }: { release: Release; prominent?: boolean }) {
+  const checksum = release.bundleSha256 ?? release.sha256;
+  return (
+    <article className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <h2 className={prominent ? "font-mono text-2xl" : "font-mono text-base"}>
+          {release.version ?? "unknown"}
+        </h2>
+        <span className="rounded-full border border-[#D6D3C8] px-2.5 py-1 text-xs uppercase tracking-[0.12em] text-[#5C5A4F]">
+          {release.channel ?? "stable"}
+        </span>
+        {release.severity && release.severity !== "normal" && (
+          <span className="rounded-full bg-[#D06F25] px-2.5 py-1 text-xs uppercase tracking-[0.12em] text-white">
+            {release.severity}
+          </span>
+        )}
+      </div>
+      {release.changelog && (
+        <p className={prominent ? "text-base leading-7 text-[#32352E]" : "text-sm leading-6 text-[#5C5A4F]"}>
+          {release.changelog}
+        </p>
+      )}
+      <dl className="grid gap-2 text-xs text-[#5C5A4F] sm:grid-cols-2">
+        <Meta label="Published" value={formatDate(release.createdAt ?? release.buildTime)} />
+        <Meta label="Commit" value={release.gitCommit?.slice(0, 12)} />
+        <Meta label="Ref" value={release.gitRef ?? undefined} />
+        <Meta label="Bundle" value={formatSize(release.size) ?? undefined} />
+        <Meta label="Checksum" value={checksum?.slice(0, 16)} />
+        <Meta label="Update type" value={release.updateType} />
+      </dl>
+    </article>
+  );
+}
+
+function Meta({ label, value }: { label: string; value?: string }) {
+  if (!value) return null;
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-3">
+      <dt>{label}</dt>
+      <dd className="truncate font-mono text-[#32352E]">{value}</dd>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a public `/releases` website page backed by the platform release registry for stable host-bundle changelog and upgrade guidance.
- Link Releases from the landing page while preserving PR #225's Developers section and skills.md-driven setup flow.
- Export reported customer VPS runtime versions as `matrix_vps_runtime_info` and use it in Grafana to show release drift and reachable VPSes not on stable.
- Document the fleet upgrade operating model: outbound control agent target state, inbound fast path, break-glass SSH, blocked-machine handling, and public release surface rules.

## Invariants

- Source of truth: platform Postgres remains canonical for host-bundle release metadata/channel pointers; reachable VPSes report installed runtime version through their system-info probe; the website only renders public stable release metadata and never exposes signed bundle URLs.
- Lock/transaction scope: no new writes or transactions are introduced. Metrics are refreshed from probe snapshots and reset before each collection cycle so stale runtime-version labels do not persist.
- Acceptable orphan states: a VPS can be provisioned but not report `matrix_vps_runtime_info` when its authenticated probe fails; dashboards label that as control reachability/runtime drift, not as a successful upgrade.
- Auth source of truth: release publishing, channel promotion, and deploy actions remain behind existing platform admin auth. The public release page reads the existing public list endpoint only.
- Deferred scope: the durable outbound VPS control agent and break-glass forced-command SSH installation are documented as the target setup, not implemented in this PR.

## Tests

- [x] `bun run test -- tests/platform/metrics.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check:patterns` (0 violations; existing warnings only)
- [x] Dashboard JSON parse for `vps-fleet-overview.json` and `release-channels.json`
- [x] `pnpm --dir www exec tsc --noEmit`
