### PR TITLE
fix(runtime): standardize owner linux home

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -17,7 +17,16 @@ write_files:
     owner: root:root
     permissions: "0644"
     content: |
-      export PATH="/opt/matrix/runtime/node/bin:$PATH"
+      if [ "$(id -un 2>/dev/null || true)" = "matrix" ]; then
+        export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+        export HOME="$MATRIX_HOME"
+        export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+        export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+        export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+        export PATH="$HOME/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:$PATH"
+      else
+        export PATH="/opt/matrix/bin:/opt/matrix/runtime/node/bin:$PATH"
+      fi
       test -x /home/linuxbrew/.linuxbrew/bin/brew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"
   - path: /opt/matrix/postgres-compose.yml
     owner: root:root
@@ -155,7 +164,11 @@ write_files:
       Type=oneshot
       User=matrix
       Group=matrix
-      Environment=HOME=/home/matrix
+      Environment=MATRIX_HOME=/home/matrix/home
+      Environment=HOME=/home/matrix/home
+      Environment=XDG_CONFIG_HOME=/home/matrix/home/.config
+      Environment=XDG_DATA_HOME=/home/matrix/home/.local/share
+      Environment=XDG_CACHE_HOME=/home/matrix/home/.cache
       ExecStart=/opt/matrix/bin/matrix-install-linux-tools
       Restart=on-failure
       RestartSec=10m
@@ -728,28 +741,36 @@ runcmd:
     install -d -o root -g matrix -m 0770 /opt/matrix
     install -d -o root -g matrix -m 0750 /opt/matrix/env /opt/matrix/bin /opt/matrix/tls
     install -d -o matrix -g matrix -m 0755 /opt/matrix/messaging /opt/matrix/messaging/bin
-    install -d -o matrix -g matrix -m 0755 /home/matrix /home/matrix/.local /home/matrix/.cache /home/matrix/.config
-    install -d -o matrix -g matrix -m 0755 /home/matrix/.config/systemd
+    install -d -o matrix -g matrix -m 0755 /home/matrix /home/matrix/home /home/matrix/home/.local /home/matrix/home/.local/bin /home/matrix/home/.local/share /home/matrix/home/.cache /home/matrix/home/.config
+    install -d -o matrix -g matrix -m 0755 /home/matrix/home/.config/systemd /home/matrix/home/.config/systemd/user
     install -d -o root -g root -m 0750 /etc/sudoers.d
     printf 'matrix ALL=(ALL) NOPASSWD:ALL\n' >/etc/sudoers.d/matrix
     chmod 0440 /etc/sudoers.d/matrix
     visudo -cf /etc/sudoers.d/matrix
-    install -d -o matrix -g matrix -m 0750 /home/matrix/home /home/matrix/projects /var/lib/matrix/db/snapshots /var/lib/matrix/logs
-    install -d -o matrix -g matrix -m 0755 /home/matrix/home/.config /home/matrix/home/.config/systemd /home/matrix/home/.config/systemd/user
-    install -d -o matrix -g matrix -m 0700 /home/matrix/home/.config/gh
-    if [ -d /home/matrix/.config/gh ] && [ ! -L /home/matrix/.config/gh ]; then
-      if cp -an /home/matrix/.config/gh/. /home/matrix/home/.config/gh/; then
-        rm -rf /home/matrix/.config/gh
-      else
-        echo "matrix-host: failed to migrate .config/gh; skipping removal" >&2
+    usermod -d /home/matrix/home matrix
+    install -d -o matrix -g matrix -m 0750 /home/matrix/home /home/matrix/home/projects /home/matrix/projects /var/lib/matrix/db/snapshots /var/lib/matrix/logs
+    ensure_owner_link() {
+      local name="$1" mode="$2" legacy="/home/matrix/$1" target="/home/matrix/home/$1"
+      install -d -o matrix -g matrix -m "$mode" "$target"
+      if [ -d "$legacy" ] && [ ! -L "$legacy" ]; then
+        if cp -an "$legacy/." "$target/"; then
+          rm -rf "$legacy"
+        else
+          echo "matrix-host: failed to migrate $legacy; skipping removal" >&2
+        fi
       fi
-    fi
-    if [ ! -e /home/matrix/.config/gh ] || [ -L /home/matrix/.config/gh ]; then
-      ln -sfn /home/matrix/home/.config/gh /home/matrix/.config/gh
-      chown -h matrix:matrix /home/matrix/.config/gh
-    else
-      echo "matrix-host: .config/gh remains a real directory; skipping symlink" >&2
-    fi
+      if [ ! -e "$legacy" ] || [ -L "$legacy" ]; then
+        ln -sfn "$target" "$legacy"
+        chown -h matrix:matrix "$legacy"
+      else
+        echo "matrix-host: $legacy remains a real path; skipping symlink" >&2
+      fi
+    }
+    ensure_owner_link .local 0755
+    ensure_owner_link .cache 0755
+    ensure_owner_link .config 0755
+    ensure_owner_link .hermes 0700
+    install -d -o matrix -g matrix -m 0700 /home/matrix/home/.config/gh
     install -d -o matrix -g matrix -m 0700 /home/matrix/home/.ssh
     if [ -d /home/matrix/.ssh ] && [ ! -L /home/matrix/.ssh ]; then
       if cp -an /home/matrix/.ssh/. /home/matrix/home/.ssh/; then
