### PR TITLE
fix(shell): inline-style, a11y, semantic-tag, export-layout cleanup

### DIFF
--- a/shell/src/app/error.tsx
+++ b/shell/src/app/error.tsx
@@ -1,26 +1,25 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { createErrorId, describeUnknownError } from "../lib/error-boundary-utils";
 import { capturePostHogException, reportClientError } from "../lib/posthog-client";
 
+const LOGO_MARK_STYLE: CSSProperties = {
+  WebkitMaskImage: "url('/matrix-logo.svg')",
+  WebkitMaskPosition: "center",
+  WebkitMaskRepeat: "no-repeat",
+  WebkitMaskSize: "contain",
+  maskImage: "url('/matrix-logo.svg')",
+  maskPosition: "center",
+  maskRepeat: "no-repeat",
+  maskSize: "contain",
+};
+
 function MatrixLogoMark() {
   return (
     <div className="relative flex size-16 items-center justify-center rounded-2xl border border-forest/15 bg-[#fbf7ed] shadow-[0_18px_50px_rgba(83,68,48,0.12)]">
-      <div
-        className="size-9 bg-deep"
-        aria-hidden="true"
-        style={{
-          WebkitMaskImage: "url('/matrix-logo.svg')",
-          WebkitMaskPosition: "center",
-          WebkitMaskRepeat: "no-repeat",
-          WebkitMaskSize: "contain",
-          maskImage: "url('/matrix-logo.svg')",
-          maskPosition: "center",
-          maskRepeat: "no-repeat",
-          maskSize: "contain",
-        }}
-      />
+      <div className="size-9 bg-deep" aria-hidden="true" style={LOGO_MARK_STYLE} />
     </div>
   );
 }

--- a/shell/src/app/global-error.tsx
+++ b/shell/src/app/global-error.tsx
@@ -1,8 +1,92 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { createErrorId, describeUnknownError } from "../lib/error-boundary-utils";
 import { capturePostHogException, reportClientError } from "../lib/posthog-client";
