### PR TITLE
ci(release): gate host bundles on same-sha CI

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -6,7 +6,7 @@
 # Version format: v{YYYY.MM.DD}-{run_number} (date-based, monotonically increasing)
 #
 # Flow:
-#   1. test — typecheck + unit tests
+#   1. ci-gate — wait for same-SHA CI and verify all CI jobs succeeded
 #   2. build — compile gateway, shell, kernel into host bundle tarball
 #   3. publish — upload immutable R2 artifacts and register metadata in platform DB
 #   4. (optional) auto-deploy if severity is "security"
@@ -109,8 +109,28 @@ jobs:
               continue
             fi
 
+            success_id="$(printf '%s' "$runs" | jq -r 'map(select(.status == "completed" and .conclusion == "success")) | .[0].databaseId // ""')"
             success_url="$(printf '%s' "$runs" | jq -r 'map(select(.status == "completed" and .conclusion == "success")) | .[0].url // ""')"
-            if [ -n "$success_url" ]; then
+            if [ -n "$success_id" ]; then
+              if ! run_jobs="$(gh run view "$success_id" \
+                --repo "$GITHUB_REPOSITORY" \
+                --json jobs)"; then
+                if [ "$SECONDS" -ge "$deadline" ]; then
+                  echo "Timed out verifying CI jobs for $TARGET_SHA after repeated GitHub API failures" >&2
+                  exit 1
+                fi
+                echo "Could not read CI jobs for $TARGET_SHA; retrying..."
+                sleep 20
+                continue
+              fi
+
+              failed_job="$(printf '%s' "$run_jobs" | jq -r '.jobs | map(select(.conclusion != "success" and .conclusion != "skipped")) | .[0] | if . then "\(.name) (\(.conclusion // "unknown"))" else "" end')"
+              if [ -n "$failed_job" ]; then
+                echo "CI workflow run passed but a job was not successful for $TARGET_SHA: $failed_job" >&2
+                printf '%s\n' "$run_jobs" >&2
+                exit 1
+              fi
+
               echo "CI passed for $TARGET_SHA: $success_url"
               exit 0
             fi

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -51,6 +51,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: host-bundle-release-${{ github.event_name == 'workflow_dispatch' && inputs.channel || github.ref_type == 'tag' && github.ref_name || 'dev' }}
@@ -76,35 +77,55 @@ jobs:
           set -euo pipefail
           scripts/ci/dev-bundle-gate.sh
 
-  test:
-    name: Test
+  ci-gate:
+    name: Same-SHA CI gate
     needs: dev-bundle-gate
     if: needs.dev-bundle-gate.outputs.should_build == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v6
+      - name: Wait for CI on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
 
-      - uses: pnpm/action-setup@v6
+          deadline=$((SECONDS + 30 * 60))
+          while true; do
+            runs="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow CI \
+              --commit "$TARGET_SHA" \
+              --limit 20 \
+              --json databaseId,status,conclusion,url,headSha,workflowName)"
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
+            success_url="$(printf '%s' "$runs" | jq -r 'map(select(.status == "completed" and .conclusion == "success")) | .[0].url // ""')"
+            if [ -n "$success_url" ]; then
+              echo "CI passed for $TARGET_SHA: $success_url"
+              exit 0
+            fi
 
-      - uses: oven-sh/setup-bun@v2
+            pending_count="$(printf '%s' "$runs" | jq 'map(select(.status != "completed")) | length')"
+            failed_url="$(printf '%s' "$runs" | jq -r 'map(select(.status == "completed" and .conclusion != "success")) | .[0].url // ""')"
+            if [ "$pending_count" -eq 0 ] && [ -n "$failed_url" ]; then
+              echo "CI completed without a successful run for $TARGET_SHA: $failed_url" >&2
+              exit 1
+            fi
 
-      - run: pnpm install --frozen-lockfile
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "Timed out waiting for CI to pass on $TARGET_SHA" >&2
+              printf '%s\n' "$runs" >&2
+              exit 1
+            fi
 
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Unit tests
-        run: bun run test
+            echo "Waiting for CI to pass on $TARGET_SHA..."
+            sleep 20
+          done
 
   build:
     name: Build host bundle
-    needs: [dev-bundle-gate, test]
+    needs: [dev-bundle-gate, ci-gate]
     if: needs.dev-bundle-gate.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -88,17 +88,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ github.sha }}
+          CI_WORKFLOW_FILE: ci.yml
         run: |
           set -euo pipefail
 
           deadline=$((SECONDS + 30 * 60))
           while true; do
-            runs="$(gh run list \
+            if ! runs="$(gh run list \
               --repo "$GITHUB_REPOSITORY" \
-              --workflow CI \
+              --workflow "$CI_WORKFLOW_FILE" \
               --commit "$TARGET_SHA" \
               --limit 20 \
-              --json databaseId,status,conclusion,url,headSha,workflowName)"
+              --json databaseId,status,conclusion,url,headSha,workflowName)"; then
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "Timed out waiting for CI to pass on $TARGET_SHA after repeated GitHub API failures" >&2
+                exit 1
+              fi
+              echo "Could not read CI workflow status for $TARGET_SHA; retrying..."
+              sleep 20
+              continue
+            fi
 
             success_url="$(printf '%s' "$runs" | jq -r 'map(select(.status == "completed" and .conclusion == "success")) | .[0].url // ""')"
             if [ -n "$success_url" ]; then
