### PR TITLE
fix(shell): improve update progress and runtime chrome

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -126,7 +126,7 @@ jobs:
           echo "count=$CHANGED" >> "$GITHUB_OUTPUT"
 
       - name: Commit updated snapshots
-        if: steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -134,7 +134,7 @@ jobs:
           git push
 
       - name: Comment on PR
-        if: steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
         with:
           script: |
@@ -147,7 +147,7 @@ jobs:
             });
 
       - name: Upload updated snapshots for fork PRs
-        if: steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name != github.repository
+        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name != github.repository
         uses: actions/upload-artifact@v7
         with:
           name: updated-screenshots

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -3,8 +3,11 @@ name: Screenshots
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "shell/**"
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+concurrency:
+  group: screenshots-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -13,6 +16,7 @@ permissions:
 jobs:
   screenshots:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
         with:
@@ -20,31 +24,91 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
+      - name: Decide whether screenshots are needed
+        id: screenshots
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((label) => label.name.toLowerCase());
+            const forced = labels.some((label) => ["screenshots", "visual"].includes(label));
+            const skipped = labels.some((label) => ["skip-screenshots", "no-screenshots"].includes(label));
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+            const visualPatterns = [
+              /^shell\/e2e\//,
+              /^shell\/public\//,
+              /^shell\/src\/app\/.*\.(css|tsx)$/,
+              /^shell\/src\/components\/.*\.tsx$/,
+              /^shell\/src\/stores\/(desktop-config|desktop-mode|mobile-shell-store|preferences|terminal-settings)\.ts$/,
+              /^shell\/src\/lib\/(dock-sections|icon-url|theme-presets|ui-blocks)\.ts$/,
+              /^shell\/playwright\.config\.ts$/,
+              /^shell\/package\.json$/,
+              /^shell\/pnpm-lock\.yaml$/,
+            ];
+            const changedVisualFiles = files
+              .map((file) => file.filename)
+              .filter((filename) => visualPatterns.some((pattern) => pattern.test(filename)));
+            const shouldRun = !skipped && (forced || changedVisualFiles.length > 0);
+            const reason = skipped
+              ? "skipped by label"
+              : forced
+                ? "forced by label"
+                : changedVisualFiles.length > 0
+                  ? `visual files changed: ${changedVisualFiles.join(", ")}`
+                  : "no visual shell files changed";
+            core.setOutput("should_run", shouldRun ? "true" : "false");
+            core.setOutput("reason", reason);
+            await core.summary
+              .addHeading("Screenshot decision")
+              .addRaw(`Run screenshots: ${shouldRun ? "yes" : "no"}\n`)
+              .addRaw(`Reason: ${reason}\n`)
+              .write();
+
       - uses: oven-sh/setup-bun@v2
+        if: steps.screenshots.outputs.should_run == 'true'
 
       - uses: pnpm/action-setup@v6
+        if: steps.screenshots.outputs.should_run == 'true'
 
       - uses: actions/setup-node@v6
+        if: steps.screenshots.outputs.should_run == 'true'
         with:
           node-version: 24
           cache: pnpm
 
+      - name: Cache Playwright Chromium
+        if: steps.screenshots.outputs.should_run == 'true'
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'shell/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
       - run: pnpm install --frozen-lockfile
+        if: steps.screenshots.outputs.should_run == 'true'
 
       - name: Build shell
+        if: steps.screenshots.outputs.should_run == 'true'
         run: cd shell && pnpm build
         env:
           E2E_TEST_BYPASS: "1"
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY || 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k' }}
 
       - name: Install Playwright Chromium
+        if: steps.screenshots.outputs.should_run == 'true'
         run: cd shell && pnpm exec playwright install chromium
 
       - name: Run Playwright tests
+        if: steps.screenshots.outputs.should_run == 'true'
         run: cd shell && pnpm exec playwright test --update-snapshots
 
       - name: Upload test artifacts
-        if: failure()
+        if: failure() && steps.screenshots.outputs.should_run == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: playwright-results
@@ -55,6 +119,7 @@ jobs:
 
       - name: Check for snapshot changes
         id: snapshots
+        if: steps.screenshots.outputs.should_run == 'true'
         run: |
           git add -A
           CHANGED=$(git diff --cached --name-only -- '*.png' '*.jpg' '*.jpeg' | wc -l | tr -d ' ')

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -126,7 +126,7 @@ jobs:
           echo "count=$CHANGED" >> "$GITHUB_OUTPUT"
 
       - name: Commit updated snapshots
-        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.conclusion == 'success' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -134,7 +134,7 @@ jobs:
           git push
 
       - name: Comment on PR
-        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.conclusion == 'success' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v9
         with:
           script: |
@@ -147,7 +147,7 @@ jobs:
             });
 
       - name: Upload updated snapshots for fork PRs
-        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name != github.repository
+        if: steps.screenshots.outputs.should_run == 'true' && steps.snapshots.conclusion == 'success' && steps.snapshots.outputs.count != '0' && github.event.pull_request.head.repo.full_name != github.repository
         uses: actions/upload-artifact@v7
         with:
           name: updated-screenshots

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,7 @@ Do not request review while still pushing commits. Either declare a review commi
 
 - **All changes ship via PR from a manual `git worktree`** -- no direct commits to `main`, no exceptions. Create the worktree with `git worktree add -b <kebab-branch> ../<dir-name> origin/main` and do all work there. Applies to code AND docs.
 - **No PR merge until Greptile reports 5/5** -- every finding must be fixed in the diff or explicitly deferred in the PR body with a linked follow-up issue.
+- **Do not spam Greptile re-review comments** -- Greptile is configured to review every new commit. If the score/footer is stale after a push, it means the review is still running; wait and poll instead of repeatedly mentioning it.
 - No bare `catch {}` or `.catch(() => {})` -- every catch must check error type and log
 - No `fetch()` without `signal: AbortSignal.timeout()` -- 10s APIs, 30s downloads
 - No `writeFileSync`/`appendFileSync` in request handlers -- use `fs/promises`