+
+const PAGE_STYLE: CSSProperties = {
+  alignItems: "center",
+  background: "#f6f4ec",
+  boxSizing: "border-box",
+  color: "#32352E",
+  display: "flex",
+  fontFamily: "Inter, system-ui, sans-serif",
+  height: "100vh",
+  justifyContent: "center",
+  padding: 24,
+  width: "100vw",
+};
+
+const CARD_STYLE: CSSProperties = {
+  alignItems: "center",
+  background: "rgba(255,255,255,0.82)",
+  border: "1px solid rgba(67,78,63,0.12)",
+  borderRadius: 28,
+  boxShadow: "0 24px 80px rgba(67,78,63,0.16)",
+  boxSizing: "border-box",
+  display: "flex",
+  flexDirection: "column",
+  maxWidth: 448,
+  padding: 32,
+  textAlign: "center",
+  width: "100%",
+};
+
+const LOGO_BOX_STYLE: CSSProperties = {
+  alignItems: "center",
+  background: "#fbf7ed",
+  border: "1px solid rgba(67,78,63,0.15)",
+  borderRadius: 18,
+  boxShadow: "0 18px 50px rgba(83,68,48,0.12)",
+  display: "flex",
+  height: 64,
+  justifyContent: "center",
+  width: 64,
+};
+
+const LOGO_MASK_STYLE: CSSProperties = {
+  background: "#32352E",
+  height: 36,
+  WebkitMaskImage: "url('/matrix-logo.svg')",
+  WebkitMaskPosition: "center",
+  WebkitMaskRepeat: "no-repeat",
+  WebkitMaskSize: "contain",
+  maskImage: "url('/matrix-logo.svg')",
+  maskPosition: "center",
+  maskRepeat: "no-repeat",
+  maskSize: "contain",
+  width: 36,
+};
+
+const COPY_BUTTON_STYLE: CSSProperties = {
+  alignItems: "center",
+  background: "#fbf7ed",
+  border: "1px solid rgba(67,78,63,0.12)",
+  borderRadius: 12,
+  color: "rgba(67,78,63,0.72)",
+  cursor: "pointer",
+  display: "inline-flex",
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  fontSize: 12,
+  gap: 8,
+  marginTop: 20,
+  maxWidth: "100%",
+  padding: "8px 12px",
+};
+
+const RESET_BUTTON_STYLE: CSSProperties = {
+  background: "#434E3F",
+  border: "none",
+  borderRadius: 12,
+  color: "#FAFAF5",
+  cursor: "pointer",
+  fontSize: 14,
+  fontWeight: 700,
+  height: 44,
+  marginTop: 24,
+  padding: "0 20px",
+};
 
 export default function GlobalError({
   error,
@@ -39,67 +123,12 @@ export default function GlobalError({
   }
 
   return (
-    <html>
+    <html lang="en">
       <body>
-        <div
-          style={{
-            alignItems: "center",
-            background: "#f6f4ec",
-            boxSizing: "border-box",
-            color: "#32352E",
-            display: "flex",
-            fontFamily: "Inter, system-ui, sans-serif",
-            height: "100vh",
-            justifyContent: "center",
-            padding: 24,
-            width: "100vw",
-          }}
-        >
-          <div
-            style={{
-              alignItems: "center",
-              background: "rgba(255,255,255,0.82)",
-              border: "1px solid rgba(67,78,63,0.12)",
-              borderRadius: 28,
-              boxShadow: "0 24px 80px rgba(67,78,63,0.16)",
-              boxSizing: "border-box",
-              display: "flex",
-              flexDirection: "column",
-              maxWidth: 448,
-              padding: 32,
-              textAlign: "center",
-              width: "100%",
-            }}
-          >
-            <div
-              style={{
-                alignItems: "center",
-                background: "#fbf7ed",
-                border: "1px solid rgba(67,78,63,0.15)",
-                borderRadius: 18,
-                boxShadow: "0 18px 50px rgba(83,68,48,0.12)",
-                display: "flex",
-                height: 64,
-                justifyContent: "center",
-                width: 64,
-              }}
-            >
-              <div
-                aria-hidden="true"
-                style={{
-                  background: "#32352E",
-                  height: 36,
-                  WebkitMaskImage: "url('/matrix-logo.svg')",
-                  WebkitMaskPosition: "center",
-                  WebkitMaskRepeat: "no-repeat",
-                  WebkitMaskSize: "contain",
-                  maskImage: "url('/matrix-logo.svg')",
-                  maskPosition: "center",
-                  maskRepeat: "no-repeat",
-                  maskSize: "contain",
-                  width: 36,
-                }}
-              />
+        <div style={PAGE_STYLE}>
+          <div style={CARD_STYLE}>
+            <div style={LOGO_BOX_STYLE}>
+              <div aria-hidden="true" style={LOGO_MASK_STYLE} />
             </div>
             <p
               style={{
@@ -123,44 +152,19 @@ export default function GlobalError({
               type="button"
               onClick={copyErrorId}
               aria-label={`Copy error ID ${errorId}`}
-              style={{
-                alignItems: "center",
-                background: "#fbf7ed",
-                border: "1px solid rgba(67,78,63,0.12)",
-                borderRadius: 12,
-                color: "rgba(67,78,63,0.72)",
-                cursor: "pointer",
-                display: "inline-flex",
-                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-                fontSize: 12,
-                gap: 8,
-                marginTop: 20,
-                maxWidth: "100%",
-                padding: "8px 12px",
-              }}
+              style={COPY_BUTTON_STYLE}
             >
               <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                 Error ID: {errorId}
               </span>
-              <span style={{ color: "#D06F25", fontFamily: "Inter, system-ui, sans-serif", fontSize: 11, fontWeight: 700 }}>
+              <span style={{ color: "#D06F25", fontFamily: "Inter, system-ui, sans-serif", fontSize: 12, fontWeight: 700 }}>
                 {copied ? "Copied" : "Copy"}
               </span>
             </button>
             <button
               type="button"
               onClick={reset}
-              style={{
-                background: "#434E3F",
-                border: "none",
-                borderRadius: 12,
-                color: "#FAFAF5",
-                cursor: "pointer",
-                fontSize: 14,
-                fontWeight: 700,
-                height: 44,
-                marginTop: 24,
-                padding: "0 20px",
-              }}
+              style={RESET_BUTTON_STYLE}
             >
               Try again
             </button>

--- a/shell/src/app/page.tsx
+++ b/shell/src/app/page.tsx
@@ -5,9 +5,7 @@ import { ShellHome } from "@/components/ShellHome";
 function BillingGateFallback() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
-      <div className="text-sm" role="status">
-        Loading billing status
-      </div>
+      <output className="text-sm">Loading billing status</output>
     </main>
   );
 }

--- a/shell/src/components/AppSettingsDialog.tsx
+++ b/shell/src/components/AppSettingsDialog.tsx
@@ -44,6 +44,7 @@ export function AppSettingsDialog({
       <DialogContent className="max-w-xl">
         <DialogHeader>
           <div className="flex items-center gap-3">
+            {/* react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png) that cannot be statically configured for next/image */}
             <img
               key={iconUrl ?? FALLBACK_APP_ICON}
               src={iconUrl ?? FALLBACK_APP_ICON}

--- a/shell/src/components/AppTile.tsx
+++ b/shell/src/components/AppTile.tsx
@@ -42,6 +42,7 @@ export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, o
           }`}
         >
           {showImage ? (
+            // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png) that cannot be statically configured for next/image
             <img src={iconUrl} alt={name} className="size-full object-cover" onError={onImgError} />
           ) : (
             initial
@@ -49,6 +50,7 @@ export function AppTile({ name, isOpen, onClick, pinned, onTogglePin, iconUrl, o
         </div>
         {onTogglePin && (
           <span
+            // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- cannot be a native <button>: this pin toggle is nested inside the outer tile <button>, and nesting interactive elements is invalid HTML
             role="button"
             onClick={(e) => {
               e.stopPropagation();

--- a/shell/src/components/AppViewer.tsx
+++ b/shell/src/components/AppViewer.tsx
@@ -14,30 +14,16 @@ import { getGatewayUrl } from "@/lib/gateway";
 import { openAppSession } from "@/lib/app-session";
 import { capturePostHogEvent } from "@/lib/posthog-client";
 import { MATRIX_TELEMETRY_EVENTS } from "@matrix-os/observability/events";
+import {
+  APP_IFRAME_SANDBOX,
+  extractSlug,
+  shouldRenderAppIframe,
+  injectBridgeIntoAppHtml,
+} from "./app-viewer-helpers";
 
 const GATEWAY_URL = getGatewayUrl();
 const SESSION_REFRESH_DEBOUNCE_MS = 2000;
 const BRIDGE_FETCH_TIMEOUT_MS = 10_000;
-const LEGACY_NESTED_RUNTIME_APP_SLUGS = new Set([
-  "2048",
-  "backgammon",
-  "chess",
-  "minesweeper",
-  "snake",
-  "solitaire",
-  "tetris",
-]);
-export const APP_IFRAME_SANDBOX = "allow-scripts allow-forms allow-popups";
-const APP_IFRAME_CSP = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-  "script-src 'self' 'unsafe-inline'",
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob:",
-  "font-src 'self' data:",
-  "connect-src 'self'",
-].join("; ");
 
 interface AppViewerProps {
   path: string;
@@ -52,48 +38,10 @@ function appNameFromPath(path: string): string {
   return path.replace("apps/", "").replace(/\/index\.html$/, "").replace(".html", "");
 }
 
-export function extractSlug(path: string): string | null {
-  const topLevel = path.match(/^apps\/([a-z0-9][a-z0-9-]{0,63})(?:\/(?:index\.html)?)?$/);
-  if (topLevel) return topLevel[1];
-
-  // Older saved layouts used filesystem paths for migrated bundled games. Only
-  // rewrite known migrated slugs; other nested paths still load as files.
-  const nestedIndex = path.match(/^apps\/(?:[a-z0-9][a-z0-9-]{0,63}\/)+([a-z0-9][a-z0-9-]{0,63})\/index\.html$/);
-  if (nestedIndex && LEGACY_NESTED_RUNTIME_APP_SLUGS.has(nestedIndex[1])) {
-    return nestedIndex[1];
-  }
-  return null;
-}
-
-export function shouldRenderAppIframe(path: string): boolean {
-  return !path.startsWith("__");
-}
-
 function readCurrentTheme(): ThemeVars {
   if (typeof document === "undefined") return {};
   const style = getComputedStyle(document.documentElement);
   return getThemeVariables(style);
-}
-
-export function injectBridgeIntoAppHtml(
-  html: string,
-  appName: string,
-  themeVars: ThemeVars,
-  baseHref: string,
-): string {
-  const bridgeScript = buildBridgeScript(appName, themeVars)
-    + `\n;if(window.MatrixOS&&window.MatrixOS.db){useDb=true;}if(typeof loadData==="function"){loadData();}\n`;
-  const escapedBaseHref = baseHref.replace(/"/g, "&quot;");
-  const injection = [
-    `<base href="${escapedBaseHref}">`,
-    `<meta http-equiv="Content-Security-Policy" content="${APP_IFRAME_CSP.replace(/"/g, "&quot;")}">`,
-    `<script>${bridgeScript}</script>`,
-  ].join("");
-
-  if (/<head[^>]*>/i.test(html)) {
-    return html.replace(/<head([^>]*)>/i, `<head$1>${injection}`);
-  }
-  return `<!doctype html><html><head>${injection}</head><body>${html}</body></html>`;
 }
 
 async function handleBridgeFetch(payload: unknown, port: MessagePort): Promise<void> {

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -223,10 +223,10 @@ export function BillingGate({ children }: { children: ReactNode }) {
   if (!isLoaded || billingChecking) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-page-bg text-forest/70">
-        <div className="flex items-center gap-2 text-sm" role="status">
+        <output className="flex items-center gap-2 text-sm">
           <Loader2Icon className="size-4 animate-spin text-ember" aria-hidden="true" />
           Loading billing status
-        </div>
+        </output>
       </main>
     );
   }
@@ -238,10 +238,10 @@ export function BillingGate({ children }: { children: ReactNode }) {
   if (!hasBillingAccess && checkoutReturnRequested && !checkoutAttemptChecked) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-page-bg text-forest/70">
-        <div className="flex items-center gap-2 text-sm" role="status">
+        <output className="flex items-center gap-2 text-sm">
           <Loader2Icon className="size-4 animate-spin text-ember" aria-hidden="true" />
           Checking billing status...
-        </div>
+        </output>
       </main>
     );
   }

--- a/shell/src/components/ChatApp.tsx
+++ b/shell/src/components/ChatApp.tsx
@@ -11,10 +11,14 @@ import {
   Message,
   MessageContent,
 } from "@/components/ai-elements/message";
-import { Reasoning, extractThinking } from "@/components/ai-elements/reasoning";
-import { SuggestionChips, DEFAULT_SUGGESTIONS, parseSuggestions } from "@/components/ai-elements/suggestions";
-import { Plan, parsePlan } from "@/components/ai-elements/plan";
-import { Task, parseTask } from "@/components/ai-elements/task";
+import { Reasoning } from "@/components/ai-elements/reasoning";
+import { extractThinking } from "@/components/ai-elements/reasoning-utils";
+import { SuggestionChips } from "@/components/ai-elements/suggestions";
+import { DEFAULT_SUGGESTIONS, parseSuggestions } from "@/components/ai-elements/suggestions-utils";
+import { Plan } from "@/components/ai-elements/plan";
+import { parsePlan } from "@/components/ai-elements/plan-utils";
+import { Task } from "@/components/ai-elements/task";
+import { parseTask } from "@/components/ai-elements/task-utils";
 import { RichContent } from "@/components/ui-blocks";
 import { ToolCallGroup } from "@/components/ToolCallGroup";
 import { Attachments, AttachmentButton, useAttachments } from "@/components/ai-elements/attachments";
@@ -22,6 +26,11 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
 import { useVoice } from "@/hooks/useVoice";
+import {
+  DEFAULT_HERMES_MODEL,
+  DEFAULT_HERMES_CHANNELS,
+  createHermesConfiguredPrompt,
+} from "./chat-app-hermes";
 import {
   LoaderCircleIcon,
   PlusIcon,
@@ -48,8 +57,6 @@ interface ConversationMeta {
   updatedAt: number;
 }
 
-const DEFAULT_HERMES_MODEL = "Hermes default";
-const DEFAULT_HERMES_CHANNELS = ["shell"];
 const HERMES_SETUP_STORAGE_KEY = "matrix:hermes-setup";
 
 function readHermesSetup() {
@@ -395,24 +402,6 @@ export function ChatApp({
       </main>
     </div>
   );
-}
-
-export function createHermesConfiguredPrompt(text: string, _model: string, _channels: string[]) {
-  const normalizedChannels = [..._channels].sort();
-  const isDefaultSetup =
-    _model === DEFAULT_HERMES_MODEL &&
-    normalizedChannels.length === DEFAULT_HERMES_CHANNELS.length &&
-    normalizedChannels.every((channel, index) => channel === DEFAULT_HERMES_CHANNELS[index]);
-  if (isDefaultSetup) return text;
-
-  const enabledChannels = normalizedChannels.length > 0 ? normalizedChannels.join(", ") : "none";
-  return [
-    "Use this Hermes setup for this response only:",
-    `Agent mode: ${_model}`,
-    `Enabled channels: ${enabledChannels}`,
-    "",
-    text,
-  ].join("\n");
 }
 
 function EmptyState({

--- a/shell/src/components/ChatPanel.tsx
+++ b/shell/src/components/ChatPanel.tsx
@@ -11,10 +11,14 @@ import {
   Message,
   MessageContent,
 } from "@/components/ai-elements/message";
-import { Reasoning, extractThinking } from "@/components/ai-elements/reasoning";
-import { SuggestionChips, DEFAULT_SUGGESTIONS, parseSuggestions } from "@/components/ai-elements/suggestions";
-import { Plan, parsePlan } from "@/components/ai-elements/plan";
-import { Task, parseTask } from "@/components/ai-elements/task";
+import { Reasoning } from "@/components/ai-elements/reasoning";
+import { extractThinking } from "@/components/ai-elements/reasoning-utils";
+import { SuggestionChips } from "@/components/ai-elements/suggestions";
+import { DEFAULT_SUGGESTIONS, parseSuggestions } from "@/components/ai-elements/suggestions-utils";
+import { Plan } from "@/components/ai-elements/plan";
+import { parsePlan } from "@/components/ai-elements/plan-utils";
+import { Task } from "@/components/ai-elements/task";
+import { parseTask } from "@/components/ai-elements/task-utils";
 import { RichContent } from "@/components/ui-blocks";
 import { ToolCallGroup } from "@/components/ToolCallGroup";
 import { Button } from "@/components/ui/button";

--- a/shell/src/components/ChatPopover.tsx
+++ b/shell/src/components/ChatPopover.tsx
@@ -672,6 +672,7 @@ const ChatInputBar = memo(function ChatInputBar({
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
           placeholder={busy ? "Queue another message…" : "What do you want to say?"}
+          // react-doctor-disable-next-line react-doctor/no-autofocus -- chat input inside a dialog popover that mounts only when the user opens it; focus is essential so they can type immediately
           autoFocus
           className={cn(
             "flex-1 bg-transparent text-sm text-foreground outline-none",

--- a/shell/src/components/CommandPalette.tsx
+++ b/shell/src/components/CommandPalette.tsx
@@ -72,6 +72,7 @@ export function CommandPalette({
                 }}
               >
                 {cmd.icon ? (
+                  // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png) that cannot be statically configured for next/image
                   <img src={cmd.icon} alt="" className="size-7 rounded-lg object-cover shrink-0" />
                 ) : (
                   <span className="size-7 rounded-lg bg-muted flex items-center justify-center text-xs font-semibold shrink-0">

--- a/shell/src/components/ConnectionIndicator.tsx
+++ b/shell/src/components/ConnectionIndicator.tsx
@@ -2,27 +2,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useConnectionHealth } from "@/hooks/useConnectionHealth";
-import type { ConnectionState } from "@/hooks/useConnectionHealth";
 import { manualReconnect } from "@/hooks/useSocket";
 import { getGatewayUrl } from "@/lib/gateway";
+import { resolveConnectionCopy, type RuntimeStatus } from "./connection-indicator-copy";
 
 const STATUS_REFRESH_MS = 5_000;
 const STATUS_TIMEOUT_MS = 4_000;
-
-type GatewayReachability = "checking" | "online" | "unavailable";
-
-interface RuntimeStatus {
-  reachability: GatewayReachability;
-  releaseVersion?: string | null;
-  releaseChannel?: string | null;
-}
-
-interface ConnectionCopy {
-  tone: "warn" | "danger";
-  title: string;
-  detail: string;
-  action: string;
-}
 
 function classifyRuntimeStatusError(error: unknown): string {
   if (error instanceof DOMException) {
@@ -37,45 +22,6 @@ function classifyRuntimeStatusError(error: unknown): string {
 
 function logRuntimeStatusError(stage: string, error: unknown): void {
   console.warn(`[connection-indicator] ${stage} failed: ${classifyRuntimeStatusError(error)}`);
-}
-
-export function resolveConnectionCopy(state: ConnectionState, status: RuntimeStatus): ConnectionCopy {
-  if (state === "disconnected") {
-    return {
-      tone: "danger",
-      title: "Connection lost",
-      detail: status.reachability === "online"
-        ? "Your Matrix computer is online, but the live shell socket is closed."
-        : "Your Matrix computer is not reachable yet. It may be restarting after an update.",
-      action: "Reconnect",
-    };
-  }
-
-  if (status.reachability === "online") {
-    const version = status.releaseVersion ? ` ${status.releaseVersion}` : "";
-    return {
-      tone: "warn",
-      title: "Reconnecting shell",
-      detail: `The gateway is online${version}. Waiting for the live session to resume.`,
-      action: "Retry now",
-    };
-  }
-
-  if (status.reachability === "checking") {
-    return {
-      tone: "warn",
-      title: "Checking Matrix computer",
-      detail: "Matrix is checking whether your computer is restarting or applying an update.",
-      action: "Retry now",
-    };
-  }
-
-  return {
-    tone: "warn",
-    title: "Matrix computer is restarting",
-    detail: "Services are coming back online. This usually happens during bundle upgrades or gateway restarts.",
-    action: "Retry now",
-  };
 }
 
 async function loadRuntimeStatus(): Promise<RuntimeStatus> {

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, type CSSProperties } from "react";
 import { useIconWithFallback } from "@/hooks/useIconWithFallback";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
 import { useWindowManager, type LayoutWindow } from "@/hooks/useWindowManager";
@@ -71,6 +71,20 @@ const GATEWAY_FETCH_TIMEOUT_MS = 10_000;
 const MATRIX_SHIMMER =
   "linear-gradient(90deg, #2F392C 0%, #2F392C 24%, #C4A265 50%, #2F392C 76%, #2F392C 100%)";
 
+const MATRIX_FIRST_RUN_LOGO_STYLE: CSSProperties = {
+  WebkitMaskImage: "url('/matrix-logo.svg')",
+  WebkitMaskRepeat: "no-repeat",
+  WebkitMaskSize: "contain",
+  WebkitMaskPosition: "center",
+  maskImage: "url('/matrix-logo.svg')",
+  maskRepeat: "no-repeat",
+  maskSize: "contain",
+  maskPosition: "center",
+  backgroundImage: MATRIX_SHIMMER,
+  backgroundSize: "300% 100%",
+  animation: "onboard-shimmer 8s ease-in-out infinite, onboard-glow 8s ease-in-out infinite",
+};
+
 function iconUrlForSlug(slug: string | undefined): string | undefined {
   if (!slug) return undefined;
   return `/icons/${encodeURIComponent(slug)}.png`;
@@ -87,19 +101,7 @@ function MatrixFirstRunLoading() {
         <div
           aria-label="Matrix OS logo"
           className="h-[132px] w-[124px] sm:h-[156px] sm:w-[148px]"
-          style={{
-            WebkitMaskImage: "url('/matrix-logo.svg')",
-            WebkitMaskRepeat: "no-repeat",
-            WebkitMaskSize: "contain",
-            WebkitMaskPosition: "center",
-            maskImage: "url('/matrix-logo.svg')",
-            maskRepeat: "no-repeat",
-            maskSize: "contain",
-            maskPosition: "center",
-            backgroundImage: MATRIX_SHIMMER,
-            backgroundSize: "300% 100%",
-            animation: "onboard-shimmer 8s ease-in-out infinite, onboard-glow 8s ease-in-out infinite",
-          }}
+          style={MATRIX_FIRST_RUN_LOGO_STYLE}
         />
         <div className="grid max-w-[520px] gap-3">
           <h1
@@ -294,6 +296,7 @@ function DockIcon({
       style={{ width: iconSize, height: iconSize }}
     >
       {showImage ? (
+        // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host with an onError fallback chain (.png -> .svg) that next/image cannot reproduce
         <img src={iconUrl} alt={name} className="size-full object-cover" onError={onImgError} />
       ) : (
         <span className="text-sm font-semibold text-foreground">

--- a/shell/src/components/MenuBar.tsx
+++ b/shell/src/components/MenuBar.tsx
@@ -267,6 +267,7 @@ export function MenuBar({ onOpenCommandPalette, onNewWindow, onMinimizeWindow, c
         {/* Left: app icon + app menu + global menus */}
         <div className="flex items-center gap-0.5">
           <div className="flex items-center px-2 py-0.5 rounded">
+            {/* react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- active app icon served from a runtime gateway host (/icons/{slug}.png) that cannot be statically configured for next/image */}
             <img
               key={activeAppIconUrl}
               src={activeAppIconUrl}

--- a/shell/src/components/OnboardingScreen.tsx
+++ b/shell/src/components/OnboardingScreen.tsx
@@ -200,20 +200,14 @@ export function OnboardingScreen({ onComplete, onOpenManualSetup }: OnboardingSc
                 }}
               >
                 <div
+                  // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- not a plain <img>: the logo is rendered via a CSS mask of the SVG over an animated shimmer gradient background, which an <img> element cannot reproduce
                   role="img"
                   aria-label="Matrix OS logo"
                   className="h-[132px] w-[124px] sm:h-[156px] sm:w-[148px]"
                   style={{
-                    WebkitMaskImage: "url('/matrix-logo.svg')",
-                    WebkitMaskRepeat: "no-repeat",
-                    WebkitMaskSize: "contain",
-                    WebkitMaskPosition: "center",
-                    maskImage: "url('/matrix-logo.svg')",
-                    maskRepeat: "no-repeat",
-                    maskSize: "contain",
-                    maskPosition: "center",
-                    backgroundImage: SHIMMER_GRADIENT,
-                    backgroundSize: "300% 100%",
+                    WebkitMask: `url('/matrix-logo.svg') no-repeat center / contain`,
+                    mask: `url('/matrix-logo.svg') no-repeat center / contain`,
+                    background: `${SHIMMER_GRADIENT} 0 0 / 300% 100%`,
                     animation: phase === "idle" ? SHIMMER_ANIMATION : "none",
                     opacity: entranceStage === "hidden" || phase === "black" ? 0 : 1,
                     transform: entranceStage !== "settled"
@@ -394,6 +388,7 @@ export function OnboardingScreen({ onComplete, onOpenManualSetup }: OnboardingSc
                   type="text"
                   placeholder="Type your response..."
                   className="flex-1 px-4 py-3 rounded-xl bg-muted/30 border border-border/50 text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary/20 text-sm"
+                  // react-doctor-disable-next-line react-doctor/no-autofocus -- primary text-response field in the conversational onboarding flow; focus is essential so the user can immediately type their reply
                   autoFocus
                 />
                 <button

--- a/shell/src/components/VocalPanel.tsx
+++ b/shell/src/components/VocalPanel.tsx
@@ -541,6 +541,7 @@ export function VocalPanel({ active, chat, onOpenApp, onDismissChat }: VocalPane
         </div>
       )}
 
+      {/* react-doctor-disable-next-line react-doctor/no-unknown-property -- valid styled-jsx attribute */}
       <style jsx global>{`
         @keyframes vocal-breathe {
           0%, 100% { filter: brightness(0.9) saturate(1); transform: scale(1); }

--- a/shell/src/components/ai-elements/attachments-utils.ts
+++ b/shell/src/components/ai-elements/attachments-utils.ts
@@ -1,0 +1,8 @@
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}

--- a/shell/src/components/ai-elements/attachments.tsx
+++ b/shell/src/components/ai-elements/attachments.tsx
@@ -6,6 +6,7 @@ import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { FileIcon, ImageIcon, FileTextIcon, XIcon, PaperclipIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { fileToBase64 } from "@/components/ai-elements/attachments-utils";
 
 export interface AttachmentFile {
   file: File;
@@ -33,15 +34,6 @@ function isTextFile(file: File): boolean {
   );
 }
 
-export function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
-}
-
 export type AttachmentPreviewProps = HTMLAttributes<HTMLDivElement> & {
   file: File;
   preview?: string;
@@ -57,6 +49,7 @@ export function AttachmentPreview({ file, preview, className, ...props }: Attach
         )}
         {...props}
       >
+        {/* react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- blob: object URL from URL.createObjectURL(local attachment); next/image cannot optimize ephemeral client object URLs */}
         <img
           src={preview}
           alt={file.name}

--- a/shell/src/components/ai-elements/code-block.tsx
+++ b/shell/src/components/ai-elements/code-block.tsx
@@ -149,13 +149,14 @@ const getHighlighter = (
   const highlighterPromise = createHighlighter({
     langs: [language],
     themes: ["github-light", "github-dark"],
-  }).catch(() =>
+  }).catch((error: unknown) => {
+    console.warn("[ai-elements] Failed to create language highlighter:", error);
     // Fall back to 'text' for unknown languages (e.g. ui:cards during streaming)
-    createHighlighter({
+    return createHighlighter({
       langs: ["text" as BundledLanguage],
       themes: ["github-light", "github-dark"],
-    })
-  );
+    });
+  });
 
   highlighterCache.set(language, highlighterPromise);
   return highlighterPromise;

--- a/shell/src/components/ai-elements/code-block.tsx
+++ b/shell/src/components/ai-elements/code-block.tsx
@@ -178,7 +178,7 @@ const createRawTokens = (code: string): TokenizedCode => ({
 });
 
 // Synchronous highlight with callback for async results
-export const highlightCode = (
+const highlightCode = (
   code: string,
   language: BundledLanguage,
   // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-callbacks)

--- a/shell/src/components/ai-elements/conversation.tsx
+++ b/shell/src/components/ai-elements/conversation.tsx
@@ -120,7 +120,7 @@ const defaultFormatMessage = (message: ConversationMessage): string => {
   return `**${roleLabel}:** ${message.content}`;
 };
 
-export const messagesToMarkdown = (
+const messagesToMarkdown = (
   messages: ConversationMessage[],
   formatMessage: (
     message: ConversationMessage,

--- a/shell/src/components/ai-elements/plan-utils.ts
+++ b/shell/src/components/ai-elements/plan-utils.ts
@@ -1,0 +1,21 @@
+import type { PlanStep } from "./plan";
+
+export function parsePlan(content: string): PlanStep[] | null {
+  const match = content.match(
+    /```plan\n([\s\S]*?)```/,
+  );
+  if (!match) return null;
+
+  try {
+    const parsed = JSON.parse(match[1]);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (s): s is PlanStep =>
+          typeof s === "object" && s !== null && typeof s.title === "string",
+      );
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return null;
+}

--- a/shell/src/components/ai-elements/plan-utils.ts
+++ b/shell/src/components/ai-elements/plan-utils.ts
@@ -14,8 +14,10 @@ export function parsePlan(content: string): PlanStep[] | null {
           typeof s === "object" && s !== null && typeof s.title === "string",
       );
     }
-  } catch {
-    // ignore parse errors
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("[ai-elements] Failed to parse plan:", error);
+    }
   }
   return null;
 }

--- a/shell/src/components/ai-elements/plan.tsx
+++ b/shell/src/components/ai-elements/plan.tsx
@@ -109,23 +109,3 @@ function PlanStepItem({ step, index }: PlanStepItemProps) {
     </Collapsible>
   );
 }
-
-export function parsePlan(content: string): PlanStep[] | null {
-  const match = content.match(
-    /```plan\n([\s\S]*?)```/,
-  );
-  if (!match) return null;
-
-  try {
-    const parsed = JSON.parse(match[1]);
-    if (Array.isArray(parsed)) {
-      return parsed.filter(
-        (s): s is PlanStep =>
-          typeof s === "object" && s !== null && typeof s.title === "string",
-      );
-    }
-  } catch {
-    // ignore parse errors
-  }
-  return null;
-}

--- a/shell/src/components/ai-elements/reasoning-utils.ts
+++ b/shell/src/components/ai-elements/reasoning-utils.ts
@@ -1,0 +1,15 @@
+export function extractThinking(content: string): {
+  thinking: string;
+  rest: string;
+} {
+  const thinkingMatch = content.match(
+    /^<thinking>\n?([\s\S]*?)\n?<\/thinking>\n?/,
+  );
+  if (thinkingMatch) {
+    return {
+      thinking: thinkingMatch[1],
+      rest: content.slice(thinkingMatch[0].length),
+    };
+  }
+  return { thinking: "", rest: content };
+}

--- a/shell/src/components/ai-elements/reasoning.tsx
+++ b/shell/src/components/ai-elements/reasoning.tsx
@@ -70,19 +70,3 @@ function ThinkingDots() {
     </span>
   );
 }
-
-export function extractThinking(content: string): {
-  thinking: string;
-  rest: string;
-} {
-  const thinkingMatch = content.match(
-    /^<thinking>\n?([\s\S]*?)\n?<\/thinking>\n?/,
-  );
-  if (thinkingMatch) {
-    return {
-      thinking: thinkingMatch[1],
-      rest: content.slice(thinkingMatch[0].length),
-    };
-  }
-  return { thinking: "", rest: content };
-}

--- a/shell/src/components/ai-elements/suggestions-utils.ts
+++ b/shell/src/components/ai-elements/suggestions-utils.ts
@@ -14,8 +14,10 @@ export function parseSuggestions(content: string): string[] {
       if (Array.isArray(parsed)) {
         return parsed.filter((s): s is string => typeof s === "string");
       }
-    } catch {
-      // ignore parse errors
+    } catch (error: unknown) {
+      if (!(error instanceof SyntaxError)) {
+        console.warn("[ai-elements] Failed to parse suggestions:", error);
+      }
     }
   }
   return [];

--- a/shell/src/components/ai-elements/suggestions-utils.ts
+++ b/shell/src/components/ai-elements/suggestions-utils.ts
@@ -1,0 +1,22 @@
+export const DEFAULT_SUGGESTIONS = [
+  "What can you do?",
+  "Build me an app",
+  "Show my files",
+];
+
+export function parseSuggestions(content: string): string[] {
+  const match = content.match(
+    /<!-- suggestions: (.*?) -->/,
+  );
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[1]);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((s): s is string => typeof s === "string");
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+  return [];
+}

--- a/shell/src/components/ai-elements/suggestions.tsx
+++ b/shell/src/components/ai-elements/suggestions.tsx
@@ -4,12 +4,6 @@
 import type { HTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
 
-export const DEFAULT_SUGGESTIONS = [
-  "What can you do?",
-  "Build me an app",
-  "Show my files",
-];
-
 export type SuggestionChipProps = Omit<HTMLAttributes<HTMLButtonElement>, "onSelect"> & {
   label: string;
   onSelect: (label: string) => void;
@@ -62,6 +56,7 @@ export function SuggestionChips({
         "flex flex-wrap gap-2 justify-center",
         className,
       )}
+      // react-doctor-disable-next-line jsx-a11y/prefer-tag-over-role -- role="group" has no behavior-preserving native tag; the rule's suggested <address> is for contact info and adds italic styling
       role="group"
       aria-label="Suggested messages"
       {...props}
@@ -76,21 +71,4 @@ export function SuggestionChips({
       ))}
     </div>
   );
-}
-
-export function parseSuggestions(content: string): string[] {
-  const match = content.match(
-    /<!-- suggestions: (.*?) -->/,
-  );
-  if (match) {
-    try {
-      const parsed = JSON.parse(match[1]);
-      if (Array.isArray(parsed)) {
-        return parsed.filter((s): s is string => typeof s === "string");
-      }
-    } catch {
-      // ignore parse errors
-    }
-  }
-  return [];
 }

--- a/shell/src/components/ai-elements/task-utils.ts
+++ b/shell/src/components/ai-elements/task-utils.ts
@@ -16,8 +16,10 @@ export function parseTask(content: string): TaskData | null {
     ) {
       return parsed as TaskData;
     }
-  } catch {
-    // ignore parse errors
+  } catch (error: unknown) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("[ai-elements] Failed to parse task:", error);
+    }
   }
   return null;
 }

--- a/shell/src/components/ai-elements/task-utils.ts
+++ b/shell/src/components/ai-elements/task-utils.ts
@@ -1,0 +1,23 @@
+import type { TaskData } from "./task";
+
+export function parseTask(content: string): TaskData | null {
+  const match = content.match(
+    /```task\n([\s\S]*?)```/,
+  );
+  if (!match) return null;
+
+  try {
+    const parsed = JSON.parse(match[1]);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof parsed.title === "string" &&
+      typeof parsed.status === "string"
+    ) {
+      return parsed as TaskData;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return null;
+}

--- a/shell/src/components/ai-elements/task.tsx
+++ b/shell/src/components/ai-elements/task.tsx
@@ -99,25 +99,3 @@ export function TaskList({ tasks, className, ...props }: TaskListProps) {
     </div>
   );
 }
-
-export function parseTask(content: string): TaskData | null {
-  const match = content.match(
-    /```task\n([\s\S]*?)```/,
-  );
-  if (!match) return null;
-
-  try {
-    const parsed = JSON.parse(match[1]);
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      typeof parsed.title === "string" &&
-      typeof parsed.status === "string"
-    ) {
-      return parsed as TaskData;
-    }
-  } catch {
-    // ignore parse errors
-  }
-  return null;
-}

--- a/shell/src/components/ai-elements/tool.tsx
+++ b/shell/src/components/ai-elements/tool.tsx
@@ -65,7 +65,7 @@ const statusIcons: Record<ToolPart["state"], ReactNode> = {
   "output-error": <XCircleIcon className="size-4 text-red-600" />,
 };
 
-export const getStatusBadge = (status: ToolPart["state"]) => (
+const getStatusBadge = (status: ToolPart["state"]) => (
   <Badge className="gap-1.5 rounded-full text-xs" variant="secondary">
     {statusIcons[status]}
     {statusLabels[status]}

--- a/shell/src/components/app-store/AppCard.tsx
+++ b/shell/src/components/app-store/AppCard.tsx
@@ -23,6 +23,7 @@ export function AppCard({ entry, installed, onSelect, onInstall }: AppCardProps)
 
   return (
     <div
+      // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- cannot be a native <button>: this card contains a nested install <Button>, and nesting interactive elements is invalid HTML
       role="button"
       tabIndex={0}
       onClick={onSelect}

--- a/shell/src/components/app-store/AppStoreFeatured.tsx
+++ b/shell/src/components/app-store/AppStoreFeatured.tsx
@@ -51,6 +51,7 @@ export function AppStoreFeatured({ entries, onSelect, onInstall }: AppStoreFeatu
         onMouseLeave={() => setHovering(false)}
       >
         <div
+          // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- cannot be a native <button>: this card contains a nested install <Button>, and nesting interactive elements is invalid HTML
           role="button"
           tabIndex={0}
           onClick={() => onSelect(entry)}

--- a/shell/src/components/app-viewer-helpers.ts
+++ b/shell/src/components/app-viewer-helpers.ts
@@ -1,0 +1,62 @@
+import { buildBridgeScript, type ThemeVars } from "@/lib/os-bridge";
+
+const LEGACY_NESTED_RUNTIME_APP_SLUGS = new Set([
+  "2048",
+  "backgammon",
+  "chess",
+  "minesweeper",
+  "snake",
+  "solitaire",
+  "tetris",
+]);
+
+export const APP_IFRAME_SANDBOX = "allow-scripts allow-forms allow-popups";
+
+const APP_IFRAME_CSP = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+].join("; ");
+
+export function extractSlug(path: string): string | null {
+  const topLevel = path.match(/^apps\/([a-z0-9][a-z0-9-]{0,63})(?:\/(?:index\.html)?)?$/);
+  if (topLevel) return topLevel[1];
+
+  // Older saved layouts used filesystem paths for migrated bundled games. Only
+  // rewrite known migrated slugs; other nested paths still load as files.
+  const nestedIndex = path.match(/^apps\/(?:[a-z0-9][a-z0-9-]{0,63}\/)+([a-z0-9][a-z0-9-]{0,63})\/index\.html$/);
+  if (nestedIndex && LEGACY_NESTED_RUNTIME_APP_SLUGS.has(nestedIndex[1])) {
+    return nestedIndex[1];
+  }
+  return null;
+}
+
+export function shouldRenderAppIframe(path: string): boolean {
+  return !path.startsWith("__");
+}
+
+export function injectBridgeIntoAppHtml(
+  html: string,
+  appName: string,
+  themeVars: ThemeVars,
+  baseHref: string,
+): string {
+  const bridgeScript = buildBridgeScript(appName, themeVars)
+    + `\n;if(window.MatrixOS&&window.MatrixOS.db){useDb=true;}if(typeof loadData==="function"){loadData();}\n`;
+  const escapedBaseHref = baseHref.replace(/"/g, "&quot;");
+  const injection = [
+    `<base href="${escapedBaseHref}">`,
+    `<meta http-equiv="Content-Security-Policy" content="${APP_IFRAME_CSP.replace(/"/g, "&quot;")}">`,
+    `<script>${bridgeScript}</script>`,
+  ].join("");
+
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(/<head([^>]*)>/i, `<head$1>${injection}`);
+  }
+  return `<!doctype html><html><head>${injection}</head><body>${html}</body></html>`;
+}

--- a/shell/src/components/canvas/CanvasGroup.tsx
+++ b/shell/src/components/canvas/CanvasGroup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { type CSSProperties, useCallback, useRef } from "react";
 import { useCanvasGroups, type CanvasGroup } from "@/stores/canvas-groups";
 import { useCanvasTransform } from "@/hooks/useCanvasTransform";
 import { useWindowManager } from "@/hooks/useWindowManager";
@@ -8,6 +8,11 @@ import { useWindowManager } from "@/hooks/useWindowManager";
 interface CanvasGroupProps {
   group: CanvasGroup;
 }
+
+const GROUP_RECT_BASE_STYLE: CSSProperties = {
+  zIndex: 0,
+  pointerEvents: "auto",
+};
 
 export function CanvasGroupRect({ group }: CanvasGroupProps) {
   const bounds = useCanvasGroups((s) => s.getGroupBounds)(group.id);
@@ -67,14 +72,13 @@ export function CanvasGroupRect({ group }: CanvasGroupProps) {
     <div
       className="absolute rounded-xl border-2 border-dashed"
       style={{
+        ...GROUP_RECT_BASE_STYLE,
         left: bounds.x,
         top: bounds.y,
         width: bounds.width,
         height: bounds.height,
         borderColor: group.color,
         backgroundColor: `${group.color}08`,
-        zIndex: 0,
-        pointerEvents: "auto",
       }}
     >
       <div

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -12,7 +12,7 @@ import { WorkspaceCanvas } from "./WorkspaceCanvas";
 import { CanvasGroupRect } from "./CanvasGroup";
 import { CanvasTextLabel } from "./CanvasTextLabel";
 import { SelectionRect } from "./SelectionRect";
-import { autoArrangeWindows } from "./CanvasToolbar";
+import { autoArrangeWindows } from "./canvas-auto-arrange";
 import { CanvasMinimap } from "./CanvasMinimap";
 
 const GROUP_COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"];

--- a/shell/src/components/canvas/CanvasTextLabel.tsx
+++ b/shell/src/components/canvas/CanvasTextLabel.tsx
@@ -138,6 +138,7 @@ export function CanvasTextLabel({ label }: CanvasTextLabelProps) {
               onKeyDown={onKeyDown}
               className="bg-transparent border-b border-primary text-xl font-bold outline-none min-w-[60px]"
               style={{ color: label.color }}
+              // react-doctor-disable-next-line react-doctor/no-autofocus -- inline label editor mounts only on explicit double-click (not page load); focus is essential so the user can type immediately
               autoFocus
             />
           ) : (

--- a/shell/src/components/canvas/CanvasToolbar.tsx
+++ b/shell/src/components/canvas/CanvasToolbar.tsx
@@ -7,52 +7,7 @@ import { useCanvasLabels } from "@/stores/canvas-labels";
 import { Minus, Plus, Maximize, Type, LayoutGrid, Grid3X3, MousePointer, Hand, Eye, EyeOff, CircleHelpIcon } from "lucide-react";
 import { useDotGrid } from "../DotGrid";
 import { useCanvasSettings } from "@/stores/canvas-settings";
-
-export function autoArrangeWindows() {
-  const wm = useWindowManager.getState();
-  const wins = wm.windows.filter((w) => !w.minimized);
-  if (wins.length === 0) return;
-
-  const sorted = [...wins].sort((a, b) => {
-    const rowA = Math.round(a.y / 200);
-    const rowB = Math.round(b.y / 200);
-    if (rowA !== rowB) return rowA - rowB;
-    return a.x - b.x;
-  });
-
-  const gap = 24;
-  const viewW = window.innerWidth;
-  const avgWidth = sorted.reduce((s, w) => s + w.width, 0) / sorted.length;
-  const cols = Math.max(1, Math.min(sorted.length, Math.floor((viewW * 0.8) / (avgWidth + gap))));
-
-  const rows: typeof sorted[] = [];
-  for (let i = 0; i < sorted.length; i += cols) {
-    rows.push(sorted.slice(i, i + cols));
-  }
-
-  let currentY = gap;
-  for (const row of rows) {
-    const totalWidth = row.reduce((s, w) => s + w.width, 0) + (row.length - 1) * gap;
-    let currentX = -totalWidth / 2;
-    let rowHeight = 0;
-
-    for (const win of row) {
-      wm.moveWindow(win.id, currentX, currentY);
-      currentX += win.width + gap;
-      rowHeight = Math.max(rowHeight, win.height);
-    }
-
-    currentY += rowHeight + gap;
-  }
-
-  const arranged = useWindowManager.getState().windows.filter((w) => !w.minimized);
-  const cRect = useCanvasTransform.getState().containerRect;
-  useCanvasTransform.getState().fitAll(
-    arranged.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
-    cRect?.width ?? window.innerWidth,
-    cRect?.height ?? window.innerHeight,
-  );
-}
+import { autoArrangeWindows } from "./canvas-auto-arrange";
 
 interface CanvasToolbarProps {
   guideVisible?: boolean;

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -301,6 +301,7 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
         {/* Centered title with icon */}
         <div className="flex-1 flex items-center justify-center gap-1.5 min-w-0 relative z-10">
           {iconUrl ? (
+            // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png with ?v=etag) that cannot be statically configured for next/image
             <img src={iconUrl} alt="" className="size-4 rounded-md object-cover shrink-0" draggable={false} />
           ) : (
             <span className="size-4 rounded-md bg-muted flex items-center justify-center text-[9px] font-semibold text-muted-foreground shrink-0">
@@ -349,6 +350,7 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
         {/* Left: icon + title */}
         <div className="flex items-center gap-1.5 min-w-0 flex-1">
           {iconUrl ? (
+            // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png with ?v=etag) that cannot be statically configured for next/image
             <img src={iconUrl} alt="" className="size-4 object-cover shrink-0" style={{ imageRendering: "auto" }} draggable={false} />
           ) : (
             <span className="size-4 flex items-center justify-center text-[10px] font-bold shrink-0">
@@ -366,7 +368,7 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
             className="size-5 flex items-center justify-center text-foreground bg-muted hover:bg-muted/80 active:bg-muted/60"
             style={{
               ...win98Bevel,
-              fontSize: "10px",
+              fontSize: "12px",
               lineHeight: 1,
             }}
             onClick={(e) => { e.stopPropagation(); minimizeWindow(win.id); }}
@@ -379,7 +381,7 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
             className="size-5 flex items-center justify-center text-foreground bg-muted hover:bg-muted/80 active:bg-muted/60"
             style={{
               ...win98Bevel,
-              fontSize: "10px",
+              fontSize: "12px",
               lineHeight: 1,
             }}
             onClick={(e) => { e.stopPropagation(); useWindowManager.getState().toggleFullscreen(win.id); }}
@@ -513,6 +515,7 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
         {isPreview ? (
           <>
             {iconUrl ? (
+              // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png with ?v=etag) that cannot be statically configured for next/image
               <img src={iconUrl} alt={win.title} className="size-16 object-contain opacity-50" draggable={false} />
             ) : (
               <span className="text-3xl font-semibold text-muted-foreground/20">

--- a/shell/src/components/canvas/canvas-auto-arrange.ts
+++ b/shell/src/components/canvas/canvas-auto-arrange.ts
@@ -1,0 +1,48 @@
+import { useCanvasTransform } from "@/hooks/useCanvasTransform";
+import { useWindowManager } from "@/hooks/useWindowManager";
+
+export function autoArrangeWindows() {
+  const wm = useWindowManager.getState();
+  const wins = wm.windows.filter((w) => !w.minimized);
+  if (wins.length === 0) return;
+
+  const sorted = [...wins].sort((a, b) => {
+    const rowA = Math.round(a.y / 200);
+    const rowB = Math.round(b.y / 200);
+    if (rowA !== rowB) return rowA - rowB;
+    return a.x - b.x;
+  });
+
+  const gap = 24;
+  const viewW = window.innerWidth;
+  const avgWidth = sorted.reduce((s, w) => s + w.width, 0) / sorted.length;
+  const cols = Math.max(1, Math.min(sorted.length, Math.floor((viewW * 0.8) / (avgWidth + gap))));
+
+  const rows: typeof sorted[] = [];
+  for (let i = 0; i < sorted.length; i += cols) {
+    rows.push(sorted.slice(i, i + cols));
+  }
+
+  let currentY = gap;
+  for (const row of rows) {
+    const totalWidth = row.reduce((s, w) => s + w.width, 0) + (row.length - 1) * gap;
+    let currentX = -totalWidth / 2;
+    let rowHeight = 0;
+
+    for (const win of row) {
+      wm.moveWindow(win.id, currentX, currentY);
+      currentX += win.width + gap;
+      rowHeight = Math.max(rowHeight, win.height);
+    }
+
+    currentY += rowHeight + gap;
+  }
+
+  const arranged = useWindowManager.getState().windows.filter((w) => !w.minimized);
+  const cRect = useCanvasTransform.getState().containerRect;
+  useCanvasTransform.getState().fitAll(
+    arranged.map((w) => ({ x: w.x, y: w.y, width: w.width, height: w.height })),
+    cRect?.width ?? window.innerWidth,
+    cRect?.height ?? window.innerHeight,
+  );
+}

--- a/shell/src/components/chat-app-hermes.ts
+++ b/shell/src/components/chat-app-hermes.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_HERMES_MODEL = "Hermes default";
+export const DEFAULT_HERMES_CHANNELS = ["shell"];
+
+export function createHermesConfiguredPrompt(text: string, _model: string, _channels: string[]) {
+  const normalizedChannels = _channels.toSorted();
+  const isDefaultSetup =
+    _model === DEFAULT_HERMES_MODEL &&
+    normalizedChannels.length === DEFAULT_HERMES_CHANNELS.length &&
+    normalizedChannels.every((channel, index) => channel === DEFAULT_HERMES_CHANNELS[index]);
+  if (isDefaultSetup) return text;
+
+  const enabledChannels = normalizedChannels.length > 0 ? normalizedChannels.join(", ") : "none";
+  return [
+    "Use this Hermes setup for this response only:",
+    `Agent mode: ${_model}`,
+    `Enabled channels: ${enabledChannels}`,
+    "",
+    text,
+  ].join("\n");
+}

--- a/shell/src/components/connection-indicator-copy.ts
+++ b/shell/src/components/connection-indicator-copy.ts
@@ -1,0 +1,55 @@
+import type { ConnectionState } from "@/hooks/useConnectionHealth";
+
+export type GatewayReachability = "checking" | "online" | "unavailable";
+
+export interface RuntimeStatus {
+  reachability: GatewayReachability;
+  releaseVersion?: string | null;
+  releaseChannel?: string | null;
+}
+
+export interface ConnectionCopy {
+  tone: "warn" | "danger";
+  title: string;
+  detail: string;
+  action: string;
+}
+
+export function resolveConnectionCopy(state: ConnectionState, status: RuntimeStatus): ConnectionCopy {
+  if (state === "disconnected") {
+    return {
+      tone: "danger",
+      title: "Connection lost",
+      detail: status.reachability === "online"
+        ? "Your Matrix computer is online, but the live shell socket is closed."
+        : "Your Matrix computer is not reachable yet. It may be restarting after an update.",
+      action: "Reconnect",
+    };
+  }
+
+  if (status.reachability === "online") {
+    const version = status.releaseVersion ? ` ${status.releaseVersion}` : "";
+    return {
+      tone: "warn",
+      title: "Reconnecting shell",
+      detail: `The gateway is online${version}. Waiting for the live session to resume.`,
+      action: "Retry now",
+    };
+  }
+
+  if (status.reachability === "checking") {
+    return {
+      tone: "warn",
+      title: "Checking Matrix computer",
+      detail: "Matrix is checking whether your computer is restarting or applying an update.",
+      action: "Retry now",
+    };
+  }
+
+  return {
+    tone: "warn",
+    title: "Matrix computer is restarting",
+    detail: "Services are coming back online. This usually happens during bundle upgrades or gateway restarts.",
+    action: "Retry now",
+  };
+}

--- a/shell/src/components/file-browser/FileBrowser.tsx
+++ b/shell/src/components/file-browser/FileBrowser.tsx
@@ -271,6 +271,7 @@ export function FileBrowser({ windowId, mobile = false }: FileBrowserProps) {
     <div
       ref={containerRef}
       className="flex flex-col h-full outline-none"
+      // react-doctor-disable-next-line react-doctor/no-noninteractive-tabindex -- intentional focus target: this container hosts the file browser keyboard shortcut handler (arrows, copy/paste, F2, Enter)
       tabIndex={0}
       onKeyDown={handleKeyDown}
     >

--- a/shell/src/components/file-browser/FileIcon.tsx
+++ b/shell/src/components/file-browser/FileIcon.tsx
@@ -52,6 +52,7 @@ export function FileIcon({
         "hover:bg-accent/50 transition-colors",
         selected && "bg-accent ring-1 ring-primary/30",
       )}
+      // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- gridcell in a non-table flex grid (IconView role="grid"); no native HTML element maps to the ARIA gridcell role
       role="gridcell"
       aria-selected={selected}
       onClick={onClick}

--- a/shell/src/components/file-browser/ListView.tsx
+++ b/shell/src/components/file-browser/ListView.tsx
@@ -93,7 +93,7 @@ export function ListView({ renamingPath, onStartRename, onCancelRename, onOpenFi
     <div className="overflow-auto h-full" role="grid" aria-label="File list">
       <table className="w-full text-sm">
         <thead className="sticky top-0 bg-background border-b">
-          <tr role="row">
+          <tr>
             {(["name", "size", "modified", "type"] as const).map((col) => (
               <th
                 key={col}
@@ -115,7 +115,6 @@ export function ListView({ renamingPath, onStartRename, onCancelRename, onOpenFi
             return (
               <tr
                 key={entry.name}
-                role="row"
                 className={cn(
                   "cursor-default hover:bg-accent/50 transition-colors",
                   selected && "bg-accent",
@@ -123,7 +122,7 @@ export function ListView({ renamingPath, onStartRename, onCancelRename, onOpenFi
                 onClick={(e) => select(entry.name, e.metaKey || e.ctrlKey)}
                 onDoubleClick={() => handleDoubleClick(entry)}
               >
-                <td className="px-3 py-1 flex items-center gap-2" role="gridcell">
+                <td className="px-3 py-1 flex items-center gap-2">
                   <Icon
                     className={cn(
                       "size-4 shrink-0",
@@ -147,13 +146,13 @@ export function ListView({ renamingPath, onStartRename, onCancelRename, onOpenFi
                     <span className="truncate">{entry.name}</span>
                   )}
                 </td>
-                <td className="px-3 py-1 text-muted-foreground" role="gridcell">
+                <td className="px-3 py-1 text-muted-foreground">
                   {entry.type === "file" ? formatSize(entry.size) : `${entry.children ?? "--"} items`}
                 </td>
-                <td className="px-3 py-1 text-muted-foreground" role="gridcell">
+                <td className="px-3 py-1 text-muted-foreground">
                   {formatDate(entry.modified)}
                 </td>
-                <td className="px-3 py-1 text-muted-foreground" role="gridcell">
+                <td className="px-3 py-1 text-muted-foreground">
                   {getTypeLabel(entry)}
                 </td>
               </tr>

--- a/shell/src/components/file-browser/PreviewPanel.tsx
+++ b/shell/src/components/file-browser/PreviewPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 
 const GATEWAY_URL = getGatewayUrl();
+const PREVIEW_PANEL_FETCH_TIMEOUT_MS = 10_000;
 
 interface FileStat {
   name: string;
@@ -51,31 +52,42 @@ export function PreviewPanel() {
       return;
     }
 
-    const controller = new AbortController();
-    const { signal } = controller;
+    let active = true;
 
     fetch(
       `${GATEWAY_URL}/api/files/stat?path=${encodeURIComponent(selectedFullPath)}`,
-      { signal },
+      { signal: AbortSignal.timeout(PREVIEW_PANEL_FETCH_TIMEOUT_MS) },
     )
       .then((r) => r.json())
-      .then((data: FileStat) => { if (!signal.aborted) setStat(data); })
-      .catch(() => { if (!signal.aborted) setStat(null); });
+      .then((data: FileStat) => { if (active) setStat(data); })
+      .catch((error: unknown) => {
+        if (!active) return;
+        console.warn("Failed to load preview file stats", error);
+        setStat(null);
+      });
 
     if (selectedName && isTextLike(selectedName)) {
-      fetch(`${GATEWAY_URL}/files/${selectedFullPath}`, { signal })
+      fetch(`${GATEWAY_URL}/files/${selectedFullPath}`, {
+        signal: AbortSignal.timeout(PREVIEW_PANEL_FETCH_TIMEOUT_MS),
+      })
         .then((r) => (r.ok ? r.text() : null))
         .then((text) => {
-          if (!signal.aborted && text) {
+          if (active && text) {
             setPreview(text.split("\n").slice(0, 20).join("\n"));
           }
         })
-        .catch(() => { if (!signal.aborted) setPreview(null); });
+        .catch((error: unknown) => {
+          if (!active) return;
+          console.warn("Failed to load preview file content", error);
+          setPreview(null);
+        });
     } else {
       setPreview(null);
     }
 
-    return () => controller.abort();
+    return () => {
+      active = false;
+    };
   }, [selectedFullPath, showPreviewPanel, selectedName]);
 
   if (!showPreviewPanel) return null;

--- a/shell/src/components/file-browser/PreviewPanel.tsx
+++ b/shell/src/components/file-browser/PreviewPanel.tsx
@@ -105,6 +105,7 @@ export function PreviewPanel() {
     <div className="w-56 border-l border-border overflow-y-auto p-3 text-sm shrink-0">
       <div className="flex flex-col items-center gap-2 mb-4">
         {isImage(stat.name) && stat.type === "file" ? (
+          // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- arbitrary user file served from gateway; next/image cannot optimize dynamic gateway URLs
           <img
             src={`${GATEWAY_URL}/files/${stat.path}`}
             alt={stat.name}

--- a/shell/src/components/file-browser/QuickLook.tsx
+++ b/shell/src/components/file-browser/QuickLook.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { XIcon } from "lucide-react";
 
 const GATEWAY_URL = getGatewayUrl();
+const QUICK_LOOK_FETCH_TIMEOUT_MS = 10_000;
 
 export function QuickLook() {
   const quickLookPath = useFileBrowser((s) => s.quickLookPath);
@@ -33,19 +34,26 @@ export function QuickLook() {
       return;
     }
 
-    const controller = new AbortController();
-    const { signal } = controller;
+    let active = true;
 
-    fetch(`${GATEWAY_URL}/files/${fullPath}`, { signal })
+    fetch(`${GATEWAY_URL}/files/${fullPath}`, {
+      signal: AbortSignal.timeout(QUICK_LOOK_FETCH_TIMEOUT_MS),
+    })
       .then((r) => (r.ok ? r.text() : null))
       .then((text) => {
-        if (signal.aborted) return;
+        if (!active) return;
         if (text) setContent(text.split("\n").slice(0, 50).join("\n"));
         else setContent(null);
       })
-      .catch(() => { if (!signal.aborted) setContent(null); });
+      .catch((error: unknown) => {
+        if (!active) return;
+        console.warn("Failed to load quick look preview", error);
+        setContent(null);
+      });
 
-    return () => controller.abort();
+    return () => {
+      active = false;
+    };
   }, [fullPath, quickLookPath]);
 
   if (!quickLookPath || !fullPath) return null;

--- a/shell/src/components/file-browser/QuickLook.tsx
+++ b/shell/src/components/file-browser/QuickLook.tsx
@@ -53,6 +53,7 @@ export function QuickLook() {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
+      // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- custom overlay modal with backdrop; native <dialog> would change top-layer/focus semantics
       role="dialog"
       aria-modal="true"
     >
@@ -89,14 +90,17 @@ export function QuickLook() {
 
         <div className="flex-1 overflow-auto p-4 min-h-0">
           {isImage(quickLookPath) ? (
+            // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- arbitrary user file served from gateway; next/image cannot optimize dynamic gateway URLs
             <img
               src={`${GATEWAY_URL}/files/${fullPath}`}
               alt={quickLookPath}
               className="max-w-full max-h-full mx-auto object-contain"
             />
           ) : isAudio(quickLookPath) ? (
+            // react-doctor-disable-next-line react-doctor/media-has-caption -- arbitrary user audio file preview; no caption track exists
             <audio controls className="w-full" src={`${GATEWAY_URL}/files/${fullPath}`} />
           ) : isVideo(quickLookPath) ? (
+            // react-doctor-disable-next-line react-doctor/media-has-caption -- arbitrary user video file preview; no caption track exists
             <video controls className="w-full max-h-96" src={`${GATEWAY_URL}/files/${fullPath}`} />
           ) : content !== null ? (
             <pre className="text-xs font-mono whitespace-pre-wrap break-all">

--- a/shell/src/components/mobile/MobileShell.tsx
+++ b/shell/src/components/mobile/MobileShell.tsx
@@ -18,6 +18,7 @@
  *   apps they've installed.
  */
 
+import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useChatContext } from "@/stores/chat-context";
 import { useTheme } from "@/hooks/useTheme";
@@ -56,6 +57,79 @@ const BUILT_IN_APPS: MobileApp[] = [
 function iconUrl(slug: string): string {
   return `/icons/${slug}.png`;
 }
+
+const LAUNCHER_APP_BUTTON_STYLE: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 6,
+  background: "transparent",
+  border: "none",
+  color: "inherit",
+  cursor: "pointer",
+  padding: 0,
+};
+
+const LAUNCHER_APP_LABEL_STYLE: CSSProperties = {
+  fontSize: 12,
+  lineHeight: 1.2,
+  textAlign: "center",
+  maxWidth: 70,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const SWITCHER_CLOSE_BUTTON_STYLE: CSSProperties = {
+  background: "transparent",
+  border: "1px solid rgba(244,237,224,0.18)",
+  color: "inherit",
+  borderRadius: 999,
+  width: 28,
+  height: 28,
+  cursor: "pointer",
+  opacity: 0.75,
+  fontSize: 12,
+};
+
+const SWITCHER_RESUME_BUTTON_STYLE: CSSProperties = {
+  alignSelf: "center",
+  marginTop: 4,
+  background: "var(--primary, #c2703a)",
+  color: "var(--primary-foreground, #fff)",
+  border: "none",
+  borderRadius: 999,
+  padding: "10px 18px",
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+const DOCK_BUTTON_BASE_STYLE: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 2,
+  background: "transparent",
+  border: "none",
+  color: "inherit",
+  padding: "4px 10px",
+  position: "relative",
+  cursor: "pointer",
+};
+
+const DOCK_BADGE_STYLE: CSSProperties = {
+  position: "absolute",
+  top: 2,
+  right: 6,
+  background: "var(--primary, #c2703a)",
+  color: "white",
+  fontSize: 12,
+  fontWeight: 700,
+  borderRadius: 999,
+  padding: "1px 5px",
+  lineHeight: 1.2,
+};
 
 interface MobileShellProps {
   launchAppPath?: string | null;
@@ -471,32 +545,10 @@ function Launcher({ apps, onOpen, onOpenSettings, openStackCount, onShowSwitcher
             key={app.id}
             type="button"
             onClick={() => onOpen(app)}
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: 6,
-              background: "transparent",
-              border: "none",
-              color: "inherit",
-              cursor: "pointer",
-              padding: 0,
-            }}
+            style={LAUNCHER_APP_BUTTON_STYLE}
           >
             <AppIcon slug={app.iconSlug} size={56} />
-            <span
-              style={{
-                fontSize: 11,
-                lineHeight: 1.2,
-                textAlign: "center",
-                maxWidth: 70,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {app.name}
-            </span>
+            <span style={LAUNCHER_APP_LABEL_STYLE}>{app.name}</span>
           </button>
         ))}
       </div>
@@ -591,7 +643,7 @@ function AppSwitcher({
                 }}
               >
                 <div style={{ fontSize: 14, fontWeight: 600 }}>{o.app.name}</div>
-                <div style={{ fontSize: 11, opacity: 0.6 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>
                   Opened {new Date(o.openedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
                 </div>
               </button>
@@ -599,39 +651,14 @@ function AppSwitcher({
                 onClick={() => onClose(o.id)}
                 type="button"
                 aria-label={`Close ${o.app.name}`}
-                style={{
-                  background: "transparent",
-                  border: "1px solid rgba(244,237,224,0.18)",
-                  color: "inherit",
-                  borderRadius: 999,
-                  width: 28,
-                  height: 28,
-                  cursor: "pointer",
-                  opacity: 0.75,
-                  fontSize: 12,
-                }}
+                style={SWITCHER_CLOSE_BUTTON_STYLE}
               >
                 ×
               </button>
             </div>
           ))}
         {open.length > 0 && (
-          <button
-            onClick={onResume}
-            type="button"
-            style={{
-              alignSelf: "center",
-              marginTop: 4,
-              background: "var(--primary, #c2703a)",
-              color: "var(--primary-foreground, #fff)",
-              border: "none",
-              borderRadius: 999,
-              padding: "10px 18px",
-              fontSize: 13,
-              fontWeight: 600,
-              cursor: "pointer",
-            }}
-          >
+          <button onClick={onResume} type="button" style={SWITCHER_RESUME_BUTTON_STYLE}>
             Resume foreground app
           </button>
         )}
@@ -657,39 +684,13 @@ function DockButton({
     <button
       onClick={onClick}
       type="button"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        gap: 2,
-        background: "transparent",
-        border: "none",
-        color: "inherit",
-        opacity: highlighted ? 1 : 0.65,
-        padding: "4px 10px",
-        position: "relative",
-        cursor: "pointer",
-      }}
+      style={{ ...DOCK_BUTTON_BASE_STYLE, opacity: highlighted ? 1 : 0.65 }}
       aria-label={label}
     >
       <AppIcon slug={iconSlug} size={32} />
-      <span style={{ fontSize: 10, opacity: 0.8 }}>{label}</span>
+      <span style={{ fontSize: 12, opacity: 0.8 }}>{label}</span>
       {badge !== undefined && (
-        <span
-          aria-hidden
-          style={{
-            position: "absolute",
-            top: 2,
-            right: 6,
-            background: "var(--primary, #c2703a)",
-            color: "white",
-            fontSize: 9,
-            fontWeight: 700,
-            borderRadius: 999,
-            padding: "1px 5px",
-            lineHeight: 1.2,
-          }}
-        >
+        <span aria-hidden style={DOCK_BADGE_STYLE}>
           {badge}
         </span>
       )}
@@ -710,6 +711,7 @@ function AppIcon({ slug, size }: { slug: string; size: number }) {
   }, [slug]);
 
   return (
+    // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- icon src is swapped at runtime via onError fallback chain (.png -> .svg -> /icon-192.png), which next/image does not support; <img> preserves the graceful-degradation behavior.
     <img
       src={src}
       alt=""

--- a/shell/src/components/onboarding/VoiceOrb.tsx
+++ b/shell/src/components/onboarding/VoiceOrb.tsx
@@ -61,6 +61,7 @@ export function VoiceOrb({ state, size = 160 }: VoiceOrbProps) {
         {state === "idle" ? "ready" : state}
       </div>
 
+      {/* react-doctor-disable-next-line react-doctor/no-unknown-property -- valid styled-jsx attribute */}
       <style jsx>{`
         @keyframes orb-pulse {
           0%, 100% { opacity: 1; transform: scale(${style.scale}); }

--- a/shell/src/components/preview-window/ImageViewer.tsx
+++ b/shell/src/components/preview-window/ImageViewer.tsx
@@ -53,6 +53,7 @@ export function ImageViewer({ path }: ImageViewerProps) {
           backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
         }}
       >
+        {/* react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- arbitrary user file served from gateway; next/image cannot optimize dynamic gateway URLs */}
         <img
           src={`${GATEWAY_URL}/files/${path}`}
           alt={path.split("/").pop()}

--- a/shell/src/components/preview-window/MediaPlayer.tsx
+++ b/shell/src/components/preview-window/MediaPlayer.tsx
@@ -15,6 +15,7 @@ export function MediaPlayer({ path, type }: MediaPlayerProps) {
   if (type === "audio") {
     return (
       <div className="flex items-center justify-center h-full p-8">
+        {/* react-doctor-disable-next-line react-doctor/media-has-caption -- arbitrary user audio file preview; no caption track exists */}
         <audio controls className="w-full max-w-md" src={url} />
       </div>
     );
@@ -22,6 +23,7 @@ export function MediaPlayer({ path, type }: MediaPlayerProps) {
 
   return (
     <div className="flex items-center justify-center h-full p-4">
+      {/* react-doctor-disable-next-line react-doctor/media-has-caption -- arbitrary user video file preview; no caption track exists */}
       <video controls className="max-w-full max-h-full" src={url} />
     </div>
   );

--- a/shell/src/components/pwa/InstallPrompt.tsx
+++ b/shell/src/components/pwa/InstallPrompt.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { useEffect, useState } from "react";
+import Image from "next/image";
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -9,6 +11,46 @@ interface BeforeInstallPromptEvent extends Event {
 
 const DISMISS_KEY = "matrix-os:pwa-install-dismissed";
 const DISMISS_DAYS = 14;
+
+const CONTAINER_STYLE: CSSProperties = {
+  position: "fixed",
+  left: "50%",
+  bottom: "max(env(safe-area-inset-bottom, 0px), 16px)",
+  transform: "translateX(-50%)",
+  zIndex: 9999,
+  width: "min(420px, calc(100vw - 24px))",
+  background: "var(--card, #1c241b)",
+  color: "var(--foreground, #f4ede0)",
+  border: "1px solid var(--border, rgba(244,237,224,0.15))",
+  borderRadius: 14,
+  padding: "12px 14px",
+  boxShadow: "0 12px 40px rgba(0,0,0,0.35)",
+  display: "flex",
+  gap: 12,
+  alignItems: "center",
+};
+
+const INSTALL_BUTTON_STYLE: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  padding: "8px 12px",
+  borderRadius: 8,
+  border: "none",
+  background: "var(--primary, #c2703a)",
+  color: "var(--primary-foreground, #fff)",
+  cursor: "pointer",
+};
+
+const DISMISS_BUTTON_STYLE: CSSProperties = {
+  fontSize: 16,
+  padding: "6px 10px",
+  borderRadius: 8,
+  border: "1px solid var(--border, rgba(244,237,224,0.15))",
+  background: "transparent",
+  color: "inherit",
+  cursor: "pointer",
+  opacity: 0.6,
+};
 
 function isDismissed(): boolean {
   if (typeof window === "undefined") return true;
@@ -100,28 +142,9 @@ export function InstallPrompt() {
   if (dismissed || (!deferred && !iosHint)) return null;
 
   return (
-    <div
-      role="dialog"
-      aria-label="Install Matrix OS"
-      style={{
-        position: "fixed",
-        left: "50%",
-        bottom: "max(env(safe-area-inset-bottom, 0px), 16px)",
-        transform: "translateX(-50%)",
-        zIndex: 9999,
-        width: "min(420px, calc(100vw - 24px))",
-        background: "var(--card, #1c241b)",
-        color: "var(--foreground, #f4ede0)",
-        border: "1px solid var(--border, rgba(244,237,224,0.15))",
-        borderRadius: 14,
-        padding: "12px 14px",
-        boxShadow: "0 12px 40px rgba(0,0,0,0.35)",
-        display: "flex",
-        gap: 12,
-        alignItems: "center",
-      }}
-    >
-      <img
+    // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- native <dialog> defaults to display:none and requires imperative show()/showModal(); this is a persistently-rendered positioned banner, so role="dialog" preserves behavior.
+    <div role="dialog" aria-label="Install Matrix OS" style={CONTAINER_STYLE}>
+      <Image
         src="/icon-192.png"
         alt=""
         width={40}
@@ -132,7 +155,7 @@ export function InstallPrompt() {
         <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 2 }}>
           Install Matrix OS
         </div>
-        <div style={{ fontSize: 11, opacity: 0.75, lineHeight: 1.35 }}>
+        <div style={{ fontSize: 12, opacity: 0.75, lineHeight: 1.35 }}>
           {iosHint
             ? "Tap Share, then \"Add to Home Screen\" to install."
             : "Add to your home screen for a faster, full-screen shell."}
@@ -140,38 +163,11 @@ export function InstallPrompt() {
       </div>
       <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
         {deferred && (
-          <button
-            type="button"
-            onClick={() => void install()}
-            style={{
-              fontSize: 12,
-              fontWeight: 600,
-              padding: "8px 12px",
-              borderRadius: 8,
-              border: "none",
-              background: "var(--primary, #c2703a)",
-              color: "var(--primary-foreground, #fff)",
-              cursor: "pointer",
-            }}
-          >
+          <button type="button" onClick={() => void install()} style={INSTALL_BUTTON_STYLE}>
             Install
           </button>
         )}
-        <button
-          type="button"
-          aria-label="Dismiss"
-          onClick={dismiss}
-          style={{
-            fontSize: 16,
-            padding: "6px 10px",
-            borderRadius: 8,
-            border: "1px solid var(--border, rgba(244,237,224,0.15))",
-            background: "transparent",
-            color: "inherit",
-            cursor: "pointer",
-            opacity: 0.6,
-          }}
-        >
+        <button type="button" aria-label="Dismiss" onClick={dismiss} style={DISMISS_BUTTON_STYLE}>
           ×
         </button>
       </div>

--- a/shell/src/components/settings/BackgroundEditor.tsx
+++ b/shell/src/components/settings/BackgroundEditor.tsx
@@ -246,6 +246,7 @@ export function BackgroundEditor() {
                         : "border-border hover:border-primary/50"
                     }`}
                   >
+                    {/* react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- user-uploaded wallpaper served from a runtime gateway host that cannot be statically configured for next/image */}
                     <img
                       src={`${getGatewayUrl()}/files/system/wallpapers/${name}`}
                       alt={name}

--- a/shell/src/components/settings/sections/AppearanceSection.tsx
+++ b/shell/src/components/settings/sections/AppearanceSection.tsx
@@ -339,6 +339,7 @@ export function AppearanceSection() {
                           : "border-border hover:border-primary/40"
                       }`}
                     >
+                      {/* react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- user-uploaded wallpaper served from a runtime gateway host that cannot be statically configured for next/image */}
                       <img
                         src={`${getGatewayUrl()}/files/system/wallpapers/${name}`}
                         alt={name}

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -808,10 +808,10 @@ export function BillingPanel({
   if (active === null) {
     return (
       <div className="flex min-h-48 items-center justify-center rounded-xl border border-border/60 bg-card p-4">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
+        <output className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />
           Checking billing status
-        </div>
+        </output>
       </div>
     );
   }

--- a/shell/src/components/settings/sections/IntegrationsSection.tsx
+++ b/shell/src/components/settings/sections/IntegrationsSection.tsx
@@ -3,7 +3,11 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
 import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
-import { hasNewConnectionForService, shouldLogIntegrationWarning } from "./integrations-helpers";
+import {
+  hasNewConnectionForService,
+  shouldLogIntegrationWarning,
+  type ConnectedService,
+} from "./integrations-helpers";
 
 const GATEWAY = getGatewayUrl();
 
@@ -14,15 +18,6 @@ interface ServiceDef {
   icon: string;
   logoUrl?: string;
   actions: Record<string, unknown>;
-}
-
-interface ConnectedService {
-  id: string;
-  service: string;
-  account_label: string;
-  account_email: string | null;
-  status: string;
-  connected_at: string;
 }
 
 const CATEGORY_COLORS: Record<string, string> = {

--- a/shell/src/components/settings/sections/IntegrationsSection.tsx
+++ b/shell/src/components/settings/sections/IntegrationsSection.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
 import { buildAuthenticatedWebSocketUrl } from "@/lib/websocket-auth";
+import { hasNewConnectionForService, shouldLogIntegrationWarning } from "./integrations-helpers";
 
 const GATEWAY = getGatewayUrl();
 
@@ -24,20 +25,6 @@ interface ConnectedService {
   connected_at: string;
 }
 
-export function hasNewConnectionForService(
-  previousIds: Set<string>,
-  serviceId: string,
-  connections: Array<Pick<ConnectedService, "id" | "service">>,
-): boolean {
-  return connections.some((connection) =>
-    connection.service === serviceId && !previousIds.has(connection.id),
-  );
-}
-
-export function shouldLogIntegrationWarning(err: unknown): boolean {
-  return !(err instanceof DOMException && err.name === "AbortError");
-}
-
 const CATEGORY_COLORS: Record<string, string> = {
   google: "bg-blue-500",
   developer: "bg-gray-700",
@@ -50,6 +37,7 @@ function ServiceLogo({ name, category, logoUrl }: { name: string; category: stri
 
   if (logoUrl && !imgError) {
     return (
+      // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- remote service logo from arbitrary unconfigured host; next/image would require host allowlisting
       <img
         src={logoUrl}
         alt={name}
@@ -526,6 +514,7 @@ export function IntegrationsSection() {
                             {renamingId === conn.id ? (
                               <input
                                 type="text"
+                                // react-doctor-disable-next-line react-doctor/no-autofocus -- inline rename field rendered only after user clicks rename; focus is essential to the edit affordance
                                 autoFocus
                                 value={renameDraft}
                                 onChange={(e) => setRenameDraft(e.target.value)}

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -82,13 +82,10 @@ interface SystemReleaseList {
 }
 
 import {
-  normalizeMatrixReleaseTag,
-  isNewer,
   releaseActionLabel,
   severityBadgeStyle,
   resolveSystemUpdateState,
 } from "./system-update-state";
-export { normalizeMatrixReleaseTag, isNewer, releaseActionLabel, severityBadgeStyle, resolveSystemUpdateState };
 
 const RELEASE_CHANNELS = ["stable", "canary", "beta", "dev"] as const;
 type ReleaseChannel = typeof RELEASE_CHANNELS[number];

--- a/shell/src/components/settings/sections/integrations-helpers.ts
+++ b/shell/src/components/settings/sections/integrations-helpers.ts
@@ -1,4 +1,4 @@
-interface ConnectedService {
+export interface ConnectedService {
   id: string;
   service: string;
   account_label: string;

--- a/shell/src/components/settings/sections/integrations-helpers.ts
+++ b/shell/src/components/settings/sections/integrations-helpers.ts
@@ -1,0 +1,22 @@
+interface ConnectedService {
+  id: string;
+  service: string;
+  account_label: string;
+  account_email: string | null;
+  status: string;
+  connected_at: string;
+}
+
+export function hasNewConnectionForService(
+  previousIds: Set<string>,
+  serviceId: string,
+  connections: Array<Pick<ConnectedService, "id" | "service">>,
+): boolean {
+  return connections.some((connection) =>
+    connection.service === serviceId && !previousIds.has(connection.id),
+  );
+}
+
+export function shouldLogIntegrationWarning(err: unknown): boolean {
+  return !(err instanceof DOMException && err.name === "AbortError");
+}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useRef, useCallback, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useCallback, useState, type CSSProperties } from "react";
 import {
   BotIcon,
   FilesIcon,
@@ -21,11 +21,92 @@ import { useTerminalSettings } from "@/stores/terminal-settings";
 import { getTerminalThemePreset } from "./terminal-themes";
 import { TerminalPreferencesPanel } from "./preferences-panel";
 import { TerminalKeyBar } from "./TerminalKeyBar";
-import { isCanonicalShellSessionId, isLegacyPtySessionId } from "./TerminalPane";
+import { isCanonicalShellSessionId, isLegacyPtySessionId } from "./terminal-session-id";
 import { TERMINAL_INPUT_EVENT, type TerminalInputEventDetail } from "./terminal-input-event";
 
 export { TERMINAL_INPUT_EVENT };
 export type { TerminalInputEventDetail };
+
+const TOOLBAR_BTN_BASE_STYLE: CSSProperties = {
+  height: 28,
+  minWidth: 28,
+  fontSize: 12,
+  borderRadius: 6,
+};
+
+const PREFERENCES_DROPDOWN_STYLE: CSSProperties = {
+  position: "absolute",
+  top: 32,
+  right: 0,
+  zIndex: 50,
+  background: "var(--card)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+  padding: 0,
+  minWidth: 260,
+};
+
+const TAB_ITEM_BASE_STYLE: CSSProperties = {
+  borderRadius: 6,
+  fontSize: 12,
+  height: 34,
+};
+
+const TAB_CLOSE_BUTTON_STYLE: CSSProperties = {
+  width: 16,
+  height: 16,
+  borderRadius: 3,
+  border: "none",
+  background: "transparent",
+  color: "var(--muted-foreground)",
+  opacity: 0.5,
+  marginLeft: 2,
+};
+
+const SHELL_NEW_BUTTON_BASE_STYLE: CSSProperties = {
+  height: 28,
+  padding: "0 10px",
+  borderRadius: 6,
+  border: "1px solid transparent",
+  background: "var(--primary)",
+  color: "var(--primary-foreground)",
+  fontSize: 12,
+  fontWeight: 600,
+  whiteSpace: "nowrap",
+};
+
+const SIDEBAR_RAIL_BUTTON_BASE_STYLE: CSSProperties = {
+  width: 34,
+  height: 34,
+  borderRadius: 8,
+  fontSize: 12,
+  fontWeight: 700,
+};
+
+const SHELL_CARD_NAME_BUTTON_STYLE: CSSProperties = {
+  color: "var(--foreground)",
+  fontSize: 12,
+  fontWeight: 650,
+  fontFamily: "var(--font-mono, ui-monospace, monospace)",
+  background: "transparent",
+  border: "none",
+  padding: 0,
+  textAlign: "left",
+  cursor: "copy",
+};
+
+const PROJECT_BRANCH_BADGE_STYLE: CSSProperties = {
+  padding: "1px 5px",
+  borderRadius: 3,
+  background: "var(--background)",
+  border: "1px solid var(--border)",
+  fontFamily: "var(--font-mono, ui-monospace, monospace)",
+  maxWidth: 100,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
 
 function dispatchPaneInput(paneId: string | null, data: string): void {
   if (!paneId) return;
@@ -858,12 +939,9 @@ function ToolbarBtn({ onClick, title, children, variant = "default" }: ToolbarBt
       type="button"
       className="cursor-pointer transition-colors flex items-center justify-center gap-1.5"
       style={{
-        height: 28,
-        minWidth: 28,
+        ...TOOLBAR_BTN_BASE_STYLE,
         padding: variant === "default" ? "0 6px" : "0 10px",
-        fontSize: 12,
         fontWeight: variant === "default" ? 400 : 500,
-        borderRadius: 6,
         background: colors.bg,
         color: colors.color,
         border: `1px solid ${colors.border}`,
@@ -917,20 +995,7 @@ function ThemePickerButton() {
         <IconPalette />
       </ToolbarBtn>
       {open && (
-        <div
-          style={{
-            position: "absolute",
-            top: 32,
-            right: 0,
-            zIndex: 50,
-            background: "var(--card)",
-            border: "1px solid var(--border)",
-            borderRadius: 8,
-            boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
-            padding: 0,
-            minWidth: 260,
-          }}
-        >
+        <div style={PREFERENCES_DROPDOWN_STYLE}>
           <TerminalPreferencesPanel sessionName={sessionName} />
         </div>
       )}
@@ -972,13 +1037,11 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
               key={tab.id}
               className="flex items-center gap-1.5 cursor-pointer whitespace-nowrap transition-colors"
               style={{
+                ...TAB_ITEM_BASE_STYLE,
                 background: active ? "var(--background)" : "transparent",
                 color: active ? "var(--foreground)" : "var(--muted-foreground)",
                 border: `1px solid ${active ? "var(--border)" : "transparent"}`,
-                borderRadius: 6,
                 padding: ctx.mobile ? "0 8px" : "0 10px",
-                fontSize: 12,
-                height: ctx.mobile ? 34 : 34,
                 fontWeight: active ? 500 : 400,
                 minWidth: ctx.mobile ? 112 : 136,
                 maxWidth: ctx.mobile ? 168 : 220,
@@ -1008,16 +1071,7 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
                 type="button"
                 className="cursor-pointer flex items-center justify-center transition-colors"
                 onClick={(e) => { e.stopPropagation(); ctx.closeTab(tab.id); }}
-                style={{
-                  width: 16,
-                  height: 16,
-                  borderRadius: 3,
-                  border: "none",
-                  background: "transparent",
-                  color: "var(--muted-foreground)",
-                  opacity: 0.5,
-                  marginLeft: 2,
-                }}
+                style={TAB_CLOSE_BUTTON_STYLE}
                 onMouseEnter={(e) => { e.currentTarget.style.opacity = "1"; e.currentTarget.style.background = "var(--accent)"; }}
                 onMouseLeave={(e) => { e.currentTarget.style.opacity = "0.5"; e.currentTarget.style.background = "transparent"; }}
                 aria-label="Close tab"
@@ -1521,7 +1575,7 @@ function LocalTerminalSidebar() {
                 className="truncate"
                 style={{
                   color: "var(--muted-foreground)",
-                  fontSize: 10,
+                  fontSize: 12,
                   fontFamily: "var(--font-mono, ui-monospace, monospace)",
                   marginTop: 3,
                 }}
@@ -1536,15 +1590,7 @@ function LocalTerminalSidebar() {
                 disabled={creatingShell}
                 className="flex items-center gap-1.5 cursor-pointer"
                 style={{
-                  height: 28,
-                  padding: "0 10px",
-                  borderRadius: 6,
-                  border: "1px solid transparent",
-                  background: "var(--primary)",
-                  color: "var(--primary-foreground)",
-                  fontSize: 12,
-                  fontWeight: 600,
-                  whiteSpace: "nowrap",
+                  ...SHELL_NEW_BUTTON_BASE_STYLE,
                   cursor: creatingShell ? "not-allowed" : "pointer",
                   opacity: creatingShell ? 0.75 : 1,
                 }}
@@ -1748,14 +1794,10 @@ function SidebarRailButton({
       onClick={onClick}
       className="flex items-center justify-center cursor-pointer transition-colors"
       style={{
-        width: 34,
-        height: 34,
-        borderRadius: 8,
+        ...SIDEBAR_RAIL_BUTTON_BASE_STYLE,
         border: `1px solid ${active ? "var(--border)" : "transparent"}`,
         background: active ? "var(--card)" : "transparent",
         color: active ? "var(--foreground)" : "var(--muted-foreground)",
-        fontSize: 12,
-        fontWeight: 700,
         boxShadow: active ? "0 1px 0 rgba(0,0,0,0.08)" : "none",
       }}
       title={label}
@@ -1818,27 +1860,17 @@ function ShellCard({
           type="button"
           aria-label={`Copy attach command for ${shell.name}`}
           className="min-w-0 flex-1 truncate"
-          style={{
-            color: "var(--foreground)",
-            fontSize: 12,
-            fontWeight: 650,
-            fontFamily: "var(--font-mono, ui-monospace, monospace)",
-            background: "transparent",
-            border: "none",
-            padding: 0,
-            textAlign: "left",
-            cursor: "copy",
-          }}
+          style={SHELL_CARD_NAME_BUTTON_STYLE}
           title={copied ? "Copied" : `Copy: matrix shell connect ${shell.name}`}
           onClick={() => void copyAttachCommand()}
         >
           {shell.name}
         </button>
-        <span style={{ color: "var(--muted-foreground)", fontSize: 10, whiteSpace: "nowrap" }}>
+        <span style={{ color: "var(--muted-foreground)", fontSize: 12, whiteSpace: "nowrap" }}>
           {shell.attachedClients ?? 0} attached
         </span>
       </div>
-      <div className="truncate" style={{ color: "var(--muted-foreground)", fontSize: 10, paddingLeft: 15 }}>
+      <div className="truncate" style={{ color: "var(--muted-foreground)", fontSize: 12, paddingLeft: 15 }}>
         {shell.status ?? "active"} · {tabs.length} zellij tab{tabs.length === 1 ? "" : "s"}
       </div>
       {focusedTab ? (
@@ -1846,7 +1878,7 @@ function ShellCard({
           className="truncate"
           style={{
             color: "var(--muted-foreground)",
-            fontSize: 10,
+            fontSize: 12,
             paddingLeft: 15,
             marginTop: 2,
             fontFamily: "var(--font-mono, ui-monospace, monospace)",
@@ -2012,19 +2044,7 @@ function ProjectCard({ project, onOpenShell, onOpenClaude, onOpenZellij, onSelec
       </div>
       <div className="flex items-center gap-1.5 text-[10px]" style={{ color: "var(--muted-foreground)", paddingLeft: 12 }}>
         {project.isGit && project.branch && (
-          <span
-            style={{
-              padding: "1px 5px",
-              borderRadius: 3,
-              background: "var(--background)",
-              border: "1px solid var(--border)",
-              fontFamily: "var(--font-mono, ui-monospace, monospace)",
-              maxWidth: 100,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
+          <span style={PROJECT_BRANCH_BADGE_STYLE}>
             {project.branch}
           </span>
         )}

--- a/shell/src/components/terminal/TerminalKeyBar.tsx
+++ b/shell/src/components/terminal/TerminalKeyBar.tsx
@@ -70,6 +70,25 @@ interface TerminalKeyBarProps {
   accent?: string;
 }
 
+const MORE_BUTTON_STYLE: CSSProperties = {
+  fontSize: 13,
+  padding: "8px 10px",
+  background: "transparent",
+  borderRadius: 6,
+  minWidth: 36,
+  flexShrink: 0,
+  marginLeft: "auto",
+};
+
+const KEY_BUTTON_BASE_STYLE: CSSProperties = {
+  fontSize: 13,
+  lineHeight: 1,
+  padding: "8px 10px",
+  borderRadius: 6,
+  fontFamily: "var(--font-mono, ui-monospace, monospace)",
+  cursor: "pointer",
+};
+
 function readVisualViewportKeyboardInset(): number {
   if (typeof window === "undefined" || !window.visualViewport) return 0;
   const inset = window.innerHeight - window.visualViewport.height - window.visualViewport.offsetTop;
@@ -161,15 +180,9 @@ export function TerminalKeyBar({
           aria-label={expanded ? "Show fewer keys" : "Show more keys"}
           onClick={() => setExpanded((v) => !v)}
           style={{
-            fontSize: 13,
-            padding: "8px 10px",
-            background: "transparent",
+            ...MORE_BUTTON_STYLE,
             color: mutedForeground,
             border: `1px dashed ${accent}`,
-            borderRadius: 6,
-            minWidth: 36,
-            flexShrink: 0,
-            marginLeft: "auto",
           }}
         >
           {expanded ? "Less" : "More"}
@@ -232,17 +245,12 @@ function TerminalKeyButton({
         onSend(keyDef.data);
       }}
       style={{
-        fontSize: 13,
-        lineHeight: 1,
-        padding: "8px 10px",
+        ...KEY_BUTTON_BASE_STYLE,
         background,
         color: foreground,
         border: `1px solid ${border}`,
-        borderRadius: 6,
         minWidth: wide ? 112 : 36,
         flex: wide ? "0 1 160px" : "0 0 auto",
-        fontFamily: "var(--font-mono, ui-monospace, monospace)",
-        cursor: "pointer",
       }}
     >
       {keyDef.label}

--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useCallback, useState } from "react";
+import { useEffect, useRef, useCallback, useState, type CSSProperties } from "react";
 import { getGatewayUrl, getGatewayWs } from "@/lib/gateway";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 import { createSocketHealth } from "@/lib/socket-health";
@@ -18,6 +18,11 @@ import { WebLinkProvider } from "./web-link-provider";
 import { cacheTerminal, getCached, removeCached, type CachedTerminal } from "./terminal-cache";
 import { discardStaleCachedTerminal, getCachedTerminalRestorePlan } from "./terminal-restore";
 import { TERMINAL_INPUT_EVENT, type TerminalInputEventDetail } from "./terminal-input-event";
+import {
+  isCanonicalShellSessionId,
+  isLegacyPtySessionId,
+  terminalWebSocketPathForSession,
+} from "./terminal-session-id";
 
 function buildXtermTheme(theme: Theme, terminalThemeId: TerminalThemeId) {
   if (terminalThemeId !== "system") {
@@ -68,6 +73,33 @@ function buildTerminalFontStack(fontFamily: TerminalFontFamily, themeMono: strin
   return `${TERMINAL_FONT_STACKS[fontFamily]}, ${fallback}`;
 }
 
+const AUTH_BANNER_BASE_STYLE: CSSProperties = {
+  position: "absolute",
+  top: 8,
+  left: 8,
+  right: 8,
+  zIndex: 20,
+  color: "#fff",
+  borderRadius: 8,
+  padding: "8px 12px",
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  fontSize: 13,
+  boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
+};
+
+const AUTH_BANNER_ACTION_STYLE: CSSProperties = {
+  background: "rgba(255,255,255,0.2)",
+  border: "1px solid rgba(255,255,255,0.3)",
+  color: "#fff",
+  borderRadius: 6,
+  padding: "4px 12px",
+  cursor: "pointer",
+  fontSize: 13,
+  whiteSpace: "nowrap",
+};
+
 type TerminalServerMessage =
   | { type: "attached"; sessionId: string; state: "running" | "exited"; exitCode: number | null }
   | { type: "output"; data: string; seq: number | null }
@@ -76,21 +108,6 @@ type TerminalServerMessage =
   | { type: "replay-end" }
   | { type: "exit"; code: number | null }
   | { type: "error"; message: string };
-
-const LEGACY_PTY_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const CANONICAL_SHELL_SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
-
-export function isLegacyPtySessionId(sessionId: string): boolean {
-  return LEGACY_PTY_SESSION_ID_PATTERN.test(sessionId);
-}
-
-export function isCanonicalShellSessionId(sessionId: string): boolean {
-  return CANONICAL_SHELL_SESSION_NAME_PATTERN.test(sessionId);
-}
-
-export function terminalWebSocketPathForSession(sessionId: string | null): "/ws/terminal" | "/ws/terminal/session" {
-  return sessionId && isCanonicalShellSessionId(sessionId) ? "/ws/terminal/session" : "/ws/terminal";
-}
 
 function toFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -1191,30 +1208,18 @@ export function TerminalPane({
       {authUrl && (
         <div
           style={{
-            position: "absolute",
-            top: 8,
-            left: 8,
-            right: 8,
-            zIndex: 20,
+            ...AUTH_BANNER_BASE_STYLE,
             background: theme.colors.primary || "#c2703a",
-            color: "#fff",
-            borderRadius: 8,
-            padding: "8px 12px",
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-            fontSize: 13,
-            boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
           }}
         >
           <div style={{ flex: 1, minWidth: 0 }}>
             <div>Claude Code login required</div>
-            <div style={{ fontSize: 11, opacity: 0.85 }}>
+            <div style={{ fontSize: 12, opacity: 0.85 }}>
               Detected from terminal output. Terminal apps can spoof this. Only continue if you initiated Claude Code login.
             </div>
             <div
               style={{
-                fontSize: 11,
+                fontSize: 12,
                 opacity: 0.9,
                 overflow: "hidden",
                 textOverflow: "ellipsis",
@@ -1230,16 +1235,7 @@ export function TerminalPane({
             onClick={() => {
               window.open(authUrl, "_blank", "noopener,noreferrer");
             }}
-            style={{
-              background: "rgba(255,255,255,0.2)",
-              border: "1px solid rgba(255,255,255,0.3)",
-              color: "#fff",
-              borderRadius: 6,
-              padding: "4px 12px",
-              cursor: "pointer",
-              fontSize: 13,
-              whiteSpace: "nowrap",
-            }}
+            style={AUTH_BANNER_ACTION_STYLE}
           >
             Open login
           </button>
@@ -1258,16 +1254,7 @@ export function TerminalPane({
                 document.body.removeChild(ta);
               });
             }}
-            style={{
-              background: "rgba(255,255,255,0.2)",
-              border: "1px solid rgba(255,255,255,0.3)",
-              color: "#fff",
-              borderRadius: 6,
-              padding: "4px 12px",
-              cursor: "pointer",
-              fontSize: 13,
-              whiteSpace: "nowrap",
-            }}
+            style={AUTH_BANNER_ACTION_STYLE}
           >
             Copy URL
           </button>

--- a/shell/src/components/terminal/TerminalSearchBar.tsx
+++ b/shell/src/components/terminal/TerminalSearchBar.tsx
@@ -133,11 +133,9 @@ export function TerminalSearchBar({ searchAddon, isOpen, onClose, theme }: Termi
       }}
       onKeyDown={handleKeyDown}
     >
-      <style>{`.matrix-terminal-search-input:focus-visible{outline:2px solid var(--primary, ${primary});outline-offset:1px;border-radius:2px;}`}</style>
       <input
         ref={inputRef}
         type="text"
-        className="matrix-terminal-search-input"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search..."

--- a/shell/src/components/terminal/TerminalSearchBar.tsx
+++ b/shell/src/components/terminal/TerminalSearchBar.tsx
@@ -1,7 +1,36 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, type CSSProperties } from "react";
 import type { Theme } from "@/hooks/useTheme";
+
+const CONTAINER_BASE_STYLE: CSSProperties = {
+  position: "absolute",
+  top: 8,
+  right: 8,
+  zIndex: 10,
+  display: "flex",
+  alignItems: "center",
+  gap: 4,
+  padding: "4px 8px",
+  borderRadius: 6,
+  fontSize: 12,
+  fontFamily: "system-ui, sans-serif",
+};
+
+const CASE_BUTTON_BASE_STYLE: CSSProperties = {
+  borderRadius: 3,
+  cursor: "pointer",
+  padding: "1px 4px",
+  fontSize: 12,
+};
+
+const ICON_BUTTON_STYLE: CSSProperties = {
+  background: "transparent",
+  border: "none",
+  cursor: "pointer",
+  padding: "1px 4px",
+  fontSize: 13,
+};
 
 interface SearchAddon {
   findNext: (query: string, options?: { caseSensitive?: boolean }) => boolean;
@@ -97,40 +126,31 @@ export function TerminalSearchBar({ searchAddon, isOpen, onClose, theme }: Termi
   return (
     <div
       style={{
-        position: "absolute",
-        top: 8,
-        right: 8,
-        zIndex: 10,
-        display: "flex",
-        alignItems: "center",
-        gap: 4,
-        padding: "4px 8px",
-        borderRadius: 6,
+        ...CONTAINER_BASE_STYLE,
         background: surface,
         border: `1px solid ${border}`,
         color: fg,
-        fontSize: 12,
-        fontFamily: "system-ui, sans-serif",
       }}
       onKeyDown={handleKeyDown}
     >
+      <style>{`.matrix-terminal-search-input:focus-visible{outline:2px solid var(--primary, ${primary});outline-offset:1px;border-radius:2px;}`}</style>
       <input
         ref={inputRef}
         type="text"
+        className="matrix-terminal-search-input"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search..."
         style={{
           background: "transparent",
           border: "none",
-          outline: "none",
           color: fg,
           width: 160,
           fontSize: 12,
         }}
       />
       {query && hasSearched && (
-        <span style={{ opacity: 0.7, whiteSpace: "nowrap", fontSize: 11 }}>
+        <span style={{ opacity: 0.7, whiteSpace: "nowrap", fontSize: 12 }}>
           {resultCount > 0 ? `${resultIndex + 1} of ${resultCount}` : "No results"}
         </span>
       )}
@@ -139,13 +159,10 @@ export function TerminalSearchBar({ searchAddon, isOpen, onClose, theme }: Termi
         onClick={() => setCaseSensitive((v) => !v)}
         title="Case Sensitive"
         style={{
+          ...CASE_BUTTON_BASE_STYLE,
           background: caseSensitive ? primary + "33" : "transparent",
           border: `1px solid ${caseSensitive ? primary : "transparent"}`,
-          borderRadius: 3,
           color: fg,
-          cursor: "pointer",
-          padding: "1px 4px",
-          fontSize: 11,
           fontWeight: caseSensitive ? 600 : 400,
         }}
       >
@@ -155,14 +172,7 @@ export function TerminalSearchBar({ searchAddon, isOpen, onClose, theme }: Termi
         type="button"
         onClick={findPrevious}
         title="Previous Match (Shift+Enter)"
-        style={{
-          background: "transparent",
-          border: "none",
-          color: fg,
-          cursor: "pointer",
-          padding: "1px 4px",
-          fontSize: 13,
-        }}
+        style={{ ...ICON_BUTTON_STYLE, color: fg }}
       >
         &uarr;
       </button>
@@ -170,14 +180,7 @@ export function TerminalSearchBar({ searchAddon, isOpen, onClose, theme }: Termi
         type="button"
         onClick={findNext}
         title="Next Match (Enter)"
-        style={{
-          background: "transparent",
-          border: "none",
-          color: fg,
-          cursor: "pointer",
-          padding: "1px 4px",
-          fontSize: 13,
-        }}
+        style={{ ...ICON_BUTTON_STYLE, color: fg }}
       >
         &darr;
       </button>
@@ -185,14 +188,7 @@ export function TerminalSearchBar({ searchAddon, isOpen, onClose, theme }: Termi
         type="button"
         onClick={close}
         title="Close (Escape)"
-        style={{
-          background: "transparent",
-          border: "none",
-          color: fg,
-          cursor: "pointer",
-          padding: "1px 4px",
-          fontSize: 13,
-        }}
+        style={{ ...ICON_BUTTON_STYLE, color: fg }}
       >
         &times;
       </button>

--- a/shell/src/components/terminal/terminal-session-id.ts
+++ b/shell/src/components/terminal/terminal-session-id.ts
@@ -1,0 +1,14 @@
+const LEGACY_PTY_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CANONICAL_SHELL_SESSION_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,30}$/;
+
+export function isLegacyPtySessionId(sessionId: string): boolean {
+  return LEGACY_PTY_SESSION_ID_PATTERN.test(sessionId);
+}
+
+export function isCanonicalShellSessionId(sessionId: string): boolean {
+  return CANONICAL_SHELL_SESSION_NAME_PATTERN.test(sessionId);
+}
+
+export function terminalWebSocketPathForSession(sessionId: string | null): "/ws/terminal" | "/ws/terminal/session" {
+  return sessionId && isCanonicalShellSessionId(sessionId) ? "/ws/terminal/session" : "/ws/terminal";
+}

--- a/shell/src/components/ui/badge-variants.ts
+++ b/shell/src/components/ui/badge-variants.ts
@@ -1,0 +1,23 @@
+import { cva } from "class-variance-authority"
+
+export const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)

--- a/shell/src/components/ui/badge.tsx
+++ b/shell/src/components/ui/badge.tsx
@@ -1,30 +1,9 @@
 import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
-
-const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
-          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
-        destructive:
-          "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 [a&]:hover:underline",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
+import { badgeVariants } from "@/components/ui/badge-variants"
 
 function Badge({
   className,
@@ -45,4 +24,4 @@ function Badge({
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/shell/src/components/ui/button-group-variants.ts
+++ b/shell/src/components/ui/button-group-variants.ts
@@ -1,0 +1,18 @@
+import { cva } from "class-variance-authority"
+
+export const buttonGroupVariants = cva(
+  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md has-[>[data-slot=button-group]]:gap-2",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  }
+)

--- a/shell/src/components/ui/button-group.tsx
+++ b/shell/src/components/ui/button-group.tsx
@@ -1,25 +1,9 @@
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 import { Separator } from "@/components/ui/separator"
-
-const buttonGroupVariants = cva(
-  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md has-[>[data-slot=button-group]]:gap-2",
-  {
-    variants: {
-      orientation: {
-        horizontal:
-          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
-        vertical:
-          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
-      },
-    },
-    defaultVariants: {
-      orientation: "horizontal",
-    },
-  }
-)
+import { buttonGroupVariants } from "@/components/ui/button-group-variants"
 
 function ButtonGroup({
   className,
@@ -28,6 +12,7 @@ function ButtonGroup({
 }: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
   return (
     <div
+      // react-doctor-disable-next-line jsx-a11y/prefer-tag-over-role -- role="group" has no behavior-preserving native tag; the rule's suggested <address> is for contact info and adds italic styling
       role="group"
       data-slot="button-group"
       data-orientation={orientation}
@@ -79,5 +64,4 @@ export {
   ButtonGroup,
   ButtonGroupSeparator,
   ButtonGroupText,
-  buttonGroupVariants,
 }

--- a/shell/src/components/ui/button-variants.ts
+++ b/shell/src/components/ui/button-variants.ts
@@ -1,0 +1,35 @@
+import { cva } from "class-variance-authority"
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)

--- a/shell/src/components/ui/button.tsx
+++ b/shell/src/components/ui/button.tsx
@@ -1,42 +1,9 @@
 import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { buttonVariants } from "@/components/ui/button-variants"
 
 function Button({
   className,
@@ -61,4 +28,4 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/shell/src/components/ui/orb.tsx
+++ b/shell/src/components/ui/orb.tsx
@@ -250,7 +250,9 @@ function Scene({
 
   return (
     <mesh ref={circleRef}>
+      {/* react-doctor-disable-next-line react-doctor/no-unknown-property -- valid react-three-fiber prop */}
       <circleGeometry args={[3.5, 64]} />
+      {/* react-doctor-disable-next-line react-doctor/no-unknown-property -- valid react-three-fiber prop */}
       <shaderMaterial
         uniforms={uniforms}
         fragmentShader={fragmentShader}

--- a/shell/src/components/ui/tabs-variants.ts
+++ b/shell/src/components/ui/tabs-variants.ts
@@ -1,0 +1,16 @@
+import { cva } from "class-variance-authority"
+
+export const tabsListVariants = cva(
+  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)

--- a/shell/src/components/ui/tabs.tsx
+++ b/shell/src/components/ui/tabs.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { type VariantProps } from "class-variance-authority"
 import { Tabs as TabsPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
+import { tabsListVariants } from "@/components/ui/tabs-variants"
 
 function Tabs({
   className,
@@ -24,21 +25,6 @@ function Tabs({
     />
   )
 }
-
-const tabsListVariants = cva(
-  "rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
-  {
-    variants: {
-      variant: {
-        default: "bg-muted",
-        line: "gap-1 bg-transparent",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
 
 function TabsList({
   className,
@@ -88,4 +74,4 @@ function TabsContent({
   )
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/tests/shell/ai-elements-phase-k.test.ts
+++ b/tests/shell/ai-elements-phase-k.test.ts
@@ -53,7 +53,7 @@ describe("T2101: attachments", () => {
 
   it("fileToBase64 is exported as a function", async () => {
     const mod = await import(
-      "../../shell/src/components/ai-elements/attachments"
+      "../../shell/src/components/ai-elements/attachments-utils"
     );
     expect(typeof mod.fileToBase64).toBe("function");
   });
@@ -72,12 +72,15 @@ describe("T2102: reasoning display", () => {
       "../../shell/src/components/ai-elements/reasoning"
     );
     expect(mod.Reasoning).toBeDefined();
-    expect(mod.extractThinking).toBeDefined();
+    const utils = await import(
+      "../../shell/src/components/ai-elements/reasoning-utils"
+    );
+    expect(utils.extractThinking).toBeDefined();
   });
 
   it("extractThinking extracts thinking block from content", async () => {
     const { extractThinking } = await import(
-      "../../shell/src/components/ai-elements/reasoning"
+      "../../shell/src/components/ai-elements/reasoning-utils"
     );
 
     const result = extractThinking(
@@ -89,7 +92,7 @@ describe("T2102: reasoning display", () => {
 
   it("extractThinking returns empty thinking for no block", async () => {
     const { extractThinking } = await import(
-      "../../shell/src/components/ai-elements/reasoning"
+      "../../shell/src/components/ai-elements/reasoning-utils"
     );
 
     const result = extractThinking("Just a regular message.");
@@ -99,7 +102,7 @@ describe("T2102: reasoning display", () => {
 
   it("extractThinking handles multi-line thinking", async () => {
     const { extractThinking } = await import(
-      "../../shell/src/components/ai-elements/reasoning"
+      "../../shell/src/components/ai-elements/reasoning-utils"
     );
 
     const content = `<thinking>
@@ -116,7 +119,7 @@ The final answer.`;
 
   it("extractThinking only matches at the start of content", async () => {
     const { extractThinking } = await import(
-      "../../shell/src/components/ai-elements/reasoning"
+      "../../shell/src/components/ai-elements/reasoning-utils"
     );
 
     const result = extractThinking(
@@ -137,12 +140,15 @@ describe("T2103: suggestion chips", () => {
     );
     expect(mod.SuggestionChips).toBeDefined();
     expect(mod.SuggestionChip).toBeDefined();
-    expect(mod.DEFAULT_SUGGESTIONS).toBeDefined();
+    const utils = await import(
+      "../../shell/src/components/ai-elements/suggestions-utils"
+    );
+    expect(utils.DEFAULT_SUGGESTIONS).toBeDefined();
   });
 
   it("DEFAULT_SUGGESTIONS has 3 items", async () => {
     const { DEFAULT_SUGGESTIONS } = await import(
-      "../../shell/src/components/ai-elements/suggestions"
+      "../../shell/src/components/ai-elements/suggestions-utils"
     );
     expect(DEFAULT_SUGGESTIONS).toHaveLength(3);
     expect(DEFAULT_SUGGESTIONS).toContain("What can you do?");
@@ -152,7 +158,7 @@ describe("T2103: suggestion chips", () => {
 
   it("parseSuggestions extracts suggestions from comment", async () => {
     const { parseSuggestions } = await import(
-      "../../shell/src/components/ai-elements/suggestions"
+      "../../shell/src/components/ai-elements/suggestions-utils"
     );
 
     const content =
@@ -163,7 +169,7 @@ describe("T2103: suggestion chips", () => {
 
   it("parseSuggestions returns empty array for no comment", async () => {
     const { parseSuggestions } = await import(
-      "../../shell/src/components/ai-elements/suggestions"
+      "../../shell/src/components/ai-elements/suggestions-utils"
     );
 
     const result = parseSuggestions("Just a message.");
@@ -172,7 +178,7 @@ describe("T2103: suggestion chips", () => {
 
   it("parseSuggestions handles malformed JSON gracefully", async () => {
     const { parseSuggestions } = await import(
-      "../../shell/src/components/ai-elements/suggestions"
+      "../../shell/src/components/ai-elements/suggestions-utils"
     );
 
     const result = parseSuggestions("<!-- suggestions: not-json -->");
@@ -181,7 +187,7 @@ describe("T2103: suggestion chips", () => {
 
   it("parseSuggestions filters non-string values", async () => {
     const { parseSuggestions } = await import(
-      "../../shell/src/components/ai-elements/suggestions"
+      "../../shell/src/components/ai-elements/suggestions-utils"
     );
 
     const result = parseSuggestions(
@@ -198,12 +204,15 @@ describe("T2104: plan component", () => {
       "../../shell/src/components/ai-elements/plan"
     );
     expect(mod.Plan).toBeDefined();
-    expect(mod.parsePlan).toBeDefined();
+    const utils = await import(
+      "../../shell/src/components/ai-elements/plan-utils"
+    );
+    expect(utils.parsePlan).toBeDefined();
   });
 
   it("parsePlan extracts plan steps from code block", async () => {
     const { parsePlan } = await import(
-      "../../shell/src/components/ai-elements/plan"
+      "../../shell/src/components/ai-elements/plan-utils"
     );
 
     const content = `Here is the plan:
@@ -227,21 +236,21 @@ Let me start.`;
 
   it("parsePlan returns null for no plan block", async () => {
     const { parsePlan } = await import(
-      "../../shell/src/components/ai-elements/plan"
+      "../../shell/src/components/ai-elements/plan-utils"
     );
     expect(parsePlan("No plan here.")).toBeNull();
   });
 
   it("parsePlan returns null for invalid JSON", async () => {
     const { parsePlan } = await import(
-      "../../shell/src/components/ai-elements/plan"
+      "../../shell/src/components/ai-elements/plan-utils"
     );
     expect(parsePlan("```plan\nnot json\n```")).toBeNull();
   });
 
   it("parsePlan filters invalid step objects", async () => {
     const { parsePlan } = await import(
-      "../../shell/src/components/ai-elements/plan"
+      "../../shell/src/components/ai-elements/plan-utils"
     );
 
     const content =
@@ -260,12 +269,15 @@ describe("T2104: task component", () => {
     );
     expect(mod.Task).toBeDefined();
     expect(mod.TaskList).toBeDefined();
-    expect(mod.parseTask).toBeDefined();
+    const utils = await import(
+      "../../shell/src/components/ai-elements/task-utils"
+    );
+    expect(utils.parseTask).toBeDefined();
   });
 
   it("parseTask extracts task from code block", async () => {
     const { parseTask } = await import(
-      "../../shell/src/components/ai-elements/task"
+      "../../shell/src/components/ai-elements/task-utils"
     );
 
     const content = `Working on it:
@@ -281,21 +293,21 @@ describe("T2104: task component", () => {
 
   it("parseTask returns null for no task block", async () => {
     const { parseTask } = await import(
-      "../../shell/src/components/ai-elements/task"
+      "../../shell/src/components/ai-elements/task-utils"
     );
     expect(parseTask("No task here.")).toBeNull();
   });
 
   it("parseTask returns null for invalid JSON", async () => {
     const { parseTask } = await import(
-      "../../shell/src/components/ai-elements/task"
+      "../../shell/src/components/ai-elements/task-utils"
     );
     expect(parseTask("```task\nnot json\n```")).toBeNull();
   });
 
   it("parseTask returns null for missing required fields", async () => {
     const { parseTask } = await import(
-      "../../shell/src/components/ai-elements/task"
+      "../../shell/src/components/ai-elements/task-utils"
     );
     expect(parseTask('```task\n{"title":"Only title"}\n```')).toBeNull();
     expect(parseTask('```task\n{"status":"pending"}\n```')).toBeNull();

--- a/tests/shell/app-viewer-runtime-modes.test.ts
+++ b/tests/shell/app-viewer-runtime-modes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   APP_IFRAME_SANDBOX,
   injectBridgeIntoAppHtml,
-} from "../../shell/src/components/AppViewer.js";
+} from "../../shell/src/components/app-viewer-helpers.js";
 
 // These tests verify the AppViewer decision logic without rendering React components.
 // The actual AppViewer.tsx modification is tested here by verifying the URL construction

--- a/tests/shell/app-viewer-slug.test.ts
+++ b/tests/shell/app-viewer-slug.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractSlug, shouldRenderAppIframe } from "../../shell/src/components/AppViewer.js";
+import { extractSlug, shouldRenderAppIframe } from "../../shell/src/components/app-viewer-helpers.js";
 
 describe("AppViewer extractSlug (spec 063 regression)", () => {
   it("extracts slug from top-level app paths", () => {

--- a/tests/shell/chat-app.test.ts
+++ b/tests/shell/chat-app.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createHermesConfiguredPrompt } from "../../shell/src/components/ChatApp.js";
+import { createHermesConfiguredPrompt } from "../../shell/src/components/chat-app-hermes.js";
 
 describe("createHermesConfiguredPrompt", () => {
   it("keeps the submitted prompt plain for the default Hermes configuration", () => {

--- a/tests/shell/connection-indicator.test.tsx
+++ b/tests/shell/connection-indicator.test.tsx
@@ -4,7 +4,8 @@ import React from "react";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useConnectionHealth } from "../../shell/src/hooks/useConnectionHealth.js";
-import { ConnectionIndicator, resolveConnectionCopy } from "../../shell/src/components/ConnectionIndicator.js";
+import { ConnectionIndicator } from "../../shell/src/components/ConnectionIndicator.js";
+import { resolveConnectionCopy } from "../../shell/src/components/connection-indicator-copy.js";
 
 const mocks = vi.hoisted(() => ({
   manualReconnect: vi.fn(),

--- a/tests/shell/integrations-section.test.ts
+++ b/tests/shell/integrations-section.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   hasNewConnectionForService,
   shouldLogIntegrationWarning,
-} from "../../shell/src/components/settings/sections/IntegrationsSection";
+} from "../../shell/src/components/settings/sections/integrations-helpers";
 
 describe("IntegrationsSection polling helper", () => {
   it("ignores newly added connections for a different service", () => {

--- a/tests/shell/terminal.test.ts
+++ b/tests/shell/terminal.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   isCanonicalShellSessionId,
   terminalWebSocketPathForSession,
-} from "../../shell/src/components/terminal/TerminalPane.js";
+} from "../../shell/src/components/terminal/terminal-session-id.js";
 
 class MockTerminalWebSocket {
   static instances: MockTerminalWebSocket[] = [];


### PR DESCRIPTION
Part 6 of the stacked react-doctor-to-100 series. **Stacked on #280** (base `rd/05-shell-button-type`). Second shell slice.

## What (~133 findings cleared; score 39 → 46)
Safe, behavior-preserving cleanup:
- `no-inline-exhaustive-style`: hoisted static inline `style` objects to module-scope consts.
- A11y: `no-tiny-text` (bumped <12px text), `no-redundant-roles` (removed redundant ARIA roles), `prefer-tag-over-role` (role="status" → `<output>`, semantic tags), `html-has-lang`, `no-outline-none` (focus-visible ring).
- `only-export-components`: moved non-component exports (cva variants, parser/util helpers, context) into sibling modules (`*-variants.ts`, `*-utils.ts`, `*-helpers.ts`); updated all importers **and the `tests/shell` test imports**.

## Suppressions (true false positives, justified inline)
R3F / styled-jsx props flagged as unknown DOM attrs; `<img>` for `blob:`/object-URL and runtime-gateway-host images (next/image can't optimize them); `media-has-caption` for arbitrary user file previews; `autoFocus` on click-opened inline editors; `role="dialog"` on a persistently-rendered banner; `role="group"` containers with no native equivalent.

## Verification
- **832/832 `tests/shell` tests pass** (shell has real coverage via the root `tests/shell` suite).
- `tsc --noEmit` clean (only the 2 pre-existing `@clerk/ui/themes` errors, unrelated).

Large file count (~77) but each change is a small, mechanical lint fix. shell's score is insensitive to partial cleanup; remaining shell families (behavioral effects/state, dead-code) continue in later slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)