### PR TITLE
fix(www): make early access form scrollable

### DIFF
--- a/tests/www/early-access.test.ts
+++ b/tests/www/early-access.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+async function readRepoFile(path: string) {
+  return readFile(resolve(root, path), "utf8");
+}
+
+describe("www early access page", () => {
+  it("uses an internally scrollable Tally iframe instead of mobile-fragile dynamic height", async () => {
+    const page = await readRepoFile("www/src/app/early-access/page.tsx");
+
+    expect(page).toContain("scrolling=\"yes\"");
+    expect(page).toContain("overflow-hidden");
+    expect(page).not.toContain("dynamicHeight");
+  });
+});

--- a/www/src/app/early-access/page.tsx
+++ b/www/src/app/early-access/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 
 const TALLY_FORM_ID = "2ED9lb";
 const DISCORD_URL = "https://discord.gg/cSBBQWtPwV";
@@ -68,23 +67,23 @@ export default async function EarlyAccessPage({ searchParams }: { searchParams: 
           </div>
         </section>
 
-        <section className="flex min-h-[760px] flex-col">
+        <section className="flex h-[min(820px,calc(100vh-3rem))] min-h-[680px] flex-col overflow-hidden md:sticky md:top-10 md:h-[calc(100vh-5rem)] md:min-h-[760px]">
           <iframe
-            data-tally-src={tallyUrl}
+            src={tallyUrl}
             loading="lazy"
             width="100%"
-            height="760"
+            height="100%"
             frameBorder="0"
             marginHeight={0}
             marginWidth={0}
+            scrolling="yes"
             sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
             referrerPolicy="strict-origin-when-cross-origin"
             title="Matrix Early Access Request"
-            className="min-h-[760px] w-full flex-1"
+            className="h-full w-full flex-1"
           />
         </section>
       </div>
-      <Script src="https://tally.so/widgets/embed.js" strategy="afterInteractive" />
     </main>
   );
 }
@@ -94,7 +93,6 @@ function buildTallyEmbedUrl(searchParams: Awaited<SearchParams>) {
     alignLeft: "1",
     hideTitle: "1",
     transparentBackground: "1",
-    dynamicHeight: "1",
   });
 
   for (const key of TALLY_QUERY_KEYS) {


### PR DESCRIPTION
## Summary

- Make the early access Tally form load directly in a bounded iframe.
- Remove Tally dynamic-height mode so mobile users can scroll inside the form reliably.
- Add a regression test for the early-access embed contract.

## Tests

- `pnpm test tests/www/early-access.test.ts`
- `bun run check:patterns:diff`
- Playwright mobile and desktop verification: Tally iframe scrolls from `scrollY: 0` to `1400`

## Notes

- `pnpm --filter www exec tsc --noEmit` is blocked by existing Fumadocs generated type issues in `www/src/app/docs/[[...slug]]/page.tsx`, `www/src/app/sitemap.ts`, `www/src/lib/get-llm-text.ts`, and `www/src/lib/source.ts`.
