### PR TITLE
feat(analytics): add EU PostHog cookie consent

### DIFF
--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -14,6 +14,11 @@
       "import": "./dist/client.js",
       "default": "./dist/client.js"
     },
+    "./cookie-consent": {
+      "types": "./src/cookie-consent.ts",
+      "import": "./dist/cookie-consent.js",
+      "default": "./dist/cookie-consent.js"
+    },
     "./events": {
       "types": "./src/events.ts",
       "import": "./dist/events.js",
@@ -26,6 +31,10 @@
   "dependencies": {
     "hono": "^4.11.9",
     "posthog-node": "^5.24.15"
+  },
+  "peerDependencies": {
+    "posthog-js": "^1.376.0",
+    "react": "^19.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.3",

--- a/packages/observability/src/client.ts
+++ b/packages/observability/src/client.ts
@@ -10,9 +10,54 @@ export interface ResolvePostHogClientApiHostOptions {
   allowRelativeApiHost?: boolean;
 }
 
+export interface HeadersLike {
+  get(name: string): string | null;
+}
+
 const CLIENT_TOKEN_ENV_KEYS = ["NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN", "NEXT_PUBLIC_POSTHOG_KEY"];
 const CLIENT_API_HOST_ENV_KEYS = ["NEXT_PUBLIC_POSTHOG_API_HOST"];
 const CLIENT_UI_HOST_ENV_KEYS = ["NEXT_PUBLIC_POSTHOG_HOST"];
+const GEO_COUNTRY_HEADERS = [
+  "x-vercel-ip-country",
+  "cf-ipcountry",
+  "cloudfront-viewer-country",
+  "x-country-code",
+  "x-geo-country",
+];
+const POSTHOG_COOKIE_CONSENT_COUNTRIES = new Set([
+  "AT",
+  "BE",
+  "BG",
+  "HR",
+  "CY",
+  "CZ",
+  "DK",
+  "EE",
+  "FI",
+  "FR",
+  "DE",
+  "GR",
+  "HU",
+  "IE",
+  "IT",
+  "LV",
+  "LT",
+  "LU",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SK",
+  "SI",
+  "ES",
+  "SE",
+  "IS",
+  "LI",
+  "NO",
+  "GB",
+  "CH",
+]);
 
 export function getPostHogClientConfig(env: EnvSource = process.env): PostHogClientConfig | null {
   const token = firstEnv(env, CLIENT_TOKEN_ENV_KEYS);
@@ -37,6 +82,25 @@ export function resolvePostHogClientApiHost(
   return config.uiHost;
 }
 
+export function getPostHogVisitorCountry(headers: HeadersLike): string | null {
+  for (const header of GEO_COUNTRY_HEADERS) {
+    const country = normalizeCountryCode(headers.get(header));
+    if (country) return country;
+  }
+  return null;
+}
+
+export function requiresPostHogCookieConsent(countryCode: string | null | undefined): boolean {
+  const country = normalizeCountryCode(countryCode);
+  return country ? POSTHOG_COOKIE_CONSENT_COUNTRIES.has(country) : false;
+}
+
+export function buildPostHogCookieConsentInitOptions(
+  countryCode: string | null | undefined,
+): Record<string, "on_reject"> {
+  return requiresPostHogCookieConsent(countryCode) ? { cookieless_mode: "on_reject" } : {};
+}
+
 function firstEnv(env: EnvSource, keys: string[]): string | undefined {
   for (const key of keys) {
     const value = env[key]?.trim();
@@ -53,4 +117,10 @@ function isAbsoluteHttpUrl(value: string): boolean {
     if (err instanceof TypeError) return false;
     throw err;
   }
+}
+
+function normalizeCountryCode(countryCode: string | null | undefined): string | null {
+  const country = countryCode?.trim().toUpperCase();
+  if (!country || country === "UNKNOWN" || !/^[A-Z]{2}$/.test(country)) return null;
+  return country;
 }

--- a/packages/observability/src/client.ts
+++ b/packages/observability/src/client.ts
@@ -97,7 +97,7 @@ export function requiresPostHogCookieConsent(countryCode: string | null | undefi
 
 export function buildPostHogCookieConsentInitOptions(
   countryCode: string | null | undefined,
-): Record<string, "on_reject"> {
+): { cookieless_mode?: "on_reject" } {
   return requiresPostHogCookieConsent(countryCode) ? { cookieless_mode: "on_reject" } : {};
 }
 

--- a/packages/observability/src/cookie-consent.ts
+++ b/packages/observability/src/cookie-consent.ts
@@ -1,0 +1,128 @@
+"use client";
+
+import { createElement, useEffect, useState } from "react";
+import posthog from "posthog-js";
+import { requiresPostHogCookieConsent, type PostHogClientConfig } from "./client.js";
+
+type ConsentStatus = "pending" | "granted" | "denied" | "unknown";
+type PostHogLoadState = { __loaded?: boolean };
+type PostHogConsentClient = PostHogLoadState & {
+  get_explicit_consent_status(): ConsentStatus | undefined;
+  opt_in_capturing(): void;
+};
+
+const COOKIE_CONSENT_STORAGE_KEY = "matrix_posthog_cookie_consent";
+const posthogClient = posthog as unknown as PostHogConsentClient;
+
+function hasDeclinedCookieConsent(): boolean {
+  try {
+    return window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY) === "declined";
+  } catch (err: unknown) {
+    console.warn("Failed to read PostHog cookie consent:", err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
+function persistDeclinedCookieConsent(): void {
+  try {
+    window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, "declined");
+  } catch (err: unknown) {
+    console.warn("Failed to store PostHog cookie consent:", err instanceof Error ? err.message : err);
+  }
+}
+
+function clearDeclinedCookieConsent(): void {
+  try {
+    window.localStorage.removeItem(COOKIE_CONSENT_STORAGE_KEY);
+  } catch (err: unknown) {
+    console.warn("Failed to clear PostHog cookie consent:", err instanceof Error ? err.message : err);
+  }
+}
+
+export function PostHogCookieBanner({
+  config,
+  visitorCountry,
+}: {
+  config: PostHogClientConfig | null;
+  visitorCountry: string | null;
+}) {
+  const consentRequired = requiresPostHogCookieConsent(visitorCountry);
+  const [consentStatus, setConsentStatus] = useState<ConsentStatus>("unknown");
+
+  useEffect(() => {
+    if (!config || !consentRequired) return;
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+
+    function refreshConsentStatus() {
+      if (cancelled) return;
+      if (hasDeclinedCookieConsent()) {
+        setConsentStatus("denied");
+        return;
+      }
+      if (!posthogClient.__loaded) {
+        timeout = setTimeout(refreshConsentStatus, 100);
+        return;
+      }
+      setConsentStatus(posthogClient.get_explicit_consent_status() ?? "pending");
+    }
+
+    refreshConsentStatus();
+
+    return () => {
+      cancelled = true;
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [config, consentRequired]);
+
+  if (!config || !consentRequired || consentStatus !== "pending") return null;
+
+  return createElement(
+    "aside",
+    {
+      "aria-label": "Cookie consent",
+      "aria-live": "polite",
+      className:
+        "fixed inset-x-3 bottom-3 z-[10000] mx-auto flex max-w-4xl flex-col gap-4 rounded-lg border border-white/15 bg-[#101411]/95 p-4 text-white shadow-2xl shadow-black/35 backdrop-blur md:inset-x-6 md:bottom-6 md:flex-row md:items-center md:justify-between",
+    },
+    createElement(
+      "p",
+      { className: "max-w-2xl text-sm leading-6 text-white/82" },
+      "Matrix OS uses PostHog analytics cookies to understand product usage and improve reliability. You can accept analytics cookies or continue with cookieless tracking.",
+    ),
+    createElement(
+      "div",
+      { className: "flex shrink-0 flex-col gap-2 sm:flex-row" },
+      createElement(
+        "button",
+        {
+          type: "button",
+          className:
+            "rounded-md border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
+          onClick: () => {
+            if (!posthogClient.__loaded) return;
+            persistDeclinedCookieConsent();
+            setConsentStatus("denied");
+          },
+        },
+        "Decline",
+      ),
+      createElement(
+        "button",
+        {
+          type: "button",
+          className:
+            "rounded-md bg-white px-4 py-2 text-sm font-semibold text-[#101411] transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
+          onClick: () => {
+            if (!posthogClient.__loaded) return;
+            clearDeclinedCookieConsent();
+            posthogClient.opt_in_capturing();
+            setConsentStatus("granted");
+          },
+        },
+        "Accept",
+      ),
+    ),
+  );
+}

--- a/packages/observability/src/cookie-consent.ts
+++ b/packages/observability/src/cookie-consent.ts
@@ -12,6 +12,8 @@ type PostHogConsentClient = PostHogLoadState & {
 };
 
 const COOKIE_CONSENT_STORAGE_KEY = "matrix_posthog_cookie_consent";
+const POSTHOG_LOAD_POLL_INTERVAL_MS = 100;
+const POSTHOG_LOAD_MAX_RETRIES = 50;
 const posthogClient = posthog as unknown as PostHogConsentClient;
 
 function hasDeclinedCookieConsent(): boolean {
@@ -54,6 +56,7 @@ export function PostHogCookieBanner({
 
     let timeout: ReturnType<typeof setTimeout> | undefined;
     let cancelled = false;
+    let retries = 0;
 
     function refreshConsentStatus() {
       if (cancelled) return;
@@ -62,7 +65,10 @@ export function PostHogCookieBanner({
         return;
       }
       if (!posthogClient.__loaded) {
-        timeout = setTimeout(refreshConsentStatus, 100);
+        if (retries < POSTHOG_LOAD_MAX_RETRIES) {
+          retries += 1;
+          timeout = setTimeout(refreshConsentStatus, POSTHOG_LOAD_POLL_INTERVAL_MS);
+        }
         return;
       }
       setConsentStatus(posthogClient.get_explicit_consent_status() ?? "pending");

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2,7 +2,7 @@ import { createHmac, randomBytes } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
-import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS, type MatrixTelemetryEvent } from '@matrix-os/observability';
+import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
 import { createConnection, type Socket } from 'node:net';
 import { connect as createTlsConnection } from 'node:tls';
 import type { IncomingMessage, Server } from 'node:http';
@@ -1759,7 +1759,7 @@ export type PlatformApp = Hono<{
   };
 }> & {
   capturePlatformEvent(
-    event: MatrixTelemetryEvent,
+    event: string,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void;
   shutdownPostHog(): Promise<void>;
@@ -1900,7 +1900,7 @@ export function createApp(deps: {
   });
   const posthogShutdowns: Array<() => Promise<void>> = [() => posthogErrorTracker.shutdown()];
   function capturePlatformEvent(
-    event: MatrixTelemetryEvent,
+    event: string,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void {
     void posthogErrorTracker.captureEvent(event, {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2,7 +2,7 @@ import { createHmac, randomBytes } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
-import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
+import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS, type MatrixTelemetryEvent } from '@matrix-os/observability';
 import { createConnection, type Socket } from 'node:net';
 import { connect as createTlsConnection } from 'node:tls';
 import type { IncomingMessage, Server } from 'node:http';
@@ -1759,7 +1759,7 @@ export type PlatformApp = Hono<{
   };
 }> & {
   capturePlatformEvent(
-    event: string,
+    event: MatrixTelemetryEvent,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void;
   shutdownPostHog(): Promise<void>;
@@ -1900,7 +1900,7 @@ export function createApp(deps: {
   });
   const posthogShutdowns: Array<() => Promise<void>> = [() => posthogErrorTracker.shutdown()];
   function capturePlatformEvent(
-    event: string,
+    event: MatrixTelemetryEvent,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void {
     void posthogErrorTracker.captureEvent(event, {
@@ -2278,7 +2278,12 @@ export function createApp(deps: {
         jwtSecret: platformJwtSecret,
         platformUrl: platformPublicUrl,
         gatewayUrlForHandle: getGatewayUrlForHandle,
-        captureEvent: capturePlatformEvent,
+        captureEvent: (event, properties) => {
+          capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.CLI_COMMAND_RUN, {
+            auth_event: event,
+            ...properties,
+          });
+        },
       }),
     );
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,9 +406,15 @@ importers:
       hono:
         specifier: ^4.11.9
         version: 4.12.8
+      posthog-js:
+        specifier: ^1.376.0
+        version: 1.376.0
       posthog-node:
         specifier: ^5.24.15
         version: 5.28.4
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
     devDependencies:
       '@types/node':
         specifier: ^25.2.3
@@ -24329,8 +24335,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.3
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -24352,7 +24358,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -24363,22 +24369,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24389,7 +24395,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/shell/instrumentation-client.ts
+++ b/shell/instrumentation-client.ts
@@ -1,5 +1,6 @@
 import posthog from "posthog-js";
 import {
+  buildPostHogCookieConsentInitOptions,
   getPostHogClientConfig,
   resolvePostHogClientApiHost,
 } from "@matrix-os/observability/client";
@@ -22,5 +23,6 @@ if (config) {
     defaults: "2026-01-30",
     capture_exceptions: true,
     debug: process.env.NODE_ENV === "development",
+    ...buildPostHogCookieConsentInitOptions(document.documentElement.dataset.posthogVisitorCountry),
   } as PostHogInitOptions);
 }

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -1,12 +1,15 @@
 import type { Metadata, Viewport } from "next";
+import { headers } from "next/headers";
 import { Inter, JetBrains_Mono, Cormorant_Garamond, Orbitron } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
+import { getPostHogVisitorCountry } from "@matrix-os/observability/client";
 import "@xterm/xterm/css/xterm.css";
 import "@fontsource/jetbrains-mono/400.css";
 import "@fontsource/jetbrains-mono/500.css";
 import "@fontsource/fira-code/400.css";
 import "@fontsource/fira-code/500.css";
 import "./globals.css";
+import { PostHogCookieBanner } from "@/components/PostHogCookieBanner";
 import { PwaRegister } from "@/components/pwa/PwaRegister";
 import { InstallPrompt } from "@/components/pwa/InstallPrompt";
 
@@ -98,16 +101,19 @@ export const viewport: Viewport = {
   ],
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const visitorCountry = getPostHogVisitorCountry(await headers());
+
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" data-posthog-visitor-country={visitorCountry ?? undefined}>
         <body className={`${inter.variable} ${jetbrainsMono.variable} ${cormorant.variable} ${orbitron.variable}`}>
           {children}
+          <PostHogCookieBanner visitorCountry={visitorCountry} />
           <PwaRegister />
           <InstallPrompt />
         </body>

--- a/shell/src/components/PostHogCookieBanner.tsx
+++ b/shell/src/components/PostHogCookieBanner.tsx
@@ -8,6 +8,7 @@ import {
 } from "@matrix-os/observability/client";
 
 type ConsentStatus = "pending" | "granted" | "denied" | "unknown";
+type PostHogLoadState = { __loaded?: boolean };
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -22,7 +23,25 @@ export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string
 
   useEffect(() => {
     if (!config || !consentRequired) return;
-    setConsentStatus(posthog.get_explicit_consent_status() ?? "pending");
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+
+    function refreshConsentStatus() {
+      if (cancelled) return;
+      if (!(posthog as PostHogLoadState).__loaded) {
+        timeout = setTimeout(refreshConsentStatus, 100);
+        return;
+      }
+      setConsentStatus(posthog.get_explicit_consent_status() ?? "pending");
+    }
+
+    refreshConsentStatus();
+
+    return () => {
+      cancelled = true;
+      if (timeout) clearTimeout(timeout);
+    };
   }, [consentRequired]);
 
   if (!config || !consentRequired || consentStatus !== "pending") return null;
@@ -42,6 +61,7 @@ export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string
           type="button"
           className="rounded-md border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           onClick={() => {
+            if (!(posthog as PostHogLoadState).__loaded) return;
             posthog.opt_out_capturing();
             setConsentStatus("denied");
           }}
@@ -52,6 +72,7 @@ export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string
           type="button"
           className="rounded-md bg-white px-4 py-2 text-sm font-semibold text-[#101411] transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           onClick={() => {
+            if (!(posthog as PostHogLoadState).__loaded) return;
             posthog.opt_in_capturing();
             setConsentStatus("granted");
           }}

--- a/shell/src/components/PostHogCookieBanner.tsx
+++ b/shell/src/components/PostHogCookieBanner.tsx
@@ -1,15 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import posthog from "posthog-js";
-import {
-  getPostHogClientConfig,
-  requiresPostHogCookieConsent,
-} from "@matrix-os/observability/client";
-
-type ConsentStatus = "pending" | "granted" | "denied" | "unknown";
-type PostHogLoadState = { __loaded?: boolean };
-const COOKIE_CONSENT_STORAGE_KEY = "matrix_posthog_cookie_consent";
+import { getPostHogClientConfig } from "@matrix-os/observability/client";
+import { PostHogCookieBanner as SharedPostHogCookieBanner } from "@matrix-os/observability/cookie-consent";
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -18,99 +10,6 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
 });
 
-function hasDeclinedCookieConsent(): boolean {
-  try {
-    return window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY) === "declined";
-  } catch (err: unknown) {
-    console.warn("Failed to read PostHog cookie consent:", err instanceof Error ? err.message : err);
-    return false;
-  }
-}
-
-function persistDeclinedCookieConsent(): void {
-  try {
-    window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, "declined");
-  } catch (err: unknown) {
-    console.warn("Failed to store PostHog cookie consent:", err instanceof Error ? err.message : err);
-  }
-}
-
-function clearDeclinedCookieConsent(): void {
-  try {
-    window.localStorage.removeItem(COOKIE_CONSENT_STORAGE_KEY);
-  } catch (err: unknown) {
-    console.warn("Failed to clear PostHog cookie consent:", err instanceof Error ? err.message : err);
-  }
-}
-
 export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string | null }) {
-  const consentRequired = requiresPostHogCookieConsent(visitorCountry);
-  const [consentStatus, setConsentStatus] = useState<ConsentStatus>("unknown");
-
-  useEffect(() => {
-    if (!config || !consentRequired) return;
-
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    let cancelled = false;
-
-    function refreshConsentStatus() {
-      if (cancelled) return;
-      if (hasDeclinedCookieConsent()) {
-        setConsentStatus("denied");
-        return;
-      }
-      if (!(posthog as PostHogLoadState).__loaded) {
-        timeout = setTimeout(refreshConsentStatus, 100);
-        return;
-      }
-      setConsentStatus(posthog.get_explicit_consent_status() ?? "pending");
-    }
-
-    refreshConsentStatus();
-
-    return () => {
-      cancelled = true;
-      if (timeout) clearTimeout(timeout);
-    };
-  }, [consentRequired]);
-
-  if (!config || !consentRequired || consentStatus !== "pending") return null;
-
-  return (
-    <aside
-      aria-label="Cookie consent"
-      aria-live="polite"
-      className="fixed inset-x-3 bottom-3 z-[10000] mx-auto flex max-w-4xl flex-col gap-4 rounded-lg border border-white/14 bg-[#101411]/95 p-4 text-white shadow-2xl shadow-black/35 backdrop-blur md:inset-x-6 md:bottom-6 md:flex-row md:items-center md:justify-between"
-    >
-      <p className="max-w-2xl text-sm leading-6 text-white/82">
-        Matrix OS uses PostHog analytics cookies to understand product usage and improve reliability. You can accept
-        analytics cookies or continue with cookieless tracking.
-      </p>
-      <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
-        <button
-          type="button"
-          className="rounded-md border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-          onClick={() => {
-            if (!(posthog as PostHogLoadState).__loaded) return;
-            persistDeclinedCookieConsent();
-            setConsentStatus("denied");
-          }}
-        >
-          Decline
-        </button>
-        <button
-          type="button"
-          className="rounded-md bg-white px-4 py-2 text-sm font-semibold text-[#101411] transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-          onClick={() => {
-            if (!(posthog as PostHogLoadState).__loaded) return;
-            clearDeclinedCookieConsent();
-            posthog.opt_in_capturing();
-            setConsentStatus("granted");
-          }}
-        >
-          Accept
-        </button>
-      </div>
-    </aside>
-  );
+  return <SharedPostHogCookieBanner config={config} visitorCountry={visitorCountry} />;
 }

--- a/shell/src/components/PostHogCookieBanner.tsx
+++ b/shell/src/components/PostHogCookieBanner.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import posthog from "posthog-js";
+import {
+  getPostHogClientConfig,
+  requiresPostHogCookieConsent,
+} from "@matrix-os/observability/client";
+
+type ConsentStatus = "pending" | "granted" | "denied" | "unknown";
+
+const config = getPostHogClientConfig({
+  NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
+  NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+  NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
+});
+
+export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string | null }) {
+  const consentRequired = requiresPostHogCookieConsent(visitorCountry);
+  const [consentStatus, setConsentStatus] = useState<ConsentStatus>("unknown");
+
+  useEffect(() => {
+    if (!config || !consentRequired) return;
+    setConsentStatus(posthog.get_explicit_consent_status() ?? "pending");
+  }, [consentRequired]);
+
+  if (!config || !consentRequired || consentStatus !== "pending") return null;
+
+  return (
+    <aside
+      aria-label="Cookie consent"
+      aria-live="polite"
+      className="fixed inset-x-3 bottom-3 z-[10000] mx-auto flex max-w-4xl flex-col gap-4 rounded-lg border border-white/14 bg-[#101411]/95 p-4 text-white shadow-2xl shadow-black/35 backdrop-blur md:inset-x-6 md:bottom-6 md:flex-row md:items-center md:justify-between"
+    >
+      <p className="max-w-2xl text-sm leading-6 text-white/82">
+        Matrix OS uses PostHog analytics cookies to understand product usage and improve reliability. You can accept
+        analytics cookies or continue with cookieless tracking.
+      </p>
+      <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+        <button
+          type="button"
+          className="rounded-md border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          onClick={() => {
+            posthog.opt_out_capturing();
+            setConsentStatus("denied");
+          }}
+        >
+          Decline
+        </button>
+        <button
+          type="button"
+          className="rounded-md bg-white px-4 py-2 text-sm font-semibold text-[#101411] transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          onClick={() => {
+            posthog.opt_in_capturing();
+            setConsentStatus("granted");
+          }}
+        >
+          Accept
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -583,7 +583,8 @@ describe("PostHog error tracking", () => {
     expect(platformAuthRoutes).toContain('"cli_device_code_created"');
     expect(platformAuthRoutes).toContain('"cli_device_token_issued"');
     expect(platformAuthRoutes).toContain('"cli_runtime_lookup_resolved"');
-    expect(platformMain).toContain("captureEvent: capturePlatformEvent");
+    expect(platformMain).toContain("MATRIX_TELEMETRY_EVENTS.CLI_COMMAND_RUN");
+    expect(platformMain).toContain("auth_event: event");
     expect(gatewayServer).not.toContain('captureGatewayProductEvent("terminal_input"');
     expect(gatewayServer).not.toContain('captureGatewayProductEvent("message_text"');
   });

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import {
+  buildPostHogCookieConsentInitOptions,
   getPostHogClientConfig,
+  getPostHogVisitorCountry,
+  requiresPostHogCookieConsent,
   resolvePostHogClientApiHost,
 } from "../../packages/observability/src/client.ts";
 import {
@@ -57,8 +60,45 @@ describe("PostHog error tracking", () => {
     );
 
     const shellClient = await readFile("shell/instrumentation-client.ts", "utf8");
+    const wwwClient = await readFile("www/instrumentation-client.ts", "utf8");
     expect(shellClient).toContain("resolvePostHogClientApiHost");
     expect(shellClient).toContain("allowRelativeApiHost: false");
+    expect(shellClient).toContain("buildPostHogCookieConsentInitOptions");
+    expect(wwwClient).toContain("buildPostHogCookieConsentInitOptions");
+  });
+
+  it("extracts visitor country from deployment geolocation headers", () => {
+    expect(
+      getPostHogVisitorCountry(
+        new Headers({
+          "x-vercel-ip-country": "se",
+        }),
+      ),
+    ).toBe("SE");
+    expect(
+      getPostHogVisitorCountry(
+        new Headers({
+          "cf-ipcountry": "DE",
+        }),
+      ),
+    ).toBe("DE");
+    expect(getPostHogVisitorCountry(new Headers({ "x-vercel-ip-country": "unknown" }))).toBeNull();
+    expect(getPostHogVisitorCountry(new Headers({ "x-vercel-ip-country": "123" }))).toBeNull();
+  });
+
+  it("requires explicit PostHog cookie consent for European visitors", () => {
+    expect(requiresPostHogCookieConsent("SE")).toBe(true);
+    expect(requiresPostHogCookieConsent("de")).toBe(true);
+    expect(requiresPostHogCookieConsent("NO")).toBe(true);
+    expect(requiresPostHogCookieConsent("GB")).toBe(true);
+    expect(requiresPostHogCookieConsent("CH")).toBe(true);
+    expect(requiresPostHogCookieConsent("US")).toBe(false);
+    expect(requiresPostHogCookieConsent(null)).toBe(false);
+  });
+
+  it("uses PostHog cookieless mode until explicit cookie consent is granted", () => {
+    expect(buildPostHogCookieConsentInitOptions("SE")).toEqual({ cookieless_mode: "on_reject" });
+    expect(buildPostHogCookieConsentInitOptions("US")).toEqual({});
   });
 
   it("stays disabled when no PostHog token is configured", async () => {

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -13,6 +13,22 @@ vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
   TerminalApp: () => <div data-testid="terminal-app" />,
 }));
 
