### PR TITLE
fix(platform): disable legacy container routing in VPS mode

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -202,6 +202,9 @@ services:
       # tokens issued here validate against the gateway. Min 32 chars.
       - PLATFORM_JWT_SECRET=${PLATFORM_JWT_SECRET:-dev-platform-jwt-secret-please-change-32}
       - PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL:-http://localhost:9000}
+      # Legacy local Docker runtime is opt-in. VPS-native production ignores
+      # this flag whenever CUSTOMER_VPS_ENABLED wires a customerVpsService.
+      - MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=${MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED:-true}
       # Single-tenant dev: every issued JWT points at the local gateway.
       - GATEWAY_URL_TEMPLATE=${GATEWAY_URL_TEMPLATE:-http://localhost:4000}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1415,20 +1415,96 @@ function getNoContainerPage() {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Matrix OS</title>
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { min-height: 100vh; display: flex; align-items: center; justify-content: center; background: #0a0a0a; color: #fff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
-    .card { text-align: center; max-width: 400px; padding: 2rem; }
-    h1 { font-size: 1.5rem; margin-bottom: 1rem; }
-    p { color: #999; margin-bottom: 1.5rem; line-height: 1.6; }
-    a { color: #3b82f6; text-decoration: none; }
-    a:hover { text-decoration: underline; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background:
+        radial-gradient(circle at 50% 46%, rgba(196, 162, 101, 0.16), transparent 32%),
+        linear-gradient(180deg, #fffdf6 0%, #f4efe4 100%);
+      color: #2f392c;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      padding: 28px;
+    }
+    main {
+      width: min(620px, 100%);
+      display: grid;
+      justify-items: center;
+      gap: 26px;
+      text-align: center;
+    }
+    .mark {
+      width: 74px;
+      height: 74px;
+      border-radius: 24px;
+      border: 1px solid rgba(47, 57, 44, 0.18);
+      position: relative;
+      background: rgba(255, 255, 255, 0.42);
+      box-shadow: 0 24px 70px rgba(47, 57, 44, 0.12);
+    }
+    .mark::before {
+      content: "";
+      position: absolute;
+      inset: 11px;
+      border-radius: 18px;
+      border: 2px solid rgba(47, 57, 44, 0.16);
+      border-top-color: #c4a265;
+      animation: spin 1.3s linear infinite;
+    }
+    .mark::after {
+      content: "M";
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: 30px;
+      font-weight: 700;
+      color: #2f392c;
+    }
+    h1 {
+      margin: 0;
+      font-size: clamp(34px, 8vw, 68px);
+      font-weight: 500;
+      line-height: 0.96;
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+    p {
+      max-width: 520px;
+      color: rgba(47, 57, 44, 0.68);
+      font-size: 16px;
+      line-height: 1.65;
+      margin: 0;
+    }
+    .status {
+      min-height: 34px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      border: 1px solid rgba(47, 57, 44, 0.12);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.48);
+      padding: 7px 12px;
+      color: rgba(47, 57, 44, 0.72);
+      font-size: 13px;
+      box-shadow: 0 12px 40px rgba(47, 57, 44, 0.08);
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) {
+      .mark::before { animation-duration: 1ms; animation-iteration-count: 1; }
+    }
   </style>
 </head>
 <body>
-  <div class="card">
-    <h1>No instance yet</h1>
-    <p>Your account doesn't have a Matrix OS instance provisioned. Visit the <a href="https://matrix-os.com/dashboard">dashboard</a> to set one up.</p>
-  </div>
+  <main>
+    <div class="mark" aria-hidden="true"></div>
+    <h1>Preparing Matrix OS</h1>
+    <p>Your cloud computer is not ready yet. Matrix will bring you here automatically as soon as provisioning finishes.</p>
+    <p class="status">Computer status: pending</p>
+  </main>
 </body>
 </html>`;
 }
@@ -1866,6 +1942,8 @@ export function createApp(deps: {
 }) {
   const { db, docker, orchestrator, clerkAuth, matrixProvisioner } = deps;
   const appEnv = deps.env ?? process.env;
+  const legacyContainerRoutingEnabled =
+    appEnv.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED === 'true' && !deps.customerVpsService;
   const platformSecret = deps.platformSecret ?? appEnv.PLATFORM_SECRET ?? '';
   type CachedVpsRuntimeMetrics = {
     machineKey: string;
@@ -2829,35 +2907,42 @@ export function createApp(deps: {
       }
     }
 
-    const record = await getContainer(db, identity.handle);
-    if (!record) {
-      const activeMachine = requestedActiveMachine ?? (identity.userId
-        ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
-        : await getActiveUserMachineByHandle(db, identity.handle));
-      if (activeMachine) {
-        if (
-          !entitlement.runtimeProxyAllowed &&
-          !shouldProxyShellForBillingGate({
-            isAppDomain,
-            method: c.req.method,
-            upstreamPath: path,
-          })
-        ) {
-          applyNoStoreHeaders(c);
-          return c.json({ error: 'Paid beta access required' }, 402);
-        }
-        if (isCodeDomain || isGatewayPath) {
-          applyNoStoreHeaders(c);
-          return c.json({
-            error: 'VPS provisioning',
-            status: activeMachine.status,
-          }, 503);
-        }
+    const activeMachine = requestedActiveMachine ?? (identity.userId
+      ? await getActiveUserMachineByClerkId(db, identity.userId, runtimeSlot)
+      : await getActiveUserMachineByHandle(db, identity.handle));
+    if (activeMachine) {
+      if (
+        !entitlement.runtimeProxyAllowed &&
+        !shouldProxyShellForBillingGate({
+          isAppDomain,
+          method: c.req.method,
+          upstreamPath: path,
+        })
+      ) {
         applyNoStoreHeaders(c);
-        return c.html(getVpsBootPage({ status: activeMachine.status }), 503);
+        return c.json({ error: 'Paid beta access required' }, 402);
+      }
+      if (isCodeDomain || isGatewayPath) {
+        applyNoStoreHeaders(c);
+        return c.json({
+          error: 'VPS provisioning',
+          status: activeMachine.status,
+        }, 503);
+      }
+      applyNoStoreHeaders(c);
+      return c.html(getVpsBootPage({ status: activeMachine.status }), 503);
+    }
+
+    if (!legacyContainerRoutingEnabled) {
+      applyNoStoreHeaders(c);
+      if (isCodeDomain || isGatewayPath) {
+        return c.json({ error: 'Matrix computer unavailable' }, 503);
       }
       return c.html(getNoContainerPage());
     }
+
+    const record = await getContainer(db, identity.handle);
+    if (!record) return c.html(getNoContainerPage());
 
     if (
       !entitlement.runtimeProxyAllowed &&
@@ -3480,6 +3565,10 @@ export function createApp(deps: {
       }
     }
 
+    if (!legacyContainerRoutingEnabled) {
+      return c.json({ error: 'Matrix computer unavailable' }, 404);
+    }
+
     const record = await getContainer(db, handle);
     if (!record) return c.json({ error: 'Unknown handle' }, 404);
 
@@ -3785,6 +3874,8 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
   }
 
   const appEnv = process.env;
+  const legacyContainerRoutingEnabled =
+    appEnv.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED === 'true' && !customerVpsService;
   const app = createApp({
     db,
     docker,
@@ -3939,7 +4030,9 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     if (runningMachine) {
       runtimeSlot = runningMachine.runtimeSlot;
     }
-    const record = await getContainer(db, identity.handle);
+    const record = legacyContainerRoutingEnabled
+      ? await getContainer(db, identity.handle)
+      : undefined;
     if (!runningMachine && !record) { socket.destroy(); return; }
     const entitlement = runningMachine
       ? await getRuntimeEntitlementDecisionForUser(db, runningMachine.clerkUserId, appEnv)

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1413,6 +1413,7 @@ function getNoContainerPage() {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="refresh" content="8">
   <title>Matrix OS</title>
   <style>
     * { box-sizing: border-box; }
@@ -2938,7 +2939,7 @@ export function createApp(deps: {
       if (isCodeDomain || isGatewayPath) {
         return c.json({ error: 'Matrix computer unavailable' }, 503);
       }
-      return c.html(getNoContainerPage());
+      return c.html(getNoContainerPage(), 503);
     }
 
     const record = await getContainer(db, identity.handle);

--- a/tests/platform/profile-routing-vps.test.ts
+++ b/tests/platform/profile-routing-vps.test.ts
@@ -8,6 +8,7 @@ import {
 import { createApp } from '../../packages/platform/src/main.js';
 import { buildCustomerVpsProxyUrl } from '../../packages/platform/src/profile-routing.js';
 import type { Orchestrator } from '../../packages/platform/src/orchestrator.js';
+import type { CustomerVpsService } from '../../packages/platform/src/customer-vps.js';
 import type Dockerode from 'dockerode';
 
 function stubOrchestrator(): Orchestrator {
@@ -46,6 +47,7 @@ describe('platform/profile-routing-vps', () => {
 
   beforeEach(async () => {
     delete process.env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS;
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = 'true';
     ({ db } = await createTestPlatformDb());
     await insertContainer(db, {
       handle: 'alice',
@@ -59,6 +61,7 @@ describe('platform/profile-routing-vps', () => {
   afterEach(async () => {
     await destroyTestPlatformDb(db);
     vi.restoreAllMocks();
+    delete process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED;
   });
 
   it('builds a customer VPS HTTPS proxy URL from a running machine', () => {
@@ -253,5 +256,28 @@ describe('platform/profile-routing-vps', () => {
 
     expect(res.status).toBe(200);
     expect(fetchMock.mock.calls[0]?.[0]).toBe('http://matrixos-alice:3000/api/ping');
+  });
+
+  it('does not fall back to legacy containers when VPS-native routing is configured', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('wrong target'));
+    const docker = stubDocker();
+    const orchestrator = stubOrchestrator();
+    const app = createApp({
+      db,
+      docker,
+      orchestrator,
+      platformSecret: 'platform-secret',
+      customerVpsService: {} as CustomerVpsService,
+    });
+
+    const res = await app.request('/proxy/alice/api/ping', {
+      headers: { authorization: 'Bearer platform-secret' },
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Matrix computer unavailable' });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(docker.getContainer).not.toHaveBeenCalled();
+    expect(orchestrator.start).not.toHaveBeenCalled();
   });
 });

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -6,6 +6,7 @@ import {
   getContainer,
   insertContainer,
   insertUserMachine,
+  updateContainerStatus,
   upsertBillingEntitlement,
 } from "../../packages/platform/src/db.js";
 import {
@@ -21,6 +22,7 @@ import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
 import { issueSyncJwt } from "../../packages/platform/src/sync-jwt.js";
 import * as syncJwt from "../../packages/platform/src/sync-jwt.js";
 import { buildPlatformVerificationToken } from "../../packages/platform/src/platform-token.js";
+import type { CustomerVpsService } from "../../packages/platform/src/customer-vps.js";
 import type Dockerode from "dockerode";
 import { createTestPlatformDb, destroyTestPlatformDb } from "./platform-db-test-helper.js";
 
@@ -75,6 +77,7 @@ describe("platform proxy routing", () => {
   let db: PlatformDB;
 
   beforeEach(async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "true";
     ({ db } = await createTestPlatformDb());
     await insertContainer(db, {
       handle: "alice",
@@ -92,6 +95,7 @@ describe("platform proxy routing", () => {
     delete process.env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS;
     delete process.env.MATRIX_STRIPE_BILLING_ENABLED;
     delete process.env.HETZNER_SERVER_TYPE;
+    delete process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED;
   });
 
   it("escapes JSON embedded in auth page inline scripts", () => {
@@ -481,7 +485,10 @@ describe("platform proxy routing", () => {
         verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
       }),
       platformSecret: "platform-secret-123",
-      env: { MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "expired" } as NodeJS.ProcessEnv,
+      env: {
+        MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED: "true",
+        MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "expired",
+      } as NodeJS.ProcessEnv,
     });
 
     const res = await app.request("/", {
@@ -853,6 +860,40 @@ describe("platform proxy routing", () => {
     expect(res.status).toBe(200);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.12:443/");
     expect(fetchMock.mock.calls[0]?.[1]?.dispatcher).toBeDefined();
+  });
+
+  it("ignores stale legacy containers on app.matrix-os.com when VPS-native routing is configured", async () => {
+    await updateContainerStatus(db, "alice", "stopped", "stale-container-id");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const orchestrator = stubOrchestrator();
+    const app = createApp({
+      db,
+      orchestrator,
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: {} as CustomerVpsService,
+      env: {
+        MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED: "true",
+      } as NodeJS.ProcessEnv,
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Preparing Matrix OS");
+    expect(html).not.toContain("Failed to wake container");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(orchestrator.start).not.toHaveBeenCalled();
   });
 
   it("routes Clerk sessions to the selected staging VPS slot", async () => {
@@ -2082,7 +2123,10 @@ describe("platform proxy routing", () => {
         verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
       }),
       platformSecret: "platform-secret-123",
-      env: { MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "expired" } as NodeJS.ProcessEnv,
+      env: {
+        MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED: "true",
+        MATRIX_PAID_BETA_ENTITLEMENT_STATUS: "expired",
+      } as NodeJS.ProcessEnv,
     });
 
     const res = await app.request("/", {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -888,9 +888,10 @@ describe("platform proxy routing", () => {
       },
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
     const html = await res.text();
     expect(html).toContain("Preparing Matrix OS");
+    expect(html).toContain('http-equiv="refresh" content="8"');
     expect(html).not.toContain("Failed to wake container");
     expect(fetchMock).not.toHaveBeenCalled();
     expect(orchestrator.start).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Gate legacy Docker/container runtime proxying behind `MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=true` and disable it whenever VPS-native routing is configured.
- Stop app/code/proxy/websocket traffic from reading stale `containers` rows or starting Docker in VPS-native production.
- Replace the dead "No instance yet" page with a branded Matrix OS preparing-computer fallback.
- Add regressions for stale container rows on `app.matrix-os.com` and `/proxy/:handle` in VPS-native mode.

## Tests
- `bun run test tests/platform/proxy-routing.test.ts tests/platform/profile-routing-vps.test.ts` — 75 passed
- `bun run typecheck` — passed
- `bun run check:patterns` — 0 violations, existing warnings only
- `bun run test` — 484 files passed, 5201 tests passed, 3 files/20 tests skipped

## Review/Monitoring
- Greptile should review the pushed commit automatically. Do not merge until the latest trusted Greptile result for this head is 5/5.
- CI should be marked ready after Greptile is 5/5.

## Invariants
- Source of truth: VPS runtime routing uses `user_machines` as the production runtime source of truth; legacy `containers` rows are ignored unless explicitly enabled for legacy/local routing and no customer VPS service is configured.
- Lock/transaction scope: no new multi-write transaction is introduced; this only changes route selection before proxy/start side effects.
- Acceptable orphan states: stale `containers` rows may remain in the database, but they no longer wake Docker or receive production app/code/proxy/websocket traffic in VPS-native mode.
- Auth source of truth: existing Clerk/session/sync-JWT resolution remains unchanged before runtime routing decisions.
- Deferred scope: admin container-management endpoints and explicit legacy local-test routing remain for compatibility; production user-facing routing no longer uses Docker fallback.
