### PR TITLE
feat(onboarding): add selectable tool packs

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -216,7 +216,29 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: host-bundle
-          path: dist/host-bundle
+          path: dist/host-bundle-artifact
+
+      - name: Normalize downloaded bundle artifact
+        run: |
+          set -euo pipefail
+          ARTIFACT_DIR="dist/host-bundle-artifact"
+          TARGET_DIR="dist/host-bundle"
+          BUNDLE_FILE="$(find "$ARTIFACT_DIR" -type f -name matrix-host-bundle.tar.gz -print -quit)"
+          if [ -z "$BUNDLE_FILE" ]; then
+            echo "Downloaded host bundle artifact did not contain matrix-host-bundle.tar.gz" >&2
+            find "$ARTIFACT_DIR" -maxdepth 4 -type f -print >&2
+            exit 1
+          fi
+          SOURCE_DIR="$(dirname "$BUNDLE_FILE")"
+          mkdir -p "$TARGET_DIR"
+          for file in matrix-host-bundle.tar.gz matrix-host-bundle.tar.gz.sha256 manifest.json release.json; do
+            if [ ! -f "$SOURCE_DIR/$file" ]; then
+              echo "Downloaded host bundle artifact is missing $file" >&2
+              find "$ARTIFACT_DIR" -maxdepth 4 -type f -print >&2
+              exit 1
+            fi
+            cp "$SOURCE_DIR/$file" "$TARGET_DIR/$file"
+          done
 
       - name: Install AWS CLI
         run: |

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -54,7 +54,7 @@ permissions:
 
 concurrency:
   group: host-bundle-release-${{ github.event_name == 'workflow_dispatch' && inputs.channel || github.ref_type == 'tag' && github.ref_name || 'dev' }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.ref_type != 'tag' && (github.event_name != 'workflow_dispatch' || inputs.channel == 'dev' || inputs.channel == '') }}
 
 jobs:
   dev-bundle-gate:
@@ -188,7 +188,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: host-bundle
-          path: dist/host-bundle/
+          path: |
+            dist/host-bundle/matrix-host-bundle.tar.gz
+            dist/host-bundle/matrix-host-bundle.tar.gz.sha256
+            dist/host-bundle/manifest.json
+            dist/host-bundle/release.json
           if-no-files-found: error
           retention-days: 14
 
@@ -212,7 +216,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: host-bundle
-          path: dist/host-bundle/
+          path: dist/host-bundle
 
       - name: Install AWS CLI
         run: |

--- a/distro/customer-vps/host-bin/matrix-install-tool-pack
+++ b/distro/customer-vps/host-bin/matrix-install-tool-pack
@@ -124,6 +124,14 @@ install_hermes() {
 
 install_linux_tools() {
   log "installing Linux developer tools"
+  if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files matrix-linux-tools.service >/dev/null 2>&1; then
+    if [ "$(id -u)" = "0" ]; then
+      systemctl start matrix-linux-tools.service
+    else
+      sudo systemctl start matrix-linux-tools.service
+    fi
+    return
+  fi
   if [ "$(id -u)" = "0" ]; then
     sudo -H -u "$MATRIX_RUNTIME_USER" /opt/matrix/bin/matrix-install-linux-tools
   else

--- a/distro/customer-vps/host-bin/matrix-install-tool-pack
+++ b/distro/customer-vps/host-bin/matrix-install-tool-pack
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MATRIX_RUNTIME_USER="${MATRIX_RUNTIME_USER:-matrix}"
+MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-/home/matrix}"
+MATRIX_APP_DIR="${MATRIX_APP_DIR:-/opt/matrix/app}"
+MATRIX_RUNTIME_DIR="${MATRIX_RUNTIME_DIR:-/opt/matrix/runtime}"
+NODE_PREFIX="${MATRIX_NODE_PREFIX:-$MATRIX_RUNTIME_DIR/node}"
+CODE_SERVER_VERSION="${HOST_BUNDLE_CODE_SERVER_VERSION:-4.116.0}"
+CODE_SERVER_DIST="code-server-${CODE_SERVER_VERSION}-linux-amd64"
+CODE_SERVER_ARCHIVE="${CODE_SERVER_DIST}.tar.gz"
+CODE_SERVER_URL="https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/${CODE_SERVER_ARCHIVE}"
+export PATH="$NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+log() {
+  printf 'matrix-install-tool-pack: %s\n' "$*"
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: matrix-install-tool-pack <coding-agents|code-server|hermes|linux-tools|all>
+EOF
+}
+
+retry() {
+  local max_attempts="$1"
+  local delay_seconds="$2"
+  shift 2
+  local attempt=1
+  until "$@"; do
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      return 1
+    fi
+    log "attempt ${attempt} failed, retrying in ${delay_seconds}s"
+    sleep "$delay_seconds"
+    attempt=$((attempt + 1))
+  done
+}
+
+run_as_matrix() {
+  if [ "$(id -u -n)" = "$MATRIX_RUNTIME_USER" ]; then
+    env HOME="$MATRIX_RUNTIME_HOME" PATH="$NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" "$@"
+    return
+  fi
+  sudo -H -u "$MATRIX_RUNTIME_USER" env \
+    HOME="$MATRIX_RUNTIME_HOME" \
+    PATH="$NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \
+    "$@"
+}
+
+runtime_chmod() {
+  if [ "$(id -u)" = "0" ]; then
+    chmod -R g+rwX "$NODE_PREFIX/lib/node_modules" "$NODE_PREFIX/bin"
+    find "$NODE_PREFIX/lib/node_modules" "$NODE_PREFIX/bin" -type d -exec chmod g+s {} +
+    return
+  fi
+  sudo chmod -R g+rwX "$NODE_PREFIX/lib/node_modules" "$NODE_PREFIX/bin"
+  sudo find "$NODE_PREFIX/lib/node_modules" "$NODE_PREFIX/bin" -type d -exec chmod g+s {} +
+}
+
+with_pack_lock() {
+  local pack="$1"
+  shift
+  local lock_path="/tmp/matrix-tool-pack-${pack}.lock"
+  exec 9>"$lock_path"
+  if ! flock -n 9; then
+    log "${pack} install is already running"
+    exit 0
+  fi
+  "$@"
+}
+
+sync_agent_skills() {
+  if [ -x "$MATRIX_APP_DIR/scripts/sync-matrix-agent-skills.sh" ] && [ -d "$MATRIX_APP_DIR/skills/matrix" ]; then
+    run_as_matrix bash -lc "cd '$MATRIX_APP_DIR' && MATRIX_SKILL_TARGETS=matrix,claude,codex MATRIX_SKILLS_SOURCE='$MATRIX_APP_DIR/skills/matrix' MATRIX_HOME='${MATRIX_HOME:-$MATRIX_RUNTIME_HOME/home}' ./scripts/sync-matrix-agent-skills.sh"
+  fi
+}
+
+install_coding_agents() {
+  log "installing coding agent CLIs"
+  run_as_matrix timeout 900 "$NODE_PREFIX/bin/npm" install -g --prefix "$NODE_PREFIX" \
+    @anthropic-ai/claude-code@latest \
+    @openai/codex@latest \
+    opencode-ai@1.14.25 \
+    @mariozechner/pi-coding-agent@0.70.2
+  runtime_chmod
+  sync_agent_skills
+  log "coding agent CLIs installed"
+}
+
+install_code_server() {
+  if command -v code-server >/dev/null 2>&1; then
+    log "code-server is already installed"
+    return
+  fi
+  log "installing code-server ${CODE_SERVER_VERSION}"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir:-}"' RETURN
+  retry 3 15 curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
+    --connect-timeout 10 --max-time 180 \
+    "$CODE_SERVER_URL" -o "$tmp_dir/$CODE_SERVER_ARCHIVE"
+  tar -xzf "$tmp_dir/$CODE_SERVER_ARCHIVE" -C "$tmp_dir"
+  sudo rm -rf "$MATRIX_RUNTIME_DIR/code-server"
+  sudo mv "$tmp_dir/$CODE_SERVER_DIST" "$MATRIX_RUNTIME_DIR/code-server"
+  sudo chown -R root:matrix "$MATRIX_RUNTIME_DIR/code-server"
+  sudo chmod -R g+rwX "$MATRIX_RUNTIME_DIR/code-server"
+  cat > "$NODE_PREFIX/bin/code-server" <<'EOS'
+#!/usr/bin/env sh
+exec /opt/matrix/runtime/code-server/bin/code-server "$@"
+EOS
+  chmod 0755 "$NODE_PREFIX/bin/code-server"
+  log "code-server installed"
+}
+
+install_hermes() {
+  log "installing Hermes"
+  if [ "$(id -u)" = "0" ]; then
+    /opt/matrix/bin/matrix-install-hermes
+  else
+    sudo /opt/matrix/bin/matrix-install-hermes
+  fi
+}
+
+install_linux_tools() {
+  log "installing Linux developer tools"
+  if [ "$(id -u)" = "0" ]; then
+    sudo -H -u "$MATRIX_RUNTIME_USER" /opt/matrix/bin/matrix-install-linux-tools
+  else
+    /opt/matrix/bin/matrix-install-linux-tools
+  fi
+}
+
+pack="${1:-}"
+case "$pack" in
+  coding-agents) with_pack_lock "$pack" install_coding_agents ;;
+  code-server) with_pack_lock "$pack" install_code_server ;;
+  hermes) with_pack_lock "$pack" install_hermes ;;
+  linux-tools) with_pack_lock "$pack" install_linux_tools ;;
+  all)
+    with_pack_lock coding-agents install_coding_agents &
+    pid_coding_agents="$!"
+    with_pack_lock code-server install_code_server &
+    pid_code_server="$!"
+    with_pack_lock hermes install_hermes &
+    pid_hermes="$!"
+    with_pack_lock linux-tools install_linux_tools &
+    pid_linux_tools="$!"
+    wait "$pid_coding_agents" "$pid_code_server" "$pid_hermes" "$pid_linux_tools"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/distro/customer-vps/host-bin/matrix-install-tool-pack
+++ b/distro/customer-vps/host-bin/matrix-install-tool-pack
@@ -65,7 +65,7 @@ with_pack_lock() {
   exec 9>"$lock_path"
   if ! flock -n 9; then
     log "${pack} install is already running"
-    exit 0
+    return 75
   fi
   "$@"
 }
