### PR TITLE
fix(terminal): use canonical shell attach routes

### DIFF
--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -86,7 +86,7 @@ const HMAC_WEBHOOK_PREFIXES = [
 ];
 const MESSAGE_APPSERVICE_PREFIX = "/api/messages/appservice/";
 const MESSAGE_HERMES_REPLY_PATH = /^\/api\/messages\/conversations\/[^/]+\/reply$/;
-const WS_QUERY_TOKEN_PATHS = ["/ws", "/ws/voice", "/ws/terminal", "/ws/onboarding", "/ws/vocal"];
+const WS_QUERY_TOKEN_PATHS = ["/ws", "/ws/voice", "/ws/terminal", "/ws/terminal/session", "/ws/onboarding", "/ws/vocal"];
 const WS_QUERY_TOKEN_PATH_PATTERNS = [/^\/api\/canvases\/[^/]+\/ws$/];
 
 // Constant-time string compare. Previously, the length-mismatch branch ran

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -193,6 +193,7 @@ import {
   LayoutStore,
   ScrollbackStore,
   ShellPreferencesStore,
+  createPendingTerminalInputQueue,
   createShellWsHandler,
   createZellijAdapter,
   ShellRegistry as ZellijShellRegistry,
@@ -239,7 +240,7 @@ export function registerTerminalSessionRoutes(
     maxSize: TERMINAL_SESSION_DELETE_BODY_LIMIT_BYTES,
   });
 
