### PR TITLE
docs(cli): add matrix tui specification

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/083-elixir-symphony"
+  "feature_directory": "specs/084-matrix-cli-tui"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,8 @@ Read these on demand, not every session:
 - Owner-local Postgres on the customer VPS for Matrix OS permission/audit data; separate homeserver database; separate Telegram bridge database; separate WhatsApp bridge database; owner-local media/cache paths covered by backup/restore policy (077-matrix-messaging-bridge)
 - TypeScript 5.5+ strict, ES modules, Node.js 24+, React 19, Next.js 16 shell/platform, Hono gateway + Hono, Zod 4 via `zod/v4`, Kysely/Postgres, existing onboarding WebSocket, existing Symphony routes, existing integrations registry/Pipedream proxy, existing terminal stack, lucide-react, Playwright/Vitest, always-on Hermes with Claude/Codex augmentation, Finna-inspired admin/control surface patterns (082-paid-beta-readiness)
 - Owner-controlled Postgres/Kysely for readiness, integration capability, agent action, admin/control activity, company context, and audit data; owner home files for inspectable onboarding completion/profile/config exports under `~/system/`; no new embedded database or ORM (082-paid-beta-readiness)
+- TypeScript 5.5+ strict, ES modules, Node.js 24+ + citty, Ink + React, ws, Zod 4, existing sync-client/gateway command clients (084-matrix-cli-tui)
+- Existing `~/.matrixos` profile/auth/config files plus owner-readable TUI preferences; no new database (084-matrix-cli-tui)
 
 - TypeScript 5.5+ strict, ES modules + node-pty (backend), @xterm/xterm + addon-webgl + addon-search + addon-serialize + addon-fit (frontend), Hono WebSocket (gateway), Zod 4 (validation) (056-terminal-upgrade)
 - Files — `~/system/terminal-sessions.json` (session metadata), `~/system/terminal-layout.json` (layout with sessionId) (056-terminal-upgrade)
@@ -354,5 +356,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/082-paid-beta-readiness/plan.md`.
+Current Spec Kit plan: `specs/084-matrix-cli-tui/plan.md`.
 <!-- SPECKIT END -->

--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -6,6 +6,16 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 `0.3.2` is the prepared CLI patch release for terminal attach input handling. It keeps the `0.3.1` shell/session features and adds stronger local terminal cleanup plus stale mouse/focus filtering so returning to an inactive attach tab does not forward mouse escape sequences into the remote shell.
 
+### Matrix CLI TUI release notes
+
+The Matrix CLI TUI work makes bare interactive `matrix` open a prompt-first terminal cockpit while preserving direct commands for scripts. The release includes:
+
+- `matrix tui` as the explicit TUI command and bare interactive launch routing for `matrix`, `matrixos`, and `mos`.
+- Prompt-first home, status aggregation, no-color/80x24-safe rendering, and command palette discovery.
+- Matrix session cockpit over the existing zellij-backed shell routes and workspace coding-session routes.
+- First-run account/profile/sync/instance surfaces and safe destructive confirmation overlays.
+- Compatibility guardrails for `--help`, `--version`, `--json`, non-TTY use, and all direct command families.
+
 ## Versioning
 
 - Use semver without a leading `v` in `packages/sync-client/package.json`.

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -17,6 +17,8 @@ curl -sL get.matrix-os.com | sh
 
 ## Usage
 
+Running `matrix` with no arguments opens the interactive TUI in an interactive terminal. Use `matrix tui` explicitly when you want the same cockpit from scripts or docs examples. Direct commands remain script-safe and continue to work exactly as command invocations.
+
 ```bash
 matrix login              # device-code flow against app.matrix-os.com
 matrix sync ~/matrixos    # start the sync daemon against the logged-in instance

--- a/specs/084-matrix-cli-tui/checklists/requirements.md
+++ b/specs/084-matrix-cli-tui/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Matrix CLI TUI
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-28  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated after incorporating MatrixTUISpec.txt and chat decisions. Implementation-specific choices are deferred to plan.md and design artifacts.

--- a/specs/084-matrix-cli-tui/contracts/action-registry.md
+++ b/specs/084-matrix-cli-tui/contracts/action-registry.md
@@ -1,0 +1,46 @@
+# Contract: TUI Action Registry
+
+## Purpose
+
+The TUI action registry is the canonical catalog for palette commands, keyboard shortcuts, help, dangerous-action confirmations, and coverage tests.
+
+## Entry Shape
+
+```ts
+type TuiAction = {
+  id: string;
+  title: string;
+  group: string;
+  aliases: string[];
+  intents: string[];
+  shortcut?: string;
+  directCommand?: string;
+  requiresContext?: string[];
+  danger: "none" | "confirm" | "exact-phrase";
+  confirmationPhrase?: string;
+  handler: "view" | "flow" | "direct-command" | "external-attach";
+};
+```
+
+## Required Groups
+
+- Account and Profile
+- Instance
+- Status and Doctor
+- File Sync and Peers
+- Shell and Remote Run
+- Projects and Worktrees
+- Sessions and Agents
+- Reviews
+- Tasks
+- Previews
+- Workspace Data
+- Utility
+
+## Invariants
+
+- Every current command family has at least one action.
+- Every destructive action has `danger` other than `none`.
+- Workspace data deletion uses `exact-phrase` with `delete project workspace data`.
+- Search matches title, group, aliases, intents, and known object labels.
+- Direct command equivalents remain descriptive; the TUI handler is responsible for safe validation and feedback.

--- a/specs/084-matrix-cli-tui/contracts/cli-launch.md
+++ b/specs/084-matrix-cli-tui/contracts/cli-launch.md
@@ -1,0 +1,28 @@
+# Contract: CLI Launch Routing
+
+## Interactive Default
+
+- `matrix`, `matrixos`, and `mos` with no arguments open the TUI when stdin and stdout are interactive terminals.
+- `matrix tui` explicitly opens the TUI.
+
+## Direct Command Preservation
+
+The following never open the default TUI unless explicitly requested:
+
+- `matrix --help`
+- `matrix help`
+- `matrix --version`
+- `matrix <existing-command>`
+- Any explicit command with `--json`
+
+## Non-Interactive Behavior
+
+When stdout is not interactive, bare `matrix` must not render the TUI. It returns concise help or an existing machine-safe response and exits successfully unless the existing CLI conventions dictate otherwise.
+
+## Required Tests
+
+- Bare TTY launch routes to TUI.
+- Bare non-TTY launch does not route to TUI.
+- Help/version/direct subcommands bypass TUI.
+- `matrix tui` routes to TUI.
+- Aliases `matrixos` and `mos` follow the same rules.

--- a/specs/084-matrix-cli-tui/contracts/gateway-clients.md
+++ b/specs/084-matrix-cli-tui/contracts/gateway-clients.md
@@ -1,0 +1,45 @@
+# Contract: Gateway And Daemon Clients
+
+## Common Rules
+
+- Resolve profile and auth through existing CLI profile/auth logic.
+- Include bearer auth for gateway requests when available.
+- Every network request has a timeout.
+- Every daemon IPC request has a timeout and response size cap.
+- Client-visible errors use safe codes/messages and do not expose raw internals.
+
+## Main Kernel Stream
+
+The home prompt uses the existing main WebSocket message protocol:
+
+```json
+{ "type": "message", "text": "user text", "sessionId": "optional", "requestId": "optional" }
+```
+
+Supported client-side control messages include:
+
+```json
+{ "type": "switch_session", "sessionId": "session id" }
+{ "type": "approval_response", "id": "approval id", "approved": true }
+{ "type": "abort", "requestId": "request id" }
+{ "type": "ping" }
+```
+
+The TUI consumes server messages as streaming assistant output, tool/activity state, session switch/init state, errors, and abort/completion state.
+
+## Shell And Coding Sessions
+
+- Shell sessions use existing shell/session list/create/attach/remove/tab/pane/layout clients.
+- Coding sessions use workspace session routes for start/list/get/send/observe/takeover/kill.
+- Native zellij attach details are displayed as details/copy affordances, not the primary product language.
+
+## Workspace Families
+
+TUI clients cover projects, worktrees, agents, reviews, tasks, previews, workspace events, export, and delete using existing gateway surfaces before adding new endpoints.
+
+## Safety Requirements
+
+- Preview URLs are validated before submission.
+- Paths and cwd values are validated before submission.
+- Session/project/task/review/preview identifiers are encoded and bounded.
+- Mutating flows only clear local UI state after server confirmation.

