### PR TITLE
fix(terminal): polish shell controls

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2,7 +2,7 @@ import { createHmac, randomBytes } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
-import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS, type MatrixTelemetryEvent } from '@matrix-os/observability';
+import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
 import { createConnection, type Socket } from 'node:net';
 import { connect as createTlsConnection } from 'node:tls';
 import type { IncomingMessage, Server } from 'node:http';
@@ -1759,7 +1759,7 @@ export type PlatformApp = Hono<{
   };
 }> & {
   capturePlatformEvent(
-    event: MatrixTelemetryEvent,
+    event: string,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void;
   shutdownPostHog(): Promise<void>;
@@ -1900,7 +1900,7 @@ export function createApp(deps: {
   });
   const posthogShutdowns: Array<() => Promise<void>> = [() => posthogErrorTracker.shutdown()];
   function capturePlatformEvent(
-    event: MatrixTelemetryEvent,
+    event: string,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void {
     void posthogErrorTracker.captureEvent(event, {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2,7 +2,7 @@ import { createHmac, randomBytes } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
-import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
+import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS, type MatrixTelemetryEvent } from '@matrix-os/observability';
 import { createConnection, type Socket } from 'node:net';
 import { connect as createTlsConnection } from 'node:tls';
 import type { IncomingMessage, Server } from 'node:http';
@@ -1759,7 +1759,7 @@ export type PlatformApp = Hono<{
   };
 }> & {
   capturePlatformEvent(
-    event: string,
+    event: MatrixTelemetryEvent,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void;
   shutdownPostHog(): Promise<void>;
@@ -1900,7 +1900,7 @@ export function createApp(deps: {
   });
   const posthogShutdowns: Array<() => Promise<void>> = [() => posthogErrorTracker.shutdown()];
   function capturePlatformEvent(
-    event: string,
+    event: MatrixTelemetryEvent,
     properties: Record<string, string | number | boolean | null | undefined>,
   ): void {
     void posthogErrorTracker.captureEvent(event, {
@@ -2278,7 +2278,12 @@ export function createApp(deps: {
         jwtSecret: platformJwtSecret,
         platformUrl: platformPublicUrl,
         gatewayUrlForHandle: getGatewayUrlForHandle,
-        captureEvent: capturePlatformEvent,
+        captureEvent: (event, properties) => {
+          capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.CLI_COMMAND_RUN, {
+            auth_event: event,
+            ...properties,
+          });
+        },
       }),
     );
   }

--- a/packages/sync-client/src/cli/commands/completion.ts
+++ b/packages/sync-client/src/cli/commands/completion.ts
@@ -100,7 +100,7 @@ function fishCompletion(): string {
   const shellCommandList = SHELL_COMMANDS.join(" ");
   return `# Matrix CLI completion for fish
 complete -c matrix -f -n '__fish_use_subcommand' -a '${commandList}'
-complete -c matrix -f -n '__fish_seen_subcommand_from shell sh' -a '${shellCommandList}'
+complete -c matrix -f -n '__fish_seen_subcommand_from shell sh; and not __fish_seen_subcommand_from ${SHELL_COMMANDS.join(" ")}' -a '${shellCommandList}'
 complete -c matrix -f -n '__fish_seen_subcommand_from shell sh; and __fish_seen_subcommand_from connect attach rm' -a '(matrix shell list --json 2>/dev/null | tr "," "\\n" | sed -n "s/.*\\"name\\"[[:space:]]*:[[:space:]]*\\"\\\\([^\\"]*\\\\)\\".*/\\\\1/p")'
 `;
 }

--- a/packages/sync-client/src/cli/commands/completion.ts
+++ b/packages/sync-client/src/cli/commands/completion.ts
@@ -30,10 +30,17 @@ const SHELL_COMMANDS = [
 
 function bashCompletion(): string {
   return `# Matrix CLI completion for bash
+_matrix_shell_sessions() {
+  matrix shell list --json 2>/dev/null \\
+    | tr ',' '\\n' \\
+    | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p'
+}
+
 _matrix_completion() {
-  local cur command
+  local cur command shell_command
   cur="\${COMP_WORDS[COMP_CWORD]}"
   command="\${COMP_WORDS[1]}"
+  shell_command="\${COMP_WORDS[2]}"
 
   if [[ "$COMP_CWORD" -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "${COMMANDS.join(" ")}" -- "$cur") )
@@ -41,6 +48,10 @@ _matrix_completion() {
   fi
 
   if [[ "$command" == "shell" || "$command" == "sh" ]]; then
+    if [[ "$COMP_CWORD" -eq 3 && ("$shell_command" == "connect" || "$shell_command" == "attach" || "$shell_command" == "rm") ]]; then
+      COMPREPLY=( $(compgen -W "$(_matrix_shell_sessions)" -- "$cur") )
+      return 0
+    fi
     COMPREPLY=( $(compgen -W "${SHELL_COMMANDS.join(" ")}" -- "$cur") )
     return 0
   fi
@@ -52,8 +63,14 @@ complete -F _matrix_completion matrix
 function zshCompletion(): string {
   return `#compdef matrix
 # Matrix CLI completion for zsh
+_matrix_shell_sessions() {
+  matrix shell list --json 2>/dev/null \\
+    | tr ',' '\\n' \\
+    | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p'
+}
+
 _matrix() {
-  local -a commands shell_commands
+  local -a commands shell_commands shell_sessions
   commands=(${COMMANDS.map((command) => `'${command}:${command}'`).join(" ")})
   shell_commands=(${SHELL_COMMANDS.map((command) => `'${command}:${command}'`).join(" ")})
 
@@ -63,6 +80,11 @@ _matrix() {
   fi
 
   if [[ "\${words[2]}" == "shell" || "\${words[2]}" == "sh" ]]; then
+    if (( CURRENT == 4 )) && [[ "\${words[3]}" == "connect" || "\${words[3]}" == "attach" || "\${words[3]}" == "rm" ]]; then
+      shell_sessions=("\${(@f)$(_matrix_shell_sessions)}")
+      _describe 'matrix shell session' shell_sessions
+      return
+    fi
     _describe 'matrix shell command' shell_commands
     return
   fi
@@ -79,6 +101,7 @@ function fishCompletion(): string {
   return `# Matrix CLI completion for fish
 complete -c matrix -f -n '__fish_use_subcommand' -a '${commandList}'
 complete -c matrix -f -n '__fish_seen_subcommand_from shell sh' -a '${shellCommandList}'
+complete -c matrix -f -n '__fish_seen_subcommand_from shell sh; and __fish_seen_subcommand_from connect attach rm' -a '(matrix shell list --json 2>/dev/null | tr "," "\\n" | sed -n "s/.*\\"name\\"[[:space:]]*:[[:space:]]*\\"\\\\([^\\"]*\\\\)\\".*/\\\\1/p")'
 `;
 }
 

--- a/shell/src/components/terminal/PaneGrid.tsx
+++ b/shell/src/components/terminal/PaneGrid.tsx
@@ -13,9 +13,11 @@ interface PaneGridProps {
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
   shouldDestroyPane?: (paneId: string) => boolean;
+  allowRemoteResize?: boolean;
+  suppressNativeKeyboard?: boolean;
 }
 
-export function PaneGrid({ paneTree, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane }: PaneGridProps) {
+export function PaneGrid({ paneTree, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false }: PaneGridProps) {
   return (
     <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
       <PaneNodeRenderer
@@ -26,6 +28,8 @@ export function PaneGrid({ paneTree, theme, focusedPaneId, onFocusPane, onSessio
         onSessionAttached={onSessionAttached}
         shouldCachePane={shouldCachePane}
         shouldDestroyPane={shouldDestroyPane}
+        allowRemoteResize={allowRemoteResize}
+        suppressNativeKeyboard={suppressNativeKeyboard}
       />
     </div>
   );
@@ -39,9 +43,11 @@ interface PaneNodeRendererProps {
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
   shouldDestroyPane?: (paneId: string) => boolean;
+  allowRemoteResize?: boolean;
+  suppressNativeKeyboard?: boolean;
 }
 
-function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane }: PaneNodeRendererProps) {
+function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false }: PaneNodeRendererProps) {
   if (node.type === "pane") {
     return (
       <div key={node.id} className="h-full w-full min-h-0 min-w-0">
@@ -58,6 +64,8 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAt
           onSessionAttached={onSessionAttached}
           shouldCacheOnUnmount={shouldCachePane}
           shouldDestroyOnUnmount={shouldDestroyPane}
+          allowRemoteResize={allowRemoteResize}
+          suppressNativeKeyboard={suppressNativeKeyboard}
         />
       </div>
     );
@@ -75,6 +83,8 @@ function PaneNodeRenderer({ node, theme, focusedPaneId, onFocusPane, onSessionAt
       onSessionAttached={onSessionAttached}
       shouldCachePane={shouldCachePane}
       shouldDestroyPane={shouldDestroyPane}
+      allowRemoteResize={allowRemoteResize}
+      suppressNativeKeyboard={suppressNativeKeyboard}
     />
   );
 }
@@ -90,9 +100,11 @@ interface SplitContainerProps {
   onSessionAttached?: (paneId: string, sessionId: string) => void;
   shouldCachePane?: (paneId: string) => boolean;
   shouldDestroyPane?: (paneId: string) => boolean;
+  allowRemoteResize?: boolean;
+  suppressNativeKeyboard?: boolean;
 }
 
-function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane }: SplitContainerProps) {
+function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, onFocusPane, onSessionAttached, shouldCachePane, shouldDestroyPane, allowRemoteResize = true, suppressNativeKeyboard = false }: SplitContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentRatio, setCurrentRatio] = useState(ratio);
 
@@ -146,6 +158,8 @@ function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, o
           onSessionAttached={onSessionAttached}
           shouldCachePane={shouldCachePane}
           shouldDestroyPane={shouldDestroyPane}
+          allowRemoteResize={allowRemoteResize}
+          suppressNativeKeyboard={suppressNativeKeyboard}
         />
       </div>
       <div
@@ -162,6 +176,8 @@ function SplitContainer({ direction, ratio, left, right, theme, focusedPaneId, o
           onSessionAttached={onSessionAttached}
           shouldCachePane={shouldCachePane}
           shouldDestroyPane={shouldDestroyPane}
+          allowRemoteResize={allowRemoteResize}
+          suppressNativeKeyboard={suppressNativeKeyboard}
         />
       </div>
     </div>

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -48,10 +48,14 @@ async function copyTextToClipboard(text: string): Promise<void> {
   textarea.style.opacity = "0";
   document.body.appendChild(textarea);
   textarea.select();
+  let ok = false;
   try {
-    document.execCommand("copy");
+    ok = document.execCommand("copy");
   } finally {
     textarea.remove();
+  }
+  if (!ok) {
+    throw new Error("execCommand copy failed");
   }
 }
 

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1283,9 +1283,6 @@ function LocalTerminalSidebar() {
     return (
       <div
         className="absolute left-2 top-2 z-20"
-        style={{
-          position: "absolute",
-        }}
       >
         <button
           className="flex items-center justify-center rounded cursor-pointer hover:bg-[var(--accent)] transition-colors"

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -21,7 +21,7 @@ import { useTerminalSettings } from "@/stores/terminal-settings";
 import { getTerminalThemePreset } from "./terminal-themes";
 import { TerminalPreferencesPanel } from "./preferences-panel";
 import { TerminalKeyBar } from "./TerminalKeyBar";
-import { isCanonicalShellSessionId } from "./TerminalPane";
+import { isCanonicalShellSessionId, isLegacyPtySessionId } from "./TerminalPane";
 import { TERMINAL_INPUT_EVENT, type TerminalInputEventDetail } from "./terminal-input-event";
 
 export { TERMINAL_INPUT_EVENT };
@@ -35,6 +35,24 @@ function dispatchPaneInput(paneId: string | null, data: string): void {
       detail: { paneId, data },
     }),
   );
+}
+
+async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand("copy");
+  } finally {
+    textarea.remove();
+  }
 }
 
 const DEFAULT_CWD = "projects";
@@ -260,6 +278,10 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     const uniqueIds = Array.from(new Set(sessionIds.filter((sessionId) => sessionId.length > 0)));
     for (const sessionId of uniqueIds) {
       const isCanonical = isCanonicalShellSessionId(sessionId);
+      const isLegacyPty = isLegacyPtySessionId(sessionId);
+      if (!isCanonical && !isLegacyPty) {
+        continue;
+      }
       const path = isCanonical
         ? `/api/terminal/sessions/${encodeURIComponent(sessionId)}?force=1`
         : `/api/terminal/pty-sessions/${encodeURIComponent(sessionId)}`;
@@ -683,7 +705,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
     >
       <TerminalAppContext.Provider value={storeApi}>
         <LocalTerminalTabBar defaultCwd={DEFAULT_CWD} />
-        <div className="flex flex-1 min-h-0">
+        <div className="relative flex flex-1 min-h-0">
           {!mobile && <LocalTerminalSidebar />}
           {activeTab ? (
             <div
@@ -699,6 +721,8 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
                   onSessionAttached={handleSessionAttached}
                   shouldCachePane={shouldCachePane}
                   shouldDestroyPane={shouldDestroyPane}
+                  allowRemoteResize={!mobile}
+                  suppressNativeKeyboard={mobile}
                 />
                 {mobile && (
                   <TerminalKeyBar
@@ -913,11 +937,6 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
   const dragIndexRef = useRef<number | null>(null);
 
   const getCwd = () => ctx.sidebarSelectedPath ?? defaultCwd;
-  const activeTab = ctx.tabs.find((tab) => tab.id === ctx.activeTabId);
-  const activePaneId = activeTab ? ctx.focusedPaneId ?? getFirstPaneId(activeTab.paneTree) : null;
-  const activeCwd = activeTab && activePaneId
-    ? getPaneCwd(activeTab.paneTree, activePaneId) ?? defaultCwd
-    : defaultCwd;
 
   return (
     <div
@@ -942,8 +961,6 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
       >
         {ctx.tabs.map((tab, i) => {
           const active = tab.id === ctx.activeTabId;
-          const tabPaneId = getFirstPaneId(tab.paneTree);
-          const tabSessionId = getPaneSessionId(tab.paneTree, tabPaneId);
           return (
             <div
               key={tab.id}
@@ -976,24 +993,10 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
                 }}
               />
               <span
-                className="flex min-w-0 flex-col leading-tight"
+                className="min-w-0 truncate"
                 style={{ overflow: "hidden" }}
               >
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{tab.label}</span>
-                {(ctx.mobile || active) && (
-                  <span
-                    style={{
-                      color: "var(--muted-foreground)",
-                      fontSize: 10,
-                      fontWeight: 400,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      fontFamily: "var(--font-mono, ui-monospace, monospace)",
-                    }}
-                  >
-                    {active ? formatCwd(activeCwd) : tabSessionId ?? formatCwd(getPaneCwd(tab.paneTree, tabPaneId) ?? defaultCwd)}
-                  </span>
-                )}
               </span>
               <button
                 className="cursor-pointer flex items-center justify-center transition-colors"
@@ -1235,7 +1238,9 @@ function LocalTerminalSidebar() {
         return;
       }
       const data = (await res.json()) as { sessions?: WorkspaceSessionSummary[] };
-      setSessions(Array.isArray(data.sessions) ? data.sessions : []);
+      setSessions(Array.isArray(data.sessions)
+        ? data.sessions.filter((session) => typeof session.id === "string" && session.id.length > 0)
+        : []);
     } catch (err: unknown) {
       console.warn("Failed to load workspace sessions:", err instanceof Error ? err.message : err);
       setSessionsError("Could not reach gateway");
@@ -1276,10 +1281,23 @@ function LocalTerminalSidebar() {
 
   if (!ctx.sidebarOpen) {
     return (
-      <div className="flex flex-col items-center py-2 gap-2 shrink-0" style={{ width: 44, background: "var(--card)", borderRight: "1px solid var(--border)" }}>
+      <div
+        className="absolute left-2 top-2 z-20"
+        style={{
+          position: "absolute",
+        }}
+      >
         <button
           className="flex items-center justify-center rounded cursor-pointer hover:bg-[var(--accent)] transition-colors"
-          style={{ width: 30, height: 30, fontSize: 14 }}
+          style={{
+            width: 30,
+            height: 30,
+            fontSize: 14,
+            background: "var(--card)",
+            color: "var(--foreground)",
+            border: "1px solid var(--border)",
+            boxShadow: "0 8px 18px rgba(0,0,0,0.18)",
+          }}
           onClick={() => ctx.setSidebarOpen(true)}
           title="Open sidebar (Ctrl+Shift+B)"
         >
@@ -1361,6 +1379,10 @@ function LocalTerminalSidebar() {
   };
 
   const openWorkspaceTransport = async (session: WorkspaceSessionSummary, mode: "observe" | "takeover") => {
+    if (!session.id) {
+      setSessionsError("Session is missing an id");
+      return;
+    }
     try {
       const res = await fetch(`${getGatewayUrl()}/api/sessions/${encodeURIComponent(session.id)}/${mode}`, {
         method: "POST",
@@ -1752,6 +1774,16 @@ function ShellCard({
       : shell.status === "degraded"
         ? "var(--warning)"
         : "var(--muted-foreground)";
+  const [copied, setCopied] = useState(false);
+  const copyAttachCommand = async () => {
+    try {
+      await copyTextToClipboard(`matrix shell connect ${shell.name}`);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch (err: unknown) {
+      console.warn("Failed to copy shell attach command:", err instanceof Error ? err.message : err);
+    }
+  };
   return (
     <div
       style={{
@@ -1772,17 +1804,26 @@ function ShellCard({
             flexShrink: 0,
           }}
         />
-        <span
+        <button
+          type="button"
+          aria-label={`Copy attach command for ${shell.name}`}
           className="min-w-0 flex-1 truncate"
           style={{
             color: "var(--foreground)",
             fontSize: 12,
             fontWeight: 650,
             fontFamily: "var(--font-mono, ui-monospace, monospace)",
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            textAlign: "left",
+            cursor: "copy",
           }}
+          title={copied ? "Copied" : `Copy: matrix shell connect ${shell.name}`}
+          onClick={() => void copyAttachCommand()}
         >
           {shell.name}
-        </span>
+        </button>
         <span style={{ color: "var(--muted-foreground)", fontSize: 10, whiteSpace: "nowrap" }}>
           {shell.attachedClients ?? 0} attached
         </span>

--- a/shell/src/components/terminal/TerminalKeyBar.tsx
+++ b/shell/src/components/terminal/TerminalKeyBar.tsx
@@ -26,6 +26,7 @@ interface KeyDef {
 const KEYS: KeyDef[] = [
   { label: "Esc", data: "\x1b", primary: true, ariaLabel: "Escape" },
   { label: "Tab", data: "\t", primary: true, ariaLabel: "Tab" },
+  { label: "Enter", data: "\r", primary: true, ariaLabel: "Enter" },
   { label: "Ctrl+C", data: "\x03", primary: true, ariaLabel: "Control C" },
   { label: "↑", data: "\x1b[A", primary: true, ariaLabel: "Up arrow" },
   { label: "↓", data: "\x1b[B", primary: true, ariaLabel: "Down arrow" },
@@ -46,6 +47,21 @@ const KEYS: KeyDef[] = [
   { label: "Ctrl+A", data: "\x01", ariaLabel: "Control A" },
   { label: "Ctrl+E", data: "\x05", ariaLabel: "Control E" },
   { label: "Ctrl+R", data: "\x12", ariaLabel: "Control R" },
+];
+
+const KEYBOARD_ROWS: KeyDef[][] = [
+  "qwertyuiop".split("").map((letter) => ({ label: letter, data: letter, ariaLabel: `letter ${letter}` })),
+  "asdfghjkl".split("").map((letter) => ({ label: letter, data: letter, ariaLabel: `letter ${letter}` })),
+  [
+    ...("zxcvbnm".split("").map((letter) => ({ label: letter, data: letter, ariaLabel: `letter ${letter}` }))),
+    { label: "⌫", data: "\x7f", ariaLabel: "Backspace" },
+  ],
+  [
+    { label: "Space", data: " ", ariaLabel: "Space" },
+    { label: ".", data: "." },
+    { label: "_", data: "_" },
+    { label: "Enter", data: "\r", ariaLabel: "Enter" },
+  ],
 ];
 
 interface TerminalKeyBarProps {
@@ -91,7 +107,7 @@ export function TerminalKeyBar({
   const [expanded, setExpanded] = useState(false);
   const keyboardInset = useVisualViewportKeyboardInset();
 
-  const visible = expanded ? KEYS : KEYS.filter((k) => k.primary);
+  const visible = KEYS.filter((k) => expanded || k.primary);
   const buttonBackground = `color-mix(in srgb, ${foreground} 10%, transparent)`;
   const buttonBorder = `color-mix(in srgb, ${foreground} 18%, transparent)`;
   const mutedForeground = `color-mix(in srgb, ${foreground} 66%, transparent)`;
@@ -105,7 +121,8 @@ export function TerminalKeyBar({
       style={{
         "--matrix-terminal-keybar-bottom": bottomInset,
         display: "flex",
-        alignItems: "center",
+        alignItems: "stretch",
+        flexDirection: "column",
         gap: 4,
         padding: "6px 4px max(6px, env(safe-area-inset-bottom))",
         position: "sticky",
@@ -113,59 +130,122 @@ export function TerminalKeyBar({
         zIndex: 5,
         background,
         borderTop: `1px solid ${buttonBorder}`,
-        overflowX: "auto",
+        overflow: "hidden",
         flexShrink: 0,
-        touchAction: "pan-x",
+        touchAction: "none",
         WebkitOverflowScrolling: "touch",
         boxShadow: `0 -10px 20px color-mix(in srgb, ${background} 70%, transparent)`,
       } as CSSProperties & Record<"--matrix-terminal-keybar-bottom", string>}
     >
-      {visible.map((k) => (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+          overflowX: "auto",
+          WebkitOverflowScrolling: "touch",
+        }}
+      >
+        {visible.map((k) => (
+          <TerminalKeyButton
+            key={k.label}
+            keyDef={k}
+            onSend={onSend}
+            background={buttonBackground}
+            foreground={foreground}
+            border={buttonBorder}
+          />
+        ))}
         <button
-          key={k.label}
           type="button"
-          aria-label={k.ariaLabel ?? k.label}
-          onPointerDown={(e) => {
-            // Send on pointer-down for responsiveness (matches Termius). Block
-            // the default to keep the xterm from losing focus to the bar.
-            e.preventDefault();
-            onSend(k.data);
-          }}
+          aria-label={expanded ? "Show fewer keys" : "Show more keys"}
+          onClick={() => setExpanded((v) => !v)}
           style={{
             fontSize: 13,
-            lineHeight: 1,
             padding: "8px 10px",
-            background: buttonBackground,
-            color: foreground,
-            border: `1px solid ${buttonBorder}`,
+            background: "transparent",
+            color: mutedForeground,
+            border: `1px dashed ${accent}`,
             borderRadius: 6,
             minWidth: 36,
             flexShrink: 0,
-            fontFamily: "var(--font-mono, ui-monospace, monospace)",
-            cursor: "pointer",
+            marginLeft: "auto",
           }}
         >
-          {k.label}
+          {expanded ? "Less" : "More"}
         </button>
-      ))}
-      <button
-        type="button"
-        aria-label={expanded ? "Show fewer keys" : "Show more keys"}
-        onClick={() => setExpanded((v) => !v)}
-        style={{
-          fontSize: 13,
-          padding: "8px 10px",
-          background: "transparent",
-          color: mutedForeground,
-          border: `1px dashed ${accent}`,
-          borderRadius: 6,
-          minWidth: 36,
-          flexShrink: 0,
-          marginLeft: "auto",
-        }}
-      >
-        {expanded ? "Less" : "More"}
-      </button>
+      </div>
+      {expanded && (
+        <div style={{ display: "grid", gap: 4 }}>
+          {KEYBOARD_ROWS.map((row, index) => (
+            <div
+              key={index}
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                gap: 4,
+                minWidth: 0,
+              }}
+            >
+              {row.map((k) => (
+                <TerminalKeyButton
+                  key={k.ariaLabel ?? k.label}
+                  keyDef={k}
+                  onSend={onSend}
+                  background={buttonBackground}
+                  foreground={foreground}
+                  border={buttonBorder}
+                  wide={k.label === "Space"}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
+  );
+}
+
+function TerminalKeyButton({
+  keyDef,
+  onSend,
+  background,
+  foreground,
+  border,
+  wide,
+}: {
+  keyDef: KeyDef;
+  onSend: (data: string) => void;
+  background: string;
+  foreground: string;
+  border: string;
+  wide?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={keyDef.ariaLabel ?? keyDef.label}
+      onPointerDown={(e) => {
+        // Send on pointer-down for responsiveness (matches Termius). Block
+        // the default to keep xterm focus and prevent the native keyboard.
+        e.preventDefault();
+        onSend(keyDef.data);
+      }}
+      style={{
+        fontSize: 13,
+        lineHeight: 1,
+        padding: "8px 10px",
+        background,
+        color: foreground,
+        border: `1px solid ${border}`,
+        borderRadius: 6,
+        minWidth: wide ? 112 : 36,
+        flex: wide ? "0 1 160px" : "0 0 auto",
+        fontFamily: "var(--font-mono, ui-monospace, monospace)",
+        cursor: "pointer",
+      }}
+    >
+      {keyDef.label}
+    </button>
   );
 }

--- a/shell/src/components/terminal/TerminalKeyBar.tsx
+++ b/shell/src/components/terminal/TerminalKeyBar.tsx
@@ -60,7 +60,6 @@ const KEYBOARD_ROWS: KeyDef[][] = [
     { label: "Space", data: " ", ariaLabel: "Space" },
     { label: ".", data: "." },
     { label: "_", data: "_" },
-    { label: "Enter", data: "\r", ariaLabel: "Enter" },
   ],
 ];
 

--- a/shell/src/components/terminal/TerminalKeyBar.tsx
+++ b/shell/src/components/terminal/TerminalKeyBar.tsx
@@ -143,6 +143,7 @@ export function TerminalKeyBar({
           gap: 4,
           overflowX: "auto",
           WebkitOverflowScrolling: "touch",
+          touchAction: "pan-x",
         }}
       >
         {visible.map((k) => (

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -67,12 +67,6 @@ function buildTerminalFontStack(fontFamily: TerminalFontFamily, themeMono: strin
   return `${TERMINAL_FONT_STACKS[fontFamily]}, ${fallback}`;
 }
 
-function displayCwd(cwd: string): string {
-  if (cwd === "projects") return "~/projects";
-  if (cwd.startsWith("projects/")) return `~/${cwd}`;
-  return cwd;
-}
-
 type TerminalServerMessage =
   | { type: "attached"; sessionId: string; state: "running" | "exited"; exitCode: number | null }
   | { type: "output"; data: string; seq: number | null }
@@ -215,6 +209,19 @@ function terminalDebug(event: string, details: Record<string, unknown>): void {
   console.info("[terminal-debug][pane]", event, details);
 }
 
+function suppressXtermNativeKeyboard(container: HTMLElement): void {
+  const helper = container.querySelector("textarea.xterm-helper-textarea");
+  if (!(helper instanceof HTMLTextAreaElement)) {
+    return;
+  }
+  helper.inputMode = "none";
+  helper.readOnly = true;
+  helper.autocomplete = "off";
+  helper.autocapitalize = "none";
+  helper.spellcheck = false;
+  helper.setAttribute("aria-hidden", "true");
+}
+
 function describeReadyState(ws: WebSocket | null): string {
   if (!ws) {
     return "null";
@@ -247,6 +254,8 @@ interface TerminalPaneProps {
   isClosing?: boolean;
   shouldCacheOnUnmount?: (paneId: string) => boolean;
   shouldDestroyOnUnmount?: (paneId: string) => boolean;
+  allowRemoteResize?: boolean;
+  suppressNativeKeyboard?: boolean;
 }
 
 export function TerminalPane({
@@ -262,6 +271,8 @@ export function TerminalPane({
   isClosing,
   shouldCacheOnUnmount,
   shouldDestroyOnUnmount,
+  allowRemoteResize = true,
+  suppressNativeKeyboard = false,
 }: TerminalPaneProps) {
   const terminalThemeId = useTerminalSettings((s) => s.themeId);
   const terminalFontSize = useTerminalSettings((s) => s.fontSize);
@@ -279,6 +290,7 @@ export function TerminalPane({
   const lastSeqRef = useRef<number>(0);
   const reconnectAttemptRef = useRef<number>(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingReconnectBannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectLinesWrittenRef = useRef<number>(0);
   const onSessionAttachedRef = useRef(onSessionAttached);
   const shouldCacheOnUnmountRef = useRef(shouldCacheOnUnmount);
@@ -297,11 +309,13 @@ export function TerminalPane({
   const isClosingRef = useRef(false);
   const heartbeatRef = useRef<ReturnType<typeof createSocketHealth> | null>(null);
   const isFocusedRef = useRef(isFocused);
+  const allowRemoteResizeRef = useRef(allowRemoteResize);
 
   onSessionAttachedRef.current = onSessionAttached;
   shouldCacheOnUnmountRef.current = shouldCacheOnUnmount;
   shouldDestroyOnUnmountRef.current = shouldDestroyOnUnmount;
   isFocusedRef.current = isFocused;
+  allowRemoteResizeRef.current = allowRemoteResize;
 
   const handleFocus = useCallback(() => {
     onFocus?.(paneId);
@@ -360,6 +374,13 @@ export function TerminalPane({
         if (reconnectTimerRef.current) {
           clearTimeout(reconnectTimerRef.current);
           reconnectTimerRef.current = null;
+        }
+      };
+
+      const clearPendingReconnectBanner = () => {
+        if (pendingReconnectBannerTimerRef.current) {
+          clearTimeout(pendingReconnectBannerTimerRef.current);
+          pendingReconnectBannerTimerRef.current = null;
         }
       };
 
@@ -424,6 +445,9 @@ export function TerminalPane({
           termElement.style.width = "100%";
           termElement.style.height = "100%";
           container.appendChild(termElement);
+          if (suppressNativeKeyboard) {
+            suppressXtermNativeKeyboard(container);
+          }
         }
         term = cached.terminal;
         fitAddon = cached.fitAddon;
@@ -465,6 +489,9 @@ export function TerminalPane({
         const nextFitAddon = new FitAddon();
         xterm.loadAddon(nextFitAddon);
         xterm.open(container);
+        if (suppressNativeKeyboard) {
+          suppressXtermNativeKeyboard(container);
+        }
         const xtermElement = (xterm as { element?: HTMLElement }).element;
         if (xtermElement) {
           xtermElement.style.width = "100%";
@@ -589,7 +616,9 @@ export function TerminalPane({
             fromSeq: lastSeqRef.current,
           });
           if (isCanonicalShellSession) {
-            ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+            if (allowRemoteResizeRef.current) {
+              ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+            }
             return;
           }
           if (currentSessionId) {
@@ -602,7 +631,9 @@ export function TerminalPane({
             ws.send(JSON.stringify({ type: "attach", cwd }));
           }
 
-          ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+          if (allowRemoteResizeRef.current) {
+            ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+          }
 
           const startup = sessionIdRef.current
             ? null
@@ -619,6 +650,7 @@ export function TerminalPane({
         ws.onopen = () => {
           reconnectAttemptRef.current = 0;
           clearReconnectTimer();
+          clearPendingReconnectBanner();
           if (reconnectLinesWrittenRef.current > 0) {
             // Erase the "[Reconnecting in Ns...]" lines we appended while
             // disconnected so the scrollback stays clean after recovery.
@@ -674,8 +706,14 @@ export function TerminalPane({
             const delay = Math.pow(2, attempt) * 1000; // 1s, 2s, 4s
             reconnectAttemptRef.current = attempt + 1;
             log("schedule-reconnect", { delayMs: delay, nextAttempt: reconnectAttemptRef.current });
-            term.write(`\r\n\x1b[33m[Reconnecting in ${delay / 1000}s...]\x1b[0m\r\n`);
-            reconnectLinesWrittenRef.current += 2;
+            clearPendingReconnectBanner();
+            pendingReconnectBannerTimerRef.current = setTimeout(() => {
+              pendingReconnectBannerTimerRef.current = null;
+              if (!disposed && !isClosingRef.current && wsRef.current?.readyState !== WebSocket.OPEN) {
+                term.write(`\r\n\x1b[33m[Reconnecting in ${delay / 1000}s...]\x1b[0m\r\n`);
+                reconnectLinesWrittenRef.current += 2;
+              }
+            }, 750);
             reconnectTimerRef.current = setTimeout(() => {
               reconnectTimerRef.current = null;
               if (!disposed && !isClosingRef.current) {
@@ -884,6 +922,9 @@ export function TerminalPane({
 
       onResizeDisposableRef.current?.dispose();
       onResizeDisposableRef.current = term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
+        if (!allowRemoteResizeRef.current) {
+          return;
+        }
         const ws = wsRef.current;
         if (ws && ws.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: "resize", cols, rows }));
@@ -981,6 +1022,7 @@ export function TerminalPane({
         resizeObserver.disconnect();
         clearAuthDetectTimer();
         clearReconnectTimer();
+        clearPendingReconnectBanner();
         heartbeatRef.current?.stop();
         detachWebglContextLostHandler();
         onDataDisposableRef.current?.dispose();
@@ -1047,7 +1089,9 @@ export function TerminalPane({
   }, [
     claudeMode,
     cwd,
+    allowRemoteResize,
     paneId,
+    suppressNativeKeyboard,
   ]);
 
   useEffect(() => {
@@ -1103,21 +1147,6 @@ export function TerminalPane({
       onPointerDown={handleFocus}
       onClick={handleFocus}
     >
-      <div
-        aria-hidden
-        className="pointer-events-none absolute left-2 top-1 z-10 flex items-center gap-1 rounded bg-background/80 px-1.5 py-0.5 font-mono text-[10px] leading-none text-foreground shadow-sm backdrop-blur-sm"
-      >
-        <span>{displayCwd(cwd)}</span>
-        <span
-          className={isFocused ? "opacity-100" : "opacity-45"}
-          style={{
-            display: "inline-block",
-            width: 5,
-            height: 10,
-            background: "currentColor",
-          }}
-        />
-      </div>
       {authUrl && (
         <div
           style={{

--- a/shell/src/hooks/useTaskBoard.ts
+++ b/shell/src/hooks/useTaskBoard.ts
@@ -51,11 +51,15 @@ export function useTaskBoard() {
   useEffect(() => {
     fetch(`${GATEWAY_URL}/api/tasks`, { signal: AbortSignal.timeout(10_000) })
       .then((res) => res.json())
-      .then((data: TaskItem[]) => {
+      .then((data: unknown) => {
+        if (!Array.isArray(data)) {
+          setTasks([]);
+          return;
+        }
         setTasks(
           data.map((t) => ({
-            ...t,
-            appName: parseAppName(t.input),
+            ...(t as TaskItem),
+            appName: parseAppName((t as TaskItem).input),
           })),
         );
       })

--- a/tests/cli/unified-command-tree.test.ts
+++ b/tests/cli/unified-command-tree.test.ts
@@ -82,4 +82,21 @@ describe("unified CLI command tree", () => {
     expect(script).toContain("matrix shell list --json");
     expect(script).toContain('"connect" || "$shell_command" == "attach" || "$shell_command" == "rm"');
   });
+
+  it("prevents fish shell command completions from mixing with session completions", async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (line?: unknown) => {
+      logs.push(String(line));
+    };
+    try {
+      await completionCommand.run?.({ args: { shell: "fish" } } as never);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const script = logs.join("\n");
+    expect(script).toContain("and not __fish_seen_subcommand_from list ls new connect attach rm tab pane layout");
+    expect(script).toContain("__fish_seen_subcommand_from connect attach rm");
+  });
 });

--- a/tests/cli/unified-command-tree.test.ts
+++ b/tests/cli/unified-command-tree.test.ts
@@ -64,4 +64,22 @@ describe("unified CLI command tree", () => {
     expect(logs.join("\n")).toContain("connect");
     expect(logs.join("\n")).not.toContain("ssh");
   });
+
+  it("prints dynamic shell session completion for attach/connect/rm", async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (line?: unknown) => {
+      logs.push(String(line));
+    };
+    try {
+      await completionCommand.run?.({ args: { shell: "bash" } } as never);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const script = logs.join("\n");
+    expect(script).toContain("_matrix_shell_sessions");
+    expect(script).toContain("matrix shell list --json");
+    expect(script).toContain('"connect" || "$shell_command" == "attach" || "$shell_command" == "rm"');
+  });
 });

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -543,7 +543,8 @@ describe("PostHog error tracking", () => {
     expect(platformAuthRoutes).toContain('"cli_device_code_created"');
     expect(platformAuthRoutes).toContain('"cli_device_token_issued"');
     expect(platformAuthRoutes).toContain('"cli_runtime_lookup_resolved"');
-    expect(platformMain).toContain("captureEvent: capturePlatformEvent");
+    expect(platformMain).toContain("MATRIX_TELEMETRY_EVENTS.CLI_COMMAND_RUN");
+    expect(platformMain).toContain("auth_event: event");
     expect(gatewayServer).not.toContain('captureGatewayProductEvent("terminal_input"');
     expect(gatewayServer).not.toContain('captureGatewayProductEvent("message_text"');
   });

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -13,6 +13,22 @@ vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
   TerminalApp: () => <div data-testid="terminal-app" />,
 }));
 
+vi.mock("@clerk/nextjs", () => ({
+  PricingTable: () => <div data-testid="pricing-table" />,
+  useAuth: () => ({
+    isLoaded: true,
+    isSignedIn: true,
+    has: () => false,
+  }),
+  UserButton: Object.assign(
+    ({ children }: { children?: React.ReactNode }) => <div data-testid="clerk-user-button">{children}</div>,
+    {
+      MenuItems: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+      Link: ({ href, label }: { href: string; label: string; labelIcon?: React.ReactElement }) => <a href={href}>{label}</a>,
+    },
+  ),
+}));
+
 vi.mock("@/hooks/useTheme", () => ({
   DEFAULT_THEME: {
     name: "test",

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -95,7 +95,7 @@ describe("TerminalApp", () => {
     });
   });
 
-  it("keeps the active cwd visible in the mobile terminal chrome", async () => {
+  it("keeps the mobile terminal chrome clear of cwd badges that overlap zellij tabs", async () => {
     render(<TerminalApp mobile />);
 
     await act(async () => {
@@ -103,7 +103,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByText("~/projects")).toBeTruthy();
+    expect(screen.queryByText("~/projects")).toBeNull();
     expect(screen.getByTitle("New tab (Ctrl+Shift+T)")).toBeTruthy();
   });
 
@@ -121,6 +121,82 @@ describe("TerminalApp", () => {
     expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("env(keyboard-inset-height, 0px)");
     expect(keyBar.style.background).toContain("16, 24, 32");
     expect(screen.getByRole("button", { name: "Control C" }).style.color).toContain("240, 239, 231");
+    expect(screen.getByRole("button", { name: "Enter" })).toBeTruthy();
+  });
+
+  it("does not let mobile terminal clients take ownership of the remote zellij size", async () => {
+    render(<TerminalApp mobile />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      allowRemoteResize: false,
+      suppressNativeKeyboard: true,
+    });
+  });
+
+  it("fully removes the sidebar from layout flow when hidden", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTitle("Hide sidebar (Ctrl+Shift+B)"));
+
+    const openButton = screen.getByTitle("Open sidebar (Ctrl+Shift+B)");
+    expect(openButton.parentElement?.style.position).toBe("absolute");
+    expect(openButton.parentElement?.style.width).not.toBe("44px");
+  });
+
+  it("copies a local CLI attach command when clicking a shell session name", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ sessions: [{ name: "main", status: "active", attachedClients: 1, tabs: [] }] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Shells" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy attach command for main" }));
+      await Promise.resolve();
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("matrix shell connect main");
   });
 
   it("does not persist the mobile-forced sidebar state into shared terminal layout", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -149,7 +149,7 @@ describe("TerminalApp", () => {
     fireEvent.click(screen.getByTitle("Hide sidebar (Ctrl+Shift+B)"));
 
     const openButton = screen.getByTitle("Open sidebar (Ctrl+Shift+B)");
-    expect(openButton.parentElement?.style.position).toBe("absolute");
+    expect(openButton.parentElement?.className).toContain("absolute");
     expect(openButton.parentElement?.style.width).not.toBe("44px");
   });
 

--- a/tests/shell/terminal-keybar.test.tsx
+++ b/tests/shell/terminal-keybar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TerminalKeyBar } from "../../shell/src/components/terminal/TerminalKeyBar.js";
 
@@ -66,5 +66,26 @@ describe("TerminalKeyBar", () => {
     });
 
     expect(keyBar.style.getPropertyValue("--matrix-terminal-keybar-bottom")).toBe("env(keyboard-inset-height, 0px)");
+  });
+
+  it("sends enter from the primary mobile key row", () => {
+    const onSend = vi.fn();
+
+    render(<TerminalKeyBar onSend={onSend} />);
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Enter" }));
+
+    expect(onSend).toHaveBeenCalledWith("\r");
+  });
+
+  it("shows a full English keyboard when expanded", () => {
+    render(<TerminalKeyBar onSend={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more keys" }));
+
+    expect(screen.getByRole("button", { name: "letter q" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "letter m" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Space" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Backspace" })).toBeTruthy();
   });
 });

--- a/tests/shell/terminal-keybar.test.tsx
+++ b/tests/shell/terminal-keybar.test.tsx
@@ -87,5 +87,6 @@ describe("TerminalKeyBar", () => {
     expect(screen.getByRole("button", { name: "letter m" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Space" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Backspace" })).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "Enter" })).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- make the terminal sidebar close out of layout flow and let shell names copy `matrix shell connect <name>`
- stop mobile terminal clients from resizing the shared zellij session, suppress native mobile keyboard, add Enter plus an expanded English key layout
- remove terminal cwd badges that overlap zellij tabs, delay reconnect banners for transient reconnects, and ignore invalid session ids on close
- add dynamic shell-session completions for `matrix shell connect|attach|rm`

## Tests
- `pnpm exec vitest run tests/shell/terminal-keybar.test.tsx tests/shell/terminal-app-component.test.tsx`
- `pnpm exec vitest run tests/cli/unified-command-tree.test.ts`
- `pnpm --filter shell build` reached and finished TypeScript, then failed during prerender because this worktree has no Clerk publishable key configured

## Invariants
- Source of truth: terminal session existence remains the canonical gateway/zellij session API; UI changes only consume and display it.
- Resize ownership: desktop clients can resize remote sessions; mobile clients fit locally without shrinking the shared zellij session.
- Deferred scope: the 401 boot-time auth noise needs platform/shell auth-token sequencing work; this PR only removes terminal/session UI noise and the task-board error-envelope map crash.