### PR TITLE
fix(platform): provision runtime after checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,13 +134,16 @@ RUN apk add --no-cache \
 
 RUN corepack enable && corepack prepare pnpm@10.6.2 --activate
 
-# AI coding CLIs. Claude Code and Codex intentionally use latest at image build
-# time so fresh Matrix runtimes start with current agent CLIs.
+# AI coding CLIs. Defaults track latest so fresh Matrix runtimes start current;
+# build args allow reproducible rebuilds when pinning a release is required.
+ARG OPENCODE_AI_VERSION=latest
+ARG PI_CODING_AGENT_VERSION=latest
 RUN npm install -g \
     @anthropic-ai/claude-code@latest \
     @openai/codex@latest \
-    opencode-ai@1.14.25 \
-    @mariozechner/pi-coding-agent@0.70.2
+    "opencode-ai@${OPENCODE_AI_VERSION}"
+RUN npm install -g --ignore-scripts \
+    "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 
 RUN curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh \
     -o /tmp/hermes-agent-install.sh && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -69,12 +69,15 @@ RUN apk add --no-cache \
 # pnpm via corepack (Agent SDK bundles its own claude runtime)
 RUN corepack enable && corepack prepare pnpm@10.6.2 --activate
 
-# AI coding CLIs
+# AI coding CLIs. Defaults track latest; build args allow reproducible pins.
+ARG OPENCODE_AI_VERSION=latest
+ARG PI_CODING_AGENT_VERSION=latest
 RUN npm install -g \
     @anthropic-ai/claude-code@latest \
     @openai/codex@latest \
-    opencode-ai@1.14.25 \
-    @mariozechner/pi-coding-agent@0.70.2
+    "opencode-ai@${OPENCODE_AI_VERSION}"
+RUN npm install -g --ignore-scripts \
+    "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
 
 RUN curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh \
     -o /tmp/hermes-agent-install.sh && \

--- a/distro/customer-vps/host-bin/matrix-install-tool-pack
+++ b/distro/customer-vps/host-bin/matrix-install-tool-pack
@@ -7,6 +7,8 @@ MATRIX_APP_DIR="${MATRIX_APP_DIR:-/opt/matrix/app}"
 MATRIX_RUNTIME_DIR="${MATRIX_RUNTIME_DIR:-/opt/matrix/runtime}"
 NODE_PREFIX="${MATRIX_NODE_PREFIX:-$MATRIX_RUNTIME_DIR/node}"
 CODE_SERVER_VERSION="${HOST_BUNDLE_CODE_SERVER_VERSION:-4.116.0}"
+OPENCODE_AI_VERSION="${OPENCODE_AI_VERSION:-latest}"
+PI_CODING_AGENT_VERSION="${PI_CODING_AGENT_VERSION:-latest}"
 CODE_SERVER_DIST="code-server-${CODE_SERVER_VERSION}-linux-amd64"
 CODE_SERVER_ARCHIVE="${CODE_SERVER_DIST}.tar.gz"
 CODE_SERVER_URL="https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/${CODE_SERVER_ARCHIVE}"
