### PR TITLE
ci(release): harden host bundle validation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,60 @@
+# GitHub Actions Workflows
+
+This directory owns the GitHub Actions workflows for Matrix OS. Keep workflow
+changes small and explicit: PR checks optimize for actionable signal, while
+main, release, and scheduled workflows preserve comprehensive validation.
+
+## Required Checks
+
+The branch protection rule should require `CI Results` from `ci.yml` as the stable
+aggregate gate. Do not require every internal shard directly unless branch
+protection is also updated when the shard list changes.
+
+`CI Results` depends on:
+
+- `Detect CI-relevant changes`
+- `Type Check`
+- `Pattern Scan`
+- `Sync Client Package`
+- `Unit Tests`
+- `E2E Tests`
+
+The aggregate job writes a summary table and fails when any required internal
+job fails or is cancelled. Internal jobs may still be inspected directly for
+logs and artifacts.
+
+## Workflow Ownership
+
+| Workflow | Owner | When it runs | Required? |
+| --- | --- | --- | --- |
+| `ci.yml` | Core code validation | `ready-for-ci`, ready PRs, merge queue, `main`, manual | Yes, via `CI Results` |
+| `docker-test.yml` | Legacy/local Docker scenario validation | `ready-for-ci`, ready PRs, merge queue, `main`, nightly, manual | Required when Docker/runtime paths are touched |
+| `host-bundle-release.yml` | VPS-native customer runtime release | `main`, `v*` tags, manual | Required for host bundle publishing |
+| `release.yml` / `cli-release.yml` | Installable `@finnaai/matrix` CLI release | Manual CLI release | Required for CLI publishing |
+| `screenshots.yml` | Shell visual snapshot maintenance | PRs when visual files changed or labels force it | Optional unless visual evidence is requested |
+| `pr-title.yml` | Conventional Commit PR title policy | PR title changes | Yes |
+| `docker.yml` | Legacy Docker image publishing/deploy path | `v*` tags, manual | Legacy only, not the customer runtime path |
+
+## Release Rules
+
+The `Host Bundle Release` workflow publishes code that customer VPSes install
+under `/opt/matrix/app`. For that reason, host bundle release tests are blocking:
+typecheck or unit-test failures must stop the workflow before build or publish.
+
+Release workflows must not skip host-bundle, shell, or default-app validation
+based only on changed-file heuristics. Path-aware skips are acceptable for PR
+speed, but `main`, tag, and manual release paths should stay comprehensive.
+
+The host bundle workflow may skip a dev bundle only for an explicit manual
+maintenance dispatch using `skip_dev_bundle`. Commit-message markers and
+metadata-only path detection are not accepted release skips.
+
+## Optional Visual Jobs
+
+`Screenshots` is intentionally optional. It is optimized for fast feedback by
+running only when shell visual files change or when a `screenshots`/`visual`
+label forces it. A `skip-screenshots` or `no-screenshots` label can skip the job
+when visual evidence is not relevant.
+
+For UI PRs, reviewers may still require screenshot evidence in the PR body even
+though the workflow itself is explicitly optional.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,3 +278,55 @@ jobs:
           name: e2e-test-results
           path: tests/e2e/
           retention-days: 7
