### PR TITLE
feat(billing): add Stripe entitlement core

### DIFF
--- a/packages/platform/src/billing.ts
+++ b/packages/platform/src/billing.ts
@@ -1,0 +1,389 @@
+export const BILLING_GRACE_PERIOD_MS = 3 * 24 * 60 * 60 * 1000;
+
+export type MatrixBillingPlanSlug = 'matrix_starter' | 'matrix_builder' | 'matrix_max';
+export type MatrixBillingInterval = 'monthly' | 'annual';
+export type RuntimeCatalogSku = 'starter' | 'builder' | 'max';
+export type BillingEntitlementSource = 'stripe' | 'override';
+export type BillingEntitlementStatus =
+  | 'active'
+  | 'trialing'
+  | 'past_due'
+  | 'canceled'
+  | 'incomplete'
+  | 'unpaid'
+  | 'ended'
+  | 'none';
+
+export interface BillingPlanDefinition {
+  slug: MatrixBillingPlanSlug;
+  marketingName: string;
+  monthlyUsd: number;
+  annualUsd: number;
+  includedRuntimeSlots: number;
+  defaultCatalogSku: RuntimeCatalogSku;
+  allowedCatalogSkus: RuntimeCatalogSku[];
+  rank: number;
+}
+
+export interface RuntimeCatalogProfile {
+  sku: string;
+  label: string;
+  provider: 'hetzner';
+  serverType: string;
+  vcpu: number;
+  memoryGb: number;
+  diskGb: number;
+  active: boolean;
+}
+
+export interface RuntimeCatalog {
+  profiles: RuntimeCatalogProfile[];
+}
+
+export type StripePriceCatalogEntry =
+  | {
+      kind: 'base_plan';
+      planSlug: MatrixBillingPlanSlug;
+      interval: MatrixBillingInterval;
+    }
+  | {
+      kind: 'extra_runtime_slot';
+      interval: MatrixBillingInterval;
+    };
+
+export interface StripePriceCatalog {
+  priceToPlan: Map<string, StripePriceCatalogEntry>;
+}
+
+export interface StripeSubscriptionItemProjection {
+  priceId: string;
+  quantity?: number | null;
+}
+
+export interface StripeSubscriptionProjection {
+  clerkUserId: string;
+  stripeCustomerId: string;
+  stripeSubscriptionId: string;
+  status: BillingEntitlementStatus;
+  currentPeriodEnd?: string | null;
+  items: StripeSubscriptionItemProjection[];
+}
+
+export interface BillingEntitlement {
+  clerkUserId: string;
+  source: BillingEntitlementSource;
+  planSlug: MatrixBillingPlanSlug | 'internal';
+  status: BillingEntitlementStatus;
+  maxRuntimeSlots: number;
+  includedRuntimeSlots: number;
+  addonRuntimeSlots: number;
+  defaultServerType: string;
+  allowedServerTypes: string[];
+  stripeSubscriptionId: string | null;
+  stripePriceId: string | null;
+  gracePeriodEndsAt: string | null;
+  effectiveFrom: string;
+  effectiveUntil: string | null;
+  updatedAt: string;
+}
+
+export interface BillingEntitlementOverride {
+  id: string;
+  clerkUserId: string;
+  planSlug: 'internal' | MatrixBillingPlanSlug;
+  status: 'active';
+  maxRuntimeSlots: number;
+  includedRuntimeSlots: number;
+  addonRuntimeSlots: number;
+  defaultServerType: string;
+  allowedServerTypes: string[];
+  reason: string;
+  createdBy: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+export interface RuntimeAccessDecision {
+  runtimeProxyAllowed: boolean;
+  reason: 'active' | 'grace_period' | 'payment_required' | 'no_entitlement';
+  gracePeriodEndsAt?: string | null;
+}
+
+export const DEFAULT_BILLING_PLAN_DEFINITIONS: BillingPlanDefinition[] = [
+  {
+    slug: 'matrix_starter',
+    marketingName: 'Starter',
+    monthlyUsd: 14,
+    annualUsd: 140,
+    includedRuntimeSlots: 1,
+    defaultCatalogSku: 'starter',
+    allowedCatalogSkus: ['starter'],
+    rank: 10,
+  },
+  {
+    slug: 'matrix_builder',
+    marketingName: 'Builder',
+    monthlyUsd: 19,
+    annualUsd: 190,
+    includedRuntimeSlots: 1,
+    defaultCatalogSku: 'builder',
+    allowedCatalogSkus: ['starter', 'builder'],
+    rank: 20,
+  },
+  {
+    slug: 'matrix_max',
+    marketingName: 'Max',
+    monthlyUsd: 49,
+    annualUsd: 490,
+    includedRuntimeSlots: 3,
+    defaultCatalogSku: 'max',
+    allowedCatalogSkus: ['starter', 'builder', 'max'],
+    rank: 30,
+  },
+];
+
+const DEFAULT_RUNTIME_CATALOG: RuntimeCatalog = {
+  profiles: [
+    {
+      sku: 'starter',
+      label: 'Starter',
+      provider: 'hetzner',
+      serverType: 'cpx22',
+      vcpu: 2,
+      memoryGb: 4,
+      diskGb: 80,
+      active: true,
+    },
+    {
+      sku: 'builder',
+      label: 'Builder',
+      provider: 'hetzner',
+      serverType: 'cpx32',
+      vcpu: 4,
+      memoryGb: 8,
+      diskGb: 160,
+      active: true,
+    },
+    {
+      sku: 'max',
+      label: 'Max',
+      provider: 'hetzner',
+      serverType: 'cpx52',
+      vcpu: 12,
+      memoryGb: 24,
+      diskGb: 480,
+      active: true,
+    },
+  ],
+};
+
+export function loadRuntimeCatalog(env: NodeJS.ProcessEnv): RuntimeCatalog {
+  const raw = env.MATRIX_RUNTIME_CATALOG_JSON;
+  if (!raw) return DEFAULT_RUNTIME_CATALOG;
+  try {
+    const parsed = JSON.parse(raw) as Partial<RuntimeCatalog>;
+    if (!Array.isArray(parsed.profiles)) return DEFAULT_RUNTIME_CATALOG;
+    const profiles = parsed.profiles.filter(isRuntimeCatalogProfile);
+    return profiles.length > 0 ? { profiles } : DEFAULT_RUNTIME_CATALOG;
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError) return DEFAULT_RUNTIME_CATALOG;
+    throw err;
+  }
+}
+
+function isRuntimeCatalogProfile(value: unknown): value is RuntimeCatalogProfile {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<RuntimeCatalogProfile>;
+  return (
+    typeof candidate.sku === 'string' &&
+    typeof candidate.label === 'string' &&
+    candidate.provider === 'hetzner' &&
+    typeof candidate.serverType === 'string' &&
+    typeof candidate.vcpu === 'number' &&
+    typeof candidate.memoryGb === 'number' &&
+    typeof candidate.diskGb === 'number' &&
+    typeof candidate.active === 'boolean'
+  );
+}
+
+export function loadStripePriceCatalog(env: NodeJS.ProcessEnv): StripePriceCatalog {
+  const priceToPlan = new Map<string, StripePriceCatalogEntry>();
+  addBasePrice(priceToPlan, env.STRIPE_PRICE_MATRIX_STARTER_MONTHLY, 'matrix_starter', 'monthly');
+  addBasePrice(priceToPlan, env.STRIPE_PRICE_MATRIX_STARTER_ANNUAL, 'matrix_starter', 'annual');
+  addBasePrice(priceToPlan, env.STRIPE_PRICE_MATRIX_BUILDER_MONTHLY, 'matrix_builder', 'monthly');
+  addBasePrice(priceToPlan, env.STRIPE_PRICE_MATRIX_BUILDER_ANNUAL, 'matrix_builder', 'annual');
+  addBasePrice(priceToPlan, env.STRIPE_PRICE_MATRIX_MAX_MONTHLY, 'matrix_max', 'monthly');
+  addBasePrice(priceToPlan, env.STRIPE_PRICE_MATRIX_MAX_ANNUAL, 'matrix_max', 'annual');
+  addAddonPrice(priceToPlan, env.STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY, 'monthly');
+  addAddonPrice(priceToPlan, env.STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL, 'annual');
+  return { priceToPlan };
+}
+
+function addBasePrice(
+  map: Map<string, StripePriceCatalogEntry>,
+  priceId: string | undefined,
+  planSlug: MatrixBillingPlanSlug,
+  interval: MatrixBillingInterval,
+): void {
+  if (!priceId) return;
+  map.set(priceId, { kind: 'base_plan', planSlug, interval });
+}
+
+function addAddonPrice(
+  map: Map<string, StripePriceCatalogEntry>,
+  priceId: string | undefined,
+  interval: MatrixBillingInterval,
+): void {
+  if (!priceId) return;
+  map.set(priceId, { kind: 'extra_runtime_slot', interval });
+}
+
+export function deriveStripeEntitlement(
+  subscription: StripeSubscriptionProjection,
+  options: {
+    priceCatalog: StripePriceCatalog;
+    runtimeCatalog: RuntimeCatalog;
+    now: Date;
+  },
+): BillingEntitlement {
+  let selectedPlan: BillingPlanDefinition | undefined;
+  let selectedPriceId: string | null = null;
+  let addonRuntimeSlots = 0;
+
+  for (const item of subscription.items) {
+    const entry = options.priceCatalog.priceToPlan.get(item.priceId);
+    if (!entry) continue;
+    if (entry.kind === 'extra_runtime_slot') {
+      const quantity = Math.max(0, Math.floor(item.quantity ?? 0));
+      addonRuntimeSlots += quantity;
+      continue;
+    }
+    const plan = getPlanDefinition(entry.planSlug);
+    if (!selectedPlan || plan.rank > selectedPlan.rank) {
+      selectedPlan = plan;
+      selectedPriceId = item.priceId;
+    }
+  }
+
+  if (!selectedPlan) {
+    return {
+      clerkUserId: subscription.clerkUserId,
+      source: 'stripe',
+      planSlug: 'matrix_starter',
+      status: 'none',
+      maxRuntimeSlots: 0,
+      includedRuntimeSlots: 0,
+      addonRuntimeSlots: 0,
+      defaultServerType: '',
+      allowedServerTypes: [],
+      stripeSubscriptionId: subscription.stripeSubscriptionId,
+      stripePriceId: null,
+      gracePeriodEndsAt: null,
+      effectiveFrom: options.now.toISOString(),
+      effectiveUntil: null,
+      updatedAt: options.now.toISOString(),
+    };
+  }
+
+  const defaultServerType = resolveServerType(options.runtimeCatalog, selectedPlan.defaultCatalogSku);
+  const allowedServerTypes = selectedPlan.allowedCatalogSkus
+    .map((sku) => resolveServerType(options.runtimeCatalog, sku))
+    .filter((serverType): serverType is string => Boolean(serverType));
+  const gracePeriodEndsAt = getGracePeriodEnd(subscription.status, subscription.currentPeriodEnd);
+
+  return {
+    clerkUserId: subscription.clerkUserId,
+    source: 'stripe',
+    planSlug: selectedPlan.slug,
+    status: subscription.status,
+    maxRuntimeSlots: selectedPlan.includedRuntimeSlots + addonRuntimeSlots,
+    includedRuntimeSlots: selectedPlan.includedRuntimeSlots,
+    addonRuntimeSlots,
+    defaultServerType: defaultServerType ?? '',
+    allowedServerTypes,
+    stripeSubscriptionId: subscription.stripeSubscriptionId,
+    stripePriceId: selectedPriceId,
+    gracePeriodEndsAt,
+    effectiveFrom: options.now.toISOString(),
+    effectiveUntil: null,
+    updatedAt: options.now.toISOString(),
+  };
+}
+
+function getPlanDefinition(slug: MatrixBillingPlanSlug): BillingPlanDefinition {
+  const plan = DEFAULT_BILLING_PLAN_DEFINITIONS.find((candidate) => candidate.slug === slug);
+  if (!plan) {
+    throw new Error(`Unknown Matrix billing plan: ${slug}`);
+  }
+  return plan;
+}
+
+function resolveServerType(catalog: RuntimeCatalog, sku: string): string | null {
+  return catalog.profiles.find((profile) => profile.sku === sku && profile.active)?.serverType ?? null;
+}
+
+function getGracePeriodEnd(status: BillingEntitlementStatus, currentPeriodEnd: string | null | undefined): string | null {
+  if ((status === 'active' || status === 'trialing') && currentPeriodEnd) {
+    return new Date(Date.parse(currentPeriodEnd) + BILLING_GRACE_PERIOD_MS).toISOString();
+  }
+  if (!currentPeriodEnd) return null;
+  if (status === 'past_due' || status === 'unpaid' || status === 'canceled' || status === 'ended') {
+    return new Date(Date.parse(currentPeriodEnd) + BILLING_GRACE_PERIOD_MS).toISOString();
+  }
+  return null;
+}
+
+export function getRuntimeAccessDecision(
+  entitlement: BillingEntitlement | null | undefined,
+  now: Date,
+): RuntimeAccessDecision {
+  if (!entitlement) return { runtimeProxyAllowed: false, reason: 'no_entitlement' };
+  if (entitlement.status === 'active' || entitlement.status === 'trialing') {
+    return {
+      runtimeProxyAllowed: true,
+      reason: 'active',
+      gracePeriodEndsAt: entitlement.gracePeriodEndsAt,
+    };
+  }
+  if (entitlement.gracePeriodEndsAt && Date.parse(entitlement.gracePeriodEndsAt) >= now.getTime()) {
+    return {
+      runtimeProxyAllowed: true,
+      reason: 'grace_period',
+      gracePeriodEndsAt: entitlement.gracePeriodEndsAt,
+    };
+  }
+  return {
+    runtimeProxyAllowed: false,
+    reason: 'payment_required',
+    gracePeriodEndsAt: entitlement.gracePeriodEndsAt,
+  };
+}
+
+export function computeEffectiveEntitlement(input: {
+  stripeEntitlement?: BillingEntitlement | null;
+  override?: BillingEntitlementOverride | null;
+  now: Date;
+}): BillingEntitlement | null {
+  const override = input.override;
+  if (override && !override.revokedAt && (!override.expiresAt || Date.parse(override.expiresAt) > input.now.getTime())) {
+    return {
+      clerkUserId: override.clerkUserId,
+      source: 'override',
+      planSlug: override.planSlug,
+      status: override.status,
+      maxRuntimeSlots: override.maxRuntimeSlots,
+      includedRuntimeSlots: override.includedRuntimeSlots,
+      addonRuntimeSlots: override.addonRuntimeSlots,
+      defaultServerType: override.defaultServerType,
+      allowedServerTypes: override.allowedServerTypes,
+      stripeSubscriptionId: null,
+      stripePriceId: null,
+      gracePeriodEndsAt: override.expiresAt,
+      effectiveFrom: override.createdAt,
+      effectiveUntil: override.expiresAt,
+      updatedAt: override.createdAt,
+    };
+  }
+  return input.stripeEntitlement ?? null;
+}

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -1,5 +1,10 @@
 import { Kysely, PostgresDialect, sql, type Transaction } from 'kysely';
 import pg from 'pg';