@@ -764,8 +785,6 @@ runcmd:
     else
       echo "matrix-host: .ssh remains a real directory; skipping symlink" >&2
     fi
-    ln -sfn /home/matrix/home/.config/systemd/user /home/matrix/.config/systemd/user
-    chown -h matrix:matrix /home/matrix/.config/systemd/user
     install -d -o root -g root -m 0755 /home/matrixos
     ln -sfn /home/matrix/home /home/matrixos/home
     chown root:matrix /opt/matrix/postgres-compose.yml /opt/matrix/bin/matrixctl /opt/matrix/bin/matrix-db-backup.sh /opt/matrix/bin/matrix-restore.sh /opt/matrix/env/host.env /opt/matrix/env/postgres.env /opt/matrix/env/registration.env
@@ -801,7 +820,7 @@ runcmd:
       chown root:matrix /opt/matrix/release.json
       chmod 0644 /opt/matrix/release.json
     fi
-    for required_bin in matrixctl matrix-db-backup.sh matrix-restore.sh matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-symphony matrix-install-hermes; do
+    for required_bin in matrixctl matrix-db-backup.sh matrix-restore.sh matrix-owner-env matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-symphony matrix-install-hermes; do
       chmod 0750 "/opt/matrix/bin/${required_bin}"
     done
     for optional_bin in matrix-install-linux-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do

--- a/distro/customer-vps/host-bin/matrix-code
+++ b/distro/customer-vps/host-bin/matrix-code
@@ -2,13 +2,21 @@
 set -euo pipefail
 
 source /opt/matrix/env/host.env
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+fi
 
 CODE_SERVER_PORT="${MATRIX_CODE_SERVER_PORT:-8787}"
 CODE_SERVER_UPSTREAM_PORT="${MATRIX_CODE_SERVER_UPSTREAM_PORT:-8788}"
-MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+if declare -F matrix_export_owner_env >/dev/null 2>&1; then
+  matrix_export_owner_env
+else
+  export HOME="$MATRIX_HOME"
+fi
 CODE_SERVER_ROOT="$MATRIX_HOME/system/code-server"
 
-export PATH="/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
 
 if ! command -v code-server >/dev/null 2>&1; then
   echo "matrix-code: code-server is not installed" >&2

--- a/distro/customer-vps/host-bin/matrix-code
+++ b/distro/customer-vps/host-bin/matrix-code
@@ -13,10 +13,9 @@ if declare -F matrix_export_owner_env >/dev/null 2>&1; then
   matrix_export_owner_env
 else
   export HOME="$MATRIX_HOME"
+  export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
 fi
 CODE_SERVER_ROOT="$MATRIX_HOME/system/code-server"
-
-export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
 
 if ! command -v code-server >/dev/null 2>&1; then
   echo "matrix-code: code-server is not installed" >&2

--- a/distro/customer-vps/host-bin/matrix-gateway
+++ b/distro/customer-vps/host-bin/matrix-gateway
@@ -8,6 +8,9 @@ fi
 if [ -f /opt/matrix/env/registration.env ]; then
   source /opt/matrix/env/registration.env
 fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+fi
 
 NODE_BIN="${MATRIX_NODE_BIN:-/opt/matrix/runtime/node/bin/node}"
 APP_DIR="${MATRIX_APP_DIR:-/opt/matrix/app}"
@@ -16,6 +19,11 @@ REGISTER_FLAG="/opt/matrix/register-complete"
 
 export NODE_ENV="${NODE_ENV:-production}"
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+if declare -F matrix_export_owner_env >/dev/null 2>&1; then
+  matrix_export_owner_env
+else
+  export HOME="$MATRIX_HOME"
+fi
 export MATRIX_USER_ID="${MATRIX_USER_ID:-$MATRIX_CLERK_USER_ID}"
 export MATRIX_HANDLE
 if [ -z "${DATABASE_URL:-}" ] && [ -n "${POSTGRES_USER:-}" ] && [ -n "${POSTGRES_PASSWORD:-}" ] && [ -n "${POSTGRES_DB:-}" ]; then
@@ -27,7 +35,7 @@ export PORT="$GATEWAY_PORT"
 export GATEWAY_URL="${GATEWAY_URL:-http://127.0.0.1:${GATEWAY_PORT}}"
 export NEXT_PUBLIC_GATEWAY_URL="${NEXT_PUBLIC_GATEWAY_URL:-http://127.0.0.1:${GATEWAY_PORT}}"
 export NEXT_PUBLIC_GATEWAY_WS="${NEXT_PUBLIC_GATEWAY_WS:-wss://code.matrix-os.com/ws}"
