### PR TITLE
feat(billing): add Stripe billing routes

### DIFF
--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -1,0 +1,372 @@
+import { Hono, type Context } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { z } from 'zod/v4';
+import {
+  getBillingCustomerByClerkUserId,
+  getBillingCustomerByStripeCustomerId,
+  getBillingEntitlement,
+  insertBillingCustomerIfAbsent,
+  insertBillingWebhookEvent,
+  runBillingWebhookTransaction,
+  upsertBillingEntitlement,
+  type BillingCustomerRecord,
+  type PlatformDB,
+} from './db.js';
+import {
+  DEFAULT_BILLING_PLAN_DEFINITIONS,
+  deriveStripeEntitlement,
+  getRuntimeAccessDecision,
+  loadRuntimeCatalog,
+  loadStripePriceCatalog,
+  type BillingEntitlementStatus,
+  type BillingEntitlement,
+  type MatrixBillingPlanSlug,
+  type MatrixBillingInterval,
+  type StripeSubscriptionProjection,
+} from './billing.js';
+
+const BILLING_BODY_LIMIT = 16 * 1024;
+const STRIPE_WEBHOOK_BODY_LIMIT = 1024 * 1024;
+const MAX_STRIPE_API_TIMEOUT_MS = 10_000;
+const CUSTOMER_CREATION_INFLIGHT_LIMIT = 1024;
+const customerCreationInflight = new Map<string, Promise<BillingCustomerRecord>>();
+
+const CheckoutRequestSchema = z.object({
+  planSlug: z.enum(['matrix_starter', 'matrix_builder', 'matrix_max']),
+  interval: z.enum(['monthly', 'annual']).default('monthly'),
+});
+
+export interface StripeCheckoutSessionInput {
+  customerId: string;
+  priceId: string;
+  mode: 'subscription';
+  automaticTax: boolean;
+}
+
+export interface StripeBillingClient {
+  apiTimeoutMs: number;
+  /**
+   * Implementations must pass idempotencyKey through to Stripe and use a bounded
+   * network timeout. Callers rely on that to avoid duplicate customer creation
+   * without holding database locks across external API calls.
+   */
+  createCustomer(input: { clerkUserId: string; idempotencyKey: string }): Promise<{ id: string }>;
+  createCheckoutSession(input: StripeCheckoutSessionInput): Promise<{ url: string }>;
+  createPortalSession(input: { customerId: string }): Promise<{ url: string }>;
+  constructWebhookEvent(rawBody: string, signature: string, webhookSecret: string): StripeWebhookEvent;
+}
+
+export interface StripeWebhookEvent {
+  id: string;
+  type: string;
+  created: number;
+  data: { object: unknown };
+}
+
+export function createBillingRoutes(options: {
+  db: PlatformDB;
+  stripe: StripeBillingClient;
+  env?: NodeJS.ProcessEnv;
+  resolveClerkUserId: (c: Context) => Promise<string | null>;
+  now?: () => Date;
+  upsertEntitlement?: typeof upsertBillingEntitlement;
+}): Hono {
+  const app = new Hono();
+  const env = options.env ?? process.env;
+  const now = options.now ?? (() => new Date());
+  const persistEntitlement = options.upsertEntitlement ?? upsertBillingEntitlement;
+
+  async function resolveRouteClerkUserId(c: Context, route: string): Promise<string | null> {
+    try {
+      return await options.resolveClerkUserId(c);
+    } catch (err: unknown) {
+      console.warn(`[billing] ${route} auth resolution failed:`, err instanceof Error ? err.name : typeof err);
+      return null;
+    }
+  }
+
+  app.post('/checkout', bodyLimit({ maxSize: BILLING_BODY_LIMIT }), async (c) => {
+    const clerkUserId = await resolveRouteClerkUserId(c, 'checkout');
+    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (err: unknown) {
+      if (err instanceof SyntaxError) return c.json({ error: 'Invalid request' }, 400);
+      throw err;
+    }
+    const parsed = CheckoutRequestSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: 'Invalid request' }, 400);
+
+    const priceId = resolvePriceId(env, parsed.data.planSlug, parsed.data.interval);
+    if (!priceId) return c.json({ error: 'Billing unavailable' }, 503);
+
+    try {
+      if (options.stripe.apiTimeoutMs > MAX_STRIPE_API_TIMEOUT_MS) {
+        throw new Error('stripe_timeout_exceeds_budget');
+      }
+      const customer = await getOrCreateCustomer(options.db, options.stripe, clerkUserId, now());
+      const session = await options.stripe.createCheckoutSession({
+        customerId: customer.stripeCustomerId,
+        priceId,
+        mode: 'subscription',
+        automaticTax: true,
+      });
+      return c.json({ url: session.url }, 200);
+    } catch (err: unknown) {
+      console.error('[billing] checkout creation failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Billing unavailable' }, 503);
+    }
+  });
+
+  app.post('/portal', bodyLimit({ maxSize: BILLING_BODY_LIMIT }), async (c) => {
+    const clerkUserId = await resolveRouteClerkUserId(c, 'portal');
+    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
+
+    try {
+      if (options.stripe.apiTimeoutMs > MAX_STRIPE_API_TIMEOUT_MS) {
+        throw new Error('stripe_timeout_exceeds_budget');
+      }
+      const customer = await getBillingCustomerByClerkUserId(options.db, clerkUserId);
+      if (!customer) return c.json({ error: 'Billing unavailable' }, 404);
+      const session = await options.stripe.createPortalSession({ customerId: customer.stripeCustomerId });
+      return c.json({ url: session.url }, 200);
+    } catch (err: unknown) {
+      console.error('[billing] portal creation failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Billing unavailable' }, 503);
+    }
+  });
+
+  app.get('/status', async (c) => {
+    const clerkUserId = await resolveRouteClerkUserId(c, 'status');
+    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
+    try {
+      const entitlement = await getBillingEntitlement(options.db, clerkUserId);
+      const access = getRuntimeAccessDecision(toDomainEntitlement(entitlement), now());
+      return c.json({ entitlement: entitlement ?? null, access }, 200);
+    } catch (err: unknown) {
+      console.error('[billing] status lookup failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Billing unavailable' }, 503);
+    }
+  });
+
+  app.post('/webhooks/stripe', bodyLimit({ maxSize: STRIPE_WEBHOOK_BODY_LIMIT }), async (c) => {
+    const signature = c.req.header('stripe-signature');
+    const webhookSecret = env.STRIPE_WEBHOOK_SECRET;
+    if (!signature || !webhookSecret) return c.json({ error: 'Invalid webhook' }, 400);
+
+    const rawBody = await c.req.text();
+    let event: StripeWebhookEvent;
+    try {
+      event = options.stripe.constructWebhookEvent(rawBody, signature, webhookSecret);
+    } catch (err: unknown) {
+      console.warn('[billing] invalid Stripe webhook signature:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Invalid webhook' }, 400);
+    }
+
+    try {
+      const result = await runBillingWebhookTransaction(options.db, async (trx) => {
+        const inserted = await insertBillingWebhookEvent(trx, {
+          stripeEventId: event.id,
+          eventType: event.type,
+          createdAtFromStripe: epochSecondsToIso(event.created),
+          processedAt: now().toISOString(),
+          status: 'processed',
+          errorCode: null,
+        });
+        if (!inserted.inserted) {
+          return { received: true, duplicate: true };
+        }
+
+        if (!isSubscriptionEvent(event.type)) {
+          return { received: true, ignored: true };
+        }
+
+        const projection = await projectSubscription(trx, event.data.object);
+        if (!projection) return { received: true, ignored: true };
+
+        const entitlement = deriveStripeEntitlement(projection, {
+          priceCatalog: loadStripePriceCatalog(env),
+          runtimeCatalog: loadRuntimeCatalog(env),
+          now: now(),
+        });
+        await persistEntitlement(trx, entitlement);
+        return { received: true, processed: true };
+      });
+      return c.json(result, 200);
+    } catch (err: unknown) {
+      console.error('[billing] Stripe webhook processing failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'Webhook processing failed' }, 500);
+    }
+  });
+
+  app.all('*', bodyLimit({ maxSize: BILLING_BODY_LIMIT }), (c) => {
+    return c.json({ error: 'Not found' }, 404);
+  });
+
+  return app;
+}
+
+async function getOrCreateCustomer(
+  db: PlatformDB,
+  stripe: StripeBillingClient,
+  clerkUserId: string,
+  currentTime: Date,
+) {
+  const existing = await getBillingCustomerByClerkUserId(db, clerkUserId);
+  if (existing) return existing;
+
+  const pending = customerCreationInflight.get(clerkUserId);
+  if (pending) return pending;
+  if (customerCreationInflight.size >= CUSTOMER_CREATION_INFLIGHT_LIMIT) {
+    throw new Error('customer_creation_inflight_limit');
+  }
+  const created = createAndPersistCustomer(db, stripe, clerkUserId, currentTime);
+  customerCreationInflight.set(clerkUserId, created);
+  try {
+    return await created;
+  } finally {
+    customerCreationInflight.delete(clerkUserId);
+  }
+}
+
+async function createAndPersistCustomer(
+  db: PlatformDB,
+  stripe: StripeBillingClient,
+  clerkUserId: string,
+  currentTime: Date,
+): Promise<BillingCustomerRecord> {
+  const customer = await stripe.createCustomer({
+    clerkUserId,
+    idempotencyKey: billingCustomerIdempotencyKey(clerkUserId),
+  });
+
+  const nowIso = currentTime.toISOString();
+  await insertBillingCustomerIfAbsent(db, {
+    clerkUserId,
+    stripeCustomerId: customer.id,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  });
+  const persisted = await getBillingCustomerByClerkUserId(db, clerkUserId);
+  if (!persisted) throw new Error('billing customer was not persisted');
+  return persisted;
+}
+
+function billingCustomerIdempotencyKey(clerkUserId: string): string {
+  return `billing-customer:${clerkUserId}`;
+}
+
+function resolvePriceId(
+  env: NodeJS.ProcessEnv,
+  planSlug: MatrixBillingPlanSlug,
+  interval: MatrixBillingInterval,
+): string | undefined {
+  const key = `STRIPE_PRICE_${planSlug.toUpperCase()}_${interval.toUpperCase()}`;
+  return env[key];
+}
+
+function isSubscriptionEvent(type: string): boolean {
+  return (
+    type === 'customer.subscription.created' ||
+    type === 'customer.subscription.updated' ||
+    type === 'customer.subscription.deleted'
+  );
+}
+
+async function projectSubscription(db: PlatformDB, value: unknown): Promise<StripeSubscriptionProjection | null> {
+  if (!value || typeof value !== 'object') return null;
+  const sub = value as {
+    id?: unknown;
+    customer?: unknown;
+    status?: unknown;
+    current_period_end?: unknown;
+    items?: { data?: unknown };
+  };
+  if (typeof sub.id !== 'string' || typeof sub.customer !== 'string') return null;
+  const customer = await getBillingCustomerByStripeCustomerId(db, sub.customer);
+  if (!customer) return null;
+  const status = normalizeSubscriptionStatus(sub.status);
+  const data = Array.isArray(sub.items?.data) ? sub.items.data : [];
+  return {
+    clerkUserId: customer.clerkUserId,
+    stripeCustomerId: customer.stripeCustomerId,
+    stripeSubscriptionId: sub.id,
+    status,
+    currentPeriodEnd: typeof sub.current_period_end === 'number'
+      ? epochSecondsToIso(sub.current_period_end)
+      : null,
+    items: data.flatMap((item) => {
+      if (!item || typeof item !== 'object') return [];
+      const candidate = item as { price?: { id?: unknown }; quantity?: unknown };
+      if (typeof candidate.price?.id !== 'string') return [];
+      return [{
+        priceId: candidate.price.id,
+        quantity: typeof candidate.quantity === 'number' ? candidate.quantity : 1,
+      }];
+    }),
+  };
+}
+
+function normalizeSubscriptionStatus(value: unknown): BillingEntitlementStatus {
+  if (
+    value === 'active' ||
+    value === 'trialing' ||
+    value === 'past_due' ||
+    value === 'canceled' ||
+    value === 'incomplete' ||
+    value === 'unpaid'
+  ) {
+    return value;
+  }
+  return 'ended';
+}
+
+function epochSecondsToIso(value: number): string {
+  return new Date(value * 1000).toISOString();
+}
+
+export function getPublicBillingPlans() {
+  return DEFAULT_BILLING_PLAN_DEFINITIONS.map((plan) => ({
+    slug: plan.slug,
+    marketingName: plan.marketingName,
+    monthlyUsd: plan.monthlyUsd,
+    annualUsd: plan.annualUsd,
+    includedRuntimeSlots: plan.includedRuntimeSlots,
+  }));
+}
+
+function toDomainEntitlement(record: Awaited<ReturnType<typeof getBillingEntitlement>>): BillingEntitlement | null {
+  if (!record) return null;
+  if (!isEntitlementSource(record.source) || !isPlanSlug(record.planSlug) || !isEntitlementStatus(record.status)) {
+    return null;
+  }
+  return {
+    ...record,
+    source: record.source,
+    planSlug: record.planSlug,
+    status: record.status,
+  };
+}
+
+function isEntitlementSource(value: string): value is BillingEntitlement['source'] {
+  return value === 'stripe' || value === 'override';
+}
+
+function isPlanSlug(value: string): value is BillingEntitlement['planSlug'] {
+  return value === 'matrix_starter' || value === 'matrix_builder' || value === 'matrix_max' || value === 'internal';
+}
+
+function isEntitlementStatus(value: string): value is BillingEntitlementStatus {
+  return (
+    value === 'active' ||
+    value === 'trialing' ||
+    value === 'past_due' ||
+    value === 'canceled' ||
+    value === 'incomplete' ||
+    value === 'unpaid' ||
+    value === 'ended' ||
+    value === 'none'
+  );
+}

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -1244,6 +1244,19 @@ export async function getBillingCustomerByClerkUserId(
   return row ? mapBillingCustomer(row) : undefined;
 }
 