+import type {
+  BillingEntitlementSource,
+  BillingEntitlementStatus,
+  MatrixBillingPlanSlug,
+} from './billing.js';
 
 const DEFAULT_PLATFORM_DB_URL =
   process.env.PLATFORM_DATABASE_URL ??
@@ -77,6 +82,57 @@ interface ProviderDeletionQueueTable {
   created_at: string;
   last_error: string | null;
   completed_at: string | null;
+}
+
+interface BillingCustomersTable {
+  clerk_user_id: string;
+  stripe_customer_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface BillingEntitlementsTable {
+  clerk_user_id: string;
+  source: string;
+  plan_slug: string;
+  status: string;
+  max_runtime_slots: number;
+  included_runtime_slots: number;
+  addon_runtime_slots: number;
+  default_server_type: string;
+  allowed_server_types: string;
+  stripe_subscription_id: string | null;
+  stripe_price_id: string | null;
+  grace_period_ends_at: string | null;
+  effective_from: string;
+  effective_until: string | null;
+  updated_at: string;
+}
+
+interface BillingEntitlementOverridesTable {
+  id: string;
+  clerk_user_id: string;
+  plan_slug: string;
+  status: string;
+  max_runtime_slots: number;
+  included_runtime_slots: number;
+  addon_runtime_slots: number;
+  default_server_type: string;
+  allowed_server_types: string;
+  reason: string;
+  created_by: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+interface BillingWebhookEventsTable {
+  stripe_event_id: string;
+  event_type: string;
+  created_at_from_stripe: string;
+  processed_at: string;
+  status: string;
+  error_code: string | null;
 }
 
 interface PortAssignmentsTable {
@@ -177,6 +233,10 @@ export interface PlatformDatabase {
   host_bundle_channels: HostBundleChannelsTable;
   host_bundle_release_channels: HostBundleReleaseChannelsTable;
   provider_deletion_queue: ProviderDeletionQueueTable;
+  billing_customers: BillingCustomersTable;
+  billing_entitlements: BillingEntitlementsTable;
+  billing_entitlement_overrides: BillingEntitlementOverridesTable;
+  billing_webhook_events: BillingWebhookEventsTable;
   port_assignments: PortAssignmentsTable;
   device_codes: DeviceCodesTable;
   matrix_users: MatrixUsersTable;
@@ -297,6 +357,70 @@ export interface ProviderDeletionQueueRecord {
   completedAt: string | null;
 }
 
+export interface BillingCustomerRecord {
+  clerkUserId: string;
+  stripeCustomerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NewBillingCustomer {
+  clerkUserId: string;
+  stripeCustomerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BillingEntitlementRecord {
+  clerkUserId: string;
+  source: BillingEntitlementSource;
+  planSlug: MatrixBillingPlanSlug | 'internal';
+  status: BillingEntitlementStatus;
+  maxRuntimeSlots: number;
+  includedRuntimeSlots: number;
+  addonRuntimeSlots: number;
+  defaultServerType: string;
+  allowedServerTypes: string[];
+  stripeSubscriptionId: string | null;
+  stripePriceId: string | null;
+  gracePeriodEndsAt: string | null;
+  effectiveFrom: string;
+  effectiveUntil: string | null;
+  updatedAt: string;
+}
+
+export type NewBillingEntitlement = BillingEntitlementRecord;
+
+export interface BillingEntitlementOverrideRecord {
+  id: string;
+  clerkUserId: string;
+  planSlug: MatrixBillingPlanSlug | 'internal';
+  status: 'active';
+  maxRuntimeSlots: number;
+  includedRuntimeSlots: number;
+  addonRuntimeSlots: number;
+  defaultServerType: string;
+  allowedServerTypes: string[];
+  reason: string;
+  createdBy: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+export type NewBillingEntitlementOverride = BillingEntitlementOverrideRecord;
+
+export interface BillingWebhookEventRecord {
+  stripeEventId: string;
+  eventType: string;
+  createdAtFromStripe: string;
+  processedAt: string;
+  status: string;
+  errorCode: string | null;
+}
+
+export type NewBillingWebhookEvent = BillingWebhookEventRecord;
+
 export interface NewUserMachine {
   machineId: string;
   clerkUserId: string;
@@ -410,6 +534,68 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_clerk_slot_status ON user_machines(clerk_user_id, runtime_slot, status)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_hetzner ON user_machines(hetzner_server_id)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS billing_customers (
+      clerk_user_id TEXT PRIMARY KEY,
+      stripe_customer_id TEXT UNIQUE NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS billing_entitlements (
+      clerk_user_id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      plan_slug TEXT NOT NULL,
+      status TEXT NOT NULL,
+      max_runtime_slots INTEGER NOT NULL,
+      included_runtime_slots INTEGER NOT NULL,
+      addon_runtime_slots INTEGER NOT NULL,
+      default_server_type TEXT NOT NULL,
+      allowed_server_types TEXT NOT NULL,
+      stripe_subscription_id TEXT,
+      stripe_price_id TEXT,
+      grace_period_ends_at TEXT,
+      effective_from TEXT NOT NULL,
+      effective_until TEXT,
+      updated_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_billing_entitlements_status ON billing_entitlements(status)`.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_billing_entitlements_subscription ON billing_entitlements(stripe_subscription_id)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS billing_entitlement_overrides (
+      id TEXT PRIMARY KEY,
+      clerk_user_id TEXT NOT NULL,
+      plan_slug TEXT NOT NULL,
+      status TEXT NOT NULL,
+      max_runtime_slots INTEGER NOT NULL,
+      included_runtime_slots INTEGER NOT NULL,
+      addon_runtime_slots INTEGER NOT NULL,
+      default_server_type TEXT NOT NULL,
+      allowed_server_types TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      created_by TEXT NOT NULL,
+      expires_at TEXT,
+      revoked_at TEXT,
+      created_at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_billing_overrides_user ON billing_entitlement_overrides(clerk_user_id, revoked_at, expires_at)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS billing_webhook_events (
+      stripe_event_id TEXT PRIMARY KEY,
+      event_type TEXT NOT NULL,
+      created_at_from_stripe TEXT NOT NULL,
+      processed_at TEXT NOT NULL,
+      status TEXT NOT NULL,
+      error_code TEXT
+    )
+  `.execute(db);
 
   await sql`
     CREATE TABLE IF NOT EXISTS host_bundle_releases (
@@ -661,6 +847,13 @@ export async function runInPlatformTransaction<T>(
   return db.transaction(fn);
 }
 
+export async function runBillingWebhookTransaction<T>(
+  db: PlatformDB,
+  fn: (trx: PlatformDB) => Promise<T>,
+): Promise<T> {
+  return db.transaction(fn);
+}
+
 function mapContainer(row: ContainersTable): ContainerRecord {
   return {
     handle: row.handle,
@@ -829,6 +1022,136 @@ function toProviderDeletionRow(record: NewProviderDeletionQueueRecord): Provider
   };
 }
 
+function parseStringArray(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError) return [];
+    throw err;
+  }
+}
+
+function mapBillingCustomer(row: BillingCustomersTable): BillingCustomerRecord {
+  return {
+    clerkUserId: row.clerk_user_id,
+    stripeCustomerId: row.stripe_customer_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toBillingCustomerRow(record: NewBillingCustomer): BillingCustomersTable {
+  return {
+    clerk_user_id: record.clerkUserId,
+    stripe_customer_id: record.stripeCustomerId,
+    created_at: record.createdAt,
+    updated_at: record.updatedAt,
+  };
+}
+
+function mapBillingEntitlement(row: BillingEntitlementsTable): BillingEntitlementRecord {
+  return {
+    clerkUserId: row.clerk_user_id,
+    source: row.source as BillingEntitlementSource,
+    planSlug: row.plan_slug as MatrixBillingPlanSlug | 'internal',
+    status: row.status as BillingEntitlementStatus,
+    maxRuntimeSlots: row.max_runtime_slots,
+    includedRuntimeSlots: row.included_runtime_slots,
+    addonRuntimeSlots: row.addon_runtime_slots,
+    defaultServerType: row.default_server_type,
+    allowedServerTypes: parseStringArray(row.allowed_server_types),
+    stripeSubscriptionId: row.stripe_subscription_id,
+    stripePriceId: row.stripe_price_id,
+    gracePeriodEndsAt: row.grace_period_ends_at,
+    effectiveFrom: row.effective_from,
+    effectiveUntil: row.effective_until,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toBillingEntitlementRow(record: NewBillingEntitlement): BillingEntitlementsTable {
+  return {
+    clerk_user_id: record.clerkUserId,
+    source: record.source,
+    plan_slug: record.planSlug,
+    status: record.status,
+    max_runtime_slots: record.maxRuntimeSlots,
+    included_runtime_slots: record.includedRuntimeSlots,
+    addon_runtime_slots: record.addonRuntimeSlots,
+    default_server_type: record.defaultServerType,
+    allowed_server_types: JSON.stringify(record.allowedServerTypes),
+    stripe_subscription_id: record.stripeSubscriptionId,
+    stripe_price_id: record.stripePriceId,
+    grace_period_ends_at: record.gracePeriodEndsAt,
+    effective_from: record.effectiveFrom,
+    effective_until: record.effectiveUntil,
+    updated_at: record.updatedAt,
+  };
+}
+
+function mapBillingOverride(row: BillingEntitlementOverridesTable): BillingEntitlementOverrideRecord {
+  return {
+    id: row.id,
+    clerkUserId: row.clerk_user_id,
+    planSlug: row.plan_slug as MatrixBillingPlanSlug | 'internal',
+    status: row.status as 'active',
+    maxRuntimeSlots: row.max_runtime_slots,
+    includedRuntimeSlots: row.included_runtime_slots,
+    addonRuntimeSlots: row.addon_runtime_slots,
+    defaultServerType: row.default_server_type,
+    allowedServerTypes: parseStringArray(row.allowed_server_types),
+    reason: row.reason,
+    createdBy: row.created_by,
+    expiresAt: row.expires_at,
+    revokedAt: row.revoked_at,
+    createdAt: row.created_at,
+  };
+}
+
+function toBillingOverrideRow(record: NewBillingEntitlementOverride): BillingEntitlementOverridesTable {
+  return {
+    id: record.id,
+    clerk_user_id: record.clerkUserId,
+    plan_slug: record.planSlug,
+    status: record.status,
+    max_runtime_slots: record.maxRuntimeSlots,
+    included_runtime_slots: record.includedRuntimeSlots,
+    addon_runtime_slots: record.addonRuntimeSlots,
+    default_server_type: record.defaultServerType,
+    allowed_server_types: JSON.stringify(record.allowedServerTypes),
+    reason: record.reason,
+    created_by: record.createdBy,
+    expires_at: record.expiresAt,
+    revoked_at: record.revokedAt,
+    created_at: record.createdAt,
+  };
+}
+
+function mapBillingWebhookEvent(row: BillingWebhookEventsTable): BillingWebhookEventRecord {
+  return {
+    stripeEventId: row.stripe_event_id,
+    eventType: row.event_type,
+    createdAtFromStripe: row.created_at_from_stripe,
+    processedAt: row.processed_at,
+    status: row.status,
+    errorCode: row.error_code,
+  };
+}
+
+function toBillingWebhookEventRow(record: NewBillingWebhookEvent): BillingWebhookEventsTable {
+  return {
+    stripe_event_id: record.stripeEventId,
+    event_type: record.eventType,
+    created_at_from_stripe: record.createdAtFromStripe,
+    processed_at: record.processedAt,
+    status: record.status,
+    error_code: record.errorCode,
+  };
+}
+
 export async function insertContainer(db: PlatformDB, record: NewContainer): Promise<void> {
   await db.ready;
   await db.executor.insertInto('containers').values(toContainerRow(record)).execute();
@@ -885,6 +1208,158 @@ export async function listContainers(db: PlatformDB, status?: string): Promise<C
 export async function deleteContainer(db: PlatformDB, handle: string): Promise<void> {
   await db.ready;
   await db.executor.deleteFrom('containers').where('handle', '=', handle).execute();
+}
+
+export async function upsertBillingCustomer(db: PlatformDB, record: NewBillingCustomer): Promise<void> {
+  await db.ready;
+  await db.executor
+    .insertInto('billing_customers')
+    .values(toBillingCustomerRow(record))
+    .onConflict((oc) => oc.column('clerk_user_id').doUpdateSet({
+      stripe_customer_id: record.stripeCustomerId,
+      updated_at: record.updatedAt,
+    }))
+    .execute();
+}
+
+export async function insertBillingCustomerIfAbsent(db: PlatformDB, record: NewBillingCustomer): Promise<void> {
+  await db.ready;
+  await db.executor
+    .insertInto('billing_customers')
+    .values(toBillingCustomerRow(record))
+    .onConflict((oc) => oc.column('clerk_user_id').doNothing())
+    .execute();
+}
+
+export async function getBillingCustomerByClerkUserId(
+  db: PlatformDB,
+  clerkUserId: string,
+): Promise<BillingCustomerRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('billing_customers')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .executeTakeFirst();
+  return row ? mapBillingCustomer(row) : undefined;
+}
+
+export async function upsertBillingEntitlement(db: PlatformDB, record: NewBillingEntitlement): Promise<void> {
+  await db.ready;
+  const row = toBillingEntitlementRow(record);
+  await db.executor
+    .insertInto('billing_entitlements')
+    .values(row)
+    .onConflict((oc) => oc.column('clerk_user_id').doUpdateSet({
+      source: row.source,
+      plan_slug: row.plan_slug,
+      status: row.status,
+      max_runtime_slots: row.max_runtime_slots,
+      included_runtime_slots: row.included_runtime_slots,
+      addon_runtime_slots: row.addon_runtime_slots,
+      default_server_type: row.default_server_type,
+      allowed_server_types: row.allowed_server_types,
+      stripe_subscription_id: row.stripe_subscription_id,
+      stripe_price_id: row.stripe_price_id,
+      grace_period_ends_at: row.grace_period_ends_at,
+      effective_from: row.effective_from,
+      effective_until: row.effective_until,
+      updated_at: row.updated_at,
+    }).where('billing_entitlements.updated_at', '<=', row.updated_at))
+    .execute();
+}
+
+export async function getBillingEntitlement(
+  db: PlatformDB,
+  clerkUserId: string,
+): Promise<BillingEntitlementRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('billing_entitlements')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .executeTakeFirst();
+  return row ? mapBillingEntitlement(row) : undefined;
+}
+
+export async function upsertBillingOverride(db: PlatformDB, record: NewBillingEntitlementOverride): Promise<void> {
+  await db.ready;
+  const row = toBillingOverrideRow(record);
+  await db.executor
+    .insertInto('billing_entitlement_overrides')
+    .values(row)
+    .onConflict((oc) => oc.column('id').doUpdateSet({
+      plan_slug: row.plan_slug,
+      status: row.status,
+      max_runtime_slots: row.max_runtime_slots,
+      included_runtime_slots: row.included_runtime_slots,
+      addon_runtime_slots: row.addon_runtime_slots,
+      default_server_type: row.default_server_type,
+      allowed_server_types: row.allowed_server_types,
+      reason: row.reason,
+      created_by: row.created_by,
+      expires_at: row.expires_at,
+    }))
+    .execute();
+}
+
+export async function getBillingOverride(
+  db: PlatformDB,
+  clerkUserId: string,
+): Promise<BillingEntitlementOverrideRecord | undefined> {
+  await db.ready;
+  const now = new Date().toISOString();
+  const row = await db.executor
+    .selectFrom('billing_entitlement_overrides')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .where('revoked_at', 'is', null)
+    .where((eb) => eb.or([
+      eb('expires_at', 'is', null),
+      eb('expires_at', '>', now),
+    ]))
+    .orderBy('created_at', 'desc')
+    .executeTakeFirst();
+  return row ? mapBillingOverride(row) : undefined;
+}
+
+export async function revokeBillingOverride(db: PlatformDB, id: string, revokedAt: string): Promise<boolean> {
+  await db.ready;
+  const row = await db.executor
+    .updateTable('billing_entitlement_overrides')
+    .set({ revoked_at: revokedAt })
+    .where('id', '=', id)
+    .where('revoked_at', 'is', null)
+    .returning('id')
+    .executeTakeFirst();
+  return Boolean(row);
+}
+
+export async function insertBillingWebhookEvent(
+  db: PlatformDB,
+  record: NewBillingWebhookEvent,
+): Promise<{ inserted: boolean }> {
+  await db.ready;
+  const result = await db.executor
+    .insertInto('billing_webhook_events')
+    .values(toBillingWebhookEventRow(record))
+    .onConflict((oc) => oc.column('stripe_event_id').doNothing())
+    .returning('stripe_event_id')
+    .executeTakeFirst();
+  return { inserted: Boolean(result?.stripe_event_id) };
+}
+
+export async function getBillingWebhookEvent(
+  db: PlatformDB,
+  stripeEventId: string,
+): Promise<BillingWebhookEventRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('billing_webhook_events')
+    .selectAll()
+    .where('stripe_event_id', '=', stripeEventId)
+    .executeTakeFirst();
+  return row ? mapBillingWebhookEvent(row) : undefined;
 }
 
 export async function insertUserMachine(db: PlatformDB, record: NewUserMachine): Promise<void> {

--- a/tests/platform/billing-db.test.ts
+++ b/tests/platform/billing-db.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getBillingCustomerByClerkUserId,
+  getBillingEntitlement,
+  getBillingOverride,
+  getBillingWebhookEvent,
+  insertBillingCustomerIfAbsent,
+  insertBillingWebhookEvent,
+  revokeBillingOverride,
+  upsertBillingCustomer,
+  upsertBillingEntitlement,
+  upsertBillingOverride,
+  type NewBillingEntitlementOverride,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+describe('platform billing db', () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  it('upserts Stripe customer links by Clerk user id', async () => {
+    await upsertBillingCustomer(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_old',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    });
+    await upsertBillingCustomer(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_new',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-31T00:00:00.000Z',
+    });
+
+    await expect(getBillingCustomerByClerkUserId(db, 'user_123')).resolves.toMatchObject({
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_new',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-31T00:00:00.000Z',
+    });
+  });
+
+  it('does not overwrite existing Stripe customer links when inserting if absent', async () => {
+    await insertBillingCustomerIfAbsent(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_first',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    });
+    await insertBillingCustomerIfAbsent(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_second',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-31T00:00:00.000Z',
+    });
+
+    await expect(getBillingCustomerByClerkUserId(db, 'user_123')).resolves.toMatchObject({
+      stripeCustomerId: 'cus_first',
+    });
+  });
+
+  it('upserts the latest effective billing entitlement', async () => {
+    await upsertBillingEntitlement(db, {
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_starter',
+      status: 'active',
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx22',
+      allowedServerTypes: ['cpx22'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_starter_monthly',
+      gracePeriodEndsAt: '2026-07-03T00:00:00.000Z',
+      effectiveFrom: '2026-06-01T00:00:00.000Z',
+      effectiveUntil: null,
+      updatedAt: '2026-06-01T00:00:00.000Z',
+    });
+    await upsertBillingEntitlement(db, {
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_max',
+      status: 'active',
+      maxRuntimeSlots: 4,
+      includedRuntimeSlots: 3,
+      addonRuntimeSlots: 1,
+      defaultServerType: 'cpx52',
+      allowedServerTypes: ['cpx22', 'cpx32', 'cpx52'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_max_monthly',
+      gracePeriodEndsAt: '2026-07-03T00:00:00.000Z',
+      effectiveFrom: '2026-06-01T00:00:00.000Z',
+      effectiveUntil: null,
+      updatedAt: '2026-06-02T00:00:00.000Z',
+    });
+
+    await expect(getBillingEntitlement(db, 'user_123')).resolves.toMatchObject({
+      clerkUserId: 'user_123',
+      planSlug: 'matrix_max',
+      maxRuntimeSlots: 4,
+      allowedServerTypes: ['cpx22', 'cpx32', 'cpx52'],
+    });
+
+    await upsertBillingEntitlement(db, {
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_starter',
+      status: 'past_due',
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx22',
+      allowedServerTypes: ['cpx22'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_starter_monthly',
+      gracePeriodEndsAt: '2026-06-03T00:00:00.000Z',
+      effectiveFrom: '2026-06-01T00:00:00.000Z',
+      effectiveUntil: null,
+      updatedAt: '2026-06-01T12:00:00.000Z',
+    });
+
+    await expect(getBillingEntitlement(db, 'user_123')).resolves.toMatchObject({
+      planSlug: 'matrix_max',
+      maxRuntimeSlots: 4,
+      updatedAt: '2026-06-02T00:00:00.000Z',
+    });
+  });
+
+  it('ignores revoked internal overrides in the effective override lookup', async () => {
+    const override: NewBillingEntitlementOverride = {
+      id: 'override_123',
+      clerkUserId: 'user_123',
+      planSlug: 'internal',
+      status: 'active',
+      maxRuntimeSlots: 5,
+      includedRuntimeSlots: 5,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx52',
+      allowedServerTypes: ['cpx22', 'cpx32', 'cpx52'],
+      reason: 'engineer test',
+      createdBy: 'ops-user',
+      expiresAt: '2026-07-01T00:00:00.000Z',
+      revokedAt: null,
+      createdAt: '2026-05-30T00:00:00.000Z',
+    };
+
+    await upsertBillingOverride(db, override);
+    await expect(getBillingOverride(db, 'user_123')).resolves.toMatchObject({
+      id: 'override_123',
+      reason: 'engineer test',
+      revokedAt: null,
+    });
+
+    await expect(revokeBillingOverride(db, 'override_123', '2026-06-01T00:00:00.000Z')).resolves.toBe(true);
+    await expect(revokeBillingOverride(db, 'override_123', '2026-06-02T00:00:00.000Z')).resolves.toBe(false);
+
+    await expect(getBillingOverride(db, 'user_123')).resolves.toBeUndefined();
+    await expect(
+      db.executor
+        .selectFrom('billing_entitlement_overrides')
+        .select('revoked_at')
+        .where('id', '=', 'override_123')
+        .executeTakeFirst(),
+    ).resolves.toEqual({ revoked_at: '2026-06-01T00:00:00.000Z' });
+
+    await upsertBillingOverride(db, {
+      ...override,
+      reason: 'should not un-revoke',
+      revokedAt: null,
+    });
+
+    await expect(getBillingOverride(db, 'user_123')).resolves.toBeUndefined();
+    await expect(revokeBillingOverride(db, 'missing_override', '2026-06-01T00:00:00.000Z')).resolves.toBe(false);
+  });
+
+  it('records Stripe webhook event ids idempotently', async () => {
+    const first = await insertBillingWebhookEvent(db, {
+      stripeEventId: 'evt_123',
+      eventType: 'customer.subscription.updated',
+      createdAtFromStripe: '2026-05-30T00:00:00.000Z',
+      processedAt: '2026-05-30T00:00:01.000Z',
+      status: 'processed',
+      errorCode: null,
+    });
+    const duplicate = await insertBillingWebhookEvent(db, {
+      stripeEventId: 'evt_123',
+      eventType: 'customer.subscription.updated',
+      createdAtFromStripe: '2026-05-30T00:00:00.000Z',
+      processedAt: '2026-05-30T00:00:02.000Z',
+      status: 'processed',
+      errorCode: null,
+    });
+
+    expect(first.inserted).toBe(true);
+    expect(duplicate.inserted).toBe(false);
+    await expect(getBillingWebhookEvent(db, 'evt_123')).resolves.toMatchObject({
+      stripeEventId: 'evt_123',
+      processedAt: '2026-05-30T00:00:01.000Z',
+    });
+  });
+});

--- a/tests/platform/billing-entitlements.test.ts
+++ b/tests/platform/billing-entitlements.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BILLING_GRACE_PERIOD_MS,
+  DEFAULT_BILLING_PLAN_DEFINITIONS,
+  computeEffectiveEntitlement,
+  deriveStripeEntitlement,
+  getRuntimeAccessDecision,
+  loadRuntimeCatalog,
+  loadStripePriceCatalog,
+  type BillingEntitlement,
+  type BillingEntitlementOverride,
+} from '../../packages/platform/src/billing.js';
+
+const baseEnv = {
+  STRIPE_PRICE_MATRIX_STARTER_MONTHLY: 'price_starter_monthly',
+  STRIPE_PRICE_MATRIX_STARTER_ANNUAL: 'price_starter_annual',
+  STRIPE_PRICE_MATRIX_BUILDER_MONTHLY: 'price_builder_monthly',
+  STRIPE_PRICE_MATRIX_BUILDER_ANNUAL: 'price_builder_annual',
+  STRIPE_PRICE_MATRIX_MAX_MONTHLY: 'price_max_monthly',
+  STRIPE_PRICE_MATRIX_MAX_ANNUAL: 'price_max_annual',
+  STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY: 'price_extra_runtime_monthly',
+  STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL: 'price_extra_runtime_annual',
+};
+
+describe('platform billing entitlements', () => {
+  it('uses marketing plan slugs with monthly and annual prices', () => {
+    expect(DEFAULT_BILLING_PLAN_DEFINITIONS.map((plan) => plan.slug)).toEqual([
+      'matrix_starter',
+      'matrix_builder',
+      'matrix_max',
+    ]);
+    expect(DEFAULT_BILLING_PLAN_DEFINITIONS.map((plan) => plan.marketingName)).toEqual([
+      'Starter',
+      'Builder',
+      'Max',
+    ]);
+    expect(DEFAULT_BILLING_PLAN_DEFINITIONS.map((plan) => [plan.monthlyUsd, plan.annualUsd])).toEqual([
+      [14, 140],
+      [19, 190],
+      [49, 490],
+    ]);
+  });
+
+  it('loads Stripe price ids without trusting client submitted prices', () => {
+    const catalog = loadStripePriceCatalog(baseEnv);
+
+    expect(catalog.priceToPlan.get('price_builder_annual')).toMatchObject({
+      kind: 'base_plan',
+      planSlug: 'matrix_builder',
+      interval: 'annual',
+    });
+    expect(catalog.priceToPlan.get('price_extra_runtime_monthly')).toMatchObject({
+      kind: 'extra_runtime_slot',
+      interval: 'monthly',
+    });
+    expect(catalog.priceToPlan.has('price_unknown')).toBe(false);
+  });
+
+  it('keeps Hetzner server types behind a runtime catalog that can be overridden', () => {
+    const defaults = loadRuntimeCatalog({});
+    expect(defaults.profiles.map((profile) => [profile.sku, profile.serverType])).toEqual([
+      ['starter', 'cpx22'],
+      ['builder', 'cpx32'],
+      ['max', 'cpx52'],
+    ]);
+
+    const overridden = loadRuntimeCatalog({
+      MATRIX_RUNTIME_CATALOG_JSON: JSON.stringify({
+        profiles: [
+          {
+            sku: 'starter',
+            label: 'Starter',
+            provider: 'hetzner',
+            serverType: 'cx22',
+            vcpu: 2,
+            memoryGb: 4,
+            diskGb: 40,
+            active: true,
+          },
+        ],
+      }),
+    });
+
+    expect(overridden.profiles).toHaveLength(1);
+    expect(overridden.profiles[0]?.serverType).toBe('cx22');
+  });
+
+  it('projects Stripe base plan and add-on prices into runtime capacity', () => {
+    const entitlement = deriveStripeEntitlement({
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      status: 'active',
+      currentPeriodEnd: '2026-06-30T00:00:00.000Z',
+      items: [
+        { priceId: 'price_builder_monthly', quantity: 1 },
+        { priceId: 'price_extra_runtime_monthly', quantity: 2 },
+      ],
+    }, {
+      priceCatalog: loadStripePriceCatalog(baseEnv),
+      runtimeCatalog: loadRuntimeCatalog({}),
+      now: new Date('2026-05-30T00:00:00.000Z'),
+    });
+
+    expect(entitlement).toMatchObject({
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_builder',
+      status: 'active',
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 2,
+      maxRuntimeSlots: 3,
+      defaultServerType: 'cpx32',
+      allowedServerTypes: ['cpx22', 'cpx32'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_builder_monthly',
+    });
+  });
+
+  it('does not count zero or null add-on quantities as runtime slots', () => {
+    const entitlement = deriveStripeEntitlement({
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_123',
+      stripeSubscriptionId: 'sub_123',
+      status: 'active',
+      currentPeriodEnd: '2026-06-30T00:00:00.000Z',
+      items: [
+        { priceId: 'price_builder_monthly', quantity: 1 },
+        { priceId: 'price_extra_runtime_monthly', quantity: 0 },
+        { priceId: 'price_extra_runtime_monthly' },
+      ],
+    }, {
+      priceCatalog: loadStripePriceCatalog(baseEnv),
+      runtimeCatalog: loadRuntimeCatalog({}),
+      now: new Date('2026-05-30T00:00:00.000Z'),
+    });
+
+    expect(entitlement).toMatchObject({
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      maxRuntimeSlots: 1,
+    });
+  });
+
+  it('allows runtime access during active billing plus a 3-day grace period', () => {
+    const entitlement: BillingEntitlement = {
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_starter',
+      status: 'past_due',
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx22',
+      allowedServerTypes: ['cpx22'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_starter_monthly',
+      gracePeriodEndsAt: '2026-06-03T00:00:00.000Z',
+      effectiveFrom: '2026-05-01T00:00:00.000Z',
+      effectiveUntil: null,
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    };
+
+    expect(getRuntimeAccessDecision(entitlement, new Date('2026-06-02T23:59:59.000Z'))).toMatchObject({
+      runtimeProxyAllowed: true,
+      reason: 'grace_period',
+    });
+    expect(getRuntimeAccessDecision(entitlement, new Date('2026-06-03T00:00:01.000Z'))).toMatchObject({
+      runtimeProxyAllowed: false,
+      reason: 'payment_required',
+    });
+  });
+
+  it('prefers unexpired production internal overrides over Stripe state', () => {
+    const stripeEntitlement: BillingEntitlement = {
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_starter',
+      status: 'past_due',
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx22',
+      allowedServerTypes: ['cpx22'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_starter_monthly',
+      gracePeriodEndsAt: new Date(Date.parse('2026-05-30T00:00:00.000Z') + BILLING_GRACE_PERIOD_MS).toISOString(),
+      effectiveFrom: '2026-05-01T00:00:00.000Z',
+      effectiveUntil: null,
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    };
+    const override: BillingEntitlementOverride = {
+      id: 'override_1',
+      clerkUserId: 'user_123',
+      planSlug: 'internal',
+      status: 'active',
+      maxRuntimeSlots: 5,
+      includedRuntimeSlots: 5,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx52',
+      allowedServerTypes: ['cpx22', 'cpx32', 'cpx52'],
+      reason: 'engineer test',
+      createdBy: 'ops-user',
+      expiresAt: '2026-07-01T00:00:00.000Z',
+      revokedAt: null,
+      createdAt: '2026-05-30T00:00:00.000Z',
+    };
+
+    expect(computeEffectiveEntitlement({
+      stripeEntitlement,
+      override,
+      now: new Date('2026-06-10T00:00:00.000Z'),
+    })).toMatchObject({
+      source: 'override',
+      planSlug: 'internal',
+      maxRuntimeSlots: 5,
+      defaultServerType: 'cpx52',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the platform billing catalog and entitlement computation for Stripe subscriptions, internal overrides, runtime slots, grace periods, and Hetzner-backed server profiles.
- Adds Kysely table creation and helpers for Stripe customers, effective entitlements, overrides, and idempotent webhook events.

## Stack
Base: #268. Next: #270.

## Tests
- `tests/platform/billing-entitlements.test.ts`
- `tests/platform/billing-db.test.ts`

## Invariants
- Source of truth: Stripe subscription events project into `billing_entitlements`; Matrix-controlled plan/runtime catalogs map billing prices to runtime policy; audited `billing_overrides` can supersede Stripe for internal access.
- Lock/transaction scope: DB helpers use unique keys and `onConflict` upserts for idempotent customer, entitlement, override, and webhook-event writes.
- Acceptable orphan states: unknown Stripe prices produce inactive/no-access entitlements rather than granting runtime access; override rows remain auditable after revocation.
- Auth source of truth: no route auth is introduced here; callers must pass already-authenticated Clerk user ids.
- Deferred scope: no admin UI, org billing, automatic machine resizing/deletion, or token-metered billing.
