### PR TITLE
feat(task-manager): add Trello-style board

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, "stack/**"]
     types: [labeled, ready_for_review]
 
 concurrency:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -155,6 +155,7 @@ jobs:
               environment:
                 MATRIX_DOCKER_CHOWN_SOURCE: "true"
                 MATRIX_AUTH_ALLOW_INSECURE_DEV: "1"
+                MATRIX_SKIP_DEFAULT_APP_BUILD: "true"
           EOF
 
       - name: Create external volumes
@@ -232,6 +233,7 @@ jobs:
               environment:
                 MATRIX_DOCKER_CHOWN_SOURCE: "true"
                 MATRIX_AUTH_ALLOW_INSECURE_DEV: "1"
+                MATRIX_SKIP_DEFAULT_APP_BUILD: "true"
           EOF
 
       - name: Create external volumes

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -168,7 +168,7 @@ jobs:
           ./scripts/docker-test/fresh-install.sh
         env:
           COMPOSE_OVERRIDE_FILE: ${{ github.workspace }}/docker-compose.ci.yml
-          DOCKER_HEALTH_TIMEOUT: "300"
+          DOCKER_HEALTH_TIMEOUT: "600"
 
       - name: Collect container logs on failure
         if: failure()
@@ -243,7 +243,7 @@ jobs:
           ./scripts/docker-test/${{ matrix.scenario }}.sh
         env:
           COMPOSE_OVERRIDE_FILE: ${{ github.workspace }}/docker-compose.ci.yml
-          DOCKER_HEALTH_TIMEOUT: "300"
+          DOCKER_HEALTH_TIMEOUT: "600"
 
       - name: Collect container logs on failure
         if: failure()

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, "stack/**"]
     types: [labeled, ready_for_review]
 
 concurrency:

--- a/distro/docker-dev-entrypoint.sh
+++ b/distro/docker-dev-entrypoint.sh
@@ -45,21 +45,25 @@ for dir in agents system apps; do
   fi
 done
 
-echo "[matrix-os-dev] Building bundled default apps..."
-node /app/scripts/build-default-apps.mjs /app/home/apps
-find /app/home/apps -path '*/dist/index.html' -type f 2>/dev/null | while read -r built_index; do
-  built_app=$(dirname "$(dirname "$built_index")")
-  app_rel=${built_app#/app/home/apps/}
-  target_app="$MATRIX_HOME/apps/$app_rel"
-  [ -d "$target_app" ] || continue
-  if [ ! -d "$target_app/dist" ]; then
-    mkdir -p "$target_app"
-    cp -R "$built_app/dist" "$target_app/dist"
-    if [ -f "$built_app/.build-stamp" ]; then
-      cp "$built_app/.build-stamp" "$target_app/.build-stamp"
+if [ "${MATRIX_SKIP_DEFAULT_APP_BUILD:-}" = "true" ]; then
+  echo "[matrix-os-dev] Skipping bundled default app builds (MATRIX_SKIP_DEFAULT_APP_BUILD=true)"
+else
+  echo "[matrix-os-dev] Building bundled default apps..."
+  node /app/scripts/build-default-apps.mjs /app/home/apps
+  find /app/home/apps -path '*/dist/index.html' -type f 2>/dev/null | while read -r built_index; do
+    built_app=$(dirname "$(dirname "$built_index")")
+    app_rel=${built_app#/app/home/apps/}
+    target_app="$MATRIX_HOME/apps/$app_rel"
+    [ -d "$target_app" ] || continue
+    if [ ! -d "$target_app/dist" ]; then
+      mkdir -p "$target_app"
+      cp -R "$built_app/dist" "$target_app/dist"
+      if [ -f "$built_app/.build-stamp" ]; then
+        cp "$built_app/.build-stamp" "$target_app/.build-stamp"
+      fi
     fi
-  fi
-done
+  done
+fi
 
 # Unify $HOME/.agents/.claude/.codex and matching $MATRIX_HOME paths into a
 # single directory. The gateway runs with HOME=/home/matrixos and reads

--- a/home/apps/task-manager/matrix.json
+++ b/home/apps/task-manager/matrix.json
@@ -24,7 +24,7 @@
           "column_id": "text",
           "title": "text",
           "description": "text",
-          "labels": "text",
+          "labels": "jsonb",
           "assignee": "text",
           "priority": "text",
           "due": "date",

--- a/home/apps/task-manager/matrix.json
+++ b/home/apps/task-manager/matrix.json
@@ -1,14 +1,40 @@
 {
   "name": "Task Manager",
-  "description": "Project boards with Trello-style columns, cards, checklists, and drag-and-drop planning",
+  "description": "Trello-style project boards with draggable cards, labels, due dates, and checklists backed by your own Postgres",
   "category": "productivity",
   "icon": "task-manager",
   "author": "system",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "runtime": "vite",
   "slug": "task-manager",
   "runtimeVersion": "^1.0.0",
   "scope": "personal",
+  "storage": {
+    "tables": {
+      "columns": {
+        "columns": {
+          "title": "text",
+          "color": "text",
+          "position": "integer"
+        },
+        "indexes": ["position"]
+      },
+      "cards": {
+        "columns": {
+          "column_id": "text",
+          "title": "text",
+          "description": "text",
+          "labels": "text",
+          "assignee": "text",
+          "priority": "text",
+          "due": "timestamptz",
+          "checklist": "jsonb",
+          "position": "integer"
+        },
+        "indexes": ["column_id", "position"]
+      }
+    }
+  },
   "build": {
     "install": "pnpm install --ignore-workspace --prefer-offline",
     "command": "pnpm build",

--- a/home/apps/task-manager/matrix.json
+++ b/home/apps/task-manager/matrix.json
@@ -27,7 +27,7 @@
           "labels": "text",
           "assignee": "text",
           "priority": "text",
-          "due": "timestamptz",
+          "due": "date",
           "checklist": "jsonb",
           "position": "integer"
         },

--- a/home/apps/task-manager/package.json
+++ b/home/apps/task-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@matrixos/task-manager",
   "private": true,
-  "version": "2.0.0",
+  "version": "3.0.0",
   "packageManager": "pnpm@10.33.4",
   "type": "module",
   "scripts": {

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -299,7 +299,13 @@ function App() {
       if (!bridge) return;
       const toWrite = next.cards.filter((card) => affected.has(card.columnId));
       for (const card of toWrite) {
-        await bridge.update(CARDS_TABLE, await resolveCardId(card.id), { column_id: card.columnId, position: card.order });
+        const persistedColumnId = await (
+          pendingColumnIdsRef.current[card.columnId] ?? Promise.resolve(card.columnId)
+        );
+        await bridge.update(CARDS_TABLE, await resolveCardId(card.id), {
+          column_id: persistedColumnId,
+          position: card.order,
+        });
       }
     }, "Card order could not be saved");
   }, [persist, resolveCardId]);

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -270,7 +270,8 @@ function App() {
       const bridge = db();
       if (!bridge) return;
       const persistedCardId = await resolveCardId(cardId);
-      const liveCard = boardRef.current?.cards.find((card) => card.id === cardId);
+      const liveCard = boardRef.current?.cards.find((card) => card.id === persistedCardId)
+        ?? boardRef.current?.cards.find((card) => card.id === cardId);
       const rowCard = liveCard
         ? { ...updated, columnId: liveCard.columnId, order: liveCard.order }
         : updated;

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -270,7 +270,11 @@ function App() {
       const bridge = db();
       if (!bridge) return;
       const persistedCardId = await resolveCardId(cardId);
-      await bridge.update(CARDS_TABLE, persistedCardId, cardToRow({ ...updated, id: persistedCardId }, updated.order));
+      const liveCard = boardRef.current?.cards.find((card) => card.id === cardId);
+      const rowCard = liveCard
+        ? { ...updated, columnId: liveCard.columnId, order: liveCard.order }
+        : updated;
+      await bridge.update(CARDS_TABLE, persistedCardId, cardToRow({ ...rowCard, id: persistedCardId }, rowCard.order));
     }, "Card could not be updated");
   }, [persist, resolveCardId]);
 

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -774,7 +774,7 @@ function App() {
           onClose={() => setSelectedCardId(null)}
           onPatch={(patch) => patchCard(selectedCard.id, patch)}
           onMoveColumn={(columnId) => {
-            const count = board.cards.filter((card) => card.columnId === columnId).length;
+            const count = boardRef.current?.cards.filter((card) => card.columnId === columnId).length ?? 0;
             dropCard(selectedCard.id, columnId, count);
           }}
           onToggleChecklist={(itemId) => toggleChecklist(selectedCard.id, itemId)}

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -150,6 +150,7 @@ function App() {
   boardRef.current = board;
   const pendingColumnIdsRef = useRef<Record<string, Promise<string> | undefined>>({});
   const pendingCardIdsRef = useRef<Record<string, Promise<string> | undefined>>({});
+  const pendingCardIdSwapsRef = useRef<Record<string, string | undefined>>({});
   const deletingColumnIdsRef = useRef<Set<string>>(new Set());
   const usingDbRef = useRef(false);
   const suppressReloadRef = useRef(false);
@@ -299,6 +300,7 @@ function App() {
         const columnId = await (pendingColumnIdsRef.current[liveCard.columnId] ?? Promise.resolve(liveCard.columnId));
         const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...liveCard, columnId }, liveCard.order));
         resolveCreatedCardId(result.id);
+        pendingCardIdSwapsRef.current[result.id] = created.id;
         setSelectedCardId((id) => (id === created.id ? result.id : id));
         setBoard((current) => current ? {
           ...current,
@@ -506,6 +508,7 @@ function App() {
       });
       return;
     }
+    if (deletingColumnIdsRef.current.has(columnId)) return;
     deletingColumnIdsRef.current.add(columnId);
     suppressReloadRef.current = true;
     void (async () => {
@@ -763,6 +766,7 @@ function App() {
         <CardDetail
           card={selectedCard}
           columns={board.columns}
+          pendingSwapFromId={pendingCardIdSwapsRef.current[selectedCard.id] ?? null}
           onClose={() => setSelectedCardId(null)}
           onPatch={(patch) => patchCard(selectedCard.id, patch)}
           onMoveColumn={(columnId) => {
@@ -1034,6 +1038,7 @@ function TaskCardView({
 function CardDetail({
   card,
   columns,
+  pendingSwapFromId,
   onClose,
   onPatch,
   onMoveColumn,
@@ -1043,6 +1048,7 @@ function CardDetail({
 }: {
   card: Card;
   columns: BoardColumn[];
+  pendingSwapFromId: string | null;
   onClose: () => void;
   onPatch: (patch: Partial<Omit<Card, "id" | "createdAt">>) => void;
   onMoveColumn: (columnId: string) => void;
@@ -1058,7 +1064,7 @@ function CardDetail({
   const previousCardRef = useRef(card);
   useEffect(() => {
     const previous = previousCardRef.current;
-    const sameCard = previous.id === card.id || (previous.createdAt === card.createdAt && previous.title === card.title);
+    const sameCard = previous.id === card.id || pendingSwapFromId === previous.id;
     if (!sameCard || title === previous.title) setTitle(card.title);
     if (!sameCard || description === previous.description) setDescription(card.description);
     if (!sameCard || assignee === previous.assignee) setAssignee(card.assignee);
@@ -1067,7 +1073,7 @@ function CardDetail({
       setChecklistInput("");
     }
     previousCardRef.current = card;
-  }, [assignee, card, description, title]);
+  }, [assignee, card, description, pendingSwapFromId, title]);
 
   const progress = checklistProgress(card.checklist);
 

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -235,9 +235,14 @@ function App() {
       await action();
     } catch (err: unknown) {
       console.warn(`[task-manager] ${failure}:`, errMessage(err));
+      try {
+        await reload();
+      } catch (reloadErr: unknown) {
+        console.warn(`[task-manager] ${failure} recovery reload failed:`, errMessage(reloadErr));
+      }
       setError(`${failure}. Reopen the board to refresh.`);
     }
-  }, []);
+  }, [reload]);
 
   const resolveCardId = useCallback((cardId: string): Promise<string> => {
     return pendingCardIdsRef.current[cardId] ?? Promise.resolve(cardId);

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -357,11 +357,18 @@ function App() {
     const position = next.columns.findIndex((column) => column.id === created.id);
     let resolveColumnId: (id: string) => void = () => undefined;
     let rejectColumnId: (err: unknown) => void = () => undefined;
-    pendingColumnIdsRef.current[created.id] = new Promise<string>((resolve, reject) => {
+    const pendingColumnId = new Promise<string>((resolve, reject) => {
       resolveColumnId = resolve;
       rejectColumnId = reject;
     });
-    void persist(async () => {
+    pendingColumnId.catch(() => undefined);
+    pendingColumnIdsRef.current[created.id] = pendingColumnId;
+    void (async () => {
+      if (!usingDbRef.current) {
+        resolveColumnId(created.id);
+        delete pendingColumnIdsRef.current[created.id];
+        return;
+      }
       const bridge = db();
       if (!bridge) {
         resolveColumnId(created.id);
@@ -377,12 +384,14 @@ function App() {
         } : current);
       } catch (err) {
         rejectColumnId(err);
-        throw err;
+        console.warn("[task-manager] Column could not be created:", errMessage(err));
+        await reload();
+        setError("Column could not be created. Reopen the board to refresh.");
       } finally {
         delete pendingColumnIdsRef.current[created.id];
       }
-    }, "Column could not be created");
-  }, [persist]);
+    })();
+  }, [reload]);
 
   const renameBoardColumn = useCallback((columnId: string, title: string) => {
     if (!boardRef.current) return;

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -131,6 +131,7 @@ function App() {
   const boardRef = useRef<Board | null>(null);
   boardRef.current = board;
   const pendingColumnIdsRef = useRef<Record<string, Promise<string> | undefined>>({});
+  const pendingCardIdsRef = useRef<Record<string, Promise<string> | undefined>>({});
   const usingDbRef = useRef(false);
   const suppressReloadRef = useRef(false);
 
@@ -204,11 +205,14 @@ function App() {
     if (!usingDbRef.current) return;
     try {
       await action();
-      setError(null);
     } catch (err: unknown) {
       console.warn(`[task-manager] ${failure}:`, errMessage(err));
       setError(`${failure}. Reopen the board to refresh.`);
     }
+  }, []);
+
+  const resolveCardId = useCallback((cardId: string): Promise<string> => {
+    return pendingCardIdsRef.current[cardId] ?? Promise.resolve(cardId);
   }, []);
 
   // --- Card mutations (optimistic) ---
@@ -222,17 +226,36 @@ function App() {
     setBoard(next);
     const created = next.cards.find((card) => !existing.has(card.id));
     if (!created) return;
+    let resolveCreatedCardId: (id: string) => void = () => undefined;
+    let rejectCreatedCardId: (err: unknown) => void = () => undefined;
+    const pendingCardId = new Promise<string>((resolve, reject) => {
+      resolveCreatedCardId = resolve;
+      rejectCreatedCardId = reject;
+    });
+    pendingCardId.catch(() => undefined);
+    pendingCardIdsRef.current[created.id] = pendingCardId;
     void persist(async () => {
       const bridge = db();
-      if (!bridge) return;
+      if (!bridge) {
+        resolveCreatedCardId(created.id);
+        return;
+      }
       const liveColumnId = boardRef.current?.cards.find((card) => card.id === created.id)?.columnId ?? created.columnId;
       const columnId = await (pendingColumnIdsRef.current[liveColumnId] ?? Promise.resolve(liveColumnId));
-      const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...created, columnId }, created.order));
-      setSelectedCardId((id) => (id === created.id ? result.id : id));
-      setBoard((current) => current ? {
-        ...current,
-        cards: current.cards.map((card) => card.id === created.id ? { ...card, id: result.id } : card),
-      } : current);
+      try {
+        const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...created, columnId }, created.order));
+        resolveCreatedCardId(result.id);
+        setSelectedCardId((id) => (id === created.id ? result.id : id));
+        setBoard((current) => current ? {
+          ...current,
+          cards: current.cards.map((card) => card.id === created.id ? { ...card, id: result.id } : card),
+        } : current);
+      } catch (err) {
+        rejectCreatedCardId(err);
+        throw err;
+      } finally {
+        delete pendingCardIdsRef.current[created.id];
+      }
     }, "Card could not be saved");
   }, [persist]);
 
@@ -246,9 +269,10 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.update(CARDS_TABLE, cardId, cardToRow(updated, updated.order));
+      const persistedCardId = await resolveCardId(cardId);
+      await bridge.update(CARDS_TABLE, persistedCardId, cardToRow({ ...updated, id: persistedCardId }, updated.order));
     }, "Card could not be updated");
-  }, [persist]);
+  }, [persist, resolveCardId]);
 
   const removeCard = useCallback((cardId: string) => {
     const current = boardRef.current;
@@ -258,9 +282,9 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.delete(CARDS_TABLE, cardId);
+      await bridge.delete(CARDS_TABLE, await resolveCardId(cardId));
     }, "Card could not be deleted");
-  }, [persist]);
+  }, [persist, resolveCardId]);
 
   const dropCard = useCallback((cardId: string, targetColumnId: string, targetIndex: number) => {
     const current = boardRef.current;
@@ -275,10 +299,10 @@ function App() {
       if (!bridge) return;
       const toWrite = next.cards.filter((card) => affected.has(card.columnId));
       for (const card of toWrite) {
-        await bridge.update(CARDS_TABLE, card.id, { column_id: card.columnId, position: card.order });
+        await bridge.update(CARDS_TABLE, await resolveCardId(card.id), { column_id: card.columnId, position: card.order });
       }
     }, "Card order could not be saved");
-  }, [persist]);
+  }, [persist, resolveCardId]);
 
   // --- Checklist (within selected card) ---
 
@@ -292,9 +316,9 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.update(CARDS_TABLE, cardId, { checklist: updated.checklist });
+      await bridge.update(CARDS_TABLE, await resolveCardId(cardId), { checklist: updated.checklist });
     }, "Checklist could not be saved");
-  }, [persist]);
+  }, [persist, resolveCardId]);
 
   const addChecklist = useCallback((cardId: string, text: string) => {
     const current = boardRef.current;
@@ -306,9 +330,9 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.update(CARDS_TABLE, cardId, { checklist: updated.checklist });
+      await bridge.update(CARDS_TABLE, await resolveCardId(cardId), { checklist: updated.checklist });
     }, "Checklist could not be saved");
-  }, [persist]);
+  }, [persist, resolveCardId]);
 
   // --- Column mutations ---
 

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -335,9 +335,7 @@ function App() {
       const persistedCardId = await resolveCardId(cardId);
       const liveCard = boardRef.current?.cards.find((card) => card.id === persistedCardId)
         ?? boardRef.current?.cards.find((card) => card.id === cardId);
-      const rowCard = liveCard
-        ? { ...updated, columnId: liveCard.columnId, order: liveCard.order, checklist: liveCard.checklist }
-        : updated;
+      const rowCard = liveCard ?? updated;
       const persistedColumnId = await (
         pendingColumnIdsRef.current[rowCard.columnId] ?? Promise.resolve(rowCard.columnId)
       );

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -150,6 +150,7 @@ function App() {
   boardRef.current = board;
   const pendingColumnIdsRef = useRef<Record<string, Promise<string> | undefined>>({});
   const pendingCardIdsRef = useRef<Record<string, Promise<string> | undefined>>({});
+  const deletingColumnIdsRef = useRef<Set<string>>(new Set());
   const usingDbRef = useRef(false);
   const suppressReloadRef = useRef(false);
 
@@ -161,7 +162,7 @@ function App() {
       const next = local && local.columns?.length ? local : createSeedBoard();
       setBoard(next);
       if (!local) saveLocalBoard(next);
-      return;
+      return true;
     }
     usingDbRef.current = true;
     try {
@@ -179,7 +180,7 @@ function App() {
             suppressReloadRef.current = false;
           }
           setError(null);
-          return;
+          return true;
         }
         // First run: seed the default workflow columns into Postgres.
         const seed = emptyBoard();
@@ -190,13 +191,15 @@ function App() {
           suppressReloadRef.current = false;
         }
         setError(null);
-        return;
+        return true;
       }
       setBoard(boardFromRows(columnRows, cardRows));
       setError(null);
+      return true;
     } catch (err: unknown) {
       console.warn("[task-manager] load failed:", errMessage(err));
       setError("Board could not be loaded. Retrying may help.");
+      return false;
     }
   }, []);
 
@@ -235,12 +238,8 @@ function App() {
       await action();
     } catch (err: unknown) {
       console.warn(`[task-manager] ${failure}:`, errMessage(err));
-      try {
-        await reload();
-      } catch (reloadErr: unknown) {
-        console.warn(`[task-manager] ${failure} recovery reload failed:`, errMessage(reloadErr));
-      }
-      setError(`${failure}. Reopen the board to refresh.`);
+      const refreshed = await reload();
+      setError(refreshed ? `${failure}. The board has been refreshed.` : `${failure}. Reopen the board to refresh.`);
     }
   }, [reload]);
 
