### PR TITLE
fix(billing): serve unpaid shell and avoid customer write

### DIFF
--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -9,7 +9,6 @@ import {
   insertBillingWebhookEvent,
   runBillingWebhookTransaction,
   upsertBillingEntitlement,
-  type BillingCustomerRecord,
   type PlatformDB,
 } from './db.js';
 import {
@@ -28,8 +27,7 @@ import {
 const BILLING_BODY_LIMIT = 16 * 1024;
 const STRIPE_WEBHOOK_BODY_LIMIT = 1024 * 1024;
 const MAX_STRIPE_API_TIMEOUT_MS = 10_000;
-const CUSTOMER_CREATION_INFLIGHT_LIMIT = 1024;
-const customerCreationInflight = new Map<string, Promise<BillingCustomerRecord>>();
+const CLERK_USER_ID_PATTERN = /^user_[A-Za-z0-9]{1,128}$/;
 
 const CheckoutRequestSchema = z.object({
   planSlug: z.enum(['matrix_starter', 'matrix_builder', 'matrix_max']),
@@ -38,7 +36,8 @@ const CheckoutRequestSchema = z.object({
 });
 
 export interface StripeCheckoutSessionInput {
-  customerId: string;
+  clerkUserId: string;
+  customerId?: string;
   priceId: string;
   mode: 'subscription';
   automaticTax: boolean;
@@ -51,11 +50,10 @@ export interface StripeCheckoutSessionInput {
 export interface StripeBillingClient {
   apiTimeoutMs: number;
   /**
-   * Implementations must pass idempotencyKey through to Stripe and use a bounded
-   * network timeout. Callers rely on that to avoid duplicate customer creation
-   * without holding database locks across external API calls.
+   * Implementations must use a bounded network timeout. Checkout creates the
+   * Stripe Customer when needed; the signed subscription webhook links it back
+   * to the Clerk user from server-written metadata.
    */
-  createCustomer(input: { clerkUserId: string; idempotencyKey: string }): Promise<{ id: string }>;
   createCheckoutSession(input: StripeCheckoutSessionInput): Promise<{ url: string }>;
   createPortalSession(input: { customerId: string; returnUrl: string }): Promise<{ url: string }>;
   constructWebhookEvent(rawBody: string, signature: string, webhookSecret: string): StripeWebhookEvent;
@@ -111,9 +109,10 @@ export function createBillingRoutes(options: {
       if (options.stripe.apiTimeoutMs > MAX_STRIPE_API_TIMEOUT_MS) {
         throw new Error('stripe_timeout_exceeds_budget');
       }
-      const customer = await getOrCreateCustomer(options.db, options.stripe, clerkUserId, now());
+      const customer = await getBillingCustomerByClerkUserId(options.db, clerkUserId);
       const session = await options.stripe.createCheckoutSession({
-        customerId: customer.stripeCustomerId,
+        clerkUserId,
+        customerId: customer?.stripeCustomerId,
         priceId,
         mode: 'subscription',
         automaticTax: true,
@@ -220,56 +219,6 @@ export function createBillingRoutes(options: {
   return app;
 }
 
-async function getOrCreateCustomer(
-  db: PlatformDB,
-  stripe: StripeBillingClient,
-  clerkUserId: string,
-  currentTime: Date,
-) {
-  const existing = await getBillingCustomerByClerkUserId(db, clerkUserId);
-  if (existing) return existing;
-
-  const pending = customerCreationInflight.get(clerkUserId);
-  if (pending) return pending;
-  if (customerCreationInflight.size >= CUSTOMER_CREATION_INFLIGHT_LIMIT) {
-    throw new Error('customer_creation_inflight_limit');
-  }
-  const created = createAndPersistCustomer(db, stripe, clerkUserId, currentTime);
-  customerCreationInflight.set(clerkUserId, created);
-  try {
-    return await created;
-  } finally {
-    customerCreationInflight.delete(clerkUserId);
-  }
-}
-
-async function createAndPersistCustomer(
-  db: PlatformDB,
-  stripe: StripeBillingClient,
-  clerkUserId: string,
-  currentTime: Date,
-): Promise<BillingCustomerRecord> {
-  const customer = await stripe.createCustomer({
-    clerkUserId,
-    idempotencyKey: billingCustomerIdempotencyKey(clerkUserId),
-  });
-
-  const nowIso = currentTime.toISOString();
-  await insertBillingCustomerIfAbsent(db, {
-    clerkUserId,
-    stripeCustomerId: customer.id,
-    createdAt: nowIso,
-    updatedAt: nowIso,
-  });
-  const persisted = await getBillingCustomerByClerkUserId(db, clerkUserId);
-  if (!persisted) throw new Error('billing customer was not persisted');
-  return persisted;
-}
-
-function billingCustomerIdempotencyKey(clerkUserId: string): string {
-  return `billing-customer:${clerkUserId}`;
-}
-
 function resolvePriceId(
   env: NodeJS.ProcessEnv,
   planSlug: MatrixBillingPlanSlug,
@@ -305,11 +254,24 @@ async function projectSubscription(db: PlatformDB, value: unknown): Promise<Stri
     customer?: unknown;
     status?: unknown;
     current_period_end?: unknown;
+    metadata?: unknown;
     items?: { data?: unknown };
   };
   if (typeof sub.id !== 'string' || typeof sub.customer !== 'string') return null;
-  const customer = await getBillingCustomerByStripeCustomerId(db, sub.customer);
-  if (!customer) return null;
+  let customer = await getBillingCustomerByStripeCustomerId(db, sub.customer);
+  if (!customer) {
+    const clerkUserId = readClerkUserIdFromStripeMetadata(sub.metadata);
+    if (!clerkUserId) return null;
+    const nowIso = new Date().toISOString();
+    await insertBillingCustomerIfAbsent(db, {
+      clerkUserId,
+      stripeCustomerId: sub.customer,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    customer = await getBillingCustomerByStripeCustomerId(db, sub.customer);
+    if (!customer) return null;
+  }
   const status = normalizeSubscriptionStatus(sub.status);
   const data = Array.isArray(sub.items?.data) ? sub.items.data : [];
   return {
@@ -330,6 +292,14 @@ async function projectSubscription(db: PlatformDB, value: unknown): Promise<Stri
       }];
     }),
   };
+}
+
+function readClerkUserIdFromStripeMetadata(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const clerkUserId = (metadata as { clerk_user_id?: unknown }).clerk_user_id;
+  return typeof clerkUserId === 'string' && CLERK_USER_ID_PATTERN.test(clerkUserId)
+    ? clerkUserId
+    : null;
 }
 
 function normalizeSubscriptionStatus(value: unknown): BillingEntitlementStatus {

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -6,9 +6,9 @@ import {
   getBillingCustomerByStripeCustomerId,
   getBillingEntitlement,
   getBillingEntitlementState,
-  insertBillingCustomerIfAbsent,
   insertBillingWebhookEvent,
   runBillingWebhookTransaction,
+  upsertBillingCustomer,
   upsertBillingEntitlement,
   type PlatformDB,
 } from './db.js';
@@ -186,12 +186,13 @@ export function createBillingRoutes(options: {
     }
 
     try {
+      const webhookProcessedAt = now();
       const result = await runBillingWebhookTransaction(options.db, async (trx) => {
         const inserted = await insertBillingWebhookEvent(trx, {
           stripeEventId: event.id,
           eventType: event.type,
           createdAtFromStripe: epochSecondsToIso(event.created),
-          processedAt: now().toISOString(),
+          processedAt: webhookProcessedAt.toISOString(),
           status: 'processed',
           errorCode: null,
         });
@@ -203,13 +204,13 @@ export function createBillingRoutes(options: {
           return { received: true, ignored: true };
         }
 
-        const projection = await projectSubscription(trx, event.data.object);
+        const projection = await projectSubscription(trx, event.data.object, webhookProcessedAt);
         if (!projection) return { received: true, ignored: true };
 
         const entitlement = deriveStripeEntitlement(projection, {
           priceCatalog: loadStripePriceCatalog(env),
           runtimeCatalog: loadRuntimeCatalog(env),
-          now: now(),
+          now: webhookProcessedAt,
         });
         await persistEntitlement(trx, entitlement);
         return { received: true, processed: true };
@@ -256,7 +257,11 @@ function isSubscriptionEvent(type: string): boolean {
   );
 }
 
-async function projectSubscription(db: PlatformDB, value: unknown): Promise<StripeSubscriptionProjection | null> {
+async function projectSubscription(
+  db: PlatformDB,
+  value: unknown,
+  currentTime: Date,
+): Promise<StripeSubscriptionProjection | null> {
   if (!value || typeof value !== 'object') return null;
   const sub = value as {
     id?: unknown;
@@ -271,8 +276,8 @@ async function projectSubscription(db: PlatformDB, value: unknown): Promise<Stri
   if (!customer) {
     const clerkUserId = readClerkUserIdFromStripeMetadata(sub.metadata);
     if (!clerkUserId) return null;
-    const nowIso = new Date().toISOString();
-    await insertBillingCustomerIfAbsent(db, {
+    const nowIso = currentTime.toISOString();
+    await upsertBillingCustomer(db, {
       clerkUserId,
       stripeCustomerId: sub.customer,
       createdAt: nowIso,

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -5,6 +5,7 @@ import {
   getBillingCustomerByClerkUserId,
   getBillingCustomerByStripeCustomerId,
   getBillingEntitlement,
+  getBillingEntitlementState,
   insertBillingCustomerIfAbsent,
   insertBillingWebhookEvent,
   runBillingWebhookTransaction,
@@ -13,11 +14,13 @@ import {
 } from './db.js';
 import {
   DEFAULT_BILLING_PLAN_DEFINITIONS,
+  computeEffectiveEntitlement,
   deriveStripeEntitlement,
   getRuntimeAccessDecision,
   loadRuntimeCatalog,
   loadStripePriceCatalog,
   parseBillingEntitlementRecord,
+  parseBillingOverrideRecord,
   type BillingEntitlementStatus,
   type MatrixBillingPlanSlug,
   type MatrixBillingInterval,
@@ -153,9 +156,15 @@ export function createBillingRoutes(options: {
     const clerkUserId = await resolveRouteClerkUserId(c, 'status');
     if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
     try {
-      const entitlement = await getBillingEntitlement(options.db, clerkUserId);
-      const access = getRuntimeAccessDecision(parseBillingEntitlementRecord(entitlement), now());
-      return c.json({ entitlement: entitlement ?? null, access }, 200);
+      const currentTime = now();
+      const state = await getBillingEntitlementState(options.db, clerkUserId, currentTime.toISOString());
+      const entitlement = computeEffectiveEntitlement({
+        stripeEntitlement: parseBillingEntitlementRecord(state.entitlement),
+        override: parseBillingOverrideRecord(state.override),
+        now: currentTime,
+      });
+      const access = getRuntimeAccessDecision(entitlement, currentTime);
+      return c.json({ entitlement, access }, 200);
     } catch (err: unknown) {
       console.error('[billing] status lookup failed:', err instanceof Error ? err.message : String(err));
       return c.json({ error: 'Billing unavailable' }, 503);

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2835,7 +2835,14 @@ export function createApp(deps: {
         ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
         : await getActiveUserMachineByHandle(db, identity.handle));
       if (activeMachine) {
-        if (!entitlement.runtimeProxyAllowed) {
+        if (
+          !entitlement.runtimeProxyAllowed &&
+          !shouldProxyShellForBillingGate({
+            isAppDomain,
+            method: c.req.method,
+            upstreamPath: path,
+          })
+        ) {
           applyNoStoreHeaders(c);
           return c.json({ error: 'Paid beta access required' }, 402);
         }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -510,6 +510,26 @@ function isAppDomainGatewayPath(path: string): boolean {
   );
 }
 
+function isRuntimeDataPath(path: string): boolean {
+  return (
+    isAppDomainGatewayPath(path) ||
+    path === '/apps' ||
+    path.startsWith('/apps/')
+  );
+}
+
+function shouldProxyShellForBillingGate(input: {
+  isAppDomain: boolean;
+  method: string;
+  upstreamPath: string;
+}): boolean {
+  return (
+    input.isAppDomain &&
+    (input.method === 'GET' || input.method === 'HEAD') &&
+    !isRuntimeDataPath(input.upstreamPath)
+  );
+}
+
 interface ExplicitVmRoute {
   handle: string;
   upstreamPath: string;
@@ -2564,7 +2584,14 @@ export function createApp(deps: {
         return c.text('Matrix OS computer unavailable', 404);
       }
       const entitlement = await getRuntimeEntitlementDecisionForUser(db, machine.clerkUserId, appEnv);
-      if (!entitlement.runtimeProxyAllowed) {
+      if (
+        !entitlement.runtimeProxyAllowed &&
+        !shouldProxyShellForBillingGate({
+          isAppDomain,
+          method: c.req.method,
+          upstreamPath: explicitVmRoute.upstreamPath,
+        })
+      ) {
         applyNoStoreHeaders(c);
         return c.json({ error: 'Paid beta access required' }, 402);
       }
@@ -2703,7 +2730,14 @@ export function createApp(deps: {
       : getRuntimeEntitlementDecision(appEnv);
     if (runningMachine) {
       const qs = buildForwardedQueryString(c.req.url);
-      if (!entitlement.runtimeProxyAllowed) {
+      if (
+        !entitlement.runtimeProxyAllowed &&
+        !shouldProxyShellForBillingGate({
+          isAppDomain,
+          method: c.req.method,
+          upstreamPath: path,
+        })
+      ) {
         applyNoStoreHeaders(c);
         return c.json({ error: 'Paid beta access required' }, 402);
       }
@@ -2818,7 +2852,14 @@ export function createApp(deps: {
       return c.html(getNoContainerPage());
     }
 
-    if (!entitlement.runtimeProxyAllowed) {
+    if (
+      !entitlement.runtimeProxyAllowed &&
+      !shouldProxyShellForBillingGate({
+        isAppDomain,
+        method: c.req.method,
+        upstreamPath: path,
+      })
+    ) {
       applyNoStoreHeaders(c);
       return c.json({ error: 'Paid beta access required' }, 402);
     }

--- a/packages/platform/src/stripe-billing.ts
+++ b/packages/platform/src/stripe-billing.ts
@@ -21,39 +21,35 @@ export function createStripeBillingClient(options: {
   return {
     apiTimeoutMs: MATRIX_STRIPE_API_TIMEOUT_MS,
 
-    async createCustomer(input) {
-      const customer = await stripe.customers.create({
-        metadata: {
-          clerk_user_id: input.clerkUserId,
-        },
-      }, {
-        idempotencyKey: input.idempotencyKey,
-      });
-      return { id: customer.id };
-    },
-
     async createCheckoutSession(input: StripeCheckoutSessionInput) {
       const session = await stripe.checkout.sessions.create({
         mode: input.mode,
-        customer: input.customerId,
+        ...(input.customerId ? { customer: input.customerId } : {}),
+        client_reference_id: input.clerkUserId,
         line_items: [{ price: input.priceId, quantity: 1 }],
         success_url: input.successUrl,
         cancel_url: input.cancelUrl,
         allow_promotion_codes: input.allowPromotionCodes,
         automatic_tax: { enabled: input.automaticTax },
         metadata: {
+          clerk_user_id: input.clerkUserId,
           matrix_region_slug: input.regionSlug,
         },
         subscription_data: {
           metadata: {
+            clerk_user_id: input.clerkUserId,
             matrix_region_slug: input.regionSlug,
           },
         },
         tax_id_collection: { enabled: true },
-        customer_update: {
-          address: 'auto',
-          name: 'auto',
-        },
+        ...(input.customerId
+          ? {
+            customer_update: {
+              address: 'auto' as const,
+              name: 'auto' as const,
+            },
+          }
+          : {}),
       });
       if (!session.url) {
         throw new Error('Stripe checkout session missing redirect URL');
@@ -81,7 +77,6 @@ export function createUnavailableStripeBillingClient(): StripeBillingClient {
   };
   return {
     apiTimeoutMs: MATRIX_STRIPE_API_TIMEOUT_MS,
-    createCustomer: unavailable,
     createCheckoutSession: unavailable,
     createPortalSession: unavailable,
     constructWebhookEvent() {

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import {
   getBillingEntitlement,
+  getBillingCustomerByClerkUserId,
   insertBillingWebhookEvent,
   upsertBillingCustomer,
   upsertBillingEntitlement,
@@ -34,7 +35,6 @@ describe('platform billing routes', () => {
     ({ db } = await createTestPlatformDb());
     stripe = {
       apiTimeoutMs: 10_000,
-      createCustomer: vi.fn().mockResolvedValue({ id: 'cus_123' }),
       createCheckoutSession: vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/session' }),
       createPortalSession: vi.fn().mockResolvedValue({ url: 'https://billing.stripe.test/session' }),
       constructWebhookEvent: vi.fn(),
@@ -68,12 +68,9 @@ describe('platform billing routes', () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ url: 'https://checkout.stripe.test/session' });
-    expect(stripe.createCustomer).toHaveBeenCalledWith({
-      clerkUserId: 'user_123',
-      idempotencyKey: 'billing-customer:user_123',
-    });
     expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
-      customerId: 'cus_123',
+      clerkUserId: 'user_123',
+      customerId: undefined,
       priceId: 'price_builder_annual',
       mode: 'subscription',
       automaticTax: true,
@@ -87,54 +84,32 @@ describe('platform billing routes', () => {
     );
   });
 
-  it('uses a stable Stripe idempotency key for concurrent customer creation', async () => {
-    let customerSequence = 0;
-    const idempotentCustomers: Record<string, string | undefined> = {};
-    vi.mocked(stripe.createCustomer).mockImplementation(async ({ idempotencyKey }) => {
-      const existing = idempotentCustomers[idempotencyKey];
-      const id = existing ?? `cus_${++customerSequence}`;
-      idempotentCustomers[idempotencyKey] = id;
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      return { id };
+  it('reuses an existing Stripe customer link when one is already known', async () => {
+    await upsertBillingCustomer(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_existing',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
     });
     const app = createApp();
 
-    const [first, second] = await Promise.all([
-      app.request('/billing/checkout', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
-      }),
-      app.request('/billing/checkout', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
-      }),
-    ]);
-
-    expect(first.status).toBe(200);
-    expect(second.status).toBe(200);
-    expect(stripe.createCustomer).toHaveBeenCalledWith({
-      clerkUserId: 'user_123',
-      idempotencyKey: 'billing-customer:user_123',
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
     });
-    expect(stripe.createCheckoutSession).toHaveBeenCalledTimes(2);
-    expect(stripe.createCheckoutSession).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      customerId: 'cus_1',
-    }));
-    expect(stripe.createCheckoutSession).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      customerId: 'cus_1',
+
+    expect(res.status).toBe(200);
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
+      clerkUserId: 'user_123',
+      customerId: 'cus_existing',
     }));
   });
 
-  it('coalesces concurrent customer creation for the same Clerk user', async () => {
-    vi.mocked(stripe.createCustomer).mockImplementation(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      return { id: 'cus_singleflight' };
-    });
-    const checkoutCustomers: string[] = [];
+  it('lets Stripe create customers during checkout when no customer link exists yet', async () => {
+    const checkoutCustomerIds: Array<string | undefined> = [];
     vi.mocked(stripe.createCheckoutSession).mockImplementation(async ({ customerId }) => {
-      checkoutCustomers.push(customerId);
+      checkoutCustomerIds.push(customerId);
       return { url: 'https://checkout.stripe.test/session' };
     });
     const app = createApp();
@@ -154,9 +129,8 @@ describe('platform billing routes', () => {
 
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
-    expect(stripe.createCustomer).toHaveBeenCalledTimes(1);
-    expect(new Set(checkoutCustomers).size).toBe(1);
-    expect(checkoutCustomers[0]).toBe('cus_singleflight');
+    expect(stripe.createCheckoutSession).toHaveBeenCalledTimes(2);
+    expect(checkoutCustomerIds).toEqual([undefined, undefined]);
   });
 
   it('terminates unknown billing paths inside the billing namespace', async () => {
@@ -166,7 +140,6 @@ describe('platform billing routes', () => {
 
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: 'Not found' });
-    expect(stripe.createCustomer).not.toHaveBeenCalled();
     expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
   });
 
@@ -208,7 +181,6 @@ describe('platform billing routes', () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: 'Unauthorized' });
-    expect(stripe.createCustomer).not.toHaveBeenCalled();
     expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
     expect(stripe.createPortalSession).not.toHaveBeenCalled();
   });
@@ -225,7 +197,7 @@ describe('platform billing routes', () => {
 
     expect(res.status).toBe(503);
     expect(await res.json()).toEqual({ error: 'Billing unavailable' });
-    expect(stripe.createCustomer).not.toHaveBeenCalled();
+    expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
   });
 
   it('creates customer portal sessions for the signed-in Stripe customer', async () => {
@@ -314,6 +286,28 @@ describe('platform billing routes', () => {
     });
   });
 
+  it('links Stripe-created checkout customers from subscription metadata', async () => {
+    const event = subscriptionEvent('evt_metadata_link');
+    vi.mocked(stripe.constructWebhookEvent).mockReturnValue(event);
+    const app = createApp(null);
+
+    const res = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true, processed: true });
+    await expect(getBillingEntitlement(db, 'user_123')).resolves.toMatchObject({
+      planSlug: 'matrix_max',
+      stripeSubscriptionId: 'sub_123',
+    });
+    await expect(getBillingCustomerByClerkUserId(db, 'user_123')).resolves.toMatchObject({
+      stripeCustomerId: 'cus_123',
+    });
+  });
+
   it('does not consume webhook event ids when entitlement projection fails', async () => {
     await upsertBillingCustomer(db, {
       clerkUserId: 'user_123',
@@ -396,6 +390,10 @@ function subscriptionEvent(id: string): StripeWebhookEvent {
         customer: 'cus_123',
         status: 'active',
         current_period_end: 1_782_432_000,
+        metadata: {
+          clerk_user_id: 'user_123',
+          matrix_region_slug: 'region_fsn1',
+        },
         items: {
           data: [
             { price: { id: 'price_max_monthly' }, quantity: 1 },

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -4,6 +4,7 @@ import {
   getBillingEntitlement,
   getBillingCustomerByClerkUserId,
   insertBillingWebhookEvent,
+  upsertBillingOverride,
   upsertBillingCustomer,
   upsertBillingEntitlement,
   type PlatformDB,
@@ -216,6 +217,43 @@ describe('platform billing routes', () => {
     expect(stripe.createPortalSession).toHaveBeenCalledWith({
       customerId: 'cus_123',
       returnUrl: 'https://app.matrix-os.com/?billing=portal',
+    });
+  });
+
+  it('reports active access from internal billing overrides', async () => {
+    await upsertBillingOverride(db, {
+      id: 'override_internal',
+      clerkUserId: 'user_123',
+      planSlug: 'internal',
+      status: 'active',
+      maxRuntimeSlots: 3,
+      includedRuntimeSlots: 3,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx52',
+      allowedServerTypes: ['cpx22', 'cpx32', 'cpx52'],
+      reason: 'internal engineer access',
+      createdBy: 'test',
+      expiresAt: null,
+      revokedAt: null,
+      createdAt: '2026-05-30T00:00:00.000Z',
+    });
+    const app = createApp();
+
+    const res = await app.request('/billing/status', { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      entitlement: {
+        source: 'override',
+        planSlug: 'internal',
+        status: 'active',
+        maxRuntimeSlots: 3,
+        defaultServerType: 'cpx52',
+      },
+      access: {
+        runtimeProxyAllowed: true,
+        reason: 'active',
+      },
     });
   });
 

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -343,6 +343,39 @@ describe('platform billing routes', () => {
     });
     await expect(getBillingCustomerByClerkUserId(db, 'user_123')).resolves.toMatchObject({
       stripeCustomerId: 'cus_123',
+      createdAt: '2026-05-30T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
+    });
+  });
+
+  it('updates stale customer links when a signed subscription webhook names a newer Stripe customer', async () => {
+    await upsertBillingCustomer(db, {
+      clerkUserId: 'user_123',
+      stripeCustomerId: 'cus_old',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const event = subscriptionEvent('evt_customer_conflict');
+    (event.data.object as { customer: string }).customer = 'cus_new';
+    vi.mocked(stripe.constructWebhookEvent).mockReturnValue(event);
+    const app = createApp(null);
+
+    const res = await app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'valid' },
+      body: '{}',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true, processed: true });
+    await expect(getBillingEntitlement(db, 'user_123')).resolves.toMatchObject({
+      planSlug: 'matrix_max',
+      stripeSubscriptionId: 'sub_123',
+    });
+    await expect(getBillingCustomerByClerkUserId(db, 'user_123')).resolves.toMatchObject({
+      stripeCustomerId: 'cus_new',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-30T00:00:00.000Z',
     });
   });
 

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1785,7 +1785,7 @@ describe("platform proxy routing", () => {
     });
   });
 
-  it("blocks runtime proxying when Stripe billing is enabled without an active entitlement", async () => {
+  it("still serves the shell for the billing gate when Stripe billing is enabled without an active entitlement", async () => {
     await insertUserMachine(db, {
       machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff127",
       clerkUserId: "user_alice",
@@ -1796,8 +1796,8 @@ describe("platform proxy routing", () => {
       imageVersion: "matrix-os-host-2026.04.26-1",
       provisionedAt: "2026-04-26T12:00:00.000Z",
     });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("wrong target", { status: 200 }),
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("shell html", { status: 200 }),
     );
     const app = createApp({
       db,
@@ -1810,6 +1810,157 @@ describe("platform proxy routing", () => {
     });
 
     const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("shell html");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.24:443/");
+    expect(res.headers.get("set-cookie")).toContain("matrix_shell_route=alice");
+  });
+
+  it("keeps runtime API paths blocked while the unpaid billing shell is visible", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff12a",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123474,
+      publicIPv4: "203.0.113.26",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_STRIPE_BILLING_ENABLED: "true" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/api/theme", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(402);
+    expect(await res.json()).toEqual({ error: "Paid beta access required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("serves shell static assets routed by cookie for unpaid users", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff12b",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123475,
+      publicIPv4: "203.0.113.27",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("icon", {
+        status: 200,
+        headers: { "content-type": "image/x-icon" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_STRIPE_BILLING_ENABLED: "true" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/favicon.ico", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        cookie: "matrix_shell_route=alice",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("icon");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.27:443/favicon.ico");
+    expect(res.headers.get("content-type")).toBe("image/x-icon");
+  });
+
+  it("serves the billing shell for explicit VM routes when Stripe access is inactive", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff12c",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123476,
+      publicIPv4: "203.0.113.28",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("explicit shell", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_STRIPE_BILLING_ENABLED: "true" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/vm/alice", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("explicit shell");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.28:443/");
+    expect(res.headers.get("set-cookie")).toContain("matrix_shell_route=alice");
+  });
+
+  it("blocks explicit VM runtime API routes when Stripe access is inactive", async () => {
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff12d",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123477,
+      publicIPv4: "203.0.113.29",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_STRIPE_BILLING_ENABLED: "true" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/vm/alice/api/theme", {
       headers: {
         host: "app.matrix-os.com",
         authorization: "Bearer clerk-session",

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -459,7 +459,7 @@ describe("platform proxy routing", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("blocks provisioning boot pages when paid-beta entitlement denies runtime access", async () => {
+  it("shows the provisioning page instead of raw billing JSON when paid-beta entitlement denies shell access", async () => {
     await deleteContainer(db, "alice");
     await insertUserMachine(db, {
       machineId: "machine-alice-provisioning-expired",
@@ -491,14 +491,17 @@ describe("platform proxy routing", () => {
       },
     });
 
-    expect(res.status).toBe(402);
+    expect(res.status).toBe(503);
     expect(res.headers.get("cache-control")).toBe("no-store, private");
     expect(res.headers.get("set-cookie")).toBeNull();
-    expect(await res.json()).toEqual({ error: "Paid beta access required" });
+    const html = await res.text();
+    expect(html).toContain("Booting Matrix OS");
+    expect(html).toContain("Instance status:");
+    expect(html).toContain("<strong>provisioning</strong>");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("blocks provisioning boot pages when Stripe billing is enabled without an active entitlement", async () => {
+  it("shows the provisioning page instead of raw billing JSON when Stripe billing is inactive", async () => {
     await deleteContainer(db, "alice");
     await insertUserMachine(db, {
       machineId: "machine-alice-provisioning-stripe-expired",
@@ -524,6 +527,46 @@ describe("platform proxy routing", () => {
     });
 
     const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(503);
+    const html = await res.text();
+    expect(html).toContain("Booting Matrix OS");
+    expect(html).toContain("Instance status:");
+    expect(html).toContain("<strong>provisioning</strong>");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps provisioning runtime API paths blocked when Stripe billing is inactive", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "machine-alice-provisioning-stripe-api-expired",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      hetznerServerId: 123,
+      publicIPv4: "203.0.113.11",
+      status: "provisioning",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      env: { MATRIX_STRIPE_BILLING_ENABLED: "true" } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/api/theme", {
       headers: {
         host: "app.matrix-os.com",
         authorization: "Bearer clerk-session",

--- a/tests/platform/stripe-billing.test.ts
+++ b/tests/platform/stripe-billing.test.ts
@@ -15,6 +15,7 @@ describe('platform/stripe-billing', () => {
 
     expect(client.apiTimeoutMs).toBe(MATRIX_STRIPE_API_TIMEOUT_MS);
     await expect(client.createCheckoutSession({
+      clerkUserId: 'user_123',
       customerId: 'cus_123',
       priceId: 'price_builder_monthly',
       mode: 'subscription',
@@ -28,16 +29,19 @@ describe('platform/stripe-billing', () => {
     expect(sessionsCreate).toHaveBeenCalledWith({
       mode: 'subscription',
       customer: 'cus_123',
+      client_reference_id: 'user_123',
       line_items: [{ price: 'price_builder_monthly', quantity: 1 }],
       success_url: 'https://app.matrix-os.com/?checkout=success',
       cancel_url: 'https://app.matrix-os.com/?billing=canceled',
       allow_promotion_codes: true,
       automatic_tax: { enabled: true },
       metadata: {
+        clerk_user_id: 'user_123',
         matrix_region_slug: 'region_nbg1',
       },
       subscription_data: {
         metadata: {
+          clerk_user_id: 'user_123',
           matrix_region_slug: 'region_nbg1',
         },
       },
@@ -50,21 +54,30 @@ describe('platform/stripe-billing', () => {
     expect(sessionsCreate.mock.calls[0]?.[0]).not.toHaveProperty('payment_method_types');
   });
 
-  it('creates customers with Clerk user metadata', async () => {
-    const customersCreate = vi.fn().mockResolvedValue({ id: 'cus_123' });
-    const client = createStripeBillingClient({
-      secretKey: 'sk_test_123',
-      stripe: fakeStripe({ customers: { create: customersCreate } }),
+  it('creates checkout sessions without customer-write permission when no customer exists yet', async () => {
+    const sessionsCreate = vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/session' });
+    const stripe = fakeStripe({
+      checkout: { sessions: { create: sessionsCreate } },
     });
+    const client = createStripeBillingClient({ secretKey: 'sk_test_123', stripe });
 
-    await expect(client.createCustomer({
+    await expect(client.createCheckoutSession({
       clerkUserId: 'user_123',
-      idempotencyKey: 'billing-customer:user_123',
-    })).resolves.toEqual({ id: 'cus_123' });
-    expect(customersCreate).toHaveBeenCalledWith(
-      { metadata: { clerk_user_id: 'user_123' } },
-      { idempotencyKey: 'billing-customer:user_123' },
-    );
+      priceId: 'price_builder_monthly',
+      mode: 'subscription',
+      automaticTax: true,
+      allowPromotionCodes: true,
+      regionSlug: 'region_nbg1',
+      successUrl: 'https://app.matrix-os.com/?checkout=success',
+      cancelUrl: 'https://app.matrix-os.com/?billing=canceled',
+    })).resolves.toEqual({ url: 'https://checkout.stripe.test/session' });
+    expect(sessionsCreate.mock.calls[0]?.[0]).not.toHaveProperty('customer');
+    expect(sessionsCreate.mock.calls[0]?.[0]).not.toHaveProperty('customer_update');
+    expect(sessionsCreate.mock.calls[0]?.[0]).toMatchObject({
+      client_reference_id: 'user_123',
+      metadata: { clerk_user_id: 'user_123' },
+      subscription_data: { metadata: { clerk_user_id: 'user_123' } },
+    });
   });
 
   it('creates portal sessions with a platform return URL', async () => {
@@ -96,7 +109,6 @@ describe('platform/stripe-billing', () => {
 function fakeStripe(overrides: Record<string, unknown>) {
   return {
     checkout: { sessions: { create: vi.fn() } },
-    customers: { create: vi.fn() },
     billingPortal: { sessions: { create: vi.fn() } },
     webhooks: { constructEvent: vi.fn() },
     ...overrides,


### PR DESCRIPTION
## Summary
- Allow unpaid signed-in users to load the shell document and static assets so the locked Billing settings page can render instead of raw 402 JSON.
- Keep runtime data paths, apps, files, modules, APIs, code-domain proxying, and websockets gated until billing access is active.
- Stop pre-creating Stripe Customers before Checkout. Checkout now creates the customer when needed, and signed subscription webhooks link the customer back through server-written Clerk metadata.

## Tests
- `bun run test tests/platform/proxy-routing.test.ts`
- `bun run test tests/platform/billing-routes.test.ts tests/platform/stripe-billing.test.ts`
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns:diff` (warnings only; no violations)

## Review/Monitoring
- Hotfixed production platform image from this branch after the restricted live Stripe key failed customer creation but succeeded Checkout Sessions.
- Needs CI and Greptile monitoring before merge.

## Invariants
- Source of truth: Stripe subscription webhooks plus `billing_customers`/`billing_entitlements` remain canonical for paid runtime access; internal test/operator access stays in `billing_entitlement_overrides`.
- Lock/transaction scope: webhook event insertion, customer link creation from signed metadata, and entitlement upsert run inside the existing billing webhook transaction; Checkout performs no entitlement writes.
- Acceptable orphan states: a Checkout Session may exist before webhook delivery; until the subscription webhook lands, runtime access remains inactive and the user stays on the billing surface.
- Auth source of truth: Clerk-authenticated platform requests can load the shell paywall; runtime data/API/websocket access still requires active entitlement decision.
- Deferred scope: full self-serve plan switching/add-on reconciliation remains outside this hotfix.