--- a/specs/084-matrix-cli-tui/contracts/tui-flows.md
+++ b/specs/084-matrix-cli-tui/contracts/tui-flows.md
@@ -1,0 +1,39 @@
+# Contract: TUI User Flows
+
+## Home
+
+- Prompt-first layout with compact status and next action.
+- Shows logged-out, healthy, degraded, busy, and blocked states.
+- Mascot is compact and disappears before critical text is hidden.
+
+## Command Palette
+
+- Opens with `/` and command shortcut.
+- Supports search by command, alias, intent, and object name.
+- Selecting an action opens a view, starts a flow, runs a direct command equivalent, or attaches externally.
+
+## Confirmation Overlay
+
+- Opens without layout shift.
+- Escape cancels.
+- Confirm requires a second deliberate action.
+- Exact-phrase actions require typing the phrase.
+
+## Sessions Cockpit
+
+- Shows shell and coding sessions in one switcher with kind, status, context, age, and attention state.
+- Enter opens details or default attach action according to selected row type.
+- Attach/takeover/observe actions return the user to the TUI after detach when possible.
+
+## First Run
+
+- Logged-out home shows login as primary action.
+- Login completion refreshes profile/auth/instance/sync state.
+- Missing sync setup offers default sync root and manual entry.
+
+## Accessibility
+
+- Keyboard-only operation.
+- 80x24 usable layout.
+- No-color mode retains status readability.
+- Decorative glyphs are never required for comprehension.

--- a/specs/084-matrix-cli-tui/data-model.md
+++ b/specs/084-matrix-cli-tui/data-model.md
@@ -1,0 +1,109 @@
+# Data Model: Matrix CLI TUI
+
+## CLI Entrypoint
+
+- **Fields**: binary alias, raw args, parsed command, stdout/stderr interactivity, json/no-color flags, resolved launch mode.
+- **Relationships**: selects either direct command execution or TUI runtime.
+- **Validation**: direct commands always win over default TUI except explicit `tui`; non-TTY disables interactive launch.
+
+## TUI Runtime State
+
+- **Fields**: active view, selected item, palette query, modal state, pending confirmation, refresh status, safe error, terminal dimensions, color mode.
+- **Relationships**: reads status snapshot and action registry; opens views and flows.
+- **Validation**: state must stay serializable except live renderer handles; narrow terminals hide decorative content first.
+
+## Action Registry Entry
+
+- **Fields**: id, title, group, aliases, intent phrases, shortcut, required context, danger level, confirmation policy, direct command equivalent, handler kind.
+- **Relationships**: powers command palette, help, keyboard shortcuts, coverage tests, and flow routing.
+- **Validation**: every command family in the spec must have at least one registry entry; dangerous entries require confirmation policy.
+
+## Status Snapshot
+
+- **Fields**: profile, auth, identity, instance, gateway, platform, sync, peers, sessions, projects, agents, reviews, blocking actions, refreshedAt.
+- **Relationships**: displayed on home, doctor/status views, and first-run flow.
+- **Validation**: each subsystem can be healthy, degraded, offline, unknown, or unauthenticated without failing the whole snapshot.
+
+## Profile
+
+- **Fields**: name, active flag, platform URL, gateway URL, source, dev flag.
+- **Relationships**: owns auth lookup and all gateway/client requests.
+- **Validation**: profile names and URLs must be validated before editing or use.
+
+## Auth State
+
+- **Fields**: authenticated, expired, rejected, identity handle, user id, recovery action.
+- **Relationships**: belongs to a profile and gates mutating actions.
+- **Validation**: missing/expired/rejected tokens produce recoverable TUI states.
+
+## Matrix Instance
+
+- **Fields**: handle/name, gateway URL, platform URL, health, logs availability, restart eligibility, last checked.
+- **Relationships**: active runtime for profile-scoped commands.
+- **Validation**: restart is destructive and requires confirmation.
+
+## Sync State
+
+- **Fields**: daemon state, sync path, gateway subtree, pause/running state, peer count, manifest version, file count, last sync time.
+- **Relationships**: displayed on home and sync view; controlled through daemon IPC and sync config.
+- **Validation**: daemon errors, stale sockets, and oversized/invalid responses become safe degraded states.
+
+## Shell Session
+
+- **Fields**: name, status, cwd, created/updated time, tabs, panes, layouts, attach state, native attach command.
+- **Relationships**: backed by zellij runtime; managed by shell/session views.
+- **Validation**: names, cwd, layout, pane ids, and tab indexes must be validated; removal requires confirmation.
+
+## Coding Session
+
+- **Fields**: id, kind, status, project slug, worktree id, task id, pull request, agent, runtime, timeline, write mode, terminal session id.
+- **Relationships**: links projects, tasks, agents, reviews, and shell runtime.
+- **Validation**: observe/takeover/write/kill actions must validate session id and current capability.
+
+## Project
+
+- **Fields**: slug, display name, repository identity, branches, pull requests, worktrees, tasks, previews, sessions, reviews, recent activity.
+- **Relationships**: parent for coding work and workspace data.
+- **Validation**: project slugs and repository URLs must be validated; removal requires confirmation.
+
+## Worktree
+
+- **Fields**: id, project slug, branch or pull request, path, dirty state, active sessions, created/updated time.
+- **Relationships**: scoped to project and used by sessions/reviews.
+- **Validation**: dirty removal requires explicit dirty-delete confirmation.
+
+## Agent
+
+- **Fields**: name, provider/tool identity, availability, sandbox status, attention state.
+- **Relationships**: selected for coding sessions and review flows.
+- **Validation**: unavailable agents are visible but not startable without recovery guidance.
+
+## Review
+
+- **Fields**: id, project slug, worktree id, pull request, status, round, findings summary, next action.
+- **Relationships**: links project/worktree/agent activity.
+- **Validation**: approve/next/stop require current review state to allow action.
+
+## Task
+
+- **Fields**: id, project slug, title, priority, status, archived/deleted state, linked sessions.
+- **Relationships**: can start coding sessions and appear in project detail.
+- **Validation**: delete requires confirmation; archive does not silently remove linked history.
+
+## Preview
+
+- **Fields**: id, project slug, task id, session id, label, URL, last status, updated time.
+- **Relationships**: attached to project/task/session work.
+- **Validation**: URLs must be validated before add/open/copy actions; removal requires confirmation.
+
+## Workspace Event
+
+- **Fields**: id, type, timestamp, scope, status, summary, payload summary.
+- **Relationships**: filterable by project, task, session, review, preview, and status.
+- **Validation**: event display must avoid raw provider/server error leakage.
+
+## TUI Preference
+
+- **Fields**: theme, no-color preference, default view, shortcut help visibility, mascot visibility, native writeback choices.
+- **Relationships**: belongs to the local owner and influences TUI rendering only.
+- **Validation**: must be owner-readable, non-secret, and safe to recover from malformed content.

