### PR TITLE
fix(shell): show runtime-aware reconnect status

### DIFF
--- a/shell/src/components/ConnectionIndicator.tsx
+++ b/shell/src/components/ConnectionIndicator.tsx
@@ -1,33 +1,161 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { useConnectionHealth } from "@/hooks/useConnectionHealth";
+import type { ConnectionState } from "@/hooks/useConnectionHealth";
 import { manualReconnect } from "@/hooks/useSocket";
+import { getGatewayUrl } from "@/lib/gateway";
+
+const STATUS_REFRESH_MS = 5_000;
+const STATUS_TIMEOUT_MS = 4_000;
+
+type GatewayReachability = "checking" | "online" | "unavailable";
+
+interface RuntimeStatus {
+  reachability: GatewayReachability;
+  releaseVersion?: string | null;
+  releaseChannel?: string | null;
+}
+
+interface ConnectionCopy {
+  tone: "warn" | "danger";
+  title: string;
+  detail: string;
+  action: string;
+}
+
+export function resolveConnectionCopy(state: ConnectionState, status: RuntimeStatus): ConnectionCopy {
+  if (state === "disconnected") {
+    return {
+      tone: "danger",
+      title: "Connection lost",
+      detail: status.reachability === "online"
+        ? "Your Matrix computer is online, but the live shell socket is closed."
+        : "Your Matrix computer is not reachable yet. It may be restarting after an update.",
+      action: "Reconnect",
+    };
+  }
+
+  if (status.reachability === "online") {
+    const version = status.releaseVersion ? ` ${status.releaseVersion}` : "";
+    return {
+      tone: "warn",
+      title: "Reconnecting shell",
+      detail: `The gateway is online${version}. Waiting for the live session to resume.`,
+      action: "Retry now",
+    };
+  }
+
+  if (status.reachability === "checking") {
+    return {
+      tone: "warn",
+      title: "Checking Matrix computer",
+      detail: "Matrix is checking whether your computer is restarting or applying an update.",
+      action: "Retry now",
+    };
+  }
+
+  return {
+    tone: "warn",
+    title: "Matrix computer is restarting",
+    detail: "Services are coming back online. This usually happens during bundle upgrades or gateway restarts.",
+    action: "Retry now",
+  };
+}
+
+async function loadRuntimeStatus(): Promise<RuntimeStatus> {
+  const gatewayUrl = getGatewayUrl();
+  const signal = AbortSignal.timeout(STATUS_TIMEOUT_MS);
+  const health = await fetch(`${gatewayUrl}/health`, {
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  if (!health.ok) return { reachability: "unavailable" };
+
+  try {
+    const info = await fetch(`${gatewayUrl}/api/system/info`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+    });
+    if (!info.ok) return { reachability: "online" };
+    const body = await info.json() as {
+      release?: { version?: string | null; channel?: string | null };
+      version?: string | null;
+    };
+    return {
+      reachability: "online",
+      releaseVersion: body.release?.version ?? body.version ?? null,
+      releaseChannel: body.release?.channel ?? null,
+    };
+  } catch (_err: unknown) {
+    return { reachability: "online" };
+  }
+}
 
 export function ConnectionIndicator() {
   const state = useConnectionHealth((s) => s.state);
+  const [status, setStatus] = useState<RuntimeStatus>({ reachability: "checking" });
+
+  useEffect(() => {
+    if (state === "connected") return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const refresh = () => {
+      void loadRuntimeStatus()
+        .then((next) => {
+          if (!cancelled) setStatus(next);
+        })
+        .catch(() => {
+          if (!cancelled) setStatus({ reachability: "unavailable" });
+        })
+        .finally(() => {
+          if (!cancelled) timer = setTimeout(refresh, STATUS_REFRESH_MS);
+        });
+    };
+
+    setStatus({ reachability: "checking" });
+    refresh();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [state]);
+
+  const copy = useMemo(() => resolveConnectionCopy(state, status), [state, status]);
+  const toneClass = copy.tone === "danger" ? "text-red-500" : "text-yellow-500";
+  const dotClass = copy.tone === "danger" ? "bg-red-500" : "bg-yellow-500";
 
   if (state === "connected") return null;
 
-  if (state === "reconnecting") {
-    return (
-      <div
-        className="flex items-center gap-1.5 px-2 py-1 text-xs text-yellow-500"
-        title="Reconnecting to server..."
-      >
-        <span className="size-2 rounded-full bg-yellow-500 animate-pulse" />
-        Reconnecting...
-      </div>
-    );
-  }
-
   return (
-    <button
-      className="flex items-center gap-1.5 px-2 py-1 text-xs text-red-500 hover:text-red-400 transition-colors"
-      onClick={manualReconnect}
-      title="Connection lost. Click to reconnect."
+    <aside
+      className="pointer-events-none fixed inset-0 z-[90] flex items-center justify-center bg-background/70 px-4 backdrop-blur-md"
+      aria-label="Matrix connection status"
+      role="status"
     >
-      <span className="size-2 rounded-full bg-red-500" />
-      Disconnected
-    </button>
+      <div className="pointer-events-auto w-full max-w-sm rounded-md border border-border bg-card/95 p-4 text-card-foreground shadow-[0_24px_80px_rgba(0,0,0,0.22)]">
+        <div className="flex items-start gap-3">
+          <span className={`mt-1 size-2.5 shrink-0 rounded-full ${dotClass} ${state === "reconnecting" ? "animate-pulse" : ""}`} />
+          <div className="min-w-0 flex-1">
+            <div className={`text-sm font-semibold ${toneClass}`}>{copy.title}</div>
+            <p className="mt-1 text-sm leading-5 text-muted-foreground">{copy.detail}</p>
+            {status.releaseChannel && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Channel <span className="font-mono">{status.releaseChannel}</span>
+              </p>
+            )}
+            <button
+              className="mt-4 inline-flex min-h-8 items-center rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground transition hover:bg-muted"
+              onClick={manualReconnect}
+              type="button"
+            >
+              {copy.action}
+            </button>
+          </div>
+        </div>
+      </div>
+    </aside>
   );
 }

--- a/shell/src/components/ConnectionIndicator.tsx
+++ b/shell/src/components/ConnectionIndicator.tsx
@@ -24,6 +24,21 @@ interface ConnectionCopy {
   action: string;
 }
 
+function classifyRuntimeStatusError(error: unknown): string {
+  if (error instanceof DOMException) {
+    if (error.name === "AbortError" || error.name === "TimeoutError") return "timeout";
+    return "dom_exception";
+  }
+  if (error instanceof SyntaxError) return "invalid_json";
+  if (error instanceof TypeError) return "network_error";
+  if (error instanceof Error) return "unexpected_error";
+  return "unknown";
+}
+
+function logRuntimeStatusError(stage: string, error: unknown): void {
+  console.warn(`[connection-indicator] ${stage} failed: ${classifyRuntimeStatusError(error)}`);
+}
+
 export function resolveConnectionCopy(state: ConnectionState, status: RuntimeStatus): ConnectionCopy {
   if (state === "disconnected") {
     return {
@@ -87,7 +102,8 @@ async function loadRuntimeStatus(): Promise<RuntimeStatus> {
       releaseVersion: body.release?.version ?? body.version ?? null,
       releaseChannel: body.release?.channel ?? null,
     };
-  } catch (_err: unknown) {
+  } catch (err: unknown) {
+    logRuntimeStatusError("system-info", err);
     return { reachability: "online" };
   }
 }
@@ -106,7 +122,8 @@ export function ConnectionIndicator() {
         .then((next) => {
           if (!cancelled) setStatus(next);
         })
-        .catch(() => {
+        .catch((err: unknown) => {
+          logRuntimeStatusError("runtime-status", err);
           if (!cancelled) setStatus({ reachability: "unavailable" });
         })
         .finally(() => {

--- a/tests/shell/connection-indicator.test.tsx
+++ b/tests/shell/connection-indicator.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useConnectionHealth } from "../../shell/src/hooks/useConnectionHealth.js";
+import { ConnectionIndicator, resolveConnectionCopy } from "../../shell/src/components/ConnectionIndicator.js";
+
+const mocks = vi.hoisted(() => ({
+  manualReconnect: vi.fn(),
+}));
+
+vi.mock("@/hooks/useSocket", () => ({
+  manualReconnect: () => mocks.manualReconnect(),
+}));
+
+vi.mock("@/lib/gateway", () => ({
+  getGatewayUrl: () => "http://gateway.test",
+}));
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    json: async () => body,
+  } as Response;
+}
+
+describe("ConnectionIndicator", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    mocks.manualReconnect.mockReset();
+    act(() => {
+      useConnectionHealth.setState({ state: "disconnected" });
+    });
+  });
+
+  it("describes gateway-online reconnects instead of a generic reconnecting label", async () => {
+    act(() => {
+      useConnectionHealth.setState({ state: "reconnecting" });
+    });
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/health")) return Promise.resolve(jsonResponse({ status: "ok" }));
+      if (url.endsWith("/api/system/info")) {
+        return Promise.resolve(jsonResponse({
+          release: { version: "v2026.05.29-test", channel: "stable" },
+        }));
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    }));
+
+    render(<ConnectionIndicator />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("status", { name: /matrix connection status/i })).toBeTruthy();
+      expect(screen.getByText("Reconnecting shell")).toBeTruthy();
+      expect(screen.getByText(/v2026\.05\.29-test/)).toBeTruthy();
+      expect(screen.getByText("stable")).toBeTruthy();
+    });
+  });
+
+  it("shows an update/restart state when the gateway is unavailable", async () => {
+    act(() => {
+      useConnectionHealth.setState({ state: "reconnecting" });
+    });
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("gateway down"))));
+
+    render(<ConnectionIndicator />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Matrix computer is restarting")).toBeTruthy();
+      expect(screen.getByText(/bundle upgrades or gateway restarts/i)).toBeTruthy();
+    });
+  });
+
+  it("lets users manually retry a disconnected live socket", async () => {
+    act(() => {
+      useConnectionHealth.setState({ state: "disconnected" });
+    });
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("gateway down"))));
+
+    render(<ConnectionIndicator />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /reconnect/i }));
+
+    expect(mocks.manualReconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveConnectionCopy", () => {
+  it("uses precise copy for disconnected but reachable runtimes", () => {
+    expect(resolveConnectionCopy("disconnected", { reachability: "online" })).toMatchObject({
+      title: "Connection lost",
+      detail: expect.stringContaining("online"),
+      action: "Reconnect",
+    });
+  });
+});