+vi.mock("@clerk/nextjs", () => ({
+  PricingTable: () => <div data-testid="pricing-table" />,
+  useAuth: () => ({
+    isLoaded: true,
+    isSignedIn: true,
+    has: () => false,
+  }),
+  UserButton: Object.assign(
+    ({ children }: { children?: React.ReactNode }) => <div data-testid="clerk-user-button">{children}</div>,
+    {
+      MenuItems: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+      Link: ({ href, label }: { href: string; label: string; labelIcon?: React.ReactElement }) => <a href={href}>{label}</a>,
+    },
+  ),
+}));
+
 vi.mock("@/hooks/useTheme", () => ({
   DEFAULT_THEME: {
     name: "test",

--- a/www/instrumentation-client.ts
+++ b/www/instrumentation-client.ts
@@ -1,5 +1,6 @@
 import posthog from "posthog-js";
 import {
+  buildPostHogCookieConsentInitOptions,
   getPostHogClientConfig,
   resolvePostHogClientApiHost,
 } from "@matrix-os/observability/client";
@@ -20,5 +21,6 @@ if (config) {
     defaults: "2026-01-30",
     capture_exceptions: true,
     debug: process.env.NODE_ENV === "development",
+    ...buildPostHogCookieConsentInitOptions(document.documentElement.dataset.posthogVisitorCountry),
   } as PostHogInitOptions);
 }

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Inter, JetBrains_Mono, Caveat, Cormorant_Garamond, Orbitron } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { Analytics } from "@vercel/analytics/react";
+import { getPostHogVisitorCountry } from "@matrix-os/observability/client";
+import { PostHogCookieBanner } from "@/components/PostHogCookieBanner";
 import "./globals.css";
 
 const inter = Inter({
@@ -65,14 +68,20 @@ export const metadata: Metadata = {
   ],
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const visitorCountry = getPostHogVisitorCountry(await headers());
+
   return (
     <ClerkProvider>
-      <html lang="en" suppressHydrationWarning>
+      <html
+        lang="en"
+        suppressHydrationWarning
+        data-posthog-visitor-country={visitorCountry ?? undefined}
+      >
         <head>
           <link rel="dns-prefetch" href="https://clerk.matrix-os.com" />
           <link rel="dns-prefetch" href="https://eu.i.posthog.com" />
@@ -81,6 +90,7 @@ export default function RootLayout({
         </head>
         <body className={`${inter.variable} ${jetbrainsMono.variable} ${caveat.variable} ${cormorant.variable} ${orbitron.variable}`}>
           {children}
+          <PostHogCookieBanner visitorCountry={visitorCountry} />
           <Analytics />
         </body>
       </html>

--- a/www/src/components/PostHogCookieBanner.tsx
+++ b/www/src/components/PostHogCookieBanner.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import posthog from "posthog-js";
+import {
+  getPostHogClientConfig,
+  requiresPostHogCookieConsent,
+} from "@matrix-os/observability/client";
+
+type ConsentStatus = "pending" | "granted" | "denied" | "unknown";
+
+const config = getPostHogClientConfig({
+  NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
+  NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+  NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest",
+});
+
+export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string | null }) {
+  const consentRequired = requiresPostHogCookieConsent(visitorCountry);
+  const [consentStatus, setConsentStatus] = useState<ConsentStatus>("unknown");
+
+  useEffect(() => {
+    if (!config || !consentRequired) return;
+    setConsentStatus(posthog.get_explicit_consent_status() ?? "pending");
+  }, [consentRequired]);
+
+  if (!config || !consentRequired || consentStatus !== "pending") return null;
+
+  return (
+    <aside
+      aria-label="Cookie consent"
+      aria-live="polite"
+      className="fixed inset-x-3 bottom-3 z-50 mx-auto flex max-w-4xl flex-col gap-4 rounded-lg border border-white/15 bg-[#101411]/95 p-4 text-white shadow-2xl shadow-black/35 backdrop-blur md:inset-x-6 md:bottom-6 md:flex-row md:items-center md:justify-between"
+    >
+      <p className="max-w-2xl text-sm leading-6 text-white/82">
+        Matrix OS uses PostHog analytics cookies to understand product usage and improve reliability. You can accept
+        analytics cookies or continue with cookieless tracking.
+      </p>
+      <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+        <button
+          type="button"
+          className="rounded-md border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          onClick={() => {
+            posthog.opt_out_capturing();
+            setConsentStatus("denied");
+          }}
+        >
+          Decline
+        </button>
+        <button
+          type="button"
+          className="rounded-md bg-white px-4 py-2 text-sm font-semibold text-[#101411] transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+          onClick={() => {
+            posthog.opt_in_capturing();
+            setConsentStatus("granted");
+          }}
+        >
+          Accept
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/www/src/components/PostHogCookieBanner.tsx
+++ b/www/src/components/PostHogCookieBanner.tsx
@@ -8,6 +8,7 @@ import {
 } from "@matrix-os/observability/client";
 
 type ConsentStatus = "pending" | "granted" | "denied" | "unknown";
+type PostHogLoadState = { __loaded?: boolean };
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -22,7 +23,25 @@ export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string
 
   useEffect(() => {
     if (!config || !consentRequired) return;
-    setConsentStatus(posthog.get_explicit_consent_status() ?? "pending");
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+
+    function refreshConsentStatus() {
+      if (cancelled) return;
+      if (!(posthog as PostHogLoadState).__loaded) {
+        timeout = setTimeout(refreshConsentStatus, 100);
+        return;
+      }
+      setConsentStatus(posthog.get_explicit_consent_status() ?? "pending");
+    }
+
+    refreshConsentStatus();
+
+    return () => {
+      cancelled = true;
+      if (timeout) clearTimeout(timeout);
+    };
   }, [consentRequired]);
 
   if (!config || !consentRequired || consentStatus !== "pending") return null;
@@ -31,7 +50,7 @@ export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string
     <aside
       aria-label="Cookie consent"
       aria-live="polite"
-      className="fixed inset-x-3 bottom-3 z-50 mx-auto flex max-w-4xl flex-col gap-4 rounded-lg border border-white/15 bg-[#101411]/95 p-4 text-white shadow-2xl shadow-black/35 backdrop-blur md:inset-x-6 md:bottom-6 md:flex-row md:items-center md:justify-between"
+      className="fixed inset-x-3 bottom-3 z-[10000] mx-auto flex max-w-4xl flex-col gap-4 rounded-lg border border-white/15 bg-[#101411]/95 p-4 text-white shadow-2xl shadow-black/35 backdrop-blur md:inset-x-6 md:bottom-6 md:flex-row md:items-center md:justify-between"
     >
       <p className="max-w-2xl text-sm leading-6 text-white/82">
         Matrix OS uses PostHog analytics cookies to understand product usage and improve reliability. You can accept
@@ -42,6 +61,7 @@ export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string
           type="button"
           className="rounded-md border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           onClick={() => {
+            if (!(posthog as PostHogLoadState).__loaded) return;
             posthog.opt_out_capturing();
             setConsentStatus("denied");
           }}