+export async function getBillingCustomerByStripeCustomerId(
+  db: PlatformDB,
+  stripeCustomerId: string,
+): Promise<BillingCustomerRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('billing_customers')
+    .selectAll()
+    .where('stripe_customer_id', '=', stripeCustomerId)
+    .executeTakeFirst();
+  return row ? mapBillingCustomer(row) : undefined;
+}
+
 export async function upsertBillingEntitlement(db: PlatformDB, record: NewBillingEntitlement): Promise<void> {
   await db.ready;
   const row = toBillingEntitlementRow(record);

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -1,0 +1,401 @@
+import { Hono } from 'hono';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getBillingEntitlement,
+  insertBillingWebhookEvent,
+  upsertBillingCustomer,
+  upsertBillingEntitlement,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import {
+  createBillingRoutes,
+  type StripeBillingClient,
+  type StripeWebhookEvent,
+} from '../../packages/platform/src/billing-routes.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const env = {
+  STRIPE_PRICE_MATRIX_STARTER_MONTHLY: 'price_starter_monthly',
+  STRIPE_PRICE_MATRIX_STARTER_ANNUAL: 'price_starter_annual',
+  STRIPE_PRICE_MATRIX_BUILDER_MONTHLY: 'price_builder_monthly',
+  STRIPE_PRICE_MATRIX_BUILDER_ANNUAL: 'price_builder_annual',
+  STRIPE_PRICE_MATRIX_MAX_MONTHLY: 'price_max_monthly',
+  STRIPE_PRICE_MATRIX_MAX_ANNUAL: 'price_max_annual',
+  STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY: 'price_extra_runtime_monthly',
+  STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL: 'price_extra_runtime_annual',
+  STRIPE_WEBHOOK_SECRET: 'whsec_test',
+};
+
+describe('platform billing routes', () => {
+  let db: PlatformDB;
+  let stripe: StripeBillingClient;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    stripe = {
+      apiTimeoutMs: 10_000,
+      createCustomer: vi.fn().mockResolvedValue({ id: 'cus_123' }),
+      createCheckoutSession: vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/session' }),
+      createPortalSession: vi.fn().mockResolvedValue({ url: 'https://billing.stripe.test/session' }),
+      constructWebhookEvent: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  function createApp(userId: string | null = 'user_123') {
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve(userId),
+      now: () => new Date('2026-05-30T00:00:00.000Z'),
+    }));
+    return app;
+  }
+
+  it('creates checkout sessions from server-owned plan slugs and omits payment_method_types', async () => {
+    const app = createApp();
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'annual' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: 'https://checkout.stripe.test/session' });
+    expect(stripe.createCustomer).toHaveBeenCalledWith({
+      clerkUserId: 'user_123',
+      idempotencyKey: 'billing-customer:user_123',
+    });
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
+      customerId: 'cus_123',
+      priceId: 'price_builder_annual',
+      mode: 'subscription',
+      automaticTax: true,
+    }));
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(
+      expect.not.objectContaining({ payment_method_types: expect.anything() }),
+    );
+  });
+
+  it('uses a stable Stripe idempotency key for concurrent customer creation', async () => {
+    let customerSequence = 0;
+    const idempotentCustomers: Record<string, string | undefined> = {};
+    vi.mocked(stripe.createCustomer).mockImplementation(async ({ idempotencyKey }) => {
+      const existing = idempotentCustomers[idempotencyKey];
+      const id = existing ?? `cus_${++customerSequence}`;
+      idempotentCustomers[idempotencyKey] = id;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return { id };
+    });
+    const app = createApp();
+
+    const [first, second] = await Promise.all([
+      app.request('/billing/checkout', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
+      }),
+      app.request('/billing/checkout', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
+      }),
+    ]);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(stripe.createCustomer).toHaveBeenCalledWith({
+      clerkUserId: 'user_123',
+      idempotencyKey: 'billing-customer:user_123',
+    });
+    expect(stripe.createCheckoutSession).toHaveBeenCalledTimes(2);
+    expect(stripe.createCheckoutSession).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      customerId: 'cus_1',
+    }));
+    expect(stripe.createCheckoutSession).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      customerId: 'cus_1',
+    }));
+  });
+
+  it('coalesces concurrent customer creation for the same Clerk user', async () => {
+    vi.mocked(stripe.createCustomer).mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return { id: 'cus_singleflight' };
+    });
+    const checkoutCustomers: string[] = [];
+    vi.mocked(stripe.createCheckoutSession).mockImplementation(async ({ customerId }) => {
+      checkoutCustomers.push(customerId);
+      return { url: 'https://checkout.stripe.test/session' };
+    });
+    const app = createApp();
+
+    const [first, second] = await Promise.all([
+      app.request('/billing/checkout', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
+      }),
+      app.request('/billing/checkout', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
+      }),
+    ]);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(stripe.createCustomer).toHaveBeenCalledTimes(1);
+    expect(new Set(checkoutCustomers).size).toBe(1);
+    expect(checkoutCustomers[0]).toBe('cus_singleflight');
+  });
+
+  it('terminates unknown billing paths inside the billing namespace', async () => {
+    const app = createApp();
+
+    const res = await app.request('/billing/not-a-route', { method: 'POST' });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Not found' });
+    expect(stripe.createCustomer).not.toHaveBeenCalled();
+    expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown checkout plan slugs with a generic validation error', async () => {
+    const app = createApp();
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ planSlug: 'price_builder_annual', interval: 'annual' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid request' });
+    expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['checkout', 'POST', JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' })],
+    ['portal', 'POST', undefined],
+    ['status', 'GET', undefined],
+  ] as const)('returns unauthorized when Clerk auth resolution throws on %s', async (path, method, body) => {
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: async () => {
+        throw new Error('jwks unavailable');
+      },
+      now: () => new Date('2026-05-30T00:00:00.000Z'),
+    }));
+
+    const res = await app.request(`/billing/${path}`, {
+      method,
+      headers: body ? { 'content-type': 'application/json' } : undefined,
+      body,
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    expect(stripe.createCustomer).not.toHaveBeenCalled();
+    expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
+    expect(stripe.createPortalSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects checkout when the Stripe client timeout exceeds the API budget', async () => {
+    stripe.apiTimeoutMs = 80_000;
+    const app = createApp();
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'Billing unavailable' });
+    expect(stripe.createCustomer).not.toHaveBeenCalled();
+  });
+
+  it('creates customer portal sessions for the signed-in Stripe customer', async () => {
+    await upsertBillingCustomer(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_123',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    });
+    const app = createApp();
+
+    const res = await app.request('/billing/portal', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: 'https://billing.stripe.test/session' });
+    expect(stripe.createPortalSession).toHaveBeenCalledWith({ customerId: 'cus_123' });
+  });
+
+  it('rejects portal creation when the Stripe client timeout exceeds the API budget', async () => {
+    await upsertBillingCustomer(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_123',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    });
+    stripe.apiTimeoutMs = 80_000;
+    const app = createApp();
+
+    const res = await app.request('/billing/portal', { method: 'POST' });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'Billing unavailable' });
+    expect(stripe.createPortalSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects Stripe webhooks with invalid signatures', async () => {
+    vi.mocked(stripe.constructWebhookEvent).mockImplementation(() => {
+      throw new Error('bad signature');
+    });
+    const app = createApp(null);
+
+    const res = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'invalid' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid webhook' });
+  });
+
+  it('processes subscription webhook events idempotently into entitlements', async () => {
+    await upsertBillingCustomer(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_123',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    });
+    const event = subscriptionEvent('evt_123');
+    vi.mocked(stripe.constructWebhookEvent).mockReturnValue(event);
+    const app = createApp(null);
+
+    const first = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+    const duplicate = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({ received: true, processed: true });
+    expect(duplicate.status).toBe(200);
+    expect(await duplicate.json()).toEqual({ received: true, duplicate: true });
+    await expect(getBillingEntitlement(db, 'user_123')).resolves.toMatchObject({
+      planSlug: 'matrix_max',
+      maxRuntimeSlots: 4,
+      defaultServerType: 'cpx52',
+      allowedServerTypes: ['cpx22', 'cpx32', 'cpx52'],
+    });
+  });
+
+  it('does not consume webhook event ids when entitlement projection fails', async () => {
+    await upsertBillingCustomer(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_123',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    });
+    const event = subscriptionEvent('evt_retry');
+    vi.mocked(stripe.constructWebhookEvent).mockReturnValue(event);
+    let shouldFail = true;
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve(null),
+      now: () => new Date('2026-05-30T00:00:00.000Z'),
+      upsertEntitlement: async (trx, entitlement) => {
+        if (shouldFail) {
+          shouldFail = false;
+          throw new Error('entitlement write timeout');
+        }
+        await upsertBillingEntitlement(trx, entitlement);
+      },
+    }));
+
+    const failed = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+    const retry = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+
+    expect(failed.status).toBe(500);
+    expect(await failed.json()).toEqual({ error: 'Webhook processing failed' });
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toEqual({ received: true, processed: true });
+    await expect(getBillingEntitlement(db, 'user_123')).resolves.toMatchObject({
+      planSlug: 'matrix_max',
+      maxRuntimeSlots: 4,
+    });
+  });
+
+  it('does not regress entitlements for previously processed event ids', async () => {
+    await insertBillingWebhookEvent(db, {
+      stripeEventId: 'evt_123',
+      eventType: 'customer.subscription.updated',
+      createdAtFromStripe: '2026-05-30T00:00:00.000Z',
+      processedAt: '2026-05-30T00:00:01.000Z',
+      status: 'processed',
+      errorCode: null,
+    });
+    vi.mocked(stripe.constructWebhookEvent).mockReturnValue(subscriptionEvent('evt_123'));
+    const app = createApp(null);
+
+    const res = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true, duplicate: true });
+    await expect(getBillingEntitlement(db, 'user_123')).resolves.toBeUndefined();
+  });
+});
+
+function subscriptionEvent(id: string): StripeWebhookEvent {
+  return {
+    id,
+    type: 'customer.subscription.updated',
+    created: 1_779_753_600,
+    data: {
+      object: {
+        id: 'sub_123',
+        customer: 'cus_123',
+        status: 'active',
+        current_period_end: 1_782_432_000,
+        items: {
+          data: [
+            { price: { id: 'price_max_monthly' }, quantity: 1 },
+            { price: { id: 'price_extra_runtime_monthly' }, quantity: 1 },
+          ],
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds platform `/billing/status`, `/billing/checkout`, `/billing/portal`, and `/billing/webhooks/stripe` routes.
- Projects Stripe subscription lifecycle events into Matrix entitlements with signature verification, idempotent webhook processing, safe client errors, and body limits.

## Stack
Base: #269. Next: #271.

## Tests
- `tests/platform/billing-routes.test.ts`

## Invariants
- Source of truth: Stripe is the event source for subscription state; platform DB stores the effective entitlement projection consumed by runtime enforcement.
- Lock/transaction scope: webhook event ids are inserted idempotently before projection so provider retries do not duplicate entitlement side effects.
- Acceptable orphan states: checkout/portal failures return generic billing errors without changing entitlement state; duplicate webhooks are acknowledged after idempotency checks.
- Auth source of truth: user routes require a Clerk-authenticated user resolver; Stripe webhook auth is the verified Stripe signature.
- Deferred scope: no Stripe SDK instantiation, operator admin endpoints, org billing, or add-on-specific UI in this layer.