--- a/shell/src/components/MenuBar.tsx
+++ b/shell/src/components/MenuBar.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { UserButton as ClerkUserButton, useAuth } from "@clerk/nextjs";
 import { useWindowManager } from "@/hooks/useWindowManager";
-import { SearchIcon, UserIcon } from "lucide-react";
+import { SearchIcon, ServerIcon, UserIcon } from "lucide-react";
 import { AppSettingsDialog } from "./AppSettingsDialog";
 
 const FALLBACK_APP_ICON = "/icon-192.png";
@@ -81,7 +81,15 @@ function MenuBarUser() {
           },
         }}
         afterSignOutUrl="https://app.matrix-os.com/sign-in"
-      />
+      >
+        <ClerkUserButton.MenuItems>
+          <ClerkUserButton.Link
+            label="Switch computer"
+            labelIcon={<ServerIcon className="size-4" aria-hidden="true" />}
+            href="/runtime"
+          />
+        </ClerkUserButton.MenuItems>
+      </ClerkUserButton>
     </div>
   );
 }
@@ -189,10 +197,6 @@ export function MenuBar({ onOpenCommandPalette, onNewWindow, onMinimizeWindow, c
   const openAppSettings = useCallback(() => {
     setAppSettingsOpen(true);
   }, []);
-  const switchComputer = useCallback(() => {
-    window.location.assign("/runtime");
-  }, []);
-
   const appItems: MenuEntry[] = [
     { label: "Settings…", shortcut: "⌘,", action: openAppSettings },
   ];
@@ -243,10 +247,6 @@ export function MenuBar({ onOpenCommandPalette, onNewWindow, onMinimizeWindow, c
     { label: "Command Palette", shortcut: "⌘K", action: onOpenCommandPalette },
   ];
 
-  const computerItems: MenuEntry[] = [
-    { label: "Switch Computer…", action: switchComputer },
-  ];
-
   return (
     <>
       <header data-menu-bar className="fixed top-0 inset-x-0 z-[60] hidden md:grid grid-cols-[1fr_auto_1fr] h-7 items-center px-3 text-[13px] leading-7 select-none bg-card/60 backdrop-blur-xl border-b border-border/30 shadow-sm">
@@ -270,7 +270,6 @@ export function MenuBar({ onOpenCommandPalette, onNewWindow, onMinimizeWindow, c
           <MenuDropdown label="File" items={fileItems} open={openMenu === "file"} onToggle={() => toggleMenu("file")} onClose={closeMenu} />
           <MenuDropdown label="Edit" items={editItems} open={openMenu === "edit"} onToggle={() => toggleMenu("edit")} onClose={closeMenu} />
           <MenuDropdown label="View" items={viewItems} open={openMenu === "view"} onToggle={() => toggleMenu("view")} onClose={closeMenu} />
-          <MenuDropdown label="Computer" items={computerItems} open={openMenu === "computer"} onToggle={() => toggleMenu("computer")} onClose={closeMenu} />
         </div>
 
         {/* Center: contextual toolbar controls — always centered via grid */}

--- a/shell/src/components/RuntimeIdentityBanner.tsx
+++ b/shell/src/components/RuntimeIdentityBanner.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangleIcon, CpuIcon, HardDriveIcon, RefreshCcwIcon, ServerIcon } from "lucide-react";
+import { AlertTriangleIcon, CpuIcon, HardDriveIcon, RefreshCcwIcon, ServerIcon, XIcon } from "lucide-react";
 import { getGatewayUrl } from "@/lib/gateway";
+
+const ATTENTION_RELEASE_CHANNELS = new Set(["dev", "canary", "beta"]);
 
 interface RuntimeInfo {
   runtime?: {
@@ -12,6 +14,7 @@ interface RuntimeInfo {
   };
   release?: {
     version?: string | null;
+    channel?: string | null;
   };
   resources?: {
     cpuCount?: number;
@@ -44,6 +47,7 @@ export function RuntimeIdentityBanner() {
   const [runtime, setRuntime] = useState<RuntimeInfo | null>(null);
   const [identity, setIdentity] = useState<IdentityInfo | null>(null);
   const [resetting, setResetting] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -82,20 +86,25 @@ export function RuntimeIdentityBanner() {
     const slot = runtime?.runtime?.runtimeSlot ?? "primary";
     const machineId = runtime?.runtime?.machineId ?? null;
     const isStaging = slot !== "primary";
+    const channel = runtime?.release?.channel?.toLowerCase() ?? null;
+    const shouldShow = isStaging || (channel ? ATTENTION_RELEASE_CHANNELS.has(channel) : false);
     return {
       handle,
       slot,
       machineId,
       shortId: shortMachineId(machineId),
       version: runtime?.release?.version ?? "version pending",
+      channel,
       cpu: runtime?.resources?.cpuCount ? `${runtime.resources.cpuCount} CPU` : null,
       memory: formatBytes(runtime?.resources?.memoryTotalBytes),
       disk: formatBytes(runtime?.resources?.diskTotalBytes),
       isStaging,
+      shouldShow,
+      label: isStaging ? "STAGING VM" : `${channel?.toUpperCase() ?? "RUNTIME"} BUILD`,
     };
   }, [identity?.handle, runtime]);
 
-  if (!summary.handle) return null;
+  if (!summary.handle || !summary.shouldShow || dismissed) return null;
 
   const resetOnboarding = async () => {
     if (resetting) return;
@@ -121,42 +130,55 @@ export function RuntimeIdentityBanner() {
         "fixed right-3 top-9 z-[95] max-w-[calc(100vw-1.5rem)] rounded-md border px-3 py-2 shadow-[0_18px_60px_rgba(0,0,0,0.18)] backdrop-blur-md",
         summary.isStaging
           ? "border-[#8a3a11]/35 bg-[#fff1df]/92 text-[#3f210d]"
-          : "border-[#17281f]/14 bg-white/82 text-[#17281f]",
+          : "border-[#8a3a11]/30 bg-[#fff8e8]/92 text-[#3f210d]",
       ].join(" ")}
       aria-label="Current Matrix VM"
     >
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-        <span className="inline-flex items-center gap-1.5 font-semibold">
-          {summary.isStaging ? <AlertTriangleIcon className="h-3.5 w-3.5 text-[#b4531f]" aria-hidden="true" /> : <ServerIcon className="h-3.5 w-3.5" aria-hidden="true" />}
-          {summary.isStaging ? "STAGING VM" : "Matrix VM"}
-        </span>
-        <span className="font-mono font-semibold">{summary.handle ?? "unknown"}</span>
-        <span className="rounded-full border border-current/15 px-2 py-0.5 font-medium">{summary.slot}</span>
-        {summary.shortId && <span className="font-mono text-current/62">#{summary.shortId}</span>}
-      </div>
-      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-current/62">
-        {summary.cpu && (
-          <span className="inline-flex items-center gap-1">
-            <CpuIcon className="h-3 w-3" aria-hidden="true" />
-            {summary.cpu}
-          </span>
-        )}
-        {summary.memory && <span>{summary.memory} RAM</span>}
-        {summary.disk && (
-          <span className="inline-flex items-center gap-1">
-            <HardDriveIcon className="h-3 w-3" aria-hidden="true" />
-            {summary.disk}
-          </span>
-        )}
-        <span className="max-w-[18rem] truncate font-mono">{summary.version}</span>
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+            <span className="inline-flex items-center gap-1.5 font-semibold">
+              {summary.isStaging ? <AlertTriangleIcon className="h-3.5 w-3.5 text-[#b4531f]" aria-hidden="true" /> : <ServerIcon className="h-3.5 w-3.5" aria-hidden="true" />}
+              {summary.label}
+            </span>
+            <span className="font-mono font-semibold">{summary.handle ?? "unknown"}</span>
+            <span className="rounded-full border border-current/15 px-2 py-0.5 font-medium">{summary.slot}</span>
+            {summary.channel && <span className="rounded-full border border-current/15 px-2 py-0.5 font-medium">{summary.channel}</span>}
+            {summary.shortId && <span className="font-mono text-current/62">#{summary.shortId}</span>}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-current/62">
+            {summary.cpu && (
+              <span className="inline-flex items-center gap-1">
+                <CpuIcon className="h-3 w-3" aria-hidden="true" />
+                {summary.cpu}
+              </span>
+            )}
+            {summary.memory && <span>{summary.memory} RAM</span>}
+            {summary.disk && (
+              <span className="inline-flex items-center gap-1">
+                <HardDriveIcon className="h-3 w-3" aria-hidden="true" />
+                {summary.disk}
+              </span>
+            )}
+            <span className="max-w-[18rem] truncate font-mono">{summary.version}</span>
+            <button
+              type="button"
+              onClick={() => void resetOnboarding()}
+              disabled={resetting}
+              className="inline-flex min-h-6 items-center gap-1 rounded-full border border-current/15 bg-white/35 px-2 py-0.5 font-medium text-current/78 transition hover:bg-white/60 disabled:cursor-wait disabled:opacity-60"
+            >
+              <RefreshCcwIcon className="h-3 w-3" aria-hidden="true" />
+              {resetting ? "Resetting" : "Reset onboarding"}
+            </button>
+          </div>
+        </div>
         <button
           type="button"
-          onClick={() => void resetOnboarding()}
-          disabled={resetting}
-          className="inline-flex min-h-6 items-center gap-1 rounded-full border border-current/15 bg-white/35 px-2 py-0.5 font-medium text-current/78 transition hover:bg-white/60 disabled:cursor-wait disabled:opacity-60"
+          onClick={() => setDismissed(true)}
+          className="-mr-1 -mt-1 inline-flex size-6 shrink-0 items-center justify-center rounded-full text-current/58 transition hover:bg-white/55 hover:text-current"
+          aria-label="Dismiss runtime banner"
         >
-          <RefreshCcwIcon className="h-3 w-3" aria-hidden="true" />
-          {resetting ? "Resetting" : "Reset onboarding"}
+          <XIcon className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
       </div>
     </aside>

--- a/shell/src/components/UserButton.tsx
+++ b/shell/src/components/UserButton.tsx
@@ -7,7 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { UserIcon } from "lucide-react";
+import { ServerIcon, UserIcon } from "lucide-react";
 
 function Placeholder() {
   return (
@@ -54,6 +54,14 @@ function MountedUserButton() {
         },
       }}
       afterSignOutUrl="https://app.matrix-os.com/sign-in"
-    />
+    >
+      <ClerkUserButton.MenuItems>
+        <ClerkUserButton.Link
+          label="Switch computer"
+          labelIcon={<ServerIcon className="size-4" aria-hidden="true" />}
+          href="/runtime"
+        />
+      </ClerkUserButton.MenuItems>
+    </ClerkUserButton>
   );
 }

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -211,6 +211,7 @@ export function SystemSection() {
           : target.channel
             ? channelInstalled && (installedVersion !== currentVersion || target.channel !== installedChannel)
             : installedVersion !== currentVersion;
+        if (!mountedRef.current) return false;
         if (installed) {
           setInfo(nextInfo);
           setUpgradeMessage("Installed. Reloading...");

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -9,6 +9,8 @@ import { MonitorIcon, ActivityIcon, InfoIcon, ArrowUpCircleIcon } from "lucide-r
 
 const GATEWAY = getGatewayUrl();
 const SETTINGS_FETCH_TIMEOUT_MS = 10_000;
+const UPDATE_INSTALL_POLL_MS = 5_000;
+const UPDATE_INSTALL_TIMEOUT_MS = 5 * 60_000;
 
 interface SystemInfo {
   version?: string;
@@ -105,6 +107,7 @@ export function SystemSection() {
   const [upgrading, setUpgrading] = useState(false);
   const [installingTarget, setInstallingTarget] = useState<string | null>(null);
   const [upgradeError, setUpgradeError] = useState<string | null>(null);
+  const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
   const releaseRequestIdRef = useRef(0);
 
   const refreshReleaseData = useCallback(async (channel: ReleaseChannel) => {
@@ -161,11 +164,61 @@ export function SystemSection() {
 
   }, [refreshReleaseData]);
 
-  const startUpdate = useCallback(async (target: { channel?: ReleaseChannel; version?: string }) => {
+  const resolvedUpdate = resolveSystemUpdateState({
+    installedVersion: info.release?.version ?? info.version,
+    latestVersion: updateStatus?.latest?.version ?? null,
+    updateAvailable: updateStatus?.updateAvailable,
+    severity: updateStatus?.latest?.severity,
+    changelog: updateStatus?.latest?.changelog,
+    updateType: updateStatus?.latest?.updateType,
+  });
+  const currentVersion = resolvedUpdate.currentVersion;
+  const latestVersion = resolvedUpdate.latestVersion;
+  const updateAvailable = resolvedUpdate.updateAvailable;
+  const installedChannel = coerceReleaseChannel(info.release?.channel);
+  const releaseRows = releaseList?.releases ?? [];
+  const canInstallSelectedChannel = Boolean(latestVersion && (updateAvailable || selectedChannel !== installedChannel));
+
+  const waitForInstalledUpdate = useCallback(async (
+    target: { channel?: ReleaseChannel; version?: string },
+    expectedVersion?: string,
+  ) => {
+    const deadline = Date.now() + UPDATE_INSTALL_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, UPDATE_INSTALL_POLL_MS));
+      try {
+        const res = await fetch(`${GATEWAY}/api/system/info`, {
+          signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS),
+        });
+        if (!res.ok) continue;
+        const nextInfo = await res.json() as SystemInfo;
+        const installedVersion = nextInfo.release?.version ?? nextInfo.version;
+        const installedChannel = coerceReleaseChannel(nextInfo.release?.channel);
+        const targetVersion = expectedVersion ?? target.version;
+        const versionInstalled = targetVersion
+          ? installedVersion === targetVersion
+          : installedVersion !== currentVersion;
+        const channelInstalled = target.channel ? installedChannel === target.channel : true;
+        const installed = versionInstalled && channelInstalled;
+        if (installed) {
+          setInfo(nextInfo);
+          setUpgradeMessage("Installed. Reloading...");
+          setTimeout(() => window.location.reload(), 2_000);
+          return true;
+        }
+      } catch (err: unknown) {
+        console.warn("[system-settings] waiting for update install:", err instanceof Error ? err.message : String(err));
+      }
+    }
+    return false;
+  }, [currentVersion]);
+
+  const startUpdate = useCallback(async (target: { channel?: ReleaseChannel; version?: string }, expectedVersion?: string) => {
     const targetKey = target.version ?? target.channel ?? "stable";
     setUpgrading(true);
     setInstallingTarget(targetKey);
     setUpgradeError(null);
+    setUpgradeMessage(`Installing ${targetKey}. This can take a few minutes...`);
 
     try {
       const res = await fetch(`${GATEWAY}/api/system/update`, {
@@ -186,6 +239,7 @@ export function SystemSection() {
           console.warn("[system-settings] failed to parse upgrade error:", err instanceof Error ? err.message : String(err));
         }
         setUpgradeError(message);
+        setUpgradeMessage(null);
         setUpgrading(false);
         setInstallingTarget(null);
         return;
@@ -193,11 +247,17 @@ export function SystemSection() {
     } catch (err: unknown) {
       // Connection drop is expected while the container is being replaced.
       console.warn("[system-settings] upgrade request interrupted:", err instanceof Error ? err.message : String(err));
+      setUpgradeMessage("Upgrade started. Waiting for services to come back...");
     }
 
-    // Container will restart; reload after 15s
-    setTimeout(() => window.location.reload(), 15000);
-  }, []);
+    const installed = await waitForInstalledUpdate(target, expectedVersion);
+    if (!installed) {
+      setUpgradeMessage(null);
+      setUpgradeError("Upgrade is still running. Check again in a minute.");
+      setUpgrading(false);
+      setInstallingTarget(null);
+    }
+  }, [waitForInstalledUpdate]);
 
   const handleChannelChange = useCallback((value: string) => {
     const channel = coerceReleaseChannel(value);
@@ -206,23 +266,8 @@ export function SystemSection() {
   }, [refreshReleaseData]);
 
   const handleUpgrade = useCallback(async () => {
-    await startUpdate({ channel: selectedChannel });
-  }, [selectedChannel, startUpdate]);
-
-  const resolvedUpdate = resolveSystemUpdateState({
-    installedVersion: info.release?.version ?? info.version,
-    latestVersion: updateStatus?.latest?.version ?? null,
-    updateAvailable: updateStatus?.updateAvailable,
-    severity: updateStatus?.latest?.severity,
-    changelog: updateStatus?.latest?.changelog,
-    updateType: updateStatus?.latest?.updateType,
-  });
-  const currentVersion = resolvedUpdate.currentVersion;
-  const latestVersion = resolvedUpdate.latestVersion;
-  const updateAvailable = resolvedUpdate.updateAvailable;
-  const installedChannel = coerceReleaseChannel(info.release?.channel);
-  const releaseRows = releaseList?.releases ?? [];
-  const canInstallSelectedChannel = Boolean(latestVersion && (updateAvailable || selectedChannel !== installedChannel));
+    await startUpdate({ channel: selectedChannel }, latestVersion ?? undefined);
+  }, [latestVersion, selectedChannel, startUpdate]);
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
@@ -355,13 +400,16 @@ export function SystemSection() {
                 className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors disabled:opacity-50"
               >
                 {upgrading
-                  ? "Installing... reloading in 15s"
+                  ? "Installing... checking status"
                   : selectedChannel !== installedChannel
                     ? `Switch to ${selectedChannel}`
                     : resolvedUpdate.autoApplying ? "Retry Update" : "Upgrade Now"}
               </button>
               {upgradeError && (
                 <p className="text-xs text-red-500">{upgradeError}</p>
+              )}
+              {upgradeMessage && (
+                <p className="text-xs text-muted-foreground">{upgradeMessage}</p>
               )}
             </div>
           )}
@@ -412,7 +460,7 @@ export function SystemSection() {
                       </p>
                     </div>
                     <button
-                      onClick={() => release.version && void startUpdate({ version: release.version })}
+                      onClick={() => release.version && void startUpdate({ version: release.version }, release.version)}
                       disabled={!canInstallRelease || upgrading}
                       className="shrink-0 rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors disabled:opacity-50"
                     >

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -193,13 +193,16 @@ export function SystemSection() {
         if (!res.ok) continue;
         const nextInfo = await res.json() as SystemInfo;
         const installedVersion = nextInfo.release?.version ?? nextInfo.version;
-        const installedChannel = coerceReleaseChannel(nextInfo.release?.channel);
+        const polledChannel = coerceReleaseChannel(nextInfo.release?.channel);
         const targetVersion = expectedVersion ?? target.version;
-        const versionInstalled = targetVersion
-          ? installedVersion === targetVersion
-          : installedVersion !== currentVersion;
-        const channelInstalled = target.channel ? installedChannel === target.channel : true;
-        const installed = versionInstalled && channelInstalled;
+        const channelInstalled = target.channel ? polledChannel === target.channel : true;
+        const installed = target.version
+          ? installedVersion === target.version && channelInstalled
+          : target.channel
+            ? channelInstalled && (installedVersion !== currentVersion || target.channel !== installedChannel)
+            : targetVersion
+              ? installedVersion === targetVersion
+              : installedVersion !== currentVersion;
         if (installed) {
           setInfo(nextInfo);
           setUpgradeMessage("Installed. Reloading...");
@@ -211,7 +214,7 @@ export function SystemSection() {
       }
     }
     return false;
-  }, [currentVersion]);
+  }, [currentVersion, installedChannel]);
 
   const startUpdate = useCallback(async (target: { channel?: ReleaseChannel; version?: string }, expectedVersion?: string) => {
     const targetKey = target.version ?? target.channel ?? "stable";

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -109,6 +109,17 @@ export function SystemSection() {
   const [upgradeError, setUpgradeError] = useState<string | null>(null);
   const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
   const releaseRequestIdRef = useRef(0);
+  const mountedRef = useRef(true);
+  const reloadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      if (reloadTimeoutRef.current) {
+        clearTimeout(reloadTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const refreshReleaseData = useCallback(async (channel: ReleaseChannel) => {
     const requestId = releaseRequestIdRef.current + 1;
@@ -181,11 +192,11 @@ export function SystemSection() {
 
   const waitForInstalledUpdate = useCallback(async (
     target: { channel?: ReleaseChannel; version?: string },
-    expectedVersion?: string,
   ) => {
     const deadline = Date.now() + UPDATE_INSTALL_TIMEOUT_MS;
     while (Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, UPDATE_INSTALL_POLL_MS));
+      if (!mountedRef.current) return false;
       try {
         const res = await fetch(`${GATEWAY}/api/system/info`, {
           signal: AbortSignal.timeout(SETTINGS_FETCH_TIMEOUT_MS),
@@ -194,19 +205,21 @@ export function SystemSection() {
         const nextInfo = await res.json() as SystemInfo;
         const installedVersion = nextInfo.release?.version ?? nextInfo.version;
         const polledChannel = coerceReleaseChannel(nextInfo.release?.channel);
-        const targetVersion = expectedVersion ?? target.version;
         const channelInstalled = target.channel ? polledChannel === target.channel : true;
         const installed = target.version
           ? installedVersion === target.version && channelInstalled
           : target.channel
             ? channelInstalled && (installedVersion !== currentVersion || target.channel !== installedChannel)
-            : targetVersion
-              ? installedVersion === targetVersion
-              : installedVersion !== currentVersion;
+            : installedVersion !== currentVersion;
         if (installed) {
           setInfo(nextInfo);
           setUpgradeMessage("Installed. Reloading...");
-          setTimeout(() => window.location.reload(), 2_000);
+          setUpgrading(false);
+          setInstallingTarget(null);
+          if (reloadTimeoutRef.current) {
+            clearTimeout(reloadTimeoutRef.current);
+          }
+          reloadTimeoutRef.current = setTimeout(() => window.location.reload(), 2_000);
           return true;
         }
       } catch (err: unknown) {
@@ -216,7 +229,7 @@ export function SystemSection() {
     return false;
   }, [currentVersion, installedChannel]);
 
-  const startUpdate = useCallback(async (target: { channel?: ReleaseChannel; version?: string }, expectedVersion?: string) => {
+  const startUpdate = useCallback(async (target: { channel?: ReleaseChannel; version?: string }) => {
     const targetKey = target.version ?? target.channel ?? "stable";
     setUpgrading(true);
     setInstallingTarget(targetKey);
@@ -253,7 +266,8 @@ export function SystemSection() {
       setUpgradeMessage("Upgrade started. Waiting for services to come back...");
     }
 
-    const installed = await waitForInstalledUpdate(target, expectedVersion);
+    const installed = await waitForInstalledUpdate(target);
+    if (!mountedRef.current) return;
     if (!installed) {
       setUpgradeMessage(null);
       setUpgradeError("Upgrade is still running. Check again in a minute.");
@@ -269,8 +283,8 @@ export function SystemSection() {
   }, [refreshReleaseData]);
 
   const handleUpgrade = useCallback(async () => {
-    await startUpdate({ channel: selectedChannel }, latestVersion ?? undefined);
-  }, [latestVersion, selectedChannel, startUpdate]);
+    await startUpdate({ channel: selectedChannel });
+  }, [selectedChannel, startUpdate]);
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
@@ -463,7 +477,7 @@ export function SystemSection() {
                       </p>
                     </div>
                     <button
-                      onClick={() => release.version && void startUpdate({ version: release.version }, release.version)}
+                      onClick={() => release.version && void startUpdate({ version: release.version })}
                       disabled={!canInstallRelease || upgrading}
                       className="shrink-0 rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors disabled:opacity-50"
                     >

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -409,8 +409,14 @@ export function SystemSection() {
               This is a security update scheduled for automatic installation. Use the button below if it hasn't taken effect.
             </p>
           )}
+          {upgradeError && (
+            <p className="text-xs text-red-500">{upgradeError}</p>
+          )}
+          {upgradeMessage && (
+            <p className="text-xs text-muted-foreground">{upgradeMessage}</p>
+          )}
           {canInstallSelectedChannel && (
-            <div className="pt-1 space-y-2">
+            <div className="pt-1">
               <button
                 onClick={handleUpgrade}
                 disabled={upgrading}
@@ -422,12 +428,6 @@ export function SystemSection() {
                     ? `Switch to ${selectedChannel}`
                     : resolvedUpdate.autoApplying ? "Retry Update" : "Upgrade Now"}
               </button>
-              {upgradeError && (
-                <p className="text-xs text-red-500">{upgradeError}</p>
-              )}
-              {upgradeMessage && (
-                <p className="text-xs text-muted-foreground">{upgradeMessage}</p>
-              )}
             </div>
           )}
           {latestVersion && !canInstallSelectedChannel && (

--- a/tests/shell/menu-bar-focus.test.tsx
+++ b/tests/shell/menu-bar-focus.test.tsx
@@ -1,14 +1,20 @@
 // @vitest-environment jsdom
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWindowManager } from "../../shell/src/hooks/useWindowManager.js";
 
 let MenuBar: typeof import("../../shell/src/components/MenuBar.js").MenuBar;
 
 vi.mock("@clerk/nextjs", () => ({
-  useAuth: () => ({ isLoaded: true, isSignedIn: false }),
-  UserButton: () => null,
+  useAuth: () => ({ isLoaded: true, isSignedIn: true }),
+  UserButton: Object.assign(
+    ({ children }: { children?: React.ReactNode }) => <div data-testid="clerk-user-button">{children}</div>,
+    {
+      MenuItems: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+      Link: ({ href, label }: { href: string; label: string; labelIcon?: React.ReactElement }) => <a href={href}>{label}</a>,
+    },
+  ),
 }));
 
 vi.mock("../../shell/src/components/AppSettingsDialog.js", () => ({
@@ -65,22 +71,14 @@ describe("MenuBar focus display", () => {
     expect(screen.queryByRole("button", { name: "Matrix OS" })).toBeNull();
   });
 
-  it("offers switch-computer from the menu bar", () => {
-    const assign = vi.fn();
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: { assign },
-    });
-
+  it("puts switch-computer under the Clerk user button instead of the top menu", () => {
     render(
       <MenuBar onOpenCommandPalette={() => {}} onNewWindow={() => {}}>
         <button type="button">Fit</button>
       </MenuBar>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Computer" }));
-    fireEvent.click(screen.getByRole("button", { name: "Switch Computer…" }));
-
-    expect(assign).toHaveBeenCalledWith("/runtime");
+    expect(screen.queryByRole("button", { name: "Computer" })).toBeNull();
+    expect(screen.getByRole("link", { name: "Switch computer" }).getAttribute("href")).toBe("/runtime");
   });
 });

--- a/tests/shell/runtime-identity-banner.test.tsx
+++ b/tests/shell/runtime-identity-banner.test.tsx
@@ -32,7 +32,7 @@ describe("RuntimeIdentityBanner", () => {
             machineId: "11111111-2222-3333-4444-555555555555",
             runtimeSlot: "staging",
           },
-          release: { version: "v082-test" },
+          release: { version: "v082-test", channel: "stable" },
           resources: {
             cpuCount: 2,
             memoryTotalBytes: 4 * 1024 * 1024 * 1024,
@@ -59,7 +59,7 @@ describe("RuntimeIdentityBanner", () => {
     });
   });
 
-  it("uses runtime slot, not handle text, to decide whether the VM is staging", async () => {
+  it("hides the primary VM banner for stable releases", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith("/api/system/info")) {
@@ -69,7 +69,7 @@ describe("RuntimeIdentityBanner", () => {
             machineId: "11111111-2222-3333-4444-555555555556",
             runtimeSlot: "primary",
           },
-          release: { version: "v082-test" },
+          release: { version: "v082-test", channel: "stable" },
         }));
       }
       if (url.endsWith("/api/identity")) {
@@ -81,10 +81,59 @@ describe("RuntimeIdentityBanner", () => {
     render(<RuntimeIdentityBanner />);
 
     await waitFor(() => {
-      expect(screen.getByText("Matrix VM")).toBeTruthy();
-      expect(screen.queryByText("STAGING VM")).toBeNull();
-      expect(screen.getByText("primary")).toBeTruthy();
+      expect(screen.queryByLabelText("Current Matrix VM")).toBeNull();
     });
+  });
+
+  it("shows the primary VM banner for dev, canary, and beta releases", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        return Promise.resolve(jsonResponse({
+          runtime: {
+            handle: "hamedmp",
+            machineId: "11111111-2222-3333-4444-555555555557",
+            runtimeSlot: "primary",
+          },
+          release: { version: "v2026.05.28-151", channel: "dev" },
+        }));
+      }
+      if (url.endsWith("/api/identity")) {
+        return Promise.resolve(jsonResponse({ handle: "hamedmp" }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    }));
+
+    render(<RuntimeIdentityBanner />);
+
+    await waitFor(() => {
+      expect(screen.getByText("DEV BUILD")).toBeTruthy();
+      expect(screen.getByText("hamedmp")).toBeTruthy();
+      expect(screen.getByText("primary")).toBeTruthy();
+      expect(screen.getByText("dev")).toBeTruthy();
+    });
+  });
+
+  it("dismisses the banner until the page refreshes", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        return Promise.resolve(jsonResponse({
+          runtime: { handle: "hamedmp", runtimeSlot: "primary" },
+          release: { version: "v2026.05.28-151", channel: "beta" },
+        }));
+      }
+      if (url.endsWith("/api/identity")) {
+        return Promise.resolve(jsonResponse({ handle: "hamedmp" }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    }));
+
+    render(<RuntimeIdentityBanner />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /dismiss runtime banner/i }));
+
+    expect(screen.queryByLabelText("Current Matrix VM")).toBeNull();
   });
 
   it("posts onboarding reset from the VM banner", async () => {

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -29,6 +29,7 @@ function jsonResponse(body: unknown) {
 
 describe("SystemSection release refresh", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -120,5 +121,105 @@ describe("SystemSection release refresh", () => {
     });
     expect(screen.queryByText("Latest stable release")).toBeNull();
     expect(screen.queryByText("v2026.05.14-2")).toBeNull();
+  });
+
+  it("keeps showing install progress while a VPS update is still applying", async () => {
+    let updateStarted = false;
+    let infoPollsAfterUpdate = 0;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        if (updateStarted) {
+          infoPollsAfterUpdate += 1;
+        }
+        if (infoPollsAfterUpdate >= 4) {
+          return Promise.resolve(jsonResponse({
+            version: "v2026.05.28-151",
+            release: {
+              version: "v2026.05.28-151",
+              channel: "stable",
+              buildTime: "2026-05-28T19:53:18.421Z",
+            },
+          }));
+        }
+        return Promise.resolve(jsonResponse({
+          version: "v2026.05.28-145",
+          release: {
+            version: "v2026.05.28-145",
+            channel: "dev",
+            buildTime: "2026-05-28T15:32:51.000Z",
+          },
+        }));
+      }
+      if (url.endsWith("/health")) {
+        return Promise.resolve(jsonResponse({ status: "ok", cronJobs: 0, channels: {} }));
+      }
+      if (url.endsWith("/api/system/update?channel=dev")) {
+        return Promise.resolve(jsonResponse({
+          channel: "dev",
+          latest: { version: "v2026.05.28-145" },
+          updateAvailable: false,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=dev")) {
+        return Promise.resolve(jsonResponse({ channel: "dev", releases: [] }));
+      }
+      if (url.endsWith("/api/system/update?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          latest: { version: "v2026.05.28-151" },
+          updateAvailable: true,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          releases: [{ version: "v2026.05.28-151", buildTime: "2026-05-28T19:53:18.421Z" }],
+        }));
+      }
+      if (url.endsWith("/api/system/update") && init?.method === "POST") {
+        updateStarted = true;
+        return Promise.resolve(jsonResponse({ ok: true, status: "started", channel: "stable" }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SystemSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Installed channel")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText("Release channel"), {
+      target: { value: "stable" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Switch to stable")).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByText("Switch to stable"));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Installing... checking status")).toBeTruthy();
+    expect(screen.getByText("Installing stable. This can take a few minutes...")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    expect(screen.getByText("Installing... checking status")).toBeTruthy();
+    expect(screen.getByText("Installing stable. This can take a few minutes...")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(screen.getByText("Installed. Reloading...")).toBeTruthy();
   });
 });

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -307,4 +307,173 @@ describe("SystemSection release refresh", () => {
     expect(screen.getByText("Installed. Reloading...")).toBeTruthy();
     expect(screen.queryByText("Upgrade is still running. Check again in a minute.")).toBeNull();
   });
+
+  it("re-enables update controls when install polling times out", async () => {
+    let updateStarted = false;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        return Promise.resolve(jsonResponse({
+          version: "v2026.05.28-145",
+          release: {
+            version: "v2026.05.28-145",
+            channel: "dev",
+            buildTime: "2026-05-28T15:32:51.000Z",
+          },
+        }));
+      }
+      if (url.endsWith("/health")) {
+        return Promise.resolve(jsonResponse({ status: "ok", cronJobs: 0, channels: {} }));
+      }
+      if (url.endsWith("/api/system/update?channel=dev")) {
+        return Promise.resolve(jsonResponse({
+          channel: "dev",
+          latest: { version: "v2026.05.28-145" },
+          updateAvailable: false,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=dev")) {
+        return Promise.resolve(jsonResponse({ channel: "dev", releases: [] }));
+      }
+      if (url.endsWith("/api/system/update?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          latest: { version: "v2026.05.28-151" },
+          updateAvailable: true,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          releases: [{ version: "v2026.05.28-151", buildTime: "2026-05-28T19:53:18.421Z" }],
+        }));
+      }
+      if (url.endsWith("/api/system/update") && init?.method === "POST") {
+        updateStarted = true;
+        return Promise.resolve(jsonResponse({ ok: true, status: "started", channel: "stable" }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SystemSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Installed channel")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText("Release channel"), {
+      target: { value: "stable" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Switch to stable")).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByText("Switch to stable"));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(305_000);
+    });
+
+    expect(updateStarted).toBe(true);
+    expect(screen.getByText("Upgrade is still running. Check again in a minute.")).toBeTruthy();
+    expect(screen.queryByText("Installing... checking status")).toBeNull();
+    expect(screen.getByText("Switch to stable")).toBeTruthy();
+  });
+
+  it("clears the scheduled reload when unmounted after a successful install", async () => {
+    let updateStarted = false;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        if (updateStarted) {
+          return Promise.resolve(jsonResponse({
+            version: "v2026.05.28-151",
+            release: {
+              version: "v2026.05.28-151",
+              channel: "stable",
+              buildTime: "2026-05-28T19:53:18.421Z",
+            },
+          }));
+        }
+        return Promise.resolve(jsonResponse({
+          version: "v2026.05.28-145",
+          release: {
+            version: "v2026.05.28-145",
+            channel: "dev",
+            buildTime: "2026-05-28T15:32:51.000Z",
+          },
+        }));
+      }
+      if (url.endsWith("/health")) {
+        return Promise.resolve(jsonResponse({ status: "ok", cronJobs: 0, channels: {} }));
+      }
+      if (url.endsWith("/api/system/update?channel=dev")) {
+        return Promise.resolve(jsonResponse({
+          channel: "dev",
+          latest: { version: "v2026.05.28-145" },
+          updateAvailable: false,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=dev")) {
+        return Promise.resolve(jsonResponse({ channel: "dev", releases: [] }));
+      }
+      if (url.endsWith("/api/system/update?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          latest: { version: "v2026.05.28-151" },
+          updateAvailable: true,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          releases: [{ version: "v2026.05.28-151", buildTime: "2026-05-28T19:53:18.421Z" }],
+        }));
+      }
+      if (url.endsWith("/api/system/update") && init?.method === "POST") {
+        updateStarted = true;
+        return Promise.resolve(jsonResponse({ ok: true, status: "started", channel: "stable" }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { unmount } = render(<SystemSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Installed channel")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText("Release channel"), {
+      target: { value: "stable" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Switch to stable")).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    fireEvent.click(screen.getByText("Switch to stable"));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(screen.getByText("Installed. Reloading...")).toBeTruthy();
+    const clearCallsBeforeUnmount = clearTimeoutSpy.mock.calls.length;
+
+    act(() => {
+      unmount();
+    });
+
+    expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(clearCallsBeforeUnmount);
+  });
 });

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -476,4 +476,100 @@ describe("SystemSection release refresh", () => {
 
     expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(clearCallsBeforeUnmount);
   });
+
+  it("does not schedule a reload when unmounted before a successful poll resolves", async () => {
+    let updateStarted = false;
+    const successfulPoll = deferred<Response>();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        if (updateStarted) {
+          return successfulPoll.promise;
+        }
+        return Promise.resolve(jsonResponse({
+          version: "v2026.05.28-145",
+          release: {
+            version: "v2026.05.28-145",
+            channel: "dev",
+            buildTime: "2026-05-28T15:32:51.000Z",
+          },
+        }));
+      }
+      if (url.endsWith("/health")) {
+        return Promise.resolve(jsonResponse({ status: "ok", cronJobs: 0, channels: {} }));
+      }
+      if (url.endsWith("/api/system/update?channel=dev")) {
+        return Promise.resolve(jsonResponse({
+          channel: "dev",
+          latest: { version: "v2026.05.28-145" },
+          updateAvailable: false,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=dev")) {
+        return Promise.resolve(jsonResponse({ channel: "dev", releases: [] }));
+      }
+      if (url.endsWith("/api/system/update?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          latest: { version: "v2026.05.28-151" },
+          updateAvailable: true,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          releases: [{ version: "v2026.05.28-151", buildTime: "2026-05-28T19:53:18.421Z" }],
+        }));
+      }
+      if (url.endsWith("/api/system/update") && init?.method === "POST") {
+        updateStarted = true;
+        return Promise.resolve(jsonResponse({ ok: true, status: "started", channel: "stable" }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { unmount } = render(<SystemSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Installed channel")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText("Release channel"), {
+      target: { value: "stable" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Switch to stable")).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    fireEvent.click(screen.getByText("Switch to stable"));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    await act(async () => {
+      successfulPoll.resolve(jsonResponse({
+        version: "v2026.05.28-151",
+        release: {
+          version: "v2026.05.28-151",
+          channel: "stable",
+          buildTime: "2026-05-28T19:53:18.421Z",
+        },
+      }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === 2_000)).toBe(false);
+  });
 });

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -222,4 +222,89 @@ describe("SystemSection release refresh", () => {
 
     expect(screen.getByText("Installed. Reloading...")).toBeTruthy();
   });
+
+  it("accepts a channel switch when a newer release installs than the click-time latest", async () => {
+    let updateStarted = false;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/system/info")) {
+        if (updateStarted) {
+          return Promise.resolve(jsonResponse({
+            version: "v2026.05.28-152",
+            release: {
+              version: "v2026.05.28-152",
+              channel: "stable",
+              buildTime: "2026-05-28T20:02:18.421Z",
+            },
+          }));
+        }
+        return Promise.resolve(jsonResponse({
+          version: "v2026.05.28-145",
+          release: {
+            version: "v2026.05.28-145",
+            channel: "dev",
+            buildTime: "2026-05-28T15:32:51.000Z",
+          },
+        }));
+      }
+      if (url.endsWith("/health")) {
+        return Promise.resolve(jsonResponse({ status: "ok", cronJobs: 0, channels: {} }));
+      }
+      if (url.endsWith("/api/system/update?channel=dev")) {
+        return Promise.resolve(jsonResponse({
+          channel: "dev",
+          latest: { version: "v2026.05.28-145" },
+          updateAvailable: false,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=dev")) {
+        return Promise.resolve(jsonResponse({ channel: "dev", releases: [] }));
+      }
+      if (url.endsWith("/api/system/update?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          latest: { version: "v2026.05.28-151" },
+          updateAvailable: true,
+        }));
+      }
+      if (url.endsWith("/api/system/releases?channel=stable")) {
+        return Promise.resolve(jsonResponse({
+          channel: "stable",
+          releases: [{ version: "v2026.05.28-151", buildTime: "2026-05-28T19:53:18.421Z" }],
+        }));
+      }
+      if (url.endsWith("/api/system/update") && init?.method === "POST") {
+        updateStarted = true;
+        return Promise.resolve(jsonResponse({ ok: true, status: "started", channel: "stable" }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SystemSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Installed channel")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText("Release channel"), {
+      target: { value: "stable" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Switch to stable")).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByText("Switch to stable"));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(screen.getByText("Installed. Reloading...")).toBeTruthy();
+    expect(screen.queryByText("Upgrade is still running. Check again in a minute.")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Keep the Settings update UI in an installing state while the VPS host-bundle updater is still applying a channel or version change.
- Poll /api/system/info until the expected release/channel is actually installed, then reload after confirmation instead of after a fixed 15 seconds.
- Restrict the runtime identity banner so stable primary VPSes do not show it, keep it for staging/non-primary and dev/canary/beta primary builds, and add a refresh-scoped dismiss button.
- Move Switch computer out of the top-level menu bar and into the Clerk UserButton menu.

## Tests
- bun run typecheck
- bun run check:patterns
- bun run test
- bun run test tests/shell/system-section-refresh.test.tsx
- bun run test tests/shell/runtime-identity-banner.test.tsx tests/shell/menu-bar-focus.test.tsx tests/shell/user-button-hydration.test.tsx tests/shell/system-section-refresh.test.tsx

## Invariants
- Source of truth: /api/system/info release metadata remains the canonical installed runtime state displayed by Settings and used by the runtime banner.
- Lock/transaction scope: this PR adds client-side polling and shell chrome behavior only; it does not change backend release registration, promotion, updater locking, or runtime routing.
- Acceptable orphan states: if polling times out, the UI reports that the upgrade is still running and lets the user check again instead of declaring failure or reloading early. Banner dismissal is intentionally local component state and returns on refresh.
- Auth source of truth: existing gateway auth for /api/system/update, /api/system/info, /api/identity, and Clerk UserButton session state is unchanged.
- Deferred scope: no changes to host-bundle publishing, matrix-update service behavior, fleet deploy orchestration, or Clerk account/profile pages.