### PR TITLE
ci(actions): reduce queued runner load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "CI relevant changes: true (workflow_dispatch always runs)"
+            exit 0
+          fi
+
           should_run_trigger=true
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             should_run_trigger=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect CI-relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      should_run: ${{ steps.changed.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect source changes
+        id: changed
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before || '' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+            changed_files="$(git diff --name-only "origin/$GITHUB_BASE_REF" "$GITHUB_SHA")"
+          else
+            zero_sha="0000000000000000000000000000000000000000"
+            if [ -n "${GITHUB_EVENT_BEFORE:-}" ] && [ "$GITHUB_EVENT_BEFORE" != "$zero_sha" ] && git cat-file -e "${GITHUB_EVENT_BEFORE}^{commit}" 2>/dev/null; then
+              changed_files="$(git diff --name-only "$GITHUB_EVENT_BEFORE" "$GITHUB_SHA")"
+            else
+              changed_files="$(git show --pretty= --name-only "$GITHUB_SHA")"
+            fi
+          fi
+
+          should_run=false
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              docs/*|specs/*|www/*|*.md) ;;
+              *) should_run=true; break ;;
+            esac
+          done <<EOF
+          $changed_files
+          EOF
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "CI relevant changes: $should_run"
+
   # ── Gate 1: Mechanical checks ──
   typecheck:
     name: Type Check
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # TODO: remove continue-on-error once baseline type errors in kernel are fixed
@@ -37,6 +83,8 @@ jobs:
 
   patterns:
     name: Pattern Scan
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
@@ -67,7 +115,8 @@ jobs:
 
   sync-client:
     name: Sync Client Package
-    needs: [typecheck, patterns]
+    needs: [changes, patterns]
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -94,7 +143,8 @@ jobs:
   # ── Gate 2: Tests ──
   unit:
     name: Unit Tests (${{ matrix.shard }}/4)
-    needs: [typecheck, patterns, sync-client]
+    needs: [changes, patterns]
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -124,7 +174,8 @@ jobs:
 
   e2e:
     name: E2E Tests
-    needs: unit
+    needs: [changes, sync-client, unit]
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
 on:
+  workflow_dispatch:
+  merge_group:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [labeled, ready_for_review]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -25,9 +28,25 @@ jobs:
       - name: Detect source changes
         id: changed
         env:
+          PR_ACTION: ${{ github.event.action || '' }}
+          PR_LABEL_NAME: ${{ github.event.label.name || '' }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before || '' }}
         run: |
           set -euo pipefail
+
+          should_run_trigger=true
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            should_run_trigger=false
+            if [ "$PR_ACTION" = "ready_for_review" ] || { [ "$PR_ACTION" = "labeled" ] && [ "$PR_LABEL_NAME" = "ready-for-ci" ]; }; then
+              should_run_trigger=true
+            fi
+          fi
+
+          if [ "$should_run_trigger" != "true" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "CI trigger not requested; add the ready-for-ci label, mark the PR ready for review, or run manually."
+            exit 0
+          fi
 
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     types: [labeled, ready_for_review]
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name != 'ready-for-ci' && github.run_id || 'shared' }}
   cancel-in-progress: true
 
 jobs:
@@ -34,10 +34,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Manual dispatch is an explicit request to run CI, regardless of changed paths.
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          # Manual and merge-queue runs must execute CI regardless of changed paths.
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
-            echo "CI relevant changes: true (manual dispatch)"
+            echo "CI relevant changes: true ($GITHUB_EVENT_NAME always runs)"
             exit 0
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,10 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Manual dispatch is an explicit request to run CI, regardless of changed paths.
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
-            echo "CI relevant changes: true (workflow_dispatch always runs)"
+            echo "CI relevant changes: true (manual dispatch)"
             exit 0
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
   # ── Gate 2: Tests ──
   unit:
     name: Unit Tests (${{ matrix.shard }}/4)
-    needs: [changes, patterns]
+    needs: [changes, patterns, sync-client]
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,43 +59,58 @@ jobs:
   typecheck:
     name: Type Check
     needs: changes
-    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # TODO: remove continue-on-error once baseline type errors in kernel are fixed
     continue-on-error: true
     steps:
+      - name: Skip expensive CI for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No CI-relevant source changes detected; skipping typecheck."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: pnpm/action-setup@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.should_run == 'true'
         with:
           node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+        if: needs.changes.outputs.should_run == 'true'
 
       - name: Type check all packages
+        if: needs.changes.outputs.should_run == 'true'
         run: bun run typecheck
 
   patterns:
     name: Pattern Scan
     needs: changes
-    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
+      - name: Skip expensive CI for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No CI-relevant source changes detected; skipping pattern scan."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
         with:
           fetch-depth: 0
 
       - name: Install ripgrep
+        if: needs.changes.outputs.should_run == 'true'
         run: sudo apt-get install -y ripgrep
 
       - name: Run CLAUDE.md pattern scanner on changed files
+        if: needs.changes.outputs.should_run == 'true'
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             ./scripts/review/check-patterns.sh --diff origin/${{ github.base_ref }}
@@ -116,35 +131,44 @@ jobs:
   sync-client:
     name: Sync Client Package
     needs: [changes, patterns]
-    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Skip expensive CI for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No CI-relevant source changes detected; skipping sync-client checks."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: pnpm/action-setup@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.should_run == 'true'
         with:
           node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+        if: needs.changes.outputs.should_run == 'true'
 
       - name: Build sync client
+        if: needs.changes.outputs.should_run == 'true'
         run: pnpm --filter @finnaai/matrix build
 
       - name: Test sync client
+        if: needs.changes.outputs.should_run == 'true'
         run: pnpm --filter @finnaai/matrix test
 
       - name: Verify publish shape
+        if: needs.changes.outputs.should_run == 'true'
         run: pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
 
   # ── Gate 2: Tests ──
   unit:
     name: Unit Tests (${{ matrix.shard }}/4)
     needs: [changes, patterns, sync-client]
-    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -152,52 +176,73 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
+      - name: Skip expensive CI for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No CI-relevant source changes detected; skipping unit shard."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: pnpm/action-setup@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.should_run == 'true'
         with:
           node-version: 24
           cache: pnpm
 
       - name: Configure git for tests
+        if: needs.changes.outputs.should_run == 'true'
         run: |
           git config --global user.name "CI"
           git config --global user.email "ci@matrix-os.com"
 
       - run: pnpm install --frozen-lockfile
+        if: needs.changes.outputs.should_run == 'true'
 
       - run: bun run test -- --shard=${{ matrix.shard }}/4
+        if: needs.changes.outputs.should_run == 'true'
 
   e2e:
     name: E2E Tests
     needs: [changes, sync-client, unit]
-    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Skip expensive CI for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No CI-relevant source changes detected; skipping e2e tests."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: oven-sh/setup-bun@v2
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: pnpm/action-setup@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.should_run == 'true'
         with:
           node-version: 24
           cache: pnpm
 
       - name: Configure git for tests
+        if: needs.changes.outputs.should_run == 'true'
         run: |
           git config --global user.name "CI"
           git config --global user.email "ci@matrix-os.com"
 
       - run: pnpm install --frozen-lockfile
+        if: needs.changes.outputs.should_run == 'true'
 
       - name: Run E2E tests
+        if: needs.changes.outputs.should_run == 'true'
         run: bun run test:e2e
 
       - name: Upload test results on failure

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -5,10 +5,12 @@ on:
   schedule:
     # Keep the full Docker scenario matrix exercised even when PRs only run smoke.
     - cron: "17 3 * * *"
+  merge_group:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [labeled, ready_for_review]
 
 concurrency:
   group: docker-test-${{ github.ref }}
@@ -29,6 +31,8 @@ jobs:
       - name: Detect source changes
         id: changed
         env:
+          PR_ACTION: ${{ github.event.action || '' }}
+          PR_LABEL_NAME: ${{ github.event.label.name || '' }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before || '' }}
         run: |
           set -euo pipefail
@@ -36,6 +40,20 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Docker relevant changes: true"
+            exit 0
+          fi
+
+          should_run_trigger=true
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            should_run_trigger=false
+            if [ "$PR_ACTION" = "ready_for_review" ] || { [ "$PR_ACTION" = "labeled" ] && [ "$PR_LABEL_NAME" = "ready-for-ci" ]; }; then
+              should_run_trigger=true
+            fi
+          fi
+
+          if [ "$should_run_trigger" != "true" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "Docker trigger not requested; add the ready-for-ci label, mark the PR ready for review, or run manually."
             exit 0
           fi
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -68,16 +68,22 @@ jobs:
   docker-build:
     name: Build Docker Test Image
     needs: changes
-    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Skip Docker build for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No Docker-relevant source changes detected; skipping image build."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - name: Set up Docker Buildx
+        if: needs.changes.outputs.should_run == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Populate dev image cache
+        if: needs.changes.outputs.should_run == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -88,17 +94,24 @@ jobs:
   docker-smoke:
     name: Docker Smoke Test
     needs: [changes, docker-build]
-    if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
+      - name: Skip Docker smoke for docs-only changes
+        if: needs.changes.outputs.should_run != 'true'
+        run: echo "No Docker-relevant source changes detected; skipping smoke scenario."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.should_run == 'true'
 
       - name: Set up Docker Buildx
+        if: needs.changes.outputs.should_run == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Build dev image
+        if: needs.changes.outputs.should_run == 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -108,10 +121,12 @@ jobs:
           cache-from: type=gha,scope=dev-image
 
       - name: Create CI env file
+        if: needs.changes.outputs.should_run == 'true'
         run: |
           echo "ANTHROPIC_API_KEY=test-not-used-in-docker-scenarios" > .env.docker
 
       - name: Create CI compose override
+        if: needs.changes.outputs.should_run == 'true'
         run: |
           cat > docker-compose.ci.yml <<'EOF'
           services:
@@ -124,9 +139,11 @@ jobs:
           EOF
 
       - name: Create external volumes
+        if: needs.changes.outputs.should_run == 'true'
         run: docker volume create matrixos-ai-auth
 
       - name: Run scenario tests
+        if: needs.changes.outputs.should_run == 'true'
         run: |
           chmod +x scripts/docker-test/*.sh
           ./scripts/docker-test/fresh-install.sh

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -86,6 +86,7 @@ jobs:
   docker-build:
     name: Build Docker Test Image
     needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -112,7 +113,7 @@ jobs:
   docker-smoke:
     name: Docker Smoke Test
     needs: [changes, docker-build]
-    if: github.event_name == 'pull_request'
+    if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,6 +1,10 @@
 name: Docker Tests
 
 on:
+  workflow_dispatch:
+  schedule:
+    # Keep the full Docker scenario matrix exercised even when PRs only run smoke.
+    - cron: "17 3 * * *"
   push:
     branches: [main]
   pull_request:
@@ -11,8 +15,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Docker-relevant changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      should_run: ${{ steps.changed.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect source changes
+        id: changed
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before || '' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Docker relevant changes: true"
+            exit 0
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+            changed_files="$(git diff --name-only "origin/$GITHUB_BASE_REF" "$GITHUB_SHA")"
+          else
+            zero_sha="0000000000000000000000000000000000000000"
+            if [ -n "${GITHUB_EVENT_BEFORE:-}" ] && [ "$GITHUB_EVENT_BEFORE" != "$zero_sha" ] && git cat-file -e "${GITHUB_EVENT_BEFORE}^{commit}" 2>/dev/null; then
+              changed_files="$(git diff --name-only "$GITHUB_EVENT_BEFORE" "$GITHUB_SHA")"
+            else
+              changed_files="$(git show --pretty= --name-only "$GITHUB_SHA")"
+            fi
+          fi
+
+          should_run=false
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              docs/*|specs/*|www/*|*.md) ;;
+              *) should_run=true; break ;;
+            esac
+          done <<EOF
+          $changed_files
+          EOF
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+          echo "Docker relevant changes: $should_run"
+
   docker-build:
     name: Build Docker Test Image
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -29,9 +85,74 @@ jobs:
           cache-from: type=gha,scope=dev-image
           cache-to: type=gha,mode=max,scope=dev-image
 
+  docker-smoke:
+    name: Docker Smoke Test
+    needs: [changes, docker-build]
+    if: needs.changes.outputs.should_run == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build dev image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.dev
+          load: true
+          tags: matrix-os-dev:ci
+          cache-from: type=gha,scope=dev-image
+
+      - name: Create CI env file
+        run: |
+          echo "ANTHROPIC_API_KEY=test-not-used-in-docker-scenarios" > .env.docker
+
+      - name: Create CI compose override
+        run: |
+          cat > docker-compose.ci.yml <<'EOF'
+          services:
+            dev:
+              image: matrix-os-dev:ci
+              build: null
+              environment:
+                MATRIX_DOCKER_CHOWN_SOURCE: "true"
+                MATRIX_AUTH_ALLOW_INSECURE_DEV: "1"
+          EOF
+
+      - name: Create external volumes
+        run: docker volume create matrixos-ai-auth
+
+      - name: Run scenario tests
+        run: |
+          chmod +x scripts/docker-test/*.sh
+          ./scripts/docker-test/fresh-install.sh
+        env:
+          COMPOSE_OVERRIDE_FILE: ${{ github.workspace }}/docker-compose.ci.yml
+          DOCKER_HEALTH_TIMEOUT: "300"
+
+      - name: Collect container logs on failure
+        if: failure()
+        run: |
+          mkdir -p /tmp/docker-test-logs
+          docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml logs --tail 100 > /tmp/docker-test-logs/compose.log 2>&1 || true
+          docker compose -f docker-compose.dev.yml -f docker-compose.ci.yml ps -a > /tmp/docker-test-logs/containers.log 2>&1 || true
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: docker-test-logs-fresh-install
+          path: /tmp/docker-test-logs/
+          retention-days: 7
+
   docker-scenarios:
     name: Docker Scenario Tests (${{ matrix.scenario }})
-    needs: docker-build
+    needs: [changes, docker-build]
+    if: needs.changes.outputs.should_run == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -13,7 +13,7 @@ on:
     types: [labeled, ready_for_review]
 
 concurrency:
-  group: docker-test-${{ github.ref }}
+  group: docker-test-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name != 'ready-for-ci' && github.run_id || 'shared' }}
   cancel-in-progress: true
 
 jobs:
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Docker relevant changes: true"
             exit 0

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -54,7 +54,7 @@ permissions:
 
 concurrency:
   group: host-bundle-release-${{ github.event_name == 'workflow_dispatch' && inputs.channel || github.ref_type == 'tag' && github.ref_name || 'dev' }}
-  cancel-in-progress: ${{ github.event_name == 'push' && github.ref_type == 'branch' }}
+  cancel-in-progress: false
 
 jobs:
   dev-bundle-gate:

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -53,8 +53,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: host-bundle-release
-  cancel-in-progress: false
+  group: host-bundle-release-${{ github.event_name == 'workflow_dispatch' && inputs.channel || github.ref_type == 'tag' && github.ref_name || 'dev' }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.ref_type == 'branch' }}
 
 jobs:
   dev-bundle-gate:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,7 @@ name: PR Title
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
   pull-requests: read

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,10 +2,14 @@ name: PR Title
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   check:


### PR DESCRIPTION
## Summary

- Adds cheap change-detection gates before expensive CI and Docker jobs so docs/specs/www/markdown-only changes do not burn the full runner matrix.
- Makes expensive PR CI opt-in: add the `ready-for-ci` label, mark the PR ready for review, or run the workflow manually when the branch is ready to merge.
- Runs only the Docker fresh-install smoke scenario on PR opt-in runs, while keeping the full Docker scenario matrix on main, scheduled, manual, and merge-queue runs.
- Collapses duplicate PR title checks and scopes host-bundle release concurrency without cancellable publish steps.

## How to run CI before merge

- Add the `ready-for-ci` label to the PR to trigger PR-attached `CI` and `Docker Tests` runs.
- Or use `workflow_dispatch` from the Actions tab against the branch.
- `PR Title` still runs automatically on normal PR title/update events.

## Tests

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`
- `bun run check:patterns` (0 violations; existing warnings only)
- `bun run typecheck` attempted, but blocked locally because this fresh worktree has no `node_modules` and TypeScript could not create `packages/observability/dist` under the sandbox; the failure also reported missing local package types/dependencies.

## Invariants

- **Source of truth**: GitHub Actions workflow YAML remains the canonical CI definition.
- **Lock/transaction scope**: Not applicable; this changes workflow scheduling/concurrency only and does not touch runtime data stores.
- **Acceptable orphan states**: Existing queued or cancelled runs may remain under older workflow definitions until rerun or naturally drained; new PR runs only execute expensive CI when explicitly triggered by `ready-for-ci`, `ready_for_review`, or manual dispatch.
- **Auth source of truth**: Existing GitHub Actions permissions and repository branch protection remain unchanged.
- **Deferred scope**: Does not add larger runners or self-hosted runner infrastructure; it only reduces unnecessary runner demand and stale queue buildup.
