### PR TITLE
feat(notes): add rich document workspace

### DIFF
--- a/home/apps/notes/matrix.json
+++ b/home/apps/notes/matrix.json
@@ -16,8 +16,7 @@
           "tags": "text"
         },
         "indexes": [
-          "pinned",
-          "tags"
+          "pinned"
         ]
       }
     }

--- a/home/apps/notes/matrix.json
+++ b/home/apps/notes/matrix.json
@@ -16,7 +16,8 @@
           "tags": "text"
         },
         "indexes": [
-          "pinned"
+          "pinned",
+          "tags"
         ]
       }
     }

--- a/home/apps/notes/matrix.json
+++ b/home/apps/notes/matrix.json
@@ -12,7 +12,8 @@
           "title": "text",
           "content": "text",
           "content_json": "jsonb",
-          "pinned": "boolean"
+          "pinned": "boolean",
+          "tags": "text"
         },
         "indexes": [
           "pinned"

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -76,9 +76,12 @@ async function persistNote(note: Note, isNew: boolean): Promise<Note> {
   const db = window.MatrixOS?.db;
   if (!db) return note;
   const data = noteRowData(note);
-  if (isNew || note.id.startsWith("note-")) {
+  if (isNew) {
     const result = await db.insert("notes", data);
     return { ...note, id: result.id };
+  }
+  if (note.id.startsWith("note-")) {
+    throw new Error("Cannot update a note before it has a database id.");
   }
   await db.update("notes", note.id, data);
   return note;
@@ -159,6 +162,12 @@ function App() {
   const [nowMs, setNowMs] = useState(() => Date.now());
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
+  const notesRef = useRef<Note[]>([]);
+  const pendingCreatesRef = useRef<Map<string, Promise<Note>>>(new Map());
+
+  useEffect(() => {
+    notesRef.current = notes;
+  }, [notes]);
 
   const reload = useCallback(() => {
     setError(null);
@@ -208,6 +217,7 @@ function App() {
 
   const createNewNote = useCallback(() => {
     const draft = createNote({
+      id: `note-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       title: "Untitled",
       content: "",
       content_json: {
@@ -223,27 +233,50 @@ function App() {
     setNotes(nextNotes);
     setActiveId(draft.id);
     setSaveState("saving");
-    persistNote(draft, true)
+    const createPromise = persistNote(draft, true);
+    pendingCreatesRef.current.set(draft.id, createPromise);
+    createPromise
       .then((saved) => {
-        const savedNotes = nextNotes.map((note) => (note.id === draft.id ? saved : note));
-        setNotes(savedNotes);
-        setActiveId(saved.id);
-        persistAllIfFallback(savedNotes);
+        setNotes((currentNotes) => {
+          const savedNotes = currentNotes.map((note) =>
+            note.id === draft.id ? { ...note, id: saved.id, created_at: saved.created_at } : note,
+          );
+          persistAllIfFallback(savedNotes);
+          return savedNotes;
+        });
+        setActiveId((current) => (current === draft.id ? saved.id : current));
         setSaveState("saved");
       })
       .catch((err: unknown) => {
         console.warn("[notes] create failed:", err instanceof Error ? err.message : String(err));
         setError("Note could not be created.");
         setSaveState("error");
+      })
+      .finally(() => {
+        pendingCreatesRef.current.delete(draft.id);
       });
   }, [notes, persistAllIfFallback]);
+
+  const persistWhenReady = useCallback(async (note: Note): Promise<Note> => {
+    if (!note.id.startsWith("note-")) return persistNote(note, false);
+    const pendingCreate = pendingCreatesRef.current.get(note.id);
+    if (!pendingCreate) return persistNote(note, false);
+    const saved = await pendingCreate;
+    const latest = notesRef.current.find((candidate) => candidate.id === saved.id)
+      ?? notesRef.current.find((candidate) => candidate.id === note.id)
+      ?? note;
+    return persistNote({ ...latest, id: saved.id, created_at: saved.created_at }, false);
+  }, []);
 
   const updateActiveNote = useCallback(
     (patch: Partial<Pick<Note, "title" | "content" | "content_json" | "pinned" | "tags">>) => {
       if (!activeNote) return;
+      const shouldRecomputeTags =
+        !("tags" in patch) && ("content" in patch || "content_json" in patch);
       const nextNote = createNote({
         ...activeNote,
         ...patch,
+        tags: shouldRecomputeTags ? null : (patch.tags ?? activeNote.tags),
         updated_at: new Date().toISOString(),
       });
       const nextNotes = notes.map((note) => (note.id === activeNote.id ? nextNote : note));
@@ -251,9 +284,9 @@ function App() {
       setSaveState("saving");
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => {
-        persistNote(nextNote, false)
+        persistWhenReady(nextNote)
           .then((saved) => {
-            const savedNotes = nextNotes.map((note) => (note.id === saved.id ? saved : note));
+            const savedNotes = notesRef.current.map((note) => (note.id === saved.id ? saved : note));
             persistAllIfFallback(savedNotes);
             setSaveState("saved");
           })
@@ -264,7 +297,7 @@ function App() {
           });
       }, SAVE_DELAY_MS);
     },
-    [activeNote, notes, persistAllIfFallback],
+    [activeNote, notes, persistAllIfFallback, persistWhenReady],
   );
 
   const deleteActiveNote = useCallback(() => {

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -1,119 +1,108 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
 import {
   BookOpenText,
-  Bold,
   Check,
-  Code,
+  Clock3,
   FilePlus2,
   Hash,
-  Heading1,
-  Heading2,
-  Italic,
-  List,
-  ListOrdered,
   Pin,
   PinOff,
-  Quote,
   Save,
   Search,
   Trash2,
 } from "lucide-react";
-import { htmlToMarkdown, markdownToHtml } from "./markdown";
+import RichEditor from "./RichEditor";
 import {
   collectTags,
   createNote,
-  emptyTiptapDoc,
   filterNotes,
   hydrateNote,
+  serializeTags,
   type Note,
   type TiptapDoc,
 } from "./notes-model";
 
 const APP_ID = "notes";
 const KV_KEY = "notes";
+const LOCAL_KEY = `matrixos.${APP_ID}.${KV_KEY}`;
 const SAVE_DELAY_MS = 500;
-const FETCH_TIMEOUT_MS = 10_000;
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
+// Apps run inside a sandboxed, null-origin srcdoc iframe with CSP
+// `connect-src 'self'`, so a direct fetch() to the gateway is always blocked.
+// The only valid persistence transport is window.MatrixOS.db (postMessage).
+// This local fallback is for the no-bridge case (e.g. jsdom tests); in the
+// real shell window.MatrixOS.db is always injected and is used instead.
 async function readKvNotes(): Promise<Note[]> {
-  const params = new URLSearchParams({ app: APP_ID, key: KV_KEY });
-  const response = await fetch(`/api/bridge/data?${params.toString()}`, {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
-  if (!response.ok) return [];
-  const payload = (await response.json()) as { value?: string | null };
-  if (!payload.value) return [];
   try {
-    const rows = JSON.parse(payload.value) as unknown;
+    const raw = globalThis.localStorage?.getItem(LOCAL_KEY);
+    if (!raw) return [];
+    const rows = JSON.parse(raw) as unknown;
     return Array.isArray(rows) ? rows.map((row) => hydrateNote(row as Record<string, unknown>)) : [];
   } catch (err: unknown) {
-    console.warn("[notes] ignored invalid fallback payload:", err instanceof Error ? err.message : String(err));
+    console.warn("[notes] local fallback read failed:", err instanceof Error ? err.message : String(err));
     return [];
   }
 }
 
 async function writeKvNotes(notes: Note[]): Promise<void> {
-  await fetch("/api/bridge/data", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    body: JSON.stringify({
-      action: "write",
-      app: APP_ID,
-      key: KV_KEY,
-      value: JSON.stringify(notes),
-    }),
-  });
+  try {
+    globalThis.localStorage?.setItem(LOCAL_KEY, JSON.stringify(notes));
+  } catch (err: unknown) {
+    console.warn("[notes] local fallback write failed:", err instanceof Error ? err.message : String(err));
+  }
 }
 
 async function loadNotes(): Promise<Note[]> {
   if (window.MatrixOS?.db) {
-    const rows = await window.MatrixOS.db.find("notes", { orderBy: { updated_at: "desc" } });
+    const rows = await window.MatrixOS.db.find("notes", { orderBy: { created_at: "desc" } });
     return rows.map((row) => hydrateNote(row as Record<string, unknown>));
   }
   return readKvNotes();
 }
 
+function noteRowData(note: Note) {
+  return {
+    title: note.title,
+    content: note.content,
+    content_json: note.content_json,
+    pinned: note.pinned,
+    tags: serializeTags(note.tags),
+  };
+}
+
 async function persistNote(note: Note, isNew: boolean): Promise<Note> {
-  if (window.MatrixOS?.db) {
-    const data = {
-      title: note.title,
-      content: note.content,
-      content_json: note.content_json,
-      pinned: note.pinned,
-    };
-    const legacyData = {
-      title: note.title,
-      content: note.content,
-      pinned: note.pinned,
-    };
-    try {
-      if (isNew || note.id.startsWith("note-")) {
-        const result = await window.MatrixOS.db.insert("notes", data);
-        return { ...note, id: result.id };
-      }
-      await window.MatrixOS.db.update("notes", note.id, data);
-      return note;
-    } catch (err: unknown) {
-      console.warn("[notes] JSON content save fell back to legacy schema.");
-      if (isNew || note.id.startsWith("note-")) {
-        const result = await window.MatrixOS.db.insert("notes", legacyData);
-        return { ...note, id: result.id };
-      }
-      await window.MatrixOS.db.update("notes", note.id, legacyData);
-      return note;
-    }
+  const db = window.MatrixOS?.db;
+  if (!db) return note;
+  const data = noteRowData(note);
+  if (isNew || note.id.startsWith("note-")) {
+    const result = await db.insert("notes", data);
+    return { ...note, id: result.id };
   }
+  await db.update("notes", note.id, data);
   return note;
 }
 
 async function deletePersistedNote(note: Note): Promise<void> {
-  if (window.MatrixOS?.db && !note.id.startsWith("note-")) {
-    await window.MatrixOS.db.delete("notes", note.id);
+  const db = window.MatrixOS?.db;
+  if (db && !note.id.startsWith("note-")) {
+    await db.delete("notes", note.id);
   }
+}
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "just now";
+  const diffMs = Date.now() - then;
+  const minutes = Math.round(diffMs / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days} day${days === 1 ? "" : "s"} ago`;
+  return new Date(iso).toLocaleDateString();
 }
 
 function EmptyState({ onCreate }: { onCreate: () => void }) {
@@ -123,7 +112,7 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
         <BookOpenText size={34} />
       </div>
       <h2>No notes yet</h2>
-      <p>Capture a thought, draft a plan, or save a reference in markdown.</p>
+      <p>Capture a thought, draft a plan, or save a reference. Press Cmd/Ctrl+N to begin.</p>
       <button className="button button--primary" type="button" onClick={onCreate}>
         <FilePlus2 size={16} />
         New note
@@ -132,80 +121,28 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
   );
 }
 
-function MarkdownEditor({
+function NoteCard({
   note,
-  onChange,
+  active,
+  onSelect,
 }: {
   note: Note;
-  onChange: (patch: { content: string; content_json: TiptapDoc }) => void;
+  active: boolean;
+  onSelect: (id: string) => void;
 }) {
-  const [mode, setMode] = useState<"rich" | "source">("rich");
-  const lastAppliedNoteIdRef = useRef<string | null>(null);
-  const editor = useEditor({
-    extensions: [StarterKit],
-    content: note.content_json.content?.length ? note.content_json : markdownToHtml(note.content),
-    immediatelyRender: false,
-    editorProps: {
-      attributes: {
-        class: "rich-editor-content",
-      },
-    },
-    onUpdate({ editor: activeEditor }) {
-      onChange({
-        content: htmlToMarkdown(activeEditor.getHTML()),
-        content_json: activeEditor.getJSON() as TiptapDoc,
-      });
-    },
-  });
-
-  useEffect(() => {
-    if (!editor || lastAppliedNoteIdRef.current === note.id) return;
-    lastAppliedNoteIdRef.current = note.id;
-    editor.commands.setContent(
-      note.content_json.content?.length ? note.content_json : markdownToHtml(note.content),
-      { emitUpdate: false },
-    );
-  }, [editor, note.content, note.content_json, note.id]);
-
-  const updateMarkdownSource = useCallback((markdown: string) => {
-    if (!editor) {
-      onChange({ content: markdown, content_json: emptyTiptapDoc() });
-      return;
-    }
-    editor.commands.setContent(markdownToHtml(markdown), { emitUpdate: false });
-    onChange({
-      content: markdown,
-      content_json: editor.getJSON() as TiptapDoc,
-    });
-  }, [editor, onChange]);
-
   return (
-    <div className="markdown-editor">
-      <div className="format-toolbar" aria-label="Formatting toolbar">
-        <button className={mode === "rich" ? "format-button format-button--active" : "format-button"} type="button" onClick={() => setMode("rich")}>Rich</button>
-        <button className={mode === "source" ? "format-button format-button--active" : "format-button"} type="button" onClick={() => setMode("source")}>Markdown</button>
-        <span className="format-divider" />
-        <button className="format-button" type="button" onClick={() => editor?.chain().focus().toggleHeading({ level: 1 }).run()} title="Heading 1"><Heading1 size={15} /></button>
-        <button className="format-button" type="button" onClick={() => editor?.chain().focus().toggleHeading({ level: 2 }).run()} title="Heading 2"><Heading2 size={15} /></button>
-        <button className="format-button" type="button" onClick={() => editor?.chain().focus().toggleBold().run()} title="Bold"><Bold size={15} /></button>
-        <button className="format-button" type="button" onClick={() => editor?.chain().focus().toggleItalic().run()} title="Italic"><Italic size={15} /></button>
-        <button className="format-button" type="button" onClick={() => editor?.chain().focus().toggleBulletList().run()} title="Bullet list"><List size={15} /></button>
-        <button className="format-button" type="button" onClick={() => editor?.chain().focus().toggleOrderedList().run()} title="Numbered list"><ListOrdered size={15} /></button>
-        <button className="format-button" type="button" onClick={() => editor?.chain().focus().toggleBlockquote().run()} title="Quote"><Quote size={15} /></button>
-        <button className="format-button" type="button" onClick={() => editor?.chain().focus().toggleCodeBlock().run()} title="Code block"><Code size={15} /></button>
-      </div>
-      {mode === "source" ? (
-        <textarea
-          className="content-input"
-          value={note.content}
-          onChange={(event) => updateMarkdownSource(event.target.value)}
-          spellCheck
-          aria-label="Markdown content"
-        />
-      ) : (
-        <EditorContent editor={editor} className="rich-editor" />
-      )}
-    </div>
+    <button
+      className={active ? "note-card note-card--active" : "note-card"}
+      type="button"
+      onClick={() => onSelect(note.id)}
+    >
+      <span className="note-card__title">
+        {note.pinned ? <Pin size={13} /> : null}
+        {note.title}
+      </span>
+      <span className="note-card__preview">{note.preview}</span>
+      <span className="note-card__meta">{relativeTime(note.updated_at)}</span>
+    </button>
   );
 }
 
@@ -218,6 +155,7 @@ function App() {
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const [error, setError] = useState<string | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
 
   const reload = useCallback(() => {
     setError(null);
@@ -245,6 +183,8 @@ function App() {
   }, []);
 
   const visibleNotes = useMemo(() => filterNotes(notes, query, activeTag), [notes, query, activeTag]);
+  const pinnedNotes = useMemo(() => visibleNotes.filter((note) => note.pinned), [visibleNotes]);
+  const otherNotes = useMemo(() => visibleNotes.filter((note) => !note.pinned), [visibleNotes]);
   const tags = useMemo(() => collectTags(notes), [notes]);
   const activeNote = notes.find((note) => note.id === activeId) ?? null;
   const wordCount = activeNote?.content.trim() ? activeNote.content.trim().split(/\s+/).length : 0;
@@ -261,12 +201,12 @@ function App() {
   const createNewNote = useCallback(() => {
     const draft = createNote({
       title: "Untitled",
-      content: "# New note\n\nStart writing...",
+      content: "",
       content_json: {
         type: "doc",
         content: [
-          { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "New note" }] },
-          { type: "paragraph", content: [{ type: "text", text: "Start writing..." }] },
+          { type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Untitled" }] },
+          { type: "paragraph" },
         ],
       },
       pinned: false,
@@ -290,31 +230,34 @@ function App() {
       });
   }, [notes, persistAllIfFallback]);
 
-  const updateActiveNote = useCallback((patch: Partial<Pick<Note, "title" | "content" | "content_json" | "pinned">>) => {
-    if (!activeNote) return;
-    const nextNote = createNote({
-      ...activeNote,
-      ...patch,
-      updated_at: new Date().toISOString(),
-    });
-    const nextNotes = notes.map((note) => (note.id === activeNote.id ? nextNote : note));
-    setNotes(nextNotes);
-    setSaveState("saving");
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(() => {
-      persistNote(nextNote, false)
-        .then((saved) => {
-          const savedNotes = nextNotes.map((note) => (note.id === saved.id ? saved : note));
-          persistAllIfFallback(savedNotes);
-          setSaveState("saved");
-        })
-        .catch((err: unknown) => {
-          console.warn("[notes] update failed:", err instanceof Error ? err.message : String(err));
-          setError("Note could not be saved.");
-          setSaveState("error");
-        });
-    }, SAVE_DELAY_MS);
-  }, [activeNote, notes, persistAllIfFallback]);
+  const updateActiveNote = useCallback(
+    (patch: Partial<Pick<Note, "title" | "content" | "content_json" | "pinned" | "tags">>) => {
+      if (!activeNote) return;
+      const nextNote = createNote({
+        ...activeNote,
+        ...patch,
+        updated_at: new Date().toISOString(),
+      });
+      const nextNotes = notes.map((note) => (note.id === activeNote.id ? nextNote : note));
+      setNotes(nextNotes);
+      setSaveState("saving");
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        persistNote(nextNote, false)
+          .then((saved) => {
+            const savedNotes = nextNotes.map((note) => (note.id === saved.id ? saved : note));
+            persistAllIfFallback(savedNotes);
+            setSaveState("saved");
+          })
+          .catch((err: unknown) => {
+            console.warn("[notes] update failed:", err instanceof Error ? err.message : String(err));
+            setError("Note could not be saved.");
+            setSaveState("error");
+          });
+      }, SAVE_DELAY_MS);
+    },
+    [activeNote, notes, persistAllIfFallback],
+  );
 
   const deleteActiveNote = useCallback(() => {
     if (!activeNote) return;
@@ -334,14 +277,25 @@ function App() {
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       const modifier = event.metaKey || event.ctrlKey;
-      if (!modifier) return;
-      if (event.key.toLowerCase() === "n") {
+      if (modifier && event.key.toLowerCase() === "n") {
         event.preventDefault();
         createNewNote();
+        return;
       }
-      if (event.key.toLowerCase() === "s") {
+      if (modifier && event.key.toLowerCase() === "f") {
+        event.preventDefault();
+        searchRef.current?.focus();
+        searchRef.current?.select();
+        return;
+      }
+      if (modifier && event.key.toLowerCase() === "s") {
         event.preventDefault();
         if (activeNote) updateActiveNote({});
+        return;
+      }
+      if (event.key === "Escape" && document.activeElement === searchRef.current) {
+        setQuery("");
+        searchRef.current?.blur();
       }
     }
     window.addEventListener("keydown", onKeyDown);
@@ -360,16 +314,18 @@ function App() {
             <span className="eyebrow">Workspace</span>
             <h1>Notes</h1>
           </div>
-          <button className="icon-button" type="button" onClick={createNewNote} title="New note">
+          <button className="icon-button" type="button" onClick={createNewNote} title="New note (Cmd/Ctrl+N)">
             <FilePlus2 size={18} />
           </button>
         </div>
         <label className="search-field">
           <Search size={15} />
           <input
+            ref={searchRef}
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder="Search notes"
+            aria-label="Search notes"
           />
         </label>
         <div className="tag-strip" aria-label="Tags">
@@ -384,7 +340,7 @@ function App() {
             <button
               className={activeTag === tag ? "tag tag--active" : "tag"}
               type="button"
-              onClick={() => setActiveTag(tag)}
+              onClick={() => setActiveTag(activeTag === tag ? "all" : tag)}
               key={tag}
             >
               <Hash size={12} />
@@ -393,24 +349,25 @@ function App() {
           ))}
         </div>
         <div className="note-list">
-          {visibleNotes.map((note) => (
-            <button
-              className={note.id === activeId ? "note-card note-card--active" : "note-card"}
-              key={note.id}
-              type="button"
-              onClick={() => setActiveId(note.id)}
-            >
-              <span className="note-card__title">
-                {note.pinned ? <Pin size={13} /> : null}
-                {note.title}
-              </span>
-              <span className="note-card__preview">{note.preview}</span>
-              <span className="note-card__meta">{new Date(note.updated_at).toLocaleDateString()}</span>
-            </button>
-          ))}
-          {visibleNotes.length === 0 ? (
-            <div className="empty-list">No matching notes</div>
+          {pinnedNotes.length > 0 ? (
+            <>
+              <div className="note-list__section" aria-hidden>
+                <Pin size={11} /> Pinned
+              </div>
+              {pinnedNotes.map((note) => (
+                <NoteCard key={note.id} note={note} active={note.id === activeId} onSelect={setActiveId} />
+              ))}
+            </>
           ) : null}
+          {otherNotes.length > 0 && pinnedNotes.length > 0 ? (
+            <div className="note-list__section" aria-hidden>
+              Notes
+            </div>
+          ) : null}
+          {otherNotes.map((note) => (
+            <NoteCard key={note.id} note={note} active={note.id === activeId} onSelect={setActiveId} />
+          ))}
+          {visibleNotes.length === 0 ? <div className="empty-list">No matching notes</div> : null}
         </div>
       </aside>
 
@@ -419,6 +376,11 @@ function App() {
           <div className="toolbar__status" aria-live="polite">
             {saveState === "saving" ? <Save size={14} /> : <Check size={14} />}
             {saveState === "error" ? "Save failed" : saveState === "saving" ? "Saving" : "Saved"}
+            {activeNote ? (
+              <span className="toolbar__meta">
+                <Clock3 size={12} /> Updated {relativeTime(activeNote.updated_at)}
+              </span>
+            ) : null}
           </div>
           <div className="toolbar__actions">
             <button
@@ -445,14 +407,21 @@ function App() {
                 value={activeNote.title}
                 onChange={(event) => updateActiveNote({ title: event.target.value })}
                 aria-label="Note title"
+                placeholder="Untitled"
               />
-              <MarkdownEditor
-                note={activeNote}
-                onChange={(patch) => updateActiveNote(patch)}
-              />
+              <RichEditor note={activeNote} onChange={(patch) => updateActiveNote(patch)} />
               <footer className="editor-footer">
                 <span>{wordCount} words</span>
-                <span>{activeNote.tags.length} tags</span>
+                <span className="editor-footer__tags">
+                  {activeNote.tags.length > 0
+                    ? activeNote.tags.map((tag) => (
+                        <span className="footer-tag" key={tag}>
+                          <Hash size={10} />
+                          {tag}
+                        </span>
+                      ))
+                    : "Add #tags inline to organize"}
+                </span>
               </footer>
             </section>
           </div>

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -91,10 +91,10 @@ async function deletePersistedNote(note: Note): Promise<void> {
   }
 }
 
-function relativeTime(iso: string): string {
+function relativeTime(iso: string, nowMs = Date.now()): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return "just now";
-  const diffMs = Date.now() - then;
+  const diffMs = nowMs - then;
   const minutes = Math.round(diffMs / 60_000);
   if (minutes < 1) return "just now";
   if (minutes < 60) return `${minutes} min ago`;
@@ -124,10 +124,12 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
 function NoteCard({
   note,
   active,
+  nowMs,
   onSelect,
 }: {
   note: Note;
   active: boolean;
+  nowMs: number;
   onSelect: (id: string) => void;
 }) {
   return (
@@ -141,7 +143,7 @@ function NoteCard({
         {note.title}
       </span>
       <span className="note-card__preview">{note.preview}</span>
-      <span className="note-card__meta">{relativeTime(note.updated_at)}</span>
+      <span className="note-card__meta">{relativeTime(note.updated_at, nowMs)}</span>
     </button>
   );
 }
@@ -154,6 +156,7 @@ function App() {
   const [loaded, setLoaded] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const [error, setError] = useState<string | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
 
@@ -180,6 +183,11 @@ function App() {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     };
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => window.clearInterval(timer);
   }, []);
 
   const visibleNotes = useMemo(() => filterNotes(notes, query, activeTag), [notes, query, activeTag]);
@@ -355,7 +363,7 @@ function App() {
                 <Pin size={11} /> Pinned
               </div>
               {pinnedNotes.map((note) => (
-                <NoteCard key={note.id} note={note} active={note.id === activeId} onSelect={setActiveId} />
+                <NoteCard key={note.id} note={note} active={note.id === activeId} nowMs={nowMs} onSelect={setActiveId} />
               ))}
             </>
           ) : null}
@@ -365,7 +373,7 @@ function App() {
             </div>
           ) : null}
           {otherNotes.map((note) => (
-            <NoteCard key={note.id} note={note} active={note.id === activeId} onSelect={setActiveId} />
+            <NoteCard key={note.id} note={note} active={note.id === activeId} nowMs={nowMs} onSelect={setActiveId} />
           ))}
           {visibleNotes.length === 0 ? <div className="empty-list">No matching notes</div> : null}
         </div>
@@ -378,7 +386,7 @@ function App() {
             {saveState === "error" ? "Save failed" : saveState === "saving" ? "Saving" : "Saved"}
             {activeNote ? (
               <span className="toolbar__meta">
-                <Clock3 size={12} /> Updated {relativeTime(activeNote.updated_at)}
+                <Clock3 size={12} /> Updated {relativeTime(activeNote.updated_at, nowMs)}
               </span>
             ) : null}
           </div>

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -285,6 +285,10 @@ function App() {
         }
         pendingCreatesRef.current.set(note.id, retryPromise);
         const saved = await retryPromise;
+        if (resolvedCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
+          evictOldestMapEntry(resolvedCreatesRef.current);
+        }
+        resolvedCreatesRef.current.set(note.id, saved.id);
         const latest = notesRef.current.find((candidate) => candidate.id === note.id) ?? note;
         const savedLatest = { ...latest, id: saved.id, created_at: saved.created_at };
         setNotes((currentNotes) => {
@@ -327,8 +331,13 @@ function App() {
       saveTimerRef.current = setTimeout(() => {
         persistWhenReady(nextNote)
           .then((saved) => {
-            const savedNotes = notesRef.current.map((note) => (note.id === saved.id ? saved : note));
-            persistAllIfFallback(savedNotes);
+            setNotes((currentNotes) => {
+              const savedNotes = currentNotes.map((note) =>
+                note.id === saved.id || note.id === nextNote.id ? saved : note,
+              );
+              persistAllIfFallback(savedNotes);
+              return savedNotes;
+            });
             setSaveState("saved");
           })
           .catch((err: unknown) => {

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -313,12 +313,13 @@ function App() {
         setActiveId((current) => (current === note.id ? saved.id : current));
         return savedLatest;
       }
-      resolvedCreatesRef.current.delete(note.id);
       const latest = notesRef.current.find((candidate) => candidate.id === resolvedId) ?? {
         ...note,
         id: resolvedId,
       };
-      return persistNote(latest, false);
+      return persistNote(latest, false).finally(() => {
+        resolvedCreatesRef.current.delete(note.id);
+      });
     }
     const saved = await pendingCreate;
     const latest = notesRef.current.find((candidate) => candidate.id === saved.id)

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -276,7 +276,16 @@ function App() {
     const pendingCreate = pendingCreatesRef.current.get(note.id);
     if (!pendingCreate) {
       const resolvedId = resolvedCreatesRef.current.get(note.id);
-      if (!resolvedId) return persistNote(note, false);
+      if (!resolvedId) {
+        const saved = await persistNote(note, true);
+        setNotes((currentNotes) => {
+          const savedNotes = currentNotes.map((candidate) => (candidate.id === note.id ? saved : candidate));
+          persistAllIfFallback(savedNotes);
+          return savedNotes;
+        });
+        setActiveId((current) => (current === note.id ? saved.id : current));
+        return saved;
+      }
       resolvedCreatesRef.current.delete(note.id);
       const latest = notesRef.current.find((candidate) => candidate.id === resolvedId) ?? {
         ...note,
@@ -289,7 +298,7 @@ function App() {
       ?? notesRef.current.find((candidate) => candidate.id === note.id)
       ?? note;
     return persistNote({ ...latest, id: saved.id, created_at: saved.created_at }, false);
-  }, []);
+  }, [persistAllIfFallback]);
 
   const updateActiveNote = useCallback(
     (patch: Partial<Pick<Note, "title" | "content" | "content_json" | "pinned" | "tags">>) => {

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -56,7 +56,7 @@ async function writeKvNotes(notes: Note[]): Promise<void> {
 
 async function loadNotes(): Promise<Note[]> {
   if (window.MatrixOS?.db) {
-    const rows = await window.MatrixOS.db.find("notes", { orderBy: { created_at: "desc" } });
+    const rows = await window.MatrixOS.db.find("notes", { orderBy: { updated_at: "desc" } });
     return rows.map((row) => hydrateNote(row as Record<string, unknown>));
   }
   return readKvNotes();

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -260,7 +260,9 @@ function App() {
         if (resolvedCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
           evictOldestMapEntry(resolvedCreatesRef.current);
         }
-        resolvedCreatesRef.current.set(draft.id, saved.id);
+        if (saved.id !== draft.id) {
+          resolvedCreatesRef.current.set(draft.id, saved.id);
+        }
         setNotes((currentNotes) => {
           const savedNotes = currentNotes.map((note) =>
             note.id === draft.id ? { ...note, id: saved.id, created_at: saved.created_at } : note,
@@ -298,7 +300,9 @@ function App() {
         if (resolvedCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
           evictOldestMapEntry(resolvedCreatesRef.current);
         }
-        resolvedCreatesRef.current.set(note.id, saved.id);
+        if (saved.id !== note.id) {
+          resolvedCreatesRef.current.set(note.id, saved.id);
+        }
         const latest = notesRef.current.find((candidate) => candidate.id === note.id) ?? note;
         const savedLatest = { ...latest, id: saved.id, created_at: saved.created_at };
         setNotes((currentNotes) => {
@@ -362,6 +366,10 @@ function App() {
 
   const deleteActiveNote = useCallback(() => {
     if (!activeNote) return;
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
     if (activeNote.id.startsWith("note-")) {
       if (deletedCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
         evictOldestMapEntry(deletedCreatesRef.current);

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -26,8 +26,14 @@ const APP_ID = "notes";
 const KV_KEY = "notes";
 const LOCAL_KEY = `matrixos.${APP_ID}.${KV_KEY}`;
 const SAVE_DELAY_MS = 500;
+const MAX_CREATE_TRACKERS = 100;
 
 type SaveState = "idle" | "saving" | "saved" | "error";
+
+function evictOldestMapEntry<K, V>(map: Map<K, V>): void {
+  const oldest = map.keys().next();
+  if (!oldest.done) map.delete(oldest.value);
+}
 
 // Apps run inside a sandboxed, null-origin srcdoc iframe with CSP
 // `connect-src 'self'`, so a direct fetch() to the gateway is always blocked.
@@ -164,6 +170,7 @@ function App() {
   const searchRef = useRef<HTMLInputElement | null>(null);
   const notesRef = useRef<Note[]>([]);
   const pendingCreatesRef = useRef<Map<string, Promise<Note>>>(new Map());
+  const resolvedCreatesRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     notesRef.current = notes;
@@ -234,9 +241,16 @@ function App() {
     setActiveId(draft.id);
     setSaveState("saving");
     const createPromise = persistNote(draft, true);
+    if (pendingCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
+      evictOldestMapEntry(pendingCreatesRef.current);
+    }
     pendingCreatesRef.current.set(draft.id, createPromise);
     createPromise
       .then((saved) => {
+        if (resolvedCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
+          evictOldestMapEntry(resolvedCreatesRef.current);
+        }
+        resolvedCreatesRef.current.set(draft.id, saved.id);
         setNotes((currentNotes) => {
           const savedNotes = currentNotes.map((note) =>
             note.id === draft.id ? { ...note, id: saved.id, created_at: saved.created_at } : note,
@@ -260,7 +274,16 @@ function App() {
   const persistWhenReady = useCallback(async (note: Note): Promise<Note> => {
     if (!note.id.startsWith("note-")) return persistNote(note, false);
     const pendingCreate = pendingCreatesRef.current.get(note.id);
-    if (!pendingCreate) return persistNote(note, false);
+    if (!pendingCreate) {
+      const resolvedId = resolvedCreatesRef.current.get(note.id);
+      if (!resolvedId) return persistNote(note, false);
+      resolvedCreatesRef.current.delete(note.id);
+      const latest = notesRef.current.find((candidate) => candidate.id === resolvedId) ?? {
+        ...note,
+        id: resolvedId,
+      };
+      return persistNote(latest, false);
+    }
     const saved = await pendingCreate;
     const latest = notesRef.current.find((candidate) => candidate.id === saved.id)
       ?? notesRef.current.find((candidate) => candidate.id === note.id)

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -171,6 +171,7 @@ function App() {
   const notesRef = useRef<Note[]>([]);
   const pendingCreatesRef = useRef<Map<string, Promise<Note>>>(new Map());
   const resolvedCreatesRef = useRef<Map<string, string>>(new Map());
+  const deletedCreatesRef = useRef<Map<string, true>>(new Map());
 
   useEffect(() => {
     notesRef.current = notes;
@@ -247,6 +248,15 @@ function App() {
     pendingCreatesRef.current.set(draft.id, createPromise);
     createPromise
       .then((saved) => {
+        if (deletedCreatesRef.current.delete(draft.id)) {
+          resolvedCreatesRef.current.delete(draft.id);
+          deletePersistedNote(saved).catch((err: unknown) => {
+            console.warn("[notes] pending create cleanup failed:", err instanceof Error ? err.message : String(err));
+            setError("Note could not be deleted.");
+          });
+          setSaveState("saved");
+          return;
+        }
         if (resolvedCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
           evictOldestMapEntry(resolvedCreatesRef.current);
         }
@@ -352,18 +362,26 @@ function App() {
 
   const deleteActiveNote = useCallback(() => {
     if (!activeNote) return;
-    const remaining = notes.filter((note) => note.id !== activeNote.id);
+    if (activeNote.id.startsWith("note-")) {
+      if (deletedCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
+        evictOldestMapEntry(deletedCreatesRef.current);
+      }
+      deletedCreatesRef.current.set(activeNote.id, true);
+    }
     deletePersistedNote(activeNote)
       .then(() => {
-        setNotes(remaining);
-        setActiveId(remaining[0]?.id ?? null);
-        persistAllIfFallback(remaining);
+        setNotes((currentNotes) => {
+          const remaining = currentNotes.filter((note) => note.id !== activeNote.id);
+          setActiveId(remaining[0]?.id ?? null);
+          persistAllIfFallback(remaining);
+          return remaining;
+        });
       })
       .catch((err: unknown) => {
         console.warn("[notes] delete failed:", err instanceof Error ? err.message : String(err));
         setError("Note could not be deleted.");
       });
-  }, [activeNote, notes, persistAllIfFallback]);
+  }, [activeNote, persistAllIfFallback]);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -263,13 +263,11 @@ function App() {
         if (saved.id !== draft.id) {
           resolvedCreatesRef.current.set(draft.id, saved.id);
         }
-        setNotes((currentNotes) => {
-          const savedNotes = currentNotes.map((note) =>
-            note.id === draft.id ? { ...note, id: saved.id, created_at: saved.created_at } : note,
-          );
-          persistAllIfFallback(savedNotes);
-          return savedNotes;
-        });
+        const savedNotes = notesRef.current.map((note) =>
+          note.id === draft.id ? { ...note, id: saved.id, created_at: saved.created_at } : note,
+        );
+        setNotes(savedNotes);
+        persistAllIfFallback(savedNotes);
         setActiveId((current) => (current === draft.id ? saved.id : current));
         setSaveState("saved");
       })
@@ -305,11 +303,9 @@ function App() {
         }
         const latest = notesRef.current.find((candidate) => candidate.id === note.id) ?? note;
         const savedLatest = { ...latest, id: saved.id, created_at: saved.created_at };
-        setNotes((currentNotes) => {
-          const savedNotes = currentNotes.map((candidate) => (candidate.id === note.id ? savedLatest : candidate));
-          persistAllIfFallback(savedNotes);
-          return savedNotes;
-        });
+        const savedNotes = notesRef.current.map((candidate) => (candidate.id === note.id ? savedLatest : candidate));
+        setNotes(savedNotes);
+        persistAllIfFallback(savedNotes);
         setActiveId((current) => (current === note.id ? saved.id : current));
         return savedLatest;
       }
@@ -346,13 +342,11 @@ function App() {
       saveTimerRef.current = setTimeout(() => {
         persistWhenReady(nextNote)
           .then((saved) => {
-            setNotes((currentNotes) => {
-              const savedNotes = currentNotes.map((note) =>
-                note.id === saved.id || note.id === nextNote.id ? saved : note,
-              );
-              persistAllIfFallback(savedNotes);
-              return savedNotes;
-            });
+            const savedNotes = notesRef.current.map((note) =>
+              note.id === saved.id || note.id === nextNote.id ? saved : note,
+            );
+            setNotes(savedNotes);
+            persistAllIfFallback(savedNotes);
             setSaveState("saved");
           })
           .catch((err: unknown) => {
@@ -379,12 +373,10 @@ function App() {
     }
     deletePersistedNote(activeNote)
       .then(() => {
-        setNotes((currentNotes) => {
-          const remaining = currentNotes.filter((note) => note.id !== activeNote.id);
-          setActiveId(remaining[0]?.id ?? null);
-          persistAllIfFallback(remaining);
-          return remaining;
-        });
+        const remaining = notesRef.current.filter((note) => note.id !== activeNote.id);
+        setNotes(remaining);
+        setActiveId(remaining[0]?.id ?? null);
+        persistAllIfFallback(remaining);
       })
       .catch((err: unknown) => {
         console.warn("[notes] delete failed:", err instanceof Error ? err.message : String(err));

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -277,14 +277,23 @@ function App() {
     if (!pendingCreate) {
       const resolvedId = resolvedCreatesRef.current.get(note.id);
       if (!resolvedId) {
-        const saved = await persistNote(note, true);
+        const retryPromise = persistNote(note, true).finally(() => {
+          pendingCreatesRef.current.delete(note.id);
+        });
+        if (pendingCreatesRef.current.size >= MAX_CREATE_TRACKERS) {
+          evictOldestMapEntry(pendingCreatesRef.current);
+        }
+        pendingCreatesRef.current.set(note.id, retryPromise);
+        const saved = await retryPromise;
+        const latest = notesRef.current.find((candidate) => candidate.id === note.id) ?? note;
+        const savedLatest = { ...latest, id: saved.id, created_at: saved.created_at };
         setNotes((currentNotes) => {
-          const savedNotes = currentNotes.map((candidate) => (candidate.id === note.id ? saved : candidate));
+          const savedNotes = currentNotes.map((candidate) => (candidate.id === note.id ? savedLatest : candidate));
           persistAllIfFallback(savedNotes);
           return savedNotes;
         });
         setActiveId((current) => (current === note.id ? saved.id : current));
-        return saved;
+        return savedLatest;
       }
       resolvedCreatesRef.current.delete(note.id);
       const latest = notesRef.current.find((candidate) => candidate.id === resolvedId) ?? {

--- a/home/apps/notes/src/App.tsx
+++ b/home/apps/notes/src/App.tsx
@@ -152,7 +152,7 @@ function NoteCard({
         {note.title}
       </span>
       <span className="note-card__preview">{note.preview}</span>
-      <span className="note-card__meta">{relativeTime(note.updated_at, nowMs)}</span>
+      <span className="note-card__meta">{relativeTime(note.updated_at ?? "", nowMs)}</span>
     </button>
   );
 }
@@ -442,7 +442,7 @@ function App() {
             {saveState === "error" ? "Save failed" : saveState === "saving" ? "Saving" : "Saved"}
             {activeNote ? (
               <span className="toolbar__meta">
-                <Clock3 size={12} /> Updated {relativeTime(activeNote.updated_at, nowMs)}
+                <Clock3 size={12} /> Updated {relativeTime(activeNote.updated_at ?? "", nowMs)}
               </span>
             ) : null}
           </div>

--- a/home/apps/notes/src/RichEditor.tsx
+++ b/home/apps/notes/src/RichEditor.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EditorContent, useEditor, type Editor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  Bold,
+  Code,
+  Heading1,
+  Heading2,
+  Heading3,
+  Italic,
+  List,
+  ListChecks,
+  ListOrdered,
+  Quote,
+  Slash,
+  Strikethrough,
+} from "lucide-react";
+import { htmlToMarkdown, markdownToHtml } from "./markdown";
+import { emptyTiptapDoc, type Note, type TiptapDoc } from "./notes-model";
+
+type SlashCommand = {
+  id: string;
+  label: string;
+  hint: string;
+  icon: typeof Heading1;
+  run: (editor: Editor) => void;
+};
+
+const SLASH_COMMANDS: SlashCommand[] = [
+  { id: "h1", label: "Heading 1", hint: "Large section title", icon: Heading1, run: (e) => e.chain().focus().toggleHeading({ level: 1 }).run() },
+  { id: "h2", label: "Heading 2", hint: "Medium section title", icon: Heading2, run: (e) => e.chain().focus().toggleHeading({ level: 2 }).run() },
+  { id: "h3", label: "Heading 3", hint: "Small section title", icon: Heading3, run: (e) => e.chain().focus().toggleHeading({ level: 3 }).run() },
+  { id: "ul", label: "Bullet list", hint: "Simple bulleted list", icon: List, run: (e) => e.chain().focus().toggleBulletList().run() },
+  { id: "ol", label: "Numbered list", hint: "Ordered list", icon: ListOrdered, run: (e) => e.chain().focus().toggleOrderedList().run() },
+  { id: "todo", label: "To-do list", hint: "Track tasks with checkboxes", icon: ListChecks, run: (e) => e.chain().focus().toggleBulletList().run() },
+  { id: "quote", label: "Quote", hint: "Capture a quote", icon: Quote, run: (e) => e.chain().focus().toggleBlockquote().run() },
+  { id: "code", label: "Code block", hint: "Monospaced code", icon: Code, run: (e) => e.chain().focus().toggleCodeBlock().run() },
+];
+
+export interface RichEditorProps {
+  note: Note;
+  onChange: (patch: { content: string; content_json: TiptapDoc }) => void;
+}
+
+export default function RichEditor({ note, onChange }: RichEditorProps) {
+  const [mode, setMode] = useState<"rich" | "source">("rich");
+  const [slashOpen, setSlashOpen] = useState(false);
+  const [slashQuery, setSlashQuery] = useState("");
+  const [slashIndex, setSlashIndex] = useState(0);
+  const lastAppliedNoteIdRef = useRef<string | null>(null);
+
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: note.content_json.content?.length ? note.content_json : markdownToHtml(note.content),
+    immediatelyRender: false,
+    editorProps: {
+      attributes: { class: "rich-editor-content", "aria-label": "Note body" },
+    },
+    onUpdate({ editor: activeEditor }) {
+      onChange({
+        content: htmlToMarkdown(activeEditor.getHTML()),
+        content_json: activeEditor.getJSON() as TiptapDoc,
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (!editor || lastAppliedNoteIdRef.current === note.id) return;
+    lastAppliedNoteIdRef.current = note.id;
+    editor.commands.setContent(
+      note.content_json.content?.length ? note.content_json : markdownToHtml(note.content),
+      { emitUpdate: false },
+    );
+  }, [editor, note.content, note.content_json, note.id]);
+
+  const filteredCommands = useMemo(() => {
+    const q = slashQuery.trim().toLowerCase();
+    if (!q) return SLASH_COMMANDS;
+    return SLASH_COMMANDS.filter((cmd) => cmd.label.toLowerCase().includes(q) || cmd.id.includes(q));
+  }, [slashQuery]);
+
+  const closeSlash = useCallback(() => {
+    setSlashOpen(false);
+    setSlashQuery("");
+    setSlashIndex(0);
+  }, []);
+
+  const applyCommand = useCallback(
+    (command: SlashCommand) => {
+      if (editor) command.run(editor);
+      closeSlash();
+      editor?.commands.focus();
+    },
+    [editor, closeSlash],
+  );
+
+  const updateMarkdownSource = useCallback(
+    (markdown: string) => {
+      if (!editor) {
+        onChange({ content: markdown, content_json: emptyTiptapDoc() });
+        return;
+      }
+      editor.commands.setContent(markdownToHtml(markdown), { emitUpdate: false });
+      onChange({ content: markdown, content_json: editor.getJSON() as TiptapDoc });
+    },
+    [editor, onChange],
+  );
+
+  const handleEditorKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!slashOpen) {
+        if (event.key === "/" && editor?.isFocused) {
+          // Open the block menu affordance; the "/" is also typed into the doc.
+          setSlashOpen(true);
+          setSlashQuery("");
+          setSlashIndex(0);
+        }
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeSlash();
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSlashIndex((i) => (i + 1) % Math.max(filteredCommands.length, 1));
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSlashIndex((i) => (i - 1 + filteredCommands.length) % Math.max(filteredCommands.length, 1));
+        return;
+      }
+      if (event.key === "Enter") {
+        const command = filteredCommands[slashIndex];
+        if (command) {
+          event.preventDefault();
+          applyCommand(command);
+        }
+      }
+    },
+    [slashOpen, editor, closeSlash, filteredCommands, slashIndex, applyCommand],
+  );
+
+  const btn = (active: boolean) => (active ? "format-button format-button--active" : "format-button");
+
+  return (
+    <div className="markdown-editor">
+      <div className="format-toolbar" aria-label="Formatting toolbar">
+        <div className="mode-toggle" role="tablist" aria-label="Editor mode">
+          <button className={mode === "rich" ? "mode-button mode-button--active" : "mode-button"} type="button" role="tab" aria-selected={mode === "rich"} onClick={() => setMode("rich")}>Rich</button>
+          <button className={mode === "source" ? "mode-button mode-button--active" : "mode-button"} type="button" role="tab" aria-selected={mode === "source"} onClick={() => setMode("source")}>Markdown</button>
+        </div>
+        <span className="format-divider" />
+        <button className={btn(!!editor?.isActive("heading", { level: 1 }))} type="button" onClick={() => editor?.chain().focus().toggleHeading({ level: 1 }).run()} title="Heading 1"><Heading1 size={15} /></button>
+        <button className={btn(!!editor?.isActive("heading", { level: 2 }))} type="button" onClick={() => editor?.chain().focus().toggleHeading({ level: 2 }).run()} title="Heading 2"><Heading2 size={15} /></button>
+        <button className={btn(!!editor?.isActive("bold"))} type="button" onClick={() => editor?.chain().focus().toggleBold().run()} title="Bold"><Bold size={15} /></button>
+        <button className={btn(!!editor?.isActive("italic"))} type="button" onClick={() => editor?.chain().focus().toggleItalic().run()} title="Italic"><Italic size={15} /></button>
+        <button className={btn(!!editor?.isActive("strike"))} type="button" onClick={() => editor?.chain().focus().toggleStrike().run()} title="Strikethrough"><Strikethrough size={15} /></button>
+        <button className={btn(!!editor?.isActive("bulletList"))} type="button" onClick={() => editor?.chain().focus().toggleBulletList().run()} title="Bullet list"><List size={15} /></button>
+        <button className={btn(!!editor?.isActive("orderedList"))} type="button" onClick={() => editor?.chain().focus().toggleOrderedList().run()} title="Numbered list"><ListOrdered size={15} /></button>
+        <button className={btn(!!editor?.isActive("blockquote"))} type="button" onClick={() => editor?.chain().focus().toggleBlockquote().run()} title="Quote"><Quote size={15} /></button>
+        <button className={btn(!!editor?.isActive("codeBlock"))} type="button" onClick={() => editor?.chain().focus().toggleCodeBlock().run()} title="Code block"><Code size={15} /></button>
+        <span className="format-spacer" />
+        <button
+          className="format-button slash-trigger"
+          type="button"
+          onClick={() => {
+            editor?.commands.focus();
+            setSlashOpen(true);
+            setSlashQuery("");
+            setSlashIndex(0);
+          }}
+          title="Insert block ( / )"
+        >
+          <Slash size={14} />
+        </button>
+      </div>
+
+      {mode === "source" ? (
+        <textarea
+          className="content-input"
+          value={note.content}
+          onChange={(event) => updateMarkdownSource(event.target.value)}
+          spellCheck
+          aria-label="Markdown content"
+        />
+      ) : (
+        <div className="rich-editor-wrap" onKeyDown={handleEditorKeyDown}>
+          <EditorContent editor={editor} className="rich-editor" />
+          {slashOpen ? (
+            <div className="slash-menu" role="menu" aria-label="Insert block">
+              <div className="slash-menu__search">
+                <Slash size={13} />
+                <input
+                  autoFocus
+                  value={slashQuery}
+                  placeholder="Filter blocks"
+                  onChange={(event) => {
+                    setSlashQuery(event.target.value);
+                    setSlashIndex(0);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      event.preventDefault();
+                      closeSlash();
+                    } else if (event.key === "ArrowDown") {
+                      event.preventDefault();
+                      setSlashIndex((i) => (i + 1) % Math.max(filteredCommands.length, 1));
+                    } else if (event.key === "ArrowUp") {
+                      event.preventDefault();
+                      setSlashIndex((i) => (i - 1 + filteredCommands.length) % Math.max(filteredCommands.length, 1));
+                    } else if (event.key === "Enter") {
+                      const command = filteredCommands[slashIndex];
+                      if (command) {
+                        event.preventDefault();
+                        applyCommand(command);
+                      }
+                    }
+                  }}
+                  aria-label="Filter blocks"
+                />
+              </div>
+              <div className="slash-menu__list">
+                {filteredCommands.map((command, index) => {
+                  const Icon = command.icon;
+                  return (
+                    <button
+                      key={command.id}
+                      type="button"
+                      role="menuitem"
+                      className={index === slashIndex ? "slash-item slash-item--active" : "slash-item"}
+                      onMouseEnter={() => setSlashIndex(index)}
+                      onClick={() => applyCommand(command)}
+                    >
+                      <span className="slash-item__icon"><Icon size={15} /></span>
+                      <span className="slash-item__text">
+                        <span className="slash-item__label">{command.label}</span>
+                        <span className="slash-item__hint">{command.hint}</span>
+                      </span>
+                    </button>
+                  );
+                })}
+                {filteredCommands.length === 0 ? <div className="slash-empty">No blocks match</div> : null}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/home/apps/notes/src/RichEditor.tsx
+++ b/home/apps/notes/src/RichEditor.tsx
@@ -123,7 +123,7 @@ export default function RichEditor({ note, onChange }: RichEditorProps) {
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (!slashOpen) {
         if (event.key === "/" && editor?.isFocused) {
-          // Open the block menu affordance; the "/" is also typed into the doc.
+          event.preventDefault();
           setSlashOpen(true);
           setSlashQuery("");
           setSlashIndex(0);

--- a/home/apps/notes/src/RichEditor.tsx
+++ b/home/apps/notes/src/RichEditor.tsx
@@ -46,6 +46,13 @@ export default function RichEditor({ note, onChange }: RichEditorProps) {
   const [slashQuery, setSlashQuery] = useState("");
   const [slashIndex, setSlashIndex] = useState(0);
   const lastAppliedNoteIdRef = useRef<string | null>(null);
+  const slashMenuRef = useRef<HTMLDivElement | null>(null);
+
+  const closeSlash = useCallback(() => {
+    setSlashOpen(false);
+    setSlashQuery("");
+    setSlashIndex(0);
+  }, []);
 
   const editor = useEditor({
     extensions: [StarterKit],
@@ -65,11 +72,12 @@ export default function RichEditor({ note, onChange }: RichEditorProps) {
   useEffect(() => {
     if (!editor || lastAppliedNoteIdRef.current === note.id) return;
     lastAppliedNoteIdRef.current = note.id;
+    closeSlash();
     editor.commands.setContent(
       note.content_json.content?.length ? note.content_json : markdownToHtml(note.content),
       { emitUpdate: false },
     );
-  }, [editor, note.content, note.content_json, note.id]);
+  }, [closeSlash, editor, note.content, note.content_json, note.id]);
 
   const filteredCommands = useMemo(() => {
     const q = slashQuery.trim().toLowerCase();
@@ -77,11 +85,18 @@ export default function RichEditor({ note, onChange }: RichEditorProps) {
     return SLASH_COMMANDS.filter((cmd) => cmd.label.toLowerCase().includes(q) || cmd.id.includes(q));
   }, [slashQuery]);
 
-  const closeSlash = useCallback(() => {
-    setSlashOpen(false);
-    setSlashQuery("");
-    setSlashIndex(0);
-  }, []);
+  useEffect(() => {
+    if (!slashOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && slashMenuRef.current?.contains(target)) return;
+      closeSlash();
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [closeSlash, slashOpen]);
 
   const applyCommand = useCallback(
     (command: SlashCommand) => {
@@ -188,7 +203,7 @@ export default function RichEditor({ note, onChange }: RichEditorProps) {
         <div className="rich-editor-wrap" onKeyDown={handleEditorKeyDown}>
           <EditorContent editor={editor} className="rich-editor" />
           {slashOpen ? (
-            <div className="slash-menu" role="menu" aria-label="Insert block">
+            <div ref={slashMenuRef} className="slash-menu" role="menu" aria-label="Insert block">
               <div className="slash-menu__search">
                 <Slash size={13} />
                 <input

--- a/home/apps/notes/src/RichEditor.tsx
+++ b/home/apps/notes/src/RichEditor.tsx
@@ -9,7 +9,6 @@ import {
   Heading3,
   Italic,
   List,
-  ListChecks,
   ListOrdered,
   Quote,
   Slash,
@@ -32,7 +31,6 @@ const SLASH_COMMANDS: SlashCommand[] = [
   { id: "h3", label: "Heading 3", hint: "Small section title", icon: Heading3, run: (e) => e.chain().focus().toggleHeading({ level: 3 }).run() },
   { id: "ul", label: "Bullet list", hint: "Simple bulleted list", icon: List, run: (e) => e.chain().focus().toggleBulletList().run() },
   { id: "ol", label: "Numbered list", hint: "Ordered list", icon: ListOrdered, run: (e) => e.chain().focus().toggleOrderedList().run() },
-  { id: "todo", label: "To-do list", hint: "Track tasks with checkboxes", icon: ListChecks, run: (e) => e.chain().focus().toggleBulletList().run() },
   { id: "quote", label: "Quote", hint: "Capture a quote", icon: Quote, run: (e) => e.chain().focus().toggleBlockquote().run() },
   { id: "code", label: "Code block", hint: "Monospaced code", icon: Code, run: (e) => e.chain().focus().toggleCodeBlock().run() },
 ];
@@ -204,17 +202,21 @@ export default function RichEditor({ note, onChange }: RichEditorProps) {
                   onKeyDown={(event) => {
                     if (event.key === "Escape") {
                       event.preventDefault();
+                      event.stopPropagation();
                       closeSlash();
                     } else if (event.key === "ArrowDown") {
                       event.preventDefault();
+                      event.stopPropagation();
                       setSlashIndex((i) => (i + 1) % Math.max(filteredCommands.length, 1));
                     } else if (event.key === "ArrowUp") {
                       event.preventDefault();
+                      event.stopPropagation();
                       setSlashIndex((i) => (i - 1 + filteredCommands.length) % Math.max(filteredCommands.length, 1));
                     } else if (event.key === "Enter") {
                       const command = filteredCommands[slashIndex];
                       if (command) {
                         event.preventDefault();
+                        event.stopPropagation();
                         applyCommand(command);
                       }
                     }

--- a/home/apps/notes/src/RichEditor.tsx
+++ b/home/apps/notes/src/RichEditor.tsx
@@ -71,7 +71,9 @@ export default function RichEditor({ note, onChange }: RichEditorProps) {
 
   useEffect(() => {
     if (!editor || lastAppliedNoteIdRef.current === note.id) return;
+    const previousNoteId = lastAppliedNoteIdRef.current;
     lastAppliedNoteIdRef.current = note.id;
+    if (previousNoteId?.startsWith("note-") && !note.id.startsWith("note-")) return;
     closeSlash();
     editor.commands.setContent(
       note.content_json.content?.length ? note.content_json : markdownToHtml(note.content),

--- a/home/apps/notes/src/matrix-os.d.ts
+++ b/home/apps/notes/src/matrix-os.d.ts
@@ -1,21 +1,25 @@
 interface MatrixOSDb {
-  find(table: string, opts?: { orderBy?: Record<string, "asc" | "desc"> }): Promise<unknown[]>;
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
   insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
-  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok?: boolean }>;
-  delete(table: string, id: string): Promise<{ ok?: boolean }>;
-  onChange?(table: string, callback: () => void): () => void;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
 }
-
 interface MatrixOS {
   db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
   readData?(key: string): Promise<unknown>;
   writeData?(key: string, value: unknown): Promise<void>;
 }
-
 declare global {
-  interface Window {
-    MatrixOS?: MatrixOS;
-  }
+  interface Window { MatrixOS?: MatrixOS; }
 }
-
 export {};

--- a/home/apps/notes/src/notes-model.ts
+++ b/home/apps/notes/src/notes-model.ts
@@ -102,7 +102,7 @@ export function normalizeTags(input: string[] | string | null | undefined): stri
   for (const item of raw) {
     const tag = item.replace(/^#/, "").trim().toLowerCase();
     if (!tag) continue;
-    if (!/^[a-z][a-z0-9-]{0,40}$/.test(tag)) continue;
+    if (!/^[a-z][a-z0-9-]{1,40}$/.test(tag)) continue;
     if (!out.includes(tag)) out.push(tag);
   }
   return out;

--- a/home/apps/notes/src/notes-model.ts
+++ b/home/apps/notes/src/notes-model.ts
@@ -31,6 +31,7 @@ export interface NoteInput {
   pinned?: boolean | null;
   created_at?: string | null;
   updated_at?: string | null;
+  tags?: string[] | string | null;
 }
 
 let sequence = 0;
@@ -90,6 +91,28 @@ export function extractTags(content: string): string[] {
   return tags;
 }
 
+/** Normalize an arbitrary tag input (array or comma/space-joined string) into a clean, deduped list. */
+export function normalizeTags(input: string[] | string | null | undefined): string[] {
+  const raw = Array.isArray(input)
+    ? input
+    : typeof input === "string"
+      ? input.split(/[,\s]+/)
+      : [];
+  const out: string[] = [];
+  for (const item of raw) {
+    const tag = item.replace(/^#/, "").trim().toLowerCase();
+    if (!tag) continue;
+    if (!/^[a-z][a-z0-9-]{0,40}$/.test(tag)) continue;
+    if (!out.includes(tag)) out.push(tag);
+  }
+  return out;
+}
+
+/** Serialize tags for the `tags text` column (comma-joined). */
+export function serializeTags(tags: string[]): string {
+  return normalizeTags(tags).join(",");
+}
+
 export function buildNotePreview(content: string): string {
   return content
     .replace(/```[\s\S]*?```/g, " ")
@@ -111,6 +134,7 @@ export function createNote(input: NoteInput = {}): Note {
     ? input.content_json
     : emptyTiptapDoc();
   const searchableText = [content, tiptapDocToText(contentJson)].join(" ");
+  const tags = normalizeTags([...normalizeTags(input.tags), ...extractTags(searchableText)]);
   return {
     id: input.id ?? globalThis.crypto?.randomUUID?.() ?? fallbackId(),
     title: (input.title ?? "").trim() || "Untitled",
@@ -119,7 +143,7 @@ export function createNote(input: NoteInput = {}): Note {
     pinned: Boolean(input.pinned),
     created_at: input.created_at ?? now,
     updated_at: input.updated_at ?? now,
-    tags: extractTags(searchableText),
+    tags,
     preview: buildNotePreview(searchableText) || "No content yet",
   };
 }
@@ -134,6 +158,7 @@ export function hydrateNote(row: Record<string, unknown>): Note {
     pinned: typeof row.pinned === "boolean" ? row.pinned : false,
     created_at: typeof row.created_at === "string" ? row.created_at : null,
     updated_at: typeof row.updated_at === "string" ? row.updated_at : null,
+    tags: typeof row.tags === "string" ? row.tags : Array.isArray(row.tags) ? (row.tags as string[]) : null,
   });
 }
 

--- a/home/apps/notes/src/notes-model.ts
+++ b/home/apps/notes/src/notes-model.ts
@@ -134,7 +134,8 @@ export function createNote(input: NoteInput = {}): Note {
     ? input.content_json
     : emptyTiptapDoc();
   const searchableText = [content, tiptapDocToText(contentJson)].join(" ");
-  const tags = normalizeTags([...normalizeTags(input.tags), ...extractTags(searchableText)]);
+  const extractedTags = extractTags(searchableText);
+  const tags = extractedTags.length > 0 ? extractedTags : normalizeTags(input.tags);
   return {
     id: input.id ?? globalThis.crypto?.randomUUID?.() ?? fallbackId(),
     title: (input.title ?? "").trim() || "Untitled",

--- a/home/apps/notes/src/styles.css
+++ b/home/apps/notes/src/styles.css
@@ -272,6 +272,32 @@ h1 {
   font-size: 13px;
 }
 
+.toolbar__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 10px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.note-list__section {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 8px 8px 2px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.note-list__section:first-child {
+  margin-top: 2px;
+}
+
 .error-banner {
   margin: 12px 16px 0;
   border: 1px solid color-mix(in srgb, var(--danger) 30%, var(--border));
@@ -374,6 +400,179 @@ h1 {
   height: 22px;
   margin: 0 4px;
   background: var(--border);
+}
+
+.format-spacer {
+  flex: 1;
+}
+
+.mode-toggle {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+}
+
+.mode-button {
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.mode-button--active {
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: 0 1px 3px rgba(50, 53, 46, 0.12);
+}
+
+.slash-trigger {
+  color: var(--accent);
+}
+
+.rich-editor-wrap {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.slash-menu {
+  position: absolute;
+  top: 12px;
+  left: 24px;
+  z-index: 5;
+  width: 280px;
+  max-height: 320px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(214, 211, 200, 0.6);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(16px) saturate(160%);
+  box-shadow: 0 12px 32px rgba(50, 53, 46, 0.16);
+  animation: slash-pop 0.12s ease;
+}
+
+@keyframes slash-pop {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slash-menu {
+    animation: none;
+  }
+}
+
+.slash-menu__search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+}
+
+.slash-menu__search input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 13px;
+}
+
+.slash-menu__list {
+  overflow-y: auto;
+  padding: 6px;
+}
+
+.slash-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--foreground);
+  padding: 7px 9px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+
+.slash-item--active,
+.slash-item:hover {
+  background: var(--accent-soft);
+}
+
+.slash-item__icon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border-radius: 8px;
+  background: var(--card);
+  color: var(--accent);
+}
+
+.slash-item__text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.slash-item__label {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.slash-item__hint {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.slash-empty {
+  padding: 14px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.editor-footer__tags {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.footer-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 2px 7px;
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .rich-editor {

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -95,6 +95,15 @@ describe("Notes app", () => {
     expect(screen.getByText("Weekend")).toBeTruthy();
   });
 
+  it("loads notes in recently updated order", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+
+    await screen.findByText("No notes yet");
+
+    expect(db.find).toHaveBeenCalledWith("notes", { orderBy: { updated_at: "desc" } });
+  });
+
   it("shows the onboarding empty state when there are no notes", async () => {
     installMatrixDb([]);
     render(<App />);

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -250,6 +250,42 @@ describe("Notes app", () => {
     );
   });
 
+  it("retries insert for an orphaned draft after the initial create fails", async () => {
+    vi.useFakeTimers();
+    const db = installMatrixDb([]);
+    db.insert.mockRejectedValueOnce(new Error("temporary insert failure"));
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /new note/i })[0]);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Note could not be created.")).toBeTruthy();
+
+    const titleInput = screen.getByLabelText("Note title") as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "Recovered draft" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).toHaveBeenCalledTimes(2);
+    expect(db.insert.mock.calls[1][1]).toEqual(expect.objectContaining({ title: "Recovered draft" }));
+    expect(db.update).not.toHaveBeenCalledWith(
+      "notes",
+      expect.stringMatching(/^note-/),
+      expect.anything(),
+    );
+  });
+
   it("does not steal selection when a new note insert resolves", async () => {
     const db = installMatrixDb([
       {

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -216,6 +216,40 @@ describe("Notes app", () => {
     );
   });
 
+  it("saves edits when a new note insert resolves before the debounce fires", async () => {
+    vi.useFakeTimers();
+    const db = installMatrixDb([]);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /new note/i })[0]);
+    const titleInput = screen.getByLabelText("Note title") as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "Fast bridge draft" } });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(db.insert).toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.update).toHaveBeenCalledWith(
+      "notes",
+      "db-1",
+      expect.objectContaining({ title: "Fast bridge draft" }),
+    );
+  });
+
   it("does not steal selection when a new note insert resolves", async () => {
     const db = installMatrixDb([
       {

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -388,6 +388,36 @@ describe("Notes app", () => {
     expect((screen.getByLabelText("Note title") as HTMLInputElement).value).toBe("Second note");
   });
 
+  it("deletes a pending create when its insert resolves after removal", async () => {
+    const db = installMatrixDb([]);
+    let resolveInsert: ((value: { id: string }) => void) | null = null;
+    db.insert.mockImplementationOnce(
+      async (_table: string, data: DbRow) =>
+        new Promise<{ id: string }>((resolve) => {
+          db.rows.unshift({ id: "db-new", created_at: new Date().toISOString(), ...data });
+          resolveInsert = resolve;
+        }),
+    );
+
+    render(<App />);
+    await screen.findByText("No notes yet");
+
+    fireEvent.click(screen.getAllByRole("button", { name: /new note/i })[0]);
+    await screen.findByLabelText("Note title");
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    await act(async () => {
+      resolveInsert?.({ id: "db-new" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.delete).toHaveBeenCalledWith("notes", "db-new");
+    });
+    expect(db.rows.some((row) => row.id === "db-new")).toBe(false);
+  });
+
   it("clears stored inline tags when the editor content removes them", async () => {
     const db = installMatrixDb([
       {

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -221,4 +221,33 @@ describe("Notes app", () => {
     expect(sections.some((text) => /Pinned/i.test(text ?? ""))).toBe(true);
     expect(screen.getByText("Pinned idea")).toBeTruthy();
   });
+
+  it("refreshes relative timestamps every minute", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-31T10:00:10.000Z"));
+    installMatrixDb([
+      {
+        id: "n-1",
+        title: "Fresh note",
+        content: "body",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-31T10:00:00.000Z",
+      },
+    ]);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("just now")).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(screen.getByText("1 min ago")).toBeTruthy();
+  });
 });

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The Tiptap rich editor ships its own React copy under the app's node_modules,
+// which collides with the root React in the jsdom runtime ("Invalid hook call").
+// It is exercised in the build + manually; here we mock the local RichEditor
+// module so we can assert the app's list, persistence, and filtering behavior.
+vi.mock("../../home/apps/notes/src/RichEditor", () => ({
+  default: ({ note }: { note: { content: string } }) =>
+    React.createElement("div", { "data-testid": "rich-editor-mock" }, note.content),
+}));
+
+const { default: App } = await import("../../home/apps/notes/src/App");
+
+type DbRow = Record<string, unknown>;
+
+type FakeDb = {
+  find: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  onChange: ReturnType<typeof vi.fn>;
+  rows: DbRow[];
+};
+
+function installMatrixDb(initial: DbRow[] = []): FakeDb {
+  const rows: DbRow[] = [...initial];
+  let seq = 0;
+  const db = {
+    rows,
+    find: vi.fn(async () => rows.map((row) => ({ ...row }))),
+    insert: vi.fn(async (_table: string, data: DbRow) => {
+      seq += 1;
+      const id = `db-${seq}`;
+      rows.unshift({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    }),
+    update: vi.fn(async (_table: string, id: string, data: DbRow) => {
+      const found = rows.find((row) => row.id === id);
+      if (found) Object.assign(found, data);
+      return { ok: true };
+    }),
+    delete: vi.fn(async (_table: string, id: string) => {
+      const idx = rows.findIndex((row) => row.id === id);
+      if (idx >= 0) rows.splice(idx, 1);
+      return { ok: true };
+    }),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db as unknown as FakeDb;
+}
+
+describe("Notes app", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+  });
+
+  it("renders the document list from the Matrix DB", async () => {
+    installMatrixDb([
+      {
+        id: "n-1",
+        title: "Launch plan",
+        content: "Ship the canvas upgrade",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-31T10:00:00.000Z",
+      },
+      {
+        id: "n-2",
+        title: "Weekend",
+        content: "Groceries and rest",
+        content_json: { type: "doc", content: [] },
+        pinned: true,
+        tags: "personal",
+        updated_at: "2026-05-30T09:25:00.000Z",
+      },
+    ]);
+
+    render(<App />);
+
+    expect(await screen.findByText("Launch plan")).toBeTruthy();
+    expect(screen.getByText("Weekend")).toBeTruthy();
+  });
+
+  it("shows the onboarding empty state when there are no notes", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    expect(await screen.findByText("No notes yet")).toBeTruthy();
+    expect(screen.getByText("Capture a thought, draft a plan, or save a reference. Press Cmd/Ctrl+N to begin.")).toBeTruthy();
+  });
+
+  it("creates a note via the bridge insert when clicking New", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+
+    await screen.findByText("No notes yet");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "New note" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.insert).toHaveBeenCalled());
+    expect(db.insert.mock.calls[0][0]).toBe("notes");
+    const inserted = db.insert.mock.calls[0][1] as DbRow;
+    expect(inserted).toHaveProperty("title");
+    expect(inserted).toHaveProperty("content");
+    expect(inserted).toHaveProperty("content_json");
+  });
+
+  it("autosaves an edited title via a debounced bridge update", async () => {
+    const db = installMatrixDb([
+      {
+        id: "n-1",
+        title: "Draft",
+        content: "Body text",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-31T10:00:00.000Z",
+      },
+    ]);
+
+    render(<App />);
+    const titleInput = (await screen.findByLabelText("Note title")) as HTMLInputElement;
+
+    fireEvent.change(titleInput, { target: { value: "Renamed plan" } });
+    expect(titleInput.value).toBe("Renamed plan");
+
+    await waitFor(() => expect(db.update).toHaveBeenCalled(), { timeout: 3000 });
+    const updateCall = db.update.mock.calls.at(-1)!;
+    expect(updateCall[0]).toBe("notes");
+    expect(updateCall[1]).toBe("n-1");
+    expect((updateCall[2] as DbRow).title).toBe("Renamed plan");
+  });
+
+  it("filters notes by the search query", async () => {
+    installMatrixDb([
+      {
+        id: "n-1",
+        title: "Launch plan",
+        content: "ship",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-31T10:00:00.000Z",
+      },
+      {
+        id: "n-2",
+        title: "Groceries",
+        content: "milk eggs",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-30T10:00:00.000Z",
+      },
+    ]);
+
+    render(<App />);
+    await screen.findByText("Launch plan");
+
+    const search = screen.getByPlaceholderText("Search notes");
+    fireEvent.change(search, { target: { value: "groc" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Launch plan")).toBeNull();
+      expect(screen.getByText("Groceries")).toBeTruthy();
+    });
+  });
+
+  it("surfaces pinned notes in a dedicated pinned section", async () => {
+    installMatrixDb([
+      {
+        id: "n-1",
+        title: "Pinned idea",
+        content: "important",
+        content_json: { type: "doc", content: [] },
+        pinned: true,
+        tags: "",
+        updated_at: "2026-05-31T10:00:00.000Z",
+      },
+      {
+        id: "n-2",
+        title: "Loose thought",
+        content: "later",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-30T10:00:00.000Z",
+      },
+    ]);
+
+    const { container } = render(<App />);
+    await screen.findByText("Pinned idea");
+    const sections = Array.from(container.querySelectorAll(".note-list__section")).map((el) =>
+      el.textContent?.trim(),
+    );
+    expect(sections.some((text) => /Pinned/i.test(text ?? ""))).toBe(true);
+    expect(screen.getByText("Pinned idea")).toBeTruthy();
+  });
+});

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -8,8 +8,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // It is exercised in the build + manually; here we mock the local RichEditor
 // module so we can assert the app's list, persistence, and filtering behavior.
 vi.mock("../../home/apps/notes/src/RichEditor", () => ({
-  default: ({ note }: { note: { content: string } }) =>
-    React.createElement("div", { "data-testid": "rich-editor-mock" }, note.content),
+  default: ({
+    note,
+    onChange,
+  }: {
+    note: { content: string };
+    onChange: (patch: { content: string; content_json: { type: "doc"; content: [] } }) => void;
+  }) =>
+    React.createElement(
+      "div",
+      null,
+      React.createElement("div", { "data-testid": "rich-editor-mock" }, note.content),
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          onClick: () => onChange({ content: "No tags left", content_json: { type: "doc", content: [] } }),
+        },
+        "Clear inline tag",
+      ),
+    ),
 }));
 
 const { default: App } = await import("../../home/apps/notes/src/App");
@@ -155,6 +173,119 @@ describe("Notes app", () => {
     expect(updateCall[0]).toBe("notes");
     expect(updateCall[1]).toBe("n-1");
     expect((updateCall[2] as DbRow).title).toBe("Renamed plan");
+  });
+
+  it("saves edits made before a newly inserted note receives its database id", async () => {
+    vi.useFakeTimers();
+    const db = installMatrixDb([]);
+    let resolveInsert: ((value: { id: string }) => void) | null = null;
+    db.insert.mockImplementationOnce(
+      async (_table: string, data: DbRow) =>
+        new Promise<{ id: string }>((resolve) => {
+          db.rows.unshift({ id: "db-new", created_at: new Date().toISOString(), ...data });
+          resolveInsert = resolve;
+        }),
+    );
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /new note/i })[0]);
+    const titleInput = screen.getByLabelText("Note title") as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "Fast draft" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveInsert?.({ id: "db-new" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.update).toHaveBeenCalledWith(
+      "notes",
+      "db-new",
+      expect.objectContaining({ title: "Fast draft" }),
+    );
+  });
+
+  it("does not steal selection when a new note insert resolves", async () => {
+    const db = installMatrixDb([
+      {
+        id: "n-1",
+        title: "First note",
+        content: "One",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-31T10:00:00.000Z",
+      },
+      {
+        id: "n-2",
+        title: "Second note",
+        content: "Two",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-30T10:00:00.000Z",
+      },
+    ]);
+    let resolveInsert: ((value: { id: string }) => void) | null = null;
+    db.insert.mockImplementationOnce(
+      async (_table: string, data: DbRow) =>
+        new Promise<{ id: string }>((resolve) => {
+          db.rows.unshift({ id: "db-new", created_at: new Date().toISOString(), ...data });
+          resolveInsert = resolve;
+        }),
+    );
+
+    render(<App />);
+    await screen.findByText("First note");
+
+    fireEvent.click(screen.getAllByRole("button", { name: /new note/i })[0]);
+    fireEvent.click(screen.getByText("Second note"));
+
+    await act(async () => {
+      resolveInsert?.({ id: "db-new" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect((screen.getByLabelText("Note title") as HTMLInputElement).value).toBe("Second note");
+  });
+
+  it("clears stored inline tags when the editor content removes them", async () => {
+    const db = installMatrixDb([
+      {
+        id: "n-1",
+        title: "Tagged",
+        content: "Draft #old",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "old",
+        updated_at: "2026-05-31T10:00:00.000Z",
+      },
+    ]);
+
+    render(<App />);
+    await screen.findByText("Tagged");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear inline tag" }));
+
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith(
+        "notes",
+        "n-1",
+        expect.objectContaining({ content: "No tags left", tags: "" }),
+      );
+    });
   });
 
   it("filters notes by the search query", async () => {

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -175,6 +175,56 @@ describe("Notes app", () => {
     expect((updateCall[2] as DbRow).title).toBe("Renamed plan");
   });
 
+  it("cancels pending autosave when deleting the active note", async () => {
+    const db = installMatrixDb([
+      {
+        id: "n-1",
+        title: "Draft",
+        content: "Body text",
+        content_json: { type: "doc", content: [] },
+        pinned: false,
+        tags: "",
+        updated_at: "2026-05-31T10:00:00.000Z",
+      },
+    ]);
+
+    render(<App />);
+    const titleInput = (await screen.findByLabelText("Note title")) as HTMLInputElement;
+    vi.useFakeTimers();
+    fireEvent.change(titleInput, { target: { value: "Renamed plan" } });
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.delete).toHaveBeenCalledWith("notes", "n-1");
+    expect(db.update).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("saves debounced local fallback edits without a database bridge", async () => {
+    render(<App />);
+    await screen.findByText("No notes yet");
+
+    fireEvent.click(screen.getByRole("button", { name: "New note" }));
+    const titleInput = screen.getByLabelText("Note title") as HTMLInputElement;
+    vi.useFakeTimers();
+    fireEvent.change(titleInput, { target: { value: "Local draft" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("Note could not be saved.")).toBeNull();
+    expect(screen.queryByText("Save failed")).toBeNull();
+    vi.useRealTimers();
+  });
+
   it("saves edits made before a newly inserted note receives its database id", async () => {
     vi.useFakeTimers();
     const db = installMatrixDb([]);

--- a/tests/default-apps/notes-app.test.tsx
+++ b/tests/default-apps/notes-app.test.tsx
@@ -286,6 +286,63 @@ describe("Notes app", () => {
     );
   });
 
+  it("tracks a retry insert so concurrent debounces do not create duplicate rows", async () => {
+    vi.useFakeTimers();
+    const db = installMatrixDb([]);
+    let resolveRetry: ((value: { id: string }) => void) | null = null;
+    db.insert
+      .mockRejectedValueOnce(new Error("temporary insert failure"))
+      .mockImplementationOnce(
+        async (_table: string, data: DbRow) =>
+          new Promise<{ id: string }>((resolve) => {
+            db.rows.unshift({ id: "db-retry", created_at: new Date().toISOString(), ...data });
+            resolveRetry = resolve;
+          }),
+      );
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /new note/i })[0]);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const titleInput = screen.getByLabelText("Note title") as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "Retry draft" } });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.change(titleInput, { target: { value: "Retry draft updated" } });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveRetry?.({ id: "db-retry" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).toHaveBeenCalledTimes(2);
+    expect(db.update).toHaveBeenCalledWith(
+      "notes",
+      "db-retry",
+      expect.objectContaining({ title: "Retry draft updated" }),
+    );
+  });
+
   it("does not steal selection when a new note insert resolves", async () => {
     const db = installMatrixDb([
       {

--- a/tests/default-apps/notes-model.test.ts
+++ b/tests/default-apps/notes-model.test.ts
@@ -4,6 +4,7 @@ import {
   createNote,
   extractTags,
   filterNotes,
+  normalizeTags,
   tiptapDocToText,
   type Note,
 } from "../../home/apps/notes/src/notes-model";
@@ -39,6 +40,7 @@ describe("notes model", () => {
       "team",
       "research-ops",
     ]);
+    expect(normalizeTags(["a", "ai", "#b", "board"])).toEqual(["ai", "board"]);
     expect(buildNotePreview("- [ ] Review **spec**\n```ts\nconst x = 1\n```")).toBe(
       "Review spec",
     );

--- a/tests/default-apps/notes-model.test.ts
+++ b/tests/default-apps/notes-model.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildNotePreview,
@@ -8,6 +10,8 @@ import {
   tiptapDocToText,
   type Note,
 } from "../../home/apps/notes/src/notes-model";
+
+const REPO_ROOT = join(__dirname, "..", "..");
 
 describe("notes model", () => {
   it("creates searchable notes with tags extracted from markdown content", () => {
@@ -67,5 +71,13 @@ describe("notes model", () => {
     expect(note.content_json.type).toBe("doc");
     expect(tiptapDocToText(note.content_json)).toBe("Research #AI");
     expect(note.tags).toEqual(["ai"]);
+  });
+
+  it("declares an index for stored tag strings", () => {
+    const manifest = JSON.parse(
+      readFileSync(join(REPO_ROOT, "home", "apps", "notes", "matrix.json"), "utf-8"),
+    ) as { storage?: { tables?: { notes?: { indexes?: string[] } } } };
+
+    expect(manifest.storage?.tables?.notes?.indexes).toContain("tags");
   });
 });

--- a/tests/default-apps/notes-model.test.ts
+++ b/tests/default-apps/notes-model.test.ts
@@ -73,11 +73,12 @@ describe("notes model", () => {
     expect(note.tags).toEqual(["ai"]);
   });
 
-  it("declares an index for stored tag strings", () => {
+  it("does not index comma-separated tag strings", () => {
     const manifest = JSON.parse(
       readFileSync(join(REPO_ROOT, "home", "apps", "notes", "matrix.json"), "utf-8"),
     ) as { storage?: { tables?: { notes?: { indexes?: string[] } } } };
 
-    expect(manifest.storage?.tables?.notes?.indexes).toContain("tags");
+    expect(manifest.storage?.tables?.notes?.indexes).toContain("pinned");
+    expect(manifest.storage?.tables?.notes?.indexes).not.toContain("tags");
   });
 });

--- a/tests/default-apps/notes-rich-editor.test.tsx
+++ b/tests/default-apps/notes-rich-editor.test.tsx
@@ -60,4 +60,14 @@ describe("RichEditor", () => {
     expect(event).toBe(false);
     expect(screen.getByRole("menu", { name: "Insert block" })).toBeTruthy();
   });
+
+  it("does not reset content when a temporary note id is promoted", () => {
+    const tempNote = { ...note, id: "note-temp" };
+    const { rerender } = render(<RichEditor note={tempNote} onChange={vi.fn()} />);
+    fakeEditor.commands.setContent.mockClear();
+
+    rerender(<RichEditor note={{ ...tempNote, id: "db-note" }} onChange={vi.fn()} />);
+
+    expect(fakeEditor.commands.setContent).not.toHaveBeenCalled();
+  });
 });

--- a/tests/default-apps/notes-rich-editor.test.tsx
+++ b/tests/default-apps/notes-rich-editor.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Note } from "../../home/apps/notes/src/notes-model";
+
+const fakeEditor = {
+  isFocused: true,
+  getHTML: vi.fn(() => "<p></p>"),
+  getJSON: vi.fn(() => ({ type: "doc", content: [] })),
+  chain: vi.fn(() => fakeEditor),
+  focus: vi.fn(() => fakeEditor),
+  toggleHeading: vi.fn(() => fakeEditor),
+  toggleBulletList: vi.fn(() => fakeEditor),
+  toggleOrderedList: vi.fn(() => fakeEditor),
+  toggleBlockquote: vi.fn(() => fakeEditor),
+  toggleCodeBlock: vi.fn(() => fakeEditor),
+  run: vi.fn(() => true),
+  isActive: vi.fn(() => false),
+  commands: {
+    focus: vi.fn(),
+    setContent: vi.fn(),
+  },
+};
+
+vi.mock("@tiptap/react", () => ({
+  EditorContent: () => React.createElement("div", { "data-testid": "editor-content" }),
+  useEditor: () => fakeEditor,
+}));
+
+vi.mock("@tiptap/starter-kit", () => ({
+  default: {},
+}));
+
+const { default: RichEditor } = await import("../../home/apps/notes/src/RichEditor");
+
+const note: Note = {
+  id: "n-1",
+  title: "Note",
+  content: "",
+  content_json: { type: "doc", content: [] },
+  preview: "",
+  pinned: false,
+  tags: [],
+  created_at: "2026-05-31T10:00:00.000Z",
+  updated_at: "2026-05-31T10:00:00.000Z",
+};
+
+describe("RichEditor", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prevents the slash trigger from being inserted into the document", () => {
+    render(<RichEditor note={note} onChange={vi.fn()} />);
+
+    const wrap = screen.getByTestId("editor-content").parentElement!;
+    const event = fireEvent.keyDown(wrap, { key: "/" });
+
+    expect(event).toBe(false);
+    expect(screen.getByRole("menu", { name: "Insert block" })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Stack: 2/22
Branch: stack/default-apps-notes

Scope: Notes app rich document workspace and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.