### PR TITLE
fix(gateway): keep upgrade endpoint reachable

### DIFF
--- a/docs/dev/fleet-upgrade-operations.md
+++ b/docs/dev/fleet-upgrade-operations.md
@@ -24,6 +24,14 @@ handle)`. That is fail-closed, but old VPSes can drift if they were provisioned
 with a previous secret or token format. The outbound agent fixes this by letting
 the VPS initiate trust refreshes and receive token-rotation commands.
 
+Provisioning must also write the same per-host token to `MATRIX_AUTH_TOKEN`.
+Older gateway bundles mounted global bearer auth before `/api/internal/upgrade`;
+without `MATRIX_AUTH_TOKEN`, the request was rejected before the route-specific
+`UPGRADE_TOKEN` check could run. Current gateway auth explicitly lets
+`/api/internal/upgrade` reach its route-scoped token verifier, but the host env
+must still keep `UPGRADE_TOKEN`, `MATRIX_AUTH_TOKEN`, and
+`MATRIX_CODE_PROXY_TOKEN` populated and aligned.
+
 ## Standard Release Flow
 
 1. Merge to `main` and wait for the `Host Bundle Release` workflow.
@@ -98,10 +106,15 @@ release probes and upgrade triggers with `401`, or times out entirely.
 3. If both fail, use break-glass SSH:
 
    ```bash
+   ssh root@<vps-ip> 'grep -E "^(MATRIX_HANDLE|UPGRADE_TOKEN|MATRIX_AUTH_TOKEN|MATRIX_CODE_PROXY_TOKEN)=" /opt/matrix/env/host.env'
    ssh matrix@<vps-ip> 'sudo -n /opt/matrix/bin/matrix-update stable'
    ssh matrix@<vps-ip> 'cat /opt/matrix/release.json'
    ssh matrix@<vps-ip> 'systemctl is-active matrix-gateway matrix-shell matrix-sync-agent'
    ```
+
+   If `UPGRADE_TOKEN` exists but `MATRIX_AUTH_TOKEN` is missing on an older
+   bundle, repair the host env by setting `MATRIX_AUTH_TOKEN` to the same
+   per-host token value, restart `matrix-gateway`, and re-run the inbound deploy.
 
 4. If SSH is unavailable, treat the VPS as unmanaged drift. Repair requires
    Hetzner console/rescue access or reprovision/recover through backup restore.

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -84,6 +84,11 @@ const APP_IFRAME_PREFIXES = ["/apps/"];
 const HMAC_WEBHOOK_PREFIXES = [
   "/api/integrations/webhook/",
 ];
+// These endpoints own bearer validation in their route handlers because they
+// use service-specific tokens instead of the user/session MATRIX_AUTH_TOKEN.
+const ROUTE_SCOPED_BEARER_PATHS = [
+  "/api/internal/upgrade",
+];
 const MESSAGE_APPSERVICE_PREFIX = "/api/messages/appservice/";
 const MESSAGE_HERMES_REPLY_PATH = /^\/api\/messages\/conversations\/[^/]+\/reply$/;
 const WS_QUERY_TOKEN_PATHS = ["/ws", "/ws/voice", "/ws/terminal", "/ws/terminal/session", "/ws/onboarding", "/ws/vocal"];
@@ -184,6 +189,14 @@ export function authMiddleware(
     if (HMAC_WEBHOOK_PREFIXES.some((p) => normalizedPath.startsWith(p))) {
       const ip = getClientIp(c);
       if (!webhookRateLimiter.check(ip)) {
+        return tooManyRequests(c);
+      }
+      return nextWithReady(c, next);
+    }
+
+    if (ROUTE_SCOPED_BEARER_PATHS.some((p) => normalizedPath === p)) {
+      const ip = getClientIp(c);
+      if (!rateLimiter.check(ip)) {
         return tooManyRequests(c);
       }
       return nextWithReady(c, next);

--- a/tests/gateway/auth.test.ts
+++ b/tests/gateway/auth.test.ts
@@ -265,6 +265,16 @@ describe("T133: Auth token middleware", () => {
     expect(nextCalled).toBe(true);
   });
 
+  it("allows internal upgrade requests to reach the route-scoped upgrade token check", async () => {
+    const mw = authMiddleware(undefined);
+    let nextCalled = false;
+    await mw(
+      mockContext("/api/internal/upgrade", "Bearer upgrade-token", undefined, "10.77.77.77"),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
   it("rate-limits integrations webhook separately from auth failures", async () => {
     // The integrations webhook limiter is more permissive (120/min) than the
     // failed-auth limiter (10/min) because legit providers retry aggressively.

--- a/tests/gateway/auth.test.ts
+++ b/tests/gateway/auth.test.ts
@@ -269,10 +269,29 @@ describe("T133: Auth token middleware", () => {
     const mw = authMiddleware(undefined);
     let nextCalled = false;
     await mw(
-      mockContext("/api/internal/upgrade", "Bearer upgrade-token", undefined, "10.77.77.77"),
+      mockContext("/api/internal/upgrade", "Bearer upgrade-token", undefined, "10.77.77.78"),
       async () => { nextCalled = true; },
     );
     expect(nextCalled).toBe(true);
+  });
+
+  it("rate-limits internal upgrade requests before the route-scoped token check", async () => {
+    const mw = authMiddleware(undefined);
+    const testIp = "10.77.77.79";
+    for (let i = 0; i < 10; i++) {
+      await mw(
+        mockContext("/api/internal/upgrade", "Bearer invalid-upgrade-token", undefined, testIp),
+        async () => {},
+      );
+    }
+
+    let nextCalled = false;
+    const result = await mw(
+      mockContext("/api/internal/upgrade", "Bearer invalid-upgrade-token", undefined, testIp),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(false);
+    expect(result?.status).toBe(429);
   });
 
   it("rate-limits integrations webhook separately from auth failures", async () => {


### PR DESCRIPTION
## Summary
- let `/api/internal/upgrade` reach its route-scoped `UPGRADE_TOKEN` verifier instead of failing global `MATRIX_AUTH_TOKEN` first
- keep failed-upgrade probes rate-limited at the auth middleware boundary
- document the fleet drift mode where `UPGRADE_TOKEN` exists but `MATRIX_AUTH_TOKEN` is missing on older bundles

## Validation
- `bun run test tests/gateway/auth.test.ts`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`

## Invariants
- **Source of truth**: `/api/internal/upgrade` is authenticated by its route-owned `UPGRADE_TOKEN`; normal gateway routes remain authenticated by `MATRIX_AUTH_TOKEN` or their existing explicit auth mechanism.
- **Lock/transaction scope**: this middleware change performs no database or filesystem writes; it only routes the request to the existing upgrade handler after rate limiting.
- **Acceptable orphan states**: requests with missing or invalid upgrade tokens still fail in the upgrade route; a missing global auth token no longer blocks the route-specific verifier.
- **Auth source of truth**: internal upgrade bearer validation lives at the upgrade endpoint, while global bearer auth continues to protect user/session APIs.
- **Deferred scope**: outbound VPS control agents and forced-command SSH are not implemented here; the docs record the current break-glass repair path.
