### PR TITLE
feat(todo): add smart task planner

### DIFF
--- a/home/apps/todo/matrix.json
+++ b/home/apps/todo/matrix.json
@@ -1,24 +1,27 @@
 {
   "name": "Todo",
-  "description": "Task list with categories and due dates",
+  "description": "Fast personal task manager with inbox capture, smart lists, and recurring tasks.",
   "category": "productivity",
   "icon": "todo",
   "author": "system",
   "version": "2.0.0",
+  "scope": "personal",
   "storage": {
     "tables": {
       "tasks": {
         "columns": {
-          "text": "text",
-          "done": "boolean",
+          "title": "text",
+          "notes": "text",
           "due": "timestamptz",
-          "category": "text",
-          "priority": "text"
+          "priority": "integer",
+          "project": "text",
+          "status": "text",
+          "recur": "text"
         },
         "indexes": [
           "due",
-          "category",
-          "done"
+          "project",
+          "status"
         ]
       }
     }

--- a/home/apps/todo/matrix.json
+++ b/home/apps/todo/matrix.json
@@ -11,11 +11,14 @@
       "tasks": {
         "columns": {
           "title": "text",
+          "text": "text",
           "notes": "text",
           "due": "timestamptz",
           "priority": "integer",
           "project": "text",
+          "category": "text",
           "status": "text",
+          "done": "boolean",
           "recur": "text"
         },
         "indexes": [

--- a/home/apps/todo/matrix.json
+++ b/home/apps/todo/matrix.json
@@ -14,7 +14,7 @@
           "text": "text",
           "notes": "text",
           "due": "timestamptz",
-          "priority": "integer",
+          "priority": "text",
           "project": "text",
           "category": "text",
           "status": "text",

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -99,6 +99,12 @@ function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function taskWritePatch(patch: Partial<Task>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...patch };
+  if (typeof out.priority === "number") out.priority = String(out.priority);
+  return out;
+}
+
 // --- formatting -------------------------------------------------------------
 
 function toDateInputValue(iso: string | null): string {
@@ -229,7 +235,7 @@ export default function App() {
         title,
         notes: "",
         due: optimistic.due,
-        priority: 0,
+        priority: "0",
         project,
         status: "open",
         recur: null,
@@ -248,7 +254,7 @@ export default function App() {
       const db = getDb();
       if (!db) return;
       try {
-        await db.update(TASKS_TABLE, id, patch as Record<string, unknown>);
+        await db.update(TASKS_TABLE, id, taskWritePatch(patch));
       } catch (err: unknown) {
         console.warn("[todo] task update failed:", errMessage(err));
         await reload();
@@ -296,7 +302,7 @@ export default function App() {
                 title: task.title,
                 notes: task.notes,
                 due: nextDue,
-                priority: task.priority,
+                priority: String(task.priority),
                 project: task.project,
                 status: "open",
                 recur: task.recur,

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -668,7 +668,7 @@ function Inspector({
           value={toDateInputValue(task.due)}
           onChange={(e) => {
             const due = fromDateInputValue(e.target.value);
-            onPatch(due ? { due } : { due: null });
+            onPatch(due ? { due } : { due: null, recur: null });
           }}
         />
       </label>

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -377,7 +377,10 @@ export default function App() {
       } else if ((e.key === " " || e.key === "Enter") && selectedId) {
         e.preventDefault();
         const task = visible.find((t) => t.id === selectedId);
-        if (task) void completeTask(task);
+        if (task) {
+          setSelectedId(null);
+          void completeTask(task);
+        }
       } else if (e.key === "Backspace" && (e.metaKey || e.ctrlKey) && selectedId) {
         e.preventDefault();
         const task = visible.find((t) => t.id === selectedId);

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -318,11 +318,11 @@ export default function App() {
               console.warn("[todo] task completion rollback failed:", errMessage(rollbackErr));
             }
           }
-          await reload();
+          if (db) await reload();
           setError("Could not complete task.");
           return;
         }
-        await reload();
+        if (db) await reload();
       } finally {
         inFlightComplete.current.delete(task.id);
       }
@@ -614,6 +614,7 @@ export default function App() {
 
         {selectedId && (
           <Inspector
+            key={selectedTask?.id}
             task={selectedTask}
             onClose={() => setSelectedId(null)}
             onPatch={patchSelectedTask}

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -114,6 +114,15 @@ function fromDateInputValue(value: string): string | null {
   return Number.isNaN(d.getTime()) ? null : d.toISOString();
 }
 
+function defaultDueForView(view: View, now: Date): string | null {
+  if (view === "today") return now.toISOString();
+  if (view !== "upcoming") return null;
+  const due = new Date(now);
+  due.setDate(due.getDate() + 1);
+  due.setHours(9, 0, 0, 0);
+  return due.toISOString();
+}
+
 function formatDue(iso: string | null, now: Date): { label: string; tone: "overdue" | "today" | "soon" | "later" } | null {
   if (!iso) return null;
   const d = new Date(iso);
@@ -182,6 +191,10 @@ export default function App() {
     [selectedId, visible],
   );
 
+  useEffect(() => {
+    if (selectedId && !visible.some((task) => task.id === selectedId)) setSelectedId(null);
+  }, [selectedId, visible]);
+
   const activeSmart: SmartViewMeta | null =
     typeof view === "string" ? SMART_VIEWS.find((v) => v.id === view) ?? null : null;
   const headerTitle = typeof view === "string" ? activeSmart?.label ?? "Tasks" : view.project;
@@ -196,7 +209,7 @@ export default function App() {
       id: `local-${Date.now()}`,
       title,
       notes: "",
-      due: view === "today" ? now.toISOString() : null,
+      due: defaultDueForView(view, now),
       priority: 0,
       project,
       status: "open",
@@ -243,9 +256,9 @@ export default function App() {
 
   const patchSelectedTask = useCallback(
     (patch: Partial<Task>) => {
-      if (selectedId) void persistUpdate(selectedId, patch);
+      if (selectedTask?.id) void persistUpdate(selectedTask.id, patch);
     },
-    [persistUpdate, selectedId],
+    [persistUpdate, selectedTask?.id],
   );
 
   const completeTask = useCallback(
@@ -360,7 +373,9 @@ export default function App() {
         if (task) void completeTask(task);
       } else if (e.key === "Backspace" && (e.metaKey || e.ctrlKey) && selectedId) {
         e.preventDefault();
-        void deleteTask(selectedId);
+        const task = visible.find((t) => t.id === selectedId);
+        if (task) void deleteTask(task.id);
+        else setSelectedId(null);
       }
     },
     [editingId, visible, selectedId, completeTask, deleteTask],
@@ -620,11 +635,26 @@ function Inspector({
 }) {
   const [notesDraft, setNotesDraft] = useState(task?.notes ?? "");
   const [projectDraft, setProjectDraft] = useState(task?.project ?? "");
+  const latestDraftRef = useRef({ task, notesDraft, projectDraft });
+
+  latestDraftRef.current = { task, notesDraft, projectDraft };
+
+  const flushDrafts = useCallback(() => {
+    const current = latestDraftRef.current;
+    if (!current.task?.id) return;
+    const patch: Partial<Task> = {};
+    if (current.notesDraft !== current.task.notes) patch.notes = current.notesDraft;
+    const project = current.projectDraft.trim() || null;
+    if (project !== (current.task.project ?? null)) patch.project = project;
+    if (Object.keys(patch).length > 0) onPatch(patch);
+  }, [onPatch]);
 
   useEffect(() => {
     setNotesDraft(task?.notes ?? "");
     setProjectDraft(task?.project ?? "");
   }, [task?.id]);
+
+  useEffect(() => () => flushDrafts(), [flushDrafts, task?.id]);
 
   useEffect(() => {
     if (!task?.id || notesDraft === task.notes) return undefined;
@@ -647,7 +677,15 @@ function Inspector({
     <div className="inspector" role="dialog" aria-label={`Details for ${task.title}`}>
       <div className="inspector-head">
         <strong>Details</strong>
-        <button type="button" className="inspector-close" onClick={onClose} aria-label="Close details">
+        <button
+          type="button"
+          className="inspector-close"
+          onClick={() => {
+            flushDrafts();
+            onClose();
+          }}
+          aria-label="Close details"
+        >
           ✕
         </button>
       </div>

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -251,6 +251,11 @@ export default function App() {
   const completeTask = useCallback(
     async (task: Task) => {
       if (inFlightComplete.current.has(task.id)) return;
+      if (task.recur && !task.due) {
+        setError("Add a due date before completing a repeating task.");
+        setSelectedId(task.id);
+        return;
+      }
       inFlightComplete.current.add(task.id);
       // Optimistically mark done.
       setTasks((cur) => cur.map((t) => (t.id === task.id ? { ...t, status: "done" } : t)));
@@ -661,7 +666,10 @@ function Inspector({
         <input
           type="date"
           value={toDateInputValue(task.due)}
-          onChange={(e) => onPatch({ due: fromDateInputValue(e.target.value) })}
+          onChange={(e) => {
+            const due = fromDateInputValue(e.target.value);
+            onPatch(due ? { due } : { due: null, recur: null });
+          }}
         />
       </label>
 
@@ -678,7 +686,8 @@ function Inspector({
       <label className="field">
         <span>Repeat</span>
         <select
-          value={task.recur ?? ""}
+          value={task.due ? (task.recur ?? "") : ""}
+          disabled={!task.due}
           onChange={(e) => onPatch({ recur: (e.target.value || null) as Recurrence | null })}
         >
           {RECUR_OPTIONS.map((opt) => (
@@ -687,6 +696,7 @@ function Inspector({
             </option>
           ))}
         </select>
+        {!task.due && <span className="field-hint">Add a due date to repeat this task.</span>}
       </label>
     </div>
   );

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -177,6 +177,10 @@ export default function App() {
   }, [tasks]);
 
   const visible = useMemo(() => sortTasks(filterTasks(tasks, view, now)), [tasks, view, now]);
+  const selectedTask = useMemo(
+    () => (selectedId ? visible.find((t) => t.id === selectedId) ?? null : null),
+    [selectedId, visible],
+  );
 
   const activeSmart: SmartViewMeta | null =
     typeof view === "string" ? SMART_VIEWS.find((v) => v.id === view) ?? null : null;
@@ -235,6 +239,13 @@ export default function App() {
       }
     },
     [reload],
+  );
+
+  const patchSelectedTask = useCallback(
+    (patch: Partial<Task>) => {
+      if (selectedId) void persistUpdate(selectedId, patch);
+    },
+    [persistUpdate, selectedId],
   );
 
   const completeTask = useCallback(
@@ -566,9 +577,9 @@ export default function App() {
 
         {selectedId && (
           <Inspector
-            task={visible.find((t) => t.id === selectedId) ?? null}
+            task={selectedTask}
             onClose={() => setSelectedId(null)}
-            onPatch={(patch) => selectedId && void persistUpdate(selectedId, patch)}
+            onPatch={patchSelectedTask}
           />
         )}
       </main>
@@ -603,18 +614,28 @@ function Inspector({
   onPatch: (patch: Partial<Task>) => void;
 }) {
   const [notesDraft, setNotesDraft] = useState(task?.notes ?? "");
+  const [projectDraft, setProjectDraft] = useState(task?.project ?? "");
 
   useEffect(() => {
     setNotesDraft(task?.notes ?? "");
+    setProjectDraft(task?.project ?? "");
   }, [task?.id]);
 
   useEffect(() => {
-    if (!task || notesDraft === task.notes) return undefined;
+    if (!task?.id || notesDraft === task.notes) return undefined;
     const timer = window.setTimeout(() => {
       onPatch({ notes: notesDraft });
     }, NOTES_SAVE_DELAY_MS);
     return () => window.clearTimeout(timer);
-  }, [notesDraft, onPatch, task]);
+  }, [notesDraft, onPatch, task?.id, task?.notes]);
+
+  useEffect(() => {
+    if (!task?.id || projectDraft === (task.project ?? "")) return undefined;
+    const timer = window.setTimeout(() => {
+      onPatch({ project: projectDraft.trim() || null });
+    }, NOTES_SAVE_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [onPatch, projectDraft, task?.id, task?.project]);
 
   if (!task) return null;
   return (
@@ -648,9 +669,9 @@ function Inspector({
         <span>Project</span>
         <input
           type="text"
-          value={task.project ?? ""}
+          value={projectDraft}
           placeholder="No project"
-          onChange={(e) => onPatch({ project: e.target.value.trim() || null })}
+          onChange={(e) => setProjectDraft(e.target.value)}
         />
       </label>
 

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -1,0 +1,649 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import {
+  CalendarClock,
+  CalendarDays,
+  Check,
+  Flag,
+  Folder,
+  Inbox,
+  Plus,
+  Repeat,
+  Trash2,
+} from "lucide-react";
+import "./styles.css";
+import {
+  countByView,
+  filterTasks,
+  nextRecurrence,
+  normalizeTask,
+  projectNames,
+  sortTasks,
+  type Recurrence,
+  type Task,
+  type View,
+} from "./todo-model";
+
+const TASKS_TABLE = "tasks";
+
+type SmartViewId = "inbox" | "today" | "upcoming";
+
+const PRIORITY_LABELS = ["No flag", "Low", "Medium", "High"] as const;
+const RECUR_OPTIONS: { value: Recurrence | ""; label: string }[] = [
+  { value: "", label: "No repeat" },
+  { value: "daily", label: "Daily" },
+  { value: "weekdays", label: "Weekdays" },
+  { value: "weekly", label: "Weekly" },
+];
+
+interface SmartViewMeta {
+  id: SmartViewId;
+  label: string;
+  icon: typeof Inbox;
+  empty: { title: string; body: string };
+}
+
+const SMART_VIEWS: SmartViewMeta[] = [
+  {
+    id: "inbox",
+    label: "Inbox",
+    icon: Inbox,
+    empty: {
+      title: "Your inbox is clear",
+      body: "Capture anything on your mind. Type a task above and press Enter.",
+    },
+  },
+  {
+    id: "today",
+    label: "Today",
+    icon: CalendarDays,
+    empty: {
+      title: "Nothing due today",
+      body: "Tasks scheduled for today or overdue show up here. Enjoy the calm.",
+    },
+  },
+  {
+    id: "upcoming",
+    label: "Upcoming",
+    icon: CalendarClock,
+    empty: {
+      title: "No upcoming plans",
+      body: "Give a task a future due date and it will land here.",
+    },
+  },
+];
+
+// --- DB helpers (guarded, typed try/catch by caller) -----------------------
+
+function getDb(): NonNullable<Window["MatrixOS"]>["db"] | undefined {
+  return typeof window !== "undefined" ? window.MatrixOS?.db : undefined;
+}
+
+async function loadTasks(): Promise<Task[]> {
+  const db = getDb();
+  if (!db) return [];
+  const rows = await db.find(TASKS_TABLE, { orderBy: { created_at: "desc" }, limit: 500 });
+  return rows
+    .map(normalizeTask)
+    .filter((t): t is Task => t !== null);
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// --- formatting -------------------------------------------------------------
+
+function toDateInputValue(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function fromDateInputValue(value: string): string | null {
+  if (!value) return null;
+  const d = new Date(`${value}T09:00:00`);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function formatDue(iso: string | null, now: Date): { label: string; tone: "overdue" | "today" | "soon" | "later" } | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const day = 86_400_000;
+  const diff = Math.floor((new Date(d).setHours(0, 0, 0, 0) - start.getTime()) / day);
+  if (diff < 0) return { label: diff === -1 ? "Yesterday" : `${Math.abs(diff)}d overdue`, tone: "overdue" };
+  if (diff === 0) return { label: "Today", tone: "today" };
+  if (diff === 1) return { label: "Tomorrow", tone: "soon" };
+  if (diff < 7) return { label: d.toLocaleDateString(undefined, { weekday: "long" }), tone: "soon" };
+  return { label: d.toLocaleDateString(undefined, { month: "short", day: "numeric" }), tone: "later" };
+}
+
+// --- component --------------------------------------------------------------
+
+export default function App() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [view, setView] = useState<View>("inbox");
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [now] = useState(() => new Date());
+  const inFlightComplete = useRef<Set<string>>(new Set());
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const reload = useCallback(async () => {
+    try {
+      setError(null);
+      setTasks(await loadTasks());
+    } catch (err: unknown) {
+      console.warn("[todo] task load failed:", errMessage(err));
+      setError("Tasks could not be loaded. They may be out of date.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+    const db = getDb();
+    if (!db?.onChange) return undefined;
+    return db.onChange(TASKS_TABLE, () => void reload());
+  }, [reload]);
+
+  const counts = useMemo(() => countByView(tasks, now), [tasks, now]);
+  const projects = useMemo(() => projectNames(tasks), [tasks]);
+
+  const projectCounts = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const t of tasks) {
+      if (t.status === "open" && t.project) map.set(t.project, (map.get(t.project) ?? 0) + 1);
+    }
+    return map;
+  }, [tasks]);
+
+  const visible = useMemo(() => sortTasks(filterTasks(tasks, view, now)), [tasks, view, now]);
+
+  const activeSmart: SmartViewMeta | null =
+    typeof view === "string" ? SMART_VIEWS.find((v) => v.id === view) ?? null : null;
+  const headerTitle = typeof view === "string" ? activeSmart?.label ?? "Tasks" : view.project;
+
+  // --- mutations ------------------------------------------------------------
+
+  const addTask = useCallback(async () => {
+    const title = draft.trim();
+    if (!title) return;
+    const project = typeof view === "object" ? view.project : null;
+    const optimistic: Task = {
+      id: `local-${Date.now()}`,
+      title,
+      notes: "",
+      due: view === "today" ? now.toISOString() : null,
+      priority: 0,
+      project,
+      status: "open",
+      recur: null,
+      created_at: new Date().toISOString(),
+    };
+    setTasks((cur) => [optimistic, ...cur]);
+    setDraft("");
+    const db = getDb();
+    if (!db) return;
+    try {
+      await db.insert(TASKS_TABLE, {
+        title,
+        notes: "",
+        due: optimistic.due,
+        priority: 0,
+        project,
+        status: "open",
+        recur: null,
+      });
+      await reload();
+    } catch (err: unknown) {
+      console.warn("[todo] task insert failed:", errMessage(err));
+      setError("Task could not be saved.");
+      setTasks((cur) => cur.filter((t) => t.id !== optimistic.id));
+    }
+  }, [draft, view, now, reload]);
+
+  const persistUpdate = useCallback(
+    async (id: string, patch: Partial<Task>) => {
+      setTasks((cur) => cur.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+      const db = getDb();
+      if (!db) return;
+      try {
+        await db.update(TASKS_TABLE, id, patch as Record<string, unknown>);
+      } catch (err: unknown) {
+        console.warn("[todo] task update failed:", errMessage(err));
+        setError("Change could not be saved.");
+        await reload();
+      }
+    },
+    [reload],
+  );
+
+  const completeTask = useCallback(
+    async (task: Task) => {
+      if (inFlightComplete.current.has(task.id)) return;
+      inFlightComplete.current.add(task.id);
+      // Optimistically mark done.
+      setTasks((cur) => cur.map((t) => (t.id === task.id ? { ...t, status: "done" } : t)));
+      const db = getDb();
+      try {
+        if (db) await db.update(TASKS_TABLE, task.id, { status: "done" });
+        // Recurring task: schedule the next occurrence.
+        const nextDue = task.due ? nextRecurrence(task.recur, new Date(task.due)) : null;
+        if (task.recur && nextDue) {
+          const followUp: Task = {
+            ...task,
+            id: `local-${Date.now()}`,
+            due: nextDue,
+            status: "open",
+            created_at: new Date().toISOString(),
+          };
+          setTasks((cur) => [followUp, ...cur]);
+          if (db) {
+            await db.insert(TASKS_TABLE, {
+              title: task.title,
+              notes: task.notes,
+              due: nextDue,
+              priority: task.priority,
+              project: task.project,
+              status: "open",
+              recur: task.recur,
+            });
+          }
+        }
+        if (db) await reload();
+      } catch (err: unknown) {
+        console.warn("[todo] task complete failed:", errMessage(err));
+        setError("Could not complete task.");
+        await reload();
+      } finally {
+        inFlightComplete.current.delete(task.id);
+      }
+    },
+    [reload],
+  );
+
+  const deleteTask = useCallback(
+    async (id: string) => {
+      setTasks((cur) => cur.filter((t) => t.id !== id));
+      if (selectedId === id) setSelectedId(null);
+      const db = getDb();
+      if (!db) return;
+      try {
+        await db.delete(TASKS_TABLE, id);
+        await reload();
+      } catch (err: unknown) {
+        console.warn("[todo] task delete failed:", errMessage(err));
+        setError("Task could not be deleted.");
+        await reload();
+      }
+    },
+    [reload, selectedId],
+  );
+
+  const cyclePriority = useCallback(
+    (task: Task) => {
+      const next = ((task.priority + 1) % 4) as Task["priority"];
+      void persistUpdate(task.id, { priority: next });
+    },
+    [persistUpdate],
+  );
+
+  const commitEdit = useCallback(
+    (task: Task) => {
+      const title = editTitle.trim();
+      setEditingId(null);
+      if (title && title !== task.title) void persistUpdate(task.id, { title });
+    },
+    [editTitle, persistUpdate],
+  );
+
+  // --- keyboard navigation --------------------------------------------------
+
+  const onListKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (editingId) return;
+      if (visible.length === 0) return;
+      const idx = visible.findIndex((t) => t.id === selectedId);
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = visible[Math.min(visible.length - 1, idx < 0 ? 0 : idx + 1)];
+        setSelectedId(next.id);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        const next = visible[Math.max(0, idx < 0 ? 0 : idx - 1)];
+        setSelectedId(next.id);
+      } else if ((e.key === " " || e.key === "Enter") && selectedId) {
+        e.preventDefault();
+        const task = visible.find((t) => t.id === selectedId);
+        if (task) void completeTask(task);
+      } else if (e.key === "Backspace" && (e.metaKey || e.ctrlKey) && selectedId) {
+        e.preventDefault();
+        void deleteTask(selectedId);
+      }
+    },
+    [editingId, visible, selectedId, completeTask, deleteTask],
+  );
+
+  const onDraftKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        void addTask();
+      }
+    },
+    [addTask],
+  );
+
+  const isProjectView = typeof view === "object";
+
+  return (
+    <div className="todo-app">
+      <aside className="sidebar" aria-label="Views">
+        <div className="brand">
+          <span className="brand-mark" aria-hidden="true">
+            <Check size={16} strokeWidth={3} />
+          </span>
+          <span>Tasks</span>
+        </div>
+
+        <nav className="nav-group" aria-label="Smart lists">
+          {SMART_VIEWS.map((v) => {
+            const ViewIcon = v.icon;
+            const active = view === v.id;
+            const count = counts[v.id];
+            return (
+              <button
+                key={v.id}
+                type="button"
+                className={active ? "nav-item nav-item--active" : "nav-item"}
+                aria-current={active ? "page" : undefined}
+                onClick={() => {
+                  setView(v.id);
+                  setSelectedId(null);
+                }}
+              >
+                <ViewIcon size={17} />
+                <span className="nav-label">{v.label}</span>
+                {count > 0 && <span className="nav-count">{count}</span>}
+              </button>
+            );
+          })}
+        </nav>
+
+        {projects.length > 0 && (
+          <div className="nav-group">
+            <p className="nav-heading">Projects</p>
+            {projects.map((name) => {
+              const active = isProjectView && (view as { project: string }).project === name;
+              const count = projectCounts.get(name) ?? 0;
+              return (
+                <button
+                  key={name}
+                  type="button"
+                  className={active ? "nav-item nav-item--active" : "nav-item"}
+                  onClick={() => {
+                    setView({ kind: "project", project: name });
+                    setSelectedId(null);
+                  }}
+                >
+                  <Folder size={17} />
+                  <span className="nav-label">{name}</span>
+                  {count > 0 && <span className="nav-count">{count}</span>}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </aside>
+
+      <main className="content">
+        <header className="content-head">
+          <h1>{headerTitle}</h1>
+          <p className="content-sub">
+            {visible.length} {visible.length === 1 ? "task" : "tasks"}
+          </p>
+        </header>
+
+        <div className="capture">
+          <Plus size={18} className="capture-icon" aria-hidden="true" />
+          <input
+            className="capture-input"
+            placeholder={
+              isProjectView ? `Add a task to ${headerTitle}` : "Add a task, press Enter"
+            }
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={onDraftKeyDown}
+            aria-label="New task"
+          />
+        </div>
+
+        {error && (
+          <div className="banner banner--error" role="alert">
+            {error}
+          </div>
+        )}
+
+        <div
+          className="task-list"
+          data-testid="task-list"
+          role="list"
+          tabIndex={0}
+          ref={listRef}
+          onKeyDown={onListKeyDown}
+        >
+          {visible.length === 0 ? (
+            <EmptyState view={view} smart={activeSmart} />
+          ) : (
+            visible.map((task) => {
+              const due = formatDue(task.due, now);
+              const selected = task.id === selectedId;
+              const editing = task.id === editingId;
+              return (
+                <div
+                  key={task.id}
+                  role="listitem"
+                  className={selected ? "task-row task-row--selected" : "task-row"}
+                  onClick={() => setSelectedId(task.id)}
+                >
+                  <button
+                    type="button"
+                    className={`check check--p${task.priority}`}
+                    aria-label={`Complete ${task.title}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void completeTask(task);
+                    }}
+                  >
+                    <Check size={14} strokeWidth={3} className="check-mark" />
+                  </button>
+
+                  <div className="task-main">
+                    {editing ? (
+                      <input
+                        className="edit-input"
+                        autoFocus
+                        value={editTitle}
+                        aria-label={`Edit ${task.title}`}
+                        onChange={(e) => setEditTitle(e.target.value)}
+                        onBlur={() => commitEdit(task)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            commitEdit(task);
+                          } else if (e.key === "Escape") {
+                            e.preventDefault();
+                            setEditingId(null);
+                          }
+                        }}
+                      />
+                    ) : (
+                      <button
+                        type="button"
+                        className="task-title"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedId(task.id);
+                          setEditingId(task.id);
+                          setEditTitle(task.title);
+                        }}
+                      >
+                        {task.title}
+                      </button>
+                    )}
+                    {(due || task.recur || (isProjectView ? false : task.project)) && (
+                      <div className="task-meta">
+                        {due && <span className={`due due--${due.tone}`}>{due.label}</span>}
+                        {task.recur && (
+                          <span className="meta-chip">
+                            <Repeat size={11} /> {task.recur}
+                          </span>
+                        )}
+                        {!isProjectView && task.project && (
+                          <span className="meta-chip">
+                            <Folder size={11} /> {task.project}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+
+                  <button
+                    type="button"
+                    className={task.priority > 0 ? `flag flag--p${task.priority}` : "flag"}
+                    title={PRIORITY_LABELS[task.priority]}
+                    aria-label={`Priority for ${task.title}: ${PRIORITY_LABELS[task.priority]}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      cyclePriority(task);
+                    }}
+                  >
+                    <Flag size={14} />
+                  </button>
+
+                  <button
+                    type="button"
+                    className="row-delete"
+                    aria-label={`Delete ${task.title}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void deleteTask(task.id);
+                    }}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {selectedId && (
+          <Inspector
+            task={visible.find((t) => t.id === selectedId) ?? null}
+            now={now}
+            onClose={() => setSelectedId(null)}
+            onPatch={(patch) => selectedId && void persistUpdate(selectedId, patch)}
+          />
+        )}
+      </main>
+    </div>
+  );
+}
+
+function EmptyState({ view, smart }: { view: View; smart: SmartViewMeta | null }) {
+  const Icon = smart?.icon ?? Folder;
+  const title =
+    smart?.empty.title ?? (typeof view === "object" ? `No tasks in ${view.project}` : "All done");
+  const body =
+    smart?.empty.body ?? "Add a task above to start filling out this project.";
+  return (
+    <div className="empty-state">
+      <span className="empty-icon" aria-hidden="true">
+        <Icon size={26} />
+      </span>
+      <strong>{title}</strong>
+      <p>{body}</p>
+    </div>
+  );
+}
+
+function Inspector({
+  task,
+  now,
+  onClose,
+  onPatch,
+}: {
+  task: Task | null;
+  now: Date;
+  onClose: () => void;
+  onPatch: (patch: Partial<Task>) => void;
+}) {
+  if (!task) return null;
+  void now;
+  return (
+    <div className="inspector" role="dialog" aria-label={`Details for ${task.title}`}>
+      <div className="inspector-head">
+        <strong>Details</strong>
+        <button type="button" className="inspector-close" onClick={onClose} aria-label="Close details">
+          ✕
+        </button>
+      </div>
+
+      <label className="field">
+        <span>Notes</span>
+        <textarea
+          value={task.notes}
+          placeholder="Add notes…"
+          onChange={(e) => onPatch({ notes: e.target.value })}
+        />
+      </label>
+
+      <label className="field">
+        <span>Due date</span>
+        <input
+          type="date"
+          value={toDateInputValue(task.due)}
+          onChange={(e) => onPatch({ due: fromDateInputValue(e.target.value) })}
+        />
+      </label>
+
+      <label className="field">
+        <span>Project</span>
+        <input
+          type="text"
+          value={task.project ?? ""}
+          placeholder="No project"
+          onChange={(e) => onPatch({ project: e.target.value.trim() || null })}
+        />
+      </label>
+
+      <label className="field">
+        <span>Repeat</span>
+        <select
+          value={task.recur ?? ""}
+          onChange={(e) => onPatch({ recur: (e.target.value || null) as Recurrence | null })}
+        >
+          {RECUR_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -519,6 +519,7 @@ export default function App() {
                     aria-label={`Complete ${task.title}`}
                     onClick={(e) => {
                       e.stopPropagation();
+                      setSelectedId(null);
                       void completeTask(task);
                     }}
                   >

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -31,6 +31,7 @@ import {
 } from "./todo-model";
 
 const TASKS_TABLE = "tasks";
+const NOTES_SAVE_DELAY_MS = 500;
 
 type SmartViewId = "inbox" | "today" | "upcoming";
 
@@ -138,7 +139,7 @@ export default function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState("");
-  const [now] = useState(() => new Date());
+  const [now, setNow] = useState(() => new Date());
   const inFlightComplete = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -158,6 +159,11 @@ export default function App() {
     if (!db?.onChange) return undefined;
     return db.onChange(TASKS_TABLE, () => void reload());
   }, [reload]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(new Date()), 60_000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   const counts = useMemo(() => countByView(tasks, now), [tasks, now]);
   const projects = useMemo(() => projectNames(tasks), [tasks]);
@@ -267,6 +273,13 @@ export default function App() {
       } catch (err: unknown) {
         console.warn("[todo] task complete failed:", errMessage(err));
         setError("Could not complete task.");
+        if (db) {
+          try {
+            await db.update(TASKS_TABLE, task.id, { status: "open" });
+          } catch (rollbackErr: unknown) {
+            console.warn("[todo] task completion rollback failed:", errMessage(rollbackErr));
+          }
+        }
         await reload();
       } finally {
         inFlightComplete.current.delete(task.id);
@@ -554,7 +567,6 @@ export default function App() {
         {selectedId && (
           <Inspector
             task={visible.find((t) => t.id === selectedId) ?? null}
-            now={now}
             onClose={() => setSelectedId(null)}
             onPatch={(patch) => selectedId && void persistUpdate(selectedId, patch)}
           />
@@ -583,17 +595,28 @@ function EmptyState({ view, smart }: { view: View; smart: SmartViewMeta | null }
 
 function Inspector({
   task,
-  now,
   onClose,
   onPatch,
 }: {
   task: Task | null;
-  now: Date;
   onClose: () => void;
   onPatch: (patch: Partial<Task>) => void;
 }) {
+  const [notesDraft, setNotesDraft] = useState(task?.notes ?? "");
+
+  useEffect(() => {
+    setNotesDraft(task?.notes ?? "");
+  }, [task?.id, task?.notes]);
+
+  useEffect(() => {
+    if (!task || notesDraft === task.notes) return undefined;
+    const timer = window.setTimeout(() => {
+      onPatch({ notes: notesDraft });
+    }, NOTES_SAVE_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [notesDraft, onPatch, task]);
+
   if (!task) return null;
-  void now;
   return (
     <div className="inspector" role="dialog" aria-label={`Details for ${task.title}`}>
       <div className="inspector-head">
@@ -606,9 +629,9 @@ function Inspector({
       <label className="field">
         <span>Notes</span>
         <textarea
-          value={task.notes}
+          value={notesDraft}
           placeholder="Add notes…"
-          onChange={(e) => onPatch({ notes: e.target.value })}
+          onChange={(e) => setNotesDraft(e.target.value)}
         />
       </label>
 

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -191,13 +191,13 @@ export default function App() {
 
   const visible = useMemo(() => sortTasks(filterTasks(tasks, view, now)), [tasks, view, now]);
   const selectedTask = useMemo(
-    () => (selectedId ? visible.find((t) => t.id === selectedId) ?? null : null),
-    [selectedId, visible],
+    () => (selectedId ? tasks.find((t) => t.id === selectedId) ?? null : null),
+    [selectedId, tasks],
   );
 
   useEffect(() => {
-    if (selectedId && !visible.some((task) => task.id === selectedId)) setSelectedId(null);
-  }, [selectedId, visible]);
+    if (selectedId && !tasks.some((task) => task.id === selectedId)) setSelectedId(null);
+  }, [selectedId, tasks]);
 
   const activeSmart: SmartViewMeta | null =
     typeof view === "string" ? SMART_VIEWS.find((v) => v.id === view) ?? null : null;

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -247,8 +247,8 @@ export default function App() {
         await db.update(TASKS_TABLE, id, patch as Record<string, unknown>);
       } catch (err: unknown) {
         console.warn("[todo] task update failed:", errMessage(err));
-        setError("Change could not be saved.");
         await reload();
+        setError("Change could not be saved.");
       }
     },
     [reload],
@@ -301,7 +301,6 @@ export default function App() {
         if (db) await reload();
       } catch (err: unknown) {
         console.warn("[todo] task complete failed:", errMessage(err));
-        setError("Could not complete task.");
         if (db) {
           try {
             await db.update(TASKS_TABLE, task.id, { status: "open" });
@@ -310,6 +309,7 @@ export default function App() {
           }
         }
         await reload();
+        setError("Could not complete task.");
       } finally {
         inFlightComplete.current.delete(task.id);
       }
@@ -328,8 +328,8 @@ export default function App() {
         await reload();
       } catch (err: unknown) {
         console.warn("[todo] task delete failed:", errMessage(err));
-        setError("Task could not be deleted.");
         await reload();
+        setError("Task could not be deleted.");
       }
     },
     [reload, selectedId],

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -635,17 +635,31 @@ function Inspector({
 }) {
   const [notesDraft, setNotesDraft] = useState(task?.notes ?? "");
   const [projectDraft, setProjectDraft] = useState(task?.project ?? "");
-  const latestDraftRef = useRef({ task, notesDraft, projectDraft });
+  const latestDraftRef = useRef({
+    taskId: task?.id ?? null,
+    notesDraft,
+    projectDraft,
+    originalNotes: task?.notes ?? "",
+    originalProject: task?.project ?? null,
+  });
 
-  latestDraftRef.current = { task, notesDraft, projectDraft };
+  useEffect(() => {
+    latestDraftRef.current = {
+      taskId: task?.id ?? null,
+      notesDraft,
+      projectDraft,
+      originalNotes: task?.notes ?? "",
+      originalProject: task?.project ?? null,
+    };
+  }, [notesDraft, projectDraft, task?.id, task?.notes, task?.project]);
 
   const flushDrafts = useCallback(() => {
     const current = latestDraftRef.current;
-    if (!current.task?.id) return;
+    if (!current.taskId) return;
     const patch: Partial<Task> = {};
-    if (current.notesDraft !== current.task.notes) patch.notes = current.notesDraft;
+    if (current.notesDraft !== current.originalNotes) patch.notes = current.notesDraft;
     const project = current.projectDraft.trim() || null;
-    if (project !== (current.task.project ?? null)) patch.project = project;
+    if (project !== current.originalProject) patch.project = project;
     if (Object.keys(patch).length > 0) onPatch(patch);
   }, [onPatch]);
 

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -660,16 +660,13 @@ function Inspector({
     originalNotes: task?.notes ?? "",
     originalProject: task?.project ?? null,
   });
-
-  useEffect(() => {
-    latestDraftRef.current = {
-      taskId: task?.id ?? null,
-      notesDraft,
-      projectDraft,
-      originalNotes: task?.notes ?? "",
-      originalProject: task?.project ?? null,
-    };
-  }, [notesDraft, projectDraft, task?.id, task?.notes, task?.project]);
+  latestDraftRef.current = {
+    taskId: task?.id ?? null,
+    notesDraft,
+    projectDraft,
+    originalNotes: task?.notes ?? "",
+    originalProject: task?.project ?? null,
+  };
 
   const flushDrafts = useCallback(() => {
     const current = latestDraftRef.current;

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -606,7 +606,7 @@ function Inspector({
 
   useEffect(() => {
     setNotesDraft(task?.notes ?? "");
-  }, [task?.id, task?.notes]);
+  }, [task?.id]);
 
   useEffect(() => {
     if (!task || notesDraft === task.notes) return undefined;

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -89,7 +89,7 @@ function getDb(): NonNullable<Window["MatrixOS"]>["db"] | undefined {
 async function loadTasks(): Promise<Task[]> {
   const db = getDb();
   if (!db) return [];
-  const rows = await db.find(TASKS_TABLE, { orderBy: { created_at: "desc" }, limit: 500 });
+  const rows = await db.find(TASKS_TABLE, { orderBy: { created_at: "desc" } });
   return rows
     .map(normalizeTask)
     .filter((t): t is Task => t !== null);
@@ -668,7 +668,7 @@ function Inspector({
           value={toDateInputValue(task.due)}
           onChange={(e) => {
             const due = fromDateInputValue(e.target.value);
-            onPatch(due ? { due } : { due: null, recur: null });
+            onPatch(due ? { due } : { due: null });
           }}
         />
       </label>

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -278,42 +278,45 @@ export default function App() {
       setTasks((cur) => cur.map((t) => (t.id === task.id ? { ...t, status: "done" } : t)));
       const db = getDb();
       try {
-        if (db) await db.update(TASKS_TABLE, task.id, { status: "done" });
-        // Recurring task: schedule the next occurrence.
-        const nextDue = task.due ? nextRecurrence(task.recur, new Date(task.due)) : null;
-        if (task.recur && nextDue) {
-          const followUp: Task = {
-            ...task,
-            id: `local-${Date.now()}`,
-            due: nextDue,
-            status: "open",
-            created_at: new Date().toISOString(),
-          };
-          setTasks((cur) => [followUp, ...cur]);
-          if (db) {
-            await db.insert(TASKS_TABLE, {
-              title: task.title,
-              notes: task.notes,
+        try {
+          if (db) await db.update(TASKS_TABLE, task.id, { status: "done" });
+          // Recurring task: schedule the next occurrence.
+          const nextDue = task.due ? nextRecurrence(task.recur, new Date(task.due)) : null;
+          if (task.recur && nextDue) {
+            const followUp: Task = {
+              ...task,
+              id: `local-${Date.now()}`,
               due: nextDue,
-              priority: task.priority,
-              project: task.project,
               status: "open",
-              recur: task.recur,
-            });
+              created_at: new Date().toISOString(),
+            };
+            setTasks((cur) => [followUp, ...cur]);
+            if (db) {
+              await db.insert(TASKS_TABLE, {
+                title: task.title,
+                notes: task.notes,
+                due: nextDue,
+                priority: task.priority,
+                project: task.project,
+                status: "open",
+                recur: task.recur,
+              });
+            }
           }
-        }
-        if (db) await reload();
-      } catch (err: unknown) {
-        console.warn("[todo] task complete failed:", errMessage(err));
-        if (db) {
-          try {
-            await db.update(TASKS_TABLE, task.id, { status: "open" });
-          } catch (rollbackErr: unknown) {
-            console.warn("[todo] task completion rollback failed:", errMessage(rollbackErr));
+        } catch (err: unknown) {
+          console.warn("[todo] task complete failed:", errMessage(err));
+          if (db) {
+            try {
+              await db.update(TASKS_TABLE, task.id, { status: "open" });
+            } catch (rollbackErr: unknown) {
+              console.warn("[todo] task completion rollback failed:", errMessage(rollbackErr));
+            }
           }
+          await reload();
+          setError("Could not complete task.");
+          return;
         }
         await reload();
-        setError("Could not complete task.");
       } finally {
         inFlightComplete.current.delete(task.id);
       }

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -635,7 +635,7 @@ function Inspector({
   }, [notesDraft, onPatch, task?.id, task?.notes]);
 
   useEffect(() => {
-    if (!task?.id || projectDraft === (task.project ?? "")) return undefined;
+    if (!task?.id || projectDraft.trim() === (task.project ?? "")) return undefined;
     const timer = window.setTimeout(() => {
       onPatch({ project: projectDraft.trim() || null });
     }, NOTES_SAVE_DELAY_MS);

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -694,10 +694,7 @@ function Inspector({
         <button
           type="button"
           className="inspector-close"
-          onClick={() => {
-            flushDrafts();
-            onClose();
-          }}
+          onClick={onClose}
           aria-label="Close details"
         >
           ✕

--- a/home/apps/todo/src/App.tsx
+++ b/home/apps/todo/src/App.tsx
@@ -115,7 +115,11 @@ function fromDateInputValue(value: string): string | null {
 }
 
 function defaultDueForView(view: View, now: Date): string | null {
-  if (view === "today") return now.toISOString();
+  if (view === "today") {
+    const due = new Date(now);
+    due.setHours(9, 0, 0, 0);
+    return due.toISOString();
+  }
   if (view !== "upcoming") return null;
   const due = new Date(now);
   due.setDate(due.getDate() + 1);

--- a/home/apps/todo/src/main.tsx
+++ b/home/apps/todo/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("todo" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/todo/src/matrix-os.d.ts
+++ b/home/apps/todo/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/todo/src/styles.css
+++ b/home/apps/todo/src/styles.css
@@ -499,6 +499,17 @@ body {
   border-color: color-mix(in srgb, var(--app-accent) 55%, transparent);
   background: var(--app-bg);
 }
+.field select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.field-hint {
+  color: var(--app-muted-fg);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
 
 @media (prefers-reduced-motion: reduce) {
   * {

--- a/home/apps/todo/src/styles.css
+++ b/home/apps/todo/src/styles.css
@@ -1,0 +1,508 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+  --shadow-soft: 0 4px 12px rgba(50, 53, 46, 0.08);
+  --shadow-pop: 0 10px 30px rgba(50, 53, 46, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  color: var(--app-fg);
+  background: var(--app-bg);
+}
+
+.todo-app {
+  display: grid;
+  grid-template-columns: 232px 1fr;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--app-bg);
+  color: var(--app-fg);
+}
+
+/* ---- sidebar ---- */
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 20px 14px;
+  background: color-mix(in srgb, var(--app-muted) 55%, var(--app-bg));
+  border-right: 1px solid color-mix(in srgb, var(--app-border) 60%, transparent);
+  overflow-y: auto;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 2px 8px 6px;
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: -0.01em;
+}
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 9px;
+  background: var(--app-accent);
+  color: #fff;
+  box-shadow: var(--shadow-soft);
+}
+.nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.nav-heading {
+  margin: 8px 10px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--app-muted-fg);
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 11px;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--app-fg);
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.nav-item:hover {
+  background: color-mix(in srgb, var(--app-fg) 5%, transparent);
+}
+.nav-item--active {
+  background: var(--app-card);
+  color: var(--app-fg);
+  box-shadow: var(--shadow-soft);
+}
+.nav-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.nav-count {
+  min-width: 20px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--app-fg) 8%, transparent);
+  color: var(--app-muted-fg);
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+}
+.nav-item--active .nav-count {
+  background: color-mix(in srgb, var(--app-accent) 18%, transparent);
+  color: var(--app-accent);
+}
+
+/* ---- content ---- */
+.content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  padding: 24px 28px 0;
+  overflow: hidden;
+}
+.content-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.content-head h1 {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.content-sub {
+  margin: 0;
+  color: var(--app-muted-fg);
+  font-size: 13px;
+}
+
+.capture {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 16px 0 8px;
+  flex-shrink: 0;
+}
+.capture-icon {
+  position: absolute;
+  left: 16px;
+  color: var(--app-accent);
+  pointer-events: none;
+}
+.capture-input {
+  width: 100%;
+  padding: 14px 16px 14px 44px;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  font-size: 15px;
+  font-family: inherit;
+  box-shadow: var(--shadow-soft);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.capture-input::placeholder {
+  color: var(--app-muted-fg);
+}
+.capture-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--app-accent) 60%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--app-accent) 18%, transparent);
+}
+
+.banner {
+  margin: 6px 0;
+  padding: 9px 14px;
+  border-radius: 12px;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+.banner--error {
+  background: color-mix(in srgb, var(--app-danger) 12%, transparent);
+  color: var(--app-danger);
+}
+
+/* ---- task list ---- */
+.task-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 0 28px;
+  outline: none;
+}
+.task-list:focus-visible {
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--app-accent) 35%, transparent);
+  border-radius: 14px;
+}
+
+.task-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 11px 12px;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.task-row:hover {
+  background: color-mix(in srgb, var(--app-fg) 4%, transparent);
+}
+.task-row:hover .row-delete {
+  opacity: 1;
+}
+.task-row--selected {
+  background: var(--app-card);
+  box-shadow: var(--shadow-soft);
+}
+
+.check {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  margin-top: 1px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--app-muted-fg) 55%, transparent);
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, transform 0.1s ease;
+}
+.check:hover {
+  border-color: var(--app-success);
+  transform: scale(1.08);
+}
+.check:active {
+  transform: scale(0.92);
+}
+.check--p1 {
+  border-color: color-mix(in srgb, var(--app-warning) 70%, var(--app-muted-fg));
+}
+.check--p2 {
+  border-color: var(--app-warning);
+}
+.check--p3 {
+  border-color: var(--app-danger);
+}
+.check-mark {
+  opacity: 0;
+  transform: scale(0.4);
+  transition: opacity 0.15s ease, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.check:hover .check-mark {
+  opacity: 0.5;
+  transform: scale(1);
+}
+
+.task-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.task-title {
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  font-size: 14.5px;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--app-fg);
+  text-align: left;
+  cursor: text;
+  line-height: 1.35;
+}
+.edit-input {
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid var(--app-accent);
+  background: transparent;
+  padding: 0 0 2px;
+  font-size: 14.5px;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--app-fg);
+}
+.edit-input:focus {
+  outline: none;
+}
+.task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.due,
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 7px;
+}
+.meta-chip {
+  color: var(--app-muted-fg);
+  background: color-mix(in srgb, var(--app-fg) 6%, transparent);
+  text-transform: capitalize;
+}
+.due--overdue {
+  color: var(--app-danger);
+  background: color-mix(in srgb, var(--app-danger) 12%, transparent);
+}
+.due--today {
+  color: var(--app-accent);
+  background: color-mix(in srgb, var(--app-accent) 12%, transparent);
+}
+.due--soon {
+  color: var(--app-warning);
+}
+.due--later {
+  color: var(--app-muted-fg);
+}
+
+.flag,
+.row-delete {
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--app-muted-fg);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+}
+.flag:hover,
+.row-delete:hover {
+  background: color-mix(in srgb, var(--app-fg) 7%, transparent);
+}
+.flag {
+  opacity: 0;
+}
+.task-row:hover .flag,
+.flag--p1,
+.flag--p2,
+.flag--p3 {
+  opacity: 1;
+}
+.flag--p1 {
+  color: color-mix(in srgb, var(--app-warning) 70%, var(--app-muted-fg));
+}
+.flag--p2 {
+  color: var(--app-warning);
+}
+.flag--p3 {
+  color: var(--app-danger);
+}
+.row-delete {
+  opacity: 0;
+}
+.row-delete:hover {
+  color: var(--app-danger);
+}
+
+/* ---- empty state ---- */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+  margin: 56px auto;
+  max-width: 320px;
+  color: var(--app-muted-fg);
+}
+.empty-icon {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: var(--app-card);
+  color: var(--app-accent);
+  box-shadow: var(--shadow-soft);
+  margin-bottom: 4px;
+}
+.empty-state strong {
+  font-size: 16px;
+  color: var(--app-fg);
+}
+.empty-state p {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+/* ---- inspector (overlay, no layout shift) ---- */
+.inspector {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  bottom: 16px;
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 18px;
+  background: var(--app-card);
+  box-shadow: var(--shadow-pop);
+  overflow-y: auto;
+  animation: inspector-in 0.18s ease;
+}
+@keyframes inspector-in {
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+}
+.inspector-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 14px;
+}
+.inspector-close {
+  border: none;
+  background: transparent;
+  color: var(--app-muted-fg);
+  font-size: 15px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px;
+  border-radius: 8px;
+}
+.inspector-close:hover {
+  background: color-mix(in srgb, var(--app-fg) 7%, transparent);
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--app-muted-fg);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.field textarea,
+.field input,
+.field select {
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--app-fg);
+  background: var(--app-muted);
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 9px 11px;
+}
+.field textarea {
+  resize: vertical;
+  min-height: 70px;
+}
+.field textarea:focus,
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--app-accent) 55%, transparent);
+  background: var(--app-bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/home/apps/todo/src/todo-model.ts
+++ b/home/apps/todo/src/todo-model.ts
@@ -54,7 +54,7 @@ export function normalizeTask(row: unknown): Task | null {
   const status: TaskStatus =
     data.status === "done" || data.done === true ? "done" : "open";
   return {
-    id: typeof data.id === "string" ? data.id : crypto.randomUUID(),
+    id: data.id != null ? String(data.id) : crypto.randomUUID(),
     title,
     notes: typeof data.notes === "string" ? data.notes : "",
     due: toStringOrNull(data.due),

--- a/home/apps/todo/src/todo-model.ts
+++ b/home/apps/todo/src/todo-model.ts
@@ -170,17 +170,15 @@ export function nextRecurrence(recur: Recurrence | null, from: Date): string | n
   if (!recur || !RECURRENCES.has(recur)) return null;
   const next = new Date(from);
   if (Number.isNaN(next.getTime())) return null;
-  // Operate in UTC so results are deterministic regardless of the host timezone.
-  const DAY = 24 * 60 * 60 * 1000;
   if (recur === "daily") {
-    next.setTime(next.getTime() + DAY);
+    next.setDate(next.getDate() + 1);
   } else if (recur === "weekly") {
-    next.setTime(next.getTime() + 7 * DAY);
+    next.setDate(next.getDate() + 7);
   } else {
-    // weekdays: advance at least one day, skipping Sat (6) and Sun (0) in UTC
-    next.setTime(next.getTime() + DAY);
-    while (next.getUTCDay() === 0 || next.getUTCDay() === 6) {
-      next.setTime(next.getTime() + DAY);
+    // weekdays: advance at least one local day, skipping Sat (6) and Sun (0).
+    next.setDate(next.getDate() + 1);
+    while (next.getDay() === 0 || next.getDay() === 6) {
+      next.setDate(next.getDate() + 1);
     }
   }
   return next.toISOString();

--- a/home/apps/todo/src/todo-model.ts
+++ b/home/apps/todo/src/todo-model.ts
@@ -1,0 +1,180 @@
+// Pure, UI-free task model: filtering, sorting, recurrence. Unit-tested.
+
+export type TaskStatus = "open" | "done";
+export type Recurrence = "daily" | "weekly" | "weekdays";
+
+export interface Task {
+  id: string;
+  title: string;
+  notes: string;
+  due: string | null; // ISO timestamptz
+  priority: 0 | 1 | 2 | 3;
+  project: string | null;
+  status: TaskStatus;
+  recur: Recurrence | null;
+  created_at: string;
+}
+
+export type SmartView = "inbox" | "today" | "upcoming";
+export type ProjectView = { kind: "project"; project: string };
+export type View = SmartView | ProjectView;
+
+const RECURRENCES: ReadonlySet<string> = new Set(["daily", "weekly", "weekdays"]);
+
+function clampPriority(value: unknown): 0 | 1 | 2 | 3 {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return 0;
+  const rounded = Math.round(n);
+  if (rounded <= 0) return 0;
+  if (rounded >= 3) return 3;
+  return rounded as 1 | 2;
+}
+
+function toStringOrNull(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Coerce an untyped DB row into a Task, or null if invalid (e.g. empty title). */
+export function normalizeTask(row: unknown): Task | null {
+  if (!row || typeof row !== "object") return null;
+  const data = row as Record<string, unknown>;
+  const title = typeof data.title === "string" ? data.title.trim() : "";
+  if (title.length === 0) return null;
+  const recurRaw = toStringOrNull(data.recur);
+  const recur = recurRaw && RECURRENCES.has(recurRaw) ? (recurRaw as Recurrence) : null;
+  return {
+    id: typeof data.id === "string" ? data.id : crypto.randomUUID(),
+    title,
+    notes: typeof data.notes === "string" ? data.notes : "",
+    due: toStringOrNull(data.due),
+    priority: clampPriority(data.priority),
+    project: toStringOrNull(data.project),
+    status: data.status === "done" ? "done" : "open",
+    recur,
+    created_at: typeof data.created_at === "string" ? data.created_at : new Date().toISOString(),
+  };
+}
+
+function startOfDay(date: Date): number {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function endOfDay(date: Date): number {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d.getTime();
+}
+
+function dueTime(task: Task): number | null {
+  if (!task.due) return null;
+  const t = new Date(task.due).getTime();
+  return Number.isNaN(t) ? null : t;
+}
+
+export function isOpen(task: Task): boolean {
+  return task.status === "open";
+}
+
+/** A task belongs to Today if it is open and due on/before the end of `now`'s day. */
+export function isToday(task: Task, now: Date): boolean {
+  if (!isOpen(task)) return false;
+  const t = dueTime(task);
+  return t !== null && t <= endOfDay(now);
+}
+
+/** Upcoming: open and due strictly after today. */
+export function isUpcoming(task: Task, now: Date): boolean {
+  if (!isOpen(task)) return false;
+  const t = dueTime(task);
+  return t !== null && t > endOfDay(now);
+}
+
+/** Inbox: open tasks with no project assigned. */
+export function isInbox(task: Task): boolean {
+  return isOpen(task) && task.project === null;
+}
+
+export function filterTasks(tasks: Task[], view: View, now: Date): Task[] {
+  if (typeof view === "object") {
+    return tasks.filter((t) => isOpen(t) && t.project === view.project);
+  }
+  switch (view) {
+    case "inbox":
+      return tasks.filter(isInbox);
+    case "today":
+      return tasks.filter((t) => isToday(t, now));
+    case "upcoming":
+      return tasks.filter((t) => isUpcoming(t, now));
+    default:
+      return tasks.filter(isOpen);
+  }
+}
+
+export interface ViewCounts {
+  inbox: number;
+  today: number;
+  upcoming: number;
+}
+
+export function countByView(tasks: Task[], now: Date): ViewCounts {
+  return {
+    inbox: tasks.filter(isInbox).length,
+    today: tasks.filter((t) => isToday(t, now)).length,
+    upcoming: tasks.filter((t) => isUpcoming(t, now)).length,
+  };
+}
+
+/** Distinct project names among open tasks, sorted alphabetically. */
+export function projectNames(tasks: Task[]): string[] {
+  const names = new Set<string>();
+  for (const t of tasks) {
+    if (t.project) names.add(t.project);
+  }
+  return [...names].sort((a, b) => a.localeCompare(b));
+}
+
+/** Sort: priority desc, then due asc (nulls last), then created_at asc. */
+export function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    if (a.priority !== b.priority) return b.priority - a.priority;
+    const da = dueTime(a);
+    const db = dueTime(b);
+    if (da !== db) {
+      if (da === null) return 1;
+      if (db === null) return -1;
+      return da - db;
+    }
+    return a.created_at.localeCompare(b.created_at);
+  });
+}
+
+/**
+ * Compute the next occurrence ISO string for a recurring task.
+ * `daily` +1 day, `weekly` +7 days, `weekdays` next Mon-Fri.
+ * Returns null when there is no recurrence.
+ */
+export function nextRecurrence(recur: Recurrence | null, from: Date): string | null {
+  if (!recur || !RECURRENCES.has(recur)) return null;
+  const next = new Date(from);
+  if (Number.isNaN(next.getTime())) return null;
+  // Operate in UTC so results are deterministic regardless of the host timezone.
+  const DAY = 24 * 60 * 60 * 1000;
+  if (recur === "daily") {
+    next.setTime(next.getTime() + DAY);
+  } else if (recur === "weekly") {
+    next.setTime(next.getTime() + 7 * DAY);
+  } else {
+    // weekdays: advance at least one day, skipping Sat (6) and Sun (0) in UTC
+    next.setTime(next.getTime() + DAY);
+    while (next.getUTCDay() === 0 || next.getUTCDay() === 6) {
+      next.setTime(next.getTime() + DAY);
+    }
+  }
+  return next.toISOString();
+}
+
+void startOfDay; // reserved for future range views

--- a/home/apps/todo/src/todo-model.ts
+++ b/home/apps/todo/src/todo-model.ts
@@ -22,6 +22,12 @@ export type View = SmartView | ProjectView;
 const RECURRENCES: ReadonlySet<string> = new Set(["daily", "weekly", "weekdays"]);
 
 function clampPriority(value: unknown): 0 | 1 | 2 | 3 {
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "high") return 3;
+    if (normalized === "medium") return 2;
+    if (normalized === "low") return 1;
+  }
   const n = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(n)) return 0;
   const rounded = Math.round(n);
@@ -40,18 +46,21 @@ function toStringOrNull(value: unknown): string | null {
 export function normalizeTask(row: unknown): Task | null {
   if (!row || typeof row !== "object") return null;
   const data = row as Record<string, unknown>;
-  const title = typeof data.title === "string" ? data.title.trim() : "";
+  const titleRaw = typeof data.title === "string" ? data.title : data.text;
+  const title = typeof titleRaw === "string" ? titleRaw.trim() : "";
   if (title.length === 0) return null;
   const recurRaw = toStringOrNull(data.recur);
   const recur = recurRaw && RECURRENCES.has(recurRaw) ? (recurRaw as Recurrence) : null;
+  const status: TaskStatus =
+    data.status === "done" || data.done === true ? "done" : "open";
   return {
     id: typeof data.id === "string" ? data.id : crypto.randomUUID(),
     title,
     notes: typeof data.notes === "string" ? data.notes : "",
     due: toStringOrNull(data.due),
     priority: clampPriority(data.priority),
-    project: toStringOrNull(data.project),
-    status: data.status === "done" ? "done" : "open",
+    project: toStringOrNull(data.project) ?? toStringOrNull(data.category),
+    status,
     recur,
     created_at: typeof data.created_at === "string" ? data.created_at : new Date().toISOString(),
   };

--- a/home/apps/todo/src/todo-model.ts
+++ b/home/apps/todo/src/todo-model.ts
@@ -141,7 +141,7 @@ export function countByView(tasks: Task[], now: Date): ViewCounts {
 export function projectNames(tasks: Task[]): string[] {
   const names = new Set<string>();
   for (const t of tasks) {
-    if (t.project) names.add(t.project);
+    if (t.status === "open" && t.project) names.add(t.project);
   }
   return [...names].sort((a, b) => a.localeCompare(b));
 }

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -145,6 +145,19 @@ describe("Todo app", () => {
     });
   });
 
+  it("keeps update failure errors visible after reloading", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Prioritize", status: "open", priority: 0, due: null },
+    ]);
+    db.update.mockRejectedValueOnce(new Error("update failed"));
+
+    render(<App />);
+    await screen.findByText("Prioritize");
+    fireEvent.click(screen.getByRole("button", { name: /priority for prioritize/i }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("Change could not be saved.");
+  });
+
   it("rolls a recurring task back open when scheduling the next occurrence fails", async () => {
     const db = installMatrixDb([
       {
@@ -172,6 +185,19 @@ describe("Todo app", () => {
     expect(await screen.findByText("Standup")).toBeTruthy();
     expect(screen.getByRole("button", { name: /complete .*standup/i })).toBeTruthy();
     expect(screen.queryByText(/tomorrow/i)).toBeNull();
+  });
+
+  it("keeps complete failure errors visible after reloading", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Finish report", status: "open", priority: 0, due: null },
+    ]);
+    db.update.mockRejectedValueOnce(new Error("complete failed"));
+
+    render(<App />);
+    await screen.findByText("Finish report");
+    fireEvent.click(screen.getByRole("button", { name: /complete .*finish report/i }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("Could not complete task.");
   });
 
   it("requires a due date before completing a repeating task", async () => {
@@ -296,6 +322,19 @@ describe("Todo app", () => {
     await waitFor(() => {
       expect(db.delete).toHaveBeenCalledWith("tasks", "t1");
     });
+  });
+
+  it("keeps delete failure errors visible after reloading", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Disposable", status: "open", priority: 0, due: null },
+    ]);
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+
+    render(<App />);
+    await screen.findByText("Disposable");
+    fireEvent.click(screen.getByRole("button", { name: /delete .*disposable/i }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("Task could not be deleted.");
   });
 
   it("debounces note edits from the inspector", async () => {

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -8,6 +8,7 @@ type DbRow = Record<string, unknown>;
 
 function isoDaysFromNow(days: number): string {
   const d = new Date();
+  d.setHours(0, 0, 0, 0);
   d.setDate(d.getDate() + days);
   return d.toISOString();
 }
@@ -173,6 +174,23 @@ describe("Todo app", () => {
     });
   });
 
+  it("closes the inspector when completing a selected task with the check button", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Finish report", status: "open", priority: 0, due: null },
+    ]);
+    render(<App />);
+    await screen.findByText("Finish report");
+    fireEvent.click(screen.getByRole("listitem"));
+    expect(screen.getByRole("dialog", { name: /details for finish report/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /complete .*finish report/i }));
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { status: "done" });
+    });
+
+    expect(screen.queryByRole("dialog", { name: /details for finish report/i })).toBeNull();
+  });
+
   it("does not roll back a completed task when the follow-up reload fails", async () => {
     const db = installMatrixDb([
       { id: "t1", title: "Finish report", status: "open", priority: 0, due: null },
@@ -319,7 +337,7 @@ describe("Todo app", () => {
         title: "Today only",
         status: "open",
         priority: 0,
-        due: new Date().toISOString(),
+        due: isoDaysFromNow(0),
         recur: null,
       },
     ]);

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -125,6 +125,34 @@ describe("Todo app", () => {
     expect(await screen.findByText("Plan launch")).toBeTruthy();
   });
 
+  it("adds tasks captured from Today with a stable 9am due date", async () => {
+    const today = new Date();
+    const db = installMatrixDb([]);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /^today/i }));
+    const input = await screen.findByPlaceholderText(/add a task|new task|capture/i);
+    fireEvent.change(input, { target: { value: "Daily review" } });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.insert).toHaveBeenCalledWith(
+        "tasks",
+        expect.objectContaining({ title: "Daily review", due: expect.any(String) }),
+      );
+    });
+    const payload = db.insert.mock.calls.find((call) => call[0] === "tasks")?.[1] as DbRow;
+    const due = new Date(String(payload.due));
+    expect(due.getFullYear()).toBe(today.getFullYear());
+    expect(due.getMonth()).toBe(today.getMonth());
+    expect(due.getDate()).toBe(today.getDate());
+    expect(due.getHours()).toBe(9);
+    expect(due.getMinutes()).toBe(0);
+  });
+
   it("completing a task calls db.update with done status", async () => {
     const db = installMatrixDb([
       { id: "t1", title: "Finish report", status: "open", priority: 0, due: null },

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -380,6 +380,32 @@ describe("Todo app", () => {
     vi.useRealTimers();
   });
 
+  it("flushes the previous task draft when switching tasks with matching notes", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Alpha", status: "open", priority: 0, due: null, notes: "Original" },
+      { id: "t2", title: "Beta", status: "open", priority: 0, due: null, notes: "Shared" },
+    ]);
+    render(<App />);
+    await screen.findByText("Alpha");
+
+    vi.useFakeTimers();
+    const alphaRow = screen.getByText("Alpha").closest('[role="listitem"]');
+    if (!alphaRow) throw new Error("Alpha row was not rendered");
+    fireEvent.click(alphaRow);
+    fireEvent.change(screen.getByPlaceholderText("Add notes…"), { target: { value: "Shared" } });
+    db.update.mockClear();
+
+    const betaRow = screen.getByText("Beta").closest('[role="listitem"]');
+    if (!betaRow) throw new Error("Beta row was not rendered");
+    await act(async () => {
+      fireEvent.click(betaRow);
+      await Promise.resolve();
+    });
+
+    expect(db.update).toHaveBeenCalledWith("tasks", "t1", { notes: "Shared" });
+    vi.useRealTimers();
+  });
+
   it("debounces project edits from the inspector", async () => {
     const db = installMatrixDb([
       { id: "t1", title: "Organize", status: "open", priority: 0, due: null, notes: "", project: null },

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -553,4 +553,22 @@ describe("Todo app", () => {
     render(<App />);
     expect(await screen.findByPlaceholderText(/add a task|new task|capture/i)).toBeTruthy();
   });
+
+  it("keeps in-memory tasks after completing one without MatrixOS.db", async () => {
+    render(<App />);
+    const input = await screen.findByPlaceholderText(/add a task|new task|capture/i);
+
+    fireEvent.change(input, { target: { value: "Alpha" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.change(input, { target: { value: "Beta" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(await screen.findByText("Alpha")).toBeTruthy();
+    expect(screen.getByText("Beta")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Complete Alpha" }));
+
+    await waitFor(() => expect(screen.queryByText("Alpha")).toBeNull());
+    expect(screen.getByText("Beta")).toBeTruthy();
+  });
 });

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -173,6 +173,33 @@ describe("Todo app", () => {
     });
   });
 
+  it("does not roll back a completed task when the follow-up reload fails", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Finish report", status: "open", priority: 0, due: null },
+    ]);
+
+    render(<App />);
+    await screen.findByText("Finish report");
+    db.find.mockRejectedValueOnce(new Error("reload failed"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /complete .*finish report/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { status: "done" });
+    });
+    expect(
+      db.update.mock.calls.some(
+        (call) => call[0] === "tasks" && call[1] === "t1" && call[2]?.status === "open",
+      ),
+    ).toBe(false);
+    expect(screen.queryByText("Finish report")).toBeNull();
+    expect((await screen.findByRole("alert")).textContent).toBe("Tasks could not be loaded. They may be out of date.");
+  });
+
   it("keeps update failure errors visible after reloading", async () => {
     const db = installMatrixDb([
       { id: "t1", title: "Prioritize", status: "open", priority: 0, due: null },

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -54,6 +54,7 @@ describe("Todo app", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
   });
@@ -113,6 +114,32 @@ describe("Todo app", () => {
     });
   });
 
+  it("rolls a recurring task back open when scheduling the next occurrence fails", async () => {
+    const db = installMatrixDb([
+      {
+        id: "t1",
+        title: "Standup",
+        status: "open",
+        priority: 0,
+        due: "2026-06-01T09:00:00.000Z",
+        recur: "daily",
+      },
+    ]);
+    db.insert.mockRejectedValueOnce(new Error("insert failed"));
+
+    render(<App />);
+    await screen.findByText("Standup");
+    const checkbox = screen.getByRole("button", { name: /complete .*standup/i });
+    await act(async () => {
+      fireEvent.click(checkbox);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { status: "open" });
+    });
+  });
+
   it("filters tasks into Today and Upcoming views", async () => {
     installMatrixDb([
       { id: "td", title: "Due today task", status: "open", priority: 0, due: isoDaysFromNow(0) },
@@ -149,6 +176,33 @@ describe("Todo app", () => {
     await waitFor(() => {
       expect(db.delete).toHaveBeenCalledWith("tasks", "t1");
     });
+  });
+
+  it("debounces note edits from the inspector", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Annotate", status: "open", priority: 0, due: null, notes: "" },
+    ]);
+    render(<App />);
+    await screen.findByText("Annotate");
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("listitem"));
+    const notes = screen.getByPlaceholderText("Add notes…");
+    fireEvent.change(notes, { target: { value: "Draft note" } });
+
+    expect(db.update).not.toHaveBeenCalledWith(
+      "tasks",
+      "t1",
+      expect.objectContaining({ notes: "Draft note" }),
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(db.update).toHaveBeenCalledWith("tasks", "t1", { notes: "Draft note" });
+    vi.useRealTimers();
   });
 
   it("survives a missing MatrixOS.db without crashing", async () => {

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/todo/src/App";
+
+type DbRow = Record<string, unknown>;
+
+function isoDaysFromNow(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString();
+}
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const store = [...rows];
+  const db = {
+    find: vi.fn(async () => [...store]),
+    findOne: vi.fn(async (_t: string, id: string) => store.find((r) => r.id === id) ?? null),
+    insert: vi.fn(async (_t: string, data: DbRow) => {
+      const id = `new-${store.length + 1}`;
+      store.push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    }),
+    update: vi.fn(async (_t: string, id: string, data: DbRow) => {
+      const row = store.find((r) => r.id === id);
+      if (row) Object.assign(row, data);
+      return { ok: true };
+    }),
+    delete: vi.fn(async (_t: string, id: string) => {
+      const idx = store.findIndex((r) => r.id === id);
+      if (idx >= 0) store.splice(idx, 1);
+      return { ok: true };
+    }),
+    count: vi.fn(async () => store.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+describe("Todo app", () => {
+  beforeEach(() => {
+    if (!window.matchMedia) {
+      // jsdom lacks matchMedia; reduced-motion check needs it
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        value: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+      });
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+  });
+
+  it("renders tasks from the database", async () => {
+    installMatrixDb([
+      { id: "t1", title: "Write the spec", status: "open", priority: 1, due: null },
+      { id: "t2", title: "Review PR", status: "open", priority: 0, due: null },
+    ]);
+    render(<App />);
+    expect(await screen.findByText("Write the spec")).toBeTruthy();
+    expect(screen.getByText("Review PR")).toBeTruthy();
+  });
+
+  it("shows an onboarding empty state when there are no tasks", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    expect(await screen.findByText(/your inbox is clear/i)).toBeTruthy();
+  });
+
+  it("adds a task to the inbox via Enter and persists with db.insert", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+    const input = await screen.findByPlaceholderText(/add a task|new task|capture/i);
+    fireEvent.change(input, { target: { value: "Buy groceries" } });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(db.insert).toHaveBeenCalledWith(
+        "tasks",
+        expect.objectContaining({ title: "Buy groceries", status: "open" }),
+      );
+    });
+    // optimistic render
+    expect(screen.getByText("Buy groceries")).toBeTruthy();
+  });
+
+  it("completing a task calls db.update with done status", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Finish report", status: "open", priority: 0, due: null },
+    ]);
+    render(<App />);
+    await screen.findByText("Finish report");
+    const checkbox = screen.getByRole("button", { name: /complete .*finish report/i });
+    await act(async () => {
+      fireEvent.click(checkbox);
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith(
+        "tasks",
+        "t1",
+        expect.objectContaining({ status: "done" }),
+      );
+    });
+  });
+
+  it("filters tasks into Today and Upcoming views", async () => {
+    installMatrixDb([
+      { id: "td", title: "Due today task", status: "open", priority: 0, due: isoDaysFromNow(0) },
+      { id: "up", title: "Future task", status: "open", priority: 0, due: isoDaysFromNow(5) },
+      { id: "ib", title: "No date task", status: "open", priority: 0, due: null },
+    ]);
+    render(<App />);
+    await screen.findByText("No date task");
+
+    // Today view
+    fireEvent.click(screen.getByRole("button", { name: /^today/i }));
+    const list = screen.getByTestId("task-list");
+    expect(within(list).getByText("Due today task")).toBeTruthy();
+    expect(within(list).queryByText("Future task")).toBeNull();
+
+    // Upcoming view
+    fireEvent.click(screen.getByRole("button", { name: /^upcoming/i }));
+    const list2 = screen.getByTestId("task-list");
+    expect(within(list2).getByText("Future task")).toBeTruthy();
+    expect(within(list2).queryByText("Due today task")).toBeNull();
+  });
+
+  it("deletes a task via db.delete", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Disposable", status: "open", priority: 0, due: null },
+    ]);
+    render(<App />);
+    await screen.findByText("Disposable");
+    const del = screen.getByRole("button", { name: /delete .*disposable/i });
+    await act(async () => {
+      fireEvent.click(del);
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(db.delete).toHaveBeenCalledWith("tasks", "t1");
+    });
+  });
+
+  it("survives a missing MatrixOS.db without crashing", async () => {
+    render(<App />);
+    expect(await screen.findByPlaceholderText(/add a task|new task|capture/i)).toBeTruthy();
+  });
+});

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -286,7 +286,7 @@ describe("Todo app", () => {
     fireEvent.click(screen.getByRole("listitem"));
     const project = screen.getByPlaceholderText("No project");
     fireEvent.change(project, { target: { value: "W" } });
-    fireEvent.change(project, { target: { value: "Work" } });
+    fireEvent.change(project, { target: { value: "Work " } });
 
     expect(db.update).not.toHaveBeenCalledWith(
       "tasks",
@@ -300,6 +300,12 @@ describe("Todo app", () => {
     });
 
     expect(db.update).toHaveBeenCalledWith("tasks", "t1", { project: "Work" });
+    db.update.mockClear();
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
 

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -69,6 +69,16 @@ describe("Todo app", () => {
     expect(screen.getByText("Review PR")).toBeTruthy();
   });
 
+  it("loads tasks without a silent result ceiling", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Long-running task", status: "open", priority: 0, due: null },
+    ]);
+    render(<App />);
+
+    expect(await screen.findByText("Long-running task")).toBeTruthy();
+    expect(db.find).toHaveBeenCalledWith("tasks", { orderBy: { created_at: "desc" } });
+  });
+
   it("shows an onboarding empty state when there are no tasks", async () => {
     installMatrixDb([]);
     render(<App />);
@@ -169,6 +179,37 @@ describe("Todo app", () => {
       "Add a due date before completing a repeating task.",
     );
     expect(db.update).not.toHaveBeenCalledWith("tasks", "t1", { status: "done" });
+  });
+
+  it("preserves recurrence when clearing a due date", async () => {
+    const db = installMatrixDb([
+      {
+        id: "t1",
+        title: "Standup",
+        status: "open",
+        priority: 0,
+        due: "2026-06-01T09:00:00.000Z",
+        recur: "daily",
+      },
+    ]);
+
+    render(<App />);
+    await screen.findByText("Standup");
+    fireEvent.click(screen.getByRole("listitem"));
+
+    const dueInput = screen.getByText("Due date").closest("label")?.querySelector("input") as HTMLInputElement | null;
+    expect(dueInput).toBeInstanceOf(HTMLInputElement);
+    if (!dueInput) throw new Error("Due date input was not rendered");
+    fireEvent.change(dueInput, { target: { value: "" } });
+
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { due: null });
+    });
+    expect(db.update).not.toHaveBeenCalledWith(
+      "tasks",
+      "t1",
+      expect.objectContaining({ recur: null }),
+    );
   });
 
   it("filters tasks into Today and Upcoming views", async () => {

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -205,6 +205,34 @@ describe("Todo app", () => {
     vi.useRealTimers();
   });
 
+  it("debounces project edits from the inspector", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Organize", status: "open", priority: 0, due: null, notes: "", project: null },
+    ]);
+    render(<App />);
+    await screen.findByText("Organize");
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("listitem"));
+    const project = screen.getByPlaceholderText("No project");
+    fireEvent.change(project, { target: { value: "W" } });
+    fireEvent.change(project, { target: { value: "Work" } });
+
+    expect(db.update).not.toHaveBeenCalledWith(
+      "tasks",
+      "t1",
+      expect.objectContaining({ project: "Work" }),
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(db.update).toHaveBeenCalledWith("tasks", "t1", { project: "Work" });
+    vi.useRealTimers();
+  });
+
   it("survives a missing MatrixOS.db without crashing", async () => {
     render(<App />);
     expect(await screen.findByPlaceholderText(/add a task|new task|capture/i)).toBeTruthy();

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -148,6 +148,9 @@ describe("Todo app", () => {
     await waitFor(() => {
       expect(db.update).toHaveBeenCalledWith("tasks", "t1", { status: "open" });
     });
+    expect(await screen.findByText("Standup")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /complete .*standup/i })).toBeTruthy();
+    expect(screen.queryByText(/tomorrow/i)).toBeNull();
   });
 
   it("requires a due date before completing a repeating task", async () => {
@@ -181,7 +184,7 @@ describe("Todo app", () => {
     expect(db.update).not.toHaveBeenCalledWith("tasks", "t1", { status: "done" });
   });
 
-  it("preserves recurrence when clearing a due date", async () => {
+  it("clears recurrence when clearing a due date", async () => {
     const db = installMatrixDb([
       {
         id: "t1",
@@ -203,13 +206,8 @@ describe("Todo app", () => {
     fireEvent.change(dueInput, { target: { value: "" } });
 
     await waitFor(() => {
-      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { due: null });
+      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { due: null, recur: null });
     });
-    expect(db.update).not.toHaveBeenCalledWith(
-      "tasks",
-      "t1",
-      expect.objectContaining({ recur: null }),
-    );
   });
 
   it("filters tasks into Today and Upcoming views", async () => {

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -343,6 +343,25 @@ describe("Todo app", () => {
     expect(db.delete).not.toHaveBeenCalled();
   });
 
+  it("clears keyboard selection after completing the selected task", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Finish report", status: "open", priority: 0, due: null },
+    ]);
+    render(<App />);
+    await screen.findByText("Finish report");
+    fireEvent.click(screen.getByRole("listitem"));
+    expect(screen.getByRole("dialog", { name: /details for finish report/i })).toBeTruthy();
+
+    fireEvent.keyDown(screen.getByTestId("task-list"), { key: "Enter" });
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { status: "done" });
+    });
+
+    expect(screen.queryByRole("dialog", { name: /details for finish report/i })).toBeNull();
+    fireEvent.keyDown(screen.getByTestId("task-list"), { key: "Backspace", ctrlKey: true });
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
   it("filters tasks into Today and Upcoming views", async () => {
     installMatrixDb([
       { id: "td", title: "Due today task", status: "open", priority: 0, due: isoDaysFromNow(0) },

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -361,6 +361,7 @@ describe("Todo app", () => {
     });
 
     expect(db.update).toHaveBeenCalledWith("tasks", "t1", { notes: "Draft note" });
+    expect(db.update.mock.calls.filter((call) => call[0] === "tasks" && call[1] === "t1")).toHaveLength(1);
     vi.useRealTimers();
   });
 

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -104,6 +104,27 @@ describe("Todo app", () => {
     expect(screen.getByText("Buy groceries")).toBeTruthy();
   });
 
+  it("adds tasks captured from Upcoming with a future due date", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /^upcoming/i }));
+    const input = await screen.findByPlaceholderText(/add a task|new task|capture/i);
+    fireEvent.change(input, { target: { value: "Plan launch" } });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.insert).toHaveBeenCalledWith(
+        "tasks",
+        expect.objectContaining({ title: "Plan launch", due: expect.any(String) }),
+      );
+    });
+    expect(await screen.findByText("Plan launch")).toBeTruthy();
+  });
+
   it("completing a task calls db.update with done status", async () => {
     const db = installMatrixDb([
       { id: "t1", title: "Finish report", status: "open", priority: 0, due: null },
@@ -210,6 +231,35 @@ describe("Todo app", () => {
     });
   });
 
+  it("does not delete a task after a due-date edit removes it from the current view", async () => {
+    const db = installMatrixDb([
+      {
+        id: "t1",
+        title: "Today only",
+        status: "open",
+        priority: 0,
+        due: new Date().toISOString(),
+        recur: null,
+      },
+    ]);
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: /^today/i }));
+    await screen.findByText("Today only");
+    fireEvent.click(screen.getByRole("listitem"));
+
+    const dueInput = screen.getByText("Due date").closest("label")?.querySelector("input") as HTMLInputElement | null;
+    expect(dueInput).toBeInstanceOf(HTMLInputElement);
+    if (!dueInput) throw new Error("Due date input was not rendered");
+    fireEvent.change(dueInput, { target: { value: "" } });
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { due: null, recur: null });
+    });
+
+    fireEvent.keyDown(screen.getByTestId("task-list"), { key: "Backspace", ctrlKey: true });
+
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
   it("filters tasks into Today and Upcoming views", async () => {
     installMatrixDb([
       { id: "td", title: "Due today task", status: "open", priority: 0, due: isoDaysFromNow(0) },
@@ -270,6 +320,22 @@ describe("Todo app", () => {
       vi.advanceTimersByTime(500);
       await Promise.resolve();
     });
+
+    expect(db.update).toHaveBeenCalledWith("tasks", "t1", { notes: "Draft note" });
+    vi.useRealTimers();
+  });
+
+  it("flushes pending note edits when closing the inspector", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Annotate", status: "open", priority: 0, due: null, notes: "" },
+    ]);
+    render(<App />);
+    await screen.findByText("Annotate");
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("listitem"));
+    fireEvent.change(screen.getByPlaceholderText("Add notes…"), { target: { value: "Draft note" } });
+    fireEvent.click(screen.getByRole("button", { name: /close details/i }));
 
     expect(db.update).toHaveBeenCalledWith("tasks", "t1", { notes: "Draft note" });
     vi.useRealTimers();

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -98,11 +98,25 @@ describe("Todo app", () => {
     await waitFor(() => {
       expect(db.insert).toHaveBeenCalledWith(
         "tasks",
-        expect.objectContaining({ title: "Buy groceries", status: "open" }),
+        expect.objectContaining({ title: "Buy groceries", status: "open", priority: "0" }),
       );
     });
     // optimistic render
     expect(screen.getByText("Buy groceries")).toBeTruthy();
+  });
+
+  it("serializes priority updates as text for the bridge schema", async () => {
+    const db = installMatrixDb([
+      { id: "t1", title: "Prioritize", status: "open", priority: 0, due: null },
+    ]);
+
+    render(<App />);
+    await screen.findByText("Prioritize");
+    fireEvent.click(screen.getByRole("button", { name: /priority for prioritize/i }));
+
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("tasks", "t1", { priority: "1" });
+    });
   });
 
   it("adds tasks captured from Upcoming with a future due date", async () => {

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -335,6 +335,8 @@ describe("Todo app", () => {
     await waitFor(() => {
       expect(db.update).toHaveBeenCalledWith("tasks", "t1", { due: null, recur: null });
     });
+    expect(screen.getByRole("dialog", { name: /details for today only/i })).toBeTruthy();
+    expect(within(screen.getByTestId("task-list")).queryByText("Today only")).toBeNull();
 
     fireEvent.keyDown(screen.getByTestId("task-list"), { key: "Backspace", ctrlKey: true });
 

--- a/tests/default-apps/todo-app.test.tsx
+++ b/tests/default-apps/todo-app.test.tsx
@@ -140,6 +140,37 @@ describe("Todo app", () => {
     });
   });
 
+  it("requires a due date before completing a repeating task", async () => {
+    const db = installMatrixDb([
+      {
+        id: "t1",
+        title: "Standup",
+        status: "open",
+        priority: 0,
+        due: null,
+        recur: "daily",
+      },
+    ]);
+
+    render(<App />);
+    await screen.findByText("Standup");
+    fireEvent.click(screen.getByRole("listitem"));
+
+    const repeat = screen.getByText("Repeat").closest("label")?.querySelector("select") as HTMLSelectElement | null;
+    expect(repeat).toBeInstanceOf(HTMLSelectElement);
+    if (!repeat) throw new Error("Repeat select was not rendered");
+    expect(repeat.disabled).toBe(true);
+    expect(screen.getByText("Add a due date to repeat this task.")).toBeTruthy();
+
+    const checkbox = screen.getByRole("button", { name: /complete .*standup/i });
+    fireEvent.click(checkbox);
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "Add a due date before completing a repeating task.",
+    );
+    expect(db.update).not.toHaveBeenCalledWith("tasks", "t1", { status: "done" });
+  });
+
   it("filters tasks into Today and Upcoming views", async () => {
     installMatrixDb([
       { id: "td", title: "Due today task", status: "open", priority: 0, due: isoDaysFromNow(0) },

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -46,6 +46,26 @@ describe("normalizeTask", () => {
     expect(normalizeTask({ id: "x", title: "ok", priority: 99 })!.priority).toBe(3);
     expect(normalizeTask({ id: "x", title: "ok", priority: -5 })!.priority).toBe(0);
   });
+
+  it("hydrates legacy task rows from the previous default app schema", () => {
+    const task = normalizeTask({
+      id: "legacy",
+      text: "Ship migration",
+      done: true,
+      category: "Launch",
+      priority: "high",
+      due: "2026-06-02T09:00:00.000Z",
+    });
+
+    expect(task).toMatchObject({
+      id: "legacy",
+      title: "Ship migration",
+      status: "done",
+      project: "Launch",
+      priority: 3,
+      due: "2026-06-02T09:00:00.000Z",
+    });
+  });
 });
 
 describe("filterTasks", () => {

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   countByView,
@@ -25,6 +27,7 @@ function makeTask(partial: Partial<Task> = {}): Task {
 }
 
 const NOW = new Date("2026-05-31T12:00:00.000Z"); // Sunday
+const REPO_ROOT = join(__dirname, "..", "..");
 
 describe("normalizeTask", () => {
   it("coerces loose db rows into typed tasks", () => {
@@ -65,6 +68,24 @@ describe("normalizeTask", () => {
       project: "Launch",
       priority: 3,
       due: "2026-06-02T09:00:00.000Z",
+    });
+  });
+});
+
+describe("todo manifest schema", () => {
+  it("keeps legacy task columns declared during the schema transition", () => {
+    const manifest = JSON.parse(
+      readFileSync(join(REPO_ROOT, "home", "apps", "todo", "matrix.json"), "utf-8"),
+    ) as { storage?: { tables?: { tasks?: { columns?: Record<string, string> } } } };
+    const columns = manifest.storage?.tables?.tasks?.columns ?? {};
+
+    expect(columns).toMatchObject({
+      title: "text",
+      text: "text",
+      status: "text",
+      done: "boolean",
+      project: "text",
+      category: "text",
     });
   });
 });

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -4,6 +4,7 @@ import {
   filterTasks,
   nextRecurrence,
   normalizeTask,
+  projectNames,
   sortTasks,
   type Task,
   type View,
@@ -118,6 +119,17 @@ describe("countByView", () => {
     expect(counts.inbox).toBe(3);
     expect(counts.today).toBe(1);
     expect(counts.upcoming).toBe(1);
+  });
+});
+
+describe("projectNames", () => {
+  it("only includes projects with open tasks", () => {
+    const tasks = [
+      makeTask({ id: "open", project: "Work", status: "open" }),
+      makeTask({ id: "done", project: "Archive", status: "done" }),
+    ];
+
+    expect(projectNames(tasks)).toEqual(["Work"]);
   });
 });
 

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -84,6 +84,7 @@ describe("todo manifest schema", () => {
       text: "text",
       status: "text",
       done: "boolean",
+      priority: "text",
       project: "text",
       category: "text",
     });

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -20,7 +20,7 @@ function makeTask(partial: Partial<Task> = {}): Task {
     status: partial.status ?? "open",
     recur: partial.recur ?? null,
     created_at: partial.created_at ?? "2026-05-31T00:00:00.000Z",
-  });
+  })!;
 }
 
 const NOW = new Date("2026-05-31T12:00:00.000Z"); // Sunday

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -51,6 +51,10 @@ describe("normalizeTask", () => {
     expect(normalizeTask({ id: "x", title: "ok", priority: -5 })!.priority).toBe(0);
   });
 
+  it("coerces numeric ids to stable string ids", () => {
+    expect(normalizeTask({ id: 42, title: "Numeric id" })?.id).toBe("42");
+  });
+
   it("hydrates legacy task rows from the previous default app schema", () => {
     const task = normalizeTask({
       id: "legacy",

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  countByView,
+  filterTasks,
+  nextRecurrence,
+  normalizeTask,
+  sortTasks,
+  type Task,
+  type View,
+} from "../../home/apps/todo/src/todo-model";
+
+function makeTask(partial: Partial<Task> = {}): Task {
+  return normalizeTask({
+    id: partial.id ?? crypto.randomUUID(),
+    title: partial.title ?? "Task",
+    notes: partial.notes ?? "",
+    due: partial.due ?? null,
+    priority: partial.priority ?? 0,
+    project: partial.project ?? null,
+    status: partial.status ?? "open",
+    recur: partial.recur ?? null,
+    created_at: partial.created_at ?? "2026-05-31T00:00:00.000Z",
+  });
+}
+
+const NOW = new Date("2026-05-31T12:00:00.000Z"); // Sunday
+
+describe("normalizeTask", () => {
+  it("coerces loose db rows into typed tasks", () => {
+    const t = normalizeTask({
+      id: "a",
+      title: " Buy milk ",
+      priority: "2",
+      status: "done",
+      due: "2026-06-01T00:00:00.000Z",
+    });
+    expect(t).not.toBeNull();
+    expect(t!.title).toBe("Buy milk");
+    expect(t!.priority).toBe(2);
+    expect(t!.status).toBe("done");
+    expect(t!.due).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("clamps priority to 0-3 and rejects empty titles", () => {
+    expect(normalizeTask({ id: "x", title: "   " })).toBeNull();
+    expect(normalizeTask({ id: "x", title: "ok", priority: 99 })!.priority).toBe(3);
+    expect(normalizeTask({ id: "x", title: "ok", priority: -5 })!.priority).toBe(0);
+  });
+});
+
+describe("filterTasks", () => {
+  const overdue = makeTask({ id: "1", title: "overdue", due: "2026-05-30T09:00:00.000Z" });
+  const today = makeTask({ id: "2", title: "today", due: "2026-05-31T18:00:00.000Z" });
+  const tomorrow = makeTask({ id: "3", title: "tomorrow", due: "2026-06-01T09:00:00.000Z" });
+  const noDate = makeTask({ id: "4", title: "inbox-item", due: null });
+  const projItem = makeTask({ id: "5", title: "proj", project: "Work", due: null });
+  const done = makeTask({ id: "6", title: "done", status: "done", due: "2026-05-31T08:00:00.000Z" });
+  const all = [overdue, today, tomorrow, noDate, projItem, done];
+
+  it("Inbox shows open tasks with no project", () => {
+    const ids = filterTasks(all, "inbox", NOW).map((t) => t.id);
+    expect(ids).toContain("4");
+    expect(ids).not.toContain("5"); // has project
+    expect(ids).not.toContain("6"); // done
+  });
+
+  it("Today shows open tasks due today or overdue", () => {
+    const ids = filterTasks(all, "today", NOW).map((t) => t.id);
+    expect(ids).toContain("1"); // overdue
+    expect(ids).toContain("2"); // today
+    expect(ids).not.toContain("3"); // tomorrow
+    expect(ids).not.toContain("6"); // done
+  });
+
+  it("Upcoming shows open tasks due after today", () => {
+    const ids = filterTasks(all, "upcoming", NOW).map((t) => t.id);
+    expect(ids).toContain("3");
+    expect(ids).not.toContain("1");
+    expect(ids).not.toContain("2");
+    expect(ids).not.toContain("4"); // no due date
+  });
+
+  it("project view filters by project name", () => {
+    const ids = filterTasks(all, { kind: "project", project: "Work" }, NOW).map((t) => t.id);
+    expect(ids).toEqual(["5"]);
+  });
+});
+
+describe("countByView", () => {
+  it("returns per-view open counts", () => {
+    const tasks = [
+      makeTask({ id: "1", due: "2026-05-31T18:00:00.000Z" }),
+      makeTask({ id: "2", due: "2026-06-02T18:00:00.000Z" }),
+      makeTask({ id: "3", due: null }),
+      makeTask({ id: "4", status: "done", due: "2026-05-31T18:00:00.000Z" }),
+    ];
+    const counts = countByView(tasks, NOW);
+    expect(counts.inbox).toBe(3);
+    expect(counts.today).toBe(1);
+    expect(counts.upcoming).toBe(1);
+  });
+});
+
+describe("sortTasks", () => {
+  it("orders by priority desc then due asc then created", () => {
+    const a = makeTask({ id: "a", priority: 1, due: "2026-06-02T00:00:00.000Z" });
+    const b = makeTask({ id: "b", priority: 3, due: null });
+    const c = makeTask({ id: "c", priority: 1, due: "2026-06-01T00:00:00.000Z" });
+    const sorted = sortTasks([a, b, c]).map((t) => t.id);
+    expect(sorted[0]).toBe("b"); // highest priority
+    expect(sorted.slice(1)).toEqual(["c", "a"]); // same prio, earlier due first
+  });
+});
+
+describe("nextRecurrence", () => {
+  it("daily adds one day", () => {
+    expect(nextRecurrence("daily", new Date("2026-05-31T09:00:00.000Z"))).toBe(
+      "2026-06-01T09:00:00.000Z",
+    );
+  });
+
+  it("weekly adds seven days", () => {
+    expect(nextRecurrence("weekly", new Date("2026-05-31T09:00:00.000Z"))).toBe(
+      "2026-06-07T09:00:00.000Z",
+    );
+  });
+
+  it("weekdays skips weekend (Fri -> Mon)", () => {
+    // 2026-06-05 is a Friday
+    expect(nextRecurrence("weekdays", new Date("2026-06-05T09:00:00.000Z"))).toBe(
+      "2026-06-08T09:00:00.000Z",
+    );
+  });
+
+  it("weekdays Sunday -> Monday", () => {
+    // 2026-05-31 is a Sunday
+    expect(nextRecurrence("weekdays", new Date("2026-05-31T09:00:00.000Z"))).toBe(
+      "2026-06-01T09:00:00.000Z",
+    );
+  });
+
+  it("returns null for no recurrence", () => {
+    expect(nextRecurrence(null, NOW)).toBeNull();
+    expect(nextRecurrence("nonsense" as never, NOW)).toBeNull();
+  });
+});
+
+// type export sanity
+const _v: View = "inbox";
+void _v;

--- a/tests/default-apps/todo-model.test.ts
+++ b/tests/default-apps/todo-model.test.ts
@@ -185,15 +185,19 @@ describe("nextRecurrence", () => {
 
   it("weekdays skips weekend (Fri -> Mon)", () => {
     // 2026-06-05 is a Friday
-    expect(nextRecurrence("weekdays", new Date("2026-06-05T09:00:00.000Z"))).toBe(
-      "2026-06-08T09:00:00.000Z",
+    const friday = new Date("2026-06-05T09:00:00");
+    const monday = new Date("2026-06-08T09:00:00").toISOString();
+    expect(nextRecurrence("weekdays", friday)).toBe(
+      monday,
     );
   });
 
   it("weekdays Sunday -> Monday", () => {
     // 2026-05-31 is a Sunday
-    expect(nextRecurrence("weekdays", new Date("2026-05-31T09:00:00.000Z"))).toBe(
-      "2026-06-01T09:00:00.000Z",
+    const sunday = new Date("2026-05-31T09:00:00");
+    const monday = new Date("2026-06-01T09:00:00").toISOString();
+    expect(nextRecurrence("weekdays", sunday)).toBe(
+      monday,
     );
   });
 


### PR DESCRIPTION
Stack: 3/22
Branch: stack/default-apps-todo

Scope: Todo app planner UI/model and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.