@@ -52,6 +72,7 @@ export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string
           type="button"
           className="rounded-md bg-white px-4 py-2 text-sm font-semibold text-[#101411] transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           onClick={() => {
+            if (!(posthog as PostHogLoadState).__loaded) return;
             posthog.opt_in_capturing();
             setConsentStatus("granted");
           }}

--- a/www/src/components/PostHogCookieBanner.tsx
+++ b/www/src/components/PostHogCookieBanner.tsx
@@ -1,15 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import posthog from "posthog-js";
-import {
-  getPostHogClientConfig,
-  requiresPostHogCookieConsent,
-} from "@matrix-os/observability/client";
-
-type ConsentStatus = "pending" | "granted" | "denied" | "unknown";
-type PostHogLoadState = { __loaded?: boolean };
-const COOKIE_CONSENT_STORAGE_KEY = "matrix_posthog_cookie_consent";
+import { getPostHogClientConfig } from "@matrix-os/observability/client";
+import { PostHogCookieBanner as SharedPostHogCookieBanner } from "@matrix-os/observability/cookie-consent";
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -18,99 +10,6 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest",
 });
 
-function hasDeclinedCookieConsent(): boolean {
-  try {
-    return window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY) === "declined";
-  } catch (err: unknown) {
-    console.warn("Failed to read PostHog cookie consent:", err instanceof Error ? err.message : err);
-    return false;
-  }
-}
-
-function persistDeclinedCookieConsent(): void {
-  try {
-    window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, "declined");
-  } catch (err: unknown) {
-    console.warn("Failed to store PostHog cookie consent:", err instanceof Error ? err.message : err);
-  }
-}
-
-function clearDeclinedCookieConsent(): void {
-  try {
-    window.localStorage.removeItem(COOKIE_CONSENT_STORAGE_KEY);
-  } catch (err: unknown) {
-    console.warn("Failed to clear PostHog cookie consent:", err instanceof Error ? err.message : err);
-  }
-}
-
 export function PostHogCookieBanner({ visitorCountry }: { visitorCountry: string | null }) {
-  const consentRequired = requiresPostHogCookieConsent(visitorCountry);
-  const [consentStatus, setConsentStatus] = useState<ConsentStatus>("unknown");
-
-  useEffect(() => {
-    if (!config || !consentRequired) return;
-
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    let cancelled = false;
-
-    function refreshConsentStatus() {
-      if (cancelled) return;
-      if (hasDeclinedCookieConsent()) {
-        setConsentStatus("denied");
-        return;
-      }
-      if (!(posthog as PostHogLoadState).__loaded) {
-        timeout = setTimeout(refreshConsentStatus, 100);
-        return;
-      }
-      setConsentStatus(posthog.get_explicit_consent_status() ?? "pending");
-    }
-
-    refreshConsentStatus();
-
-    return () => {
-      cancelled = true;
-      if (timeout) clearTimeout(timeout);
-    };
-  }, [consentRequired]);
-
-  if (!config || !consentRequired || consentStatus !== "pending") return null;
-
-  return (
-    <aside
-      aria-label="Cookie consent"
-      aria-live="polite"
-      className="fixed inset-x-3 bottom-3 z-[10000] mx-auto flex max-w-4xl flex-col gap-4 rounded-lg border border-white/15 bg-[#101411]/95 p-4 text-white shadow-2xl shadow-black/35 backdrop-blur md:inset-x-6 md:bottom-6 md:flex-row md:items-center md:justify-between"
-    >
-      <p className="max-w-2xl text-sm leading-6 text-white/82">
-        Matrix OS uses PostHog analytics cookies to understand product usage and improve reliability. You can accept
-        analytics cookies or continue with cookieless tracking.
-      </p>
-      <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
-        <button
-          type="button"
-          className="rounded-md border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-          onClick={() => {
-            if (!(posthog as PostHogLoadState).__loaded) return;
-            persistDeclinedCookieConsent();
-            setConsentStatus("denied");
-          }}
-        >
-          Decline
-        </button>
-        <button
-          type="button"
-          className="rounded-md bg-white px-4 py-2 text-sm font-semibold text-[#101411] transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-          onClick={() => {
-            if (!(posthog as PostHogLoadState).__loaded) return;
-            clearDeclinedCookieConsent();
-            posthog.opt_in_capturing();
-            setConsentStatus("granted");
-          }}
-        >
-          Accept
-        </button>
-      </div>
-    </aside>
-  );
+  return <SharedPostHogCookieBanner config={config} visitorCountry={visitorCountry} />;
 }


