### PR TITLE
fix(terminal): keep mobile keybar above keyboard

### DIFF
--- a/shell/src/components/terminal/TerminalKeyBar.tsx
+++ b/shell/src/components/terminal/TerminalKeyBar.tsx
@@ -12,7 +12,7 @@
  *   the bar stays one row tall by default.
  */
 
-import { useState, type CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 
 interface KeyDef {
   label: string;
@@ -55,6 +55,33 @@ interface TerminalKeyBarProps {
   accent?: string;
 }
 
+function readVisualViewportKeyboardInset(): number {
+  if (typeof window === "undefined" || !window.visualViewport) return 0;
+  const inset = window.innerHeight - window.visualViewport.height - window.visualViewport.offsetTop;
+  return Math.max(0, Math.round(inset));
+}
+
+function useVisualViewportKeyboardInset(): number {
+  const [inset, setInset] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.visualViewport) return;
+    const viewport = window.visualViewport;
+    const update = () => setInset(readVisualViewportKeyboardInset());
+    update();
+    viewport.addEventListener("resize", update);
+    viewport.addEventListener("scroll", update);
+    window.addEventListener("orientationchange", update);
+    return () => {
+      viewport.removeEventListener("resize", update);
+      viewport.removeEventListener("scroll", update);
+      window.removeEventListener("orientationchange", update);
+    };
+  }, []);
+
+  return inset;
+}
+
 export function TerminalKeyBar({
   onSend,
   background = "var(--background)",
@@ -62,11 +89,13 @@ export function TerminalKeyBar({
   accent = "var(--primary)",
 }: TerminalKeyBarProps) {
   const [expanded, setExpanded] = useState(false);
+  const keyboardInset = useVisualViewportKeyboardInset();
 
   const visible = expanded ? KEYS : KEYS.filter((k) => k.primary);
   const buttonBackground = `color-mix(in srgb, ${foreground} 10%, transparent)`;
   const buttonBorder = `color-mix(in srgb, ${foreground} 18%, transparent)`;
   const mutedForeground = `color-mix(in srgb, ${foreground} 66%, transparent)`;
+  const bottomInset = keyboardInset > 0 ? `${keyboardInset}px` : "env(keyboard-inset-height, 0px)";
 
   return (
     <div
@@ -74,7 +103,7 @@ export function TerminalKeyBar({
       aria-label="Terminal accessory keys"
       data-testid="terminal-key-bar"
       style={{
-        "--matrix-terminal-keybar-bottom": "env(keyboard-inset-height, 0px)",
+        "--matrix-terminal-keybar-bottom": bottomInset,
         display: "flex",
         alignItems: "center",
         gap: 4,

--- a/tests/shell/terminal-keybar.test.tsx
+++ b/tests/shell/terminal-keybar.test.tsx
@@ -5,6 +5,17 @@ import { act, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TerminalKeyBar } from "../../shell/src/components/terminal/TerminalKeyBar.js";
 
+const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight");
+const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
+
+function restoreWindowProperty(name: "innerHeight" | "visualViewport", descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) {
+    Object.defineProperty(window, name, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(window, name);
+}
+
 function installVisualViewportMock(input: { height: number; offsetTop: number }) {
   const listeners = new Map<string, Set<() => void>>();
   const viewport = {
@@ -30,6 +41,8 @@ function installVisualViewportMock(input: { height: number; offsetTop: number })
 describe("TerminalKeyBar", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    restoreWindowProperty("innerHeight", originalInnerHeight);
+    restoreWindowProperty("visualViewport", originalVisualViewport);
   });
 
   it("uses virtual keyboard env inset when visualViewport has no keyboard overlap", () => {

--- a/tests/shell/terminal-keybar.test.tsx
+++ b/tests/shell/terminal-keybar.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TerminalKeyBar } from "../../shell/src/components/terminal/TerminalKeyBar.js";
+
+function installVisualViewportMock(input: { height: number; offsetTop: number }) {
+  const listeners = new Map<string, Set<() => void>>();
+  const viewport = {
+    height: input.height,
+    offsetTop: input.offsetTop,
+    addEventListener: vi.fn((type: string, listener: () => void) => {
+      const set = listeners.get(type) ?? new Set<() => void>();
+      set.add(listener);
+      listeners.set(type, set);
+    }),
+    removeEventListener: vi.fn((type: string, listener: () => void) => {
+      listeners.get(type)?.delete(listener);
+    }),
+    dispatch(type: string) {
+      for (const listener of listeners.get(type) ?? []) listener();
+    },
+  };
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+  Object.defineProperty(window, "visualViewport", { configurable: true, value: viewport });
+  return viewport;
+}
+
+describe("TerminalKeyBar", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses virtual keyboard env inset when visualViewport has no keyboard overlap", () => {
+    render(<TerminalKeyBar onSend={vi.fn()} />);
+
+    const keyBar = screen.getByTestId("terminal-key-bar");
+    expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("env(keyboard-inset-height, 0px)");
+  });
+
+  it("tracks visualViewport keyboard overlap for mobile browsers without keyboard-inset env support", () => {
+    const viewport = installVisualViewportMock({ height: 560, offsetTop: 0 });
+
+    render(<TerminalKeyBar onSend={vi.fn()} />);
+
+    const keyBar = screen.getByTestId("terminal-key-bar");
+    expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("240px");
+
+    act(() => {
+      viewport.height = 800;
+      viewport.dispatch("resize");
+    });
+
+    expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("env(keyboard-inset-height, 0px)");
+  });
+});


### PR DESCRIPTION
## Summary
- Keep the mobile terminal accessory key bar above software keyboards in browsers that expose keyboard movement through `visualViewport`.
- Preserve the existing `env(keyboard-inset-height)` fallback for browsers with Virtual Keyboard API support.
- Add focused tests for default env behavior and visualViewport resize recovery.

## Tests
- pnpm exec vitest run tests/shell/terminal-keybar.test.tsx tests/shell/terminal-app-component.test.tsx
- pnpm --filter './shell' exec tsc --noEmit

## Review/Monitoring
- Fourth PR in the shell reliability stack, stacked on #255.

## Invariants
- Source of truth: the terminal key bar still sends raw key sequences only through the focused terminal pane.
- UI behavior: `visualViewport` only adjusts the sticky bottom inset; it does not resize terminal sessions or mutate layout state.
- Failure behavior: browsers without `visualViewport` continue using `env(keyboard-inset-height, 0px)`.
- Resource management: resize/scroll/orientation listeners are removed when the key bar unmounts.
- Deferred scope: this does not alter terminal session routing, CLI attach transport, or xterm rendering options.
