### PR TITLE
fix(apps): require shipped default app icons

### DIFF
--- a/home/apps/profile/matrix.json
+++ b/home/apps/profile/matrix.json
@@ -3,6 +3,7 @@
   "description": "Your Matrix profile page",
   "runtime": "vite",
   "category": "social",
+  "icon": "profile",
   "version": "1.0.0",
   "slug": "profile",
   "runtimeVersion": "^1.0.0",

--- a/shell/src/lib/error-boundary-utils.ts
+++ b/shell/src/lib/error-boundary-utils.ts
@@ -16,7 +16,8 @@ export function describeUnknownError(error: unknown): string {
   if (error instanceof globalThis.Error) return `${error.name}: ${error.message}`;
   try {
     return String(error);
-  } catch {
+  } catch (stringifyError) {
+    if (stringifyError instanceof globalThis.Error) return stringifyError.name;
     return typeof error;
   }
 }

--- a/shell/src/lib/error-boundary-utils.ts
+++ b/shell/src/lib/error-boundary-utils.ts
@@ -17,7 +17,7 @@ export function describeUnknownError(error: unknown): string {
   try {
     return String(error);
   } catch (stringifyError) {
-    if (stringifyError instanceof globalThis.Error) return stringifyError.name;
+    void stringifyError;
     return typeof error;
   }
 }

--- a/tests/gateway/apps.test.ts
+++ b/tests/gateway/apps.test.ts
@@ -262,7 +262,7 @@ describe("T711: GET /api/apps", () => {
     expect(names).toContain("Timer");
   });
 
-  it("ships icons for every default app manifest", () => {
+  it("requires every default app manifest to declare a shipped icon", () => {
     const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
     const appsRoot = join(repoRoot, "home/apps");
     const iconsRoot = join(repoRoot, "home/system/icons");
@@ -287,7 +287,9 @@ describe("T711: GET /api/apps", () => {
           continue;
         }
         const manifest = JSON.parse(readFileSync(fullPath, "utf8")) as { icon?: unknown };
-        if (typeof manifest.icon === "string" && !shippedIcons.has(manifest.icon)) {
+        if (typeof manifest.icon !== "string") {
+          missing.push(`${fullPath.replace(`${repoRoot}/`, "")}: missing icon`);
+        } else if (!shippedIcons.has(manifest.icon)) {
           missing.push(`${fullPath.replace(`${repoRoot}/`, "")}: ${manifest.icon}`);
         }
       }

--- a/tests/shell/error-boundary-utils.test.ts
+++ b/tests/shell/error-boundary-utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { describeUnknownError } from "../../shell/src/lib/error-boundary-utils";
+
+describe("describeUnknownError", () => {
+  it("falls back to the original value type when string coercion throws", () => {
+    const errorLikeValue = {
+      [Symbol.toPrimitive]() {
+        throw new TypeError("string coercion failed");
+      },
+    };
+
+    expect(describeUnknownError(errorLikeValue)).toBe("object");
+  });
+});


### PR DESCRIPTION
## Summary

- Add the Profile default app manifest icon mapping to the committed `profile` asset.
- Tighten default app manifest validation so missing `icon` fields fail, not only unknown icon strings.
- Keep `describeUnknownError` fallback diagnostics tied to the original value type when string coercion itself throws, with a regression test for the Greptile feedback item.

## Tests

- `node scripts/build-default-apps.mjs home/apps`
- `bun run test -- tests/gateway/apps.test.ts tests/gateway/default-icons.test.ts tests/shell/error-boundary-utils.test.ts`
- `bun run test -- tests/shell/error-boundary-utils.test.ts`
- `bun run typecheck`
- `bun run check:patterns` (warnings only)
- `bun run test`

## Generic Icons Retained

- `home/apps/games/**` default game manifests intentionally continue to use the shared `game-center` icon.
- `home/apps/symphony/matrix.json` intentionally continues to use the existing shared `code` icon.

## Invariants

- **Source of truth:** default app `matrix.json` icon slugs are canonical for launch metadata, and committed files under `home/system/icons/` are canonical for shipped icon assets.
- **Lock/transaction scope:** no database writes, filesystem mutations at runtime, or critical sections are introduced.
- **Acceptable orphan states:** no new orphan runtime state is possible; a manifest referencing a missing or absent icon now fails the app manifest test before shipping.
- **Auth source of truth:** unchanged; icon asset resolution continues through the existing gateway/shell paths.
- **Deferred scope:** no new icon generation system, Gemini regeneration changes, route behavior changes, or non-icon default app behavior changes.