-  app.get("/api/terminal/sessions", (c) => {
+  app.get("/api/terminal/pty-sessions", (c) => {
     const publicSessions = sessionRegistry.list().map((session: SessionInfo) => {
       const displayCwd = relative(homePath, session.cwd) || "~";
       return {
@@ -255,7 +256,7 @@ export function registerTerminalSessionRoutes(
     return c.json(publicSessions);
   });
 
-  app.delete("/api/terminal/sessions/:id", terminalSessionDeleteBodyLimit, (c) => {
+  app.delete("/api/terminal/pty-sessions/:id", terminalSessionDeleteBodyLimit, (c) => {
     const id = c.req.param("id");
     logTerminalDebug("rest-destroy-request", { sessionId: id });
     if (!UUID_REGEX.test(id)) return c.json({ error: "Invalid session ID" }, 400);
@@ -1508,12 +1509,14 @@ export async function createGateway(config: GatewayConfig) {
   app.route("/api/admin", createAdminControlRoutes({ service: adminControlService }));
   app.route("/api/company-brain", createCompanyBrainRoutes({ service: companyBrainService }));
   app.route("/api/support-growth", createDraftActionRoutes({ service: draftActionService }));
-  app.route("/api", createShellRoutes({
+  const shellRouteDeps = {
     registry: zellijShellRegistry,
     preferences: shellPreferencesStore,
     workspace: zellijAdapter,
     layouts: shellLayoutStore,
-  }));
+  };
+  app.route("/api/terminal", createShellRoutes(shellRouteDeps));
+  app.route("/api", createShellRoutes(shellRouteDeps));
 
   // HKDF master secret for per-app session cookies. In production MATRIX_AUTH_TOKEN
   // is the source. When it is absent (local dev, .env.example default) we mint an
@@ -2103,6 +2106,90 @@ export async function createGateway(config: GatewayConfig) {
           if (clients.delete(ws)) {
             wsConnectionsActive.dec();
           }
+        },
+      };
+    }),
+  );
+
+  app.get(
+    "/ws/terminal/session",
+    upgradeWebSocket((c) => {
+      const namedSession = c.req.query("session");
+      const fromSeqParam = c.req.query("fromSeq");
+      let namedHandle: { onMessage(raw: string): void; onClose(): void } | null = null;
+      let namedSocketClosed = false;
+      const pendingInput = createPendingTerminalInputQueue();
+
+      return {
+        onOpen(_evt, ws) {
+          if (!namedSession) {
+            ws.send(JSON.stringify({
+              type: "error",
+              code: "invalid_request",
+              message: "Invalid request",
+            }));
+            ws.close();
+            return;
+          }
+          const fromSeq =
+            typeof fromSeqParam === "string" && /^\d+$/.test(fromSeqParam)
+              ? Number(fromSeqParam)
+              : 0;
+          void zellijShellWs.open({
+            ws,
+            session: namedSession,
+            fromSeq,
+          }).then((session) => {
+            if (namedSocketClosed) {
+              session.onClose();
+              return;
+            }
+            namedHandle = session;
+            pendingInput.drain((raw) => {
+              session.onMessage(raw);
+            });
+          }).catch((err: unknown) => {
+            console.warn("[shell] terminal session attach failed:", err instanceof Error ? err.message : String(err));
+            pendingInput.clear();
+            if (namedSocketClosed) {
+              return;
+            }
+            try {
+              ws.send(JSON.stringify({
+                type: "error",
+                code: "attach_failed",
+                message: "Shell attach failed",
+              }));
+            } catch (sendErr: unknown) {
+              logUnexpectedWsSendFailure("Terminal WebSocket send failed", sendErr);
+            }
+            ws.close();
+          });
+        },
+        onMessage(evt, ws) {
+          const raw = typeof evt.data === "string" ? evt.data : "";
+          if (namedHandle) {
+            namedHandle.onMessage(raw);
+            return;
+          }
+          if (!pendingInput.enqueue(raw)) {
+            try {
+              ws.send(JSON.stringify({
+                type: "error",
+                code: "buffer_overflow",
+                message: "Input buffer overflow before session was ready",
+              }));
+            } catch (sendErr: unknown) {
+              logUnexpectedWsSendFailure("Terminal WebSocket send failed", sendErr);
+            }
+            ws.close();
+          }
+        },
+        onClose() {
+          namedSocketClosed = true;
+          pendingInput.clear();
+          namedHandle?.onClose();
+          namedHandle = null;
         },
       };
     }),

--- a/packages/gateway/src/shell/index.ts
+++ b/packages/gateway/src/shell/index.ts
@@ -3,6 +3,7 @@ export * from "./osc133.js";
 export * from "./atomic-write.js";
 export * from "./errors.js";
 export * from "./layouts.js";
+export * from "./pending-input.js";
 export * from "./preferences.js";
 export * from "./registry.js";
 export * from "./replay-buffer.js";

--- a/packages/gateway/src/shell/pending-input.ts
+++ b/packages/gateway/src/shell/pending-input.ts
@@ -1,0 +1,40 @@
+export const TERMINAL_SESSION_PENDING_INPUT_MAX_BYTES = 65_536;
+
+export interface PendingTerminalInputQueue {
+  readonly sizeBytes: number;
+  enqueue(raw: string): boolean;
+  drain(onMessage: (raw: string) => void): void;
+  clear(): void;
+}
+
+export function createPendingTerminalInputQueue(
+  maxBytes = TERMINAL_SESSION_PENDING_INPUT_MAX_BYTES,
+): PendingTerminalInputQueue {
+  const frames: string[] = [];
+  let sizeBytes = 0;
+
+  return {
+    get sizeBytes() {
+      return sizeBytes;
+    },
+    enqueue(raw: string) {
+      const nextSize = sizeBytes + Buffer.byteLength(raw, "utf8");
+      if (nextSize > maxBytes) {
+        return false;
+      }
+      frames.push(raw);
+      sizeBytes = nextSize;
+      return true;
+    },
+    drain(onMessage) {
+      for (const frame of frames.splice(0)) {
+        onMessage(frame);
+      }
+      sizeBytes = 0;
+    },
+    clear() {
+      frames.length = 0;
+      sizeBytes = 0;
+    },
+  };
+}

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -236,6 +236,15 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
     }
   });
 
+  app.get("/sessions/:name/layout", async (c) => {
+    try {
+      if (!deps.workspace) return unavailable(c, "workspace_unavailable");
+      return c.json({ layout: await deps.workspace.dumpLayout(SafeSessionNameSchema.parse(c.req.param("name"))) });
+    } catch (err) {
+      return safeError(c, err);
+    }
+  });
+
   app.get("/sessions/:name/preferences", async (c) => {
     try {
       if (!deps.preferences) {

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -108,6 +108,10 @@ function attachEnv(source: NodeJS.ProcessEnv = process.env): Record<string, stri
     }
   }
   env.TERM = "xterm-256color";
+  env.COLORTERM = "truecolor";
+  env.CLICOLOR = "1";
+  env.FORCE_COLOR = "3";
+  env.LANG = env.LANG || "en_US.UTF-8";
   return env;
 }
 
@@ -169,7 +173,12 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       const child = execFile(
         "zellij",
         args,
-        { timeout, signal: controller.signal, cwd: runCwd },
+        {
+          timeout,
+          signal: controller.signal,
+          cwd: runCwd,
+          env: attachEnv(deps.env),
+        },
         (err, stdout, stderr) => {
           if (err) {
             const safe = shellError("zellij_failed", "Shell operation failed", 500);

--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -72,6 +72,7 @@ export async function createOrAttachRunSession(
     command: string[];
     cwd?: string;
     sessionProvided: boolean;
+    mouse?: boolean;
   },
 ): Promise<{ detached: boolean }> {
   try {
@@ -85,7 +86,9 @@ export async function createOrAttachRunSession(
       throw err;
     }
   }
-  return await client.attachSession(input.name);
+  return input.mouse === undefined
+    ? await client.attachSession(input.name)
+    : await client.attachSession(input.name, { mouse: input.mouse });
 }
 
 function isInteractive(args: Record<string, unknown>, rawArgs: string[] | undefined): boolean {
@@ -141,6 +144,12 @@ export const runCommand = defineCommand({
     dev: { type: "boolean", required: false, default: false },
     gateway: { type: "string", required: false },
     token: { type: "string", required: false },
+    noMouse: {
+      type: "boolean",
+      required: false,
+      default: false,
+      description: "Drop local terminal mouse escape sequences before forwarding input",
+    },
     json: { type: "boolean", required: false, default: false },
   },
   run: async ({ args, rawArgs }) => {
@@ -165,6 +174,7 @@ export const runCommand = defineCommand({
         cwd: typeof args.cwd === "string" ? args.cwd : undefined,
         command,
         sessionProvided,
+        mouse: args.noMouse === true ? false : undefined,
       });
       console.log(
         json

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -119,6 +119,9 @@ function attachOptionsFromArgs(args: Record<string, unknown>) {
   const options: ShellAttachOptions = {
     fromSeq: parseFromSeq(args.fromSeq),
   };
+  if (args.noMouse === true) {
+    options.mouse = false;
+  }
   if (typeof args.WebSocketImpl === "function") {
     options.WebSocketImpl = args.WebSocketImpl as ShellAttachOptions["WebSocketImpl"];
   }
@@ -178,6 +181,7 @@ function attachCommand(name: string, description: string) {
       cwd: { type: "string", required: false },
       layout: { type: "string", required: false },
       cmd: { type: "string", required: false },
+      noMouse: { type: "boolean", required: false, default: false },
       fromSeq: { type: "string", required: false },
       ...commonArgs,
     },
@@ -239,6 +243,7 @@ export const shellCommand = defineCommand({
         layout: { type: "string", required: false },
         cmd: { type: "string", required: false },
         attach: { type: "boolean", required: false, default: false },
+        noMouse: { type: "boolean", required: false, default: false },
         ...commonArgs,
       },
       run: async ({ args }) => {

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -47,10 +47,13 @@ export interface ShellAttachOptions {
   output?: NodeJS.WriteStream;
   errorOutput?: NodeJS.WriteStream;
   detachSequence?: string;
+  mouse?: boolean;
   WebSocketImpl?: new (url: string, options?: { headers?: Record<string, string> }) => AttachWebSocket;
 }
 
 export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
+const LOCAL_TERMINAL_INPUT_RESET = "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l\u001b[?1004l";
+const MAX_PENDING_MOUSE_SEQUENCE_CHARS = 128;
 
 type MaybeTtyStream = NodeJS.ReadStream & {
   isTTY?: boolean;
@@ -78,13 +81,86 @@ function terminalSize(input: MaybeTtyStream, output: NodeJS.WriteStream): {
   return { cols, rows };
 }
 
+function createTerminalInputFilter(options: { dropMouse: boolean }) {
+  let focused = true;
+  let pendingMouseSequence = "";
+
+  return {
+    filter(chunk: string): string {
+      const input = pendingMouseSequence + chunk;
+      pendingMouseSequence = "";
+      let output = "";
+      for (let i = 0; i < input.length;) {
+        if (input[i] !== "\u001b" || input[i + 1] !== "[") {
+          output += input[i] ?? "";
+          i += 1;
+          continue;
+        }
+
+        const third = input[i + 2];
+        if (third === undefined) {
+          pendingMouseSequence = input.slice(i);
+          break;
+        }
+
+        if (third === "I" || third === "O") {
+          focused = third === "I";
+          if (!options.dropMouse) {
+            output += input.slice(i, i + 3);
+          }
+          i += 3;
+          continue;
+        }
+
+        if (third === "<") {
+          let end = i + 3;
+          while (end < input.length && input[end] !== "M" && input[end] !== "m") {
+            end += 1;
+          }
+          if (end >= input.length) {
+            pendingMouseSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_MOUSE_SEQUENCE_CHARS));
+            break;
+          }
+          if (!options.dropMouse && focused) {
+            output += input.slice(i, end + 1);
+          }
+          i = end + 1;
+          continue;
+        }
+
+        if (third === "M") {
+          if (i + 6 > input.length) {
+            pendingMouseSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_MOUSE_SEQUENCE_CHARS));
+            break;
+          }
+          if (!options.dropMouse && focused) {
+            output += input.slice(i, i + 6);
+          }
+          i += 6;
+          continue;
+        }
+
+        output += input[i] ?? "";
+        i += 1;
+      }
+      return output;
+    },
+    reset() {
+      focused = true;
+      pendingMouseSequence = "";
+    },
+  };
+}
+
 export function createShellClient(options: ShellClientOptions): ShellClient {
   const fetchImpl = options.fetch ?? fetch;
   const timeoutMs = options.timeoutMs ?? 10_000;
   const base = options.gatewayUrl.replace(/\/+$/, "");
+  const terminalSessionsPath = "/api/terminal/sessions";
+  const terminalLayoutsPath = "/api/terminal/layouts";
 
   function createAttachUrl(name: string, attachOptions: { fromSeq?: number; token?: string } = {}): string {
-    const url = new URL(`${base}/ws/terminal`);
+    const url = new URL(`${base}/ws/terminal/session`);
     url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
     url.searchParams.set("session", name);
     if (typeof attachOptions.fromSeq === "number") {
@@ -138,7 +214,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
 
   return {
     async listSessions() {
-      const payload = await request("/api/sessions");
+      const payload = await request(terminalSessionsPath);
       if (
         typeof payload === "object" &&
         payload !== null &&
@@ -150,77 +226,77 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       return [];
     },
     async createSession(input) {
-      return (await request("/api/sessions", {
+      return (await request(terminalSessionsPath, {
         method: "POST",
         body: JSON.stringify(input),
       })) as Record<string, unknown>;
     },
     async deleteSession(name, options = {}) {
       const suffix = options.force ? "?force=1" : "";
-      await request(`/api/sessions/${encodeURIComponent(name)}${suffix}`, {
+      await request(`${terminalSessionsPath}/${encodeURIComponent(name)}${suffix}`, {
         method: "DELETE",
       });
     },
     async listTabs(name) {
-      const payload = await request(`/api/sessions/${encodeURIComponent(name)}/tabs`);
+      const payload = await request(`${terminalSessionsPath}/${encodeURIComponent(name)}/tabs`);
       return typeof payload === "object" && payload !== null && "tabs" in payload && Array.isArray((payload as { tabs: unknown }).tabs)
         ? (payload as { tabs: unknown[] }).tabs
         : [];
     },
     async createTab(name, input) {
-      return (await request(`/api/sessions/${encodeURIComponent(name)}/tabs`, {
+      return (await request(`${terminalSessionsPath}/${encodeURIComponent(name)}/tabs`, {
         method: "POST",
         body: JSON.stringify(input),
       })) as Record<string, unknown>;
     },
     async switchTab(name, tab) {
-      return (await request(`/api/sessions/${encodeURIComponent(name)}/tabs/${tab}/go`, {
+      return (await request(`${terminalSessionsPath}/${encodeURIComponent(name)}/tabs/${tab}/go`, {
         method: "POST",
       })) as Record<string, unknown>;
     },
     async closeTab(name, tab) {
-      return (await request(`/api/sessions/${encodeURIComponent(name)}/tabs/${tab}`, {
+      return (await request(`${terminalSessionsPath}/${encodeURIComponent(name)}/tabs/${tab}`, {
         method: "DELETE",
       })) as Record<string, unknown>;
     },
     async splitPane(name, input) {
-      return (await request(`/api/sessions/${encodeURIComponent(name)}/panes`, {
+      return (await request(`${terminalSessionsPath}/${encodeURIComponent(name)}/panes`, {
         method: "POST",
         body: JSON.stringify(input),
       })) as Record<string, unknown>;
     },
     async closePane(name, pane) {
-      return (await request(`/api/sessions/${encodeURIComponent(name)}/panes/${encodeURIComponent(pane)}`, {
+      return (await request(`${terminalSessionsPath}/${encodeURIComponent(name)}/panes/${encodeURIComponent(pane)}`, {
         method: "DELETE",
       })) as Record<string, unknown>;
     },
     async listLayouts() {
-      const payload = await request("/api/layouts");
+      const payload = await request(terminalLayoutsPath);
       return typeof payload === "object" && payload !== null && "layouts" in payload && Array.isArray((payload as { layouts: unknown }).layouts)
         ? (payload as { layouts: unknown[] }).layouts
         : [];
     },
     async showLayout(name) {
-      return (await request(`/api/layouts/${encodeURIComponent(name)}`)) as Record<string, unknown>;
+      return (await request(`${terminalLayoutsPath}/${encodeURIComponent(name)}`)) as Record<string, unknown>;
     },
     async saveLayout(name, kdl) {
-      return (await request(`/api/layouts/${encodeURIComponent(name)}`, {
+      return (await request(`${terminalLayoutsPath}/${encodeURIComponent(name)}`, {
         method: "PUT",
         body: JSON.stringify({ kdl }),
       })) as Record<string, unknown>;
     },
     async deleteLayout(name) {
-      return (await request(`/api/layouts/${encodeURIComponent(name)}`, {
+      return (await request(`${terminalLayoutsPath}/${encodeURIComponent(name)}`, {
         method: "DELETE",
       })) as Record<string, unknown>;
     },
     async applyLayout(session, layout) {
-      return (await request(`/api/sessions/${encodeURIComponent(session)}/layouts/${encodeURIComponent(layout)}/apply`, {
+      return (await request(`${terminalSessionsPath}/${encodeURIComponent(session)}/layouts/${encodeURIComponent(layout)}/apply`, {
         method: "POST",
       })) as Record<string, unknown>;
     },
     async dumpLayout(session) {
-      return (await request(`/api/sessions/${encodeURIComponent(session)}/layout/dump`)) as Record<string, unknown>;
+      return (await request(`${terminalSessionsPath}/${encodeURIComponent(session)}/layout`)) as Record<string, unknown>;
     },
     createAttachUrl,
     async attachSession(name, attachOptions = {}) {
@@ -237,6 +313,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       const errorOutput = attachOptions.errorOutput ?? process.stderr;
       const input = (attachOptions.input ?? process.stdin) as MaybeTtyStream;
       const detachSequence = attachOptions.detachSequence ?? "\u001c\u001c";
+      const dropMouse = attachOptions.mouse === false;
+      const inputFilter = createTerminalInputFilter({ dropMouse });
       let pendingInput = "";
 
       return new Promise<{ detached: boolean }>((resolve, reject) => {
@@ -254,10 +332,16 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           clearTimeout(timeout);
           input.off?.("data", onInput);
           process.off("SIGWINCH", onResize);
+          process.off("SIGINT", onSignal);
+          process.off("SIGTERM", onSignal);
+          process.off("exit", onProcessExit);
           ws.off?.("open", onOpen);
           ws.off?.("message", onMessage);
           ws.off?.("close", onClose);
           ws.off?.("error", onError);
+          pendingInput = "";
+          inputFilter.reset();
+          output.write(LOCAL_TERMINAL_INPUT_RESET);
           if (rawModeEnabled) {
             input.setRawMode?.(false);
             rawModeEnabled = false;
@@ -311,7 +395,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           }
         };
         const onInput = (chunk: Buffer | string) => {
-          const data = Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : String(chunk);
+          const rawData = Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : String(chunk);
+          const data = inputFilter.filter(rawData);
           let outbound = "";
           for (const char of data) {
             pendingInput += char;
@@ -346,6 +431,18 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         };
         const onResize = () => {
           sendResizeFrame();
+        };
+        const onSignal = () => {
+          sendFrame(JSON.stringify({ type: "detach" }));
+          ws.close();
+          settle(() => resolve({ detached: true }));
+        };
+        const onProcessExit = () => {
+          output.write(LOCAL_TERMINAL_INPUT_RESET);
+          if (rawModeEnabled) {
+            input.setRawMode?.(false);
+            rawModeEnabled = false;
+          }
         };
         const onOpen = () => {
           markOpen();
@@ -396,6 +493,9 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           input.resume?.();
           process.on("SIGWINCH", onResize);
         }
+        process.once("SIGINT", onSignal);
+        process.once("SIGTERM", onSignal);
+        process.once("exit", onProcessExit);
         input.on?.("data", onInput);
       });
     },

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -223,7 +223,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const destroyTerminalSessions = useCallback((sessionIds: string[]) => {
     const uniqueIds = Array.from(new Set(sessionIds.filter((sessionId) => sessionId.length > 0)));
     for (const sessionId of uniqueIds) {
-      void fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(sessionId)}`, {
+      void fetch(`${getGatewayUrl()}/api/terminal/pty-sessions/${encodeURIComponent(sessionId)}`, {
         method: "DELETE",
         keepalive: true,
         signal: AbortSignal.timeout(5_000),

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -48,6 +48,23 @@ describe("run CLI command", () => {
     expect(client.attachSession).toHaveBeenCalledWith("setup");
   });
 
+  it("passes no-mouse mode through interactive run attach", async () => {
+    const client = {
+      createSession: vi.fn(async () => ({ name: "setup" })),
+      attachSession: vi.fn(async () => ({ detached: true })),
+    };
+
+    await expect(
+      createOrAttachRunSession(client, {
+        name: "setup",
+        command: ["claude"],
+        sessionProvided: true,
+        mouse: false,
+      }),
+    ).resolves.toEqual({ detached: true });
+    expect(client.attachSession).toHaveBeenCalledWith("setup", { mouse: false });
+  });
+
   it("does not reuse an accidental ephemeral session collision", async () => {
     const client = {
       createSession: vi.fn(async () => {

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -72,7 +72,7 @@ describe("shell REST client", () => {
 
     await expect(client.listSessions()).resolves.toEqual([]);
     expect(fetchImpl).toHaveBeenCalledWith(
-      "http://gateway/api/sessions",
+      "http://gateway/api/terminal/sessions",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer tok" }),
         signal: expect.any(AbortSignal),
@@ -104,7 +104,7 @@ describe("shell REST client", () => {
     });
 
     expect(client.createAttachUrl("main", { fromSeq: 7 })).toBe(
-      "wss://gateway.example/ws/terminal?session=main&fromSeq=7",
+      "wss://gateway.example/ws/terminal/session?session=main&fromSeq=7",
     );
   });
 
@@ -115,7 +115,7 @@ describe("shell REST client", () => {
     });
 
     expect(client.createAttachUrl("main", { token: "query-token" })).toBe(
-      "wss://gateway.example/ws/terminal?session=main&token=query-token",
+      "wss://gateway.example/ws/terminal/session?session=main&token=query-token",
     );
   });
 
@@ -174,7 +174,7 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("close");
 
     await expect(attached).resolves.toEqual({ detached: true });
-    expect(ControlledWebSocket.lastUrl).toBe("ws://gateway/ws/terminal?session=main");
+    expect(ControlledWebSocket.lastUrl).toBe("ws://gateway/ws/terminal/session?session=main");
     expect(ControlledWebSocket.lastOptions).toEqual({
       headers: { Authorization: "Bearer tok" },
     });
@@ -276,6 +276,99 @@ describe("shell REST client", () => {
       { type: "input", data: "a" },
       { type: "input", data: "\u001cb" },
       { type: "detach" },
+    ]);
+  });
+
+  it("resets local mouse and focus modes on websocket errors", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("error", new Error("boom"));
+
+    await expect(attached).rejects.toMatchObject({ code: "attach_failed" });
+    expect((input as unknown as FakeTtyInput).rawModes).toEqual([true, false]);
+    expect(output.write).toHaveBeenCalledWith("\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l\u001b[?1004l");
+  });
+
+  it("drops mouse escape sequences when no-mouse attach mode is enabled", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      mouse: false,
+    });
+    ControlledWebSocket.last?.emit("open");
+    input.emit("data", "a\u001b[<0;10;20M\u001b[Mabc\u001b[I\u001b[O");
+    ControlledWebSocket.last?.emit("close");
+
+    await expect(attached).resolves.toEqual({ detached: true });
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "resize", cols: 80, rows: 24 },
+      { type: "input", data: "a" },
+    ]);
+  });
+
+  it("forwards focus reporting sequences while still dropping mouse input when unfocused", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    input.emit("data", "\u001b[Ia\u001b[O\u001b[<0;10;20M");
+    ControlledWebSocket.last?.emit("close");
+
+    await expect(attached).resolves.toEqual({ detached: true });
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "resize", cols: 80, rows: 24 },
+      { type: "input", data: "\u001b[Ia\u001b[O" },
+    ]);
+  });
+
+  it("buffers fragmented SGR mouse sequences instead of forwarding partial escape bytes", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      mouse: false,
+    });
+    ControlledWebSocket.last?.emit("open");
+    input.emit("data", "a\u001b[<0;10;");
+    input.emit("data", "20Mbc");
+    ControlledWebSocket.last?.emit("close");
+
+    await expect(attached).resolves.toEqual({ detached: true });
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "resize", cols: 80, rows: 24 },
+      { type: "input", data: "a" },
+      { type: "input", data: "bc" },
     ]);
   });
 });

--- a/tests/cli/shell-workspace.test.ts
+++ b/tests/cli/shell-workspace.test.ts
@@ -39,13 +39,13 @@ describe("shell workspace CLI commands", () => {
 
   it("emits JSON for tab, pane, and layout operations", async () => {
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url.endsWith("/api/sessions/main/tabs") && init?.method === "POST") {
+      if (url.endsWith("/api/terminal/sessions/main/tabs") && init?.method === "POST") {
         return new Response(JSON.stringify({ tab: { idx: 1, name: "api" } }));
       }
-      if (url.endsWith("/api/sessions/main/panes") && init?.method === "POST") {
+      if (url.endsWith("/api/terminal/sessions/main/panes") && init?.method === "POST") {
         return new Response(JSON.stringify({ pane: { paneId: "pane-2" } }));
       }
-      if (url.endsWith("/api/layouts/dev") && init?.method === "PUT") {
+      if (url.endsWith("/api/terminal/layouts/dev") && init?.method === "PUT") {
         return new Response(JSON.stringify({ ok: true }));
       }
       return new Response(JSON.stringify({ ok: true }));
@@ -112,8 +112,8 @@ describe("shell workspace CLI commands", () => {
     } as never);
 
     expect(calls).toEqual([
-      { url: "http://localhost:4000/api/sessions/main/tabs/1/go", method: "POST" },
-      { url: "http://localhost:4000/api/sessions/main/tabs/1", method: "DELETE" },
+      { url: "http://localhost:4000/api/terminal/sessions/main/tabs/1/go", method: "POST" },
+      { url: "http://localhost:4000/api/terminal/sessions/main/tabs/1", method: "DELETE" },
     ]);
   });
 

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -209,10 +209,10 @@ describe("shell CLI command", () => {
 
   it("emits versioned JSON for ls, new, and rm", async () => {
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url.endsWith("/api/sessions") && init?.method === "POST") {
+      if (url.endsWith("/api/terminal/sessions") && init?.method === "POST") {
         return new Response(JSON.stringify({ name: "main", created: true }), { status: 201 });
       }
-      if (url.endsWith("/api/sessions/main")) {
+      if (url.endsWith("/api/terminal/sessions/main")) {
         return new Response(JSON.stringify({ ok: true }));
       }
       return new Response(JSON.stringify({ sessions: [{ name: "main" }] }));
@@ -242,7 +242,7 @@ describe("shell CLI command", () => {
 
   it("creates shell sessions without attaching by default", async () => {
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url.endsWith("/api/sessions") && init?.method === "POST") {
+      if (/\/api\/(?:terminal\/)?sessions$/.test(url) && init?.method === "POST") {
         return new Response(JSON.stringify({ name: "main", created: true }), { status: 201 });
       }
       throw new Error(`unexpected fetch ${url}`);
@@ -305,7 +305,7 @@ describe("shell CLI command", () => {
     } as never);
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      expect.stringMatching(/\/api\/sessions$/),
+      expect.stringMatching(/\/api\/terminal\/sessions$/),
       expect.objectContaining({ method: "POST" }),
     );
     expect(logs).toContain("Created shell session 1. Connecting...");

--- a/tests/gateway/auth.test.ts
+++ b/tests/gateway/auth.test.ts
@@ -208,6 +208,16 @@ describe("T133: Auth token middleware", () => {
     expect(nextCalled).toBe(true);
   });
 
+  it("allows /ws/terminal/session with query token", async () => {
+    const mw = authMiddleware("secret-token");
+    let nextCalled = false;
+    await mw(
+      mockContext("/ws/terminal/session", undefined, "secret-token", "10.0.0.1"),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
   it("allows canvas WebSocket paths with query token", async () => {
     const mw = authMiddleware("secret-token");
     let nextCalled = false;

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -9,6 +9,7 @@ describe("gateway shell routes", () => {
     delete: (name: string, options?: { force?: boolean }) => Promise<void>;
   }) {
     const app = new Hono();
+    app.route("/api/terminal", createShellRoutes({ registry }));
     app.route("/api", createShellRoutes({ registry }));
     return app;
   }
@@ -26,6 +27,29 @@ describe("gateway shell routes", () => {
     await expect(res.json()).resolves.toEqual({
       sessions: [{ name: "main", status: "active" }],
     });
+  });
+
+  it("serves canonical terminal sessions routes under /api/terminal", async () => {
+    const registry = {
+      list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      create: vi.fn(async () => ({ name: "setup" })),
+      delete: vi.fn(async () => undefined),
+    };
+    const app = appWithRegistry(registry);
+
+    await expect((await app.request("/api/terminal/sessions")).json()).resolves.toEqual({
+      sessions: [{ name: "main", status: "active" }],
+    });
+    const created = await app.request("/api/terminal/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "setup" }),
+    });
+    expect(created.status).toBe(201);
+    await app.request("/api/terminal/sessions/setup?force=1", { method: "DELETE" });
+
+    expect(registry.create).toHaveBeenCalledWith({ name: "setup" });
+    expect(registry.delete).toHaveBeenCalledWith("setup", { force: true });
   });
 
   it("creates sessions through a bounded JSON route", async () => {
@@ -150,6 +174,7 @@ describe("gateway shell routes", () => {
       dumpLayout: vi.fn(),
     };
     const app = new Hono();
+    app.route("/api/terminal", createShellRoutes({ registry, workspace }));
     app.route("/api", createShellRoutes({ registry, workspace }));
 
     const res = await app.request("/api/sessions/main/layouts/BadLayout/apply", { method: "POST" });

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -156,6 +156,7 @@ describe("zellij adapter", () => {
         ZELLIJ_SESSION_NAME: "main",
         ZELLIJ_PANE_ID: "1",
         ZELLIJ_SOCKET_DIR: "/run/user/999/zellij",
+        LANG: "fr_FR.UTF-8",
         SECRET_TOKEN: "nope",
       },
       cwd: "/opt/matrix/app",
@@ -175,6 +176,10 @@ describe("zellij adapter", () => {
           HOME: "/home/matrix",
           PATH: "/opt/matrix/bin",
           TERM: "xterm-256color",
+          COLORTERM: "truecolor",
+          CLICOLOR: "1",
+          FORCE_COLOR: "3",
+          LANG: "fr_FR.UTF-8",
           XDG_RUNTIME_DIR: "/run/user/999",
           ZELLIJ_CONFIG_DIR: "/home/matrix/.config/zellij",
           ZELLIJ_CONFIG_FILE: "/home/matrix/.config/zellij/config.kdl",
@@ -186,6 +191,7 @@ describe("zellij adapter", () => {
     expect(env).not.toHaveProperty("ZELLIJ");
     expect(env).not.toHaveProperty("ZELLIJ_SESSION_NAME");
     expect(env).not.toHaveProperty("ZELLIJ_PANE_ID");
+    expect(env).not.toHaveProperty("LC_ALL");
     expect(env).not.toHaveProperty("SECRET_TOKEN");
   });
 
@@ -234,9 +240,46 @@ describe("zellij adapter", () => {
     expect(execFile).toHaveBeenCalledWith(
       "zellij",
       ["--session", "main", "attach", "--create-background", "main"],
-      expect.objectContaining({ timeout: 25, cwd: "/home/alice/work" }),
+      expect.objectContaining({
+        timeout: 25,
+        cwd: "/home/alice/work",
+        env: expect.objectContaining({
+          TERM: "xterm-256color",
+          COLORTERM: "truecolor",
+          CLICOLOR: "1",
+          FORCE_COLOR: "3",
+        }),
+      }),
       expect.any(Function),
     );
+  });
+
+  it("creates tabs and panes with terminal-capable environment at process launch", async () => {
+    const child = childProcess();
+    const execFile = vi.fn((_file, _args, _opts, cb) => {
+      cb(null, "", "");
+      return child;
+    });
+    const adapter = createZellijAdapter({
+      execFile,
+      spawn: vi.fn(),
+      timeoutMs: 25,
+      env: { TERM: "dumb", COLORTERM: "", PATH: "/usr/bin" },
+    });
+
+    await adapter.createTab("main", { name: "tools" });
+    await adapter.splitPane("main", { direction: "right" });
+
+    for (const call of execFile.mock.calls) {
+      expect(call[2]).toEqual(expect.objectContaining({
+        env: expect.objectContaining({
+          TERM: "xterm-256color",
+          COLORTERM: "truecolor",
+          CLICOLOR: "1",
+          FORCE_COLOR: "3",
+        }),
+      }));
+    }
   });
 
   it("splits multi-word commands into argv tokens for zellij actions", async () => {

--- a/tests/gateway/terminal-pending-input.test.ts
+++ b/tests/gateway/terminal-pending-input.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPendingTerminalInputQueue,
+  TERMINAL_SESSION_PENDING_INPUT_MAX_BYTES,
+} from "../../packages/gateway/src/shell/pending-input.js";
+
+describe("terminal websocket pending input queue", () => {
+  it("buffers and drains input frames received before a named terminal attach is ready", () => {
+    const queue = createPendingTerminalInputQueue();
+    const onMessage = vi.fn();
+
+    expect(queue.enqueue(JSON.stringify({ type: "input", data: "pwd\r" }))).toBe(true);
+    queue.drain(onMessage);
+
+    expect(onMessage).toHaveBeenCalledWith(JSON.stringify({ type: "input", data: "pwd\r" }));
+    expect(queue.sizeBytes).toBe(0);
+  });
+
+  it("rejects queued input once the startup cap would be exceeded", () => {
+    const queue = createPendingTerminalInputQueue();
+
+    expect(queue.enqueue("x".repeat(TERMINAL_SESSION_PENDING_INPUT_MAX_BYTES))).toBe(true);
+    expect(queue.enqueue("x")).toBe(false);
+  });
+});

--- a/tests/gateway/terminal-ws.test.ts
+++ b/tests/gateway/terminal-ws.test.ts
@@ -199,7 +199,7 @@ describe("Terminal session REST routes", () => {
     };
     const app = appWithTerminalRegistry(registry);
 
-    const res = await app.request("/api/terminal/sessions");
+    const res = await app.request("/api/terminal/pty-sessions");
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([{
@@ -220,7 +220,7 @@ describe("Terminal session REST routes", () => {
     };
     const app = appWithTerminalRegistry(registry);
 
-    const res = await app.request("/api/terminal/sessions/not-a-uuid", { method: "DELETE" });
+    const res = await app.request("/api/terminal/pty-sessions/not-a-uuid", { method: "DELETE" });
 
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: "Invalid session ID" });
@@ -236,7 +236,7 @@ describe("Terminal session REST routes", () => {
     };
     const app = appWithTerminalRegistry(registry);
 
-    const res = await app.request(`/api/terminal/sessions/${SESSION_ID}`, { method: "DELETE" });
+    const res = await app.request(`/api/terminal/pty-sessions/${SESSION_ID}`, { method: "DELETE" });
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
@@ -251,7 +251,7 @@ describe("Terminal session REST routes", () => {
     };
     const app = appWithTerminalRegistry(registry);
 
-    const res = await app.request(`/api/terminal/sessions/${SESSION_ID}`, {
+    const res = await app.request(`/api/terminal/pty-sessions/${SESSION_ID}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "text/plain",

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -219,7 +219,7 @@ describe("TerminalApp", () => {
 
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
     const deleteCalls = fetchMock.mock.calls.filter(([input, init]) => (
-      String(input).includes("/api/terminal/sessions/session-pending-close") && init?.method === "DELETE"
+      String(input).includes("/api/terminal/pty-sessions/session-pending-close") && init?.method === "DELETE"
     ));
 
     expect(deleteCalls.length).toBe(1);
@@ -324,6 +324,6 @@ describe("TerminalApp", () => {
       expect.stringContaining("/api/sessions/sess_abc123"),
       expect.objectContaining({ method: "DELETE" }),
     );
-    expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining("/api/terminal/sessions"), expect.objectContaining({ method: "GET" }));
+    expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining("/api/terminal/pty-sessions"), expect.objectContaining({ method: "GET" }));
   });
 });


### PR DESCRIPTION
## Summary
- Add backend-neutral terminal routes for zellij-backed shell sessions: `/api/terminal/sessions`, `/api/terminal/layouts`, and `/ws/terminal/session`.
- Keep the old `/api/sessions` shell routes as a one-release compatibility shim, and move legacy web pty REST cleanup to `/api/terminal/pty-sessions`.
- Fix zellij launch-time terminal environment so newly-created sessions, tabs, panes, and attaches start with `TERM=xterm-256color`, `COLORTERM=truecolor`, and color flags.
- Add CLI attach cleanup and `--no-mouse` support so local mouse/focus escape sequences do not leak into remote shells.

## Invariants
- Source of truth: zellij-backed `ShellRegistry` remains canonical for named shell sessions in this slice; legacy pty sessions are only preserved for existing web terminal cleanup.
- Lock/transaction scope: no DB writes; route changes delegate to existing registry operations without network calls inside mutation locks.
- Acceptable orphan states: old `/api/sessions` callers continue to work while new CLI calls use `/api/terminal/sessions`; legacy pty sessions can still be destroyed via `/api/terminal/pty-sessions/:id`.
- Auth source of truth: existing bearer/query-token auth remains unchanged, with `/ws/terminal/session` added to the browser query-token allowlist.
- Deferred scope: full workspace session namespace migration to `/api/workspace/sessions` and web terminal default attach-to-`main` are intentionally left for the next slice.

## Verification
- `bun run test tests/gateway/shell-zellij.test.ts tests/cli/shell-client.test.ts tests/cli/run.test.ts tests/cli/shell.test.ts tests/cli/shell-workspace.test.ts tests/gateway/shell-routes.test.ts tests/gateway/terminal-ws.test.ts tests/gateway/auth.test.ts`
