### PR TITLE
feat(analytics): track Matrix activation funnel

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -503,6 +503,30 @@ export async function createGateway(config: GatewayConfig) {
     adapter: zellijAdapter,
     scrollbackStore: shellScrollbackStore,
   });
+  const captureTerminalEvent = (
+    event: string,
+    properties: Record<string, string | number | boolean | undefined> = {},
+  ) => {
+    void posthogErrorTracker.captureEvent("gateway_terminal_ws", {
+      properties: {
+        source: "gateway-terminal-ws",
+        event,
+        ...properties,
+      },
+    });
+  };
+  const captureGatewayProductEvent = (
+    event: string,
+    properties: Record<string, string | number | boolean | undefined> = {},
+  ) => {
+    void posthogErrorTracker.captureEvent("gateway_product", {
+      properties: {
+        source: "gateway",
+        event,
+        ...properties,
+      },
+    });
+  };
   const dispatcher: Dispatcher = createDispatcher({
     homePath,
     model: config.model,
@@ -1929,6 +1953,9 @@ export async function createGateway(config: GatewayConfig) {
           evictOldestMainWsClientIfNeeded();
           clients.add(ws);
           wsConnectionsActive.inc();
+          captureGatewayProductEvent("shell_ws_open", {
+            active_clients: clients.size,
+          });
           approvalBridge = createApprovalBridge({
             send: (msg) => send(ws, msg),
             timeout: approvalPolicy.timeout,
@@ -1958,6 +1985,7 @@ export async function createGateway(config: GatewayConfig) {
 
           const parsedResult = MainWsClientMessageSchema.safeParse(rawMessage);
           if (!parsedResult.success) {
+            captureGatewayProductEvent("shell_ws_invalid_message");
             send(ws, { type: "kernel:error", message: "Invalid message format" });
             return;
           }
@@ -2010,6 +2038,10 @@ export async function createGateway(config: GatewayConfig) {
           }
 
           if (parsed.type === "sync:subscribe" && syncPeerRegistry) {
+            captureGatewayProductEvent("sync_peer_subscribe", {
+              shell_surface: "gateway_ws",
+              client_version_present: Boolean(parsed.clientVersion),
+            });
             syncPeerLifecycle?.subscribe({
               peerId: parsed.peerId,
               hostname: parsed.hostname,
@@ -2034,6 +2066,11 @@ export async function createGateway(config: GatewayConfig) {
             pendingText = parsed.displayText ?? parsed.text;
             const requestId = parsed.requestId;
             let lastToolName: string | undefined;
+            captureGatewayProductEvent("agent_task_started", {
+              shell_surface: "gateway_ws",
+              request_id_present: Boolean(requestId),
+              session_id_present: Boolean(parsed.sessionId),
+            });
 
             // Register abort controller so the user can stop this run.
             // Skip if no requestId (legacy clients) -- they can't target
@@ -2068,10 +2105,18 @@ export async function createGateway(config: GatewayConfig) {
                   publishConversationRunMessage(activeSessionId, msg);
                   conversations.addToolEnd(activeSessionId, lastToolName ?? "unknown", msg.input);
                 } else if (msg.type === "kernel:result" && activeSessionId) {
+                  captureGatewayProductEvent("agent_task_completed", {
+                    shell_surface: "gateway_ws",
+                    request_id_present: Boolean(requestId),
+                  });
                   publishConversationRunMessage(activeSessionId, msg);
                   finalizeWithSummary(activeSessionId);
                   conversationRuns.complete(activeSessionId);
                 } else if (msg.type === "kernel:error" && activeSessionId) {
+                  captureGatewayProductEvent("agent_task_failed", {
+                    shell_surface: "gateway_ws",
+                    request_id_present: Boolean(requestId),
+                  });
                   publishConversationRunMessage(activeSessionId, {
                     ...msg,
                     message: CLIENT_KERNEL_ERROR_MESSAGE,
@@ -2086,6 +2131,10 @@ export async function createGateway(config: GatewayConfig) {
               }, undefined, abortController)
               .catch((err: Error) => {
                 console.error("[gateway] Conversation dispatch failed:", err);
+                captureGatewayProductEvent("agent_task_dispatch_failed", {
+                  shell_surface: "gateway_ws",
+                  request_id_present: Boolean(requestId),
+                });
                 if (activeSessionId) {
                   publishConversationRunMessage(activeSessionId, {
                     type: "kernel:error",
@@ -2120,6 +2169,9 @@ export async function createGateway(config: GatewayConfig) {
           if (clients.delete(ws)) {
             wsConnectionsActive.dec();
           }
+          captureGatewayProductEvent("shell_ws_close", {
+            active_clients: clients.size,
+          });
         },
       };
     }),
@@ -2246,6 +2298,10 @@ export async function createGateway(config: GatewayConfig) {
             cwdParam: cwdParam ?? null,
             namedSession: namedSession ?? null,
           });
+          captureTerminalEvent("open", {
+            hasCwdParam: Boolean(cwdParam),
+            namedSession: Boolean(namedSession),
+          });
           const sendJson = (msg: PtyServerMessage) => {
             try {
               ws.send(JSON.stringify(msg));
@@ -2271,6 +2327,10 @@ export async function createGateway(config: GatewayConfig) {
               namedHandle = session;
             }).catch((err: unknown) => {
               console.warn("[shell] zellij terminal attach failed:", err instanceof Error ? err.message : String(err));
+              captureTerminalEvent("named-attach-failed", {
+                namedSession: true,
+                socketClosed: namedSocketClosed,
+              });
               if (namedSocketClosed) {
                 return;
               }
@@ -2317,6 +2377,9 @@ export async function createGateway(config: GatewayConfig) {
                   autoCreatedSessionId = null;
                 }
                 console.error("Terminal session create error:", err);
+                captureTerminalEvent("auto-create-failed", {
+                  hasCwdParam: Boolean(cwdParam),
+                });
                 sendJson({ type: "error", message: "Failed to create session" });
               }
             }, 100);
@@ -2334,12 +2397,14 @@ export async function createGateway(config: GatewayConfig) {
             parsed = JSON.parse(raw);
           } catch (err: unknown) {
             logUnexpectedJsonParseFailure("Failed to parse terminal WebSocket message", err);
+            captureTerminalEvent("invalid-json");
             ws.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
             return;
           }
 
           const result = ClientMessageSchema.safeParse(parsed);
           if (!result.success) {
+            captureTerminalEvent("invalid-message");
             ws.send(JSON.stringify({ type: "error", message: "Invalid message format" }));
             return;
           }
@@ -2363,6 +2428,10 @@ export async function createGateway(config: GatewayConfig) {
                 cwd: "cwd" in msg ? msg.cwd : null,
                 sessionId: "sessionId" in msg ? msg.sessionId : null,
                 fromSeq: "fromSeq" in msg ? (msg.fromSeq ?? 0) : null,
+              });
+              captureTerminalEvent("attach-request", {
+                mode: "cwd" in msg ? "create" : "reattach",
+                hasFromSeq: "fromSeq" in msg && msg.fromSeq !== undefined,
               });
               if (autoCreateTimer) {
                 clearTimeout(autoCreateTimer);
@@ -2399,6 +2468,9 @@ export async function createGateway(config: GatewayConfig) {
                     sessionRegistry.destroy(sessionId);
                   }
                   console.error("Terminal session create error:", err);
+                  captureTerminalEvent("create-failed", {
+                    hasShell: Boolean(msg.shell),
+                  });
                   sendJson({ type: "error", message: "Failed to create session" });
                 }
               } else {
@@ -2418,6 +2490,7 @@ export async function createGateway(config: GatewayConfig) {
                     handle.replay(msg.fromSeq ?? 0);
                   } else {
                     logTerminalDebug("attach-existing-miss", { sessionId: msg.sessionId });
+                    captureTerminalEvent("attach-miss");
                     sendJson({ type: "error", message: "Session not found" });
                   }
                 } catch (err: unknown) {
@@ -2426,6 +2499,7 @@ export async function createGateway(config: GatewayConfig) {
                     handle = null;
                   }
                   console.error("Terminal session attach error:", err);
+                  captureTerminalEvent("attach-failed");
                   sendJson({ type: "error", message: "Failed to attach session" });
                 }
               }
@@ -2440,6 +2514,7 @@ export async function createGateway(config: GatewayConfig) {
             case "detach":
               if (handle) {
                 logTerminalDebug("ws-detach", { sessionId: handle.sessionId });
+                captureTerminalEvent("detach");
                 handle.detach();
                 handle = null;
               }
@@ -2448,6 +2523,7 @@ export async function createGateway(config: GatewayConfig) {
               if (handle) {
                 const sessionId = handle.sessionId;
                 logTerminalDebug("ws-destroy", { sessionId });
+                captureTerminalEvent("destroy");
                 handle.detach();
                 handle = null;
                 sessionRegistry.destroy(sessionId);
@@ -2468,6 +2544,11 @@ export async function createGateway(config: GatewayConfig) {
           logTerminalDebug("ws-close", {
             handleSessionId: handle?.sessionId ?? null,
             autoCreatedSessionId,
+          });
+          captureTerminalEvent("close", {
+            hadHandle: Boolean(handle),
+            hadAutoCreatedSession: Boolean(autoCreatedSessionId),
+            namedSession: Boolean(namedSession),
           });
           if (autoCreateTimer) {
             clearTimeout(autoCreateTimer);

--- a/shell/src/app/__error-preview/page.tsx
+++ b/shell/src/app/__error-preview/page.tsx
@@ -1,0 +1,10 @@
+import { notFound } from "next/navigation";
+import ErrorPreviewCrash from "./preview-crash";
+
+export default function ErrorPreviewPage() {
+  if (process.env.NODE_ENV === "production") {
+    notFound();
+  }
+
+  return <ErrorPreviewCrash />;
+}

--- a/shell/src/app/__error-preview/preview-crash.tsx
+++ b/shell/src/app/__error-preview/preview-crash.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function ErrorPreviewCrash(): never {
+  throw new Error("Matrix OS error preview: verify PostHog error tracking");
+}

--- a/shell/src/app/error.tsx
+++ b/shell/src/app/error.tsx
@@ -1,7 +1,29 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createErrorId, describeUnknownError } from "../lib/error-boundary-utils";
 import { capturePostHogException } from "../lib/posthog-client";
+
+function MatrixLogoMark() {
+  return (
+    <div className="relative flex size-16 items-center justify-center rounded-2xl border border-forest/15 bg-[#fbf7ed] shadow-[0_18px_50px_rgba(83,68,48,0.12)]">
+      <div
+        className="size-9 bg-deep"
+        aria-hidden="true"
+        style={{
+          WebkitMaskImage: "url('/matrix-logo.svg')",
+          WebkitMaskPosition: "center",
+          WebkitMaskRepeat: "no-repeat",
+          WebkitMaskSize: "contain",
+          maskImage: "url('/matrix-logo.svg')",
+          maskPosition: "center",
+          maskRepeat: "no-repeat",
+          maskSize: "contain",
+        }}
+      />
+    </div>
+  );
+}
 
 export default function Error({
   error,
@@ -10,21 +32,56 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const errorId = useMemo(() => createErrorId(error), [error]);
+  const [copied, setCopied] = useState(false);
+
   useEffect(() => {
     capturePostHogException(error, {
       source: "shell-error-boundary",
       digest: error.digest,
+      errorId,
     });
-  }, [error]);
+  }, [error, errorId]);
+
+  async function copyErrorId() {
+    try {
+      await navigator.clipboard.writeText(errorId);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch (err: unknown) {
+      console.warn("[error-boundary] Failed to copy error ID:", describeUnknownError(err));
+      setCopied(false);
+    }
+  }
 
   return (
-    <div className="flex h-screen w-screen items-center justify-center bg-background">
-      <div className="flex flex-col items-center gap-4 text-center">
-        <h2 className="text-lg font-semibold text-foreground">Something went wrong</h2>
-        <p className="text-sm text-muted-foreground max-w-sm">An unexpected error occurred. Please try again.</p>
+    <div className="flex h-screen w-screen items-center justify-center bg-[#f6f4ec] px-6 text-deep">
+      <div className="flex w-full max-w-md flex-col items-center rounded-[28px] border border-forest/12 bg-white/80 p-8 text-center shadow-[0_24px_80px_rgba(67,78,63,0.16)] backdrop-blur-xl">
+        <MatrixLogoMark />
+        <p className="mt-6 text-xs font-semibold uppercase tracking-[0.2em] text-forest/55">
+          Matrix OS
+        </p>
+        <h2 className="mt-3 text-3xl font-semibold tracking-tight text-deep">
+          Something went wrong
+        </h2>
+        <p className="mt-3 max-w-sm text-sm leading-6 text-forest/65">
+          Matrix hit an unexpected state. Try again and we will reload the shell.
+        </p>
         <button
+          type="button"
+          onClick={copyErrorId}
+          className="mt-5 inline-flex max-w-full items-center gap-2 rounded-xl border border-forest/12 bg-[#fbf7ed] px-3 py-2 font-mono text-xs text-forest/70 transition-colors hover:border-ember/35 hover:text-deep"
+          aria-label={`Copy error ID ${errorId}`}
+        >
+          <span className="truncate">Error ID: {errorId}</span>
+          <span className="font-sans text-[11px] font-semibold text-ember">
+            {copied ? "Copied" : "Copy"}
+          </span>
+        </button>
+        <button
+          type="button"
           onClick={reset}
-          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          className="mt-6 inline-flex h-11 items-center justify-center rounded-xl bg-forest px-5 text-sm font-semibold text-ember-foreground transition-colors hover:bg-deep"
         >
           Try again
         </button>

--- a/shell/src/app/global-error.tsx
+++ b/shell/src/app/global-error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createErrorId, describeUnknownError } from "../lib/error-boundary-utils";
 import { capturePostHogException } from "../lib/posthog-client";
 
 export default function GlobalError({
@@ -10,23 +11,151 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const errorId = useMemo(() => createErrorId(error), [error]);
+  const [copied, setCopied] = useState(false);
+
   useEffect(() => {
     capturePostHogException(error, {
       source: "shell-global-error-boundary",
       digest: error.digest,
+      errorId,
     });
-  }, [error]);
+  }, [error, errorId]);
+
+  async function copyErrorId() {
+    try {
+      await navigator.clipboard.writeText(errorId);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch (err: unknown) {
+      console.warn("[global-error-boundary] Failed to copy error ID:", describeUnknownError(err));
+      setCopied(false);
+    }
+  }
 
   return (
     <html>
       <body>
-        <div style={{ display: "flex", height: "100vh", width: "100vw", alignItems: "center", justifyContent: "center", fontFamily: "system-ui, sans-serif" }}>
-          <div style={{ textAlign: "center" }}>
-            <h2 style={{ fontSize: "1.125rem", fontWeight: 600 }}>Something went wrong</h2>
-            <p style={{ fontSize: "0.875rem", color: "#6c7178", marginTop: "0.5rem" }}>An unexpected error occurred. Please try again.</p>
+        <div
+          style={{
+            alignItems: "center",
+            background: "#f6f4ec",
+            boxSizing: "border-box",
+            color: "#32352E",
+            display: "flex",
+            fontFamily: "Inter, system-ui, sans-serif",
+            height: "100vh",
+            justifyContent: "center",
+            padding: 24,
+            width: "100vw",
+          }}
+        >
+          <div
+            style={{
+              alignItems: "center",
+              background: "rgba(255,255,255,0.82)",
+              border: "1px solid rgba(67,78,63,0.12)",
+              borderRadius: 28,
+              boxShadow: "0 24px 80px rgba(67,78,63,0.16)",
+              boxSizing: "border-box",
+              display: "flex",
+              flexDirection: "column",
+              maxWidth: 448,
+              padding: 32,
+              textAlign: "center",
+              width: "100%",
+            }}
+          >
+            <div
+              style={{
+                alignItems: "center",
+                background: "#fbf7ed",
+                border: "1px solid rgba(67,78,63,0.15)",
+                borderRadius: 18,
+                boxShadow: "0 18px 50px rgba(83,68,48,0.12)",
+                display: "flex",
+                height: 64,
+                justifyContent: "center",
+                width: 64,
+              }}
+            >
+              <div
+                aria-hidden="true"
+                style={{
+                  background: "#32352E",
+                  height: 36,
+                  WebkitMaskImage: "url('/matrix-logo.svg')",
+                  WebkitMaskPosition: "center",
+                  WebkitMaskRepeat: "no-repeat",
+                  WebkitMaskSize: "contain",
+                  maskImage: "url('/matrix-logo.svg')",
+                  maskPosition: "center",
+                  maskRepeat: "no-repeat",
+                  maskSize: "contain",
+                  width: 36,
+                }}
+              />
+            </div>
+            <p
+              style={{
+                color: "rgba(67,78,63,0.55)",
+                fontSize: 12,
+                fontWeight: 700,
+                letterSpacing: "0.2em",
+                margin: "24px 0 0",
+                textTransform: "uppercase",
+              }}
+            >
+              Matrix OS
+            </p>
+            <h2 style={{ fontSize: 30, fontWeight: 650, letterSpacing: "-0.01em", lineHeight: 1.08, margin: "12px 0 0" }}>
+              Something went wrong
+            </h2>
+            <p style={{ color: "rgba(67,78,63,0.65)", fontSize: 14, lineHeight: 1.6, margin: "12px 0 0", maxWidth: 360 }}>
+              Matrix hit an unexpected state. Try again and we will reload the shell.
+            </p>
             <button
+              type="button"
+              onClick={copyErrorId}
+              aria-label={`Copy error ID ${errorId}`}
+              style={{
+                alignItems: "center",
+                background: "#fbf7ed",
+                border: "1px solid rgba(67,78,63,0.12)",
+                borderRadius: 12,
+                color: "rgba(67,78,63,0.72)",
+                cursor: "pointer",
+                display: "inline-flex",
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                fontSize: 12,
+                gap: 8,
+                marginTop: 20,
+                maxWidth: "100%",
+                padding: "8px 12px",
+              }}
+            >
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                Error ID: {errorId}
+              </span>
+              <span style={{ color: "#D06F25", fontFamily: "Inter, system-ui, sans-serif", fontSize: 11, fontWeight: 700 }}>
+                {copied ? "Copied" : "Copy"}
+              </span>
+            </button>
+            <button
+              type="button"
               onClick={reset}
-              style={{ marginTop: "1rem", padding: "0.5rem 1rem", borderRadius: "0.375rem", backgroundColor: "#8CC7BE", color: "#1a1f18", border: "none", cursor: "pointer", fontSize: "0.875rem", fontWeight: 500 }}
+              style={{
+                background: "#434E3F",
+                border: "none",
+                borderRadius: 12,
+                color: "#FAFAF5",
+                cursor: "pointer",
+                fontSize: 14,
+                fontWeight: 700,
+                height: 44,
+                marginTop: 24,
+                padding: "0 20px",
+              }}
             >
               Try again
             </button>

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
+import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 import { createSocketHealth } from "@/lib/socket-health";
 import { isTerminalDebugEnabled } from "@/lib/terminal-debug";
 import { useTerminalSettings } from "@/stores/terminal-settings";
@@ -215,6 +216,16 @@ function terminalDebug(event: string, details: Record<string, unknown>): void {
   console.info("[terminal-debug][pane]", event, details);
 }
 
+function terminalTelemetry(event: string, properties: Record<string, string | number | boolean | undefined>): void {
+  const payload = {
+    source: "terminal-pane",
+    event,
+    ...properties,
+  };
+  capturePostHogEvent("shell_terminal_ws", payload);
+  capturePostHogLog(event.includes("error") ? "error" : "info", `terminal websocket ${event}`, payload);
+}
+
 function describeReadyState(ws: WebSocket | null): string {
   if (!ws) {
     return "null";
@@ -345,6 +356,16 @@ export function TerminalPane({
           sessionId: sessionIdRef.current,
           lastSeq: lastSeqRef.current,
           wsState: describeReadyState(wsRef.current),
+          ...details,
+        });
+      };
+
+      const track = (event: string, details: Record<string, string | number | boolean | undefined> = {}) => {
+        terminalTelemetry(event, {
+          paneId,
+          hasSession: Boolean(sessionIdRef.current),
+          wsState: describeReadyState(wsRef.current),
+          reconnectAttempt: reconnectAttemptRef.current,
           ...details,
         });
       };
@@ -578,6 +599,7 @@ export function TerminalPane({
           attachOnOpen,
           boundWsState: describeReadyState(ws),
         });
+        track("bind", { attachOnOpen, boundWsState: describeReadyState(ws) });
 
         const sendAttach = () => {
           const currentSessionId = sessionIdRef.current;
@@ -631,6 +653,7 @@ export function TerminalPane({
             reconnectLinesWrittenRef.current = 0;
           }
           log("ws-open", { attachOnOpen });
+          track("open", { attachOnOpen });
 
           // Start heartbeat
           if (heartbeatRef.current) heartbeatRef.current.stop();
@@ -653,6 +676,7 @@ export function TerminalPane({
 
         ws.onerror = () => {
           log("ws-error");
+          track("error");
           if (!sessionIdRef.current) {
             term.write("\r\n\x1b[31mConnection error. Is the gateway running?\x1b[0m\r\n");
           }
@@ -665,6 +689,10 @@ export function TerminalPane({
             isClosing: isClosingRef.current,
             reconnectAttempt: reconnectAttemptRef.current,
           });
+          track("close", {
+            disposed,
+            isClosing: isClosingRef.current,
+          });
           if (disposed || isClosingRef.current) return;
 
           // Attempt reconnection with exponential backoff
@@ -674,6 +702,7 @@ export function TerminalPane({
             const delay = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s
             reconnectAttemptRef.current = attempt + 1;
             log("schedule-reconnect", { delayMs: delay, nextAttempt: reconnectAttemptRef.current });
+            track("schedule-reconnect", { delayMs: delay, nextAttempt: reconnectAttemptRef.current });
             term.write(`\r\n\x1b[33m[Reconnecting in ${delay / 1000}s...]\x1b[0m\r\n`);
             reconnectLinesWrittenRef.current += 2;
             reconnectTimerRef.current = setTimeout(() => {
@@ -715,6 +744,10 @@ export function TerminalPane({
                 attachedSessionId: msg.sessionId,
                 state: msg.state,
                 exitCode: msg.exitCode ?? null,
+              });
+              track("attached", {
+                state: msg.state,
+                hasExitCode: msg.exitCode != null,
               });
               sessionIdRef.current = msg.sessionId;
               onSessionAttachedRef.current?.(paneId, msg.sessionId);
@@ -784,6 +817,9 @@ export function TerminalPane({
             case "error": {
               const safeMsg = stripTerminalControls(msg.message);
               log("server-error", { message: safeMsg });
+              track("server-error", {
+                sessionNotFound: safeMsg === "Session not found",
+              });
               if (safeMsg === "Session not found" && sessionIdRef.current && isLegacyPtySessionId(sessionIdRef.current)) {
                 log("session-not-found-reset");
                 sessionIdRef.current = null;
@@ -837,11 +873,16 @@ export function TerminalPane({
           .then((wsUrl) => {
             if (disposed || isClosingRef.current) {
               log("connect-ws-abort", { reason: disposed ? "disposed" : "closing" });
+              track("connect-abort", { reason: disposed ? "disposed" : "closing" });
               return;
             }
             log("connect-ws-url", {
               urlIncludesCwd: wsUrl.includes("cwd="),
               urlIncludesToken: wsUrl.includes("token="),
+            });
+            track("connect", {
+              urlIncludesToken: wsUrl.includes("token="),
+              hasCwdQuery: wsUrl.includes("cwd="),
             });
             const ws = new WebSocket(wsUrl);
             bindWs(ws, true);

--- a/shell/src/lib/error-boundary-utils.ts
+++ b/shell/src/lib/error-boundary-utils.ts
@@ -1,0 +1,22 @@
+export function createErrorId(error: Error & { digest?: string }): string {
+  const suffix =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID().slice(0, 8)
+      : Math.random().toString(36).slice(2, 10);
+  if (error.digest) return `mx-${error.digest}-${suffix}`;
+  const source = `${error.name}:${error.message}`;
+  let hash = 5381;
+  for (let i = 0; i < source.length; i += 1) {
+    hash = (hash * 33) ^ source.charCodeAt(i);
+  }
+  return `mx-${(hash >>> 0).toString(36)}-${suffix}`;
+}
+
+export function describeUnknownError(error: unknown): string {
+  if (error instanceof globalThis.Error) return `${error.name}: ${error.message}`;
+  try {
+    return String(error);
+  } catch {
+    return typeof error;
+  }
+}

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -433,6 +433,121 @@ describe("PostHog error tracking", () => {
     expect(wwwPostHogClient).toContain('NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest"');
   });
 
+  it("configures browser PostHog logs without console autocapture", async () => {
+    const shellPostHogClient = await readFile("shell/src/lib/posthog-client.ts", "utf8");
+
+    expect(shellPostHogClient).toContain("capturePostHogLog");
+    expect(shellPostHogClient).toContain("posthog as PostHogWithLogger");
+    expect(shellPostHogClient).toContain("serviceName: \"matrix-shell\"");
+    expect(shellPostHogClient).toContain("captureConsoleLogs: false");
+    expect(shellPostHogClient).not.toContain("captureConsoleLogs: true");
+  });
+
+  it("keeps the shell error preview dev-only and wired through the route error boundary", async () => {
+    const [pageSource, crashSource] = await Promise.all([
+      readFile("shell/src/app/__error-preview/page.tsx", "utf8"),
+      readFile("shell/src/app/__error-preview/preview-crash.tsx", "utf8"),
+    ]);
+
+    expect(pageSource).toContain('process.env.NODE_ENV === "production"');
+    expect(pageSource).toContain("notFound()");
+    expect(crashSource).toContain('"use client"');
+    expect(crashSource).toContain("Matrix OS error preview: verify PostHog error tracking");
+  });
+
+  it("captures shell error-boundary exceptions with copyable error IDs", async () => {
+    const [routeError, globalError, errorUtils] = await Promise.all([
+      readFile("shell/src/app/error.tsx", "utf8"),
+      readFile("shell/src/app/global-error.tsx", "utf8"),
+      readFile("shell/src/lib/error-boundary-utils.ts", "utf8"),
+    ]);
+
+    for (const source of [routeError, globalError]) {
+      expect(source).toContain("capturePostHogException(error");
+      expect(source).toContain("errorId");
+      expect(source).toContain("Copy error ID");
+      expect(source).toContain("createErrorId");
+    }
+    expect(errorUtils).toContain("crypto.randomUUID");
+    expect(errorUtils).toContain("describeUnknownError");
+  });
+
+  it("tracks terminal websocket lifecycle without terminal output payloads", async () => {
+    const [terminalPane, gatewayServer] = await Promise.all([
+      readFile("shell/src/components/terminal/TerminalPane.tsx", "utf8"),
+      readFile("packages/gateway/src/server.ts", "utf8"),
+    ]);
+
+    expect(terminalPane).toContain('capturePostHogEvent("shell_terminal_ws"');
+    expect(terminalPane).toContain("capturePostHogLog");
+    expect(terminalPane).toContain('track("schedule-reconnect"');
+    expect(terminalPane).not.toContain("capturePostHogEvent(\"shell_terminal_ws\", { data");
+    expect(gatewayServer).toContain('posthogErrorTracker.captureEvent("gateway_terminal_ws"');
+    expect(gatewayServer).toContain('captureTerminalEvent("attach-request"');
+    expect(gatewayServer).not.toContain('captureTerminalEvent("input"');
+  });
+
+  it("tracks billing provisioning decisions as metadata-only events", async () => {
+    const billingPanel = await readFile(
+      "shell/src/components/settings/sections/BillingPanel.tsx",
+      "utf8",
+    );
+
+    expect(billingPanel).toContain('capturePostHogEvent("shell_billing"');
+    expect(billingPanel).toContain("capturePostHogLog");
+    expect(billingPanel).toContain('"view_provisioning_billing"');
+    expect(billingPanel).toContain('"profile_select"');
+    expect(billingPanel).toContain('"region_select"');
+    expect(billingPanel).toContain('"checkout_intent"');
+    expect(billingPanel).toContain('"checkout_pricing_table_available"');
+    expect(billingPanel).toContain('"checkout_local_preview_unavailable"');
+    expect(billingPanel).toContain("selected_hetzner_type");
+    expect(billingPanel).toContain("selected_region_slug");
+    expect(billingPanel).not.toContain("cardNumber");
+    expect(billingPanel).not.toContain("terminalData");
+  });
+
+  it("tracks the landing to billing funnel before the shell handoff", async () => {
+    const [landingPage, landingTelemetry, landingBilling, wwwPostHogClient] = await Promise.all([
+      readFile("www/src/app/page.tsx", "utf8"),
+      readFile("www/src/components/landing/LandingTelemetry.tsx", "utf8"),
+      readFile("www/src/components/landing/LandingBilling.tsx", "utf8"),
+      readFile("www/src/lib/posthog-client.ts", "utf8"),
+    ]);
+
+    expect(wwwPostHogClient).toContain("capturePostHogEvent");
+    expect(landingPage).toContain("<LandingTelemetry />");
+    expect(landingPage).toContain('data-ph-event="marketing_cta_clicked"');
+    expect(landingTelemetry).toContain('"marketing_landing_viewed"');
+    expect(landingTelemetry).toContain("[data-ph-event]");
+    expect(landingBilling).toContain('"marketing_billing_viewed"');
+    expect(landingBilling).toContain('"marketing_billing_cta_clicked"');
+    expect(landingBilling).toContain('"marketing_billing_pricing_error"');
+  });
+
+  it("tracks shell, gateway, and CLI/TUI product activity without content payloads", async () => {
+    const [billingGate, gatewayServer, platformAuthRoutes, platformMain] = await Promise.all([
+      readFile("shell/src/components/BillingGate.tsx", "utf8"),
+      readFile("packages/gateway/src/server.ts", "utf8"),
+      readFile("packages/platform/src/auth-routes.ts", "utf8"),
+      readFile("packages/platform/src/main.ts", "utf8"),
+    ]);
+
+    expect(billingGate).toContain('"shell_access_state_changed"');
+    expect(billingGate).toContain('"billing_checkout_confirmed"');
+    expect(gatewayServer).toContain('captureEvent("gateway_product"');
+    expect(gatewayServer).toContain('"shell_ws_open"');
+    expect(gatewayServer).toContain('"agent_task_started"');
+    expect(gatewayServer).toContain('"agent_task_completed"');
+    expect(gatewayServer).toContain('"sync_peer_subscribe"');
+    expect(platformAuthRoutes).toContain('"cli_device_code_created"');
+    expect(platformAuthRoutes).toContain('"cli_device_token_issued"');
+    expect(platformAuthRoutes).toContain('"cli_runtime_lookup_resolved"');
+    expect(platformMain).toContain("captureEvent: capturePlatformEvent");
+    expect(gatewayServer).not.toContain('captureGatewayProductEvent("terminal_input"');
+    expect(gatewayServer).not.toContain('captureGatewayProductEvent("message_text"');
+  });
+
   it("queues Next server PostHog reporting off the request-error hook path", async () => {
     const serverEntrypoints = [
       "shell/instrumentation.ts",

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/gateway", () => ({
@@ -30,6 +30,7 @@ function jsonResponse(body: unknown) {
 describe("SystemSection release refresh", () => {
   afterEach(() => {
     vi.useRealTimers();
+    cleanup();
     vi.restoreAllMocks();
   });
 
@@ -574,6 +575,7 @@ describe("SystemSection release refresh", () => {
   });
 
   it("keeps system upgrades read-only until billing is active", async () => {
+    vi.useRealTimers();
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith("/api/system/info")) {
@@ -617,8 +619,13 @@ describe("SystemSection release refresh", () => {
 
     render(<SystemSection billingActive={false} />);
 
-    expect(await screen.findByText("System upgrades are locked until billing is active.")).toBeTruthy();
-    const upgradeButton = await screen.findByRole("button", { name: "Upgrade Now" });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("System upgrades are locked until billing is active.")).toBeTruthy();
+    const upgradeButton = screen.getByRole("button", { name: "Upgrade Now" });
     expect((upgradeButton as HTMLButtonElement).disabled).toBe(true);
 
     fireEvent.click(upgradeButton);


### PR DESCRIPTION
## Stack

Stack: 2/2 on top of #259 (`billing-hosted-runtime-launch`).

Downstack: #236 -> #259.

## Summary

- Add branded shell error pages with copyable PostHog error IDs and a dev-only error preview route.
- Track terminal, gateway WebSocket, sync, CLI/TUI, and agent task lifecycle events as metadata-only product events.
- Extend observability tests for landing, billing, shell, gateway, and CLI/TUI paths.

## Tests

- `pnpm test tests/observability/posthog-error-tracking.test.ts tests/shell/billing-section.test.tsx tests/shell/billing-gate.test.tsx`
- `pnpm --dir shell exec tsc --noEmit --incremental false`
- `pnpm --dir www exec tsc --noEmit --incremental false`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit --incremental false`
- `bun run typecheck`
- `bun run check:patterns` (5 existing warnings, 0 violations)
- `git diff --check`

## Invariants

- **Source of truth**: PostHog is the analytics/error source of truth. Product events are emitted from the shell browser client, gateway, and platform device-auth routes; runtime ownership and billing state remain owned by Clerk/platform data, not analytics.
- **Lock/transaction scope**: Event capture is fire-and-forget and not inside customer-data transactions. Gateway terminal and agent lifecycle telemetry does not block WebSocket responses or session cleanup.
- **Acceptable orphan states**: A product action can succeed even if PostHog capture fails. An error ID can be shown to a user even if network delivery to PostHog fails; the ID is still useful in local reproduction and support screenshots.
- **Auth source of truth**: Existing Clerk/session/JWT/platform auth remains authoritative. Analytics events never grant access and never replace gateway authorization.
- **Deferred scope**: This does not enable raw console autocapture, terminal input/output capture, source-map release upload, Clerk billing webhooks, paid-trial grace-period deletion, or R2 final-sync enforcement before VPS deletion.