### PR TITLE
fix(terminal): stop session polling churn

### DIFF
--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -318,6 +318,7 @@ maybe_clean_staging() {
 log "Started for ${MATRIX_MACHINE_ID} (version: $(current_version))"
 mkdir -p "$STAGING_DIR"
 clean_staging
+last_staging_cleanup="$(date +%s)"
 
 while true; do
   # React to trigger files and signals

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -22,6 +22,8 @@ readonly UPDATE_VERSION_FILE="$APP_DIR/.update-version"
 readonly ROLLBACK_TRIGGER="$APP_DIR/.rollback-now"
 readonly HEALTH_URL="http://127.0.0.1:4000/health"
 readonly AUTO_APPLY_FAILED_MARKER="$APP_DIR/.auto-apply-failed"
+readonly STAGING_ARTIFACT_TTL_SECONDS="${MATRIX_STAGING_ARTIFACT_TTL_SECONDS:-86400}"
+readonly STAGING_CLEANUP_INTERVAL_SECONDS="${MATRIX_STAGING_CLEANUP_INTERVAL_SECONDS:-3600}"
 
 log() { echo "matrix-sync-agent: $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
 current_version() { cat "$VERSION_FILE" 2>/dev/null || echo "unknown"; }
@@ -149,6 +151,7 @@ apply_update() {
 
   sudo mkdir -p "$STAGING_DIR"
   sudo chown matrix:matrix "$STAGING_DIR"
+  clean_staging || true
   bundle_file="$STAGING_DIR/bundle-${version}.tar.gz"
   extract_dir="$STAGING_DIR/bundle-${version}"
 
@@ -240,6 +243,7 @@ apply_update() {
     return 1
   fi
   rm -rf "$extract_dir" "$bundle_file"
+  clean_staging || true
 }
 
 # ── Rollback ─────────────────────────────────────────────────────────
@@ -280,15 +284,34 @@ trap on_sigusr1 USR1
 # ── Staging cleanup ──────────────────────────────────────────────────
 clean_staging() {
   [ -d "$STAGING_DIR" ] || return 0
-  local count=0
-  for d in "$STAGING_DIR"/failed-* "$STAGING_DIR"/bundle-*; do
-    [ -e "$d" ] || continue
-    sudo rm -rf "$d"; count=$((count + 1))
-  done
+  local count=0 now cutoff path
+  now="$(date +%s)"
+  cutoff=$((now - STAGING_ARTIFACT_TTL_SECONDS))
+  while IFS= read -r -d '' path; do
+    [ -e "$path" ] || continue
+    [ ! -L "$path" ] || continue
+    if [ "$(stat -c %Y "$path" 2>/dev/null || echo "$now")" -gt "$cutoff" ]; then
+      continue
+    fi
+    sudo rm -rf -- "$path"
+    count=$((count + 1))
+  done < <(find "$STAGING_DIR" -mindepth 1 -maxdepth 1 \( -name 'failed-*' -o -name 'bundle-*' \) -print0)
   if [ "$count" -gt 0 ]; then
     log "Cleaned $count stale staging artifacts"
   fi
   return 0
+}
+
+last_staging_cleanup=0
+
+maybe_clean_staging() {
+  local now
+  now="$(date +%s)"
+  if [ $((now - last_staging_cleanup)) -lt "$STAGING_CLEANUP_INTERVAL_SECONDS" ]; then
+    return 0
+  fi
+  last_staging_cleanup="$now"
+  clean_staging || true
 }
 
 # ── Main loop ────────────────────────────────────────────────────────
@@ -332,6 +355,7 @@ while true; do
 
   # Poll for new version
   check_for_update || true
+  maybe_clean_staging
 
   # Sleep in 6s increments (50x = 5 min) so we react quickly to triggers
   for _ in $(seq 1 50); do

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -142,7 +142,6 @@ async function copyTextToClipboard(text: string): Promise<void> {
 
 const DEFAULT_CWD = "projects";
 const DEFAULT_SHELL_SESSION_NAME = "main";
-const SHELL_SESSION_REFRESH_MS = 5_000;
 
 interface Tab {
   id: string;
@@ -245,6 +244,21 @@ function layoutUsesOnlyCanonicalShellSessions(layout: TerminalLayout): boolean {
   return sessionIds.length > 0 && sessionIds.every((sessionId) => isCanonicalShellSessionId(sessionId));
 }
 
+function getCanonicalShellSessionIds(layout: TerminalLayout): string[] {
+  if (!Array.isArray(layout.tabs)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  for (const tab of layout.tabs) {
+    for (const sessionId of getSessionIds(tab.paneTree)) {
+      if (isCanonicalShellSessionId(sessionId)) {
+        seen.add(sessionId);
+      }
+    }
+  }
+  return Array.from(seen);
+}
+
 function destroyTerminalSessions(sessionIds: string[]) {
   const uniqueIds = Array.from(new Set(sessionIds.filter((sessionId) => sessionId.length > 0)));
   for (const sessionId of uniqueIds) {
@@ -273,29 +287,55 @@ function destroyTerminalSessions(sessionIds: string[]) {
   }
 }
 
-async function ensureDefaultShellSession(): Promise<boolean> {
+async function ensureShellSessions(sessionNames: string[]): Promise<boolean> {
+  const requestedNames = Array.from(new Set(
+    sessionNames.filter((name) => isCanonicalShellSessionId(name)),
+  ));
+  if (requestedNames.length === 0) {
+    return true;
+  }
+
   try {
     const listRes = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
       signal: AbortSignal.timeout(10_000),
     });
+    const existingNames = new Set<string>();
     if (listRes.ok) {
       const data = await listRes.json() as { sessions?: Array<{ name?: unknown }> };
-      if (Array.isArray(data.sessions) && data.sessions.some((session) => session.name === DEFAULT_SHELL_SESSION_NAME)) {
-        return true;
+      if (Array.isArray(data.sessions)) {
+        for (const session of data.sessions) {
+          if (typeof session.name === "string") {
+            existingNames.add(session.name);
+          }
+        }
       }
     }
 
-    const createRes = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: DEFAULT_SHELL_SESSION_NAME, cwd: DEFAULT_CWD }),
-      signal: AbortSignal.timeout(10_000),
-    });
-    return createRes.ok || createRes.status === 409;
+    for (const name of requestedNames) {
+      if (existingNames.has(name)) {
+        continue;
+      }
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop -- ordered repair: each missing saved zellij session is recreated once before layout restore; these are user-visible session names, not a fan-out workload.
+      const createRes = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, cwd: DEFAULT_CWD }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!createRes.ok && createRes.status !== 409) {
+        return false;
+      }
+    }
+
+    return true;
   } catch (err: unknown) {
-    console.warn("Failed to ensure default terminal session:", err instanceof Error ? err.message : err);
+    console.warn("Failed to ensure terminal sessions:", err instanceof Error ? err.message : err);
     return false;
   }
+}
+
+async function ensureDefaultShellSession(): Promise<boolean> {
+  return ensureShellSessions([DEFAULT_SHELL_SESSION_NAME]);
 }
 
 function getSafePreferencesSessionName(value: string | null): string | null {
@@ -528,14 +568,17 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
           const data = await res.json() as TerminalLayout;
           if (!cancelled && Array.isArray(data.tabs) && data.tabs.length > 0) {
             if (layoutUsesOnlyCanonicalShellSessions(data)) {
-              const nextActiveTabId = data.activeTabId ?? data.tabs[0].id;
-              const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
-              setTabs(data.tabs);
-              setActiveTabId(nextActiveTabId);
-              setSidebarOpen(initialMobileRef.current ? false : data.sidebarOpen ?? true);
-              setFocusedPaneId(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
-              setInitialized(true);
-              return;
+              const sessionReady = await ensureShellSessions(getCanonicalShellSessionIds(data));
+              if (!cancelled && sessionReady) {
+                const nextActiveTabId = data.activeTabId ?? data.tabs[0].id;
+                const nextActiveTab = data.tabs.find((tab) => tab.id === nextActiveTabId) ?? data.tabs[0];
+                setTabs(data.tabs);
+                setActiveTabId(nextActiveTabId);
+                setSidebarOpen(initialMobileRef.current ? false : data.sidebarOpen ?? true);
+                setFocusedPaneId(nextActiveTab ? getFirstPaneId(nextActiveTab.paneTree) : null);
+                setInitialized(true);
+                return;
+              }
             }
 
             const sessionReady = await ensureDefaultShellSession();
@@ -1227,6 +1270,55 @@ interface WorkspaceSessionSummary {
   transcriptPath?: string;
 }
 
+function shellSessionsEqual(left: ShellSessionSummary[], right: ShellSessionSummary[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((session, index) => {
+    const next = right[index];
+    if (!next) return false;
+    if (
+      session.name !== next.name ||
+      session.status !== next.status ||
+      session.updatedAt !== next.updatedAt ||
+      session.attachedClients !== next.attachedClients
+    ) {
+      return false;
+    }
+    const tabs = session.tabs ?? [];
+    const nextTabs = next.tabs ?? [];
+    if (tabs.length !== nextTabs.length) return false;
+    return tabs.every((tab, tabIndex) => {
+      const nextTab = nextTabs[tabIndex];
+      if (!nextTab) return false;
+      return (
+        tab.idx === nextTab.idx &&
+        tab.name === nextTab.name &&
+        tab.focused === nextTab.focused
+      );
+    });
+  });
+}
+
+function workspaceSessionsEqual(left: WorkspaceSessionSummary[], right: WorkspaceSessionSummary[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((session, index) => {
+    const next = right[index];
+    return (
+      next !== undefined &&
+      session.id === next.id &&
+      session.kind === next.kind &&
+      session.projectSlug === next.projectSlug &&
+      session.taskId === next.taskId &&
+      session.worktreeId === next.worktreeId &&
+      session.pr === next.pr &&
+      session.agent === next.agent &&
+      session.runtime?.status === next.runtime?.status &&
+      session.status === next.status &&
+      session.transcriptPath === next.transcriptPath &&
+      (session.nativeAttachCommand ?? []).join("\u0000") === (next.nativeAttachCommand ?? []).join("\u0000")
+    );
+  });
+}
+
 // react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- no-giant-component: cohesive core terminal sidebar component; extraction tracked separately. prefer-useReducer: the 15 useState fields are several independent clusters, not one related cluster: projects/shells/sessions/files each carry their own data+loading+error triplet with separate fetch lifecycles, plus orthogonal tab/filter/rootPath/tree UI state; collapsing them into one reducer would obscure the independent update sites and would not be a mechanical, behavior-identical change.
 function LocalTerminalSidebar() {
   const ctx = useTerminalAppContext();
@@ -1248,7 +1340,6 @@ function LocalTerminalSidebar() {
   const [rootPath, setRootPath] = useState("projects");
   const [tree, setTree] = useState<TreeNode[]>([]);
   const [filter, setFilter] = useState("");
-  const shellPollAbortRef = useRef<AbortController | null>(null);
 
   const selectSidebarTab = (nextTab: SidebarTab) => {
     setTab(nextTab);
@@ -1286,7 +1377,7 @@ function LocalTerminalSidebar() {
     if (tab === "projects") void fetchProjects();
   }, [tab, fetchProjects]);
 
-  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity for effect dep: `fetchShells` is in the dependency array of the shells-tab load and shells-poll useEffects below.
+  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity for effect dep: `fetchShells` is in the dependency array of the shells-tab load useEffect below and command handlers.
   const fetchShells = useCallback(async (options: { silent?: boolean; signal?: AbortSignal } = {}) => {
     if (!options.silent) setShellsLoading(true);
     if (!options.silent) setShellsError(null);
@@ -1301,7 +1392,8 @@ function LocalTerminalSidebar() {
         return;
       }
       const data = (await res.json()) as { sessions?: ShellSessionSummary[] };
-      setShells(Array.isArray(data.sessions) ? data.sessions : []);
+      const nextShells = Array.isArray(data.sessions) ? data.sessions : [];
+      setShells((prev) => shellSessionsEqual(prev, nextShells) ? prev : nextShells);
       setShellsError(null);
     } catch (err: unknown) {
       if (options.silent && err instanceof DOMException && err.name === "AbortError") return;
@@ -1316,31 +1408,6 @@ function LocalTerminalSidebar() {
   useEffect(() => {
     // react-doctor-disable-next-line react-hooks-js/set-state-in-effect, react-doctor/no-event-handler -- async network load of the shell-session list when the Shells tab becomes active; `tab` is live derived state that can change from many sources (restore, programmatic nav, deep link), not a single DOM click handler, so the fetch belongs in the effect and cannot be hoisted to one parent handler
     if (tab === "shells") void fetchShells();
-  }, [fetchShells, tab]);
-
-  // react-doctor-disable-next-line react-doctor/exhaustive-deps -- teardown must abort the LIVE in-flight poll controller: shellPollAbortRef.current is reassigned by each refresh(), so snapshotting it at effect setup would capture null and never cancel the request that is actually outstanding at unmount/tab-switch
-  useEffect(() => {
-    if (tab !== "shells") return;
-    const refresh = () => {
-      shellPollAbortRef.current?.abort();
-      const controller = new AbortController();
-      shellPollAbortRef.current = controller;
-      const timeout = setTimeout(() => controller.abort(), 10_000);
-      void fetchShells({ silent: true, signal: controller.signal }).finally(() => {
-        clearTimeout(timeout);
-        if (shellPollAbortRef.current === controller) {
-          shellPollAbortRef.current = null;
-        }
-      });
-    };
-    const timer = setInterval(() => {
-      refresh();
-    }, SHELL_SESSION_REFRESH_MS);
-    return () => {
-      clearInterval(timer);
-      shellPollAbortRef.current?.abort();
-      shellPollAbortRef.current = null;
-    };
   }, [fetchShells, tab]);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity for effect dep: `fetchSessions` is in the dependency array of the sessions-tab useEffect below.
@@ -1358,9 +1425,10 @@ function LocalTerminalSidebar() {
         return;
       }
       const data = (await res.json()) as { sessions?: WorkspaceSessionSummary[] };
-      setSessions(Array.isArray(data.sessions)
+      const nextSessions = Array.isArray(data.sessions)
         ? data.sessions.filter((session) => typeof session.id === "string" && session.id.length > 0)
-        : []);
+        : [];
+      setSessions((prev) => workspaceSessionsEqual(prev, nextSessions) ? prev : nextSessions);
     } catch (err: unknown) {
       console.warn("Failed to load workspace sessions:", err instanceof Error ? err.message : err);
       setSessionsError("Could not reach gateway");

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1272,8 +1272,10 @@ interface WorkspaceSessionSummary {
 
 function shellSessionsEqual(left: ShellSessionSummary[], right: ShellSessionSummary[]): boolean {
   if (left.length !== right.length) return false;
-  return left.every((session, index) => {
-    const next = right[index];
+  const sortedLeft = [...left].sort((a, b) => a.name.localeCompare(b.name));
+  const sortedRight = [...right].sort((a, b) => a.name.localeCompare(b.name));
+  return sortedLeft.every((session, index) => {
+    const next = sortedRight[index];
     if (!next) return false;
     if (
       session.name !== next.name ||
@@ -1300,8 +1302,10 @@ function shellSessionsEqual(left: ShellSessionSummary[], right: ShellSessionSumm
 
 function workspaceSessionsEqual(left: WorkspaceSessionSummary[], right: WorkspaceSessionSummary[]): boolean {
   if (left.length !== right.length) return false;
-  return left.every((session, index) => {
-    const next = right[index];
+  const sortedLeft = [...left].sort((a, b) => a.id.localeCompare(b.id));
+  const sortedRight = [...right].sort((a, b) => a.id.localeCompare(b.id));
+  return sortedLeft.every((session, index) => {
+    const next = sortedRight[index];
     return (
       next !== undefined &&
       session.id === next.id &&

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -352,6 +352,7 @@ describe('customer VPS host bundle', () => {
     expect(syncAgent).toContain("find \"$STAGING_DIR\" -mindepth 1 -maxdepth 1 \\( -name 'failed-*' -o -name 'bundle-*' \\) -print0");
     expect(syncAgent).toContain('maybe_clean_staging');
     expect(syncAgent).toContain('clean_staging || true');
+    expect(syncAgent).toContain('last_staging_cleanup="$(date +%s)"');
   });
 
   it('sync agent replaces the app tree with root permissions', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -343,6 +343,17 @@ describe('customer VPS host bundle', () => {
     expect(syncAgent).toContain('sudo systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service');
   });
 
+  it('sync agent periodically cleans stale local bundle artifacts', () => {
+    const root = process.cwd();
+    const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
+
+    expect(syncAgent).toContain('readonly STAGING_ARTIFACT_TTL_SECONDS="${MATRIX_STAGING_ARTIFACT_TTL_SECONDS:-86400}"');
+    expect(syncAgent).toContain('readonly STAGING_CLEANUP_INTERVAL_SECONDS="${MATRIX_STAGING_CLEANUP_INTERVAL_SECONDS:-3600}"');
+    expect(syncAgent).toContain("find \"$STAGING_DIR\" -mindepth 1 -maxdepth 1 \\( -name 'failed-*' -o -name 'bundle-*' \\) -print0");
+    expect(syncAgent).toContain('maybe_clean_staging');
+    expect(syncAgent).toContain('clean_staging || true');
+  });
+
   it('sync agent replaces the app tree with root permissions', () => {
     const root = process.cwd();
     const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -336,6 +336,54 @@ describe("TerminalApp", () => {
     expect(props.paneTree.sessionId).toBe("main");
   });
 
+  it("recreates saved canonical shell sessions before restoring a layout", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/terminal/layout") && init?.method !== "PUT") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            tabs: [{
+              id: "bench-tab",
+              label: "bench",
+              paneTree: {
+                type: "pane",
+                id: "bench-pane",
+                cwd: "projects",
+                sessionId: "bench",
+              },
+            }],
+            activeTabId: "bench-tab",
+          }),
+        });
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({ ok: true, json: async () => ({ sessions: [{ name: "main" }] }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/terminal/sessions"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "bench", cwd: "projects" }),
+      }),
+    );
+    const props = paneGridSpy.mock.lastCall?.[0] as {
+      paneTree: { type: "pane"; sessionId?: string };
+    };
+    expect(props.paneTree.sessionId).toBe("bench");
+  });
+
   it("does not replace a legacy layout after unmount while ensuring the canonical session", async () => {
     let resolveSessions: ((value: { ok: boolean; json: () => Promise<{ sessions: Array<{ name: string }> }> }) => void) | null = null;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
@@ -918,7 +966,7 @@ describe("TerminalApp", () => {
     expect(deleteCalls).toHaveLength(1);
   });
 
-  it("keeps the Shells sidebar synchronized with newly adopted zellij sessions", async () => {
+  it("keeps the Shells sidebar synchronized after manual refresh", async () => {
     let revealBench = false;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -960,7 +1008,7 @@ describe("TerminalApp", () => {
 
     await act(async () => {
       revealBench = true;
-      vi.advanceTimersByTime(5_000);
+      fireEvent.click(screen.getByTitle("Refresh"));
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -1013,7 +1061,7 @@ describe("TerminalApp", () => {
     shellListMode = "fail";
 
     await act(async () => {
-      vi.advanceTimersByTime(5_001);
+      fireEvent.click(screen.getByTitle("Refresh"));
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -1022,7 +1070,7 @@ describe("TerminalApp", () => {
     expect(screen.getByText("Failed to load shells")).toBeTruthy();
 
     await act(async () => {
-      vi.advanceTimersByTime(5_000);
+      fireEvent.click(screen.getByTitle("Refresh"));
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -1031,9 +1079,7 @@ describe("TerminalApp", () => {
     expect(screen.queryByText("Failed to load shells")).toBeNull();
   });
 
-  it("aborts an in-flight silent Shells refresh before starting the next poll", async () => {
-    let blockNextShellList = false;
-    let firstSilentSignal: AbortSignal | undefined;
+  it("does not poll shell sessions while the Shells sidebar is open", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/files/tree")) {
@@ -1046,21 +1092,9 @@ describe("TerminalApp", () => {
         return Promise.resolve({ ok: true, json: async () => ({}) });
       }
       if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
-        if (blockNextShellList && !firstSilentSignal) {
-          firstSilentSignal = init?.signal ?? undefined;
-          return new Promise((_resolve, reject) => {
-            init?.signal?.addEventListener("abort", () => {
-              reject(new DOMException("aborted", "AbortError"));
-            }, { once: true });
-          });
-        }
         return Promise.resolve({
           ok: true,
-          json: async () => ({
-            sessions: firstSilentSignal
-              ? [{ name: "main", status: "active" }, { name: "bench", status: "active" }]
-              : [{ name: "main", status: "active" }],
-          }),
+          json: async () => ({ sessions: [{ name: "main", status: "active" }] }),
         });
       }
       return Promise.resolve({ ok: true, json: async () => ({}) });
@@ -1077,23 +1111,20 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
     expect(screen.getAllByText("main").length).toBeGreaterThan(0);
-    blockNextShellList = true;
+    const shellListCallsBeforeWait = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).endsWith("/api/terminal/sessions") && init?.method !== "POST"
+    )).length;
 
     await act(async () => {
-      vi.advanceTimersByTime(5_000);
-      await Promise.resolve();
-    });
-
-    expect(firstSilentSignal?.aborted).toBe(false);
-
-    await act(async () => {
-      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(20_000);
       await Promise.resolve();
       await Promise.resolve();
     });
 
-    expect(firstSilentSignal?.aborted).toBe(true);
-    expect(screen.getByText("bench")).toBeTruthy();
+    const shellListCallsAfterWait = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
+      String(input).endsWith("/api/terminal/sessions") && init?.method !== "POST"
+    )).length;
+    expect(shellListCallsAfterWait).toBe(shellListCallsBeforeWait);
   });
 
   it("surfaces shell creation failures in the Shells sidebar", async () => {


### PR DESCRIPTION
## Summary
- stop the Terminal Shells sidebar from polling `/api/terminal/sessions` every 5 seconds
- preserve manual/create/delete refreshes while avoiding redundant shell/session state writes
- recreate saved canonical zellij sessions before restoring terminal layouts so missing sessions do not attach to dead names
- prune stale local host-bundle staging artifacts from `matrix-sync-agent` on an hourly cadence after a 24h TTL

## Invariants
- **Source of truth**: zellij remains the source of truth for live shell sessions; terminal layout remains persisted through `/api/terminal/layout`; sync-agent staging remains local under `/opt/matrix/staging`.
- **Lock/transaction scope**: no database writes are introduced. Session repair does a bounded list-then-create before layout restore; local staging cleanup only targets top-level `failed-*` and `bundle-*` paths under the fixed staging directory.
- **Acceptable orphan states**: if a saved shell session cannot be recreated, the terminal falls back to the canonical `main` session path instead of restoring a broken layout. If cleanup fails, update flow continues and retries later.
- **Auth source of truth**: existing gateway auth for terminal/session endpoints is unchanged; no new endpoints are introduced.
- **Deferred scope**: this does not add realtime push updates for the Shells sidebar and does not delete remote R2 bundle objects.

## Tests
- `bun run test -- tests/shell/terminal-app-component.test.tsx tests/platform/customer-vps-host-bundle.test.ts`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