--- a/specs/084-matrix-cli-tui/plan.md
+++ b/specs/084-matrix-cli-tui/plan.md
@@ -1,0 +1,95 @@
+# Implementation Plan: Matrix CLI TUI
+
+**Branch**: `084-matrix-cli-tui` | **Date**: 2026-05-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/084-matrix-cli-tui/spec.md`
+
+## Summary
+
+Build the Matrix CLI TUI as the default interactive experience for `matrix`, `matrixos`, and `mos`. The published CLI gains a prompt-first, status-aware terminal cockpit with a command palette, first-run setup, safe account/sync/instance flows, zellij-backed shell/session management, and workspace/coding controls while preserving every direct command for scripts and power users.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.5+ strict, ES modules, Node.js 24+  
+**Primary Dependencies**: citty, Ink + React, ws, Zod 4, existing sync-client/gateway command clients  
+**Storage**: Existing `~/.matrixos` profile/auth/config files plus owner-readable TUI preferences; no new database  
+**Testing**: Vitest unit/render/client tests, existing gateway/session tests, root typecheck and pattern checks  
+**Target Platform**: Published Matrix CLI on macOS/Linux terminals, local source development, customer/dev VPS gateways  
+**Project Type**: CLI package with gateway integrations and public docs  
+**Performance Goals**: First paint within 1 second when local state is readable; status refresh completes within bounded timeouts; session attach begins within existing shell attach latency  
+**Constraints**: Preserve direct CLI command compatibility; no unbounded fetch/daemon/WebSocket waits; safe errors only; 80x24 and no-color support; no new persistence system  
+**Scale/Scope**: Full current Matrix CLI command-family surface, implemented as stacked PR milestones to satisfy PR size limits
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Data Belongs to Its Owner**: PASS. TUI state is owner-readable under existing CLI/home configuration locations; no platform-owned persistence or new database.
+- **AI Is the Kernel**: PASS. Prompt and agent flows route through existing gateway/kernel/session paths rather than adding a separate backend brain.
+- **Headless Core, Multi-Shell**: PASS. CLI is a shell renderer over the gateway/kernel and zellij/session substrate; core behavior remains headless.
+- **Defense in Depth**: PASS WITH DESIGN REQUIREMENTS. Plan requires auth reuse, input validation, bounded calls, safe client errors, destructive confirmations, and WebSocket/client contracts.
+- **TDD**: PASS. Test-first implementation is required for launch routing, registry coverage, status aggregation, rendering, clients, and destructive confirmations.
+- **Worktree/PR/Greptile**: PASS. Work is in a manual feature worktree and should ship as stacked PRs with Greptile 5/5 before merge.
+- **Documentation-Driven Development**: PASS. Public CLI docs updates are included.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/084-matrix-cli-tui/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── action-registry.md
+│   ├── cli-launch.md
+│   ├── gateway-clients.md
+│   └── tui-flows.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+packages/sync-client/
+├── src/cli/
+│   ├── index.ts
+│   ├── tui/
+│   │   ├── app.tsx
+│   │   ├── actions.ts
+│   │   ├── clients.ts
+│   │   ├── status.ts
+│   │   ├── state.ts
+│   │   └── views/
+│   └── commands/
+├── tests/
+│   ├── unit/
+│   └── tui/
+└── package.json
+
+www/content/docs/guide/cli.mdx
+```
+
+**Structure Decision**: Implement the production TUI inside the published `packages/sync-client` CLI package. Reuse the root `bin/tui` prototype only as reference and avoid making the private repo-root CLI the source of truth.
+
+## Complexity Tracking
+
+No constitution violations or exceptional complexity waivers are required.
+
+## Phase 0 Research Summary
+
+See [research.md](./research.md). Decisions resolved: Ink + React for v1, prompt-first home, explicit launch routing, shared action registry, bounded status aggregation, zellij as hidden substrate, gateway `/ws` for prompt streaming, and owner-readable preference storage.
+
+## Phase 1 Design Summary
+
+See [data-model.md](./data-model.md) and [contracts/](./contracts/). The design defines CLI/TUI runtime entities, command/action contracts, launch behavior, gateway client behavior, destructive-confirmation rules, and user flow contracts.
+
+## Post-Design Constitution Check
+
+- **Data Ownership**: PASS. TUI preference data is owner-readable and secrets remain in existing auth stores.
+- **Headless/Multi-Shell**: PASS. No core coupling to Ink; CLI uses existing gateway and session surfaces.
+- **Defense in Depth**: PASS. Contracts require auth propagation, input validation, timeouts, safe errors, no wildcard new trust boundary, and confirmation gates.
+- **TDD**: PASS. Quickstart and later tasks must start with failing tests before implementation.
+- **Worktree/PR Discipline**: PASS. Feature is scoped for stacked PRs.

--- a/specs/084-matrix-cli-tui/pr-notes.md
+++ b/specs/084-matrix-cli-tui/pr-notes.md
@@ -1,0 +1,34 @@
+# PR Notes: Matrix CLI TUI
+
+## Stack review note
+
+- This bottom spec/docs PR intentionally leaves `tasks.md` unchecked and `spec.md` ready for implementation; the implementation and final completion markers live in the upper Graphite stack PRs.
+
+## Invariants
+
+### Source of truth
+
+- Existing CLI profile/auth/config files remain the source of truth for local account and gateway resolution.
+- Existing gateway workspace/session routes remain the source of truth for shell, coding, project, worktree, review, task, preview, and workspace data.
+- TUI preferences are local, owner-readable, non-secret display preferences only.
+
+### Lock/transaction scope
+
+- This stack adds client-side TUI wrappers and does not add server-side persistence, database writes, or transaction scopes.
+- Gateway mutations continue to use their existing route/service transaction and validation behavior.
+
+### Acceptable orphan states
+
+- TUI actions do not clear local UI state until the underlying client operation resolves.
+- Partial status failures degrade the affected subsystem and show safe recovery-oriented state instead of failing the whole TUI.
+
+### Auth source of truth
+
+- Bearer auth continues to come from the existing profile token store or explicit `--token` path.
+- Missing, expired, or rejected auth produces first-run/login recovery views and does not expose token contents.
+
+### Deferred scope
+
+- This stack does not add new gateway APIs or change zellij as the runtime substrate.
+- Native terminal attach remains a handoff through existing clients; richer embedded terminal behavior is deferred.
+- The feature should ship as the planned Graphite stack layers rather than one oversized PR.

--- a/specs/084-matrix-cli-tui/quickstart.md
+++ b/specs/084-matrix-cli-tui/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: Matrix CLI TUI
+
+## Prerequisites
+
+- Use the manual feature worktree for `084-matrix-cli-tui`.
+- Install dependencies from the repository root after dependency changes.
+- Keep direct CLI command behavior compatible throughout implementation.
+
+## Implementation Validation Loop
+
+1. Add failing tests for launch routing and action registry coverage.
+2. Implement the minimum TUI entrypoint and route bare interactive `matrix` to it.
+3. Add failing render tests for home, palette, no-color, and 80x24 layout.
+4. Implement status aggregation with safe partial-failure states.
+5. Add failing client tests for account/sync/instance/session/workspace flows.
+6. Implement clients and views in stacked milestones.
+7. Add destructive confirmation tests before enabling mutating actions.
+8. Update CLI docs before release.
+
+## Manual Smoke Scenarios
+
+```bash
+matrix --help
+matrix --version
+matrix status --json
+matrix tui
+matrix
+```
+
+Verify:
+
+- `matrix --help` and `matrix --version` never open TUI.
+- Bare `matrix` opens TUI only in an interactive terminal.
+- Non-interactive bare `matrix` returns concise command guidance.
+- Logged-out state shows login and command palette.
+- Logged-in state shows profile, gateway, sync, sessions, projects, and next action.
+- `/sessions` opens the session cockpit.
+- Destructive actions require confirmation.
+
+## Automated Checks
+
+```bash
+pnpm --filter @finnaai/matrix test
+pnpm --filter @finnaai/matrix build
+bun run typecheck
+bun run check:patterns
+bun run test -- tests/gateway/workspace-routes.test.ts tests/gateway/session-runtime-bridge.test.ts tests/gateway/terminal-zellij-ws.test.ts
+```
+
+## Documentation Check
+
+Update `www/content/docs/guide/cli.mdx` so it documents:
+
+- default TUI launch,
+- explicit direct command compatibility,
+- first-run login/sync setup,
+- session detach/return behavior,
+- no-color/non-interactive behavior.