@@ -146,7 +146,13 @@ case "$pack" in
     pid_hermes="$!"
     with_pack_lock linux-tools install_linux_tools &
     pid_linux_tools="$!"
-    wait "$pid_coding_agents" "$pid_code_server" "$pid_hermes" "$pid_linux_tools"
+    failed=0
+    for pid in "$pid_coding_agents" "$pid_code_server" "$pid_hermes" "$pid_linux_tools"; do
+      if ! wait "$pid"; then
+        failed=1
+      fi
+    done
+    exit "$failed"
     ;;
   *)
     usage

--- a/packages/gateway/src/onboarding/activation-contracts.ts
+++ b/packages/gateway/src/onboarding/activation-contracts.ts
@@ -285,6 +285,74 @@ export const RetryGateResponseSchema = z.object({
 });
 export type RetryGateResponse = z.infer<typeof RetryGateResponseSchema>;
 
+export const ToolPackIdSchema = z.enum([
+  "coding-agents",
+  "code-server",
+  "hermes",
+  "linux-tools",
+]);
+export type ToolPackId = z.infer<typeof ToolPackIdSchema>;
+
+export const ToolPackCategorySchema = z.enum([
+  "agent",
+  "editor",
+  "system",
+]);
+export type ToolPackCategory = z.infer<typeof ToolPackCategorySchema>;
+
+export const ToolPackInstallStatusSchema = z.enum([
+  "available",
+  "selected",
+  "installing",
+  "installed",
+  "failed",
+  "unavailable",
+]);
+export type ToolPackInstallStatus = z.infer<typeof ToolPackInstallStatusSchema>;
+
+export const ToolPackSummarySchema = z.object({
+  id: ToolPackIdSchema,
+  category: ToolPackCategorySchema,
+  label: z.string().trim().min(1).max(80),
+  description: z.string().trim().min(1).max(240),
+  commands: z.array(z.string().trim().min(1).max(40).regex(SAFE_ID)).max(8),
+  selected: z.boolean(),
+  installed: z.boolean(),
+  defaultSelected: z.boolean(),
+  status: ToolPackInstallStatusSchema,
+  installJobId: ReadinessGateIdSchema.nullable(),
+});
+export type ToolPackSummary = z.infer<typeof ToolPackSummarySchema>;
+
+export const ToolPackInstallJobStatusSchema = z.enum([
+  "installing",
+  "installed",
+  "failed",
+]);
+export type ToolPackInstallJobStatus = z.infer<typeof ToolPackInstallJobStatusSchema>;
+
+export const ToolPackInstallJobSummarySchema = z.object({
+  id: ReadinessGateIdSchema,
+  packId: ToolPackIdSchema,
+  status: ToolPackInstallJobStatusSchema,
+  startedAt: ActivationDateSchema,
+  completedAt: ActivationDateSchema.nullable(),
+  message: OptionalSafeDisplayTextSchema,
+});
+export type ToolPackInstallJobSummary = z.infer<typeof ToolPackInstallJobSummarySchema>;
+
+export const ToolPacksResponseSchema = z.object({
+  packs: z.array(ToolPackSummarySchema).min(1).max(8),
+  selectedPackIds: z.array(ToolPackIdSchema).max(8),
+  installJobs: z.array(ToolPackInstallJobSummarySchema).max(64),
+});
+export type ToolPacksResponse = z.infer<typeof ToolPacksResponseSchema>;
+
+export const SelectToolPacksRequestSchema = z.object({
+  packIds: z.array(ToolPackIdSchema).min(1).max(8),
+});
+export type SelectToolPacksRequest = z.infer<typeof SelectToolPacksRequestSchema>;
+
 export const ActivationErrorResponseSchema = z.object({
   error: z.string().min(1).max(80),
   message: z.string().min(1).max(160),

--- a/packages/gateway/src/onboarding/tool-pack-routes.ts
+++ b/packages/gateway/src/onboarding/tool-pack-routes.ts
@@ -1,0 +1,59 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { SelectToolPacksRequestSchema } from "./activation-contracts.js";
+import { mapActivationError } from "./activation-errors.js";
+import type { ToolPackService } from "./tool-packs.js";
+import {
+  requireRequestPrincipal,
+  type RequestPrincipal,
+} from "../request-principal.js";
+
+const TOOL_PACK_BODY_LIMIT = 2048;
+
+export interface ToolPackRouteDeps {
+  service: ToolPackService;
+  getPrincipal?: (c: Context) => RequestPrincipal;
+}
+
+function jsonError(c: Context, err: unknown) {
+  const mapped = mapActivationError(err);
+  return c.json(mapped.body, mapped.status as ContentfulStatusCode);
+}
+
+export function createToolPackRoutes(deps: ToolPackRouteDeps): Hono {
+  const app = new Hono();
+  const limited = bodyLimit({ maxSize: TOOL_PACK_BODY_LIMIT });
+  const principalFor = (c: Context) => deps.getPrincipal?.(c) ?? requireRequestPrincipal(c);
+
+  app.get("/tools", async (c) => {
+    try {
+      const principal = principalFor(c);
+      return c.json(await deps.service.listToolPacks(principal.userId));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/tools/selection", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      const body = SelectToolPacksRequestSchema.parse(await c.req.json());
+      return c.json(await deps.service.selectToolPacks(principal.userId, body.packIds));
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  app.post("/tools/install", limited, async (c) => {
+    try {
+      const principal = principalFor(c);
+      const body = SelectToolPacksRequestSchema.parse(await c.req.json());
+      return c.json(await deps.service.installToolPacks(principal.userId, body.packIds), 202);
+    } catch (err) {
+      return jsonError(c, err);
+    }
+  });
+
+  return app;
+}

--- a/packages/gateway/src/onboarding/tool-packs.ts
+++ b/packages/gateway/src/onboarding/tool-packs.ts
@@ -131,9 +131,11 @@ export function createHostToolPackInstaller(options: {
 export function createToolPackService(options: {
   repository: ToolPackRepository;
   installer?: ToolPackInstaller;
+  installTimeoutMs?: number;
   now?: () => Date;
 }): ToolPackService {
   const now = options.now ?? (() => new Date());
+  const installTimeoutMs = options.installTimeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
   let jobCounter = 0;
 
   function createEmptyRecord(ownerId: string): ToolPackRecord {
@@ -153,9 +155,24 @@ export function createToolPackService(options: {
     return Array.from(new Set(packIds));
   }
 
-  function latestJobForPack(record: ToolPackRecord, packId: ToolPackId): ToolPackInstallJobSummary | null {
-    for (let index = record.installJobs.length - 1; index >= 0; index -= 1) {
-      const job = record.installJobs[index];
+  function normalizeJob(job: ToolPackInstallJobSummary): ToolPackInstallJobSummary {
+    if (job.status !== "installing") return job;
+    const startedAtMs = Date.parse(job.startedAt);
+    if (!Number.isFinite(startedAtMs) || now().getTime() - startedAtMs <= installTimeoutMs) return job;
+    return {
+      ...job,
+      status: "failed",
+      completedAt: now().toISOString(),
+      message: "Install status unavailable",
+    };
+  }
+
+  function latestJobForPack(
+    installJobs: ToolPackInstallJobSummary[],
+    packId: ToolPackId,
+  ): ToolPackInstallJobSummary | null {
+    for (let index = installJobs.length - 1; index >= 0; index -= 1) {
+      const job = installJobs[index];
       if (job.packId === packId) return job;
     }
     return null;
@@ -163,8 +180,9 @@ export function createToolPackService(options: {
 
   function responseFor(record: ToolPackRecord): ToolPacksResponse {
     const selected = new Set(record.selectedPackIds);
+    const installJobs = record.installJobs.map(normalizeJob);
     const packs = TOOL_PACKS.map<ToolPackSummary>((pack) => {
-      const latestJob = latestJobForPack(record, pack.id);
+      const latestJob = latestJobForPack(installJobs, pack.id);
       const installed = latestJob?.status === "installed";
       const selectedPack = selected.has(pack.id);
       return {
@@ -178,7 +196,7 @@ export function createToolPackService(options: {
     return {
       packs,
       selectedPackIds: [...record.selectedPackIds],
-      installJobs: [...record.installJobs],
+      installJobs,
     };
   }
 
@@ -214,6 +232,19 @@ export function createToolPackService(options: {
     });
   }
 
+  async function safelyMarkJob(
+    ownerId: string,
+    jobId: string,
+    status: ToolPackInstallJobSummary["status"],
+    message: string | null,
+  ): Promise<void> {
+    try {
+      await markJob(ownerId, jobId, status, message);
+    } catch (err: unknown) {
+      console.warn("[onboarding] tool pack job status update failed:", err instanceof Error ? err.message : String(err));
+    }
+  }
+
   function runInstall(ownerId: string, job: ToolPackInstallJobSummary): void {
     void (async () => {
       try {
@@ -221,10 +252,10 @@ export function createToolPackService(options: {
           throw new Error("Tool pack installer is unavailable");
         }
         await options.installer.install(ownerId, job.packId);
-        await markJob(ownerId, job.id, "installed", "Installed");
+        await safelyMarkJob(ownerId, job.id, "installed", "Installed");
       } catch (err: unknown) {
         console.warn("[onboarding] tool pack install failed:", err instanceof Error ? err.message : String(err));
-        await markJob(ownerId, job.id, "failed", "Install failed");
+        await safelyMarkJob(ownerId, job.id, "failed", "Install failed");
       }
     })();
   }

--- a/packages/gateway/src/onboarding/tool-packs.ts
+++ b/packages/gateway/src/onboarding/tool-packs.ts
@@ -186,7 +186,7 @@ export function createToolPackService(options: {
     const installJobs = record.installJobs.map(normalizeJob);
     const packs = TOOL_PACKS.map<ToolPackSummary>((pack) => {
       const latestJob = latestJobForPack(installJobs, pack.id);
-      const installed = latestJob?.status === "installed";
+      const installed = installJobs.some((job) => job.packId === pack.id && job.status === "installed");
       const selectedPack = selected.has(pack.id);
       return {
         ...pack,

--- a/packages/gateway/src/onboarding/tool-packs.ts
+++ b/packages/gateway/src/onboarding/tool-packs.ts
@@ -56,6 +56,7 @@ const DEFAULT_SELECTED_PACK_IDS = TOOL_PACKS
 const MAX_TOOL_PACK_RECORDS = 512;
 const MAX_INSTALL_JOBS_PER_OWNER = 64;
 const DEFAULT_INSTALL_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_LINUX_TOOLS_INSTALL_TIMEOUT_MS = 30 * 60 * 1000;
 const MAX_INSTALL_OUTPUT_BYTES = 16_384;
 
 export interface ToolPackRecord {
@@ -117,13 +118,15 @@ export class InMemoryToolPackRepository implements ToolPackRepository {
 export function createHostToolPackInstaller(options: {
   scriptPath?: string;
   timeoutMs?: number;
+  linuxToolsTimeoutMs?: number;
 } = {}): ToolPackInstaller {
   const scriptPath = options.scriptPath ?? "/opt/matrix/bin/matrix-install-tool-pack";
   const timeoutMs = options.timeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
+  const linuxToolsTimeoutMs = options.linuxToolsTimeoutMs ?? DEFAULT_LINUX_TOOLS_INSTALL_TIMEOUT_MS;
 
   return {
     install: async (ownerId, packId) => {
-      await runHostInstaller(scriptPath, ownerId, packId, timeoutMs);
+      await runHostInstaller(scriptPath, ownerId, packId, packId === "linux-tools" ? linuxToolsTimeoutMs : timeoutMs);
     },
   };
 }

--- a/packages/gateway/src/onboarding/tool-packs.ts
+++ b/packages/gateway/src/onboarding/tool-packs.ts
@@ -1,0 +1,296 @@
+import { spawn } from "node:child_process";
+import type {
+  ToolPackId,
+  ToolPackInstallJobSummary,
+  ToolPackSummary,
+  ToolPacksResponse,
+} from "./activation-contracts.js";
+
+interface ToolPackDefinition {
+  id: ToolPackId;
+  category: ToolPackSummary["category"];
+  label: string;
+  description: string;
+  commands: string[];
+  defaultSelected: boolean;
+}
+
+const TOOL_PACKS: ToolPackDefinition[] = [
+  {
+    id: "hermes",
+    category: "agent",
+    label: "Hermes",
+    description: "Matrix system agent, bundled Matrix skills, and Hermes runtime setup.",
+    commands: ["hermes", "uv", "uvx"],
+    defaultSelected: true,
+  },
+  {
+    id: "coding-agents",
+    category: "agent",
+    label: "Coding agents",
+    description: "Claude Code, Codex, OpenCode, and Pi command-line coding agents.",
+    commands: ["claude", "codex", "opencode", "pi"],
+    defaultSelected: false,
+  },
+  {
+    id: "code-server",
+    category: "editor",
+    label: "Browser editor",
+    description: "code-server for the browser-based editor path on the owner VPS.",
+    commands: ["code-server"],
+    defaultSelected: false,
+  },
+  {
+    id: "linux-tools",
+    category: "system",
+    label: "Linux developer tools",
+    description: "Homebrew, Graphite, GitHub CLI, and build tools for local workflow polish.",
+    commands: ["brew", "gt", "gh"],
+    defaultSelected: false,
+  },
+];
+
+const DEFAULT_SELECTED_PACK_IDS = TOOL_PACKS
+  .filter((pack) => pack.defaultSelected)
+  .map((pack) => pack.id);
+const MAX_TOOL_PACK_RECORDS = 512;
+const MAX_INSTALL_JOBS_PER_OWNER = 64;
+const DEFAULT_INSTALL_TIMEOUT_MS = 15 * 60 * 1000;
+const MAX_INSTALL_OUTPUT_BYTES = 16_384;
+
+export interface ToolPackRecord {
+  ownerId: string;
+  selectedPackIds: ToolPackId[];
+  installJobs: ToolPackInstallJobSummary[];
+  updatedAt: string;
+}
+
+export interface ToolPackRepository {
+  get(ownerId: string): Promise<ToolPackRecord | null>;
+  save(record: ToolPackRecord): Promise<ToolPackRecord>;
+  update(ownerId: string, updater: (record: ToolPackRecord | null) => ToolPackRecord): Promise<ToolPackRecord>;
+}
+
+export interface ToolPackInstaller {
+  install(ownerId: string, packId: ToolPackId): Promise<void>;
+}
+
+export interface ToolPackService {
+  listToolPacks(ownerId: string): Promise<ToolPacksResponse>;
+  selectToolPacks(ownerId: string, packIds: ToolPackId[]): Promise<ToolPacksResponse>;
+  installToolPacks(ownerId: string, packIds: ToolPackId[]): Promise<ToolPacksResponse>;
+}
+
+export class InMemoryToolPackRepository implements ToolPackRepository {
+  private readonly records = new Map<string, ToolPackRecord>();
+
+  async get(ownerId: string): Promise<ToolPackRecord | null> {
+    const record = this.records.get(ownerId);
+    if (record) {
+      this.records.delete(ownerId);
+      this.records.set(ownerId, record);
+    }
+    return record ? structuredClone(record) : null;
+  }
+
+  async save(record: ToolPackRecord): Promise<ToolPackRecord> {
+    const cloned = structuredClone(record);
+    if (!this.records.has(record.ownerId) && this.records.size >= MAX_TOOL_PACK_RECORDS) {
+      const oldestKey = this.records.keys().next().value as string | undefined;
+      if (oldestKey) this.records.delete(oldestKey);
+    }
+    this.records.delete(record.ownerId);
+    this.records.set(record.ownerId, cloned);
+    return structuredClone(cloned);
+  }
+
+  async update(ownerId: string, updater: (record: ToolPackRecord | null) => ToolPackRecord): Promise<ToolPackRecord> {
+    const current = this.records.get(ownerId) ?? null;
+    const next = updater(current ? structuredClone(current) : null);
+    if (next.ownerId !== ownerId) {
+      throw new Error("Tool pack repository update cannot change ownerId");
+    }
+    return this.save(next);
+  }
+}
+
+export function createHostToolPackInstaller(options: {
+  scriptPath?: string;
+  timeoutMs?: number;
+} = {}): ToolPackInstaller {
+  const scriptPath = options.scriptPath ?? "/opt/matrix/bin/matrix-install-tool-pack";
+  const timeoutMs = options.timeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
+
+  return {
+    install: async (ownerId, packId) => {
+      await runHostInstaller(scriptPath, ownerId, packId, timeoutMs);
+    },
+  };
+}
+
+export function createToolPackService(options: {
+  repository: ToolPackRepository;
+  installer?: ToolPackInstaller;
+  now?: () => Date;
+}): ToolPackService {
+  const now = options.now ?? (() => new Date());
+  let jobCounter = 0;
+
+  function createEmptyRecord(ownerId: string): ToolPackRecord {
+    return {
+      ownerId,
+      selectedPackIds: [...DEFAULT_SELECTED_PACK_IDS],
+      installJobs: [],
+      updatedAt: now().toISOString(),
+    };
+  }
+
+  async function ensureRecord(ownerId: string): Promise<ToolPackRecord> {
+    return options.repository.update(ownerId, (record) => record ?? createEmptyRecord(ownerId));
+  }
+
+  function uniquePackIds(packIds: ToolPackId[]): ToolPackId[] {
+    return Array.from(new Set(packIds));
+  }
+
+  function latestJobForPack(record: ToolPackRecord, packId: ToolPackId): ToolPackInstallJobSummary | null {
+    for (let index = record.installJobs.length - 1; index >= 0; index -= 1) {
+      const job = record.installJobs[index];
+      if (job.packId === packId) return job;
+    }
+    return null;
+  }
+
+  function responseFor(record: ToolPackRecord): ToolPacksResponse {
+    const selected = new Set(record.selectedPackIds);
+    const packs = TOOL_PACKS.map<ToolPackSummary>((pack) => {
+      const latestJob = latestJobForPack(record, pack.id);
+      const installed = latestJob?.status === "installed";
+      const selectedPack = selected.has(pack.id);
+      return {
+        ...pack,
+        selected: selectedPack,
+        installed,
+        status: latestJob?.status ?? (selectedPack ? "selected" : "available"),
+        installJobId: latestJob?.id ?? null,
+      };
+    });
+    return {
+      packs,
+      selectedPackIds: [...record.selectedPackIds],
+      installJobs: [...record.installJobs],
+    };
+  }
+
+  async function listToolPacks(ownerId: string): Promise<ToolPacksResponse> {
+    return responseFor(await ensureRecord(ownerId));
+  }
+
+  async function selectToolPacks(ownerId: string, packIds: ToolPackId[]): Promise<ToolPacksResponse> {
+    const selectedPackIds = uniquePackIds(packIds);
+    const record = await options.repository.update(ownerId, (current) => ({
+      ...(current ?? createEmptyRecord(ownerId)),
+      selectedPackIds,
+      updatedAt: now().toISOString(),
+    }));
+    return responseFor(record);
+  }
+
+  async function markJob(
+    ownerId: string,
+    jobId: string,
+    status: ToolPackInstallJobSummary["status"],
+    message: string | null,
+  ): Promise<void> {
+    await options.repository.update(ownerId, (current) => {
+      const record = current ?? createEmptyRecord(ownerId);
+      return {
+        ...record,
+        installJobs: record.installJobs.map((job) => job.id === jobId
+          ? { ...job, status, completedAt: now().toISOString(), message }
+          : job),
+        updatedAt: now().toISOString(),
+      };
+    });
+  }
+
+  function runInstall(ownerId: string, job: ToolPackInstallJobSummary): void {
+    void (async () => {
+      try {
+        if (!options.installer) {
+          throw new Error("Tool pack installer is unavailable");
+        }
+        await options.installer.install(ownerId, job.packId);
+        await markJob(ownerId, job.id, "installed", "Installed");
+      } catch (err: unknown) {
+        console.warn("[onboarding] tool pack install failed:", err instanceof Error ? err.message : String(err));
+        await markJob(ownerId, job.id, "failed", "Install failed");
+      }
+    })();
+  }
+
+  async function installToolPacks(ownerId: string, packIds: ToolPackId[]): Promise<ToolPacksResponse> {
+    const requestedPackIds = uniquePackIds(packIds);
+    const createdJobs: ToolPackInstallJobSummary[] = requestedPackIds.map((packId) => ({
+      id: `tool-pack-${packId}-${Date.now()}-${jobCounter += 1}`,
+      packId,
+      status: "installing",
+      startedAt: now().toISOString(),
+      completedAt: null,
+      message: null,
+    }));
+    const record = await options.repository.update(ownerId, (current) => {
+      const base = current ?? createEmptyRecord(ownerId);
+      const selectedPackIds = uniquePackIds([...base.selectedPackIds, ...requestedPackIds]);
+      return {
+        ...base,
+        selectedPackIds,
+        installJobs: [...base.installJobs, ...createdJobs].slice(-MAX_INSTALL_JOBS_PER_OWNER),
+        updatedAt: now().toISOString(),
+      };
+    });
+    for (const job of createdJobs) runInstall(ownerId, job);
+    return responseFor(record);
+  }
+
+  return { listToolPacks, selectToolPacks, installToolPacks };
+}
+
+async function runHostInstaller(
+  scriptPath: string,
+  ownerId: string,
+  packId: ToolPackId,
+  timeoutMs: number,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(scriptPath, [packId], {
+      env: {
+        ...process.env,
+        MATRIX_TOOL_PACK_OWNER_ID: ownerId,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let outputTail = "";
+    const appendOutput = (chunk: Buffer) => {
+      outputTail = `${outputTail}${chunk.toString("utf8")}`.slice(-MAX_INSTALL_OUTPUT_BYTES);
+    };
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`tool pack install timed out for ${packId}`));
+    }, timeoutMs);
+    child.stdout.on("data", appendOutput);
+    child.stderr.on("data", appendOutput);
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`tool pack install failed for ${packId} with exit code ${code}; ${outputTail}`));
+    });
+  });
+}

--- a/packages/gateway/src/onboarding/tool-packs.ts
+++ b/packages/gateway/src/onboarding/tool-packs.ts
@@ -171,11 +171,14 @@ export function createToolPackService(options: {
     installJobs: ToolPackInstallJobSummary[],
     packId: ToolPackId,
   ): ToolPackInstallJobSummary | null {
-    for (let index = installJobs.length - 1; index >= 0; index -= 1) {
-      const job = installJobs[index];
-      if (job.packId === packId) return job;
-    }
-    return null;
+    const packJobs = installJobs.filter((job) => job.packId === packId);
+    const installingJob = packJobs.find((job) => job.status === "installing");
+    if (installingJob) return installingJob;
+    return packJobs.toSorted((left, right) => {
+      const leftTime = Date.parse(left.completedAt ?? left.startedAt);
+      const rightTime = Date.parse(right.completedAt ?? right.startedAt);
+      return rightTime - leftTime;
+    })[0] ?? null;
   }
 
   function responseFor(record: ToolPackRecord): ToolPacksResponse {
@@ -262,17 +265,26 @@ export function createToolPackService(options: {
 
   async function installToolPacks(ownerId: string, packIds: ToolPackId[]): Promise<ToolPacksResponse> {
     const requestedPackIds = uniquePackIds(packIds);
-    const createdJobs: ToolPackInstallJobSummary[] = requestedPackIds.map((packId) => ({
-      id: `tool-pack-${packId}-${Date.now()}-${jobCounter += 1}`,
-      packId,
-      status: "installing",
-      startedAt: now().toISOString(),
-      completedAt: null,
-      message: null,
-    }));
+    let createdJobs: ToolPackInstallJobSummary[] = [];
     const record = await options.repository.update(ownerId, (current) => {
       const base = current ?? createEmptyRecord(ownerId);
       const selectedPackIds = uniquePackIds([...base.selectedPackIds, ...requestedPackIds]);
+      const activePackIds = new Set(
+        base.installJobs
+          .map(normalizeJob)
+          .filter((job) => job.status === "installing")
+          .map((job) => job.packId),
+      );
+      createdJobs = requestedPackIds
+        .filter((packId) => !activePackIds.has(packId))
+        .map((packId) => ({
+          id: `tool-pack-${packId}-${Date.now()}-${jobCounter += 1}`,
+          packId,
+          status: "installing",
+          startedAt: now().toISOString(),
+          completedAt: null,
+          message: null,
+        }));
       return {
         ...base,
         selectedPackIds,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -78,6 +78,8 @@ import { createReadinessService } from "./onboarding/readiness-service.js";
 import { ReadinessStatusCache } from "./onboarding/readiness-cache.js";
 import type { ReadinessResponse } from "./onboarding/activation-contracts.js";
 import { createReadinessRoutes } from "./onboarding/readiness-routes.js";
+import { createHostToolPackInstaller, createToolPackService, InMemoryToolPackRepository } from "./onboarding/tool-packs.js";
+import { createToolPackRoutes } from "./onboarding/tool-pack-routes.js";
 import type { CodingSetupStatus } from "./onboarding/coding-setup.js";
 import { createAgentCredentialStatusService } from "./onboarding/agent-credential-status.js";
 import { createAgentCredentialRoutes } from "./onboarding/agent-credential-routes.js";
@@ -545,6 +547,7 @@ export async function createGateway(config: GatewayConfig) {
   const conversationRuns = new ConversationRunRegistry();
   const clients = new Set<WSContext>();
   const readinessRepository = new InMemoryReadinessRepository();
+  const toolPackRepository = new InMemoryToolPackRepository();
   const readinessCache = new ReadinessStatusCache<ReadinessResponse>({ maxEntries: 512, ttlMs: 10_000 });
   const internalPlatformUrl = process.env.PLATFORM_INTERNAL_URL;
   const internalPlatformToken = process.env.UPGRADE_TOKEN;
@@ -649,6 +652,10 @@ export async function createGateway(config: GatewayConfig) {
     codingSetup: {
       getCodingSetup: async () => unavailableCodingSetup,
     },
+  });
+  const toolPackService = createToolPackService({
+    repository: toolPackRepository,
+    installer: createHostToolPackInstaller(),
   });
   const adminControlService = createAdminControlService({
     agentCredentials: agentCredentialService,
@@ -1545,6 +1552,7 @@ export async function createGateway(config: GatewayConfig) {
   app.use("*", securityHeadersMiddleware());
   app.use("*", authMiddleware(process.env.MATRIX_AUTH_TOKEN));
   app.route("/api/onboarding", createReadinessRoutes({ service: readinessService }));
+  app.route("/api/onboarding", createToolPackRoutes({ service: toolPackService }));
   app.route("/api/agents", createAgentCredentialRoutes({ service: agentCredentialService }));
   app.route("/api/integrations", createIntegrationCapabilityRoutes({
     service: integrationCapabilityService,

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -10,10 +10,6 @@ NODE_DIST="node-v${NODE_VERSION}-linux-x64"
 NODE_ARCHIVE="${NODE_DIST}.tar.xz"
 NODE_BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}"
 NODE_URL="${NODE_BASE_URL}/${NODE_ARCHIVE}"
-CODE_SERVER_VERSION="${HOST_BUNDLE_CODE_SERVER_VERSION:-4.116.0}"
-CODE_SERVER_DIST="code-server-${CODE_SERVER_VERSION}-linux-amd64"
-CODE_SERVER_ARCHIVE="${CODE_SERVER_DIST}.tar.gz"
-CODE_SERVER_URL="https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/${CODE_SERVER_ARCHIVE}"
 ZELLIJ_VERSION="${HOST_BUNDLE_ZELLIJ_VERSION:-0.44.1}"
 ZELLIJ_ARCHIVE="zellij-x86_64-unknown-linux-musl.tar.gz"
 ZELLIJ_URL="https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/${ZELLIJ_ARCHIVE}"
@@ -59,29 +55,16 @@ grep "  ${NODE_ARCHIVE}$" "$DIST_DIR/SHASUMS256.txt" > "$DIST_DIR/${NODE_ARCHIVE
 tar -xJf "$DIST_DIR/$NODE_ARCHIVE" -C "$STAGE_DIR/runtime"
 mv "$STAGE_DIR/runtime/$NODE_DIST" "$STAGE_DIR/runtime/node"
 
-curl --fail --location --max-time 180 "$CODE_SERVER_URL" -o "$DIST_DIR/$CODE_SERVER_ARCHIVE"
-tar -xzf "$DIST_DIR/$CODE_SERVER_ARCHIVE" -C "$STAGE_DIR/runtime"
-mv "$STAGE_DIR/runtime/$CODE_SERVER_DIST" "$STAGE_DIR/runtime/code-server"
 curl --fail --location --max-time 180 "$ZELLIJ_URL" -o "$DIST_DIR/$ZELLIJ_ARCHIVE"
 tar -xzf "$DIST_DIR/$ZELLIJ_ARCHIVE" -C "$STAGE_DIR/bin" zellij
 chmod 0755 "$STAGE_DIR/bin/zellij"
 curl --fail --location --max-time 180 "$GH_URL" -o "$DIST_DIR/$GH_ARCHIVE"
 tar -xzf "$DIST_DIR/$GH_ARCHIVE" -C "$DIST_DIR"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/runtime/node/bin/gh"
-cat > "$STAGE_DIR/runtime/node/bin/code-server" <<'EOS'
-#!/usr/bin/env sh
-exec /opt/matrix/runtime/code-server/bin/code-server "$@"
-EOS
-chmod 0755 "$STAGE_DIR/runtime/node/bin/code-server"
-"$STAGE_DIR/runtime/node/bin/npm" install -g --prefix "$STAGE_DIR/runtime/node" \
-  @anthropic-ai/claude-code@latest \
-  @openai/codex@latest \
-  opencode-ai@1.14.25 \
-  @mariozechner/pi-coding-agent@0.70.2
 curl --fail --location --max-time 120 "$UV_INSTALLER_URL" -o "$DIST_DIR/uv-install.sh"
 INSTALLER_NO_MODIFY_PATH=1 UV_INSTALL_DIR="$STAGE_DIR/runtime/node/bin" sh "$DIST_DIR/uv-install.sh"
-# Customer VPS terminals run as the matrix user. Keep global CLI packages and
-# bin shims group-writable so Codex/Claude/opencode/pi/uv can self-update in place.
+# Customer VPS terminals run as the matrix user. Keep the runtime prefix
+# group-writable so selectable boot-time tool packs can install in place.
 chmod -R g+rwX "$STAGE_DIR/runtime/node/lib/node_modules" "$STAGE_DIR/runtime/node/bin"
 find "$STAGE_DIR/runtime/node/lib/node_modules" "$STAGE_DIR/runtime/node/bin" -type d -exec chmod g+s {} +
 
@@ -89,7 +72,7 @@ cp -a "$ROOT_DIR/distro/customer-vps/host-bin/." "$STAGE_DIR/bin/"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"
 # The bundle is usually extracted as root:root during in-place upgrades, while
 # the systemd units execute these wrappers as the matrix user.
-chmod 0755 "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
+chmod 0755 "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
 
 cp -a "$ROOT_DIR/node_modules" "$STAGE_DIR/app/node_modules"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -199,6 +199,30 @@ describe("onboarding tool packs", () => {
       installed: true,
       status: "installed",
     });
+
+    await repository.save({
+      ...baseRecord,
+      installJobs: [
+        {
+          ...baseRecord.installJobs[0]!,
+          status: "installed",
+          completedAt: "2026-05-31T00:00:03.000Z",
+          message: "Installed",
+        },
+        {
+          ...baseRecord.installJobs[1]!,
+          completedAt: "2026-05-31T00:00:04.000Z",
+        },
+      ],
+    });
+    currentTime = new Date("2026-05-31T00:00:05.000Z");
+    const afterFailedRetry = await service.listToolPacks(testPrincipal.userId);
+
+    expect(afterFailedRetry.packs.find((pack) => pack.id === "coding-agents")).toMatchObject({
+      installJobId: "lock-collision",
+      installed: true,
+      status: "failed",
+    });
   });
 
   it("deduplicates install requests for packs that are already installing", async () => {

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+  SelectToolPacksRequestSchema,
+  ToolPacksResponseSchema,
+} from "../../packages/gateway/src/onboarding/activation-contracts.js";
+import { createToolPackRoutes } from "../../packages/gateway/src/onboarding/tool-pack-routes.js";
+import {
+  InMemoryToolPackRepository,
+  createToolPackService,
+  type ToolPackInstaller,
+} from "../../packages/gateway/src/onboarding/tool-packs.js";
+import { testPrincipal } from "../helpers/activation-readiness.js";
+
+function jsonRequest(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("onboarding tool packs", () => {
+  it("exposes selectable boot-time tool packs without requiring every tool in the bundle", async () => {
+    const service = createToolPackService({
+      repository: new InMemoryToolPackRepository(),
+      now: () => new Date("2026-05-31T00:00:00.000Z"),
+    });
+
+    const response = await service.listToolPacks(testPrincipal.userId);
+
+    expect(() => ToolPacksResponseSchema.parse(response)).not.toThrow();
+    expect(response.packs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "coding-agents",
+        status: "available",
+        selected: false,
+        commands: ["claude", "codex", "opencode", "pi"],
+      }),
+      expect.objectContaining({
+        id: "hermes",
+        category: "agent",
+        status: "selected",
+        selected: true,
+      }),
+      expect.objectContaining({
+        id: "code-server",
+        category: "editor",
+        status: "available",
+      }),
+    ]));
+    expect(response.selectedPackIds).toEqual(["hermes"]);
+  });
+
+  it("validates bounded tool selections and preserves selected pack order", async () => {
+    expect(() => SelectToolPacksRequestSchema.parse({
+      packIds: ["coding-agents", "code-server", "hermes"],
+    })).not.toThrow();
+    expect(() => SelectToolPacksRequestSchema.parse({ packIds: [] })).toThrow();
+    expect(() => SelectToolPacksRequestSchema.parse({ packIds: ["../../bin/sh"] })).toThrow();
+
+    const service = createToolPackService({
+      repository: new InMemoryToolPackRepository(),
+      now: () => new Date("2026-05-31T00:00:00.000Z"),
+    });
+    const response = await service.selectToolPacks(testPrincipal.userId, [
+      "coding-agents",
+      "hermes",
+      "coding-agents",
+    ]);
+
+    expect(response.selectedPackIds).toEqual(["coding-agents", "hermes"]);
+    expect(response.packs.find((pack) => pack.id === "coding-agents")).toMatchObject({
+      selected: true,
+      status: "selected",
+    });
+  });
+
+  it("starts selected tool installs in parallel and returns live job state", async () => {
+    const started: string[] = [];
+    const installer: ToolPackInstaller = {
+      install: async (_ownerId, packId) => {
+        started.push(packId);
+      },
+    };
+    const service = createToolPackService({
+      repository: new InMemoryToolPackRepository(),
+      installer,
+      now: () => new Date("2026-05-31T00:00:00.000Z"),
+    });
+
+    const response = await service.installToolPacks(testPrincipal.userId, ["coding-agents", "code-server"]);
+
+    expect(response.installJobs).toHaveLength(2);
+    expect(response.installJobs.map((job) => job.status)).toEqual(["installing", "installing"]);
+    expect(response.packs.find((pack) => pack.id === "coding-agents")).toMatchObject({
+      selected: true,
+      status: "installing",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const completed = await service.listToolPacks(testPrincipal.userId);
+
+    expect(started).toEqual(expect.arrayContaining(["coding-agents", "code-server"]));
+    expect(completed.installJobs.map((job) => job.status)).toEqual(["installed", "installed"]);
+    expect(completed.packs.find((pack) => pack.id === "code-server")).toMatchObject({
+      installed: true,
+      status: "installed",
+    });
+  });
+
+  it("routes selection and install requests through owner-scoped onboarding APIs", async () => {
+    const service = createToolPackService({
+      repository: new InMemoryToolPackRepository(),
+      installer: { install: async () => {} },
+      now: () => new Date("2026-05-31T00:00:00.000Z"),
+    });
+    const app = createToolPackRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const selection = await app.request(jsonRequest("/tools/selection", {
+      packIds: ["coding-agents", "hermes"],
+    }));
+    expect(selection.status).toBe(200);
+    await expect(selection.json()).resolves.toMatchObject({
+      selectedPackIds: ["coding-agents", "hermes"],
+    });
+
+    const install = await app.request(jsonRequest("/tools/install", {
+      packIds: ["coding-agents"],
+    }));
+    expect(install.status).toBe(202);
+    await expect(install.json()).resolves.toMatchObject({
+      selectedPackIds: ["coding-agents", "hermes"],
+      installJobs: [expect.objectContaining({ packId: "coding-agents", status: "installing" })],
+    });
+  });
+
+  it("rejects invalid tool pack route payloads with a generic client-safe error", async () => {
+    const service = createToolPackService({
+      repository: new InMemoryToolPackRepository(),
+      now: () => new Date("2026-05-31T00:00:00.000Z"),
+    });
+    const app = createToolPackRoutes({ service, getPrincipal: () => testPrincipal });
+
+    const res = await app.request(jsonRequest("/tools/selection", {
+      packIds: ["../../secrets"],
+    }));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "invalid_request",
+      message: "Request is invalid",
+      retryable: false,
+    });
+  });
+});

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -141,6 +141,98 @@ describe("onboarding tool packs", () => {
     });
   });
 
+  it("does not let a duplicate install collision shadow the active or completed job", async () => {
+    const repository = new InMemoryToolPackRepository();
+    let currentTime = new Date("2026-05-31T00:00:02.000Z");
+    const service = createToolPackService({
+      repository,
+      now: () => currentTime,
+    });
+    const baseRecord: ToolPackRecord = {
+      ownerId: testPrincipal.userId,
+      selectedPackIds: ["hermes", "coding-agents"],
+      updatedAt: "2026-05-31T00:00:01.000Z",
+      installJobs: [
+        {
+          id: "first-install",
+          packId: "coding-agents",
+          status: "installing",
+          startedAt: "2026-05-31T00:00:00.000Z",
+          completedAt: null,
+          message: null,
+        },
+        {
+          id: "lock-collision",
+          packId: "coding-agents",
+          status: "failed",
+          startedAt: "2026-05-31T00:00:01.000Z",
+          completedAt: "2026-05-31T00:00:01.500Z",
+          message: "Install failed",
+        },
+      ],
+    };
+    await repository.save(baseRecord);
+
+    const duringInstall = await service.listToolPacks(testPrincipal.userId);
+
+    expect(duringInstall.packs.find((pack) => pack.id === "coding-agents")).toMatchObject({
+      installJobId: "first-install",
+      status: "installing",
+    });
+
+    await repository.save({
+      ...baseRecord,
+      installJobs: baseRecord.installJobs.map((job) => job.id === "first-install"
+        ? {
+            ...job,
+            status: "installed",
+            completedAt: "2026-05-31T00:00:03.000Z",
+            message: "Installed",
+          }
+        : job),
+    });
+    currentTime = new Date("2026-05-31T00:00:04.000Z");
+    const afterInstall = await service.listToolPacks(testPrincipal.userId);
+
+    expect(afterInstall.packs.find((pack) => pack.id === "coding-agents")).toMatchObject({
+      installJobId: "first-install",
+      installed: true,
+      status: "installed",
+    });
+  });
+
+  it("deduplicates install requests for packs that are already installing", async () => {
+    const started: string[] = [];
+    let releaseInstall: (() => void) | null = null;
+    const installer: ToolPackInstaller = {
+      install: async (_ownerId, packId) => {
+        started.push(packId);
+        await new Promise<void>((resolve) => {
+          releaseInstall = resolve;
+        });
+      },
+    };
+    const service = createToolPackService({
+      repository: new InMemoryToolPackRepository(),
+      installer,
+      now: () => new Date("2026-05-31T00:00:00.000Z"),
+    });
+
+    const first = await service.installToolPacks(testPrincipal.userId, ["coding-agents"]);
+    const second = await service.installToolPacks(testPrincipal.userId, ["coding-agents"]);
+
+    expect(first.installJobs).toHaveLength(1);
+    expect(second.installJobs).toHaveLength(1);
+    expect(second.installJobs[0]).toMatchObject({
+      packId: "coding-agents",
+      status: "installing",
+    });
+    expect(started).toEqual(["coding-agents"]);
+
+    releaseInstall?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
   it("expires installing jobs if the async settlement write fails", async () => {
     let currentTime = new Date("2026-05-31T00:00:00.000Z");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   SelectToolPacksRequestSchema,
   ToolPacksResponseSchema,
@@ -8,6 +8,8 @@ import {
   InMemoryToolPackRepository,
   createToolPackService,
   type ToolPackInstaller,
+  type ToolPackRecord,
+  type ToolPackRepository,
 } from "../../packages/gateway/src/onboarding/tool-packs.js";
 import { testPrincipal } from "../helpers/activation-readiness.js";
 
@@ -17,6 +19,37 @@ function jsonRequest(path: string, body: unknown): Request {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+class FailingSettlementRepository implements ToolPackRepository {
+  private record: ToolPackRecord | null = null;
+  private shouldFailSettlement = true;
+
+  async get(): Promise<ToolPackRecord | null> {
+    return this.record ? structuredClone(this.record) : null;
+  }
+
+  async save(record: ToolPackRecord): Promise<ToolPackRecord> {
+    this.record = structuredClone(record);
+    return structuredClone(record);
+  }
+
+  async update(ownerId: string, updater: (record: ToolPackRecord | null) => ToolPackRecord): Promise<ToolPackRecord> {
+    const current = this.record ? structuredClone(this.record) : null;
+    const next = updater(current);
+    const settlingJob = current?.installJobs.some((job) => job.status === "installing")
+      && next.installJobs.some((job) => job.status !== "installing");
+
+    if (this.shouldFailSettlement && settlingJob) {
+      this.shouldFailSettlement = false;
+      throw new Error("settlement write failed");
+    }
+
+    if (next.ownerId !== ownerId) {
+      throw new Error("owner mismatch");
+    }
+    return this.save(next);
+  }
 }
 
 describe("onboarding tool packs", () => {
@@ -106,6 +139,46 @@ describe("onboarding tool packs", () => {
       installed: true,
       status: "installed",
     });
+  });
+
+  it("expires installing jobs if the async settlement write fails", async () => {
+    let currentTime = new Date("2026-05-31T00:00:00.000Z");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const service = createToolPackService({
+      repository: new FailingSettlementRepository(),
+      installer: { install: async () => {} },
+      installTimeoutMs: 1_000,
+      now: () => currentTime,
+    });
+
+    try {
+      const response = await service.installToolPacks(testPrincipal.userId, ["coding-agents"]);
+
+      expect(response.installJobs).toEqual([
+        expect.objectContaining({ packId: "coding-agents", status: "installing" }),
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      currentTime = new Date("2026-05-31T00:00:02.000Z");
+      const expired = await service.listToolPacks(testPrincipal.userId);
+
+      expect(expired.installJobs).toEqual([
+        expect.objectContaining({
+          packId: "coding-agents",
+          status: "failed",
+          message: "Install status unavailable",
+        }),
+      ]);
+      expect(expired.packs.find((pack) => pack.id === "coding-agents")).toMatchObject({
+        status: "failed",
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[onboarding] tool pack job status update failed:",
+        "settlement write failed",
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("routes selection and install requests through owner-scoped onboarding APIs", async () => {

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -1,3 +1,6 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   SelectToolPacksRequestSchema,
@@ -6,6 +9,7 @@ import {
 import { createToolPackRoutes } from "../../packages/gateway/src/onboarding/tool-pack-routes.js";
 import {
   InMemoryToolPackRepository,
+  createHostToolPackInstaller,
   createToolPackService,
   type ToolPackInstaller,
   type ToolPackRecord,
@@ -255,6 +259,36 @@ describe("onboarding tool packs", () => {
 
     releaseInstall?.();
     await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it("uses the existing Linux tools service timeout budget for host installs", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "matrix-tool-pack-installer-"));
+    const scriptPath = join(tempDir, "installer");
+    await writeFile(scriptPath, [
+      "#!/usr/bin/env bash",
+      "if [ \"$1\" = \"linux-tools\" ]; then",
+      "  sleep 0.1",
+      "else",
+      "  sleep 1",
+      "fi",
+      "",
+    ].join("\n"));
+    await chmod(scriptPath, 0o755);
+
+    try {
+      const installer = createHostToolPackInstaller({
+        scriptPath,
+        timeoutMs: 50,
+        linuxToolsTimeoutMs: 500,
+      });
+
+      await installer.install(testPrincipal.userId, "linux-tools");
+      await expect(installer.install(testPrincipal.userId, "code-server")).rejects.toThrow(
+        "tool pack install timed out for code-server",
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("expires installing jobs if the async settlement write fails", async () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -89,6 +89,7 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('failed=0');
     expect(installer).toContain('if ! wait "$pid"; then');
     expect(installer).toContain('exit "$failed"');
+    expect(installer).not.toMatch(/wait "\$pid_coding_agents" "\$pid_code_server"/);
   });
 
   it('host bundle manifest keeps the sync-agent compatibility fields', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -84,6 +84,11 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors');
     expect(installer).toContain('sync-matrix-agent-skills.sh');
     expect(installer).toContain('coding-agents|code-server|hermes|linux-tools|all');
+    expect(installer).toContain('return 75');
+    expect(installer).not.toContain('exit 0');
+    expect(installer).toContain('failed=0');
+    expect(installer).toContain('if ! wait "$pid"; then');
+    expect(installer).toContain('exit "$failed"');
   });
 
   it('host bundle manifest keeps the sync-agent compatibility fields', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -170,6 +170,28 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('paths-ignore:');
   });
 
+  it('host bundle release workflow uploads only publishable bundle artifacts', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('name: Upload bundle artifact');
+    expect(workflow).toContain('dist/host-bundle/matrix-host-bundle.tar.gz');
+    expect(workflow).toContain('dist/host-bundle/matrix-host-bundle.tar.gz.sha256');
+    expect(workflow).toContain('dist/host-bundle/manifest.json');
+    expect(workflow).toContain('dist/host-bundle/release.json');
+    expect(workflow).not.toContain('path: dist/host-bundle/');
+    expect(workflow).not.toContain('dist/host-bundle/stage');
+  });
+
+  it('host bundle release workflow cancels only superseded dev-channel builds', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain("group: host-bundle-release-${{ github.event_name == 'workflow_dispatch' && inputs.channel || github.ref_type == 'tag' && github.ref_name || 'dev' }}");
+    expect(workflow).toContain("cancel-in-progress: ${{ github.ref_type != 'tag' && (github.event_name != 'workflow_dispatch' || inputs.channel == 'dev' || inputs.channel == '') }}");
+    expect(workflow).not.toContain('cancel-in-progress: false');
+  });
+
   it('dev bundle gate builds branch pushes even when commit messages request a skip', () => {
     const result = runDevBundleGate({
       GITHUB_EVENT_NAME: 'push',

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -183,6 +183,18 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('dist/host-bundle/stage');
   });
 
+  it('host bundle release workflow normalizes downloaded artifact layout before publishing', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('path: dist/host-bundle-artifact');
+    expect(workflow).toContain('name: Normalize downloaded bundle artifact');
+    expect(workflow).toContain('BUNDLE_FILE="$(find "$ARTIFACT_DIR" -type f -name matrix-host-bundle.tar.gz -print -quit)"');
+    expect(workflow).toContain('TARGET_DIR="dist/host-bundle"');
+    expect(workflow).toContain('for file in matrix-host-bundle.tar.gz matrix-host-bundle.tar.gz.sha256 manifest.json release.json; do');
+    expect(workflow).toContain('cp "$SOURCE_DIR/$file" "$TARGET_DIR/$file"');
+  });
+
   it('host bundle release workflow cancels only superseded dev-channel builds', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -86,6 +86,8 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('coding-agents|code-server|hermes|linux-tools|all');
     expect(installer).toContain('return 75');
     expect(installer).not.toContain('exit 0');
+    expect(installer).toContain('systemctl start matrix-linux-tools.service');
+    expect(installer).toContain('sudo systemctl start matrix-linux-tools.service');
     expect(installer).toContain('failed=0');
     expect(installer).toContain('if ! wait "$pid"; then');
     expect(installer).toContain('exit "$failed"');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -51,17 +51,11 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('manifest.json');
     expect(script).toContain('release.json');
     expect(script).toContain('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:?set NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY before building the customer host bundle');
-    expect(script).toContain('CODE_SERVER_VERSION="${HOST_BUNDLE_CODE_SERVER_VERSION:-4.116.0}"');
-    expect(script).toContain('CODE_SERVER_URL="https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/${CODE_SERVER_ARCHIVE}"');
     expect(script).toContain('GH_VERSION="${HOST_BUNDLE_GH_VERSION:-2.86.0}"');
     expect(script).toContain('GH_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_ARCHIVE}"');
     expect(script).toContain('install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/runtime/node/bin/gh"');
     expect(script).toContain('install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"');
-    expect(script).toContain('runtime/code-server');
-    expect(script).toContain('/opt/matrix/runtime/code-server/bin/code-server "$@"');
     expect(script).toContain('chmod 0755 "$STAGE_DIR/bin/matrix-gateway"');
-    expect(script).toContain('chmod -R g+rwX "$STAGE_DIR/runtime/node/lib/node_modules" "$STAGE_DIR/runtime/node/bin"');
-    expect(script).toContain('find "$STAGE_DIR/runtime/node/lib/node_modules" "$STAGE_DIR/runtime/node/bin" -type d -exec chmod g+s {} +');
     expect(script).toContain('rm -rf "$STAGE_DIR/app/shell/.next/cache" "$STAGE_DIR/app/shell/e2e" "$STAGE_DIR/app/shell/node_modules"');
     expect(script).toContain('find "$STAGE_DIR/app/home/apps" -type d -name node_modules -prune -exec rm -rf {} +');
     expect(script).toContain('matrix-update');
@@ -69,6 +63,27 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('matrix-messaging-health');
     expect(script).toContain('"$STAGE_DIR/runtime/node/bin/gh"');
     expect(script).toContain('bin app runtime systemd release.json');
+  });
+
+  it('host bundle defers heavy optional tools to selectable boot-time packs', () => {
+    const root = process.cwd();
+    const script = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
+    const installer = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-tool-pack'), 'utf8');
+
+    expect(script).toContain('matrix-install-tool-pack');
+    expect(script).not.toContain('curl --fail --location --max-time 180 "$CODE_SERVER_URL"');
+    expect(script).not.toContain('tar -xzf "$DIST_DIR/$CODE_SERVER_ARCHIVE"');
+    expect(script).not.toContain('"$STAGE_DIR/runtime/node/bin/npm" install -g --prefix "$STAGE_DIR/runtime/node"');
+    expect(installer).toContain('install_coding_agents()');
+    expect(installer).toContain('install_code_server()');
+    expect(installer).toContain('install_hermes()');
+    expect(installer).toContain('@anthropic-ai/claude-code@latest');
+    expect(installer).toContain('@openai/codex@latest');
+    expect(installer).toContain('opencode-ai@1.14.25');
+    expect(installer).toContain('@mariozechner/pi-coding-agent@0.70.2');
+    expect(installer).toContain('curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors');
+    expect(installer).toContain('sync-matrix-agent-skills.sh');
+    expect(installer).toContain('coding-agents|code-server|hermes|linux-tools|all');
   });
 
   it('host bundle manifest keeps the sync-agent compatibility fields', () => {


### PR DESCRIPTION
## Summary

- Add onboarding tool-pack contracts and owner-scoped APIs for listing, selecting, and starting tool installs.
- Add a bounded tool-pack install job service and host installer wrapper for parallel live installs.
- Defer code-server and global coding-agent CLI installation out of `build-host-bundle.sh` into `matrix-install-tool-pack`.

## Invariants

- **Source of truth**: the onboarding tool-pack service owns selected pack IDs and recent install jobs for the owner. This PR uses the same bounded in-memory onboarding pattern as existing readiness state; durable owner Postgres persistence is deferred.
- **Lock/transaction scope**: route writes update the owner record in one repository update. Host installs run after job creation through the installer boundary; network/package installation is outside the state update.
- **Acceptable orphan states**: a job may remain `installing` if the gateway process exits mid-install. A follow-up durable installer can reconcile process state; this PR caps retained jobs and keeps failures generic to clients.
- **Auth source of truth**: onboarding routes use the existing request principal resolver. Tool IDs are Zod enums, so route input cannot select arbitrary commands or paths.
- **Deferred scope**: signup/onboarding UI controls and durable install reconciliation are left for the UI/follow-up PR.

## Verification

- `pnpm test tests/gateway/onboarding-tool-packs.test.ts tests/platform/customer-vps-host-bundle.test.ts`
- `pnpm --filter @matrix-os/gateway build`
- `bash -n distro/customer-vps/host-bin/matrix-install-tool-pack`
- `bun run check:patterns`