-export PATH="/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
 
 sync_bundled_home_assets() {
   local bundled_home="$APP_DIR/home"
@@ -77,7 +85,7 @@ sync_bundled_home_assets
 if [ -x "$APP_DIR/scripts/sync-matrix-agent-skills.sh" ] && [ -d "$APP_DIR/skills/matrix" ]; then
   MATRIX_SKILL_TARGETS=matrix,claude,codex \
     MATRIX_SKILLS_SOURCE="$APP_DIR/skills/matrix" \
-    HOME="${HOME:-/home/matrix}" \
+    HOME="$MATRIX_HOME" \
     MATRIX_HOME="$MATRIX_HOME" \
     bash "$APP_DIR/scripts/sync-matrix-agent-skills.sh"
 fi

--- a/distro/customer-vps/host-bin/matrix-gateway
+++ b/distro/customer-vps/host-bin/matrix-gateway
@@ -35,7 +35,11 @@ export PORT="$GATEWAY_PORT"
 export GATEWAY_URL="${GATEWAY_URL:-http://127.0.0.1:${GATEWAY_PORT}}"
 export NEXT_PUBLIC_GATEWAY_URL="${NEXT_PUBLIC_GATEWAY_URL:-http://127.0.0.1:${GATEWAY_PORT}}"
 export NEXT_PUBLIC_GATEWAY_WS="${NEXT_PUBLIC_GATEWAY_WS:-wss://code.matrix-os.com/ws}"
-export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+if declare -F matrix_prepend_path_once >/dev/null 2>&1; then
+  matrix_prepend_path_once "/opt/matrix/app/node_modules/.bin"
+else
+  export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+fi
 
 sync_bundled_home_assets() {
   local bundled_home="$APP_DIR/home"

--- a/distro/customer-vps/host-bin/matrix-install-hermes
+++ b/distro/customer-vps/host-bin/matrix-install-hermes
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 MATRIX_RUNTIME_USER="${MATRIX_RUNTIME_USER:-matrix}"
-MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-/home/matrix}"
+if [ -r /opt/matrix/env/host.env ]; then
+  source /opt/matrix/env/host.env
+fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+  matrix_export_owner_env
+fi
+MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-${MATRIX_HOME:-/home/matrix/home}}"
 HERMES_INSTALLER_URL="${HERMES_INSTALLER_URL:-https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh}"
 HERMES_HOME="${HERMES_HOME:-$MATRIX_RUNTIME_HOME/.hermes}"
 HERMES_INSTALLER_PATH="${HERMES_INSTALLER_PATH:-/tmp/hermes-agent-install.sh}"
@@ -24,6 +31,12 @@ install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_USER" -m 0755 \
   "$MATRIX_RUNTIME_HOME/.cache" \
   "$MATRIX_RUNTIME_HOME/.config" \
   "$HERMES_HOME"
+if declare -F matrix_migrate_legacy_dotdir >/dev/null 2>&1; then
+  matrix_migrate_legacy_dotdir ".local" 0755
+  matrix_migrate_legacy_dotdir ".cache" 0755
+  matrix_migrate_legacy_dotdir ".config" 0755
+  matrix_migrate_legacy_dotdir ".hermes" 0700
+fi
 
 curl --fail --location --retry 3 --retry-delay 5 --retry-all-errors \
   --connect-timeout 10 --max-time 180 \
@@ -34,7 +47,10 @@ log "installing Hermes Agent for $MATRIX_RUNTIME_USER"
 sudo -H -u "$MATRIX_RUNTIME_USER" env \
   HOME="$MATRIX_RUNTIME_HOME" \
   HERMES_HOME="$HERMES_HOME" \
-  PATH="/opt/matrix/runtime/node/bin:$MATRIX_RUNTIME_HOME/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+  XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \
+  XDG_DATA_HOME="$MATRIX_RUNTIME_HOME/.local/share" \
+  XDG_CACHE_HOME="$MATRIX_RUNTIME_HOME/.cache" \
+  PATH="$MATRIX_RUNTIME_HOME/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:/usr/bin:/bin" \
   bash "$HERMES_INSTALLER_PATH" --skip-setup
 
 for cli in uv uvx hermes; do