--- a/specs/084-matrix-cli-tui/research.md
+++ b/specs/084-matrix-cli-tui/research.md
@@ -1,0 +1,49 @@
+# Research: Matrix CLI TUI
+
+## Decision: Build v1 with Ink + React inside `packages/sync-client`
+
+**Rationale**: The published CLI already lives in `packages/sync-client`, and Matrix is already TypeScript/React-heavy. Ink gives a fast path to the OpenCode-inspired UI while preserving existing citty commands and avoiding a second terminal stack.
+
+**Alternatives considered**: OpenTUI/Solid for closer OpenCode internals, rejected for added stack risk; zellij-native UI, rejected because Matrix needs a portable CLI control surface above zellij.
+
+## Decision: Bare interactive `matrix` opens TUI everywhere
+
+**Rationale**: The desired product feel is opening Matrix OS, not reading help. Explicit direct commands, help, version, and non-TTY behavior remain unchanged to protect automation.
+
+**Alternatives considered**: Installed-only default, rejected because local source development should match production; `matrix tui` only, rejected because it weakens the main UX shift.
+
+## Decision: Use a prompt-first, status-aware home screen
+
+**Rationale**: The OpenCode references work because the input surface is the center of gravity. Matrix also needs immediate operational state, so status appears as a compact rail/strip with blocking actions prioritized.
+
+**Alternatives considered**: Dashboard-first home, rejected as too heavy for daily launch; empty prompt-only home, rejected because Matrix must show auth, gateway, sync, and active work state.
+
+## Decision: Add a shared action registry
+
+**Rationale**: The command surface is large. A registry provides one source for palette search, keyboard shortcuts, help text, command coverage tests, destructive-action metadata, and later docs generation.
+
+**Alternatives considered**: Hard-coded per-view actions, rejected because coverage would drift; shelling out to direct commands, rejected because interactive flows need richer state and safe confirmations.
+
+## Decision: Keep zellij hidden behind Matrix sessions
+
+**Rationale**: Zellij remains the proven runtime substrate. The TUI should expose Matrix-level sessions, projects, agents, tasks, and reviews, with native zellij attach details available only when useful.
+
+**Alternatives considered**: Embed a full terminal emulator in Ink, rejected for v1 complexity; replace zellij, rejected because existing gateway/session work is already zellij-backed.
+
+## Decision: Use existing gateway and daemon surfaces before adding APIs
+
+**Rationale**: The TUI should be a shell renderer over current Matrix capabilities. Existing profile/auth, daemon IPC, shell clients, workspace routes, and main `/ws` kernel stream cover the first version.
+
+**Alternatives considered**: Add a dedicated TUI backend endpoint, rejected unless implementation discovers a specific missing read/flow that cannot be composed safely.
+
+## Decision: Store only client preferences locally
+
+**Rationale**: Profiles, auth, sync config, and runtime state already have owners. TUI-specific defaults should be owner-readable and non-secret; native writeback should use explicit adapters and avoid whole-file symlinks.
+
+**Alternatives considered**: Store all TUI state on the gateway, rejected as unnecessary; symlink vendor config wholesale, rejected because it can leak or overwrite unrelated user settings and secrets.
+
+## Decision: Require bounded calls and generic user-facing errors
+
+**Rationale**: The TUI aggregates many systems, so partial failure is normal. Every fetch, daemon request, and attach/setup action must have timeouts and safe messages to avoid hangs or internal leakage.
+
+**Alternatives considered**: Let underlying commands print raw errors, rejected because the TUI is a user-facing shell and must preserve defense-in-depth expectations.

