### PR TITLE
refactor(proxy): migrate from SQLite to Postgres via Kysely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ GEMINI_API_KEY=
 PORT=4000
 MATRIX_HOME=
 
+# Proxy (api usage + quotas)
+# Defaults to PLATFORM_DATABASE_URL when unset. Postgres only (Kysely).
+PROXY_DATABASE_URL=
+
 # Shell (Next.js)
 NEXT_PUBLIC_GATEWAY_WS=ws://localhost:4000/ws
 NEXT_PUBLIC_GATEWAY_URL=http://localhost:4000

--- a/README.md
+++ b/README.md
@@ -224,6 +224,29 @@ bun run test:integration  # Integration tests (needs API key, uses haiku)
 bun run test:coverage     # Coverage report
 ```
 
+### Postgres (host dev only)
+
+Matrix OS uses PostgreSQL for all persistence (platform, kernel durable state, proxy usage tracking). The Docker dev stack runs Postgres for you; if you're running on the host via `bun run dev`, you need a Postgres available.
+
+The easiest path on macOS:
+
+```bash
+brew install postgresql@17           # one-time
+brew services start postgresql@17
+createdb matrixos_platform
+```
+
+Then in your `.env`:
+
+```bash
+PROXY_DATABASE_URL=postgresql://localhost:5432/matrixos_platform
+PLATFORM_DATABASE_URL=postgresql://localhost:5432/matrixos_platform
+```
+
+Homebrew's Postgres uses your local user with no password (local trust auth). The proxy creates its tables automatically on first boot.
+
+Don't need the proxy locally? Skip Postgres entirely and run only the gateway + shell: `bun run dev:gateway & bun run dev:shell`.
+
 ### Start Development
 
 ```bash
@@ -261,6 +284,8 @@ The gateway boots the home directory at `~/matrixos/` on first run.
 | `PORT` | Gateway port | `4000` |
 | `FAL_API_KEY` | AI icon generation (fal.ai) | -- |
 | `DATABASE_URL` | Postgres connection (social/app data) | -- |
+| `PLATFORM_DATABASE_URL` | Postgres for platform metadata | -- |
+| `PROXY_DATABASE_URL` | Postgres for proxy usage/quotas (falls back to `PLATFORM_DATABASE_URL`) | -- |
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -152,6 +152,8 @@ services:
     depends_on:
       dev:
         condition: service_healthy
+      postgres:
+        condition: service_healthy
     ports:
       - "8080:8080"
     volumes:
@@ -160,11 +162,10 @@ services:
       - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
       - ./tsconfig.json:/app/tsconfig.json
       - dev-node-modules:/app/node_modules
-      - proxy-data:/data
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - PROXY_PORT=8080
-      - PROXY_DB_PATH=/data/proxy.db
+      - PROXY_DATABASE_URL=${PROXY_DATABASE_URL:-${PLATFORM_DATABASE_URL:-postgresql://matrixos:matrixos@postgres:5432/matrixos_platform}}
       - POSTHOG_TOKEN=${POSTHOG_TOKEN:-}
       - POSTHOG_HOST=${POSTHOG_HOST:-}
     healthcheck:
@@ -393,7 +394,6 @@ volumes:
   ai-auth:
     external: true
     name: matrixos-ai-auth
-  proxy-data:
   platform-data:
   user-data:
   conduit-data:

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -4,21 +4,23 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/main.ts",
+    "dev": "tsx watch --env-file-if-exists=../../.env src/main.ts",
     "start": "node --import=tsx src/main.ts",
     "build": "pnpm --dir ../.. --filter '@matrix-os/observability' build && tsc"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.2.3",
+    "@types/pg": "^8.15.6",
+    "kysely-pglite": "^0.6.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.9",
     "@matrix-os/observability": "workspace:*",
-    "better-sqlite3": "^12.10.0",
     "hono": "^4.11.9",
+    "kysely": "^0.28.13",
+    "pg": "^8.21.0",
     "prom-client": "^15.1.3"
   }
 }

