### PR TITLE
ci(docker): reduce cache export timeout risk

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -88,7 +88,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - name: Skip Docker build for docs-only changes
         if: needs.changes.outputs.should_run != 'true'


### PR DESCRIPTION
## Summary
- raise the Docker test image build timeout from 15 to 45 minutes
- keep Buildx cache export at mode=max so downstream Docker smoke/scenario jobs retain intermediate-stage cache hits

## Invariants
- Source of truth: GitHub Actions remains the source of truth for Docker scenario validation.
- Lock/transaction scope: not applicable; workflow-only change.
- Acceptable orphan states: if cache upload is slow, the build job now has enough room to finish exporting the full cache before scenario jobs run; no product state is modified.
- Auth source of truth: unchanged.
- Deferred scope: does not alter Docker scenarios, runtime code, or customer VPS deployment.

## Validation
- git diff --check
- Greptile 5/5 on current head e56859e4