@@ -253,10 +252,12 @@ function App() {
   const createCard = useCallback((columnId: string, title: string) => {
     const current = boardRef.current;
     if (!current || !title.trim()) return;
+    if (deletingColumnIdsRef.current.has(columnId)) return;
     const projectId = current.projects[0]?.id ?? "project-default";
     const existing = new Set(current.cards.map((card) => card.id));
     const next = addCard(current, { columnId, projectId, title });
     setBoard(next);
+    boardRef.current = next;
     const created = next.cards.find((card) => !existing.has(card.id));
     if (!created) return;
     let resolveCreatedCardId: (id: string) => void = () => undefined;
@@ -273,11 +274,30 @@ function App() {
         resolveCreatedCardId(created.id);
         return;
       }
-      const liveColumnId = boardRef.current?.cards.find((card) => card.id === created.id)?.columnId ?? created.columnId;
-      const columnId = await (pendingColumnIdsRef.current[liveColumnId] ?? Promise.resolve(liveColumnId));
       try {
-        const liveOrder = boardRef.current?.cards.find((card) => card.id === created.id)?.order ?? created.order;
-        const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...created, columnId }, liveOrder));
+        let liveCard = boardRef.current?.cards.find((card) => card.id === created.id);
+        if (!liveCard) {
+          resolveCreatedCardId(created.id);
+          return;
+        }
+        const liveColumnExists = boardRef.current?.columns.some((column) => column.id === liveCard.columnId) ?? false;
+        if (!liveColumnExists) {
+          resolveCreatedCardId(created.id);
+          return;
+        }
+        await (pendingColumnIdsRef.current[liveCard.columnId] ?? Promise.resolve(liveCard.columnId));
+        liveCard = boardRef.current?.cards.find((card) => card.id === created.id);
+        if (!liveCard) {
+          resolveCreatedCardId(created.id);
+          return;
+        }
+        const latestColumnExists = boardRef.current?.columns.some((column) => column.id === liveCard.columnId) ?? false;
+        if (!latestColumnExists) {
+          resolveCreatedCardId(created.id);
+          return;
+        }
+        const columnId = await (pendingColumnIdsRef.current[liveCard.columnId] ?? Promise.resolve(liveCard.columnId));
+        const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...liveCard, columnId }, liveCard.order));
         resolveCreatedCardId(result.id);
         setSelectedCardId((id) => (id === created.id ? result.id : id));
         setBoard((current) => current ? {
@@ -286,11 +306,6 @@ function App() {
         } : current);
       } catch (err) {
         rejectCreatedCardId(err);
-        try {
-          await reload();
-        } catch (reloadErr: unknown) {
-          console.warn("[task-manager] card recovery reload failed:", errMessage(reloadErr));
-        }
         throw err;
       } finally {
         delete pendingCardIdsRef.current[created.id];
@@ -303,6 +318,7 @@ function App() {
     if (!current) return;
     const next = updateCard(current, cardId, patch);
     setBoard(next);
+    boardRef.current = next;
     const updated = next.cards.find((card) => card.id === cardId);
     if (!updated) return;
     void persist(async () => {
@@ -312,7 +328,7 @@ function App() {
       const liveCard = boardRef.current?.cards.find((card) => card.id === persistedCardId)
         ?? boardRef.current?.cards.find((card) => card.id === cardId);
       const rowCard = liveCard
-        ? { ...updated, columnId: liveCard.columnId, order: liveCard.order }
+        ? { ...updated, columnId: liveCard.columnId, order: liveCard.order, checklist: liveCard.checklist }
         : updated;
       const persistedColumnId = await (
         pendingColumnIdsRef.current[rowCard.columnId] ?? Promise.resolve(rowCard.columnId)
@@ -328,30 +344,25 @@ function App() {
   const removeCard = useCallback((cardId: string) => {
     const current = boardRef.current;
     if (!current) return;
-    setBoard(deleteCard(current, cardId));
+    const next = deleteCard(current, cardId);
+    setBoard(next);
+    boardRef.current = next;
     setSelectedCardId((id) => (id === cardId ? null : id));
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      try {
-        await bridge.delete(CARDS_TABLE, await resolveCardId(cardId));
-      } catch (err) {
-        try {
-          await reload();
-        } catch (reloadErr: unknown) {
-          console.warn("[task-manager] card delete recovery reload failed:", errMessage(reloadErr));
-        }
-        throw err;
-      }
+      await bridge.delete(CARDS_TABLE, await resolveCardId(cardId));
     }, "Card could not be deleted");
-  }, [persist, reload, resolveCardId]);
+  }, [persist, resolveCardId]);
 
   const dropCard = useCallback((cardId: string, targetColumnId: string, targetIndex: number) => {
     const current = boardRef.current;
     if (!current) return;
+    if (deletingColumnIdsRef.current.has(targetColumnId)) return;
     const before = current.cards.find((card) => card.id === cardId);
     const next = moveCard(current, cardId, targetColumnId, targetIndex);
     setBoard(next);
+    boardRef.current = next;
     // Persist new column + position for every card in affected columns.
     const affected = new Set([before?.columnId, targetColumnId].filter(Boolean) as string[]);
     void persist(async () => {
@@ -382,12 +393,16 @@ function App() {
     if (!current) return;
     const next = toggleChecklistItem(current, cardId, itemId);
     setBoard(next);
+    boardRef.current = next;
     const updated = next.cards.find((card) => card.id === cardId);
     if (!updated) return;
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.update(CARDS_TABLE, await resolveCardId(cardId), { checklist: updated.checklist });
+      const persistedCardId = await resolveCardId(cardId);
+      const liveCard = boardRef.current?.cards.find((card) => card.id === persistedCardId)
+        ?? boardRef.current?.cards.find((card) => card.id === cardId);
+      await bridge.update(CARDS_TABLE, persistedCardId, { checklist: liveCard?.checklist ?? updated.checklist });
     }, "Checklist could not be saved");
   }, [persist, resolveCardId]);
 
@@ -396,12 +411,16 @@ function App() {
     if (!current || !text.trim()) return;
     const next = addChecklistItem(current, cardId, text);
     setBoard(next);
+    boardRef.current = next;
     const updated = next.cards.find((card) => card.id === cardId);
     if (!updated) return;
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.update(CARDS_TABLE, await resolveCardId(cardId), { checklist: updated.checklist });
+      const persistedCardId = await resolveCardId(cardId);
+      const liveCard = boardRef.current?.cards.find((card) => card.id === persistedCardId)
+        ?? boardRef.current?.cards.find((card) => card.id === cardId);
+      await bridge.update(CARDS_TABLE, persistedCardId, { checklist: liveCard?.checklist ?? updated.checklist });
     }, "Checklist could not be saved");
   }, [persist, resolveCardId]);
 
@@ -413,6 +432,7 @@ function App() {
     const existing = new Set(current.columns.map((column) => column.id));
     const next = addColumn(current, title);
     setBoard(next);
+    boardRef.current = next;
     const created = next.columns.find((column) => !existing.has(column.id));
     if (!created) return;
     const position = next.columns.findIndex((column) => column.id === created.id);
@@ -438,11 +458,16 @@ function App() {
       try {
         const result = await bridge.insert(COLUMNS_TABLE, columnToRow(created, position));
         resolveColumnId(result.id);
-        setBoard((current) => current ? {
-          ...current,
-          columns: current.columns.map((column) => column.id === created.id ? { ...column, id: result.id } : column),
-          cards: current.cards.map((card) => card.columnId === created.id ? { ...card, columnId: result.id } : card),
-        } : current);
+        const latest = boardRef.current;
+        if (latest) {
+          const next = {
+            ...latest,
+            columns: latest.columns.map((column) => column.id === created.id ? { ...column, id: result.id } : column),
+            cards: latest.cards.map((card) => card.columnId === created.id ? { ...card, columnId: result.id } : card),
+          };
+          boardRef.current = next;
+          setBoard(next);
+        }
       } catch (err) {
         rejectColumnId(err);
         console.warn("[task-manager] Column could not be created:", errMessage(err));
@@ -473,24 +498,43 @@ function App() {
     const removedCards = current.cards.filter((card) => card.columnId === columnId).map((card) => card.id);
     const bridge = db();
     if (!usingDbRef.current || !bridge) {
-      setBoard((latest) => (latest ? deleteColumn(latest, columnId) : latest));
+      setBoard((latest) => {
+        if (!latest) return latest;
+        const next = deleteColumn(latest, columnId);
+        boardRef.current = next;
+        return next;
+      });
       return;
     }
+    deletingColumnIdsRef.current.add(columnId);
     suppressReloadRef.current = true;
     void (async () => {
+      let persistedDeleteColumnId: string | null = null;
       try {
         for (const cardId of removedCards) {
           await bridge.delete(CARDS_TABLE, await resolveCardId(cardId));
         }
         const persistedColumnId = await (pendingColumnIdsRef.current[columnId] ?? Promise.resolve(columnId));
+        persistedDeleteColumnId = persistedColumnId;
+        deletingColumnIdsRef.current.add(persistedColumnId);
         await bridge.delete(COLUMNS_TABLE, persistedColumnId);
         setError(null);
-        setBoard((latest) => (latest ? deleteColumn(latest, columnId) : latest));
+        setBoard((latest) => {
+          if (!latest) return latest;
+          const deleteId = latest.columns.some((column) => column.id === persistedColumnId)
+            ? persistedColumnId
+            : columnId;
+          const next = deleteColumn(latest, deleteId);
+          boardRef.current = next;
+          return next;
+        });
       } catch (err: unknown) {
         console.warn("[task-manager] Column could not be deleted:", errMessage(err));
         await reload();
         setError("Column could not be deleted. Reopen the board to refresh.");
       } finally {
+        deletingColumnIdsRef.current.delete(columnId);
+        if (persistedDeleteColumnId) deletingColumnIdsRef.current.delete(persistedDeleteColumnId);
         suppressReloadRef.current = false;
       }
     })();
@@ -501,12 +545,21 @@ function App() {
     if (!current) return;
     const next = moveColumn(current, columnId, targetIndex);
     setBoard(next);
+    boardRef.current = next;
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      for (let i = 0; i < next.columns.length; i += 1) {
-        const persistedColumnId = await (pendingColumnIdsRef.current[next.columns[i].id] ?? Promise.resolve(next.columns[i].id));
-        await bridge.update(COLUMNS_TABLE, persistedColumnId, { position: i });
+      const columnIds = next.columns.map((column) => column.id);
+      for (const originalColumnId of columnIds) {
+        const persistedColumnId = await (
+          pendingColumnIdsRef.current[originalColumnId] ?? Promise.resolve(originalColumnId)
+        );
+        const liveColumns = boardRef.current?.columns ?? next.columns;
+        const liveIndex = liveColumns.findIndex((column) =>
+          column.id === persistedColumnId || column.id === originalColumnId,
+        );
+        if (liveIndex < 0) continue;
+        await bridge.update(COLUMNS_TABLE, persistedColumnId, { position: liveIndex });
       }
     }, "Column order could not be saved");
   }, [persist]);
@@ -805,7 +858,11 @@ function BoardColumnView(props: ColumnViewProps) {
         {isEditing ? (
           <form
             className="column__rename"
-            onSubmit={(event) => { event.preventDefault(); onRename(renameValue); }}
+            onSubmit={(event) => {
+              event.preventDefault();
+              skipNextRenameBlurRef.current = true;
+              onRename(renameValue);
+            }}
           >
             <input
               autoFocus
@@ -1039,7 +1096,7 @@ function CardDetail({
           className="detail-title"
           value={title}
           onChange={(event) => setTitle(event.target.value)}
-          onBlur={() => { if (title.trim() && title !== card.title) onPatch({ title: title.trim() }); else setTitle(card.title); }}
+          onBlur={() => { if (title.trim() && title.trim() !== card.title) onPatch({ title: title.trim() }); else setTitle(card.title); }}
           aria-label="Card title"
         />
 

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -381,9 +381,8 @@ function App() {
   }, [persist]);
 
   const renameBoardColumn = useCallback((columnId: string, title: string) => {
-    const current = boardRef.current;
-    if (!current) return;
-    setBoard(renameColumn(current, columnId, title));
+    if (!boardRef.current) return;
+    setBoard((current) => (current ? renameColumn(current, columnId, title) : current));
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
@@ -398,7 +397,7 @@ function App() {
     const removedCards = current.cards.filter((card) => card.columnId === columnId).map((card) => card.id);
     const bridge = db();
     if (!usingDbRef.current || !bridge) {
-      setBoard(deleteColumn(current, columnId));
+      setBoard((latest) => (latest ? deleteColumn(latest, columnId) : latest));
       return;
     }
     suppressReloadRef.current = true;
@@ -410,7 +409,7 @@ function App() {
         const persistedColumnId = await (pendingColumnIdsRef.current[columnId] ?? Promise.resolve(columnId));
         await bridge.delete(COLUMNS_TABLE, persistedColumnId);
         setError(null);
-        setBoard(deleteColumn(current, columnId));
+        setBoard((latest) => (latest ? deleteColumn(latest, columnId) : latest));
       } catch (err: unknown) {
         console.warn("[task-manager] Column could not be deleted:", errMessage(err));
         await reload();

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -302,14 +302,19 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      const toWrite = next.cards.filter((card) => affected.has(card.columnId));
-      for (const card of toWrite) {
+      const cardIds = next.cards.filter((card) => affected.has(card.columnId)).map((card) => card.id);
+      for (const cardId of cardIds) {
+        const persistedCardId = await resolveCardId(cardId);
+        const liveCard = boardRef.current?.cards.find((card) => card.id === persistedCardId)
+          ?? boardRef.current?.cards.find((card) => card.id === cardId)
+          ?? next.cards.find((card) => card.id === cardId);
+        if (!liveCard) continue;
         const persistedColumnId = await (
-          pendingColumnIdsRef.current[card.columnId] ?? Promise.resolve(card.columnId)
+          pendingColumnIdsRef.current[liveCard.columnId] ?? Promise.resolve(liveCard.columnId)
         );
-        await bridge.update(CARDS_TABLE, await resolveCardId(card.id), {
+        await bridge.update(CARDS_TABLE, persistedCardId, {
           column_id: persistedColumnId,
-          position: card.order,
+          position: liveCard.order,
         });
       }
     }, "Card order could not be saved");
@@ -922,9 +927,15 @@ function CardDetail({
   const [assignee, setAssignee] = useState(card.assignee);
   const [labelInput, setLabelInput] = useState("");
   const [checklistInput, setChecklistInput] = useState("");
-  useEffect(() => { setTitle(card.title); }, [card.id, card.title]);
-  useEffect(() => { setDescription(card.description); }, [card.id, card.description]);
-  useEffect(() => { setAssignee(card.assignee); }, [card.id, card.assignee]);
+  const previousCardRef = useRef(card);
+  useEffect(() => {
+    const previous = previousCardRef.current;
+    const sameCard = previous.createdAt === card.createdAt;
+    if (!sameCard || title === previous.title) setTitle(card.title);
+    if (!sameCard || description === previous.description) setDescription(card.description);
+    if (!sameCard || assignee === previous.assignee) setAssignee(card.assignee);
+    previousCardRef.current = card;
+  }, [assignee, card, description, title]);
 
   const progress = checklistProgress(card.checklist);
 

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -252,12 +252,17 @@ function App() {
         } : current);
       } catch (err) {
         rejectCreatedCardId(err);
+        try {
+          await reload();
+        } catch (reloadErr: unknown) {
+          console.warn("[task-manager] card recovery reload failed:", errMessage(reloadErr));
+        }
         throw err;
       } finally {
         delete pendingCardIdsRef.current[created.id];
       }
     }, "Card could not be saved");
-  }, [persist]);
+  }, [persist, reload]);
 
   const patchCard = useCallback((cardId: string, patch: Partial<Omit<Card, "id" | "createdAt">>) => {
     const current = boardRef.current;

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -401,7 +401,8 @@ function App() {
         for (const cardId of removedCards) {
           await bridge.delete(CARDS_TABLE, await resolveCardId(cardId));
         }
-        await bridge.delete(COLUMNS_TABLE, columnId);
+        const persistedColumnId = await (pendingColumnIdsRef.current[columnId] ?? Promise.resolve(columnId));
+        await bridge.delete(COLUMNS_TABLE, persistedColumnId);
         setError(null);
         setBoard(deleteColumn(current, columnId));
       } catch (err: unknown) {
@@ -423,7 +424,8 @@ function App() {
       const bridge = db();
       if (!bridge) return;
       for (let i = 0; i < next.columns.length; i += 1) {
-        await bridge.update(COLUMNS_TABLE, next.columns[i].id, { position: i });
+        const persistedColumnId = await (pendingColumnIdsRef.current[next.columns[i].id] ?? Promise.resolve(next.columns[i].id));
+        await bridge.update(COLUMNS_TABLE, persistedColumnId, { position: i });
       }
     }, "Column order could not be saved");
   }, [persist]);

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -243,7 +243,8 @@ function App() {
       const liveColumnId = boardRef.current?.cards.find((card) => card.id === created.id)?.columnId ?? created.columnId;
       const columnId = await (pendingColumnIdsRef.current[liveColumnId] ?? Promise.resolve(liveColumnId));
       try {
-        const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...created, columnId }, created.order));
+        const liveOrder = boardRef.current?.cards.find((card) => card.id === created.id)?.order ?? created.order;
+        const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...created, columnId }, liveOrder));
         resolveCreatedCardId(result.id);
         setSelectedCardId((id) => (id === created.id ? result.id : id));
         setBoard((current) => current ? {
@@ -280,7 +281,14 @@ function App() {
       const rowCard = liveCard
         ? { ...updated, columnId: liveCard.columnId, order: liveCard.order }
         : updated;
-      await bridge.update(CARDS_TABLE, persistedCardId, cardToRow({ ...rowCard, id: persistedCardId }, rowCard.order));
+      const persistedColumnId = await (
+        pendingColumnIdsRef.current[rowCard.columnId] ?? Promise.resolve(rowCard.columnId)
+      );
+      await bridge.update(
+        CARDS_TABLE,
+        persistedCardId,
+        cardToRow({ ...rowCard, id: persistedCardId, columnId: persistedColumnId }, rowCard.order),
+      );
     }, "Card could not be updated");
   }, [persist, resolveCardId]);
 
@@ -711,6 +719,7 @@ function BoardColumnView(props: ColumnViewProps) {
     onSetDropTarget, onCardDrop, onOpenCard,
   } = props;
   const [renameValue, setRenameValue] = useState(column.title);
+  const skipNextRenameBlurRef = useRef(false);
   useEffect(() => setRenameValue(column.title), [column.title]);
 
   const isColumnDropTarget = draggingColumnId !== null && draggingColumnId !== column.id;
@@ -758,8 +767,21 @@ function BoardColumnView(props: ColumnViewProps) {
               autoFocus
               value={renameValue}
               onChange={(event) => setRenameValue(event.target.value)}
-              onBlur={() => onRename(renameValue)}
-              onKeyDown={(event) => { if (event.key === "Escape") { setRenameValue(column.title); onCancelEdit(); } }}
+              onBlur={() => {
+                if (skipNextRenameBlurRef.current) {
+                  skipNextRenameBlurRef.current = false;
+                  return;
+                }
+                onRename(renameValue);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  skipNextRenameBlurRef.current = true;
+                  setRenameValue(column.title);
+                  onCancelEdit();
+                }
+              }}
             />
           </form>
         ) : (

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -381,7 +381,8 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.update(COLUMNS_TABLE, columnId, { title: title.trim() });
+      const persistedColumnId = await (pendingColumnIdsRef.current[columnId] ?? Promise.resolve(columnId));
+      await bridge.update(COLUMNS_TABLE, persistedColumnId, { title: title.trim() });
     }, "Column could not be renamed");
   }, [persist]);
 
