### PR TITLE
ci(release): add dev bundle skip gate

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -18,15 +18,6 @@ on:
     branches: [main]
     tags:
       - "v*"
-    paths-ignore:
-      - "www/**"
-      - "docs/**"
-      - "specs/**"
-      - "audit/**"
-      - "README.md"
-      - "README.*"
-      - "AGENTS.md"
-      - "CLAUDE.md"
   workflow_dispatch:
     inputs:
       channel:
@@ -73,36 +64,30 @@ jobs:
       should_build: ${{ steps.decision.outputs.should_build }}
       reason: ${{ steps.decision.outputs.reason }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Decide whether to build
         id: decision
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF_TYPE: ${{ github.ref_type }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before || '' }}
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           SKIP_DEV_BUNDLE_INPUT: ${{ github.event.inputs.skip_dev_bundle || 'false' }}
         run: |
           set -euo pipefail
 
-          should_build=true
-          reason="host bundle build required"
-
-          if [ "$SKIP_DEV_BUNDLE_INPUT" = "true" ]; then
-            should_build=false
-            reason="skip_dev_bundle workflow input was true"
-          elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
-            reason="tag releases always build by default"
-          elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
-            case "$HEAD_COMMIT_MESSAGE" in
-              *"[skip dev-bundle]"*|*"[skip dev bundle]"*|*"Skip-Dev-Bundle: true"*|*"skip-dev-bundle: true"*|*"skip_dev_bundle: true"*)
-                should_build=false
-                reason="commit message requested dev bundle skip"
-                ;;
-            esac
+          changed_files=""
+          zero_sha="0000000000000000000000000000000000000000"
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_TYPE" = "branch" ]; then
+            if [ -n "${GITHUB_EVENT_BEFORE:-}" ] && [ "$GITHUB_EVENT_BEFORE" != "$zero_sha" ] && git cat-file -e "${GITHUB_EVENT_BEFORE}^{commit}" 2>/dev/null; then
+              changed_files="$(git diff --name-only "$GITHUB_EVENT_BEFORE" "$GITHUB_SHA")"
+            else
+              changed_files="$(git show --pretty= --name-only "$GITHUB_SHA")"
+            fi
           fi
 
-          echo "should_build=$should_build" >> "$GITHUB_OUTPUT"
-          echo "reason=$reason" >> "$GITHUB_OUTPUT"
-          echo "Dev bundle gate: $reason"
+          CHANGED_FILES="$changed_files" scripts/ci/dev-bundle-gate.sh
 
   test:
     name: Test

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -18,6 +18,15 @@ on:
     branches: [main]
     tags:
       - "v*"
+    paths-ignore:
+      - "www/**"
+      - "docs/**"
+      - "specs/**"
+      - "audit/**"
+      - "README.md"
+      - "README.*"
+      - "AGENTS.md"
+      - "CLAUDE.md"
   workflow_dispatch:
     inputs:
       channel:
@@ -43,6 +52,11 @@ on:
         required: false
         default: ""
         type: string
+      skip_dev_bundle:
+        description: "Skip dev host-bundle build/publish for metadata-only stack layers"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -52,8 +66,48 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  dev-bundle-gate:
+    name: Dev bundle gate
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.decision.outputs.should_build }}
+      reason: ${{ steps.decision.outputs.reason }}
+    steps:
+      - name: Decide whether to build
+        id: decision
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          SKIP_DEV_BUNDLE_INPUT: ${{ github.event.inputs.skip_dev_bundle || 'false' }}
+        run: |
+          set -euo pipefail
+
+          should_build=true
+          reason="host bundle build required"
+
+          if [ "$SKIP_DEV_BUNDLE_INPUT" = "true" ]; then
+            should_build=false
+            reason="skip_dev_bundle workflow input was true"
+          elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            reason="tag releases always build by default"
+          elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            case "$HEAD_COMMIT_MESSAGE" in
+              *"[skip dev-bundle]"*|*"[skip dev bundle]"*|*"Skip-Dev-Bundle: true"*|*"skip-dev-bundle: true"*|*"skip_dev_bundle: true"*)
+                should_build=false
+                reason="commit message requested dev bundle skip"
+                ;;
+            esac
+          fi
+
+          echo "should_build=$should_build" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "Dev bundle gate: $reason"
+
   test:
     name: Test
+    needs: dev-bundle-gate
+    if: needs.dev-bundle-gate.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -80,7 +134,8 @@ jobs:
 
   build:
     name: Build host bundle
-    needs: test
+    needs: [dev-bundle-gate, test]
+    if: needs.dev-bundle-gate.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -155,7 +210,8 @@ jobs:
 
   publish:
     name: Publish to R2