--- a/packages/proxy/src/db.ts
+++ b/packages/proxy/src/db.ts
@@ -156,17 +156,28 @@ export function createProxyDb(opts: string | { dialect: unknown } = DEFAULT_PROX
     },
     async getUsageSummary() {
       await ready;
-      const users = await kysely
-        .selectFrom('api_usage')
-        .select('user_id')
-        .distinct()
-        .execute();
-      return Promise.all(
-        users.map(async (u) => ({
-          userId: u.user_id,
-          ...(await this.getUserUsage(u.user_id)),
-        })),
-      );
+      // Single grouped query with FILTER aggregates: O(1) round-trips
+      // regardless of user count. Previous implementation was 1 + 3N.
+      const result = await sql<{
+        user_id: string;
+        daily: string | number;
+        monthly: string | number;
+        total: string | number;
+      }>`
+        SELECT
+          user_id,
+          COALESCE(SUM(cost_usd) FILTER (WHERE timestamp >= current_date), 0) AS daily,
+          COALESCE(SUM(cost_usd) FILTER (WHERE timestamp >= date_trunc('month', current_date)), 0) AS monthly,
+          COALESCE(SUM(cost_usd), 0) AS total
+        FROM api_usage
+        GROUP BY user_id
+      `.execute(kysely);
+      return result.rows.map((r) => ({
+        userId: r.user_id,
+        daily: Number(r.daily),
+        monthly: Number(r.monthly),
+        total: Number(r.total),
+      }));
     },
     async getMetricsSeed() {
       await ready;

--- a/packages/proxy/src/db.ts
+++ b/packages/proxy/src/db.ts
@@ -1,45 +1,30 @@
-import Database from 'better-sqlite3';
+import { Kysely, PostgresDialect, sql, type Generated } from 'kysely';
+import pg from 'pg';
 
-const DB_PATH = process.env.PROXY_DB_PATH ?? '/data/proxy.db';
-
-let db: Database.Database;
-
-export function getDb(): Database.Database {
-  if (!db) {
-    db = new Database(DB_PATH);
-    db.pragma('journal_mode = WAL');
-    db.pragma('foreign_keys = ON');
-    migrate(db);
-  }
-  return db;
+interface ApiUsageTable {
+  id: Generated<number>;
+  timestamp: Generated<Date>;
+  user_id: string;
+  model: string;
+  input_tokens: Generated<number>;
+  output_tokens: Generated<number>;
+  cache_read_tokens: Generated<number>;
+  cache_write_tokens: Generated<number>;
+  cost_usd: Generated<number>;
+  session_id: string | null;
+  status: Generated<number>;
 }
 
-function migrate(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS api_usage (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      timestamp TEXT NOT NULL DEFAULT (datetime('now')),
-      user_id TEXT NOT NULL,
-      model TEXT NOT NULL,
-      input_tokens INTEGER NOT NULL DEFAULT 0,
-      output_tokens INTEGER NOT NULL DEFAULT 0,
-      cache_read_tokens INTEGER NOT NULL DEFAULT 0,
-      cache_write_tokens INTEGER NOT NULL DEFAULT 0,
-      cost_usd REAL NOT NULL DEFAULT 0,
-      session_id TEXT,
-      status INTEGER NOT NULL DEFAULT 200
-    );
+interface UserQuotasTable {
+  user_id: string;
+  daily_limit_usd: number | null;
+  monthly_limit_usd: number | null;
+  enabled: Generated<boolean>;
+}
 
-    CREATE INDEX IF NOT EXISTS idx_usage_user ON api_usage(user_id);
-    CREATE INDEX IF NOT EXISTS idx_usage_timestamp ON api_usage(timestamp);
-
-    CREATE TABLE IF NOT EXISTS user_quotas (
-      user_id TEXT PRIMARY KEY,
-      daily_limit_usd REAL,
-      monthly_limit_usd REAL,
-      enabled INTEGER NOT NULL DEFAULT 1
-    );
-  `);
+interface ProxyDatabase {
+  api_usage: ApiUsageTable;
+  user_quotas: UserQuotasTable;
 }
 
 export interface UsageRecord {
@@ -54,19 +39,6 @@ export interface UsageRecord {
   status: number;
 }
 
-export function insertUsage(record: UsageRecord): void {
-  const stmt = getDb().prepare(`
-    INSERT INTO api_usage (user_id, model, input_tokens, output_tokens,
-      cache_read_tokens, cache_write_tokens, cost_usd, session_id, status)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `);
-  stmt.run(
-    record.userId, record.model, record.inputTokens, record.outputTokens,
-    record.cacheReadTokens, record.cacheWriteTokens, record.costUsd,
-    record.sessionId ?? null, record.status
-  );
-}
-
 export interface QuotaCheck {
   allowed: boolean;
   dailyUsed: number;
@@ -75,73 +47,225 @@ export interface QuotaCheck {
   monthlyLimit: number | null;
 }
 
-export function checkQuota(userId: string): QuotaCheck {
-  const db = getDb();
+export interface ProxyDB {
+  ready: Promise<void>;
+  insertUsage(record: UsageRecord): Promise<void>;
+  checkQuota(userId: string): Promise<QuotaCheck>;
+  setQuota(userId: string, dailyLimitUsd: number | null, monthlyLimitUsd: number | null): Promise<void>;
+  getUserUsage(userId: string): Promise<{ daily: number; monthly: number; total: number }>;
+  getUsageSummary(): Promise<Array<{ userId: string; daily: number; monthly: number; total: number }>>;
+  getMetricsSeed(): Promise<Array<{ user_id: string; model: string; cost: number; calls: number }>>;
+  destroy(): Promise<void>;
+}
 
-  const quota = db.prepare(
-    'SELECT daily_limit_usd, monthly_limit_usd, enabled FROM user_quotas WHERE user_id = ?'
-  ).get(userId) as { daily_limit_usd: number | null; monthly_limit_usd: number | null; enabled: number } | undefined;
+const DEFAULT_PROXY_DB_URL =
+  process.env.PROXY_DATABASE_URL ??
+  process.env.PLATFORM_DATABASE_URL ??
+  (process.env.POSTGRES_URL ? `${process.env.POSTGRES_URL}/matrixos_platform` : undefined);
 
-  if (!quota || !quota.enabled) {
-    return { allowed: true, dailyUsed: 0, dailyLimit: null, monthlyUsed: 0, monthlyLimit: null };
+export function createProxyDb(opts: string | { dialect: unknown } = DEFAULT_PROXY_DB_URL ?? ''): ProxyDB {
+  if (typeof opts === 'string' && !opts) {
+    throw new Error('Proxy Postgres URL is required: set PROXY_DATABASE_URL or PLATFORM_DATABASE_URL');
   }
 
-  const dailyUsed = (db.prepare(
-    "SELECT COALESCE(SUM(cost_usd), 0) as total FROM api_usage WHERE user_id = ? AND timestamp >= date('now')"
-  ).get(userId) as { total: number }).total;
+  let pool: pg.Pool | null = null;
+  const kysely: Kysely<ProxyDatabase> = typeof opts === 'string'
+    ? (() => {
+        pool = new pg.Pool({ connectionString: opts, max: 10 });
+        pool.on('error', (err) => {
+          console.error('[proxy-db] Idle pool client error:', err.message);
+        });
+        return new Kysely<ProxyDatabase>({ dialect: new PostgresDialect({ pool }) });
+      })()
+    : new Kysely<ProxyDatabase>({ dialect: opts.dialect as never });
 
-  const monthlyUsed = (db.prepare(
-    "SELECT COALESCE(SUM(cost_usd), 0) as total FROM api_usage WHERE user_id = ? AND timestamp >= date('now', 'start of month')"
-  ).get(userId) as { total: number }).total;
-
-  const allowed =
-    (quota.daily_limit_usd === null || dailyUsed < quota.daily_limit_usd) &&
-    (quota.monthly_limit_usd === null || monthlyUsed < quota.monthly_limit_usd);
+  const ready = migrate(kysely);
 
   return {
-    allowed,
-    dailyUsed,
-    dailyLimit: quota.daily_limit_usd,
-    monthlyUsed,
-    monthlyLimit: quota.monthly_limit_usd,
+    ready,
+    async insertUsage(record) {
+      await ready;
+      await kysely
+        .insertInto('api_usage')
+        .values({
+          user_id: record.userId,
+          model: record.model,
+          input_tokens: record.inputTokens,
+          output_tokens: record.outputTokens,
+          cache_read_tokens: record.cacheReadTokens,
+          cache_write_tokens: record.cacheWriteTokens,
+          cost_usd: record.costUsd,
+          session_id: record.sessionId ?? null,
+          status: record.status,
+        })
+        .execute();
+    },
+    async checkQuota(userId) {
+      await ready;
+      const quota = await kysely
+        .selectFrom('user_quotas')
+        .select(['daily_limit_usd', 'monthly_limit_usd', 'enabled'])
+        .where('user_id', '=', userId)
+        .executeTakeFirst();
+
+      if (!quota || !quota.enabled) {
+        return { allowed: true, dailyUsed: 0, dailyLimit: null, monthlyUsed: 0, monthlyLimit: null };
+      }
+
+      const dailyUsed = await sumCost(kysely, userId, 'day');
+      const monthlyUsed = await sumCost(kysely, userId, 'month');
+
+      const allowed =
+        (quota.daily_limit_usd === null || dailyUsed < quota.daily_limit_usd) &&
+        (quota.monthly_limit_usd === null || monthlyUsed < quota.monthly_limit_usd);
+
+      return {
+        allowed,
+        dailyUsed,
+        dailyLimit: quota.daily_limit_usd,
+        monthlyUsed,
+        monthlyLimit: quota.monthly_limit_usd,
+      };
+    },
+    async setQuota(userId, dailyLimitUsd, monthlyLimitUsd) {
+      await ready;
+      await kysely
+        .insertInto('user_quotas')
+        .values({
+          user_id: userId,
+          daily_limit_usd: dailyLimitUsd,
+          monthly_limit_usd: monthlyLimitUsd,
+          enabled: true,
+        })
+        .onConflict((oc) =>
+          oc.column('user_id').doUpdateSet({
+            daily_limit_usd: dailyLimitUsd,
+            monthly_limit_usd: monthlyLimitUsd,
+          }),
+        )
+        .execute();
+    },
+    async getUserUsage(userId) {
+      await ready;
+      const [daily, monthly, total] = await Promise.all([
+        sumCost(kysely, userId, 'day'),
+        sumCost(kysely, userId, 'month'),
+        sumCost(kysely, userId, 'all'),
+      ]);
+      return { daily, monthly, total };
+    },
+    async getUsageSummary() {
+      await ready;
+      const users = await kysely
+        .selectFrom('api_usage')
+        .select('user_id')
+        .distinct()
+        .execute();
+      return Promise.all(
+        users.map(async (u) => ({
+          userId: u.user_id,
+          ...(await this.getUserUsage(u.user_id)),
+        })),
+      );
+    },
+    async getMetricsSeed() {
+      await ready;
+      const rows = await kysely
+        .selectFrom('api_usage')
+        .select((eb) => [
+          'user_id',
+          'model',
+          eb.fn.sum<number>('cost_usd').as('cost'),
+          eb.fn.countAll<number>().as('calls'),
+        ])
+        .groupBy(['user_id', 'model'])
+        .execute();
+      return rows.map((r) => ({
+        user_id: r.user_id,
+        model: r.model,
+        cost: Number(r.cost),
+        calls: Number(r.calls),
+      }));
+    },
+    async destroy() {
+      // Kysely's PostgresDialect ends the pg.Pool on destroy(); calling
+      // pool.end() again would throw "Called end on pool more than once".
+      await kysely.destroy();
+    },
   };
 }
 
-export function setQuota(userId: string, dailyLimitUsd: number | null, monthlyLimitUsd: number | null): void {
-  getDb().prepare(`
-    INSERT INTO user_quotas (user_id, daily_limit_usd, monthly_limit_usd)
-    VALUES (?, ?, ?)
-    ON CONFLICT(user_id) DO UPDATE SET daily_limit_usd = ?, monthly_limit_usd = ?
-  `).run(userId, dailyLimitUsd, monthlyLimitUsd, dailyLimitUsd, monthlyLimitUsd);
+async function sumCost(
+  kysely: Kysely<ProxyDatabase>,
+  userId: string,
+  window: 'day' | 'month' | 'all',
+): Promise<number> {
+  // Day/month boundaries follow the Postgres session timezone (UTC in our
+  // Docker/server defaults). Quotas reset at midnight in that zone, not the
+  // user's local TZ.
+  let query = kysely
+    .selectFrom('api_usage')
+    .select((eb) => eb.fn.sum<number>('cost_usd').as('total'))
+    .where('user_id', '=', userId);
+
+  if (window === 'day') {
+    query = query.where('timestamp', '>=', sql<Date>`current_date`);
+  } else if (window === 'month') {
+    query = query.where('timestamp', '>=', sql<Date>`date_trunc('month', current_date)`);
+  }
+
+  const row = await query.executeTakeFirst();
+  return Number(row?.total ?? 0);
 }
 
-export function getUserUsage(userId: string): { daily: number; monthly: number; total: number } {
-  const db = getDb();
+async function migrate(db: Kysely<ProxyDatabase>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS api_usage (
+      id BIGSERIAL PRIMARY KEY,
+      timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+      user_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens BIGINT NOT NULL DEFAULT 0,
+      output_tokens BIGINT NOT NULL DEFAULT 0,
+      cache_read_tokens BIGINT NOT NULL DEFAULT 0,
+      cache_write_tokens BIGINT NOT NULL DEFAULT 0,
+      cost_usd DOUBLE PRECISION NOT NULL DEFAULT 0,
+      session_id TEXT,
+      status INTEGER NOT NULL DEFAULT 200
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_usage_user ON api_usage(user_id)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_usage_timestamp ON api_usage(timestamp)`.execute(db);
 
-  const daily = (db.prepare(
-    "SELECT COALESCE(SUM(cost_usd), 0) as total FROM api_usage WHERE user_id = ? AND timestamp >= date('now')"
-  ).get(userId) as { total: number }).total;
-
-  const monthly = (db.prepare(
-    "SELECT COALESCE(SUM(cost_usd), 0) as total FROM api_usage WHERE user_id = ? AND timestamp >= date('now', 'start of month')"
-  ).get(userId) as { total: number }).total;
-
-  const total = (db.prepare(
-    'SELECT COALESCE(SUM(cost_usd), 0) as total FROM api_usage WHERE user_id = ?'
-  ).get(userId) as { total: number }).total;
-
-  return { daily, monthly, total };
+  await sql`
+    CREATE TABLE IF NOT EXISTS user_quotas (
+      user_id TEXT PRIMARY KEY,
+      daily_limit_usd DOUBLE PRECISION,
+      monthly_limit_usd DOUBLE PRECISION,
+      enabled BOOLEAN NOT NULL DEFAULT TRUE
+    )
+  `.execute(db);
 }
 
-export function getUsageSummary(): Array<{ userId: string; daily: number; monthly: number; total: number }> {
-  const db = getDb();
-  const users = db.prepare('SELECT DISTINCT user_id FROM api_usage').all() as Array<{ user_id: string }>;
-  return users.map(u => ({ userId: u.user_id, ...getUserUsage(u.user_id) }));
+let singleton: ProxyDB | undefined;
+
+export function getProxyDb(): ProxyDB {
+  if (!singleton) singleton = createProxyDb();
+  return singleton;
 }
 
-export function getMetricsSeed(): Array<{ user_id: string; model: string; cost: number; calls: number }> {
-  const db = getDb();
-  return db.prepare(
-    'SELECT user_id, model, SUM(cost_usd) as cost, COUNT(*) as calls FROM api_usage GROUP BY user_id, model'
-  ).all() as Array<{ user_id: string; model: string; cost: number; calls: number }>;
+export async function resetProxyDb(): Promise<void> {
+  if (singleton) {
+    await singleton.destroy();
+    singleton = undefined;
+  }
 }
+
+// Convenience re-exports for callers that don't manage the singleton themselves.
+export const insertUsage = (record: UsageRecord) => getProxyDb().insertUsage(record);
+export const checkQuota = (userId: string) => getProxyDb().checkQuota(userId);
+export const setQuota = (userId: string, daily: number | null, monthly: number | null) =>
+  getProxyDb().setQuota(userId, daily, monthly);
+export const getUserUsage = (userId: string) => getProxyDb().getUserUsage(userId);
+export const getUsageSummary = () => getProxyDb().getUsageSummary();
+export const getMetricsSeed = () => getProxyDb().getMetricsSeed();

--- a/packages/proxy/src/main.ts
+++ b/packages/proxy/src/main.ts
@@ -329,17 +329,22 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   console.log(`[proxy] Received ${signal}, shutting down`);
   server.close();
   const forceExit = setTimeout(() => process.exit(1), 6_000);
-  try {
-    await Promise.allSettled([
-      posthogErrorTracker.shutdown(),
-      resetProxyDb(),
-    ]);
-  } catch (err: unknown) {
-    console.warn('[proxy] Failed during shutdown:', err instanceof Error ? err.message : String(err));
-  } finally {
-    clearTimeout(forceExit);
-    process.exit(0);
+  // allSettled never rejects — inspect each result individually so DB pool
+  // errors don't get swallowed alongside PostHog flush failures.
+  const results = await Promise.allSettled([
+    posthogErrorTracker.shutdown(),
+    resetProxyDb(),
+  ]);
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.warn(
+        '[proxy] Failed during shutdown:',
+        result.reason instanceof Error ? result.reason.message : String(result.reason),
+      );
+    }
   }
+  clearTimeout(forceExit);
+  process.exit(0);
 }
 
 process.once('SIGTERM', () => {

--- a/packages/proxy/src/main.ts
+++ b/packages/proxy/src/main.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { serve } from '@hono/node-server';
 import { installPostHogHonoErrorTracking } from '@matrix-os/observability';
-import { insertUsage, checkQuota, setQuota, getUserUsage, getUsageSummary, getMetricsSeed } from './db.js';
+import { insertUsage, checkQuota, setQuota, getUserUsage, getUsageSummary, getMetricsSeed, resetProxyDb } from './db.js';
 import { calculateCost } from './cost.js';
 import { proxyMetricsRegistry, apiCallsTotal, apiCostTotal, quotaRejections } from './metrics.js';
 import { isAuthorizedProxyAdminRequest, parseProxyApiKey } from './auth.js';
@@ -95,19 +95,19 @@ app.post('/send/:targetHandle', async (c) => {
 });
 
 // Usage endpoints
-app.get('/usage/:userId', (c) => {
+app.get('/usage/:userId', async (c) => {
   if (!isAuthorizedProxyAdminRequest(c.req.raw.headers, PROXY_ADMIN_TOKEN)) {
     return c.json({ error: 'Unauthorized' }, 401);
   }
-  const usage = getUserUsage(c.req.param('userId'));
+  const usage = await getUserUsage(c.req.param('userId'));
   return c.json(usage);
 });
 
-app.get('/usage/summary', (c) => {
+app.get('/usage/summary', async (c) => {
   if (!isAuthorizedProxyAdminRequest(c.req.raw.headers, PROXY_ADMIN_TOKEN)) {
     return c.json({ error: 'Unauthorized' }, 401);
   }
-  return c.json(getUsageSummary());
+  return c.json(await getUsageSummary());
 });
 
 app.post('/quotas/:userId', async (c) => {
@@ -115,7 +115,7 @@ app.post('/quotas/:userId', async (c) => {
     return c.json({ error: 'Unauthorized' }, 401);
   }
   const body = await c.req.json<{ dailyLimitUsd?: number | null; monthlyLimitUsd?: number | null }>();
-  setQuota(c.req.param('userId'), body.dailyLimitUsd ?? null, body.monthlyLimitUsd ?? null);
+  await setQuota(c.req.param('userId'), body.dailyLimitUsd ?? null, body.monthlyLimitUsd ?? null);
   return c.json({ ok: true });
 });
 
@@ -132,7 +132,7 @@ app.all('/v1/*', async (c) => {
   const sessionId = c.req.header('x-matrix-session') ?? undefined;
 
   // Check quota
-  const quota = checkQuota(userId);
+  const quota = await checkQuota(userId);
   if (!quota.allowed) {
     quotaRejections.inc({ user_id: userId });
     return c.json({
@@ -228,7 +228,7 @@ app.all('/v1/*', async (c) => {
 
   const costUsd = calculateCost({ model, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens });
 
-  insertUsage({
+  await insertUsage({
     userId, model, inputTokens, outputTokens,
     cacheReadTokens, cacheWriteTokens, costUsd,
     sessionId, status: upstream.status,
@@ -297,7 +297,7 @@ async function collectStreamUsage(
   }
 
   const costUsd = calculateCost({ model, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens });
-  insertUsage({
+  await insertUsage({
     userId, model, inputTokens, outputTokens,
     cacheReadTokens, cacheWriteTokens, costUsd,
     sessionId, status,
@@ -310,7 +310,7 @@ async function collectStreamUsage(
 }
 
 // Seed Prometheus counters from DB so metrics survive restarts
-for (const row of getMetricsSeed()) {
+for (const row of await getMetricsSeed()) {
   apiCallsTotal.inc({ user_id: row.user_id, model: row.model, status: '200' }, row.calls);
   if (row.cost > 0) {
     apiCostTotal.inc({ user_id: row.user_id, model: row.model }, row.cost);
@@ -330,7 +330,10 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   server.close();
   const forceExit = setTimeout(() => process.exit(1), 6_000);
   try {
-    await posthogErrorTracker.shutdown();
+    await Promise.allSettled([
+      posthogErrorTracker.shutdown(),
+      resetProxyDb(),
+    ]);
   } catch (err: unknown) {
     console.warn('[proxy] Failed during shutdown:', err instanceof Error ? err.message : String(err));
   } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,22 +477,28 @@ importers:
       '@matrix-os/observability':
         specifier: workspace:*
         version: link:../observability
-      better-sqlite3:
-        specifier: ^12.10.0
-        version: 12.10.0
       hono:
         specifier: ^4.11.9
         version: 4.12.8
+      kysely:
+        specifier: ^0.28.13
+        version: 0.28.14
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
     devDependencies:
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
       '@types/node':
         specifier: ^25.2.3
         version: 25.5.0
+      '@types/pg':
+        specifier: ^8.15.6
+        version: 8.20.0
+      kysely-pglite:
+        specifier: ^0.6.1
+        version: 0.6.1(@electric-sql/pglite@0.4.1)(better-sqlite3@12.10.0)(kysely@0.28.14)(pg@8.21.0)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -21898,7 +21904,7 @@ snapshots:
   '@types/pg@8.15.6':
     dependencies:
       '@types/node': 25.5.0
-      pg-protocol: 1.13.0
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/pg@8.20.0':
@@ -21975,7 +21981,7 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 25.5.0
 
   '@types/ws@8.18.1':
     dependencies:

--- a/tests/proxy/db.test.ts
+++ b/tests/proxy/db.test.ts
@@ -65,6 +65,31 @@ describe("proxy db (Postgres)", () => {
     expect(check.monthlyLimit).toBeNull();
   });
 
+  it("getUsageSummary rolls up daily/monthly/total per user in a single query", async () => {
+    await db.insertUsage({
+      userId: "alice", model: "opus-4", inputTokens: 0, outputTokens: 0,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.10, status: 200,
+    });
+    await db.insertUsage({
+      userId: "alice", model: "haiku", inputTokens: 0, outputTokens: 0,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.02, status: 200,
+    });
+    await db.insertUsage({
+      userId: "bob", model: "opus-4", inputTokens: 0, outputTokens: 0,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.50, status: 200,
+    });
+
+    const summary = await db.getUsageSummary();
+    const alice = summary.find((u) => u.userId === "alice");
+    const bob = summary.find((u) => u.userId === "bob");
+    expect(alice).toMatchObject({ userId: "alice" });
+    expect(alice?.total).toBeCloseTo(0.12);
+    expect(alice?.daily).toBeCloseTo(0.12);
+    expect(alice?.monthly).toBeCloseTo(0.12);
+    expect(bob?.total).toBeCloseTo(0.50);
+    expect(summary).toHaveLength(2);
+  });
+
   it("getMetricsSeed groups by user_id and model", async () => {
     await db.insertUsage({
       userId: "alice", model: "opus-4", inputTokens: 0, outputTokens: 0,

--- a/tests/proxy/db.test.ts
+++ b/tests/proxy/db.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { KyselyPGlite } from "kysely-pglite";
+import {
+  createProxyDb,
+  type ProxyDB,
+} from "../../packages/proxy/src/db.js";
+
+describe("proxy db (Postgres)", () => {
+  let pglite: InstanceType<typeof KyselyPGlite>;
+  let db: ProxyDB;
+
+  beforeEach(async () => {
+    pglite = await KyselyPGlite.create();
+    db = createProxyDb({ dialect: pglite.dialect });
+    await db.ready;
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("insertUsage + getUserUsage rolls up cost for a user", async () => {
+    await db.insertUsage({
+      userId: "alice", model: "opus-4", inputTokens: 10, outputTokens: 20,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.05, status: 200,
+    });
+    await db.insertUsage({
+      userId: "alice", model: "haiku", inputTokens: 5, outputTokens: 5,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.002, status: 200,
+    });
+
+    const usage = await db.getUserUsage("alice");
+    expect(usage.total).toBeCloseTo(0.052);
+    expect(usage.daily).toBeCloseTo(0.052);
+    expect(usage.monthly).toBeCloseTo(0.052);
+  });
+
+  it("setQuota upserts and checkQuota enforces daily limit", async () => {
+    await db.setQuota("bob", 0.01, null);
+
+    let check = await db.checkQuota("bob");
+    expect(check.allowed).toBe(true);
+    expect(check.dailyLimit).toBeCloseTo(0.01);
+
+    await db.insertUsage({
+      userId: "bob", model: "opus-4", inputTokens: 1, outputTokens: 1,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.02, status: 200,
+    });
+
+    check = await db.checkQuota("bob");
+    expect(check.allowed).toBe(false);
+    expect(check.dailyUsed).toBeCloseTo(0.02);
+
+    // setQuota again — verifies ON CONFLICT upsert path
+    await db.setQuota("bob", 1.0, null);
+    check = await db.checkQuota("bob");
+    expect(check.allowed).toBe(true);
+    expect(check.dailyLimit).toBeCloseTo(1.0);
+  });
+
+  it("checkQuota returns allowed=true for users with no quota row", async () => {
+    const check = await db.checkQuota("never-seen");
+    expect(check.allowed).toBe(true);
+    expect(check.dailyLimit).toBeNull();
+    expect(check.monthlyLimit).toBeNull();
+  });
+
+  it("getMetricsSeed groups by user_id and model", async () => {
+    await db.insertUsage({
+      userId: "alice", model: "opus-4", inputTokens: 0, outputTokens: 0,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.10, status: 200,
+    });
+    await db.insertUsage({
+      userId: "alice", model: "opus-4", inputTokens: 0, outputTokens: 0,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.05, status: 200,
+    });
+    await db.insertUsage({
+      userId: "bob", model: "haiku", inputTokens: 0, outputTokens: 0,
+      cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0.001, status: 200,
+    });
+
+    const seed = await db.getMetricsSeed();
+    const aliceOpus = seed.find((r) => r.user_id === "alice" && r.model === "opus-4");
+    const bobHaiku = seed.find((r) => r.user_id === "bob" && r.model === "haiku");
+    expect(aliceOpus?.calls).toBe(2);
+    expect(aliceOpus?.cost).toBeCloseTo(0.15);
+    expect(bobHaiku?.calls).toBe(1);
+    expect(bobHaiku?.cost).toBeCloseTo(0.001);
+  });
+});


### PR DESCRIPTION
Replaces better-sqlite3 with Kysely + pg, matching the project-wide "PostgreSQL via Kysely" rule in CLAUDE.md. Adds PROXY_DATABASE_URL with fallback to PLATFORM_DATABASE_URL, removes the SQLite file path default and the proxy-data Docker volume. Tests use kysely-pglite (in-memory PG) following tests/platform/platform-db-test-helper.ts.

Behavior change: host-mode bun run dev now requires a Postgres available (Homebrew or Docker). README documents both paths. Docker stack unchanged for users -- PROXY_DATABASE_URL defaults to the existing postgres service.

Also wires DB pool cleanup into the SIGTERM/SIGINT shutdown handler via resetProxyDb() so the pool doesn't outlive graceful shutdown.