### PR TITLE
fix(cli): explain expired auth sessions

### DIFF
--- a/packages/sync-client/src/cli/auth-state.ts
+++ b/packages/sync-client/src/cli/auth-state.ts
@@ -1,0 +1,52 @@
+import { isExpired, loadProfileAuth, type AuthData } from "../auth/token-store.js";
+import type { ResolvedCliProfile } from "./profiles.js";
+
+export type CliAuthStatus =
+  | { status: "authenticated"; token: string; auth: AuthData | null }
+  | { status: "expired"; auth: AuthData }
+  | { status: "missing"; auth: null };
+
+export function notAuthenticatedMessage(profileName: string): string {
+  return `Not logged in for profile "${profileName}". Run \`matrix login\` first.`;
+}
+
+export function authExpiredMessage(profileName: string, expiresAt: number): string {
+  return `Auth for profile "${profileName}" expired on ${new Date(expiresAt).toISOString()}. Run \`matrix login --profile ${profileName}\` to refresh.`;
+}
+
+export function createNotAuthenticatedError(profileName: string): Error {
+  return Object.assign(new Error(notAuthenticatedMessage(profileName)), {
+    code: "not_authenticated",
+  });
+}
+
+export function createAuthExpiredError(profileName: string, expiresAt: number): Error {
+  return Object.assign(new Error(authExpiredMessage(profileName, expiresAt)), {
+    code: "auth_expired",
+  });
+}
+
+export async function resolveCliAuthStatus(profile: ResolvedCliProfile): Promise<CliAuthStatus> {
+  if (profile.token) {
+    return { status: "authenticated", token: profile.token, auth: null };
+  }
+  const auth = await loadProfileAuth(profile.name);
+  if (!auth) {
+    return { status: "missing", auth: null };
+  }
+  if (isExpired(auth)) {
+    return { status: "expired", auth };
+  }
+  return { status: "authenticated", token: auth.accessToken, auth };
+}
+
+export async function requireCliAuthToken(profile: ResolvedCliProfile): Promise<string> {
+  const authStatus = await resolveCliAuthStatus(profile);
+  if (authStatus.status === "authenticated") {
+    return authStatus.token;
+  }
+  if (authStatus.status === "expired") {
+    throw createAuthExpiredError(profile.name, authStatus.auth.expiresAt);
+  }
+  throw createNotAuthenticatedError(profile.name);
+}

--- a/packages/sync-client/src/cli/commands/doctor.ts
+++ b/packages/sync-client/src/cli/commands/doctor.ts
@@ -1,9 +1,9 @@
 import { defineCommand } from "citty";
-import { isExpired, loadProfileAuth } from "../../auth/token-store.js";
 import { formatCliSuccess } from "../output.js";
 import { isDaemonRunning } from "../daemon-client.js";
 import { resolveCliProfile } from "../profiles.js";
 import { probeGatewayHealth } from "../gateway-health.js";