-    needs: build
+    needs: [dev-bundle-gate, build]
+    if: needs.dev-bundle-gate.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/scripts/ci/dev-bundle-gate.sh
+++ b/scripts/ci/dev-bundle-gate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+should_build=true
+reason="host bundle build required"
+
+is_metadata_only_change() {
+  local saw_file=false
+  local file
+
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    saw_file=true
+
+    case "$file" in
+      www/*|docs/*|specs/*|audit/*|README.md|README.*|AGENTS.md|CLAUDE.md)
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  done <<< "${CHANGED_FILES:-}"
+
+  [ "$saw_file" = true ]
+}
+
+if [ "${SKIP_DEV_BUNDLE_INPUT:-false}" = "true" ]; then
+  should_build=false
+  reason="skip_dev_bundle workflow input was true"
+elif [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+  reason="tag releases always build by default"
+elif [ "${GITHUB_EVENT_NAME:-}" = "push" ]; then
+  case "${HEAD_COMMIT_MESSAGE:-}" in
+    *"[skip dev-bundle]"*|*"[skip dev bundle]"*|*"Skip-Dev-Bundle: true"*|*"skip-dev-bundle: true"*|*"skip_dev_bundle: true"*)
+      should_build=false
+      reason="commit message requested dev bundle skip"
+      ;;
+  esac
+
+  if [ "$should_build" = "true" ] && is_metadata_only_change; then
+    should_build=false
+    reason="only landing/docs/readme metadata changed"
+  fi
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "should_build=$should_build"
+    echo "reason=$reason"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+echo "Dev bundle gate: $reason"

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function runDevBundleGate(env: Record<string, string>) {
+  const root = process.cwd();
+  const tempDir = mkdtempSync(join(tmpdir(), 'matrix-dev-bundle-gate-'));
+  const outputPath = join(tempDir, 'github-output');
+
+  try {
+    const result = spawnSync('bash', [join(root, 'scripts/ci/dev-bundle-gate.sh')], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        ...env,
+      },
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+
+    return {
+      output: readFileSync(outputPath, 'utf8'),
+      stdout: result.stdout,
+    };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
 
 describe('customer VPS host bundle', () => {
   it('build script packages the systemd entrypoint binaries', () => {
@@ -120,26 +149,69 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('skip_dev_bundle:');
     expect(workflow).toContain('Dev bundle gate');
     expect(workflow).toContain('SKIP_DEV_BUNDLE_INPUT');
-    expect(workflow).toContain('[skip dev-bundle]');
-    expect(workflow).toContain('[skip dev bundle]');
-    expect(workflow).toContain('Skip-Dev-Bundle: true');
-    expect(workflow).toContain('should_build=false');
+    expect(workflow).toContain('scripts/ci/dev-bundle-gate.sh');
     expect(workflow).toContain("needs.dev-bundle-gate.outputs.should_build == 'true'");
   });
 
-  it('host bundle release workflow ignores landing page and readme-only changes', () => {
+  it('host bundle release workflow keeps tag pushes triggerable', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
 
-    expect(workflow).toContain('paths-ignore:');
-    expect(workflow).toContain('www/**');
-    expect(workflow).toContain('docs/**');
-    expect(workflow).toContain('specs/**');
-    expect(workflow).toContain('audit/**');
-    expect(workflow).toContain('README.md');
-    expect(workflow).toContain('README.*');
-    expect(workflow).toContain('AGENTS.md');
-    expect(workflow).toContain('CLAUDE.md');
+    expect(workflow).toContain('tags:');
+    expect(workflow).toContain('- "v*"');
+    expect(workflow).not.toContain('paths-ignore:');
+  });
+
+  it('dev bundle gate skips flagged stack commits', () => {
+    const result = runDevBundleGate({
+      GITHUB_EVENT_NAME: 'push',
+      GITHUB_REF_TYPE: 'branch',
+      HEAD_COMMIT_MESSAGE: 'feat: update docs [skip dev-bundle]',
+      SKIP_DEV_BUNDLE_INPUT: 'false',
+      CHANGED_FILES: 'packages/kernel/src/index.ts',
+    });
+
+    expect(result.output).toContain('should_build=false');
+    expect(result.output).toContain('reason=commit message requested dev bundle skip');
+  });
+
+  it('dev bundle gate skips landing page and readme-only branch changes', () => {
+    const result = runDevBundleGate({
+      GITHUB_EVENT_NAME: 'push',
+      GITHUB_REF_TYPE: 'branch',
+      HEAD_COMMIT_MESSAGE: 'docs: update landing page',
+      SKIP_DEV_BUNDLE_INPUT: 'false',
+      CHANGED_FILES: ['www/content/docs/index.mdx', 'docs/dev/releases.md', 'README.md', 'AGENTS.md'].join('\n'),
+    });
+
+    expect(result.output).toContain('should_build=false');
+    expect(result.output).toContain('reason=only landing/docs/readme metadata changed');
+  });
+
+  it('dev bundle gate builds tag releases even for metadata-only tag targets', () => {
+    const result = runDevBundleGate({
+      GITHUB_EVENT_NAME: 'push',
+      GITHUB_REF_TYPE: 'tag',
+      HEAD_COMMIT_MESSAGE: 'docs: release notes [skip dev-bundle]',
+      SKIP_DEV_BUNDLE_INPUT: 'false',
+      CHANGED_FILES: 'README.md',
+    });
+
+    expect(result.output).toContain('should_build=true');
+    expect(result.output).toContain('reason=tag releases always build by default');
+  });
+
+  it('dev bundle gate builds branch pushes with host-bundle-relevant changes', () => {
+    const result = runDevBundleGate({
+      GITHUB_EVENT_NAME: 'push',
+      GITHUB_REF_TYPE: 'branch',
+      HEAD_COMMIT_MESSAGE: 'feat: update gateway',
+      SKIP_DEV_BUNDLE_INPUT: 'false',
+      CHANGED_FILES: ['docs/dev/releases.md', 'packages/gateway/src/index.ts'].join('\n'),
+    });
+
+    expect(result.output).toContain('should_build=true');
+    expect(result.output).toContain('reason=host bundle build required');
   });
 
   it('update launcher triggers the sync agent update and rollback paths', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -113,6 +113,35 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('-X POST "https://app.matrix-os.com/vps/deploy"');
   });
 
+  it('host bundle release workflow can skip dev bundles for flagged stack commits', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('skip_dev_bundle:');
+    expect(workflow).toContain('Dev bundle gate');
+    expect(workflow).toContain('SKIP_DEV_BUNDLE_INPUT');
+    expect(workflow).toContain('[skip dev-bundle]');
+    expect(workflow).toContain('[skip dev bundle]');
+    expect(workflow).toContain('Skip-Dev-Bundle: true');
+    expect(workflow).toContain('should_build=false');
+    expect(workflow).toContain("needs.dev-bundle-gate.outputs.should_build == 'true'");
+  });
+
+  it('host bundle release workflow ignores landing page and readme-only changes', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('paths-ignore:');
+    expect(workflow).toContain('www/**');
+    expect(workflow).toContain('docs/**');
+    expect(workflow).toContain('specs/**');
+    expect(workflow).toContain('audit/**');
+    expect(workflow).toContain('README.md');
+    expect(workflow).toContain('README.*');
+    expect(workflow).toContain('AGENTS.md');
+    expect(workflow).toContain('CLAUDE.md');
+  });
+
   it('update launcher triggers the sync agent update and rollback paths', () => {
     const root = process.cwd();
     const updater = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-update'), 'utf8');


### PR DESCRIPTION
## Summary

- Add a dev-bundle gate to the host-bundle release workflow.
- Support manual `skip_dev_bundle` and commit-message flags such as `[skip dev-bundle]`, `[skip dev bundle]`, and `Skip-Dev-Bundle: true`.
- Skip dev host-bundle publishing for branch pushes whose changed files are limited to landing page/docs/specs/audit/README/agent-instruction metadata.
- Keep tag releases and normal relevant branch pushes building by default.
- Add executable gate-behavior tests plus workflow syntax/trigger coverage.

## Tests

- `bun run test -- tests/platform/customer-vps-host-bundle.test.ts -t "dev bundle gate|host bundle release workflow"`
- `bun run test -- tests/platform/customer-vps-host-bundle.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/host-bundle-release.yml"); puts "yaml ok"'`
- `git diff --check HEAD~3..HEAD`
- `bun run typecheck`
- `bun run check:patterns`
- `bun run test`

## Invariants

- Source of truth: GitHub Actions release workflow plus `scripts/ci/dev-bundle-gate.sh` controls whether dev host bundles build and publish.
- Lock/transaction scope: no database or release artifact mutation happens when the gate skips downstream jobs.
- Acceptable orphan states: skipped metadata-only branch pushes produce no host-bundle artifact; tag releases and relevant branch pushes still build by default.
- Auth source of truth: unchanged GitHub Actions secrets and GitHub event context.
- Deferred scope: no changes to `build-host-bundle.sh` or `publish-release.sh` packaging/publishing semantics.

Linear: MAT-45