### PR TITLE
ci(release): extend host bundle test timeout

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -81,7 +81,7 @@ jobs:
     needs: dev-bundle-gate
     if: needs.dev-bundle-gate.outputs.should_build == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Increase the Host Bundle Release `Test` job timeout from 15 to 30 minutes
- The latest main release run reached passing typecheck and continued passing unit tests until GitHub cancelled the job at 15m17s

## Validation
- `bun run check:patterns`

## Invariants
- Source of truth: GitHub Actions workflow configuration remains the release gate definition.
- Lock/transaction scope: no runtime data or persistence changes.
- Acceptable orphan states: no release artifacts are produced by this PR itself; it only lets the existing release workflow complete.
- Auth source of truth: unchanged.
- Deferred scope: no test splitting or suite optimization; this only corrects the observed timeout budget.