+import { resolveCliAuthStatus } from "../auth-state.js";
 
 interface DoctorCheck {
   name: string;
@@ -38,11 +38,18 @@ export const doctorCommand = defineCommand({
 
     let token: string | undefined;
     if (profile) {
-      const auth = profile.token ? null : await loadProfileAuth(profile.name);
-      token = profile.token ?? (auth && !isExpired(auth) ? auth.accessToken : undefined);
-      checks.push(token
+      const authStatus = await resolveCliAuthStatus(profile);
+      token = authStatus.status === "authenticated" ? authStatus.token : undefined;
+      checks.push(authStatus.status === "authenticated"
         ? { name: "auth", ok: true }
-        : { name: "auth", ok: false, code: "not_authenticated", hint: "Run `matrix login`." });
+        : authStatus.status === "expired"
+          ? {
+              name: "auth",
+              ok: false,
+              code: "auth_expired",
+              hint: `Run \`matrix login --profile ${profile.name}\` to refresh.`,
+            }
+          : { name: "auth", ok: false, code: "not_authenticated", hint: "Run `matrix login`." });
     } else {
       checks.push({ name: "auth", ok: false, code: "profile_not_found", hint: "Run `matrix login`." });
     }

--- a/packages/sync-client/src/cli/commands/instance.ts
+++ b/packages/sync-client/src/cli/commands/instance.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
-import { isExpired, loadProfileAuth } from "../../auth/token-store.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 import { resolveCliProfile } from "../profiles.js";
+import { requireCliAuthToken } from "../auth-state.js";
 
 interface InstanceRequestOptions {
   method?: "GET" | "POST";
@@ -12,7 +12,11 @@ function writeError(err: unknown, json: boolean): void {
     err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
       ? (err as { code: string }).code
       : "instance_request_failed";
-  console.error(json ? formatCliError(code) : `Error: Request failed (${code})`);
+  const safeMessage =
+    (code === "not_authenticated" || code === "auth_expired") && err instanceof Error
+      ? err.message
+      : undefined;
+  console.error(json ? formatCliError(code, safeMessage) : safeMessage ?? `Error: Request failed (${code})`);
 }
 
 async function requestInstance(
@@ -21,11 +25,7 @@ async function requestInstance(
   options: InstanceRequestOptions = {},
 ): Promise<Record<string, unknown>> {
   const profile = await resolveCliProfile(args);
-  const auth = profile.token ? null : await loadProfileAuth(profile.name);
-  const token = profile.token ?? (auth && !isExpired(auth) ? auth.accessToken : undefined);
-  if (!token) {
-    throw Object.assign(new Error("not_authenticated"), { code: "not_authenticated" });
-  }
+  const token = await requireCliAuthToken(profile);
 
   const res = await fetch(`${profile.platformUrl}${path}`, {
     ...(options.method ? { method: options.method } : {}),

--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -1,23 +1,16 @@
 import { defineCommand } from "citty";
 import { randomUUID } from "node:crypto";
-import { isExpired, loadProfileAuth } from "../../auth/token-store.js";
 import { resolveCliProfile } from "../profiles.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 import { createShellClient, type ShellClient } from "../shell-client.js";
+import { requireCliAuthToken } from "../auth-state.js";
 
 const RUN_USAGE = "Usage: matrix run -it [--session <name>] [-C <dir>] -- <command>";
 const RUN_VALUE_OPTIONS = new Set(["--gateway", "--profile", "--token", "--session", "-C", "--cwd"]);
 
 async function clientFromArgs(args: Record<string, unknown>) {
   const profile = await resolveCliProfile(args);
-  const auth = profile.token ? null : await loadProfileAuth(profile.name);
-  const token = profile.token ?? (auth && !isExpired(auth) ? auth.accessToken : undefined);
-  if (!token) {
-    throw Object.assign(
-      new Error(`Not logged in for profile "${profile.name}". Run \`matrix login\` first.`),
-      { code: "not_authenticated" },
-    );
-  }
+  const token = await requireCliAuthToken(profile);
   return createShellClient({ gatewayUrl: profile.gatewayUrl, token });
 }
 
@@ -104,7 +97,7 @@ function writeError(err: unknown, json: boolean): void {
       ? (err as { code: string }).code
       : "request_failed";
   const safeMessage =
-    code === "not_authenticated" || code === "invalid_request" || code === "not_implemented"
+    code === "not_authenticated" || code === "auth_expired" || code === "invalid_request" || code === "not_implemented"
       ? err instanceof Error ? err.message : undefined
       : undefined;
   console.error(json ? formatCliError(code, safeMessage) : safeMessage ?? `Error: Request failed (${code})`);

--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
 import { randomUUID } from "node:crypto";
 import { resolveCliProfile } from "../profiles.js";
-import { formatCliError, formatCliSuccess } from "../output.js";
+import { formatCliError, formatCliErrorMessage, formatCliSuccess } from "../output.js";
 import { createShellClient, type ShellClient } from "../shell-client.js";
 import { requireCliAuthToken } from "../auth-state.js";
 
@@ -96,11 +96,22 @@ function writeError(err: unknown, json: boolean): void {
     err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
       ? (err as { code: string }).code
       : "request_failed";
+  const canShowErrorMessage =
+    code === "not_authenticated" ||
+    (code === "auth_expired" && err instanceof Error && err.message !== "Request failed") ||
+    code === "invalid_request" ||
+    code === "not_implemented";
   const safeMessage =
-    code === "not_authenticated" || code === "auth_expired" || code === "invalid_request" || code === "not_implemented"
+    canShowErrorMessage
       ? err instanceof Error ? err.message : undefined
       : undefined;
-  console.error(json ? formatCliError(code, safeMessage) : safeMessage ?? `Error: Request failed (${code})`);
+  console.error(
+    json
+      ? formatCliError(code, safeMessage)
+      : code === "auth_expired"
+        ? formatCliErrorMessage(code, safeMessage)
+        : safeMessage ?? `Error: Request failed (${code})`,
+  );
 }
 
 export const runCommand = defineCommand({

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "citty";
 import { resolveCliProfile } from "../profiles.js";
-import { formatCliError, formatCliSuccess } from "../output.js";
+import { formatCliError, formatCliErrorMessage, formatCliSuccess } from "../output.js";
 import { createShellClient } from "../shell-client.js";
 import type { ShellAttachOptions } from "../shell-client.js";
 import { requireCliAuthToken } from "../auth-state.js";
@@ -73,13 +73,18 @@ function writeError(err: unknown, json: boolean): void {
     err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
       ? (err as { code: string }).code
       : "request_failed";
+  const canShowErrorMessage =
+    code === "not_authenticated" ||
+    (code === "auth_expired" && err instanceof Error && err.message !== "Request failed");
   const safeMessage =
-    (code === "not_authenticated" || code === "auth_expired") && err instanceof Error
+    canShowErrorMessage && err instanceof Error
       ? err.message
       : undefined;
   const output = json
     ? formatCliError(code, safeMessage)
-    : safeMessage ?? `Error: Request failed (${code})`;
+    : code === "auth_expired"
+      ? formatCliErrorMessage(code, safeMessage)
+      : safeMessage ?? `Error: Request failed (${code})`;
   console.error(output);
 }
 

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -1,9 +1,9 @@
 import { defineCommand } from "citty";
-import { isExpired, loadProfileAuth } from "../../auth/token-store.js";
 import { resolveCliProfile } from "../profiles.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 import { createShellClient } from "../shell-client.js";
 import type { ShellAttachOptions } from "../shell-client.js";
+import { requireCliAuthToken } from "../auth-state.js";
 
 const SHELL_USAGE = "Usage: matrix shell list|new|connect|rm|tab|pane|layout";
 const SHELL_SUBCOMMANDS = new Set([
@@ -39,14 +39,7 @@ function hasShellSubCommand(rawArgs: string[] | undefined): boolean {
 
 async function clientFromArgs(args: Record<string, unknown>) {
   const profile = await resolveCliProfile(args);
-  const auth = profile.token ? null : await loadProfileAuth(profile.name);
-  const token = profile.token ?? (auth && !isExpired(auth) ? auth.accessToken : undefined);
-  if (!token) {
-    throw Object.assign(
-      new Error(`Not logged in for profile "${profile.name}". Run \`matrix login\` first.`),
-      { code: "not_authenticated" },
-    );
-  }
+  const token = await requireCliAuthToken(profile);
   return createShellClient({ gatewayUrl: profile.gatewayUrl, token });
 }
 
@@ -81,7 +74,9 @@ function writeError(err: unknown, json: boolean): void {
       ? (err as { code: string }).code
       : "request_failed";
   const safeMessage =
-    code === "not_authenticated" && err instanceof Error ? err.message : undefined;
+    (code === "not_authenticated" || code === "auth_expired") && err instanceof Error
+      ? err.message
+      : undefined;
   const output = json
     ? formatCliError(code, safeMessage)
     : safeMessage ?? `Error: Request failed (${code})`;

--- a/packages/sync-client/src/cli/commands/status.ts
+++ b/packages/sync-client/src/cli/commands/status.ts
@@ -1,8 +1,8 @@
 import { defineCommand } from "citty";
-import { isExpired, loadProfileAuth } from "../../auth/token-store.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 import { resolveCliProfile } from "../profiles.js";
 import { probeGatewayHealth } from "../gateway-health.js";
+import { resolveCliAuthStatus } from "../auth-state.js";
 
 function writeError(err: unknown, json: boolean): void {
   const code =
@@ -25,13 +25,14 @@ export const statusCommand = defineCommand({
     const json = args.json === true;
     try {
       const profile = await resolveCliProfile(args);
-      const auth = profile.token ? null : await loadProfileAuth(profile.name);
-      const token = profile.token ?? (auth && !isExpired(auth) ? auth.accessToken : undefined);
+      const authStatus = await resolveCliAuthStatus(profile);
+      const token = authStatus.status === "authenticated" ? authStatus.token : undefined;
       const gateway = await probeGatewayHealth(profile.gatewayUrl, token);
       const data = {
         profile: profile.name,
         gatewayUrl: profile.gatewayUrl,
         authenticated: !!token,
+        ...(authStatus.status === "expired" ? { auth: "expired" as const } : {}),
         gateway,
       };
 
@@ -40,7 +41,7 @@ export const statusCommand = defineCommand({
       } else {
         console.log(`Profile: ${data.profile}`);
         console.log(`Gateway: ${data.gatewayUrl} (${data.gateway.status})`);
-        console.log(`Authenticated: ${data.authenticated ? "yes" : "no"}`);
+        console.log(`Authenticated: ${data.authenticated ? "yes" : authStatus.status === "expired" ? "expired" : "no"}`);
       }
     } catch (err: unknown) {
       writeError(err, json);

--- a/packages/sync-client/src/cli/commands/whoami.ts
+++ b/packages/sync-client/src/cli/commands/whoami.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
-import { isExpired, loadProfileAuth } from "../../auth/token-store.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 import { resolveCliProfile } from "../profiles.js";
+import { resolveCliAuthStatus } from "../auth-state.js";
 
 function writeError(err: unknown, json: boolean): void {
   const code =
@@ -22,23 +22,26 @@ export const whoamiCommand = defineCommand({
     const json = args.json === true;
     try {
       const profile = await resolveCliProfile(args);
-      const auth = await loadProfileAuth(profile.name);
-      const data = auth && !isExpired(auth)
+      const authStatus = await resolveCliAuthStatus(profile);
+      const data = authStatus.status === "authenticated" && authStatus.auth
         ? {
             profile: profile.name,
             authenticated: true,
-            userId: auth.userId,
-            handle: auth.handle,
+            userId: authStatus.auth.userId,
+            handle: authStatus.auth.handle,
           }
         : {
             profile: profile.name,
             authenticated: false,
+            ...(authStatus.status === "expired" ? { auth: "expired" as const } : {}),
           };
 
       if (json) {
         console.log(formatCliSuccess(data));
       } else if (data.authenticated) {
         console.log(`@${data.handle} (${data.profile})`);
+      } else if ("auth" in data && data.auth === "expired") {
+        console.log(`Login expired (${data.profile}). Run \`matrix login --profile ${data.profile}\` to refresh.`);
       } else {
         console.log(`Not logged in (${data.profile}).`);
       }

--- a/packages/sync-client/src/cli/commands/whoami.ts
+++ b/packages/sync-client/src/cli/commands/whoami.ts
@@ -23,23 +23,24 @@ export const whoamiCommand = defineCommand({
     try {
       const profile = await resolveCliProfile(args);
       const authStatus = await resolveCliAuthStatus(profile);
-      const data = authStatus.status === "authenticated" && authStatus.auth
-        ? {
-            profile: profile.name,
-            authenticated: true,
-            userId: authStatus.auth.userId,
-            handle: authStatus.auth.handle,
-          }
-        : {
-            profile: profile.name,
-            authenticated: false,
-            ...(authStatus.status === "expired" ? { auth: "expired" as const } : {}),
-          };
+      const data = {
+        profile: profile.name,
+        authenticated: authStatus.status === "authenticated",
+        ...(authStatus.status === "authenticated" && authStatus.auth
+          ? {
+              userId: authStatus.auth.userId,
+              handle: authStatus.auth.handle,
+            }
+          : {}),
+        ...(authStatus.status === "expired" ? { auth: "expired" as const } : {}),
+      };
 
       if (json) {
         console.log(formatCliSuccess(data));
-      } else if (data.authenticated) {
+      } else if (data.authenticated && "handle" in data) {
         console.log(`@${data.handle} (${data.profile})`);
+      } else if (data.authenticated) {
+        console.log(`Authenticated with explicit token (${data.profile}).`);
       } else if ("auth" in data && data.auth === "expired") {
         console.log(`Login expired (${data.profile}). Run \`matrix login --profile ${data.profile}\` to refresh.`);
       } else {

--- a/packages/sync-client/src/cli/output.ts
+++ b/packages/sync-client/src/cli/output.ts
@@ -11,12 +11,16 @@ export function formatCliSuccess(data: Record<string, unknown>): string {
   return JSON.stringify({ v: CLI_OUTPUT_VERSION, ok: true, data });
 }
 
+export function formatCliErrorMessage(code: string, message?: string): string {
+  return message ?? GENERIC_MESSAGES[code] ?? "Request failed";
+}
+
 export function formatCliError(code: string, message?: string): string {
   return JSON.stringify({
     v: CLI_OUTPUT_VERSION,
     error: {
       code,
-      message: message ?? GENERIC_MESSAGES[code] ?? "Request failed",
+      message: formatCliErrorMessage(code, message),
     },
   });
 }

--- a/packages/sync-client/src/cli/output.ts
+++ b/packages/sync-client/src/cli/output.ts
@@ -4,6 +4,7 @@ const GENERIC_MESSAGES: Record<string, string> = {
   zellij_failed: "Request failed",
   unknown_command: "Request failed",
   unsupported_version: "Request failed",
+  auth_expired: "Matrix CLI auth expired. Run `matrix login` to refresh your session.",
 };
 
 export function formatCliSuccess(data: Record<string, unknown>): string {

--- a/packages/sync-client/src/cli/recovery-hints.ts
+++ b/packages/sync-client/src/cli/recovery-hints.ts
@@ -4,6 +4,7 @@ const HINTS: Record<string, string> = {
   invalid_layout: "Layout is invalid. Inspect it with `matrix shell layout show <name>` before applying it.",
   timeout: "The request timed out. Check `matrix doctor` and retry.",
   attach_failed: "Terminal attach failed. reattach with `matrix shell connect <name>`.",
+  auth_expired: "Auth expired. Run `matrix login` to refresh this profile.",
   unsupported_version: "Daemon protocol is incompatible. Please update the Matrix CLI and restart the daemon.",
   unknown_command: "Daemon command is not supported. Please update the Matrix CLI and daemon together.",
 };

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -261,7 +261,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         typeof (payload as { error?: { code?: unknown } }).error?.code === "string"
           ? (payload as { error: { code: string } }).error.code
           : undefined;
-      const code = payloadCode ?? (res.status === 401 || res.status === 403 ? "auth_expired" : "request_failed");
+      const code = payloadCode ?? (res.status === 401 ? "auth_expired" : "request_failed");
       throw Object.assign(new Error("Request failed"), { code });
     }
 

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -254,13 +254,14 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
     }
 
     if (!res.ok) {
-      const code =
+      const payloadCode =
         typeof payload === "object" &&
         payload !== null &&
         "error" in payload &&
         typeof (payload as { error?: { code?: unknown } }).error?.code === "string"
           ? (payload as { error: { code: string } }).error.code
-          : "request_failed";
+          : undefined;
+      const code = payloadCode ?? (res.status === 401 || res.status === 403 ? "auth_expired" : "request_failed");
       throw Object.assign(new Error("Request failed"), { code });
     }
 

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -66,4 +66,35 @@ describe("doctor CLI command", () => {
     });
     await rm(root, { recursive: true, force: true });
   });
+
+  it("prompts to refresh expired profile auth", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-doctor-cli-"));
+    process.env.HOME = root;
+    await saveProfileAuth("cloud", {
+      accessToken: "expired-token",
+      expiresAt: Date.parse("2026-05-29T23:24:06.000Z"),
+      userId: "user_cloud",
+      handle: "cloud",
+    });
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ status: "ok" })));
+    vi.stubGlobal("fetch", fetchImpl);
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+
+    await doctorCommand.run!({ args: { json: true } } as never);
+
+    const parsed = JSON.parse(logs[0]);
+    expect(parsed.data.checks.find((check: { name: string }) => check.name === "auth")).toEqual({
+      name: "auth",
+      ok: false,
+      code: "auth_expired",
+      hint: "Run `matrix login --profile cloud` to refresh.",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith("https://app.matrix-os.com/api/system/info", {
+      signal: expect.any(AbortSignal),
+    });
+    await rm(root, { recursive: true, force: true });
+  });
 });

--- a/tests/cli/profile-auth.test.ts
+++ b/tests/cli/profile-auth.test.ts
@@ -134,6 +134,21 @@ describe("profile-aware auth CLI commands", () => {
     ]);
   });
 
+  it("reports authenticated when whoami uses an explicit token override", async () => {
+    const logs = captureLogs();
+
+    await whoamiCommand.run!({ args: { dev: true, token: "operator-token", json: true } } as never);
+
+    expect(JSON.parse(logs[0]!)).toEqual({
+      v: 1,
+      ok: true,
+      data: {
+        profile: "local",
+        authenticated: true,
+      },
+    });
+  });
+
   it("uses the resolved profile and token for status checks", async () => {
     await mkdir(join(process.env.HOME!, ".matrixos"), { recursive: true });
     await writeFile(

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -100,6 +100,23 @@ describe("shell REST client", () => {
     });
   });
 
+  it("maps gateway auth rejection to an auth refresh error", async () => {
+    const fetchImpl = vi.fn(async () => new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401 },
+    ));
+    const client = createShellClient({
+      gatewayUrl: "http://gateway",
+      token: "stale-token",
+      fetch: fetchImpl,
+    });
+
+    await expect(client.listSessions()).rejects.toMatchObject({
+      code: "auth_expired",
+      message: "Request failed",
+    });
+  });
+
   it("builds terminal websocket URLs without leaking bearer auth by default", () => {
     const client = createShellClient({
       gatewayUrl: "https://gateway.example",

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -117,6 +117,23 @@ describe("shell REST client", () => {
     });
   });
 
+  it("keeps gateway forbidden responses generic", async () => {
+    const fetchImpl = vi.fn(async () => new Response(
+      JSON.stringify({ error: "Forbidden" }),
+      { status: 403 },
+    ));
+    const client = createShellClient({
+      gatewayUrl: "http://gateway",
+      token: "valid-but-forbidden-token",
+      fetch: fetchImpl,
+    });
+
+    await expect(client.listSessions()).rejects.toMatchObject({
+      code: "request_failed",
+      message: "Request failed",
+    });
+  });
+
   it("builds terminal websocket URLs without leaking bearer auth by default", () => {
     const client = createShellClient({
       gatewayUrl: "https://gateway.example",

--- a/tests/cli/shell-recovery.test.ts
+++ b/tests/cli/shell-recovery.test.ts
@@ -8,5 +8,6 @@ describe("CLI recovery hints", () => {
     expect(recoveryHintForCode("invalid_layout")).toContain("matrix shell layout");
     expect(recoveryHintForCode("unsupported_version")).toContain("update");
     expect(recoveryHintForCode("attach_failed")).toContain("reattach");
+    expect(recoveryHintForCode("auth_expired")).toContain("matrix login");
   });
 });

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -156,11 +156,11 @@ describe("shell CLI command", () => {
     ]);
   });
 
-  it("treats expired profile auth as not authenticated", async () => {
+  it("prompts for login when profile auth is expired", async () => {
     await saveProfileAuth("local", {
       accessToken: "expired-token",
       refreshToken: "refresh-token",
-      expiresAt: Date.now() - 1,
+      expiresAt: Date.parse("2026-05-29T23:24:06.000Z"),
       userId: "user-1",
       handle: "local",
     });
@@ -179,8 +179,8 @@ describe("shell CLI command", () => {
     expect(JSON.parse(errors[0]!)).toEqual({
       v: 1,
       error: {
-        code: "not_authenticated",
-        message: 'Not logged in for profile "local". Run `matrix login` first.',
+        code: "auth_expired",
+        message: 'Auth for profile "local" expired on 2026-05-29T23:24:06.000Z. Run `matrix login --profile local` to refresh.',
       },
     });
   });

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -185,6 +185,36 @@ describe("shell CLI command", () => {
     });
   });
 
+  it("prompts for login when the gateway rejects profile auth", async () => {
+    await saveProfileAuth("local", {
+      accessToken: "stale-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 60_000,
+      userId: "user-1",
+      handle: "local",
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401 },
+    )));
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((line?: unknown) => {
+      errors.push(String(line));
+    });
+
+    await shellCommand.subCommands!.ls.run!({
+      args: { dev: true, json: true },
+    } as never);
+
+    expect(JSON.parse(errors[0]!)).toEqual({
+      v: 1,
+      error: {
+        code: "auth_expired",
+        message: "Matrix CLI auth expired. Run `matrix login` to refresh your session.",
+      },
+    });
+  });
+
   it("emits one clean JSON error from the real CLI when auth is missing", () => {
     const bin = join(process.cwd(), "packages/sync-client/bin/matrix.mjs");
 


### PR DESCRIPTION
## Summary
- distinguish expired saved CLI auth from missing auth and prompt users to refresh the selected profile
- map gateway 401 terminal REST responses to the stable `auth_expired` code while keeping 403 permission failures generic
- show expired auth in `matrix doctor`, `matrix status`, `matrix whoami`, recovery hints, JSON output, and gateway-rejection shell/run paths without leaking token details

## Invariants
- Source of truth: the per-profile auth file remains the canonical CLI session source; explicit `--token` stays an operator override and is treated as authenticated without saved profile metadata.
- Lock/transaction scope: no persistent writes are introduced; commands only read local profile/auth files and attach the resolved bearer token to existing requests.
- Acceptable orphan states: if a saved token expires or the gateway rejects it with 401, commands fail closed with `auth_expired` and do not delete profile data or mutate runtime state.
- Auth source of truth: local expiry is checked before network calls, gateway 401 remains authoritative for rejected bearer tokens, and 403 remains a generic permission/request failure.
- Deferred scope: this does not implement token refresh or browser sign-out propagation; users still refresh the CLI session with `matrix login`.

## Validation
- `bun run test tests/cli/shell.test.ts tests/cli/shell-client.test.ts tests/cli/shell-recovery.test.ts tests/cli/doctor.test.ts tests/cli/status.test.ts tests/cli/profile-auth.test.ts tests/cli/instance.test.ts tests/cli/run.test.ts`
- `bun run test tests/cli/shell-client.test.ts tests/cli/profile-auth.test.ts tests/cli/whoami.test.ts`
- `bun run test tests/cli/shell.test.ts tests/cli/shell-client.test.ts tests/cli/profile-auth.test.ts tests/cli/run.test.ts tests/cli/json-output.test.ts`
- `bun run check:patterns` (0 violations, existing warnings only)
- `bun run typecheck`
- `bun run test` (passed on earlier head before the Greptile follow-up fixes)

## Review/Monitoring
- Monitoring exact head `67e826611355fe6fae7a5809eb6ae634bae33012` for CI and Greptile.