@@ -397,7 +398,9 @@ function App() {
     suppressReloadRef.current = true;
     void (async () => {
       try {
-        for (const cardId of removedCards) await bridge.delete(CARDS_TABLE, cardId);
+        for (const cardId of removedCards) {
+          await bridge.delete(CARDS_TABLE, await resolveCardId(cardId));
+        }
         await bridge.delete(COLUMNS_TABLE, columnId);
         setError(null);
         setBoard(deleteColumn(current, columnId));
@@ -409,7 +412,7 @@ function App() {
         suppressReloadRef.current = false;
       }
     })();
-  }, [reload]);
+  }, [reload, resolveCardId]);
 
   const dropColumn = useCallback((columnId: string, targetIndex: number) => {
     const current = boardRef.current;

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -935,10 +935,14 @@ function CardDetail({
   const previousCardRef = useRef(card);
   useEffect(() => {
     const previous = previousCardRef.current;
-    const sameCard = previous.createdAt === card.createdAt;
+    const sameCard = previous.id === card.id || (previous.createdAt === card.createdAt && previous.title === card.title);
     if (!sameCard || title === previous.title) setTitle(card.title);
     if (!sameCard || description === previous.description) setDescription(card.description);
     if (!sameCard || assignee === previous.assignee) setAssignee(card.assignee);
+    if (!sameCard) {
+      setLabelInput("");
+      setChecklistInput("");
+    }
     previousCardRef.current = card;
   }, [assignee, card, description, title]);
 

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -40,6 +40,7 @@ import {
   cardToRow,
   columnToRow,
   emptyBoard,
+  loadBridgeBoard,
   loadLocalBoard,
   saveLocalBoard,
 } from "./persistence";
@@ -64,6 +65,8 @@ function labelColor(label: string): string {
 function db(): NonNullable<Window["MatrixOS"]>["db"] | undefined {
   return typeof window !== "undefined" ? window.MatrixOS?.db : undefined;
 }
+
+type MatrixDb = NonNullable<NonNullable<Window["MatrixOS"]>["db"]>;
 
 function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -91,6 +94,26 @@ function formatDue(due: string): string {
   return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
+async function persistBoardToBridge(bridge: MatrixDb, source: Board): Promise<Board> {
+  const columnIdMap = new Map<string, string>();
+  for (let i = 0; i < source.columns.length; i += 1) {
+    const column = source.columns[i];
+    const result = await bridge.insert(COLUMNS_TABLE, columnToRow(column, i));
+    columnIdMap.set(column.id, result.id);
+  }
+  for (const card of source.cards) {
+    await bridge.insert(CARDS_TABLE, {
+      ...cardToRow(card, card.order),
+      column_id: columnIdMap.get(card.columnId) ?? card.columnId,
+    });
+  }
+  const [columnRows, cardRows] = await Promise.all([
+    bridge.find(COLUMNS_TABLE, { orderBy: { position: "asc" } }),
+    bridge.find(CARDS_TABLE, { orderBy: { position: "asc" } }),
+  ]);
+  return boardFromRows(columnRows, cardRows);
+}
+
 function App() {
   const [board, setBoard] = useState<Board | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -108,6 +131,7 @@ function App() {
   const boardRef = useRef<Board | null>(null);
   boardRef.current = board;
   const usingDbRef = useRef(false);
+  const suppressReloadRef = useRef(false);
 
   const reload = useCallback(async () => {
     const bridge = db();
@@ -126,13 +150,15 @@ function App() {
         bridge.find(CARDS_TABLE, { orderBy: { position: "asc" } }),
       ]);
       if (columnRows.length === 0) {
+        const legacy = await loadBridgeBoard();
+        if (legacy) {
+          setBoard(await persistBoardToBridge(bridge, legacy));
+          setError(null);
+          return;
+        }
         // First run: seed the default workflow columns into Postgres.
         const seed = emptyBoard();
-        for (let i = 0; i < seed.columns.length; i += 1) {
-          await bridge.insert(COLUMNS_TABLE, columnToRow(seed.columns[i], i));
-        }
-        const seeded = await bridge.find(COLUMNS_TABLE, { orderBy: { position: "asc" } });
-        setBoard(boardFromRows(seeded, []));
+        setBoard(await persistBoardToBridge(bridge, seed));
         setError(null);
         return;
       }
@@ -148,8 +174,11 @@ function App() {
     void reload();
     const bridge = db();
     if (!bridge) return undefined;
-    const offColumns = bridge.onChange(COLUMNS_TABLE, () => void reload());
-    const offCards = bridge.onChange(CARDS_TABLE, () => void reload());
+    const guardedReload = () => {
+      if (!suppressReloadRef.current) void reload();
+    };
+    const offColumns = bridge.onChange(COLUMNS_TABLE, guardedReload);
+    const offCards = bridge.onChange(CARDS_TABLE, guardedReload);
     return () => {
       offColumns?.();
       offCards?.();
@@ -195,7 +224,12 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.insert(CARDS_TABLE, cardToRow(created, created.order));
+      const result = await bridge.insert(CARDS_TABLE, cardToRow(created, created.order));
+      setSelectedCardId((id) => (id === created.id ? result.id : id));
+      setBoard((current) => current ? {
+        ...current,
+        cards: current.cards.map((card) => card.id === created.id ? { ...card, id: result.id } : card),
+      } : current);
     }, "Card could not be saved");
   }, [persist]);
 
@@ -287,7 +321,12 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.insert(COLUMNS_TABLE, columnToRow(created, position));
+      const result = await bridge.insert(COLUMNS_TABLE, columnToRow(created, position));
+      setBoard((current) => current ? {
+        ...current,
+        columns: current.columns.map((column) => column.id === created.id ? { ...column, id: result.id } : column),
+        cards: current.cards.map((card) => card.columnId === created.id ? { ...card, columnId: result.id } : card),
+      } : current);
     }, "Column could not be created");
   }, [persist]);
 
@@ -306,14 +345,27 @@ function App() {
     const current = boardRef.current;
     if (!current || current.columns.length <= 1) return;
     const removedCards = current.cards.filter((card) => card.columnId === columnId).map((card) => card.id);
-    setBoard(deleteColumn(current, columnId));
-    void persist(async () => {
-      const bridge = db();
-      if (!bridge) return;
-      for (const cardId of removedCards) await bridge.delete(CARDS_TABLE, cardId);
-      await bridge.delete(COLUMNS_TABLE, columnId);
-    }, "Column could not be deleted");
-  }, [persist]);
+    const bridge = db();
+    if (!usingDbRef.current || !bridge) {
+      setBoard(deleteColumn(current, columnId));
+      return;
+    }
+    suppressReloadRef.current = true;
+    void (async () => {
+      try {
+        for (const cardId of removedCards) await bridge.delete(CARDS_TABLE, cardId);
+        await bridge.delete(COLUMNS_TABLE, columnId);
+        setError(null);
+        setBoard(deleteColumn(current, columnId));
+      } catch (err: unknown) {
+        console.warn("[task-manager] Column could not be deleted:", errMessage(err));
+        setError("Column could not be deleted. Reopen the board to refresh.");
+        await reload();
+      } finally {
+        suppressReloadRef.current = false;
+      }
+    })();
+  }, [reload]);
 
   const dropColumn = useCallback((columnId: string, targetIndex: number) => {
     const current = boardRef.current;

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -701,7 +701,7 @@ function BoardColumnView(props: ColumnViewProps) {
       aria-label={column.title}
       onDragOver={(event) => {
         if (draggingColumnId && draggingColumnId !== column.id) event.preventDefault();
-        else if (draggingCardId) {
+        else if (draggingCardId && !isFiltering) {
           event.preventDefault();
           onSetDropTarget(cards.length);
         }
@@ -712,7 +712,7 @@ function BoardColumnView(props: ColumnViewProps) {
           onColumnDrop();
           return;
         }
-        if (draggingCardId) {
+        if (draggingCardId && !isFiltering) {
           event.preventDefault();
           onCardDrop(cards.length);
         }
@@ -768,7 +768,7 @@ function BoardColumnView(props: ColumnViewProps) {
             {dropTarget === index && draggingCardId ? <div className="drop-indicator" /> : null}
             <div
               onDragOver={(event) => {
-                if (!draggingCardId) return;
+                if (!draggingCardId || isFiltering) return;
                 event.preventDefault();
                 event.stopPropagation();
                 onSetDropTarget(index);
@@ -777,6 +777,7 @@ function BoardColumnView(props: ColumnViewProps) {
                 if (!draggingCardId) return;
                 event.preventDefault();
                 event.stopPropagation();
+                if (isFiltering) return;
                 onCardDrop(index);
               }}
             >

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -304,6 +304,9 @@ function App() {
         const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...liveCard, columnId }, liveCard.order));
         resolveCreatedCardId(result.id);
         pendingCardIdSwapsRef.current[result.id] = created.id;
+        window.setTimeout(() => {
+          delete pendingCardIdSwapsRef.current[result.id];
+        }, 0);
         setSelectedCardId((id) => (id === created.id ? result.id : id));
         setBoard((current) => current ? {
           ...current,

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -300,9 +300,18 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      await bridge.delete(CARDS_TABLE, await resolveCardId(cardId));
+      try {
+        await bridge.delete(CARDS_TABLE, await resolveCardId(cardId));
+      } catch (err) {
+        try {
+          await reload();
+        } catch (reloadErr: unknown) {
+          console.warn("[task-manager] card delete recovery reload failed:", errMessage(reloadErr));
+        }
+        throw err;
+      }
     }, "Card could not be deleted");
-  }, [persist, resolveCardId]);
+  }, [persist, reload, resolveCardId]);
 
   const dropCard = useCallback((cardId: string, targetColumnId: string, targetIndex: number) => {
     const current = boardRef.current;

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -1,787 +1,941 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  Archive,
-  ArrowLeft,
-  ArrowRight,
-  Bot,
   CalendarDays,
+  Check,
   CheckCircle2,
   Circle,
-  ClipboardList,
-  FolderKanban,
   GripVertical,
   LayoutDashboard,
   ListChecks,
+  Pencil,
   Plus,
   Search,
-  Send,
-  Sparkles,
+  Tag,
   Trash2,
-  Users,
+  User,
   X,
 } from "lucide-react";
 import {
   addCard,
   addChecklistItem,
-  addProject,
-  clearDelegation,
+  addColumn,
   createSeedBoard,
-  delegateCard,
   deleteCard,
-  hydrateBoard,
+  deleteColumn,
   moveCard,
-  moveCardToAdjacentColumn,
-  resolveColumnId,
-  summarizeBoard,
+  moveColumn,
+  renameColumn,
   toggleChecklistItem,
   updateCard,
   type Board,
+  type BoardColumn,
   type Card,
-  type CardDelegation,
-  type DelegationStatus,
-  type DelegationTarget,
-  type DelegationTrigger,
+  type ChecklistItem,
   type Priority,
 } from "./board-model";
+import {
+  CARDS_TABLE,
+  COLUMNS_TABLE,
+  boardFromRows,
+  cardToRow,
+  columnToRow,
+  emptyBoard,
+  loadLocalBoard,
+  saveLocalBoard,
+} from "./persistence";
+import "./styles.css";
 
-const APP_ID = "task-manager";
-const BOARD_KEY = "project-board";
-const FETCH_TIMEOUT_MS = 10_000;
-
-const TRIGGER_LABELS: Record<DelegationTrigger, string> = {
-  manual: "Manual",
-  when_ready: "When ready",
-  on_review: "On review",
-  scheduled: "Scheduled",
+const PRIORITY_ORDER: Priority[] = ["low", "medium", "high", "urgent"];
+const PRIORITY_LABEL: Record<Priority, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  urgent: "Urgent",
 };
 
-const STATUS_LABELS: Record<DelegationStatus, string> = {
-  queued: "Queued",
-  active: "Active",
-  blocked: "Blocked",
-  done: "Done",
-};
+const LABEL_PALETTE = ["#D06F25", "#3A7D44", "#434E3F", "#D49B2A", "#C4342D", "#7A7768"];
 
-const DELEGATION_LABELS: Record<DelegationTarget, string> = {
-  matrix: "Matrix",
-  hermes: "Hermes",
-};
-
-type DraftDelegationTarget = DelegationTarget | "none";
-
-interface QuickDraft {
-  title: string;
-  columnId: string;
-  priority: Priority;
-  delegationTarget: DraftDelegationTarget;
+function labelColor(label: string): string {
+  let hash = 0;
+  for (let i = 0; i < label.length; i += 1) hash = (hash * 31 + label.charCodeAt(i)) >>> 0;
+  return LABEL_PALETTE[hash % LABEL_PALETTE.length];
 }
 
-function makeDefaultQuickDraft(board?: Board | null): QuickDraft {
-  return {
-    title: "",
-    columnId: board ? resolveColumnId(board, null) : "backlog",
-    priority: "medium",
-    delegationTarget: "none",
-  };
+function db(): NonNullable<Window["MatrixOS"]>["db"] | undefined {
+  return typeof window !== "undefined" ? window.MatrixOS?.db : undefined;
 }
 
-const DEFAULT_QUICK_DRAFT: QuickDraft = makeDefaultQuickDraft();
-
-async function readBoard(): Promise<Board> {
-  const params = new URLSearchParams({ app: APP_ID, key: BOARD_KEY });
-  const response = await fetch(`/api/bridge/data?${params.toString()}`, {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
-  if (!response.ok) return createSeedBoard();
-  if (!response.headers.get("content-type")?.includes("application/json")) {
-    throw new Error("Bridge returned a non-JSON response");
-  }
-  let payload: { value?: string | null } | null;
-  try {
-    payload = (await response.json()) as { value?: string | null } | null;
-  } catch (err: unknown) {
-    throw new Error(`Bridge returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
-  }
-  if (!payload?.value) return createSeedBoard();
-  try {
-    return hydrateBoard(JSON.parse(payload.value));
-  } catch (err: unknown) {
-    throw new Error(`Bridge returned invalid board payload: ${err instanceof Error ? err.message : String(err)}`);
-  }
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
-function timeoutSignal(signal?: AbortSignal): AbortSignal {
-  if (!signal) return AbortSignal.timeout(FETCH_TIMEOUT_MS);
-  return AbortSignal.any([signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)]);
+function checklistProgress(checklist: ChecklistItem[]): { done: number; total: number } {
+  return { done: checklist.filter((item) => item.done).length, total: checklist.length };
 }
 
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === "AbortError";
+function dueState(due: string): "overdue" | "soon" | "none" | "later" {
+  if (!due) return "none";
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const date = new Date(`${due}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return "none";
+  const diff = Math.round((date.getTime() - today.getTime()) / 86_400_000);
+  if (diff < 0) return "overdue";
+  if (diff <= 2) return "soon";
+  return "later";
 }
 
-async function writeBoard(board: Board, signal?: AbortSignal): Promise<void> {
-  const response = await fetch("/api/bridge/data", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    signal: timeoutSignal(signal),
-    body: JSON.stringify({
-      action: "write",
-      app: APP_ID,
-      key: BOARD_KEY,
-      value: JSON.stringify(board),
-    }),
-  });
-  if (!response.ok) {
-    throw new Error("Board save failed");
-  }
-}
-
-function priorityClass(priority: Priority): string {
-  return `priority priority--${priority}`;
-}
-
-function delegationClass(target: DelegationTarget): string {
-  return `delegation-badge delegation-badge--${target}`;
-}
-
-function defaultDelegationInstructions(card: Card): string {
-  return card.description.trim() || card.title;
-}
-
-function columnCardCount(board: Board, columnId: string): number {
-  return board.cards.filter((card) => card.columnId === columnId).length;
-}
-
-function cardDropIndex(board: Board, targetCardId: string, movingCardId: string): number {
-  const targetCard = board.cards.find((card) => card.id === targetCardId);
-  if (!targetCard) return 0;
-  const targetCards = board.cards
-    .filter((card) => card.columnId === targetCard.columnId && card.id !== movingCardId)
-    .sort((a, b) => a.order - b.order);
-  const targetIndex = targetCards.findIndex((card) => card.id === targetCardId);
-  return targetIndex < 0 ? targetCards.length : targetIndex;
-}
-
-function CardView({
-  card,
-  projectName,
-  columnTitle,
-  canMovePrevious,
-  canMoveNext,
-  onOpen,
-  onDragStart,
-  onMovePrevious,
-  onMoveNext,
-}: {
-  card: Card;
-  projectName: string;
-  columnTitle: string;
-  canMovePrevious: boolean;
-  canMoveNext: boolean;
-  onOpen: () => void;
-  onDragStart: () => void;
-  onMovePrevious: () => void;
-  onMoveNext: () => void;
-}) {
-  const done = card.checklist.filter((item) => item.done).length;
-  return (
-    <article className={card.delegation ? "task-card task-card--delegated" : "task-card"} draggable onDragStart={onDragStart}>
-      <button className="task-card__open" type="button" onClick={onOpen}>
-        <span className="task-card__drag">
-          <GripVertical size={14} />
-        </span>
-        <span className="task-card__main">
-          <span className="task-card__title">{card.title}</span>
-          <span className="task-card__status">{columnTitle}</span>
-        </span>
-        <span className={priorityClass(card.priority)}>{card.priority}</span>
-      </button>
-      {card.description ? <p>{card.description}</p> : null}
-      <div className="label-row">
-        {card.labels.map((label) => (
-          <span className="label" key={label}>{label}</span>
-        ))}
-        {card.delegation ? (
-          <span className={delegationClass(card.delegation.target)}>
-            <Bot size={12} />
-            {DELEGATION_LABELS[card.delegation.target]}
-          </span>
-        ) : null}
-      </div>
-      <footer className="task-card__meta">
-        <span><FolderKanban size={13} />{projectName}</span>
-        {card.dueDate ? <span><CalendarDays size={13} />{card.dueDate}</span> : null}
-        {card.assignee ? <span><Users size={13} />{card.assignee}</span> : null}
-        {card.checklist.length > 0 ? <span><CheckCircle2 size={13} />{done}/{card.checklist.length}</span> : null}
-      </footer>
-      <div className="task-card__actions">
-        <button className="icon-button icon-button--compact" type="button" onClick={onMovePrevious} disabled={!canMovePrevious} title="Move previous">
-          <ArrowLeft size={15} />
-        </button>
-        <button className="button button--compact" type="button" onClick={onOpen}>
-          <ListChecks size={14} />
-          Details
-        </button>
-        <button className="icon-button icon-button--compact" type="button" onClick={onMoveNext} disabled={!canMoveNext} title="Move next">
-          <ArrowRight size={15} />
-        </button>
-      </div>
-    </article>
-  );
+function formatDue(due: string): string {
+  const date = new Date(`${due}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return due;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
 function App() {
   const [board, setBoard] = useState<Board | null>(null);
-  const [activeProjectId, setActiveProjectId] = useState<string>("all");
+  const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  const [labelFilter, setLabelFilter] = useState<string | null>(null);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [draggingCardId, setDraggingCardId] = useState<string | null>(null);
-  const [quickDraft, setQuickDraft] = useState<QuickDraft>(DEFAULT_QUICK_DRAFT);
+  const [draggingColumnId, setDraggingColumnId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{ columnId: string; index: number } | null>(null);
+  const [editingColumnId, setEditingColumnId] = useState<string | null>(null);
   const [columnDrafts, setColumnDrafts] = useState<Record<string, string>>({});
-  const [newProjectName, setNewProjectName] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const detailSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingDetailBoardRef = useRef<Board | null>(null);
-  const saveAbortRef = useRef<AbortController | null>(null);
+  const [addingColumn, setAddingColumn] = useState(false);
+  const [newColumnTitle, setNewColumnTitle] = useState("");
 
-  useEffect(() => {
-    readBoard()
-      .then((nextBoard) => {
-        setBoard(nextBoard);
-        setQuickDraft(makeDefaultQuickDraft(nextBoard));
-      })
-      .catch((err: unknown) => {
-        console.warn("[task-manager] load failed:", err instanceof Error ? err.message : String(err));
-        setError("Board could not be loaded.");
-      });
-  }, []);
+  const boardRef = useRef<Board | null>(null);
+  boardRef.current = board;
+  const usingDbRef = useRef(false);
 
-  useEffect(() => {
-    if (!board) return;
-    setQuickDraft((draft) => {
-      const columnId = resolveColumnId(board, draft.columnId);
-      return columnId === draft.columnId ? draft : { ...draft, columnId };
-    });
-  }, [board]);
-
-  useEffect(() => {
-    if (!selectedCardId) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setSelectedCardId(null);
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [selectedCardId]);
-
-  const persistBoard = useCallback((nextBoard: Board) => {
-    saveAbortRef.current?.abort();
-    const controller = new AbortController();
-    saveAbortRef.current = controller;
-    writeBoard(nextBoard, controller.signal)
-      .catch((err: unknown) => {
-        if (isAbortError(err)) return;
-        console.warn("[task-manager] save failed:", err instanceof Error ? err.message : String(err));
-        setError("Board could not be saved.");
-      })
-      .finally(() => {
-        if (saveAbortRef.current === controller) saveAbortRef.current = null;
-      });
-  }, []);
-
-  const saveBoard = useCallback((nextBoard: Board) => {
-    if (detailSaveTimerRef.current) {
-      clearTimeout(detailSaveTimerRef.current);
-      detailSaveTimerRef.current = null;
-      pendingDetailBoardRef.current = null;
-    }
-    setBoard(nextBoard);
-    setError(null);
-    persistBoard(nextBoard);
-  }, [persistBoard]);
-
-  const queueBoardSave = useCallback((nextBoard: Board) => {
-    setBoard(nextBoard);
-    setError(null);
-    pendingDetailBoardRef.current = nextBoard;
-    if (detailSaveTimerRef.current) clearTimeout(detailSaveTimerRef.current);
-    detailSaveTimerRef.current = setTimeout(() => {
-      detailSaveTimerRef.current = null;
-      const pendingBoard = pendingDetailBoardRef.current ?? nextBoard;
-      pendingDetailBoardRef.current = null;
-      persistBoard(pendingBoard);
-    }, 400);
-  }, [persistBoard]);
-
-  useEffect(() => {
-    return () => {
-      const pendingBoard = pendingDetailBoardRef.current;
-      if (detailSaveTimerRef.current) clearTimeout(detailSaveTimerRef.current);
-      detailSaveTimerRef.current = null;
-      pendingDetailBoardRef.current = null;
-      if (!pendingBoard) return;
-      saveAbortRef.current?.abort();
-      saveAbortRef.current = null;
-      writeBoard(pendingBoard).catch((err: unknown) => {
-        if (isAbortError(err)) return;
-        console.warn("[task-manager] save failed:", err instanceof Error ? err.message : String(err));
-      });
-    };
-  }, []);
-
-  const summary = useMemo(() => board ? summarizeBoard(board) : null, [board]);
-  const selectedCard = board?.cards.find((card) => card.id === selectedCardId) ?? null;
-  const visibleCards = useMemo(() => {
-    if (!board) return [];
-    const normalizedQuery = query.trim().toLowerCase();
-    return board.cards.filter((card) => {
-      const projectMatch = activeProjectId === "all" || card.projectId === activeProjectId;
-      if (!projectMatch) return false;
-      if (!normalizedQuery) return true;
-      return [
-        card.title,
-        card.description,
-        card.assignee,
-        card.priority,
-        card.delegation?.target,
-        card.delegation?.instructions,
-        ...card.labels,
-        board.projects.find((project) => project.id === card.projectId)?.name ?? "",
-      ].join(" ").toLowerCase().includes(normalizedQuery);
-    });
-  }, [activeProjectId, board, query]);
-
-  const createCard = useCallback((
-    columnId: string,
-    title: string,
-    options?: { priority?: Priority; delegationTarget?: DraftDelegationTarget },
-  ) => {
-    if (!board || !title.trim()) return;
-    const projectId = activeProjectId === "all" ? board.projects[0]?.id : activeProjectId;
-    if (!projectId) return;
-    const existingIds = new Set(board.cards.map((card) => card.id));
-    const targetColumnId = resolveColumnId(board, columnId);
-    let nextBoard = addCard(board, {
-      columnId: targetColumnId,
-      projectId,
-      title,
-      priority: options?.priority ?? "medium",
-      labels: [],
-    });
-    const createdCard = nextBoard.cards.find((card) => !existingIds.has(card.id));
-    if (createdCard && options?.delegationTarget && options.delegationTarget !== "none") {
-      nextBoard = delegateCard(nextBoard, createdCard.id, {
-        target: options.delegationTarget,
-        trigger: "manual",
-        instructions: createdCard.title,
-      });
-    }
-    saveBoard(nextBoard);
-  }, [activeProjectId, board, saveBoard]);
-
-  const createProject = useCallback(() => {
-    if (!board || !newProjectName.trim()) return;
-    const nextBoard = addProject(board, newProjectName);
-    saveBoard(nextBoard);
-    setActiveProjectId(nextBoard.projects[nextBoard.projects.length - 1].id);
-    setNewProjectName("");
-  }, [board, newProjectName, saveBoard]);
-
-  const updateSelectedCard = useCallback((patch: Partial<Omit<Card, "id" | "createdAt">>) => {
-    if (!board || !selectedCard) return;
-    queueBoardSave(updateCard(board, selectedCard.id, patch));
-  }, [board, queueBoardSave, selectedCard]);
-
-  const moveSelectedCard = useCallback((columnId: string) => {
-    if (!board || !selectedCard || selectedCard.columnId === columnId) return;
-    const targetCount = board.cards.filter((card) => card.columnId === columnId).length;
-    saveBoard(moveCard(board, selectedCard.id, columnId, targetCount));
-  }, [board, saveBoard, selectedCard]);
-
-  const updateDelegation = useCallback((patch: Partial<Omit<CardDelegation, "updatedAt">>) => {
-    if (!board || !selectedCard) return;
-    const current = selectedCard.delegation;
-    const target = patch.target ?? current?.target;
-    if (!target) return;
-    queueBoardSave(delegateCard(board, selectedCard.id, {
-      target,
-      trigger: patch.trigger ?? current?.trigger ?? "manual",
-      instructions: patch.instructions ?? current?.instructions ?? defaultDelegationInstructions(selectedCard),
-      status: patch.status ?? current?.status ?? "queued",
-    }));
-  }, [board, queueBoardSave, selectedCard]);
-
-  const setDelegationTarget = useCallback((target: DraftDelegationTarget) => {
-    if (!board || !selectedCard) return;
-    if (target === "none") {
-      saveBoard(clearDelegation(board, selectedCard.id));
+  const reload = useCallback(async () => {
+    const bridge = db();
+    if (!bridge) {
+      usingDbRef.current = false;
+      const local = loadLocalBoard();
+      const next = local && local.columns?.length ? local : createSeedBoard();
+      setBoard(next);
+      if (!local) saveLocalBoard(next);
       return;
     }
-    saveBoard(delegateCard(board, selectedCard.id, {
-      target,
-      trigger: selectedCard.delegation?.trigger ?? "manual",
-      instructions: selectedCard.delegation?.instructions ?? defaultDelegationInstructions(selectedCard),
-      status: selectedCard.delegation?.status ?? "queued",
-    }));
-  }, [board, saveBoard, selectedCard]);
+    usingDbRef.current = true;
+    try {
+      const [columnRows, cardRows] = await Promise.all([
+        bridge.find(COLUMNS_TABLE, { orderBy: { position: "asc" } }),
+        bridge.find(CARDS_TABLE, { orderBy: { position: "asc" } }),
+      ]);
+      if (columnRows.length === 0) {
+        // First run: seed the default workflow columns into Postgres.
+        const seed = emptyBoard();
+        for (let i = 0; i < seed.columns.length; i += 1) {
+          await bridge.insert(COLUMNS_TABLE, columnToRow(seed.columns[i], i));
+        }
+        const seeded = await bridge.find(COLUMNS_TABLE, { orderBy: { position: "asc" } });
+        setBoard(boardFromRows(seeded, []));
+        setError(null);
+        return;
+      }
+      setBoard(boardFromRows(columnRows, cardRows));
+      setError(null);
+    } catch (err: unknown) {
+      console.warn("[task-manager] load failed:", errMessage(err));
+      setError("Board could not be loaded. Retrying may help.");
+    }
+  }, []);
 
-  if (!board || !summary) {
-    return <div className="loading">{error ?? "Opening Task Manager"}</div>;
+  useEffect(() => {
+    void reload();
+    const bridge = db();
+    if (!bridge) return undefined;
+    const offColumns = bridge.onChange(COLUMNS_TABLE, () => void reload());
+    const offCards = bridge.onChange(CARDS_TABLE, () => void reload());
+    return () => {
+      offColumns?.();
+      offCards?.();
+    };
+  }, [reload]);
+
+  useEffect(() => {
+    if (!selectedCardId) return undefined;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setSelectedCardId(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedCardId]);
+
+  // Persist a localStorage snapshot whenever the board changes in fallback mode.
+  useEffect(() => {
+    if (board && !usingDbRef.current) saveLocalBoard(board);
+  }, [board]);
+
+  const persist = useCallback(async (action: () => Promise<void>, failure: string) => {
+    if (!usingDbRef.current) return;
+    try {
+      await action();
+      setError(null);
+    } catch (err: unknown) {
+      console.warn(`[task-manager] ${failure}:`, errMessage(err));
+      setError(`${failure}. Reopen the board to refresh.`);
+    }
+  }, []);
+
+  // --- Card mutations (optimistic) ---
+
+  const createCard = useCallback((columnId: string, title: string) => {
+    const current = boardRef.current;
+    if (!current || !title.trim()) return;
+    const projectId = current.projects[0]?.id ?? "project-default";
+    const existing = new Set(current.cards.map((card) => card.id));
+    const next = addCard(current, { columnId, projectId, title });
+    setBoard(next);
+    const created = next.cards.find((card) => !existing.has(card.id));
+    if (!created) return;
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      await bridge.insert(CARDS_TABLE, cardToRow(created, created.order));
+    }, "Card could not be saved");
+  }, [persist]);
+
+  const patchCard = useCallback((cardId: string, patch: Partial<Omit<Card, "id" | "createdAt">>) => {
+    const current = boardRef.current;
+    if (!current) return;
+    const next = updateCard(current, cardId, patch);
+    setBoard(next);
+    const updated = next.cards.find((card) => card.id === cardId);
+    if (!updated) return;
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      await bridge.update(CARDS_TABLE, cardId, cardToRow(updated, updated.order));
+    }, "Card could not be updated");
+  }, [persist]);
+
+  const removeCard = useCallback((cardId: string) => {
+    const current = boardRef.current;
+    if (!current) return;
+    setBoard(deleteCard(current, cardId));
+    setSelectedCardId((id) => (id === cardId ? null : id));
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      await bridge.delete(CARDS_TABLE, cardId);
+    }, "Card could not be deleted");
+  }, [persist]);
+
+  const dropCard = useCallback((cardId: string, targetColumnId: string, targetIndex: number) => {
+    const current = boardRef.current;
+    if (!current) return;
+    const before = current.cards.find((card) => card.id === cardId);
+    const next = moveCard(current, cardId, targetColumnId, targetIndex);
+    setBoard(next);
+    // Persist new column + position for every card in affected columns.
+    const affected = new Set([before?.columnId, targetColumnId].filter(Boolean) as string[]);
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      const toWrite = next.cards.filter((card) => affected.has(card.columnId));
+      for (const card of toWrite) {
+        await bridge.update(CARDS_TABLE, card.id, { column_id: card.columnId, position: card.order });
+      }
+    }, "Card order could not be saved");
+  }, [persist]);
+
+  // --- Checklist (within selected card) ---
+
+  const toggleChecklist = useCallback((cardId: string, itemId: string) => {
+    const current = boardRef.current;
+    if (!current) return;
+    const next = toggleChecklistItem(current, cardId, itemId);
+    setBoard(next);
+    const updated = next.cards.find((card) => card.id === cardId);
+    if (!updated) return;
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      await bridge.update(CARDS_TABLE, cardId, { checklist: updated.checklist });
+    }, "Checklist could not be saved");
+  }, [persist]);
+
+  const addChecklist = useCallback((cardId: string, text: string) => {
+    const current = boardRef.current;
+    if (!current || !text.trim()) return;
+    const next = addChecklistItem(current, cardId, text);
+    setBoard(next);
+    const updated = next.cards.find((card) => card.id === cardId);
+    if (!updated) return;
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      await bridge.update(CARDS_TABLE, cardId, { checklist: updated.checklist });
+    }, "Checklist could not be saved");
+  }, [persist]);
+
+  // --- Column mutations ---
+
+  const createColumn = useCallback((title: string) => {
+    const current = boardRef.current;
+    if (!current || !title.trim()) return;
+    const existing = new Set(current.columns.map((column) => column.id));
+    const next = addColumn(current, title);
+    setBoard(next);
+    const created = next.columns.find((column) => !existing.has(column.id));
+    if (!created) return;
+    const position = next.columns.findIndex((column) => column.id === created.id);
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      await bridge.insert(COLUMNS_TABLE, columnToRow(created, position));
+    }, "Column could not be created");
+  }, [persist]);
+
+  const renameBoardColumn = useCallback((columnId: string, title: string) => {
+    const current = boardRef.current;
+    if (!current) return;
+    setBoard(renameColumn(current, columnId, title));
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      await bridge.update(COLUMNS_TABLE, columnId, { title: title.trim() });
+    }, "Column could not be renamed");
+  }, [persist]);
+
+  const removeColumn = useCallback((columnId: string) => {
+    const current = boardRef.current;
+    if (!current || current.columns.length <= 1) return;
+    const removedCards = current.cards.filter((card) => card.columnId === columnId).map((card) => card.id);
+    setBoard(deleteColumn(current, columnId));
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      for (const cardId of removedCards) await bridge.delete(CARDS_TABLE, cardId);
+      await bridge.delete(COLUMNS_TABLE, columnId);
+    }, "Column could not be deleted");
+  }, [persist]);
+
+  const dropColumn = useCallback((columnId: string, targetIndex: number) => {
+    const current = boardRef.current;
+    if (!current) return;
+    const next = moveColumn(current, columnId, targetIndex);
+    setBoard(next);
+    void persist(async () => {
+      const bridge = db();
+      if (!bridge) return;
+      for (let i = 0; i < next.columns.length; i += 1) {
+        await bridge.update(COLUMNS_TABLE, next.columns[i].id, { position: i });
+      }
+    }, "Column order could not be saved");
+  }, [persist]);
+
+  // --- Derived ---
+
+  const allLabels = useMemo(() => {
+    if (!board) return [];
+    const set = new Set<string>();
+    for (const card of board.cards) for (const label of card.labels) set.add(label);
+    return [...set].sort();
+  }, [board]);
+
+  const filteredCards = useMemo(() => {
+    if (!board) return [];
+    const q = query.trim().toLowerCase();
+    return board.cards.filter((card) => {
+      if (labelFilter && !card.labels.includes(labelFilter)) return false;
+      if (!q) return true;
+      return [card.title, card.description, card.assignee, ...card.labels]
+        .join(" ")
+        .toLowerCase()
+        .includes(q);
+    });
+  }, [board, labelFilter, query]);
+
+  const totalShown = filteredCards.length;
+  const selectedCard = board?.cards.find((card) => card.id === selectedCardId) ?? null;
+  const isFiltering = Boolean(query.trim()) || Boolean(labelFilter);
+
+  if (!board) {
+    return (
+      <main className="board-shell board-shell--loading">
+        <div className="loading">{error ?? "Opening Task Manager…"}</div>
+      </main>
+    );
   }
-
-  const projectById = Object.fromEntries(board.projects.map((project) => [project.id, project]));
-  const columnById = Object.fromEntries(board.columns.map((column) => [column.id, column]));
-  const selectedColumn = selectedCard ? columnById[selectedCard.columnId] : null;
 
   return (
     <main className="board-shell">
       <header className="app-header">
         <div className="app-title">
-          <span className="app-icon"><LayoutDashboard size={24} /></span>
+          <span className="app-icon"><LayoutDashboard size={22} /></span>
           <div>
-            <span className="eyebrow">Proactive board</span>
+            <span className="eyebrow">Project board</span>
             <h1>Task Manager</h1>
           </div>
         </div>
-        <label className="search-field">
-          <Search size={15} />
-          <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search tasks, projects, agents" />
-        </label>
+        <div className="header-tools">
+          <label className="search-field">
+            <Search size={15} />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search cards"
+              aria-label="Search cards"
+            />
+          </label>
+        </div>
       </header>
 
-      <section className="summary-grid" aria-label="Board summary">
-        <div className="summary-card"><ClipboardList size={17} /><span>{summary.totalCards}</span><small>Tasks</small></div>
-        <div className="summary-card"><FolderKanban size={17} /><span>{summary.activeProjects}</span><small>Projects</small></div>
-        <div className="summary-card"><Send size={17} /><span>{summary.delegatedCards}</span><small>Delegated</small></div>
-        <div className="summary-card"><Sparkles size={17} /><span>{summary.urgentCards}</span><small>Urgent</small></div>
-        <div className="summary-card"><CheckCircle2 size={17} /><span>{summary.doneCards}</span><small>Done</small></div>
-        <div className="summary-card"><Archive size={17} /><span>{summary.checklistDone}/{summary.checklistTotal}</span><small>Checklist</small></div>
-      </section>
-
-      {error ? <div className="error-banner">{error}</div> : null}
-
-      <section className="control-row">
-        <div className="project-tabs" aria-label="Project filter">
-          <button className={activeProjectId === "all" ? "project-tab project-tab--active" : "project-tab"} type="button" onClick={() => setActiveProjectId("all")}>All</button>
-          {board.projects.map((project) => (
+      {allLabels.length > 0 ? (
+        <div className="filter-bar" aria-label="Label filters">
+          <button
+            type="button"
+            className={labelFilter === null ? "label-chip label-chip--active" : "label-chip"}
+            onClick={() => setLabelFilter(null)}
+          >
+            All
+          </button>
+          {allLabels.map((label) => (
             <button
-              className={activeProjectId === project.id ? "project-tab project-tab--active" : "project-tab"}
               type="button"
-              key={project.id}
-              onClick={() => setActiveProjectId(project.id)}
+              key={label}
+              className={labelFilter === label ? "label-chip label-chip--active" : "label-chip"}
+              style={{ "--chip": labelColor(label) } as React.CSSProperties}
+              onClick={() => setLabelFilter((current) => (current === label ? null : label))}
             >
-              <span style={{ background: project.color }} />
-              {project.name}
+              <span className="label-chip__dot" />
+              {label}
             </button>
           ))}
         </div>
-        <form className="inline-form" onSubmit={(event) => { event.preventDefault(); createProject(); }}>
-          <input value={newProjectName} onChange={(event) => setNewProjectName(event.target.value)} placeholder="New project" />
-          <button className="button" type="submit"><Plus size={15} />Project</button>
-        </form>
-      </section>
+      ) : null}
 
-      <form
-        className="quick-add"
-        onSubmit={(event) => {
-          event.preventDefault();
-          createCard(quickDraft.columnId, quickDraft.title, {
-            priority: quickDraft.priority,
-            delegationTarget: quickDraft.delegationTarget,
-          });
-          setQuickDraft((draft) => ({ ...draft, title: "", delegationTarget: "none" }));
-        }}
-      >
-        <label className="quick-add__title">
-          <span className="sr-only">Task title</span>
-          <input
-            value={quickDraft.title}
-            onChange={(event) => setQuickDraft((draft) => ({ ...draft, title: event.target.value }))}
-            placeholder="Capture a task"
-          />
-        </label>
-        <label>
-          <span className="sr-only">Status</span>
-          <select value={quickDraft.columnId} onChange={(event) => setQuickDraft((draft) => ({ ...draft, columnId: event.target.value }))}>
-            {board.columns.map((column) => <option key={column.id} value={column.id}>{column.title}</option>)}
-          </select>
-        </label>
-        <label>
-          <span className="sr-only">Priority</span>
-          <select value={quickDraft.priority} onChange={(event) => setQuickDraft((draft) => ({ ...draft, priority: event.target.value as Priority }))}>
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-            <option value="urgent">Urgent</option>
-          </select>
-        </label>
-        <label>
-          <span className="sr-only">Agent</span>
-          <select value={quickDraft.delegationTarget} onChange={(event) => setQuickDraft((draft) => ({ ...draft, delegationTarget: event.target.value as DraftDelegationTarget }))}>
-            <option value="none">No agent</option>
-            <option value="matrix">Matrix</option>
-            <option value="hermes">Hermes</option>
-          </select>
-        </label>
-        <button className="button button--primary" type="submit"><Plus size={15} />Add task</button>
-      </form>
+      {error ? <div className="error-banner" role="alert">{error}</div> : null}
 
       <section className="board" aria-label="Kanban board">
         {board.columns.map((column, columnIndex) => {
-          const cards = visibleCards
+          const cards = filteredCards
             .filter((card) => card.columnId === column.id)
             .sort((a, b) => a.order - b.order);
-          const totalCards = columnCardCount(board, column.id);
-          const draftValue = columnDrafts[column.id] ?? "";
+          const total = board.cards.filter((card) => card.columnId === column.id).length;
           return (
-            <div
-              className="column"
+            <BoardColumnView
               key={column.id}
-              onDragOver={(event) => event.preventDefault()}
-              onDrop={() => {
-                if (!draggingCardId) return;
-                saveBoard(moveCard(board, draggingCardId, column.id, columnCardCount(board, column.id)));
-                setDraggingCardId(null);
+              column={column}
+              columnIndex={columnIndex}
+              cards={cards}
+              total={total}
+              shownCount={cards.length}
+              isFiltering={isFiltering}
+              isEditing={editingColumnId === column.id}
+              draftValue={columnDrafts[column.id] ?? ""}
+              draggingCardId={draggingCardId}
+              draggingColumnId={draggingColumnId}
+              dropTarget={dropTarget?.columnId === column.id ? dropTarget.index : null}
+              onStartEdit={() => setEditingColumnId(column.id)}
+              onRename={(value) => {
+                renameBoardColumn(column.id, value);
+                setEditingColumnId(null);
               }}
-            >
-              <header className="column__header">
-                <span style={{ background: column.color }} />
-                <div>
-                  <h2>{column.title}</h2>
-                  <small>{cards.length === totalCards ? `${totalCards} tasks` : `${cards.length}/${totalCards} shown`}</small>
-                </div>
-              </header>
-              <form
-                className="column__quick-add"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  createCard(column.id, draftValue);
-                  setColumnDrafts((drafts) => ({ ...drafts, [column.id]: "" }));
-                }}
-              >
-                <input
-                  value={draftValue}
-                  onChange={(event) => setColumnDrafts((drafts) => ({ ...drafts, [column.id]: event.target.value }))}
-                  placeholder={`Add to ${column.title}`}
-                />
-                <button className="icon-button icon-button--compact" type="submit" title={`Add to ${column.title}`}>
-                  <Plus size={15} />
-                </button>
-              </form>
-              <div className="column__cards">
-                {cards.map((card, index) => (
-                  <div
-                    key={card.id}
-                    onDragOver={(event) => event.preventDefault()}
-                    onDrop={(event) => {
-                      event.stopPropagation();
-                      if (!draggingCardId) return;
-                      if (draggingCardId === card.id) {
-                        setDraggingCardId(null);
-                        return;
-                      }
-                      saveBoard(moveCard(board, draggingCardId, column.id, cardDropIndex(board, card.id, draggingCardId)));
-                      setDraggingCardId(null);
-                    }}
-                  >
-                    <CardView
-                      card={card}
-                      projectName={projectById[card.projectId]?.name ?? "Project"}
-                      columnTitle={column.title}
-                      canMovePrevious={columnIndex > 0}
-                      canMoveNext={columnIndex < board.columns.length - 1}
-                      onOpen={() => setSelectedCardId(card.id)}
-                      onDragStart={() => setDraggingCardId(card.id)}
-                      onMovePrevious={() => saveBoard(moveCardToAdjacentColumn(board, card.id, "previous"))}
-                      onMoveNext={() => saveBoard(moveCardToAdjacentColumn(board, card.id, "next"))}
-                    />
-                  </div>
-                ))}
-                {cards.length === 0 ? (
-                  <div className="column-empty">
-                    <Circle size={16} />
-                    <span>No tasks</span>
-                  </div>
-                ) : null}
-              </div>
-            </div>
+              onCancelEdit={() => setEditingColumnId(null)}
+              onDelete={() => removeColumn(column.id)}
+              canDelete={board.columns.length > 1}
+              onDraftChange={(value) => setColumnDrafts((drafts) => ({ ...drafts, [column.id]: value }))}
+              onAddCard={() => {
+                createCard(column.id, columnDrafts[column.id] ?? "");
+                setColumnDrafts((drafts) => ({ ...drafts, [column.id]: "" }));
+              }}
+              onCardDragStart={(cardId) => setDraggingCardId(cardId)}
+              onCardDragEnd={() => {
+                setDraggingCardId(null);
+                setDropTarget(null);
+              }}
+              onColumnDragStart={() => setDraggingColumnId(column.id)}
+              onColumnDragEnd={() => setDraggingColumnId(null)}
+              onColumnDrop={() => {
+                if (draggingColumnId && draggingColumnId !== column.id) {
+                  dropColumn(draggingColumnId, columnIndex);
+                }
+                setDraggingColumnId(null);
+              }}
+              onSetDropTarget={(index) => setDropTarget({ columnId: column.id, index })}
+              onCardDrop={(index) => {
+                if (draggingCardId) dropCard(draggingCardId, column.id, index);
+                setDraggingCardId(null);
+                setDropTarget(null);
+              }}
+              onOpenCard={(cardId) => setSelectedCardId(cardId)}
+            />
           );
         })}
-      </section>
 
-      {selectedCard ? (
-        <aside className="detail-panel" aria-label="Card details">
-          <div className="detail-panel__backdrop" onClick={() => setSelectedCardId(null)} />
-          <section className="detail-panel__sheet">
-            <header>
-              <div>
-                <span className="eyebrow">Task</span>
-                <h2>{selectedCard.title}</h2>
-                {selectedColumn ? <small>{selectedColumn.title}</small> : null}
-              </div>
-              <button className="icon-button" type="button" onClick={() => setSelectedCardId(null)} title="Close">
-                <X size={18} />
-              </button>
-            </header>
-            <label>
-              Title
-              <input
-                value={selectedCard.title}
-                onChange={(event) => updateSelectedCard({ title: event.target.value })}
-              />
-            </label>
-            <label>
-              Description
-              <textarea
-                value={selectedCard.description}
-                onChange={(event) => updateSelectedCard({ description: event.target.value })}
-              />
-            </label>
-            <div className="field-grid">
-              <label>
-                Status
-                <select value={selectedCard.columnId} onChange={(event) => moveSelectedCard(event.target.value)}>
-                  {board.columns.map((column) => <option key={column.id} value={column.id}>{column.title}</option>)}
-                </select>
-              </label>
-              <label>
-                Project
-                <select value={selectedCard.projectId} onChange={(event) => updateSelectedCard({ projectId: event.target.value })}>
-                  {board.projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
-                </select>
-              </label>
-            </div>
-            <div className="field-grid">
-              <label>
-                Priority
-                <select
-                  value={selectedCard.priority}
-                  onChange={(event) => updateSelectedCard({ priority: event.target.value as Priority })}
-                >
-                  <option value="low">Low</option>
-                  <option value="medium">Medium</option>
-                  <option value="high">High</option>
-                  <option value="urgent">Urgent</option>
-                </select>
-              </label>
-              <label>
-                Due
-                <input
-                  type="date"
-                  value={selectedCard.dueDate}
-                  onChange={(event) => updateSelectedCard({ dueDate: event.target.value })}
-                />
-              </label>
-            </div>
-            <label>
-              Assignee
-              <input
-                value={selectedCard.assignee}
-                onChange={(event) => updateSelectedCard({ assignee: event.target.value })}
-                placeholder="Owner"
-              />
-            </label>
-            <label>
-              Labels
-              <input
-                value={selectedCard.labels.join(", ")}
-                onChange={(event) => updateSelectedCard({
-                  labels: event.target.value.split(",").map((item) => item.trim()).filter(Boolean),
-                })}
-                placeholder="design, launch"
-              />
-            </label>
-
-            <section className="delegation-panel" aria-label="Agent delegation">
-              <header>
-                <h3><Bot size={16} />Delegate</h3>
-                {selectedCard.delegation ? <span>{STATUS_LABELS[selectedCard.delegation.status]}</span> : <span>Unassigned</span>}
-              </header>
-              <div className="delegate-options" role="group" aria-label="Delegation target">
-                {(["none", "matrix", "hermes"] as DraftDelegationTarget[]).map((target) => {
-                  const active = target === "none" ? !selectedCard.delegation : selectedCard.delegation?.target === target;
-                  return (
-                    <button
-                      className={active ? "delegate-option delegate-option--active" : "delegate-option"}
-                      type="button"
-                      key={target}
-                      onClick={() => setDelegationTarget(target)}
-                    >
-                      {target === "none" ? <Circle size={14} /> : <Bot size={14} />}
-                      {target === "none" ? "No agent" : DELEGATION_LABELS[target]}
-                    </button>
-                  );
-                })}
-              </div>
-              {selectedCard.delegation ? (
-                <div className="delegation-fields">
-                  <div className="field-grid">
-                    <label>
-                      Trigger
-                      <select
-                        value={selectedCard.delegation.trigger}
-                        onChange={(event) => updateDelegation({ trigger: event.target.value as DelegationTrigger })}
-                      >
-                        {Object.entries(TRIGGER_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
-                      </select>
-                    </label>
-                    <label>
-                      State
-                      <select
-                        value={selectedCard.delegation.status}
-                        onChange={(event) => updateDelegation({ status: event.target.value as DelegationStatus })}
-                      >
-                        {Object.entries(STATUS_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
-                      </select>
-                    </label>
-                  </div>
-                  <label>
-                    Agent brief
-                    <textarea
-                      value={selectedCard.delegation.instructions}
-                      onChange={(event) => updateDelegation({ instructions: event.target.value })}
-                    />
-                  </label>
-                </div>
-              ) : null}
-            </section>
-
-            <div className="checklist">
-              <h3>Checklist</h3>
-              {selectedCard.checklist.map((item) => (
-                <button
-                  className="checklist-item"
-                  type="button"
-                  key={item.id}
-                  onClick={() => saveBoard(toggleChecklistItem(board, selectedCard.id, item.id))}
-                >
-                  {item.done ? <CheckCircle2 size={16} /> : <Circle size={16} />}
-                  {item.text}
-                </button>
-              ))}
-              <form onSubmit={(event) => {
+        <div className="column-adder">
+          {addingColumn ? (
+            <form
+              className="column-adder__form"
+              onSubmit={(event) => {
                 event.preventDefault();
-                const input = event.currentTarget.elements.namedItem("checklist") as HTMLInputElement;
-                saveBoard(addChecklistItem(board, selectedCard.id, input.value));
-                input.value = "";
-              }}>
-                <input name="checklist" placeholder="Add checklist item" />
-              </form>
-            </div>
-            <button
-              className="button button--danger"
-              type="button"
-              onClick={() => {
-                saveBoard(deleteCard(board, selectedCard.id));
-                setSelectedCardId(null);
+                createColumn(newColumnTitle);
+                setNewColumnTitle("");
+                setAddingColumn(false);
               }}
             >
-              <Trash2 size={15} />
-              Delete task
+              <input
+                autoFocus
+                value={newColumnTitle}
+                onChange={(event) => setNewColumnTitle(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") {
+                    setAddingColumn(false);
+                    setNewColumnTitle("");
+                  }
+                }}
+                placeholder="Column name"
+              />
+              <div className="column-adder__actions">
+                <button className="button button--primary" type="submit"><Check size={14} />Add</button>
+                <button className="icon-button" type="button" onClick={() => { setAddingColumn(false); setNewColumnTitle(""); }}>
+                  <X size={15} />
+                </button>
+              </div>
+            </form>
+          ) : (
+            <button className="column-adder__trigger" type="button" onClick={() => setAddingColumn(true)}>
+              <Plus size={16} />
+              Add column
             </button>
-          </section>
-        </aside>
+          )}
+        </div>
+      </section>
+
+      {board.cards.length === 0 && !isFiltering ? (
+        <div className="empty-state" role="status">
+          <span className="empty-state__icon"><ListChecks size={28} /></span>
+          <h2>Plan your first project</h2>
+          <p>Add a card to any column to start tracking work. Drag cards to move them across your workflow.</p>
+        </div>
+      ) : null}
+
+      {totalShown === 0 && isFiltering ? (
+        <div className="empty-state empty-state--filter" role="status">
+          <span className="empty-state__icon"><Search size={24} /></span>
+          <h2>No matching cards</h2>
+          <p>Try a different search term or clear the label filter.</p>
+        </div>
+      ) : null}
+
+      {selectedCard ? (
+        <CardDetail
+          card={selectedCard}
+          columns={board.columns}
+          onClose={() => setSelectedCardId(null)}
+          onPatch={(patch) => patchCard(selectedCard.id, patch)}
+          onMoveColumn={(columnId) => {
+            const count = board.cards.filter((card) => card.columnId === columnId).length;
+            dropCard(selectedCard.id, columnId, count);
+          }}
+          onToggleChecklist={(itemId) => toggleChecklist(selectedCard.id, itemId)}
+          onAddChecklist={(text) => addChecklist(selectedCard.id, text)}
+          onDelete={() => removeCard(selectedCard.id)}
+        />
       ) : null}
     </main>
+  );
+}
+
+interface ColumnViewProps {
+  column: BoardColumn;
+  columnIndex: number;
+  cards: Card[];
+  total: number;
+  shownCount: number;
+  isFiltering: boolean;
+  isEditing: boolean;
+  draftValue: string;
+  draggingCardId: string | null;
+  draggingColumnId: string | null;
+  dropTarget: number | null;
+  canDelete: boolean;
+  onStartEdit: () => void;
+  onRename: (value: string) => void;
+  onCancelEdit: () => void;
+  onDelete: () => void;
+  onDraftChange: (value: string) => void;
+  onAddCard: () => void;
+  onCardDragStart: (cardId: string) => void;
+  onCardDragEnd: () => void;
+  onColumnDragStart: () => void;
+  onColumnDragEnd: () => void;
+  onColumnDrop: () => void;
+  onSetDropTarget: (index: number) => void;
+  onCardDrop: (index: number) => void;
+  onOpenCard: (cardId: string) => void;
+}
+
+function BoardColumnView(props: ColumnViewProps) {
+  const {
+    column, cards, total, shownCount, isFiltering, isEditing, draftValue,
+    draggingCardId, draggingColumnId, dropTarget, canDelete,
+    onStartEdit, onRename, onCancelEdit, onDelete, onDraftChange, onAddCard,
+    onCardDragStart, onCardDragEnd, onColumnDragStart, onColumnDragEnd, onColumnDrop,
+    onSetDropTarget, onCardDrop, onOpenCard,
+  } = props;
+  const [renameValue, setRenameValue] = useState(column.title);
+  useEffect(() => setRenameValue(column.title), [column.title]);
+
+  const isColumnDropTarget = draggingColumnId !== null && draggingColumnId !== column.id;
+
+  return (
+    <section
+      className={draggingColumnId === column.id ? "column column--dragging" : "column"}
+      aria-label={column.title}
+      onDragOver={(event) => {
+        if (draggingColumnId && draggingColumnId !== column.id) event.preventDefault();
+        else if (draggingCardId) {
+          event.preventDefault();
+          onSetDropTarget(cards.length);
+        }
+      }}
+      onDrop={(event) => {
+        if (draggingColumnId && draggingColumnId !== column.id) {
+          event.preventDefault();
+          onColumnDrop();
+          return;
+        }
+        if (draggingCardId) {
+          event.preventDefault();
+          onCardDrop(cards.length);
+        }
+      }}
+    >
+      <header className="column__header">
+        <span
+          className="column__grip"
+          draggable
+          onDragStart={onColumnDragStart}
+          onDragEnd={onColumnDragEnd}
+          title="Reorder column"
+        >
+          <span className="column__swatch" style={{ background: column.color }} />
+          <GripVertical size={13} />
+        </span>
+        {isEditing ? (
+          <form
+            className="column__rename"
+            onSubmit={(event) => { event.preventDefault(); onRename(renameValue); }}
+          >
+            <input
+              autoFocus
+              value={renameValue}
+              onChange={(event) => setRenameValue(event.target.value)}
+              onBlur={() => onRename(renameValue)}
+              onKeyDown={(event) => { if (event.key === "Escape") { setRenameValue(column.title); onCancelEdit(); } }}
+            />
+          </form>
+        ) : (
+          <button className="column__title" type="button" onClick={onStartEdit} title="Rename column">
+            <h2>{column.title}</h2>
+            <span className="column__count">
+              {isFiltering && shownCount !== total ? `${shownCount}/${total}` : total}
+            </span>
+          </button>
+        )}
+        <div className="column__menu">
+          <button className="icon-button icon-button--ghost" type="button" onClick={onStartEdit} title="Rename column">
+            <Pencil size={13} />
+          </button>
+          {canDelete ? (
+            <button className="icon-button icon-button--ghost" type="button" onClick={onDelete} title="Delete column">
+              <Trash2 size={13} />
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      <div className={isColumnDropTarget ? "column__cards column__cards--target" : "column__cards"}>
+        {cards.map((card, index) => (
+          <div key={card.id} className="card-slot">
+            {dropTarget === index && draggingCardId ? <div className="drop-indicator" /> : null}
+            <div
+              onDragOver={(event) => {
+                if (!draggingCardId) return;
+                event.preventDefault();
+                event.stopPropagation();
+                onSetDropTarget(index);
+              }}
+              onDrop={(event) => {
+                if (!draggingCardId) return;
+                event.preventDefault();
+                event.stopPropagation();
+                onCardDrop(index);
+              }}
+            >
+              <TaskCardView
+                card={card}
+                onOpen={() => onOpenCard(card.id)}
+                onDragStart={() => onCardDragStart(card.id)}
+                onDragEnd={onCardDragEnd}
+              />
+            </div>
+          </div>
+        ))}
+        {dropTarget === cards.length && draggingCardId ? <div className="drop-indicator" /> : null}
+        {cards.length === 0 ? (
+          <div className="column-empty">
+            <Circle size={14} />
+            <span>{isFiltering ? "No matches" : "Drop a card here"}</span>
+          </div>
+        ) : null}
+      </div>
+
+      <form
+        className="column__quick-add"
+        onSubmit={(event) => { event.preventDefault(); onAddCard(); }}
+      >
+        <input
+          value={draftValue}
+          onChange={(event) => onDraftChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              onAddCard();
+            }
+          }}
+          placeholder={`Add a card to ${column.title}`}
+          aria-label={`Add a card to ${column.title}`}
+        />
+        <button className="icon-button icon-button--compact" type="submit" title="Add card">
+          <Plus size={15} />
+        </button>
+      </form>
+    </section>
+  );
+}
+
+function TaskCardView({
+  card,
+  onOpen,
+  onDragStart,
+  onDragEnd,
+}: {
+  card: Card;
+  onOpen: () => void;
+  onDragStart: () => void;
+  onDragEnd: () => void;
+}) {
+  const progress = checklistProgress(card.checklist);
+  const due = dueState(card.dueDate);
+  return (
+    <article
+      className="task-card"
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onClick={onOpen}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen();
+        }
+      }}
+    >
+      {card.labels.length > 0 ? (
+        <div className="task-card__labels">
+          {card.labels.map((label) => (
+            <span className="task-card__label" key={label} style={{ background: labelColor(label) }} title={label} />
+          ))}
+        </div>
+      ) : null}
+      <h3 className="task-card__title">{card.title}</h3>
+      {card.description ? <p className="task-card__desc">{card.description}</p> : null}
+      <footer className="task-card__meta">
+        {card.priority !== "medium" ? (
+          <span className={`pill pill--${card.priority}`}>{PRIORITY_LABEL[card.priority]}</span>
+        ) : null}
+        {card.dueDate ? (
+          <span className={`meta meta--due-${due}`}>
+            <CalendarDays size={12} />
+            {formatDue(card.dueDate)}
+          </span>
+        ) : null}
+        {progress.total > 0 ? (
+          <span className={progress.done === progress.total ? "meta meta--done" : "meta"}>
+            <CheckCircle2 size={12} />
+            {progress.done}/{progress.total}
+          </span>
+        ) : null}
+        {card.assignee ? (
+          <span className="meta meta--assignee" title={card.assignee}>
+            <User size={12} />
+            {card.assignee}
+          </span>
+        ) : null}
+      </footer>
+    </article>
+  );
+}
+
+function CardDetail({
+  card,
+  columns,
+  onClose,
+  onPatch,
+  onMoveColumn,
+  onToggleChecklist,
+  onAddChecklist,
+  onDelete,
+}: {
+  card: Card;
+  columns: BoardColumn[];
+  onClose: () => void;
+  onPatch: (patch: Partial<Omit<Card, "id" | "createdAt">>) => void;
+  onMoveColumn: (columnId: string) => void;
+  onToggleChecklist: (itemId: string) => void;
+  onAddChecklist: (text: string) => void;
+  onDelete: () => void;
+}) {
+  const [title, setTitle] = useState(card.title);
+  const [description, setDescription] = useState(card.description);
+  const [assignee, setAssignee] = useState(card.assignee);
+  const [labelInput, setLabelInput] = useState("");
+  const [checklistInput, setChecklistInput] = useState("");
+  useEffect(() => { setTitle(card.title); }, [card.id, card.title]);
+  useEffect(() => { setDescription(card.description); }, [card.id, card.description]);
+  useEffect(() => { setAssignee(card.assignee); }, [card.id, card.assignee]);
+
+  const progress = checklistProgress(card.checklist);
+
+  const addLabel = () => {
+    const value = labelInput.trim();
+    if (!value || card.labels.includes(value)) {
+      setLabelInput("");
+      return;
+    }
+    onPatch({ labels: [...card.labels, value] });
+    setLabelInput("");
+  };
+
+  return (
+    <div className="detail-overlay" role="dialog" aria-modal="true" aria-label="Card details">
+      <div className="detail-overlay__backdrop" onClick={onClose} />
+      <section className="detail-sheet">
+        <header className="detail-sheet__header">
+          <span className="eyebrow">Card</span>
+          <button className="icon-button" type="button" onClick={onClose} title="Close" aria-label="Close">
+            <X size={18} />
+          </button>
+        </header>
+
+        <input
+          className="detail-title"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          onBlur={() => { if (title.trim() && title !== card.title) onPatch({ title: title.trim() }); else setTitle(card.title); }}
+          aria-label="Card title"
+        />
+
+        <div className="detail-grid">
+          <label className="field">
+            <span>Column</span>
+            <select value={card.columnId} onChange={(event) => onMoveColumn(event.target.value)}>
+              {columns.map((column) => <option key={column.id} value={column.id}>{column.title}</option>)}
+            </select>
+          </label>
+          <label className="field">
+            <span>Priority</span>
+            <select value={card.priority} onChange={(event) => onPatch({ priority: event.target.value as Priority })}>
+              {PRIORITY_ORDER.map((p) => <option key={p} value={p}>{PRIORITY_LABEL[p]}</option>)}
+            </select>
+          </label>
+          <label className="field">
+            <span>Due date</span>
+            <input type="date" value={card.dueDate} onChange={(event) => onPatch({ dueDate: event.target.value })} />
+          </label>
+          <label className="field">
+            <span>Assignee</span>
+            <input
+              value={assignee}
+              onChange={(event) => setAssignee(event.target.value)}
+              onBlur={() => { if (assignee !== card.assignee) onPatch({ assignee: assignee.trim() }); }}
+              placeholder="Unassigned"
+            />
+          </label>
+        </div>
+
+        <label className="field field--block">
+          <span>Description</span>
+          <textarea
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            onBlur={() => { if (description !== card.description) onPatch({ description }); }}
+            placeholder="Add more detail…"
+            rows={3}
+          />
+        </label>
+
+        <div className="field field--block">
+          <span className="field__label"><Tag size={13} />Labels</span>
+          <div className="label-editor">
+            {card.labels.map((label) => (
+              <span className="label-tag" key={label} style={{ background: labelColor(label) }}>
+                {label}
+                <button type="button" onClick={() => onPatch({ labels: card.labels.filter((l) => l !== label) })} aria-label={`Remove ${label}`}>
+                  <X size={11} />
+                </button>
+              </span>
+            ))}
+            <form onSubmit={(event) => { event.preventDefault(); addLabel(); }}>
+              <input
+                value={labelInput}
+                onChange={(event) => setLabelInput(event.target.value)}
+                placeholder="Add label"
+                aria-label="Add label"
+              />
+            </form>
+          </div>
+        </div>
+
+        <div className="field field--block">
+          <span className="field__label">
+            <ListChecks size={13} />
+            Checklist {progress.total > 0 ? <em>{progress.done}/{progress.total}</em> : null}
+          </span>
+          {progress.total > 0 ? (
+            <div className="checklist-progress">
+              <div className="checklist-progress__bar" style={{ width: `${(progress.done / progress.total) * 100}%` }} />
+            </div>
+          ) : null}
+          <div className="checklist">
+            {card.checklist.map((item) => (
+              <button
+                className={item.done ? "checklist-item checklist-item--done" : "checklist-item"}
+                type="button"
+                key={item.id}
+                onClick={() => onToggleChecklist(item.id)}
+              >
+                {item.done ? <CheckCircle2 size={16} /> : <Circle size={16} />}
+                <span>{item.text}</span>
+              </button>
+            ))}
+            <form onSubmit={(event) => { event.preventDefault(); onAddChecklist(checklistInput); setChecklistInput(""); }}>
+              <input
+                value={checklistInput}
+                onChange={(event) => setChecklistInput(event.target.value)}
+                placeholder="Add checklist item"
+                aria-label="Add checklist item"
+              />
+            </form>
+          </div>
+        </div>
+
+        <button className="button button--danger detail-delete" type="button" onClick={onDelete}>
+          <Trash2 size={15} />
+          Delete card
+        </button>
+      </section>
+    </div>
   );
 }
 

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -286,7 +286,8 @@ function App() {
           resolveCreatedCardId(created.id);
           return;
         }
-        await (pendingColumnIdsRef.current[liveCard.columnId] ?? Promise.resolve(liveCard.columnId));
+        const pendingColumnId = liveCard.columnId;
+        let columnId = await (pendingColumnIdsRef.current[pendingColumnId] ?? Promise.resolve(pendingColumnId));
         liveCard = boardRef.current?.cards.find((card) => card.id === created.id);
         if (!liveCard) {
           resolveCreatedCardId(created.id);
@@ -297,7 +298,9 @@ function App() {
           resolveCreatedCardId(created.id);
           return;
         }
-        const columnId = await (pendingColumnIdsRef.current[liveCard.columnId] ?? Promise.resolve(liveCard.columnId));
+        if (liveCard.columnId !== pendingColumnId) {
+          columnId = await (pendingColumnIdsRef.current[liveCard.columnId] ?? Promise.resolve(liveCard.columnId));
+        }
         const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...liveCard, columnId }, liveCard.order));
         resolveCreatedCardId(result.id);
         pendingCardIdSwapsRef.current[result.id] = created.id;

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -130,6 +130,7 @@ function App() {
 
   const boardRef = useRef<Board | null>(null);
   boardRef.current = board;
+  const pendingColumnIdsRef = useRef<Record<string, Promise<string> | undefined>>({});
   const usingDbRef = useRef(false);
   const suppressReloadRef = useRef(false);
 
@@ -224,7 +225,9 @@ function App() {
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
-      const result = await bridge.insert(CARDS_TABLE, cardToRow(created, created.order));
+      const liveColumnId = boardRef.current?.cards.find((card) => card.id === created.id)?.columnId ?? created.columnId;
+      const columnId = await (pendingColumnIdsRef.current[liveColumnId] ?? Promise.resolve(liveColumnId));
+      const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...created, columnId }, created.order));
       setSelectedCardId((id) => (id === created.id ? result.id : id));
       setBoard((current) => current ? {
         ...current,
@@ -318,15 +321,32 @@ function App() {
     const created = next.columns.find((column) => !existing.has(column.id));
     if (!created) return;
     const position = next.columns.findIndex((column) => column.id === created.id);
+    let resolveColumnId: (id: string) => void = () => undefined;
+    let rejectColumnId: (err: unknown) => void = () => undefined;
+    pendingColumnIdsRef.current[created.id] = new Promise<string>((resolve, reject) => {
+      resolveColumnId = resolve;
+      rejectColumnId = reject;
+    });
     void persist(async () => {
       const bridge = db();
-      if (!bridge) return;
-      const result = await bridge.insert(COLUMNS_TABLE, columnToRow(created, position));
-      setBoard((current) => current ? {
-        ...current,
-        columns: current.columns.map((column) => column.id === created.id ? { ...column, id: result.id } : column),
-        cards: current.cards.map((card) => card.columnId === created.id ? { ...card, columnId: result.id } : card),
-      } : current);
+      if (!bridge) {
+        resolveColumnId(created.id);
+        return;
+      }
+      try {
+        const result = await bridge.insert(COLUMNS_TABLE, columnToRow(created, position));
+        resolveColumnId(result.id);
+        setBoard((current) => current ? {
+          ...current,
+          columns: current.columns.map((column) => column.id === created.id ? { ...column, id: result.id } : column),
+          cards: current.cards.map((card) => card.columnId === created.id ? { ...card, columnId: result.id } : card),
+        } : current);
+      } catch (err) {
+        rejectColumnId(err);
+        throw err;
+      } finally {
+        delete pendingColumnIdsRef.current[created.id];
+      }
     }, "Column could not be created");
   }, [persist]);
 
@@ -359,8 +379,8 @@ function App() {
         setBoard(deleteColumn(current, columnId));
       } catch (err: unknown) {
         console.warn("[task-manager] Column could not be deleted:", errMessage(err));
-        setError("Column could not be deleted. Reopen the board to refresh.");
         await reload();
+        setError("Column could not be deleted. Reopen the board to refresh.");
       } finally {
         suppressReloadRef.current = false;
       }

--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -96,16 +96,34 @@ function formatDue(due: string): string {
 
 async function persistBoardToBridge(bridge: MatrixDb, source: Board): Promise<Board> {
   const columnIdMap = new Map<string, string>();
-  for (let i = 0; i < source.columns.length; i += 1) {
-    const column = source.columns[i];
-    const result = await bridge.insert(COLUMNS_TABLE, columnToRow(column, i));
-    columnIdMap.set(column.id, result.id);
-  }
-  for (const card of source.cards) {
-    await bridge.insert(CARDS_TABLE, {
-      ...cardToRow(card, card.order),
-      column_id: columnIdMap.get(card.columnId) ?? card.columnId,
-    });
+  const insertedColumnIds: string[] = [];
+  const insertedCardIds: string[] = [];
+  try {
+    for (let i = 0; i < source.columns.length; i += 1) {
+      const column = source.columns[i];
+      const result = await bridge.insert(COLUMNS_TABLE, columnToRow(column, i));
+      insertedColumnIds.push(result.id);
+      columnIdMap.set(column.id, result.id);
+    }
+    for (const card of source.cards) {
+      const result = await bridge.insert(CARDS_TABLE, {
+        ...cardToRow(card, card.order),
+        column_id: columnIdMap.get(card.columnId) ?? card.columnId,
+      });
+      insertedCardIds.push(result.id);
+    }
+  } catch (err) {
+    for (const cardId of [...insertedCardIds].reverse()) {
+      await bridge.delete(CARDS_TABLE, cardId).catch((cleanupErr: unknown) => {
+        console.warn("[task-manager] seed card cleanup failed:", errMessage(cleanupErr));
+      });
+    }
+    for (const columnId of [...insertedColumnIds].reverse()) {
+      await bridge.delete(COLUMNS_TABLE, columnId).catch((cleanupErr: unknown) => {
+        console.warn("[task-manager] seed column cleanup failed:", errMessage(cleanupErr));
+      });
+    }
+    throw err;
   }
   const [columnRows, cardRows] = await Promise.all([
     bridge.find(COLUMNS_TABLE, { orderBy: { position: "asc" } }),
@@ -154,13 +172,23 @@ function App() {
       if (columnRows.length === 0) {
         const legacy = await loadBridgeBoard();
         if (legacy) {
-          setBoard(await persistBoardToBridge(bridge, legacy));
+          suppressReloadRef.current = true;
+          try {
+            setBoard(await persistBoardToBridge(bridge, legacy));
+          } finally {
+            suppressReloadRef.current = false;
+          }
           setError(null);
           return;
         }
         // First run: seed the default workflow columns into Postgres.
         const seed = emptyBoard();
-        setBoard(await persistBoardToBridge(bridge, seed));
+        suppressReloadRef.current = true;
+        try {
+          setBoard(await persistBoardToBridge(bridge, seed));
+        } finally {
+          suppressReloadRef.current = false;
+        }
         setError(null);
         return;
       }
@@ -423,12 +451,14 @@ function App() {
 
   const renameBoardColumn = useCallback((columnId: string, title: string) => {
     if (!boardRef.current) return;
+    const trimmedTitle = title.trim();
     setBoard((current) => (current ? renameColumn(current, columnId, title) : current));
+    if (!trimmedTitle) return;
     void persist(async () => {
       const bridge = db();
       if (!bridge) return;
       const persistedColumnId = await (pendingColumnIdsRef.current[columnId] ?? Promise.resolve(columnId));
-      await bridge.update(COLUMNS_TABLE, persistedColumnId, { title: title.trim() });
+      await bridge.update(COLUMNS_TABLE, persistedColumnId, { title: trimmedTitle });
     }, "Column could not be renamed");
   }, [persist]);
 

--- a/home/apps/task-manager/src/board-model.ts
+++ b/home/apps/task-manager/src/board-model.ts
@@ -135,7 +135,7 @@ export function createSeedBoard(): Board {
     description: "Capture what a professional Matrix OS app should feel like.",
     priority: "high",
     labels: ["product", "design"],
-    assignee: "Hamed",
+    assignee: "Product",
     checklist: [
       { id: "seed-1", text: "Notes upgrade", done: true },
       { id: "seed-2", text: "Task board upgrade", done: false },

--- a/home/apps/task-manager/src/board-model.ts
+++ b/home/apps/task-manager/src/board-model.ts
@@ -94,6 +94,7 @@ export const DEFAULT_COLUMNS: BoardColumn[] = [
 ];
 
 const PROJECT_COLORS = ["#434E3F", "#3A7D44", "#D06F25", "#D6AB8B", "#32352E"];
+const COLUMN_COLORS = ["#7A7768", "#434E3F", "#D06F25", "#D6AB8B", "#3A7D44", "#32352E"];
 let sequence = 0;
 
 function now(): string {
@@ -281,6 +282,45 @@ export function addChecklistItem(board: Board, cardId: string, text: string): Bo
   return updateCard(board, cardId, {
     checklist: [...card.checklist, { id: id("check"), text: text.trim() || "Checklist item", done: false }],
   });
+}
+
+export function addColumn(board: Board, title: string): Board {
+  const column: BoardColumn = {
+    id: id("column"),
+    title: title.trim() || "New column",
+    color: COLUMN_COLORS[board.columns.length % COLUMN_COLORS.length],
+  };
+  return { ...board, columns: [...board.columns, column], updatedAt: now() };
+}
+
+export function renameColumn(board: Board, columnId: string, title: string): Board {
+  return {
+    ...board,
+    columns: board.columns.map((column) =>
+      column.id === columnId ? { ...column, title: title.trim() || column.title } : column,
+    ),
+    updatedAt: now(),
+  };
+}
+
+export function deleteColumn(board: Board, columnId: string): Board {
+  if (board.columns.length <= 1) return board;
+  return {
+    ...board,
+    columns: board.columns.filter((column) => column.id !== columnId),
+    cards: normalizeOrders(board.cards.filter((card) => card.columnId !== columnId)),
+    updatedAt: now(),
+  };
+}
+
+export function moveColumn(board: Board, columnId: string, targetIndex: number): Board {
+  const current = board.columns.findIndex((column) => column.id === columnId);
+  if (current < 0) return board;
+  const next = board.columns.slice();
+  const [moved] = next.splice(current, 1);
+  const clamped = Math.max(0, Math.min(targetIndex, next.length));
+  next.splice(clamped, 0, moved);
+  return { ...board, columns: next, updatedAt: now() };
 }
 
 export function resolveColumnId(board: Board, preferredColumnId: string | null | undefined): string {

--- a/home/apps/task-manager/src/matrix-os.d.ts
+++ b/home/apps/task-manager/src/matrix-os.d.ts
@@ -1,13 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
 interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
   readData?(key: string): Promise<unknown>;
   writeData?(key: string, value: unknown): Promise<void>;
-  onDataChange?(callback: (key: string, app: string) => void): () => void;
 }
-
 declare global {
-  interface Window {
-    MatrixOS?: MatrixOS;
-  }
+  interface Window { MatrixOS?: MatrixOS; }
 }
-
 export {};

--- a/home/apps/task-manager/src/persistence.ts
+++ b/home/apps/task-manager/src/persistence.ts
@@ -165,7 +165,7 @@ export function cardToRow(card: Card, position: number): Record<string, unknown>
     column_id: card.columnId,
     title: card.title,
     description: card.description,
-    labels: JSON.stringify(card.labels),
+    labels: card.labels,
     assignee: card.assignee,
     priority: card.priority,
     due: card.dueDate ? card.dueDate : null,

--- a/home/apps/task-manager/src/persistence.ts
+++ b/home/apps/task-manager/src/persistence.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_COLUMNS,
   createBoard,
+  hydrateBoard,
   type Board,
   type BoardColumn,
   type Card,
@@ -15,6 +16,7 @@ import {
 export const COLUMNS_TABLE = "columns";
 export const CARDS_TABLE = "cards";
 const LOCAL_KEY = "task-manager:board";
+const LEGACY_BRIDGE_KEYS = ["project-board", LOCAL_KEY] as const;
 const DEFAULT_PROJECT_ID = "project-default";
 
 function asString(value: unknown, fallback = ""): string {
@@ -104,7 +106,7 @@ export function boardFromRows(columnRows: Record<string, unknown>[], cardRows: R
         delegation: null,
         order: asNumber(row.position),
         createdAt: asString(row.created_at, new Date().toISOString()),
-        updatedAt: asString(row.created_at, new Date().toISOString()),
+        updatedAt: asString(row.updated_at, asString(row.created_at, new Date().toISOString())),
       };
     })
     .filter((card) => card.id && card.columnId);
@@ -116,6 +118,37 @@ export function boardFromRows(columnRows: Record<string, unknown>[], cardRows: R
     cards,
     updatedAt: new Date().toISOString(),
   };
+}
+
+function parseStoredBoard(value: unknown): Board | null {
+  let raw = value;
+  if (typeof raw === "string") {
+    if (!raw.trim()) return null;
+    try {
+      raw = JSON.parse(raw);
+    } catch (err: unknown) {
+      console.warn("[task-manager] stored board parse failed:", err instanceof Error ? err.message : String(err));
+      return null;
+    }
+  }
+  if (!raw || typeof raw !== "object") return null;
+  const candidate = raw as Partial<Board>;
+  if (!Array.isArray(candidate.columns) || !Array.isArray(candidate.cards)) return null;
+  return hydrateBoard(candidate);
+}
+
+export async function loadBridgeBoard(): Promise<Board | null> {
+  const readData = window.MatrixOS?.readData;
+  if (!readData) return null;
+  for (const key of LEGACY_BRIDGE_KEYS) {
+    try {
+      const board = parseStoredBoard(await readData(key));
+      if (board && board.columns.length > 0) return board;
+    } catch (err: unknown) {
+      console.warn("[task-manager] legacy board load failed:", err instanceof Error ? err.message : String(err));
+    }
+  }
+  return null;
 }
 
 /** Serialize a card's app-shaped fields into DB column values. */
@@ -142,8 +175,7 @@ export function columnToRow(column: BoardColumn, position: number): Record<strin
 export function loadLocalBoard(): Board | null {
   try {
     const raw = localStorage.getItem(LOCAL_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw) as Board;
+    return parseStoredBoard(raw);
   } catch (err: unknown) {
     console.warn("[task-manager] local board parse failed:", err instanceof Error ? err.message : String(err));
     return null;

--- a/home/apps/task-manager/src/persistence.ts
+++ b/home/apps/task-manager/src/persistence.ts
@@ -37,6 +37,13 @@ function asPriority(value: unknown): Priority {
 function parseLabels(value: unknown): string[] {
   if (Array.isArray(value)) return value.filter((v): v is string => typeof v === "string");
   if (typeof value === "string") {
+    if (!value.trim()) return [];
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed.filter((v): v is string => typeof v === "string");
+    } catch {
+      // Older rows used comma-separated labels. Keep reading them as a migration fallback.
+    }
     return value.split(",").map((part) => part.trim()).filter(Boolean);
   }
   return [];
@@ -158,7 +165,7 @@ export function cardToRow(card: Card, position: number): Record<string, unknown>
     column_id: card.columnId,
     title: card.title,
     description: card.description,
-    labels: card.labels.join(", "),
+    labels: JSON.stringify(card.labels),
     assignee: card.assignee,
     priority: card.priority,
     due: card.dueDate ? card.dueDate : null,

--- a/home/apps/task-manager/src/persistence.ts
+++ b/home/apps/task-manager/src/persistence.ts
@@ -139,16 +139,17 @@ function parseStoredBoard(value: unknown): Board | null {
 
 export async function loadBridgeBoard(): Promise<Board | null> {
   const readData = window.MatrixOS?.readData;
-  if (!readData) return null;
-  for (const key of LEGACY_BRIDGE_KEYS) {
-    try {
-      const board = parseStoredBoard(await readData(key));
-      if (board && board.columns.length > 0) return board;
-    } catch (err: unknown) {
-      console.warn("[task-manager] legacy board load failed:", err instanceof Error ? err.message : String(err));
+  if (readData) {
+    for (const key of LEGACY_BRIDGE_KEYS) {
+      try {
+        const board = parseStoredBoard(await readData(key));
+        if (board && board.columns.length > 0) return board;
+      } catch (err: unknown) {
+        console.warn("[task-manager] legacy board load failed:", err instanceof Error ? err.message : String(err));
+      }
     }
   }
-  return null;
+  return loadLocalBoard();
 }
 
 /** Serialize a card's app-shaped fields into DB column values. */

--- a/home/apps/task-manager/src/persistence.ts
+++ b/home/apps/task-manager/src/persistence.ts
@@ -68,7 +68,7 @@ function parseChecklist(value: unknown): ChecklistItem[] {
 
 function parseDue(value: unknown): string {
   if (typeof value !== "string" || !value) return "";
-  // Detail panel uses yyyy-mm-dd; timestamptz round-trips include time.
+  // Detail panel uses yyyy-mm-dd; tolerate older timestamp rows by truncating.
   return value.slice(0, 10);
 }
 

--- a/home/apps/task-manager/src/persistence.ts
+++ b/home/apps/task-manager/src/persistence.ts
@@ -1,0 +1,163 @@
+import {
+  DEFAULT_COLUMNS,
+  createBoard,
+  type Board,
+  type BoardColumn,
+  type Card,
+  type ChecklistItem,
+  type Priority,
+} from "./board-model";
+
+// Persistence bridges the pure, UI-free board model to owner-controlled
+// Postgres via window.MatrixOS.db. The board model keeps a single implicit
+// project; the durable schema only persists columns + cards.
+
+export const COLUMNS_TABLE = "columns";
+export const CARDS_TABLE = "cards";
+const LOCAL_KEY = "task-manager:board";
+const DEFAULT_PROJECT_ID = "project-default";
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function asPriority(value: unknown): Priority {
+  return value === "low" || value === "medium" || value === "high" || value === "urgent"
+    ? value
+    : "medium";
+}
+
+function parseLabels(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === "string");
+  if (typeof value === "string") {
+    return value.split(",").map((part) => part.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function parseChecklist(value: unknown): ChecklistItem[] {
+  let raw: unknown = value;
+  if (typeof value === "string" && value.trim()) {
+    try {
+      raw = JSON.parse(value);
+    } catch {
+      raw = [];
+    }
+  }
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item): ChecklistItem | null => {
+      if (!item || typeof item !== "object") return null;
+      const record = item as Record<string, unknown>;
+      if (typeof record.text !== "string") return null;
+      return {
+        id: typeof record.id === "string" ? record.id : `check-${Math.random().toString(36).slice(2, 8)}`,
+        text: record.text,
+        done: record.done === true,
+      };
+    })
+    .filter((item): item is ChecklistItem => item !== null);
+}
+
+function parseDue(value: unknown): string {
+  if (typeof value !== "string" || !value) return "";
+  // Detail panel uses yyyy-mm-dd; timestamptz round-trips include time.
+  return value.slice(0, 10);
+}
+
+/** Build the in-memory board from raw DB column + card rows. */
+export function boardFromRows(columnRows: Record<string, unknown>[], cardRows: Record<string, unknown>[]): Board {
+  const columns: BoardColumn[] = columnRows
+    .slice()
+    .sort((a, b) => asNumber(a.position) - asNumber(b.position))
+    .map((row) => ({
+      id: asString(row.id),
+      title: asString(row.title, "Untitled"),
+      color: asString(row.color, "#7A7768"),
+    }))
+    .filter((column) => column.id);
+
+  const columnIds = new Set(columns.map((column) => column.id));
+  const fallbackColumnId = columns[0]?.id ?? "";
+
+  const cards: Card[] = cardRows
+    .slice()
+    .sort((a, b) => asNumber(a.position) - asNumber(b.position))
+    .map((row) => {
+      const columnId = asString(row.column_id);
+      return {
+        id: asString(row.id),
+        projectId: DEFAULT_PROJECT_ID,
+        columnId: columnIds.has(columnId) ? columnId : fallbackColumnId,
+        title: asString(row.title, "Untitled card"),
+        description: asString(row.description),
+        priority: asPriority(row.priority),
+        labels: parseLabels(row.labels),
+        assignee: asString(row.assignee),
+        dueDate: parseDue(row.due),
+        checklist: parseChecklist(row.checklist),
+        delegation: null,
+        order: asNumber(row.position),
+        createdAt: asString(row.created_at, new Date().toISOString()),
+        updatedAt: asString(row.created_at, new Date().toISOString()),
+      };
+    })
+    .filter((card) => card.id && card.columnId);
+
+  return {
+    version: 1,
+    projects: [{ id: DEFAULT_PROJECT_ID, name: "Board", color: "#434E3F", description: "" }],
+    columns: columns.length > 0 ? columns : DEFAULT_COLUMNS,
+    cards,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/** Serialize a card's app-shaped fields into DB column values. */
+export function cardToRow(card: Card, position: number): Record<string, unknown> {
+  return {
+    column_id: card.columnId,
+    title: card.title,
+    description: card.description,
+    labels: card.labels.join(", "),
+    assignee: card.assignee,
+    priority: card.priority,
+    due: card.dueDate ? card.dueDate : null,
+    checklist: card.checklist,
+    position,
+  };
+}
+
+export function columnToRow(column: BoardColumn, position: number): Record<string, unknown> {
+  return { title: column.title, color: column.color, position };
+}
+
+// ---- localStorage fallback (only used when window.MatrixOS.db is undefined) ----
+
+export function loadLocalBoard(): Board | null {
+  try {
+    const raw = localStorage.getItem(LOCAL_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as Board;
+  } catch (err: unknown) {
+    console.warn("[task-manager] local board parse failed:", err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+export function saveLocalBoard(board: Board): void {
+  try {
+    localStorage.setItem(LOCAL_KEY, JSON.stringify(board));
+  } catch (err: unknown) {
+    console.warn("[task-manager] local board save failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+export function emptyBoard(): Board {
+  return createBoard("Board");
+}

--- a/home/apps/task-manager/src/styles.css
+++ b/home/apps/task-manager/src/styles.css
@@ -1,746 +1,523 @@
 :root {
-  color-scheme: light;
-  --background: #F7F1E7;
-  --foreground: var(--matrix-fg, #32352E);
-  --card: rgba(255,255,255,0.55);
-  --muted: var(--matrix-muted-fg, #7A7768);
-  --border: var(--matrix-border, #D6D3C8);
-  --accent: var(--matrix-accent, #434E3F);
-  --accent-soft: color-mix(in srgb, var(--accent) 11%, transparent);
-  --danger: #C4342D;
-  --warning: #D06F25;
-  --success: #3A7D44;
-  --surface: rgba(255,255,255,0.35);
-  --sand-light: #F7F1E7;
-  --sand-mid: #F3EAE0;
-  --sand-warm: #D6AB8B;
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --app-bg: var(--matrix-bg, #FAFAF5);
+  --app-fg: var(--matrix-fg, #32352E);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #F0EDE4);
+  --app-muted-fg: var(--matrix-muted-fg, #7A7768);
+  --app-border: var(--matrix-border, #D6D3C8);
+  --app-primary: var(--matrix-primary, #434E3F);
+  --app-primary-fg: var(--matrix-primary-fg, #FAFAF5);
+  --app-accent: var(--matrix-accent, #D06F25);
+  --app-success: var(--matrix-success, #3A7D44);
+  --app-warning: var(--matrix-warning, #D49B2A);
+  --app-danger: var(--matrix-destructive, #C4342D);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, 'Inter', system-ui, sans-serif);
+  --shadow-sm: 0 1px 2px rgba(50, 53, 46, 0.06);
+  --shadow-md: 0 4px 12px rgba(50, 53, 46, 0.08);
+  --shadow-lg: 0 18px 48px rgba(50, 53, 46, 0.22);
 }
 
-* {
-  box-sizing: border-box;
-}
-
+* { box-sizing: border-box; }
+html, body, #root { width: 100%; height: 100%; margin: 0; }
 body {
-  margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
-  background: linear-gradient(170deg, var(--sand-light) 0%, var(--sand-mid) 30%, #F7F3ED 60%, var(--sand-light) 100%);
-  color: var(--foreground);
-  -webkit-font-smoothing: antialiased;
-}
-
-button,
-input,
-textarea,
-select {
-  font: inherit;
-}
-
-button:focus-visible,
-input:focus-visible,
-textarea:focus-visible,
-select:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 52%, transparent);
-  outline-offset: 2px;
-}
-
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.38;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  color: var(--app-fg);
+  background: var(--app-bg);
 }
+
+button { font-family: inherit; cursor: pointer; }
+input, textarea, select { font-family: inherit; }
 
 .board-shell {
   display: flex;
-  min-height: 100vh;
   flex-direction: column;
-  gap: 14px;
-  padding: 18px;
+  height: 100vh;
   overflow: hidden;
+  background:
+    radial-gradient(120% 90% at 100% 0%, color-mix(in srgb, var(--app-accent) 7%, transparent), transparent 55%),
+    var(--app-bg);
 }
+.board-shell--loading { align-items: center; justify-content: center; }
+.loading { color: var(--app-muted-fg); font-size: 0.95rem; }
 
-.app-header,
-.control-row,
-.quick-add {
+/* Header */
+.app-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 14px;
+  gap: 16px;
+  padding: 18px 22px 12px;
+  flex-shrink: 0;
 }
-
-.app-title {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 12px;
-}
-
+.app-title { display: flex; align-items: center; gap: 12px; }
 .app-icon {
   display: grid;
-  width: 46px;
-  height: 46px;
-  flex: 0 0 auto;
   place-items: center;
-  border: 1px solid rgba(214,211,200,0.35);
+  width: 42px; height: 42px;
   border-radius: 14px;
-  background: rgba(255,255,255,0.55);
-  backdrop-filter: blur(12px);
-  color: var(--accent);
+  background: var(--app-primary);
+  color: var(--app-primary-fg);
+  box-shadow: var(--shadow-md);
 }
-
 .eyebrow {
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 750;
-  letter-spacing: 0.08em;
+  font-size: 0.7rem;
   text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--app-muted-fg);
+  font-weight: 600;
 }
-
-h1,
-h2,
-h3,
-p {
-  margin: 0;
-}
-
-h1 {
-  overflow-wrap: anywhere;
-  font-size: 28px;
-  line-height: 1.1;
-}
-
-.search-field,
-.inline-form,
-.quick-add {
+.app-title h1 { margin: 2px 0 0; font-size: 1.18rem; font-weight: 700; letter-spacing: -0.01em; }
+.header-tools { display: flex; align-items: center; gap: 10px; }
+.search-field {
   display: flex;
   align-items: center;
   gap: 8px;
-}
-
-.search-field {
-  min-width: min(390px, 42vw);
-  border: 1.5px solid rgba(214,211,200,0.5);
-  border-radius: 50px;
-  background: rgba(255,255,255,0.7);
-  color: var(--muted);
-  padding: 8px 14px;
-}
-
-input,
-textarea,
-select {
-  min-width: 0;
-  border: 1.5px solid rgba(214,211,200,0.5);
-  border-radius: 50px;
-  background: rgba(255,255,255,0.7);
-  color: var(--foreground);
   padding: 9px 14px;
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 13px;
+  color: var(--app-muted-fg);
+  box-shadow: var(--shadow-sm);
+  transition: border-color .15s ease, box-shadow .15s ease;
 }
+.search-field:focus-within { border-color: var(--app-accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--app-accent) 18%, transparent); }
+.search-field input { border: none; outline: none; background: transparent; color: var(--app-fg); width: 200px; font-size: 0.9rem; }
 
-textarea {
-  border-radius: 22px;
-  line-height: 1.45;
+/* Filter bar */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 22px 12px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
 }
-
-.search-field input {
-  width: 100%;
-  border: 0;
-  outline: 0;
-  padding: 0;
-}
-
-.button,
-.icon-button {
+.label-chip {
+  --chip: var(--app-muted-fg);
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 36px;
-  border: 1px solid rgba(214,211,200,0.5);
-  border-radius: 50px;
-  background: rgba(255,255,255,0.7);
-  backdrop-filter: blur(8px);
-  color: var(--foreground);
-  cursor: pointer;
-  font-weight: 700;
-  transition: background 160ms ease, border-color 160ms ease, transform 120ms ease;
+  gap: 7px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--app-border);
+  background: var(--app-card);
+  color: var(--app-fg);
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: all .15s ease;
 }
-
-.button {
-  padding: 8px 12px;
-}
-
-.button--compact {
-  min-height: 32px;
-  padding: 6px 10px;
-  font-size: 12px;
-}
-
-.icon-button {
-  width: 36px;
-}
-
-.icon-button--compact {
-  width: 32px;
-  min-height: 32px;
-}
-
-.button:hover:not(:disabled),
-.icon-button:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
-  background: var(--accent-soft);
-}
-
-.button:active:not(:disabled),
-.icon-button:active:not(:disabled) {
-  transform: translateY(1px);
-}
-
-.button--primary {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: white;
-}
-
-.button--danger {
-  color: var(--danger);
-}
-
-.summary-grid {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(116px, 1fr));
-  gap: 10px;
-}
-
-.summary-card {
-  display: grid;
-  min-width: 0;
-  grid-template-columns: auto 1fr;
-  gap: 2px 10px;
-  align-items: center;
-  border: 1px solid rgba(214,211,200,0.35);
-  border-radius: 22px;
-  background: rgba(255,255,255,0.55);
-  backdrop-filter: blur(12px);
-  padding: 12px;
-  box-shadow: 0 2px 4px rgba(50,53,46,0.06);
-}
-
-.summary-card svg {
-  color: var(--accent);
-}
-
-.summary-card span {
-  min-width: 0;
-  overflow-wrap: anywhere;
-  font-size: 20px;
-  font-weight: 800;
-}
-
-.summary-card small {
-  grid-column: 2;
-  color: var(--muted);
-}
+.label-chip:hover { background: color-mix(in srgb, var(--app-fg) 4%, transparent); }
+.label-chip--active { border-color: var(--chip); background: color-mix(in srgb, var(--chip) 14%, var(--app-card)); }
+.label-chip__dot { width: 9px; height: 9px; border-radius: 50%; background: var(--chip); }
 
 .error-banner {
-  border: 1px solid color-mix(in srgb, var(--danger) 32%, var(--border));
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--danger) 8%, var(--card));
-  color: var(--danger);
-  padding: 9px 12px;
-  font-size: 13px;
+  margin: 0 22px 12px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--app-danger) 12%, var(--app-card));
+  color: var(--app-danger);
+  font-size: 0.85rem;
+  flex-shrink: 0;
 }
 
-.project-tabs {
-  display: flex;
-  min-width: 0;
-  gap: 7px;
-  overflow-x: auto;
-}
-
-.project-tab,
-.delegate-option {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  min-height: 34px;
-  white-space: nowrap;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--card);
-  color: var(--muted);
-  padding: 6px 11px;
-  cursor: pointer;
-}
-
-.project-tab span {
-  width: 8px;
-  height: 8px;
-  flex: 0 0 auto;
-  border-radius: 99px;
-}
-
-.project-tab--active,
-.delegate-option--active {
-  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
-  background: var(--accent-soft);
-  color: var(--accent);
-}
-
-.quick-add {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--card);
-  padding: 10px;
-}
-
-.quick-add__title {
-  flex: 1 1 260px;
-}
-
-.quick-add input,
-.quick-add select {
-  width: 100%;
-}
-
+/* Board */
 .board {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(250px, 1fr));
-  gap: 12px;
-  min-height: 0;
   flex: 1;
-  overflow-x: auto;
-  padding-bottom: 8px;
-}
-
-.column {
   display: flex;
-  min-width: 250px;
-  min-height: 430px;
-  flex-direction: column;
-  border: 1px solid rgba(214,211,200,0.35);
-  border-radius: 22px;
-  background: rgba(255,255,255,0.45);
-  backdrop-filter: blur(12px);
+  gap: 16px;
+  padding: 4px 22px 22px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  align-items: flex-start;
+  min-height: 0;
 }
-
+.column {
+  flex: 0 0 296px;
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+  background: color-mix(in srgb, var(--app-muted) 65%, var(--app-bg));
+  border: 1px solid var(--app-border);
+  border-radius: var(--app-radius);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow .15s ease, transform .15s ease, opacity .15s ease;
+}
+.column--dragging { opacity: 0.45; }
 .column__header {
   display: flex;
   align-items: center;
-  gap: 9px;
-  border-bottom: 1px solid var(--border);
-  padding: 11px 12px;
+  gap: 6px;
+  padding: 14px 14px 8px;
 }
-
-.column__header > span {
-  width: 9px;
-  height: 9px;
-  flex: 0 0 auto;
-  border-radius: 99px;
-}
-
-.column__header div {
-  min-width: 0;
-}
-
-.column__header h2 {
-  overflow-wrap: anywhere;
-  font-size: 14px;
-}
-
-.column__header small {
-  color: var(--muted);
-  font-size: 11px;
-}
-
-.column__quick-add {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 7px;
-  border-bottom: 1px solid var(--border);
-  padding: 9px;
-}
-
-.column__quick-add input {
-  background: var(--card);
-  font-size: 13px;
-}
-
-.column__cards {
-  display: flex;
-  min-height: 0;
-  flex: 1;
-  flex-direction: column;
-  gap: 9px;
-  overflow-y: auto;
-  padding: 10px;
-}
-
-.task-card {
-  min-width: 0;
-  border: 1px solid rgba(214,211,200,0.35);
-  border-radius: 16px;
-  background: rgba(255,255,255,0.65);
-  backdrop-filter: blur(8px);
-  box-shadow: 0 2px 4px rgba(50,53,46,0.06);
-}
-
-.task-card--delegated {
-  border-color: color-mix(in srgb, var(--success) 24%, var(--border));
-}
-
-.task-card__open {
-  display: grid;
-  width: 100%;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 7px;
-  align-items: start;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  padding: 11px 11px 7px;
-  text-align: left;
-  cursor: pointer;
-}
-
-.task-card__drag {
-  color: var(--muted);
-}
-
-.task-card__main {
-  display: grid;
-  min-width: 0;
-  gap: 3px;
-}
-
-.task-card__title {
-  min-width: 0;
-  overflow-wrap: anywhere;
-  font-size: 14px;
-  font-weight: 750;
-  line-height: 1.3;
-}
-
-.task-card__status {
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 650;
-}
-
-.task-card p {
-  color: var(--muted);
-  overflow-wrap: anywhere;
-  padding: 0 11px 8px;
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-.priority,
-.label,
-.delegation-badge {
+.column__grip {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  border-radius: 8px;
-  padding: 2px 7px;
-  font-size: 11px;
-  font-weight: 750;
+  color: var(--app-muted-fg);
+  cursor: grab;
 }
-
-.priority--low {
-  background: rgba(67,78,63,0.08);
-  color: #3A7D44;
-}
-
-.priority--medium {
-  background: rgba(224,225,202,0.4);
-  color: #434E3F;
-}
-
-.priority--high {
-  background: rgba(208,111,37,0.12);
-  color: #D06F25;
-}
-
-.priority--urgent {
-  background: rgba(196,52,45,0.1);
-  color: #C4342D;
-}
-
-.label-row {
+.column__grip:active { cursor: grabbing; }
+.column__swatch { width: 10px; height: 10px; border-radius: 3px; }
+.column__title {
+  flex: 1;
   display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  padding: 0 11px 8px;
-}
-
-.label {
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  color: color-mix(in srgb, var(--accent) 82%, black);
-}
-
-.delegation-badge--matrix {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: color-mix(in srgb, var(--accent) 80%, black);
-}
-
-.delegation-badge--hermes {
-  background: color-mix(in srgb, var(--success) 12%, transparent);
-  color: color-mix(in srgb, var(--success) 78%, black);
-}
-
-.task-card__meta,
-.task-card__actions {
-  display: flex;
-  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
-  border-top: 1px solid var(--border);
-  color: var(--muted);
-  padding: 8px 11px;
-  font-size: 11px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 2px 4px;
+  border-radius: 8px;
+  color: var(--app-fg);
+}
+.column__title:hover { background: color-mix(in srgb, var(--app-fg) 5%, transparent); }
+.column__title h2 { margin: 0; font-size: 0.92rem; font-weight: 700; }
+.column__count {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--app-muted-fg);
+  background: var(--app-card);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+.column__rename { flex: 1; }
+.column__rename input {
+  width: 100%;
+  padding: 4px 8px;
+  border: 1px solid var(--app-accent);
+  border-radius: 8px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  font-size: 0.9rem;
+  font-weight: 600;
+  outline: none;
+}
+.column__menu { display: flex; gap: 2px; opacity: 0; transition: opacity .15s ease; }
+.column:hover .column__menu { opacity: 1; }
+
+.column__cards {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 10px;
+  overflow-y: auto;
+  min-height: 24px;
+}
+.column__cards--target { background: color-mix(in srgb, var(--app-accent) 7%, transparent); border-radius: 14px; }
+.card-slot { display: flex; flex-direction: column; gap: 8px; }
+.drop-indicator {
+  height: 3px;
+  border-radius: 3px;
+  background: var(--app-accent);
+  margin: 1px 2px;
+}
+.column-empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 18px 12px;
+  color: var(--app-muted-fg);
+  font-size: 0.82rem;
+  border: 1.5px dashed var(--app-border);
+  border-radius: 14px;
+  justify-content: center;
 }
 
-.task-card__meta span {
+/* Task card */
+.task-card {
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 14px;
+  padding: 11px 13px;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: box-shadow .15s ease, transform .12s ease, border-color .15s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.task-card:hover { box-shadow: var(--shadow-md); transform: translateY(-1px); border-color: color-mix(in srgb, var(--app-accent) 30%, var(--app-border)); }
+.task-card:focus-visible { outline: 2px solid var(--app-accent); outline-offset: 2px; }
+.task-card:active { cursor: grabbing; }
+.task-card__labels { display: flex; gap: 4px; flex-wrap: wrap; }
+.task-card__label { width: 30px; height: 6px; border-radius: 999px; }
+.task-card__title { margin: 0; font-size: 0.9rem; font-weight: 600; line-height: 1.3; }
+.task-card__desc {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--app-muted-fg);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.task-card__meta { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.meta {
   display: inline-flex;
-  min-width: 0;
   align-items: center;
   gap: 4px;
-  overflow-wrap: anywhere;
-}
-
-.task-card__actions {
-  justify-content: space-between;
-}
-
-.column-empty {
-  display: grid;
-  min-height: 92px;
-  place-items: center;
-  border: 1px dashed var(--border);
-  border-radius: 8px;
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.detail-panel {
-  position: fixed;
-  inset: 0;
-  z-index: 20;
-}
-
-.detail-panel__backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(50,53,46,0.18);
-}
-
-.detail-panel__sheet {
-  position: absolute;
-  top: 0;
-  right: 0;
-  display: flex;
-  width: min(480px, 100vw);
-  height: 100%;
-  flex-direction: column;
-  gap: 14px;
-  overflow-y: auto;
-  border-left: 1px solid var(--border);
-  background: var(--card);
-  padding: 18px;
-  box-shadow: -20px 0 60px rgba(50,53,46,0.14);
-}
-
-.detail-panel__sheet header,
-.delegation-panel header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 14px;
-}
-
-.detail-panel__sheet header small {
-  color: var(--muted);
-}
-
-.detail-panel__sheet label,
-.checklist,
-.delegation-fields {
-  display: grid;
-  gap: 7px;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 750;
-}
-
-.detail-panel__sheet label input,
-.detail-panel__sheet label textarea,
-.detail-panel__sheet label select {
-  color: var(--foreground);
-  font-size: 14px;
+  font-size: 0.72rem;
+  color: var(--app-muted-fg);
   font-weight: 500;
 }
-
-.detail-panel__sheet textarea {
-  min-height: 120px;
-  resize: vertical;
+.meta--done { color: var(--app-success); }
+.meta--due-overdue { color: var(--app-danger); font-weight: 600; }
+.meta--due-soon { color: var(--app-warning); font-weight: 600; }
+.meta--assignee {
+  background: var(--app-muted);
+  border-radius: 999px;
+  padding: 2px 8px;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-
-.field-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
+.pill {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--app-muted);
+  color: var(--app-fg);
 }
+.pill--low { background: color-mix(in srgb, var(--app-muted-fg) 18%, var(--app-card)); }
+.pill--high { background: color-mix(in srgb, var(--app-warning) 22%, var(--app-card)); color: color-mix(in srgb, var(--app-warning) 80%, #000); }
+.pill--urgent { background: color-mix(in srgb, var(--app-danger) 18%, var(--app-card)); color: var(--app-danger); }
 
-.delegation-panel {
-  display: grid;
-  gap: 10px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
+/* Quick add */
+.column__quick-add {
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px 12px;
+}
+.column__quick-add input {
+  flex: 1;
+  padding: 9px 12px;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  font-size: 0.85rem;
+  outline: none;
+  transition: border-color .15s ease;
+}
+.column__quick-add input:focus { border-color: var(--app-accent); }
+.column__quick-add input::placeholder { color: var(--app-muted-fg); }
+
+/* Column adder */
+.column-adder { flex: 0 0 240px; padding-top: 4px; }
+.column-adder__trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 16px;
+  border: 1.5px dashed var(--app-border);
+  border-radius: var(--app-radius);
+  background: color-mix(in srgb, var(--app-card) 50%, transparent);
+  color: var(--app-muted-fg);
+  font-size: 0.88rem;
+  font-weight: 600;
+  transition: all .15s ease;
+}
+.column-adder__trigger:hover { border-color: var(--app-accent); color: var(--app-accent); background: color-mix(in srgb, var(--app-accent) 6%, transparent); }
+.column-adder__form {
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: var(--app-radius);
   padding: 12px;
+  box-shadow: var(--shadow-sm);
 }
+.column-adder__form input {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--app-border);
+  border-radius: 11px;
+  font-size: 0.88rem;
+  outline: none;
+  margin-bottom: 8px;
+}
+.column-adder__form input:focus { border-color: var(--app-accent); }
+.column-adder__actions { display: flex; gap: 6px; }
 
-.delegation-panel h3 {
+/* Buttons */
+.button {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  font-size: 14px;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid var(--app-border);
+  border-radius: 11px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: all .15s ease;
 }
-
-.delegation-panel header span {
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 750;
+.button:hover { background: color-mix(in srgb, var(--app-fg) 5%, var(--app-card)); }
+.button--primary { background: var(--app-accent); border-color: var(--app-accent); color: #fff; }
+.button--primary:hover { background: color-mix(in srgb, var(--app-accent) 88%, #000); }
+.button--danger { background: transparent; border-color: color-mix(in srgb, var(--app-danger) 40%, var(--app-border)); color: var(--app-danger); }
+.button--danger:hover { background: color-mix(in srgb, var(--app-danger) 10%, transparent); }
+.icon-button {
+  display: grid;
+  place-items: center;
+  width: 34px; height: 34px;
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  background: var(--app-card);
+  color: var(--app-muted-fg);
+  transition: all .15s ease;
 }
+.icon-button:hover { color: var(--app-fg); background: color-mix(in srgb, var(--app-fg) 5%, var(--app-card)); }
+.icon-button--compact { width: 36px; height: 36px; }
+.icon-button--ghost { width: 26px; height: 26px; border: none; background: transparent; }
+.icon-button--ghost:hover { background: color-mix(in srgb, var(--app-fg) 8%, transparent); }
 
-.delegate-options {
+/* Empty states */
+.empty-state {
+  position: absolute;
+  left: 50%;
+  bottom: 22%;
+  transform: translateX(-50%);
+  text-align: center;
+  max-width: 360px;
+  padding: 24px;
+  pointer-events: none;
+}
+.empty-state--filter { bottom: 30%; }
+.empty-state__icon {
+  display: inline-grid;
+  place-items: center;
+  width: 60px; height: 60px;
+  border-radius: 20px;
+  background: var(--app-card);
+  color: var(--app-accent);
+  box-shadow: var(--shadow-md);
+  margin-bottom: 14px;
+}
+.empty-state h2 { margin: 0 0 6px; font-size: 1.1rem; }
+.empty-state p { margin: 0; color: var(--app-muted-fg); font-size: 0.88rem; line-height: 1.45; }
+
+/* Detail overlay */
+.detail-overlay { position: fixed; inset: 0; z-index: 50; display: flex; justify-content: flex-end; }
+.detail-overlay__backdrop { position: absolute; inset: 0; background: rgba(50, 53, 46, 0.32); backdrop-filter: blur(2px); animation: fade .15s ease; }
+.detail-sheet {
+  position: relative;
+  width: min(460px, 100%);
+  height: 100%;
+  background: var(--app-bg);
+  border-left: 1px solid var(--app-border);
+  box-shadow: var(--shadow-lg);
+  padding: 20px 22px 24px;
+  overflow-y: auto;
   display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
+  flex-direction: column;
+  gap: 16px;
+  animation: slide-in .2s cubic-bezier(0.22, 1, 0.36, 1);
 }
-
-.checklist h3 {
-  color: var(--foreground);
-  font-size: 14px;
+@keyframes slide-in { from { transform: translateX(24px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+@keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+.detail-sheet__header { display: flex; align-items: center; justify-content: space-between; }
+.detail-title {
+  width: 100%;
+  border: 1px solid transparent;
+  background: transparent;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--app-fg);
+  padding: 6px 8px;
+  border-radius: 10px;
+  outline: none;
+  transition: all .15s ease;
 }
+.detail-title:hover { background: color-mix(in srgb, var(--app-fg) 4%, transparent); }
+.detail-title:focus { border-color: var(--app-accent); background: var(--app-card); }
 
+.detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.field { display: flex; flex-direction: column; gap: 5px; font-size: 0.78rem; color: var(--app-muted-fg); font-weight: 600; }
+.field--block { grid-column: 1 / -1; }
+.field__label { display: flex; align-items: center; gap: 6px; font-size: 0.78rem; color: var(--app-muted-fg); font-weight: 600; }
+.field__label em { font-style: normal; color: var(--app-accent); }
+.field input, .field select, .field textarea, .field--block textarea {
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  padding: 9px 11px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--app-fg);
+  background: var(--app-card);
+  outline: none;
+  transition: border-color .15s ease;
+}
+.field input:focus, .field select:focus, .field textarea:focus { border-color: var(--app-accent); }
+.field--block textarea { width: 100%; resize: vertical; margin-top: 6px; }
+
+.label-editor { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin-top: 6px; }
+.label-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #fff;
+  font-size: 0.76rem;
+  font-weight: 600;
+  padding: 4px 4px 4px 10px;
+  border-radius: 999px;
+}
+.label-tag button { display: grid; place-items: center; border: none; background: rgba(255,255,255,0.25); border-radius: 50%; width: 16px; height: 16px; color: #fff; }
+.label-editor form { flex: 1; min-width: 110px; }
+.label-editor input {
+  width: 100%;
+  border: 1px dashed var(--app-border);
+  border-radius: 999px;
+  padding: 5px 12px;
+  font-size: 0.78rem;
+  outline: none;
+}
+.label-editor input:focus { border-style: solid; border-color: var(--app-accent); }
+
+.checklist-progress { height: 6px; border-radius: 999px; background: var(--app-muted); margin: 8px 0; overflow: hidden; }
+.checklist-progress__bar { height: 100%; background: var(--app-success); border-radius: 999px; transition: width .2s ease; }
+.checklist { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
 .checklist-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--background);
-  color: var(--foreground);
-  padding: 9px 10px;
+  gap: 9px;
+  border: none;
+  background: transparent;
   text-align: left;
-  cursor: pointer;
+  padding: 7px 8px;
+  border-radius: 9px;
+  color: var(--app-fg);
+  font-size: 0.86rem;
+  transition: background .15s ease;
 }
-
-.loading {
-  display: grid;
-  min-height: 100vh;
-  place-items: center;
-  color: var(--muted);
+.checklist-item:hover { background: color-mix(in srgb, var(--app-fg) 4%, transparent); }
+.checklist-item svg { color: var(--app-muted-fg); flex-shrink: 0; }
+.checklist-item--done svg { color: var(--app-success); }
+.checklist-item--done span { text-decoration: line-through; color: var(--app-muted-fg); }
+.checklist form input {
+  width: 100%;
+  border: 1px solid var(--app-border);
+  border-radius: 9px;
+  padding: 8px 10px;
+  font-size: 0.84rem;
+  outline: none;
+  margin-top: 4px;
 }
+.checklist form input:focus { border-color: var(--app-accent); }
 
-@media (max-width: 1180px) {
-  .summary-grid {
-    grid-template-columns: repeat(3, minmax(120px, 1fr));
-  }
-}
+.detail-delete { margin-top: 6px; align-self: flex-start; }
 
-@media (max-width: 920px) {
-  .board-shell {
-    overflow-y: auto;
-  }
-
-  .app-header,
-  .control-row {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .search-field {
-    width: 100%;
-    min-width: 0;
-  }
-
-  .quick-add {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .quick-add__title {
-    grid-column: 1 / -1;
-  }
-
-  .summary-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .board {
-    display: flex;
-    min-height: 470px;
-    scroll-snap-type: x mandatory;
-    overflow-x: auto;
-  }
-
-  .column {
-    flex: 0 0 min(86vw, 360px);
-    min-width: 0;
-    scroll-snap-align: start;
-  }
-}
-
-@media (max-width: 560px) {
-  .board-shell {
-    gap: 12px;
-    padding: 12px;
-  }
-
-  .app-icon {
-    width: 40px;
-    height: 40px;
-  }
-
-  h1 {
-    font-size: 23px;
-  }
-
-  .quick-add,
-  .field-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .summary-grid {
-    gap: 8px;
-  }
-
-  .summary-card {
-    padding: 10px;
-  }
-
-  .detail-panel__sheet {
-    width: 100vw;
-    border-left: 0;
-    padding: 14px;
-  }
-}
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
 
 @media (prefers-reduced-motion: reduce) {
-  .button,
-  .icon-button {
-    transition: none;
-  }
+  * { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; }
 }

--- a/tests/default-apps/manifest-quality.test.ts
+++ b/tests/default-apps/manifest-quality.test.ts
@@ -13,7 +13,7 @@ const ICONS_DIR = join(REPO_ROOT, "home", "system", "icons");
 // Apps whose current runtime already depends on durable structured data living
 // in owner-controlled Postgres (per spec 083). Newly migrated apps should add
 // themselves here in the same PR that declares storage.tables.
-const DURABLE_DATA_APPS = new Set(["notes", "todo", "expense-tracker"]);
+const DURABLE_DATA_APPS = new Set(["notes", "task-manager", "todo", "expense-tracker"]);
 
 interface Manifest {
   slug?: string;

--- a/tests/default-apps/manifest-quality.test.ts
+++ b/tests/default-apps/manifest-quality.test.ts
@@ -53,6 +53,14 @@ describe("default app manifest quality (spec 083)", () => {
     expect(dirs.length).toBeGreaterThan(5);
   });
 
+  it("keeps task-manager due dates as date-only storage", () => {
+    const manifest = JSON.parse(
+      readFileSync(join(APPS_DIR, "task-manager", "matrix.json"), "utf-8"),
+    ) as { storage?: { tables?: { cards?: { columns?: Record<string, string> } } } };
+
+    expect(manifest.storage?.tables?.cards?.columns?.due).toBe("date");
+  });
+
   for (const dir of dirs) {
     const appId = appIdForDir(dir);
     describe(appId, () => {

--- a/tests/default-apps/task-board-model.test.ts
+++ b/tests/default-apps/task-board-model.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   addCard,
+  addColumn,
   createBoard,
   delegateCard,
+  deleteColumn,
   hydrateBoard,
   moveCardToAdjacentColumn,
   moveCard,
+  moveColumn,
+  renameColumn,
   resolveColumnId,
   summarizeBoard,
   toggleChecklistItem,
@@ -270,6 +274,44 @@ describe("task board model", () => {
     expect(board.cards[0].id).toMatch(/^card-/);
     expect(board.cards[0].projectId).toBe("");
     expect(moveCard(board, board.cards[0].id, "today", 0).cards[0].id).toBe(board.cards[0].id);
+  });
+
+  it("adds, renames, reorders, and deletes columns", () => {
+    let board = createBoard("Default");
+    const initialCount = board.columns.length;
+
+    board = addColumn(board, "Blocked");
+    expect(board.columns.length).toBe(initialCount + 1);
+    expect(board.columns[board.columns.length - 1].title).toBe("Blocked");
+
+    const blockedId = board.columns[board.columns.length - 1].id;
+    board = renameColumn(board, blockedId, "On hold");
+    expect(board.columns[board.columns.length - 1].title).toBe("On hold");
+
+    board = moveColumn(board, blockedId, 0);
+    expect(board.columns[0].id).toBe(blockedId);
+
+    board = deleteColumn(board, blockedId);
+    expect(board.columns.some((column) => column.id === blockedId)).toBe(false);
+  });
+
+  it("removes cards belonging to a deleted column", () => {
+    let board = createBoard("Default");
+    board = addColumn(board, "Blocked");
+    const blockedId = board.columns[board.columns.length - 1].id;
+    board = addCard(board, { columnId: blockedId, title: "Orphan", projectId: board.projects[0].id });
+    expect(board.cards.length).toBe(1);
+
+    board = deleteColumn(board, blockedId);
+    expect(board.cards.length).toBe(0);
+  });
+
+  it("refuses to delete the last remaining column", () => {
+    let board = createBoard("Default");
+    board = { ...board, columns: [board.columns[0]] };
+    const onlyId = board.columns[0].id;
+    board = deleteColumn(board, onlyId);
+    expect(board.columns.length).toBe(1);
   });
 
   it("hydrates cards with malformed titles into visible card names", () => {

--- a/tests/default-apps/task-board-model.test.ts
+++ b/tests/default-apps/task-board-model.test.ts
@@ -3,6 +3,7 @@ import {
   addCard,
   addColumn,
   createBoard,
+  createSeedBoard,
   delegateCard,
   deleteColumn,
   hydrateBoard,
@@ -27,6 +28,13 @@ describe("task board model", () => {
       "Review",
       "Done",
     ]);
+  });
+
+  it("keeps fallback seed board assignees generic", () => {
+    const board = createSeedBoard();
+
+    expect(board.cards.map((card) => card.assignee)).not.toContain("Hamed");
+    expect(board.cards.some((card) => card.assignee === "Product")).toBe(true);
   });
 
   it("adds and moves cards across columns without losing ordering", () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/task-manager/src/App";
+import { boardFromRows } from "../../home/apps/task-manager/src/persistence";
 
 type DbRow = Record<string, unknown>;
 
@@ -11,7 +12,7 @@ interface FakeDb {
   cards: DbRow[];
 }
 
-function installMatrixDb(initial?: Partial<FakeDb>) {
+function installMatrixDb(initial?: Partial<FakeDb>, legacyBoard?: unknown) {
   const store: FakeDb = {
     columns: initial?.columns ? [...initial.columns] : [],
     cards: initial?.cards ? [...initial.cards] : [],
@@ -70,7 +71,10 @@ function installMatrixDb(initial?: Partial<FakeDb>) {
 
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
-    value: { db },
+    value: {
+      db,
+      readData: vi.fn(async (key: string) => key === "project-board" ? legacyBoard : null),
+    },
   });
   return { db, store };
 }
@@ -83,6 +87,22 @@ describe("Task Manager app", () => {
     localStorage.clear();
   });
 
+  it("hydrates card updatedAt from the updated_at DB column", () => {
+    const board = boardFromRows(
+      [{ id: "col-1", title: "To do", color: "#7A7768", position: 0 }],
+      [{
+        id: "card-1",
+        column_id: "col-1",
+        title: "Fresh edit",
+        position: 0,
+        created_at: "2026-05-01T00:00:00.000Z",
+        updated_at: "2026-05-02T00:00:00.000Z",
+      }],
+    );
+
+    expect(board.cards[0].updatedAt).toBe("2026-05-02T00:00:00.000Z");
+  });
+
   it("seeds default columns into Postgres on first run", async () => {
     const { db } = installMatrixDb();
     render(<App />);
@@ -91,6 +111,43 @@ describe("Task Manager app", () => {
     await waitFor(() => expect(db.insert).toHaveBeenCalledWith("columns", expect.objectContaining({ title: "Backlog" })));
     expect(await screen.findByRole("heading", { name: "Backlog" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Done" })).toBeTruthy();
+  });
+
+  it("migrates the legacy project-board bridge data before seeding defaults", async () => {
+    const legacyBoard = {
+      version: 1,
+      projects: [{ id: "project-default", name: "Legacy", color: "#434E3F", description: "" }],
+      columns: [{ id: "legacy-col", title: "Legacy Queue", color: "#7A7768" }],
+      cards: [{
+        id: "legacy-card",
+        projectId: "project-default",
+        columnId: "legacy-col",
+        title: "Migrated card",
+        description: "",
+        priority: "medium",
+        labels: [],
+        assignee: "",
+        dueDate: "",
+        checklist: [],
+        delegation: null,
+        order: 0,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      }],
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    };
+    const { db } = installMatrixDb(undefined, legacyBoard);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(window.MatrixOS?.readData).toHaveBeenCalledWith("project-board");
+      expect(db.insert).toHaveBeenCalledWith("columns", expect.objectContaining({ title: "Legacy Queue" }));
+      expect(db.insert).toHaveBeenCalledWith("cards", expect.objectContaining({
+        title: "Migrated card",
+        column_id: "columns-1",
+      }));
+    });
   });
 
   it("loads existing columns + cards from Postgres", async () => {
@@ -124,6 +181,16 @@ describe("Task Manager app", () => {
       expect(db.insert).toHaveBeenCalledWith("cards", expect.objectContaining({ title: "Ship the board", column_id: "col-1" })),
     );
     expect(await screen.findByText("Ship the board")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Ship the board"));
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Ship the board");
+    fireEvent.change(titleInput, { target: { value: "Real DB id" } });
+    fireEvent.blur(titleInput);
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith("cards", "cards-1", expect.objectContaining({ title: "Real DB id" })),
+    );
   });
 
   it("filters cards by text query", async () => {
@@ -178,6 +245,26 @@ describe("Task Manager app", () => {
     await waitFor(() =>
       expect(db.update).toHaveBeenCalledWith("cards", "card-1", expect.objectContaining({ title: "Edited title" })),
     );
+  });
+
+  it("keeps a column visible when a DB column delete fails", async () => {
+    const { db } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Keep me", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getAllByTitle("Delete column")[0]);
+
+    expect(await screen.findByText(/column could not be deleted/i)).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
   });
 
   it("shows a friendly error when the bridge fails to load", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -248,6 +248,69 @@ describe("Task Manager app", () => {
     );
   });
 
+  it("persists pending card edits with the latest live column and order", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [],
+    });
+    let resolveCardInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "cards") {
+        await new Promise<void>((resolve) => {
+          resolveCardInsert = resolve;
+        });
+        const id = "cards-created";
+        store.cards.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    const input = await screen.findByPlaceholderText("Add a card to To do");
+    fireEvent.change(input, { target: { value: "Race card" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    fireEvent.click(await screen.findByText("Race card"));
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Race card");
+    fireEvent.change(titleInput, { target: { value: "Moved card" } });
+    fireEvent.blur(titleInput);
+    fireEvent.change(within(dialog).getByLabelText("Column"), { target: { value: "col-2" } });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalledWith(
+      "cards",
+      expect.stringMatching(/^card-/),
+      expect.anything(),
+    );
+
+    await act(async () => {
+      resolveCardInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith(
+        "cards",
+        "cards-created",
+        expect.objectContaining({
+          title: "Moved card",
+          column_id: "col-2",
+          position: 0,
+        }),
+      ),
+    );
+  });
+
   it("persists a card created in a new column with the resolved DB column id", async () => {
     const { db, store } = installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -1090,6 +1090,34 @@ describe("Task Manager app", () => {
     expect((within(dialog).getByLabelText("Add checklist item") as HTMLInputElement).value).toBe("");
   });
 
+  it("resets detail drafts when switching between same-title same-createdAt cards", async () => {
+    installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Duplicate", description: "Alpha detail", labels: "", assignee: "Alice", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00.000Z" },
+        { id: "card-2", column_id: "col-1", title: "Duplicate", description: "Beta detail", labels: "", assignee: "Bob", priority: "medium", due: null, checklist: [], position: 1, created_at: "2026-05-01T00:00:00.000Z" },
+      ],
+    });
+    render(<App />);
+
+    await screen.findAllByText("Duplicate");
+    const cards = screen.getAllByText("Duplicate").filter((node) => node.closest(".task-card"));
+    fireEvent.click(cards[0]);
+    let dialog = await screen.findByRole("dialog");
+    fireEvent.change(within(dialog).getByLabelText("Card title"), { target: { value: "Unsaved Alpha" } });
+    fireEvent.change(within(dialog).getByPlaceholderText("Add more detail…"), {
+      target: { value: "Unsaved details" },
+    });
+    fireEvent.change(within(dialog).getByPlaceholderText("Unassigned"), { target: { value: "Morgan" } });
+
+    fireEvent.click(cards[1]);
+
+    dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByDisplayValue("Duplicate")).toBeTruthy();
+    expect(within(dialog).getByDisplayValue("Beta detail")).toBeTruthy();
+    expect(within(dialog).getByDisplayValue("Bob")).toBeTruthy();
+  });
+
   it("does not persist card reorders while a filter is active", async () => {
     const { db } = installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
@@ -1238,6 +1266,42 @@ describe("Task Manager app", () => {
 
     await waitFor(() => expect(screen.queryByRole("heading", { name: "To do" })).toBeNull());
     expect(screen.getByText("Concurrent card")).toBeTruthy();
+  });
+
+  it("ignores duplicate delete clicks while a column delete is in flight", async () => {
+    const { db } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [],
+    });
+    let resolveColumnDelete: (() => void) | null = null;
+    db.delete.mockImplementation(async (table: string, id: string) => {
+      if (table === "columns" && id === "col-1") {
+        await new Promise<void>((resolve) => {
+          resolveColumnDelete = resolve;
+        });
+      }
+      return { ok: true };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    const deleteButton = screen.getAllByTitle("Delete column")[0];
+    fireEvent.click(deleteButton);
+    fireEvent.click(deleteButton);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.delete.mock.calls.filter(([table, id]) => table === "columns" && id === "col-1")).toHaveLength(1);
+
+    await act(async () => {
+      resolveColumnDelete?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
   });
 
   it("does not add cards to a column while its deletion is in flight", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -249,6 +249,55 @@ describe("Task Manager app", () => {
     expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
   });
 
+  it("does not claim the board refreshed when failed persistence cannot reload", async () => {
+    const { db } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Write the spec", description: "", labels: "", assignee: "", priority: "high", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    render(<App />);
+
+    fireEvent.click(await screen.findByText("Write the spec"));
+    db.update.mockRejectedValueOnce(new Error("offline"));
+    db.find.mockRejectedValue(new Error("still offline"));
+
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Write the spec");
+    fireEvent.change(titleInput, { target: { value: "Offline edit" } });
+    fireEvent.blur(titleInput);
+
+    expect(await screen.findByText("Card could not be updated. Reopen the board to refresh.")).toBeTruthy();
+  });
+
+  it("does not persist a title edit that only changes whitespace", async () => {
+    const { db } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Write the spec", description: "", labels: "", assignee: "", priority: "high", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    render(<App />);
+
+    fireEvent.click(await screen.findByText("Write the spec"));
+    db.update.mockClear();
+
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Write the spec");
+    fireEvent.change(titleInput, { target: { value: "  Write the spec  " } });
+    fireEvent.blur(titleInput);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalled();
+    expect(within(dialog).getByDisplayValue("Write the spec")).toBeTruthy();
+  });
+
   it("adds a card via Enter and persists it to Postgres", async () => {
     const { db } = installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
@@ -329,6 +378,57 @@ describe("Task Manager app", () => {
         expect.objectContaining({ title: "Resolved card" }),
       ),
     );
+  });
+
+  it("persists pending checklist changes with the latest live checklist", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+    let resolveCardInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "cards") {
+        await new Promise<void>((resolve) => {
+          resolveCardInsert = resolve;
+        });
+        const id = "cards-created";
+        store.cards.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    const input = await screen.findByPlaceholderText("Add a card to To do");
+    fireEvent.change(input, { target: { value: "Checklist pending" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    fireEvent.click(await screen.findByText("Checklist pending"));
+    const dialog = await screen.findByRole("dialog");
+    const checklistInput = within(dialog).getByLabelText("Add checklist item");
+    fireEvent.change(checklistInput, { target: { value: "first" } });
+    fireEvent.submit(checklistInput.closest("form") as HTMLFormElement);
+    await waitFor(() => expect(within(dialog).getByText("first")).toBeTruthy());
+    fireEvent.change(checklistInput, { target: { value: "second" } });
+    fireEvent.submit(checklistInput.closest("form") as HTMLFormElement);
+
+    await act(async () => {
+      resolveCardInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      const checklistUpdates = db.update.mock.calls.filter(
+        ([table, id, data]) => table === "cards" && id === "cards-created" && Array.isArray(data.checklist),
+      );
+      expect(checklistUpdates.at(-1)?.[2].checklist).toEqual([
+        expect.objectContaining({ text: "first" }),
+        expect.objectContaining({ text: "second" }),
+      ]);
+    });
   });
 
   it("persists pending card edits with the latest live column and order", async () => {
@@ -684,6 +784,24 @@ describe("Task Manager app", () => {
     expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
   });
 
+  it("does not duplicate column rename writes when Enter submission blurs the input", async () => {
+    const { db } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+
+    render(<App />);
+    const heading = await screen.findByRole("heading", { name: "To do" });
+    fireEvent.click(heading.closest("button")!);
+    const renameInput = screen.getByDisplayValue("To do");
+    fireEvent.change(renameInput, { target: { value: "Ready" } });
+    fireEvent.submit(renameInput.closest("form")!);
+    fireEvent.blur(renameInput);
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledTimes(1));
+    expect(db.update).toHaveBeenCalledWith("columns", "col-1", { title: "Ready" });
+  });
+
   it("does not persist an empty column title on rename", async () => {
     const { db } = installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
@@ -827,6 +945,92 @@ describe("Task Manager app", () => {
     await waitFor(() =>
       expect(db.update).toHaveBeenCalledWith("cards", "card-1", expect.objectContaining({ title: "Edited title" })),
     );
+  });
+
+  it("preserves live checklist state when saving a title edit", async () => {
+    const { db } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [
+        {
+          id: "card-1",
+          column_id: "col-1",
+          title: "Checklist race",
+          description: "",
+          labels: "",
+          assignee: "",
+          priority: "medium",
+          due: null,
+          checklist: [{ id: "item-1", text: "Persist me", done: false }],
+          position: 0,
+          created_at: "2026-05-01T00:00:00Z",
+        },
+      ],
+    });
+    render(<App />);
+
+    fireEvent.click(await screen.findByText("Checklist race"));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: /persist me/i }));
+    const titleInput = within(dialog).getByDisplayValue("Checklist race");
+    fireEvent.change(titleInput, { target: { value: "Checklist title" } });
+    fireEvent.blur(titleInput);
+
+    await waitFor(() => {
+      const titleUpdate = db.update.mock.calls.find(
+        ([table, id, data]) => table === "cards" && id === "card-1" && data.title === "Checklist title",
+      );
+      expect(titleUpdate?.[2]).toEqual(expect.objectContaining({
+        checklist: [expect.objectContaining({ id: "item-1", done: true })],
+      }));
+    });
+  });
+
+  it("keeps a deleted column deleted when a stale card update resolves later", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [
+        { id: "col-a", title: "Doing", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-b", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [
+        { id: "card-a", column_id: "col-a", title: "Race card", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    const baseUpdate = db.update.getMockImplementation();
+    let releaseCardUpdate: (() => void) | null = null;
+    db.update.mockImplementation(async (table: string, id: string, data: DbRow) => {
+      if (table === "cards" && id === "card-a" && data.title === "Edited while deleting") {
+        await new Promise<void>((resolve) => {
+          releaseCardUpdate = resolve;
+        });
+      }
+      return baseUpdate?.(table, id, data) ?? { ok: true };
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByText("Race card"));
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Race card");
+    fireEvent.change(titleInput, { target: { value: "Edited while deleting" } });
+    fireEvent.blur(titleInput);
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith("cards", "card-a", expect.objectContaining({ title: "Edited while deleting" })),
+    );
+
+    const doingColumn = screen.getByRole("heading", { name: "Doing" }).closest("section");
+    fireEvent.click(within(doingColumn as HTMLElement).getByTitle("Delete column"));
+    await waitFor(() => expect(db.delete).toHaveBeenCalledWith("cards", "card-a"));
+    await waitFor(() => expect(db.delete).toHaveBeenCalledWith("columns", "col-a"));
+
+    await act(async () => {
+      releaseCardUpdate?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(store.columns.some((column) => column.id === "col-a")).toBe(false);
+    expect(store.cards.some((card) => card.id === "card-a")).toBe(false);
+    expect(screen.queryByRole("heading", { name: "Doing" })).toBeNull();
   });
 
   it("reloads checklist state when a DB checklist update fails", async () => {
@@ -1036,6 +1240,89 @@ describe("Task Manager app", () => {
     expect(screen.getByText("Concurrent card")).toBeTruthy();
   });
 
+  it("does not add cards to a column while its deletion is in flight", async () => {
+    const { db } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [],
+    });
+    let resolveColumnDelete: (() => void) | null = null;
+    db.delete.mockImplementation(async (table: string, id: string) => {
+      if (table === "columns" && id === "col-1") {
+        await new Promise<void>((resolve) => {
+          resolveColumnDelete = resolve;
+        });
+      }
+      return { ok: true };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getAllByTitle("Delete column")[0]);
+
+    const input = screen.getByPlaceholderText("Add a card to To do");
+    fireEvent.change(input, { target: { value: "Late card" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.queryByText("Late card")).toBeNull();
+    expect(db.insert).not.toHaveBeenCalledWith("cards", expect.objectContaining({ title: "Late card" }));
+
+    await act(async () => {
+      resolveColumnDelete?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  it("does not move cards into a column while its deletion is in flight", async () => {
+    const { db } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Stay put", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    let resolveColumnDelete: (() => void) | null = null;
+    db.delete.mockImplementation(async (table: string, id: string) => {
+      if (table === "columns" && id === "col-2") {
+        await new Promise<void>((resolve) => {
+          resolveColumnDelete = resolve;
+        });
+      }
+      return { ok: true };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "Done" })).toBeTruthy();
+    fireEvent.click(screen.getAllByTitle("Delete column")[1]);
+
+    const card = screen.getByText("Stay put").closest(".task-card");
+    if (!card) throw new Error("Expected task card");
+    fireEvent.dragStart(card);
+    fireEvent.drop(screen.getByLabelText("Done"));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(within(screen.getByLabelText("To do")).getByText("Stay put")).toBeTruthy();
+    expect(db.update).not.toHaveBeenCalledWith(
+      "cards",
+      "card-1",
+      expect.objectContaining({ column_id: "col-2" }),
+    );
+
+    await act(async () => {
+      resolveColumnDelete?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
   it("waits for a pending column insert before deleting the column row", async () => {
     const { db, store } = installMatrixDb({
       columns: [
@@ -1080,6 +1367,7 @@ describe("Task Manager app", () => {
     });
 
     await waitFor(() => expect(db.delete).toHaveBeenCalledWith("columns", "columns-sprint"));
+    await waitFor(() => expect(screen.queryByRole("heading", { name: "Sprint" })).toBeNull());
   });
 
   it("waits for a pending column insert before persisting reordered positions", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -1,186 +1,210 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/task-manager/src/App";
-import { addCard, createBoard, type Board } from "../../home/apps/task-manager/src/board-model";
 
-function jsonResponse(value: unknown): Response {
-  return new Response(JSON.stringify(value), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
+type DbRow = Record<string, unknown>;
+
+interface FakeDb {
+  columns: DbRow[];
+  cards: DbRow[];
+}
+
+function installMatrixDb(initial?: Partial<FakeDb>) {
+  const store: FakeDb = {
+    columns: initial?.columns ? [...initial.columns] : [],
+    cards: initial?.cards ? [...initial.cards] : [],
+  };
+  let seq = 0;
+  const listeners: Record<string, Array<() => void>> = {};
+  const emit = (table: string) => {
+    for (const cb of listeners[table] ?? []) cb();
+  };
+
+  const db = {
+    find: vi.fn(async (table: string, opts?: { orderBy?: Record<string, "asc" | "desc"> }) => {
+      const rows = [...(store[table as keyof FakeDb] ?? [])];
+      const orderBy = opts?.orderBy;
+      if (orderBy) {
+        const [key, dir] = Object.entries(orderBy)[0] ?? [];
+        if (key) {
+          rows.sort((a, b) => {
+            const av = Number(a[key] ?? 0);
+            const bv = Number(b[key] ?? 0);
+            return dir === "desc" ? bv - av : av - bv;
+          });
+        }
+      }
+      return rows;
+    }),
+    findOne: vi.fn(async (table: string, id: string) =>
+      (store[table as keyof FakeDb] ?? []).find((row) => row.id === id) ?? null),
+    insert: vi.fn(async (table: string, data: DbRow) => {
+      seq += 1;
+      const id = `${table}-${seq}`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      emit(table);
+      return { id };
+    }),
+    update: vi.fn(async (table: string, id: string, data: DbRow) => {
+      const list = store[table as keyof FakeDb];
+      const idx = list.findIndex((row) => row.id === id);
+      if (idx >= 0) list[idx] = { ...list[idx], ...data };
+      emit(table);
+      return { ok: true };
+    }),
+    delete: vi.fn(async (table: string, id: string) => {
+      store[table as keyof FakeDb] = store[table as keyof FakeDb].filter((row) => row.id !== id);
+      emit(table);
+      return { ok: true };
+    }),
+    count: vi.fn(async (table: string) => (store[table as keyof FakeDb] ?? []).length),
+    onChange: vi.fn((table: string, cb: () => void) => {
+      (listeners[table] ??= []).push(cb);
+      return () => {
+        listeners[table] = (listeners[table] ?? []).filter((fn) => fn !== cb);
+      };
+    }),
+  };
+
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
   });
+  return { db, store };
 }
 
-function boardValue(board: Board): { value: string } {
-  return { value: JSON.stringify(board) };
-}
-
-describe("Task Manager app persistence", () => {
+describe("Task Manager app", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+    localStorage.clear();
   });
 
-  it("blocks editing when the bridge returns a non-JSON response", async () => {
-    const fetchMock = vi.fn(async () => new Response("<html>bad gateway</html>", {
-      status: 200,
-      headers: { "Content-Type": "text/html" },
-    }));
-    vi.stubGlobal("fetch", fetchMock);
-
+  it("seeds default columns into Postgres on first run", async () => {
+    const { db } = installMatrixDb();
     render(<App />);
 
-    expect(await screen.findByText("Board could not be loaded.")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /add task/i })).toBeNull();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The empty board seeds the default workflow columns.
+    await waitFor(() => expect(db.insert).toHaveBeenCalledWith("columns", expect.objectContaining({ title: "Backlog" })));
+    expect(await screen.findByRole("heading", { name: "Backlog" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Done" })).toBeTruthy();
   });
 
-  it("blocks editing when the persisted board payload is malformed", async () => {
-    const fetchMock = vi.fn(async () => new Response("{", {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    }));
-    vi.stubGlobal("fetch", fetchMock);
-
+  it("loads existing columns + cards from Postgres", async () => {
+    installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Write the spec", description: "", labels: "", assignee: "", priority: "high", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
     render(<App />);
 
-    expect(await screen.findByText("Board could not be loaded.")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /add task/i })).toBeNull();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Write the spec")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
   });
 
-  it("debounces detail edits and persists only the latest board", async () => {
-    let board = createBoard("Matrix OS");
-    board = addCard(board, {
-      columnId: "backlog",
-      projectId: board.projects[0].id,
-      title: "Initial title",
+  it("adds a card via Enter and persists it to Postgres", async () => {
+    const { db } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
     });
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.method === "POST") return jsonResponse({ ok: true });
-      return jsonResponse(boardValue(board));
+    render(<App />);
+
+    const input = await screen.findByPlaceholderText("Add a card to To do");
+    fireEvent.change(input, { target: { value: "Ship the board" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(db.insert).toHaveBeenCalledWith("cards", expect.objectContaining({ title: "Ship the board", column_id: "col-1" })),
+    );
+    expect(await screen.findByText("Ship the board")).toBeTruthy();
+  });
+
+  it("filters cards by text query", async () => {
+    installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Buy milk", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "card-2", column_id: "col-1", title: "Fix the bug", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
     });
-    vi.stubGlobal("fetch", fetchMock);
+    render(<App />);
+
+    await screen.findByText("Buy milk");
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "bug" } });
+
+    expect(screen.queryByText("Buy milk")).toBeNull();
+    expect(screen.getByText("Fix the bug")).toBeTruthy();
+  });
+
+  it("opens a card detail and closes it with Escape", async () => {
+    installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Inspect me", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    render(<App />);
+
+    fireEvent.click(await screen.findByText("Inspect me"));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByDisplayValue("Inspect me")).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("persists a card update through the DB bridge", async () => {
+    const { db } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Edit me", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    render(<App />);
+
+    fireEvent.click(await screen.findByText("Edit me"));
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Edit me");
+    fireEvent.change(titleInput, { target: { value: "Edited title" } });
+    fireEvent.blur(titleInput);
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith("cards", "card-1", expect.objectContaining({ title: "Edited title" })),
+    );
+  });
+
+  it("shows a friendly error when the bridge fails to load", async () => {
+    const db = {
+      find: vi.fn(async () => {
+        throw new Error("connection refused");
+      }),
+      findOne: vi.fn(),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+      onChange: vi.fn(() => () => undefined),
+    };
+    Object.defineProperty(window, "MatrixOS", { configurable: true, value: { db } });
 
     render(<App />);
-    fireEvent.click(await screen.findByText("Initial title"));
-    fetchMock.mockClear();
-    vi.useFakeTimers();
-
-    const titleInput = screen.getByLabelText("Title");
-    fireEvent.change(titleInput, { target: { value: "First edit" } });
-    fireEvent.change(titleInput, { target: { value: "Final edit" } });
-
-    await act(async () => {
-      vi.advanceTimersByTime(399);
-    });
-    expect(fetchMock).not.toHaveBeenCalled();
-
-    await act(async () => {
-      vi.advanceTimersByTime(1);
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    const [, requestInit] = fetchMock.mock.calls[0];
-    const body = JSON.parse(String(requestInit?.body)) as { value: string };
-    const savedBoard = JSON.parse(body.value) as Board;
-    expect(savedBoard.cards[0].title).toBe("Final edit");
+    expect(await screen.findByText(/could not be loaded/i)).toBeTruthy();
   });
 
-  it("flushes a pending detail edit when the app unmounts", async () => {
-    let board = createBoard("Matrix OS");
-    board = addCard(board, {
-      columnId: "backlog",
-      projectId: board.projects[0].id,
-      title: "Initial title",
-    });
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.method === "POST") return jsonResponse({ ok: true });
-      return jsonResponse(boardValue(board));
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    const { unmount } = render(<App />);
-    fireEvent.click(await screen.findByText("Initial title"));
-    fetchMock.mockClear();
-    vi.useFakeTimers();
-
-    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Unmounted edit" } });
-    unmount();
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, requestInit] = fetchMock.mock.calls[0];
-    const body = JSON.parse(String(requestInit?.body)) as { value: string };
-    const savedBoard = JSON.parse(body.value) as Board;
-    expect(savedBoard.cards[0].title).toBe("Unmounted edit");
-  });
-
-  it("preserves an immediate in-flight save when the app unmounts", async () => {
-    let board = createBoard("Matrix OS");
-    board = addCard(board, {
-      columnId: "backlog",
-      projectId: board.projects[0].id,
-      title: "Move me",
-    });
-    let writeSignal: AbortSignal | undefined;
-    let resolveWrite: ((response: Response) => void) | undefined;
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.method === "POST") {
-        writeSignal = init.signal ?? undefined;
-        return new Promise<Response>((resolve) => {
-          resolveWrite = resolve;
-        });
-      }
-      return jsonResponse(boardValue(board));
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    const { unmount } = render(<App />);
-    await screen.findByText("Move me");
-    fireEvent.click(screen.getByTitle("Move next"));
-
-    expect(writeSignal).toBeDefined();
-    unmount();
-    expect(writeSignal?.aborted).toBe(false);
-
-    await act(async () => {
-      resolveWrite?.(jsonResponse({ ok: true }));
-    });
-  });
-
-  it("does not persist a card self-drop", async () => {
-    let board = createBoard("Matrix OS");
-    board = addCard(board, {
-      columnId: "backlog",
-      projectId: board.projects[0].id,
-      title: "First",
-    });
-    board = addCard(board, {
-      columnId: "backlog",
-      projectId: board.projects[0].id,
-      title: "Middle",
-    });
-    board = addCard(board, {
-      columnId: "backlog",
-      projectId: board.projects[0].id,
-      title: "Last",
-    });
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.method === "POST") return jsonResponse({ ok: true });
-      return jsonResponse(boardValue(board));
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
+  it("falls back to localStorage when no DB bridge is present", async () => {
     render(<App />);
-    const middleTitle = await screen.findByText("Middle");
-    const middleCard = middleTitle.closest("article");
-    expect(middleCard).toBeTruthy();
-    fetchMock.mockClear();
+    const input = await screen.findByPlaceholderText("Add a card to Backlog");
+    fireEvent.change(input, { target: { value: "Local task" } });
+    fireEvent.keyDown(input, { key: "Enter" });
 
-    fireEvent.dragStart(middleCard!);
-    fireEvent.drop(middleCard!);
-
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(await screen.findByText("Local task")).toBeTruthy();
+    await waitFor(() => expect(localStorage.getItem("task-manager:board")).toBeTruthy());
   });
 });

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -309,6 +309,18 @@ describe("Task Manager app", () => {
         }),
       ),
     );
+    const cardUpdates = db.update.mock.calls.filter(
+      (call) => call[0] === "cards" && call[1] === "cards-created",
+    );
+    expect(cardUpdates.at(-1)?.[2]).toMatchObject({
+      column_id: "col-2",
+      position: 0,
+    });
+    expect(store.cards.find((card) => card.id === "cards-created")).toMatchObject({
+      title: "Moved card",
+      column_id: "col-2",
+      position: 0,
+    });
   });
 
   it("persists a card created in a new column with the resolved DB column id", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -138,6 +138,25 @@ describe("Task Manager app", () => {
     await waitFor(() => expect(db.insert).toHaveBeenCalledWith("columns", expect.objectContaining({ title: "Backlog" })));
     expect(await screen.findByRole("heading", { name: "Backlog" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Done" })).toBeTruthy();
+    expect(db.find.mock.calls.filter((call) => call[0] === "columns")).toHaveLength(2);
+  });
+
+  it("cleans up partially seeded columns when first-run seeding fails", async () => {
+    const { db, store } = installMatrixDb();
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "columns" && data.title === "Ready") {
+        throw new Error("seed failed");
+      }
+      const id = `${table}-${store[table as keyof FakeDb].length + 1}`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText(/board could not be loaded/i)).toBeTruthy();
+    await waitFor(() => expect(db.delete).toHaveBeenCalledWith("columns", "columns-1"));
+    expect(store.columns).toHaveLength(0);
   });
 
   it("migrates the legacy project-board bridge data before seeding defaults", async () => {
@@ -662,6 +681,28 @@ describe("Task Manager app", () => {
     });
 
     expect(db.update).not.toHaveBeenCalledWith("columns", "col-1", { title: "Cancelled" });
+    expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
+  });
+
+  it("does not persist an empty column title on rename", async () => {
+    const { db } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+
+    render(<App />);
+    const heading = await screen.findByRole("heading", { name: "To do" });
+    fireEvent.click(heading.closest("button")!);
+    const renameInput = screen.getByDisplayValue("To do");
+    fireEvent.change(renameInput, { target: { value: "   " } });
+    fireEvent.blur(renameInput);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(db.update).not.toHaveBeenCalledWith("columns", "col-1", { title: "" });
+    expect(db.update).not.toHaveBeenCalledWith("columns", "col-1", { title: "   " });
     expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
   });
 

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -193,6 +193,55 @@ describe("Task Manager app", () => {
     );
   });
 
+  it("persists a card created in a new column with the resolved DB column id", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+    let resolveColumnInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "columns" && data.title === "Sprint") {
+        await new Promise<void>((resolve) => {
+          resolveColumnInsert = resolve;
+        });
+        const id = "columns-sprint";
+        store.columns.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      if (table === "cards") {
+        const id = "cards-sprint";
+        store.cards.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /add column/i }));
+    fireEvent.change(screen.getByPlaceholderText("Column name"), { target: { value: "Sprint" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    const sprintInput = await screen.findByPlaceholderText("Add a card to Sprint");
+    fireEvent.change(sprintInput, { target: { value: "Resolve the id race" } });
+    fireEvent.keyDown(sprintInput, { key: "Enter" });
+
+    expect(db.insert).not.toHaveBeenCalledWith("cards", expect.objectContaining({ title: "Resolve the id race" }));
+    await act(async () => {
+      resolveColumnInsert?.();
+    });
+
+    await waitFor(() =>
+      expect(db.insert).toHaveBeenCalledWith("cards", expect.objectContaining({
+        title: "Resolve the id race",
+        column_id: "columns-sprint",
+      })),
+    );
+  });
+
   it("filters cards by text query", async () => {
     installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -297,6 +297,54 @@ describe("Task Manager app", () => {
     );
   });
 
+  it("waits for a new column insert before persisting an immediate rename", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+    let resolveColumnInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "columns" && data.title === "Sprint") {
+        await new Promise<void>((resolve) => {
+          resolveColumnInsert = resolve;
+        });
+        const id = "columns-sprint";
+        store.columns.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /add column/i }));
+    fireEvent.change(screen.getByPlaceholderText("Column name"), { target: { value: "Sprint" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    const sprintHeading = await screen.findByRole("heading", { name: "Sprint" });
+    fireEvent.click(sprintHeading.closest("button")!);
+    const renameInput = screen.getByDisplayValue("Sprint");
+    fireEvent.change(renameInput, { target: { value: "Ready" } });
+    fireEvent.blur(renameInput);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalledWith("columns", expect.stringMatching(/^column-/), expect.anything());
+
+    await act(async () => {
+      resolveColumnInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith("columns", "columns-sprint", { title: "Ready" }),
+    );
+  });
+
   it("filters cards by text query", async () => {
     installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
@@ -369,6 +417,54 @@ describe("Task Manager app", () => {
 
     expect(await screen.findByText(/column could not be deleted/i)).toBeTruthy();
     expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
+  });
+
+  it("waits for pending card inserts before deleting cards with their column", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [],
+    });
+    let resolveCardInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "cards") {
+        await new Promise<void>((resolve) => {
+          resolveCardInsert = resolve;
+        });
+        const id = "cards-created";
+        store.cards.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    const input = await screen.findByPlaceholderText("Add a card to To do");
+    fireEvent.change(input, { target: { value: "Remove with column" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(await screen.findByText("Remove with column")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByTitle("Delete column")[0]);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.delete).not.toHaveBeenCalledWith("cards", expect.stringMatching(/^card-/));
+
+    await act(async () => {
+      resolveCardInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.delete).toHaveBeenCalledWith("cards", "cards-created");
+      expect(db.delete).toHaveBeenCalledWith("columns", "col-1");
+    });
   });
 
   it("keeps an existing error visible after unrelated card saves", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -323,6 +323,51 @@ describe("Task Manager app", () => {
     });
   });
 
+  it("keeps card detail drafts when a pending card id resolves", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+    let resolveCardInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "cards") {
+        await new Promise<void>((resolve) => {
+          resolveCardInsert = resolve;
+        });
+        const id = "cards-created";
+        store.cards.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    const input = await screen.findByPlaceholderText("Add a card to To do");
+    fireEvent.change(input, { target: { value: "Draft card" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    fireEvent.click(await screen.findByText("Draft card"));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(within(dialog).getByLabelText("Card title"), { target: { value: "Unsaved title" } });
+    fireEvent.change(within(dialog).getByPlaceholderText("Add more detail…"), {
+      target: { value: "Unsaved details" },
+    });
+    fireEvent.change(within(dialog).getByPlaceholderText("Unassigned"), { target: { value: "Morgan" } });
+
+    await act(async () => {
+      resolveCardInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const updatedDialog = await screen.findByRole("dialog");
+    expect(within(updatedDialog).getByDisplayValue("Unsaved title")).toBeTruthy();
+    expect(within(updatedDialog).getByDisplayValue("Unsaved details")).toBeTruthy();
+    expect(within(updatedDialog).getByDisplayValue("Morgan")).toBeTruthy();
+  });
+
   it("persists a card created in a new column with the resolved DB column id", async () => {
     const { db, store } = installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/task-manager/src/App";
-import { boardFromRows } from "../../home/apps/task-manager/src/persistence";
+import { boardFromRows, cardToRow } from "../../home/apps/task-manager/src/persistence";
 
 type DbRow = Record<string, unknown>;
 
@@ -101,6 +101,33 @@ describe("Task Manager app", () => {
     );
 
     expect(board.cards[0].updatedAt).toBe("2026-05-02T00:00:00.000Z");
+  });
+
+  it("round-trips labels containing commas through text storage", () => {
+    const row = cardToRow({
+      id: "card-1",
+      projectId: "project-default",
+      columnId: "col-1",
+      title: "Tagged",
+      description: "",
+      priority: "medium",
+      labels: ["bug, ui", "release"],
+      assignee: "",
+      dueDate: "",
+      checklist: [],
+      delegation: null,
+      order: 0,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    }, 0);
+
+    expect(row.labels).toBe(JSON.stringify(["bug, ui", "release"]));
+
+    const board = boardFromRows(
+      [{ id: "col-1", title: "To do", color: "#7A7768", position: 0 }],
+      [{ id: "card-1", created_at: "2026-05-01T00:00:00.000Z", ...row }],
+    );
+    expect(board.cards[0].labels).toEqual(["bug, ui", "release"]);
   });
 
   it("seeds default columns into Postgres on first run", async () => {
@@ -360,6 +387,66 @@ describe("Task Manager app", () => {
     });
   });
 
+  it("resolves a pending destination column before persisting card detail edits", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [{ id: "card-1", column_id: "col-1", title: "Move me", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" }],
+    });
+    let resolveColumnInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "columns" && data.title === "Sprint") {
+        await new Promise<void>((resolve) => {
+          resolveColumnInsert = resolve;
+        });
+        const id = "columns-sprint";
+        store.columns.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    expect(await screen.findByText("Move me")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /add column/i }));
+    fireEvent.change(screen.getByPlaceholderText("Column name"), { target: { value: "Sprint" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    fireEvent.click(screen.getByText("Move me"));
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Move me");
+    fireEvent.change(titleInput, { target: { value: "Moved with title" } });
+    fireEvent.blur(titleInput);
+    const columnSelect = within(dialog).getByLabelText("Column") as HTMLSelectElement;
+    const sprintOption = Array.from(columnSelect.options).find((option) => option.textContent === "Sprint");
+    expect(sprintOption?.value).toMatch(/^column-/);
+    fireEvent.change(columnSelect, { target: { value: sprintOption!.value } });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalledWith(
+      "cards",
+      "card-1",
+      expect.objectContaining({ column_id: expect.stringMatching(/^column-/) }),
+    );
+
+    await act(async () => {
+      resolveColumnInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith(
+        "cards",
+        "card-1",
+        expect.objectContaining({ title: "Moved with title", column_id: "columns-sprint" }),
+      ),
+    );
+  });
+
   it("keeps card detail drafts when a pending card id resolves", async () => {
     const { db, store } = installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
@@ -454,6 +541,60 @@ describe("Task Manager app", () => {
     );
   });
 
+  it("persists pending new-column cards with their latest live order", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+    let resolveColumnInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "columns" && data.title === "Sprint") {
+        await new Promise<void>((resolve) => {
+          resolveColumnInsert = resolve;
+        });
+        const id = "columns-sprint";
+        store.columns.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      if (table === "cards") {
+        const id = `cards-${String(data.title).toLowerCase()}`;
+        store.cards.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /add column/i }));
+    fireEvent.change(screen.getByPlaceholderText("Column name"), { target: { value: "Sprint" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    const sprintInput = await screen.findByPlaceholderText("Add a card to Sprint");
+    fireEvent.change(sprintInput, { target: { value: "Alpha" } });
+    fireEvent.keyDown(sprintInput, { key: "Enter" });
+    fireEvent.change(sprintInput, { target: { value: "Beta" } });
+    fireEvent.keyDown(sprintInput, { key: "Enter" });
+
+    fireEvent.click(await screen.findByText("Alpha"));
+    fireEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: /delete card/i }));
+
+    await act(async () => {
+      resolveColumnInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(db.insert).toHaveBeenCalledWith(
+        "cards",
+        expect.objectContaining({ title: "Beta", column_id: "columns-sprint", position: 0 }),
+      ),
+    );
+  });
+
   it("waits for a new column insert before persisting an immediate rename", async () => {
     const { db, store } = installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
@@ -500,6 +641,28 @@ describe("Task Manager app", () => {
     await waitFor(() =>
       expect(db.update).toHaveBeenCalledWith("columns", "columns-sprint", { title: "Ready" }),
     );
+  });
+
+  it("does not persist a cancelled column rename after Escape blurs the input", async () => {
+    const { db } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+
+    render(<App />);
+    const heading = await screen.findByRole("heading", { name: "To do" });
+    fireEvent.click(heading.closest("button")!);
+    const renameInput = screen.getByDisplayValue("To do");
+    fireEvent.change(renameInput, { target: { value: "Cancelled" } });
+    fireEvent.keyDown(renameInput, { key: "Escape" });
+    fireEvent.blur(renameInput);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(db.update).not.toHaveBeenCalledWith("columns", "col-1", { title: "Cancelled" });
+    expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
   });
 
   it("reloads away a phantom column when its insert fails", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -658,6 +658,15 @@ describe("Task Manager app", () => {
         column_id: "columns-sprint",
       })),
     );
+    const cardInserts = db.insert.mock.calls.filter(([table]) => table === "cards");
+    expect(cardInserts).not.toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([
+          "cards",
+          expect.objectContaining({ column_id: expect.stringMatching(/^column-/) }),
+        ]),
+      ]),
+    );
   });
 
   it("persists pending new-column cards with their latest live order", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -829,6 +829,38 @@ describe("Task Manager app", () => {
     );
   });
 
+  it("reloads checklist state when a DB checklist update fails", async () => {
+    const { db } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [
+        {
+          id: "card-1",
+          column_id: "col-1",
+          title: "Verify rollback",
+          description: "",
+          labels: "",
+          assignee: "",
+          priority: "medium",
+          due: null,
+          checklist: [{ id: "item-1", text: "Persist me", done: false }],
+          position: 0,
+          created_at: "2026-05-01T00:00:00Z",
+        },
+      ],
+    });
+    db.update.mockRejectedValueOnce(new Error("update failed"));
+
+    render(<App />);
+    fireEvent.click(await screen.findByText("Verify rollback"));
+    const checklistItem = within(await screen.findByRole("dialog")).getByRole("button", { name: /persist me/i });
+    fireEvent.click(checklistItem);
+
+    expect(await screen.findByText(/checklist could not be saved/i)).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.getByText("Checklist").parentElement?.textContent).toContain("0/1"),
+    );
+  });
+
   it("clears draft label and checklist inputs when switching selected cards", async () => {
     installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -467,6 +467,43 @@ describe("Task Manager app", () => {
     });
   });
 
+  it("keeps concurrent card additions when a column delete finishes", async () => {
+    const { db } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [],
+    });
+    let resolveColumnDelete: (() => void) | null = null;
+    db.delete.mockImplementation(async (table: string, id: string) => {
+      if (table === "columns" && id === "col-1") {
+        await new Promise<void>((resolve) => {
+          resolveColumnDelete = resolve;
+        });
+      }
+      return { ok: true };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getAllByTitle("Delete column")[0]);
+
+    const doneInput = screen.getByPlaceholderText("Add a card to Done");
+    fireEvent.change(doneInput, { target: { value: "Concurrent card" } });
+    fireEvent.keyDown(doneInput, { key: "Enter" });
+    expect(await screen.findByText("Concurrent card")).toBeTruthy();
+
+    await act(async () => {
+      resolveColumnDelete?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.queryByRole("heading", { name: "To do" })).toBeNull());
+    expect(screen.getByText("Concurrent card")).toBeTruthy();
+  });
+
   it("waits for a pending column insert before deleting the column row", async () => {
     const { db, store } = installMatrixDb({
       columns: [

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -150,6 +150,43 @@ describe("Task Manager app", () => {
     });
   });
 
+  it("migrates local fallback board data when the DB bridge becomes available", async () => {
+    const localBoard = {
+      version: 1,
+      projects: [{ id: "project-default", name: "Local", color: "#434E3F", description: "" }],
+      columns: [{ id: "local-col", title: "Local Queue", color: "#7A7768" }],
+      cards: [{
+        id: "local-card",
+        projectId: "project-default",
+        columnId: "local-col",
+        title: "Recovered local card",
+        description: "",
+        priority: "medium",
+        labels: [],
+        assignee: "",
+        dueDate: "",
+        checklist: [],
+        delegation: null,
+        order: 0,
+        createdAt: "2026-05-01T00:00:00.000Z",
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      }],
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    };
+    localStorage.setItem("task-manager:board", JSON.stringify(localBoard));
+    const { db } = installMatrixDb();
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(db.insert).toHaveBeenCalledWith("columns", expect.objectContaining({ title: "Local Queue" }));
+      expect(db.insert).toHaveBeenCalledWith("cards", expect.objectContaining({
+        title: "Recovered local card",
+        column_id: "columns-1",
+      }));
+    });
+  });
+
   it("loads existing columns + cards from Postgres", async () => {
     installMatrixDb({
       columns: [
@@ -586,6 +623,31 @@ describe("Task Manager app", () => {
     await waitFor(() =>
       expect(db.update).toHaveBeenCalledWith("cards", "card-1", expect.objectContaining({ title: "Edited title" })),
     );
+  });
+
+  it("clears draft label and checklist inputs when switching selected cards", async () => {
+    installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Alpha", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "card-2", column_id: "col-1", title: "Beta", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    render(<App />);
+
+    fireEvent.click(await screen.findByText("Alpha"));
+    let dialog = await screen.findByRole("dialog");
+    const labelInput = within(dialog).getByLabelText("Add label") as HTMLInputElement;
+    const checklistInput = within(dialog).getByLabelText("Add checklist item") as HTMLInputElement;
+    fireEvent.change(labelInput, { target: { value: "bug" } });
+    fireEvent.change(checklistInput, { target: { value: "verify" } });
+
+    fireEvent.click(screen.getByText("Beta"));
+
+    dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByDisplayValue("Beta")).toBeTruthy();
+    expect((within(dialog).getByLabelText("Add label") as HTMLInputElement).value).toBe("");
+    expect((within(dialog).getByLabelText("Add checklist item") as HTMLInputElement).value).toBe("");
   });
 
   it("does not persist card reorders while a filter is active", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -408,6 +408,41 @@ describe("Task Manager app", () => {
     );
   });
 
+  it("reloads away a phantom column when its insert fails", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+    let rejectColumnInsert: ((error: Error) => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "columns" && data.title === "Sprint") {
+        await new Promise<never>((_resolve, reject) => {
+          rejectColumnInsert = reject;
+        });
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /add column/i }));
+    fireEvent.change(screen.getByPlaceholderText("Column name"), { target: { value: "Sprint" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(await screen.findByRole("heading", { name: "Sprint" })).toBeTruthy();
+    await act(async () => {
+      rejectColumnInsert?.(new Error("insert failed"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText(/column could not be created/i)).toBeTruthy();
+    await waitFor(() => expect(screen.queryByRole("heading", { name: "Sprint" })).toBeNull());
+    expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
+  });
+
   it("filters cards by text query", async () => {
     installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -859,6 +859,25 @@ describe("Task Manager app", () => {
     expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
   });
 
+  it("keeps a card visible when a DB card delete fails", async () => {
+    const { db } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Keep me", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+    render(<App />);
+
+    fireEvent.click(await screen.findByText("Keep me"));
+    fireEvent.click(within(await screen.findByRole("dialog")).getByRole("button", { name: /delete card/i }));
+
+    expect(await screen.findByText(/card could not be deleted/i)).toBeTruthy();
+    expect(await screen.findByText("Keep me")).toBeTruthy();
+  });
+
   it("waits for pending card inserts before deleting cards with their column", async () => {
     const { db, store } = installMatrixDb({
       columns: [

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -500,6 +500,40 @@ describe("Task Manager app", () => {
     expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
   });
 
+  it("reloads away a phantom card when its insert fails", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+    let rejectCardInsert: ((error: Error) => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "cards" && data.title === "Ghost card") {
+        await new Promise<never>((_resolve, reject) => {
+          rejectCardInsert = reject;
+        });
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    const input = await screen.findByPlaceholderText("Add a card to To do");
+    fireEvent.change(input, { target: { value: "Ghost card" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(await screen.findByText("Ghost card")).toBeTruthy();
+    await act(async () => {
+      rejectCardInsert?.(new Error("insert failed"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText(/card could not be saved/i)).toBeTruthy();
+    await waitFor(() => expect(screen.queryByText("Ghost card")).toBeNull());
+    expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
+  });
+
   it("filters cards by text query", async () => {
     installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -467,6 +467,100 @@ describe("Task Manager app", () => {
     });
   });
 
+  it("waits for a pending column insert before deleting the column row", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [],
+    });
+    let resolveColumnInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "columns" && data.title === "Sprint") {
+        await new Promise<void>((resolve) => {
+          resolveColumnInsert = resolve;
+        });
+        const id = "columns-sprint";
+        store.columns.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /add column/i }));
+    fireEvent.change(screen.getByPlaceholderText("Column name"), { target: { value: "Sprint" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    const sprintColumn = await screen.findByLabelText("Sprint");
+    fireEvent.click(within(sprintColumn).getByTitle("Delete column"));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.delete).not.toHaveBeenCalledWith("columns", expect.stringMatching(/^column-/));
+
+    await act(async () => {
+      resolveColumnInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.delete).toHaveBeenCalledWith("columns", "columns-sprint"));
+  });
+
+  it("waits for a pending column insert before persisting reordered positions", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [],
+    });
+    let resolveColumnInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "columns" && data.title === "Sprint") {
+        await new Promise<void>((resolve) => {
+          resolveColumnInsert = resolve;
+        });
+        const id = "columns-sprint";
+        store.columns.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /add column/i }));
+    fireEvent.change(screen.getByPlaceholderText("Column name"), { target: { value: "Sprint" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    const sprintColumn = await screen.findByLabelText("Sprint");
+    const todoColumn = screen.getByLabelText("To do");
+    fireEvent.dragStart(within(sprintColumn).getByTitle("Reorder column"));
+    fireEvent.drop(todoColumn);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalledWith("columns", expect.stringMatching(/^column-/), expect.anything());
+
+    await act(async () => {
+      resolveColumnInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("columns", "columns-sprint", { position: 0 }));
+  });
+
   it("keeps an existing error visible after unrelated card saves", async () => {
     const { db, store } = installMatrixDb({
       columns: [

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -103,7 +103,7 @@ describe("Task Manager app", () => {
     expect(board.cards[0].updatedAt).toBe("2026-05-02T00:00:00.000Z");
   });
 
-  it("round-trips labels containing commas through text storage", () => {
+  it("round-trips labels containing commas through structured storage", () => {
     const row = cardToRow({
       id: "card-1",
       projectId: "project-default",
@@ -121,7 +121,7 @@ describe("Task Manager app", () => {
       updatedAt: "2026-05-01T00:00:00.000Z",
     }, 0);
 
-    expect(row.labels).toBe(JSON.stringify(["bug, ui", "release"]));
+    expect(row.labels).toEqual(["bug, ui", "release"]);
 
     const board = boardFromRows(
       [{ id: "col-1", title: "To do", color: "#7A7768", position: 0 }],

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -193,6 +193,61 @@ describe("Task Manager app", () => {
     );
   });
 
+  it("waits for a new card insert before persisting immediate edits", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [],
+    });
+    let resolveCardInsert: (() => void) | null = null;
+    db.insert.mockImplementation(async (table: string, data: DbRow) => {
+      if (table === "cards") {
+        await new Promise<void>((resolve) => {
+          resolveCardInsert = resolve;
+        });
+        const id = "cards-created";
+        store.cards.push({ id, created_at: new Date().toISOString(), ...data });
+        return { id };
+      }
+      const id = `${table}-fallback`;
+      store[table as keyof FakeDb].push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    });
+
+    render(<App />);
+    const input = await screen.findByPlaceholderText("Add a card to To do");
+    fireEvent.change(input, { target: { value: "Race card" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    fireEvent.click(await screen.findByText("Race card"));
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Race card");
+    fireEvent.change(titleInput, { target: { value: "Resolved card" } });
+    fireEvent.blur(titleInput);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalledWith(
+      "cards",
+      expect.stringMatching(/^card-/),
+      expect.anything(),
+    );
+
+    await act(async () => {
+      resolveCardInsert?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith(
+        "cards",
+        "cards-created",
+        expect.objectContaining({ title: "Resolved card" }),
+      ),
+    );
+  });
+
   it("persists a card created in a new column with the resolved DB column id", async () => {
     const { db, store } = installMatrixDb({
       columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
@@ -314,6 +369,42 @@ describe("Task Manager app", () => {
 
     expect(await screen.findByText(/column could not be deleted/i)).toBeTruthy();
     expect(screen.getByRole("heading", { name: "To do" })).toBeTruthy();
+  });
+
+  it("keeps an existing error visible after unrelated card saves", async () => {
+    const { db, store } = installMatrixDb({
+      columns: [
+        { id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "col-2", title: "Done", color: "#3A7D44", position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Keep me", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "To do" })).toBeTruthy();
+    fireEvent.click(screen.getAllByTitle("Delete column")[0]);
+    const banner = await screen.findByText(/column could not be deleted/i);
+    expect(banner).toBeTruthy();
+    db.update.mockImplementationOnce(async (table: string, id: string, data: DbRow) => {
+      const list = store[table as keyof FakeDb];
+      const idx = list.findIndex((row) => row.id === id);
+      if (idx >= 0) list[idx] = { ...list[idx], ...data };
+      return { ok: true };
+    });
+
+    fireEvent.click(screen.getByText("Keep me"));
+    const dialog = await screen.findByRole("dialog");
+    const titleInput = within(dialog).getByDisplayValue("Keep me");
+    fireEvent.change(titleInput, { target: { value: "Still visible" } });
+    fireEvent.blur(titleInput);
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith("cards", "card-1", expect.objectContaining({ title: "Still visible" })),
+    );
+    expect(screen.getByText(/column could not be deleted/i)).toBeTruthy();
   });
 
   it("shows a friendly error when the bridge fails to load", async () => {

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -18,9 +18,9 @@ function installMatrixDb(initial?: Partial<FakeDb>, legacyBoard?: unknown) {
     cards: initial?.cards ? [...initial.cards] : [],
   };
   let seq = 0;
-  const listeners: Record<string, Array<() => void>> = {};
+  const listeners: Record<string, Array<(event: { table: string }) => void>> = {};
   const emit = (table: string) => {
-    for (const cb of listeners[table] ?? []) cb();
+    for (const cb of listeners[table] ?? []) cb({ table });
   };
 
   const db = {
@@ -61,7 +61,7 @@ function installMatrixDb(initial?: Partial<FakeDb>, legacyBoard?: unknown) {
       return { ok: true };
     }),
     count: vi.fn(async (table: string) => (store[table as keyof FakeDb] ?? []).length),
-    onChange: vi.fn((table: string, cb: () => void) => {
+    onChange: vi.fn((table: string, cb: (event: { table: string }) => void) => {
       (listeners[table] ??= []).push(cb);
       return () => {
         listeners[table] = (listeners[table] ?? []).filter((fn) => fn !== cb);

--- a/tests/default-apps/task-manager-app.test.tsx
+++ b/tests/default-apps/task-manager-app.test.tsx
@@ -462,6 +462,32 @@ describe("Task Manager app", () => {
     );
   });
 
+  it("does not persist card reorders while a filter is active", async () => {
+    const { db } = installMatrixDb({
+      columns: [{ id: "col-1", title: "To do", color: "#7A7768", position: 0, created_at: "2026-05-01T00:00:00Z" }],
+      cards: [
+        { id: "card-1", column_id: "col-1", title: "Visible card", description: "", labels: "urgent", assignee: "", priority: "medium", due: null, checklist: [], position: 0, created_at: "2026-05-01T00:00:00Z" },
+        { id: "card-2", column_id: "col-1", title: "Hidden card", description: "", labels: "", assignee: "", priority: "medium", due: null, checklist: [], position: 1, created_at: "2026-05-01T00:00:00Z" },
+      ],
+    });
+    render(<App />);
+
+    await screen.findByText("Visible card");
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: "Visible" } });
+    expect(screen.queryByText("Hidden card")).toBeNull();
+
+    const visibleCard = screen.getByText("Visible card").closest(".task-card");
+    const column = screen.getByLabelText("To do");
+    if (!visibleCard) throw new Error("Expected visible task card");
+    fireEvent.dragStart(visibleCard);
+    fireEvent.drop(column);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
   it("keeps a column visible when a DB column delete fails", async () => {
     const { db } = installMatrixDb({
       columns: [


### PR DESCRIPTION
Stack: 5/22
Branch: stack/default-apps-task-manager

Scope: Task manager board model/UI, persistence, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.