### PR TITLE
chore(gitignore): ignore pnpm store artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.pnpm-store/
 dist/
 build/
 .next/


### PR DESCRIPTION
Summary
- Ignore local pnpm store directories so generated cache artifacts like home/.pnpm-store stay out of git status.

Tests
- flox activate -- bun run typecheck
- bun run check:patterns (0 violations; existing scanner warnings only)
- flox activate -- bun run test (fails: local temp volume ran out of space with ENOSPC/SQLITE_FULL during the suite)