### PR DESCRIPTION
## Summary

- Add shared PostHog visitor country detection and EU/EEA/UK/CH consent helpers.
- Initialize PostHog in cookieless-on-reject mode for European visitors.
- Mount PostHog cookie consent banners in both the marketing site and shell.

## Tests

- [x] `pnpm test tests/observability/posthog-error-tracking.test.ts`
- [x] `pnpm --filter @matrix-os/observability build`
- [x] `pnpm --filter './shell' exec tsc --noEmit`
- [x] `pnpm --filter './www' exec tsc --noEmit`
- [x] `bun run typecheck`
- [x] `bun run check:patterns` (0 violations; existing warnings only)
- [ ] `bun run test` (failed in unrelated environment-heavy suites: E2E gateway tests could not bind local ports with `listen EPERM`, and app-runtime/template build suites timed out or failed while spawning/building fixture apps)

## Invariants

- **Source of truth**: PostHog remains the analytics source of truth. The browser's PostHog explicit consent state controls whether analytics cookies are used after the banner decision.
- **Lock/transaction scope**: No database writes or transactions are introduced. The change only reads deployment geolocation headers at render time and updates client-side PostHog consent state.
- **Acceptable orphan states**: If geolocation headers are absent or unrecognized, no banner is shown and the existing non-EU behavior is preserved. If PostHog is not configured, the banner does not render.
- **Auth source of truth**: Auth behavior is unchanged. The banner is public UI and does not affect Clerk/session routing or gateway auth.
- **Deferred scope**: This does not add a cookie preference settings page, server-side consent storage, or Vercel Analytics consent gating.
