### PR TITLE
fix(shell): lift checkout and consent overlays

### DIFF
--- a/packages/observability/src/client.ts
+++ b/packages/observability/src/client.ts
@@ -92,7 +92,7 @@ export function getPostHogVisitorCountry(headers: HeadersLike): string | null {
 
 export function requiresPostHogCookieConsent(countryCode: string | null | undefined): boolean {
   const country = normalizeCountryCode(countryCode);
-  return country ? POSTHOG_COOKIE_CONSENT_COUNTRIES.has(country) : false;
+  return country ? POSTHOG_COOKIE_CONSENT_COUNTRIES.has(country) : true;
 }
 
 export function buildPostHogCookieConsentInitOptions(

--- a/shell/instrumentation-client.ts
+++ b/shell/instrumentation-client.ts
@@ -1,28 +1,3 @@
-import posthog from "posthog-js";
-import {
-  buildPostHogCookieConsentInitOptions,
-  getPostHogClientConfig,
-  resolvePostHogClientApiHost,
-} from "@matrix-os/observability/client";
+import { initializeShellPostHog } from "./src/lib/posthog-client";
 
-type PostHogInitOptions = Parameters<typeof posthog.init>[1];
-
-const config = getPostHogClientConfig({
-  NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
-  NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
-  NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
-});
-
-if (config) {
-  posthog.init(config.token, {
-    // Shell has no local PostHog /ingest proxy, so an unset api_host lets
-    // posthog-js use its default endpoint.
-    api_host: resolvePostHogClientApiHost(config, { allowRelativeApiHost: false }),
-    ui_host: config.uiHost,
-    defaults: "2026-01-30",
-    capture_exceptions: true,
-    debug: process.env.NODE_ENV === "development",
-    ...buildPostHogCookieConsentInitOptions(document.documentElement.dataset.posthogVisitorCountry),
-  } as PostHogInitOptions);
-}
+initializeShellPostHog(document.documentElement.dataset.posthogVisitorCountry);

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -222,6 +222,7 @@ function CheckoutPanel({
   telemetryProperties: BillingTelemetryProperties;
 }) {
   const checkoutTelemetryKey = `${redirectUrl ? "redirect" : "pending"}:${shouldRenderClerkPricing ? "clerk" : "fallback"}`;
+  const redirectUrlRef = useRef(redirectUrl);
   const telemetryPropertiesRef = useRef(telemetryProperties);
 
   useEffect(() => {
@@ -229,15 +230,20 @@ function CheckoutPanel({
   }, [telemetryProperties]);
 
   useEffect(() => {
+    redirectUrlRef.current = redirectUrl;
+  }, [redirectUrl]);
+
+  useEffect(() => {
+    const currentRedirectUrl = redirectUrlRef.current;
     captureBillingTelemetry(
-      redirectUrl && shouldRenderClerkPricing
+      currentRedirectUrl && shouldRenderClerkPricing
         ? "checkout_pricing_table_available"
-        : redirectUrl
+        : currentRedirectUrl
           ? "checkout_local_preview_unavailable"
           : "checkout_redirect_pending",
       telemetryPropertiesRef.current,
     );
-  }, [checkoutTelemetryKey, redirectUrl]);
+  }, [checkoutTelemetryKey]);
 
   return (
     <div

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -33,6 +33,27 @@ const shouldRenderClerkPricing =
 
 export type BillingPanelMode = "settings" | "provisioning";
 
+const CHECKOUT_OVERLAY_Z_INDEX = 10_000;
+const checkoutOverlayAppearance = {
+  elements: {
+    drawerBackdrop: {
+      zIndex: CHECKOUT_OVERLAY_Z_INDEX,
+    },
+    drawerRoot: {
+      zIndex: CHECKOUT_OVERLAY_Z_INDEX + 1,
+    },
+    drawerContent: {
+      zIndex: CHECKOUT_OVERLAY_Z_INDEX + 1,
+    },
+    modalBackdrop: {
+      zIndex: CHECKOUT_OVERLAY_Z_INDEX,
+    },
+    modalContent: {
+      zIndex: CHECKOUT_OVERLAY_Z_INDEX + 1,
+    },
+  },
+};
+
 const profileLabels = ["Starter", "Recommended", "Scale"] as const;
 
 type BillingTelemetryProperties = {
@@ -216,7 +237,7 @@ function CheckoutPanel({
           : "checkout_redirect_pending",
       telemetryPropertiesRef.current,
     );
-  }, [checkoutTelemetryKey]);
+  }, [checkoutTelemetryKey, redirectUrl]);
 
   return (
     <div
@@ -237,6 +258,7 @@ function CheckoutPanel({
           <PricingTable
             for="user"
             newSubscriptionRedirectUrl={redirectUrl}
+            checkoutProps={{ appearance: checkoutOverlayAppearance }}
             fallback={<BillingTableFallback />}
           />
         </BillingTableBoundary>

--- a/shell/src/lib/billing.ts
+++ b/shell/src/lib/billing.ts
@@ -1,6 +1,11 @@
 import type { useAuth } from "@clerk/nextjs";
 
-export const MATRIX_BILLING_PLAN_SLUGS = ["early_adopter"] as const;
+export const MATRIX_BILLING_PLAN_SLUGS = [
+  "matrix_starter",
+  "matrix_builder",
+  "matrix_max",
+  "early_adopter",
+] as const;
 export const MATRIX_BILLING_RETURN_PATH = "/";
 export const MATRIX_BILLING_SUCCESS_RETURN_PATH = "/?checkout=success";
 export const MATRIX_BILLING_DEFAULT_APP_URL = "https://app.matrix-os.com";

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -12,6 +12,7 @@ type PostHogLogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 type PostHogWithLogger = typeof posthog & {
   logger?: Partial<Record<PostHogLogLevel, (message: string, properties?: Record<string, string | number | boolean>) => void>>;
 };
+type PostHogLoadState = typeof posthog & { __loaded?: boolean };
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -20,6 +21,7 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
 });
 let initialized = false;
+const posthogClient = posthog as PostHogLoadState;
 
 export function capturePostHogException(error: unknown, properties: ClientProperties = {}) {
   if (!config) return;
@@ -66,7 +68,10 @@ export function capturePostHogLog(
 }
 
 function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
-  if (initialized) return;
+  if (initialized || posthogClient.__loaded) {
+    initialized = true;
+    return;
+  }
   const apiHost = resolvePostHogClientApiHost(currentConfig, { allowRelativeApiHost: false });
   posthog.init(currentConfig.token, {
     ...(apiHost ? { api_host: apiHost } : {}),

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -2,6 +2,7 @@
 
 import posthog from "posthog-js";
 import {
+  buildPostHogCookieConsentInitOptions,
   getPostHogClientConfig,
   resolvePostHogClientApiHost,
 } from "@matrix-os/observability/client";
@@ -12,7 +13,6 @@ type PostHogLogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 type PostHogWithLogger = typeof posthog & {
   logger?: Partial<Record<PostHogLogLevel, (message: string, properties?: Record<string, string | number | boolean>) => void>>;
 };
-type PostHogLoadState = typeof posthog & { __loaded?: boolean };
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -21,7 +21,6 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
 });
 let initialized = false;
-const posthogClient = posthog as PostHogLoadState;
 
 export function capturePostHogException(error: unknown, properties: ClientProperties = {}) {
   if (!config) return;
@@ -68,12 +67,18 @@ export function capturePostHogLog(
 }
 
 function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
-  if (initialized || posthogClient.__loaded) {
-    initialized = true;
-    return;
-  }
+  initializeShellPostHog(getPostHogVisitorCountry(), currentConfig);
+}
+
+export function initializeShellPostHog(
+  visitorCountry?: string | null,
+  currentConfig: typeof config = config,
+) {
+  if (!currentConfig || initialized) return;
   const apiHost = resolvePostHogClientApiHost(currentConfig, { allowRelativeApiHost: false });
   posthog.init(currentConfig.token, {
+    // Shell has no local PostHog /ingest proxy, so an unset api_host lets
+    // posthog-js use its default endpoint.
     ...(apiHost ? { api_host: apiHost } : {}),
     ui_host: currentConfig.uiHost,
     defaults: "2026-01-30",
@@ -85,8 +90,14 @@ function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
       environment: process.env.NODE_ENV,
       serviceVersion: process.env.NEXT_PUBLIC_MATRIX_BUILD_SHA,
     },
+    ...buildPostHogCookieConsentInitOptions(visitorCountry),
   } as PostHogInitOptions);
   initialized = true;
+}
+
+function getPostHogVisitorCountry(): string | null {
+  if (typeof document === "undefined") return null;
+  return document.documentElement.dataset.posthogVisitorCountry ?? null;
 }
 
 function sanitizeProperties(properties: ClientProperties): Record<string, string | number | boolean> {

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -59,8 +59,8 @@ describe("PostHog error tracking", () => {
       "https://eu.i.posthog.com",
     );
 
-    const shellClient = await readFile("shell/instrumentation-client.ts", "utf8");
-    const wwwClient = await readFile("www/instrumentation-client.ts", "utf8");
+    const shellClient = await readFile("shell/src/lib/posthog-client.ts", "utf8");
+    const wwwClient = await readFile("www/src/lib/posthog-client.ts", "utf8");
     expect(shellClient).toContain("resolvePostHogClientApiHost");
     expect(shellClient).toContain("allowRelativeApiHost: false");
     expect(shellClient).toContain("buildPostHogCookieConsentInitOptions");
@@ -451,9 +451,7 @@ describe("PostHog error tracking", () => {
 
   it("uses explicit public env references in Next client PostHog entrypoints", async () => {
     const clientEntrypoints = [
-      "shell/instrumentation-client.ts",
       "shell/src/lib/posthog-client.ts",
-      "www/instrumentation-client.ts",
       "www/src/lib/posthog-client.ts",
     ];
 
@@ -466,16 +464,22 @@ describe("PostHog error tracking", () => {
     }
 
     const shellClient = await readFile("shell/instrumentation-client.ts", "utf8");
-    expect(shellClient).toContain("Shell has no local PostHog /ingest proxy");
+    expect(shellClient).toContain("initializeShellPostHog");
+
+    const shellPostHogClient = await readFile("shell/src/lib/posthog-client.ts", "utf8");
+    expect(shellPostHogClient).toContain("Shell has no local PostHog /ingest proxy");
+    expect(shellPostHogClient).toContain("buildPostHogCookieConsentInitOptions");
+    expect(shellPostHogClient).not.toContain("__loaded");
 
     const wwwPostHogClient = await readFile("www/src/lib/posthog-client.ts", "utf8");
     expect(wwwPostHogClient).toContain("ensurePostHogInitialized(config)");
     expect(wwwPostHogClient).toContain("posthog.init(currentConfig.token");
-    expect(wwwPostHogClient).toContain("posthogClient.__loaded");
+    expect(wwwPostHogClient).toContain("buildPostHogCookieConsentInitOptions");
+    expect(wwwPostHogClient).not.toContain("__loaded");
     expect(wwwPostHogClient).toContain('NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest"');
 
-    const shellPostHogClient = await readFile("shell/src/lib/posthog-client.ts", "utf8");
-    expect(shellPostHogClient).toContain("posthogClient.__loaded");
+    const wwwClient = await readFile("www/instrumentation-client.ts", "utf8");
+    expect(wwwClient).toContain("initializeWwwPostHog");
   });
 
   it("configures browser PostHog logs without console autocapture", async () => {

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -86,18 +86,19 @@ describe("PostHog error tracking", () => {
     expect(getPostHogVisitorCountry(new Headers({ "x-vercel-ip-country": "123" }))).toBeNull();
   });
 
-  it("requires explicit PostHog cookie consent for European visitors", () => {
+  it("requires explicit PostHog cookie consent for European and unknown visitors", () => {
     expect(requiresPostHogCookieConsent("SE")).toBe(true);
     expect(requiresPostHogCookieConsent("de")).toBe(true);
     expect(requiresPostHogCookieConsent("NO")).toBe(true);
     expect(requiresPostHogCookieConsent("GB")).toBe(true);
     expect(requiresPostHogCookieConsent("CH")).toBe(true);
     expect(requiresPostHogCookieConsent("US")).toBe(false);
-    expect(requiresPostHogCookieConsent(null)).toBe(false);
+    expect(requiresPostHogCookieConsent(null)).toBe(true);
   });
 
   it("uses PostHog cookieless mode until explicit cookie consent is granted", () => {
     expect(buildPostHogCookieConsentInitOptions("SE")).toEqual({ cookieless_mode: "on_reject" });
+    expect(buildPostHogCookieConsentInitOptions(null)).toEqual({ cookieless_mode: "on_reject" });
     expect(buildPostHogCookieConsentInitOptions("US")).toEqual({});
   });
 
@@ -470,7 +471,11 @@ describe("PostHog error tracking", () => {
     const wwwPostHogClient = await readFile("www/src/lib/posthog-client.ts", "utf8");
     expect(wwwPostHogClient).toContain("ensurePostHogInitialized(config)");
     expect(wwwPostHogClient).toContain("posthog.init(currentConfig.token");
+    expect(wwwPostHogClient).toContain("posthogClient.__loaded");
     expect(wwwPostHogClient).toContain('NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest"');
+
+    const shellPostHogClient = await readFile("shell/src/lib/posthog-client.ts", "utf8");
+    expect(shellPostHogClient).toContain("posthogClient.__loaded");
   });
 
   it("configures browser PostHog logs without console autocapture", async () => {

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const clerkState = vi.hoisted(() => ({
   isLoaded: true,
   isSignedIn: true,
-  hasPlan: false,
+  activePlan: null as string | null,
 }));
 const navigationState = vi.hoisted(() => ({
   replace: vi.fn(),
@@ -32,7 +32,7 @@ vi.mock("@clerk/nextjs", () => ({
   useAuth: () => ({
     isLoaded: clerkState.isLoaded,
     isSignedIn: clerkState.isSignedIn,
-    has: ({ plan }: { plan: string }) => plan === "early_adopter" && clerkState.hasPlan,
+    has: ({ plan }: { plan: string }) => plan === clerkState.activePlan,
   }),
 }));
 
@@ -54,7 +54,7 @@ describe("BillingGate", () => {
     vi.stubEnv("NEXT_PUBLIC_E2E_TEST_BYPASS", "1");
     clerkState.isLoaded = true;
     clerkState.isSignedIn = true;
-    clerkState.hasPlan = false;
+    clerkState.activePlan = null;
     vi.resetModules();
 
     const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
@@ -71,11 +71,13 @@ describe("BillingGate", () => {
     vi.resetModules();
   });
 
-  it("renders Matrix OS when the signed-in user has a paid plan", async () => {
+  it.each(["matrix_starter", "matrix_builder", "matrix_max", "early_adopter"])(
+    "renders Matrix OS when the signed-in user has the %s plan",
+    async (plan) => {
     vi.unstubAllEnvs();
     clerkState.isLoaded = true;
     clerkState.isSignedIn = true;
-    clerkState.hasPlan = true;
+    clerkState.activePlan = plan;
     vi.resetModules();
 
     const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
@@ -88,13 +90,14 @@ describe("BillingGate", () => {
 
     expect(screen.getByText("Matrix workspace")).toBeTruthy();
     expect(screen.queryByTestId("pricing-table")).toBeNull();
-  });
+    },
+  );
 
   it("keeps the shell visible behind locked billing settings when the user has not subscribed", async () => {
     vi.unstubAllEnvs();
     clerkState.isLoaded = true;
     clerkState.isSignedIn = true;
-    clerkState.hasPlan = false;
+    clerkState.activePlan = null;
     vi.resetModules();
 
     const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
@@ -128,7 +131,7 @@ describe("BillingGate", () => {
     window.sessionStorage.setItem("matrix.billing.checkoutAttemptAt", String(Date.now()));
     clerkState.isLoaded = true;
     clerkState.isSignedIn = true;
-    clerkState.hasPlan = false;
+    clerkState.activePlan = null;
     vi.resetModules();
 
     const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
@@ -149,7 +152,7 @@ describe("BillingGate", () => {
     window.history.replaceState({}, "", "/?checkout=success");
     clerkState.isLoaded = true;
     clerkState.isSignedIn = true;
-    clerkState.hasPlan = true;
+    clerkState.activePlan = "matrix_starter";
     vi.resetModules();
 
     const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
@@ -169,7 +172,7 @@ describe("BillingGate", () => {
     window.history.replaceState({}, "", "/?checkout=success");
     clerkState.isLoaded = true;
     clerkState.isSignedIn = true;
-    clerkState.hasPlan = false;
+    clerkState.activePlan = null;
     vi.resetModules();
 
     const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
@@ -188,7 +191,7 @@ describe("BillingGate", () => {
     vi.unstubAllEnvs();
     clerkState.isLoaded = true;
     clerkState.isSignedIn = true;
-    clerkState.hasPlan = false;
+    clerkState.activePlan = null;
     vi.resetModules();
 
     const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
@@ -211,7 +214,7 @@ describe("BillingGate", () => {
     vi.unstubAllEnvs();
     clerkState.isLoaded = true;
     clerkState.isSignedIn = false;
-    clerkState.hasPlan = false;
+    clerkState.activePlan = null;
     vi.resetModules();
 
     const { BillingGate } = await import("../../shell/src/components/BillingGate.js");

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -30,6 +30,7 @@ vi.mock("@clerk/nextjs", () => ({
       data-redirect={props.newSubscriptionRedirectUrl}
       data-drawer-backdrop-z={props.checkoutProps?.appearance?.elements?.drawerBackdrop?.zIndex}
       data-drawer-root-z={props.checkoutProps?.appearance?.elements?.drawerRoot?.zIndex}
+      data-drawer-content-z={props.checkoutProps?.appearance?.elements?.drawerContent?.zIndex}
       data-modal-backdrop-z={props.checkoutProps?.appearance?.elements?.modalBackdrop?.zIndex}
       data-modal-content-z={props.checkoutProps?.appearance?.elements?.modalContent?.zIndex}
       data-testid="pricing-table"
@@ -81,6 +82,9 @@ describe("BillingSection", () => {
       "10000",
     );
     expect(screen.getByTestId("pricing-table").getAttribute("data-drawer-root-z")).toBe(
+      "10001",
+    );
+    expect(screen.getByTestId("pricing-table").getAttribute("data-drawer-content-z")).toBe(
       "10001",
     );
     expect(screen.getByTestId("pricing-table").getAttribute("data-modal-backdrop-z")).toBe(

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -6,28 +6,46 @@ import { describe, expect, it, vi } from "vitest";
 
 const clerkState = vi.hoisted(() => ({
   isLoaded: true,
-  hasPlan: false,
+  activePlan: null as string | null,
 }));
 
 vi.mock("@clerk/nextjs", () => ({
-  PricingTable: (props: { for?: string; newSubscriptionRedirectUrl?: string }) => (
+  PricingTable: (props: {
+    for?: string;
+    newSubscriptionRedirectUrl?: string;
+    checkoutProps?: {
+      appearance?: {
+        elements?: {
+          drawerBackdrop?: { zIndex?: number };
+          drawerRoot?: { zIndex?: number };
+          drawerContent?: { zIndex?: number };
+          modalBackdrop?: { zIndex?: number };
+          modalContent?: { zIndex?: number };
+        };
+      };
+    };
+  }) => (
     <div
       data-for={props.for}
       data-redirect={props.newSubscriptionRedirectUrl}
+      data-drawer-backdrop-z={props.checkoutProps?.appearance?.elements?.drawerBackdrop?.zIndex}
+      data-drawer-root-z={props.checkoutProps?.appearance?.elements?.drawerRoot?.zIndex}
+      data-modal-backdrop-z={props.checkoutProps?.appearance?.elements?.modalBackdrop?.zIndex}
+      data-modal-content-z={props.checkoutProps?.appearance?.elements?.modalContent?.zIndex}
       data-testid="pricing-table"
     />
   ),
   useAuth: () => ({
     isLoaded: clerkState.isLoaded,
     isSignedIn: true,
-    has: ({ plan }: { plan: string }) => plan === "early_adopter" && clerkState.hasPlan,
+    has: ({ plan }: { plan: string }) => plan === clerkState.activePlan,
   }),
 }));
 
 describe("BillingSection", () => {
   it("waits for Clerk before rendering a subscription state", async () => {
     clerkState.isLoaded = false;
-    clerkState.hasPlan = true;
+    clerkState.activePlan = "matrix_starter";
 
     const { BillingSection } = await import(
       "../../shell/src/components/settings/sections/BillingSection.js"
@@ -42,7 +60,7 @@ describe("BillingSection", () => {
 
   it("surfaces the subscription state and Clerk pricing table", async () => {
     clerkState.isLoaded = true;
-    clerkState.hasPlan = false;
+    clerkState.activePlan = null;
 
     const { BillingSection } = await import(
       "../../shell/src/components/settings/sections/BillingSection.js"
@@ -59,11 +77,23 @@ describe("BillingSection", () => {
     expect(screen.getByTestId("pricing-table").getAttribute("data-redirect")).toBe(
       "http://localhost:3000/?checkout=success",
     );
+    expect(screen.getByTestId("pricing-table").getAttribute("data-drawer-backdrop-z")).toBe(
+      "10000",
+    );
+    expect(screen.getByTestId("pricing-table").getAttribute("data-drawer-root-z")).toBe(
+      "10001",
+    );
+    expect(screen.getByTestId("pricing-table").getAttribute("data-modal-backdrop-z")).toBe(
+      "10000",
+    );
+    expect(screen.getByTestId("pricing-table").getAttribute("data-modal-content-z")).toBe(
+      "10001",
+    );
   });
 
   it("uses provisioning copy when billing is shown before the hosted computer exists", async () => {
     clerkState.isLoaded = true;
-    clerkState.hasPlan = false;
+    clerkState.activePlan = null;
 
     const { BillingSection } = await import(
       "../../shell/src/components/settings/sections/BillingSection.js"
@@ -90,9 +120,11 @@ describe("BillingSection", () => {
     expect(await screen.findByTestId("pricing-table")).toBeTruthy();
   });
 
-  it("marks billing as active when Clerk grants a paid plan", async () => {
+  it.each(["matrix_starter", "matrix_builder", "matrix_max", "early_adopter"])(
+    "marks billing as active when Clerk grants the %s plan",
+    async (plan) => {
     clerkState.isLoaded = true;
-    clerkState.hasPlan = true;
+    clerkState.activePlan = plan;
 
     const { BillingSection } = await import(
       "../../shell/src/components/settings/sections/BillingSection.js"
@@ -105,5 +137,6 @@ describe("BillingSection", () => {
       screen.getByText("Billing is active for this Clerk account."),
     ).toBeTruthy();
     expect(screen.queryByTestId("pricing-table")).toBeNull();
-  });
+    },
+  );
 });

--- a/www/instrumentation-client.ts
+++ b/www/instrumentation-client.ts
@@ -1,26 +1,3 @@
-import posthog from "posthog-js";
-import {
-  buildPostHogCookieConsentInitOptions,
-  getPostHogClientConfig,
-  resolvePostHogClientApiHost,
-} from "@matrix-os/observability/client";
+import { initializeWwwPostHog } from "./src/lib/posthog-client";
 
-type PostHogInitOptions = Parameters<typeof posthog.init>[1];
-
-const config = getPostHogClientConfig({
-  NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
-  NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
-  NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest",
-});
-
-if (config) {
-  posthog.init(config.token, {
-    api_host: resolvePostHogClientApiHost(config),
-    ui_host: config.uiHost,
-    defaults: "2026-01-30",
-    capture_exceptions: true,
-    debug: process.env.NODE_ENV === "development",
-    ...buildPostHogCookieConsentInitOptions(document.documentElement.dataset.posthogVisitorCountry),
-  } as PostHogInitOptions);
-}
+initializeWwwPostHog(document.documentElement.dataset.posthogVisitorCountry);

--- a/www/src/lib/posthog-client.ts
+++ b/www/src/lib/posthog-client.ts
@@ -2,13 +2,13 @@
 
 import posthog from "posthog-js";
 import {
+  buildPostHogCookieConsentInitOptions,
   getPostHogClientConfig,
   resolvePostHogClientApiHost,
 } from "@matrix-os/observability/client";
 
 type ClientProperties = Record<string, string | number | boolean | undefined>;
 type PostHogInitOptions = Parameters<typeof posthog.init>[1];
-type PostHogLoadState = typeof posthog & { __loaded?: boolean };
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -17,7 +17,6 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest",
 });
 let initialized = false;
-const posthogClient = posthog as PostHogLoadState;
 
 export function capturePostHogException(error: unknown, properties: ClientProperties = {}) {
   if (!config) return;
@@ -40,10 +39,14 @@ export function capturePostHogEvent(event: string, properties: ClientProperties 
 }
 
 function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
-  if (initialized || posthogClient.__loaded) {
-    initialized = true;
-    return;
-  }
+  initializeWwwPostHog(getPostHogVisitorCountry(), currentConfig);
+}
+
+export function initializeWwwPostHog(
+  visitorCountry?: string | null,
+  currentConfig: typeof config = config,
+) {
+  if (!currentConfig || initialized) return;
   const apiHost = resolvePostHogClientApiHost(currentConfig, { allowRelativeApiHost: true });
   posthog.init(currentConfig.token, {
     ...(apiHost ? { api_host: apiHost } : {}),
@@ -51,8 +54,14 @@ function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
     defaults: "2026-01-30",
     capture_exceptions: true,
     debug: process.env.NODE_ENV === "development",
+    ...buildPostHogCookieConsentInitOptions(visitorCountry),
   } as PostHogInitOptions);
   initialized = true;
+}
+
+function getPostHogVisitorCountry(): string | null {
+  if (typeof document === "undefined") return null;
+  return document.documentElement.dataset.posthogVisitorCountry ?? null;
 }
 
 function sanitizeProperties(properties: ClientProperties): Record<string, string | number | boolean> {

--- a/www/src/lib/posthog-client.ts
+++ b/www/src/lib/posthog-client.ts
@@ -8,6 +8,7 @@ import {
 
 type ClientProperties = Record<string, string | number | boolean | undefined>;
 type PostHogInitOptions = Parameters<typeof posthog.init>[1];
+type PostHogLoadState = typeof posthog & { __loaded?: boolean };
 
 const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
@@ -16,6 +17,7 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest",
 });
 let initialized = false;
+const posthogClient = posthog as PostHogLoadState;
 
 export function capturePostHogException(error: unknown, properties: ClientProperties = {}) {
   if (!config) return;
@@ -38,7 +40,10 @@ export function capturePostHogEvent(event: string, properties: ClientProperties 
 }
 
 function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
-  if (initialized) return;
+  if (initialized || posthogClient.__loaded) {
+    initialized = true;
+    return;
+  }
   const apiHost = resolvePostHogClientApiHost(currentConfig, { allowRelativeApiHost: true });
   posthog.init(currentConfig.token, {
     ...(apiHost ? { api_host: apiHost } : {}),


### PR DESCRIPTION
## Summary
- raise Clerk checkout drawer/modal layers above shell Settings and canvas windows
- recognize Matrix Starter, Builder, and Max Clerk plan slugs while preserving early_adopter access
- avoid duplicate browser PostHog init when the Next instrumentation client has already loaded the SDK
- require PostHog consent by default when visitor country headers are missing, so EU visitors are not silently treated as non-consent regions
- add billing and observability tests for checkout overlay z-index, accepted plan slugs, duplicate-init guards, and SE/unknown consent behavior

## Invariants
- Source of truth: Clerk Billing remains the source of truth for visible checkout plans and active user plan claims; shell constants only define which Clerk plan slugs unlock Matrix.
- Lock/transaction scope: no persistence or database writes are changed.
- Acceptable orphan states: legacy early_adopter subscriptions continue to unlock access while new plans are created in Clerk.
- Auth source of truth: Clerk session/auth and useAuth().has({ plan }) remain authoritative.
- Deferred scope: this PR does not create Clerk dashboard plans or bind selected server/region choices to a specific checkout plan.

## Validation
- bun run test tests/observability/posthog-error-tracking.test.ts tests/shell/billing-section.test.tsx tests/shell/billing-gate.test.tsx
- pnpm --filter @matrix-os/observability exec tsc --noEmit
- pnpm --dir shell exec tsc --noEmit
- pnpm --dir shell exec eslint src/components/settings/sections/BillingPanel.tsx src/lib/billing.ts src/lib/posthog-client.ts

## Notes
- pnpm --dir www exec tsc --noEmit is currently blocked by existing Fumadocs/PageData type errors in docs routes and sitemap, unrelated to this change.