### PR TITLE
feat(clock): add world clock and timers

### DIFF
--- a/home/apps/clock/matrix.json
+++ b/home/apps/clock/matrix.json
@@ -17,7 +17,9 @@
           "position": "integer"
         },
         "indexes": [
-          "position",
+          "position"
+        ],
+        "uniqueIndexes": [
           "tz"
         ]
       },
@@ -27,7 +29,10 @@
           "label": "text",
           "repeat": "text",
           "enabled": "boolean"
-        }
+        },
+        "indexes": [
+          "time"
+        ]
       }
     }
   },

--- a/home/apps/clock/matrix.json
+++ b/home/apps/clock/matrix.json
@@ -17,7 +17,8 @@
           "position": "integer"
         },
         "indexes": [
-          "position"
+          "position",
+          "tz"
         ]
       },
       "alarms": {

--- a/home/apps/clock/matrix.json
+++ b/home/apps/clock/matrix.json
@@ -1,6 +1,6 @@
 {
   "name": "Clock",
-  "description": "Analog and digital clock with timer",
+  "description": "World clock, alarms, timers, and stopwatch.",
   "runtime": "vite",
   "category": "utility",
   "icon": "clock",
@@ -9,6 +9,27 @@
   "slug": "clock",
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
+  "storage": {
+    "tables": {
+      "zones": {
+        "columns": {
+          "tz": "text",
+          "position": "integer"
+        },
+        "indexes": [
+          "position"
+        ]
+      },
+      "alarms": {
+        "columns": {
+          "time": "text",
+          "label": "text",
+          "repeat": "text",
+          "enabled": "boolean"
+        }
+      }
+    }
+  },
   "build": {
     "install": "true",
     "command": "vite build --base ./ --outDir dist",

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -644,14 +644,18 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
     setRingQueue(rest);
   }, [ringQueue, ringing]);
 
-  const persistAlarmEnabled = useCallback(
-    async (alarm: AlarmModel, enabled: boolean, next: AlarmModel[]) => {
+  const persistAutoDisabledAlarms = useCallback(
+    async (disabledAlarms: AlarmModel[], next: AlarmModel[]) => {
       if (!window.MatrixOS?.db) {
         await persistLocal(next);
         return;
       }
       try {
-        await window.MatrixOS.db.update(ALARMS_TABLE, alarm.id, { enabled });
+        await Promise.all(
+          disabledAlarms.map((alarm) =>
+            window.MatrixOS!.db!.update(ALARMS_TABLE, alarm.id, { enabled: false }),
+          ),
+        );
       } catch (err: unknown) {
         console.warn("[clock] alarm auto-disable failed:", err instanceof Error ? err.message : String(err));
         setError("Alarm could not be updated.");
@@ -674,6 +678,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
     }
 
     const key = alarmMinuteKey(now);
+    const oneShotAlarmsToDisable: AlarmModel[] = [];
     for (const alarm of alarms) {
       const guard = `${alarm.id}@${key}`;
       if (firedRef.current.has(guard)) continue;
@@ -685,13 +690,17 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         queueRing(alarm);
         beep(3);
         if (alarm.repeat.length === 0) {
-          const next = alarms.map((a) => (a.id === alarm.id ? { ...a, enabled: false } : a));
-          setAlarms(next);
-          void persistAlarmEnabled(alarm, false, next);
+          oneShotAlarmsToDisable.push(alarm);
         }
       }
     }
-  }, [alarms, now, persistAlarmEnabled, queueRing]);
+    if (oneShotAlarmsToDisable.length > 0) {
+      const disabledIds = new Set(oneShotAlarmsToDisable.map((alarm) => alarm.id));
+      const next = alarms.map((alarm) => (disabledIds.has(alarm.id) ? { ...alarm, enabled: false } : alarm));
+      setAlarms(next);
+      void persistAutoDisabledAlarms(oneShotAlarmsToDisable, next);
+    }
+  }, [alarms, now, persistAutoDisabledAlarms, queueRing]);
 
   const addAlarm = useCallback(async () => {
     const draft: AlarmModel = {

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -358,7 +358,12 @@ function WorldClock({ now }: { now: Date }) {
         await window.MatrixOS.db.insert(ZONES_TABLE, { tz, position });
         await reload();
       } catch (err: unknown) {
-        console.warn("[clock] zone save failed:", err instanceof Error ? err.message : String(err));
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn("[clock] zone save failed:", message);
+        if (/duplicate|unique/i.test(message)) {
+          await reload();
+          return;
+        }
         setError("City could not be saved.");
         setZones((cur) => cur.filter((z) => z.id !== optimistic.id));
         void reload().finally(() => setError("City could not be saved."));

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -46,6 +46,7 @@ import {
 const ZONES_TABLE = "zones";
 const ALARMS_TABLE = "alarms";
 const SNOOZE_MS = 5 * 60_000;
+const MAX_BEEPED_TIMERS = 200;
 
 type TabId = "world" | "alarms" | "timers" | "stopwatch";
 
@@ -390,6 +391,10 @@ function WorldClock({ now }: { now: Date }) {
       const fromIdx = zones.findIndex((z) => z.id === fromId);
       const toIdx = zones.findIndex((z) => z.id === toId);
       if (fromIdx < 0 || toIdx < 0) return;
+      if (window.MatrixOS?.db && zones.some((zone) => zone.id.startsWith("local-"))) {
+        setError("Wait for the city to finish saving before reordering.");
+        return;
+      }
       const next = [...zones];
       const [moved] = next.splice(fromIdx, 1);
       next.splice(toIdx, 0, moved);
@@ -589,6 +594,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
   const [draftLabel, setDraftLabel] = useState("");
   const [draftDays, setDraftDays] = useState<WeekDay[]>([]);
   const [ringing, setRinging] = useState<AlarmModel | null>(null);
+  const [ringQueue, setRingQueue] = useState<AlarmModel[]>([]);
   const firedRef = useRef<Set<string>>(new Set());
   const snoozedRef = useRef<Array<{ alarm: AlarmModel; dueAt: number }>>([]);
   const persistenceLabel = storageLabel();
@@ -621,6 +627,23 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
     );
   }, []);
 
+  const queueRing = useCallback((alarm: AlarmModel) => {
+    setRingQueue((current) => current.some((queued) => queued.id === alarm.id) ? current : [...current, alarm]);
+  }, []);
+
+  const clearAlarmRuntime = useCallback((alarmId: string) => {
+    snoozedRef.current = snoozedRef.current.filter((entry) => entry.alarm.id !== alarmId);
+    setRingQueue((current) => current.filter((alarm) => alarm.id !== alarmId));
+    setRinging((current) => current?.id === alarmId ? null : current);
+  }, []);
+
+  useEffect(() => {
+    if (ringing || ringQueue.length === 0) return;
+    const [next, ...rest] = ringQueue;
+    setRinging(next);
+    setRingQueue(rest);
+  }, [ringQueue, ringing]);
+
   const persistAlarmEnabled = useCallback(
     async (alarm: AlarmModel, enabled: boolean, next: AlarmModel[]) => {
       if (!window.MatrixOS?.db) {
@@ -643,7 +666,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
     const dueSnooze = snoozedRef.current.find((entry) => now.getTime() >= entry.dueAt);
     if (dueSnooze) {
       snoozedRef.current = snoozedRef.current.filter((entry) => entry !== dueSnooze);
-      setRinging(dueSnooze.alarm);
+      queueRing(dueSnooze.alarm);
       beep(3);
     }
 
@@ -656,7 +679,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         if (firedRef.current.size > 200) {
           firedRef.current = new Set([...firedRef.current].slice(-100));
         }
-        setRinging(alarm);
+        queueRing(alarm);
         beep(3);
         if (alarm.repeat.length === 0) {
           const next = alarms.map((a) => (a.id === alarm.id ? { ...a, enabled: false } : a));
@@ -665,7 +688,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         }
       }
     }
-  }, [alarms, now, persistAlarmEnabled]);
+  }, [alarms, now, persistAlarmEnabled, queueRing]);
 
   const addAlarm = useCallback(async () => {
     const draft: AlarmModel = {
@@ -706,6 +729,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
       const enabled = !alarm.enabled;
       const next = alarms.map((a) => (a.id === alarm.id ? { ...a, enabled } : a));
       setAlarms(next);
+      if (!enabled) clearAlarmRuntime(alarm.id);
       if (!window.MatrixOS?.db) {
         await persistLocal(next);
         return;
@@ -718,13 +742,14 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         void reload();
       }
     },
-    [alarms, persistLocal, reload],
+    [alarms, clearAlarmRuntime, persistLocal, reload],
   );
 
   const removeAlarm = useCallback(
     async (alarm: AlarmModel) => {
       const next = alarms.filter((a) => a.id !== alarm.id);
       setAlarms(next);
+      clearAlarmRuntime(alarm.id);
       if (!window.MatrixOS?.db) {
         await persistLocal(next);
         return;
@@ -737,7 +762,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         void reload();
       }
     },
-    [alarms, persistLocal, reload],
+    [alarms, clearAlarmRuntime, persistLocal, reload],
   );
 
   const snooze = useCallback(() => {
@@ -939,6 +964,9 @@ function Timers() {
     for (const timer of timers) {
       if (timer.done && !beepedTimersRef.current.has(timer.id)) {
         beepedTimersRef.current.add(timer.id);
+        if (beepedTimersRef.current.size > MAX_BEEPED_TIMERS) {
+          beepedTimersRef.current = new Set([...beepedTimersRef.current].slice(-100));
+        }
         beep(3);
       }
     }

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -666,8 +666,11 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
     const dueSnooze = snoozedRef.current.find((entry) => now.getTime() >= entry.dueAt);
     if (dueSnooze) {
       snoozedRef.current = snoozedRef.current.filter((entry) => entry !== dueSnooze);
-      queueRing(dueSnooze.alarm);
-      beep(3);
+      const currentAlarm = alarms.find((alarm) => alarm.id === dueSnooze.alarm.id);
+      if (currentAlarm?.enabled) {
+        queueRing(currentAlarm);
+        beep(3);
+      }
     }
 
     const key = alarmMinuteKey(now);

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -277,7 +277,7 @@ export default function App() {
           <Timers />
         </div>
         <div hidden={tab !== "stopwatch"}>
-          <Stopwatch />
+          <Stopwatch active={tab === "stopwatch"} />
         </div>
       </section>
     </main>
@@ -361,6 +361,7 @@ function WorldClock({ now }: { now: Date }) {
         console.warn("[clock] zone save failed:", err instanceof Error ? err.message : String(err));
         setError("City could not be saved.");
         setZones((cur) => cur.filter((z) => z.id !== optimistic.id));
+        void reload().finally(() => setError("City could not be saved."));
       }
     },
     [persistLocal, reload, zones],
@@ -412,9 +413,8 @@ function WorldClock({ now }: { now: Date }) {
         );
       } catch (err: unknown) {
         console.warn("[clock] reorder failed:", err instanceof Error ? err.message : String(err));
-        setError("New order could not be saved.");
         setZones(previous);
-        void reload();
+        void reload().finally(() => setError("New order could not be saved."));
       }
     },
     [persistLocal, reload, zones],
@@ -596,7 +596,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
   const [ringing, setRinging] = useState<AlarmModel | null>(null);
   const [ringQueue, setRingQueue] = useState<AlarmModel[]>([]);
   const firedRef = useRef<Set<string>>(new Set());
-  const snoozedRef = useRef<Array<{ alarm: AlarmModel; dueAt: number }>>([]);
+  const snoozedRef = useRef<Array<{ alarm: AlarmModel; dueAt: number; ringWhenDisabled: boolean }>>([]);
   const persistenceLabel = storageLabel();
 
   const reload = useCallback(async () => {
@@ -667,8 +667,8 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
     if (dueSnooze) {
       snoozedRef.current = snoozedRef.current.filter((entry) => entry !== dueSnooze);
       const currentAlarm = alarms.find((alarm) => alarm.id === dueSnooze.alarm.id);
-      if (currentAlarm?.enabled) {
-        queueRing(currentAlarm);
+      if (currentAlarm && (currentAlarm.enabled || dueSnooze.ringWhenDisabled)) {
+        queueRing(currentAlarm.enabled ? currentAlarm : dueSnooze.alarm);
         beep(3);
       }
     }
@@ -724,6 +724,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
       console.warn("[clock] alarm save failed:", err instanceof Error ? err.message : String(err));
       setError("Alarm could not be saved.");
       setAlarms((cur) => cur.filter((a) => a.id !== draft.id));
+      void reload().finally(() => setError("Alarm could not be saved."));
     }
   }, [alarms, draftDays, draftLabel, draftTime, persistLocal, reload]);
 
@@ -772,7 +773,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
     if (ringing) {
       snoozedRef.current = [
         ...snoozedRef.current.filter((entry) => entry.alarm.id !== ringing.id),
-        { alarm: ringing, dueAt: now.getTime() + SNOOZE_MS },
+        { alarm: ringing, dueAt: now.getTime() + SNOOZE_MS, ringWhenDisabled: ringing.repeat.length === 0 },
       ];
     }
     setRinging(null);
@@ -1139,7 +1140,7 @@ function swReducer(s: SwState, a: SwAction): SwState {
   }
 }
 
-function Stopwatch() {
+function Stopwatch({ active }: { active: boolean }) {
   const [state, dispatch] = useReducer(swReducer, {
     running: false,
     elapsed: 0,
@@ -1153,6 +1154,10 @@ function Stopwatch() {
       setDisplay(state.elapsed);
       return undefined;
     }
+    if (!active) {
+      setDisplay(nowElapsed(state, performance.now()));
+      return undefined;
+    }
     let raf = 0;
     const tick = () => {
       setDisplay(nowElapsed(state, performance.now()));
@@ -1160,7 +1165,7 @@ function Stopwatch() {
     };
     raf = window.requestAnimationFrame(tick);
     return () => window.cancelAnimationFrame(raf);
-  }, [state]);
+  }, [active, state]);
 
   const laps = useMemo(() => computeLaps(state.marks), [state.marks]);
   const ext = useMemo(() => lapExtremes(laps), [laps]);

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -86,6 +86,17 @@ function allTimeZones(): string[] {
 // --- audio (WebAudio beep, gracefully degrades) --------------------------------
 
 let sharedCtx: AudioContext | null = null;
+let audioCleanupRegistered = false;
+
+function closeSharedCtx(): void {
+  const ctx = sharedCtx;
+  sharedCtx = null;
+  if (!ctx || ctx.state === "closed") return;
+  void ctx.close().catch((err: unknown) => {
+    console.warn("[clock] audio cleanup failed:", err instanceof Error ? err.message : String(err));
+  });
+}
+
 function getCtx(): AudioContext | null {
   try {
     const Ctor =
@@ -93,7 +104,13 @@ function getCtx(): AudioContext | null {
         .AudioContext ||
       (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
     if (!Ctor) return null;
-    if (!sharedCtx) sharedCtx = new Ctor();
+    if (!sharedCtx) {
+      sharedCtx = new Ctor();
+      if (!audioCleanupRegistered) {
+        audioCleanupRegistered = true;
+        window.addEventListener("pagehide", closeSharedCtx);
+      }
+    }
     return sharedCtx;
   } catch (err) {
     console.warn("[clock] audio unavailable:", err instanceof Error ? err.message : String(err));
@@ -628,7 +645,6 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
       snoozedRef.current = snoozedRef.current.filter((entry) => entry !== dueSnooze);
       setRinging(dueSnooze.alarm);
       beep(3);
-      return;
     }
 
     const key = alarmMinuteKey(now);
@@ -893,6 +909,7 @@ function Timers() {
   const [timers, setTimers] = useState<TimerInstance[]>([]);
   const [draft, setDraft] = useState("5:00");
   const [label, setLabel] = useState("");
+  const [draftError, setDraftError] = useState<string | null>(null);
   const beepedTimersRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -947,6 +964,11 @@ function Timers() {
 
   const startCustom = useCallback(() => {
     const seconds = parseDuration(draft);
+    if (seconds <= 0) {
+      setDraftError("Enter a duration greater than zero.");
+      return;
+    }
+    setDraftError(null);
     addTimer(seconds, label);
     setLabel("");
   }, [addTimer, draft, label]);
@@ -982,9 +1004,13 @@ function Timers() {
           <input
             className="duration-input"
             aria-label="Timer duration"
+            aria-invalid={draftError ? "true" : "false"}
             placeholder="MM:SS"
             value={draft}
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              if (draftError) setDraftError(null);
+            }}
             onKeyDown={(e) => e.key === "Enter" && startCustom()}
           />
           <input
@@ -999,6 +1025,7 @@ function Timers() {
             <Plus size={16} /> Start
           </button>
         </div>
+        {draftError ? <div className="banner banner--error">{draftError}</div> : null}
       </div>
 
       {timers.length === 0 ? (

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -124,24 +124,32 @@ function beep(times = 1): void {
   }
 }
 
-// --- localStorage fallback -----------------------------------------------------
+// --- MatrixOS KV fallback ------------------------------------------------------
 
-function lsGet<T>(key: string, fallback: T): T {
+const fallbackData: Record<string, unknown> = {};
+
+async function readAppData<T>(key: string, fallback: T): Promise<T> {
   try {
-    const raw = window.localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
+    if (window.MatrixOS?.readData) {
+      const value = await window.MatrixOS.readData(key);
+      return value === undefined || value === null ? fallback : (value as T);
+    }
   } catch (err) {
-    console.warn("[clock] localStorage read failed:", err instanceof Error ? err.message : String(err));
-    return fallback;
+    console.warn("[clock] MatrixOS data read failed:", err instanceof Error ? err.message : String(err));
   }
+  return Object.prototype.hasOwnProperty.call(fallbackData, key) ? (fallbackData[key] as T) : fallback;
 }
 
-function lsSet<T>(key: string, value: T): void {
+async function writeAppData<T>(key: string, value: T): Promise<void> {
   try {
-    window.localStorage.setItem(key, JSON.stringify(value));
+    if (window.MatrixOS?.writeData) {
+      await window.MatrixOS.writeData(key, value);
+      return;
+    }
   } catch (err) {
-    console.warn("[clock] localStorage write failed:", err instanceof Error ? err.message : String(err));
+    console.warn("[clock] MatrixOS data write failed:", err instanceof Error ? err.message : String(err));
   }
+  fallbackData[key] = value;
 }
 
 // --- shared types --------------------------------------------------------------
@@ -174,6 +182,17 @@ function coerceAlarm(row: unknown, idx: number): AlarmModel | null {
     repeat: parseRepeat(d.repeat),
     enabled: d.enabled !== false,
   };
+}
+
+function dedupeZones(rows: ZoneRow[]): ZoneRow[] {
+  const seen = new Set<string>();
+  const deduped: ZoneRow[] = [];
+  for (const zone of [...rows].sort((a, b) => a.position - b.position || a.tz.localeCompare(b.tz))) {
+    if (seen.has(zone.tz)) continue;
+    seen.add(zone.tz);
+    deduped.push(zone);
+  }
+  return deduped;
 }
 
 // =================================================================================
@@ -242,13 +261,13 @@ function WorldClock({ now }: { now: Date }) {
   const reload = useCallback(async () => {
     setError(null);
     if (!window.MatrixOS?.db) {
-      const stored = lsGet<ZoneRow[]>("clock.zones", []);
-      setZones([...stored].sort((a, b) => a.position - b.position));
+      const stored = await readAppData<ZoneRow[]>("clock.zones", []);
+      setZones(dedupeZones(stored.map(coerceZone).filter((z): z is ZoneRow => z !== null)));
       return;
     }
     try {
       const rows = await window.MatrixOS.db.find(ZONES_TABLE, { orderBy: { position: "asc" } });
-      setZones(rows.map(coerceZone).filter((z): z is ZoneRow => z !== null));
+      setZones(dedupeZones(rows.map(coerceZone).filter((z): z is ZoneRow => z !== null)));
     } catch (err: unknown) {
       console.warn("[clock] zones load failed:", err instanceof Error ? err.message : String(err));
       setError("Saved cities could not be loaded.");
@@ -260,13 +279,25 @@ function WorldClock({ now }: { now: Date }) {
     return window.MatrixOS?.db?.onChange?.(ZONES_TABLE, () => void reload());
   }, [reload]);
 
-  const persistLocal = useCallback((next: ZoneRow[]) => {
-    lsSet("clock.zones", next);
+  const persistLocal = useCallback(async (next: ZoneRow[]) => {
+    await writeAppData("clock.zones", next);
   }, []);
 
   const addZone = useCallback(
     async (tz: string) => {
-      if (zones.some((z) => z.tz === tz)) {
+      const alreadyVisible = zones.some((z) => z.tz === tz);
+      let existingRows: Record<string, unknown>[] = [];
+      try {
+        existingRows = window.MatrixOS?.db
+          ? await window.MatrixOS.db.find(ZONES_TABLE, { where: { tz }, limit: 1 })
+          : [];
+      } catch (err) {
+        console.warn("[clock] duplicate zone check failed:", err instanceof Error ? err.message : String(err));
+        setError("Saved cities could not be checked.");
+        return;
+      }
+      if (alreadyVisible || existingRows.length > 0) {
+        if (!alreadyVisible) await reload();
         setAdding(false);
         setQuery("");
         return;
@@ -279,7 +310,7 @@ function WorldClock({ now }: { now: Date }) {
       setQuery("");
 
       if (!window.MatrixOS?.db) {
-        persistLocal(next);
+        await persistLocal(next);
         return;
       }
       try {
@@ -299,7 +330,7 @@ function WorldClock({ now }: { now: Date }) {
       const next = zones.filter((z) => z.id !== zone.id);
       setZones(next);
       if (!window.MatrixOS?.db) {
-        persistLocal(next);
+        await persistLocal(next);
         return;
       }
       try {
@@ -325,16 +356,18 @@ function WorldClock({ now }: { now: Date }) {
       const repositioned = next.map((z, i) => ({ ...z, position: i }));
       setZones(repositioned);
       if (!window.MatrixOS?.db) {
-        persistLocal(repositioned);
+        await persistLocal(repositioned);
         return;
       }
+      const previous = zones;
       try {
-        await Promise.all(
-          repositioned.map((z) => window.MatrixOS!.db!.update(ZONES_TABLE, z.id, { position: z.position })),
-        );
+        for (const z of repositioned) {
+          await window.MatrixOS.db.update(ZONES_TABLE, z.id, { position: z.position });
+        }
       } catch (err: unknown) {
         console.warn("[clock] reorder failed:", err instanceof Error ? err.message : String(err));
         setError("New order could not be saved.");
+        setZones(previous);
         void reload();
       }
     },
@@ -500,7 +533,8 @@ function Alarms({ now }: { now: Date }) {
   const reload = useCallback(async () => {
     setError(null);
     if (!window.MatrixOS?.db) {
-      setAlarms(lsGet<AlarmModel[]>("clock.alarms", []).map((a) => ({ ...a, repeat: parseRepeat(a.repeat) })));
+      const stored = await readAppData<AlarmModel[]>("clock.alarms", []);
+      setAlarms(stored.map((a) => ({ ...a, repeat: parseRepeat(a.repeat) })));
       return;
     }
     try {
@@ -517,8 +551,8 @@ function Alarms({ now }: { now: Date }) {
     return window.MatrixOS?.db?.onChange?.(ALARMS_TABLE, () => void reload());
   }, [reload]);
 
-  const persistLocal = useCallback((next: AlarmModel[]) => {
-    lsSet(
+  const persistLocal = useCallback(async (next: AlarmModel[]) => {
+    await writeAppData(
       "clock.alarms",
       next.map((a) => ({ ...a, repeat: serializeRepeat(a.repeat) })),
     );
@@ -557,7 +591,7 @@ function Alarms({ now }: { now: Date }) {
     setDraftTime("07:00");
 
     if (!window.MatrixOS?.db) {
-      persistLocal(next);
+      await persistLocal(next);
       return;
     }
     try {
@@ -581,7 +615,7 @@ function Alarms({ now }: { now: Date }) {
       const next = alarms.map((a) => (a.id === alarm.id ? { ...a, enabled } : a));
       setAlarms(next);
       if (!window.MatrixOS?.db) {
-        persistLocal(next);
+        await persistLocal(next);
         return;
       }
       try {
@@ -600,7 +634,7 @@ function Alarms({ now }: { now: Date }) {
       const next = alarms.filter((a) => a.id !== alarm.id);
       setAlarms(next);
       if (!window.MatrixOS?.db) {
-        persistLocal(next);
+        await persistLocal(next);
         return;
       }
       try {

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -1,0 +1,1041 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
+import {
+  AlarmClock,
+  Bell,
+  Check,
+  Clock3,
+  Flag,
+  Globe2,
+  GripVertical,
+  Pause,
+  Play,
+  Plus,
+  RotateCcw,
+  Search,
+  Timer as TimerIcon,
+  Trash2,
+  X,
+} from "lucide-react";
+import "./styles.css";
+import {
+  alarmMinuteKey,
+  computeLaps,
+  formatClock,
+  formatStopwatch,
+  formatZoneTime,
+  lapExtremes,
+  parseDuration,
+  parseRepeat,
+  repeatLabel,
+  searchZones,
+  serializeRepeat,
+  shouldAlarmFire,
+  zoneCityLabel,
+  zoneRegionLabel,
+  type AlarmModel,
+  type WeekDay,
+} from "./clock-model";
+
+const ZONES_TABLE = "zones";
+const ALARMS_TABLE = "alarms";
+
+type TabId = "world" | "alarms" | "timers" | "stopwatch";
+
+const TABS: { id: TabId; label: string; icon: typeof Globe2 }[] = [
+  { id: "world", label: "World Clock", icon: Globe2 },
+  { id: "alarms", label: "Alarms", icon: AlarmClock },
+  { id: "timers", label: "Timer", icon: TimerIcon },
+  { id: "stopwatch", label: "Stopwatch", icon: Clock3 },
+];
+
+const LOCAL_TZ =
+  (typeof Intl !== "undefined" && Intl.DateTimeFormat().resolvedOptions().timeZone) || "UTC";
+
+function allTimeZones(): string[] {
+  try {
+    const fn = (Intl as unknown as { supportedValuesOf?: (k: string) => string[] })
+      .supportedValuesOf;
+    if (typeof fn === "function") return fn("timeZone");
+  } catch (err) {
+    console.warn("[clock] supportedValuesOf failed:", err instanceof Error ? err.message : String(err));
+  }
+  return [
+    "UTC",
+    "America/New_York",
+    "America/Los_Angeles",
+    "America/Chicago",
+    "Europe/London",
+    "Europe/Paris",
+    "Europe/Berlin",
+    "Asia/Tokyo",
+    "Asia/Shanghai",
+    "Asia/Kolkata",
+    "Asia/Dubai",
+    "Australia/Sydney",
+  ];
+}
+
+// --- audio (WebAudio beep, gracefully degrades) --------------------------------
+
+let sharedCtx: AudioContext | null = null;
+function getCtx(): AudioContext | null {
+  try {
+    const Ctor =
+      (window as unknown as { AudioContext?: typeof AudioContext; webkitAudioContext?: typeof AudioContext })
+        .AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return null;
+    if (!sharedCtx) sharedCtx = new Ctor();
+    return sharedCtx;
+  } catch (err) {
+    console.warn("[clock] audio unavailable:", err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+function beep(times = 1): void {
+  const ctx = getCtx();
+  if (!ctx) return;
+  try {
+    void ctx.resume?.();
+    for (let i = 0; i < times; i++) {
+      const start = ctx.currentTime + i * 0.5;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.value = 880;
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(0.25, start + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.4);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(start);
+      osc.stop(start + 0.42);
+    }
+  } catch (err) {
+    console.warn("[clock] beep failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+// --- localStorage fallback -----------------------------------------------------
+
+function lsGet<T>(key: string, fallback: T): T {
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch (err) {
+    console.warn("[clock] localStorage read failed:", err instanceof Error ? err.message : String(err));
+    return fallback;
+  }
+}
+
+function lsSet<T>(key: string, value: T): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (err) {
+    console.warn("[clock] localStorage write failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+// --- shared types --------------------------------------------------------------
+
+interface ZoneRow {
+  id: string;
+  tz: string;
+  position: number;
+}
+
+function coerceZone(row: unknown, idx: number): ZoneRow | null {
+  if (!row || typeof row !== "object") return null;
+  const d = row as Record<string, unknown>;
+  if (typeof d.tz !== "string" || !d.tz) return null;
+  return {
+    id: typeof d.id === "string" ? d.id : `local-${idx}`,
+    tz: d.tz,
+    position: typeof d.position === "number" ? d.position : idx,
+  };
+}
+
+function coerceAlarm(row: unknown, idx: number): AlarmModel | null {
+  if (!row || typeof row !== "object") return null;
+  const d = row as Record<string, unknown>;
+  if (typeof d.time !== "string") return null;
+  return {
+    id: typeof d.id === "string" ? d.id : `local-${idx}`,
+    time: d.time,
+    label: typeof d.label === "string" ? d.label : "",
+    repeat: parseRepeat(d.repeat),
+    enabled: d.enabled !== false,
+  };
+}
+
+// =================================================================================
+
+export default function App() {
+  const [tab, setTab] = useState<TabId>("world");
+  const [now, setNow] = useState(() => new Date());
+
+  // Global 1s tick used by world clock + alarms.
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  return (
+    <main className="clock-app">
+      <header className="topbar">
+        <div className="brand">
+          <span className="brand-mark" aria-hidden="true">
+            <Clock3 size={18} />
+          </span>
+          <span>Clock</span>
+        </div>
+        <nav className="tabs" role="tablist" aria-label="Clock sections">
+          {TABS.map(({ id, label, icon: Icon }) => (
+            <button
+              key={id}
+              role="tab"
+              type="button"
+              aria-selected={tab === id}
+              className={tab === id ? "tab tab--active" : "tab"}
+              onClick={() => setTab(id)}
+            >
+              <Icon size={16} />
+              <span>{label}</span>
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      <section className="panel" role="tabpanel">
+        {tab === "world" && <WorldClock now={now} />}
+        {tab === "alarms" && <Alarms now={now} />}
+        {tab === "timers" && <Timers />}
+        {tab === "stopwatch" && <Stopwatch />}
+      </section>
+    </main>
+  );
+}
+
+// ---------------------------------------------------------------------------------
+// World Clock
+// ---------------------------------------------------------------------------------
+
+function WorldClock({ now }: { now: Date }) {
+  const [zones, setZones] = useState<ZoneRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [query, setQuery] = useState("");
+  const [dragId, setDragId] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const allZones = useMemo(() => allTimeZones(), []);
+  const hasDb = typeof window !== "undefined" && !!window.MatrixOS?.db;
+
+  const reload = useCallback(async () => {
+    setError(null);
+    if (!window.MatrixOS?.db) {
+      const stored = lsGet<ZoneRow[]>("clock.zones", []);
+      setZones([...stored].sort((a, b) => a.position - b.position));
+      return;
+    }
+    try {
+      const rows = await window.MatrixOS.db.find(ZONES_TABLE, { orderBy: { position: "asc" } });
+      setZones(rows.map(coerceZone).filter((z): z is ZoneRow => z !== null));
+    } catch (err: unknown) {
+      console.warn("[clock] zones load failed:", err instanceof Error ? err.message : String(err));
+      setError("Saved cities could not be loaded.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+    return window.MatrixOS?.db?.onChange?.(ZONES_TABLE, () => void reload());
+  }, [reload]);
+
+  const persistLocal = useCallback((next: ZoneRow[]) => {
+    lsSet("clock.zones", next);
+  }, []);
+
+  const addZone = useCallback(
+    async (tz: string) => {
+      if (zones.some((z) => z.tz === tz)) {
+        setAdding(false);
+        setQuery("");
+        return;
+      }
+      const position = zones.length;
+      const optimistic: ZoneRow = { id: `local-${Date.now()}`, tz, position };
+      const next = [...zones, optimistic];
+      setZones(next);
+      setAdding(false);
+      setQuery("");
+
+      if (!window.MatrixOS?.db) {
+        persistLocal(next);
+        return;
+      }
+      try {
+        await window.MatrixOS.db.insert(ZONES_TABLE, { tz, position });
+        await reload();
+      } catch (err: unknown) {
+        console.warn("[clock] zone save failed:", err instanceof Error ? err.message : String(err));
+        setError("City could not be saved.");
+        setZones((cur) => cur.filter((z) => z.id !== optimistic.id));
+      }
+    },
+    [persistLocal, reload, zones],
+  );
+
+  const removeZone = useCallback(
+    async (zone: ZoneRow) => {
+      const next = zones.filter((z) => z.id !== zone.id);
+      setZones(next);
+      if (!window.MatrixOS?.db) {
+        persistLocal(next);
+        return;
+      }
+      try {
+        await window.MatrixOS.db.delete(ZONES_TABLE, zone.id);
+      } catch (err: unknown) {
+        console.warn("[clock] zone delete failed:", err instanceof Error ? err.message : String(err));
+        setError("City could not be removed.");
+        void reload();
+      }
+    },
+    [persistLocal, reload, zones],
+  );
+
+  const reorder = useCallback(
+    async (fromId: string, toId: string) => {
+      if (fromId === toId) return;
+      const fromIdx = zones.findIndex((z) => z.id === fromId);
+      const toIdx = zones.findIndex((z) => z.id === toId);
+      if (fromIdx < 0 || toIdx < 0) return;
+      const next = [...zones];
+      const [moved] = next.splice(fromIdx, 1);
+      next.splice(toIdx, 0, moved);
+      const repositioned = next.map((z, i) => ({ ...z, position: i }));
+      setZones(repositioned);
+      if (!window.MatrixOS?.db) {
+        persistLocal(repositioned);
+        return;
+      }
+      try {
+        await Promise.all(
+          repositioned.map((z) => window.MatrixOS!.db!.update(ZONES_TABLE, z.id, { position: z.position })),
+        );
+      } catch (err: unknown) {
+        console.warn("[clock] reorder failed:", err instanceof Error ? err.message : String(err));
+        setError("New order could not be saved.");
+        void reload();
+      }
+    },
+    [persistLocal, reload, zones],
+  );
+
+  const results = useMemo(() => searchZones(allZones, query, 60), [allZones, query]);
+
+  useEffect(() => {
+    if (adding) searchRef.current?.focus();
+  }, [adding]);
+
+  return (
+    <div className="world">
+      <div className="world-head">
+        <div>
+          <p className="eyebrow">{hasDb ? "Synced to Matrix Postgres" : "Saved on this device"}</p>
+          <h1>World Clock</h1>
+        </div>
+        <button className="primary-btn" type="button" onClick={() => setAdding(true)}>
+          <Plus size={16} /> Add city
+        </button>
+      </div>
+
+      {error && <div className="banner banner--error">{error}</div>}
+
+      {zones.length === 0 ? (
+        <div className="empty">
+          <Globe2 size={28} />
+          <strong>No cities yet</strong>
+          <span>Track the time anywhere. Add your first city to get started.</span>
+          <button className="primary-btn" type="button" onClick={() => setAdding(true)}>
+            <Plus size={16} /> Add city
+          </button>
+        </div>
+      ) : (
+        <ul className="zone-list">
+          {zones.map((zone) => {
+            const z = formatZoneTime(zone.tz, LOCAL_TZ, now);
+            return (
+              <li
+                key={zone.id}
+                className={dragId === zone.id ? "zone-row zone-row--drag" : "zone-row"}
+                draggable
+                onDragStart={() => setDragId(zone.id)}
+                onDragEnd={() => setDragId(null)}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={() => {
+                  if (dragId) void reorder(dragId, zone.id);
+                  setDragId(null);
+                }}
+              >
+                <span className="drag-handle" aria-hidden="true">
+                  <GripVertical size={16} />
+                </span>
+                <AnalogFace zone={z} />
+                <div className="zone-meta">
+                  <strong>{zoneCityLabel(zone.tz)}</strong>
+                  <span>
+                    {z.dayLabel} · {z.offsetLabel} · {zoneRegionLabel(zone.tz)}
+                  </span>
+                </div>
+                <div className="zone-time">
+                  <strong>{z.time}</strong>
+                  <span>{z.meridiem}</span>
+                </div>
+                <button
+                  className="ghost-btn"
+                  type="button"
+                  aria-label={`Remove ${zoneCityLabel(zone.tz)}`}
+                  onClick={() => void removeZone(zone)}
+                >
+                  <Trash2 size={16} />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {adding && (
+        <div className="overlay" onClick={() => setAdding(false)}>
+          <div className="search-card" onClick={(e) => e.stopPropagation()}>
+            <div className="search-field">
+              <Search size={16} />
+              <input
+                ref={searchRef}
+                placeholder="Search cities or time zones"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") setAdding(false);
+                  if (e.key === "Enter" && results[0]) void addZone(results[0]);
+                }}
+              />
+              <button className="ghost-btn" type="button" aria-label="Close" onClick={() => setAdding(false)}>
+                <X size={16} />
+              </button>
+            </div>
+            <ul className="option-list" role="listbox">
+              {results.length === 0 ? (
+                <li className="option option--empty">No matching time zones</li>
+              ) : (
+                results.map((tz) => (
+                  <li key={tz}>
+                    <button
+                      className="option"
+                      type="button"
+                      role="option"
+                      aria-selected={false}
+                      onClick={() => void addZone(tz)}
+                    >
+                      <span className="option-city">{zoneCityLabel(tz)}</span>
+                      <span className="option-region">{zoneRegionLabel(tz)}</span>
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AnalogFace({ zone }: { zone: ReturnType<typeof formatZoneTime> }) {
+  return (
+    <div className="analog" aria-hidden="true">
+      <span className="hand hand--hour" style={{ transform: `rotate(${zone.hourAngle}deg)` }} />
+      <span className="hand hand--minute" style={{ transform: `rotate(${zone.minuteAngle}deg)` }} />
+      <span className="hand hand--second" style={{ transform: `rotate(${zone.secondAngle}deg)` }} />
+      <span className="analog-pin" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------------
+// Alarms
+// ---------------------------------------------------------------------------------
+
+const DAY_LETTERS: { day: WeekDay; label: string }[] = [
+  { day: 1, label: "M" },
+  { day: 2, label: "T" },
+  { day: 3, label: "W" },
+  { day: 4, label: "T" },
+  { day: 5, label: "F" },
+  { day: 6, label: "S" },
+  { day: 0, label: "S" },
+];
+
+function Alarms({ now }: { now: Date }) {
+  const [alarms, setAlarms] = useState<AlarmModel[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [draftTime, setDraftTime] = useState("07:00");
+  const [draftLabel, setDraftLabel] = useState("");
+  const [draftDays, setDraftDays] = useState<WeekDay[]>([]);
+  const [ringing, setRinging] = useState<AlarmModel | null>(null);
+  const firedRef = useRef<Set<string>>(new Set());
+  const hasDb = typeof window !== "undefined" && !!window.MatrixOS?.db;
+
+  const reload = useCallback(async () => {
+    setError(null);
+    if (!window.MatrixOS?.db) {
+      setAlarms(lsGet<AlarmModel[]>("clock.alarms", []).map((a) => ({ ...a, repeat: parseRepeat(a.repeat) })));
+      return;
+    }
+    try {
+      const rows = await window.MatrixOS.db.find(ALARMS_TABLE, { orderBy: { time: "asc" } });
+      setAlarms(rows.map(coerceAlarm).filter((a): a is AlarmModel => a !== null));
+    } catch (err: unknown) {
+      console.warn("[clock] alarms load failed:", err instanceof Error ? err.message : String(err));
+      setError("Alarms could not be loaded.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+    return window.MatrixOS?.db?.onChange?.(ALARMS_TABLE, () => void reload());
+  }, [reload]);
+
+  const persistLocal = useCallback((next: AlarmModel[]) => {
+    lsSet(
+      "clock.alarms",
+      next.map((a) => ({ ...a, repeat: serializeRepeat(a.repeat) })),
+    );
+  }, []);
+
+  // Ring scheduling: when the global tick lands on a matching minute, fire once.
+  useEffect(() => {
+    const key = alarmMinuteKey(now);
+    for (const alarm of alarms) {
+      const guard = `${alarm.id}@${key}`;
+      if (firedRef.current.has(guard)) continue;
+      if (shouldAlarmFire(alarm, now)) {
+        firedRef.current.add(guard);
+        if (firedRef.current.size > 200) {
+          firedRef.current = new Set([...firedRef.current].slice(-100));
+        }
+        setRinging(alarm);
+        beep(3);
+      }
+    }
+  }, [alarms, now]);
+
+  const addAlarm = useCallback(async () => {
+    const draft: AlarmModel = {
+      id: `local-${Date.now()}`,
+      time: draftTime,
+      label: draftLabel.trim(),
+      repeat: draftDays,
+      enabled: true,
+    };
+    const next = [...alarms, draft].sort((a, b) => a.time.localeCompare(b.time));
+    setAlarms(next);
+    setEditing(false);
+    setDraftLabel("");
+    setDraftDays([]);
+    setDraftTime("07:00");
+
+    if (!window.MatrixOS?.db) {
+      persistLocal(next);
+      return;
+    }
+    try {
+      await window.MatrixOS.db.insert(ALARMS_TABLE, {
+        time: draft.time,
+        label: draft.label,
+        repeat: serializeRepeat(draft.repeat),
+        enabled: true,
+      });
+      await reload();
+    } catch (err: unknown) {
+      console.warn("[clock] alarm save failed:", err instanceof Error ? err.message : String(err));
+      setError("Alarm could not be saved.");
+      setAlarms((cur) => cur.filter((a) => a.id !== draft.id));
+    }
+  }, [alarms, draftDays, draftLabel, draftTime, persistLocal, reload]);
+
+  const toggleAlarm = useCallback(
+    async (alarm: AlarmModel) => {
+      const enabled = !alarm.enabled;
+      const next = alarms.map((a) => (a.id === alarm.id ? { ...a, enabled } : a));
+      setAlarms(next);
+      if (!window.MatrixOS?.db) {
+        persistLocal(next);
+        return;
+      }
+      try {
+        await window.MatrixOS.db.update(ALARMS_TABLE, alarm.id, { enabled });
+      } catch (err: unknown) {
+        console.warn("[clock] alarm toggle failed:", err instanceof Error ? err.message : String(err));
+        setError("Alarm could not be updated.");
+        void reload();
+      }
+    },
+    [alarms, persistLocal, reload],
+  );
+
+  const removeAlarm = useCallback(
+    async (alarm: AlarmModel) => {
+      const next = alarms.filter((a) => a.id !== alarm.id);
+      setAlarms(next);
+      if (!window.MatrixOS?.db) {
+        persistLocal(next);
+        return;
+      }
+      try {
+        await window.MatrixOS.db.delete(ALARMS_TABLE, alarm.id);
+      } catch (err: unknown) {
+        console.warn("[clock] alarm delete failed:", err instanceof Error ? err.message : String(err));
+        setError("Alarm could not be removed.");
+        void reload();
+      }
+    },
+    [alarms, persistLocal, reload],
+  );
+
+  const snooze = useCallback(() => {
+    // Re-arm guard for the next minute so it does not instantly re-ring.
+    setRinging(null);
+  }, []);
+
+  const toggleDraftDay = (day: WeekDay) =>
+    setDraftDays((cur) => (cur.includes(day) ? cur.filter((d) => d !== day) : [...cur, day]));
+
+  return (
+    <div className="alarms">
+      <div className="world-head">
+        <div>
+          <p className="eyebrow">{hasDb ? "Synced to Matrix Postgres" : "Saved on this device"}</p>
+          <h1>Alarms</h1>
+        </div>
+        <button className="primary-btn" type="button" onClick={() => setEditing(true)}>
+          <Plus size={16} /> New alarm
+        </button>
+      </div>
+
+      {error && <div className="banner banner--error">{error}</div>}
+
+      {alarms.length === 0 ? (
+        <div className="empty">
+          <Bell size={28} />
+          <strong>No alarms set</strong>
+          <span>Alarms ring while Clock is open. Create one to wake up or stay on schedule.</span>
+          <button className="primary-btn" type="button" onClick={() => setEditing(true)}>
+            <Plus size={16} /> New alarm
+          </button>
+        </div>
+      ) : (
+        <ul className="alarm-list">
+          {alarms.map((alarm) => (
+            <li key={alarm.id} className={alarm.enabled ? "alarm-row" : "alarm-row alarm-row--off"}>
+              <div className="alarm-meta">
+                <strong>{alarm.time}</strong>
+                <span>
+                  {alarm.label ? `${alarm.label} · ` : ""}
+                  {repeatLabel(alarm.repeat)}
+                </span>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={alarm.enabled}
+                aria-label={`${alarm.enabled ? "Disable" : "Enable"} alarm ${alarm.time}`}
+                className={alarm.enabled ? "toggle toggle--on" : "toggle"}
+                onClick={() => void toggleAlarm(alarm)}
+              >
+                <span className="toggle-knob" />
+              </button>
+              <button
+                className="ghost-btn"
+                type="button"
+                aria-label={`Delete alarm ${alarm.time}`}
+                onClick={() => void removeAlarm(alarm)}
+              >
+                <Trash2 size={16} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {editing && (
+        <div className="overlay" onClick={() => setEditing(false)}>
+          <div className="edit-card" onClick={(e) => e.stopPropagation()}>
+            <h2>New alarm</h2>
+            <label className="field">
+              <span>Time</span>
+              <input type="time" value={draftTime} onChange={(e) => setDraftTime(e.target.value)} />
+            </label>
+            <label className="field">
+              <span>Label</span>
+              <input
+                type="text"
+                placeholder="Wake up"
+                value={draftLabel}
+                onChange={(e) => setDraftLabel(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void addAlarm();
+                  if (e.key === "Escape") setEditing(false);
+                }}
+              />
+            </label>
+            <div className="field">
+              <span>Repeat</span>
+              <div className="day-picker">
+                {DAY_LETTERS.map(({ day, label }) => (
+                  <button
+                    key={day}
+                    type="button"
+                    aria-pressed={draftDays.includes(day)}
+                    className={draftDays.includes(day) ? "day day--on" : "day"}
+                    onClick={() => toggleDraftDay(day)}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="edit-actions">
+              <button className="secondary-btn" type="button" onClick={() => setEditing(false)}>
+                Cancel
+              </button>
+              <button className="primary-btn" type="button" onClick={() => void addAlarm()}>
+                <Check size={16} /> Save alarm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {ringing && (
+        <div className="overlay overlay--ring">
+          <div className="ring-card">
+            <span className="ring-mark">
+              <Bell size={28} />
+            </span>
+            <strong>{ringing.time}</strong>
+            <span>{ringing.label || "Alarm"}</span>
+            <div className="edit-actions">
+              <button className="secondary-btn" type="button" onClick={snooze}>
+                Snooze
+              </button>
+              <button className="primary-btn" type="button" onClick={() => setRinging(null)}>
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------------
+// Timers
+// ---------------------------------------------------------------------------------
+
+interface TimerInstance {
+  id: string;
+  label: string;
+  total: number; // seconds
+  remaining: number; // seconds
+  running: boolean;
+  done: boolean;
+}
+
+const PRESETS = [
+  { label: "1 min", seconds: 60 },
+  { label: "5 min", seconds: 300 },
+  { label: "10 min", seconds: 600 },
+  { label: "25 min", seconds: 1500 },
+];
+
+function Timers() {
+  const [timers, setTimers] = useState<TimerInstance[]>([]);
+  const [draft, setDraft] = useState("5:00");
+  const [label, setLabel] = useState("");
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setTimers((cur) => {
+        let changed = false;
+        const next = cur.map((t) => {
+          if (!t.running || t.remaining <= 0) return t;
+          changed = true;
+          const remaining = t.remaining - 1;
+          if (remaining <= 0) {
+            beep(3);
+            return { ...t, remaining: 0, running: false, done: true };
+          }
+          return { ...t, remaining };
+        });
+        return changed ? next : cur;
+      });
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const addTimer = useCallback(
+    (seconds: number, name = "") => {
+      if (seconds <= 0) return;
+      setTimers((cur) => [
+        {
+          id: `t-${Date.now()}-${cur.length}`,
+          label: name.trim(),
+          total: seconds,
+          remaining: seconds,
+          running: true,
+          done: false,
+        },
+        ...cur,
+      ]);
+    },
+    [],
+  );
+
+  const startCustom = useCallback(() => {
+    const seconds = parseDuration(draft);
+    addTimer(seconds, label);
+    setLabel("");
+  }, [addTimer, draft, label]);
+
+  const toggle = (id: string) =>
+    setTimers((cur) =>
+      cur.map((t) =>
+        t.id === id ? { ...t, running: !t.running && t.remaining > 0, done: false } : t,
+      ),
+    );
+  const reset = (id: string) =>
+    setTimers((cur) => cur.map((t) => (t.id === id ? { ...t, remaining: t.total, running: false, done: false } : t)));
+  const remove = (id: string) => setTimers((cur) => cur.filter((t) => t.id !== id));
+
+  return (
+    <div className="timers">
+      <div className="world-head">
+        <div>
+          <p className="eyebrow">Session only</p>
+          <h1>Timer</h1>
+        </div>
+      </div>
+
+      <div className="timer-setup">
+        <div className="presets">
+          {PRESETS.map((p) => (
+            <button key={p.label} className="chip" type="button" onClick={() => addTimer(p.seconds)}>
+              {p.label}
+            </button>
+          ))}
+        </div>
+        <div className="custom-row">
+          <input
+            className="duration-input"
+            aria-label="Timer duration"
+            placeholder="MM:SS"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && startCustom()}
+          />
+          <input
+            className="label-input"
+            aria-label="Timer label"
+            placeholder="Label (optional)"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && startCustom()}
+          />
+          <button className="primary-btn" type="button" onClick={startCustom}>
+            <Plus size={16} /> Start
+          </button>
+        </div>
+      </div>
+
+      {timers.length === 0 ? (
+        <div className="empty">
+          <TimerIcon size={28} />
+          <strong>No timers running</strong>
+          <span>Pick a preset or enter a duration to start a countdown.</span>
+        </div>
+      ) : (
+        <ul className="timer-list">
+          {timers.map((t) => {
+            const pct = t.total > 0 ? 1 - t.remaining / t.total : 1;
+            return (
+              <li key={t.id} className={t.done ? "timer-card timer-card--done" : "timer-card"}>
+                <div
+                  className="timer-ring"
+                  style={{ "--p": `${Math.max(0, Math.min(360, pct * 360))}deg` } as React.CSSProperties}
+                >
+                  <div className="timer-ring-core">
+                    <strong>{formatClock(t.remaining)}</strong>
+                    {t.label && <span>{t.label}</span>}
+                    {t.done && <em>Done</em>}
+                  </div>
+                </div>
+                <div className="timer-controls">
+                  <button className="icon-btn" type="button" aria-label="Start or pause" onClick={() => toggle(t.id)}>
+                    {t.running ? <Pause size={18} /> : <Play size={18} />}
+                  </button>
+                  <button className="icon-btn" type="button" aria-label="Reset timer" onClick={() => reset(t.id)}>
+                    <RotateCcw size={18} />
+                  </button>
+                  <button className="icon-btn" type="button" aria-label="Remove timer" onClick={() => remove(t.id)}>
+                    <Trash2 size={18} />
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------------
+// Stopwatch
+// ---------------------------------------------------------------------------------
+
+interface SwState {
+  running: boolean;
+  elapsed: number; // accumulated ms while paused
+  startedAt: number | null; // performance.now() when started
+  marks: number[]; // cumulative elapsed ms at each lap
+}
+
+type SwAction =
+  | { type: "start"; at: number }
+  | { type: "stop"; at: number }
+  | { type: "reset" }
+  | { type: "lap"; at: number };
+
+function nowElapsed(s: SwState, at: number): number {
+  return s.running && s.startedAt !== null ? s.elapsed + (at - s.startedAt) : s.elapsed;
+}
+
+function swReducer(s: SwState, a: SwAction): SwState {
+  switch (a.type) {
+    case "start":
+      if (s.running) return s;
+      return { ...s, running: true, startedAt: a.at };
+    case "stop":
+      if (!s.running) return s;
+      return { ...s, running: false, elapsed: nowElapsed(s, a.at), startedAt: null };
+    case "reset":
+      return { running: false, elapsed: 0, startedAt: null, marks: [] };
+    case "lap":
+      return { ...s, marks: [...s.marks, nowElapsed(s, a.at)] };
+    default:
+      return s;
+  }
+}
+
+function Stopwatch() {
+  const [state, dispatch] = useReducer(swReducer, {
+    running: false,
+    elapsed: 0,
+    startedAt: null,
+    marks: [],
+  });
+  const [display, setDisplay] = useState(0);
+
+  useEffect(() => {
+    if (!state.running) {
+      setDisplay(state.elapsed);
+      return undefined;
+    }
+    let raf = 0;
+    const tick = () => {
+      setDisplay(nowElapsed(state, performance.now()));
+      raf = window.requestAnimationFrame(tick);
+    };
+    raf = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(raf);
+  }, [state]);
+
+  const laps = useMemo(() => computeLaps(state.marks), [state.marks]);
+  const ext = useMemo(() => lapExtremes(laps), [laps]);
+
+  return (
+    <div className="stopwatch">
+      <div className="sw-readout" data-testid="stopwatch-readout">
+        {formatStopwatch(display)}
+      </div>
+
+      <div className="sw-controls">
+        {!state.running ? (
+          <button className="primary-btn primary-btn--lg" type="button" onClick={() => dispatch({ type: "start", at: performance.now() })}>
+            <Play size={18} /> Start
+          </button>
+        ) : (
+          <button className="primary-btn primary-btn--lg" type="button" onClick={() => dispatch({ type: "stop", at: performance.now() })}>
+            <Pause size={18} /> Stop
+          </button>
+        )}
+        <button
+          className="secondary-btn secondary-btn--lg"
+          type="button"
+          disabled={!state.running}
+          onClick={() => dispatch({ type: "lap", at: performance.now() })}
+        >
+          <Flag size={18} /> Lap
+        </button>
+        <button
+          className="secondary-btn secondary-btn--lg"
+          type="button"
+          disabled={state.running || (state.elapsed === 0 && state.marks.length === 0)}
+          onClick={() => dispatch({ type: "reset" })}
+        >
+          <RotateCcw size={18} /> Reset
+        </button>
+      </div>
+
+      {laps.length === 0 ? (
+        <div className="empty empty--sw">
+          <Clock3 size={28} />
+          <strong>No laps yet</strong>
+          <span>Start the stopwatch, then tap Lap to record splits.</span>
+        </div>
+      ) : (
+        <ul className="lap-list">
+          {[...laps].reverse().map((lap) => (
+            <li
+              key={lap.index}
+              className={
+                lap.index - 1 === ext.fastest
+                  ? "lap-row lap-row--fast"
+                  : lap.index - 1 === ext.slowest
+                    ? "lap-row lap-row--slow"
+                    : "lap-row"
+              }
+            >
+              <span>Lap {lap.index}</span>
+              <span className="lap-split">{formatStopwatch(lap.lap)}</span>
+              <span className="lap-total">{formatStopwatch(lap.total)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -45,6 +45,7 @@ import {
 
 const ZONES_TABLE = "zones";
 const ALARMS_TABLE = "alarms";
+const SNOOZE_MS = 5 * 60_000;
 
 type TabId = "world" | "alarms" | "timers" | "stopwatch";
 
@@ -195,6 +196,22 @@ function dedupeZones(rows: ZoneRow[]): ZoneRow[] {
   return deduped;
 }
 
+function storageLabel(): string {
+  if (typeof window === "undefined") return "Session only";
+  if (window.MatrixOS?.db) return "Synced to Matrix Postgres";
+  if (window.MatrixOS?.readData && window.MatrixOS?.writeData) return "Synced to device storage";
+  return "Session only";
+}
+
+function safeFormatZoneTime(timeZone: string, now: Date): ReturnType<typeof formatZoneTime> | null {
+  try {
+    return formatZoneTime(timeZone, LOCAL_TZ, now);
+  } catch (err) {
+    console.warn("[clock] invalid timezone skipped:", err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
 // =================================================================================
 
 export default function App() {
@@ -234,10 +251,16 @@ export default function App() {
       </header>
 
       <section className="panel" role="tabpanel">
-        {tab === "world" && <WorldClock now={now} />}
-        {tab === "alarms" && <Alarms now={now} />}
-        {tab === "timers" && <Timers />}
-        {tab === "stopwatch" && <Stopwatch />}
+        <div hidden={tab !== "world"}>
+          <WorldClock now={now} />
+        </div>
+        <Alarms now={now} active={tab === "alarms"} />
+        <div hidden={tab !== "timers"}>
+          <Timers />
+        </div>
+        <div hidden={tab !== "stopwatch"}>
+          <Stopwatch />
+        </div>
       </section>
     </main>
   );
@@ -256,7 +279,7 @@ function WorldClock({ now }: { now: Date }) {
   const searchRef = useRef<HTMLInputElement>(null);
 
   const allZones = useMemo(() => allTimeZones(), []);
-  const hasDb = typeof window !== "undefined" && !!window.MatrixOS?.db;
+  const persistenceLabel = storageLabel();
 
   const reload = useCallback(async () => {
     setError(null);
@@ -302,7 +325,7 @@ function WorldClock({ now }: { now: Date }) {
         setQuery("");
         return;
       }
-      const position = zones.length;
+      const position = zones.reduce((max, zone) => Math.max(max, zone.position), -1) + 1;
       const optimistic: ZoneRow = { id: `local-${Date.now()}`, tz, position };
       const next = [...zones, optimistic];
       setZones(next);
@@ -361,9 +384,10 @@ function WorldClock({ now }: { now: Date }) {
       }
       const previous = zones;
       try {
-        for (const z of repositioned) {
-          await window.MatrixOS.db.update(ZONES_TABLE, z.id, { position: z.position });
-        }
+        await window.MatrixOS.db.bulkUpdate(
+          ZONES_TABLE,
+          repositioned.map((z) => ({ id: z.id, data: { position: z.position } })),
+        );
       } catch (err: unknown) {
         console.warn("[clock] reorder failed:", err instanceof Error ? err.message : String(err));
         setError("New order could not be saved.");
@@ -384,7 +408,7 @@ function WorldClock({ now }: { now: Date }) {
     <div className="world">
       <div className="world-head">
         <div>
-          <p className="eyebrow">{hasDb ? "Synced to Matrix Postgres" : "Saved on this device"}</p>
+          <p className="eyebrow">{persistenceLabel}</p>
           <h1>World Clock</h1>
         </div>
         <button className="primary-btn" type="button" onClick={() => setAdding(true)}>
@@ -406,7 +430,28 @@ function WorldClock({ now }: { now: Date }) {
       ) : (
         <ul className="zone-list">
           {zones.map((zone) => {
-            const z = formatZoneTime(zone.tz, LOCAL_TZ, now);
+            const z = safeFormatZoneTime(zone.tz, now);
+            if (!z) {
+              return (
+                <li key={zone.id} className="zone-row zone-row--invalid">
+                  <span className="drag-handle" aria-hidden="true">
+                    <GripVertical size={16} />
+                  </span>
+                  <div className="zone-meta">
+                    <strong>{zoneCityLabel(zone.tz)}</strong>
+                    <span>Invalid time zone</span>
+                  </div>
+                  <button
+                    className="ghost-btn"
+                    type="button"
+                    aria-label={`Remove ${zoneCityLabel(zone.tz)}`}
+                    onClick={() => void removeZone(zone)}
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </li>
+              );
+            }
             return (
               <li
                 key={zone.id}
@@ -519,7 +564,7 @@ const DAY_LETTERS: { day: WeekDay; label: string }[] = [
   { day: 0, label: "S" },
 ];
 
-function Alarms({ now }: { now: Date }) {
+function Alarms({ now, active }: { now: Date; active: boolean }) {
   const [alarms, setAlarms] = useState<AlarmModel[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
@@ -528,7 +573,8 @@ function Alarms({ now }: { now: Date }) {
   const [draftDays, setDraftDays] = useState<WeekDay[]>([]);
   const [ringing, setRinging] = useState<AlarmModel | null>(null);
   const firedRef = useRef<Set<string>>(new Set());
-  const hasDb = typeof window !== "undefined" && !!window.MatrixOS?.db;
+  const snoozedRef = useRef<Array<{ alarm: AlarmModel; dueAt: number }>>([]);
+  const persistenceLabel = storageLabel();
 
   const reload = useCallback(async () => {
     setError(null);
@@ -558,8 +604,33 @@ function Alarms({ now }: { now: Date }) {
     );
   }, []);
 
+  const persistAlarmEnabled = useCallback(
+    async (alarm: AlarmModel, enabled: boolean, next: AlarmModel[]) => {
+      if (!window.MatrixOS?.db) {
+        await persistLocal(next);
+        return;
+      }
+      try {
+        await window.MatrixOS.db.update(ALARMS_TABLE, alarm.id, { enabled });
+      } catch (err: unknown) {
+        console.warn("[clock] alarm auto-disable failed:", err instanceof Error ? err.message : String(err));
+        setError("Alarm could not be updated.");
+        void reload();
+      }
+    },
+    [persistLocal, reload],
+  );
+
   // Ring scheduling: when the global tick lands on a matching minute, fire once.
   useEffect(() => {
+    const dueSnooze = snoozedRef.current.find((entry) => now.getTime() >= entry.dueAt);
+    if (dueSnooze) {
+      snoozedRef.current = snoozedRef.current.filter((entry) => entry !== dueSnooze);
+      setRinging(dueSnooze.alarm);
+      beep(3);
+      return;
+    }
+
     const key = alarmMinuteKey(now);
     for (const alarm of alarms) {
       const guard = `${alarm.id}@${key}`;
@@ -571,9 +642,14 @@ function Alarms({ now }: { now: Date }) {
         }
         setRinging(alarm);
         beep(3);
+        if (alarm.repeat.length === 0) {
+          const next = alarms.map((a) => (a.id === alarm.id ? { ...a, enabled: false } : a));
+          setAlarms(next);
+          void persistAlarmEnabled(alarm, false, next);
+        }
       }
     }
-  }, [alarms, now]);
+  }, [alarms, now, persistAlarmEnabled]);
 
   const addAlarm = useCallback(async () => {
     const draft: AlarmModel = {
@@ -649,18 +725,24 @@ function Alarms({ now }: { now: Date }) {
   );
 
   const snooze = useCallback(() => {
-    // Re-arm guard for the next minute so it does not instantly re-ring.
+    if (ringing) {
+      snoozedRef.current = [
+        ...snoozedRef.current.filter((entry) => entry.alarm.id !== ringing.id),
+        { alarm: ringing, dueAt: now.getTime() + SNOOZE_MS },
+      ];
+    }
     setRinging(null);
-  }, []);
+  }, [now, ringing]);
 
   const toggleDraftDay = (day: WeekDay) =>
     setDraftDays((cur) => (cur.includes(day) ? cur.filter((d) => d !== day) : [...cur, day]));
 
   return (
-    <div className="alarms">
+    <>
+    <div className="alarms" hidden={!active}>
       <div className="world-head">
         <div>
-          <p className="eyebrow">{hasDb ? "Synced to Matrix Postgres" : "Saved on this device"}</p>
+          <p className="eyebrow">{persistenceLabel}</p>
           <h1>Alarms</h1>
         </div>
         <button className="primary-btn" type="button" onClick={() => setEditing(true)}>
@@ -762,6 +844,8 @@ function Alarms({ now }: { now: Date }) {
         </div>
       )}
 
+    </div>
+
       {ringing && (
         <div className="overlay overlay--ring">
           <div className="ring-card">
@@ -781,7 +865,7 @@ function Alarms({ now }: { now: Date }) {
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }
 
@@ -809,6 +893,7 @@ function Timers() {
   const [timers, setTimers] = useState<TimerInstance[]>([]);
   const [draft, setDraft] = useState("5:00");
   const [label, setLabel] = useState("");
+  const beepedTimersRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     const id = window.setInterval(() => {
@@ -819,7 +904,6 @@ function Timers() {
           changed = true;
           const remaining = t.remaining - 1;
           if (remaining <= 0) {
-            beep(3);
             return { ...t, remaining: 0, running: false, done: true };
           }
           return { ...t, remaining };
@@ -829,6 +913,19 @@ function Timers() {
     }, 1000);
     return () => window.clearInterval(id);
   }, []);
+
+  useEffect(() => {
+    for (const id of [...beepedTimersRef.current]) {
+      const timer = timers.find((candidate) => candidate.id === id);
+      if (!timer || !timer.done) beepedTimersRef.current.delete(id);
+    }
+    for (const timer of timers) {
+      if (timer.done && !beepedTimersRef.current.has(timer.id)) {
+        beepedTimersRef.current.add(timer.id);
+        beep(3);
+      }
+    }
+  }, [timers]);
 
   const addTimer = useCallback(
     (seconds: number, name = "") => {

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -651,10 +651,13 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         return;
       }
       try {
-        await Promise.all(
-          disabledAlarms.map((alarm) =>
-            window.MatrixOS!.db!.update(ALARMS_TABLE, alarm.id, { enabled: false }),
-          ),
+        if (disabledAlarms.length === 1) {
+          await window.MatrixOS.db.update(ALARMS_TABLE, disabledAlarms[0]!.id, { enabled: false });
+          return;
+        }
+        await window.MatrixOS.db.bulkUpdate(
+          ALARMS_TABLE,
+          disabledAlarms.map((alarm) => ({ id: alarm.id, data: { enabled: false } })),
         );
       } catch (err: unknown) {
         console.warn("[clock] alarm auto-disable failed:", err instanceof Error ? err.message : String(err));

--- a/home/apps/clock/src/App.tsx
+++ b/home/apps/clock/src/App.tsx
@@ -364,7 +364,6 @@ function WorldClock({ now }: { now: Date }) {
           await reload();
           return;
         }
-        setError("City could not be saved.");
         setZones((cur) => cur.filter((z) => z.id !== optimistic.id));
         void reload().finally(() => setError("City could not be saved."));
       }
@@ -384,8 +383,7 @@ function WorldClock({ now }: { now: Date }) {
         await window.MatrixOS.db.delete(ZONES_TABLE, zone.id);
       } catch (err: unknown) {
         console.warn("[clock] zone delete failed:", err instanceof Error ? err.message : String(err));
-        setError("City could not be removed.");
-        void reload();
+        void reload().finally(() => setError("City could not be removed."));
       }
     },
     [persistLocal, reload, zones],
@@ -666,8 +664,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         );
       } catch (err: unknown) {
         console.warn("[clock] alarm auto-disable failed:", err instanceof Error ? err.message : String(err));
-        setError("Alarm could not be updated.");
-        void reload();
+        void reload().finally(() => setError("Alarm could not be updated."));
       }
     },
     [persistLocal, reload],
@@ -739,7 +736,6 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
       await reload();
     } catch (err: unknown) {
       console.warn("[clock] alarm save failed:", err instanceof Error ? err.message : String(err));
-      setError("Alarm could not be saved.");
       setAlarms((cur) => cur.filter((a) => a.id !== draft.id));
       void reload().finally(() => setError("Alarm could not be saved."));
     }
@@ -759,8 +755,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         await window.MatrixOS.db.update(ALARMS_TABLE, alarm.id, { enabled });
       } catch (err: unknown) {
         console.warn("[clock] alarm toggle failed:", err instanceof Error ? err.message : String(err));
-        setError("Alarm could not be updated.");
-        void reload();
+        void reload().finally(() => setError("Alarm could not be updated."));
       }
     },
     [alarms, clearAlarmRuntime, persistLocal, reload],
@@ -779,8 +774,7 @@ function Alarms({ now, active }: { now: Date; active: boolean }) {
         await window.MatrixOS.db.delete(ALARMS_TABLE, alarm.id);
       } catch (err: unknown) {
         console.warn("[clock] alarm delete failed:", err instanceof Error ? err.message : String(err));
-        setError("Alarm could not be removed.");
-        void reload();
+        void reload().finally(() => setError("Alarm could not be removed."));
       }
     },
     [alarms, clearAlarmRuntime, persistLocal, reload],

--- a/home/apps/clock/src/clock-model.ts
+++ b/home/apps/clock/src/clock-model.ts
@@ -234,7 +234,7 @@ export function shouldAlarmFire(alarm: AlarmModel, now: Date = new Date()): bool
   const [hStr, mStr] = alarm.time.split(":");
   const h = Number(hStr);
   const m = Number(mStr);
-  if (!Number.isInteger(h) || !Number.isInteger(m)) return false;
+  if (!hStr || !mStr || !Number.isInteger(h) || !Number.isInteger(m)) return false;
   if (now.getHours() !== h || now.getMinutes() !== m) return false;
   const repeat = normalizeDays(alarm.repeat);
   if (repeat.length === 0) return true; // one-shot fires whenever the clock hits the time

--- a/home/apps/clock/src/clock-model.ts
+++ b/home/apps/clock/src/clock-model.ts
@@ -236,7 +236,6 @@ export function shouldAlarmFire(alarm: AlarmModel, now: Date = new Date()): bool
   const m = Number(mStr);
   if (!Number.isInteger(h) || !Number.isInteger(m)) return false;
   if (now.getHours() !== h || now.getMinutes() !== m) return false;
-  if (now.getSeconds() !== 0) return false;
   const repeat = normalizeDays(alarm.repeat);
   if (repeat.length === 0) return true; // one-shot fires whenever the clock hits the time
   return repeat.includes(now.getDay() as WeekDay);

--- a/home/apps/clock/src/clock-model.ts
+++ b/home/apps/clock/src/clock-model.ts
@@ -1,0 +1,318 @@
+// Pure, UI-free helpers for the Clock app. Unit-tested in
+// tests/default-apps/clock-model.test.ts.
+
+export type WeekDay = 0 | 1 | 2 | 3 | 4 | 5 | 6; // 0 = Sunday
+
+export interface ZoneTime {
+  /** Hour:minute label in 24h form, e.g. "14:05". */
+  time: string;
+  /** 12h hour string, e.g. "2". */
+  hour12: string;
+  minute: string;
+  /** "AM" | "PM". */
+  meridiem: string;
+  /** Short weekday + relative day, e.g. "Mon, Today" / "Tue, Tomorrow" / "Sun, Yesterday". */
+  dayLabel: string;
+  /** Offset from the local zone, e.g. "+3h" / "-5h30m" / "Same time". */
+  offsetLabel: string;
+  /** Hour/minute/second hand angles in degrees for an analog face. */
+  hourAngle: number;
+  minuteAngle: number;
+  secondAngle: number;
+}
+
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * Return the wall-clock parts for a timezone using Intl. `now` defaults to the
+ * current instant; pass an explicit Date for deterministic tests.
+ */
+export function zoneParts(
+  timeZone: string,
+  now: Date = new Date(),
+): { year: number; month: number; day: number; hour: number; minute: number; second: number; weekday: WeekDay } {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    weekday: "short",
+  });
+  const parts = fmt.formatToParts(now);
+  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? "0";
+  const weekdayMap: Record<string, WeekDay> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  let hour = Number(get("hour"));
+  if (hour === 24) hour = 0; // some engines emit 24 for midnight
+  return {
+    year: Number(get("year")),
+    month: Number(get("month")),
+    day: Number(get("day")),
+    hour,
+    minute: Number(get("minute")),
+    second: Number(get("second")),
+    weekday: weekdayMap[get("weekday")] ?? 0,
+  };
+}
+
+/**
+ * Offset in minutes of a timezone relative to UTC at the given instant.
+ * Positive = ahead of UTC.
+ */
+export function zoneOffsetMinutes(timeZone: string, now: Date = new Date()): number {
+  const p = zoneParts(timeZone, now);
+  // Construct the UTC ms that the wall-clock parts represent, then diff with the
+  // actual UTC instant. Rounded to the minute to avoid sub-minute drift.
+  const asUTC = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+  const diff = asUTC - now.getTime();
+  return Math.round(diff / MS_PER_MINUTE);
+}
+
+function formatOffset(deltaMinutes: number): string {
+  if (deltaMinutes === 0) return "Same time";
+  const sign = deltaMinutes > 0 ? "+" : "-";
+  const abs = Math.abs(deltaMinutes);
+  const h = Math.floor(abs / 60);
+  const m = abs % 60;
+  return m === 0 ? `${sign}${h}h` : `${sign}${h}h${m}m`;
+}
+
+const WEEKDAY_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+/**
+ * Full render model for one saved zone, relative to a local reference zone.
+ */
+export function formatZoneTime(
+  timeZone: string,
+  localTimeZone: string,
+  now: Date = new Date(),
+): ZoneTime {
+  const p = zoneParts(timeZone, now);
+  const local = zoneParts(localTimeZone, now);
+
+  const hh = p.hour.toString().padStart(2, "0");
+  const mm = p.minute.toString().padStart(2, "0");
+  const meridiem = p.hour >= 12 ? "PM" : "AM";
+  let h12 = p.hour % 12;
+  if (h12 === 0) h12 = 12;
+
+  // Relative day vs local calendar day.
+  const zoneDayNum = Date.UTC(p.year, p.month - 1, p.day);
+  const localDayNum = Date.UTC(local.year, local.month - 1, local.day);
+  const dayDelta = Math.round((zoneDayNum - localDayNum) / 86_400_000);
+  let relative = "";
+  if (dayDelta === 0) relative = "Today";
+  else if (dayDelta === 1) relative = "Tomorrow";
+  else if (dayDelta === -1) relative = "Yesterday";
+  else relative = dayDelta > 0 ? `+${dayDelta} days` : `${dayDelta} days`;
+
+  const deltaMinutes =
+    zoneOffsetMinutes(timeZone, now) - zoneOffsetMinutes(localTimeZone, now);
+
+  const hourAngle = (p.hour % 12) * 30 + p.minute * 0.5;
+  const minuteAngle = p.minute * 6 + p.second * 0.1;
+  const secondAngle = p.second * 6;
+
+  return {
+    time: `${hh}:${mm}`,
+    hour12: String(h12),
+    minute: mm,
+    meridiem,
+    dayLabel: `${WEEKDAY_SHORT[p.weekday]}, ${relative}`,
+    offsetLabel: formatOffset(deltaMinutes),
+    hourAngle,
+    minuteAngle,
+    secondAngle,
+  };
+}
+
+/** Human label for a tz id, e.g. "America/New_York" -> "New York". */
+export function zoneCityLabel(timeZone: string): string {
+  const tail = timeZone.split("/").pop() ?? timeZone;
+  return tail.replace(/_/g, " ");
+}
+
+/** Region label, e.g. "America/New_York" -> "America". */
+export function zoneRegionLabel(timeZone: string): string {
+  const head = timeZone.split("/")[0] ?? "";
+  return head.replace(/_/g, " ");
+}
+
+/**
+ * Case-insensitive substring filter over a tz id list. Returns at most `limit`.
+ */
+export function searchZones(zones: readonly string[], query: string, limit = 40): string[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return zones.slice(0, limit);
+  const needle = q.replace(/\s+/g, "_");
+  const out: string[] = [];
+  for (const z of zones) {
+    if (z.toLowerCase().includes(needle) || z.toLowerCase().includes(q)) {
+      out.push(z);
+      if (out.length >= limit) break;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Alarms
+// ---------------------------------------------------------------------------
+
+export interface AlarmModel {
+  id: string;
+  /** "HH:MM" 24h. */
+  time: string;
+  label: string;
+  /** Sorted unique weekday numbers; empty = one-shot / every day handled by UI. */
+  repeat: WeekDay[];
+  enabled: boolean;
+}
+
+/** Parse a stored repeat string ("1,2,3") into a sorted unique WeekDay[]. */
+export function parseRepeat(raw: unknown): WeekDay[] {
+  if (Array.isArray(raw)) {
+    return normalizeDays(raw.map((d) => Number(d)));
+  }
+  if (typeof raw === "string") {
+    if (!raw.trim()) return [];
+    return normalizeDays(raw.split(",").map((d) => Number(d.trim())));
+  }
+  return [];
+}
+
+export function serializeRepeat(days: WeekDay[]): string {
+  return normalizeDays(days).join(",");
+}
+
+function normalizeDays(days: number[]): WeekDay[] {
+  const set = new Set<WeekDay>();
+  for (const d of days) {
+    if (Number.isInteger(d) && d >= 0 && d <= 6) set.add(d as WeekDay);
+  }
+  return [...set].sort((a, b) => a - b);
+}
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+export function repeatLabel(days: WeekDay[]): string {
+  const d = normalizeDays(days);
+  if (d.length === 0) return "Once";
+  if (d.length === 7) return "Every day";
+  if (d.length === 5 && d.every((x) => x >= 1 && x <= 5)) return "Weekdays";
+  if (d.length === 2 && d.includes(0) && d.includes(6)) return "Weekends";
+  return d.map((x) => DAY_NAMES[x]).join(" ");
+}
+
+/**
+ * Decide whether an alarm should fire for the minute represented by `now`.
+ * `lastFiredMinute` is a per-alarm guard key ("YYYY-MM-DD HH:MM" in local time)
+ * to avoid re-firing within the same minute.
+ */
+export function alarmMinuteKey(now: Date): string {
+  const y = now.getFullYear();
+  const mo = (now.getMonth() + 1).toString().padStart(2, "0");
+  const d = now.getDate().toString().padStart(2, "0");
+  const h = now.getHours().toString().padStart(2, "0");
+  const mi = now.getMinutes().toString().padStart(2, "0");
+  return `${y}-${mo}-${d} ${h}:${mi}`;
+}
+
+export function shouldAlarmFire(alarm: AlarmModel, now: Date = new Date()): boolean {
+  if (!alarm.enabled) return false;
+  const [hStr, mStr] = alarm.time.split(":");
+  const h = Number(hStr);
+  const m = Number(mStr);
+  if (!Number.isInteger(h) || !Number.isInteger(m)) return false;
+  if (now.getHours() !== h || now.getMinutes() !== m) return false;
+  if (now.getSeconds() !== 0) return false;
+  const repeat = normalizeDays(alarm.repeat);
+  if (repeat.length === 0) return true; // one-shot fires whenever the clock hits the time
+  return repeat.includes(now.getDay() as WeekDay);
+}
+
+// ---------------------------------------------------------------------------
+// Timer + Stopwatch formatting
+// ---------------------------------------------------------------------------
+
+/** Parse "1:30", "90", "1:02:03" into total seconds; returns 0 on garbage. */
+export function parseDuration(raw: string): number {
+  const trimmed = raw.trim();
+  if (!trimmed) return 0;
+  const parts = trimmed.split(":").map((p) => p.trim());
+  if (parts.some((p) => p !== "" && !/^\d+$/.test(p))) return 0;
+  const nums = parts.map((p) => Number(p || 0));
+  if (nums.some((n) => !Number.isFinite(n))) return 0;
+  let seconds = 0;
+  if (nums.length === 1) seconds = nums[0];
+  else if (nums.length === 2) seconds = nums[0] * 60 + nums[1];
+  else if (nums.length === 3) seconds = nums[0] * 3600 + nums[1] * 60 + nums[2];
+  else return 0;
+  return Math.max(0, Math.floor(seconds));
+}
+
+/** Format whole seconds as "M:SS" or "H:MM:SS". */
+export function formatClock(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  const h = Math.floor(safe / 3600);
+  const m = Math.floor((safe % 3600) / 60);
+  const s = safe % 60;
+  if (h > 0) {
+    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  }
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+/** Format milliseconds for the stopwatch as "MM:SS.cs" (centiseconds). */
+export function formatStopwatch(ms: number): string {
+  const safe = Math.max(0, Math.floor(ms));
+  const totalSeconds = Math.floor(safe / 1000);
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  const cs = Math.floor((safe % 1000) / 10);
+  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}.${cs
+    .toString()
+    .padStart(2, "0")}`;
+}
+
+export interface LapModel {
+  index: number;
+  /** Lap split (this lap only) in ms. */
+  lap: number;
+  /** Cumulative elapsed at lap time in ms. */
+  total: number;
+}
+
+/** Compute lap splits from cumulative lap-mark timestamps (ms elapsed). */
+export function computeLaps(markTimes: number[]): LapModel[] {
+  const laps: LapModel[] = [];
+  let prev = 0;
+  markTimes.forEach((total, i) => {
+    laps.push({ index: i + 1, lap: total - prev, total });
+    prev = total;
+  });
+  return laps;
+}
+
+/** Index of fastest/slowest lap in a list (by `lap`). Returns -1 for <2 laps. */
+export function lapExtremes(laps: LapModel[]): { fastest: number; slowest: number } {
+  if (laps.length < 2) return { fastest: -1, slowest: -1 };
+  let fastest = 0;
+  let slowest = 0;
+  laps.forEach((l, i) => {
+    if (l.lap < laps[fastest].lap) fastest = i;
+    if (l.lap > laps[slowest].lap) slowest = i;
+  });
+  return { fastest, slowest };
+}

--- a/home/apps/clock/src/main.tsx
+++ b/home/apps/clock/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("clock" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/clock/src/matrix-os.d.ts
+++ b/home/apps/clock/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/clock/src/matrix-os.d.ts
+++ b/home/apps/clock/src/matrix-os.d.ts
@@ -8,6 +8,7 @@ interface MatrixOSDb {
   findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
   insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
   update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  bulkUpdate(table: string, updates: Array<{ id: string; data: Record<string, unknown> }>): Promise<{ ok: boolean }>;
   delete(table: string, id: string): Promise<{ ok: boolean }>;
   count(table: string, filter?: Record<string, unknown>): Promise<number>;
   onChange(table: string, callback: (e: { table: string }) => void): () => void;

--- a/home/apps/clock/src/styles.css
+++ b/home/apps/clock/src/styles.css
@@ -1,0 +1,857 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+  --app-mono: var(--matrix-font-mono, "JetBrains Mono", monospace);
+  --shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+  --shadow-lg: 0 18px 48px rgba(50, 53, 46, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  background: var(--app-bg);
+  color: var(--app-fg);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.clock-app {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--app-bg);
+}
+
+/* topbar + tabs ----------------------------------------------------------- */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--app-border);
+  background: color-mix(in srgb, var(--app-card) 70%, transparent);
+  flex-wrap: wrap;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-weight: 750;
+  font-size: 15px;
+}
+
+.brand-mark {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: var(--app-primary);
+  color: var(--app-primary-fg);
+}
+
+.tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 14px;
+  background: var(--app-muted);
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  background: transparent;
+  color: var(--app-muted-fg);
+  font-weight: 650;
+  font-size: 13px;
+  padding: 8px 13px;
+  border-radius: 11px;
+  transition: all 0.15s ease;
+}
+
+.tab:hover {
+  background: color-mix(in srgb, var(--app-fg) 4%, transparent);
+}
+
+.tab--active {
+  background: var(--app-card);
+  color: var(--app-fg);
+  box-shadow: var(--shadow);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+/* panel ------------------------------------------------------------------- */
+
+.panel {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 22px;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--app-accent);
+}
+
+h1 {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.1;
+}
+
+h2 {
+  margin: 0 0 12px;
+  font-size: 19px;
+}
+
+.world-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+/* buttons ----------------------------------------------------------------- */
+
+.primary-btn,
+.secondary-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  border-radius: 12px;
+  padding: 10px 15px;
+  font-weight: 700;
+  font-size: 14px;
+  transition: all 0.15s ease;
+}
+
+.primary-btn {
+  background: var(--app-accent);
+  color: #fff;
+  box-shadow: var(--shadow);
+}
+
+.primary-btn:hover {
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+}
+
+.secondary-btn {
+  background: var(--app-muted);
+  color: var(--app-fg);
+}
+
+.secondary-btn:hover {
+  background: color-mix(in srgb, var(--app-fg) 6%, var(--app-muted));
+}
+
+.secondary-btn:disabled,
+.primary-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.primary-btn--lg,
+.secondary-btn--lg {
+  padding: 13px 22px;
+  font-size: 15px;
+  border-radius: 14px;
+}
+
+.ghost-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--app-muted-fg);
+  transition: all 0.15s ease;
+}
+
+.ghost-btn:hover {
+  background: color-mix(in srgb, var(--app-danger) 12%, transparent);
+  color: var(--app-danger);
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--app-border);
+  border-radius: 12px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  transition: all 0.15s ease;
+}
+
+.icon-btn:hover {
+  background: color-mix(in srgb, var(--app-fg) 5%, var(--app-card));
+}
+
+.chip {
+  border: 1px solid var(--app-border);
+  background: var(--app-card);
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-weight: 650;
+  font-size: 13px;
+  transition: all 0.15s ease;
+}
+
+.chip:hover {
+  border-color: var(--app-accent);
+  color: var(--app-accent);
+}
+
+.banner {
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 650;
+  margin-bottom: 14px;
+}
+
+.banner--error {
+  background: color-mix(in srgb, var(--app-danger) 12%, transparent);
+  color: var(--app-danger);
+}
+
+/* empty states ------------------------------------------------------------ */
+
+.empty {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 9px;
+  text-align: center;
+  padding: 48px 24px;
+  border: 1px dashed var(--app-border);
+  border-radius: var(--app-radius);
+  color: var(--app-muted-fg);
+  background: color-mix(in srgb, var(--app-card) 50%, transparent);
+}
+
+.empty strong {
+  color: var(--app-fg);
+  font-size: 17px;
+}
+
+.empty span {
+  max-width: 32ch;
+}
+
+.empty .primary-btn {
+  margin-top: 8px;
+}
+
+.empty--sw {
+  margin-top: 22px;
+}
+
+/* world clock ------------------------------------------------------------- */
+
+.zone-list,
+.alarm-list,
+.timer-list,
+.lap-list,
+.option-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.zone-row {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: var(--app-radius);
+  background: var(--app-card);
+  box-shadow: var(--shadow);
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.zone-row--drag {
+  opacity: 0.6;
+  box-shadow: var(--shadow-lg);
+}
+
+.drag-handle {
+  color: var(--app-muted-fg);
+  cursor: grab;
+  display: inline-flex;
+}
+
+.zone-meta {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.zone-meta strong {
+  font-size: 16px;
+}
+
+.zone-meta span {
+  color: var(--app-muted-fg);
+  font-size: 12.5px;
+}
+
+.zone-time {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.zone-time strong {
+  font-size: 28px;
+  font-family: var(--app-mono);
+}
+
+.zone-time span {
+  color: var(--app-muted-fg);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.analog {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--app-muted);
+  border: 2px solid var(--app-border);
+  flex-shrink: 0;
+}
+
+.hand {
+  position: absolute;
+  left: 50%;
+  bottom: 50%;
+  transform-origin: bottom center;
+  border-radius: 2px;
+  background: var(--app-fg);
+}
+
+.hand--hour {
+  width: 2.5px;
+  height: 13px;
+  margin-left: -1.25px;
+}
+
+.hand--minute {
+  width: 2px;
+  height: 18px;
+  margin-left: -1px;
+}
+
+.hand--second {
+  width: 1px;
+  height: 19px;
+  margin-left: -0.5px;
+  background: var(--app-accent);
+}
+
+.analog-pin {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 5px;
+  height: 5px;
+  margin: -2.5px 0 0 -2.5px;
+  border-radius: 50%;
+  background: var(--app-accent);
+}
+
+/* overlays + search ------------------------------------------------------- */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--app-fg) 36%, transparent);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  z-index: 50;
+  animation: fade 0.12s ease;
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+}
+
+.search-card,
+.edit-card,
+.ring-card {
+  width: min(440px, 100%);
+  background: var(--app-card);
+  border-radius: var(--app-radius);
+  box-shadow: var(--shadow-lg);
+  padding: 16px;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--app-muted);
+  color: var(--app-muted-fg);
+  margin-bottom: 12px;
+}
+
+.search-field input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--app-fg);
+  font-size: 15px;
+  outline: none;
+}
+
+.option-list {
+  max-height: 320px;
+  overflow-y: auto;
+  gap: 2px;
+}
+
+.option {
+  width: 100%;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: var(--app-fg);
+  transition: all 0.12s ease;
+}
+
+.option:hover {
+  background: color-mix(in srgb, var(--app-accent) 10%, transparent);
+}
+
+.option-city {
+  font-weight: 650;
+}
+
+.option-region {
+  color: var(--app-muted-fg);
+  font-size: 12.5px;
+}
+
+.option--empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--app-muted-fg);
+}
+
+/* alarms ------------------------------------------------------------------ */
+
+.alarm-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: var(--app-radius);
+  background: var(--app-card);
+  box-shadow: var(--shadow);
+}
+
+.alarm-row--off {
+  opacity: 0.55;
+}
+
+.alarm-meta {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.alarm-meta strong {
+  font-size: 26px;
+  font-family: var(--app-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.alarm-meta span {
+  color: var(--app-muted-fg);
+  font-size: 13px;
+}
+
+.toggle {
+  width: 46px;
+  height: 27px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--app-border);
+  position: relative;
+  transition: background 0.15s ease;
+}
+
+.toggle--on {
+  background: var(--app-success);
+}
+
+.toggle-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 21px;
+  height: 21px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.15s ease;
+}
+
+.toggle--on .toggle-knob {
+  transform: translateX(19px);
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.field > span {
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--app-muted-fg);
+}
+
+.field input[type="time"],
+.field input[type="text"] {
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 15px;
+  background: var(--app-bg);
+  color: var(--app-fg);
+  outline: none;
+}
+
+.field input:focus {
+  border-color: var(--app-accent);
+}
+
+.day-picker {
+  display: flex;
+  gap: 6px;
+}
+
+.day {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--app-border);
+  border-radius: 50%;
+  background: var(--app-card);
+  color: var(--app-muted-fg);
+  font-weight: 700;
+  transition: all 0.15s ease;
+}
+
+.day--on {
+  background: var(--app-accent);
+  border-color: var(--app-accent);
+  color: #fff;
+}
+
+.edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.overlay--ring .ring-card {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 8px;
+  padding: 28px;
+}
+
+.ring-mark {
+  width: 64px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--app-accent) 18%, transparent);
+  color: var(--app-accent);
+  animation: ring-pulse 1s ease infinite;
+}
+
+.ring-card strong {
+  font-size: 34px;
+  font-family: var(--app-mono);
+}
+
+@keyframes ring-pulse {
+  50% {
+    transform: scale(1.08);
+  }
+}
+
+/* timers ------------------------------------------------------------------ */
+
+.timer-setup {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.custom-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.duration-input,
+.label-input {
+  border: 1px solid var(--app-border);
+  border-radius: 12px;
+  padding: 10px 13px;
+  font-size: 15px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  outline: none;
+}
+
+.duration-input {
+  width: 110px;
+  font-family: var(--app-mono);
+}
+
+.label-input {
+  flex: 1;
+  min-width: 140px;
+}
+
+.duration-input:focus,
+.label-input:focus {
+  border-color: var(--app-accent);
+}
+
+.timer-list {
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+.timer-card {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  padding: 20px;
+  border-radius: var(--app-radius);
+  background: var(--app-card);
+  box-shadow: var(--shadow);
+}
+
+.timer-card--done {
+  outline: 2px solid var(--app-accent);
+}
+
+.timer-ring {
+  --p: 0deg;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: conic-gradient(var(--app-accent) var(--p), var(--app-muted) 0);
+}
+
+.timer-ring-core {
+  width: 124px;
+  height: 124px;
+  border-radius: 50%;
+  background: var(--app-card);
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 2px;
+  text-align: center;
+}
+
+.timer-ring-core strong {
+  font-size: 30px;
+  font-family: var(--app-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.timer-ring-core span {
+  color: var(--app-muted-fg);
+  font-size: 12px;
+}
+
+.timer-ring-core em {
+  color: var(--app-accent);
+  font-style: normal;
+  font-weight: 800;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.timer-controls {
+  display: flex;
+  gap: 8px;
+}
+
+/* stopwatch --------------------------------------------------------------- */
+
+.stopwatch {
+  display: grid;
+  justify-items: center;
+  gap: 22px;
+}
+
+.sw-readout {
+  font-family: var(--app-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(56px, 16vw, 104px);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-top: 18px;
+}
+
+.sw-controls {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.lap-list {
+  width: min(460px, 100%);
+}
+
+.lap-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 16px;
+  border-radius: 12px;
+  background: var(--app-card);
+  box-shadow: var(--shadow);
+  font-variant-numeric: tabular-nums;
+}
+
+.lap-row > span:first-child {
+  font-weight: 650;
+  color: var(--app-muted-fg);
+}
+
+.lap-split {
+  font-family: var(--app-mono);
+  text-align: center;
+}
+
+.lap-total {
+  font-family: var(--app-mono);
+  color: var(--app-muted-fg);
+  font-size: 13px;
+}
+
+.lap-row--fast .lap-split {
+  color: var(--app-success);
+  font-weight: 700;
+}
+
+.lap-row--slow .lap-split {
+  color: var(--app-danger);
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .topbar {
+    gap: 10px;
+  }
+  .tab span {
+    display: none;
+  }
+  .zone-row {
+    grid-template-columns: auto auto minmax(0, 1fr) auto;
+  }
+  .zone-row .drag-handle {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/packages/gateway/src/app-db-query.ts
+++ b/packages/gateway/src/app-db-query.ts
@@ -160,6 +160,8 @@ export function createQueryEngine(db: AppDb): QueryEngine {
       parseSafeName(schema, "schema");
       parseSafeName(table, "table");
       if (updates.length === 0) return;
+      // Parameter count scales with row count and changed column count
+      // (up to 2 * rows * columns + rows), so keep this cap conservative.
       if (updates.length > 200) throw new Error("bulkUpdate: too many rows");
       const seenIds = new Set<string>();
       for (const update of updates) {
@@ -172,10 +174,10 @@ export function createQueryEngine(db: AppDb): QueryEngine {
         seenIds.add(update.id);
       }
 
-      const cols = Array.from(new Set(updates.flatMap((update) => Object.keys(update.data)))).filter((col) => {
+      const cols = Array.from(new Set(updates.flatMap((update) => Object.keys(update.data))));
+      for (const col of cols) {
         parseSafeName(col, "column");
-        return true;
-      });
+      }
       if (cols.length === 0) throw new Error("bulkUpdate: data must have at least one column");
 
       const params: unknown[] = [];

--- a/packages/gateway/src/app-db-query.ts
+++ b/packages/gateway/src/app-db-query.ts
@@ -19,6 +19,11 @@ export interface QueryEngine {
   findOne(schema: string, table: string, id: string): Promise<Record<string, unknown> | null>;
   insert(schema: string, table: string, data: Record<string, unknown>): Promise<{ id: string }>;
   update(schema: string, table: string, id: string, data: Record<string, unknown>): Promise<void>;
+  bulkUpdate(
+    schema: string,
+    table: string,
+    updates: Array<{ id: string; data: Record<string, unknown> }>,
+  ): Promise<void>;
   delete(schema: string, table: string, id: string): Promise<void>;
   count(schema: string, table: string, filter?: Record<string, FilterValue>): Promise<number>;
 }
@@ -148,6 +153,45 @@ export function createQueryEngine(db: AppDb): QueryEngine {
       await db.raw(
         `UPDATE ${qualifiedTable(schema, table)} SET ${sets}, updated_at = now() WHERE id = $${vals.length}`,
         vals,
+      );
+    },
+
+    async bulkUpdate(schema, table, updates) {
+      parseSafeName(schema, "schema");
+      parseSafeName(table, "table");
+      if (updates.length === 0) return;
+      if (updates.length > 200) throw new Error("bulkUpdate: too many rows");
+
+      const cols = Array.from(new Set(updates.flatMap((update) => Object.keys(update.data)))).filter((col) => {
+        parseSafeName(col, "column");
+        return true;
+      });
+      if (cols.length === 0) throw new Error("bulkUpdate: data must have at least one column");
+
+      const params: unknown[] = [];
+      const setClauses = cols.map((col) => {
+        const cases: string[] = [];
+        for (const update of updates) {
+          if (typeof update.id !== "string" || update.id.length === 0) {
+            throw new Error("bulkUpdate: id is required");
+          }
+          if (Object.prototype.hasOwnProperty.call(update.data, col)) {
+            params.push(update.id, update.data[col]);
+            cases.push(`WHEN $${params.length - 1} THEN $${params.length}`);
+          }
+        }
+        return `"${col}" = CASE "id"::text ${cases.join(" ")} ELSE "${col}" END`;
+      });
+      const whereIds = updates.map((update) => {
+        params.push(update.id);
+        return `$${params.length}`;
+      });
+
+      await db.raw(
+        `UPDATE ${qualifiedTable(schema, table)}
+         SET ${setClauses.join(", ")}, updated_at = now()
+         WHERE "id"::text IN (${whereIds.join(", ")})`,
+        params,
       );
     },
 

--- a/packages/gateway/src/app-db-query.ts
+++ b/packages/gateway/src/app-db-query.ts
@@ -179,6 +179,13 @@ export function createQueryEngine(db: AppDb): QueryEngine {
         parseSafeName(col, "column");
       }
       if (cols.length === 0) throw new Error("bulkUpdate: data must have at least one column");
+      for (const update of updates) {
+        for (const col of Object.keys(update.data)) {
+          if (update.data[col] === undefined) {
+            throw new Error(`bulkUpdate: value for column "${col}" in id "${update.id}" must not be undefined`);
+          }
+        }
+      }
 
       const params: unknown[] = [];
       const setClauses = cols.map((col) => {

--- a/packages/gateway/src/app-db-query.ts
+++ b/packages/gateway/src/app-db-query.ts
@@ -161,6 +161,16 @@ export function createQueryEngine(db: AppDb): QueryEngine {
       parseSafeName(table, "table");
       if (updates.length === 0) return;
       if (updates.length > 200) throw new Error("bulkUpdate: too many rows");
+      const seenIds = new Set<string>();
+      for (const update of updates) {
+        if (typeof update.id !== "string" || update.id.length === 0) {
+          throw new Error("bulkUpdate: id is required");
+        }
+        if (seenIds.has(update.id)) {
+          throw new Error("bulkUpdate: duplicate id");
+        }
+        seenIds.add(update.id);
+      }
 
       const cols = Array.from(new Set(updates.flatMap((update) => Object.keys(update.data)))).filter((col) => {
         parseSafeName(col, "column");
@@ -172,9 +182,6 @@ export function createQueryEngine(db: AppDb): QueryEngine {
       const setClauses = cols.map((col) => {
         const cases: string[] = [];
         for (const update of updates) {
-          if (typeof update.id !== "string" || update.id.length === 0) {
-            throw new Error("bulkUpdate: id is required");
-          }
           if (Object.prototype.hasOwnProperty.call(update.data, col)) {
             params.push(update.id, update.data[col]);
             cases.push(`WHEN $${params.length - 1} THEN $${params.length}`);

--- a/packages/gateway/src/app-db-registry.ts
+++ b/packages/gateway/src/app-db-registry.ts
@@ -43,7 +43,7 @@ export function createAppRegistry(db: AppDb, kysely: Kysely<any>): AppRegistry {
         // Create schema and tables via AppDb (outside trx -- DDL is auto-committed in PG)
         await db.createAppSchema(slug);
         for (const [tableName, tableDef] of Object.entries(opts.tables)) {
-          await db.createTable(slug, tableName, tableDef.columns, tableDef.indexes);
+          await db.createTable(slug, tableName, tableDef.columns, tableDef.indexes, tableDef.uniqueIndexes);
         }
 
         // Upsert registry row inside transaction

--- a/packages/gateway/src/app-db-types.ts
+++ b/packages/gateway/src/app-db-types.ts
@@ -20,6 +20,7 @@ export function isSafeName(s: string): s is SafeName {
 export interface TableDef {
   columns: Record<string, string>;
   indexes?: string[];
+  uniqueIndexes?: string[];
 }
 
 export type Comparable = string | number | boolean | null;

--- a/packages/gateway/src/app-db.ts
+++ b/packages/gateway/src/app-db.ts
@@ -13,6 +13,7 @@ export interface AppDb {
     table: string,
     columns: Record<string, string>,
     indexes?: string[],
+    uniqueIndexes?: string[],
   ): Promise<void>;
   raw(query: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
   destroy(): Promise<void>;
@@ -110,6 +111,7 @@ export function createAppDb(opts: string | { dialect: any }): AppDbWithKysely {
       table: string,
       columns: Record<string, string>,
       indexes?: string[],
+      uniqueIndexes?: string[],
     ): Promise<void> {
       parseAppSlug(schema);
       if (!isSafeName(table)) throw new Error(`Invalid table name: ${table}`);
@@ -155,11 +157,23 @@ export function createAppDb(opts: string | { dialect: any }): AppDbWithKysely {
 
       if (indexes) {
         for (const col of indexes) {
-          if (!isSafeName(col)) continue;
+          if (!isSafeName(col)) throw new Error(`Invalid index column name: ${col}`);
           const idxName = `idx_${schema}_${table}_${col}`.replace(/-/g, "_");
           await sql
             .raw(
               `CREATE INDEX IF NOT EXISTS "${idxName}" ON ${fullTable} ("${col}")`,
+            )
+            .execute(kysely);
+        }
+      }
+
+      if (uniqueIndexes) {
+        for (const col of uniqueIndexes) {
+          if (!isSafeName(col)) throw new Error(`Invalid unique index column name: ${col}`);
+          const idxName = `uidx_${schema}_${table}_${col}`.replace(/-/g, "_");
+          await sql
+            .raw(
+              `CREATE UNIQUE INDEX IF NOT EXISTS "${idxName}" ON ${fullTable} ("${col}")`,
             )
             .execute(kysely);
         }

--- a/packages/gateway/src/app-manifest.ts
+++ b/packages/gateway/src/app-manifest.ts
@@ -2,6 +2,34 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod/v4";
 
+const AppStorageTableSchema = z
+  .object({
+    columns: z.record(z.string(), z.string()),
+    indexes: z.array(z.string()).optional(),
+    uniqueIndexes: z.array(z.string()).optional(),
+  })
+  .superRefine((table, ctx) => {
+    const declaredColumns = new Set(Object.keys(table.columns));
+    for (const [index, column] of (table.indexes ?? []).entries()) {
+      if (!declaredColumns.has(column)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Storage index column "${column}" is not declared in columns`,
+          path: ["indexes", index],
+        });
+      }
+    }
+    for (const [index, column] of (table.uniqueIndexes ?? []).entries()) {
+      if (!declaredColumns.has(column)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Storage unique index column "${column}" is not declared in columns`,
+          path: ["uniqueIndexes", index],
+        });
+      }
+    }
+  });
+
 export const AppManifestSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -25,11 +53,7 @@ export const AppManifestSchema = z.object({
     .object({
       tables: z.record(
         z.string(),
-        z.object({
-          columns: z.record(z.string(), z.string()),
-          indexes: z.array(z.string()).optional(),
-          uniqueIndexes: z.array(z.string()).optional(),
-        }),
+        AppStorageTableSchema,
       ).default({}),
     })
     .optional(),

--- a/packages/gateway/src/app-manifest.ts
+++ b/packages/gateway/src/app-manifest.ts
@@ -28,6 +28,7 @@ export const AppManifestSchema = z.object({
         z.object({
           columns: z.record(z.string(), z.string()),
           indexes: z.array(z.string()).optional(),
+          uniqueIndexes: z.array(z.string()).optional(),
         }),
       ).default({}),
     })

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -3147,9 +3147,32 @@ export async function createGateway(config: GatewayConfig) {
     if ((action === "insert" || action === "update") && JSON.stringify(body.data).length > 1_000_000) {
       return c.json({ error: "data too large (max 1MB)" }, 413);
     }
+    if (action === "bulkUpdate") {
+      if (!Array.isArray(body.updates)) {
+        return c.json({ error: "updates must be an array" }, 400);
+      }
+      if (body.updates.length > 200) {
+        return c.json({ error: "updates too large (max 200 rows)" }, 413);
+      }
+      if (JSON.stringify(body.updates).length > 1_000_000) {
+        return c.json({ error: "updates too large (max 1MB)" }, 413);
+      }
+      for (const update of body.updates) {
+        if (!update || typeof update !== "object" || Array.isArray(update)) {
+          return c.json({ error: "updates entries must be objects" }, 400);
+        }
+        const candidate = update as Record<string, unknown>;
+        if (typeof candidate.id !== "string" || candidate.id.length === 0) {
+          return c.json({ error: "updates entries require id" }, 400);
+        }
+        if (!candidate.data || typeof candidate.data !== "object" || Array.isArray(candidate.data)) {
+          return c.json({ error: "updates entries require data" }, 400);
+        }
+      }
+    }
 
     // Validate table is present for actions that need it
-    const needsTable = ["find", "findOne", "insert", "update", "delete", "count"].includes(action);
+    const needsTable = ["find", "findOne", "insert", "update", "bulkUpdate", "delete", "count"].includes(action);
     const safeTable = typeof body.table === "string" ? body.table.replace(/[^a-zA-Z0-9_-]/g, "") : "";
     if (needsTable && !safeTable) {
       return c.json({ error: "table is required and must contain valid characters" }, 400);
@@ -3214,6 +3237,15 @@ export async function createGateway(config: GatewayConfig) {
           broadcast({ type: "data:change", app: appSlug, key: safeTable });
           return c.json({ ok: true });
         }
+        case "bulkUpdate": {
+          await queryEngine.bulkUpdate(
+            appSlug,
+            safeTable,
+            body.updates as Array<{ id: string; data: Record<string, unknown> }>,
+          );
+          broadcast({ type: "data:change", app: appSlug, key: safeTable });
+          return c.json({ ok: true });
+        }
         case "delete": {
           await queryEngine.delete(appSlug, safeTable, body.id as string);
           broadcast({ type: "data:change", app: appSlug, key: safeTable });
@@ -3231,7 +3263,11 @@ export async function createGateway(config: GatewayConfig) {
     } catch (e) {
       const msg = (e as Error).message;
       console.error("[app-db] Query error:", msg);
-      const isValidation = msg.startsWith("Invalid ") || msg.startsWith("insert:") || msg.startsWith("update:");
+      const isValidation =
+        msg.startsWith("Invalid ") ||
+        msg.startsWith("insert:") ||
+        msg.startsWith("update:") ||
+        msg.startsWith("bulkUpdate:");
       const safe = isValidation ? msg : "Query failed";
       return c.json({ error: safe }, isValidation ? 400 : 500);
     }

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -721,7 +721,7 @@ export async function createGateway(config: GatewayConfig) {
         }
         shouldCacheProvisionAttempt = true;
         const tables = manifest.storage?.tables as
-          | Record<string, { columns: Record<string, string>; indexes?: string[] }>
+          | Record<string, { columns: Record<string, string>; indexes?: string[]; uniqueIndexes?: string[] }>
           | undefined;
         if (tables && Object.keys(tables).length > 0) {
           await registry.register({
@@ -848,7 +848,10 @@ export async function createGateway(config: GatewayConfig) {
               version: manifest.version,
               author: manifest.author,
               category: manifest.category,
-              tables: manifest.storage.tables as Record<string, { columns: Record<string, string>; indexes?: string[] }>,
+              tables: manifest.storage.tables as Record<
+                string,
+                { columns: Record<string, string>; indexes?: string[]; uniqueIndexes?: string[] }
+              >,
             });
             registered++;
             rememberProvisionedAppSlug(storageSlug);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -3171,6 +3171,9 @@ export async function createGateway(config: GatewayConfig) {
         if (!candidate.data || typeof candidate.data !== "object" || Array.isArray(candidate.data)) {
           return c.json({ error: "updates entries require data" }, 400);
         }
+        if (Object.keys(candidate.data).length === 0) {
+          return c.json({ error: "updates entries require at least one data field" }, 400);
+        }
       }
     }
 

--- a/shell/src/lib/os-bridge.ts
+++ b/shell/src/lib/os-bridge.ts
@@ -300,15 +300,23 @@ export function buildBridgeScript(appName: string, themeVars?: ThemeVars): strin
 	        }, 10000).then(function(r) { return r.json(); });
 	      },
 
-	      update: function(table, id, data) {
-	        return parentFetch("/api/bridge/query", {
-	          method: "POST",
-	          headers: { "Content-Type": "application/json" },
-	          body: JSON.stringify({ app: app, action: "update", table: table, id: id, data: data })
-	        }, 10000).then(function(r) { return r.json(); });
-	      },
+		      update: function(table, id, data) {
+		        return parentFetch("/api/bridge/query", {
+		          method: "POST",
+		          headers: { "Content-Type": "application/json" },
+		          body: JSON.stringify({ app: app, action: "update", table: table, id: id, data: data })
+		        }, 10000).then(function(r) { return r.json(); });
+		      },
 
-	      delete: function(table, id) {
+		      bulkUpdate: function(table, updates) {
+		        return parentFetch("/api/bridge/query", {
+		          method: "POST",
+		          headers: { "Content-Type": "application/json" },
+		          body: JSON.stringify({ app: app, action: "bulkUpdate", table: table, updates: updates })
+		        }, 10000).then(function(r) { return r.json(); });
+		      },
+
+		      delete: function(table, id) {
 	        return parentFetch("/api/bridge/query", {
 	          method: "POST",
 	          headers: { "Content-Type": "application/json" },

--- a/shell/src/lib/os-bridge.ts
+++ b/shell/src/lib/os-bridge.ts
@@ -317,12 +317,12 @@ export function buildBridgeScript(appName: string, themeVars?: ThemeVars): strin
 		      },
 
 		      delete: function(table, id) {
-	        return parentFetch("/api/bridge/query", {
-	          method: "POST",
-	          headers: { "Content-Type": "application/json" },
-	          body: JSON.stringify({ app: app, action: "delete", table: table, id: id })
-	        }, 10000).then(function(r) { return r.json(); });
-	      },
+		        return parentFetch("/api/bridge/query", {
+		          method: "POST",
+		          headers: { "Content-Type": "application/json" },
+		          body: JSON.stringify({ app: app, action: "delete", table: table, id: id })
+		        }, 10000).then(function(r) { return r.json(); });
+		      },
 
 	      count: function(table, filter) {
 	        return parentFetch("/api/bridge/query", {

--- a/shell/src/lib/os-bridge.ts
+++ b/shell/src/lib/os-bridge.ts
@@ -300,29 +300,29 @@ export function buildBridgeScript(appName: string, themeVars?: ThemeVars): strin
 	        }, 10000).then(function(r) { return r.json(); });
 	      },
 
-		      update: function(table, id, data) {
-		        return parentFetch("/api/bridge/query", {
-		          method: "POST",
-		          headers: { "Content-Type": "application/json" },
-		          body: JSON.stringify({ app: app, action: "update", table: table, id: id, data: data })
-		        }, 10000).then(function(r) { return r.json(); });
-		      },
+	      update: function(table, id, data) {
+	        return parentFetch("/api/bridge/query", {
+	          method: "POST",
+	          headers: { "Content-Type": "application/json" },
+	          body: JSON.stringify({ app: app, action: "update", table: table, id: id, data: data })
+	        }, 10000).then(function(r) { return r.json(); });
+	      },
 
-		      bulkUpdate: function(table, updates) {
-		        return parentFetch("/api/bridge/query", {
-		          method: "POST",
-		          headers: { "Content-Type": "application/json" },
-		          body: JSON.stringify({ app: app, action: "bulkUpdate", table: table, updates: updates })
-		        }, 10000).then(function(r) { return r.json(); });
-		      },
+	      bulkUpdate: function(table, updates) {
+	        return parentFetch("/api/bridge/query", {
+	          method: "POST",
+	          headers: { "Content-Type": "application/json" },
+	          body: JSON.stringify({ app: app, action: "bulkUpdate", table: table, updates: updates })
+	        }, 10000).then(function(r) { return r.json(); });
+	      },
 
-		      delete: function(table, id) {
-		        return parentFetch("/api/bridge/query", {
-		          method: "POST",
-		          headers: { "Content-Type": "application/json" },
-		          body: JSON.stringify({ app: app, action: "delete", table: table, id: id })
-		        }, 10000).then(function(r) { return r.json(); });
-		      },
+	      delete: function(table, id) {
+	        return parentFetch("/api/bridge/query", {
+	          method: "POST",
+	          headers: { "Content-Type": "application/json" },
+	          body: JSON.stringify({ app: app, action: "delete", table: table, id: id })
+	        }, 10000).then(function(r) { return r.json(); });
+	      },
 
 	      count: function(table, filter) {
 	        return parentFetch("/api/bridge/query", {

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -13,20 +13,44 @@ interface FakeStore {
 
 function installMatrixDb(store: FakeStore) {
   const db = {
-    find: vi.fn(async (table: string) => (table === "zones" ? store.zones : store.alarms)),
+    find: vi.fn(async (table: string, opts?: { where?: Record<string, unknown>; limit?: number }) => {
+      let rows = table === "zones" ? store.zones : store.alarms;
+      if (opts?.where) {
+        rows = rows.filter((row) =>
+          Object.entries(opts.where ?? {}).every(([key, value]) => row[key] === value),
+        );
+      }
+      return typeof opts?.limit === "number" ? rows.slice(0, opts.limit) : rows;
+    }),
     findOne: vi.fn(async () => null),
     insert: vi.fn(async (table: string, data: DbRow) => {
       const id = `${table}-${Math.random().toString(36).slice(2)}`;
       (table === "zones" ? store.zones : store.alarms).push({ id, created_at: new Date().toISOString(), ...data });
       return { id };
     }),
-    update: vi.fn(async () => ({ ok: true })),
+    update: vi.fn(async (table: string, id: string, data: DbRow) => {
+      const rows = table === "zones" ? store.zones : store.alarms;
+      const index = rows.findIndex((row) => row.id === id);
+      if (index >= 0) rows[index] = { ...rows[index], ...data };
+      return { ok: true };
+    }),
     delete: vi.fn(async () => ({ ok: true })),
     count: vi.fn(async () => 0),
     onChange: vi.fn(() => () => undefined),
   };
   Object.defineProperty(window, "MatrixOS", { configurable: true, value: { db } });
   return db;
+}
+
+function installMatrixDataBridge(data = new Map<string, unknown>()) {
+  const bridge = {
+    readData: vi.fn(async (key: string) => data.get(key) ?? null),
+    writeData: vi.fn(async (key: string, value: unknown) => {
+      data.set(key, value);
+    }),
+  };
+  Object.defineProperty(window, "MatrixOS", { configurable: true, value: bridge });
+  return bridge;
 }
 
 describe("Clock app", () => {
@@ -80,6 +104,50 @@ describe("Clock app", () => {
       expect(db.insert).toHaveBeenCalledWith(
         "zones",
         expect.objectContaining({ tz: "Asia/Tokyo" }),
+      );
+    });
+  });
+
+  it("does not insert a duplicate world-clock zone", async () => {
+    const db = installMatrixDb({
+      zones: [{ id: "zone-1", tz: "Asia/Tokyo", position: 0 }],
+      alarms: [],
+    });
+    render(<App />);
+
+    expect(await screen.findByText(/tokyo/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /add city/i }));
+    const search = await screen.findByPlaceholderText(/search cities/i);
+    fireEvent.change(search, { target: { value: "Tokyo" } });
+
+    const option = await screen.findByRole("option", { name: /tokyo/i });
+    await act(async () => {
+      fireEvent.click(option);
+      await Promise.resolve();
+    });
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("uses the MatrixOS data bridge when app DB is unavailable", async () => {
+    const bridge = installMatrixDataBridge();
+    render(<App />);
+
+    expect(await screen.findByText(/no cities yet/i)).toBeTruthy();
+    fireEvent.click(screen.getAllByRole("button", { name: /add city/i })[0]);
+    const search = await screen.findByPlaceholderText(/search cities/i);
+    fireEvent.change(search, { target: { value: "Tokyo" } });
+
+    const option = await screen.findByRole("option", { name: /tokyo/i });
+    await act(async () => {
+      fireEvent.click(option);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(bridge.writeData).toHaveBeenCalledWith(
+        "clock.zones",
+        expect.arrayContaining([expect.objectContaining({ tz: "Asia/Tokyo" })]),
       );
     });
   });

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -208,7 +208,7 @@ describe("Clock app", () => {
 
   it("rings alarms while another tab is active, disables one-shot alarms, and snoozes", async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-01T06:59:59.000Z"));
+    vi.setSystemTime(new Date(2026, 5, 1, 6, 59, 59));
     const db = installMatrixDb({
       zones: [],
       alarms: [{ id: "alarm-1", time: "07:00", label: "Morning", repeat: "", enabled: true }],
@@ -235,6 +235,18 @@ describe("Clock app", () => {
     });
 
     expect(screen.getByRole("button", { name: /snooze/i })).toBeTruthy();
+  });
+
+  it("shows feedback for invalid custom timer input", async () => {
+    installMatrixDb({ zones: [], alarms: [] });
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /timers?/i }));
+    fireEvent.change(screen.getByLabelText("Timer duration"), { target: { value: "abc" } });
+    fireEvent.click(screen.getByRole("button", { name: /^start$/i }));
+
+    expect(await screen.findByText(/duration greater than zero/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /start or pause/i })).toBeNull();
   });
 
   it("marks a timer done when it reaches zero", async () => {

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/clock/src/App";
+
+type DbRow = Record<string, unknown>;
+
+interface FakeStore {
+  zones: DbRow[];
+  alarms: DbRow[];
+}
+
+function installMatrixDb(store: FakeStore) {
+  const db = {
+    find: vi.fn(async (table: string) => (table === "zones" ? store.zones : store.alarms)),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async (table: string, data: DbRow) => {
+      const id = `${table}-${Math.random().toString(36).slice(2)}`;
+      (table === "zones" ? store.zones : store.alarms).push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    }),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => 0),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", { configurable: true, value: { db } });
+  return db;
+}
+
+describe("Clock app", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // jsdom lacks AudioContext; stub so alarm/timer audio paths don't throw.
+    (window as unknown as { AudioContext?: unknown }).AudioContext = vi.fn(() => ({
+      createOscillator: () => ({ connect: () => undefined, start: () => undefined, stop: () => undefined, frequency: { value: 0 }, type: "sine" }),
+      createGain: () => ({ connect: () => undefined, gain: { value: 0, setValueAtTime: () => undefined, exponentialRampToValueAtTime: () => undefined } }),
+      destination: {},
+      currentTime: 0,
+      close: () => Promise.resolve(),
+      resume: () => Promise.resolve(),
+    }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+  });
+
+  it("renders the four tabs", async () => {
+    installMatrixDb({ zones: [], alarms: [] });
+    render(<App />);
+    expect(await screen.findByRole("tab", { name: /world clock/i })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /alarms/i })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /timers?/i })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /stopwatch/i })).toBeTruthy();
+  });
+
+  it("shows the world-clock empty state and persists an added zone via db.insert", async () => {
+    const db = installMatrixDb({ zones: [], alarms: [] });
+    render(<App />);
+
+    // Empty onboarding state visible.
+    expect(await screen.findByText(/no cities yet/i)).toBeTruthy();
+
+    // Open the add-zone search and pick a zone (header button is first).
+    fireEvent.click(screen.getAllByRole("button", { name: /add city/i })[0]);
+    const search = await screen.findByPlaceholderText(/search cities/i);
+    fireEvent.change(search, { target: { value: "Tokyo" } });
+
+    const option = await screen.findByRole("option", { name: /tokyo/i });
+    await act(async () => {
+      fireEvent.click(option);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(db.insert).toHaveBeenCalledWith(
+        "zones",
+        expect.objectContaining({ tz: "Asia/Tokyo" }),
+      );
+    });
+  });
+
+  it("starts the stopwatch and advances the displayed time", async () => {
+    installMatrixDb({ zones: [], alarms: [] });
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: /stopwatch/i }));
+
+    const readout = await screen.findByTestId("stopwatch-readout");
+    expect(readout.textContent).toBe("00:00.00");
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("button", { name: /^start$/i }));
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(readout.textContent).not.toBe("00:00.00");
+  });
+});

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -371,6 +371,34 @@ describe("Clock app", () => {
     );
   });
 
+  it("uses one atomic bulk update for same-minute one-shot alarms in DB storage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 1, 6, 59, 59));
+    const db = installMatrixDb({
+      zones: [],
+      alarms: [
+        { id: "alarm-1", time: "07:00", label: "Morning", repeat: "", enabled: true },
+        { id: "alarm-2", time: "07:00", label: "Standup", repeat: "", enabled: true },
+      ],
+    });
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+    });
+
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.bulkUpdate).toHaveBeenCalledWith("alarms", [
+      { id: "alarm-1", data: { enabled: false } },
+      { id: "alarm-2", data: { enabled: false } },
+    ]);
+  });
+
   it("renders alarms in bridge order by time", async () => {
     installMatrixDb({
       zones: [],

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -13,12 +13,25 @@ interface FakeStore {
 
 function installMatrixDb(store: FakeStore) {
   const db = {
-    find: vi.fn(async (table: string, opts?: { where?: Record<string, unknown>; limit?: number }) => {
-      let rows = table === "zones" ? store.zones : store.alarms;
+    find: vi.fn(async (table: string, opts?: { where?: Record<string, unknown>; limit?: number; orderBy?: Record<string, "asc" | "desc"> }) => {
+      let rows = [...(table === "zones" ? store.zones : store.alarms)];
       if (opts?.where) {
         rows = rows.filter((row) =>
           Object.entries(opts.where ?? {}).every(([key, value]) => row[key] === value),
         );
+      }
+      if (opts?.orderBy) {
+        const [key, dir] = Object.entries(opts.orderBy)[0] ?? [];
+        if (key) {
+          rows.sort((a, b) => {
+            const av = a[key];
+            const bv = b[key];
+            const cmp = typeof av === "number" && typeof bv === "number"
+              ? av - bv
+              : String(av ?? "").localeCompare(String(bv ?? ""));
+            return dir === "desc" ? -cmp : cmp;
+          });
+        }
       }
       return typeof opts?.limit === "number" ? rows.slice(0, opts.limit) : rows;
     }),
@@ -244,7 +257,7 @@ describe("Clock app", () => {
     expect(screen.getByRole("button", { name: /remove zone/i })).toBeTruthy();
   });
 
-  it("rings alarms while another tab is active, disables one-shot alarms, and snoozes", async () => {
+  it("rings alarms while another tab is active and does not re-ring snoozed one-shot alarms", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 5, 1, 6, 59, 59));
     const db = installMatrixDb({
@@ -272,7 +285,26 @@ describe("Clock app", () => {
       await vi.advanceTimersByTimeAsync(5 * 60_000);
     });
 
-    expect(screen.getByRole("button", { name: /snooze/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /snooze/i })).toBeNull();
+  });
+
+  it("renders alarms in bridge order by time", async () => {
+    installMatrixDb({
+      zones: [],
+      alarms: [
+        { id: "alarm-late", time: "09:00", label: "Late", repeat: "", enabled: true },
+        { id: "alarm-early", time: "06:00", label: "Early", repeat: "", enabled: true },
+      ],
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("tab", { name: /alarms/i }));
+
+    const toggles = await screen.findAllByRole("switch");
+    expect(toggles.map((toggle) => toggle.getAttribute("aria-label"))).toEqual([
+      "Disable alarm 06:00",
+      "Disable alarm 09:00",
+    ]);
   });
 
   it("clears snoozed alarms when they are disabled", async () => {

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -152,6 +152,32 @@ describe("Clock app", () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
+  it("reloads saved zones after a failed optimistic zone insert", async () => {
+    const store = { zones: [] as DbRow[], alarms: [] as DbRow[] };
+    const db = installMatrixDb(store);
+    db.insert.mockImplementationOnce(async () => {
+      store.zones.push({ id: "zone-paris", tz: "Europe/Paris", position: 0 });
+      throw new Error("insert failed");
+    });
+    render(<App />);
+
+    expect(await screen.findByText(/no cities yet/i)).toBeTruthy();
+    fireEvent.click(screen.getAllByRole("button", { name: /add city/i })[0]);
+    const search = await screen.findByPlaceholderText(/search cities/i);
+    fireEvent.change(search, { target: { value: "Tokyo" } });
+    const option = await screen.findByRole("option", { name: /tokyo/i });
+
+    await act(async () => {
+      fireEvent.click(option);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("City could not be saved.")).toBeTruthy();
+    expect(await screen.findByText(/paris/i)).toBeTruthy();
+    expect(screen.queryByText(/tokyo/i)).toBeNull();
+  });
+
   it("persists world-clock zone reorders with bulkUpdate", async () => {
     const db = installMatrixDb({
       zones: [
@@ -181,6 +207,28 @@ describe("Clock app", () => {
         ]),
       );
     });
+  });
+
+  it("keeps the reorder failure banner visible after recovery reload", async () => {
+    const db = installMatrixDb({
+      zones: [
+        { id: "zone-tokyo", tz: "Asia/Tokyo", position: 0 },
+        { id: "zone-london", tz: "Europe/London", position: 1 },
+      ],
+      alarms: [],
+    });
+    db.bulkUpdate.mockRejectedValueOnce(new Error("bulk update failed"));
+    render(<App />);
+
+    const tokyo = (await screen.findByText(/tokyo/i)).closest("li");
+    const london = (await screen.findByText(/london/i)).closest("li");
+    if (!tokyo || !london) throw new Error("Expected zone rows to render");
+
+    fireEvent.dragStart(london);
+    fireEvent.dragOver(tokyo);
+    fireEvent.drop(tokyo);
+
+    expect(await screen.findByText("New order could not be saved.")).toBeTruthy();
   });
 
   it("does not persist reorders while a zone id is still optimistic", async () => {
@@ -257,7 +305,7 @@ describe("Clock app", () => {
     expect(screen.getByRole("button", { name: /remove zone/i })).toBeTruthy();
   });
 
-  it("rings alarms while another tab is active and does not re-ring snoozed one-shot alarms", async () => {
+  it("rings alarms while another tab is active and re-rings snoozed one-shot alarms", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 5, 1, 6, 59, 59));
     const db = installMatrixDb({
@@ -285,7 +333,7 @@ describe("Clock app", () => {
       await vi.advanceTimersByTimeAsync(5 * 60_000);
     });
 
-    expect(screen.queryByRole("button", { name: /snooze/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /snooze/i })).toBeTruthy();
   });
 
   it("renders alarms in bridge order by time", async () => {
@@ -305,6 +353,30 @@ describe("Clock app", () => {
       "Disable alarm 06:00",
       "Disable alarm 09:00",
     ]);
+  });
+
+  it("reloads saved alarms after a failed optimistic alarm insert", async () => {
+    const store = { zones: [] as DbRow[], alarms: [] as DbRow[] };
+    const db = installMatrixDb(store);
+    db.insert.mockImplementationOnce(async () => {
+      store.alarms.push({ id: "alarm-existing", time: "09:00", label: "Existing", repeat: "", enabled: true });
+      throw new Error("insert failed");
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("tab", { name: /alarms/i }));
+    fireEvent.click(screen.getAllByRole("button", { name: /new alarm/i })[0]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save alarm/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Alarm could not be saved.")).toBeTruthy();
+    await waitFor(() => {
+      expect(db.find.mock.calls.filter(([table]) => table === "alarms").length).toBeGreaterThan(1);
+    });
   });
 
   it("clears snoozed alarms when they are disabled", async () => {
@@ -406,5 +478,23 @@ describe("Clock app", () => {
     fireEvent.click(screen.getByRole("tab", { name: /world clock/i }));
     fireEvent.click(screen.getByRole("tab", { name: /stopwatch/i }));
     expect(readout.textContent).not.toBe("00:00.00");
+  });
+
+  it("stops the stopwatch animation loop when the panel is hidden", async () => {
+    installMatrixDb({ zones: [], alarms: [] });
+    vi.useFakeTimers();
+    const requestFrame = vi.spyOn(window, "requestAnimationFrame");
+    const cancelFrame = vi.spyOn(window, "cancelAnimationFrame");
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /stopwatch/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^start$/i }));
+    expect(requestFrame).toHaveBeenCalled();
+    requestFrame.mockClear();
+
+    fireEvent.click(screen.getByRole("tab", { name: /world clock/i }));
+
+    expect(cancelFrame).toHaveBeenCalled();
+    expect(requestFrame).not.toHaveBeenCalled();
   });
 });

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -57,14 +57,16 @@ describe("Clock app", () => {
   beforeEach(() => {
     window.localStorage.clear();
     // jsdom lacks AudioContext; stub so alarm/timer audio paths don't throw.
-    (window as unknown as { AudioContext?: unknown }).AudioContext = vi.fn(() => ({
+    (window as unknown as { AudioContext?: unknown }).AudioContext = vi.fn(function AudioContextMock() {
+      return {
       createOscillator: () => ({ connect: () => undefined, start: () => undefined, stop: () => undefined, frequency: { value: 0 }, type: "sine" }),
       createGain: () => ({ connect: () => undefined, gain: { value: 0, setValueAtTime: () => undefined, exponentialRampToValueAtTime: () => undefined } }),
       destination: {},
       currentTime: 0,
       close: () => Promise.resolve(),
       resume: () => Promise.resolve(),
-    }));
+      };
+    });
   });
 
   afterEach(() => {
@@ -133,6 +135,7 @@ describe("Clock app", () => {
     const bridge = installMatrixDataBridge();
     render(<App />);
 
+    expect(await screen.findAllByText("Synced to device storage")).not.toHaveLength(0);
     expect(await screen.findByText(/no cities yet/i)).toBeTruthy();
     fireEvent.click(screen.getAllByRole("button", { name: /add city/i })[0]);
     const search = await screen.findByPlaceholderText(/search cities/i);
@@ -152,6 +155,65 @@ describe("Clock app", () => {
     });
   });
 
+  it("contains invalid saved time zones to one row", async () => {
+    installMatrixDb({
+      zones: [{ id: "bad-zone", tz: "Invalid/Zone", position: 0 }],
+      alarms: [],
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Invalid time zone")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /remove zone/i })).toBeTruthy();
+  });
+
+  it("rings alarms while another tab is active, disables one-shot alarms, and snoozes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T06:59:59.000Z"));
+    const db = installMatrixDb({
+      zones: [],
+      alarms: [{ id: "alarm-1", time: "07:00", label: "Morning", repeat: "", enabled: true }],
+    });
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/no cities yet/i)).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(screen.getByRole("button", { name: /snooze/i })).toBeTruthy();
+    expect(db.update).toHaveBeenCalledWith("alarms", "alarm-1", { enabled: false });
+
+    fireEvent.click(screen.getByRole("button", { name: /snooze/i }));
+    expect(screen.queryByRole("button", { name: /snooze/i })).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    });
+
+    expect(screen.getByRole("button", { name: /snooze/i })).toBeTruthy();
+  });
+
+  it("marks a timer done when it reaches zero", async () => {
+    vi.useFakeTimers();
+    installMatrixDb({ zones: [], alarms: [] });
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /timers?/i }));
+    fireEvent.change(screen.getByLabelText("Timer duration"), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("button", { name: /^start$/i }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(screen.getByText("Done")).toBeTruthy();
+  });
+
   it("starts the stopwatch and advances the displayed time", async () => {
     installMatrixDb({ zones: [], alarms: [] });
     render(<App />);
@@ -166,6 +228,10 @@ describe("Clock app", () => {
     act(() => {
       vi.advanceTimersByTime(1_000);
     });
+    expect(readout.textContent).not.toBe("00:00.00");
+
+    fireEvent.click(screen.getByRole("tab", { name: /world clock/i }));
+    fireEvent.click(screen.getByRole("tab", { name: /stopwatch/i }));
     expect(readout.textContent).not.toBe("00:00.00");
   });
 });

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -152,6 +152,31 @@ describe("Clock app", () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
+  it("treats concurrent duplicate zone inserts as an idempotent reload", async () => {
+    const store = { zones: [] as DbRow[], alarms: [] as DbRow[] };
+    const db = installMatrixDb(store);
+    db.insert.mockImplementationOnce(async () => {
+      store.zones.push({ id: "zone-tokyo", tz: "Asia/Tokyo", position: 0 });
+      throw new Error("unique constraint violated");
+    });
+    render(<App />);
+
+    expect(await screen.findByText(/no cities yet/i)).toBeTruthy();
+    fireEvent.click(screen.getAllByRole("button", { name: /add city/i })[0]);
+    const search = await screen.findByPlaceholderText(/search cities/i);
+    fireEvent.change(search, { target: { value: "Tokyo" } });
+    const option = await screen.findByRole("option", { name: /tokyo/i });
+
+    await act(async () => {
+      fireEvent.click(option);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.queryByText("City could not be saved.")).toBeNull());
+    expect(await screen.findByText(/tokyo/i)).toBeTruthy();
+  });
+
   it("reloads saved zones after a failed optimistic zone insert", async () => {
     const store = { zones: [] as DbRow[], alarms: [] as DbRow[] };
     const db = installMatrixDb(store);

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -34,6 +34,14 @@ function installMatrixDb(store: FakeStore) {
       if (index >= 0) rows[index] = { ...rows[index], ...data };
       return { ok: true };
     }),
+    bulkUpdate: vi.fn(async (table: string, updates: Array<{ id: string; data: DbRow }>) => {
+      const rows = table === "zones" ? store.zones : store.alarms;
+      for (const { id, data } of updates) {
+        const index = rows.findIndex((row) => row.id === id);
+        if (index >= 0) rows[index] = { ...rows[index], ...data };
+      }
+      return { ok: true };
+    }),
     delete: vi.fn(async () => ({ ok: true })),
     count: vi.fn(async () => 0),
     onChange: vi.fn(() => () => undefined),
@@ -129,6 +137,37 @@ describe("Clock app", () => {
     });
 
     expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("persists world-clock zone reorders with bulkUpdate", async () => {
+    const db = installMatrixDb({
+      zones: [
+        { id: "zone-tokyo", tz: "Asia/Tokyo", position: 0 },
+        { id: "zone-london", tz: "Europe/London", position: 1 },
+      ],
+      alarms: [],
+    });
+    render(<App />);
+
+    const tokyo = (await screen.findByText(/tokyo/i)).closest("li");
+    const london = (await screen.findByText(/london/i)).closest("li");
+    expect(tokyo).toBeTruthy();
+    expect(london).toBeTruthy();
+    if (!tokyo || !london) throw new Error("Expected zone rows to render");
+
+    fireEvent.dragStart(london);
+    fireEvent.dragOver(tokyo);
+    fireEvent.drop(tokyo);
+
+    await waitFor(() => {
+      expect(db.bulkUpdate).toHaveBeenCalledWith(
+        "zones",
+        expect.arrayContaining([
+          { id: "zone-london", data: { position: 0 } },
+          { id: "zone-tokyo", data: { position: 1 } },
+        ]),
+      );
+    });
   });
 
   it("uses the MatrixOS data bridge when app DB is unavailable", async () => {

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -336,6 +336,41 @@ describe("Clock app", () => {
     expect(screen.getByRole("button", { name: /snooze/i })).toBeTruthy();
   });
 
+  it("disables all same-minute one-shot alarms when using bridge storage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 1, 6, 59, 59));
+    const bridgeData = new Map<string, unknown>([
+      [
+        "clock.alarms",
+        [
+          { id: "alarm-1", time: "07:00", label: "Morning", repeat: "", enabled: true },
+          { id: "alarm-2", time: "07:00", label: "Standup", repeat: "", enabled: true },
+        ],
+      ],
+    ]);
+    const bridge = installMatrixDataBridge(bridgeData);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getAllByText("Synced to device storage")).not.toHaveLength(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+    });
+
+    const lastWrite = bridge.writeData.mock.calls.at(-1);
+    expect(lastWrite?.[0]).toBe("clock.alarms");
+    expect(lastWrite?.[1]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "alarm-1", enabled: false }),
+        expect.objectContaining({ id: "alarm-2", enabled: false }),
+      ]),
+    );
+  });
+
   it("renders alarms in bridge order by time", async () => {
     installMatrixDb({
       zones: [],

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -170,6 +170,44 @@ describe("Clock app", () => {
     });
   });
 
+  it("does not persist reorders while a zone id is still optimistic", async () => {
+    const db = installMatrixDb({
+      zones: [{ id: "zone-london", tz: "Europe/London", position: 0 }],
+      alarms: [],
+    });
+    let resolveInsert: (() => void) | undefined;
+    db.insert.mockImplementation(async (table: string) => {
+      await new Promise<void>((resolve) => {
+        resolveInsert = resolve;
+      });
+      return { id: `${table}-saved` };
+    });
+    render(<App />);
+
+    expect(await screen.findByText(/london/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /add city/i }));
+    const search = await screen.findByPlaceholderText(/search cities/i);
+    fireEvent.change(search, { target: { value: "Tokyo" } });
+    const option = await screen.findByRole("option", { name: /tokyo/i });
+    fireEvent.click(option);
+
+    const tokyo = (await screen.findByText(/tokyo/i)).closest("li");
+    const london = (await screen.findByText(/london/i)).closest("li");
+    expect(tokyo).toBeTruthy();
+    expect(london).toBeTruthy();
+    if (!tokyo || !london) throw new Error("Expected zone rows to render");
+
+    fireEvent.dragStart(tokyo);
+    fireEvent.dragOver(london);
+    fireEvent.drop(london);
+
+    expect(db.bulkUpdate).not.toHaveBeenCalled();
+    await act(async () => {
+      resolveInsert?.();
+      await Promise.resolve();
+    });
+  });
+
   it("uses the MatrixOS data bridge when app DB is unavailable", async () => {
     const bridge = installMatrixDataBridge();
     render(<App />);
@@ -235,6 +273,58 @@ describe("Clock app", () => {
     });
 
     expect(screen.getByRole("button", { name: /snooze/i })).toBeTruthy();
+  });
+
+  it("clears snoozed alarms when they are disabled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 1, 6, 59, 59));
+    installMatrixDb({
+      zones: [],
+      alarms: [{ id: "alarm-1", time: "07:00", label: "Standup", repeat: "1", enabled: true }],
+    });
+
+    render(<App />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(screen.getByRole("button", { name: /snooze/i })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /snooze/i }));
+    fireEvent.click(screen.getByRole("tab", { name: /alarms/i }));
+    fireEvent.click(screen.getByRole("switch", { name: /disable alarm 07:00/i }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+    });
+
+    expect(screen.queryByRole("button", { name: /snooze/i })).toBeNull();
+  });
+
+  it("queues alarms that fire in the same tick", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 1, 6, 59, 59));
+    installMatrixDb({
+      zones: [],
+      alarms: [
+        { id: "alarm-1", time: "07:00", label: "First", repeat: "", enabled: true },
+        { id: "alarm-2", time: "07:00", label: "Second", repeat: "", enabled: true },
+      ],
+    });
+
+    render(<App />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("First")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Second")).toBeTruthy();
   });
 
   it("shows feedback for invalid custom timer input", async () => {

--- a/tests/default-apps/clock-app.test.tsx
+++ b/tests/default-apps/clock-app.test.tsx
@@ -256,6 +256,21 @@ describe("Clock app", () => {
     expect(await screen.findByText("New order could not be saved.")).toBeTruthy();
   });
 
+  it("keeps the remove-zone failure banner visible after recovery reload", async () => {
+    const db = installMatrixDb({
+      zones: [{ id: "zone-london", tz: "Europe/London", position: 0 }],
+      alarms: [],
+    });
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+    render(<App />);
+
+    expect(await screen.findByText(/london/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /remove london/i }));
+
+    expect(await screen.findByText("City could not be removed.")).toBeTruthy();
+    expect(await screen.findByText(/london/i)).toBeTruthy();
+  });
+
   it("does not persist reorders while a zone id is still optimistic", async () => {
     const db = installMatrixDb({
       zones: [{ id: "zone-london", tz: "Europe/London", position: 0 }],
@@ -465,6 +480,36 @@ describe("Clock app", () => {
     await waitFor(() => {
       expect(db.find.mock.calls.filter(([table]) => table === "alarms").length).toBeGreaterThan(1);
     });
+  });
+
+  it("keeps the alarm-toggle failure banner visible after recovery reload", async () => {
+    const db = installMatrixDb({
+      zones: [],
+      alarms: [{ id: "alarm-1", time: "07:00", label: "Standup", repeat: "", enabled: true }],
+    });
+    db.update.mockRejectedValueOnce(new Error("update failed"));
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("tab", { name: /alarms/i }));
+    fireEvent.click(await screen.findByRole("switch", { name: /disable alarm 07:00/i }));
+
+    expect(await screen.findByText("Alarm could not be updated.")).toBeTruthy();
+    expect(await screen.findByRole("switch", { name: /disable alarm 07:00/i })).toBeTruthy();
+  });
+
+  it("keeps the alarm-delete failure banner visible after recovery reload", async () => {
+    const db = installMatrixDb({
+      zones: [],
+      alarms: [{ id: "alarm-1", time: "07:00", label: "Standup", repeat: "", enabled: true }],
+    });
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("tab", { name: /alarms/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /delete alarm 07:00/i }));
+
+    expect(await screen.findByText("Alarm could not be removed.")).toBeTruthy();
+    expect(await screen.findByText("07:00")).toBeTruthy();
   });
 
   it("clears snoozed alarms when they are disabled", async () => {

--- a/tests/default-apps/clock-model.test.ts
+++ b/tests/default-apps/clock-model.test.ts
@@ -101,13 +101,13 @@ describe("alarm helpers", () => {
     expect(shouldAlarmFire(alarm, at)).toBe(false);
   });
 
-  it("fires a one-shot at exactly its time at second 0", () => {
+  it("fires a one-shot throughout its matching minute", () => {
     const alarm: AlarmModel = { id: "a", time: "07:00", label: "", repeat: [], enabled: true };
     const at = new Date(2026, 5, 1, 7, 0, 0); // local Mon 07:00:00
-    const off = new Date(2026, 5, 1, 7, 0, 30); // 07:00:30
+    const withinMinute = new Date(2026, 5, 1, 7, 0, 30); // 07:00:30
     const wrong = new Date(2026, 5, 1, 7, 1, 0);
     expect(shouldAlarmFire(alarm, at)).toBe(true);
-    expect(shouldAlarmFire(alarm, off)).toBe(false);
+    expect(shouldAlarmFire(alarm, withinMinute)).toBe(true);
     expect(shouldAlarmFire(alarm, wrong)).toBe(false);
   });
 

--- a/tests/default-apps/clock-model.test.ts
+++ b/tests/default-apps/clock-model.test.ts
@@ -111,6 +111,12 @@ describe("alarm helpers", () => {
     expect(shouldAlarmFire(alarm, wrong)).toBe(false);
   });
 
+  it("does not treat malformed time strings as midnight", () => {
+    const alarm: AlarmModel = { id: "a", time: ":", label: "", repeat: [], enabled: true };
+    const midnight = new Date(2026, 5, 1, 0, 0, 0);
+    expect(shouldAlarmFire(alarm, midnight)).toBe(false);
+  });
+
   it("respects repeat weekdays", () => {
     // 2026-06-01 is a Monday (getDay() === 1).
     const monday = new Date(2026, 5, 1, 8, 0, 0);

--- a/tests/default-apps/clock-model.test.ts
+++ b/tests/default-apps/clock-model.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  alarmMinuteKey,
+  computeLaps,
+  formatClock,
+  formatStopwatch,
+  formatZoneTime,
+  lapExtremes,
+  parseDuration,
+  parseRepeat,
+  repeatLabel,
+  searchZones,
+  serializeRepeat,
+  shouldAlarmFire,
+  zoneCityLabel,
+  zoneOffsetMinutes,
+  zoneRegionLabel,
+  type AlarmModel,
+  type WeekDay,
+} from "../../home/apps/clock/src/clock-model";
+
+// A fixed instant: 2026-06-01T12:00:00Z (Monday).
+const FIXED = new Date("2026-06-01T12:00:00.000Z");
+
+describe("timezone helpers", () => {
+  it("UTC offset is zero", () => {
+    expect(zoneOffsetMinutes("UTC", FIXED)).toBe(0);
+  });
+
+  it("computes a positive offset for an ahead-of-UTC zone", () => {
+    // Tokyo is UTC+9 year-round.
+    expect(zoneOffsetMinutes("Asia/Tokyo", FIXED)).toBe(9 * 60);
+  });
+
+  it("computes a negative offset for a behind-UTC zone", () => {
+    // New York in June is DST: UTC-4.
+    expect(zoneOffsetMinutes("America/New_York", FIXED)).toBe(-4 * 60);
+  });
+
+  it("renders zone time with offset and day labels relative to local", () => {
+    const tokyo = formatZoneTime("Asia/Tokyo", "UTC", FIXED);
+    expect(tokyo.time).toBe("21:00");
+    expect(tokyo.meridiem).toBe("PM");
+    expect(tokyo.hour12).toBe("9");
+    expect(tokyo.offsetLabel).toBe("+9h");
+    expect(tokyo.dayLabel).toContain("Today");
+  });
+
+  it("marks a zone past midnight as Tomorrow", () => {
+    // At 12:00 UTC, Tokyo is 21:00 same day; pick a late-UTC instant where Tokyo rolls over.
+    const late = new Date("2026-06-01T20:00:00.000Z"); // Tokyo = 05:00 next day
+    const tokyo = formatZoneTime("Asia/Tokyo", "UTC", late);
+    expect(tokyo.dayLabel).toContain("Tomorrow");
+  });
+
+  it("computes analog hand angles", () => {
+    // 21:00 -> hour hand at 9 o'clock = 270deg, minute at 0.
+    const tokyo = formatZoneTime("Asia/Tokyo", "UTC", FIXED);
+    expect(tokyo.hourAngle).toBe(270);
+    expect(tokyo.minuteAngle).toBe(0);
+  });
+
+  it("labels city and region", () => {
+    expect(zoneCityLabel("America/New_York")).toBe("New York");
+    expect(zoneRegionLabel("America/New_York")).toBe("America");
+  });
+
+  it("searches the zone list case-insensitively, including spaces", () => {
+    const zones = ["America/New_York", "Asia/Tokyo", "Europe/London"];
+    expect(searchZones(zones, "tokyo")).toEqual(["Asia/Tokyo"]);
+    expect(searchZones(zones, "new york")).toEqual(["America/New_York"]);
+    expect(searchZones(zones, "")).toEqual(zones);
+    expect(searchZones(zones, "xyz")).toEqual([]);
+  });
+
+  it("respects the search limit", () => {
+    const zones = Array.from({ length: 100 }, (_, i) => `Z/${i}`);
+    expect(searchZones(zones, "Z", 5)).toHaveLength(5);
+  });
+});
+
+describe("alarm helpers", () => {
+  it("parses and serializes repeat days, deduped and sorted", () => {
+    expect(parseRepeat("3,1,1,5")).toEqual([1, 3, 5]);
+    expect(parseRepeat("")).toEqual([]);
+    expect(parseRepeat([6, 0, 0])).toEqual([0, 6]);
+    expect(serializeRepeat([5, 1, 1] as WeekDay[])).toBe("1,5");
+  });
+
+  it("labels common repeat patterns", () => {
+    expect(repeatLabel([])).toBe("Once");
+    expect(repeatLabel([0, 1, 2, 3, 4, 5, 6])).toBe("Every day");
+    expect(repeatLabel([1, 2, 3, 4, 5])).toBe("Weekdays");
+    expect(repeatLabel([0, 6])).toBe("Weekends");
+    expect(repeatLabel([1, 3])).toBe("Mon Wed");
+  });
+
+  it("does not fire when disabled", () => {
+    const alarm: AlarmModel = { id: "a", time: "07:00", label: "", repeat: [], enabled: false };
+    const at = new Date("2026-06-01T07:00:00.000");
+    expect(shouldAlarmFire(alarm, at)).toBe(false);
+  });
+
+  it("fires a one-shot at exactly its time at second 0", () => {
+    const alarm: AlarmModel = { id: "a", time: "07:00", label: "", repeat: [], enabled: true };
+    const at = new Date(2026, 5, 1, 7, 0, 0); // local Mon 07:00:00
+    const off = new Date(2026, 5, 1, 7, 0, 30); // 07:00:30
+    const wrong = new Date(2026, 5, 1, 7, 1, 0);
+    expect(shouldAlarmFire(alarm, at)).toBe(true);
+    expect(shouldAlarmFire(alarm, off)).toBe(false);
+    expect(shouldAlarmFire(alarm, wrong)).toBe(false);
+  });
+
+  it("respects repeat weekdays", () => {
+    // 2026-06-01 is a Monday (getDay() === 1).
+    const monday = new Date(2026, 5, 1, 8, 0, 0);
+    const onMon: AlarmModel = { id: "a", time: "08:00", label: "", repeat: [1], enabled: true };
+    const onTue: AlarmModel = { id: "b", time: "08:00", label: "", repeat: [2], enabled: true };
+    expect(shouldAlarmFire(onMon, monday)).toBe(true);
+    expect(shouldAlarmFire(onTue, monday)).toBe(false);
+  });
+
+  it("builds a per-minute guard key", () => {
+    const at = new Date(2026, 5, 1, 7, 5, 12);
+    expect(alarmMinuteKey(at)).toBe("2026-06-01 07:05");
+  });
+});
+
+describe("duration + timer formatting", () => {
+  it("parses durations in multiple forms", () => {
+    expect(parseDuration("90")).toBe(90);
+    expect(parseDuration("1:30")).toBe(90);
+    expect(parseDuration("1:02:03")).toBe(3723);
+    expect(parseDuration("  2:00 ")).toBe(120);
+    expect(parseDuration("")).toBe(0);
+    expect(parseDuration("abc")).toBe(0);
+    expect(parseDuration("1:2:3:4")).toBe(0);
+  });
+
+  it("formats clock seconds", () => {
+    expect(formatClock(0)).toBe("0:00");
+    expect(formatClock(65)).toBe("1:05");
+    expect(formatClock(3661)).toBe("1:01:01");
+    expect(formatClock(-5)).toBe("0:00");
+  });
+
+  it("formats stopwatch ms with centiseconds", () => {
+    expect(formatStopwatch(0)).toBe("00:00.00");
+    expect(formatStopwatch(1234)).toBe("00:01.23");
+    expect(formatStopwatch(65_430)).toBe("01:05.43");
+  });
+});
+
+describe("stopwatch laps", () => {
+  it("computes lap splits from cumulative marks", () => {
+    const laps = computeLaps([1000, 3000, 3500]);
+    expect(laps).toEqual([
+      { index: 1, lap: 1000, total: 1000 },
+      { index: 2, lap: 2000, total: 3000 },
+      { index: 3, lap: 500, total: 3500 },
+    ]);
+  });
+
+  it("identifies fastest and slowest laps", () => {
+    const laps = computeLaps([1000, 3000, 3500]);
+    expect(lapExtremes(laps)).toEqual({ fastest: 2, slowest: 1 });
+    expect(lapExtremes(computeLaps([1000]))).toEqual({ fastest: -1, slowest: -1 });
+  });
+});

--- a/tests/gateway/app-db-query.test.ts
+++ b/tests/gateway/app-db-query.test.ts
@@ -153,6 +153,19 @@ describe("QueryEngine", () => {
     expect(row!.done).toBe(true);
   });
 
+  it("bulk-updates rows in one statement", async () => {
+    const first = await engine.insert("todo", "tasks", { title: "A", done: false, priority: 1 });
+    const second = await engine.insert("todo", "tasks", { title: "B", done: false, priority: 2 });
+
+    await engine.bulkUpdate("todo", "tasks", [
+      { id: first.id, data: { priority: 2 } },
+      { id: second.id, data: { priority: 1 } },
+    ]);
+
+    const rows = await engine.find("todo", "tasks", { orderBy: { priority: "asc" } });
+    expect(rows.map((row) => row.title)).toEqual(["B", "A"]);
+  });
+
   it("deletes a row by id", async () => {
     const { id } = await engine.insert("todo", "tasks", { title: "Delete me", done: false });
     await engine.delete("todo", "tasks", id);

--- a/tests/gateway/app-db-query.test.ts
+++ b/tests/gateway/app-db-query.test.ts
@@ -194,6 +194,16 @@ describe("QueryEngine", () => {
     ).rejects.toThrow(/duplicate id/i);
   });
 
+  it("rejects undefined values in bulk updates", async () => {
+    const { id } = await engine.insert("todo", "tasks", { title: "A", done: false, priority: 1 });
+
+    await expect(
+      engine.bulkUpdate("todo", "tasks", [
+        { id, data: { priority: undefined } },
+      ]),
+    ).rejects.toThrow(/must not be undefined/i);
+  });
+
   it("deletes a row by id", async () => {
     const { id } = await engine.insert("todo", "tasks", { title: "Delete me", done: false });
     await engine.delete("todo", "tasks", id);

--- a/tests/gateway/app-db-query.test.ts
+++ b/tests/gateway/app-db-query.test.ts
@@ -166,6 +166,23 @@ describe("QueryEngine", () => {
     expect(rows.map((row) => row.title)).toEqual(["B", "A"]);
   });
 
+  it("bulk-updates sparse row data without changing omitted columns", async () => {
+    const first = await engine.insert("todo", "tasks", { title: "A", done: false, priority: 1 });
+    const second = await engine.insert("todo", "tasks", { title: "B", done: false, priority: 2 });
+
+    await engine.bulkUpdate("todo", "tasks", [
+      { id: first.id, data: { priority: 3 } },
+      { id: second.id, data: { priority: 4, done: true } },
+    ]);
+
+    const firstRow = await engine.findOne("todo", "tasks", first.id);
+    const secondRow = await engine.findOne("todo", "tasks", second.id);
+    expect(firstRow!.priority).toBe(3);
+    expect(firstRow!.done).toBe(false);
+    expect(secondRow!.priority).toBe(4);
+    expect(secondRow!.done).toBe(true);
+  });
+
   it("rejects duplicate ids in bulk updates", async () => {
     const { id } = await engine.insert("todo", "tasks", { title: "A", done: false, priority: 1 });
 

--- a/tests/gateway/app-db-query.test.ts
+++ b/tests/gateway/app-db-query.test.ts
@@ -166,6 +166,17 @@ describe("QueryEngine", () => {
     expect(rows.map((row) => row.title)).toEqual(["B", "A"]);
   });
 
+  it("rejects duplicate ids in bulk updates", async () => {
+    const { id } = await engine.insert("todo", "tasks", { title: "A", done: false, priority: 1 });
+
+    await expect(
+      engine.bulkUpdate("todo", "tasks", [
+        { id, data: { priority: 2 } },
+        { id, data: { priority: 3 } },
+      ]),
+    ).rejects.toThrow(/duplicate id/i);
+  });
+
   it("deletes a row by id", async () => {
     const { id } = await engine.insert("todo", "tasks", { title: "Delete me", done: false });
     await engine.delete("todo", "tasks", id);

--- a/tests/gateway/app-db-registry.test.ts
+++ b/tests/gateway/app-db-registry.test.ts
@@ -31,6 +31,7 @@ describe("AppRegistry", () => {
         tasks: {
           columns: { title: "text", done: "boolean", due: "timestamptz" },
           indexes: ["due"],
+          uniqueIndexes: ["title"],
         },
       },
     });
@@ -39,6 +40,23 @@ describe("AppRegistry", () => {
     expect(app).toBeDefined();
     expect(app!.name).toBe("Todo");
     expect(app!.tables).toHaveProperty("tasks");
+    expect(app!.tables.tasks.uniqueIndexes).toEqual(["title"]);
+  });
+
+  it("provisions unique indexes declared in app schemas", async () => {
+    await registry.register({
+      slug: "todo",
+      name: "Todo",
+      tables: {
+        tasks: {
+          columns: { title: "text" },
+          uniqueIndexes: ["title"],
+        },
+      },
+    });
+
+    await db.raw('INSERT INTO "todo"."tasks" (title) VALUES ($1)', ["Inbox"]);
+    await expect(db.raw('INSERT INTO "todo"."tasks" (title) VALUES ($1)', ["Inbox"])).rejects.toThrow();
   });
 
   it("creates Postgres schema and tables on register", async () => {

--- a/tests/gateway/app-db.test.ts
+++ b/tests/gateway/app-db.test.ts
@@ -93,6 +93,33 @@ describe("AppDb connection", () => {
     expect(indexes.rows[0].indexname).toContain("title");
   });
 
+  it("creates unique indexes on specified columns", async () => {
+    await db.createAppSchema("test-app");
+    await db.createTable("test-app", "items", { title: "text" }, undefined, ["title"]);
+
+    const indexes = await db.raw(
+      "SELECT indexname FROM pg_indexes WHERE schemaname = 'test-app' AND tablename = 'items' AND indexname LIKE 'uidx_%'",
+    );
+    expect(indexes.rows).toHaveLength(1);
+    expect(indexes.rows[0].indexname).toContain("title");
+
+    await db.raw('INSERT INTO "test-app"."items" (title) VALUES ($1)', ["Unique title"]);
+    await expect(
+      db.raw('INSERT INTO "test-app"."items" (title) VALUES ($1)', ["Unique title"]),
+    ).rejects.toThrow();
+  });
+
+  it("rejects invalid index column names instead of silently skipping manifest constraints", async () => {
+    await db.createAppSchema("test-app");
+
+    await expect(
+      db.createTable("test-app", "items", { title: "text" }, ["../title"]),
+    ).rejects.toThrow(/invalid index column name/i);
+    await expect(
+      db.createTable("test-app", "items", { title: "text" }, undefined, ["../title"]),
+    ).rejects.toThrow(/invalid unique index column name/i);
+  });
+
   it("maps type aliases correctly", async () => {
     await db.createAppSchema("test-app");
     await db.createTable("test-app", "typed", {

--- a/tests/gateway/app-runtime.test.ts
+++ b/tests/gateway/app-runtime.test.ts
@@ -152,6 +152,38 @@ icon: N
       expect(manifest.autoStart).toBe(true);
     });
 
+    it("rejects storage indexes that reference undeclared columns", () => {
+      expect(() =>
+        parseAppManifest({
+          name: "Bad Index",
+          storage: {
+            tables: {
+              tasks: {
+                columns: { title: "text" },
+                indexes: ["missing"],
+              },
+            },
+          },
+        }),
+      ).toThrow(/Storage index column/);
+    });
+
+    it("rejects storage unique indexes that reference undeclared columns", () => {
+      expect(() =>
+        parseAppManifest({
+          name: "Bad Unique Index",
+          storage: {
+            tables: {
+              tasks: {
+                columns: { title: "text" },
+                uniqueIndexes: ["missing"],
+              },
+            },
+          },
+        }),
+      ).toThrow(/Storage unique index column/);
+    });
+
     it("defaults autoStart to false", () => {
       const manifest = parseAppManifest({ name: "Lazy" });
       expect(manifest.autoStart).toBe(false);

--- a/tests/gateway/utility-apps.test.ts
+++ b/tests/gateway/utility-apps.test.ts
@@ -80,15 +80,26 @@ describe("T1430-T1433: Core utility apps", () => {
   describe("clock specifics", () => {
     const appSource = () => appOrSharedSource("clock");
 
-    it("has local time and focus timer surfaces", () => {
-      expect(appSource().toLowerCase()).toContain("time-card");
-      expect(appSource()).toContain("Local time");
-      expect(appSource().toLowerCase()).toContain("focus timer");
+    it("has world clock, timer, and stopwatch surfaces", () => {
+      const source = appSource().toLowerCase();
+      expect(source).toContain("world clock");
+      expect(source).toContain("timer");
+      expect(source).toContain("stopwatch");
     });
 
     it("has timer functionality", () => {
       expect(appSource().toLowerCase()).toContain("timer");
-      expect(appSource()).toContain("25:00");
+      expect(appSource()).toContain("25 min");
+    });
+
+    it("indexes alarms by scheduled time", () => {
+      const manifest = JSON.parse(readFileSync(join(APPS_DIR, "clock", "matrix.json"), "utf-8"));
+      expect(manifest.storage?.tables?.alarms?.indexes).toContain("time");
+    });
+
+    it("enforces unique saved world clock zones", () => {
+      const manifest = JSON.parse(readFileSync(join(APPS_DIR, "clock", "matrix.json"), "utf-8"));
+      expect(manifest.storage?.tables?.zones?.uniqueIndexes).toContain("tz");
     });
   });
 });


### PR DESCRIPTION
Stack: 7/22
Branch: stack/default-apps-clock

Scope: Clock app with world clocks, timers, model, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.