--- a/specs/084-matrix-cli-tui/spec.md
+++ b/specs/084-matrix-cli-tui/spec.md
@@ -1,0 +1,182 @@
+# Feature Specification: Matrix CLI TUI
+
+**Feature Branch**: `084-matrix-cli-tui`  
+**Created**: 2026-05-28  
+**Status**: Ready for implementation  
+**Input**: User description: "Create an OpenCode-inspired Matrix OS terminal UI opened by matrix/matrixos/mos, using the supplied Matrix CLI TUI draft plus chat decisions: full command-family coverage, prompt-first status-aware home, zellij-backed session cockpit, Ink + React implementation direction, and bare matrix opens TUI in interactive terminals."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Open Matrix From Terminal (Priority: P1)
+
+A Matrix user runs `matrix` in an interactive terminal and lands in a clear Matrix OS control surface rather than command help. They can immediately see whether they are logged in, which profile and instance are active, whether the gateway and sync are healthy, and what action needs attention next.
+
+**Why this priority**: This makes the CLI feel like opening Matrix OS and gives every other TUI workflow a trustworthy starting point.
+
+**Independent Test**: Can be tested by launching `matrix` with different profile/auth/gateway/sync states and verifying the first screen communicates the current state and next action without extra navigation.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interactive terminal with a valid profile and reachable instance, **When** the user runs `matrix`, **Then** the TUI opens and shows the active profile, identity when available, instance, gateway state, sync state, session/project summaries, and any active work.
+2. **Given** an interactive terminal with no valid auth, **When** the user runs `matrix`, **Then** the TUI opens in a logged-out state with a clear login action and non-blocking access to help, command palette, and exit.
+3. **Given** a non-interactive environment, **When** `matrix` is run with no arguments, **Then** the interactive TUI does not open and the CLI returns concise command guidance using the existing non-interactive conventions.
+
+---
+
+### User Story 2 - Discover Actions Through Command Palette (Priority: P2)
+
+A user presses `/` or the command shortcut and searches for Matrix actions by command name, object name, alias, or plain-language intent. They can reach every existing command family without memorizing syntax.
+
+**Why this priority**: The command palette turns a large CLI surface into a discoverable daily tool while preserving direct commands for power users and scripts.
+
+**Independent Test**: Can be tested by opening the palette and confirming every command family appears, can be searched, and routes to the appropriate view, flow, or direct action.
+
+**Acceptance Scenarios**:
+
+1. **Given** the TUI home screen, **When** the user opens the command palette and searches "sessions", **Then** the session switcher and shell/coding session actions are visible.
+2. **Given** the TUI home screen, **When** the user searches for "diagnose" or "doctor", **Then** status and doctor actions are visible.
+3. **Given** an action that can destroy or restart resources, **When** it is selected from the palette, **Then** the TUI requires explicit confirmation before proceeding.
+
+---
+
+### User Story 3 - Manage Zellij-Backed Sessions Elegantly (Priority: P3)
+
+A coding user opens the session cockpit to create, inspect, switch, observe, take over, attach to, or stop shell and coding sessions. They see Matrix concepts such as sessions, agents, projects, tasks, and worktrees while zellij remains the underlying runtime detail.
+
+**Why this priority**: Session management is the daily developer workflow and the clearest place to deliver the OpenCode-inspired UX improvement.
+
+**Independent Test**: Can be tested by creating shell and agent sessions, inspecting details, attaching/detaching, observing, taking over, sending input, and safely stopping sessions from the TUI.
+
+**Acceptance Scenarios**:
+
+1. **Given** existing shell and coding sessions, **When** the user opens `/sessions`, **Then** they see a switcher with status, age, kind, context, and attention state.
+2. **Given** a selected session, **When** the user chooses attach, observe, takeover, send input, or stop, **Then** the TUI performs the requested action or asks for required confirmation.
+3. **Given** a shell session with tabs, panes, or layouts, **When** the user opens session details, **Then** tabs, panes, layouts, and native attach information are discoverable without memorizing subcommands.
+
+---
+
+### User Story 4 - Complete First-Run Setup (Priority: P4)
+
+A first-run user launches the TUI, sees missing setup state, starts login, discovers whether an instance exists, and starts file sync without reading command documentation.
+
+**Why this priority**: First-run success turns the CLI into an onboarding surface rather than a power-user-only tool.
+
+**Independent Test**: Can be tested from an empty or expired profile state by walking through login, profile discovery, instance state, and sync setup prompts.
+
+**Acceptance Scenarios**:
+
+1. **Given** no valid profile/auth exists, **When** the user runs `matrix`, **Then** the TUI presents login as the primary action while keeping command palette and exit available.
+2. **Given** login succeeds, **When** the TUI refreshes, **Then** it shows the resolved profile, gateway, platform, instance, and sync state.
+3. **Given** sync is not configured, **When** the user chooses setup sync, **Then** they can accept a default sync root or enter a path and start sync.
+
+---
+
+### User Story 5 - Preserve Scriptable CLI Behavior (Priority: P5)
+
+A power user or automation continues using direct commands, help, version, and machine-readable output exactly as before, even though bare interactive `matrix` now opens the TUI.
+
+**Why this priority**: Matrix CLI must become friendlier without breaking docs, scripts, release checks, or developer muscle memory.
+
+**Independent Test**: Can be tested by running existing direct CLI command tests and verifying no behavior change for explicit subcommands and machine-readable output.
+
+**Acceptance Scenarios**:
+
+1. **Given** any environment, **When** the user runs `matrix --help`, `matrix help`, or `matrix --version`, **Then** the CLI prints the expected non-TUI output.
+2. **Given** any explicit command such as `matrix status --json` or `matrix shell ls`, **When** it runs, **Then** the direct command path is used without opening the TUI.
+3. **Given** an automation pipeline, **When** commands use machine-readable output, **Then** payload shape and exit behavior remain compatible.
+
+---
+
+### Edge Cases
+
+- Interactive input exists but output is not a terminal, or output is piped to another process.
+- Gateway or platform is unreachable, slow, returns malformed data, or requires re-authentication.
+- Token is missing, expired, rejected, or belongs to a profile different from the active one.
+- Sync daemon socket is missing, stale, paused, or returns an oversized/invalid response.
+- Terminal is exactly 80x24, very narrow, no-color, or missing decorative glyph support.
+- User starts a destructive action by accident and cancels confirmation.
+- Session list contains stale, exited, missing-runtime, running, waiting, observed, or owner-attached sessions.
+- User detaches from an attached shell and expects to return to the TUI without killing the session.
+- A command action depends on a project, worktree, task, preview, or review that no longer exists.
+- Native writeback target for an external agent tool is missing, unreadable, or contains unrelated user configuration.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Running `matrix`, `matrixos`, or `mos` with no arguments in an interactive terminal MUST open the Matrix OS TUI.
+- **FR-002**: Running `matrix --help`, `matrix help`, `matrix --version`, `matrix tui`, or any explicit existing command MUST preserve the expected direct command behavior, except `matrix tui` explicitly opens the TUI.
+- **FR-003**: In non-interactive contexts, bare `matrix` MUST NOT launch the TUI and MUST provide concise command guidance or machine-safe behavior consistent with existing CLI conventions.
+- **FR-004**: The TUI home screen MUST show product identity, active profile, auth state, identity when available, active instance, gateway reachability, platform reachability when relevant, sync state, sync root, peers, shell sessions, projects, agent runtime status, review status, and blocking actions.
+- **FR-005**: The home screen MUST use a prompt-first layout where status and next actions are visible without turning the first view into a dense dashboard.
+- **FR-006**: The TUI MUST provide a command palette reachable from keyboard shortcuts and searchable by command name, aliases, object names, and plain-language intent.
+- **FR-007**: The command palette MUST expose every current Matrix command family: account/profile, instance, status/doctor, file sync, peers, shell, remote run, projects, worktrees, sessions, agents, reviews, tasks, previews, workspace data, utility, help, version, and completion.
+- **FR-008**: The TUI MUST provide first-run flows for login, profile discovery, instance discovery, and sync setup without requiring users to read CLI help.
+- **FR-009**: The TUI MUST provide account/profile flows for login, logout, identity display, profile listing, profile switching, profile editing, and expired-token recovery.
+- **FR-010**: The TUI MUST provide status and doctor views that distinguish auth, gateway, platform, daemon, sync, protocol, and profile configuration issues.
+- **FR-011**: The TUI MUST provide instance views for info, logs, and restart with progress and failure feedback.
+- **FR-012**: The TUI MUST provide sync views for starting sync, viewing status, pausing, resuming, viewing peers, viewing sync root, and viewing recent sync metadata.
+- **FR-013**: The TUI MUST provide shell and remote run views for session list, create, attach, remove, tabs, panes, layouts, and interactive command running.
+- **FR-014**: The TUI MUST provide a zellij-backed session cockpit that presents sessions as Matrix concepts and exposes attach, observe, takeover, send input, stop, and native attach command details.
+- **FR-015**: The TUI MUST provide project and worktree views for adding projects, listing projects, inspecting pull requests and branches, creating worktrees from branches or pull requests, listing worktrees, and removing worktrees.
+- **FR-016**: The TUI MUST provide coding session and agent views for starting sessions, listing/filtering sessions, inspecting timeline/status, sending input, observing, taking over, killing sessions, listing agents, and viewing sandbox status.
+- **FR-017**: The TUI MUST provide review views for starting, listing, watching/status, advancing, approving, and stopping review loops.
+- **FR-018**: The TUI MUST provide task views for creating, listing/filtering, starting work, archiving, removing, and inspecting resulting sessions.
+- **FR-019**: The TUI MUST provide preview views for adding, listing, opening/copying, and removing preview links.
+- **FR-020**: The TUI MUST provide workspace data views for export, project-scoped export, event browsing, filtering, and protected deletion.
+- **FR-021**: Destructive actions MUST require explicit confirmation and MUST NOT complete from a single accidental keypress.
+- **FR-022**: Workspace data deletion MUST require the exact existing confirmation phrase: `delete project workspace data`.
+- **FR-023**: User-entered URLs, paths, IDs, profile names, session names, project slugs, and command inputs MUST be validated before use or submission.
+- **FR-024**: TUI-visible errors MUST be safe for users and MUST NOT expose provider internals, raw server errors, database details, filesystem paths, or secrets.
+- **FR-025**: All status checks, network calls, daemon calls, and long-running actions initiated by the TUI MUST have bounded waits and visible fallback states.
+- **FR-026**: The TUI MUST remain usable by keyboard only and MUST support arrow keys, `j/k`, Enter, Escape, `q`, refresh, help, account/profile, sessions, projects, agents, and doctor/status shortcuts.
+- **FR-027**: The TUI MUST remain usable at 80x24 and MUST hide or simplify decorative elements before critical text becomes unreadable.
+- **FR-028**: The TUI MUST support no-color mode and MUST not rely on decorative glyphs for core status meaning.
+- **FR-029**: The 8-bit rabbit mascot MUST be decorative, compact, stateful, and never obscure or displace critical status text.
+- **FR-030**: TUI preferences and Matrix-managed configuration changes MUST be owner-readable and explainable to the user.
+- **FR-031**: Native writeback for agent/skill/tool configuration MUST avoid whole-file symlinks for vendor config files and MUST NOT symlink or copy secrets across tools.
+- **FR-032**: Direct CLI commands and machine-readable output MUST remain compatible with existing docs, release checks, and automation.
+- **FR-033**: Public CLI documentation MUST be updated to describe the default TUI, explicit command behavior, and first-run flow.
+
+### Key Entities
+
+- **CLI Entrypoint**: The command invocation context, including binary alias, arguments, interactivity, output mode, and direct-command routing.
+- **TUI Session**: The active terminal UI runtime state, including current view, palette query, selected item, modal state, refresh state, and safe error state.
+- **Profile**: A named CLI configuration containing platform and gateway connection settings and active selection state.
+- **Auth State**: The user's current authentication status, identity if known, token validity, and recovery action.
+- **Matrix Instance**: The active Matrix OS runtime associated with a profile, including handle/name, reachability, health, logs, and restart state.
+- **Sync State**: Local sync daemon status, sync root, gateway subtree, pause/running state, peers, manifest/version metadata, and last sync information.
+- **Shell Session**: A terminal session backed by the Matrix runtime, including name, status, cwd, tabs, panes, layouts, attach state, and native attach command.
+- **Coding Session**: A Matrix workspace session for shell or agent work, including kind, project, worktree, task, pull request, agent, runtime, timeline, write mode, and status.
+- **Project**: A tracked coding project with repository identity, branches, pull requests, worktrees, tasks, previews, sessions, reviews, and recent activity.
+- **Worktree**: A project workspace tied to a branch or pull request, with path, dirty state, and removal safety state.
+- **Agent**: A coding or system agent available to start or continue work, including sandbox/availability status.
+- **Review**: A review loop with project, worktree, pull request, status, rounds, findings, and available next actions.
+- **Task**: A project-scoped work item with title, priority, status, archived/deleted state, and linked sessions.
+- **Preview**: A named URL associated with a project, task, or session, including copy/open/remove actions and status.
+- **Workspace Event**: A timestamped activity item filterable by project, task, status, session, review, or preview.
+- **TUI Preference**: Owner-readable preferences for theme, no-color behavior, shortcut visibility, default view, and native writeback choices.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 90% of beta users can identify their auth, profile, gateway, and sync state within 10 seconds of launching `matrix`.
+- **SC-002**: 100% of current Matrix CLI command families are reachable from the TUI command palette.
+- **SC-003**: Existing direct CLI command tests continue passing with no machine-readable output regressions.
+- **SC-004**: A logged-out first-run user can start login from the TUI within 2 keypresses from launch.
+- **SC-005**: A logged-in user can open the session switcher and attach to an existing shell session within 5 keypresses from launch.
+- **SC-006**: 100% of destructive TUI actions require confirmation beyond the initial action selection.
+- **SC-007**: The TUI remains readable and navigable at 80 columns by 24 rows with no critical text hidden behind decorative elements.
+- **SC-008**: Gateway-offline, token-expired, daemon-stopped, and sync-paused states each produce a clear recovery action on the relevant screen.
+- **SC-009**: Users can complete sync start, pause, and resume from the TUI without consulting documentation.
+- **SC-010**: Public CLI documentation explains default TUI behavior and explicit command compatibility before release.
+
+## Assumptions
+
+- The TUI is the default interactive entrypoint for installed CLI and local source development.
+- The home screen is prompt-first and status-aware rather than dashboard-first.
+- The initial feature covers the full command-family surface, even if implementation ships in stacked milestones.
+- The mascot remains unnamed in this specification; exact pixel art can be finalized during design.
+- Zellij remains the underlying shell/session runtime, but user-facing language should emphasize Matrix sessions.
+- Native writeback should initially be explicit and explainable, with secrets excluded and vendor config files modified only through safe adapters or managed snippets.

