### PR TITLE
feat(expense): add spend dashboard

### DIFF
--- a/home/apps/expense-tracker/matrix.json
+++ b/home/apps/expense-tracker/matrix.json
@@ -1,7 +1,7 @@
 {
   "name": "Expense Tracker",
-  "description": "Track daily expenses and budgets",
-  "category": "productivity",
+  "description": "Track spending, budgets, and recurring bills with a monthly dashboard.",
+  "category": "finance",
   "icon": "expense-tracker",
   "author": "system",
   "version": "2.0.0",
@@ -10,12 +10,22 @@
       "expenses": {
         "columns": {
           "amount": "float",
-          "description": "text",
           "category": "text",
-          "date": "timestamptz"
+          "note": "text",
+          "spent_at": "timestamptz",
+          "recurring": "boolean"
         },
         "indexes": [
-          "date",
+          "spent_at",
+          "category"
+        ]
+      },
+      "budgets": {
+        "columns": {
+          "category": "text",
+          "monthly_limit": "float"
+        },
+        "indexes": [
           "category"
         ]
       }

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -72,7 +72,7 @@ type LoadState = "loading" | "ready" | "error";
 
 function todayInputValue(): string {
   const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
 }
 
 async function findAllRows(

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -137,6 +137,35 @@ export default function App() {
   const budgetDuplicatesRef = useRef<Map<string, BudgetRow[]>>(new Map());
   const currency = useMemo(() => currencyForLocale(navigator.language), []);
 
+  const refreshBudgets = useCallback(async () => {
+    const db = window.MatrixOS?.db;
+    if (!db) return;
+    try {
+      const rawBudgets = await findAllRows(db, BUDGETS_TABLE);
+      const coercedBudgets = rawBudgets
+        .map(coerceBudget)
+        .filter((row): row is BudgetRow => row !== null);
+      const duplicates = new Map<string, BudgetRow[]>();
+      const seen = new Set<string>();
+      for (const budget of coercedBudgets) {
+        if (!seen.has(budget.category)) {
+          seen.add(budget.category);
+          continue;
+        }
+        const rows = duplicates.get(budget.category) ?? [];
+        rows.push(budget);
+        duplicates.set(budget.category, rows);
+      }
+      budgetDuplicatesRef.current = duplicates;
+      setBudgets(dedupeBudgets(coercedBudgets));
+    } catch (err: unknown) {
+      console.warn(
+        "[expense-tracker] budget refresh failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }, []);
+
   const reload = useCallback(async () => {
     const db = window.MatrixOS?.db;
     if (!db) {
@@ -412,6 +441,7 @@ export default function App() {
           ? dedupeBudgets([...rollbackBase, ...insertedBudgets])
           : rollbackBase,
       );
+      void refreshBudgets();
       setBudgetEditor(true);
       setError("Could not save your budgets.");
       return;
@@ -422,7 +452,7 @@ export default function App() {
       );
     }
     void reload();
-  }, [budgetDraft, budgets, reload]);
+  }, [budgetDraft, budgets, refreshBudgets, reload]);
 
   const isEmpty = loadState === "ready" && expenses.length === 0 && budgets.length === 0;
   const maxCategoryTotal = summary.breakdown[0]?.total ?? 0;

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -110,7 +110,8 @@ interface DraftExpense {
 
 type BudgetOperationResult =
   | { type: "insert"; budget: BudgetRow }
-  | { type: "update" | "delete" };
+  | { type: "delete"; id: string }
+  | { type: "update" };
 
 function emptyDraft(): DraftExpense {
   return {
@@ -251,9 +252,11 @@ export default function App() {
 
       if (editingId) {
         const previous = expenses;
+        const previousMonth = selectedMonth;
         setExpenses((current) =>
           current.map((e) => (e.id === editingId ? { ...e, ...payload } : e)),
         );
+        setSelectedMonth(monthKey(payload.spent_at));
         resetDraft();
         try {
           if (db) await db.update(EXPENSES_TABLE, editingId, payload);
@@ -263,6 +266,7 @@ export default function App() {
             err instanceof Error ? err.message : String(err),
           );
           setExpenses(previous);
+          setSelectedMonth(previousMonth);
           setError("Could not save that change.");
           return;
         } finally {
@@ -361,10 +365,10 @@ export default function App() {
       const existingRows = existingByCategory.get(category) ?? [];
       const existing = existingRows[0];
       for (const duplicate of existingRows.slice(1)) {
-        if (db) operations.push(db.delete(BUDGETS_TABLE, duplicate.id).then(() => ({ type: "delete" })));
+        if (db) operations.push(db.delete(BUDGETS_TABLE, duplicate.id).then(() => ({ type: "delete", id: duplicate.id })));
       }
       if (!value || !Number.isFinite(limit) || limit <= 0) {
-        if (existing && db) operations.push(db.delete(BUDGETS_TABLE, existing.id).then(() => ({ type: "delete" })));
+        if (existing && db) operations.push(db.delete(BUDGETS_TABLE, existing.id).then(() => ({ type: "delete", id: existing.id })));
         continue;
       }
       const localId = existing?.id ?? `local-${category}`;
@@ -389,12 +393,25 @@ export default function App() {
           result.status === "fulfilled" && result.value.type === "insert",
       )
       .map((result) => (result.value as { type: "insert"; budget: BudgetRow }).budget);
+    const deletedBudgetIds = new Set(
+      results
+        .filter(
+          (result): result is PromiseFulfilledResult<BudgetOperationResult> =>
+            result.status === "fulfilled" && result.value.type === "delete",
+        )
+        .map((result) => (result.value as { type: "delete"; id: string }).id),
+    );
     if (failed) {
       console.warn(
         "[expense-tracker] budget save failed:",
         failed.reason instanceof Error ? failed.reason.message : String(failed.reason),
       );
-      setBudgets(insertedBudgets.length > 0 ? dedupeBudgets([...previous, ...insertedBudgets]) : previous);
+      const rollbackBase = previous.filter((budget) => !deletedBudgetIds.has(budget.id));
+      setBudgets(
+        insertedBudgets.length > 0
+          ? dedupeBudgets([...rollbackBase, ...insertedBudgets])
+          : rollbackBase,
+      );
       setBudgetEditor(true);
       setError("Could not save your budgets.");
       return;

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -1,0 +1,652 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import {
+  AlertTriangle,
+  ArrowDownUp,
+  ChevronLeft,
+  ChevronRight,
+  Pencil,
+  PiggyBank,
+  Plus,
+  Repeat,
+  Trash2,
+  TrendingDown,
+  Wallet,
+  X,
+} from "lucide-react";
+import {
+  budgetStatus,
+  coerceBudget,
+  coerceExpense,
+  formatMoney,
+  monthKey,
+  monthLabel,
+  shiftMonth,
+  summarizeMonth,
+  type BudgetRow,
+  type ExpenseRow,
+} from "./expense-model";
+import "./styles.css";
+
+const EXPENSES_TABLE = "expenses";
+const BUDGETS_TABLE = "budgets";
+
+const DEFAULT_CATEGORIES = [
+  "Groceries",
+  "Rent",
+  "Dining",
+  "Transport",
+  "Utilities",
+  "Shopping",
+  "Health",
+  "Entertainment",
+  "Subscriptions",
+  "Other",
+] as const;
+
+// Stable, accessible palette for category accents.
+const CATEGORY_PALETTE = [
+  "#D06F25", // clay
+  "#3A7D44", // moss
+  "#3E6DAF", // slate blue
+  "#B0573E", // terracotta
+  "#7A5BB0", // plum
+  "#C99A2E", // amber
+  "#2F8A8A", // teal
+  "#B23A6E", // berry
+  "#5E7A2F", // olive
+  "#7A7768", // stone
+];
+
+function colorForCategory(category: string): string {
+  let hash = 0;
+  for (let i = 0; i < category.length; i += 1) {
+    hash = (hash * 31 + category.charCodeAt(i)) >>> 0;
+  }
+  return CATEGORY_PALETTE[hash % CATEGORY_PALETTE.length];
+}
+
+type LoadState = "loading" | "ready" | "error";
+
+function todayInputValue(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function dateInputToIso(value: string): string {
+  if (!value) return new Date().toISOString();
+  const parsed = new Date(`${value}T12:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+}
+
+function isoToDateInput(iso: string): string {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? todayInputValue() : date.toISOString().slice(0, 10);
+}
+
+interface DraftExpense {
+  amount: string;
+  category: string;
+  note: string;
+  date: string;
+  recurring: boolean;
+}
+
+function emptyDraft(): DraftExpense {
+  return {
+    amount: "",
+    category: DEFAULT_CATEGORIES[0],
+    note: "",
+    date: todayInputValue(),
+    recurring: false,
+  };
+}
+
+export default function App() {
+  const [expenses, setExpenses] = useState<ExpenseRow[]>([]);
+  const [budgets, setBudgets] = useState<BudgetRow[]>([]);
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [selectedMonth, setSelectedMonth] = useState<string>(() => monthKey(new Date()));
+  const [draft, setDraft] = useState<DraftExpense>(emptyDraft);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [budgetEditor, setBudgetEditor] = useState(false);
+  const [budgetDraft, setBudgetDraft] = useState<Record<string, string>>({});
+  const submittingRef = useRef(false);
+
+  const reload = useCallback(async () => {
+    const db = window.MatrixOS?.db;
+    if (!db) {
+      setLoadState("ready");
+      return;
+    }
+    try {
+      const [rawExpenses, rawBudgets] = await Promise.all([
+        db.find(EXPENSES_TABLE, { orderBy: { spent_at: "desc" }, limit: 1000 }),
+        db.find(BUDGETS_TABLE, { limit: 200 }),
+      ]);
+      setExpenses(
+        rawExpenses
+          .map(coerceExpense)
+          .filter((row): row is ExpenseRow => row !== null),
+      );
+      setBudgets(
+        rawBudgets
+          .map(coerceBudget)
+          .filter((row): row is BudgetRow => row !== null),
+      );
+      setError(null);
+      setLoadState("ready");
+    } catch (err: unknown) {
+      console.warn(
+        "[expense-tracker] load failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      setError("Could not load your spending data. Showing what's available locally.");
+      setLoadState("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+    const db = window.MatrixOS?.db;
+    if (!db?.onChange) return undefined;
+    const unsubExpenses = db.onChange(EXPENSES_TABLE, () => void reload());
+    const unsubBudgets = db.onChange(BUDGETS_TABLE, () => void reload());
+    return () => {
+      unsubExpenses?.();
+      unsubBudgets?.();
+    };
+  }, [reload]);
+
+  const summary = useMemo(
+    () => summarizeMonth(expenses, budgets, selectedMonth),
+    [expenses, budgets, selectedMonth],
+  );
+
+  const monthExpenses = useMemo(
+    () =>
+      expenses
+        .filter((e) => monthKey(e.spent_at) === selectedMonth)
+        .sort((a, b) => b.spent_at.localeCompare(a.spent_at)),
+    [expenses, selectedMonth],
+  );
+
+  const knownCategories = useMemo(() => {
+    const set = new Set<string>(DEFAULT_CATEGORIES);
+    for (const e of expenses) set.add(e.category);
+    for (const b of budgets) set.add(b.category);
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [expenses, budgets]);
+
+  const resetDraft = useCallback(() => {
+    setDraft(emptyDraft());
+    setEditingId(null);
+  }, []);
+
+  const submitExpense = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault();
+      if (submittingRef.current) return;
+      const amount = Number(draft.amount);
+      if (!Number.isFinite(amount) || amount <= 0) {
+        setError("Enter an amount greater than zero.");
+        return;
+      }
+      submittingRef.current = true;
+      setError(null);
+
+      const payload = {
+        amount,
+        category: draft.category.trim() || "Other",
+        note: draft.note.trim(),
+        spent_at: dateInputToIso(draft.date),
+        recurring: draft.recurring,
+      };
+      const db = window.MatrixOS?.db;
+
+      if (editingId) {
+        const previous = expenses;
+        setExpenses((current) =>
+          current.map((e) => (e.id === editingId ? { ...e, ...payload } : e)),
+        );
+        resetDraft();
+        try {
+          if (db) await db.update(EXPENSES_TABLE, editingId, payload);
+          await reload();
+        } catch (err: unknown) {
+          console.warn(
+            "[expense-tracker] update failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+          setExpenses(previous);
+          setError("Could not save that change.");
+        } finally {
+          submittingRef.current = false;
+        }
+        return;
+      }
+
+      const optimistic: ExpenseRow = {
+        id: `local-${Date.now()}`,
+        ...payload,
+        created_at: new Date().toISOString(),
+      };
+      setExpenses((current) => [optimistic, ...current]);
+      // Keep the month in view so the new row is visible.
+      setSelectedMonth(monthKey(payload.spent_at));
+      resetDraft();
+      try {
+        if (db) await db.insert(EXPENSES_TABLE, payload);
+        await reload();
+      } catch (err: unknown) {
+        console.warn(
+          "[expense-tracker] insert failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+        setExpenses((current) => current.filter((e) => e.id !== optimistic.id));
+        setError("Could not save that transaction.");
+      } finally {
+        submittingRef.current = false;
+      }
+    },
+    [draft, editingId, expenses, reload, resetDraft],
+  );
+
+  const startEdit = useCallback((expense: ExpenseRow) => {
+    setEditingId(expense.id);
+    setDraft({
+      amount: String(expense.amount),
+      category: expense.category,
+      note: expense.note,
+      date: isoToDateInput(expense.spent_at),
+      recurring: expense.recurring,
+    });
+  }, []);
+
+  const deleteExpense = useCallback(
+    async (id: string) => {
+      const previous = expenses;
+      setExpenses((current) => current.filter((e) => e.id !== id));
+      if (editingId === id) resetDraft();
+      const db = window.MatrixOS?.db;
+      try {
+        if (db) await db.delete(EXPENSES_TABLE, id);
+        await reload();
+      } catch (err: unknown) {
+        console.warn(
+          "[expense-tracker] delete failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+        setExpenses(previous);
+        setError("Could not delete that transaction.");
+      }
+    },
+    [editingId, expenses, reload, resetDraft],
+  );
+
+  const openBudgetEditor = useCallback(() => {
+    const next: Record<string, string> = {};
+    for (const category of knownCategories) {
+      const existing = budgets.find((b) => b.category === category);
+      next[category] = existing ? String(existing.monthly_limit) : "";
+    }
+    setBudgetDraft(next);
+    setBudgetEditor(true);
+  }, [budgets, knownCategories]);
+
+  const saveBudgets = useCallback(async () => {
+    const db = window.MatrixOS?.db;
+    const next: BudgetRow[] = [];
+    const operations: Array<Promise<unknown>> = [];
+    for (const [category, value] of Object.entries(budgetDraft)) {
+      const limit = Number(value);
+      const existing = budgets.find((b) => b.category === category);
+      if (!value || !Number.isFinite(limit) || limit <= 0) {
+        if (existing && db) operations.push(db.delete(BUDGETS_TABLE, existing.id));
+        continue;
+      }
+      next.push({ id: existing?.id ?? `local-${category}`, category, monthly_limit: limit });
+      if (db) {
+        operations.push(
+          existing
+            ? db.update(BUDGETS_TABLE, existing.id, { monthly_limit: limit })
+            : db.insert(BUDGETS_TABLE, { category, monthly_limit: limit }),
+        );
+      }
+    }
+    setBudgets(next);
+    setBudgetEditor(false);
+    try {
+      await Promise.all(operations);
+      await reload();
+    } catch (err: unknown) {
+      console.warn(
+        "[expense-tracker] budget save failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      setError("Could not save your budgets.");
+    }
+  }, [budgetDraft, budgets, reload]);
+
+  const isEmpty = loadState === "ready" && expenses.length === 0 && budgets.length === 0;
+  const maxCategoryTotal = summary.breakdown[0]?.total ?? 0;
+
+  return (
+    <main className="exp-app">
+      <header className="exp-header">
+        <div className="exp-brand">
+          <span className="exp-brand__mark" aria-hidden="true">
+            <Wallet size={18} />
+          </span>
+          <div>
+            <p className="exp-eyebrow">Spending</p>
+            <h1>Money</h1>
+          </div>
+        </div>
+        <div className="exp-month-switch" role="group" aria-label="Selected month">
+          <button
+            type="button"
+            className="exp-icon-btn"
+            aria-label="Previous month"
+            onClick={() => setSelectedMonth((m) => shiftMonth(m, -1))}
+          >
+            <ChevronLeft size={18} />
+          </button>
+          <span className="exp-month-label" data-testid="selected-month">
+            {monthLabel(selectedMonth)}
+          </span>
+          <button
+            type="button"
+            className="exp-icon-btn"
+            aria-label="Next month"
+            onClick={() => setSelectedMonth((m) => shiftMonth(m, 1))}
+          >
+            <ChevronRight size={18} />
+          </button>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="exp-banner" role="status">
+          <AlertTriangle size={16} />
+          <span>{error}</span>
+        </div>
+      ) : null}
+
+      <section className="exp-kpis" aria-label="Monthly key figures">
+        <article className="exp-kpi exp-kpi--spent">
+          <span className="exp-kpi__label">
+            <TrendingDown size={15} /> Spent this month
+          </span>
+          <strong data-testid="kpi-total">{formatMoney(summary.totalSpent)}</strong>
+          <em>{summary.transactionCount} transactions</em>
+        </article>
+        <article
+          className={
+            summary.remaining < 0 ? "exp-kpi exp-kpi--over" : "exp-kpi exp-kpi--remaining"
+          }
+        >
+          <span className="exp-kpi__label">
+            <PiggyBank size={15} /> {summary.remaining < 0 ? "Over budget" : "Remaining budget"}
+          </span>
+          <strong data-testid="kpi-remaining">{formatMoney(Math.abs(summary.remaining))}</strong>
+          <em>{summary.totalBudget > 0 ? `of ${formatMoney(summary.totalBudget)}` : "No budgets set"}</em>
+        </article>
+        <article className="exp-kpi exp-kpi--top">
+          <span className="exp-kpi__label">
+            <ArrowDownUp size={15} /> Biggest category
+          </span>
+          <strong data-testid="kpi-biggest">{summary.biggestCategory?.category ?? "—"}</strong>
+          <em>{summary.biggestCategory ? formatMoney(summary.biggestCategory.total) : "Nothing yet"}</em>
+        </article>
+      </section>
+
+      {summary.overBudget.length > 0 ? (
+        <div className="exp-warning" data-testid="over-budget-warning" role="alert">
+          <AlertTriangle size={16} />
+          <span>
+            Over budget in{" "}
+            {summary.overBudget.map((b) => b.category).join(", ")} — review your spending.
+          </span>
+        </div>
+      ) : null}
+
+      <div className="exp-grid">
+        <section className="exp-card exp-breakdown" aria-label="Spending by category">
+          <div className="exp-card__head">
+            <h2>By category</h2>
+            <button type="button" className="exp-text-btn" onClick={openBudgetEditor}>
+              Edit budgets
+            </button>
+          </div>
+
+          {summary.breakdown.length === 0 ? (
+            <p className="exp-card__hint">No spending recorded for {monthLabel(selectedMonth)}.</p>
+          ) : (
+            <div className="exp-bars" data-testid="category-breakdown">
+              {summary.breakdown.map((row) => {
+                const status = budgetStatus(row.category, row.total, budgets);
+                const fill = maxCategoryTotal > 0 ? (row.total / maxCategoryTotal) * 100 : 0;
+                const color = colorForCategory(row.category);
+                return (
+                  <div className="exp-bar" key={row.category}>
+                    <div className="exp-bar__top">
+                      <span className="exp-bar__name">
+                        <span className="exp-dot" style={{ background: color }} aria-hidden="true" />
+                        {row.category}
+                        {status.over ? <span className="exp-tag exp-tag--over">over</span> : null}
+                      </span>
+                      <span className="exp-bar__amt">{formatMoney(row.total)}</span>
+                    </div>
+                    <div className="exp-bar__track">
+                      <div
+                        className="exp-bar__fill"
+                        style={{ width: `${Math.max(4, fill)}%`, background: color }}
+                      />
+                    </div>
+                    <div className="exp-bar__meta">
+                      {status.hasBudget ? (
+                        <span className={status.over ? "exp-over" : ""}>
+                          {formatMoney(row.total)} of {formatMoney(status.limit)} budget
+                          {status.over
+                            ? ` · ${formatMoney(Math.abs(status.remaining))} over`
+                            : ` · ${formatMoney(status.remaining)} left`}
+                        </span>
+                      ) : (
+                        <span>{Math.round(row.pct)}% of spend · no budget</span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <section className="exp-card exp-compose" aria-label="Add a transaction">
+          <div className="exp-card__head">
+            <h2>{editingId ? "Edit transaction" : "Add transaction"}</h2>
+            {editingId ? (
+              <button type="button" className="exp-text-btn" onClick={resetDraft}>
+                Cancel
+              </button>
+            ) : null}
+          </div>
+          <form className="exp-form" data-testid="expense-form" onSubmit={submitExpense}>
+            <label className="exp-field">
+              <span>Amount</span>
+              <input
+                aria-label="Amount"
+                inputMode="decimal"
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="0.00"
+                value={draft.amount}
+                onChange={(e) => setDraft((d) => ({ ...d, amount: e.target.value }))}
+              />
+            </label>
+            <label className="exp-field">
+              <span>Category</span>
+              <input
+                aria-label="Category"
+                list="exp-categories"
+                value={draft.category}
+                onChange={(e) => setDraft((d) => ({ ...d, category: e.target.value }))}
+              />
+              <datalist id="exp-categories">
+                {knownCategories.map((c) => (
+                  <option key={c} value={c} />
+                ))}
+              </datalist>
+            </label>
+            <label className="exp-field exp-field--wide">
+              <span>Note</span>
+              <input
+                aria-label="Note"
+                type="text"
+                placeholder="What was it for?"
+                value={draft.note}
+                onChange={(e) => setDraft((d) => ({ ...d, note: e.target.value }))}
+              />
+            </label>
+            <label className="exp-field">
+              <span>Date</span>
+              <input
+                aria-label="Date"
+                type="date"
+                value={draft.date}
+                onChange={(e) => setDraft((d) => ({ ...d, date: e.target.value }))}
+              />
+            </label>
+            <label className="exp-check">
+              <input
+                type="checkbox"
+                checked={draft.recurring}
+                onChange={(e) => setDraft((d) => ({ ...d, recurring: e.target.checked }))}
+              />
+              <Repeat size={14} /> Recurring bill
+            </label>
+            <button type="submit" className="exp-primary">
+              <Plus size={16} /> {editingId ? "Save changes" : "Add expense"}
+            </button>
+          </form>
+        </section>
+      </div>
+
+      <section className="exp-card exp-transactions" aria-label="Transactions">
+        <div className="exp-card__head">
+          <h2>Transactions</h2>
+          <span className="exp-card__hint">{monthLabel(selectedMonth)}</span>
+        </div>
+
+        {isEmpty ? (
+          <div className="exp-empty" data-testid="empty-state">
+            <span className="exp-empty__mark" aria-hidden="true">
+              <Wallet size={28} />
+            </span>
+            <strong>Track your first expense</strong>
+            <span>
+              Add what you spent above to see your monthly total, category breakdown, and budget
+              progress build up over time.
+            </span>
+          </div>
+        ) : monthExpenses.length === 0 ? (
+          <div className="exp-empty" data-testid="empty-state">
+            <span className="exp-empty__mark" aria-hidden="true">
+              <Wallet size={28} />
+            </span>
+            <strong>Nothing in {monthLabel(selectedMonth)}</strong>
+            <span>Switch months or add a transaction for this period.</span>
+          </div>
+        ) : (
+          <ul className="exp-list">
+            {monthExpenses.map((expense) => (
+              <li className="exp-row" key={expense.id}>
+                <span
+                  className="exp-dot exp-dot--lg"
+                  style={{ background: colorForCategory(expense.category) }}
+                  aria-hidden="true"
+                />
+                <div className="exp-row__main">
+                  <strong>{expense.note || expense.category}</strong>
+                  <span className="exp-row__sub">
+                    {expense.category}
+                    {expense.recurring ? (
+                      <span className="exp-tag exp-tag--recur">
+                        <Repeat size={11} /> recurring
+                      </span>
+                    ) : null}
+                    {" · "}
+                    {new Date(expense.spent_at).toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                </div>
+                <span className="exp-row__amt">{formatMoney(expense.amount)}</span>
+                <div className="exp-row__actions">
+                  <button
+                    type="button"
+                    className="exp-icon-btn exp-icon-btn--sm"
+                    aria-label={`Edit ${expense.note || expense.category}`}
+                    onClick={() => startEdit(expense)}
+                  >
+                    <Pencil size={15} />
+                  </button>
+                  <button
+                    type="button"
+                    className="exp-icon-btn exp-icon-btn--sm exp-icon-btn--danger"
+                    aria-label={`Delete ${expense.note || expense.category}`}
+                    onClick={() => void deleteExpense(expense.id)}
+                  >
+                    <Trash2 size={15} />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {budgetEditor ? (
+        <div className="exp-overlay" role="dialog" aria-modal="true" aria-label="Edit budgets">
+          <div className="exp-overlay__panel">
+            <div className="exp-card__head">
+              <h2>Monthly budgets</h2>
+              <button
+                type="button"
+                className="exp-icon-btn exp-icon-btn--sm"
+                aria-label="Close budgets"
+                onClick={() => setBudgetEditor(false)}
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="exp-budget-list">
+              {knownCategories.map((category) => (
+                <label className="exp-budget-row" key={category}>
+                  <span className="exp-dot" style={{ background: colorForCategory(category) }} aria-hidden="true" />
+                  <span className="exp-budget-name">{category}</span>
+                  <input
+                    aria-label={`${category} monthly budget`}
+                    type="number"
+                    min="0"
+                    step="1"
+                    placeholder="No limit"
+                    value={budgetDraft[category] ?? ""}
+                    onChange={(e) =>
+                      setBudgetDraft((d) => ({ ...d, [category]: e.target.value }))
+                    }
+                  />
+                </label>
+              ))}
+            </div>
+            <button type="button" className="exp-primary exp-primary--block" onClick={() => void saveBudgets()}>
+              Save budgets
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -141,7 +141,7 @@ export default function App() {
     try {
       const [rawExpenses, rawBudgets] = await Promise.all([
         findAllRows(db, EXPENSES_TABLE, { orderBy: { spent_at: "desc" } }),
-        db.find(BUDGETS_TABLE, { limit: 200 }),
+        findAllRows(db, BUDGETS_TABLE),
       ]);
       setExpenses(
         rawExpenses
@@ -242,7 +242,6 @@ export default function App() {
         resetDraft();
         try {
           if (db) await db.update(EXPENSES_TABLE, editingId, payload);
-          await reload();
         } catch (err: unknown) {
           console.warn(
             "[expense-tracker] update failed:",
@@ -250,9 +249,11 @@ export default function App() {
           );
           setExpenses(previous);
           setError("Could not save that change.");
+          return;
         } finally {
           submittingRef.current = false;
         }
+        void reload();
         return;
       }
 
@@ -267,7 +268,6 @@ export default function App() {
       resetDraft();
       try {
         if (db) await db.insert(EXPENSES_TABLE, payload);
-        await reload();
       } catch (err: unknown) {
         console.warn(
           "[expense-tracker] insert failed:",
@@ -275,9 +275,11 @@ export default function App() {
         );
         setExpenses((current) => current.filter((e) => e.id !== optimistic.id));
         setError("Could not save that transaction.");
+        return;
       } finally {
         submittingRef.current = false;
       }
+      void reload();
     },
     [draft, editingId, expenses, reload, resetDraft],
   );
@@ -360,7 +362,6 @@ export default function App() {
     setBudgetEditor(false);
     try {
       await Promise.all(operations);
-      await reload();
     } catch (err: unknown) {
       console.warn(
         "[expense-tracker] budget save failed:",
@@ -369,7 +370,9 @@ export default function App() {
       setBudgets(previous);
       setBudgetEditor(true);
       setError("Could not save your budgets.");
+      return;
     }
+    void reload();
   }, [budgetDraft, budgets, reload]);
 
   const isEmpty = loadState === "ready" && expenses.length === 0 && budgets.length === 0;

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -192,6 +192,15 @@ export default function App() {
     };
   }, [reload]);
 
+  useEffect(() => {
+    if (!budgetEditor) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setBudgetEditor(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [budgetEditor]);
+
   const summary = useMemo(
     () => summarizeMonth(expenses, budgets, selectedMonth),
     [expenses, budgets, selectedMonth],
@@ -270,6 +279,7 @@ export default function App() {
       };
       setExpenses((current) => [optimistic, ...current]);
       // Keep the month in view so the new row is visible.
+      const previousMonth = selectedMonth;
       setSelectedMonth(monthKey(payload.spent_at));
       resetDraft();
       try {
@@ -280,6 +290,7 @@ export default function App() {
           err instanceof Error ? err.message : String(err),
         );
         setExpenses((current) => current.filter((e) => e.id !== optimistic.id));
+        setSelectedMonth(previousMonth);
         setError("Could not save that transaction.");
         return;
       } finally {
@@ -287,7 +298,7 @@ export default function App() {
       }
       void reload();
     },
-    [draft, editingId, expenses, reload, resetDraft],
+    [draft, editingId, expenses, reload, resetDraft, selectedMonth],
   );
 
   const startEdit = useCallback((expense: ExpenseRow) => {
@@ -681,8 +692,14 @@ export default function App() {
       </section>
 
       {budgetEditor ? (
-        <div className="exp-overlay" role="dialog" aria-modal="true" aria-label="Edit budgets">
-          <div className="exp-overlay__panel">
+        <div
+          className="exp-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Edit budgets"
+          onClick={() => setBudgetEditor(false)}
+        >
+          <div className="exp-overlay__panel" onClick={(event) => event.stopPropagation()}>
             <div className="exp-card__head">
               <h2>Monthly budgets</h2>
               <button

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -350,12 +350,17 @@ export default function App() {
         if (existing && db) operations.push(db.delete(BUDGETS_TABLE, existing.id));
         continue;
       }
-      next.push({ id: existing?.id ?? `local-${category}`, category, monthly_limit: limit });
+      const localId = existing?.id ?? `local-${category}`;
+      next.push({ id: localId, category, monthly_limit: limit });
       if (db) {
         operations.push(
           existing
             ? db.update(BUDGETS_TABLE, existing.id, { monthly_limit: limit })
-            : db.insert(BUDGETS_TABLE, { category, monthly_limit: limit }),
+            : db.insert(BUDGETS_TABLE, { category, monthly_limit: limit }).then(({ id }) => {
+                setBudgets((current) =>
+                  current.map((budget) => (budget.id === localId ? { ...budget, id } : budget)),
+                );
+              }),
         );
       }
     }

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -577,7 +577,7 @@ export default function App() {
                 aria-label="Amount"
                 inputMode="decimal"
                 type="number"
-                min="0"
+                min="0.01"
                 step="0.01"
                 placeholder="0.00"
                 value={draft.amount}

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -111,7 +111,7 @@ interface DraftExpense {
 type BudgetOperationResult =
   | { type: "insert"; budget: BudgetRow }
   | { type: "delete"; id: string }
-  | { type: "update" };
+  | { type: "update"; budget: BudgetRow };
 
 function emptyDraft(): DraftExpense {
   return {
@@ -405,7 +405,9 @@ export default function App() {
       if (db) {
         operations.push(
           existing
-            ? db.update(BUDGETS_TABLE, existing.id, { monthly_limit: limit }).then(() => ({ type: "update" }))
+            ? db
+                .update(BUDGETS_TABLE, existing.id, { monthly_limit: limit })
+                .then(() => ({ type: "update", budget: { ...existing, monthly_limit: limit } }))
             : db
                 .insert(BUDGETS_TABLE, { category, monthly_limit: limit })
                 .then(({ id }) => ({ type: "insert", budget: { id, category, monthly_limit: limit } })),
@@ -430,12 +432,21 @@ export default function App() {
         )
         .map((result) => (result.value as { type: "delete"; id: string }).id),
     );
+    const updatedBudgets = results
+      .filter(
+        (result): result is PromiseFulfilledResult<BudgetOperationResult> =>
+          result.status === "fulfilled" && result.value.type === "update",
+      )
+      .map((result) => (result.value as { type: "update"; budget: BudgetRow }).budget);
     if (failed) {
       console.warn(
         "[expense-tracker] budget save failed:",
         failed.reason instanceof Error ? failed.reason.message : String(failed.reason),
       );
-      const rollbackBase = previous.filter((budget) => !deletedBudgetIds.has(budget.id));
+      const updatedById = new Map(updatedBudgets.map((budget) => [budget.id, budget]));
+      const rollbackBase = previous
+        .filter((budget) => !deletedBudgetIds.has(budget.id))
+        .map((budget) => updatedById.get(budget.id) ?? budget);
       setBudgets(
         insertedBudgets.length > 0
           ? dedupeBudgets([...rollbackBase, ...insertedBudgets])
@@ -451,6 +462,7 @@ export default function App() {
         current.map((budget) => insertedBudgets.find((inserted) => inserted.category === budget.category) ?? budget),
       );
     }
+    budgetDuplicatesRef.current = new Map();
     void reload();
   }, [budgetDraft, budgets, refreshBudgets, reload]);
 

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -192,6 +192,8 @@ export default function App() {
     () => summarizeMonth(expenses, budgets, selectedMonth),
     [expenses, budgets, selectedMonth],
   );
+  const hasBudget = summary.totalBudget > 0;
+  const isOverBudget = hasBudget && summary.remaining < 0;
 
   const monthExpenses = useMemo(
     () =>
@@ -436,13 +438,15 @@ export default function App() {
         </article>
         <article
           className={
-            summary.remaining < 0 ? "exp-kpi exp-kpi--over" : "exp-kpi exp-kpi--remaining"
+            isOverBudget ? "exp-kpi exp-kpi--over" : "exp-kpi exp-kpi--remaining"
           }
         >
           <span className="exp-kpi__label">
-            <PiggyBank size={15} /> {summary.remaining < 0 ? "Over budget" : "Remaining budget"}
+            <PiggyBank size={15} /> {isOverBudget ? "Over budget" : hasBudget ? "Remaining budget" : "Budget not set"}
           </span>
-          <strong data-testid="kpi-remaining">{formatMoney(Math.abs(summary.remaining), currency)}</strong>
+          <strong data-testid="kpi-remaining">
+            {formatMoney(hasBudget ? Math.abs(summary.remaining) : 0, currency)}
+          </strong>
           <em>{summary.totalBudget > 0 ? `of ${formatMoney(summary.totalBudget, currency)}` : "No budgets set"}</em>
         </article>
         <article className="exp-kpi exp-kpi--top">

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -108,6 +108,10 @@ interface DraftExpense {
   recurring: boolean;
 }
 
+type BudgetOperationResult =
+  | { type: "insert"; budget: BudgetRow }
+  | { type: "update" | "delete" };
+
 function emptyDraft(): DraftExpense {
   return {
     amount: "",
@@ -340,16 +344,16 @@ export default function App() {
       existingByCategory.set(budget.category, rows);
     }
     const next: BudgetRow[] = [];
-    const operations: Array<Promise<unknown>> = [];
+    const operations: Array<Promise<BudgetOperationResult>> = [];
     for (const [category, value] of Object.entries(budgetDraft)) {
       const limit = Number(value);
       const existingRows = existingByCategory.get(category) ?? [];
       const existing = existingRows[0];
       for (const duplicate of existingRows.slice(1)) {
-        if (db) operations.push(db.delete(BUDGETS_TABLE, duplicate.id));
+        if (db) operations.push(db.delete(BUDGETS_TABLE, duplicate.id).then(() => ({ type: "delete" })));
       }
       if (!value || !Number.isFinite(limit) || limit <= 0) {
-        if (existing && db) operations.push(db.delete(BUDGETS_TABLE, existing.id));
+        if (existing && db) operations.push(db.delete(BUDGETS_TABLE, existing.id).then(() => ({ type: "delete" })));
         continue;
       }
       const localId = existing?.id ?? `local-${category}`;
@@ -357,28 +361,37 @@ export default function App() {
       if (db) {
         operations.push(
           existing
-            ? db.update(BUDGETS_TABLE, existing.id, { monthly_limit: limit })
-            : db.insert(BUDGETS_TABLE, { category, monthly_limit: limit }).then(({ id }) => {
-                setBudgets((current) =>
-                  current.map((budget) => (budget.id === localId ? { ...budget, id } : budget)),
-                );
-              }),
+            ? db.update(BUDGETS_TABLE, existing.id, { monthly_limit: limit }).then(() => ({ type: "update" }))
+            : db
+                .insert(BUDGETS_TABLE, { category, monthly_limit: limit })
+                .then(({ id }) => ({ type: "insert", budget: { id, category, monthly_limit: limit } })),
         );
       }
     }
     setBudgets(next);
     setBudgetEditor(false);
-    try {
-      await Promise.all(operations);
-    } catch (err: unknown) {
+    const results = await Promise.allSettled(operations);
+    const failed = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+    const insertedBudgets = results
+      .filter(
+        (result): result is PromiseFulfilledResult<BudgetOperationResult> =>
+          result.status === "fulfilled" && result.value.type === "insert",
+      )
+      .map((result) => (result.value as { type: "insert"; budget: BudgetRow }).budget);
+    if (failed) {
       console.warn(
         "[expense-tracker] budget save failed:",
-        err instanceof Error ? err.message : String(err),
+        failed.reason instanceof Error ? failed.reason.message : String(failed.reason),
       );
-      setBudgets(previous);
+      setBudgets(insertedBudgets.length > 0 ? dedupeBudgets([...previous, ...insertedBudgets]) : previous);
       setBudgetEditor(true);
       setError("Could not save your budgets.");
       return;
+    }
+    if (insertedBudgets.length > 0) {
+      setBudgets((current) =>
+        current.map((budget) => insertedBudgets.find((inserted) => inserted.category === budget.category) ?? budget),
+      );
     }
     void reload();
   }, [budgetDraft, budgets, reload]);

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -17,6 +17,8 @@ import {
   budgetStatus,
   coerceBudget,
   coerceExpense,
+  currencyForLocale,
+  dedupeBudgets,
   formatMoney,
   monthKey,
   monthLabel,
@@ -73,7 +75,7 @@ function todayInputValue(): string {
 
 function dateInputToIso(value: string): string {
   if (!value) return new Date().toISOString();
-  const parsed = new Date(`${value}T12:00:00.000Z`);
+  const parsed = new Date(`${value}T00:00:00.000Z`);
   return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
 }
 
@@ -111,6 +113,8 @@ export default function App() {
   const [budgetEditor, setBudgetEditor] = useState(false);
   const [budgetDraft, setBudgetDraft] = useState<Record<string, string>>({});
   const submittingRef = useRef(false);
+  const budgetDuplicatesRef = useRef<Map<string, BudgetRow[]>>(new Map());
+  const currency = useMemo(() => currencyForLocale(navigator.language), []);
 
   const reload = useCallback(async () => {
     const db = window.MatrixOS?.db;
@@ -128,11 +132,22 @@ export default function App() {
           .map(coerceExpense)
           .filter((row): row is ExpenseRow => row !== null),
       );
-      setBudgets(
-        rawBudgets
-          .map(coerceBudget)
-          .filter((row): row is BudgetRow => row !== null),
-      );
+      const coercedBudgets = rawBudgets
+        .map(coerceBudget)
+        .filter((row): row is BudgetRow => row !== null);
+      const duplicates = new Map<string, BudgetRow[]>();
+      const seen = new Set<string>();
+      for (const budget of coercedBudgets) {
+        if (!seen.has(budget.category)) {
+          seen.add(budget.category);
+          continue;
+        }
+        const rows = duplicates.get(budget.category) ?? [];
+        rows.push(budget);
+        duplicates.set(budget.category, rows);
+      }
+      budgetDuplicatesRef.current = duplicates;
+      setBudgets(dedupeBudgets(coercedBudgets));
       setError(null);
       setLoadState("ready");
     } catch (err: unknown) {
@@ -295,11 +310,23 @@ export default function App() {
 
   const saveBudgets = useCallback(async () => {
     const db = window.MatrixOS?.db;
+    const previous = budgets;
+    const existingByCategory = new Map<string, BudgetRow[]>();
+    for (const budget of budgets) {
+      const rows = existingByCategory.get(budget.category) ?? [];
+      rows.push(budget);
+      rows.push(...(budgetDuplicatesRef.current.get(budget.category) ?? []));
+      existingByCategory.set(budget.category, rows);
+    }
     const next: BudgetRow[] = [];
     const operations: Array<Promise<unknown>> = [];
     for (const [category, value] of Object.entries(budgetDraft)) {
       const limit = Number(value);
-      const existing = budgets.find((b) => b.category === category);
+      const existingRows = existingByCategory.get(category) ?? [];
+      const existing = existingRows[0];
+      for (const duplicate of existingRows.slice(1)) {
+        if (db) operations.push(db.delete(BUDGETS_TABLE, duplicate.id));
+      }
       if (!value || !Number.isFinite(limit) || limit <= 0) {
         if (existing && db) operations.push(db.delete(BUDGETS_TABLE, existing.id));
         continue;
@@ -323,6 +350,8 @@ export default function App() {
         "[expense-tracker] budget save failed:",
         err instanceof Error ? err.message : String(err),
       );
+      setBudgets(previous);
+      setBudgetEditor(true);
       setError("Could not save your budgets.");
     }
   }, [budgetDraft, budgets, reload]);
@@ -377,7 +406,7 @@ export default function App() {
           <span className="exp-kpi__label">
             <TrendingDown size={15} /> Spent this month
           </span>
-          <strong data-testid="kpi-total">{formatMoney(summary.totalSpent)}</strong>
+          <strong data-testid="kpi-total">{formatMoney(summary.totalSpent, currency)}</strong>
           <em>{summary.transactionCount} transactions</em>
         </article>
         <article
@@ -388,15 +417,15 @@ export default function App() {
           <span className="exp-kpi__label">
             <PiggyBank size={15} /> {summary.remaining < 0 ? "Over budget" : "Remaining budget"}
           </span>
-          <strong data-testid="kpi-remaining">{formatMoney(Math.abs(summary.remaining))}</strong>
-          <em>{summary.totalBudget > 0 ? `of ${formatMoney(summary.totalBudget)}` : "No budgets set"}</em>
+          <strong data-testid="kpi-remaining">{formatMoney(Math.abs(summary.remaining), currency)}</strong>
+          <em>{summary.totalBudget > 0 ? `of ${formatMoney(summary.totalBudget, currency)}` : "No budgets set"}</em>
         </article>
         <article className="exp-kpi exp-kpi--top">
           <span className="exp-kpi__label">
             <ArrowDownUp size={15} /> Biggest category
           </span>
           <strong data-testid="kpi-biggest">{summary.biggestCategory?.category ?? "—"}</strong>
-          <em>{summary.biggestCategory ? formatMoney(summary.biggestCategory.total) : "Nothing yet"}</em>
+          <em>{summary.biggestCategory ? formatMoney(summary.biggestCategory.total, currency) : "Nothing yet"}</em>
         </article>
       </section>
 
@@ -435,7 +464,7 @@ export default function App() {
                         {row.category}
                         {status.over ? <span className="exp-tag exp-tag--over">over</span> : null}
                       </span>
-                      <span className="exp-bar__amt">{formatMoney(row.total)}</span>
+                      <span className="exp-bar__amt">{formatMoney(row.total, currency)}</span>
                     </div>
                     <div className="exp-bar__track">
                       <div
@@ -446,10 +475,10 @@ export default function App() {
                     <div className="exp-bar__meta">
                       {status.hasBudget ? (
                         <span className={status.over ? "exp-over" : ""}>
-                          {formatMoney(row.total)} of {formatMoney(status.limit)} budget
+                          {formatMoney(row.total, currency)} of {formatMoney(status.limit, currency)} budget
                           {status.over
-                            ? ` · ${formatMoney(Math.abs(status.remaining))} over`
-                            : ` · ${formatMoney(status.remaining)} left`}
+                            ? ` · ${formatMoney(Math.abs(status.remaining), currency)} over`
+                            : ` · ${formatMoney(status.remaining, currency)} left`}
                         </span>
                       ) : (
                         <span>{Math.round(row.pct)}% of spend · no budget</span>
@@ -580,10 +609,11 @@ export default function App() {
                     {new Date(expense.spent_at).toLocaleDateString(undefined, {
                       month: "short",
                       day: "numeric",
+                      timeZone: "UTC",
                     })}
                   </span>
                 </div>
-                <span className="exp-row__amt">{formatMoney(expense.amount)}</span>
+                <span className="exp-row__amt">{formatMoney(expense.amount, currency)}</span>
                 <div className="exp-row__actions">
                   <button
                     type="button"

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -31,6 +31,7 @@ import "./styles.css";
 
 const EXPENSES_TABLE = "expenses";
 const BUDGETS_TABLE = "budgets";
+const READ_PAGE_SIZE = 500;
 
 const DEFAULT_CATEGORIES = [
   "Groceries",
@@ -70,7 +71,22 @@ function colorForCategory(category: string): string {
 type LoadState = "loading" | "ready" | "error";
 
 function todayInputValue(): string {
-  return new Date().toISOString().slice(0, 10);
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+async function findAllRows(
+  db: NonNullable<NonNullable<Window["MatrixOS"]>["db"]>,
+  table: string,
+  opts: { orderBy?: Record<string, "asc" | "desc">; limit?: number } = {},
+): Promise<Record<string, unknown>[]> {
+  const pageSize = opts.limit ?? READ_PAGE_SIZE;
+  const rows: Record<string, unknown>[] = [];
+  for (let offset = 0; ; offset += pageSize) {
+    const page = await db.find(table, { orderBy: opts.orderBy, limit: pageSize, offset });
+    rows.push(...page);
+    if (page.length < pageSize) return rows;
+  }
 }
 
 function dateInputToIso(value: string): string {
@@ -124,7 +140,7 @@ export default function App() {
     }
     try {
       const [rawExpenses, rawBudgets] = await Promise.all([
-        db.find(EXPENSES_TABLE, { orderBy: { spent_at: "desc" }, limit: 1000 }),
+        findAllRows(db, EXPENSES_TABLE, { orderBy: { spent_at: "desc" } }),
         db.find(BUDGETS_TABLE, { limit: 200 }),
       ]);
       setExpenses(

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -286,7 +286,6 @@ export default function App() {
           current.map((e) => (e.id === editingId ? { ...e, ...payload } : e)),
         );
         setSelectedMonth(monthKey(payload.spent_at));
-        resetDraft();
         try {
           if (db) await db.update(EXPENSES_TABLE, editingId, payload);
         } catch (err: unknown) {
@@ -301,6 +300,7 @@ export default function App() {
         } finally {
           submittingRef.current = false;
         }
+        resetDraft();
         void reload();
         return;
       }

--- a/home/apps/expense-tracker/src/App.tsx
+++ b/home/apps/expense-tracker/src/App.tsx
@@ -303,7 +303,6 @@ export default function App() {
       const db = window.MatrixOS?.db;
       try {
         if (db) await db.delete(EXPENSES_TABLE, id);
-        await reload();
       } catch (err: unknown) {
         console.warn(
           "[expense-tracker] delete failed:",
@@ -311,7 +310,9 @@ export default function App() {
         );
         setExpenses(previous);
         setError("Could not delete that transaction.");
+        return;
       }
+      void reload();
     },
     [editingId, expenses, reload, resetDraft],
   );

--- a/home/apps/expense-tracker/src/expense-model.ts
+++ b/home/apps/expense-tracker/src/expense-model.ts
@@ -244,8 +244,12 @@ const EURO_LOCALES = new Set([
 ]);
 
 export function currencyForLocale(locale: string | undefined): CurrencyCode {
-  const region = locale?.split("-").at(-1)?.toUpperCase();
-  if (!region || region.length !== 2) return "USD";
+  const region = locale
+    ?.split("-")
+    .slice(1)
+    .find((part) => /^[A-Za-z]{2}$/.test(part))
+    ?.toUpperCase();
+  if (!region) return "USD";
   if (EURO_LOCALES.has(region)) return "EUR";
   if (region === "AU") return "AUD";
   if (region === "CA") return "CAD";

--- a/home/apps/expense-tracker/src/expense-model.ts
+++ b/home/apps/expense-tracker/src/expense-model.ts
@@ -1,0 +1,212 @@
+// Pure, UI-free spend-management logic for the Expense Tracker.
+// Everything here is deterministic and unit-tested.
+
+export interface ExpenseRow {
+  id: string;
+  amount: number;
+  category: string;
+  note: string;
+  spent_at: string; // ISO timestamp
+  recurring: boolean;
+  created_at?: string;
+}
+
+export interface BudgetRow {
+  id: string;
+  category: string;
+  monthly_limit: number;
+}
+
+export interface CategoryTotal {
+  category: string;
+  total: number;
+  pct: number; // share of the month's total spend, 0..100
+  count: number;
+}
+
+export interface BudgetStatus {
+  category: string;
+  limit: number;
+  spent: number;
+  remaining: number; // limit - spent (can be negative)
+  pct: number; // spent/limit clamped to 0..100 (for bar fill)
+  over: boolean;
+  hasBudget: boolean;
+}
+
+export interface MonthSummary {
+  monthKey: string;
+  totalSpent: number;
+  totalBudget: number;
+  remaining: number; // totalBudget - totalSpent
+  biggestCategory: CategoryTotal | null;
+  breakdown: CategoryTotal[];
+  overBudget: BudgetStatus[];
+  budgetStatuses: BudgetStatus[];
+  transactionCount: number;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function round2(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+/** Returns "YYYY-MM" for an ISO string or Date. */
+export function monthKey(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    const now = new Date();
+    return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  }
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+/** Shifts a "YYYY-MM" key by a number of months (can be negative). */
+export function shiftMonth(key: string, delta: number): string {
+  const [yearStr, monthStr] = key.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return key;
+  // month is 1-based; convert to a 0-based absolute index
+  const absolute = year * 12 + (month - 1) + delta;
+  const newYear = Math.floor(absolute / 12);
+  const newMonth = (absolute % 12 + 12) % 12; // always 0..11
+  return `${newYear}-${String(newMonth + 1).padStart(2, "0")}`;
+}
+
+/** Human-readable label such as "May 2026". */
+export function monthLabel(key: string): string {
+  const [yearStr, monthStr] = key.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return key;
+  const date = new Date(Date.UTC(year, month - 1, 1));
+  return date.toLocaleDateString(undefined, { month: "long", year: "numeric", timeZone: "UTC" });
+}
+
+export function isInMonth(expense: ExpenseRow, key: string): boolean {
+  return monthKey(expense.spent_at) === key;
+}
+
+export function coerceExpense(row: unknown): ExpenseRow | null {
+  if (!row || typeof row !== "object") return null;
+  const data = row as Record<string, unknown>;
+  const amount = toFiniteNumber(data.amount);
+  if (amount === null) return null;
+  const spentAt =
+    typeof data.spent_at === "string" && data.spent_at.trim() !== ""
+      ? data.spent_at
+      : typeof data.created_at === "string"
+        ? data.created_at
+        : new Date().toISOString();
+  return {
+    id: typeof data.id === "string" ? data.id : crypto.randomUUID(),
+    amount: round2(amount),
+    category: typeof data.category === "string" && data.category.trim() !== "" ? data.category : "Uncategorized",
+    note: typeof data.note === "string" ? data.note : "",
+    spent_at: spentAt,
+    recurring: data.recurring === true,
+    created_at: typeof data.created_at === "string" ? data.created_at : undefined,
+  };
+}
+
+export function coerceBudget(row: unknown): BudgetRow | null {
+  if (!row || typeof row !== "object") return null;
+  const data = row as Record<string, unknown>;
+  const limit = toFiniteNumber(data.monthly_limit);
+  if (limit === null || limit <= 0) return null;
+  if (typeof data.category !== "string" || data.category.trim() === "") return null;
+  return {
+    id: typeof data.id === "string" ? data.id : crypto.randomUUID(),
+    category: data.category,
+    monthly_limit: round2(limit),
+  };
+}
+
+export function monthlyTotal(expenses: ExpenseRow[]): number {
+  return round2(expenses.reduce((sum, e) => sum + e.amount, 0));
+}
+
+export function categoryBreakdown(expenses: ExpenseRow[]): CategoryTotal[] {
+  if (expenses.length === 0) return [];
+  const totals = new Map<string, { total: number; count: number }>();
+  for (const e of expenses) {
+    const entry = totals.get(e.category) ?? { total: 0, count: 0 };
+    entry.total += e.amount;
+    entry.count += 1;
+    totals.set(e.category, entry);
+  }
+  const grand = monthlyTotal(expenses);
+  return Array.from(totals.entries())
+    .map(([category, { total, count }]) => ({
+      category,
+      total: round2(total),
+      count,
+      pct: grand > 0 ? (total / grand) * 100 : 0,
+    }))
+    .sort((a, b) => b.total - a.total || a.category.localeCompare(b.category));
+}
+
+export function budgetStatus(category: string, spent: number, budgets: BudgetRow[]): BudgetStatus {
+  const budget = budgets.find((b) => b.category === category);
+  const limit = budget ? budget.monthly_limit : 0;
+  const hasBudget = Boolean(budget);
+  const remaining = round2(limit - spent);
+  const over = hasBudget && spent > limit;
+  const pct = limit > 0 ? Math.min(100, Math.max(0, (spent / limit) * 100)) : 0;
+  return {
+    category,
+    limit,
+    spent: round2(spent),
+    remaining,
+    pct,
+    over,
+    hasBudget,
+  };
+}
+
+export function summarizeMonth(allExpenses: ExpenseRow[], budgets: BudgetRow[], key: string): MonthSummary {
+  const monthExpenses = allExpenses.filter((e) => isInMonth(e, key));
+  const breakdown = categoryBreakdown(monthExpenses);
+  const totalSpent = monthlyTotal(monthExpenses);
+  const totalBudget = round2(budgets.reduce((sum, b) => sum + b.monthly_limit, 0));
+
+  // Union of categories that have either spend or a budget this month.
+  const spendByCategory = new Map<string, number>();
+  for (const item of breakdown) spendByCategory.set(item.category, item.total);
+  const categories = new Set<string>([...spendByCategory.keys(), ...budgets.map((b) => b.category)]);
+  const budgetStatuses = Array.from(categories)
+    .map((category) => budgetStatus(category, spendByCategory.get(category) ?? 0, budgets))
+    .sort((a, b) => b.spent - a.spent || a.category.localeCompare(b.category));
+
+  return {
+    monthKey: key,
+    totalSpent,
+    totalBudget,
+    remaining: round2(totalBudget - totalSpent),
+    biggestCategory: breakdown[0] ?? null,
+    breakdown,
+    overBudget: budgetStatuses.filter((s) => s.over),
+    budgetStatuses,
+    transactionCount: monthExpenses.length,
+  };
+}
+
+const MONEY_FORMAT = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export function formatMoney(value: number): string {
+  return MONEY_FORMAT.format(Number.isFinite(value) ? value : 0);
+}

--- a/home/apps/expense-tracker/src/expense-model.ts
+++ b/home/apps/expense-tracker/src/expense-model.ts
@@ -17,6 +17,8 @@ export interface BudgetRow {
   monthly_limit: number;
 }
 
+export type CurrencyCode = "AUD" | "CAD" | "CHF" | "DKK" | "EUR" | "GBP" | "JPY" | "NOK" | "SEK" | "USD";
+
 export interface CategoryTotal {
   category: string;
   total: number;
@@ -104,14 +106,22 @@ export function coerceExpense(row: unknown): ExpenseRow | null {
   const spentAt =
     typeof data.spent_at === "string" && data.spent_at.trim() !== ""
       ? data.spent_at
+      : typeof data.date === "string" && data.date.trim() !== ""
+        ? data.date
       : typeof data.created_at === "string"
         ? data.created_at
         : new Date().toISOString();
+  const note =
+    typeof data.note === "string"
+      ? data.note
+      : typeof data.description === "string"
+        ? data.description
+        : "";
   return {
     id: typeof data.id === "string" ? data.id : crypto.randomUUID(),
     amount: round2(amount),
     category: typeof data.category === "string" && data.category.trim() !== "" ? data.category : "Uncategorized",
-    note: typeof data.note === "string" ? data.note : "",
+    note,
     spent_at: spentAt,
     recurring: data.recurring === true,
     created_at: typeof data.created_at === "string" ? data.created_at : undefined,
@@ -129,6 +139,16 @@ export function coerceBudget(row: unknown): BudgetRow | null {
     category: data.category,
     monthly_limit: round2(limit),
   };
+}
+
+export function dedupeBudgets(budgets: BudgetRow[]): BudgetRow[] {
+  const byCategory = new Map<string, BudgetRow>();
+  for (const budget of budgets) {
+    if (!byCategory.has(budget.category)) {
+      byCategory.set(budget.category, budget);
+    }
+  }
+  return Array.from(byCategory.values());
 }
 
 export function monthlyTotal(expenses: ExpenseRow[]): number {
@@ -200,13 +220,49 @@ export function summarizeMonth(allExpenses: ExpenseRow[], budgets: BudgetRow[], 
   };
 }
 
-const MONEY_FORMAT = new Intl.NumberFormat(undefined, {
-  style: "currency",
-  currency: "USD",
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+const EURO_LOCALES = new Set([
+  "AT",
+  "BE",
+  "CY",
+  "DE",
+  "EE",
+  "ES",
+  "FI",
+  "FR",
+  "GR",
+  "HR",
+  "IE",
+  "IT",
+  "LT",
+  "LU",
+  "LV",
+  "MT",
+  "NL",
+  "PT",
+  "SI",
+  "SK",
+]);
 
-export function formatMoney(value: number): string {
-  return MONEY_FORMAT.format(Number.isFinite(value) ? value : 0);
+export function currencyForLocale(locale: string | undefined): CurrencyCode {
+  const region = locale?.split("-").at(-1)?.toUpperCase();
+  if (!region || region.length !== 2) return "USD";
+  if (EURO_LOCALES.has(region)) return "EUR";
+  if (region === "AU") return "AUD";
+  if (region === "CA") return "CAD";
+  if (region === "CH") return "CHF";
+  if (region === "DK") return "DKK";
+  if (region === "GB") return "GBP";
+  if (region === "JP") return "JPY";
+  if (region === "NO") return "NOK";
+  if (region === "SE") return "SEK";
+  return "USD";
+}
+
+export function formatMoney(value: number, currency: CurrencyCode = "USD"): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number.isFinite(value) ? value : 0);
 }

--- a/home/apps/expense-tracker/src/main.tsx
+++ b/home/apps/expense-tracker/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("expense-tracker" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/expense-tracker/src/matrix-os.d.ts
+++ b/home/apps/expense-tracker/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/expense-tracker/src/matrix-os.d.ts
+++ b/home/apps/expense-tracker/src/matrix-os.d.ts
@@ -10,7 +10,7 @@ interface MatrixOSDb {
   update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
   delete(table: string, id: string): Promise<{ ok: boolean }>;
   count(table: string, filter?: Record<string, unknown>): Promise<number>;
-  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+  onChange(table: string, callback: (e: { table: string }) => void): (() => void) | undefined;
 }
 interface MatrixOS {
   db?: MatrixOSDb;

--- a/home/apps/expense-tracker/src/styles.css
+++ b/home/apps/expense-tracker/src/styles.css
@@ -1,0 +1,590 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+  --app-mono: var(--matrix-font-mono, "JetBrains Mono", monospace);
+
+  --elev: 0 4px 12px rgba(50, 53, 46, 0.08);
+  --elev-lg: 0 18px 48px rgba(50, 53, 46, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  background: var(--app-bg);
+  color: var(--app-fg);
+  font-family: var(--app-font);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+button:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+.exp-app {
+  height: 100vh;
+  overflow-y: auto;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+/* ---- Header ---- */
+.exp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.exp-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.exp-brand__mark {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--app-accent) 18%, var(--app-card));
+  color: var(--app-accent);
+  box-shadow: var(--elev);
+}
+
+.exp-eyebrow {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--app-muted-fg);
+}
+
+.exp-header h1 {
+  margin: 0;
+  font-size: 26px;
+  line-height: 1.1;
+}
+
+.exp-month-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--app-card);
+  border-radius: 999px;
+  padding: 6px 8px;
+  box-shadow: var(--elev);
+}
+
+.exp-month-label {
+  min-width: 132px;
+  text-align: center;
+  font-weight: 650;
+  font-size: 14px;
+}
+
+/* ---- Buttons ---- */
+.exp-icon-btn {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--app-fg);
+  transition: all 0.15s ease;
+}
+
+.exp-icon-btn:hover {
+  background: color-mix(in srgb, var(--app-fg) 6%, transparent);
+}
+
+.exp-icon-btn--sm {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+}
+
+.exp-icon-btn--danger:hover {
+  background: color-mix(in srgb, var(--app-danger) 14%, transparent);
+  color: var(--app-danger);
+}
+
+.exp-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 0;
+  border-radius: 13px;
+  padding: 11px 16px;
+  font-weight: 650;
+  background: var(--app-accent);
+  color: #fff;
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--app-accent) 30%, transparent);
+  transition: all 0.15s ease;
+}
+
+.exp-primary:hover {
+  transform: translateY(-1px);
+}
+
+.exp-primary--block {
+  width: 100%;
+  margin-top: 8px;
+}
+
+.exp-text-btn {
+  border: 0;
+  background: transparent;
+  color: var(--app-accent);
+  font-weight: 650;
+  font-size: 13px;
+  padding: 4px 6px;
+  border-radius: 8px;
+  transition: all 0.15s ease;
+}
+
+.exp-text-btn:hover {
+  background: color-mix(in srgb, var(--app-accent) 12%, transparent);
+}
+
+/* ---- Banners ---- */
+.exp-banner,
+.exp-warning {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: 14px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.exp-banner {
+  background: color-mix(in srgb, var(--app-warning) 18%, var(--app-card));
+  color: color-mix(in srgb, var(--app-warning) 60%, var(--app-fg));
+}
+
+.exp-warning {
+  background: color-mix(in srgb, var(--app-danger) 14%, var(--app-card));
+  color: color-mix(in srgb, var(--app-danger) 55%, var(--app-fg));
+}
+
+/* ---- KPIs ---- */
+.exp-kpis {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.exp-kpi {
+  background: var(--app-card);
+  border-radius: 18px;
+  padding: 16px 18px;
+  box-shadow: var(--elev);
+  display: grid;
+  gap: 6px;
+  align-content: start;
+}
+
+.exp-kpi__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--app-muted-fg);
+}
+
+.exp-kpi strong {
+  font-size: 26px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.05;
+}
+
+.exp-kpi em {
+  font-style: normal;
+  font-size: 12px;
+  color: var(--app-muted-fg);
+}
+
+.exp-kpi--over strong {
+  color: var(--app-danger);
+}
+
+.exp-kpi--remaining strong {
+  color: var(--app-success);
+}
+
+/* ---- Layout grid ---- */
+.exp-grid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 14px;
+  align-items: start;
+}
+
+.exp-card {
+  background: var(--app-card);
+  border-radius: var(--app-radius);
+  padding: 18px 20px;
+  box-shadow: var(--elev);
+}
+
+.exp-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.exp-card__head h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.exp-card__hint {
+  margin: 0;
+  color: var(--app-muted-fg);
+  font-size: 13px;
+}
+
+/* ---- Category breakdown ---- */
+.exp-bars {
+  display: grid;
+  gap: 14px;
+}
+
+.exp-bar__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.exp-bar__name {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.exp-bar__amt {
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+}
+
+.exp-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.exp-dot--lg {
+  width: 12px;
+  height: 12px;
+}
+
+.exp-bar__track {
+  height: 9px;
+  border-radius: 999px;
+  background: var(--app-muted);
+  overflow: hidden;
+}
+
+.exp-bar__fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.35s ease;
+}
+
+.exp-bar__meta {
+  margin-top: 5px;
+  font-size: 12px;
+  color: var(--app-muted-fg);
+}
+
+.exp-over,
+.exp-bar__meta .exp-over {
+  color: var(--app-danger);
+  font-weight: 600;
+}
+
+.exp-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 999px;
+}
+
+.exp-tag--over {
+  background: color-mix(in srgb, var(--app-danger) 16%, transparent);
+  color: var(--app-danger);
+}
+
+.exp-tag--recur {
+  background: color-mix(in srgb, var(--app-accent) 14%, transparent);
+  color: var(--app-accent);
+}
+
+/* ---- Compose form ---- */
+.exp-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.exp-field {
+  display: grid;
+  gap: 5px;
+}
+
+.exp-field--wide {
+  grid-column: 1 / -1;
+}
+
+.exp-field > span {
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--app-muted-fg);
+}
+
+.exp-field input {
+  border: 1px solid var(--app-border);
+  border-radius: 11px;
+  padding: 10px 12px;
+  background: var(--app-bg);
+  color: var(--app-fg);
+  font: inherit;
+  transition: all 0.15s ease;
+}
+
+.exp-field input:focus {
+  border-color: var(--app-accent);
+}
+
+.exp-check {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--app-muted-fg);
+}
+
+.exp-check input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--app-accent);
+}
+
+.exp-form .exp-primary {
+  grid-column: 1 / -1;
+}
+
+/* ---- Transactions ---- */
+.exp-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.exp-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  transition: background 0.15s ease;
+}
+
+.exp-row:hover {
+  background: color-mix(in srgb, var(--app-fg) 4%, transparent);
+}
+
+.exp-row__main {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.exp-row__main strong {
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.exp-row__sub {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--app-muted-fg);
+}
+
+.exp-row__amt {
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.exp-row__actions {
+  display: inline-flex;
+  gap: 2px;
+  opacity: 0.55;
+  transition: opacity 0.15s ease;
+}
+
+.exp-row:hover .exp-row__actions {
+  opacity: 1;
+}
+
+/* ---- Empty state ---- */
+.exp-empty {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 8px;
+  padding: 36px 24px;
+  color: var(--app-muted-fg);
+}
+
+.exp-empty__mark {
+  width: 60px;
+  height: 60px;
+  display: grid;
+  place-items: center;
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--app-accent) 12%, var(--app-card));
+  color: var(--app-accent);
+  margin-bottom: 4px;
+}
+
+.exp-empty strong {
+  color: var(--app-fg);
+  font-size: 16px;
+}
+
+.exp-empty span {
+  max-width: 42ch;
+  line-height: 1.5;
+  font-size: 13px;
+}
+
+/* ---- Budget overlay ---- */
+.exp-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--app-fg) 32%, transparent);
+  padding: 24px;
+  z-index: 20;
+}
+
+.exp-overlay__panel {
+  width: min(440px, 100%);
+  max-height: 84vh;
+  overflow-y: auto;
+  background: var(--app-card);
+  border-radius: var(--app-radius);
+  padding: 20px;
+  box-shadow: var(--elev-lg);
+}
+
+.exp-budget-list {
+  display: grid;
+  gap: 8px;
+}
+
+.exp-budget-row {
+  display: grid;
+  grid-template-columns: auto 1fr 120px;
+  align-items: center;
+  gap: 10px;
+}
+
+.exp-budget-name {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.exp-budget-row input {
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  padding: 8px 10px;
+  background: var(--app-bg);
+  color: var(--app-fg);
+  font: inherit;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
+  }
+}
+
+@media (max-width: 820px) {
+  .exp-kpis,
+  .exp-grid,
+  .exp-form {
+    grid-template-columns: 1fr;
+  }
+
+  .exp-app {
+    padding: 16px;
+  }
+}

--- a/tests/default-apps/expense-model.test.ts
+++ b/tests/default-apps/expense-model.test.ts
@@ -4,6 +4,8 @@ import {
   categoryBreakdown,
   coerceBudget,
   coerceExpense,
+  currencyForLocale,
+  dedupeBudgets,
   formatMoney,
   isInMonth,
   monthKey,
@@ -65,6 +67,24 @@ describe("expense-model", () => {
       expect(row?.category).toBe("Uncategorized");
       expect(typeof row?.spent_at).toBe("string");
     });
+
+    it("hydrates legacy description and date fields", () => {
+      const row = coerceExpense({
+        id: "legacy",
+        amount: "17.45",
+        category: "Dining",
+        description: "Lunch",
+        date: "2026-05-04T00:00:00.000Z",
+      });
+
+      expect(row).toMatchObject({
+        id: "legacy",
+        amount: 17.45,
+        category: "Dining",
+        note: "Lunch",
+        spent_at: "2026-05-04T00:00:00.000Z",
+      });
+    });
   });
 
   describe("coerceBudget", () => {
@@ -72,6 +92,17 @@ describe("expense-model", () => {
       expect(coerceBudget({ category: "Food", monthly_limit: "200" })?.monthly_limit).toBe(200);
       expect(coerceBudget({ category: "Food", monthly_limit: -3 })).toBeNull();
       expect(coerceBudget({ monthly_limit: 10 })).toBeNull();
+    });
+
+    it("deduplicates budgets by category before summarizing", () => {
+      expect(dedupeBudgets([
+        { id: "b1", category: "Food", monthly_limit: 100 },
+        { id: "b2", category: "Food", monthly_limit: 200 },
+        { id: "b3", category: "Rent", monthly_limit: 900 },
+      ])).toEqual([
+        { id: "b1", category: "Food", monthly_limit: 100 },
+        { id: "b3", category: "Rent", monthly_limit: 900 },
+      ]);
     });
   });
 
@@ -162,6 +193,12 @@ describe("expense-model", () => {
     it("formats currency", () => {
       expect(formatMoney(1234.5)).toMatch(/1,234\.50/);
       expect(formatMoney(0)).toMatch(/0\.00/);
+    });
+
+    it("chooses a locale default currency without hardcoding every display to USD", () => {
+      expect(currencyForLocale("sv-SE")).toBe("SEK");
+      expect(currencyForLocale("en-GB")).toBe("GBP");
+      expect(currencyForLocale("fr-FR")).toBe("EUR");
     });
   });
 });

--- a/tests/default-apps/expense-model.test.ts
+++ b/tests/default-apps/expense-model.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  budgetStatus,
+  categoryBreakdown,
+  coerceBudget,
+  coerceExpense,
+  formatMoney,
+  isInMonth,
+  monthKey,
+  monthLabel,
+  monthlyTotal,
+  shiftMonth,
+  summarizeMonth,
+  type BudgetRow,
+  type ExpenseRow,
+} from "../../home/apps/expense-tracker/src/expense-model";
+
+const may = (day: number, amount: number, category = "Groceries", extra: Partial<ExpenseRow> = {}): ExpenseRow => ({
+  id: `e-${day}-${amount}`,
+  amount,
+  category,
+  note: "",
+  spent_at: `2026-05-${String(day).padStart(2, "0")}T12:00:00.000Z`,
+  recurring: false,
+  ...extra,
+});
+
+describe("expense-model", () => {
+  describe("monthKey / shiftMonth / monthLabel", () => {
+    it("derives a YYYY-MM key from an ISO timestamp", () => {
+      expect(monthKey("2026-05-14T08:30:00.000Z")).toBe("2026-05");
+      expect(monthKey(new Date("2026-12-01T00:00:00.000Z"))).toBe("2026-12");
+    });
+
+    it("shifts months across year boundaries", () => {
+      expect(shiftMonth("2026-01", -1)).toBe("2025-12");
+      expect(shiftMonth("2026-12", 1)).toBe("2027-01");
+      expect(shiftMonth("2026-05", 0)).toBe("2026-05");
+    });
+
+    it("formats a human month label", () => {
+      expect(monthLabel("2026-05")).toMatch(/May 2026/);
+    });
+  });
+
+  describe("isInMonth", () => {
+    it("matches expenses inside the month and rejects others", () => {
+      expect(isInMonth(may(3, 10), "2026-05")).toBe(true);
+      expect(isInMonth(may(3, 10, "Groceries", { spent_at: "2026-04-30T23:00:00.000Z" }), "2026-05")).toBe(false);
+    });
+  });
+
+  describe("coerceExpense", () => {
+    it("normalizes string amounts and bad rows", () => {
+      const row = coerceExpense({ id: "x", amount: "12.5", category: "Food", spent_at: "2026-05-02T00:00:00Z", recurring: true });
+      expect(row).not.toBeNull();
+      expect(row?.amount).toBe(12.5);
+      expect(row?.recurring).toBe(true);
+      expect(coerceExpense({ amount: "not-a-number" })).toBeNull();
+      expect(coerceExpense(null)).toBeNull();
+    });
+
+    it("defaults missing category and spent_at", () => {
+      const row = coerceExpense({ amount: 5 });
+      expect(row?.category).toBe("Uncategorized");
+      expect(typeof row?.spent_at).toBe("string");
+    });
+  });
+
+  describe("coerceBudget", () => {
+    it("normalizes budget rows and drops invalid limits", () => {
+      expect(coerceBudget({ category: "Food", monthly_limit: "200" })?.monthly_limit).toBe(200);
+      expect(coerceBudget({ category: "Food", monthly_limit: -3 })).toBeNull();
+      expect(coerceBudget({ monthly_limit: 10 })).toBeNull();
+    });
+  });
+
+  describe("monthlyTotal", () => {
+    it("sums amounts", () => {
+      expect(monthlyTotal([may(1, 10), may(2, 5.5), may(3, 4.5)])).toBe(20);
+      expect(monthlyTotal([])).toBe(0);
+    });
+  });
+
+  describe("categoryBreakdown", () => {
+    it("aggregates by category sorted by spend desc with percentages", () => {
+      const expenses = [
+        may(1, 30, "Groceries"),
+        may(2, 10, "Groceries"),
+        may(3, 60, "Rent"),
+      ];
+      const rows = categoryBreakdown(expenses);
+      expect(rows[0].category).toBe("Rent");
+      expect(rows[0].total).toBe(60);
+      expect(rows[1].category).toBe("Groceries");
+      expect(rows[1].total).toBe(40);
+      // 60 of 100 total
+      expect(Math.round(rows[0].pct)).toBe(60);
+    });
+
+    it("returns empty array for no expenses", () => {
+      expect(categoryBreakdown([])).toEqual([]);
+    });
+  });
+
+  describe("budgetStatus", () => {
+    const budgets: BudgetRow[] = [{ id: "b1", category: "Groceries", monthly_limit: 100 }];
+
+    it("reports under-budget status", () => {
+      const status = budgetStatus("Groceries", 40, budgets);
+      expect(status.limit).toBe(100);
+      expect(status.spent).toBe(40);
+      expect(status.remaining).toBe(60);
+      expect(status.over).toBe(false);
+      expect(Math.round(status.pct)).toBe(40);
+    });
+
+    it("flags over-budget categories", () => {
+      const status = budgetStatus("Groceries", 130, budgets);
+      expect(status.over).toBe(true);
+      expect(status.remaining).toBe(-30);
+      expect(status.pct).toBe(100); // clamped for the bar
+    });
+
+    it("handles categories with no budget", () => {
+      const status = budgetStatus("Rent", 50, budgets);
+      expect(status.limit).toBe(0);
+      expect(status.over).toBe(false);
+      expect(status.hasBudget).toBe(false);
+    });
+  });
+
+  describe("summarizeMonth", () => {
+    it("produces KPIs for the selected month", () => {
+      const expenses = [
+        may(1, 100, "Rent"),
+        may(2, 30, "Groceries"),
+        may(3, 20, "Groceries"),
+        may(4, 999, "Rent", { spent_at: "2026-04-15T00:00:00.000Z" }), // out of month
+      ];
+      const budgets: BudgetRow[] = [
+        { id: "b1", category: "Rent", monthly_limit: 120 },
+        { id: "b2", category: "Groceries", monthly_limit: 200 },
+      ];
+      const summary = summarizeMonth(expenses, budgets, "2026-05");
+      expect(summary.totalSpent).toBe(150);
+      expect(summary.totalBudget).toBe(320);
+      expect(summary.remaining).toBe(170);
+      expect(summary.biggestCategory?.category).toBe("Rent");
+      expect(summary.overBudget).toEqual([]); // Rent 100 < 120, Groceries 50 < 200
+    });
+
+    it("identifies over-budget categories", () => {
+      const expenses = [may(1, 300, "Rent")];
+      const budgets: BudgetRow[] = [{ id: "b1", category: "Rent", monthly_limit: 120 }];
+      const summary = summarizeMonth(expenses, budgets, "2026-05");
+      expect(summary.overBudget.map((b) => b.category)).toContain("Rent");
+    });
+  });
+
+  describe("formatMoney", () => {
+    it("formats currency", () => {
+      expect(formatMoney(1234.5)).toMatch(/1,234\.50/);
+      expect(formatMoney(0)).toMatch(/0\.00/);
+    });
+  });
+});

--- a/tests/default-apps/expense-model.test.ts
+++ b/tests/default-apps/expense-model.test.ts
@@ -198,6 +198,7 @@ describe("expense-model", () => {
     it("chooses a locale default currency without hardcoding every display to USD", () => {
       expect(currencyForLocale("sv-SE")).toBe("SEK");
       expect(currencyForLocale("en-GB")).toBe("GBP");
+      expect(currencyForLocale("en-GB-u-nu-latn")).toBe("GBP");
       expect(currencyForLocale("fr-FR")).toBe("EUR");
     });
   });

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -482,6 +482,7 @@ describe("Expense Tracker app", () => {
     render(<App />);
     fireEvent.click(await screen.findByRole("button", { name: /edit budgets/i }));
     fireEvent.change(screen.getByLabelText("Rent monthly budget"), { target: { value: "200" } });
+    db.find.mockClear();
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
       await Promise.resolve();
@@ -489,6 +490,7 @@ describe("Expense Tracker app", () => {
     });
 
     expect(await screen.findByText("Could not save your budgets.")).toBeTruthy();
+    await waitFor(() => expect(db.find.mock.calls.some((call) => call[0] === "budgets")).toBe(true));
     expect(db.insert.mock.calls.filter((call) => call[0] === "budgets")).toHaveLength(1);
 
     await act(async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -216,6 +216,7 @@ describe("Expense Tracker app", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: /edit budgets/i }));
+    db.find.mockImplementation(async () => new Promise<DbRow[]>(() => undefined));
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
       await Promise.resolve();
@@ -225,6 +226,14 @@ describe("Expense Tracker app", () => {
       expect(db.update).toHaveBeenCalledWith("budgets", "b1", { monthly_limit: 100 });
       expect(db.delete).toHaveBeenCalledWith("budgets", "b2");
     });
+
+    fireEvent.click(screen.getByRole("button", { name: /edit budgets/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+    });
+
+    expect(db.delete.mock.calls.filter((call) => call[0] === "budgets" && call[1] === "b2")).toHaveLength(1);
   });
 
   it("adds a transaction by calling db.insert with the right args", async () => {
@@ -402,6 +411,41 @@ describe("Expense Tracker app", () => {
     expect(db.update).toHaveBeenCalledWith("budgets", "b1", { monthly_limit: 150 });
     expect(screen.queryByRole("dialog", { name: /edit budgets/i })).toBeNull();
     expect(screen.queryByText("Could not save your budgets.")).toBeNull();
+  });
+
+  it("keeps successful budget updates visible after a mixed save failure", async () => {
+    const db = installMatrixDb(
+      [expense(2, 125, "Groceries")],
+      [{ id: "b1", category: "Groceries", monthly_limit: 100 }],
+    );
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "budgets" && data.category === "Rent") {
+        throw new Error("insert failed");
+      }
+      const id = `${table}-real`;
+      (table === "budgets" ? db.budgets : db.expenses).push({
+        id,
+        created_at: new Date().toISOString(),
+        ...data,
+      });
+      return { id };
+    });
+
+    render(<App />);
+    expect(await screen.findByTestId("over-budget-warning")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /edit budgets/i }));
+    fireEvent.change(screen.getByLabelText("Groceries monthly budget"), { target: { value: "150" } });
+    fireEvent.change(screen.getByLabelText("Rent monthly budget"), { target: { value: "200" } });
+    db.find.mockImplementation(async () => new Promise<DbRow[]>(() => undefined));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Could not save your budgets.")).toBeTruthy();
+    expect(screen.queryByTestId("over-budget-warning")).toBeNull();
   });
 
   it("dismisses budget editing with Escape and backdrop clicks", async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -289,6 +289,42 @@ describe("Expense Tracker app", () => {
     expect(screen.queryByText("Could not save your budgets.")).toBeNull();
   });
 
+  it("uses the real budget id when a new budget is edited before reload finishes", async () => {
+    const db = installMatrixDb([], []);
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      const id = table === "budgets" ? "budget-real" : `${table}-real`;
+      (table === "budgets" ? db.budgets : db.expenses).push({
+        id,
+        created_at: new Date().toISOString(),
+        ...data,
+      });
+      return { id };
+    });
+
+    render(<App />);
+    await screen.findByTestId("empty-state");
+    db.find.mockImplementation(async () => new Promise<DbRow[]>(() => undefined));
+
+    fireEvent.click(screen.getByRole("button", { name: /edit budgets/i }));
+    fireEvent.change(screen.getByLabelText("Groceries monthly budget"), { target: { value: "100" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /edit budgets/i }));
+    fireEvent.change(screen.getByLabelText("Groceries monthly budget"), { target: { value: "125" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.update).toHaveBeenCalledWith("budgets", "budget-real", { monthly_limit: 125 });
+    expect(db.update).not.toHaveBeenCalledWith("budgets", "local-Groceries", expect.anything());
+  });
+
   it("renders an empty state with onboarding when there are no transactions", async () => {
     installMatrixDb([], []);
 

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -252,6 +252,24 @@ describe("Expense Tracker app", () => {
     expect(screen.queryByText("Could not save that transaction.")).toBeNull();
   });
 
+  it("keeps a deleted transaction hidden when the follow-up reload fails", async () => {
+    const db = installMatrixDb([expense(2, 12, "Groceries", { note: "Coffee beans" })], []);
+
+    render(<App />);
+    expect(await screen.findByText("Coffee beans")).toBeTruthy();
+    db.find.mockRejectedValueOnce(new Error("read failed"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /delete coffee beans/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.delete).toHaveBeenCalled();
+    expect(screen.queryByText("Coffee beans")).toBeNull();
+    expect(screen.queryByText("Could not delete that transaction.")).toBeNull();
+  });
+
   it("does not reopen budget editing when the follow-up reload fails after a save", async () => {
     const db = installMatrixDb([], [{ id: "b1", category: "Groceries", monthly_limit: 100 }]);
 

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -34,8 +34,18 @@ function installMatrixDb(expenses: DbRow[] = [], budgets: DbRow[] = []): FakeDb 
     (table === "budgets" ? state.budgets : state.expenses).push({ id, created_at: new Date().toISOString(), ...data });
     return { id };
   });
-  state.update.mockImplementation(async () => ({ ok: true }));
-  state.delete.mockImplementation(async () => ({ ok: true }));
+  state.update.mockImplementation(async (table: string, id: string, data: DbRow) => {
+    const rows = table === "budgets" ? state.budgets : state.expenses;
+    const row = rows.find((item) => item.id === id);
+    if (row) Object.assign(row, data);
+    return { ok: true };
+  });
+  state.delete.mockImplementation(async (table: string, id: string) => {
+    const rows = table === "budgets" ? state.budgets : state.expenses;
+    const idx = rows.findIndex((item) => item.id === id);
+    if (idx >= 0) rows.splice(idx, 1);
+    return { ok: true };
+  });
 
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
@@ -116,6 +126,29 @@ describe("Expense Tracker app", () => {
     render(<App />);
 
     expect(await screen.findByTestId("over-budget-warning")).toBeTruthy();
+  });
+
+  it("deduplicates existing budgets when saving the budget sheet", async () => {
+    const db = installMatrixDb(
+      [expense(2, 30, "Groceries")],
+      [
+        { id: "b1", category: "Groceries", monthly_limit: 100 },
+        { id: "b2", category: "Groceries", monthly_limit: 125 },
+      ],
+    );
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /edit budgets/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("budgets", "b1", { monthly_limit: 100 });
+      expect(db.delete).toHaveBeenCalledWith("budgets", "b2");
+    });
   });
 
   it("adds a transaction by calling db.insert with the right args", async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -88,6 +88,7 @@ function expense(day: number, amount: number, category: string, extra: DbRow = {
 
 describe("Expense Tracker app", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
   });
@@ -238,6 +239,20 @@ describe("Expense Tracker app", () => {
     expect(call?.[1]).toMatchObject({ amount: 25.5, note: "Coffee beans" });
     expect(typeof (call?.[1] as Record<string, unknown>).category).toBe("string");
     expect(typeof (call?.[1] as Record<string, unknown>).spent_at).toBe("string");
+  });
+
+  it("defaults the expense date to the UTC day used by month selection", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T01:00:00.000Z"));
+    installMatrixDb([], []);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const dateInput = screen.getByLabelText(/date/i) as HTMLInputElement;
+    expect(dateInput.value).toBe("2026-05-01");
   });
 
   it("keeps an inserted transaction visible when the follow-up reload fails", async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -26,8 +26,21 @@ function installMatrixDb(expenses: DbRow[] = [], budgets: DbRow[] = []): FakeDb 
     delete: vi.fn(),
     onChange: vi.fn(() => () => undefined),
   };
-  state.find.mockImplementation(async (table: string) =>
-    table === "budgets" ? state.budgets : state.expenses,
+  state.find.mockImplementation(
+    async (table: string, opts?: { limit?: number; offset?: number; orderBy?: Record<string, "asc" | "desc"> }) => {
+      let rows = table === "budgets" ? state.budgets : state.expenses;
+      const orderEntry = Object.entries(opts?.orderBy ?? {})[0];
+      if (orderEntry) {
+        const [column, direction] = orderEntry;
+        rows = [...rows].sort((a, b) =>
+          direction === "desc"
+            ? String(b[column] ?? "").localeCompare(String(a[column] ?? ""))
+            : String(a[column] ?? "").localeCompare(String(b[column] ?? "")),
+        );
+      }
+      const offset = opts?.offset ?? 0;
+      return typeof opts?.limit === "number" ? rows.slice(offset, offset + opts.limit) : rows.slice(offset);
+    },
   );
   state.insert.mockImplementation(async (table: string, data: DbRow) => {
     const id = `${table}-${Math.random().toString(36).slice(2)}`;
@@ -102,6 +115,26 @@ describe("Expense Tracker app", () => {
 
     const total = await screen.findByTestId("kpi-total");
     expect(total.textContent).toMatch(/100\.00/);
+  });
+
+  it("loads expenses beyond the first page", async () => {
+    const rows = Array.from({ length: 501 }, (_, index) =>
+      expense(2, index === 500 ? 75 : 1, index === 500 ? "Health" : "Other", {
+        id: `expense-${index}`,
+        spent_at: `${YM}-02T${String(index % 24).padStart(2, "0")}:00:00.000Z`,
+      }),
+    );
+    const db = installMatrixDb(rows, []);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(db.find).toHaveBeenCalledWith(
+        "expenses",
+        expect.objectContaining({ limit: 500, offset: 500 }),
+      );
+    });
+    expect((await screen.findByTestId("kpi-total")).textContent).toMatch(/575\.00/);
   });
 
   it("renders a category breakdown", async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -137,6 +137,24 @@ describe("Expense Tracker app", () => {
     expect((await screen.findByTestId("kpi-total")).textContent).toMatch(/575\.00/);
   });
 
+  it("loads budgets beyond the first page", async () => {
+    const budgets = Array.from({ length: 501 }, (_, index) => ({
+      id: `budget-${index}`,
+      category: `Category ${index}`,
+      monthly_limit: index + 1,
+    }));
+    const db = installMatrixDb([], budgets);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(db.find).toHaveBeenCalledWith(
+        "budgets",
+        expect.objectContaining({ limit: 500, offset: 500 }),
+      );
+    });
+  });
+
   it("renders a category breakdown", async () => {
     installMatrixDb([
       expense(2, 40, "Groceries"),
@@ -210,6 +228,47 @@ describe("Expense Tracker app", () => {
     expect(call?.[1]).toMatchObject({ amount: 25.5, note: "Coffee beans" });
     expect(typeof (call?.[1] as Record<string, unknown>).category).toBe("string");
     expect(typeof (call?.[1] as Record<string, unknown>).spent_at).toBe("string");
+  });
+
+  it("keeps an inserted transaction visible when the follow-up reload fails", async () => {
+    const db = installMatrixDb([], []);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "25.50" } });
+    fireEvent.change(screen.getByLabelText(/note/i), { target: { value: "Coffee beans" } });
+    db.find.mockRejectedValueOnce(new Error("read failed"));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId("expense-form"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Coffee beans")).toBeTruthy();
+    expect(screen.queryByText("Could not save that transaction.")).toBeNull();
+  });
+
+  it("does not reopen budget editing when the follow-up reload fails after a save", async () => {
+    const db = installMatrixDb([], [{ id: "b1", category: "Groceries", monthly_limit: 100 }]);
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: /edit budgets/i }));
+    fireEvent.change(screen.getByLabelText("Groceries monthly budget"), { target: { value: "150" } });
+    db.find.mockRejectedValueOnce(new Error("read failed"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.update).toHaveBeenCalledWith("budgets", "b1", { monthly_limit: 150 });
+    expect(screen.queryByRole("dialog", { name: /edit budgets/i })).toBeNull();
+    expect(screen.queryByText("Could not save your budgets.")).toBeNull();
   });
 
   it("renders an empty state with onboarding when there are no transactions", async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -86,6 +86,20 @@ function expense(day: number, amount: number, category: string, extra: DbRow = {
   };
 }
 
+function dateInputMonthsFromCurrent(monthOffset: number, day = 2): string {
+  const [year, month] = YM.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1 + monthOffset, day));
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
+
+function monthLabelForInput(value: string): string {
+  return new Date(`${value.slice(0, 7)}-01T00:00:00.000Z`).toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 describe("Expense Tracker app", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -298,6 +312,53 @@ describe("Expense Tracker app", () => {
     expect(screen.queryByText("Bad write")).toBeNull();
   });
 
+  it("keeps an edited transaction visible when its date moves to another month", async () => {
+    const db = installMatrixDb([expense(2, 12, "Groceries", { note: "Coffee beans" })], []);
+    const nextDate = dateInputMonthsFromCurrent(1);
+
+    render(<App />);
+    expect(await screen.findByText("Coffee beans")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /edit coffee beans/i }));
+    fireEvent.change(screen.getByLabelText(/date/i), { target: { value: nextDate } });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId("expense-form"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith(
+        "expenses",
+        "e-2-12-Groceries",
+        expect.objectContaining({ spent_at: `${nextDate}T00:00:00.000Z` }),
+      );
+    });
+    expect(screen.getByTestId("selected-month").textContent).toBe(monthLabelForInput(nextDate));
+    expect(screen.getByText("Coffee beans")).toBeTruthy();
+  });
+
+  it("restores the selected month after a failed transaction edit", async () => {
+    const db = installMatrixDb([expense(2, 12, "Groceries", { note: "Coffee beans" })], []);
+    const originalMonthLabel = monthLabelForInput(`${YM}-01`);
+    db.update.mockRejectedValueOnce(new Error("write failed"));
+
+    render(<App />);
+    expect(await screen.findByText("Coffee beans")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /edit coffee beans/i }));
+    fireEvent.change(screen.getByLabelText(/date/i), { target: { value: dateInputMonthsFromCurrent(1) } });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId("expense-form"));
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Could not save that change.")).toBeTruthy();
+    expect(screen.getByTestId("selected-month").textContent).toBe(originalMonthLabel);
+    expect(screen.getByText("Coffee beans")).toBeTruthy();
+  });
+
   it("keeps a deleted transaction hidden when the follow-up reload fails", async () => {
     const db = installMatrixDb([expense(2, 12, "Groceries", { note: "Coffee beans" })], []);
 
@@ -435,6 +496,49 @@ describe("Expense Tracker app", () => {
 
     expect(db.insert.mock.calls.filter((call) => call[0] === "budgets")).toHaveLength(1);
     expect(db.update).toHaveBeenCalledWith("budgets", "budget-rent", { monthly_limit: 200 });
+  });
+
+  it("does not restore successfully deleted budgets after a mixed save failure", async () => {
+    const db = installMatrixDb(
+      [expense(2, 30, "Groceries"), expense(3, 45, "Rent")],
+      [
+        { id: "b1", category: "Groceries", monthly_limit: 100 },
+        { id: "b2", category: "Rent", monthly_limit: 200 },
+      ],
+    );
+    let rentUpdateAttempts = 0;
+    db.update.mockImplementation(async (table: string, id: string, data: DbRow) => {
+      if (table === "budgets" && id === "b2" && rentUpdateAttempts === 0) {
+        rentUpdateAttempts += 1;
+        throw new Error("update failed");
+      }
+      const rows = table === "budgets" ? db.budgets : db.expenses;
+      const row = rows.find((item) => item.id === id);
+      if (row) Object.assign(row, data);
+      return { ok: true };
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: /edit budgets/i }));
+    fireEvent.change(screen.getByLabelText("Groceries monthly budget"), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("Rent monthly budget"), { target: { value: "250" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Could not save your budgets.")).toBeTruthy();
+    expect(db.delete.mock.calls.filter((call) => call[0] === "budgets" && call[1] === "b1")).toHaveLength(1);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.delete.mock.calls.filter((call) => call[0] === "budgets" && call[1] === "b1")).toHaveLength(1);
+    expect(db.update).toHaveBeenCalledWith("budgets", "b2", { monthly_limit: 250 });
   });
 
   it("renders an empty state with onboarding when there are no transactions", async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -350,7 +350,9 @@ describe("Expense Tracker app", () => {
     expect(await screen.findByText("Coffee beans")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: /edit coffee beans/i }));
-    fireEvent.change(screen.getByLabelText(/date/i), { target: { value: dateInputMonthsFromCurrent(1) } });
+    const retryDate = dateInputMonthsFromCurrent(1);
+    fireEvent.change(screen.getByLabelText(/note/i), { target: { value: "Retry this edit" } });
+    fireEvent.change(screen.getByLabelText(/date/i), { target: { value: retryDate } });
 
     await act(async () => {
       fireEvent.submit(screen.getByTestId("expense-form"));
@@ -360,6 +362,9 @@ describe("Expense Tracker app", () => {
     expect(await screen.findByText("Could not save that change.")).toBeTruthy();
     expect(screen.getByTestId("selected-month").textContent).toBe(originalMonthLabel);
     expect(screen.getByText("Coffee beans")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /edit transaction/i })).toBeTruthy();
+    expect((screen.getByLabelText(/note/i) as HTMLInputElement).value).toBe("Retry this edit");
+    expect((screen.getByLabelText(/date/i) as HTMLInputElement).value).toBe(retryDate);
   });
 
   it("keeps a deleted transaction hidden when the follow-up reload fails", async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -262,6 +262,27 @@ describe("Expense Tracker app", () => {
     expect(screen.queryByText("Could not save that transaction.")).toBeNull();
   });
 
+  it("restores the selected month after a failed transaction insert", async () => {
+    const db = installMatrixDb([expense(2, 12, "Groceries", { note: "Coffee beans" })], []);
+    db.insert.mockRejectedValueOnce(new Error("write failed"));
+
+    render(<App />);
+    expect(await screen.findByText("Coffee beans")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "25.50" } });
+    fireEvent.change(screen.getByLabelText(/note/i), { target: { value: "Bad write" } });
+    fireEvent.change(screen.getByLabelText(/date/i), { target: { value: "2000-01-02" } });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId("expense-form"));
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Could not save that transaction.")).toBeTruthy();
+    expect(screen.getByText("Coffee beans")).toBeTruthy();
+    expect(screen.queryByText("Bad write")).toBeNull();
+  });
+
   it("keeps a deleted transaction hidden when the follow-up reload fails", async () => {
     const db = installMatrixDb([expense(2, 12, "Groceries", { note: "Coffee beans" })], []);
 
@@ -297,6 +318,21 @@ describe("Expense Tracker app", () => {
     expect(db.update).toHaveBeenCalledWith("budgets", "b1", { monthly_limit: 150 });
     expect(screen.queryByRole("dialog", { name: /edit budgets/i })).toBeNull();
     expect(screen.queryByText("Could not save your budgets.")).toBeNull();
+  });
+
+  it("dismisses budget editing with Escape and backdrop clicks", async () => {
+    installMatrixDb([], [{ id: "b1", category: "Groceries", monthly_limit: 100 }]);
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: /edit budgets/i }));
+    expect(screen.getByRole("dialog", { name: /edit budgets/i })).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: /edit budgets/i })).toBeNull());
+
+    fireEvent.click(screen.getByRole("button", { name: /edit budgets/i }));
+    fireEvent.click(screen.getByRole("dialog", { name: /edit budgets/i }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: /edit budgets/i })).toBeNull());
   });
 
   it("uses the real budget id when a new budget is edited before reload finishes", async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -179,6 +179,16 @@ describe("Expense Tracker app", () => {
     expect(await screen.findByTestId("over-budget-warning")).toBeTruthy();
   });
 
+  it("does not mark spending as over budget when no budget is configured", async () => {
+    installMatrixDb([expense(2, 300, "Groceries")]);
+
+    render(<App />);
+
+    expect(await screen.findByText("Budget not set")).toBeTruthy();
+    expect(screen.queryByText("Over budget")).toBeNull();
+    expect(screen.queryByTestId("over-budget-warning")).toBeNull();
+  });
+
   it("deduplicates existing budgets when saving the budget sheet", async () => {
     const db = installMatrixDb(
       [expense(2, 30, "Groceries")],

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -237,7 +237,10 @@ describe("Expense Tracker app", () => {
       await Promise.resolve();
     });
 
-    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "25.50" } });
+    const amountInput = screen.getByLabelText(/amount/i) as HTMLInputElement;
+    expect(amountInput.min).toBe("0.01");
+    expect(amountInput.step).toBe("0.01");
+    fireEvent.change(amountInput, { target: { value: "25.50" } });
     fireEvent.change(screen.getByLabelText(/note/i), { target: { value: "Coffee beans" } });
 
     await act(async () => {

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/expense-tracker/src/App";
+
+type DbRow = Record<string, unknown>;
+
+interface FakeDb {
+  expenses: DbRow[];
+  budgets: DbRow[];
+  find: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  onChange: ReturnType<typeof vi.fn>;
+}
+
+function installMatrixDb(expenses: DbRow[] = [], budgets: DbRow[] = []): FakeDb {
+  const state: FakeDb = {
+    expenses: [...expenses],
+    budgets: [...budgets],
+    find: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    onChange: vi.fn(() => () => undefined),
+  };
+  state.find.mockImplementation(async (table: string) =>
+    table === "budgets" ? state.budgets : state.expenses,
+  );
+  state.insert.mockImplementation(async (table: string, data: DbRow) => {
+    const id = `${table}-${Math.random().toString(36).slice(2)}`;
+    (table === "budgets" ? state.budgets : state.expenses).push({ id, created_at: new Date().toISOString(), ...data });
+    return { id };
+  });
+  state.update.mockImplementation(async () => ({ ok: true }));
+  state.delete.mockImplementation(async () => ({ ok: true }));
+
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db: state },
+  });
+  return state;
+}
+
+// Build timestamps inside the CURRENT month so the app's default selected
+// month (derived from the real clock) lines up with the fixtures.
+const now = new Date();
+const YM = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+
+function expense(day: number, amount: number, category: string, extra: DbRow = {}): DbRow {
+  const stamp = `${YM}-${String(day).padStart(2, "0")}T10:00:00.000Z`;
+  return {
+    id: `e-${day}-${amount}-${category}`,
+    amount,
+    category,
+    note: "",
+    spent_at: stamp,
+    recurring: false,
+    created_at: stamp,
+    ...extra,
+  };
+}
+
+describe("Expense Tracker app", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+  });
+
+  it("renders transactions from the database", async () => {
+    installMatrixDb([
+      expense(2, 42.5, "Groceries", { note: "Weekly shop" }),
+      expense(4, 1200, "Rent"),
+    ]);
+
+    render(<App />);
+
+    expect(await screen.findByText("Weekly shop")).toBeTruthy();
+    expect(screen.getAllByText(/Groceries/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Rent/).length).toBeGreaterThan(0);
+  });
+
+  it("computes the monthly total in the KPI header", async () => {
+    installMatrixDb([
+      expense(2, 40, "Groceries"),
+      expense(4, 60, "Rent"),
+    ]);
+
+    render(<App />);
+
+    const total = await screen.findByTestId("kpi-total");
+    expect(total.textContent).toMatch(/100\.00/);
+  });
+
+  it("renders a category breakdown", async () => {
+    installMatrixDb([
+      expense(2, 40, "Groceries"),
+      expense(4, 60, "Rent"),
+    ]);
+
+    render(<App />);
+
+    const breakdown = await screen.findByTestId("category-breakdown");
+    expect(within(breakdown).getAllByText(/Rent/).length).toBeGreaterThan(0);
+    expect(within(breakdown).getAllByText(/Groceries/).length).toBeGreaterThan(0);
+  });
+
+  it("shows an over-budget warning when spend exceeds the budget", async () => {
+    installMatrixDb(
+      [expense(2, 300, "Groceries")],
+      [{ id: "b1", category: "Groceries", monthly_limit: 100 }],
+    );
+
+    render(<App />);
+
+    expect(await screen.findByTestId("over-budget-warning")).toBeTruthy();
+  });
+
+  it("adds a transaction by calling db.insert with the right args", async () => {
+    const db = installMatrixDb([], []);
+
+    render(<App />);
+
+    // wait for initial load to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: "25.50" } });
+    fireEvent.change(screen.getByLabelText(/note/i), { target: { value: "Coffee beans" } });
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId("expense-form"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.insert).toHaveBeenCalled();
+    });
+    const call = db.insert.mock.calls.find((c) => c[0] === "expenses");
+    expect(call).toBeTruthy();
+    expect(call?.[1]).toMatchObject({ amount: 25.5, note: "Coffee beans" });
+    expect(typeof (call?.[1] as Record<string, unknown>).category).toBe("string");
+    expect(typeof (call?.[1] as Record<string, unknown>).spent_at).toBe("string");
+  });
+
+  it("renders an empty state with onboarding when there are no transactions", async () => {
+    installMatrixDb([], []);
+
+    render(<App />);
+
+    expect(await screen.findByTestId("empty-state")).toBeTruthy();
+  });
+});

--- a/tests/default-apps/expense-tracker-app.test.tsx
+++ b/tests/default-apps/expense-tracker-app.test.tsx
@@ -335,6 +335,57 @@ describe("Expense Tracker app", () => {
     expect(db.update).not.toHaveBeenCalledWith("budgets", "local-Groceries", expect.anything());
   });
 
+  it("does not reinsert a budget after a mixed save partially commits", async () => {
+    const db = installMatrixDb(
+      [expense(2, 30, "Groceries"), expense(3, 45, "Rent")],
+      [
+        { id: "b1", category: "Groceries", monthly_limit: 100 },
+        { id: "b2", category: "Groceries", monthly_limit: 125 },
+      ],
+    );
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      const id = table === "budgets" ? `budget-${String(data.category).toLowerCase()}` : `${table}-real`;
+      (table === "budgets" ? db.budgets : db.expenses).push({
+        id,
+        created_at: new Date().toISOString(),
+        ...data,
+      });
+      return { id };
+    });
+    let deleteAttempts = 0;
+    db.delete.mockImplementation(async (table: string, id: string) => {
+      if (table === "budgets" && id === "b2" && deleteAttempts === 0) {
+        deleteAttempts += 1;
+        throw new Error("delete failed");
+      }
+      const rows = table === "budgets" ? db.budgets : db.expenses;
+      const idx = rows.findIndex((item) => item.id === id);
+      if (idx >= 0) rows.splice(idx, 1);
+      return { ok: true };
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: /edit budgets/i }));
+    fireEvent.change(screen.getByLabelText("Rent monthly budget"), { target: { value: "200" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Could not save your budgets.")).toBeTruthy();
+    expect(db.insert.mock.calls.filter((call) => call[0] === "budgets")).toHaveLength(1);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save budgets/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert.mock.calls.filter((call) => call[0] === "budgets")).toHaveLength(1);
+    expect(db.update).toHaveBeenCalledWith("budgets", "budget-rent", { monthly_limit: 200 });
+  });
+
   it("renders an empty state with onboarding when there are no transactions", async () => {
     installMatrixDb([], []);
 


### PR DESCRIPTION
Stack: 4/22
Branch: stack/default-apps-expense

Scope: Expense tracker spend dashboard, persistence model, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.