### PR TITLE
fix(cli): harden terminal mouse input

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.1` is the prepared CLI patch release for the post-onboarding PR set. It includes the user-facing `matrix run` command, shell-session attachment support, completion updates, the signup/onboarding-compatible login flow, and the canonical `matrix shell connect` fixes already present in `packages/sync-client`.
+`0.3.2` is the prepared CLI patch release for terminal attach input handling. It keeps the `0.3.1` shell/session features and adds stronger local terminal cleanup plus stale mouse/focus filtering so returning to an inactive attach tab does not forward mouse escape sequences into the remote shell.
 
 ## Versioning
 
@@ -33,7 +33,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.1`. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.2`. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -57,8 +57,8 @@ For macOS, also verify the GitHub release contains `MatrixSync-0.3.0.pkg` when t
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.1` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.2` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.0 "Use @finnaai/matrix@0.3.1"
+npm deprecate @finnaai/matrix@0.3.1 "Use @finnaai/matrix@0.3.2"
 ```

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -461,7 +461,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           settle(() => resolve({ detached: true }));
         };
         const onProcessExit = () => {
-          output.write(LOCAL_TERMINAL_INPUT_RESET);
+          resetLocalInputModes();
           if (rawModeEnabled) {
             input.setRawMode?.(false);
             rawModeEnabled = false;

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -54,6 +54,8 @@ export interface ShellAttachOptions {
 export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
 const LOCAL_TERMINAL_INPUT_RESET = "\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l\u001b[?1004l";
 const MAX_PENDING_MOUSE_SEQUENCE_CHARS = 128;
+const STALE_MOUSE_FOCUS_GUARD_MS = 5_000;
+const FOCUS_MOUSE_SUPPRESS_MS = 1_000;
 
 type MaybeTtyStream = NodeJS.ReadStream & {
   isTTY?: boolean;
@@ -81,11 +83,23 @@ function terminalSize(input: MaybeTtyStream, output: NodeJS.WriteStream): {
   return { cols, rows };
 }
 
-function createTerminalInputFilter(options: { dropMouse: boolean }) {
+function createTerminalInputFilter(options: {
+  dropMouse: boolean;
+  resetLocalInputModes?: () => void;
+  now?: () => number;
+}) {
   let focused = true;
   let pendingMouseSequence = "";
+  let lastRemoteOutputAt = options.now?.() ?? Date.now();
+  let suppressMouseUntil = 0;
+
+  const now = () => options.now?.() ?? Date.now();
+  const shouldForwardMouse = () => !options.dropMouse && focused && now() >= suppressMouseUntil;
 
   return {
+    noteRemoteOutput() {
+      lastRemoteOutputAt = now();
+    },
     filter(chunk: string): string {
       const input = pendingMouseSequence + chunk;
       pendingMouseSequence = "";
@@ -104,9 +118,11 @@ function createTerminalInputFilter(options: { dropMouse: boolean }) {
         }
 
         if (third === "I" || third === "O") {
-          focused = third === "I";
-          if (!options.dropMouse) {
-            output += input.slice(i, i + 3);
+          const nextFocused = third === "I";
+          focused = nextFocused;
+          if (nextFocused && now() - lastRemoteOutputAt >= STALE_MOUSE_FOCUS_GUARD_MS) {
+            suppressMouseUntil = now() + FOCUS_MOUSE_SUPPRESS_MS;
+            options.resetLocalInputModes?.();
           }
           i += 3;
           continue;
@@ -121,7 +137,7 @@ function createTerminalInputFilter(options: { dropMouse: boolean }) {
             pendingMouseSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_MOUSE_SEQUENCE_CHARS));
             break;
           }
-          if (!options.dropMouse && focused) {
+          if (shouldForwardMouse()) {
             output += input.slice(i, end + 1);
           }
           i = end + 1;
@@ -133,7 +149,7 @@ function createTerminalInputFilter(options: { dropMouse: boolean }) {
             pendingMouseSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_MOUSE_SEQUENCE_CHARS));
             break;
           }
-          if (!options.dropMouse && focused) {
+          if (shouldForwardMouse()) {
             output += input.slice(i, i + 6);
           }
           i += 6;
@@ -148,6 +164,7 @@ function createTerminalInputFilter(options: { dropMouse: boolean }) {
     reset() {
       focused = true;
       pendingMouseSequence = "";
+      suppressMouseUntil = 0;
     },
   };
 }
@@ -314,7 +331,13 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       const input = (attachOptions.input ?? process.stdin) as MaybeTtyStream;
       const detachSequence = attachOptions.detachSequence ?? "\u001c\u001c";
       const dropMouse = attachOptions.mouse === false;
-      const inputFilter = createTerminalInputFilter({ dropMouse });
+      const resetLocalInputModes = () => {
+        output.write(LOCAL_TERMINAL_INPUT_RESET);
+      };
+      const inputFilter = createTerminalInputFilter({
+        dropMouse,
+        resetLocalInputModes,
+      });
       let pendingInput = "";
 
       return new Promise<{ detached: boolean }>((resolve, reject) => {
@@ -341,7 +364,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           ws.off?.("error", onError);
           pendingInput = "";
           inputFilter.reset();
-          output.write(LOCAL_TERMINAL_INPUT_RESET);
+          resetLocalInputModes();
           if (rawModeEnabled) {
             input.setRawMode?.(false);
             rawModeEnabled = false;
@@ -465,6 +488,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           if (msg.type === "attached") {
             markOpen();
           } else if (msg.type === "output" && typeof msg.data === "string") {
+            inputFilter.noteRemoteOutput();
             output.write(msg.data);
           } else if (msg.type === "error") {
             const code = typeof msg.code === "string" ? msg.code : "attach_failed";
@@ -488,6 +512,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         ws.on("close", onClose);
         ws.on("error", onError);
         if (input.isTTY && typeof input.setRawMode === "function") {
+          resetLocalInputModes();
           input.setRawMode(true);
           rawModeEnabled = true;
           input.resume?.();

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -323,7 +323,7 @@ describe("shell REST client", () => {
     ]);
   });
 
-  it("forwards focus reporting sequences while still dropping mouse input when unfocused", async () => {
+  it("drops focus reporting sequences while still dropping mouse input when unfocused", async () => {
     const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
     const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
     const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
@@ -342,8 +342,36 @@ describe("shell REST client", () => {
     await expect(attached).resolves.toEqual({ detached: true });
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
-      { type: "input", data: "\u001b[Ia\u001b[O" },
+      { type: "input", data: "a" },
     ]);
+  });
+
+  it("resets stale local mouse modes and drops immediate mouse bytes after focus returns", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready" }));
+    nowSpy.mockReturnValue(6_000);
+    input.emit("data", "\u001b[I\u001b[<0;10;20M\u001b[Mabcx");
+    ControlledWebSocket.last?.emit("close");
+
+    await expect(attached).resolves.toEqual({ detached: true });
+    expect(output.write).toHaveBeenCalledWith("\u001b[?1000l\u001b[?1002l\u001b[?1003l\u001b[?1006l\u001b[?1015l\u001b[?1004l");
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "resize", cols: 80, rows: 24 },
+      { type: "input", data: "x" },
+    ]);
+    nowSpy.mockRestore();
   });
 
   it("buffers fragmented SGR mouse sequences instead of forwarding partial escape bytes", async () => {


### PR DESCRIPTION
## Summary
- Drop local focus-reporting escape sequences instead of forwarding them into remote shells.
- Reset local mouse/focus modes on attach startup and when focus returns after stale remote output.
- Suppress immediate SGR/X10 mouse bytes after a stale focus-return event while keeping normal focused TUI mouse forwarding.
- Prepare CLI patch release 0.3.2.

## Invariants
- Source of truth: CLI attach transport remains the local terminal stdin/stdout stream plus the gateway terminal websocket; no new persistence is introduced.
- Lock/transaction scope: no database or file mutations are added; input filtering is synchronous per stdin chunk.
- Acceptable orphan states: if the websocket closes or errors, cleanup still restores raw mode and local mouse/focus modes; queued websocket frames are cleared by the existing settle path.
- Auth source of truth: unchanged bearer/query-token websocket auth handled by existing shell client and gateway routes.
- Deferred scope: this does not replace the web shell PTY path with canonical zellij sessions; it only fixes local CLI attach input discipline.

## Tests
- bun run test tests/cli/shell-client.test.ts tests/cli/shell.test.ts tests/cli/run.test.ts
- pnpm --filter @finnaai/matrix build
- pnpm --filter @finnaai/matrix test
- pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs