### PR TITLE
fix(shell): attach terminal app to canonical session

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -10,6 +10,7 @@ import { drainTerminalLaunchQueue, TERMINAL_LAUNCH_EVENT } from "@/lib/terminal-
 import { useTerminalSettings, type TerminalThemeId } from "@/stores/terminal-settings";
 import { getTerminalThemePreset } from "./terminal-themes";
 import { TerminalPreferencesPanel } from "./preferences-panel";
+import { isCanonicalShellSessionId } from "./TerminalPane";
 
 // Map xterm theme ids onto zellij's built-in theme names. Zellij ships with
 // these themes in 0.44, so referencing them by name "just works".
@@ -44,6 +45,7 @@ function isLightTerminalTheme(themeId: TerminalThemeId, desktopThemeSlug?: strin
 }
 
 const DEFAULT_CWD = "projects";
+const DEFAULT_SHELL_SESSION_NAME = "main";
 
 interface Tab {
   id: string;
@@ -136,6 +138,37 @@ function getSessionIds(node: PaneNode): string[] {
     return node.sessionId ? [node.sessionId] : [];
   }
   return [...getSessionIds(node.children[0]), ...getSessionIds(node.children[1])];
+}
+
+function layoutHasCanonicalShellSession(layout: TerminalLayout): boolean {
+  return Array.isArray(layout.tabs) && layout.tabs.some((tab) => (
+    getSessionIds(tab.paneTree).some((sessionId) => isCanonicalShellSessionId(sessionId))
+  ));
+}
+
+async function ensureDefaultShellSession(): Promise<boolean> {
+  try {
+    const listRes = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (listRes.ok) {
+      const data = await listRes.json() as { sessions?: Array<{ name?: unknown }> };
+      if (Array.isArray(data.sessions) && data.sessions.some((session) => session.name === DEFAULT_SHELL_SESSION_NAME)) {
+        return true;
+      }
+    }
+
+    const createRes = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: DEFAULT_SHELL_SESSION_NAME, cwd: DEFAULT_CWD }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    return createRes.ok || createRes.status === 409;
+  } catch (err: unknown) {
+    console.warn("Failed to ensure default terminal session:", err instanceof Error ? err.message : err);
+    return false;
+  }
 }
 
 function getSafePreferencesSessionName(value: string | null): string | null {
@@ -329,14 +362,22 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
         if (res.ok) {
           const data = await res.json() as TerminalLayout;
           if (!cancelled && Array.isArray(data.tabs) && data.tabs.length > 0) {
-            const nextActiveTabId = data.activeTabId ?? data.tabs[0].id;
-            const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
-            setTabs(data.tabs);
-            setActiveTabId(nextActiveTabId);
-            setSidebarOpen(initialMobileRef.current ? false : data.sidebarOpen ?? true);
-            setFocusedPaneId(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
-            setInitialized(true);
-            return;
+            if (layoutHasCanonicalShellSession(data)) {
+              const nextActiveTabId = data.activeTabId ?? data.tabs[0].id;
+              const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
+              setTabs(data.tabs);
+              setActiveTabId(nextActiveTabId);
+              setSidebarOpen(initialMobileRef.current ? false : data.sidebarOpen ?? true);
+              setFocusedPaneId(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
+              setInitialized(true);
+              return;
+            }
+
+            if (await ensureDefaultShellSession()) {
+              addSessionTab(DEFAULT_SHELL_SESSION_NAME, DEFAULT_SHELL_SESSION_NAME);
+              setInitialized(true);
+              return;
+            }
           }
         }
       } catch (err: unknown) {
@@ -344,7 +385,11 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       }
 
       if (!cancelled) {
-        addTab(DEFAULT_CWD);
+        if (await ensureDefaultShellSession()) {
+          addSessionTab(DEFAULT_SHELL_SESSION_NAME, DEFAULT_SHELL_SESSION_NAME);
+        } else {
+          addTab(DEFAULT_CWD);
+        }
         setInitialized(true);
       }
     }

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -373,7 +373,8 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
               return;
             }
 
-            if (await ensureDefaultShellSession()) {
+            const sessionReady = await ensureDefaultShellSession();
+            if (!cancelled && sessionReady) {
               addSessionTab(DEFAULT_SHELL_SESSION_NAME, DEFAULT_SHELL_SESSION_NAME);
               setInitialized(true);
               return;
@@ -385,12 +386,15 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
       }
 
       if (!cancelled) {
-        if (await ensureDefaultShellSession()) {
-          addSessionTab(DEFAULT_SHELL_SESSION_NAME, DEFAULT_SHELL_SESSION_NAME);
-        } else {
-          addTab(DEFAULT_CWD);
+        const sessionReady = await ensureDefaultShellSession();
+        if (!cancelled) {
+          if (sessionReady) {
+            addSessionTab(DEFAULT_SHELL_SESSION_NAME, DEFAULT_SHELL_SESSION_NAME);
+          } else {
+            addTab(DEFAULT_CWD);
+          }
+          setInitialized(true);
         }
-        setInitialized(true);
       }
     }
 

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -82,7 +82,7 @@ type TerminalServerMessage =
   | { type: "error"; message: string };
 
 const LEGACY_PTY_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const CANONICAL_SHELL_SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
+const CANONICAL_SHELL_SESSION_NAME_PATTERN = /^[a-z][a-z0-9-]{0,30}$/;
 
 export function isLegacyPtySessionId(sessionId: string): boolean {
   return LEGACY_PTY_SESSION_ID_PATTERN.test(sessionId);
@@ -118,7 +118,7 @@ function parseTerminalServerMessage(raw: string): TerminalServerMessage | null {
 
   const msg = parsed as Record<string, unknown>;
   switch (msg.type) {
-    case "attached":
+    case "attached": {
       const sessionId = typeof msg.sessionId === "string"
         ? msg.sessionId
         : typeof msg.session === "string"
@@ -133,6 +133,7 @@ function parseTerminalServerMessage(raw: string): TerminalServerMessage | null {
         state: msg.state,
         exitCode: toFiniteNumber(msg.exitCode),
       };
+    }
     case "output":
       if (typeof msg.data !== "string") {
         return null;

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -81,6 +81,21 @@ type TerminalServerMessage =
   | { type: "exit"; code: number | null }
   | { type: "error"; message: string };
 
+const LEGACY_PTY_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CANONICAL_SHELL_SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
+
+export function isLegacyPtySessionId(sessionId: string): boolean {
+  return LEGACY_PTY_SESSION_ID_PATTERN.test(sessionId);
+}
+
+export function isCanonicalShellSessionId(sessionId: string): boolean {
+  return CANONICAL_SHELL_SESSION_NAME_PATTERN.test(sessionId);
+}
+
+export function terminalWebSocketPathForSession(sessionId: string | null): "/ws/terminal" | "/ws/terminal/session" {
+  return sessionId && isCanonicalShellSessionId(sessionId) ? "/ws/terminal/session" : "/ws/terminal";
+}
+
 function toFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
@@ -104,12 +119,17 @@ function parseTerminalServerMessage(raw: string): TerminalServerMessage | null {
   const msg = parsed as Record<string, unknown>;
   switch (msg.type) {
     case "attached":
-      if (typeof msg.sessionId !== "string" || (msg.state !== "running" && msg.state !== "exited")) {
+      const sessionId = typeof msg.sessionId === "string"
+        ? msg.sessionId
+        : typeof msg.session === "string"
+          ? msg.session
+          : null;
+      if (!sessionId || (msg.state !== "running" && msg.state !== "exited")) {
         return null;
       }
       return {
         type: "attached",
-        sessionId: msg.sessionId,
+        sessionId,
         state: msg.state,
         exitCode: toFiniteNumber(msg.exitCode),
       };
@@ -542,16 +562,22 @@ export function TerminalPane({
         });
 
         const sendAttach = () => {
-          const attachMode = sessionIdRef.current ? "reattach" : "create";
+          const currentSessionId = sessionIdRef.current;
+          const isCanonicalShellSession = Boolean(currentSessionId && isCanonicalShellSessionId(currentSessionId));
+          const attachMode = currentSessionId ? (isCanonicalShellSession ? "canonical" : "reattach") : "create";
           log("send-attach", {
             attachMode,
-            attachSessionId: sessionIdRef.current,
+            attachSessionId: currentSessionId,
             fromSeq: lastSeqRef.current,
           });
-          if (sessionIdRef.current) {
+          if (isCanonicalShellSession) {
+            ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+            return;
+          }
+          if (currentSessionId) {
             ws.send(JSON.stringify({
               type: "attach",
-              sessionId: sessionIdRef.current,
+              sessionId: currentSessionId,
               fromSeq: lastSeqRef.current,
             }));
           } else {
@@ -740,7 +766,7 @@ export function TerminalPane({
             case "error": {
               const safeMsg = stripTerminalControls(msg.message);
               log("server-error", { message: safeMsg });
-              if (safeMsg === "Session not found" && sessionIdRef.current) {
+              if (safeMsg === "Session not found" && sessionIdRef.current && isLegacyPtySessionId(sessionIdRef.current)) {
                 log("session-not-found-reset");
                 sessionIdRef.current = null;
                 lastSeqRef.current = 0;
@@ -761,25 +787,34 @@ export function TerminalPane({
       }
 
       function connectWs() {
-        const query =
-          sessionIdRef.current || !cwd
+        const currentSessionId = sessionIdRef.current;
+        const wsPath = terminalWebSocketPathForSession(currentSessionId);
+        const query = currentSessionId && isCanonicalShellSessionId(currentSessionId)
+          ? { session: currentSessionId, fromSeq: String(lastSeqRef.current) }
+          : currentSessionId || !cwd
             ? undefined
             : { cwd };
+        const queryCwd = query && "cwd" in query ? query.cwd : null;
+        const querySession = query && "session" in query ? query.session : null;
         log("connect-ws", {
-          queryCwd: query?.cwd ?? null,
+          wsPath,
+          queryCwd,
+          querySession,
           reconnectAttempt: reconnectAttemptRef.current,
         });
 
-        void buildAuthenticatedWebSocketUrl("/ws/terminal", {
-          cwd: query?.cwd,
-        })
+        void buildAuthenticatedWebSocketUrl(wsPath, query)
           .catch((err: unknown) => {
             console.warn(
               "[terminal] Falling back to unauthenticated terminal websocket URL:",
               err instanceof Error ? err.message : err,
             );
-            const baseWs = getGatewayWs().replace("/ws", "/ws/terminal");
-            return query?.cwd ? `${baseWs}?cwd=${encodeURIComponent(query.cwd)}` : baseWs;
+            const baseWs = getGatewayWs().replace("/ws", wsPath);
+            const url = new URL(baseWs);
+            for (const [key, value] of Object.entries(query ?? {})) {
+              if (value) url.searchParams.set(key, value);
+            }
+            return url.toString();
           })
           .then((wsUrl) => {
             if (disposed || isClosingRef.current) {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -169,6 +169,54 @@ describe("TerminalApp", () => {
     expect(props.paneTree.sessionId).toBe("main");
   });
 
+  it("does not replace a legacy layout after unmount while ensuring the canonical session", async () => {
+    let resolveSessions: ((value: { ok: boolean; json: () => Promise<{ sessions: Array<{ name: string }> }> }) => void) | null = null;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method !== "PUT") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            tabs: [{
+              id: "legacy-tab",
+              label: "projects",
+              paneTree: {
+                type: "pane",
+                id: "legacy-pane",
+                cwd: "projects",
+                sessionId: "550e8400-e29b-41d4-a716-446655440000",
+              },
+            }],
+            activeTabId: "legacy-tab",
+          }),
+        });
+      }
+      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
+        return new Promise((resolve) => {
+          resolveSessions = resolve;
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+    }));
+
+    const { unmount } = render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const callsBeforeUnmount = paneGridSpy.mock.calls.length;
+
+    unmount();
+    await act(async () => {
+      resolveSessions?.({ ok: true, json: async () => ({ sessions: [{ name: "main" }] }) });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(paneGridSpy.mock.calls.length).toBe(callsBeforeUnmount);
+  });
+
   it("persists attached session ids in the saved layout", async () => {
     render(<TerminalApp />);
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -103,6 +103,72 @@ describe("TerminalApp", () => {
     expect(screen.getByTitle("New tab (Ctrl+Shift+T)")).toBeTruthy();
   });
 
+  it("starts normal terminal tabs on the canonical main shell session", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const props = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { type: "pane"; sessionId?: string };
+    };
+    expect(props.paneTree).toMatchObject({
+      type: "pane",
+      sessionId: "main",
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/terminal/sessions"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "main", cwd: "projects" }),
+      }),
+    );
+  });
+
+  it("replaces saved legacy pty layouts with the canonical main shell session", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method !== "PUT") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            tabs: [{
+              id: "legacy-tab",
+              label: "projects",
+              paneTree: {
+                type: "pane",
+                id: "legacy-pane",
+                cwd: "projects",
+                sessionId: "550e8400-e29b-41d4-a716-446655440000",
+              },
+            }],
+            activeTabId: "legacy-tab",
+          }),
+        });
+      }
+      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const props = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { type: "pane"; sessionId?: string };
+    };
+    expect(props.paneTree.sessionId).toBe("main");
+  });
+
   it("persists attached session ids in the saved layout", async () => {
     render(<TerminalApp />);
 

--- a/tests/shell/terminal.test.ts
+++ b/tests/shell/terminal.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect } from "vitest";
+import {
+  isCanonicalShellSessionId,
+  terminalWebSocketPathForSession,
+} from "../../shell/src/components/terminal/TerminalPane.js";
 
 class MockTerminalWebSocket {
   static instances: MockTerminalWebSocket[] = [];
@@ -76,5 +80,16 @@ describe("Terminal WebSocket protocol", () => {
   it("connects to the terminal WebSocket endpoint", () => {
     const ws = new MockTerminalWebSocket("ws://localhost:4000/ws/terminal");
     expect(ws.url).toBe("ws://localhost:4000/ws/terminal");
+  });
+
+  it("uses canonical zellij websocket paths only for shell session names", () => {
+    expect(isCanonicalShellSessionId("main")).toBe(true);
+    expect(isCanonicalShellSessionId("setup-1")).toBe(true);
+    expect(isCanonicalShellSessionId("term_observe_abc123")).toBe(false);
+    expect(isCanonicalShellSessionId("550e8400-e29b-41d4-a716-446655440000")).toBe(false);
+    expect(terminalWebSocketPathForSession("main")).toBe("/ws/terminal/session");
+    expect(terminalWebSocketPathForSession("term_observe_abc123")).toBe("/ws/terminal");
+    expect(terminalWebSocketPathForSession("550e8400-e29b-41d4-a716-446655440000")).toBe("/ws/terminal");
+    expect(terminalWebSocketPathForSession(null)).toBe("/ws/terminal");
   });
 });

--- a/tests/shell/terminal.test.ts
+++ b/tests/shell/terminal.test.ts
@@ -85,6 +85,7 @@ describe("Terminal WebSocket protocol", () => {
   it("uses canonical zellij websocket paths only for shell session names", () => {
     expect(isCanonicalShellSessionId("main")).toBe(true);
     expect(isCanonicalShellSessionId("setup-1")).toBe(true);
+    expect(isCanonicalShellSessionId("1test")).toBe(false);
     expect(isCanonicalShellSessionId("term_observe_abc123")).toBe(false);
     expect(isCanonicalShellSessionId("550e8400-e29b-41d4-a716-446655440000")).toBe(false);
     expect(terminalWebSocketPathForSession("main")).toBe("/ws/terminal/session");


### PR DESCRIPTION
## Summary
- Start normal web Terminal tabs on the canonical `main` shell session instead of anonymous PTY sessions.
- Route canonical shell session names through `/ws/terminal/session` while leaving workspace observe/takeover and legacy PTY ids on `/ws/terminal`.
- Replace saved legacy PTY-only layouts with `main` so CLI and web converge after upgrade.

## Validation
- `bun run test tests/shell/terminal.test.ts tests/shell/terminal-app-component.test.tsx`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warning buckets only)

## Invariants
- Source of truth: normal user terminal sessions use the canonical zellij shell session registry behind `/api/terminal/sessions`; legacy PTY ids remain compatibility-only for old layouts and workspace observe/takeover bridges.
- Lock/transaction scope: this shell change does not add gateway locks, DB writes, or filesystem writes beyond existing terminal layout persistence and the existing terminal session create endpoint.
- Acceptable orphan states: if ensuring `main` fails, the UI falls back to the prior PTY creation path so Terminal still opens instead of dead-ending.
- Auth source of truth: browser token acquisition and websocket auth behavior remain unchanged; this only changes the terminal websocket path for canonical session names.
- Deferred scope: full tab/pane/layout parity and workspace session metadata migration remain part of the broader unified terminal spec, not this bug-fix PR.