@@ -81,8 +83,11 @@ install_coding_agents() {
   run_as_matrix timeout 900 "$NODE_PREFIX/bin/npm" install -g --prefix "$NODE_PREFIX" \
     @anthropic-ai/claude-code@latest \
     @openai/codex@latest \
-    opencode-ai@1.14.25 \
-    @mariozechner/pi-coding-agent@0.70.2
+    "opencode-ai@${OPENCODE_AI_VERSION}"
+  # Upstream Pi docs recommend --ignore-scripts; the package exposes pi via
+  # bin -> dist/cli.js and does not use postinstall for binary acquisition.
+  run_as_matrix timeout 900 "$NODE_PREFIX/bin/npm" install -g --ignore-scripts --prefix "$NODE_PREFIX" \
+    "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"
   runtime_chmod
   sync_agent_skills
   log "coding agent CLIs installed"

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -100,6 +100,7 @@ const PROXY_BODY_LIMIT = 10 * 1024 * 1024;
 const CLERK_SCRIPT_ORIGIN = 'https://clerk.matrix-os.com';
 const PROXY_TIMEOUT_MS = 30_000;
 const VPS_RELEASE_PROBE_TIMEOUT_MS = 10_000;
+const CLERK_USER_LOOKUP_TIMEOUT_MS = 10_000;
 const RUNTIME_PICKER_PROBE_TIMEOUT_MS = 2_500;
 const VPS_RUNTIME_METRICS_TTL_MS = 45_000;
 const DOCKER_INSPECT_TIMEOUT_MS = 10_000;
@@ -188,6 +189,19 @@ const AppSessionExchangeBodySchema = z.object({
   redirectTo: z.string().min(1).max(2048).optional(),
   runtime: RuntimeSlotSchema.optional(),
 }).strict();
+
+const AppSessionProvisionBodySchema = z.object({
+  runtime: RuntimeSlotSchema.optional().default('primary'),
+}).strict();
+
+const ClerkUserProfileSchema = z.object({
+  username: z.string().nullable().optional(),
+  primary_email_address_id: z.string().nullable().optional(),
+  email_addresses: z.array(z.object({
+    id: z.string().optional(),
+    email_address: z.string().optional(),
+  }).passthrough()).optional(),
+}).passthrough();
 
 function sanitizeProxyResponseHeaders(headers: Headers): Headers {
   const sanitized = new Headers(headers);
@@ -675,6 +689,147 @@ function applyNoStoreHeaders(c: import('hono').Context): void {
   c.header('Cloudflare-CDN-Cache-Control', 'no-store');
   c.header('Pragma', 'no-cache');
   c.header('Expires', '0');
+}
+
+function isPostgresUniqueViolation(err: unknown): boolean {
+  return err instanceof Error && (err as Error & { code?: unknown }).code === '23505';
+}
+
+function jsonCustomerVpsError(c: import('hono').Context, err: unknown, context: string) {
+  if (err instanceof CustomerVpsError) {
+    const status = err.status === 402 ? 402 : err.status === 409 ? 409 : 503;
+    const code = err.status === 402
+      ? 'billing_required'
+      : err.status === 409
+        ? 'provisioning_conflict'
+        : 'provisioning_failed';
+    return c.json({ error: err.publicMessage, code }, status as never);
+  }
+  if (isPostgresUniqueViolation(err)) {
+    return c.json({ error: 'Handle unavailable', code: 'handle_unavailable' }, 409);
+  }
+  logPlatformRouteError(context, err);
+  return c.json({ error: 'Provisioning failed', code: 'provisioning_failed' }, 503);
+}
+
+function normalizeProvisionHandleCandidate(value: string | undefined | null): string | null {
+  if (!value) return null;
+  const candidate = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 31)
+    .replace(/-+$/g, '');
+  return HANDLE_PATTERN.test(candidate) ? candidate : null;
+}
+
+function fallbackProvisionHandleForClerkUser(userId: string, secretKey: string): string {
+  const suffix = createHmac('sha256', secretKey)
+    .update(userId)
+    .digest('hex')
+    .slice(0, 12);
+  return `u${suffix}`;
+}
+
+async function resolveProvisionHandleCandidatesFromClerkProfile(
+  userId: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string[]> {
+  const secretKey = env.CLERK_SECRET_KEY;
+  if (!secretKey) {
+    throw new CustomerVpsError(503, 'provider_unavailable', 'Provisioning unavailable');
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`https://api.clerk.com/v1/users/${encodeURIComponent(userId)}`, {
+      headers: {
+        authorization: `Bearer ${secretKey}`,
+        accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(CLERK_USER_LOOKUP_TIMEOUT_MS),
+      redirect: 'error',
+    });
+  } catch (err: unknown) {
+    logPlatformRouteError('/api/auth/provision-runtime clerk lookup', err);
+    throw new CustomerVpsError(503, 'provider_unavailable', 'Provisioning unavailable');
+  }
+  if (!response.ok) {
+    logPlatformRouteError(
+      '/api/auth/provision-runtime clerk lookup',
+      new Error(`Clerk user lookup failed with status ${response.status}`),
+    );
+    throw new CustomerVpsError(503, 'provider_unavailable', 'Provisioning unavailable');
+  }
+
+  const profile = ClerkUserProfileSchema.safeParse(await response.json());
+  if (!profile.success) {
+    throw new CustomerVpsError(503, 'provider_unavailable', 'Provisioning unavailable');
+  }
+  const candidates: string[] = [];
+  const addCandidate = (candidate: string | null) => {
+    if (candidate && !candidates.includes(candidate)) candidates.push(candidate);
+  };
+  const usernameHandle = normalizeProvisionHandleCandidate(profile.data.username);
+  addCandidate(usernameHandle);
+
+  const primaryEmail = profile.data.email_addresses?.find(
+    (email) => email.id && email.id === profile.data.primary_email_address_id,
+  )?.email_address;
+  const primaryEmailHandle = normalizeProvisionHandleCandidate(primaryEmail?.split('@')[0]);
+  addCandidate(primaryEmailHandle);
+
+  const firstEmailHandle = normalizeProvisionHandleCandidate(
+    profile.data.email_addresses?.[0]?.email_address?.split('@')[0],
+  );
+  addCandidate(firstEmailHandle);
+  addCandidate(fallbackProvisionHandleForClerkUser(userId, secretKey));
+  return candidates;
+}
+
+async function isProvisionHandleAvailableForClerkUser(
+  db: PlatformDB,
+  handle: string,
+  clerkUserId: string,
+): Promise<boolean> {
+  const conflictingActiveHandleMachine = await db.executor
+    .selectFrom('user_machines')
+    .select('clerk_user_id')
+    .where('handle', '=', handle)
+    .where('deleted_at', 'is', null)
+    .where('clerk_user_id', '!=', clerkUserId)
+    .executeTakeFirst();
+  if (conflictingActiveHandleMachine) {
+    return false;
+  }
+  // Same-user VPS machines supersede stale docker-era container rows for the same handle.
+  const ownedActiveHandleMachine = await db.executor
+    .selectFrom('user_machines')
+    .select('machine_id')
+    .where('handle', '=', handle)
+    .where('deleted_at', 'is', null)
+    .where('clerk_user_id', '=', clerkUserId)
+    .executeTakeFirst();
+  if (ownedActiveHandleMachine) {
+    return true;
+  }
+  const legacyHandleContainer = await getContainer(db, handle);
+  return !legacyHandleContainer || legacyHandleContainer.clerkUserId === clerkUserId;
+}
+
+async function selectProvisionHandleForClerkUser(
+  db: PlatformDB,
+  userId: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | null> {
+  const candidates = await resolveProvisionHandleCandidatesFromClerkProfile(userId, env);
+  for (const handle of candidates) {
+    if (await isProvisionHandleAvailableForClerkUser(db, handle, userId)) {
+      return handle;
+    }
+  }
+  return null;
 }
 
 function applyCookieRoutedShellAssetCacheHeaders(headers: Headers): void {
@@ -1454,6 +1609,37 @@ function getAuthPage(
     var redirectTarget = ${redirectTargetJson};
     var signOutTarget = ${signOutTargetJson};
     var requestedRuntime = new URLSearchParams(redirectTarget.split('?')[1] || '').get('runtime');
+    var checkoutAttemptStorageKey = 'matrix.billing.checkoutAttemptAt';
+    var checkoutAttemptMaxAgeMs = 30 * 60 * 1000;
+    function hasTrustedCheckoutReturn() {
+      try {
+        var rawAttemptAt = window.sessionStorage.getItem(checkoutAttemptStorageKey);
+        if (!rawAttemptAt) return false;
+        var attemptAt = Number(rawAttemptAt);
+        return Number.isFinite(attemptAt) && Date.now() - attemptAt <= checkoutAttemptMaxAgeMs;
+      } catch (err) {
+        console.warn('[matrix] Unable to read checkout attempt state', err instanceof Error ? err.message : String(err));
+        return false;
+      }
+    }
+    function stripCheckoutReturnParams() {
+      try {
+        var currentUrl = new URL(window.location.href);
+        currentUrl.searchParams.delete('checkout');
+        if (currentUrl.searchParams.get('billing') === 'success') currentUrl.searchParams.delete('billing');
+        window.history.replaceState(null, '', currentUrl.pathname + currentUrl.search + currentUrl.hash);
+      } catch (err) {
+        console.warn('[matrix] Unable to clear checkout return state', err instanceof Error ? err.message : String(err));
+      }
+    }
+    var checkoutReturnRequested = new URLSearchParams(window.location.search || '').get('checkout') === 'success';
+    var checkoutJustCompleted = checkoutReturnRequested && hasTrustedCheckoutReturn();
+    if (checkoutReturnRequested) stripCheckoutReturnParams();
+    var provisionStarted = false;
+    var provisioningPolls = 0;
+    var maxProvisioningPolls = 60;
+    var billingConfirmationPolls = 0;
+    var maxBillingConfirmationPolls = 60;
     var appearance = {
       variables: {
         colorPrimary: '#D06F25',
@@ -1551,10 +1737,177 @@ function getAuthPage(
     function showNoRuntimeState() {
       renderSessionState(
         'No Matrix computer is attached',
-        'This Clerk account is signed in, but it does not have a Matrix computer yet. Sign out to use another account, or ask the operator to provision this account.',
-        'Check again',
-        continueWithClerkSession
+        'This account is signed in, but Matrix could not find an attached cloud computer yet.',
+        'Provision Matrix computer',
+        startProvisioningFromClerkSession
       );
+    }
+    function showBillingRequiredState() {
+      renderSessionState(
+        'Billing required',
+        'Start hosted billing before Matrix provisions your cloud computer.',
+        'Start checkout',
+        startBillingCheckoutFromClerkSession
+      );
+    }
+    function rememberBillingCheckoutAttempt() {
+      try {
+        window.sessionStorage.setItem(checkoutAttemptStorageKey, String(Date.now()));
+      } catch (err) {
+        console.warn('[matrix] Unable to write checkout attempt state', err instanceof Error ? err.message : String(err));
+      }
+    }
+    function startBillingCheckoutFromClerkSession() {
+      showLoadingState('Opening secure checkout...');
+      if (!window.Clerk.session) {
+        showSignedInRecoveryState();
+        return;
+      }
+      window.Clerk.session.getToken()
+        .then(function(token) {
+          if (!token) {
+            showSignedInRecoveryState();
+            return null;
+          }
+          var controller = new AbortController();
+          var timeoutId = window.setTimeout(function() { controller.abort(); }, 10000);
+          return fetch('/billing/checkout', {
+            method: 'POST',
+            headers: {
+              Authorization: 'Bearer ' + token,
+              'Content-Type': 'application/json',
+              Accept: 'application/json'
+            },
+            body: JSON.stringify({
+              planSlug: 'matrix_builder',
+              interval: 'monthly',
+              regionSlug: 'region_fsn1'
+            }),
+            credentials: 'same-origin',
+            signal: controller.signal
+          }).finally(function() {
+            window.clearTimeout(timeoutId);
+          });
+        })
+        .then(function(res) {
+          if (!res) return null;
+          return res.json().catch(function(err) {
+            console.warn('[matrix] Unable to parse checkout response', err instanceof Error ? err.message : String(err));
+            return null;
+          }).then(function(body) {
+            if (!res.ok || !body || typeof body.url !== 'string') {
+              showBillingRequiredState();
+              return;
+            }
+            rememberBillingCheckoutAttempt();
+            window.location.assign(body.url);
+          });
+        })
+        .catch(function(err) {
+          console.error('[matrix] Billing checkout failed', err instanceof Error ? err.message : String(err));
+          showBillingRequiredState();
+        });
+    }
+    function pollProvisioningSession() {
+      provisioningPolls += 1;
+      if (provisioningPolls > maxProvisioningPolls) {
+        provisionStarted = false;
+        checkoutJustCompleted = false;
+        billingConfirmationPolls = 0;
+        showSignedInRecoveryState();
+        return;
+      }
+      window.setTimeout(continueWithClerkSession, 8000);
+    }
+    function retryProvisioningAfterBillingDelay() {
+      billingConfirmationPolls += 1;
+      if (billingConfirmationPolls > maxBillingConfirmationPolls) {
+        provisionStarted = false;
+        checkoutJustCompleted = false;
+        showBillingRequiredState();
+        return;
+      }
+      provisionStarted = false;
+      showLoadingState('Confirming billing...');
+      window.setTimeout(startProvisioningFromClerkSession, 8000);
+    }
+    function startProvisioningFromClerkSession() {
+      if (provisionStarted) return;
+      provisionStarted = true;
+      showLoadingState('Starting your Matrix computer...');
+      if (!window.Clerk.session) {
+        provisionStarted = false;
+        showSignedInRecoveryState();
+        return;
+      }
+      window.Clerk.session.getToken()
+        .then(function(token) {
+          if (!token) {
+            provisionStarted = false;
+            showSignedInRecoveryState();
+            return null;
+          }
+          var controller = new AbortController();
+          var timeoutId = window.setTimeout(function() { controller.abort(); }, 10000);
+          return fetch('/api/auth/provision-runtime', {
+            method: 'POST',
+            headers: {
+              Authorization: 'Bearer ' + token,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              runtime: requestedRuntime || undefined
+            }),
+            credentials: 'same-origin',
+            signal: controller.signal
+          }).finally(function() {
+            window.clearTimeout(timeoutId);
+          });
+        })
+        .then(function(res) {
+          if (!res) return null;
+          if (res.ok) {
+            billingConfirmationPolls = 0;
+            provisioningPolls = 0;
+            showLoadingState('Preparing your Matrix computer...');
+            pollProvisioningSession();
+            return null;
+          }
+          if (res.status === 402) {
+            if (checkoutJustCompleted) {
+              retryProvisioningAfterBillingDelay();
+              return null;
+            }
+            provisionStarted = false;
+            showBillingRequiredState();
+            return null;
+          }
+          if (res.status === 409) {
+            return res.json().catch(function(err) {
+              console.warn('[matrix] Unable to parse provisioning conflict response', err instanceof Error ? err.message : String(err));
+              return null;
+            }).then(function(body) {
+              if (body && body.code === 'provisioning_conflict') {
+                billingConfirmationPolls = 0;
+                provisioningPolls = 0;
+                showLoadingState('Preparing your Matrix computer...');
+                pollProvisioningSession();
+                return;
+              }
+              checkoutJustCompleted = false;
+              provisionStarted = false;
+              showSignedInRecoveryState();
+            });
+          }
+          provisionStarted = false;
+          showSignedInRecoveryState();
+          return null;
+        })
+        .catch(function(err) {
+          console.error('[matrix] Runtime provisioning failed', err instanceof Error ? err.message : String(err));
+          provisionStarted = false;
+          showSignedInRecoveryState();
+        });
     }
     function continueWithClerkSession() {
       showLoadingState('Loading your Matrix computer...');
@@ -1582,6 +1935,15 @@ function getAuthPage(
           if (!res) return null;
           if (res.ok) return res.json();
           if (res.status === 404) {
+            if (provisionStarted) {
+              showLoadingState('Preparing your Matrix computer...');
+              pollProvisioningSession();
+              return null;
+            }
+            if (checkoutJustCompleted) {
+              startProvisioningFromClerkSession();
+              return null;
+            }
             showNoRuntimeState();
             return null;
           }
@@ -2686,6 +3048,78 @@ export function createApp(deps: {
     return c.json({ cleared: true });
   });
 
+  app.post('/api/auth/provision-runtime', bodyLimit({ maxSize: 1024 }), async (c) => {
+    if (!clerkAuth) {
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    if (!deps.customerVpsService) {
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Provisioning unavailable', code: 'provisioning_unavailable' }, 503);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (err: unknown) {
+      if (!(err instanceof SyntaxError)) {
+        logPlatformRouteError('/api/auth/provision-runtime parse', err);
+      }
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Invalid request' }, 400);
+    }
+    const parsed = AppSessionProvisionBodySchema.safeParse(body);
+    if (!parsed.success) {
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Invalid request' }, 400);
+    }
+
+    const token = clerkAuth.extractToken(c.req.header('authorization'), c.req.header('cookie'));
+    if (!token) {
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    const result = await clerkAuth.verify(token);
+    if (!result.authenticated || !result.userId) {
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    try {
+      const handle = await selectProvisionHandleForClerkUser(db, result.userId, appEnv);
+      if (!handle) {
+        applyNoStoreHeaders(c);
+        return c.json({ error: 'Handle unavailable', code: 'handle_unavailable' }, 409);
+      }
+      const provisioned = await deps.customerVpsService.provision({
+        handle,
+        clerkUserId: result.userId,
+        runtimeSlot: parsed.data.runtime,
+      });
+      if (matrixProvisioner) {
+        try {
+          await matrixProvisioner.provisionUser(handle);
+        } catch (matrixErr: unknown) {
+          console.error(
+            `[matrix] Failed to provision Matrix accounts for ${handle}:`,
+            matrixErr instanceof Error ? matrixErr.message : String(matrixErr),
+          );
+        }
+      }
+      applyNoStoreHeaders(c);
+      return c.json({
+        runtime: 'customer_vps',
+        handle,
+        clerkUserId: result.userId,
+        ...provisioned,
+        runtimeSlot: parsed.data.runtime,
+      }, 202);
+    } catch (err: unknown) {
+      applyNoStoreHeaders(c);
+      return jsonCustomerVpsError(c, err, '/api/auth/provision-runtime');
+    }
+  });
+
   app.post('/api/auth/app-session', bodyLimit({ maxSize: 1024 }), async (c) => {
     if (!platformJwtSecret || !clerkAuth) {
       applyNoStoreHeaders(c);
@@ -2772,7 +3206,8 @@ export function createApp(deps: {
       reqPath === '/auth/device' ||
       reqPath.startsWith('/auth/device/') ||
       reqPath.startsWith('/api/auth/device/') ||
-      reqPath === '/api/auth/app-session'
+      reqPath === '/api/auth/app-session' ||
+      reqPath === '/api/auth/provision-runtime'
     )) {
       return next();
     }

--- a/tests/deploy/cloud-workspace-runtime.test.ts
+++ b/tests/deploy/cloud-workspace-runtime.test.ts
@@ -11,9 +11,17 @@ describe("cloud workspace runtime gates", () => {
     for (const tool of ["zellij", "tmux", "gh", "openssh-client", "bubblewrap", "git", "sudo", "code-server"]) {
       expect(dockerfile).toContain(tool);
     }
-    for (const agentCli of ["@anthropic-ai/claude-code@latest", "@openai/codex@latest", "opencode-ai", "@mariozechner/pi-coding-agent"]) {
+    for (const agentCli of [
+      "@anthropic-ai/claude-code@latest",
+      "@openai/codex@latest",
+      "OPENCODE_AI_VERSION=latest",
+      "PI_CODING_AGENT_VERSION=latest",
+      '"opencode-ai@${OPENCODE_AI_VERSION}"',
+      '"@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"',
+    ]) {
       expect(dockerfile).toContain(agentCli);
     }
+    expect(dockerfile).toContain("npm install -g --ignore-scripts");
     expect(dockerfile).toContain("hermes-agent/main/scripts/install.sh");
   });
 

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -188,22 +188,28 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors --connect-timeout 10 --max-time 30 "${MATRIX_HOST_BUNDLE_URL}.sha256"');
   });
 
-  it('exposes bundled coding agent CLIs on customer hosts', () => {
+  it('exposes selectable coding agent CLIs on customer hosts', () => {
     const root = process.cwd();
     const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
     const gateway = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-gateway'), 'utf8');
     const buildScript = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
     const toolPackInstaller = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-tool-pack'), 'utf8');
 
-    expect(toolPackInstaller).toContain('@anthropic-ai/claude-code@latest');
-    expect(toolPackInstaller).toContain('@openai/codex@latest');
-    expect(toolPackInstaller).toContain('opencode-ai@1.14.25');
-    expect(toolPackInstaller).toContain('@mariozechner/pi-coding-agent@0.70.2');
+    expect(buildScript).toContain('matrix-install-tool-pack');
     expect(buildScript).toContain('https://astral.sh/uv/install.sh');
     expect(buildScript).toContain('UV_INSTALL_DIR="$STAGE_DIR/runtime/node/bin"');
     expect(buildScript).toContain('scripts/install-hermes-matrix-skills.sh');
     expect(buildScript).toContain('scripts/sync-matrix-agent-skills.sh');
     expect(buildScript).toContain('cp -a "$ROOT_DIR/skills" "$STAGE_DIR/app/skills"');
+    expect(toolPackInstaller).toContain('install_coding_agents()');
+    expect(toolPackInstaller).toContain('install_code_server()');
+    expect(toolPackInstaller).toContain('@anthropic-ai/claude-code@latest');
+    expect(toolPackInstaller).toContain('@openai/codex@latest');
+    expect(toolPackInstaller).toContain('OPENCODE_AI_VERSION="${OPENCODE_AI_VERSION:-latest}"');
+    expect(toolPackInstaller).toContain('PI_CODING_AGENT_VERSION="${PI_CODING_AGENT_VERSION:-latest}"');
+    expect(toolPackInstaller).toContain('"opencode-ai@${OPENCODE_AI_VERSION}"');
+    expect(toolPackInstaller).toContain('"$NODE_PREFIX/bin/npm" install -g --ignore-scripts --prefix "$NODE_PREFIX"');
+    expect(toolPackInstaller).toContain('"@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"');
     expect(toolPackInstaller).toContain('CODE_SERVER_VERSION="${HOST_BUNDLE_CODE_SERVER_VERSION:-4.116.0}"');
     expect(toolPackInstaller).toContain('CODE_SERVER_URL="https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/${CODE_SERVER_ARCHIVE}"');
     expect(toolPackInstaller).toContain('runtime/code-server');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -79,8 +79,11 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('install_hermes()');
     expect(installer).toContain('@anthropic-ai/claude-code@latest');
     expect(installer).toContain('@openai/codex@latest');
-    expect(installer).toContain('opencode-ai@1.14.25');
-    expect(installer).toContain('@mariozechner/pi-coding-agent@0.70.2');
+    expect(installer).toContain('OPENCODE_AI_VERSION="${OPENCODE_AI_VERSION:-latest}"');
+    expect(installer).toContain('PI_CODING_AGENT_VERSION="${PI_CODING_AGENT_VERSION:-latest}"');
+    expect(installer).toContain('"opencode-ai@${OPENCODE_AI_VERSION}"');
+    expect(installer).toContain('"$NODE_PREFIX/bin/npm" install -g --ignore-scripts --prefix "$NODE_PREFIX"');
+    expect(installer).toContain('"@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}"');
     expect(installer).toContain('curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors');
     expect(installer).toContain('sync-matrix-agent-skills.sh');
     expect(installer).toContain('coding-agents|code-server|hermes|linux-tools|all');

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
+import { createHmac } from "node:crypto";
 import {
   type PlatformDB,
   deleteContainer,
@@ -27,6 +28,13 @@ import type Dockerode from "dockerode";
 import { createTestPlatformDb, destroyTestPlatformDb } from "./platform-db-test-helper.js";
 
 const JWT_SECRET = "test-secret-at-least-32-characters-long";
+
+function expectedFallbackProvisionHandle(clerkUserId: string, secretKey = "sk_test_matrix"): string {
+  return `u${createHmac("sha256", secretKey)
+    .update(clerkUserId)
+    .digest("hex")
+    .slice(0, 12)}`;
+}
 
 function stubOrchestrator(): Orchestrator {
   return {
@@ -1285,6 +1293,412 @@ describe("platform proxy routing", () => {
     expect(exchange.headers.get("set-cookie")).toContain("Max-Age=0");
   });
 
+  it("lets a signed-in checkout return start hosted runtime provisioning without admin credentials", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        username: "newuser",
+        primary_email_address_id: "email_1",
+        email_addresses: [{ id: "email_1", email_address: "new@example.com" }],
+      }),
+    );
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({
+        machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff150",
+        status: "provisioning",
+        etaSeconds: 90,
+      }),
+    };
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: customerVpsService as unknown as CustomerVpsService,
+      env: { ...process.env, CLERK_SECRET_KEY: "sk_test_matrix" },
+    });
+
+    const provision = await app.request("/api/auth/provision-runtime", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(provision.status).toBe(202);
+    await expect(provision.json()).resolves.toEqual({
+      runtime: "customer_vps",
+      handle: "newuser",
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff150",
+      status: "provisioning",
+      etaSeconds: 90,
+    });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: "newuser",
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.clerk.com/v1/users/user_new",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer sk_test_matrix",
+          accept: "application/json",
+        }),
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("trims generated handles again after length limiting", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "very-long-username-with-hyphen");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        username: "very-long-username-with-hyphen-x",
+        primary_email_address_id: "email_1",
+        email_addresses: [{ id: "email_1", email_address: "fallback@example.com" }],
+      }),
+    );
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({ status: "provisioning" }),
+    };
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: customerVpsService as unknown as CustomerVpsService,
+      env: { ...process.env, CLERK_SECRET_KEY: "sk_test_matrix" },
+    });
+
+    const provision = await app.request("/api/auth/provision-runtime", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(provision.status).toBe(202);
+    await expect(provision.json()).resolves.toMatchObject({
+      handle: "very-long-username-with-hyphen",
+      clerkUserId: "user_new",
+    });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: "very-long-username-with-hyphen",
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+    });
+  });
+
+  it("falls back instead of claiming another user's active Clerk handle", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff151",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123482,
+      publicIPv4: "203.0.113.33",
+      imageVersion: "matrix-os-host-2026.05.31-1",
+      serverType: "cpx22",
+      provisionedAt: "2026-05-31T12:00:00.000Z",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        username: "alice",
+        primary_email_address_id: "email_1",
+        email_addresses: [{ id: "email_1", email_address: "alice@example.com" }],
+      }),
+    );
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({ status: "provisioning" }),
+    };
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: customerVpsService as unknown as CustomerVpsService,
+      env: { ...process.env, CLERK_SECRET_KEY: "sk_test_matrix" },
+    });
+
+    const provision = await app.request("/api/auth/provision-runtime", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    const fallbackHandle = expectedFallbackProvisionHandle("user_new");
+    expect(provision.status).toBe(202);
+    await expect(provision.json()).resolves.toEqual({
+      runtime: "customer_vps",
+      handle: fallbackHandle,
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+      status: "provisioning",
+    });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: fallbackHandle,
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+    });
+  });
+
+  it("falls back instead of claiming another user's active handle in another slot", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff152",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "staging",
+      status: "running",
+      hetznerServerId: 123483,
+      publicIPv4: "203.0.113.34",
+      imageVersion: "matrix-os-host-2026.05.31-1",
+      serverType: "cpx22",
+      provisionedAt: "2026-05-31T12:00:00.000Z",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        username: "alice",
+        primary_email_address_id: "email_1",
+        email_addresses: [{ id: "email_1", email_address: "alice@example.com" }],
+      }),
+    );
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({ status: "provisioning" }),
+    };
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: customerVpsService as unknown as CustomerVpsService,
+      env: { ...process.env, CLERK_SECRET_KEY: "sk_test_matrix" },
+    });
+
+    const provision = await app.request("/api/auth/provision-runtime", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    const fallbackHandle = expectedFallbackProvisionHandle("user_new");
+    expect(provision.status).toBe(202);
+    await expect(provision.json()).resolves.toEqual({
+      runtime: "customer_vps",
+      handle: fallbackHandle,
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+      status: "provisioning",
+    });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: fallbackHandle,
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+    });
+  });
+
+  it("keeps a same-user active machine handle even with a stale legacy container row", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff153",
+      clerkUserId: "user_new",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123484,
+      publicIPv4: "203.0.113.35",
+      imageVersion: "matrix-os-host-2026.05.31-1",
+      serverType: "cpx22",
+      provisionedAt: "2026-05-31T12:00:00.000Z",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        username: "alice",
+        primary_email_address_id: "email_1",
+        email_addresses: [{ id: "email_1", email_address: "alice@example.com" }],
+      }),
+    );
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({ status: "running" }),
+    };
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: customerVpsService as unknown as CustomerVpsService,
+      env: { ...process.env, CLERK_SECRET_KEY: "sk_test_matrix" },
+    });
+
+    const provision = await app.request("/api/auth/provision-runtime", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(provision.status).toBe(202);
+    await expect(provision.json()).resolves.toEqual({
+      runtime: "customer_vps",
+      handle: "alice",
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+      status: "running",
+    });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: "alice",
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+    });
+  });
+
+  it("keeps a same-user handle when another runtime slot already uses it", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff155",
+      clerkUserId: "user_new",
+      handle: "alice",
+      runtimeSlot: "staging",
+      status: "running",
+      hetznerServerId: 123486,
+      publicIPv4: "203.0.113.37",
+      imageVersion: "matrix-os-host-2026.05.31-1",
+      serverType: "cpx22",
+      provisionedAt: "2026-05-31T12:00:00.000Z",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        username: "alice",
+        primary_email_address_id: "email_1",
+        email_addresses: [{ id: "email_1", email_address: "alice@example.com" }],
+      }),
+    );
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({ status: "provisioning" }),
+    };
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: customerVpsService as unknown as CustomerVpsService,
+      env: { ...process.env, CLERK_SECRET_KEY: "sk_test_matrix" },
+    });
+
+    const provision = await app.request("/api/auth/provision-runtime", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(provision.status).toBe(202);
+    await expect(provision.json()).resolves.toEqual({
+      runtime: "customer_vps",
+      handle: "alice",
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+      status: "provisioning",
+    });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: "alice",
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+    });
+  });
+
+  it("falls back instead of claiming another user's legacy container handle", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        username: "alice",
+        primary_email_address_id: "email_1",
+        email_addresses: [{ id: "email_1", email_address: "alice@example.com" }],
+      }),
+    );
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({ status: "provisioning" }),
+    };
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: customerVpsService as unknown as CustomerVpsService,
+      env: { ...process.env, CLERK_SECRET_KEY: "sk_test_matrix" },
+    });
+
+    const provision = await app.request("/api/auth/provision-runtime", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    const fallbackHandle = expectedFallbackProvisionHandle("user_new");
+    expect(provision.status).toBe(202);
+    await expect(provision.json()).resolves.toEqual({
+      runtime: "customer_vps",
+      handle: fallbackHandle,
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+      status: "provisioning",
+    });
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: fallbackHandle,
+      clerkUserId: "user_new",
+      runtimeSlot: "primary",
+    });
+  });
+
   it("continues signed-in auth pages through a Clerk token exchange", async () => {
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
     const app = createApp({
@@ -1304,8 +1718,29 @@ describe("platform proxy routing", () => {
     const html = await res.text();
     expect(html).toContain("window.Clerk.session.getToken()");
     expect(html).toContain("fetch('/api/auth/app-session'");
+    expect(html).toContain("fetch('/api/auth/provision-runtime'");
+    expect(html).toContain("signal: controller.signal");
+    expect(html).toContain("window.clearTimeout(timeoutId);");
+    expect(html).toContain("matrix.billing.checkoutAttemptAt");
+    expect(html).toContain("hasTrustedCheckoutReturn()");
+    expect(html).toContain("stripCheckoutReturnParams()");
+    expect(html).toContain("if (provisionStarted)");
+    expect(html).toContain("maxBillingConfirmationPolls");
+    expect(html).toContain("provisioningPolls = 0;");
+    expect(html).toContain("Billing required");
+    expect(html).toContain("fetch('/billing/checkout'");
+    expect(html).toContain("planSlug: 'matrix_builder'");
+    expect(html).toContain("Opening secure checkout");
+    expect(html).toContain("retryProvisioningAfterBillingDelay()");
+    expect(html).toContain("Confirming billing");
+    expect(html).toContain("provisioning_conflict");
+    expect(html).toContain("if (body && body.code === 'provisioning_conflict') {\n                billingConfirmationPolls = 0;\n                provisioningPolls = 0;");
+    expect(html).toContain("checkoutJustCompleted = false;");
+    expect(html).toContain("Starting your Matrix computer");
+    expect(html).toContain("Preparing your Matrix computer");
     expect(html).toContain("method: 'DELETE'");
     expect(html).toContain("Loading your Matrix computer");
+    expect(html).not.toContain("ask the operator to provision this account");
     expect(html).not.toContain("You are already signed in");
   });
 


### PR DESCRIPTION
## Summary
- add a Clerk-authenticated app-domain provisioning endpoint for successful checkout returns
- have the hosted auth page start provisioning automatically when Stripe checkout succeeds but no runtime exists yet
- keep coding-agent tool packs current by installing OpenCode with `opencode-ai@latest` and Pi with `@earendil-works/pi-coding-agent@latest` via `--ignore-scripts`
- cover the route, auth-page wiring, host-bundle tool-pack installer, and runtime CLI package expectations in tests

## Invariants
- Source of truth: `user_machines` remains the canonical hosted-runtime registry; Stripe billing entitlements remain canonical for runtime access.
- Lock/transaction scope: provisioning still delegates to `CustomerVpsService.provision`, which performs the existing billing, slot, and active-machine checks in its transaction.
- Acceptable orphan states: if provider provisioning fails, the existing service marks the machine failed and returns a generic provisioning error; checkout/billing entitlements are not rolled back by this route.
- Auth source of truth: the new route accepts only a verified Clerk bearer/session token and provisions for the verified Clerk user id, never a client-supplied user id.
- Deferred scope: this does not redesign billing plan selection or region storage; it only completes the missing post-checkout provisioning handoff. Follow-up tracked in #299.

## Validation
- `bun run test tests/platform/proxy-routing.test.ts`
- `bun run test tests/platform/proxy-routing.test.ts -t "same-user handle when another runtime slot|same-user active machine|signed-in auth pages"`
- `bun run test tests/platform/customer-vps-host-bundle.test.ts tests/platform/customer-vps-cloud-init.test.ts tests/deploy/cloud-workspace-runtime.test.ts`
- `bun run test -- --shard=4/4`
- `bun run typecheck`
- `bun run check:patterns` (0 violations, existing warnings only)
- `git diff --check`
- `npm view opencode-ai version` -> `1.15.13`
- `npm view @earendil-works/pi-coding-agent version` -> `0.78.0`; `npm view @earendil-works/pi-coding-agent scripts bin` shows `bin.pi = dist/cli.js` and no `postinstall` script.