+
+  ci-results:
+    name: CI Results
+    needs: [changes, typecheck, patterns, sync-client, unit, e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Summarize required CI jobs
+        env:
+          SHOULD_RUN: ${{ needs.changes.outputs.should_run }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+          PATTERNS_RESULT: ${{ needs.patterns.result }}
+          SYNC_CLIENT_RESULT: ${{ needs.sync-client.result }}
+          UNIT_RESULT: ${{ needs.unit.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "### CI Results"
+            echo
+            echo "Branch protection should require this aggregate job, not each internal shard."
+            echo
+            echo "CI relevant source changes: ${SHOULD_RUN:-unknown}"
+            echo
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "| Detect CI-relevant changes | $CHANGES_RESULT |"
+            echo "| Type Check | $TYPECHECK_RESULT |"
+            echo "| Pattern Scan | $PATTERNS_RESULT |"
+            echo "| Sync Client Package | $SYNC_CLIENT_RESULT |"
+            echo "| Unit Tests | $UNIT_RESULT |"
+            echo "| E2E Tests | $E2E_RESULT |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=false
+          for result in "$CHANGES_RESULT" "$TYPECHECK_RESULT" "$PATTERNS_RESULT" "$SYNC_CLIENT_RESULT" "$UNIT_RESULT" "$E2E_RESULT"; do
+            case "$result" in
+              success|skipped)
+                ;;
+              *)
+                failed=true
+                ;;
+            esac
+          done
+
+          if [ "$failed" = "true" ]; then
+            echo "One or more required CI jobs failed or were cancelled." >&2
+            exit 1
+          fi

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -44,7 +44,7 @@ on:
         default: ""
         type: string
       skip_dev_bundle:
-        description: "Skip dev host-bundle build/publish for metadata-only stack layers"
+        description: "Skip dev host-bundle build/publish for explicit manual maintenance runs"
         required: false
         default: false
         type: boolean
@@ -71,23 +71,10 @@ jobs:
       - name: Decide whether to build
         id: decision
         env:
-          GITHUB_EVENT_BEFORE: ${{ github.event.before || '' }}
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           SKIP_DEV_BUNDLE_INPUT: ${{ github.event.inputs.skip_dev_bundle || 'false' }}
         run: |
           set -euo pipefail
-
-          changed_files=""
-          zero_sha="0000000000000000000000000000000000000000"
-          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF_TYPE" = "branch" ]; then
-            if [ -n "${GITHUB_EVENT_BEFORE:-}" ] && [ "$GITHUB_EVENT_BEFORE" != "$zero_sha" ] && git cat-file -e "${GITHUB_EVENT_BEFORE}^{commit}" 2>/dev/null; then
-              changed_files="$(git diff --name-only "$GITHUB_EVENT_BEFORE" "$GITHUB_SHA")"
-            else
-              changed_files="$(git show --pretty= --name-only "$GITHUB_SHA")"
-            fi
-          fi
-
-          CHANGED_FILES="$changed_files" scripts/ci/dev-bundle-gate.sh
+          scripts/ci/dev-bundle-gate.sh
 
   test:
     name: Test
@@ -111,11 +98,9 @@ jobs:
 
       - name: Type check
         run: bun run typecheck
-        continue-on-error: true
 
       - name: Unit tests
         run: bun run test
-        continue-on-error: true
 
   build:
     name: Build host bundle
@@ -144,6 +129,20 @@ jobs:
           cache: pnpm
 
       - uses: oven-sh/setup-bun@v2
+
+      - name: Validate public build environment
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}" ]; then
+            echo "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is required for host bundle releases." >&2
+            exit 1
+          fi
+          if [ "$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" = "pk_test_Y2xlcmsuZXhhbXBsZS5jb20k" ]; then
+            echo "Refusing to publish a host bundle with the example Clerk publishable key." >&2
+            exit 1
+          fi
 
       - name: Generate version
         id: version

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -13,6 +13,7 @@ For installable CLI releases, use [CLI Release Process](cli-release.md). CLI ver
 - A customer VPS sync agent fetches DB-backed release metadata, verifies SHA-256, extracts to staging, moves the old app to `/opt/matrix/app.rollback`, moves the new app into `/opt/matrix/app`, writes `/opt/matrix/release.json`, and restarts Matrix services.
 - Host-bundle updates must never overwrite owner data. Do not delete or replace `/home/matrix/home`, `/opt/matrix/env`, or the local Postgres data directory during deploys or rollbacks.
 - `pnpm-workspace.yaml` sets `minimumReleaseAge: 10080` and CI/release paths use `pnpm install --frozen-lockfile`; do not bypass either during releases.
+- Host bundle release validation is blocking. If typecheck, tests, public build-env validation, build, publish, or registration fails, do not publish or deploy the bundle.
 - CLI releases are manual through `.github/workflows/release.yml`; bump `packages/sync-client/package.json`, run the sync-client checks, and dispatch the workflow with the same semver.
 - Fleet upgrade operations, blocked-machine handling, and the durable control-plane setup are documented in [Fleet Upgrade Operations](fleet-upgrade-operations.md).
 

--- a/docs/dev/review-pipeline.md
+++ b/docs/dev/review-pipeline.md
@@ -53,6 +53,21 @@ bun run test:e2e                      # e2e tests
 bun run check:patterns                # all files in packages/ and shell/
 ```
 
+## Required GitHub Checks
+
+Branch protection should require the `CI Results` job from
+`.github/workflows/ci.yml`. `CI Results` is the stable aggregate gate for the
+internal CI shards: typecheck, pattern scan, sync-client package checks, unit
+test shards, and e2e tests. Requiring the aggregate keeps branch protection
+stable when shards are split, renamed, or skipped for docs-only PRs.
+
+Do not require each internal shard directly unless branch protection is updated
+at the same time. The shard jobs remain visible for logs and artifacts; the
+aggregate job is the merge gate.
+
+Workflow ownership and optional checks are documented in
+`.github/workflows/README.md`.
+
 ## PR Size Guidelines
 
 | Additions | Files | Recommendation |

--- a/scripts/ci/dev-bundle-gate.sh
+++ b/scripts/ci/dev-bundle-gate.sh
@@ -4,43 +4,11 @@ set -euo pipefail
 should_build=true
 reason="host bundle build required"
 
-is_metadata_only_change() {
-  local saw_file=false
-  local file
-
-  while IFS= read -r file; do
-    [ -n "$file" ] || continue
-    saw_file=true
-
-    case "$file" in
-      www/*|docs/*|specs/*|audit/*|README.md|README.*|AGENTS.md|CLAUDE.md)
-        ;;
-      *)
-        return 1
-        ;;
-    esac
-  done <<< "${CHANGED_FILES:-}"
-
-  [ "$saw_file" = true ]
-}
-
 if [ "${SKIP_DEV_BUNDLE_INPUT:-false}" = "true" ]; then
   should_build=false
   reason="skip_dev_bundle workflow input was true"
 elif [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
   reason="tag releases always build by default"
-elif [ "${GITHUB_EVENT_NAME:-}" = "push" ]; then
-  case "${HEAD_COMMIT_MESSAGE:-}" in
-    *"[skip dev-bundle]"*|*"[skip dev bundle]"*|*"Skip-Dev-Bundle: true"*|*"skip-dev-bundle: true"*|*"skip_dev_bundle: true"*)
-      should_build=false
-      reason="commit message requested dev bundle skip"
-      ;;
-  esac
-
-  if [ "$should_build" = "true" ] && is_metadata_only_change; then
-    should_build=false
-    reason="only landing/docs/readme metadata changed"
-  fi
 fi
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('CI workflows', () => {
+  it('exposes a stable aggregate CI result job for branch protection', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');
+
+    expect(workflow).toContain('ci-results:');
+    expect(workflow).toContain('name: CI Results');
+    expect(workflow).toContain('if: always()');
+    expect(workflow).toContain('needs: [changes, typecheck, patterns, sync-client, unit, e2e]');
+    expect(workflow).toContain('### CI Results');
+    expect(workflow).toContain('needs.typecheck.result');
+    expect(workflow).toContain('needs.patterns.result');
+    expect(workflow).toContain('needs.sync-client.result');
+    expect(workflow).toContain('needs.unit.result');
+    expect(workflow).toContain('needs.e2e.result');
+    expect(workflow).toContain('Branch protection should require this aggregate job');
+  });
+});

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -19,4 +19,17 @@ describe('CI workflows', () => {
     expect(workflow).toContain('needs.e2e.result');
     expect(workflow).toContain('Branch protection should require this aggregate job');
   });
+
+  it('documents workflow ownership and required checks', () => {
+    const root = process.cwd();
+    const readme = readFileSync(join(root, '.github/workflows/README.md'), 'utf8');
+
+    expect(readme).toContain('# GitHub Actions Workflows');
+    expect(readme).toContain('CI Results');
+    expect(readme).toContain('branch protection');
+    expect(readme).toContain('Host Bundle Release');
+    expect(readme).toContain('host bundle release tests are blocking');
+    expect(readme).toContain('Screenshots');
+    expect(readme).toContain('explicitly optional');
+  });
 });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -142,7 +142,7 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('-X POST "https://app.matrix-os.com/vps/deploy"');
   });
 
-  it('host bundle release workflow can skip dev bundles for flagged stack commits', () => {
+  it('host bundle release workflow can skip dev bundles only through explicit manual input', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
 
@@ -151,6 +151,14 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('SKIP_DEV_BUNDLE_INPUT');
     expect(workflow).toContain('scripts/ci/dev-bundle-gate.sh');
     expect(workflow).toContain("needs.dev-bundle-gate.outputs.should_build == 'true'");
+    expect(workflow).toContain('Validate public build environment');
+    expect(workflow).toContain('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}');
+    expect(workflow).toContain('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is required for host bundle releases.');
+    expect(workflow).toContain('pk_test_Y2xlcmsuZXhhbXBsZS5jb20k');
+    expect(workflow).toContain('Refusing to publish a host bundle with the example Clerk publishable key.');
+    expect(workflow).not.toContain('HEAD_COMMIT_MESSAGE');
+    expect(workflow).not.toContain('CHANGED_FILES="$changed_files"');
+    expect(workflow).not.toContain('continue-on-error: true');
   });
 
   it('host bundle release workflow keeps tag pushes triggerable', () => {
@@ -162,7 +170,7 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('paths-ignore:');
   });
 
-  it('dev bundle gate skips flagged stack commits', () => {
+  it('dev bundle gate builds branch pushes even when commit messages request a skip', () => {
     const result = runDevBundleGate({
       GITHUB_EVENT_NAME: 'push',
       GITHUB_REF_TYPE: 'branch',
@@ -171,11 +179,11 @@ describe('customer VPS host bundle', () => {
       CHANGED_FILES: 'packages/kernel/src/index.ts',
     });
 
-    expect(result.output).toContain('should_build=false');
-    expect(result.output).toContain('reason=commit message requested dev bundle skip');
+    expect(result.output).toContain('should_build=true');
+    expect(result.output).toContain('reason=host bundle build required');
   });
 
-  it('dev bundle gate skips landing page and readme-only branch changes', () => {
+  it('dev bundle gate builds main branch pushes even for metadata-only changes', () => {
     const result = runDevBundleGate({
       GITHUB_EVENT_NAME: 'push',
       GITHUB_REF_TYPE: 'branch',
@@ -184,8 +192,21 @@ describe('customer VPS host bundle', () => {
       CHANGED_FILES: ['www/content/docs/index.mdx', 'docs/dev/releases.md', 'README.md', 'AGENTS.md'].join('\n'),
     });
 
+    expect(result.output).toContain('should_build=true');
+    expect(result.output).toContain('reason=host bundle build required');
+  });
+
+  it('dev bundle gate only skips when workflow dispatch explicitly requests it', () => {
+    const result = runDevBundleGate({
+      GITHUB_EVENT_NAME: 'workflow_dispatch',
+      GITHUB_REF_TYPE: 'branch',
+      HEAD_COMMIT_MESSAGE: 'docs: update workflow notes',
+      SKIP_DEV_BUNDLE_INPUT: 'true',
+      CHANGED_FILES: 'packages/gateway/src/index.ts',
+    });
+
     expect(result.output).toContain('should_build=false');
-    expect(result.output).toContain('reason=only landing/docs/readme metadata changed');
+    expect(result.output).toContain('reason=skip_dev_bundle workflow input was true');
   });
 
   it('dev bundle gate builds tag releases even for metadata-only tag targets', () => {


### PR DESCRIPTION
## Summary

- make host-bundle release validation blocking before build/publish and remove commit/path-based release skips
- add a stable `CI Results` aggregate job for branch protection
- document workflow ownership, required checks, optional screenshot behavior, and release validation rules

## Tests

- `pnpm test tests/platform/ci-workflows.test.ts tests/platform/customer-vps-host-bundle.test.ts`
- `bun run typecheck`
- `bun run check:patterns:diff`
- Attempted `pnpm test`; local run failed on environment issues unrelated to this diff:
  - global `qmd` is compiled against a different Node ABI (`better-sqlite3` NODE_MODULE_VERSION 137 vs Node 25 requiring 141)
  - several shell tests see a broken `localStorage` implementation in this local test environment

## Invariants

### Source of truth
- GitHub Actions workflow definitions remain the source of truth for CI/release behavior.
- `.github/workflows/README.md` documents ownership and expected branch-protection wiring.

### Lock/transaction scope
- No database or runtime transactions are changed.
- Release publishing remains sequenced by GitHub Actions job dependencies: validation -> build -> publish.

### Acceptable orphan states
- If validation fails, no host bundle is built or published.
- If build fails, no publish job runs.
- If publish fails, no deploy fan-out runs.

### Auth source of truth
- GitHub Actions secrets remain the auth source for release publishing.
- Public shell build env validation now fails closed when the Clerk publishable key is missing or the example key.

### Deferred scope
- GitHub Actions SHA pinning is intentionally deferred to a follow-up CI security PR.
- Codex Action automation is intentionally deferred until the release/CI gates are trustworthy.
- Product telemetry/user event work is out of scope for this CI stack.
