### PR TITLE
docs(cli): specify TUI action console follow-up

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/084-matrix-cli-tui"
+  "feature_directory": "specs/085-cli-tui-action-console-v2"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,5 +356,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/084-matrix-cli-tui/plan.md`.
+Current Spec Kit plan: `specs/085-cli-tui-action-console-v2/plan.md`.
 <!-- SPECKIT END -->

--- a/packages/sync-client/src/cli/commands/doctor.ts
+++ b/packages/sync-client/src/cli/commands/doctor.ts
@@ -50,7 +50,7 @@ export const doctorCommand = defineCommand({
 
     if (profile) {
       try {
-        const res = await fetch(`${profile.gatewayUrl}/api/health`, {
+        const res = await fetch(`${profile.gatewayUrl}/health`, {
           headers: profile.token ? { Authorization: `Bearer ${profile.token}` } : undefined,
           signal: AbortSignal.timeout(10_000),
         });

--- a/packages/sync-client/src/cli/commands/profile.ts
+++ b/packages/sync-client/src/cli/commands/profile.ts
@@ -12,6 +12,15 @@ interface ProfileView extends Profile {
   active: boolean;
 }
 
+const PROFILE_SUBCOMMANDS = new Set(["ls", "show", "use", "set"]);
+
+function hasProfileSubCommand(rawArgs: string[] | undefined): boolean {
+  if (!Array.isArray(rawArgs)) {
+    return false;
+  }
+  return rawArgs.some((arg) => PROFILE_SUBCOMMANDS.has(arg));
+}
+
 function profileView(name: string, profile: Profile, active: string): ProfileView {
   return {
     name,
@@ -157,7 +166,9 @@ export const profileCommand = defineCommand({
       }),
     }),
   },
-  run: () => {
-    console.log("Usage: matrix profile ls|show|use|set");
+  run: ({ rawArgs }) => {
+    if (!hasProfileSubCommand(rawArgs)) {
+      console.log("Usage: matrix profile ls|show|use|set");
+    }
   },
 });

--- a/packages/sync-client/src/cli/commands/status.ts
+++ b/packages/sync-client/src/cli/commands/status.ts
@@ -44,7 +44,7 @@ export const statusCommand = defineCommand({
       const auth = profile.token ? null : await loadProfileAuth(profile.name);
       const token = profile.token ?? (auth && !isExpired(auth) ? auth.accessToken : undefined);
       const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
-      const res = await fetch(`${profile.gatewayUrl}/api/health`, {
+      const res = await fetch(`${profile.gatewayUrl}/health`, {
         ...(headers ? { headers } : {}),
         signal: AbortSignal.timeout(10_000),
       });

--- a/packages/sync-client/src/cli/tui/status.ts
+++ b/packages/sync-client/src/cli/tui/status.ts
@@ -128,7 +128,7 @@ export async function aggregateTuiStatusSnapshot(deps: TuiStatusDeps = {}): Prom
   const checkGatewayStatus = async (): Promise<TuiSubsystemStatus> => deps.checkGateway
     ? deps.checkGateway()
     : profile.gatewayUrl !== "unknown"
-      ? createTuiGatewayClient({ gatewayUrl: profile.gatewayUrl, token }).requestJson("/api/health").then(() => ({ state: "healthy", label: "ok" }))
+      ? createTuiGatewayClient({ gatewayUrl: profile.gatewayUrl, token }).requestJson("/health").then(() => ({ state: "healthy", label: "ok" }))
       : { state: "unknown", label: "gateway unknown" };
 
   const checkDaemonStatus = async (): Promise<TuiSubsystemStatus> => deps.checkDaemon

--- a/packages/sync-client/tests/tui/status.test.ts
+++ b/packages/sync-client/tests/tui/status.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTuiSafeError } from "../../src/cli/tui/errors.js";
 import { aggregateTuiStatusSnapshot } from "../../src/cli/tui/status.js";
 
 describe("TUI status aggregation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it("builds a healthy snapshot from profile, auth, gateway, daemon, and sessions", async () => {
     const snapshot = await aggregateTuiStatusSnapshot({
       now: () => new Date("2026-05-28T12:00:00Z"),
@@ -118,6 +123,33 @@ describe("TUI status aggregation", () => {
     expect(snapshot.profile.state).toBe("unknown");
     expect(snapshot.gateway.state).toBe("degraded");
     expect(snapshot.safeError?.code).toBe("profile_not_found");
+  });
+
+  it("checks the gateway public health endpoint by default", async () => {
+    const seenUrls: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      seenUrls.push(String(url));
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: String(url).endsWith("/health") ? 200 : 401,
+        headers: { "content-type": "application/json" },
+      });
+    }));
+
+    const snapshot = await aggregateTuiStatusSnapshot({
+      resolveProfile: async () => ({
+        name: "local",
+        gatewayUrl: "http://localhost:4100",
+        platformUrl: "http://localhost:9000",
+        token: "dev-token",
+      }),
+      loadAuth: async () => ({ authenticated: true, expired: false, handle: "dev" }),
+      checkDaemon: async () => ({ state: "healthy", label: "running" }),
+      listShellSessions: async () => [],
+    });
+
+    expect(seenUrls).toContain("http://localhost:4100/health");
+    expect(seenUrls).not.toContain("http://localhost:4100/api/health");
+    expect(snapshot.gateway.state).toBe("healthy");
   });
 
 });

--- a/packages/sync-client/tests/unit/gateway-health-path.test.ts
+++ b/packages/sync-client/tests/unit/gateway-health-path.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveProfileAuth } from "../../src/auth/token-store.js";
+import { statusCommand } from "../../src/cli/commands/status.js";
+import { doctorCommand } from "../../src/cli/commands/doctor.js";
+import { saveProfiles } from "../../src/lib/profiles.js";
+
+const originalHome = process.env.HOME;
+
+async function withIsolatedHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), "matrix-health-path-"));
+  process.env.HOME = home;
+  await saveProfiles({
+    active: "local",
+    profiles: {
+      local: {
+        platformUrl: "http://localhost:9000",
+        gatewayUrl: "http://localhost:4100",
+      },
+    },
+  });
+  await saveProfileAuth("local", {
+    accessToken: "dev-token",
+    expiresAt: Date.now() + 60_000,
+    userId: "user_dev",
+    handle: "dev",
+  });
+  return home;
+}
+
+describe("gateway health checks", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    process.exitCode = undefined;
+    home = await withIsolatedHome();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    process.env.HOME = originalHome;
+    if (home) {
+      await rm(home, { recursive: true, force: true });
+    }
+    process.exitCode = undefined;
+  });
+
+  it("matrix status checks the public /health endpoint", async () => {
+    const seenUrls: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      seenUrls.push(String(url));
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: String(url).endsWith("/health") ? 200 : 401,
+        headers: { "content-type": "application/json" },
+      });
+    }));
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await statusCommand.run?.({ args: { profile: "local", json: true }, rawArgs: [] });
+
+    expect(seenUrls).toEqual(["http://localhost:4100/health"]);
+    expect(process.exitCode).toBeUndefined();
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"reachable":true'));
+  });
+
+  it("matrix doctor reports gateway OK when public /health is reachable", async () => {
+    const seenUrls: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request) => {
+      seenUrls.push(String(url));
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: String(url).endsWith("/health") ? 200 : 401,
+        headers: { "content-type": "application/json" },
+      });
+    }));
+    vi.doMock("../../src/cli/daemon-client.js", () => ({
+      isDaemonRunning: async () => true,
+    }));
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await doctorCommand.run?.({ args: { profile: "local" }, rawArgs: [] });
+
+    expect(seenUrls).toEqual(["http://localhost:4100/health"]);
+    expect(stdout).toHaveBeenCalledWith("OK gateway");
+  });
+});

--- a/packages/sync-client/tests/unit/profile-command.test.ts
+++ b/packages/sync-client/tests/unit/profile-command.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { profileCommand } from "../../src/cli/commands/profile.js";
+
+describe("profile command", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not print parent usage after a profile subcommand", () => {
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    profileCommand.run?.({ args: {}, rawArgs: ["show", "local"] });
+
+    expect(stdout).not.toHaveBeenCalled();
+  });
+
+  it("prints usage when no profile subcommand is present", () => {
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    profileCommand.run?.({ args: {}, rawArgs: [] });
+
+    expect(stdout).toHaveBeenCalledWith("Usage: matrix profile ls|show|use|set");
+  });
+});

--- a/specs/085-cli-tui-action-console-v2/checklists/requirements.md
+++ b/specs/085-cli-tui-action-console-v2/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Matrix CLI TUI Action Console Follow-Up
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-29
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This replacement spec intentionally approves no removals from the 084 parent TUI.
+- Implementation is deferred until the replacement spec is reviewed or explicitly accepted.

--- a/specs/085-cli-tui-action-console-v2/contracts/home-actions.md
+++ b/specs/085-cli-tui-action-console-v2/contracts/home-actions.md
@@ -1,0 +1,27 @@
+# Contract: Home Actions
+
+## Purpose
+
+Define the observable behavior for shortcuts added to the parent prompt-first home.
+
+## Minimum Actions
+
+- Login or setup when auth/setup is missing
+- New shell session
+- Sessions list
+- Doctor/status
+- Command palette
+- Quit
+
+## Action Outcomes
+
+Every action must resolve to exactly one observable outcome:
+
+- Navigate to an actionable TUI view
+- Start a bounded backend/client operation and show progress
+- Complete with a success message and refreshed state
+- Fail safely with a generic message and concrete next step
+- Report unavailable/degraded state with the missing dependency
+- Cancel without mutating state
+
+Silent no-op behavior is invalid.

--- a/specs/085-cli-tui-action-console-v2/contracts/parent-preservation.md
+++ b/specs/085-cli-tui-action-console-v2/contracts/parent-preservation.md
@@ -1,0 +1,27 @@
+# Contract: Parent TUI Preservation
+
+## Purpose
+
+Protect the `084-matrix-cli-tui-polish` TUI from accidental deletion or narrowing while this follow-up adds real actions.
+
+## Required Preserved Elements
+
+- Prompt-first home layout and Matrix OS identity
+- "Ask Matrix..." prompt region and command-family hint area
+- `/ commands`, agents tab, sessions shortcut, quit shortcut, and other parent keyboard hints
+- Compact decorative rabbit mascot with responsive fallback
+- Status line for auth, gateway, sync, sessions, and next action
+- Command palette coverage for all parent command families
+- Matrix sessions language covering shell and coding sessions
+- Direct CLI command and machine-readable output compatibility
+
+## Change Rule
+
+Any change that removes or narrows one of these elements requires:
+
+1. An entry under `Approved Removals From Parent 084` in `spec.md`
+2. Explicit user approval
+3. Replacement behavior
+4. Regression test coverage
+
+Current approved removals: none.

--- a/specs/085-cli-tui-action-console-v2/contracts/session-operations.md
+++ b/specs/085-cli-tui-action-console-v2/contracts/session-operations.md
@@ -1,0 +1,23 @@
+# Contract: Session Operations
+
+## Purpose
+
+Preserve the parent Matrix session cockpit while adding zellij-style operations.
+
+## Required Operations
+
+- Create shell session
+- List shell and coding sessions
+- Attach to session
+- Observe session
+- Take over session
+- Detach without killing session
+- Stop session with confirmation
+- Inspect native attach details, tabs, panes, and layout when available
+
+## Failure Behavior
+
+- Missing zellij/session runtime: show unavailable state with setup next step
+- Stale session: show recoverable stale state and refresh list
+- Backend timeout: show safe failure and keep current view
+- Stop/remove failure: keep session visible until backend confirms success

--- a/specs/085-cli-tui-action-console-v2/contracts/setup-wizard.md
+++ b/specs/085-cli-tui-action-console-v2/contracts/setup-wizard.md
@@ -1,0 +1,24 @@
+# Contract: Setup Wizard
+
+## Purpose
+
+Guide agent setup and local migration without copying secrets or surprising the user.
+
+## Steps
+
+1. Choose coding agents
+2. Choose whether to migrate local non-secret configuration
+3. Preview migration candidates and skipped items
+4. Confirm write plan
+5. Apply selected setup steps
+6. Show done, partial, skipped, cancelled, or safe failure state
+7. Offer terminal handoff or next action
+
+## Agent Defaults
+
+- Codex: selected by default
+- Claude: available but unchecked by default
+
+## Migration Safety
+
+Migration must skip secrets, tokens, credentials, symlinks, oversized files, unsupported formats, and unreadable files. Writes require preview and confirmation.

--- a/specs/085-cli-tui-action-console-v2/data-model.md
+++ b/specs/085-cli-tui-action-console-v2/data-model.md
@@ -1,0 +1,86 @@
+# Data Model: Matrix CLI TUI Action Console Follow-Up
+
+## Parent TUI Contract
+
+Represents the 084 behavior this follow-up must preserve.
+
+**Fields**:
+- `homeIdentity`: Matrix OS product identity and prompt-first home copy
+- `mascotPresence`: compact decorative rabbit mascot and responsive fallback
+- `statusLine`: auth/gateway/sync/session status and next action
+- `keyboardHints`: command palette, agents, sessions, quit, refresh, and help shortcuts
+- `commandFamilies`: all 084 command-family entries
+- `sessionLanguage`: Matrix session terminology and shell/coding session coverage
+- `directCliCompatibility`: explicit subcommands and machine-readable output
+
+**Validation Rules**:
+- No field may be removed without an approved-removal entry in `spec.md`.
+- Regression tests must cover any intentional extension of these fields.
+
+## TUI Action
+
+Represents an executable home or palette action.
+
+**Fields**:
+- `id`: stable action identifier
+- `label`: user-facing label
+- `source`: home shortcut, command palette, wizard, or session cockpit
+- `availability`: available, degraded, unavailable, or in-progress
+- `requires`: auth, gateway, platform, zellij, sync, project, or local file capability
+- `result`: view navigation, backend action, terminal handoff, success, cancelled, or safe failure
+- `confirmation`: none, simple confirm, exact phrase, or migration preview confirm
+
+**Validation Rules**:
+- Action IDs are stable and testable.
+- Unavailable actions include a concrete next step.
+- Destructive actions require confirmation.
+
+## Session Operation
+
+Represents a Matrix session operation backed by the zellij/session runtime.
+
+**Fields**:
+- `sessionId`: validated Matrix session identifier
+- `kind`: shell, coding, agent, or unknown-compatible
+- `status`: running, exited, stale, attaching, observing, stopping, or unavailable
+- `context`: project, worktree, task, cwd, or runtime summary
+- `operation`: create, list, attach, observe, takeover, detach, stop, inspect tabs, inspect panes, inspect layout
+- `nativeAttach`: optional command details exposed only when useful
+
+**Validation Rules**:
+- Session list reads tolerate stale runtime references.
+- Stop/remove actions require confirmation and refresh after confirmed success.
+- Missing sessions produce safe user-facing errors.
+
+## Setup Wizard
+
+Represents the agent setup and migration flow.
+
+**Fields**:
+- `selectedAgents`: Codex, Claude, or future supported agents
+- `migrationChoice`: skip, preview, selected candidates, or cancelled
+- `migrationCandidates`: discovered local non-secret files/settings
+- `writePlan`: owner-readable changes to Matrix-managed configuration
+- `completionState`: done, partial, skipped, cancelled, or failed safely
+- `handoff`: terminal action or next-step command
+
+**Validation Rules**:
+- Codex is selected by default; Claude is opt-in.
+- Secrets, credentials, symlinks, unsupported files, and oversized files are skipped.
+- Writes happen only after preview and confirmation.
+
+## Local Capability State
+
+Represents what can be evaluated on a local laptop.
+
+**Fields**:
+- `sourceCheckout`: whether the CLI is running from local source
+- `gatewayState`: running, unreachable, degraded, or unknown
+- `authState`: logged in, logged out, expired, or unknown
+- `zellijState`: available, missing, incompatible, or unknown
+- `syncState`: running, paused, missing, or unknown
+- `nextSteps`: concrete commands or setup actions
+
+**Validation Rules**:
+- Source-only mode must not present unavailable actions as working.
+- Capability checks have bounded waits and safe failures.

--- a/specs/085-cli-tui-action-console-v2/plan.md
+++ b/specs/085-cli-tui-action-console-v2/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Matrix CLI TUI Action Console Follow-Up
+
+**Branch**: `085-cli-tui-action-console-v2` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/085-cli-tui-action-console-v2/spec.md`
+
+## Summary
+
+Rebuild the TUI action-console follow-up as a clean stacked layer on top of `084-matrix-cli-tui-polish`. The work is additive: preserve the parent prompt-first TUI, mascot, command hints, command palette coverage, Matrix session language, and direct CLI compatibility while planning real action execution for home shortcuts, zellij-style session management, setup wizard flow, local migration preview, and honest local laptop evaluation states.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.5+ strict, ES modules, Node.js 24+
+**Primary Dependencies**: Ink + React TUI from the 084 stack, existing sync-client CLI/gateway/session clients, zellij-backed terminal/session stack, Zod 4 validation, Vitest
+**Storage**: Existing owner-readable Matrix CLI/profile/system files only; no new persistence system
+**Testing**: Vitest unit/render/client tests first, parent-regression tests, local quickstart validation, root typecheck and pattern checks before PR review
+**Target Platform**: Published Matrix CLI on macOS/Linux terminals, source checkout local laptops, customer/dev VPS gateways
+**Project Type**: CLI package follow-up with documentation-only planning in this PR
+**Performance Goals**: Home actions visibly start or report unavailable within 1 second when local state is known; backend calls use bounded waits; source-only degraded state appears within 10 seconds
+**Constraints**: Preserve parent 084 UI and behavior by default; no approved removals; safe errors; explicit destructive confirmations; 80x24 and no-color readability; no direct-command regressions
+**Scale/Scope**: Follow-up implementation should be split into small Graphite layers: preservation tests, action execution, session management, setup wizard/migration, docs/local validation
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Data Belongs to Its Owner**: PASS. Planned setup/migration uses owner-readable local configuration and skips secrets.
+- **AI Is the Kernel**: PASS. Agent setup exposes configuration for existing agents; it does not add a separate kernel path.
+- **Headless Core, Multi-Shell**: PASS. The TUI remains a shell over existing CLI/gateway/session capabilities.
+- **Defense in Depth**: PASS WITH DESIGN REQUIREMENTS. Plan requires validated paths/inputs, bounded waits, safe errors, confirmation gates, and secret-skipping migration.
+- **TDD**: PASS. Tasks require failing tests before implementation, including preservation/regression tests against the parent.
+- **Worktree/PR/Greptile**: PASS. This replacement is in a manual worktree and must ship through Graphite/PR with Greptile 5/5 before merge.
+- **Documentation-Driven Development**: PASS. Local evaluation and CLI docs updates are planned deliverables.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/085-cli-tui-action-console-v2/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   ├── parent-preservation.md
+│   ├── home-actions.md
+│   ├── session-operations.md
+│   └── setup-wizard.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+packages/sync-client/
+├── src/cli/
+│   ├── tui/
+│   │   ├── actions.ts
+│   │   ├── state.ts
+│   │   ├── setup/
+│   │   └── views/
+│   └── commands/
+├── tests/
+│   └── tui/
+└── package.json
+
+www/content/docs/
+└── guide/
+```
+
+**Structure Decision**: Keep implementation in the published `packages/sync-client` CLI/TUI established by the 084 stack. This PR only adds the replacement specification package; code changes should come in later stacked implementation PRs.
+
+## Complexity Tracking
+
+No constitution violations or exceptional complexity waivers are required.
+
+## Phase 0 Research Summary
+
+See [research.md](./research.md). Decisions resolved: preserve-parent contract first, action execution over visual-only selection, Matrix-session language over shell-only narrowing, wizard migration preview before writes, and source-only local capability states.
+
+## Phase 1 Design Summary
+
+See [data-model.md](./data-model.md), [quickstart.md](./quickstart.md), and [contracts/](./contracts/). The design defines the parent preservation contract, home action contract, session operation contract, setup wizard contract, and testable local evaluation flow.
+
+## Post-Design Constitution Check
+
+- **Data Ownership**: PASS. Migration candidates are user-owned files and secret data is skipped.
+- **Headless/Multi-Shell**: PASS. No new core coupling to the TUI.
+- **Defense in Depth**: PASS. Contracts include validation, bounded waits, safe errors, confirmation, and migration safety.
+- **TDD**: PASS. Tasks are test-first and explicitly require parent-regression tests.
+- **Worktree/PR Discipline**: PASS. Implementation is planned as Graphite stack layers on top of 084.

--- a/specs/085-cli-tui-action-console-v2/quickstart.md
+++ b/specs/085-cli-tui-action-console-v2/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: Matrix CLI TUI Action Console Follow-Up
+
+## Purpose
+
+Validate the replacement plan locally before implementation and later use the same scenarios as acceptance checks.
+
+## Local Evaluation States
+
+1. Source-only checkout: launch the TUI without gateway/auth/zellij and verify degraded states are explicit.
+2. Gateway running: launch the TUI and verify status/doctor actions can reach the local gateway.
+3. Authenticated profile: verify login state refreshes and auth-required actions become available.
+4. Zellij/session-ready: create a shell session, list sessions, attach/observe, detach, and stop with confirmation.
+
+## Preservation Check
+
+Compare against the parent `084-matrix-cli-tui-polish` branch:
+
+- Home prompt and product identity remain visible.
+- Rabbit mascot remains present and compact.
+- Parent keyboard hints remain visible.
+- Command palette still exposes the 084 command-family surface.
+- Sessions still use Matrix session language.
+- Direct CLI commands still bypass the TUI when explicitly invoked.
+
+## Setup Wizard Check
+
+Use a temporary home directory with fixture `.agent`, `.codex`, and `.claude` files:
+
+- Codex is selected by default.
+- Claude is opt-in.
+- Migration preview appears before writes.
+- Secrets and unsupported files are skipped.
+- Cancel leaves files unchanged.
+- Completion offers a terminal handoff or next action.

--- a/specs/085-cli-tui-action-console-v2/research.md
+++ b/specs/085-cli-tui-action-console-v2/research.md
@@ -1,0 +1,31 @@
+# Research: Matrix CLI TUI Action Console Follow-Up
+
+## Decision: Preserve Parent 084 as a Contract
+
+**Rationale**: The user complaint is specifically that the follow-up changed or removed parent TUI behavior. The first implementation layer must encode parent preservation as a regression contract before adding new actions.
+
+**Alternatives considered**: Rebuilding the home screen around quick actions was rejected because it can erase the prompt-first design and mascot work from the parent stack.
+
+## Decision: Home Shortcuts Execute Real Actions
+
+**Rationale**: The local test showed visible actions such as login felt broken because they did not do anything observable. Every shortcut needs an execution, navigation, or unavailable state.
+
+**Alternatives considered**: Keeping shortcuts as discovery-only labels was rejected because it creates silent no-op UX.
+
+## Decision: Keep Matrix Session Language With Zellij-Style Operations
+
+**Rationale**: Zellij is the substrate, but the parent spec intentionally frames the UX as Matrix sessions spanning shell and coding work. The follow-up should expose zellij-style operations without narrowing the product language to shell sessions only.
+
+**Alternatives considered**: A shell-only sessions screen was rejected because it removes coding/session cockpit scope from 084.
+
+## Decision: Setup Wizard Previews Migration Before Writes
+
+**Rationale**: Local agent configuration may include secrets or unsupported vendor formats. Preview-first migration lets the user choose Codex/Claude setup while preserving owner control and avoiding accidental credential copying.
+
+**Alternatives considered**: Auto-copying local `.agent`, `.codex`, and `.claude` directories was rejected because it risks moving secrets and unrelated settings.
+
+## Decision: Local Laptop States Are First-Class
+
+**Rationale**: Local source testing can lack gateway, platform auth, zellij, or sync services. The TUI should distinguish these capability states so a laptop does not look broken merely because services are not running.
+
+**Alternatives considered**: Treating local source mode as identical to a provisioned VPS was rejected because it hides prerequisites and causes confusing failures.

--- a/specs/085-cli-tui-action-console-v2/spec.md
+++ b/specs/085-cli-tui-action-console-v2/spec.md
@@ -1,0 +1,162 @@
+# Feature Specification: Matrix CLI TUI Action Console Follow-Up
+
+**Feature Branch**: `085-cli-tui-action-console-v2`
+**Created**: 2026-05-29
+**Status**: Draft
+**Input**: User description: "Remove the previous PR/spec and rebuild the TUI action console spec on top of the 084 Matrix CLI TUI stacked PR, preserving almost everything from the parent PR. Add real command execution, zellij-style session management, an agent setup wizard with optional local config migration, and homepage shortcuts for common shell/session actions."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preserve the Parent TUI While Adding Working Actions (Priority: P1)
+
+A user launches the Matrix CLI TUI from the 084 stack and still sees the parent prompt-first home, product identity, rabbit mascot, status line, keyboard hints, and command-family coverage. New shortcuts and action affordances execute the existing actions instead of replacing or deleting parent UI behavior.
+
+**Why this priority**: The follow-up is only valid if it is additive on top of the parent 084 TUI. Regressing the parent layout, mascot, prompt copy, shortcuts, sessions language, or direct command compatibility invalidates the work.
+
+**Independent Test**: Can be tested by comparing the TUI against the 084 parent branch, then selecting every new home/palette action and verifying that it executes or reports a bounded, safe failure without removing existing entry points.
+
+**Acceptance Scenarios**:
+
+1. **Given** the 084 parent TUI home screen, **When** this follow-up is applied, **Then** the existing prompt text, status line, command-family hints, rabbit mascot, keyboard shortcuts, and command palette remain present unless the spec explicitly lists an approved removal.
+2. **Given** a visible home shortcut such as login, doctor, new shell, or sessions, **When** the user activates it, **Then** the TUI runs the corresponding action or opens the corresponding view instead of only changing visual selection state.
+3. **Given** any parent 084 view, command-family entry, state helper, or keyboard shortcut, **When** the follow-up changes it, **Then** the change is covered by a regression test and the spec explains why the behavior is preserved or intentionally extended.
+
+---
+
+### User Story 2 - Use Home Shortcuts for Daily Shell Work (Priority: P2)
+
+A returning developer opens the TUI and can immediately create a shell session, list existing Matrix sessions, attach to a session, run doctor/status, or start login from the home screen without knowing slash commands.
+
+**Why this priority**: The user explicitly wants the home page to expose the most-used commands, especially creating shell sessions and listing zellij-backed sessions.
+
+**Independent Test**: Can be tested from the home screen by creating a session, listing sessions, attaching to one, and returning to the TUI without using command syntax.
+
+**Acceptance Scenarios**:
+
+1. **Given** a logged-in user with a reachable gateway, **When** they activate "New Shell" from the home screen, **Then** a Matrix shell session is created through the existing shell/session backend and the user receives attach/observe options.
+2. **Given** existing shell or coding sessions, **When** the user activates "Sessions" from the home screen, **Then** the zellij-backed Matrix session cockpit opens with session status, kind, age, context, and available actions.
+3. **Given** a missing login, gateway, zellij runtime, or sync dependency, **When** a home shortcut requires it, **Then** the TUI reports a safe, user-actionable message and leaves the user in the current TUI instead of silently doing nothing.
+
+---
+
+### User Story 3 - Manage Sessions Like a Zellij Workspace (Priority: P3)
+
+A developer can create, list, attach, detach, observe, take over, stop, and navigate Matrix sessions with zellij-style mental models while the UI continues to call them Matrix sessions rather than narrowing the surface to "shell sessions" only.
+
+**Why this priority**: Session management is the core daily workflow and must build on the parent session cockpit instead of replacing it with a smaller shell-only screen.
+
+**Independent Test**: Can be tested with fake and real session clients by exercising create/list/attach/observe/takeover/stop flows and verifying state refresh, confirmations, and non-destructive detach behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** no active sessions, **When** the user opens the session cockpit, **Then** the empty state invites creating a Matrix session while preserving the parent "Matrix sessions" language.
+2. **Given** multiple shell and coding sessions, **When** the user opens sessions, **Then** the list supports zellij-style actions such as attach, observe, takeover, stop, tabs, panes, and layout details where available.
+3. **Given** a destructive session action, **When** the user selects it, **Then** the TUI requires confirmation and refreshes the session list only after the backend confirms success.
+
+---
+
+### User Story 4 - Complete Agent Setup Through a Wizard (Priority: P4)
+
+A first-run or migrating user can open a setup wizard, choose which coding agents to configure, optionally migrate local non-secret configuration from existing tool directories, and finish in a terminal-ready state.
+
+**Why this priority**: The TUI should explain and perform setup work instead of leaving login/setup commands as visual placeholders.
+
+**Independent Test**: Can be tested in a temporary home directory with Codex and Claude migration fixtures, verifying preview, selection, writeback, skipped secrets, and final terminal handoff.
+
+**Acceptance Scenarios**:
+
+1. **Given** the setup wizard starts, **When** the user reaches the agent selection step, **Then** Codex is preselected, Claude is available but unchecked by default, and choices are keyboard-accessible.
+2. **Given** local `.agent`, `.codex`, or `.claude` configuration exists, **When** the user chooses migration, **Then** the TUI previews what non-secret files/settings will be copied or adapted before writing anything.
+3. **Given** setup completes, **When** all selected steps succeed or are explicitly skipped, **Then** the TUI opens or offers a terminal handoff with a concise "Done setup" completion state and a next action.
+
+---
+
+### User Story 5 - Make Local Laptop Evaluation Honest (Priority: P5)
+
+A contributor testing locally on their own laptop can tell which actions are fully available, which need a running gateway/platform/auth, and which are disabled in source-only mode.
+
+**Why this priority**: The previous local test looked broken because commands like login appeared selectable but did not visibly do anything. Local evaluation needs explicit capabilities and failure states.
+
+**Independent Test**: Can be tested on a laptop without production services by launching the TUI, attempting login/session/setup actions, and verifying clear capability states and bounded failures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a source checkout without gateway or platform services running, **When** the user opens the TUI, **Then** actions that require those services show unavailable/degraded state and a concrete local command or requirement.
+2. **Given** an action starts a backend request, **When** the backend is unreachable or slow, **Then** the TUI uses a bounded wait and shows a safe failure instead of hanging or ignoring input.
+3. **Given** the user runs the documented local test command, **When** services and auth are configured, **Then** login, setup, shell creation, and session listing can be evaluated locally without the VPS being special.
+
+### Edge Cases
+
+- The parent 084 TUI changes while this follow-up is in review; this follow-up must rebase/restack and preserve the newest parent behavior.
+- Terminal dimensions are 80x24, no-color, or too narrow for both mascot and shortcuts; critical status and prompts take priority while the mascot degrades compactly.
+- A shortcut is activated while another action is in progress; duplicate work is prevented and progress remains visible.
+- Login, gateway, platform, zellij, or shell backend is unavailable, slow, expired, or returns malformed data.
+- Local migration files are missing, unreadable, too large, symlinked, contain secrets, or mix supported and unsupported formats.
+- A session disappears between list and attach/stop.
+- A user cancels setup or a destructive session action midway.
+- The old/obsolete PR remains open in GitHub or Graphite while this replacement branch is reviewed; reviewers must treat this spec as the source of truth for the replacement.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: This follow-up MUST be stacked on `084-matrix-cli-tui-polish` and MUST treat the 084 spec and implementation as the parent source of truth.
+- **FR-002**: The follow-up MUST be additive by default: no parent home content, mascot art, shortcuts, command-family entries, session cockpit concepts, state helpers, tests, or direct CLI behavior may be removed unless a later spec revision explicitly lists the removal and the user approves it.
+- **FR-003**: The parent prompt-first home identity MUST remain visible, including the Matrix OS identity, "Ask Matrix..." prompt region, command-family hints, status line, and compact decorative rabbit mascot.
+- **FR-004**: Homepage shortcuts MUST augment the parent home screen and MUST include at minimum login/setup where relevant, new shell session, sessions list, doctor/status, command palette, and quit.
+- **FR-005**: Every visible home shortcut and command-palette action added by this follow-up MUST either execute a real action, open an actionable view, or show a safe unavailable state with a next step.
+- **FR-006**: The TUI MUST NOT silently ignore login, setup, shell, session, doctor, or migration commands.
+- **FR-007**: New action execution MUST reuse existing CLI/gateway/session clients from the 084 TUI direction rather than adding a separate persistence or command execution source of truth.
+- **FR-008**: Session management MUST preserve the parent "Matrix sessions" model while exposing zellij-style operations for shell/coding sessions.
+- **FR-009**: Users MUST be able to create a shell session from the home screen or command palette and then attach, observe, or return to the session list.
+- **FR-010**: Users MUST be able to list sessions from the home screen and see shell/coding session kind, status, age, project/context, and available attach/observe/takeover/stop actions.
+- **FR-011**: Destructive actions such as stopping/removing sessions or overwriting setup files MUST require explicit confirmation beyond initial selection.
+- **FR-012**: The setup wizard MUST offer agent selection with Codex selected by default and Claude available but not selected by default.
+- **FR-013**: The setup wizard MUST ask whether to migrate local tool configuration from `.agent`, `.codex`, `.claude`, or equivalent Matrix-supported local locations.
+- **FR-014**: Migration MUST preview planned non-secret changes before writing and MUST skip secrets, tokens, credentials, symlinks, oversized files, and unsupported formats.
+- **FR-015**: Setup completion MUST provide a terminal-ready completion state with a concise "Done setup" result and a next action.
+- **FR-016**: Local laptop testing MUST distinguish source-only, gateway-running, authenticated, and fully configured states.
+- **FR-017**: Actions that need gateway/platform/auth/zellij MUST show degraded or unavailable status when dependencies are missing and MUST include a concrete next step.
+- **FR-018**: All backend, daemon, filesystem, and network calls initiated from the TUI MUST have bounded waits and safe user-facing errors.
+- **FR-019**: User-supplied paths, session names, project identifiers, URLs, migration targets, and command inputs MUST be validated before use.
+- **FR-020**: Owner-readable setup/config changes MUST be written through existing Matrix-managed files or adapters and MUST avoid copying secrets across tools.
+- **FR-021**: Direct CLI subcommands and machine-readable output MUST remain compatible with the parent 084 requirements.
+- **FR-022**: Regression tests MUST compare the follow-up against parent 084 preservation requirements for home content, mascot presence, shortcuts, command palette coverage, and session language.
+- **FR-023**: Public CLI documentation or local quickstart documentation MUST explain how to run and evaluate the TUI locally, including service/auth prerequisites and expected degraded states.
+
+### Approved Removals From Parent 084
+
+No removals are approved in this spec.
+
+Any future removal must be added here with: parent behavior, reason, user approval reference, replacement behavior, and regression test coverage.
+
+### Key Entities
+
+- **Parent TUI Contract**: The preserved 084 user-visible behavior, including home content, mascot, shortcuts, command palette coverage, session cockpit model, and direct CLI compatibility.
+- **TUI Action**: A selectable command surfaced by the home screen or palette, including availability, execution state, success result, safe failure, and follow-up view.
+- **Home Shortcut**: A high-priority action visible on the prompt-first home screen without replacing parent prompt/status content.
+- **Session Operation**: A zellij-backed Matrix session action such as create, list, attach, observe, takeover, detach, stop, tab, pane, or layout inspection.
+- **Setup Wizard**: A multi-step flow for agent selection, optional local config migration, preview, confirmation, writeback, and terminal handoff.
+- **Migration Candidate**: A local file or setting discovered from supported tool directories, classified as copyable, adaptable, skipped, secret, unsupported, or unsafe.
+- **Local Capability State**: The current evaluation mode for a local laptop, including source-only, gateway-running, authenticated, sync-ready, and zellij-ready states.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A visual/regression review confirms 100% of parent 084 required home elements remain present unless explicitly listed under Approved Removals.
+- **SC-002**: 100% of home shortcuts introduced by this follow-up execute, navigate to an actionable view, or show a safe unavailable state with a next step.
+- **SC-003**: A logged-in local user can create a shell session and open the session list from the home screen within 3 keypresses each.
+- **SC-004**: Session create/list/attach/observe/takeover/stop flows have tests covering success, unavailable backend, stale session, and destructive confirmation.
+- **SC-005**: Setup wizard tests cover Codex-default selection, Claude opt-in, migration preview, secret skipping, cancellation, and completion handoff.
+- **SC-006**: A source-only laptop launch clearly communicates missing gateway/auth/zellij dependencies within 10 seconds and does not present silent no-op actions.
+- **SC-007**: Existing direct CLI tests from the parent stack continue passing with no output shape regressions.
+- **SC-008**: The TUI remains readable at 80x24 with critical text taking priority over decorative mascot or shortcut density.
+
+## Assumptions
+
+- The old PR that attempted this work is obsolete and should not be reviewed as the implementation source of truth.
+- This replacement PR is spec-first. Implementation should follow only after this spec is reviewed or explicitly accepted.
+- The 084 TUI parent is allowed to evolve while this follow-up is pending; the follow-up must restack and preserve the newest parent behavior before implementation.
+- The zellij runtime remains an implementation detail; user-facing language remains Matrix sessions unless native attach details are needed.
+- Migration initially handles only supported non-secret local configuration and should skip uncertain data rather than guessing.

--- a/specs/085-cli-tui-action-console-v2/tasks.md
+++ b/specs/085-cli-tui-action-console-v2/tasks.md
@@ -1,0 +1,166 @@
+# Tasks: Matrix CLI TUI Action Console Follow-Up
+
+**Input**: Design documents from `/specs/085-cli-tui-action-console-v2/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Required. This feature must follow TDD and must add preservation tests before implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and review.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the replacement spec as the source of truth and make the parent stack explicit.
+
+- [ ] T001 Confirm the implementation branch is stacked on `084-matrix-cli-tui-polish` using Graphite before code changes
+- [ ] T002 [P] Add a parent-preservation fixture or snapshot baseline for the 084 home screen in `packages/sync-client/tests/tui/`
+- [ ] T003 [P] Add a local evaluation fixture plan for source-only, gateway-running, authenticated, and zellij-ready states in `packages/sync-client/tests/tui/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the action execution and preservation guardrails that all stories depend on.
+
+- [ ] T004 Write failing preservation tests for home prompt, mascot, keyboard hints, status line, command palette coverage, and Matrix session language in `packages/sync-client/tests/tui/`
+- [ ] T005 Write failing tests proving visible home/palette actions cannot silently no-op in `packages/sync-client/tests/tui/`
+- [ ] T006 Implement or extend the TUI action result contract in `packages/sync-client/src/cli/tui/actions.ts`
+- [ ] T007 Add safe unavailable/degraded action state handling in `packages/sync-client/src/cli/tui/state.ts`
+- [ ] T008 Run the preservation tests and confirm they fail before implementation work begins
+
+**Checkpoint**: Parent preservation and action outcome contracts are testable.
+
+---
+
+## Phase 3: User Story 1 - Preserve Parent While Adding Working Actions (Priority: P1) MVP
+
+**Goal**: Keep the 084 TUI intact while making added actions observable.
+
+**Independent Test**: Compare parent-visible home elements and activate each added action.
+
+- [ ] T009 [US1] Restore or preserve parent home prompt, status line, command hints, and mascot rendering in `packages/sync-client/src/cli/tui/views/HomeView.tsx`
+- [ ] T010 [US1] Preserve parent mascot art and responsive alignment in `packages/sync-client/src/cli/tui/views/Mascot.tsx`
+- [ ] T011 [US1] Preserve parent TUI state exports/helpers or provide compatible replacements in `packages/sync-client/src/cli/tui/state.ts`
+- [ ] T012 [US1] Wire action execution results into the home and palette flows in `packages/sync-client/src/cli/tui/app.tsx`
+- [ ] T013 [US1] Run parent preservation tests and direct CLI compatibility tests for `packages/sync-client`
+
+**Checkpoint**: User Story 1 is fully functional and testable independently.
+
+---
+
+## Phase 4: User Story 2 - Home Shortcuts for Daily Shell Work (Priority: P2)
+
+**Goal**: Add home shortcuts for new shell, sessions, doctor/status, login/setup, palette, and quit without replacing parent content.
+
+**Independent Test**: Create and list sessions from home without slash commands.
+
+- [ ] T014 [P] [US2] Write failing render tests for additive home shortcuts in `packages/sync-client/tests/tui/`
+- [ ] T015 [P] [US2] Write failing action tests for new shell, sessions, doctor/status, login/setup, palette, and quit in `packages/sync-client/tests/tui/`
+- [ ] T016 [US2] Add additive shortcut rendering to `packages/sync-client/src/cli/tui/views/HomeView.tsx`
+- [ ] T017 [US2] Wire shortcut actions to existing CLI/gateway/session clients in `packages/sync-client/src/cli/tui/actions.ts`
+- [ ] T018 [US2] Add bounded progress and safe failure states for shortcut actions in `packages/sync-client/src/cli/tui/state.ts`
+
+**Checkpoint**: Home shortcuts execute, navigate, or report unavailable state.
+
+---
+
+## Phase 5: User Story 3 - Zellij-Style Matrix Session Management (Priority: P3)
+
+**Goal**: Add session create/list/attach/observe/takeover/stop flows while preserving Matrix session language.
+
+**Independent Test**: Exercise session operations against fake and real session clients.
+
+- [ ] T019 [P] [US3] Write failing tests for Matrix session empty/list/detail language in `packages/sync-client/tests/tui/`
+- [ ] T020 [P] [US3] Write failing tests for create/list/attach/observe/takeover/stop operation outcomes in `packages/sync-client/tests/tui/`
+- [ ] T021 [US3] Implement session operation action handlers in `packages/sync-client/src/cli/tui/actions.ts`
+- [ ] T022 [US3] Update the session cockpit view in `packages/sync-client/src/cli/tui/views/SessionsView.tsx`
+- [ ] T023 [US3] Add stale-session, missing-runtime, timeout, and stop-confirmation handling in `packages/sync-client/src/cli/tui/state.ts`
+
+**Checkpoint**: Matrix sessions support zellij-style operations with safe failures.
+
+---
+
+## Phase 6: User Story 4 - Agent Setup Wizard (Priority: P4)
+
+**Goal**: Add Codex-default/Claude-opt-in setup wizard with safe local migration preview.
+
+**Independent Test**: Run wizard against temporary home fixtures and verify preview/write/cancel behavior.
+
+- [ ] T024 [P] [US4] Write failing wizard selection tests in `packages/sync-client/tests/tui/`
+- [ ] T025 [P] [US4] Write failing migration preview and secret-skip tests in `packages/sync-client/tests/tui/`
+- [ ] T026 [US4] Add setup wizard state and view files under `packages/sync-client/src/cli/tui/setup/`
+- [ ] T027 [US4] Implement migration candidate discovery and classification in `packages/sync-client/src/cli/tui/setup/`
+- [ ] T028 [US4] Implement preview, confirmation, cancellation, writeback, and terminal handoff states in `packages/sync-client/src/cli/tui/setup/`
+
+**Checkpoint**: Setup wizard is safe, preview-first, and terminal-ready.
+
+---
+
+## Phase 7: User Story 5 - Honest Local Laptop Evaluation (Priority: P5)
+
+**Goal**: Make source-only/local service states explicit and testable.
+
+**Independent Test**: Launch locally with missing and available dependencies and verify state messaging.
+
+- [ ] T029 [P] [US5] Write failing local capability tests for source-only, gateway-running, authenticated, and zellij-ready states in `packages/sync-client/tests/tui/`
+- [ ] T030 [US5] Add local capability detection with bounded waits in `packages/sync-client/src/cli/tui/actions.ts`
+- [ ] T031 [US5] Surface capability states and next steps in `packages/sync-client/src/cli/tui/views/HomeView.tsx`
+- [ ] T032 [US5] Document local run/test commands and expected degraded states in `www/content/docs/guide/cli.mdx`
+
+**Checkpoint**: Local laptop testing is explicit and does not look like silent failure.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, docs, and review readiness.
+
+- [ ] T033 Run `bun run typecheck`
+- [ ] T034 Run `bun run check:patterns`
+- [ ] T035 Run `bun run test`
+- [ ] T036 Run focused TUI local quickstart validation from `specs/085-cli-tui-action-console-v2/quickstart.md`
+- [ ] T037 Update PR body invariants with source of truth, lock/transaction scope, acceptable orphan states, auth source of truth, and deferred scope
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1**: No dependencies.
+- **Phase 2**: Depends on Phase 1 and blocks all implementation stories.
+- **US1 / Phase 3**: Must land before any UI additions.
+- **US2 / Phase 4**: Depends on US1 preservation.
+- **US3 / Phase 5**: Depends on foundational action handling and can proceed after US1.
+- **US4 / Phase 6**: Depends on foundational action handling and can proceed after US1.
+- **US5 / Phase 7**: Depends on foundational degraded-state handling and can proceed after US1.
+- **Phase 8**: Depends on selected implementation phases.
+
+## Graphite Stack Plan
+
+- **Stack 1**: This replacement spec-only PR on top of `084-matrix-cli-tui-polish`.
+- **Stack 2**: Parent preservation tests and action result contract.
+- **Stack 3**: Additive home shortcuts and real action wiring.
+- **Stack 4**: Matrix session cockpit operations.
+- **Stack 5**: Setup wizard and migration preview.
+- **Stack 6**: Local laptop capability states, docs, and final validation.
+
+Each layer must stay below Matrix OS PR size limits and must not flatten the stack unless explicitly requested.
+
+## Parallel Opportunities
+
+- T002 and T003 can run in parallel.
+- T014 and T015 can run in parallel.
+- T019 and T020 can run in parallel.
+- T024 and T025 can run in parallel.
+- US3, US4, and US5 can be developed in parallel after US1 if each branch preserves the parent contract.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Land this replacement spec-only PR.
+2. Add failing preservation tests.
+3. Preserve/restored parent UI while wiring observable action outcomes.
+4. Stop and validate before adding larger session or setup flows.
+
+### Incremental Delivery
+
+Implement each user story as a stacked Graphite PR with tests first, then run typecheck, pattern checks, focused TUI tests, and Greptile review before merge.


### PR DESCRIPTION
## Summary

- Replaces the obsolete CLI TUI action-console attempt with a clean follow-up stacked on `084-matrix-cli-tui-polish`.
- Adds `specs/085-cli-tui-action-console-v2/` with spec, plan, tasks, contracts, research, data model, quickstart, and checklist.
- Explicitly preserves the parent 084 TUI by default: approved removals from parent 084 are `none`.
- Fixes CLI/TUI gateway health checks to use the gateway's public `/health` endpoint instead of protected/nonexistent `/api/health`.
- Fixes `matrix profile show/use/set/ls` so profile subcommands do not also print the parent usage line.

## Obsolete PR

PR #250 is closed and its branch was deleted. Review this PR as the replacement source of truth.

## Invariants

- **Source of truth**: `084-matrix-cli-tui-polish` remains the parent TUI source of truth. The gateway's public health endpoint is `/health`.
- **Lock/transaction scope**: No runtime writes or database transactions are introduced. Health checks are bounded read-only HTTP requests.
- **Acceptable orphan states**: None introduced. The old PR is closed; this PR points Spec Kit at the replacement plan and fixes read-only health checks.
- **Auth source of truth**: No auth behavior changes in this PR. Planned implementation must reuse existing CLI/gateway/auth contracts.
- **Deferred scope**: Real TUI action execution, setup wizard, and session-management UI work remain deferred to later stacked PRs after this replacement spec is accepted.

## Validation

- `git diff --check 084-matrix-cli-tui-polish...HEAD`
- `pnpm --filter @finnaai/matrix exec vitest run tests/unit/gateway-health-path.test.ts tests/tui/status.test.ts`
- `pnpm --filter @finnaai/matrix exec vitest run tests/unit/profile-command.test.ts tests/unit/gateway-health-path.test.ts tests/tui/status.test.ts`
- `pnpm --filter @finnaai/matrix build`
- Runtime smoke: disposable gateway on port 4100, `matrix login --dev`, `matrix status`, `matrix doctor`, `matrix profile show`, TUI render/quit, shell list/create/remove.