--- a/tests/shell/connection-indicator.test.tsx
+++ b/tests/shell/connection-indicator.test.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useConnectionHealth } from "../../shell/src/hooks/useConnectionHealth.js";
 import { ConnectionIndicator, resolveConnectionCopy } from "../../shell/src/components/ConnectionIndicator.js";
 
@@ -26,6 +26,10 @@ function jsonResponse(body: unknown) {
 }
 
 describe("ConnectionIndicator", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -94,6 +98,33 @@ describe("resolveConnectionCopy", () => {
       title: "Connection lost",
       detail: expect.stringContaining("online"),
       action: "Reconnect",
+    });
+  });
+
+  it("uses gateway-online copy while reconnecting", () => {
+    expect(resolveConnectionCopy("reconnecting", {
+      reachability: "online",
+      releaseVersion: "v2026.05.29-test",
+    })).toMatchObject({
+      title: "Reconnecting shell",
+      detail: expect.stringContaining("v2026.05.29-test"),
+      action: "Retry now",
+    });
+  });
+
+  it("uses checking copy before runtime polling settles", () => {
+    expect(resolveConnectionCopy("reconnecting", { reachability: "checking" })).toMatchObject({
+      title: "Checking Matrix computer",
+      detail: expect.stringContaining("checking"),
+      action: "Retry now",
+    });
+  });
+
+  it("uses restart copy when the runtime is unreachable", () => {
+    expect(resolveConnectionCopy("reconnecting", { reachability: "unavailable" })).toMatchObject({
+      title: "Matrix computer is restarting",
+      detail: expect.stringContaining("Services are coming back online"),
+      action: "Retry now",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace the generic shell reconnect chip with a runtime-aware Matrix loading panel.
- Poll `/health` and `/api/system/info` while the live socket is reconnecting/disconnected so the UI can distinguish gateway-online reconnects from likely runtime restarts or upgrades.
- Keep a manual retry action for hard disconnects.

## Tests
- pnpm exec vitest run tests/shell/connection-indicator.test.tsx
- pnpm --filter './shell' exec tsc --noEmit

## Review/Monitoring
- Second PR in the shell reliability stack, stacked on #252.

## Invariants
- Source of truth: connection state still comes from `useConnectionHealth`; runtime reachability is display-only polling.
- Auth source of truth: browser requests still go through the shell proxy and existing auth injection.
- Failure behavior: status polling is best-effort; failed polling shows restart/update copy and does not alter websocket reconnect logic.
- Resource limits: polling runs only while disconnected/reconnecting, has a 4s timeout, and cleans up timers on unmount/state changes.
- Deferred scope: this does not change platform deployment or terminal attach behavior.