--- a/specs/084-matrix-cli-tui/tasks.md
+++ b/specs/084-matrix-cli-tui/tasks.md
@@ -1,0 +1,296 @@
+# Tasks: Matrix CLI TUI
+
+**Input**: Design documents from `/specs/084-matrix-cli-tui/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Required. Matrix OS constitution and this feature plan require TDD; write failing tests before implementation in each phase.
+
+**Organization**: Tasks are grouped by user story to enable independently reviewable Graphite stack layers and incremental delivery.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and does not depend on incomplete tasks.
+- **[Story]**: User story label for story phases only.
+- Every task includes an exact file path.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the published CLI package and docs/spec references for the TUI work.
+
+- [ ] T001 Add Ink, React, and required React typings to `packages/sync-client/package.json`
+- [ ] T002 Run root `pnpm install` to update `pnpm-lock.yaml`
+- [ ] T003 Create TUI source directories under `packages/sync-client/src/cli/tui/`
+- [ ] T004 Create TUI test directories under `packages/sync-client/tests/tui/`
+- [ ] T005 [P] Add initial public CLI docs placeholder for TUI behavior in `www/content/docs/guide/cli.mdx`
+- [ ] T006 [P] Add exported TUI module barrel in `packages/sync-client/src/cli/tui/index.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build shared contracts, safe clients, and reusable TUI primitives needed by all stories.
+
+**CRITICAL**: No user story implementation can begin until this phase is complete.
+
+### Tests for Foundation
+
+- [ ] T007 [P] Add action registry coverage tests in `packages/sync-client/tests/tui/actions.test.ts`
+- [ ] T008 [P] Add safe gateway client timeout/error tests in `packages/sync-client/tests/tui/gateway-client.test.ts`
+- [ ] T009 [P] Add TUI preference read/write recovery tests in `packages/sync-client/tests/tui/preferences.test.ts`
+- [ ] T010 [P] Add confirmation policy tests in `packages/sync-client/tests/tui/confirmations.test.ts`
+
+### Implementation for Foundation
+
+- [ ] T011 Implement typed TUI action registry in `packages/sync-client/src/cli/tui/actions.ts`
+- [ ] T012 Implement shared timeout-bound gateway client helpers in `packages/sync-client/src/cli/tui/gateway-client.ts`
+- [ ] T013 Implement safe daemon/status adapter helpers in `packages/sync-client/src/cli/tui/daemon-client.ts`
+- [ ] T014 Implement owner-readable TUI preference loader with malformed-file recovery in `packages/sync-client/src/cli/tui/preferences.ts`
+- [ ] T015 Implement confirmation policy helpers in `packages/sync-client/src/cli/tui/confirmations.ts`
+- [ ] T016 Implement safe error normalization helpers in `packages/sync-client/src/cli/tui/errors.ts`
+- [ ] T017 Implement terminal capability helpers for TTY/no-color/80x24 detection in `packages/sync-client/src/cli/tui/terminal.ts`
+
+**Checkpoint**: Foundation ready; each user story can use common registry, client, preference, confirmation, error, and terminal helpers.
+
+---
+
+## Phase 3: User Story 1 - Open Matrix From Terminal (Priority: P1) MVP
+
+**Goal**: Bare interactive `matrix` opens a prompt-first TUI home that communicates active state and next action.
+
+**Independent Test**: Launch routing and home render tests prove interactive default behavior, non-TTY fallback, and basic status display without relying on other story flows.
+
+### Tests for User Story 1
+
+- [ ] T018 [P] [US1] Add CLI launch routing tests in `packages/sync-client/tests/tui/launch.test.ts`
+- [ ] T019 [P] [US1] Add status aggregation tests for healthy/degraded/logged-out states in `packages/sync-client/tests/tui/status.test.ts`
+- [ ] T020 [P] [US1] Add Ink render tests for prompt-first home, no-color, and 80x24 layout in `packages/sync-client/tests/tui/home-render.test.tsx`
+
+### Implementation for User Story 1
+
+- [ ] T021 [US1] Add `tui` subcommand and bare interactive launch routing in `packages/sync-client/src/cli/index.ts`
+- [ ] T022 [US1] Implement TUI entrypoint and render lifecycle in `packages/sync-client/src/cli/tui/app.tsx`
+- [ ] T023 [US1] Implement status snapshot aggregation in `packages/sync-client/src/cli/tui/status.ts`
+- [ ] T024 [US1] Implement prompt-first home view in `packages/sync-client/src/cli/tui/views/HomeView.tsx`
+- [ ] T025 [US1] Implement compact stateful mascot component in `packages/sync-client/src/cli/tui/views/Mascot.tsx`
+- [ ] T026 [US1] Wire refresh, help, quit, and safe fallback states in `packages/sync-client/src/cli/tui/state.ts`
+
+**Checkpoint**: User Story 1 works independently; `matrix` opens TUI interactively and direct/non-TTY behavior is protected.
+
+---
+
+## Phase 4: User Story 2 - Discover Actions Through Command Palette (Priority: P2)
+
+**Goal**: Users can discover every command family through a searchable command palette and protected action flows.
+
+**Independent Test**: Palette tests prove all command families are searchable and dangerous actions are gated by confirmation.
+
+### Tests for User Story 2
+
+- [ ] T027 [P] [US2] Add command palette search tests in `packages/sync-client/tests/tui/command-palette.test.tsx`
+- [ ] T028 [P] [US2] Add dangerous action confirmation render tests in `packages/sync-client/tests/tui/confirmation-render.test.tsx`
+- [ ] T029 [P] [US2] Add action registry command-family completeness tests in `packages/sync-client/tests/tui/action-coverage.test.ts`
+
+### Implementation for User Story 2
+
+- [ ] T030 [US2] Implement command palette model and fuzzy filtering in `packages/sync-client/src/cli/tui/palette.ts`
+- [ ] T031 [US2] Implement command palette view in `packages/sync-client/src/cli/tui/views/CommandPalette.tsx`
+- [ ] T032 [US2] Implement confirmation overlay view in `packages/sync-client/src/cli/tui/views/ConfirmationOverlay.tsx`
+- [ ] T033 [US2] Wire global `/`, shortcut, Escape, Enter, and modal key handling in `packages/sync-client/src/cli/tui/app.tsx`
+- [ ] T034 [US2] Populate all command-family actions in `packages/sync-client/src/cli/tui/actions.ts`
+- [ ] T035 [US2] Add help/about/completion utility views in `packages/sync-client/src/cli/tui/views/UtilityViews.tsx`
+
+**Checkpoint**: User Story 2 works independently; all command families are discoverable through the palette.
+
+---
+
+## Phase 5: User Story 3 - Manage Zellij-Backed Sessions Elegantly (Priority: P3)
+
+**Goal**: Users manage shell and coding sessions through a Matrix session cockpit while zellij remains the hidden runtime layer.
+
+**Independent Test**: Session cockpit tests cover list/detail/create/attach/observe/takeover/send/kill plus shell tabs, panes, and layouts using mocked clients.
+
+### Tests for User Story 3
+
+- [ ] T036 [P] [US3] Add shell session client tests in `packages/sync-client/tests/tui/shell-session-client.test.ts`
+- [ ] T037 [P] [US3] Add coding session client tests in `packages/sync-client/tests/tui/coding-session-client.test.ts`
+- [ ] T038 [P] [US3] Add session cockpit render/navigation tests in `packages/sync-client/tests/tui/session-cockpit.test.tsx`
+- [ ] T039 [P] [US3] Add attach/observe/takeover action tests in `packages/sync-client/tests/tui/session-actions.test.ts`
+
+### Implementation for User Story 3
+
+- [ ] T040 [US3] Implement shell session TUI client adapter in `packages/sync-client/src/cli/tui/shell-sessions.ts`
+- [ ] T041 [US3] Implement coding session TUI client adapter in `packages/sync-client/src/cli/tui/coding-sessions.ts`
+- [ ] T042 [US3] Implement unified session cockpit view in `packages/sync-client/src/cli/tui/views/SessionsView.tsx`
+- [ ] T043 [US3] Implement session detail view for timeline/status/context in `packages/sync-client/src/cli/tui/views/SessionDetailView.tsx`
+- [ ] T044 [US3] Implement shell tab/pane/layout manager views in `packages/sync-client/src/cli/tui/views/ShellRuntimeViews.tsx`
+- [ ] T045 [US3] Implement external attach/observe/takeover handoff and detach return flow in `packages/sync-client/src/cli/tui/session-actions.ts`
+- [ ] T046 [US3] Implement create session and remote run forms in `packages/sync-client/src/cli/tui/views/SessionForms.tsx`
+
+**Checkpoint**: User Story 3 works independently; `/sessions` delivers the polished zellij-backed Matrix session manager.
+
+---
+
+## Phase 6: User Story 4 - Complete First-Run Setup (Priority: P4)
+
+**Goal**: Logged-out and first-run users can log in, discover instance state, and start sync from inside the TUI.
+
+**Independent Test**: First-run tests walk logged-out, expired-token, post-login refresh, missing-instance, and sync-start flows using mocked profile/login/sync clients.
+
+### Tests for User Story 4
+
+- [ ] T047 [P] [US4] Add first-run flow tests in `packages/sync-client/tests/tui/first-run.test.tsx`
+- [ ] T048 [P] [US4] Add account/profile flow tests in `packages/sync-client/tests/tui/account-profile.test.tsx`
+- [ ] T049 [P] [US4] Add sync setup flow tests in `packages/sync-client/tests/tui/sync-flow.test.tsx`
+
+### Implementation for User Story 4
+
+- [ ] T050 [US4] Implement account/profile TUI adapters in `packages/sync-client/src/cli/tui/account.ts`
+- [ ] T051 [US4] Implement login/logout/profile views in `packages/sync-client/src/cli/tui/views/AccountViews.tsx`
+- [ ] T052 [US4] Implement first-run orchestration view in `packages/sync-client/src/cli/tui/views/FirstRunView.tsx`
+- [ ] T053 [US4] Implement sync setup/status views in `packages/sync-client/src/cli/tui/views/SyncViews.tsx`
+- [ ] T054 [US4] Implement instance status/logs/restart views in `packages/sync-client/src/cli/tui/views/InstanceViews.tsx`
+- [ ] T055 [US4] Wire post-login and post-sync refresh behavior in `packages/sync-client/src/cli/tui/state.ts`
+
+**Checkpoint**: User Story 4 works independently; a first-run user can reach login and sync setup without CLI help.
+
+---
+
+## Phase 7: User Story 5 - Preserve Scriptable CLI Behavior (Priority: P5)
+
+**Goal**: Existing explicit commands, help/version, JSON output, and automation behavior remain compatible after the default interactive TUI change.
+
+**Independent Test**: Existing command tests and new regression tests prove direct command behavior does not route through TUI.
+
+### Tests for User Story 5
+
+- [ ] T056 [P] [US5] Add direct-command regression tests in `packages/sync-client/tests/tui/direct-command-compat.test.ts`
+- [ ] T057 [P] [US5] Add JSON/non-TTY compatibility tests in `packages/sync-client/tests/tui/non-interactive-compat.test.ts`
+- [ ] T058 [P] [US5] Add CLI docs expectation tests if docs tooling supports them in `packages/sync-client/tests/tui/docs-compat.test.ts`
+
+### Implementation for User Story 5
+
+- [ ] T059 [US5] Harden direct command bypasses in `packages/sync-client/src/cli/index.ts`
+- [ ] T060 [US5] Ensure non-TTY fallback copy and exit behavior in `packages/sync-client/src/cli/tui/launch.ts`
+- [ ] T061 [US5] Update release/package validation expectations in `packages/sync-client/scripts/check-publish.mjs`
+- [ ] T062 [US5] Update CLI documentation for TUI/default/direct behavior in `www/content/docs/guide/cli.mdx`
+- [ ] T063 [US5] Update CLI README with default TUI behavior in `packages/sync-client/README.md`
+
+**Checkpoint**: User Story 5 works independently; scripts and direct commands remain compatible.
+
+---
+
+## Phase 8: Workspace Cockpit Completion (Cross-Story Full Spec Coverage)
+
+**Purpose**: Complete remaining full-spec command families beyond the MVP/session/first-run flows.
+
+- [ ] T064 [P] Add workspace client tests for projects/worktrees in `packages/sync-client/tests/tui/projects-client.test.ts`
+- [ ] T065 [P] Add workspace client tests for reviews/tasks/previews/events/export/delete in `packages/sync-client/tests/tui/workspace-client.test.ts`
+- [ ] T066 [P] Add workspace view render tests in `packages/sync-client/tests/tui/workspace-views.test.tsx`
+- [ ] T067 Implement projects/worktrees TUI client in `packages/sync-client/src/cli/tui/projects.ts`
+- [ ] T068 Implement reviews/tasks/previews/workspace data client in `packages/sync-client/src/cli/tui/workspace.ts`
+- [ ] T069 Implement projects and worktrees views in `packages/sync-client/src/cli/tui/views/ProjectViews.tsx`
+- [ ] T070 Implement reviews and tasks views in `packages/sync-client/src/cli/tui/views/ReviewTaskViews.tsx`
+- [ ] T071 Implement previews and workspace data views in `packages/sync-client/src/cli/tui/views/WorkspaceDataViews.tsx`
+- [ ] T072 Wire workspace actions into `packages/sync-client/src/cli/tui/actions.ts`
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final quality, performance, docs, and release readiness.
+
+- [ ] T073 [P] Add accessibility/no-color snapshot coverage in `packages/sync-client/tests/tui/accessibility.test.tsx`
+- [ ] T074 [P] Add malformed preference and partial status failure regression tests in `packages/sync-client/tests/tui/resilience.test.ts`
+- [ ] T075 Run and fix `pnpm --filter @finnaai/matrix test`
+- [ ] T076 Run and fix `pnpm --filter @finnaai/matrix build`
+- [ ] T077 Run and fix root `bun run typecheck`
+- [ ] T078 Run and fix root `bun run check:patterns`
+- [ ] T079 Run relevant gateway session tests from `tests/gateway/workspace-routes.test.ts`, `tests/gateway/session-runtime-bridge.test.ts`, and `tests/gateway/terminal-zellij-ws.test.ts`
+- [ ] T080 Validate quickstart scenarios from `specs/084-matrix-cli-tui/quickstart.md`
+- [ ] T081 Update release notes in `docs/dev/cli-release.md`
+- [ ] T082 Review PR body invariants and stack notes against `docs/dev/review-pipeline.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: No dependencies.
+- **Phase 2 Foundation**: Depends on Phase 1; blocks all user stories.
+- **Phase 3 US1**: Depends on Phase 2; MVP launch/home slice.
+- **Phase 4 US2**: Depends on Phase 2 and benefits from US1 app shell.
+- **Phase 5 US3**: Depends on Phase 2 and uses US2 action registry; can be developed after palette foundations exist.
+- **Phase 6 US4**: Depends on Phase 2 and US1 status/home shell.
+- **Phase 7 US5**: Depends on Phase 3 launch routing; should complete before release.
+- **Phase 8 Workspace Cockpit**: Depends on Phase 4 action registry and Phase 2 clients.
+- **Phase 9 Polish**: Depends on intended shipped phases.
+
+### User Story Dependencies
+
+- **US1**: No dependency on other stories after foundation.
+- **US2**: Requires foundation; best after US1 app shell exists.
+- **US3**: Requires foundation and action registry wiring from US2.
+- **US4**: Requires US1 home/status shell.
+- **US5**: Requires launch routing from US1.
+
+### Parallel Opportunities
+
+- T005 and T006 can run in parallel after dependency setup decisions.
+- T007 through T010 can run in parallel because they target different test files.
+- T018 through T020 can run in parallel.
+- T027 through T029 can run in parallel.
+- T036 through T039 can run in parallel.
+- T047 through T049 can run in parallel.
+- T056 through T058 can run in parallel.
+- T064 through T066 can run in parallel.
+- T073 and T074 can run in parallel.
+
+---
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "T036 Add shell session client tests in packages/sync-client/tests/tui/shell-session-client.test.ts"
+Task: "T037 Add coding session client tests in packages/sync-client/tests/tui/coding-session-client.test.ts"
+Task: "T038 Add session cockpit render/navigation tests in packages/sync-client/tests/tui/session-cockpit.test.tsx"
+Task: "T039 Add attach/observe/takeover action tests in packages/sync-client/tests/tui/session-actions.test.ts"
+```
+
+---
+
+## Graphite Stack Plan
+
+- **Stack 1: `feat(cli): add tui foundation`** — Phases 1-2. Dependency setup, TUI scaffolding, action registry, safe clients, preferences, terminal helpers, and foundational tests.
+- **Stack 2: `feat(cli): open matrix tui by default`** — Phase 3. Bare interactive launch, prompt-first home, status aggregation, mascot, and launch/home tests.
+- **Stack 3: `feat(cli): add tui command palette`** — Phase 4. Command palette, confirmation overlay, utility views, and command-family coverage.
+- **Stack 4: `feat(cli): add session cockpit`** — Phase 5. Zellij-backed Matrix session manager, shell/coding session views, attach/observe/takeover, tabs/panes/layouts.
+- **Stack 5: `feat(cli): add first-run setup flows`** — Phase 6. Login/profile/sync/instance flows.
+- **Stack 6: `feat(cli): preserve direct command compatibility`** — Phase 7. Non-TTY/direct command hardening and docs.
+- **Stack 7: `feat(cli): complete workspace cockpit`** — Phase 8. Projects, worktrees, reviews, tasks, previews, workspace data.
+- **Stack 8: `chore(cli): validate matrix tui release`** — Phase 9. Accessibility/resilience tests, release docs, full validation.
+
+Each layer must be committed independently, restacked with Graphite, kept below Matrix OS PR size limits, and submitted as a stack. Do not flatten layers unless explicitly requested.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1.
+2. Complete Phase 2.
+3. Complete Phase 3.
+4. Stop and validate `matrix`, `matrix tui`, non-TTY bare `matrix`, help/version/direct commands, and home status rendering.
+
+### Incremental Delivery
+
+1. Foundation and launch/home create a useful MVP.
+2. Command palette adds discoverability.
+3. Session cockpit delivers the daily developer UX improvement.
+4. First-run setup and direct compatibility make it release-safe.
+5. Workspace cockpit completes the full command-family spec.
+
+### TDD Rule
+
+For each phase, write and observe failing tests before implementing the corresponding code. Mark tasks complete in this file only after the test or implementation has been completed and checked.

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -32,6 +32,13 @@ matrix --version
 matrix doctor
 ```
 
+
+## Interactive TUI
+
+Running `matrix` with no arguments opens the Matrix OS terminal UI in an interactive terminal. The same experience is available explicitly with `matrix tui`, and aliases `matrixos` and `mos` follow the same routing.
+
+Direct commands such as `matrix shell ls`, `matrix login`, `matrix status --json`, `matrix --help`, and non-interactive bare invocations remain script-safe and do not render the TUI.
+
 ## First run
 
 ```bash


### PR DESCRIPTION
Summary
- Adds the Matrix CLI TUI spec, contracts, data model, quickstart, and task plan.
- Updates CLI docs/release notes so the default interactive `matrix` launch and aliases are documented.

Validation
- Stack validation run from top branch: package tests, package build, repo typecheck, pattern scan, targeted gateway regressions, and CLI smoke checks.

Invariants
- Source of truth: existing CLI profile/auth/config files and gateway routes remain canonical; this PR adds spec/docs only.
- Lock/transaction scope: no new writes, endpoints, or database transactions are introduced in this slice.
- Acceptable orphan states: documentation only; implementation failure modes are specified for the later stack branches.
- Auth source of truth: existing token/profile store and `--token` behavior remain the auth source.
- Deferred scope: no new gateway APIs, zellij remains the runtime substrate, and embedded terminal support is deferred.

