### PR TITLE
feat(shell): redesign terminal cockpit

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1274,10 +1274,13 @@ function LocalTerminalSidebar() {
     const name = await ctx.createShellSessionTab("Zellij", ctx.sidebarSelectedPath ?? DEFAULT_CWD);
     if (name) {
       await fetchShells();
+    } else {
+      setShellsError("Failed to create shell");
     }
   };
 
   const deleteManagedShell = async (name: string) => {
+    setShellsError(null);
     try {
       const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(name)}?force=1`, {
         method: "DELETE",

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1118,6 +1118,11 @@ function LocalTerminalSidebar() {
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [filter, setFilter] = useState("");
 
+  const selectSidebarTab = useCallback((nextTab: SidebarTab) => {
+    setTab(nextTab);
+    setFilter("");
+  }, []);
+
   const fetchProjects = useCallback(async () => {
     setProjectsLoading(true);
     setProjectsError(null);
@@ -1374,10 +1379,10 @@ function LocalTerminalSidebar() {
           background: "color-mix(in srgb, var(--background) 62%, var(--card))",
         }}
       >
-        <SidebarRailButton label="Projects" icon={<FolderIcon size={16} strokeWidth={1.8} />} active={tab === "projects"} onClick={() => setTab("projects")} />
-        <SidebarRailButton label="Shells" icon={<TerminalIcon size={16} strokeWidth={1.8} />} active={tab === "shells"} onClick={() => setTab("shells")} />
-        <SidebarRailButton label="Agents" icon={<BotIcon size={16} strokeWidth={1.8} />} active={tab === "sessions"} onClick={() => setTab("sessions")} />
-        <SidebarRailButton label="Files" icon={<FilesIcon size={16} strokeWidth={1.8} />} active={tab === "files"} onClick={() => setTab("files")} />
+        <SidebarRailButton label="Projects" icon={<FolderIcon size={16} strokeWidth={1.8} />} active={tab === "projects"} onClick={() => selectSidebarTab("projects")} />
+        <SidebarRailButton label="Shells" icon={<TerminalIcon size={16} strokeWidth={1.8} />} active={tab === "shells"} onClick={() => selectSidebarTab("shells")} />
+        <SidebarRailButton label="Agents" icon={<BotIcon size={16} strokeWidth={1.8} />} active={tab === "sessions"} onClick={() => selectSidebarTab("sessions")} />
+        <SidebarRailButton label="Files" icon={<FilesIcon size={16} strokeWidth={1.8} />} active={tab === "files"} onClick={() => selectSidebarTab("files")} />
         <div style={{ flex: 1 }} />
         <button
           className="flex items-center justify-center cursor-pointer transition-colors"
@@ -1453,7 +1458,7 @@ function LocalTerminalSidebar() {
           </div>
           <div className="flex items-center gap-1.5">
             <input
-              aria-label={`Search ${tab}`}
+              aria-label={`Search ${tab === "sessions" ? "agents" : tab}`}
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
               placeholder={tab === "shells" ? "Find shell..." : tab === "sessions" ? "Find agent..." : tab === "files" ? "Find file..." : "Find project..."}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { createContext, useContext, useEffect, useRef, useCallback, useState } from "react";
+import {
+  BotIcon,
+  FilesIcon,
+  FolderIcon,
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  TerminalIcon,
+} from "lucide-react";
 import { type PaneNode, countPanes as countPanesFromStore, getAllPaneIds } from "@/stores/terminal-store";
 import { PaneGrid } from "./PaneGrid";
 import { useTheme } from "@/hooks/useTheme";
@@ -898,18 +908,29 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
 
   return (
     <div
-      className="flex items-stretch border-b shrink-0 select-none"
+      className="grid items-stretch border-b shrink-0 select-none"
       style={{
         background: "var(--card)",
         borderColor: "var(--border)",
-        height: ctx.mobile ? 50 : 40,
+        height: ctx.mobile ? 50 : 44,
         padding: "4px 6px",
         gap: 4,
+        gridTemplateColumns: ctx.mobile ? "1fr auto" : "minmax(0, 1fr) auto",
+        minWidth: 0,
       }}
     >
-      <div className="flex items-stretch overflow-x-auto flex-1 min-w-0" style={{ gap: 2 }}>
+      <div
+        className="flex items-stretch overflow-x-auto min-w-0"
+        style={{
+          gap: 3,
+          scrollbarWidth: "thin",
+          overscrollBehaviorX: "contain",
+        }}
+      >
         {ctx.tabs.map((tab, i) => {
           const active = tab.id === ctx.activeTabId;
+          const tabPaneId = getFirstPaneId(tab.paneTree);
+          const tabSessionId = getPaneSessionId(tab.paneTree, tabPaneId);
           return (
             <div
               key={tab.id}
@@ -921,8 +942,10 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
                 borderRadius: 6,
                 padding: ctx.mobile ? "0 8px" : "0 10px",
                 fontSize: 12,
-                height: ctx.mobile ? 34 : 30,
+                height: ctx.mobile ? 34 : 34,
                 fontWeight: active ? 500 : 400,
+                minWidth: ctx.mobile ? 112 : 136,
+                maxWidth: ctx.mobile ? 168 : 220,
               }}
               draggable
               onClick={() => ctx.setActiveTab(tab.id)}
@@ -940,11 +963,11 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
                 }}
               />
               <span
-                className={ctx.mobile ? "flex min-w-0 flex-col leading-tight" : undefined}
-                style={{ maxWidth: ctx.mobile ? 132 : 160, overflow: "hidden" }}
+                className="flex min-w-0 flex-col leading-tight"
+                style={{ overflow: "hidden" }}
               >
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{tab.label}</span>
-                {ctx.mobile && active && (
+                {(ctx.mobile || active) && (
                   <span
                     style={{
                       color: "var(--muted-foreground)",
@@ -952,9 +975,10 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
                       fontWeight: 400,
                       overflow: "hidden",
                       textOverflow: "ellipsis",
+                      fontFamily: "var(--font-mono, ui-monospace, monospace)",
                     }}
                   >
-                    {formatCwd(activeCwd)}
+                    {active ? formatCwd(activeCwd) : tabSessionId ?? formatCwd(getPaneCwd(tab.paneTree, tabPaneId) ?? defaultCwd)}
                   </span>
                 )}
               </span>
@@ -983,7 +1007,15 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
           );
         })}
       </div>
-      <div className="flex items-center shrink-0" style={{ gap: 4, paddingLeft: 8, borderLeft: "1px solid var(--border)" }}>
+      <div
+        className="flex items-center shrink-0"
+        style={{
+          gap: 4,
+          paddingLeft: 8,
+          borderLeft: "1px solid var(--border)",
+          minWidth: 0,
+        }}
+      >
         {ctx.mobile ? (
           <ToolbarBtn
             onClick={() => ctx.addTab(getCwd())}
@@ -1044,7 +1076,15 @@ interface ProjectInfo {
   modified: string | null;
 }
 
-type SidebarTab = "projects" | "files" | "sessions";
+type SidebarTab = "projects" | "shells" | "sessions" | "files";
+
+interface ShellSessionSummary {
+  name: string;
+  status?: "active" | "exited";
+  updatedAt?: string;
+  attachedClients?: number;
+  tabs?: Array<{ idx: number; name?: string; focused?: boolean }>;
+}
 
 interface WorkspaceSessionSummary {
   id: string;
@@ -1068,6 +1108,9 @@ function LocalTerminalSidebar() {
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [projectsLoading, setProjectsLoading] = useState(true);
   const [projectsError, setProjectsError] = useState<string | null>(null);
+  const [shells, setShells] = useState<ShellSessionSummary[]>([]);
+  const [shellsLoading, setShellsLoading] = useState(false);
+  const [shellsError, setShellsError] = useState<string | null>(null);
   const [sessions, setSessions] = useState<WorkspaceSessionSummary[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(false);
   const [sessionsError, setSessionsError] = useState<string | null>(null);
@@ -1102,6 +1145,33 @@ function LocalTerminalSidebar() {
   useEffect(() => {
     if (tab === "projects") void fetchProjects();
   }, [tab, fetchProjects]);
+
+  const fetchShells = useCallback(async () => {
+    setShellsLoading(true);
+    setShellsError(null);
+    try {
+      const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        setShellsError("Failed to load shells");
+        setShells([]);
+        return;
+      }
+      const data = (await res.json()) as { sessions?: ShellSessionSummary[] };
+      setShells(Array.isArray(data.sessions) ? data.sessions : []);
+    } catch (err: unknown) {
+      console.warn("Failed to load shell sessions:", err instanceof Error ? err.message : err);
+      setShellsError("Could not reach gateway");
+      setShells([]);
+    } finally {
+      setShellsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tab === "shells") void fetchShells();
+  }, [fetchShells, tab]);
 
   const fetchSessions = useCallback(async () => {
     setSessionsLoading(true);
@@ -1157,14 +1227,14 @@ function LocalTerminalSidebar() {
 
   if (!ctx.sidebarOpen) {
     return (
-      <div className="flex flex-col items-center py-2 gap-2 shrink-0" style={{ width: 40, background: "var(--card)", borderRight: "1px solid var(--border)" }}>
+      <div className="flex flex-col items-center py-2 gap-2 shrink-0" style={{ width: 44, background: "var(--card)", borderRight: "1px solid var(--border)" }}>
         <button
           className="flex items-center justify-center rounded cursor-pointer hover:bg-[var(--accent)] transition-colors"
-          style={{ width: 28, height: 28, fontSize: 14 }}
+          style={{ width: 30, height: 30, fontSize: 14 }}
           onClick={() => ctx.setSidebarOpen(true)}
           title="Open sidebar (Ctrl+Shift+B)"
         >
-          ☰
+          <PanelLeftOpenIcon size={16} strokeWidth={1.8} />
         </button>
       </div>
     );
@@ -1175,6 +1245,13 @@ function LocalTerminalSidebar() {
     ? projects.filter((p) => p.name.toLowerCase().includes(filter.toLowerCase()))
     : projects;
   const normalizedFilter = filter.trim().toLowerCase();
+  const filteredShells = normalizedFilter
+    ? shells.filter((shell) => [
+      shell.name,
+      shell.status,
+      shell.tabs?.map((shellTab) => shellTab.name).join(" "),
+    ].filter(Boolean).join(" ").toLowerCase().includes(normalizedFilter))
+    : shells;
   const filteredSessions = normalizedFilter
     ? sessions.filter((session) => [
       session.id,
@@ -1187,6 +1264,30 @@ function LocalTerminalSidebar() {
       session.transcriptPath,
     ].filter(Boolean).join(" ").toLowerCase().includes(normalizedFilter))
     : sessions;
+
+  const createManagedShell = async () => {
+    const name = await ctx.createShellSessionTab("Zellij", ctx.sidebarSelectedPath ?? DEFAULT_CWD);
+    if (name) {
+      await fetchShells();
+    }
+  };
+
+  const deleteManagedShell = async (name: string) => {
+    try {
+      const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(name)}?force=1`, {
+        method: "DELETE",
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        setShellsError("Failed to remove shell");
+        return;
+      }
+      await fetchShells();
+    } catch (err: unknown) {
+      console.warn("Failed to remove shell session:", err instanceof Error ? err.message : err);
+      setShellsError("Could not remove shell");
+    }
+  };
 
   const openWorkspaceTransport = async (session: WorkspaceSessionSummary, mode: "observe" | "takeover") => {
     try {
@@ -1256,88 +1357,141 @@ function LocalTerminalSidebar() {
   };
 
   return (
-    <div className="flex flex-col shrink-0 overflow-hidden" style={{ width: 240, background: "var(--card)", borderRight: "1px solid var(--border)", paddingLeft: 4 }}>
-      <div className="flex items-stretch shrink-0" style={{ borderBottom: "1px solid var(--border)" }}>
+    <div
+      className="grid shrink-0 overflow-hidden"
+      style={{
+        width: 320,
+        gridTemplateColumns: "48px minmax(0, 1fr)",
+        background: "var(--card)",
+        borderRight: "1px solid var(--border)",
+      }}
+    >
+      <div
+        className="flex flex-col items-center py-2"
+        style={{
+          gap: 6,
+          borderRight: "1px solid var(--border)",
+          background: "color-mix(in srgb, var(--background) 62%, var(--card))",
+        }}
+      >
+        <SidebarRailButton label="Projects" icon={<FolderIcon size={16} strokeWidth={1.8} />} active={tab === "projects"} onClick={() => setTab("projects")} />
+        <SidebarRailButton label="Shells" icon={<TerminalIcon size={16} strokeWidth={1.8} />} active={tab === "shells"} onClick={() => setTab("shells")} />
+        <SidebarRailButton label="Agents" icon={<BotIcon size={16} strokeWidth={1.8} />} active={tab === "sessions"} onClick={() => setTab("sessions")} />
+        <SidebarRailButton label="Files" icon={<FilesIcon size={16} strokeWidth={1.8} />} active={tab === "files"} onClick={() => setTab("files")} />
+        <div style={{ flex: 1 }} />
         <button
-          aria-label="Projects"
-          className="flex-1 flex items-center justify-center gap-1.5 text-[11px] cursor-pointer transition-colors"
+          className="flex items-center justify-center cursor-pointer transition-colors"
           style={{
-            padding: "8px 6px",
-            background: tab === "projects" ? "var(--background)" : "transparent",
-            color: tab === "projects" ? "var(--foreground)" : "var(--muted-foreground)",
-            borderBottom: tab === "projects" ? "2px solid var(--primary)" : "2px solid transparent",
-            fontWeight: 500,
-            letterSpacing: "0.3px",
+            width: 32,
+            height: 32,
+            borderRadius: 6,
+            border: "1px solid transparent",
+            background: "transparent",
+            color: "var(--muted-foreground)",
+            fontSize: 14,
           }}
-          onClick={() => setTab("projects")}
-        >
-          <span style={{ fontSize: 12 }}>◆</span> Projects
-        </button>
-        <button
-          aria-label="Files"
-          className="flex-1 flex items-center justify-center gap-1.5 text-[11px] cursor-pointer transition-colors"
-          style={{
-            padding: "8px 6px",
-            background: tab === "files" ? "var(--background)" : "transparent",
-            color: tab === "files" ? "var(--foreground)" : "var(--muted-foreground)",
-            borderBottom: tab === "files" ? "2px solid var(--primary)" : "2px solid transparent",
-            fontWeight: 500,
-            letterSpacing: "0.3px",
-          }}
-          onClick={() => setTab("files")}
-        >
-          <span style={{ fontSize: 12 }}>▤</span> Files
-        </button>
-        <button
-          aria-label="Sessions"
-          className="flex-1 flex items-center justify-center gap-1.5 text-[11px] cursor-pointer transition-colors"
-          style={{
-            padding: "8px 6px",
-            background: tab === "sessions" ? "var(--background)" : "transparent",
-            color: tab === "sessions" ? "var(--foreground)" : "var(--muted-foreground)",
-            borderBottom: tab === "sessions" ? "2px solid var(--primary)" : "2px solid transparent",
-            fontWeight: 500,
-            letterSpacing: "0.3px",
-          }}
-          onClick={() => setTab("sessions")}
-        >
-          <span style={{ fontSize: 12 }}>◉</span> Sessions
-        </button>
-        <button
-          className="flex items-center justify-center cursor-pointer hover:bg-[var(--accent)] transition-colors"
-          style={{ width: 28, color: "var(--muted-foreground)", fontSize: 14 }}
           onClick={() => ctx.setSidebarOpen(false)}
           title="Hide sidebar (Ctrl+Shift+B)"
         >
-          ‹
+          <PanelLeftCloseIcon size={16} strokeWidth={1.8} />
         </button>
       </div>
 
-      {tab === "projects" ? (
-        <>
-          <div className="flex items-center gap-1.5 px-2 py-1.5 shrink-0" style={{ borderBottom: "1px solid var(--border)" }}>
+      <div className="flex min-w-0 flex-col overflow-hidden">
+        <div
+          className="shrink-0"
+          style={{
+            padding: "10px 12px 8px",
+            borderBottom: "1px solid var(--border)",
+          }}
+        >
+          <div className="flex items-center justify-between gap-2" style={{ marginBottom: 8 }}>
+            <div className="min-w-0">
+              <div
+                className="truncate"
+                style={{
+                  color: "var(--foreground)",
+                  fontSize: 13,
+                  fontWeight: 650,
+                  lineHeight: 1.1,
+                }}
+              >
+                {tab === "projects" ? "Projects" : tab === "shells" ? "Shells" : tab === "sessions" ? "Agents" : "Files"}
+              </div>
+              <div
+                className="truncate"
+                style={{
+                  color: "var(--muted-foreground)",
+                  fontSize: 10,
+                  fontFamily: "var(--font-mono, ui-monospace, monospace)",
+                  marginTop: 3,
+                }}
+              >
+                {tab === "files" ? rootPath || "~" : ctx.sidebarSelectedPath ? formatCwd(ctx.sidebarSelectedPath) : "~/projects"}
+              </div>
+            </div>
+            {tab === "shells" ? (
+              <button
+                onClick={() => void createManagedShell()}
+                className="flex items-center gap-1.5 cursor-pointer"
+                style={{
+                  height: 28,
+                  padding: "0 10px",
+                  borderRadius: 6,
+                  border: "1px solid transparent",
+                  background: "var(--primary)",
+                  color: "var(--primary-foreground)",
+                  fontSize: 12,
+                  fontWeight: 600,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                <PlusIcon size={13} strokeWidth={2} />
+                New
+              </button>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-1.5">
             <input
+              aria-label={`Search ${tab}`}
               value={filter}
               onChange={(e) => setFilter(e.target.value)}
-              placeholder="Filter..."
-              className="flex-1 text-[11px] outline-none"
+              placeholder={tab === "shells" ? "Find shell..." : tab === "sessions" ? "Find agent..." : tab === "files" ? "Find file..." : "Find project..."}
+              className="min-w-0 flex-1 text-[11px] outline-none"
               style={{
+                height: 28,
                 background: "var(--background)",
                 color: "var(--foreground)",
                 border: "1px solid var(--border)",
-                borderRadius: 4,
-                padding: "3px 6px",
+                borderRadius: 6,
+                padding: "0 8px",
               }}
             />
             <button
-              onClick={() => void fetchProjects()}
-              className="cursor-pointer hover:bg-[var(--accent)] rounded transition-colors"
-              style={{ color: "var(--muted-foreground)", fontSize: 12, padding: "2px 6px" }}
+              onClick={() => {
+                if (tab === "projects") void fetchProjects();
+                if (tab === "shells") void fetchShells();
+                if (tab === "sessions") void fetchSessions();
+                if (tab === "files") void fetchDir(rootPath).then((entries: TreeNode[]) => setTree(entries.map(e => ({ ...e, path: `${rootPath}/${e.name}` }))));
+              }}
+              className="flex items-center justify-center cursor-pointer hover:bg-[var(--accent)] transition-colors"
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+                background: "var(--background)",
+                color: "var(--muted-foreground)",
+                fontSize: 12,
+              }}
               title="Refresh"
             >
-              ↻
+              <RefreshCwIcon size={13} strokeWidth={1.8} />
             </button>
           </div>
+        </div>
+
+        {tab === "projects" ? (
           <div className="flex-1 overflow-y-auto py-1">
             {projectsLoading && (
               <div className="px-3 py-6 text-center text-[11px]" style={{ color: "var(--muted-foreground)" }}>
@@ -1372,37 +1526,37 @@ function LocalTerminalSidebar() {
               />
             ))}
           </div>
-        </>
-      ) : tab === "sessions" ? (
-        <>
-          <div className="flex items-center gap-1.5 px-2 py-1.5 shrink-0" style={{ borderBottom: "1px solid var(--border)" }}>
-            <input
-              aria-label="Search sessions and transcripts"
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
-              placeholder="Search sessions..."
-              className="flex-1 text-[11px] outline-none"
-              style={{
-                background: "var(--background)",
-                color: "var(--foreground)",
-                border: "1px solid var(--border)",
-                borderRadius: 4,
-                padding: "3px 6px",
-              }}
-            />
-            <button
-              onClick={() => void fetchSessions()}
-              className="cursor-pointer hover:bg-[var(--accent)] rounded transition-colors"
-              style={{ color: "var(--muted-foreground)", fontSize: 12, padding: "2px 6px" }}
-              title="Refresh sessions"
-            >
-              ↻
-            </button>
+        ) : tab === "shells" ? (
+          <div className="flex-1 overflow-y-auto py-1">
+            {shellsLoading && (
+              <div className="px-3 py-6 text-center text-[11px]" style={{ color: "var(--muted-foreground)" }}>
+                Loading shells...
+              </div>
+            )}
+            {!shellsLoading && shellsError && (
+              <div className="px-3 py-6 text-center text-[11px]" style={{ color: "var(--destructive)" }}>
+                {shellsError}
+              </div>
+            )}
+            {!shellsLoading && !shellsError && filteredShells.length === 0 && (
+              <div className="px-3 py-6 text-center text-[11px]" style={{ color: "var(--muted-foreground)" }}>
+                {filter ? "No shells match" : "No zellij shells"}
+              </div>
+            )}
+            {!shellsLoading && filteredShells.map((shell) => (
+              <ShellCard
+                key={shell.name}
+                shell={shell}
+                onOpen={() => ctx.addSessionTab(shell.name, shell.name)}
+                onDelete={() => void deleteManagedShell(shell.name)}
+              />
+            ))}
           </div>
+        ) : tab === "sessions" ? (
           <div className="flex-1 overflow-y-auto py-1">
             {sessionsLoading && (
               <div className="px-3 py-6 text-center text-[11px]" style={{ color: "var(--muted-foreground)" }}>
-                Loading sessions…
+                Loading sessions...
               </div>
             )}
             {!sessionsLoading && sessionsError && (
@@ -1426,9 +1580,8 @@ function LocalTerminalSidebar() {
               />
             ))}
           </div>
-        </>
-      ) : (
-        <>
+        ) : (
+          <>
           <div className="flex items-center gap-1 px-2 py-1.5 text-[10px] shrink-0" style={{ borderBottom: "1px solid var(--border)" }}>
             {!isAtRoot && (
               <button
@@ -1464,8 +1617,114 @@ function LocalTerminalSidebar() {
               </div>
             )}
           </div>
-        </>
-      )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SidebarRailButton({
+  label,
+  icon,
+  active,
+  onClick,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      onClick={onClick}
+      className="flex items-center justify-center cursor-pointer transition-colors"
+      style={{
+        width: 34,
+        height: 34,
+        borderRadius: 8,
+        border: `1px solid ${active ? "var(--border)" : "transparent"}`,
+        background: active ? "var(--card)" : "transparent",
+        color: active ? "var(--foreground)" : "var(--muted-foreground)",
+        fontSize: 12,
+        fontWeight: 700,
+        boxShadow: active ? "0 1px 0 rgba(0,0,0,0.08)" : "none",
+      }}
+      title={label}
+    >
+      {icon}
+    </button>
+  );
+}
+
+function ShellCard({
+  shell,
+  onOpen,
+  onDelete,
+}: {
+  shell: ShellSessionSummary;
+  onOpen: () => void;
+  onDelete: () => void;
+}) {
+  const tabs = shell.tabs ?? [];
+  const focusedTab = tabs.find((tab) => tab.focused) ?? tabs[0];
+  return (
+    <div
+      style={{
+        margin: "5px 8px",
+        padding: "9px 10px",
+        borderRadius: 8,
+        border: "1px solid var(--border)",
+        background: "var(--background)",
+      }}
+    >
+      <div className="flex items-center gap-2" style={{ marginBottom: 5 }}>
+        <span
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: "50%",
+            background: shell.status === "exited" ? "var(--muted-foreground)" : "var(--success)",
+            flexShrink: 0,
+          }}
+        />
+        <span
+          className="min-w-0 flex-1 truncate"
+          style={{
+            color: "var(--foreground)",
+            fontSize: 12,
+            fontWeight: 650,
+            fontFamily: "var(--font-mono, ui-monospace, monospace)",
+          }}
+        >
+          {shell.name}
+        </span>
+        <span style={{ color: "var(--muted-foreground)", fontSize: 10 }}>
+          {shell.attachedClients ?? 0}
+        </span>
+      </div>
+      <div className="truncate" style={{ color: "var(--muted-foreground)", fontSize: 10, paddingLeft: 15 }}>
+        {shell.status ?? "active"} · {tabs.length} zellij tab{tabs.length === 1 ? "" : "s"}
+      </div>
+      {focusedTab ? (
+        <div
+          className="truncate"
+          style={{
+            color: "var(--muted-foreground)",
+            fontSize: 10,
+            paddingLeft: 15,
+            marginTop: 2,
+            fontFamily: "var(--font-mono, ui-monospace, monospace)",
+          }}
+        >
+          {focusedTab.idx}: {focusedTab.name ?? "tab"}
+        </div>
+      ) : null}
+      <div className="flex items-center gap-1" style={{ marginTop: 8, paddingLeft: 15 }}>
+        <SessionActionBtn label="Open" sessionId={shell.name} onClick={onOpen} />
+        <SessionActionBtn label="Delete" sessionId={shell.name} onClick={onDelete} danger />
+      </div>
     </div>
   );
 }

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -2008,7 +2008,7 @@ function filterTreeNodes(nodes: TreeNode[], normalizedFilter: string): TreeNode[
     ].filter(Boolean).join(" ").toLowerCase().includes(normalizedFilter);
 
     if (matches) {
-      return [{ ...node }];
+      return [{ ...node, expanded: node.type === "directory" ? true : node.expanded }];
     }
     if (children.length > 0) {
       return [{ ...node, children, expanded: true }];

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1111,6 +1111,8 @@ function LocalTerminalSidebar() {
   const [shells, setShells] = useState<ShellSessionSummary[]>([]);
   const [shellsLoading, setShellsLoading] = useState(false);
   const [shellsError, setShellsError] = useState<string | null>(null);
+  const creatingShellRef = useRef(false);
+  const [creatingShell, setCreatingShell] = useState(false);
   const deletingShellsRef = useRef<Set<string>>(new Set());
   const [deletingShellNames, setDeletingShellNames] = useState<string[]>([]);
   const [sessions, setSessions] = useState<WorkspaceSessionSummary[]>([]);
@@ -1273,12 +1275,20 @@ function LocalTerminalSidebar() {
     : sessions;
 
   const createManagedShell = async () => {
+    if (creatingShellRef.current) return;
+    creatingShellRef.current = true;
+    setCreatingShell(true);
     setShellsError(null);
-    const name = await ctx.createShellSessionTab("Zellij", ctx.sidebarSelectedPath ?? DEFAULT_CWD);
-    if (name) {
-      await fetchShells();
-    } else {
-      setShellsError("Failed to create shell");
+    try {
+      const name = await ctx.createShellSessionTab("Zellij", ctx.sidebarSelectedPath ?? DEFAULT_CWD);
+      if (name) {
+        await fetchShells();
+      } else {
+        setShellsError("Failed to create shell");
+      }
+    } finally {
+      creatingShellRef.current = false;
+      setCreatingShell(false);
     }
   };
 
@@ -1450,6 +1460,7 @@ function LocalTerminalSidebar() {
             {tab === "shells" ? (
               <button
                 onClick={() => void createManagedShell()}
+                disabled={creatingShell}
                 className="flex items-center gap-1.5 cursor-pointer"
                 style={{
                   height: 28,
@@ -1461,6 +1472,8 @@ function LocalTerminalSidebar() {
                   fontSize: 12,
                   fontWeight: 600,
                   whiteSpace: "nowrap",
+                  cursor: creatingShell ? "not-allowed" : "pointer",
+                  opacity: creatingShell ? 0.75 : 1,
                 }}
               >
                 <PlusIcon size={13} strokeWidth={2} />

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1111,6 +1111,8 @@ function LocalTerminalSidebar() {
   const [shells, setShells] = useState<ShellSessionSummary[]>([]);
   const [shellsLoading, setShellsLoading] = useState(false);
   const [shellsError, setShellsError] = useState<string | null>(null);
+  const deletingShellsRef = useRef<Set<string>>(new Set());
+  const [deletingShellNames, setDeletingShellNames] = useState<string[]>([]);
   const [sessions, setSessions] = useState<WorkspaceSessionSummary[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(false);
   const [sessionsError, setSessionsError] = useState<string | null>(null);
@@ -1271,6 +1273,7 @@ function LocalTerminalSidebar() {
     : sessions;
 
   const createManagedShell = async () => {
+    setShellsError(null);
     const name = await ctx.createShellSessionTab("Zellij", ctx.sidebarSelectedPath ?? DEFAULT_CWD);
     if (name) {
       await fetchShells();
@@ -1280,6 +1283,9 @@ function LocalTerminalSidebar() {
   };
 
   const deleteManagedShell = async (name: string) => {
+    if (deletingShellsRef.current.has(name)) return;
+    deletingShellsRef.current.add(name);
+    setDeletingShellNames(Array.from(deletingShellsRef.current));
     setShellsError(null);
     try {
       const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(name)}?force=1`, {
@@ -1294,6 +1300,9 @@ function LocalTerminalSidebar() {
     } catch (err: unknown) {
       console.warn("Failed to remove shell session:", err instanceof Error ? err.message : err);
       setShellsError("Could not remove shell");
+    } finally {
+      deletingShellsRef.current.delete(name);
+      setDeletingShellNames(Array.from(deletingShellsRef.current));
     }
   };
 
@@ -1555,6 +1564,7 @@ function LocalTerminalSidebar() {
               <ShellCard
                 key={shell.name}
                 shell={shell}
+                deleting={deletingShellNames.includes(shell.name)}
                 onOpen={() => ctx.addSessionTab(shell.name, shell.name)}
                 onDelete={() => void deleteManagedShell(shell.name)}
               />
@@ -1668,10 +1678,12 @@ function SidebarRailButton({
 
 function ShellCard({
   shell,
+  deleting,
   onOpen,
   onDelete,
 }: {
   shell: ShellSessionSummary;
+  deleting?: boolean;
   onOpen: () => void;
   onDelete: () => void;
 }) {
@@ -1731,7 +1743,13 @@ function ShellCard({
       ) : null}
       <div className="flex items-center gap-1" style={{ marginTop: 8, paddingLeft: 15 }}>
         <SessionActionBtn label="Open" sessionId={shell.name} onClick={onOpen} />
-        <SessionActionBtn label="Delete" sessionId={shell.name} onClick={onDelete} danger />
+        <SessionActionBtn
+          label={deleting ? "Deleting" : "Delete"}
+          sessionId={shell.name}
+          onClick={onDelete}
+          danger
+          disabled={deleting}
+        />
       </div>
     </div>
   );
@@ -1804,16 +1822,19 @@ function SessionActionBtn({
   sessionId,
   onClick,
   danger,
+  disabled,
 }: {
   label: string;
   sessionId: string;
   onClick: () => void;
   danger?: boolean;
+  disabled?: boolean;
 }) {
   return (
     <button
       aria-label={`${label} ${sessionId}`}
       onClick={onClick}
+      disabled={disabled}
       className="text-[10px] cursor-pointer transition-colors"
       style={{
         padding: "2px 6px",
@@ -1821,6 +1842,8 @@ function SessionActionBtn({
         background: danger ? "var(--destructive)" : "var(--card)",
         color: danger ? "white" : "var(--foreground)",
         border: danger ? "none" : "1px solid var(--border)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.65 : 1,
       }}
     >
       {label}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1286,6 +1286,9 @@ function LocalTerminalSidebar() {
       } else {
         setShellsError("Failed to create shell");
       }
+    } catch (err: unknown) {
+      console.warn("Failed to create shell session:", err instanceof Error ? err.message : err);
+      setShellsError("Could not create shell");
     } finally {
       creatingShellRef.current = false;
       setCreatingShell(false);

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1250,10 +1250,10 @@ function LocalTerminalSidebar() {
   }
 
   const isAtRoot = !rootPath || rootPath === ".";
-  const filteredProjects = filter
-    ? projects.filter((p) => p.name.toLowerCase().includes(filter.toLowerCase()))
-    : projects;
   const normalizedFilter = filter.trim().toLowerCase();
+  const filteredProjects = normalizedFilter
+    ? projects.filter((p) => p.name.toLowerCase().includes(normalizedFilter))
+    : projects;
   const filteredShells = normalizedFilter
     ? shells.filter((shell) => [
       shell.name,

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -2003,7 +2003,6 @@ function filterTreeNodes(nodes: TreeNode[], normalizedFilter: string): TreeNode[
     const matches = [
       node.name,
       node.path,
-      node.type,
       node.gitStatus,
     ].filter(Boolean).join(" ").toLowerCase().includes(normalizedFilter);
 

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1273,6 +1273,7 @@ function LocalTerminalSidebar() {
       session.transcriptPath,
     ].filter(Boolean).join(" ").toLowerCase().includes(normalizedFilter))
     : sessions;
+  const filteredTree = normalizedFilter ? filterTreeNodes(tree, normalizedFilter) : tree;
 
   const createManagedShell = async () => {
     if (creatingShellRef.current) return;
@@ -1634,7 +1635,7 @@ function LocalTerminalSidebar() {
             </span>
           </div>
           <div className="flex-1 overflow-y-auto py-1 text-xs">
-            {tree.map(node => (
+            {filteredTree.map(node => (
               <TreeItem
                 key={node.path}
                 node={node}
@@ -1645,9 +1646,9 @@ function LocalTerminalSidebar() {
                 onOpenTerminal={(path) => ctx.addTab(path)}
               />
             ))}
-            {tree.length === 0 && (
+            {filteredTree.length === 0 && (
               <div className="px-3 py-4 text-center" style={{ color: "var(--muted-foreground)" }}>
-                Empty directory
+                {normalizedFilter ? "No files match" : "Empty directory"}
               </div>
             )}
           </div>
@@ -1995,6 +1996,26 @@ function ProjectActionBtn({
 interface TreeNode { name: string; type: "file" | "directory"; size?: number; gitStatus: string | null; changedCount?: number; path: string; children?: TreeNode[]; expanded?: boolean; }
 
 const GIT_COLORS: Record<string, string> = { modified: "var(--warning)", added: "var(--success)", untracked: "var(--success)", deleted: "var(--destructive)", renamed: "var(--primary)" };
+
+function filterTreeNodes(nodes: TreeNode[], normalizedFilter: string): TreeNode[] {
+  return nodes.flatMap((node) => {
+    const children = node.children ? filterTreeNodes(node.children, normalizedFilter) : [];
+    const matches = [
+      node.name,
+      node.path,
+      node.type,
+      node.gitStatus,
+    ].filter(Boolean).join(" ").toLowerCase().includes(normalizedFilter);
+
+    if (matches) {
+      return [{ ...node }];
+    }
+    if (children.length > 0) {
+      return [{ ...node, children, expanded: true }];
+    }
+    return [];
+  });
+}
 
 function TreeItem({ node, depth, selectedPath, onToggle, onSelect, onOpenTerminal }: { node: TreeNode; depth: number; selectedPath: string | null; onToggle: (n: TreeNode) => void; onSelect: (n: TreeNode) => void; onOpenTerminal: (path: string) => void }) {
   return (

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -571,7 +571,7 @@ describe("TerminalApp", () => {
     expect(screen.getByText("running health")).toBeTruthy();
     expect(screen.getByText("zellij attach matrix-sess_abc123")).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText("Search sessions"), { target: { value: "task_abc123" } });
+    fireEvent.change(screen.getByLabelText("Search agents"), { target: { value: "task_abc123" } });
     expect(screen.getByText("sess_abc123")).toBeTruthy();
 
     await act(async () => {
@@ -653,12 +653,15 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
+    fireEvent.change(screen.getByLabelText("Search projects"), { target: { value: "does-not-carry-over" } });
+
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Shells" }));
       await Promise.resolve();
       await Promise.resolve();
     });
 
+    expect(screen.getByLabelText("Search shells")).toHaveProperty("value", "");
     expect(screen.getByText("active · 1 zellij tab")).toBeTruthy();
     expect(screen.getByText("0: dev")).toBeTruthy();
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -620,7 +620,13 @@ describe("TerminalApp", () => {
           json: async () => [
             { name: "package.json", type: "file", gitStatus: null },
             { name: "README.md", type: "file", gitStatus: null },
-            { name: "src", type: "directory", gitStatus: null },
+            {
+              name: "src",
+              type: "directory",
+              gitStatus: null,
+              expanded: false,
+              children: [{ name: "app.tsx", type: "file", gitStatus: null, path: "projects/src/app.tsx" }],
+            },
           ],
         });
       }
@@ -658,6 +664,14 @@ describe("TerminalApp", () => {
     expect(screen.queryByText("package.json")).toBeNull();
     expect(screen.getByText("README.md")).toBeTruthy();
     expect(screen.queryByText("src")).toBeNull();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Search files"), { target: { value: "src" } });
+    });
+
+    expect(screen.getByText("src")).toBeTruthy();
+    expect(screen.getByText("app.tsx")).toBeTruthy();
+    expect(screen.queryByText("README.md")).toBeNull();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText("Search files"), { target: { value: "missing" } });

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -690,4 +690,47 @@ describe("TerminalApp", () => {
       expect.objectContaining({ method: "DELETE" }),
     );
   });
+
+  it("surfaces shell creation failures in the Shells sidebar", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      if (url.includes("/api/terminal/sessions") && init?.method === "POST") {
+        return Promise.resolve({ ok: false, status: 503, json: async () => ({ ok: false }) });
+      }
+      if (url.includes("/api/terminal/sessions")) {
+        return Promise.resolve({ ok: true, json: async () => ({ sessions: [{ name: "main", status: "active" }] }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Shells" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "New" }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Failed to create shell")).toBeTruthy();
+  });
 });

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -682,13 +682,15 @@ describe("TerminalApp", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /delete main/i }));
+      const deleteButton = screen.getByRole("button", { name: /delete main/i });
+      fireEvent.click(deleteButton);
+      fireEvent.click(deleteButton);
       await Promise.resolve();
     });
-    expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/api/terminal/sessions/main?force=1"),
-      expect.objectContaining({ method: "DELETE" }),
-    );
+    const deleteCalls = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes("/api/terminal/sessions/main?force=1") && init?.method === "DELETE"
+    ));
+    expect(deleteCalls).toHaveLength(1);
   });
 
   it("surfaces shell creation failures in the Shells sidebar", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -673,13 +673,15 @@ describe("TerminalApp", () => {
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "New" }));
+      const newButton = screen.getByRole("button", { name: "New" });
+      fireEvent.click(newButton);
+      fireEvent.click(newButton);
       await Promise.resolve();
     });
-    expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/api/terminal/sessions"),
-      expect.objectContaining({ method: "POST" }),
-    );
+    const createCalls = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).includes("/api/terminal/sessions") && init?.method === "POST"
+    ));
+    expect(createCalls).toHaveLength(1);
 
     await act(async () => {
       const deleteButton = screen.getByRole("button", { name: /delete main/i });

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -680,6 +680,50 @@ describe("TerminalApp", () => {
     expect(screen.getByText("No files match")).toBeTruthy();
   });
 
+  it("trims project search before filtering", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/projects")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ projects: [{ name: "matrix-os", path: "projects/matrix-os" }] }),
+        });
+      }
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("matrix-os")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Search projects"), { target: { value: "  matrix  " } });
+    });
+
+    expect(screen.getByText("matrix-os")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Search projects"), { target: { value: "   " } });
+    });
+
+    expect(screen.getByText("matrix-os")).toBeTruthy();
+  });
+
   it("manages canonical zellij shells from a dedicated sidebar surface", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -674,6 +674,13 @@ describe("TerminalApp", () => {
     expect(screen.queryByText("README.md")).toBeNull();
 
     await act(async () => {
+      fireEvent.change(screen.getByLabelText("Search files"), { target: { value: "file" } });
+    });
+
+    expect(screen.getByText("No files match")).toBeTruthy();
+    expect(screen.queryByText("package.json")).toBeNull();
+
+    await act(async () => {
       fireEvent.change(screen.getByLabelText("Search files"), { target: { value: "missing" } });
     });
 

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -611,6 +611,61 @@ describe("TerminalApp", () => {
     expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining("/api/terminal/pty-sessions"), expect.objectContaining({ method: "GET" }));
   });
 
+  it("filters the Files sidebar tree by the search input", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            { name: "package.json", type: "file", gitStatus: null },
+            { name: "README.md", type: "file", gitStatus: null },
+            { name: "src", type: "directory", gitStatus: null },
+          ],
+        });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Files" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("package.json")).toBeTruthy();
+    expect(screen.getByText("README.md")).toBeTruthy();
+    expect(screen.getByText("src")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Search files"), { target: { value: "readme" } });
+    });
+
+    expect(screen.queryByText("package.json")).toBeNull();
+    expect(screen.getByText("README.md")).toBeTruthy();
+    expect(screen.queryByText("src")).toBeNull();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Search files"), { target: { value: "missing" } });
+    });
+
+    expect(screen.getByText("No files match")).toBeTruthy();
+  });
+
   it("manages canonical zellij shells from a dedicated sidebar surface", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -562,7 +562,7 @@ describe("TerminalApp", () => {
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+      fireEvent.click(screen.getByRole("button", { name: "Agents" }));
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -571,7 +571,7 @@ describe("TerminalApp", () => {
     expect(screen.getByText("running health")).toBeTruthy();
     expect(screen.getByText("zellij attach matrix-sess_abc123")).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText("Search sessions and transcripts"), { target: { value: "task_abc123" } });
+    fireEvent.change(screen.getByLabelText("Search sessions"), { target: { value: "task_abc123" } });
     expect(screen.getByText("sess_abc123")).toBeTruthy();
 
     await act(async () => {
@@ -609,5 +609,82 @@ describe("TerminalApp", () => {
       expect.objectContaining({ method: "DELETE" }),
     );
     expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining("/api/terminal/pty-sessions"), expect.objectContaining({ method: "GET" }));
+  });
+
+  it("manages canonical zellij shells from a dedicated sidebar surface", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      if (url.includes("/api/terminal/sessions/main") && init?.method === "DELETE") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/sessions") && init?.method === "POST") {
+        return Promise.resolve({ ok: true, json: async () => ({ name: "zellij-new", created: true }) });
+      }
+      if (url.includes("/api/terminal/sessions")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessions: [{
+              name: "main",
+              status: "active",
+              attachedClients: 1,
+              tabs: [{ idx: 0, name: "dev", focused: true }],
+            }],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Shells" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("active · 1 zellij tab")).toBeTruthy();
+    expect(screen.getByText("0: dev")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /open main/i }));
+    });
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      paneTree: { sessionId: "main" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "New" }));
+      await Promise.resolve();
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/terminal/sessions"),
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /delete main/i }));
+      await Promise.resolve();
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/terminal/sessions/main?force=1"),
+      expect.objectContaining({ method: "DELETE" }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Redesigns Terminal into a cockpit layout with a bounded tab strip and separate action cluster so project/sidebar controls cannot overlap zellij tabs.
- Adds a dedicated Shells sidebar surface backed by the canonical `/api/terminal/sessions` route, including open, create, refresh, filter, and delete controls for zellij sessions.
- Splits shell sessions from coding agent sessions in the sidebar and gives the rail/icon/header layout clearer scan targets.

## Stack

- Stacked on #220, which contains the canonical zellij session/listing fix and the merge from `main`.

## Test Plan

- `bun run test tests/shell/terminal-app-component.test.tsx`
- `pnpm --dir shell exec tsc --noEmit`
- `git diff --check`
