### PR TITLE
chore(shell): add websocket telemetry coverage

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -101,7 +101,8 @@ jobs:
 
       - name: Install Playwright Chromium
         if: steps.screenshots.outputs.should_run == 'true'
-        run: cd shell && pnpm exec playwright install chromium
+        timeout-minutes: 5
+        run: cd shell && pnpm exec playwright install --only-shell chromium
 
       - name: Run Playwright tests
         if: steps.screenshots.outputs.should_run == 'true'

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -13,6 +13,11 @@
       "types": "./src/client.ts",
       "import": "./dist/client.js",
       "default": "./dist/client.js"
+    },
+    "./events": {
+      "types": "./src/events.ts",
+      "import": "./dist/events.js",
+      "default": "./dist/events.js"
     }
   },
   "scripts": {

--- a/packages/observability/src/events.ts
+++ b/packages/observability/src/events.ts
@@ -1,0 +1,28 @@
+export const MATRIX_TELEMETRY_EVENTS = {
+  USER_SIGNED_UP: "matrix_user_signed_up",
+  BILLING_EVENT_RECEIVED: "matrix_billing_event_received",
+  HOST_BUNDLE_RELEASE_REGISTERED: "host_bundle_release_registered",
+  HOST_BUNDLE_CHANNEL_PROMOTED: "host_bundle_channel_promoted",
+  RUNTIME_UPGRADE_REQUESTED: "matrix_runtime_upgrade_requested",
+  RUNTIME_UPGRADE_STARTED: "matrix_runtime_upgrade_started",
+  RUNTIME_UPGRADE_COMPLETED: "matrix_runtime_upgrade_completed",
+  RUNTIME_UPGRADE_FAILED: "matrix_runtime_upgrade_failed",
+  SHELL_LOADED: "matrix_shell_loaded",
+  SHELL_APP_OPENED: "matrix_shell_app_opened",
+  SHELL_WS_CONNECTED: "matrix_shell_ws_connected",
+  SHELL_WS_RECONNECT_STARTED: "matrix_shell_ws_reconnect_started",
+  SHELL_WS_RECONNECT_EXHAUSTED: "matrix_shell_ws_reconnect_exhausted",
+  PLATFORM_WS_AUTH_FAILED: "matrix_ws_platform_auth_failed",
+  PLATFORM_WS_UNAUTHENTICATED: "matrix_ws_platform_unauthenticated",
+  PLATFORM_WS_ENTITLEMENT_DENIED: "matrix_ws_platform_entitlement_denied",
+  PLATFORM_WS_UPSTREAM_FAILED: "matrix_ws_platform_upstream_failed",
+  CLI_INSTALLED: "matrix_cli_installed",
+  CLI_LOGGED_IN: "matrix_cli_logged_in",
+  CLI_COMMAND_RUN: "matrix_cli_command_run",
+} as const;
+
+export type MatrixTelemetryEvent = typeof MATRIX_TELEMETRY_EVENTS[keyof typeof MATRIX_TELEMETRY_EVENTS];
+
+export function isMatrixTelemetryEvent(value: string): value is MatrixTelemetryEvent {
+  return (Object.values(MATRIX_TELEMETRY_EVENTS) as string[]).includes(value);
+}

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,6 +1,7 @@
 import { PostHog } from "posthog-node";
 import type { Context, Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
+export { MATRIX_TELEMETRY_EVENTS, isMatrixTelemetryEvent, type MatrixTelemetryEvent } from "./events.js";
 
 type EnvSource = Record<string, string | undefined>;
 type PrimitiveProperty = string | number | boolean;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -626,6 +626,12 @@ export function classifyWebSocketPath(path: string): string {
   }
 }
 
+export function classifySessionRoutedHost(host: string): 'app' | 'code' | 'other' {
+  if (isAppDomainHost(host)) return 'app';
+  if (isCodeDomainHost(host)) return 'code';
+  return 'other';
+}
+
 export function buildPlatformWebSocketUpgradeHeaders(opts: {
   incomingHeaders: IncomingMessage['headers'];
   externalHost: string;
@@ -3548,6 +3554,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       return;
     }
     const isCodeDomain = isCodeDomainHost(host);
+    const hostClass = classifySessionRoutedHost(host);
 
     const requestRuntimeSlot = readRuntimeSlot(path);
     const wsToken = getWebSocketUpgradeToken(path);
@@ -3567,7 +3574,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
         `[platform] websocket auth failed host=${host} pathClass=${pathClass} error=${describeError(err)}`,
       );
       app.capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.PLATFORM_WS_AUTH_FAILED, {
-        host,
+        hostClass,
         pathClass,
         runtimeSlot: requestRuntimeSlot,
         hasToken: Boolean(wsToken),
@@ -3580,7 +3587,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     if (!identity) {
       console.warn(`[platform] websocket unauthenticated host=${host} pathClass=${pathClass} hasCookie=${Boolean(req.headers.cookie)} hasToken=${Boolean(wsToken)}`);
       app.capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.PLATFORM_WS_UNAUTHENTICATED, {
-        host,
+        hostClass,
         pathClass,
         runtimeSlot: requestRuntimeSlot,
         hasToken: Boolean(wsToken),

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2,7 +2,7 @@ import { createHmac, randomBytes } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
-import { installPostHogHonoErrorTracking } from '@matrix-os/observability';
+import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS, type MatrixTelemetryEvent } from '@matrix-os/observability';
 import { createConnection, type Socket } from 'node:net';
 import { connect as createTlsConnection } from 'node:tls';
 import type { IncomingMessage, Server } from 'node:http';
@@ -611,6 +611,61 @@ function buildCodeDomainProxyHeaders(
 function buildPlatformUserProof(handle: string, userId: string, platformSecret: string): string {
   const handleToken = buildPlatformVerificationToken(handle, platformSecret);
   return createHmac('sha256', handleToken).update(userId).digest('hex');
+}
+
+export function classifyWebSocketPath(path: string): string {
+  try {
+    const parsed = new URL(path, 'https://app.matrix-os.com');
+    if (parsed.pathname.startsWith('/ws/terminal')) return '/ws/terminal';
+    if (parsed.pathname === '/ws') return '/ws';
+    if (parsed.pathname.startsWith('/ws/')) return '/ws/*';
+    return 'other';
+  } catch (err: unknown) {
+    if (err instanceof TypeError) return 'invalid';
+    throw err;
+  }
+}
+
+export function buildPlatformWebSocketUpgradeHeaders(opts: {
+  incomingHeaders: IncomingMessage['headers'];
+  externalHost: string;
+  handle: string;
+  userId: string;
+  platformSecret: string;
+  includePlatformProof: boolean;
+  isCodeDomain: boolean;
+}): string {
+  return Object.entries(opts.incomingHeaders)
+    .filter(([k]) => (
+      k !== 'host' &&
+      k !== 'authorization' &&
+      k !== 'cookie' &&
+      k !== 'x-forwarded-host' &&
+      k !== 'x-forwarded-proto'
+    ))
+    .flatMap(([k, v]) => {
+      if (v === undefined) return [];
+      return `${k}: ${Array.isArray(v) ? v.join(', ') : v}`;
+    })
+    .concat([
+      `x-forwarded-host: ${opts.externalHost}`,
+      'x-forwarded-proto: https',
+    ])
+    .concat(
+      opts.platformSecret && opts.includePlatformProof
+        ? [
+            `authorization: Bearer ${buildPlatformVerificationToken(opts.handle, opts.platformSecret)}`,
+            `x-platform-verified: ${buildPlatformUserProof(opts.handle, opts.userId, opts.platformSecret)}`,
+            `x-platform-user-id: ${opts.userId}`,
+          ]
+        : [],
+    )
+    .concat(
+      opts.platformSecret && opts.isCodeDomain
+        ? [`x-matrix-code-proxy-token: ${buildPlatformVerificationToken(opts.handle, opts.platformSecret)}`]
+        : [],
+    )
+    .join('\r\n');
 }
 
 function requireValidHandle(handle: string): string {
@@ -1521,6 +1576,10 @@ export type PlatformApp = Hono<{
     internalContainerClerkUserId: string;
   };
 }> & {
+  capturePlatformEvent(
+    event: MatrixTelemetryEvent,
+    properties: Record<string, string | number | boolean | null | undefined>,
+  ): void;
   shutdownPostHog(): Promise<void>;
 };
 
@@ -1659,7 +1718,7 @@ export function createApp(deps: {
   });
   const posthogShutdowns: Array<() => Promise<void>> = [() => posthogErrorTracker.shutdown()];
   function capturePlatformEvent(
-    event: string,
+    event: MatrixTelemetryEvent,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void {
     void posthogErrorTracker.captureEvent(event, {
@@ -1670,6 +1729,7 @@ export function createApp(deps: {
       console.warn(`[posthog] Failed to queue platform event ${event}: ${kind}`);
     });
   }
+  app.capturePlatformEvent = capturePlatformEvent;
 
   app.use('*', async (c, next) => {
     const started = performance.now();
@@ -1815,13 +1875,13 @@ export function createApp(deps: {
       let channel;
       if (parsed.data.channel) {
         channel = await promoteHostBundleChannel(db, parsed.data.channel, release.version);
-        capturePlatformEvent('host_bundle_channel_promoted', {
+        capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.HOST_BUNDLE_CHANNEL_PROMOTED, {
           channel: parsed.data.channel,
           version: release.version,
           gitCommit: release.gitCommit,
         });
       }
-      capturePlatformEvent('host_bundle_release_registered', {
+      capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.HOST_BUNDLE_RELEASE_REGISTERED, {
         version: release.version,
         gitCommit: release.gitCommit,
         gitRef: release.gitRef,
@@ -1863,7 +1923,7 @@ export function createApp(deps: {
     }
     try {
       const promoted = await promoteHostBundleChannel(db, channel, parsed.data.version);
-      capturePlatformEvent('host_bundle_channel_promoted', {
+      capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.HOST_BUNDLE_CHANNEL_PROMOTED, {
         channel,
         version: promoted.version,
       });
@@ -3472,11 +3532,16 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       if (handledInternalGeminiLive) return;
     } catch (err: unknown) {
       console.warn('[platform] internal Gemini Live proxy failed:', describeError(err));
+      app.capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.PLATFORM_WS_UPSTREAM_FAILED, {
+        pathClass: 'internal-gemini-live',
+        errorKind: err instanceof Error ? err.name : typeof err,
+      });
       socket.destroy();
       return;
     }
 
     const path = req.url ?? '/';
+    const pathClass = classifyWebSocketPath(path);
     const host = getSessionRoutedWebSocketHost(req.headers.host, req.headers['x-forwarded-host'], path);
     if (!isSessionRoutedHost(host)) {
       socket.destroy();
@@ -3499,13 +3564,28 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       });
     } catch (err: unknown) {
       console.warn(
-        `[platform] websocket auth failed host=${host} path=${path} error=${describeError(err)}`,
+        `[platform] websocket auth failed host=${host} pathClass=${pathClass} error=${describeError(err)}`,
       );
+      app.capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.PLATFORM_WS_AUTH_FAILED, {
+        host,
+        pathClass,
+        runtimeSlot: requestRuntimeSlot,
+        hasToken: Boolean(wsToken),
+        hasCookie: Boolean(req.headers.cookie),
+        errorKind: err instanceof Error ? err.name : typeof err,
+      });
       socket.destroy();
       return;
     }
     if (!identity) {
-      console.warn(`[platform] websocket unauthenticated host=${host} path=${path} hasCookie=${Boolean(req.headers.cookie)} hasToken=${Boolean(wsToken)}`);
+      console.warn(`[platform] websocket unauthenticated host=${host} pathClass=${pathClass} hasCookie=${Boolean(req.headers.cookie)} hasToken=${Boolean(wsToken)}`);
+      app.capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.PLATFORM_WS_UNAUTHENTICATED, {
+        host,
+        pathClass,
+        runtimeSlot: requestRuntimeSlot,
+        hasToken: Boolean(wsToken),
+        hasCookie: Boolean(req.headers.cookie),
+      });
       socket.destroy();
       return;
     }
@@ -3534,39 +3614,17 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     const onSocketError = () => activeUpstream?.destroy();
     socket.on('error', onSocketError);
 
-    const buildUpgradeHeaders = (handle: string, includePlatformProof: boolean): string => {
-      return Object.entries(req.headers)
-        .filter(([k]) => (
-          k !== 'host' &&
-          k !== 'authorization' &&
-          k !== 'cookie' &&
-          k !== 'x-forwarded-host' &&
-          k !== 'x-forwarded-proto'
-        ))
-        .flatMap(([k, v]) => {
-          if (v === undefined) return [];
-          return `${k}: ${Array.isArray(v) ? v.join(', ') : v}`;
-        })
-        .concat([
-          `x-forwarded-host: ${host}`,
-          'x-forwarded-proto: https',
-        ])
-        .concat(
-          PLATFORM_SECRET && includePlatformProof
-            ? [
-                `authorization: Bearer ${buildPlatformVerificationToken(handle, PLATFORM_SECRET)}`,
-                `x-platform-verified: ${buildPlatformUserProof(handle, identity.userId, PLATFORM_SECRET)}`,
-                `x-platform-user-id: ${identity.userId}`,
-              ]
-            : [],
-        )
-        .concat(
-          PLATFORM_SECRET && isCodeDomain
-            ? [`x-matrix-code-proxy-token: ${buildPlatformVerificationToken(handle, PLATFORM_SECRET)}`]
-            : [],
-        )
-        .join('\r\n');
-    };
+    const buildUpgradeHeaders = (handle: string, includePlatformProof: boolean): string => (
+      buildPlatformWebSocketUpgradeHeaders({
+        incomingHeaders: req.headers,
+        externalHost: host,
+        handle,
+        userId: identity.userId,
+        platformSecret: PLATFORM_SECRET,
+        includePlatformProof,
+        isCodeDomain,
+      })
+    );
 
     const writeUpgradeRequest = (
       upstream: Socket,
@@ -3591,14 +3649,19 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     if (runningMachine) {
       if (!entitlement.runtimeProxyAllowed) {
         console.warn(
-          `[platform] websocket runtime proxy denied by entitlement handle=${runningMachine.handle} path=${path}`,
+          `[platform] websocket runtime proxy denied by entitlement handle=${runningMachine.handle} pathClass=${pathClass}`,
         );
+        app.capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.PLATFORM_WS_ENTITLEMENT_DENIED, {
+          handle: runningMachine.handle,
+          runtimeSlot,
+          pathClass,
+        });
         socket.destroy();
         return;
       }
       if (!runningMachine.publicIPv4) {
         console.warn(
-          `[platform] websocket runtime proxy missing upstream address handle=${runningMachine.handle} path=${path}`,
+          `[platform] websocket runtime proxy missing upstream address handle=${runningMachine.handle} pathClass=${pathClass}`,
         );
         socket.destroy();
         return;
@@ -3618,8 +3681,14 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       upstream.on('error', (err) => {
         upstream.destroy();
         console.warn(
-          `[platform] websocket vps upstream failed handle=${runningMachine.handle} host=${runningMachine.publicIPv4} path=${path} error=${describeError(err)}`,
+          `[platform] websocket vps upstream failed handle=${runningMachine.handle} host=${runningMachine.publicIPv4} pathClass=${pathClass} error=${describeError(err)}`,
         );
+        app.capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.PLATFORM_WS_UPSTREAM_FAILED, {
+          handle: runningMachine.handle,
+          runtimeSlot,
+          pathClass,
+          errorKind: err instanceof Error ? err.name : typeof err,
+        });
         socket.destroy();
       });
       return;
@@ -3628,7 +3697,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     if (!record) { socket.destroy(); return; }
     if (!entitlement.runtimeProxyAllowed) {
       console.warn(
-        `[platform] websocket legacy container proxy denied by entitlement handle=${record.handle} path=${path}`,
+        `[platform] websocket legacy container proxy denied by entitlement handle=${record.handle} pathClass=${pathClass}`,
       );
       socket.destroy();
       return;
@@ -3637,7 +3706,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       const endpoint = await resolveContainerEndpoint(docker, db, record.handle, record.containerId);
       if (!endpoint) {
         console.warn(
-          `[platform] websocket upstream unresolved handle=${record.handle} attempt=${attempt + 1} path=${path}`,
+          `[platform] websocket upstream unresolved handle=${record.handle} attempt=${attempt + 1} pathClass=${pathClass}`,
         );
         socket.destroy();
         return;
@@ -3659,7 +3728,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       upstream.on('error', (err) => {
         upstream.destroy();
         console.warn(
-          `[platform] websocket upstream failed handle=${record.handle} attempt=${attempt + 1} host=${endpoint.host} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} error=${describeError(err)}`,
+          `[platform] websocket upstream failed handle=${record.handle} attempt=${attempt + 1} host=${endpoint.host} source=${endpoint.source} containerId=${endpoint.containerId ?? 'null'} pathClass=${pathClass} error=${describeError(err)}`,
         );
         if (!connected && attempt === 0 && !socket.destroyed) {
           void connectUpstream(attempt + 1).catch((retryErr) => {

--- a/shell/src/app/page.tsx
+++ b/shell/src/app/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useTheme } from "@/hooks/useTheme";
 import { useDesktopConfig } from "@/hooks/useDesktopConfig";
 import { useChatState } from "@/hooks/useChatState";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { useCommandStore } from "@/stores/commands";
 import { ChatProvider } from "@/stores/chat-context";
+import { capturePostHogEvent } from "@/lib/posthog-client";
+import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability";
 
 import { Desktop } from "@/components/Desktop";
 import { MobileShell } from "@/components/mobile/MobileShell";
@@ -40,6 +42,7 @@ export default function Home() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [launchAppPath, setLaunchAppPath] = useState<string | null>(null);
   const isMobile = useMobileViewport();
+  const shellLoadedCaptured = useRef(false);
 
   useGlobalShortcuts(useCallback(() => setPaletteOpen(true), []));
 
@@ -63,6 +66,14 @@ export default function Home() {
   useEffect(() => {
     setLaunchAppPath(readLaunchPathFromLocation());
   }, []);
+
+  useEffect(() => {
+    if (shellLoadedCaptured.current) return;
+    shellLoadedCaptured.current = true;
+    capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_LOADED, {
+      surface: isMobile ? "mobile" : "desktop",
+    });
+  }, [isMobile]);
 
   return (
     <ChatProvider value={chat}>

--- a/shell/src/app/page.tsx
+++ b/shell/src/app/page.tsx
@@ -8,7 +8,7 @@ import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { useCommandStore } from "@/stores/commands";
 import { ChatProvider } from "@/stores/chat-context";
 import { capturePostHogEvent } from "@/lib/posthog-client";
-import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability";
+import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability/events";
 
 import { Desktop } from "@/components/Desktop";
 import { MobileShell } from "@/components/mobile/MobileShell";

--- a/shell/src/components/AppViewer.tsx
+++ b/shell/src/components/AppViewer.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/lib/os-bridge";
 import { getGatewayUrl } from "@/lib/gateway";
 import { openAppSession } from "@/lib/app-session";
+import { capturePostHogEvent } from "@/lib/posthog-client";
+import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability";
 
 const GATEWAY_URL = getGatewayUrl();
 const SESSION_REFRESH_DEBOUNCE_MS = 2000;
@@ -275,6 +277,13 @@ export function AppViewer({ path, sessionId, onOpenApp }: AppViewerProps) {
   const [sessionReady, setSessionReady] = useState(!slug);
   const lastRefreshAtRef = useRef(0);
   const refreshInFlightRef = useRef(false);
+
+  useEffect(() => {
+    capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_APP_OPENED, {
+      app: slug ?? appName,
+      runtime: slug ? "vite" : "file",
+    });
+  }, [appName, slug]);
 
   // Spec 063 session bootstrap: set the matrix_app_session__{slug} cookie
   // before the iframe ever navigates to /apps/{slug}/. Skipping this step

--- a/shell/src/components/AppViewer.tsx
+++ b/shell/src/components/AppViewer.tsx
@@ -13,7 +13,7 @@ import {
 import { getGatewayUrl } from "@/lib/gateway";
 import { openAppSession } from "@/lib/app-session";
 import { capturePostHogEvent } from "@/lib/posthog-client";
-import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability";
+import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability/events";
 
 const GATEWAY_URL = getGatewayUrl();
 const SESSION_REFRESH_DEBOUNCE_MS = 2000;

--- a/shell/src/hooks/useMobileViewport.ts
+++ b/shell/src/hooks/useMobileViewport.ts
@@ -9,7 +9,9 @@ export function isPhoneViewport(width: number): boolean {
 }
 
 export function useMobileViewport(): boolean {
-  const [mobile, setMobile] = useState(false);
+  const [mobile, setMobile] = useState(() => (
+    typeof window !== "undefined" && isPhoneViewport(window.innerWidth)
+  ));
 
   useEffect(() => {
     const update = () => setMobile(isPhoneViewport(window.innerWidth));

--- a/shell/src/hooks/useSocket.ts
+++ b/shell/src/hooks/useSocket.ts
@@ -6,7 +6,7 @@ import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 import { createSocketHealth, MessageQueue, reconnectDelay } from "@/lib/socket-health";
 import { capturePostHogEvent } from "@/lib/posthog-client";
 import { useConnectionHealth } from "./useConnectionHealth";
-import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability";
+import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability/events";
 
 export type ServerMessage =
   | { type: "kernel:init"; sessionId: string; requestId?: string }

--- a/shell/src/hooks/useSocket.ts
+++ b/shell/src/hooks/useSocket.ts
@@ -4,7 +4,9 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { getGatewayWs } from "@/lib/gateway";
 import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
 import { createSocketHealth, MessageQueue, reconnectDelay } from "@/lib/socket-health";
+import { capturePostHogEvent } from "@/lib/posthog-client";
 import { useConnectionHealth } from "./useConnectionHealth";
+import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability";
 
 export type ServerMessage =
   | { type: "kernel:init"; sessionId: string; requestId?: string }
@@ -71,6 +73,12 @@ function connect() {
   if (globalSocket?.readyState === WebSocket.OPEN) return;
   if (globalSocket?.readyState === WebSocket.CONNECTING) return;
 
+  if (connectionState !== "reconnecting") {
+    capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_STARTED, {
+      attempt: reconnectAttempt,
+      visibility: typeof document !== "undefined" ? document.visibilityState : "unknown",
+    });
+  }
   setConnectionState("reconnecting");
   void buildAuthenticatedWebSocketUrl("/ws")
     .catch((err: unknown) => {
@@ -90,6 +98,7 @@ function connect() {
       globalSocket.onopen = () => {
         reconnectAttempt = 0;
         setConnectionState("connected");
+        capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_WS_CONNECTED);
         heartbeat.start();
         drainQueue();
       };
@@ -113,6 +122,10 @@ function connect() {
         heartbeat.stop();
         if (reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
           setConnectionState("disconnected");
+          capturePostHogEvent(MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_EXHAUSTED, {
+            attempts: reconnectAttempt,
+            visibility: typeof document !== "undefined" ? document.visibilityState : "unknown",
+          });
           return;
         }
         setConnectionState("reconnecting");

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -21,6 +21,15 @@ export function capturePostHogException(error: unknown, properties: ClientProper
   }
 }
 
+export function capturePostHogEvent(event: string, properties: ClientProperties = {}) {
+  if (!config) return;
+  try {
+    posthog.capture(event, sanitizeProperties(properties));
+  } catch (err: unknown) {
+    console.warn("[posthog] Failed to capture client event:", err instanceof Error ? err.name : typeof err);
+  }
+}
+
 function sanitizeProperties(properties: ClientProperties): Record<string, string | number | boolean> {
   const sanitized: Record<string, string | number | boolean> = {};
   for (const [key, value] of Object.entries(properties)) {

--- a/tests/observability/telemetry-events.test.ts
+++ b/tests/observability/telemetry-events.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { MATRIX_TELEMETRY_EVENTS, isMatrixTelemetryEvent } from "../../packages/observability/src/events.js";
 
@@ -29,5 +30,20 @@ describe("Matrix telemetry events", () => {
       expect(isMatrixTelemetryEvent(name)).toBe(true);
     }
     expect(isMatrixTelemetryEvent("matrix_unknown_event")).toBe(false);
+  });
+
+  it("keeps browser telemetry imports on the event-only subpath", async () => {
+    const browserFiles = [
+      "shell/src/app/page.tsx",
+      "shell/src/components/AppViewer.tsx",
+      "shell/src/hooks/useSocket.ts",
+    ];
+
+    for (const file of browserFiles) {
+      const source = await readFile(file, "utf8");
+      expect(source, file).toContain("@matrix-os/observability/events");
+      expect(source, file).not.toContain(`from "@matrix-os/observability"`);
+      expect(source, file).not.toContain(`from '@matrix-os/observability'`);
+    }
   });
 });

--- a/tests/observability/telemetry-events.test.ts
+++ b/tests/observability/telemetry-events.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { MATRIX_TELEMETRY_EVENTS, isMatrixTelemetryEvent } from "../../packages/observability/src/events.js";
+
+describe("Matrix telemetry events", () => {
+  it("names product lifecycle, runtime, shell, websocket, CLI, app, and billing events explicitly", () => {
+    expect(MATRIX_TELEMETRY_EVENTS).toMatchObject({
+      USER_SIGNED_UP: "matrix_user_signed_up",
+      BILLING_EVENT_RECEIVED: "matrix_billing_event_received",
+      RUNTIME_UPGRADE_REQUESTED: "matrix_runtime_upgrade_requested",
+      RUNTIME_UPGRADE_STARTED: "matrix_runtime_upgrade_started",
+      RUNTIME_UPGRADE_COMPLETED: "matrix_runtime_upgrade_completed",
+      RUNTIME_UPGRADE_FAILED: "matrix_runtime_upgrade_failed",
+      SHELL_LOADED: "matrix_shell_loaded",
+      SHELL_APP_OPENED: "matrix_shell_app_opened",
+      SHELL_WS_RECONNECT_EXHAUSTED: "matrix_shell_ws_reconnect_exhausted",
+      PLATFORM_WS_AUTH_FAILED: "matrix_ws_platform_auth_failed",
+      CLI_INSTALLED: "matrix_cli_installed",
+      CLI_LOGGED_IN: "matrix_cli_logged_in",
+      CLI_COMMAND_RUN: "matrix_cli_command_run",
+    });
+  });
+
+  it("keeps event names low-cardinality and secret-free", () => {
+    const names = Object.values(MATRIX_TELEMETRY_EVENTS);
+    expect(new Set(names).size).toBe(names.length);
+    for (const name of names) {
+      expect(name).toMatch(/^[a-z][a-z0-9_]{2,96}$/);
+      expect(name).not.toMatch(/token|secret|cookie|jwt|bearer/i);
+      expect(isMatrixTelemetryEvent(name)).toBe(true);
+    }
+    expect(isMatrixTelemetryEvent("matrix_unknown_event")).toBe(false);
+  });
+});

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
 import { type PlatformDB, deleteContainer, getContainer, insertContainer, insertUserMachine } from "../../packages/platform/src/db.js";
-import { buildPostAuthRedirectPath, createApp, escapeInlineScriptJson } from "../../packages/platform/src/main.js";
+import {
+  buildPlatformWebSocketUpgradeHeaders,
+  buildPostAuthRedirectPath,
+  classifyWebSocketPath,
+  createApp,
+  escapeInlineScriptJson,
+} from "../../packages/platform/src/main.js";
 import type { Orchestrator } from "../../packages/platform/src/orchestrator.js";
 import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
 import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
 import * as syncJwt from "../../packages/platform/src/sync-jwt.js";
+import { buildPlatformVerificationToken } from "../../packages/platform/src/platform-token.js";
 import type Dockerode from "dockerode";
 import { createTestPlatformDb, destroyTestPlatformDb } from "./platform-db-test-helper.js";
 
@@ -214,6 +221,92 @@ describe("platform proxy routing", () => {
       expiresAt: expect.any(Number),
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("issues websocket tokens that resolve back to the selected customer VPS runtime", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "machine-alice-ws-runtime",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      hetznerServerId: 124,
+      publicIPv4: "203.0.113.12",
+      status: "running",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/api/auth/ws-token", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { token: string };
+    const claims = await syncJwt.verifySyncJwt(body.token, { secret: JWT_SECRET });
+    expect(claims).toMatchObject({
+      sub: "user_alice",
+      handle: "alice",
+      runtime_slot: "primary",
+      aud: "matrix-os-sync",
+      iss: "matrix-os-platform",
+    });
+  });
+
+  it("builds customer VPS websocket upgrade headers without leaking browser credentials or query JWTs", async () => {
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://app.matrix-os.com",
+      runtimeSlot: "primary",
+    });
+    const headers = buildPlatformWebSocketUpgradeHeaders({
+      incomingHeaders: {
+        host: "app.matrix-os.com",
+        authorization: `Bearer ${issued.token}`,
+        cookie: "__session=secret; matrix_shell_route=alice",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "https",
+        upgrade: "websocket",
+        connection: "Upgrade",
+        "sec-websocket-key": "client-key",
+      },
+      externalHost: "app.matrix-os.com",
+      handle: "alice",
+      userId: "user_alice",
+      platformSecret: "platform-secret-123",
+      includePlatformProof: true,
+      isCodeDomain: false,
+    });
+
+    const platformToken = buildPlatformVerificationToken("alice", "platform-secret-123");
+    expect(headers).toContain(`authorization: Bearer ${platformToken}`);
+    expect(headers).toContain("x-platform-user-id: user_alice");
+    expect(headers).toContain("x-platform-verified:");
+    expect(headers).toContain("x-forwarded-host: app.matrix-os.com");
+    expect(headers).toContain("sec-websocket-key: client-key");
+    expect(headers).not.toContain(issued.token);
+    expect(headers).not.toContain("__session");
+    expect(headers).not.toContain("matrix_shell_route");
+  });
+
+  it("classifies websocket paths without preserving secrets", () => {
+    expect(classifyWebSocketPath("/ws?token=secret")).toBe("/ws");
+    expect(classifyWebSocketPath("/ws/terminal/session?token=secret&session=main")).toBe("/ws/terminal");
+    expect(classifyWebSocketPath("/ws/other?token=secret")).toBe("/ws/*");
+    expect(classifyWebSocketPath("/api/ping")).toBe("other");
   });
 
   it("shows a boot page for Clerk-authenticated users while their first VPS is provisioning", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -4,6 +4,7 @@ import { type PlatformDB, deleteContainer, getContainer, insertContainer, insert
 import {
   buildPlatformWebSocketUpgradeHeaders,
   buildPostAuthRedirectPath,
+  classifySessionRoutedHost,
   classifyWebSocketPath,
   createApp,
   escapeInlineScriptJson,
@@ -307,6 +308,12 @@ describe("platform proxy routing", () => {
     expect(classifyWebSocketPath("/ws/terminal/session?token=secret&session=main")).toBe("/ws/terminal");
     expect(classifyWebSocketPath("/ws/other?token=secret")).toBe("/ws/*");
     expect(classifyWebSocketPath("/api/ping")).toBe("other");
+  });
+
+  it("classifies websocket hosts without preserving user-specific hostnames", () => {
+    expect(classifySessionRoutedHost("app.matrix-os.com")).toBe("app");
+    expect(classifySessionRoutedHost("code.matrix-os.com")).toBe("code");
+    expect(classifySessionRoutedHost("alice.matrix-os.com")).toBe("other");
   });
 
   it("shows a boot page for Clerk-authenticated users while their first VPS is provisioning", async () => {

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { renderToString } from "react-dom/server";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MobileShell } from "../../shell/src/components/mobile/MobileShell.js";
@@ -47,14 +46,12 @@ describe("mobile shell", () => {
     await waitFor(() => expect(screen.getByTestId("viewport-mode").textContent).toBe("mobile"));
   });
 
-  it("starts from the server-safe desktop value before switching to phone mode", async () => {
+  it("initializes phone mode synchronously on the client", () => {
     setPhoneViewport();
-
-    expect(renderToString(<ViewportProbe />)).toContain("desktop");
 
     render(<ViewportProbe />);
 
-    await waitFor(() => expect(screen.getByTestId("viewport-mode").textContent).toBe("mobile"));
+    expect(screen.getByTestId("viewport-mode").textContent).toBe("mobile");
   });
 
   it("updates viewport mode when a phone viewport expands", () => {

--- a/tests/shell/useSocket.test.ts
+++ b/tests/shell/useSocket.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MATRIX_TELEMETRY_EVENTS } from "../../packages/observability/src/events.js";
 
 class MockWebSocket {
   static instances: MockWebSocket[] = [];
@@ -185,6 +186,7 @@ describe("useSocket heartbeat and resilience", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.doUnmock("@/lib/posthog-client");
     vi.unstubAllGlobals();
   });
 
@@ -243,5 +245,26 @@ describe("useSocket heartbeat and resilience", () => {
     const msgs = ws2.sent.map((s) => JSON.parse(s));
     const queued = msgs.filter((m: { text?: string }) => m.text === "queued1" || m.text === "queued2");
     expect(queued).toHaveLength(2);
+  });
+
+  it("captures websocket reconnect and connected telemetry", async () => {
+    vi.resetModules();
+    const capturePostHogEvent = vi.fn();
+    vi.doMock("@/lib/posthog-client", () => ({
+      capturePostHogEvent,
+      capturePostHogException: vi.fn(),
+    }));
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal("document", { addEventListener: vi.fn(), visibilityState: "visible" });
+
+    const { ensureConnected } = await import("../../shell/src/hooks/useSocket.js");
+    ensureConnected();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      MATRIX_TELEMETRY_EVENTS.SHELL_WS_RECONNECT_STARTED,
+      expect.objectContaining({ attempt: 0, visibility: "visible" }),
+    );
+    expect(capturePostHogEvent).toHaveBeenCalledWith(MATRIX_TELEMETRY_EVENTS.SHELL_WS_CONNECTED);
   });
 });

--- a/tests/www/provision-user.test.ts
+++ b/tests/www/provision-user.test.ts
@@ -2,6 +2,25 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
+function findStepRunRange(source: string, stepName: string): { start: number; end: number } {
+  const start = source.indexOf(`step.run("${stepName}"`);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const openBrace = source.indexOf("{", start);
+  expect(openBrace).toBeGreaterThan(start);
+
+  let depth = 0;
+  for (let i = openBrace; i < source.length; i += 1) {
+    if (source[i] === "{") depth += 1;
+    if (source[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return { start, end: i };
+    }
+  }
+
+  throw new Error(`Could not find end of ${stepName} step`);
+}
+
 describe("provisionUser", () => {
   it("records signup telemetry inside an Inngest step", () => {
     const source = readFileSync(join(process.cwd(), "www/src/inngest/provision-user.ts"), "utf8");
@@ -12,5 +31,26 @@ describe("provisionUser", () => {
     expect(recordSignup).toBeGreaterThanOrEqual(0);
     expect(signupEvent).toBeGreaterThan(recordSignup);
     expect(signupEvent).toBeLessThan(provisionStep);
+  });
+
+  it("keeps PostHog operations scoped to deterministic Inngest steps", () => {
+    const source = readFileSync(join(process.cwd(), "www/src/inngest/provision-user.ts"), "utf8");
+    const stepRanges = [
+      "record-signup",
+      "record-provision-started",
+      "provision-container",
+      "verify-running",
+    ].map((stepName) => findStepRunRange(source, stepName));
+
+    const posthogOperations = [
+      ...source.matchAll(/getPostHogClient\(\)|posthog\.(?:capture|identify)\(/g),
+    ];
+    expect(posthogOperations.length).toBeGreaterThan(0);
+
+    for (const operation of posthogOperations) {
+      const index = operation.index ?? -1;
+      const isInsideStep = stepRanges.some((range) => index > range.start && index < range.end);
+      expect(isInsideStep, `${operation[0]} must be inside a step.run callback`).toBe(true);
+    }
   });
 });

--- a/tests/www/provision-user.test.ts
+++ b/tests/www/provision-user.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("provisionUser", () => {
+  it("records signup telemetry inside an Inngest step", () => {
+    const source = readFileSync(join(process.cwd(), "www/src/inngest/provision-user.ts"), "utf8");
+    const recordSignup = source.indexOf('step.run("record-signup"');
+    const signupEvent = source.indexOf("MATRIX_TELEMETRY_EVENTS.USER_SIGNED_UP");
+    const provisionStep = source.indexOf('step.run("provision-container"');
+
+    expect(recordSignup).toBeGreaterThanOrEqual(0);
+    expect(signupEvent).toBeGreaterThan(recordSignup);
+    expect(signupEvent).toBeLessThan(provisionStep);
+  });
+});

--- a/www/src/inngest/provision-user.ts
+++ b/www/src/inngest/provision-user.ts
@@ -1,5 +1,6 @@
 import { inngest } from "./client";
 import { getPostHogClient, shutdownPostHog } from "@/lib/posthog-server";
+import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability";
 import {
   getProvisionVerificationTarget,
   isCustomerVpsUsableStatus,
@@ -17,6 +18,15 @@ export const provisionUser = inngest.createFunction(
     const user = event.data;
     const handle = `${HANDLE_PREFIX}${user.username ?? user.id}`;
     const posthog = getPostHogClient();
+
+    posthog.capture({
+      distinctId: user.id,
+      event: MATRIX_TELEMETRY_EVENTS.USER_SIGNED_UP,
+      properties: {
+        handle,
+        source: "clerk_signup",
+      },
+    });
 
     posthog.capture({
       distinctId: user.id,

--- a/www/src/inngest/provision-user.ts
+++ b/www/src/inngest/provision-user.ts
@@ -19,13 +19,24 @@ export const provisionUser = inngest.createFunction(
     const handle = `${HANDLE_PREFIX}${user.username ?? user.id}`;
     const posthog = getPostHogClient();
 
-    posthog.capture({
-      distinctId: user.id,
-      event: MATRIX_TELEMETRY_EVENTS.USER_SIGNED_UP,
-      properties: {
-        handle,
-        source: "clerk_signup",
-      },
+    await step.run("record-signup", async () => {
+      posthog.capture({
+        distinctId: user.id,
+        event: MATRIX_TELEMETRY_EVENTS.USER_SIGNED_UP,
+        properties: {
+          handle,
+          source: "clerk_signup",
+        },
+      });
+
+      posthog.identify({
+        distinctId: user.id,
+        properties: {
+          handle,
+          email: user.email_addresses?.[0]?.email_address,
+          created_via: "clerk_signup",
+        },
+      });
     });
 
     posthog.capture({
@@ -34,15 +45,6 @@ export const provisionUser = inngest.createFunction(
       properties: {
         handle,
         source: "inngest",
-      },
-    });
-
-    posthog.identify({
-      distinctId: user.id,
-      properties: {
-        handle,
-        email: user.email_addresses?.[0]?.email_address,
-        created_via: "clerk_signup",
       },
     });
 

--- a/www/src/inngest/provision-user.ts
+++ b/www/src/inngest/provision-user.ts
@@ -17,9 +17,9 @@ export const provisionUser = inngest.createFunction(
   async ({ event, step }) => {
     const user = event.data;
     const handle = `${HANDLE_PREFIX}${user.username ?? user.id}`;
-    const posthog = getPostHogClient();
 
     await step.run("record-signup", async () => {
+      const posthog = getPostHogClient();
       posthog.capture({
         distinctId: user.id,
         event: MATRIX_TELEMETRY_EVENTS.USER_SIGNED_UP,
@@ -39,13 +39,16 @@ export const provisionUser = inngest.createFunction(
       });
     });
 
-    posthog.capture({
-      distinctId: user.id,
-      event: "inngest_provision_started",
-      properties: {
-        handle,
-        source: "inngest",
-      },
+    await step.run("record-provision-started", async () => {
+      const posthog = getPostHogClient();
+      posthog.capture({
+        distinctId: user.id,
+        event: "inngest_provision_started",
+        properties: {
+          handle,
+          source: "inngest",
+        },
+      });
     });
 
     const provisionResult = await step.run("provision-container", async (): Promise<ProvisionResult> => {
@@ -66,6 +69,7 @@ export const provisionUser = inngest.createFunction(
 
       if (!res.ok) {
         const body = await res.text();
+        const posthog = getPostHogClient();
         posthog.capture({
           distinctId: user.id,
           event: "inngest_provision_failed",
@@ -85,6 +89,7 @@ export const provisionUser = inngest.createFunction(
     await step.sleep("wait-for-boot", "10s");
 
     await step.run("verify-running", async () => {
+      const posthog = getPostHogClient();
       const headers: Record<string, string> = {};
       if (PLATFORM_SECRET) headers["authorization"] = `Bearer ${PLATFORM_SECRET}`;
       const target = getProvisionVerificationTarget(PLATFORM_API_URL, handle, provisionResult);


### PR DESCRIPTION
## Summary
- Add shared Matrix telemetry event names for signup, billing, runtime upgrades, shell/websocket, app opens, and CLI lifecycle events.
- Capture shell loaded, app opened, websocket connected/reconnect/exhausted, and platform websocket auth/upstream failure events through PostHog without logging raw websocket query tokens.
- Add regression coverage for app-domain websocket token routing to customer VPSes and sanitized upgrade headers.
- Speed up screenshot CI browser install with Playwright's Chromium shell and a bounded install timeout.

## Tests
- pnpm --filter '@matrix-os/observability' build
- pnpm exec vitest run tests/platform/proxy-routing.test.ts tests/shell/useSocket.test.ts tests/observability/telemetry-events.test.ts
- pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json
- pnpm --filter './shell' exec tsc --noEmit

## Review/Monitoring
- First PR in the shell reliability stack; follow-up PRs will layer UI state, terminal parity, mobile terminal polish, CLI soak fixes, and release/CI hardening.

## Invariants
- Source of truth: PostHog receives low-cardinality telemetry only; routing/session state remains in existing platform and gateway stores.
- Auth source of truth: websocket identity resolution still uses Clerk, sync JWTs, runtime-slot routing, and platform verification tokens unchanged.
- Secret handling: browser cookies and query JWTs are stripped before proxied websocket upgrades; logs classify paths instead of printing raw URLs.
- Failure behavior: telemetry capture is best-effort and never blocks websocket routing or release registration.
- Deferred scope: this PR does not change platform deployment, terminal session runtime behavior, or CLI command telemetry wiring.