### PR TITLE
fix(cli): drop stale terminal keyboard sequences

### DIFF
--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -109,6 +109,12 @@ function createTerminalInputFilter(options: {
 
   const now = () => options.now?.() ?? Date.now();
   const shouldForwardMouse = () => !options.dropMouse && focused && now() >= suppressMouseUntil;
+  const shouldForwardEnhancedKeyboard = () => focused && now() >= suppressMouseUntil;
+  const isCsiUParamChar = (char: string | undefined) => char !== undefined && (
+    (char >= "0" && char <= "9") ||
+    char === ";" ||
+    char === ":"
+  );
 
   return {
     noteRemoteOutput() {
@@ -140,6 +146,24 @@ function createTerminalInputFilter(options: {
           }
           i += 3;
           continue;
+        }
+
+        if (third >= "0" && third <= "9") {
+          let end = i + 2;
+          while (end < input.length && isCsiUParamChar(input[end])) {
+            end += 1;
+          }
+          if (end >= input.length) {
+            pendingMouseSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_MOUSE_SEQUENCE_CHARS));
+            break;
+          }
+          if (input[end] === "u") {
+            if (shouldForwardEnhancedKeyboard()) {
+              output += input.slice(i, end + 1);
+            }
+            i = end + 1;
+            continue;
+          }
         }
 
         if (third === "<") {

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -66,7 +66,7 @@ const LOCAL_TERMINAL_INPUT_RESET = [
   "\u001b[>4;0m",
   "\u001b[<1u",
 ].join("");
-const MAX_PENDING_MOUSE_SEQUENCE_CHARS = 128;
+const MAX_PENDING_ESCAPE_SEQUENCE_CHARS = 128;
 const STALE_MOUSE_FOCUS_GUARD_MS = 5_000;
 const FOCUS_MOUSE_SUPPRESS_MS = 1_000;
 
@@ -103,7 +103,7 @@ function createTerminalInputFilter(options: {
   now?: () => number;
 }) {
   let focused = true;
-  let pendingMouseSequence = "";
+  let pendingEscapeSequence = "";
   let lastRemoteOutputAt = options.now?.() ?? Date.now();
   let suppressMouseUntil = 0;
 
@@ -121,8 +121,8 @@ function createTerminalInputFilter(options: {
       lastRemoteOutputAt = now();
     },
     filter(chunk: string): string {
-      const input = pendingMouseSequence + chunk;
-      pendingMouseSequence = "";
+      const input = pendingEscapeSequence + chunk;
+      pendingEscapeSequence = "";
       let output = "";
       for (let i = 0; i < input.length;) {
         if (input[i] !== "\u001b" || input[i + 1] !== "[") {
@@ -133,7 +133,7 @@ function createTerminalInputFilter(options: {
 
         const third = input[i + 2];
         if (third === undefined) {
-          pendingMouseSequence = input.slice(i);
+          pendingEscapeSequence = input.slice(i);
           break;
         }
 
@@ -154,7 +154,7 @@ function createTerminalInputFilter(options: {
             end += 1;
           }
           if (end >= input.length) {
-            pendingMouseSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_MOUSE_SEQUENCE_CHARS));
+            pendingEscapeSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_ESCAPE_SEQUENCE_CHARS));
             break;
           }
           if (input[end] === "u") {
@@ -172,7 +172,7 @@ function createTerminalInputFilter(options: {
             end += 1;
           }
           if (end >= input.length) {
-            pendingMouseSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_MOUSE_SEQUENCE_CHARS));
+            pendingEscapeSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_ESCAPE_SEQUENCE_CHARS));
             break;
           }
           if (shouldForwardMouse()) {
@@ -184,7 +184,7 @@ function createTerminalInputFilter(options: {
 
         if (third === "M") {
           if (i + 6 > input.length) {
-            pendingMouseSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_MOUSE_SEQUENCE_CHARS));
+            pendingEscapeSequence = input.slice(i, Math.min(input.length, i + MAX_PENDING_ESCAPE_SEQUENCE_CHARS));
             break;
           }
           if (shouldForwardMouse()) {
@@ -201,7 +201,7 @@ function createTerminalInputFilter(options: {
     },
     reset() {
       focused = true;
-      pendingMouseSequence = "";
+      pendingEscapeSequence = "";
       suppressMouseUntil = 0;
     },
   };

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -399,6 +399,57 @@ describe("shell REST client", () => {
     nowSpy.mockRestore();
   });
 
+  it("drops stale enhanced keyboard protocol bytes after focus returns", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(0);
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready" }));
+    nowSpy.mockReturnValue(6_000);
+    input.emit("data", "\u001b[I\u001b[99;5u\u001b[100;5uok");
+    ControlledWebSocket.last?.emit("close");
+
+    await expect(attached).resolves.toEqual({ detached: true });
+    expect(output.write).toHaveBeenCalledWith(LOCAL_TERMINAL_INPUT_RESET);
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "resize", cols: 80, rows: 24 },
+      { type: "input", data: "ok" },
+    ]);
+    nowSpy.mockRestore();
+  });
+
+  it("keeps enhanced keyboard protocol bytes while focused", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    input.emit("data", "\u001b[99;5u");
+    ControlledWebSocket.last?.emit("close");
+
+    await expect(attached).resolves.toEqual({ detached: true });
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "resize", cols: 80, rows: 24 },
+      { type: "input", data: "\u001b[99;5u" },
+    ]);
+  });
+
   it("buffers fragmented SGR mouse sequences instead of forwarding partial escape bytes", async () => {
     const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
     const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -450,6 +450,31 @@ describe("shell REST client", () => {
     ]);
   });
 
+  it("buffers fragmented enhanced keyboard protocol sequences", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 80, rows: 24 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    input.emit("data", "a\u001b[99");
+    input.emit("data", ";5ub");
+    ControlledWebSocket.last?.emit("close");
+
+    await expect(attached).resolves.toEqual({ detached: true });
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "resize", cols: 80, rows: 24 },
+      { type: "input", data: "a" },
+      { type: "input", data: "\u001b[99;5ub" },
+    ]);
+  });
+
   it("buffers fragmented SGR mouse sequences instead of forwarding partial escape bytes", async () => {
     const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
     const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;


### PR DESCRIPTION
## Summary
- Drop stale CSI-u enhanced keyboard protocol bytes after focus returns from a long-inactive local terminal.
- Preserve focused CSI-u forwarding so TUI keyboard support still works when the attach view is active.
- Keep the existing local terminal mode reset path for stale focus recovery.

## Tests
- pnpm exec vitest run tests/cli/shell-client.test.ts packages/sync-client/tests/unit/shell-client.test.ts
- pnpm --filter '@finnaai/matrix' exec tsc --noEmit\n- pnpm --filter '@finnaai/matrix' test\n\n## Review/Monitoring\n- Greptile should review this latest head; I will avoid pushing more commits while it is reviewing unless feedback requires it.\n\n## Invariants\n- Source of truth: local attach input filtering only; no gateway/session persistence changes.\n- Lock/transaction scope: no shared state or DB writes.\n- Acceptable orphan states: if the websocket closes during cleanup, local input modes are still reset by existing cleanup paths.\n- Auth source of truth: unchanged bearer auth/websocket attach behavior.\n- Deferred scope: this does not alter Zellij session lifecycle or mobile terminal rendering.