### PR TITLE
feat(billing): enforce runtime entitlements

### DIFF
--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -18,8 +18,8 @@ import {
   getRuntimeAccessDecision,
   loadRuntimeCatalog,
   loadStripePriceCatalog,
+  parseBillingEntitlementRecord,
   type BillingEntitlementStatus,
-  type BillingEntitlement,
   type MatrixBillingPlanSlug,
   type MatrixBillingInterval,
   type StripeSubscriptionProjection,
@@ -143,7 +143,7 @@ export function createBillingRoutes(options: {
     if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
     try {
       const entitlement = await getBillingEntitlement(options.db, clerkUserId);
-      const access = getRuntimeAccessDecision(toDomainEntitlement(entitlement), now());
+      const access = getRuntimeAccessDecision(parseBillingEntitlementRecord(entitlement), now());
       return c.json({ entitlement: entitlement ?? null, access }, 200);
     } catch (err: unknown) {
       console.error('[billing] status lookup failed:', err instanceof Error ? err.message : String(err));
@@ -335,38 +335,4 @@ export function getPublicBillingPlans() {
     annualUsd: plan.annualUsd,
     includedRuntimeSlots: plan.includedRuntimeSlots,
   }));
-}
-
-function toDomainEntitlement(record: Awaited<ReturnType<typeof getBillingEntitlement>>): BillingEntitlement | null {
-  if (!record) return null;
-  if (!isEntitlementSource(record.source) || !isPlanSlug(record.planSlug) || !isEntitlementStatus(record.status)) {
-    return null;
-  }
-  return {
-    ...record,
-    source: record.source,
-    planSlug: record.planSlug,
-    status: record.status,
-  };
-}
-
-function isEntitlementSource(value: string): value is BillingEntitlement['source'] {
-  return value === 'stripe' || value === 'override';
-}
-
-function isPlanSlug(value: string): value is BillingEntitlement['planSlug'] {
-  return value === 'matrix_starter' || value === 'matrix_builder' || value === 'matrix_max' || value === 'internal';
-}
-
-function isEntitlementStatus(value: string): value is BillingEntitlementStatus {
-  return (
-    value === 'active' ||
-    value === 'trialing' ||
-    value === 'past_due' ||
-    value === 'canceled' ||
-    value === 'incomplete' ||
-    value === 'unpaid' ||
-    value === 'ended' ||
-    value === 'none'
-  );
 }

--- a/packages/platform/src/billing.ts
+++ b/packages/platform/src/billing.ts
@@ -360,6 +360,62 @@ export function getRuntimeAccessDecision(
   };
 }
 
