### PR TITLE
fix(terminal): keep shell session list current

### DIFF
--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1134,6 +1134,7 @@ function LocalTerminalSidebar() {
   const [rootPath, setRootPath] = useState("projects");
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [filter, setFilter] = useState("");
+  const shellPollAbortRef = useRef<AbortController | null>(null);
 
   const selectSidebarTab = useCallback((nextTab: SidebarTab) => {
     setTab(nextTab);
@@ -1168,12 +1169,12 @@ function LocalTerminalSidebar() {
     if (tab === "projects") void fetchProjects();
   }, [tab, fetchProjects]);
 
-  const fetchShells = useCallback(async (options: { silent?: boolean } = {}) => {
+  const fetchShells = useCallback(async (options: { silent?: boolean; signal?: AbortSignal } = {}) => {
     if (!options.silent) setShellsLoading(true);
     if (!options.silent) setShellsError(null);
     try {
       const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
-        signal: AbortSignal.timeout(10_000),
+        signal: options.signal ?? AbortSignal.timeout(10_000),
       });
       if (!res.ok) {
         setShellsError("Failed to load shells");
@@ -1182,7 +1183,9 @@ function LocalTerminalSidebar() {
       }
       const data = (await res.json()) as { sessions?: ShellSessionSummary[] };
       setShells(Array.isArray(data.sessions) ? data.sessions : []);
+      setShellsError(null);
     } catch (err: unknown) {
+      if (options.silent && err instanceof DOMException && err.name === "AbortError") return;
       console.warn("Failed to load shell sessions:", err instanceof Error ? err.message : err);
       setShellsError("Could not reach gateway");
       if (!options.silent) setShells([]);
@@ -1197,10 +1200,26 @@ function LocalTerminalSidebar() {
 
   useEffect(() => {
     if (tab !== "shells") return;
+    const refresh = () => {
+      shellPollAbortRef.current?.abort();
+      const controller = new AbortController();
+      shellPollAbortRef.current = controller;
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      void fetchShells({ silent: true, signal: controller.signal }).finally(() => {
+        clearTimeout(timeout);
+        if (shellPollAbortRef.current === controller) {
+          shellPollAbortRef.current = null;
+        }
+      });
+    };
     const timer = setInterval(() => {
-      void fetchShells({ silent: true });
+      refresh();
     }, SHELL_SESSION_REFRESH_MS);
-    return () => clearInterval(timer);
+    return () => {
+      clearInterval(timer);
+      shellPollAbortRef.current?.abort();
+      shellPollAbortRef.current = null;
+    };
   }, [fetchShells, tab]);
 
   const fetchSessions = useCallback(async () => {

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -39,6 +39,7 @@ function dispatchPaneInput(paneId: string | null, data: string): void {
 
 const DEFAULT_CWD = "projects";
 const DEFAULT_SHELL_SESSION_NAME = "main";
+const SHELL_SESSION_REFRESH_MS = 5_000;
 
 interface Tab {
   id: string;
@@ -1167,16 +1168,16 @@ function LocalTerminalSidebar() {
     if (tab === "projects") void fetchProjects();
   }, [tab, fetchProjects]);
 
-  const fetchShells = useCallback(async () => {
-    setShellsLoading(true);
-    setShellsError(null);
+  const fetchShells = useCallback(async (options: { silent?: boolean } = {}) => {
+    if (!options.silent) setShellsLoading(true);
+    if (!options.silent) setShellsError(null);
     try {
       const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
         signal: AbortSignal.timeout(10_000),
       });
       if (!res.ok) {
         setShellsError("Failed to load shells");
-        setShells([]);
+        if (!options.silent) setShells([]);
         return;
       }
       const data = (await res.json()) as { sessions?: ShellSessionSummary[] };
@@ -1184,14 +1185,22 @@ function LocalTerminalSidebar() {
     } catch (err: unknown) {
       console.warn("Failed to load shell sessions:", err instanceof Error ? err.message : err);
       setShellsError("Could not reach gateway");
-      setShells([]);
+      if (!options.silent) setShells([]);
     } finally {
-      setShellsLoading(false);
+      if (!options.silent) setShellsLoading(false);
     }
   }, []);
 
   useEffect(() => {
     if (tab === "shells") void fetchShells();
+  }, [fetchShells, tab]);
+
+  useEffect(() => {
+    if (tab !== "shells") return;
+    const timer = setInterval(() => {
+      void fetchShells({ silent: true });
+    }, SHELL_SESSION_REFRESH_MS);
+    return () => clearInterval(timer);
   }, [fetchShells, tab]);
 
   const fetchSessions = useCallback(async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -186,7 +186,7 @@ describe("TerminalApp", () => {
           }),
         });
       }
-      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
         return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
       }
       return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
@@ -239,7 +239,7 @@ describe("TerminalApp", () => {
           }),
         });
       }
-      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
         return Promise.resolve({ ok: true, json: async () => ({ sessions: [{ name: "main" }] }) });
       }
       return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
@@ -282,7 +282,7 @@ describe("TerminalApp", () => {
           }),
         });
       }
-      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
         return new Promise((resolve) => {
           resolveSessions = resolve;
         });
@@ -855,7 +855,7 @@ describe("TerminalApp", () => {
       if (url.includes("/api/terminal/layout")) {
         return Promise.resolve({ ok: true, json: async () => ({}) });
       }
-      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -893,7 +893,7 @@ describe("TerminalApp", () => {
   });
 
   it("keeps the last known Shells list visible during transient refresh failures", async () => {
-    let shellListCalls = 0;
+    let shellListMode: "initial" | "fail" | "recover" = "initial";
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/files/tree")) {
@@ -905,14 +905,18 @@ describe("TerminalApp", () => {
       if (url.includes("/api/terminal/layout")) {
         return Promise.resolve({ ok: true, json: async () => ({}) });
       }
-      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
-        shellListCalls += 1;
-        if (shellListCalls > 1) {
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        if (shellListMode === "fail") {
+          shellListMode = "recover";
           return Promise.resolve({ ok: false, status: 503, json: async () => ({}) });
         }
         return Promise.resolve({
           ok: true,
-          json: async () => ({ sessions: [{ name: "main", status: "active" }] }),
+          json: async () => ({
+            sessions: shellListMode === "recover"
+              ? [{ name: "main", status: "active" }, { name: "bench", status: "active" }]
+              : [{ name: "main", status: "active" }],
+          }),
         });
       }
       return Promise.resolve({ ok: true, json: async () => ({}) });
@@ -929,7 +933,17 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByText("main")).toBeTruthy();
+    expect(screen.getAllByText("main").length).toBeGreaterThan(0);
+    shellListMode = "fail";
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_001);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getAllByText("main").length).toBeGreaterThan(0);
+    expect(screen.getByText("Failed to load shells")).toBeTruthy();
 
     await act(async () => {
       vi.advanceTimersByTime(5_000);
@@ -937,8 +951,73 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByText("main")).toBeTruthy();
-    expect(screen.getByText("Failed to load shells")).toBeTruthy();
+    expect(screen.getByText("bench")).toBeTruthy();
+    expect(screen.queryByText("Failed to load shells")).toBeNull();
+  });
+
+  it("aborts an in-flight silent Shells refresh before starting the next poll", async () => {
+    let blockNextShellList = false;
+    let firstSilentSignal: AbortSignal | undefined;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        if (blockNextShellList && !firstSilentSignal) {
+          firstSilentSignal = init?.signal ?? undefined;
+          return new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(new DOMException("aborted", "AbortError"));
+            }, { once: true });
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessions: firstSilentSignal
+              ? [{ name: "main", status: "active" }, { name: "bench", status: "active" }]
+              : [{ name: "main", status: "active" }],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      fireEvent.click(screen.getByRole("button", { name: "Shells" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getAllByText("main").length).toBeGreaterThan(0);
+    blockNextShellList = true;
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+
+    expect(firstSilentSignal?.aborted).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(firstSilentSignal?.aborted).toBe(true);
+    expect(screen.getByText("bench")).toBeTruthy();
   });
 
   it("surfaces shell creation failures in the Shells sidebar", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -842,6 +842,105 @@ describe("TerminalApp", () => {
     expect(deleteCalls).toHaveLength(1);
   });
 
+  it("keeps the Shells sidebar synchronized with newly adopted zellij sessions", async () => {
+    let revealBench = false;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            sessions: revealBench
+              ? [{ name: "main", status: "active" }, { name: "bench", status: "active" }]
+              : [{ name: "main", status: "active" }],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      fireEvent.click(screen.getByRole("button", { name: "Shells" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getAllByText("main").length).toBeGreaterThan(0);
+    expect(screen.queryByText("bench")).toBeNull();
+
+    await act(async () => {
+      revealBench = true;
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("bench")).toBeTruthy();
+  });
+
+  it("keeps the last known Shells list visible during transient refresh failures", async () => {
+    let shellListCalls = 0;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      if (url.includes("/api/terminal/sessions") && init?.method !== "POST") {
+        shellListCalls += 1;
+        if (shellListCalls > 1) {
+          return Promise.resolve({ ok: false, status: 503, json: async () => ({}) });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ sessions: [{ name: "main", status: "active" }] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      fireEvent.click(screen.getByRole("button", { name: "Shells" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("main")).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("main")).toBeTruthy();
+    expect(screen.getByText("Failed to load shells")).toBeTruthy();
+  });
+
   it("surfaces shell creation failures in the Shells sidebar", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);


### PR DESCRIPTION
## Summary
- Keep the Terminal app Shells sidebar synchronized with canonical Zellij-backed terminal sessions while the Shells tab is open.
- Preserve the last known shell list during transient silent refresh failures instead of blanking the sidebar.
- Add regression coverage for newly adopted sessions appearing in the web shell after refresh, matching the CLI-visible canonical session source.

## Tests
- pnpm --filter '@matrix-os/observability' build
- pnpm exec vitest run tests/shell/terminal-app-component.test.tsx tests/shell/connection-indicator.test.tsx tests/shell/useSocket.test.ts tests/observability/telemetry-events.test.ts
- pnpm --filter './shell' exec tsc --noEmit

## Review/Monitoring
- Third PR in the shell reliability stack, stacked on #254.

## Invariants
- Source of truth: `/api/terminal/sessions` remains the canonical user-facing terminal session source for the web shell sidebar.
- Runtime behavior: this PR does not create/delete sessions during background refresh; it only refreshes display state.
- Failure behavior: initial load failures still show an error and empty list; later silent refresh failures keep visible stale data plus an error.
- Resource limits: refresh polling only runs while the Shells sidebar tab is active and is cleared when leaving the tab.
- Deferred scope: this does not change gateway Zellij reconciliation, CLI attach behavior, or workspace session APIs.