@@ -49,12 +65,18 @@ if [ -x "$MATRIX_RUNTIME_HOME/.local/bin/hermes" ] && [ -x "$MATRIX_APP_DIR/scri
     HOME="$MATRIX_RUNTIME_HOME" \
     HERMES_HOME="$HERMES_HOME" \
     HERMES_BIN="$MATRIX_RUNTIME_HOME/.local/bin/hermes" \
+    XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \
+    XDG_DATA_HOME="$MATRIX_RUNTIME_HOME/.local/share" \
+    XDG_CACHE_HOME="$MATRIX_RUNTIME_HOME/.cache" \
     PATH="$MATRIX_RUNTIME_HOME/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:/usr/bin:/bin" \
     bash -lc "cd '$MATRIX_APP_DIR' && ./scripts/install-hermes-matrix-skills.sh '$MATRIX_APP_DIR'"
 
   sudo -H -u "$MATRIX_RUNTIME_USER" env \
     HOME="$MATRIX_RUNTIME_HOME" \
     HERMES_HOME="$HERMES_HOME" \
+    XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \
+    XDG_DATA_HOME="$MATRIX_RUNTIME_HOME/.local/share" \
+    XDG_CACHE_HOME="$MATRIX_RUNTIME_HOME/.cache" \
     PATH="$MATRIX_RUNTIME_HOME/.local/bin:/opt/matrix/runtime/node/bin:/usr/local/bin:/usr/bin:/bin" \
     "$MATRIX_RUNTIME_HOME/.local/bin/hermes" config set skills.config.matrix.gateway_url "$MATRIX_GATEWAY_URL" || true
 fi

--- a/distro/customer-vps/host-bin/matrix-install-hermes
+++ b/distro/customer-vps/host-bin/matrix-install-hermes
@@ -25,12 +25,16 @@ if ! id "$MATRIX_RUNTIME_USER" >/dev/null 2>&1; then
   exit 1
 fi
 
-install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_USER" -m 0755 \
-  "$MATRIX_RUNTIME_HOME/.local" \
-  "$MATRIX_RUNTIME_HOME/.local/bin" \
-  "$MATRIX_RUNTIME_HOME/.cache" \
-  "$MATRIX_RUNTIME_HOME/.config" \
-  "$HERMES_HOME"
+if declare -F matrix_install_owner_dirs >/dev/null 2>&1; then
+  matrix_install_owner_dirs "$MATRIX_RUNTIME_USER" "$MATRIX_RUNTIME_USER"
+else
+  install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_USER" -m 0755 \
+    "$MATRIX_RUNTIME_HOME/.local" \
+    "$MATRIX_RUNTIME_HOME/.local/bin" \
+    "$MATRIX_RUNTIME_HOME/.cache" \
+    "$MATRIX_RUNTIME_HOME/.config"
+fi
+install -d -o "$MATRIX_RUNTIME_USER" -g "$MATRIX_RUNTIME_USER" -m 0700 "$HERMES_HOME"
 if declare -F matrix_migrate_legacy_dotdir >/dev/null 2>&1; then
   matrix_migrate_legacy_dotdir ".local" 0755
   matrix_migrate_legacy_dotdir ".cache" 0755

--- a/distro/customer-vps/host-bin/matrix-install-linux-tools
+++ b/distro/customer-vps/host-bin/matrix-install-linux-tools
@@ -4,6 +4,13 @@ set -euo pipefail
 BREW_BIN="${HOMEBREW_BIN:-/home/linuxbrew/.linuxbrew/bin/brew}"
 BREW_PREFIX="${HOMEBREW_PREFIX:-/home/linuxbrew/.linuxbrew}"
 INSTALLER_URL="${HOMEBREW_INSTALLER_URL:-https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh}"
+if [ -r /opt/matrix/env/host.env ]; then
+  source /opt/matrix/env/host.env
+fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+  matrix_export_owner_env
+fi
 
 retry() {
   local max_attempts="$1"
@@ -29,7 +36,7 @@ if command -v apt-get >/dev/null 2>&1; then
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential procps curl file git
 fi
 
-cd "${HOME:-/home/matrix}"
+cd "${HOME:-/home/matrix/home}"
 
 if [ ! -x "$BREW_BIN" ]; then
   tmp_installer="$(mktemp)"
@@ -54,7 +61,7 @@ sudo install -d -o root -g root -m 0755 /etc/profile.d
 printf '%s\n' \
   '# Homebrew on Linux' \
   'if [ -n "${PWD:-}" ] && [ ! -r "${PWD}" ]; then' \
-  '  cd "${HOME:-/home/matrix}" || true' \
+  '  cd "${HOME:-/home/matrix/home}" || true' \
   'fi' \
   "eval \"\$(${BREW_BIN} shellenv bash)\"" \
   | sudo tee /etc/profile.d/homebrew.sh >/dev/null

--- a/distro/customer-vps/host-bin/matrix-install-tool-pack
+++ b/distro/customer-vps/host-bin/matrix-install-tool-pack
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 MATRIX_RUNTIME_USER="${MATRIX_RUNTIME_USER:-matrix}"
-MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-/home/matrix}"
+if [ -r /opt/matrix/env/host.env ]; then
+  source /opt/matrix/env/host.env
+fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+  matrix_export_owner_env
+fi
+MATRIX_RUNTIME_HOME="${MATRIX_RUNTIME_HOME:-${MATRIX_HOME:-/home/matrix/home}}"
 MATRIX_APP_DIR="${MATRIX_APP_DIR:-/opt/matrix/app}"
 MATRIX_RUNTIME_DIR="${MATRIX_RUNTIME_DIR:-/opt/matrix/runtime}"
 NODE_PREFIX="${MATRIX_NODE_PREFIX:-$MATRIX_RUNTIME_DIR/node}"
@@ -41,12 +48,21 @@ retry() {
 
 run_as_matrix() {
   if [ "$(id -u -n)" = "$MATRIX_RUNTIME_USER" ]; then
-    env HOME="$MATRIX_RUNTIME_HOME" PATH="$NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" "$@"
+    env \
+      HOME="$MATRIX_RUNTIME_HOME" \
+      XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \
+      XDG_DATA_HOME="$MATRIX_RUNTIME_HOME/.local/share" \
+      XDG_CACHE_HOME="$MATRIX_RUNTIME_HOME/.cache" \
+      PATH="$MATRIX_RUNTIME_HOME/.local/bin:$NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \
+      "$@"
     return
   fi
   sudo -H -u "$MATRIX_RUNTIME_USER" env \
     HOME="$MATRIX_RUNTIME_HOME" \
-    PATH="$NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \
+    XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config" \
+    XDG_DATA_HOME="$MATRIX_RUNTIME_HOME/.local/share" \
+    XDG_CACHE_HOME="$MATRIX_RUNTIME_HOME/.cache" \
+    PATH="$MATRIX_RUNTIME_HOME/.local/bin:$NODE_PREFIX/bin:/usr/local/bin:/usr/bin:/bin" \
     "$@"
 }
 
@@ -74,7 +90,7 @@ with_pack_lock() {
 
 sync_agent_skills() {
   if [ -x "$MATRIX_APP_DIR/scripts/sync-matrix-agent-skills.sh" ] && [ -d "$MATRIX_APP_DIR/skills/matrix" ]; then
-    run_as_matrix bash -lc "cd '$MATRIX_APP_DIR' && MATRIX_SKILL_TARGETS=matrix,claude,codex MATRIX_SKILLS_SOURCE='$MATRIX_APP_DIR/skills/matrix' MATRIX_HOME='${MATRIX_HOME:-$MATRIX_RUNTIME_HOME/home}' ./scripts/sync-matrix-agent-skills.sh"
+    run_as_matrix bash -lc "cd '$MATRIX_APP_DIR' && MATRIX_SKILL_TARGETS=matrix,claude,codex MATRIX_SKILLS_SOURCE='$MATRIX_APP_DIR/skills/matrix' MATRIX_HOME='$MATRIX_RUNTIME_HOME' ./scripts/sync-matrix-agent-skills.sh"
   fi
 }
 

--- a/distro/customer-vps/host-bin/matrix-owner-env
+++ b/distro/customer-vps/host-bin/matrix-owner-env
@@ -1,12 +1,25 @@
 #!/usr/bin/env bash
 
+matrix_prepend_path_once() {
+  local entry="$1"
+  [ -n "$entry" ] || return 0
+  case ":${PATH:-}:" in
+    *":$entry:"*) ;;
+    *) PATH="$entry${PATH:+:$PATH}" ;;
+  esac
+  export PATH
+}
+
 matrix_export_owner_env() {
   export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
   export HOME="$MATRIX_HOME"
   export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
   export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
   export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
-  export PATH="$HOME/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:${PATH:-/usr/local/bin:/usr/bin:/bin}"
+  export PATH="${PATH:-/usr/local/bin:/usr/bin:/bin}"
+  matrix_prepend_path_once "/opt/matrix/runtime/node/bin"
+  matrix_prepend_path_once "/opt/matrix/bin"
+  matrix_prepend_path_once "$HOME/.local/bin"
 }
 
 matrix_install_owner_dirs() {
@@ -33,7 +46,10 @@ matrix_migrate_legacy_dotdir() {
 
   install -d -o "$owner" -g "$group" -m "$mode" "$target"
   if [ -d "$legacy" ] && [ ! -L "$legacy" ]; then
-    cp -an "$legacy/." "$target/" || return 1
+    if ! cp -an "$legacy/." "$target/"; then
+      printf 'matrix-owner-env: failed to copy %s to %s; leaving legacy directory in place\n' "$legacy" "$target" >&2
+      return 0
+    fi
     rm -rf "$legacy"
   fi
   if [ ! -e "$legacy" ] || [ -L "$legacy" ]; then

--- a/distro/customer-vps/host-bin/matrix-owner-env
+++ b/distro/customer-vps/host-bin/matrix-owner-env
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+matrix_export_owner_env() {
+  export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+  export HOME="$MATRIX_HOME"
+  export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+  export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+  export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+  export PATH="$HOME/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:${PATH:-/usr/local/bin:/usr/bin:/bin}"
+}
+
+matrix_install_owner_dirs() {
+  local owner="${1:-matrix}"
+  local group="${2:-$owner}"
+  install -d -o "$owner" -g "$group" -m 0755 \
+    "$MATRIX_HOME" \
+    "$MATRIX_HOME/.local" \
+    "$MATRIX_HOME/.local/bin" \
+    "$MATRIX_HOME/.local/share" \
+    "$MATRIX_HOME/.cache" \
+    "$MATRIX_HOME/.config" \
+    "$MATRIX_HOME/.config/systemd" \
+    "$MATRIX_HOME/.config/systemd/user"
+}
+
+matrix_migrate_legacy_dotdir() {
+  local name="$1"
+  local mode="${2:-0755}"
+  local owner="${MATRIX_RUNTIME_USER:-matrix}"
+  local group="${MATRIX_RUNTIME_GROUP:-$owner}"
+  local legacy="/home/matrix/$name"
+  local target="$MATRIX_HOME/$name"
+
+  install -d -o "$owner" -g "$group" -m "$mode" "$target"
+  if [ -d "$legacy" ] && [ ! -L "$legacy" ]; then
+    cp -an "$legacy/." "$target/" || return 1
+    rm -rf "$legacy"
+  fi
+  if [ ! -e "$legacy" ] || [ -L "$legacy" ]; then
+    ln -sfn "$target" "$legacy"
+    chown -h "$owner:$group" "$legacy"
+  fi
+}

--- a/distro/customer-vps/host-bin/matrix-shell
+++ b/distro/customer-vps/host-bin/matrix-shell
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 source /opt/matrix/env/host.env
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+fi
 
 NODE_BIN="${MATRIX_NODE_BIN:-/opt/matrix/runtime/node/bin/node}"
 APP_DIR="${MATRIX_APP_DIR:-/opt/matrix/app}"
@@ -9,6 +12,11 @@ SHELL_PORT="${SHELL_PORT:-3000}"
 
 export NODE_ENV="${NODE_ENV:-production}"
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+if declare -F matrix_export_owner_env >/dev/null 2>&1; then
+  matrix_export_owner_env
+else
+  export HOME="$MATRIX_HOME"
+fi
 export MATRIX_USER_ID="${MATRIX_USER_ID:-$MATRIX_CLERK_USER_ID}"
 export MATRIX_HANDLE
 export GATEWAY_URL="${GATEWAY_URL:-http://127.0.0.1:4000}"

--- a/distro/customer-vps/host-bin/matrix-symphony
+++ b/distro/customer-vps/host-bin/matrix-symphony
@@ -5,17 +5,25 @@ source /opt/matrix/env/host.env
 if [ -f /opt/matrix/env/registration.env ]; then
   source /opt/matrix/env/registration.env
 fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  source /opt/matrix/bin/matrix-owner-env
+fi
 
 APP_DIR="${MATRIX_APP_DIR:-/opt/matrix/app}"
 SYMPHONY_BIN="${SYMPHONY_BIN:-$APP_DIR/packages/symphony-elixir/bin/symphony}"
 WORKFLOW_FILE="${SYMPHONY_WORKFLOW_FILE:-$APP_DIR/packages/symphony-elixir/WORKFLOW.md}"
 
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+if declare -F matrix_export_owner_env >/dev/null 2>&1; then
+  matrix_export_owner_env
+else
+  export HOME="$MATRIX_HOME"
+fi
 export SYMPHONY_HOST="${SYMPHONY_HOST:-127.0.0.1}"
 export SYMPHONY_PORT="${SYMPHONY_PORT:-4766}"
 export SYMPHONY_WORKSPACE_ROOT="${SYMPHONY_WORKSPACE_ROOT:-$MATRIX_HOME/projects/matrix-os/symphony-workspaces}"
 export SYMPHONY_CODEX_COMMAND="${SYMPHONY_CODEX_COMMAND:-codex app-server}"
-export PATH="/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
 
 mkdir -p "$SYMPHONY_WORKSPACE_ROOT"
 mkdir -p "$MATRIX_HOME/system/symphony/logs"

--- a/distro/customer-vps/host-bin/matrix-symphony
+++ b/distro/customer-vps/host-bin/matrix-symphony
@@ -23,7 +23,11 @@ export SYMPHONY_HOST="${SYMPHONY_HOST:-127.0.0.1}"
 export SYMPHONY_PORT="${SYMPHONY_PORT:-4766}"
 export SYMPHONY_WORKSPACE_ROOT="${SYMPHONY_WORKSPACE_ROOT:-$MATRIX_HOME/projects/matrix-os/symphony-workspaces}"
 export SYMPHONY_CODEX_COMMAND="${SYMPHONY_CODEX_COMMAND:-codex app-server}"
-export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+if declare -F matrix_prepend_path_once >/dev/null 2>&1; then
+  matrix_prepend_path_once "/opt/matrix/app/node_modules/.bin"
+else
+  export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"
+fi
 
 mkdir -p "$SYMPHONY_WORKSPACE_ROOT"
 mkdir -p "$MATRIX_HOME/system/symphony/logs"

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -72,7 +72,7 @@ cp -a "$ROOT_DIR/distro/customer-vps/host-bin/." "$STAGE_DIR/bin/"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"
 # The bundle is usually extracted as root:root during in-place upgrades, while
 # the systemd units execute these wrappers as the matrix user.
-chmod 0755 "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
+chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
 
 cp -a "$ROOT_DIR/node_modules" "$STAGE_DIR/app/node_modules"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -215,10 +215,16 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(toolPackInstaller).toContain('runtime/code-server');
     expect(toolPackInstaller).toContain('/opt/matrix/runtime/code-server/bin/code-server "$@"');
     expect(cloudInit).toContain('path: /etc/profile.d/matrix-runtime.sh');
-    expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0755 /home/matrix /home/matrix/.local /home/matrix/.cache /home/matrix/.config');
-    expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0755 /home/matrix/home/.config /home/matrix/home/.config/systemd /home/matrix/home/.config/systemd/user');
-    expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0700 /home/matrix/home/.config/gh');
-    expect(cloudInit).toContain('ln -sfn /home/matrix/home/.config/gh /home/matrix/.config/gh');
+    expect(cloudInit).toContain('export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"');
+    expect(cloudInit).toContain('export HOME="$MATRIX_HOME"');
+    expect(cloudInit).toContain('export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"');
+    expect(cloudInit).toContain('export PATH="$HOME/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:$PATH"');
+    expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0755 /home/matrix /home/matrix/home /home/matrix/home/.local /home/matrix/home/.local/bin /home/matrix/home/.local/share /home/matrix/home/.cache /home/matrix/home/.config');
+    expect(cloudInit).toContain('usermod -d /home/matrix/home matrix');
+    expect(cloudInit).toContain('ensure_owner_link .local 0755');
+    expect(cloudInit).toContain('ensure_owner_link .cache 0755');
+    expect(cloudInit).toContain('ensure_owner_link .config 0755');
+    expect(cloudInit).toContain('ensure_owner_link .hermes 0700');
     expect(cloudInit).toContain('install -d -o matrix -g matrix -m 0700 /home/matrix/home/.ssh');
     expect(cloudInit).toContain('ln -sfn /home/matrix/home/.ssh /home/matrix/.ssh');
     expect(cloudInit).toContain('ln -sfn /home/matrix/home /home/matrixos/home');
@@ -233,7 +239,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('systemctl start --no-block matrix-linux-tools.service || echo "matrix-host: optional Linux tools install will retry via systemd" >&2');
     expect(cloudInit).not.toContain('sudo -H -u matrix /opt/matrix/bin/matrix-install-linux-tools');
     expect(cloudInit).toContain('test -x /home/linuxbrew/.linuxbrew/bin/brew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"');
-    expect(gateway).toContain('export PATH="/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
+    expect(gateway).toContain('export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
     expect(gateway).toContain('MATRIX_SKILL_TARGETS=matrix,claude,codex');
     expect(cloudInit).toContain('DATABASE_URL=postgresql://matrix:{{postgresPassword}}@127.0.0.1:5432/matrix');
     expect(cloudInit).not.toContain('owner: root:matrix');
@@ -255,7 +261,8 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('visudo -cf /etc/sudoers.d/matrix');
     expect(cloudInit).toContain('loginctl enable-linger matrix');
     expect(cloudInit).toContain('systemctl start "user@$(id -u matrix).service"');
-    expect(cloudInit).toContain('ln -sfn /home/matrix/home/.config/systemd/user /home/matrix/.config/systemd/user');
+    expect(cloudInit).toContain('ensure_owner_link .config 0755');
+    expect(cloudInit).toContain('systemctl start "user@$(id -u matrix).service"');
   });
 
   it('installs Homebrew, Graphite CLI, and GitHub CLI on customer Linux hosts', () => {
@@ -265,7 +272,7 @@ describe('platform/customer-vps-cloud-init', () => {
 
     expect(installer).toContain('https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh');
     expect(installer).toContain('retry 2 30 env NONINTERACTIVE=1 timeout 600 /bin/bash "$tmp_installer"');
-    expect(installer).toContain('cd "${HOME:-/home/matrix}"');
+    expect(installer).toContain('cd "${HOME:-/home/matrix/home}"');
     expect(installer).toContain('retry 3 30 timeout 600 "$BREW_BIN" install withgraphite/tap/graphite');
     expect(installer).toContain('retry 3 30 timeout 600 "$BREW_BIN" install gh');
     expect(installer).toContain('/etc/profile.d/homebrew.sh');

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -239,7 +239,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('systemctl start --no-block matrix-linux-tools.service || echo "matrix-host: optional Linux tools install will retry via systemd" >&2');
     expect(cloudInit).not.toContain('sudo -H -u matrix /opt/matrix/bin/matrix-install-linux-tools');
     expect(cloudInit).toContain('test -x /home/linuxbrew/.linuxbrew/bin/brew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"');
-    expect(gateway).toContain('export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
+    expect(gateway).toContain('matrix_prepend_path_once "/opt/matrix/app/node_modules/.bin"');
     expect(gateway).toContain('MATRIX_SKILL_TARGETS=matrix,claude,codex');
     expect(cloudInit).toContain('DATABASE_URL=postgresql://matrix:{{postgresPassword}}@127.0.0.1:5432/matrix');
     expect(cloudInit).not.toContain('owner: root:matrix');
@@ -262,7 +262,6 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('loginctl enable-linger matrix');
     expect(cloudInit).toContain('systemctl start "user@$(id -u matrix).service"');
     expect(cloudInit).toContain('ensure_owner_link .config 0755');
-    expect(cloudInit).toContain('systemctl start "user@$(id -u matrix).service"');
   });
 
   it('installs Homebrew, Graphite CLI, and GitHub CLI on customer Linux hosts', () => {

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -101,8 +101,11 @@ describe('customer VPS host bundle', () => {
     expect(ownerEnv).toContain('matrix_export_owner_env()');
     expect(ownerEnv).toContain('export HOME="$MATRIX_HOME"');
     expect(ownerEnv).toContain('export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"');
-    expect(ownerEnv).toContain('export PATH="$HOME/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:${PATH:-/usr/local/bin:/usr/bin:/bin}"');
+    expect(ownerEnv).toContain('matrix_prepend_path_once()');
+    expect(ownerEnv).toContain('matrix_prepend_path_once "$HOME/.local/bin"');
+    expect(ownerEnv).toContain('failed to copy %s to %s; leaving legacy directory in place');
     expect(hermesInstaller).toContain('source /opt/matrix/bin/matrix-owner-env');
+    expect(hermesInstaller).toContain('matrix_install_owner_dirs "$MATRIX_RUNTIME_USER" "$MATRIX_RUNTIME_USER"');
     expect(hermesInstaller).toContain('matrix_migrate_legacy_dotdir ".hermes" 0700');
     expect(hermesInstaller).toContain('HOME="$MATRIX_RUNTIME_HOME"');
     expect(hermesInstaller).toContain('XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config"');
@@ -398,7 +401,7 @@ describe('customer VPS host bundle', () => {
     expect(launcher).toContain('curl --fail --silent --show-error --max-time 10');
     expect(launcher).toContain('MATRIX_REGISTRATION_TOKEN');
     expect(launcher).toContain('/opt/matrix/app/node_modules/.bin');
-    expect(launcher).toContain('export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
+    expect(launcher).toContain('matrix_prepend_path_once "/opt/matrix/app/node_modules/.bin"');
     expect(launcher).toContain('export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}"');
     expect(launcher).toContain('sync_bundled_home_assets');
     expect(launcher).toContain('sync-matrix-agent-skills.sh');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -55,7 +55,7 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('GH_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_ARCHIVE}"');
     expect(script).toContain('install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/runtime/node/bin/gh"');
     expect(script).toContain('install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"');
-    expect(script).toContain('chmod 0755 "$STAGE_DIR/bin/matrix-gateway"');
+    expect(script).toContain('chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway"');
     expect(script).toContain('rm -rf "$STAGE_DIR/app/shell/.next/cache" "$STAGE_DIR/app/shell/e2e" "$STAGE_DIR/app/shell/node_modules"');
     expect(script).toContain('find "$STAGE_DIR/app/home/apps" -type d -name node_modules -prune -exec rm -rf {} +');
     expect(script).toContain('matrix-update');
@@ -69,8 +69,11 @@ describe('customer VPS host bundle', () => {
     const root = process.cwd();
     const script = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
     const installer = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-tool-pack'), 'utf8');
+    const hermesInstaller = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-hermes'), 'utf8');
+    const ownerEnv = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-owner-env'), 'utf8');
 
     expect(script).toContain('matrix-install-tool-pack');
+    expect(script).toContain('matrix-owner-env');
     expect(script).not.toContain('curl --fail --location --max-time 180 "$CODE_SERVER_URL"');
     expect(script).not.toContain('tar -xzf "$DIST_DIR/$CODE_SERVER_ARCHIVE"');
     expect(script).not.toContain('"$STAGE_DIR/runtime/node/bin/npm" install -g --prefix "$STAGE_DIR/runtime/node"');
@@ -95,6 +98,14 @@ describe('customer VPS host bundle', () => {
     expect(installer).toContain('if ! wait "$pid"; then');
     expect(installer).toContain('exit "$failed"');
     expect(installer).not.toMatch(/wait "\$pid_coding_agents" "\$pid_code_server"/);
+    expect(ownerEnv).toContain('matrix_export_owner_env()');
+    expect(ownerEnv).toContain('export HOME="$MATRIX_HOME"');
+    expect(ownerEnv).toContain('export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"');
+    expect(ownerEnv).toContain('export PATH="$HOME/.local/bin:/opt/matrix/bin:/opt/matrix/runtime/node/bin:${PATH:-/usr/local/bin:/usr/bin:/bin}"');
+    expect(hermesInstaller).toContain('source /opt/matrix/bin/matrix-owner-env');
+    expect(hermesInstaller).toContain('matrix_migrate_legacy_dotdir ".hermes" 0700');
+    expect(hermesInstaller).toContain('HOME="$MATRIX_RUNTIME_HOME"');
+    expect(hermesInstaller).toContain('XDG_CONFIG_HOME="$MATRIX_RUNTIME_HOME/.config"');
   });
 
   it('host bundle manifest keeps the sync-agent compatibility fields', () => {
@@ -387,7 +398,7 @@ describe('customer VPS host bundle', () => {
     expect(launcher).toContain('curl --fail --silent --show-error --max-time 10');
     expect(launcher).toContain('MATRIX_REGISTRATION_TOKEN');
     expect(launcher).toContain('/opt/matrix/app/node_modules/.bin');
-    expect(launcher).toContain('export PATH="/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
+    expect(launcher).toContain('export PATH="$MATRIX_HOME/.local/bin:/opt/matrix/bin:/opt/matrix/app/node_modules/.bin:/opt/matrix/runtime/node/bin:/usr/local/bin:$PATH"');
     expect(launcher).toContain('export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}"');
     expect(launcher).toContain('sync_bundled_home_assets');
     expect(launcher).toContain('sync-matrix-agent-skills.sh');


### PR DESCRIPTION
## Summary
- add a shared `matrix-owner-env` host helper that exports Linux-standard owner env: `HOME=$MATRIX_HOME`, XDG dirs, and `$HOME/.local/bin` on PATH
- make customer VPS gateway, shell, code-server, Symphony, Hermes install, Linux tools, and tool-pack installers run with the same owner env
- make first boot migrate/link conventional dotdirs (`.local`, `.cache`, `.config`, `.hermes`, `.ssh`) into `/home/matrix/home` and update the matrix account home to `/home/matrix/home`
- keep compatibility symlinks from `/home/matrix/*` so existing service/user installs still resolve

## Invariants
- **Source of truth**: owner-controlled runtime files live under `/home/matrix/home`; conventional Linux app state resolves through `HOME`, XDG dirs, and compatibility symlinks into that owner home.
- **Lock/transaction scope**: no database writes are introduced. Dotdir migration is local filesystem copy-if-absent followed by symlink replacement during first boot or trusted host installer execution.
- **Acceptable orphan states**: if a legacy real path cannot be migrated, the boot script logs and leaves it in place rather than deleting data. Existing services can still use compatibility paths.
- **Auth source of truth**: no auth behavior or endpoint exposure changes. Existing service tokens remain in `/opt/matrix/env/*` and owner app credentials stay in owner home files.
- **Deferred scope**: this does not sandbox arbitrary untrusted apps or redesign app-store permissions; it standardizes trusted Linux/CLI install behavior on customer VPS hosts.

## Tests
- `bun run test -- tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts`
- `bun run typecheck`
- `bash -n distro/customer-vps/host-bin/matrix-owner-env distro/customer-vps/host-bin/matrix-install-hermes distro/customer-vps/host-bin/matrix-install-tool-pack distro/customer-vps/host-bin/matrix-gateway distro/customer-vps/host-bin/matrix-shell distro/customer-vps/host-bin/matrix-code distro/customer-vps/host-bin/matrix-symphony distro/customer-vps/host-bin/matrix-install-linux-tools scripts/build-host-bundle.sh`
- `git diff --check`
- `bun run check:patterns` (0 violations; existing warnings only)

## Notes
- Validation used the main checkout `node_modules` via a temporary symlink because this host is currently disk constrained; the symlink was removed before commit.