+export function parseBillingEntitlementRecord(record: {
+  clerkUserId: string;
+  source: string;
+  planSlug: string;
+  status: string;
+  maxRuntimeSlots: number;
+  includedRuntimeSlots: number;
+  addonRuntimeSlots: number;
+  defaultServerType: string;
+  allowedServerTypes: string[];
+  stripeSubscriptionId: string | null;
+  stripePriceId: string | null;
+  gracePeriodEndsAt: string | null;
+  effectiveFrom: string;
+  effectiveUntil: string | null;
+  updatedAt: string;
+} | null | undefined): BillingEntitlement | null {
+  if (!record) return null;
+  if (!isEntitlementSource(record.source) || !isPlanSlug(record.planSlug) || !isEntitlementStatus(record.status)) {
+    return null;
+  }
+  return {
+    ...record,
+    source: record.source,
+    planSlug: record.planSlug,
+    status: record.status,
+  };
+}
+
+export function parseBillingOverrideRecord(record: {
+  id: string;
+  clerkUserId: string;
+  planSlug: string;
+  status: string;
+  maxRuntimeSlots: number;
+  includedRuntimeSlots: number;
+  addonRuntimeSlots: number;
+  defaultServerType: string;
+  allowedServerTypes: string[];
+  reason: string;
+  createdBy: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+} | null | undefined): BillingEntitlementOverride | null {
+  if (!record) return null;
+  if (!isPlanSlug(record.planSlug) || record.status !== 'active') {
+    return null;
+  }
+  return {
+    ...record,
+    planSlug: record.planSlug,
+    status: record.status,
+  };
+}
+
 export function computeEffectiveEntitlement(input: {
   stripeEntitlement?: BillingEntitlement | null;
   override?: BillingEntitlementOverride | null;
@@ -386,4 +442,25 @@ export function computeEffectiveEntitlement(input: {
     };
   }
   return input.stripeEntitlement ?? null;
+}
+
+function isEntitlementSource(value: string): value is BillingEntitlementSource {
+  return value === 'stripe' || value === 'override';
+}
+
+function isPlanSlug(value: string): value is BillingEntitlement['planSlug'] {
+  return value === 'matrix_starter' || value === 'matrix_builder' || value === 'matrix_max' || value === 'internal';
+}
+
+function isEntitlementStatus(value: string): value is BillingEntitlementStatus {
+  return (
+    value === 'active' ||
+    value === 'trialing' ||
+    value === 'past_due' ||
+    value === 'canceled' ||
+    value === 'incomplete' ||
+    value === 'unpaid' ||
+    value === 'ended' ||
+    value === 'none'
+  );
 }

--- a/packages/platform/src/customer-vps-errors.ts
+++ b/packages/platform/src/customer-vps-errors.ts
@@ -4,6 +4,7 @@ export type CustomerVpsFailureCode =
   | 'provider_timeout'
   | 'r2_unavailable'
   | 'invalid_state'
+  | 'billing_required'
   | 'not_found'
   | 'registration_rejected'
   | 'unknown';

--- a/packages/platform/src/customer-vps-hetzner.ts
+++ b/packages/platform/src/customer-vps-hetzner.ts
@@ -8,6 +8,7 @@ export interface CreateHetznerServerInput {
   name: string;
   userData: string;
   labels: Record<string, string>;
+  serverType?: string;
 }
 
 export interface HetznerServer {
@@ -105,7 +106,7 @@ export function createHetznerClient(
         method: 'POST',
         body: JSON.stringify({
           name: input.name,
-          server_type: config.serverType,
+          server_type: input.serverType ?? config.serverType,
           image: config.image,
           location: config.location,
           ssh_keys: config.sshKeyName ? [config.sshKeyName] : undefined,

--- a/packages/platform/src/customer-vps-schema.ts
+++ b/packages/platform/src/customer-vps-schema.ts
@@ -23,11 +23,13 @@ export const PublicIPv4Schema = z.ipv4().refine((ip) => {
   return true;
 }, 'publicIPv4 must be a public IPv4 address');
 export const RuntimeSlotSchema = z.string().min(1).max(32).regex(/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/);
+export const HetznerServerTypeSchema = z.string().min(3).max(64).regex(/^[a-z0-9][a-z0-9-]*$/);
 
 export const ProvisionRequestSchema = z.object({
   clerkUserId: ClerkUserIdSchema,
   handle: SafeHandleSchema,
   runtimeSlot: RuntimeSlotSchema.optional().default('primary'),
+  serverType: HetznerServerTypeSchema.optional(),
 });
 
 export const RegisterRequestSchema = z.object({

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -9,10 +9,12 @@ import {
   getUserMachine,
   insertUserMachine,
   insertProviderDeletion,
+  listActiveUserMachinesByClerkId,
   listPendingProviderDeletions,
   listAllUserMachines,
   listRunningUserMachines,
   listStaleUserMachines,
+  lockUserMachineProvisioning,
   markProviderDeletionCompleted,
   markProviderDeletionFailed,
   runInPlatformTransaction,
@@ -43,6 +45,10 @@ import type {
   RegisterRequest,
   RecoverRequest,
 } from './customer-vps-schema.js';
+import {
+  getRuntimeAccessDecision,
+  type BillingEntitlement,
+} from './billing.js';
 
 export interface ProvisionResponse {
   machineId: string;
@@ -120,6 +126,7 @@ export interface CustomerVpsServiceDeps {
   postgresPasswordFactory?: () => string;
   now?: () => Date;
   fetchDispatcher?: import('undici').Dispatcher;
+  resolveBillingEntitlement?: (clerkUserId: string) => Promise<BillingEntitlement | null | undefined>;
 }
 
 const DEFAULT_CLOUD_INIT_TEMPLATE = [
@@ -287,6 +294,65 @@ function buildRecoveryServerName(handle: string, machineId: string): string {
   return `${buildServerName(handle).slice(0, 54)}-${suffix}`;
 }
 
+function billingUpgradeRequired(): CustomerVpsError {
+  return new CustomerVpsError(402, 'billing_required', 'Billing upgrade required');
+}
+
+function resolveDefaultEntitlementServerType(entitlement: BillingEntitlement): string {
+  const allowedServerTypes = entitlement.allowedServerTypes.filter((serverType) => serverType.length > 0);
+  if (entitlement.defaultServerType && allowedServerTypes.includes(entitlement.defaultServerType)) {
+    return entitlement.defaultServerType;
+  }
+  const fallbackServerType = allowedServerTypes[0];
+  if (!fallbackServerType) {
+    throw billingUpgradeRequired();
+  }
+  return fallbackServerType;
+}
+
+async function resolveBillingProvisionContext(
+  deps: CustomerVpsServiceDeps,
+  input: ProvisionRequest,
+  now: Date,
+): Promise<{ entitlement: BillingEntitlement; serverType: string } | null> {
+  if (!deps.resolveBillingEntitlement) {
+    return null;
+  }
+  const entitlement = await deps.resolveBillingEntitlement(input.clerkUserId);
+  const access = getRuntimeAccessDecision(entitlement, now);
+  if (!entitlement || !access.runtimeProxyAllowed) {
+    throw billingUpgradeRequired();
+  }
+  const serverType = input.serverType ?? resolveDefaultEntitlementServerType(entitlement);
+  if (!entitlement.allowedServerTypes.includes(serverType)) {
+    throw billingUpgradeRequired();
+  }
+  return { entitlement, serverType };
+}
+
+async function resolveBillingRecoveryContext(
+  deps: CustomerVpsServiceDeps,
+  clerkUserId: string,
+  existingServerType: string | null,
+  now: Date,
+): Promise<{ serverType: string } | null> {
+  if (!deps.resolveBillingEntitlement) {
+    return null;
+  }
+  const entitlement = await deps.resolveBillingEntitlement(clerkUserId);
+  const access = getRuntimeAccessDecision(entitlement, now);
+  if (!entitlement || !access.runtimeProxyAllowed) {
+    throw billingUpgradeRequired();
+  }
+  const serverType = existingServerType && entitlement.allowedServerTypes.includes(existingServerType)
+    ? existingServerType
+    : resolveDefaultEntitlementServerType(entitlement);
+  if (!entitlement.allowedServerTypes.includes(serverType)) {
+    throw billingUpgradeRequired();
+  }
+  return { serverType };
+}
+
 export function createCustomerVpsService(deps: CustomerVpsServiceDeps): CustomerVpsService {
   const machineIdFactory = deps.machineIdFactory ?? randomUUID;
   const tokenFactory = deps.tokenFactory ?? createRegistrationToken;
@@ -395,15 +461,17 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
 
   return {
     async provision(input) {
+      const request = { ...input, runtimeSlot: input.runtimeSlot ?? 'primary' };
       const currentTime = now();
       const machineId = machineIdFactory();
       const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
       const postgresPassword = postgresPasswordFactory();
+      const billingContext = await resolveBillingProvisionContext(deps, request, currentTime);
 
       const existingBeforeBundleResolve = await getActiveUserMachineByClerkId(
         deps.db,
-        input.clerkUserId,
-        input.runtimeSlot,
+        request.clerkUserId,
+        request.runtimeSlot,
       );
       if (existingBeforeBundleResolve) {
         return activeProvisionResponse(existingBeforeBundleResolve, deps.config.provisionEtaSeconds);
@@ -412,7 +480,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const bundleRef = await resolveHostBundleRef(deps.db, deps.config);
       const hostConfig = buildHostConfig(
         deps.config,
-        input,
+        request,
         machineId,
         registration.token,
         postgresPassword,
@@ -420,18 +488,27 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       );
 
       const provisionRow = await runInPlatformTransaction(deps.db, async (trx) => {
-        const existing = await getActiveUserMachineByClerkId(trx, input.clerkUserId, input.runtimeSlot);
+        if (billingContext) {
+          await lockUserMachineProvisioning(trx, request.clerkUserId);
+        }
+        const existing = await getActiveUserMachineByClerkId(trx, request.clerkUserId, request.runtimeSlot);
         if (existing) {
           return { existing };
         }
+        if (billingContext) {
+          const activeMachines = await listActiveUserMachinesByClerkId(trx, request.clerkUserId);
+          if (activeMachines.length >= billingContext.entitlement.maxRuntimeSlots) {
+            throw billingUpgradeRequired();
+          }
+        }
         await insertUserMachine(trx, {
           machineId,
-          clerkUserId: input.clerkUserId,
-          handle: input.handle,
-          runtimeSlot: input.runtimeSlot,
+          clerkUserId: request.clerkUserId,
+          handle: request.handle,
+          runtimeSlot: request.runtimeSlot,
           status: 'provisioning',
           imageVersion: bundleRef.imageVersion,
-          serverType: deps.config.serverType,
+          serverType: billingContext?.serverType ?? deps.config.serverType,
           registrationTokenHash: registration.hash,
           registrationTokenExpiresAt: registration.expiresAt,
           provisionedAt: currentTime.toISOString(),
@@ -450,12 +527,13 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       let serverIdForCompensation: number | null = null;
       try {
         const server = await deps.hetzner.createServer({
-          name: buildServerName(input.handle),
+          name: buildServerName(request.handle),
+          serverType: billingContext?.serverType ?? deps.config.serverType,
           userData,
           labels: {
             app: 'matrix-os',
-            clerk_user_id: input.clerkUserId,
-            runtime_slot: input.runtimeSlot,
+            clerk_user_id: request.clerkUserId,
+            runtime_slot: request.runtimeSlot,
             machine_id: machineId,
           },
         });
@@ -476,7 +554,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
               providerServerId: serverIdForCompensation,
               reason: 'provision_compensation',
               machineId,
-              handle: input.handle,
+              handle: request.handle,
               err: cleanupErr,
             });
           }
@@ -575,6 +653,12 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         throw new CustomerVpsError(409, 'invalid_state', 'No backup snapshot available');
       }
       const currentTime = now();
+      const billingContext = await resolveBillingRecoveryContext(
+        deps,
+        active.clerkUserId,
+        active.serverType,
+        currentTime,
+      );
       const machineId = machineIdFactory();
       const registration = tokenFactory(currentTime, deps.config.registrationTokenTtlMs);
       const postgresPassword = postgresPasswordFactory();
@@ -608,6 +692,7 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         );
         const server = await deps.hetzner.createServer({
           name: buildRecoveryServerName(existing.handle, machineId),
+          serverType: billingContext?.serverType ?? active.serverType ?? deps.config.serverType,
           userData,
           labels: {
             app: 'matrix-os',

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -410,6 +410,11 @@ export interface BillingEntitlementOverrideRecord {
 
 export type NewBillingEntitlementOverride = BillingEntitlementOverrideRecord;
 
+export interface BillingEntitlementStateRecord {
+  entitlement?: BillingEntitlementRecord;
+  override?: BillingEntitlementOverrideRecord;
+}
+
 export interface BillingWebhookEventRecord {
   stripeEventId: string;
   eventType: string;
@@ -852,6 +857,18 @@ export async function runBillingWebhookTransaction<T>(
   fn: (trx: PlatformDB) => Promise<T>,
 ): Promise<T> {
   return db.transaction(fn);
+}
+
+export async function lockUserMachineProvisioning(
+  db: PlatformDB,
+  clerkUserId: string,
+): Promise<void> {
+  await db.ready;
+  await sql`
+    SELECT pg_advisory_xact_lock(
+      ('x' || substr(md5(${`user_machines:${clerkUserId}`}), 1, 16))::bit(64)::bigint
+    )
+  `.execute(db.executor);
 }
 
 function mapContainer(row: ContainersTable): ContainerRecord {
@@ -1334,6 +1351,39 @@ export async function getBillingOverride(
     .orderBy('created_at', 'desc')
     .executeTakeFirst();
   return row ? mapBillingOverride(row) : undefined;
+}
+
+export async function getBillingEntitlementState(
+  db: PlatformDB,
+  clerkUserId: string,
+  nowIso = new Date().toISOString(),
+): Promise<BillingEntitlementStateRecord> {
+  await db.ready;
+  const result = await sql<{
+    entitlement: BillingEntitlementsTable | null;
+    override: BillingEntitlementOverridesTable | null;
+  }>`
+    SELECT
+      (
+        SELECT row_to_json(e)
+        FROM billing_entitlements e
+        WHERE e.clerk_user_id = ${clerkUserId}
+      ) AS entitlement,
+      (
+        SELECT row_to_json(o)
+        FROM billing_entitlement_overrides o
+        WHERE o.clerk_user_id = ${clerkUserId}
+          AND o.revoked_at IS NULL
+          AND (o.expires_at IS NULL OR o.expires_at > ${nowIso})
+        ORDER BY o.created_at DESC
+        LIMIT 1
+      ) AS override
+  `.execute(db.executor);
+  const row = result.rows[0];
+  return {
+    entitlement: row?.entitlement ? mapBillingEntitlement(row.entitlement) : undefined,
+    override: row?.override ? mapBillingOverride(row.override) : undefined,
+  };
 }
 
 export async function revokeBillingOverride(db: PlatformDB, id: string, revokedAt: string): Promise<boolean> {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -16,6 +16,7 @@ import {
   getContainerByClerkId,
   getActiveUserMachineByClerkId,
   getActiveUserMachineByHandle,
+  getBillingEntitlementState,
   getRunningUserMachineByClerkId,
   getRunningUserMachineByHandle,
   listActiveUserMachinesByClerkId,
@@ -63,6 +64,14 @@ import {
   EntitlementStatusSchema,
   type EntitlementAccessDecision,
 } from './profile-routing.js';
+import {
+  computeEffectiveEntitlement,
+  getRuntimeAccessDecision,
+  parseBillingEntitlementRecord,
+  parseBillingOverrideRecord,
+  type BillingEntitlement,
+  type RuntimeAccessDecision,
+} from './billing.js';
 import type { CustomerVpsObjectStore } from './customer-vps-r2.js';
 import { handleInternalGeminiLiveProxyUpgrade } from './gemini-live-proxy.js';
 import { recordPlatformHttpRequest } from './metrics.js';
@@ -72,7 +81,7 @@ import {
   createPlatformLaunchEvidenceLoader,
 } from './launch-readiness.js';
 import { createLaunchReadinessRoutes } from './launch-readiness-routes.js';
-import { RuntimeSlotSchema } from './customer-vps-schema.js';
+import { HetznerServerTypeSchema, RuntimeSlotSchema } from './customer-vps-schema.js';
 import { shouldVerifyCustomerVpsTls } from './customer-vps-tls.js';
 
 const PORT = Number(process.env.PLATFORM_PORT ?? 9000);
@@ -200,6 +209,7 @@ const ProvisionBodySchema = z.object({
   clerkUserId: z.string().min(1).max(256),
   displayName: z.string().min(1).max(100).optional(),
   runtimeSlot: RuntimeSlotSchema.optional().default('primary'),
+  serverType: HetznerServerTypeSchema.optional(),
 });
 
 const SocialSendBodySchema = z.object({
@@ -531,6 +541,56 @@ function getRuntimeEntitlementDecision(env: NodeJS.ProcessEnv = process.env): En
     return deriveEntitlementAccess({ status: 'changed' });
   }
   return deriveEntitlementAccess({ status: parsed.data });
+}
+
+function stripeBillingEntitlementsEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env.MATRIX_STRIPE_BILLING_ENABLED === 'true' || env.MATRIX_BILLING_PROVIDER === 'stripe';
+}
+
+async function resolveEffectiveBillingEntitlement(
+  db: PlatformDB,
+  clerkUserId: string,
+  now = new Date(),
+): Promise<BillingEntitlement | null> {
+  const { entitlement, override } = await getBillingEntitlementState(db, clerkUserId, now.toISOString());
+  return computeEffectiveEntitlement({
+    stripeEntitlement: parseBillingEntitlementRecord(entitlement),
+    override: parseBillingOverrideRecord(override),
+    now,
+  });
+}
+
+async function getRuntimeEntitlementDecisionForUser(
+  db: PlatformDB,
+  clerkUserId: string,
+  env: NodeJS.ProcessEnv,
+  now = new Date(),
+): Promise<EntitlementAccessDecision> {
+  if (!stripeBillingEntitlementsEnabled(env)) {
+    return getRuntimeEntitlementDecision(env);
+  }
+  return billingAccessToProfileDecision(
+    getRuntimeAccessDecision(await resolveEffectiveBillingEntitlement(db, clerkUserId, now), now),
+  );
+}
+
+function billingAccessToProfileDecision(decision: RuntimeAccessDecision): EntitlementAccessDecision {
+  if (decision.runtimeProxyAllowed) {
+    return {
+      status: 'active',
+      runtimeProxyAllowed: true,
+      ownerDataPreserved: true,
+      ownerDataExportable: true,
+      remediation: null,
+    };
+  }
+  return {
+    status: decision.reason === 'no_entitlement' ? 'missing' : 'expired',
+    runtimeProxyAllowed: false,
+    ownerDataPreserved: true,
+    ownerDataExportable: true,
+    remediation: 'Renew paid runtime access or ask an operator to grant access.',
+  };
 }
 
 function buildCodeSessionCookie(token: string): string {
@@ -2475,7 +2535,7 @@ export function createApp(deps: {
         applyNoStoreHeaders(c);
         return c.text('Matrix OS computer unavailable', 404);
       }
-      const entitlement = getRuntimeEntitlementDecision(appEnv);
+      const entitlement = await getRuntimeEntitlementDecisionForUser(db, machine.clerkUserId, appEnv);
       if (!entitlement.runtimeProxyAllowed) {
         applyNoStoreHeaders(c);
         return c.json({ error: 'Paid beta access required' }, 402);
@@ -2608,7 +2668,11 @@ export function createApp(deps: {
     if (runningMachine) {
       runtimeSlot = runningMachine.runtimeSlot;
     }
-    const entitlement = getRuntimeEntitlementDecision(appEnv);
+    const entitlement = runningMachine
+      ? await getRuntimeEntitlementDecisionForUser(db, runningMachine.clerkUserId, appEnv)
+      : requestedActiveMachine
+        ? await getRuntimeEntitlementDecisionForUser(db, requestedActiveMachine.clerkUserId, appEnv)
+      : getRuntimeEntitlementDecision(appEnv);
     if (runningMachine) {
       const qs = buildForwardedQueryString(c.req.url);
       if (!entitlement.runtimeProxyAllowed) {
@@ -2994,13 +3058,13 @@ export function createApp(deps: {
       return c.json({ error: 'Validation error' }, 400);
     }
 
-    const { handle, clerkUserId, displayName, runtimeSlot } = parsed.data;
+    const { handle, clerkUserId, displayName, runtimeSlot, serverType } = parsed.data;
     if (!handle || !clerkUserId) {
       return c.json({ error: 'handle and clerkUserId required' }, 400);
     }
     try {
       if (deps.customerVpsService) {
-        const machine = await deps.customerVpsService.provision({ handle, clerkUserId, runtimeSlot });
+        const machine = await deps.customerVpsService.provision({ handle, clerkUserId, runtimeSlot, serverType });
 
         // Provision Matrix accounts (non-blocking: log error but don't fail VPS provision)
         if (matrixProvisioner) {
@@ -3607,6 +3671,9 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
         : createNoopCustomerVpsSystemStore(),
       cloudInitTemplate,
       fetchDispatcher: customerVpsProxyDispatcher,
+      resolveBillingEntitlement: stripeBillingEntitlementsEnabled(process.env)
+        ? (clerkUserId) => resolveEffectiveBillingEntitlement(db, clerkUserId)
+        : undefined,
     });
     const reconciliationIntervalMs = Number(process.env.CUSTOMER_VPS_RECONCILIATION_INTERVAL_MS ?? 60_000);
     if (reconciliationIntervalMs > 0) {
@@ -3798,7 +3865,11 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     }
     const record = await getContainer(db, identity.handle);
     if (!runningMachine && !record) { socket.destroy(); return; }
-    const entitlement = getRuntimeEntitlementDecision(appEnv);
+    const entitlement = runningMachine
+      ? await getRuntimeEntitlementDecisionForUser(db, runningMachine.clerkUserId, appEnv)
+      : requestedActiveMachine
+        ? await getRuntimeEntitlementDecisionForUser(db, requestedActiveMachine.clerkUserId, appEnv)
+      : getRuntimeEntitlementDecision(appEnv);
     let activeUpstream: Socket | null = null;
     const onSocketError = () => activeUpstream?.destroy();
     socket.on('error', onSocketError);

--- a/tests/platform/billing-db.test.ts
+++ b/tests/platform/billing-db.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   getBillingCustomerByClerkUserId,
   getBillingEntitlement,
+  getBillingEntitlementState,
   getBillingOverride,
   getBillingWebhookEvent,
   insertBillingCustomerIfAbsent,
@@ -180,6 +181,51 @@ describe('platform billing db', () => {
 
     await expect(getBillingOverride(db, 'user_123')).resolves.toBeUndefined();
     await expect(revokeBillingOverride(db, 'missing_override', '2026-06-01T00:00:00.000Z')).resolves.toBe(false);
+  });
+
+  it('loads entitlement and active override in one state lookup', async () => {
+    await upsertBillingEntitlement(db, {
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_builder',
+      status: 'active',
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx32',
+      allowedServerTypes: ['cpx22', 'cpx32'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_builder_monthly',
+      gracePeriodEndsAt: null,
+      effectiveFrom: '2026-06-01T00:00:00.000Z',
+      effectiveUntil: null,
+      updatedAt: '2026-06-01T00:00:00.000Z',
+    });
+    await upsertBillingOverride(db, {
+      id: 'override_123',
+      clerkUserId: 'user_123',
+      planSlug: 'internal',
+      status: 'active',
+      maxRuntimeSlots: 5,
+      includedRuntimeSlots: 5,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx52',
+      allowedServerTypes: ['cpx22', 'cpx32', 'cpx52'],
+      reason: 'engineer test',
+      createdBy: 'ops-user',
+      expiresAt: '2026-07-01T00:00:00.000Z',
+      revokedAt: null,
+      createdAt: '2026-05-30T00:00:00.000Z',
+    });
+
+    await expect(getBillingEntitlementState(
+      db,
+      'user_123',
+      '2026-06-01T00:00:00.000Z',
+    )).resolves.toMatchObject({
+      entitlement: { planSlug: 'matrix_builder' },
+      override: { id: 'override_123', planSlug: 'internal' },
+    });
   });
 
   it('records Stripe webhook event ids idempotently', async () => {

--- a/tests/platform/customer-vps.test.ts
+++ b/tests/platform/customer-vps.test.ts
@@ -18,6 +18,7 @@ import { createCustomerVpsService } from '../../packages/platform/src/customer-v
 import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
 import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
 import { CustomerVpsError } from '../../packages/platform/src/customer-vps-errors.js';
+import type { BillingEntitlement } from '../../packages/platform/src/billing.js';
 import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
 import {
   buildCustomerVpsR2Key,
@@ -71,6 +72,27 @@ describe('platform/customer-vps', () => {
     return { service, hetzner, systemStore };
   }
 
+  function activeEntitlement(overrides: Partial<BillingEntitlement> = {}): BillingEntitlement {
+    return {
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_builder',
+      status: 'active',
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx32',
+      allowedServerTypes: ['cpx22', 'cpx32'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_builder_monthly',
+      gracePeriodEndsAt: '2026-05-30T00:00:00.000Z',
+      effectiveFrom: '2026-05-01T00:00:00.000Z',
+      effectiveUntil: null,
+      updatedAt: '2026-05-30T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
   it('defaults new customer VPS provisioning to the beta host bundle channel', () => {
     const config = loadCustomerVpsConfig({
       PLATFORM_PUBLIC_URL: 'https://app.matrix-os.com',
@@ -92,6 +114,107 @@ describe('platform/customer-vps', () => {
     const row = await getActiveUserMachineByClerkId(db, 'user_123');
     expect(row?.hetznerServerId).toBe(123456);
     expect(row?.registrationTokenHash).toBe(hashRegistrationToken('registration-token'));
+  });
+
+  it('uses the active billing entitlement server type when provisioning new machines', async () => {
+    const { service, hetzner } = createService({
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement()),
+    });
+
+    await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    expect(vi.mocked(hetzner.createServer).mock.calls[0]?.[0]).toMatchObject({
+      serverType: 'cpx32',
+    });
+    await expect(getActiveUserMachineByClerkId(db, 'user_123')).resolves.toMatchObject({
+      serverType: 'cpx32',
+    });
+  });
+
+  it('falls back to the first allowed billing server type when the default is missing', async () => {
+    const { service, hetzner } = createService({
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        defaultServerType: '',
+        allowedServerTypes: ['cpx22', 'cpx32'],
+      })),
+    });
+
+    await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    expect(vi.mocked(hetzner.createServer).mock.calls[0]?.[0]).toMatchObject({
+      serverType: 'cpx22',
+    });
+    await expect(getActiveUserMachineByClerkId(db, 'user_123')).resolves.toMatchObject({
+      serverType: 'cpx22',
+    });
+  });
+
+  it('allows provisioning during the three-day billing grace period', async () => {
+    const { service, hetzner } = createService({
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        status: 'past_due',
+        gracePeriodEndsAt: '2026-04-27T00:00:00.000Z',
+      })),
+    });
+
+    await expect(service.provision({ clerkUserId: 'user_123', handle: 'alice' })).resolves.toMatchObject({
+      status: 'provisioning',
+    });
+    expect(hetzner.createServer).toHaveBeenCalledOnce();
+  });
+
+  it('blocks new machine provisioning after billing access expires', async () => {
+    const { service, hetzner } = createService({
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        status: 'past_due',
+        gracePeriodEndsAt: '2026-04-25T23:59:59.000Z',
+      })),
+    });
+
+    await expect(service.provision({ clerkUserId: 'user_123', handle: 'alice' })).rejects.toMatchObject({
+      status: 402,
+      publicMessage: 'Billing upgrade required',
+    });
+    expect(hetzner.createServer).not.toHaveBeenCalled();
+  });
+
+  it('blocks extra machines beyond the entitlement slot count without deleting existing machines', async () => {
+    let nextId = 0;
+    const ids = [
+      '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      '721c3ef8-23f6-47e4-a890-6f6dc14759d1',
+    ];
+    const { service, hetzner } = createService({
+      machineIdFactory: () => ids[nextId++] ?? ids[1]!,
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({ maxRuntimeSlots: 1 })),
+    });
+
+    const primary = await service.provision({ clerkUserId: 'user_123', handle: 'alice', runtimeSlot: 'primary' });
+    await expect(service.provision({ clerkUserId: 'user_123', handle: 'alice-tools', runtimeSlot: 'tools' })).rejects.toMatchObject({
+      status: 402,
+      publicMessage: 'Billing upgrade required',
+    });
+
+    expect(hetzner.createServer).toHaveBeenCalledTimes(1);
+    await expect(getUserMachine(db, primary.machineId)).resolves.toMatchObject({
+      handle: 'alice',
+      deletedAt: null,
+    });
+  });
+
+  it('rejects requested Hetzner server types outside the entitlement catalog', async () => {
+    const { service, hetzner } = createService({
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        allowedServerTypes: ['cpx22'],
+        defaultServerType: 'cpx22',
+      })),
+    });
+
+    await expect(service.provision({ clerkUserId: 'user_123', handle: 'alice', serverType: 'cpx52' })).rejects.toMatchObject({
+      status: 402,
+      publicMessage: 'Billing upgrade required',
+    });
+    expect(hetzner.createServer).not.toHaveBeenCalled();
   });
 
   it('pins channel image versions to the current immutable host bundle release at provision time', async () => {
@@ -567,6 +690,43 @@ describe('platform/customer-vps', () => {
       publicIPv4: '203.0.113.11',
     });
     await expect(getUserMachine(db, provisioned.machineId)).resolves.toBeUndefined();
+  });
+
+  it('recovers a legacy machine with no stored server type using the first allowed billing type', async () => {
+    const machineIds = [
+      '9f05824c-8d0a-4d83-9cb4-b312d43ff112',
+      'f973bb98-2538-4f9f-a10d-1be5920a7bf7',
+    ];
+    const hetzner = createMockHetznerClient({
+      createServer: vi
+        .fn()
+        .mockResolvedValueOnce({ id: 123456, status: 'running', publicIPv4: '203.0.113.10' })
+        .mockResolvedValueOnce({ id: 789012, status: 'running', publicIPv4: '203.0.113.11' }),
+    });
+    const { service } = createService({
+      hetzner,
+      systemStore: createMockCustomerVpsSystemStore({ hasDbLatest: vi.fn().mockResolvedValue(true) }),
+      machineIdFactory: () => machineIds.shift()!,
+      resolveBillingEntitlement: vi.fn().mockResolvedValue(activeEntitlement({
+        defaultServerType: '',
+        allowedServerTypes: ['cpx22', 'cpx32'],
+      })),
+    });
+    const provisioned = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    await service.register('registration-token', {
+      machineId: provisioned.machineId,
+      hetznerServerId: 123456,
+      publicIPv4: '203.0.113.10',
+      imageVersion: 'matrix-os-host-2026.04.26-1',
+    });
+    await updateUserMachine(db, provisioned.machineId, { serverType: null });
+
+    const recovered = await service.recover({ clerkUserId: 'user_123' });
+
+    expect(recovered.status).toBe('recovering');
+    expect(vi.mocked(hetzner.createServer).mock.calls[1]?.[0]).toMatchObject({
+      serverType: 'cpx22',
+    });
   });
 
   it('recovers the requested runtime slot without touching primary', async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
-import { type PlatformDB, deleteContainer, getContainer, insertContainer, insertUserMachine } from "../../packages/platform/src/db.js";
+import {
+  type PlatformDB,
+  deleteContainer,
+  getContainer,
+  insertContainer,
+  insertUserMachine,
+  upsertBillingEntitlement,
+} from "../../packages/platform/src/db.js";
 import {
   buildPlatformWebSocketUpgradeHeaders,
   buildPostAuthRedirectPath,
@@ -83,6 +90,7 @@ describe("platform proxy routing", () => {
     vi.restoreAllMocks();
     delete process.env.PLATFORM_JWT_SECRET;
     delete process.env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS;
+    delete process.env.MATRIX_STRIPE_BILLING_ENABLED;
     delete process.env.HETZNER_SERVER_TYPE;
   });
 
@@ -393,6 +401,43 @@ describe("platform proxy routing", () => {
     expect(res.status).toBe(402);
     expect(res.headers.get("cache-control")).toBe("no-store, private");
     expect(res.headers.get("set-cookie")).toBeNull();
+    expect(await res.json()).toEqual({ error: "Paid beta access required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks provisioning boot pages when Stripe billing is enabled without an active entitlement", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "machine-alice-provisioning-stripe-expired",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      hetznerServerId: 123,
+      publicIPv4: "203.0.113.11",
+      status: "provisioning",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_STRIPE_BILLING_ENABLED: "true" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(402);
     expect(await res.json()).toEqual({ error: "Paid beta access required" });
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -1645,6 +1690,97 @@ describe("platform proxy routing", () => {
       handle: "alice",
       clerkUserId: "user_alice",
     });
+  });
+
+  it("blocks runtime proxying when Stripe billing is enabled without an active entitlement", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff127",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123471,
+      publicIPv4: "203.0.113.24",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_STRIPE_BILLING_ENABLED: "true" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "Paid beta access required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows runtime proxying from Stripe entitlements even if the old beta env gate is expired", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff128",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123472,
+      publicIPv4: "203.0.113.25",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    await upsertBillingEntitlement(db, {
+      clerkUserId: "user_alice",
+      source: "stripe",
+      planSlug: "matrix_builder",
+      status: "active",
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: "cpx32",
+      allowedServerTypes: ["cpx22", "cpx32"],
+      stripeSubscriptionId: "sub_123",
+      stripePriceId: "price_builder_monthly",
+      gracePeriodEndsAt: "2026-06-02T00:00:00.000Z",
+      effectiveFrom: "2026-05-30T00:00:00.000Z",
+      effectiveUntil: null,
+      updatedAt: "2026-05-30T00:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("ok", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: {
+        MATRIX_STRIPE_BILLING_ENABLED: "true",
+        MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "expired",
+      } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("blocks legacy container proxying when paid-beta entitlement denies access", async () => {


### PR DESCRIPTION
## Summary
- Enforces billing entitlements during customer VPS provisioning, recovery, and app/code runtime proxying.
- Allows active billing plus 3-day grace access, blocks unpaid/expired access without deleting machines or owner data, and caps extra runtime slots.
- Adds per-request server type selection through the Matrix runtime catalog.

## Stack
Base: #270. Next: #272.

## Tests
- `tests/platform/customer-vps.test.ts`
- `tests/platform/proxy-routing.test.ts`

## Invariants
- Source of truth: platform DB machine rows remain canonical for runtime existence; billing entitlement only controls whether routing/provisioning is allowed.
- Lock/transaction scope: runtime slot limit checks and machine row creation are guarded by a per-user advisory transaction lock.
- Acceptable orphan states: expired or over-limit billing states block access/provisioning but keep machines, backups, and data intact for recovery.
- Auth source of truth: Clerk/session routing still identifies the user; Stripe-derived entitlement only authorizes paid runtime access.
- Deferred scope: no automatic server resizing, downgrade deletion, billing admin UI, or production Stripe object creation.
