### PR TITLE
ci(screenshots): bound screenshot workflow steps

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -25,6 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Decide whether screenshots are needed
+        timeout-minutes: 2
         id: screenshots
         uses: actions/github-script@v9
         with:
@@ -107,6 +108,7 @@ jobs:
 
       - name: Run Playwright tests
         if: steps.screenshots.outputs.should_run == 'true'
+        timeout-minutes: 15
         run: cd shell && pnpm exec playwright test --update-snapshots
 
       - name: Upload test artifacts


### PR DESCRIPTION
## Summary

- Add a 2-minute timeout to the screenshot workflow decision step so skip/no-screenshot paths cannot hang on PR metadata lookup.
- Add a 15-minute timeout to the Playwright screenshot generation step while preserving the existing 20-minute screenshot job timeout and upload/commit behavior.

## Validation

Exact workflow timeout assertion:

```bash
node --input-type=module - <<'NODE'
import fs from 'node:fs';
import YAML from 'yaml';
const workflow = YAML.parse(fs.readFileSync('.github/workflows/screenshots.yml', 'utf8'));
const screenshotJobs = Object.entries(workflow.jobs ?? {}).filter(([name]) => /screenshot/i.test(name));
if (screenshotJobs.length === 0) throw new Error('No screenshot jobs found');
for (const [name, job] of screenshotJobs) {
  if (!Number.isInteger(job['timeout-minutes'])) throw new Error(`${name} missing job timeout-minutes`);
}
const steps = workflow.jobs.screenshots.steps;
const requiredStepTimeouts = new Map([
  ['Decide whether screenshots are needed', 2],
  ['Install Playwright Chromium', 5],
  ['Run Playwright tests', 15],
]);
for (const [name, expected] of requiredStepTimeouts) {
  const step = steps.find((candidate) => candidate.name === name);
  if (!step) throw new Error(`Missing step: ${name}`);
  if (step['timeout-minutes'] !== expected) {
    throw new Error(`${name} timeout-minutes expected ${expected}, got ${step['timeout-minutes']}`);
  }
}
console.log(`ok: ${screenshotJobs.length} screenshot job(s) have job timeouts and required step timeouts`);
NODE
```

Outcome: passed, `ok: 1 screenshot job(s) have job timeouts and required step timeouts`.

Workflow lint/check availability:

```bash
node - <<'NODE'
const fs = require('node:fs');
const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
const matches = Object.entries(pkg.scripts || {}).filter(([name, command]) => /actionlint|yamllint|workflow/i.test(`${name} ${command}`));
if (matches.length === 0) {
  console.log('no package.json GitHub Actions workflow lint/check script found');
} else {
  for (const [name, command] of matches) console.log(`${name}: ${command}`);
}
NODE
```

Outcome: passed, `no package.json GitHub Actions workflow lint/check script found`.

```bash
command -v actionlint || true
```

Outcome: no output; `actionlint` is not installed locally.

Additional validation:

- `git diff --check` -> passed.
- `bun run typecheck` -> passed.
- `bun run check:patterns:diff` -> passed, `No TypeScript files changed vs main.`
- `bun run test` -> passed, 480 files passed, 1 skipped; 5137 tests passed, 1 skipped.

Pre-existing validation debt observed:

- `bun run check:patterns` -> failed on pre-existing `shell/src/lib/error-boundary-utils.ts:19` bare `catch {}` outside this workflow-only diff. The PR CI pattern job uses `./scripts/review/check-patterns.sh --diff origin/${{ github.base_ref }}` for pull requests; the equivalent local diff scan passed.

## Invariants

- Source of truth: `.github/workflows/screenshots.yml` remains the canonical screenshot CI workflow.
- Lock/transaction scope: not applicable; no backend writes, database transactions, or runtime state changes.
- Acceptable orphan states: unchanged; failed screenshot generation still follows the existing artifact upload and failure behavior.
- Auth source of truth: unchanged GitHub Actions PR context and existing workflow permissions.
- Deferred scope: no unrelated CI cleanup, no screenshot test behavior changes, and no changes to snapshot upload/commit paths.
