### PR TITLE
fix(proxy): default DB path to home dir and auto-create parents

### DIFF
--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/main.ts",
+    "dev": "tsx watch --env-file-if-exists=../../.env src/main.ts",
     "start": "node --import=tsx src/main.ts",
     "build": "pnpm --dir ../.. --filter '@matrix-os/observability' build && tsc"
   },

--- a/packages/proxy/src/db.ts
+++ b/packages/proxy/src/db.ts
@@ -1,11 +1,16 @@
 import Database from 'better-sqlite3';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
 
-const DB_PATH = process.env.PROXY_DB_PATH ?? '/data/proxy.db';
+const DB_PATH =
+  process.env.PROXY_DB_PATH ?? join(homedir(), 'matrixos', 'proxy.db');
 
 let db: Database.Database;
 
 export function getDb(): Database.Database {
   if (!db) {
+    mkdirSync(dirname(DB_PATH), { recursive: true });
     db = new Database(DB_PATH);
     db.pragma('journal_mode = WAL');
     db.pragma('foreign_keys = ON');

--- a/tests/proxy/db.test.ts
+++ b/tests/proxy/db.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+describe("proxy db.ts", () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let origEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "proxy-db-test-"));
+    dbPath = path.join(tmpDir, "nested", "dir", "proxy.db");
+    origEnv = process.env.PROXY_DB_PATH;
+    process.env.PROXY_DB_PATH = dbPath;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.PROXY_DB_PATH;
+    else process.env.PROXY_DB_PATH = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates the parent directory if it does not exist", async () => {
+    const { getDb } = await import("../../packages/proxy/src/db.js");
+    expect(() => getDb()).not.toThrow();
+    expect(fs.existsSync(dbPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
Running bun run dev I got: "  TypeError: Cannot open database because the directory does not exist
    at getDb (packages/proxy/src/db.ts:9:10)"