### PR TITLE
ci(release): slim host bundle artifacts

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -216,7 +216,29 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: host-bundle
-          path: dist/host-bundle
+          path: dist/host-bundle-artifact
+
+      - name: Normalize downloaded bundle artifact
+        run: |
+          set -euo pipefail
+          ARTIFACT_DIR="dist/host-bundle-artifact"
+          TARGET_DIR="dist/host-bundle"
+          BUNDLE_FILE="$(find "$ARTIFACT_DIR" -type f -name matrix-host-bundle.tar.gz -print -quit)"
+          if [ -z "$BUNDLE_FILE" ]; then
+            echo "Downloaded host bundle artifact did not contain matrix-host-bundle.tar.gz" >&2
+            find "$ARTIFACT_DIR" -maxdepth 4 -type f -print >&2
+            exit 1
+          fi
+          SOURCE_DIR="$(dirname "$BUNDLE_FILE")"
+          mkdir -p "$TARGET_DIR"
+          for file in matrix-host-bundle.tar.gz matrix-host-bundle.tar.gz.sha256 manifest.json release.json; do
+            if [ ! -f "$SOURCE_DIR/$file" ]; then
+              echo "Downloaded host bundle artifact is missing $file" >&2
+              find "$ARTIFACT_DIR" -maxdepth 4 -type f -print >&2
+              exit 1
+            fi
+            cp "$SOURCE_DIR/$file" "$TARGET_DIR/$file"
+          done
 
       - name: Install AWS CLI
         run: |

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -54,7 +54,7 @@ permissions:
 
 concurrency:
   group: host-bundle-release-${{ github.event_name == 'workflow_dispatch' && inputs.channel || github.ref_type == 'tag' && github.ref_name || 'dev' }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.ref_type != 'tag' && (github.event_name != 'workflow_dispatch' || inputs.channel == 'dev' || inputs.channel == '') }}
 
 jobs:
   dev-bundle-gate:
@@ -188,7 +188,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: host-bundle
-          path: dist/host-bundle/
+          path: |
+            dist/host-bundle/matrix-host-bundle.tar.gz
+            dist/host-bundle/matrix-host-bundle.tar.gz.sha256
+            dist/host-bundle/manifest.json
+            dist/host-bundle/release.json
           if-no-files-found: error
           retention-days: 14
 
@@ -212,7 +216,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: host-bundle
-          path: dist/host-bundle/
+          path: dist/host-bundle
 
       - name: Install AWS CLI
         run: |

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -170,6 +170,28 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('paths-ignore:');
   });
 
+  it('host bundle release workflow uploads only publishable bundle artifacts', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('name: Upload bundle artifact');
+    expect(workflow).toContain('dist/host-bundle/matrix-host-bundle.tar.gz');
+    expect(workflow).toContain('dist/host-bundle/matrix-host-bundle.tar.gz.sha256');
+    expect(workflow).toContain('dist/host-bundle/manifest.json');
+    expect(workflow).toContain('dist/host-bundle/release.json');
+    expect(workflow).not.toContain('path: dist/host-bundle/');
+    expect(workflow).not.toContain('dist/host-bundle/stage');
+  });
+
+  it('host bundle release workflow cancels only superseded dev-channel builds', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain("group: host-bundle-release-${{ github.event_name == 'workflow_dispatch' && inputs.channel || github.ref_type == 'tag' && github.ref_name || 'dev' }}");
+    expect(workflow).toContain("cancel-in-progress: ${{ github.ref_type != 'tag' && (github.event_name != 'workflow_dispatch' || inputs.channel == 'dev' || inputs.channel == '') }}");
+    expect(workflow).not.toContain('cancel-in-progress: false');
+  });
+
   it('dev bundle gate builds branch pushes even when commit messages request a skip', () => {
     const result = runDevBundleGate({
       GITHUB_EVENT_NAME: 'push',

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -183,6 +183,18 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('dist/host-bundle/stage');
   });
 
+  it('host bundle release workflow normalizes downloaded artifact layout before publishing', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('path: dist/host-bundle-artifact');
+    expect(workflow).toContain('name: Normalize downloaded bundle artifact');
+    expect(workflow).toContain('BUNDLE_FILE="$(find "$ARTIFACT_DIR" -type f -name matrix-host-bundle.tar.gz -print -quit)"');
+    expect(workflow).toContain('TARGET_DIR="dist/host-bundle"');
+    expect(workflow).toContain('for file in matrix-host-bundle.tar.gz matrix-host-bundle.tar.gz.sha256 manifest.json release.json; do');
+    expect(workflow).toContain('cp "$SOURCE_DIR/$file" "$TARGET_DIR/$file"');
+  });
+
   it('host bundle release workflow cancels only superseded dev-channel builds', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');


### PR DESCRIPTION
## Summary

- Upload only the publishable host bundle tarball, checksum, manifest, and release metadata as the GitHub artifact.
- Cancel superseded dev-channel bundle builds while keeping tags and non-dev manual releases non-canceling.

## Verification

- `pnpm test tests/platform/customer-vps-host-bundle.test.ts`
- `pnpm test tests/gateway/onboarding-tool-packs.test.ts tests/platform/customer-vps-host-bundle.test.ts`
- `pnpm --filter @matrix-os/gateway build`
- `bun run check:patterns`

## Notes

This keeps the existing build and publish split intact, but removes the 300k-file `dist/host-bundle/stage` upload that was dominating successful release runtime.