@@ -109,7 +118,8 @@ jobs:
             pending_count="$(printf '%s' "$runs" | jq 'map(select(.status != "completed")) | length')"
             failed_url="$(printf '%s' "$runs" | jq -r 'map(select(.status == "completed" and .conclusion != "success")) | .[0].url // ""')"
             if [ "$pending_count" -eq 0 ] && [ -n "$failed_url" ]; then
-              echo "CI completed without a successful run for $TARGET_SHA: $failed_url" >&2
+              echo "All same-SHA CI runs are completed but none succeeded for $TARGET_SHA: $failed_url" >&2
+              printf '%s\n' "$runs" >&2
               exit 1
             fi
 

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -195,6 +195,10 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('--workflow "$CI_WORKFLOW_FILE"');
     expect(workflow).toContain('--commit "$TARGET_SHA"');
     expect(workflow).toContain('Could not read CI workflow status for $TARGET_SHA; retrying...');
+    expect(workflow).toContain('gh run view "$success_id"');
+    expect(workflow).toContain('Could not read CI jobs for $TARGET_SHA; retrying...');
+    expect(workflow).toContain('Timed out verifying CI jobs for $TARGET_SHA after repeated GitHub API failures');
+    expect(workflow).toContain('CI workflow run passed but a job was not successful for $TARGET_SHA');
     expect(workflow).toContain('CI passed for $TARGET_SHA');
     expect(workflow).toContain('All same-SHA CI runs are completed but none succeeded for $TARGET_SHA');
     expect(workflow).toContain('Timed out waiting for CI to pass on $TARGET_SHA');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -184,6 +184,22 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('continue-on-error: true');
   });
 
+  it('host bundle release workflow waits for same-sha CI instead of duplicating the full suite', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('actions: read');
+    expect(workflow).toContain('name: Same-SHA CI gate');
+    expect(workflow).toContain('TARGET_SHA: ${{ github.sha }}');
+    expect(workflow).toContain('--workflow CI');
+    expect(workflow).toContain('--commit "$TARGET_SHA"');
+    expect(workflow).toContain('CI passed for $TARGET_SHA');
+    expect(workflow).toContain('Timed out waiting for CI to pass on $TARGET_SHA');
+    expect(workflow).toContain('needs: [dev-bundle-gate, ci-gate]');
+    expect(workflow).not.toContain('run: bun run typecheck');
+    expect(workflow).not.toContain('run: bun run test');
+  });
+
   it('host bundle release workflow keeps tag pushes triggerable', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -191,10 +191,14 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('actions: read');
     expect(workflow).toContain('name: Same-SHA CI gate');
     expect(workflow).toContain('TARGET_SHA: ${{ github.sha }}');
-    expect(workflow).toContain('--workflow CI');
+    expect(workflow).toContain('CI_WORKFLOW_FILE: ci.yml');
+    expect(workflow).toContain('--workflow "$CI_WORKFLOW_FILE"');
     expect(workflow).toContain('--commit "$TARGET_SHA"');
+    expect(workflow).toContain('Could not read CI workflow status for $TARGET_SHA; retrying...');
     expect(workflow).toContain('CI passed for $TARGET_SHA');
+    expect(workflow).toContain('All same-SHA CI runs are completed but none succeeded for $TARGET_SHA');
     expect(workflow).toContain('Timed out waiting for CI to pass on $TARGET_SHA');
+    expect(workflow).toContain('after repeated GitHub API failures');
     expect(workflow).toContain('needs: [dev-bundle-gate, ci-gate]');
     expect(workflow).not.toContain('run: bun run typecheck');
     expect(workflow).not.toContain('run: bun run test');


### PR DESCRIPTION
## Summary
- replace Host Bundle Release's duplicate full typecheck/test job with a same-SHA CI gate
- wait for the `ci.yml` workflow on `github.sha` to complete successfully before build/publish
- inspect the successful CI run's jobs so continue-on-error failures still block release publishing
- keep release publishing blocked if no successful same-SHA CI run appears within the timeout

## Validation
- `pnpm test tests/platform/customer-vps-host-bundle.test.ts`
- `git diff --check`
- checked `gh run list --workflow ci.yml --commit 62576eca933257e6b6f520b108f51cdaee9bdfb8` resolves the same-SHA green CI run

## Invariants
- Source of truth: the `CI` workflow file (`ci.yml`) and its per-job conclusions are the full test source of truth for a commit SHA; Host Bundle Release only builds after that exact SHA is green and all CI jobs succeeded or were skipped.
- Lock/transaction scope: no runtime state or database writes are changed.
- Acceptable orphan states: if CI never reports success for the SHA, if GitHub API checks keep failing, or if any CI job is non-success, bundle build/publish fails closed.
- Auth source of truth: unchanged; the workflow only adds `actions: read` for reading workflow run and job status with `github.token`.
- Deferred scope: this does not shard CI itself or change bundle build/publish logic.
