### PR TITLE
feat(weather): add Open-Meteo forecast app

### DIFF
--- a/home/apps/weather/matrix.json
+++ b/home/apps/weather/matrix.json
@@ -16,10 +16,12 @@
           "name": "text",
           "latitude": "float",
           "longitude": "float",
-          "is_default": "boolean"
+          "is_default": "boolean",
+          "created_at": "timestamptz"
         },
         "indexes": [
-          "is_default"
+          "is_default",
+          "created_at"
         ]
       }
     }

--- a/home/apps/weather/matrix.json
+++ b/home/apps/weather/matrix.json
@@ -9,6 +9,21 @@
   "slug": "weather",
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
+  "storage": {
+    "tables": {
+      "locations": {
+        "columns": {
+          "name": "text",
+          "latitude": "float",
+          "longitude": "float",
+          "is_default": "boolean"
+        },
+        "indexes": [
+          "is_default"
+        ]
+      }
+    }
+  },
   "build": {
     "install": "true",
     "command": "vite build --base ./ --outDir dist",

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -75,6 +75,24 @@ function locationKey(loc: SavedLocation): string {
   return loc.id ?? `${loc.name}:${loc.latitude}:${loc.longitude}`;
 }
 
+function sameCoordinates(a: Pick<SavedLocation, "latitude" | "longitude">, b: Pick<SavedLocation, "latitude" | "longitude">): boolean {
+  return a.latitude === b.latitude && a.longitude === b.longitude;
+}
+
+function stripLocalId(loc: SavedLocation): SavedLocation {
+  if (!loc.id?.startsWith("local-")) return loc;
+  return {
+    name: loc.name,
+    latitude: loc.latitude,
+    longitude: loc.longitude,
+    is_default: loc.is_default,
+  };
+}
+
+function storedLocations(locations: SavedLocation[]): SavedLocation[] {
+  return locations.map(stripLocalId);
+}
+
 function sameLocations(a: SavedLocation[], b: SavedLocation[]): boolean {
   if (a.length !== b.length) return false;
   return a.every((loc, index) => {
@@ -112,6 +130,7 @@ export default function App() {
     if (!db) {
       const stored = await readStoredLocations();
       setLocations((current) => (sameLocations(current, stored) ? current : stored));
+      setError(null);
       return;
     }
     try {
@@ -122,6 +141,7 @@ export default function App() {
         .filter((l): l is SavedLocation => l !== null)
         .filter((l) => !pending.includes(locationKey(l)));
       setLocations((current) => (sameLocations(current, parsed) ? current : parsed));
+      setError(null);
     } catch (err: unknown) {
       console.warn("[weather] location load failed:", errMsg(err));
       setError("Saved locations could not be loaded.");
@@ -248,6 +268,15 @@ export default function App() {
   const addLocation = useCallback(
     async (geo: GeoResult) => {
       const previousActiveId = activeId;
+      const duplicate = locations.find((loc) => sameCoordinates(loc, geo));
+      if (duplicate) {
+        setActiveId(duplicate.id ?? duplicate.name);
+        setSearchOpen(false);
+        setQuery("");
+        setResults([]);
+        setSearchError(null);
+        return;
+      }
       const label = geo.admin1 && geo.admin1 !== geo.name ? `${geo.name}, ${geo.admin1}` : geo.name;
       const candidate: SavedLocation = {
         name: label,
@@ -266,7 +295,8 @@ export default function App() {
       const db = window.MatrixOS?.db;
       if (!db) {
         const existing = await readStoredLocations();
-        await writeAppData(LOCATIONS_KEY, [...existing, candidate]);
+        await writeAppData(LOCATIONS_KEY, storedLocations([...existing, candidate]));
+        setError(null);
         return;
       }
       try {
@@ -283,6 +313,7 @@ export default function App() {
         );
         setActiveId(id);
         await reloadLocations();
+        setError(null);
       } catch (err: unknown) {
         console.warn("[weather] location save failed:", errMsg(err));
         setError("Location could not be saved.");
@@ -303,8 +334,9 @@ export default function App() {
       setLocations(remaining);
       const db = window.MatrixOS?.db;
       if (!db) {
-        await writeAppData(LOCATIONS_KEY, remaining);
+        await writeAppData(LOCATIONS_KEY, storedLocations(remaining));
         pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
+        setError(null);
         return;
       }
       if (!loc.id || loc.id.startsWith("local-")) {
@@ -315,6 +347,7 @@ export default function App() {
         await db.delete(LOCATIONS_TABLE, loc.id);
         pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
         await reloadLocations();
+        setError(null);
       } catch (err: unknown) {
         pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
         console.warn("[weather] location delete failed:", errMsg(err));

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -247,7 +247,7 @@ export default function App() {
   const addLocation = useCallback(
     async (geo: GeoResult) => {
       const previousActiveId = activeId;
-      const label = geo.admin1 && geo.admin1 !== geo.name ? `${geo.name}` : geo.name;
+      const label = geo.admin1 && geo.admin1 !== geo.name ? `${geo.name}, ${geo.admin1}` : geo.name;
       const candidate: SavedLocation = {
         name: label,
         latitude: geo.latitude,
@@ -264,7 +264,8 @@ export default function App() {
 
       const db = window.MatrixOS?.db;
       if (!db) {
-        await writeAppData(LOCATIONS_KEY, [...locations, candidate]);
+        const existing = await readStoredLocations();
+        await writeAppData(LOCATIONS_KEY, [...existing, candidate]);
         return;
       }
       try {

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -124,6 +124,7 @@ export default function App() {
   const [searchError, setSearchError] = useState<string | null>(null);
   const searchSeq = useRef(0);
   const pendingRemovalKeys = useRef<string[]>([]);
+  const pendingDefaultPromotionKeys = useRef<Set<string>>(new Set());
 
   const reloadLocations = useCallback(async () => {
     const db = window.MatrixOS?.db;
@@ -200,13 +201,11 @@ export default function App() {
   const activeForecastLocation = useMemo<SavedLocation | null>(() => {
     if (!active) return null;
     return {
-      id: active.id,
       name: active.name,
       latitude: active.latitude,
       longitude: active.longitude,
-      is_default: active.is_default,
     };
-  }, [active?.id, active?.name, active?.latitude, active?.longitude, active?.is_default]);
+  }, [active?.name, active?.latitude, active?.longitude]);
 
   // Load forecast for the active location with graceful demo fallback.
   useEffect(() => {
@@ -239,15 +238,17 @@ export default function App() {
   useEffect(() => {
     if (!searchOpen) return undefined;
     const q = query.trim();
+    const seq = ++searchSeq.current;
     if (q.length < 2) {
       setResults([]);
       setSearchError(null);
       setSearching(false);
       return undefined;
     }
-    const seq = ++searchSeq.current;
-    setSearching(true);
+    setSearching(false);
+    setSearchError(null);
     const handle = window.setTimeout(async () => {
+      setSearching(true);
       try {
         const found = await geocode(q);
         if (seq !== searchSeq.current) return;
@@ -307,18 +308,54 @@ export default function App() {
           is_default: candidate.is_default ?? false,
           created_at: new Date().toISOString(),
         });
-        const saved: SavedLocation = { ...candidate, id };
-        setLocations((curr) =>
-          curr.map((loc) => (locationKey(loc) === optimistic.id ? saved : loc)),
-        );
+        if (pendingRemovalKeys.current.includes(optimistic.id!)) {
+          try {
+            await db.delete(LOCATIONS_TABLE, id);
+            setError(null);
+          } catch (err: unknown) {
+            console.warn("[weather] pending removed location cleanup failed:", errMsg(err));
+            setError("Location could not be removed.");
+          } finally {
+            pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== optimistic.id && k !== id);
+            pendingDefaultPromotionKeys.current.delete(optimistic.id!);
+          }
+          await reloadLocations();
+          return;
+        }
+        let savedIsDefault = candidate.is_default ?? false;
+        let promotionFailed = false;
+        if (pendingDefaultPromotionKeys.current.has(optimistic.id!)) {
+          try {
+            await db.update(LOCATIONS_TABLE, id, { is_default: true });
+            savedIsDefault = true;
+          } catch (err: unknown) {
+            promotionFailed = true;
+            console.warn("[weather] default location promotion failed:", errMsg(err));
+          } finally {
+            pendingDefaultPromotionKeys.current.delete(optimistic.id!);
+          }
+        }
+        const saved: SavedLocation = { ...candidate, id, is_default: savedIsDefault };
+        setLocations((curr) => {
+          const savedKey = locationKey(saved);
+          if (curr.some((loc) => locationKey(loc) === optimistic.id)) {
+            return curr.map((loc) => (locationKey(loc) === optimistic.id ? saved : loc));
+          }
+          if (curr.some((loc) => locationKey(loc) === savedKey)) {
+            return curr.map((loc) => (locationKey(loc) === savedKey ? { ...loc, ...saved } : loc));
+          }
+          return [...curr, saved];
+        });
         setActiveId(id);
         await reloadLocations();
-        setError(null);
+        setError(promotionFailed ? "Default location could not be updated." : null);
       } catch (err: unknown) {
         console.warn("[weather] location save failed:", errMsg(err));
         setError("Location could not be saved.");
         setLocations((curr) => curr.filter((loc) => locationKey(loc) !== optimistic.id));
         setActiveId(previousActiveId);
+        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== optimistic.id);
+        pendingDefaultPromotionKeys.current.delete(optimistic.id!);
       }
     },
     [activeId, locations, reloadLocations],
@@ -335,6 +372,10 @@ export default function App() {
       const nextLocations = shouldPromoteDefault && remaining[0]
         ? remaining.map((item, index) => index === 0 ? { ...item, is_default: true } : item)
         : remaining;
+      const promotedLocalKey = shouldPromoteDefault && remaining[0] ? locationKey(remaining[0]) : null;
+      if (promotedLocalKey?.startsWith("local-")) {
+        pendingDefaultPromotionKeys.current.add(promotedLocalKey);
+      }
       setLocations(nextLocations);
       const db = window.MatrixOS?.db;
       if (!db) {
@@ -344,13 +385,14 @@ export default function App() {
         return;
       }
       if (!loc.id || loc.id.startsWith("local-")) {
-        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
+        pendingDefaultPromotionKeys.current.delete(key);
         return;
       }
       try {
         await db.delete(LOCATIONS_TABLE, loc.id);
       } catch (err: unknown) {
         pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
+        if (promotedLocalKey) pendingDefaultPromotionKeys.current.delete(promotedLocalKey);
         console.warn("[weather] location delete failed:", errMsg(err));
         setError("Location could not be removed.");
         setLocations(previousLocations);
@@ -366,6 +408,9 @@ export default function App() {
           promotionFailed = true;
           console.warn("[weather] default location promotion failed:", errMsg(err));
         }
+      }
+      if (promotedLocalKey && !promotedLocalKey.startsWith("local-")) {
+        pendingDefaultPromotionKeys.current.delete(promotedLocalKey);
       }
       pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
       await reloadLocations();

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -349,20 +349,27 @@ export default function App() {
       }
       try {
         await db.delete(LOCATIONS_TABLE, loc.id);
-        const promoted = shouldPromoteDefault ? nextLocations[0] : null;
-        if (promoted?.id && !promoted.id.startsWith("local-")) {
-          await db.update(LOCATIONS_TABLE, promoted.id, { is_default: true });
-        }
-        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
-        await reloadLocations();
-        setError(null);
       } catch (err: unknown) {
         pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
         console.warn("[weather] location delete failed:", errMsg(err));
         setError("Location could not be removed.");
         setLocations(previousLocations);
         setActiveId(previousActiveId);
+        return;
       }
+      let promotionFailed = false;
+      const promoted = shouldPromoteDefault ? nextLocations[0] : null;
+      if (promoted?.id && !promoted.id.startsWith("local-")) {
+        try {
+          await db.update(LOCATIONS_TABLE, promoted.id, { is_default: true });
+        } catch (err: unknown) {
+          promotionFailed = true;
+          console.warn("[weather] default location promotion failed:", errMsg(err));
+        }
+      }
+      pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
+      await reloadLocations();
+      setError(promotionFailed ? "Default location could not be updated." : null);
     },
     [activeId, locations, reloadLocations],
   );

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -196,7 +196,6 @@ export default function App() {
     }
     let cancelled = false;
     setStatus("loading");
-    setError(null);
     (async () => {
       try {
         const data = await fetchForecast(activeForecastLocation);
@@ -265,7 +264,7 @@ export default function App() {
 
       const db = window.MatrixOS?.db;
       if (!db) {
-        await writeAppData(LOCATIONS_KEY, [...locations, optimistic]);
+        await writeAppData(LOCATIONS_KEY, [...locations, candidate]);
         return;
       }
       try {
@@ -398,6 +397,7 @@ export default function App() {
       </aside>
 
       <section className="stage">
+        {error ? <div className="error-notice">{error}</div> : null}
         {!hasLocations ? (
           <div className="empty-state" data-testid="empty-state">
             <div className="empty-state__mark">
@@ -463,7 +463,6 @@ export default function App() {
                 Showing demo data — live forecast is unavailable right now.
               </div>
             ) : null}
-            {error ? <div className="error-notice">{error}</div> : null}
 
             <div className="panel">
               <h3 className="panel__title">Hourly forecast</h3>

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -335,6 +335,7 @@ export default function App() {
       if (!db) {
         const existing = await readStoredLocations();
         await writeAppData(LOCATIONS_KEY, storedLocations([...existing, candidate]));
+        await reloadLocations();
         setError(null);
         return;
       }
@@ -415,7 +416,13 @@ export default function App() {
         setError(null);
         return;
       }
-      if (!loc.id || loc.id.startsWith("local-")) {
+      if (!loc.id) {
+        pendingLocations.clearRemoved(key);
+        pendingLocations.clearDefaultPromotion(key);
+        return;
+      }
+      if (loc.id.startsWith("local-")) {
+        // Keep the removal key so the in-flight insert path can delete the resolved DB row.
         pendingLocations.clearDefaultPromotion(key);
         return;
       }

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -12,6 +12,7 @@ import {
   buildDaily,
   buildHourly,
   coerceLocation,
+  dailyTemperatureBar,
   DEMO_LOCATION,
   demoForecast,
   formatDay,
@@ -577,9 +578,7 @@ export default function App() {
               <h3 className="panel__title">7-day forecast</h3>
               <div className="daily-list" data-testid="daily-list">
                 {daily.map((d) => {
-                  const range = span.max - span.min || 1;
-                  const left = ((d.lowC - span.min) / range) * 100;
-                  const width = ((d.highC - d.lowC) / range) * 100;
+                  const bar = dailyTemperatureBar(d, span);
                   return (
                     <div className="daily-row" data-testid="daily-row" key={d.date}>
                       <span className="daily-row__day">{formatDay(d.date, nowIso)}</span>
@@ -590,7 +589,7 @@ export default function App() {
                       <span className="daily-row__bar">
                         <span
                           className="daily-row__bar-fill"
-                          style={{ left: `${left}%`, width: `${Math.max(8, width)}%` }}
+                          style={{ left: `${bar.left}%`, width: `${bar.width}%` }}
                         />
                       </span>
                       <span className="daily-row__high">{formatTemp(d.highC, unit)}</span>

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -369,30 +369,30 @@ export default function App() {
             const id = loc.id ?? loc.name;
             const isActive = (active?.id ?? active?.name) === id;
             return (
-              <button
+              <div
                 key={id}
-                type="button"
                 role="listitem"
                 data-testid="location-item"
                 className={isActive ? "loc-chip loc-chip--active" : "loc-chip"}
-                onClick={() => setActiveId(id)}
               >
-                <MapPin size={15} />
-                <span className="loc-chip__name">{loc.name}</span>
-                {loc.is_default ? <span className="loc-chip__badge">Default</span> : null}
-                <span
+                <button
+                  type="button"
+                  className="loc-chip__select"
+                  onClick={() => setActiveId(id)}
+                >
+                  <MapPin size={15} />
+                  <span className="loc-chip__name">{loc.name}</span>
+                  {loc.is_default ? <span className="loc-chip__badge">Default</span> : null}
+                </button>
+                <button
+                  type="button"
                   className="loc-chip__remove"
-                  role="button"
-                  tabIndex={-1}
                   aria-label={`Remove ${loc.name}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void removeLocation(loc);
-                  }}
+                  onClick={() => void removeLocation(loc)}
                 >
                   <Trash2 size={14} />
-                </span>
-              </button>
+                </button>
+              </div>
             );
           })}
           {!hasLocations ? <p className="sidebar__hint">No saved places yet.</p> : null}

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -17,6 +17,7 @@ import {
   formatDay,
   formatHour,
   formatTemp,
+  formatWindSpeed,
   isDaytime,
   tempSpan,
   weatherVisual,
@@ -444,7 +445,7 @@ export default function App() {
                   ) : null}
                   {forecast?.current?.wind_speed_10m != null ? (
                     <span className="hero__chip">
-                      <Wind size={13} /> {Math.round(forecast.current.wind_speed_10m)} km/h
+                      <Wind size={13} /> {formatWindSpeed(forecast.current.wind_speed_10m, unit)}
                     </span>
                   ) : null}
                   <button

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -33,6 +33,7 @@ import "./styles.css";
 const LOCATIONS_TABLE = "locations";
 const LOCATIONS_KEY = "matrix-weather-locations";
 const UNIT_KEY = "matrix-weather-unit";
+const MAX_PENDING_REMOVALS = 50;
 
 type LoadStatus = "loading" | "live" | "demo";
 
@@ -109,6 +110,44 @@ function sameLocations(a: SavedLocation[], b: SavedLocation[]): boolean {
   });
 }
 
+function planLocationRemoval(locations: SavedLocation[], key: string, wasDefault: boolean) {
+  const remaining = locations.filter((l) => locationKey(l) !== key);
+  const shouldPromoteDefault = wasDefault && !remaining.some((l) => l.is_default);
+  const nextLocations = shouldPromoteDefault && remaining[0]
+    ? remaining.map((item, index) => index === 0 ? { ...item, is_default: true } : item)
+    : remaining;
+  const promotedKey = shouldPromoteDefault && remaining[0] ? locationKey(remaining[0]) : null;
+  return { nextLocations, promotedKey };
+}
+
+function usePendingLocationOps() {
+  const removalKeys = useRef<string[]>([]);
+  const defaultPromotionKeys = useRef<Set<string>>(new Set());
+
+  return useMemo(() => ({
+    hiddenRemovalKeys: () => removalKeys.current,
+    markRemoved: (key: string) => {
+      removalKeys.current = [...removalKeys.current.filter((k) => k !== key), key].slice(-MAX_PENDING_REMOVALS);
+    },
+    clearRemoved: (...keys: string[]) => {
+      const cleared = new Set(keys);
+      removalKeys.current = removalKeys.current.filter((k) => !cleared.has(k));
+    },
+    isRemoved: (key: string) => removalKeys.current.includes(key),
+    markDefaultPromotion: (key: string) => {
+      defaultPromotionKeys.current.add(key);
+    },
+    clearDefaultPromotion: (key: string) => {
+      defaultPromotionKeys.current.delete(key);
+    },
+    consumeDefaultPromotion: (key: string) => {
+      const marked = defaultPromotionKeys.current.has(key);
+      if (marked) defaultPromotionKeys.current.delete(key);
+      return marked;
+    },
+  }), []);
+}
+
 export default function App() {
   const [locations, setLocations] = useState<SavedLocation[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -124,8 +163,7 @@ export default function App() {
   const [searching, setSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const searchSeq = useRef(0);
-  const pendingRemovalKeys = useRef<string[]>([]);
-  const pendingDefaultPromotionKeys = useRef<Set<string>>(new Set());
+  const pendingLocations = usePendingLocationOps();
 
   const reloadLocations = useCallback(async () => {
     const db = window.MatrixOS?.db;
@@ -137,11 +175,10 @@ export default function App() {
     }
     try {
       const rows = await db.find(LOCATIONS_TABLE, { orderBy: { created_at: "asc" } });
-      const pending = pendingRemovalKeys.current;
       const parsed = rows
         .map(coerceLocation)
         .filter((l): l is SavedLocation => l !== null)
-        .filter((l) => !pending.includes(locationKey(l)));
+        .filter((l) => !pendingLocations.hiddenRemovalKeys().includes(locationKey(l)));
       setLocations((current) => (sameLocations(current, parsed) ? current : parsed));
       setError(null);
     } catch (err: unknown) {
@@ -150,7 +187,7 @@ export default function App() {
       const stored = await readStoredLocations();
       setLocations((current) => (sameLocations(current, stored) ? current : stored));
     }
-  }, []);
+  }, [pendingLocations]);
 
   useEffect(() => {
     void reloadLocations();
@@ -309,7 +346,7 @@ export default function App() {
           is_default: candidate.is_default ?? false,
           created_at: new Date().toISOString(),
         });
-        if (pendingRemovalKeys.current.includes(optimistic.id!)) {
+        if (pendingLocations.isRemoved(optimistic.id!)) {
           try {
             await db.delete(LOCATIONS_TABLE, id);
             setError(null);
@@ -317,23 +354,21 @@ export default function App() {
             console.warn("[weather] pending removed location cleanup failed:", errMsg(err));
             setError("Location could not be removed.");
           } finally {
-            pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== optimistic.id && k !== id);
-            pendingDefaultPromotionKeys.current.delete(optimistic.id!);
+            pendingLocations.clearRemoved(optimistic.id!, id);
+            pendingLocations.clearDefaultPromotion(optimistic.id!);
           }
           await reloadLocations();
           return;
         }
         let savedIsDefault = candidate.is_default ?? false;
         let promotionFailed = false;
-        if (pendingDefaultPromotionKeys.current.has(optimistic.id!)) {
+        if (pendingLocations.consumeDefaultPromotion(optimistic.id!)) {
           try {
             await db.update(LOCATIONS_TABLE, id, { is_default: true });
             savedIsDefault = true;
           } catch (err: unknown) {
             promotionFailed = true;
             console.warn("[weather] default location promotion failed:", errMsg(err));
-          } finally {
-            pendingDefaultPromotionKeys.current.delete(optimistic.id!);
           }
         }
         const saved: SavedLocation = { ...candidate, id, is_default: savedIsDefault };
@@ -355,11 +390,11 @@ export default function App() {
         setError("Location could not be saved.");
         setLocations((curr) => curr.filter((loc) => locationKey(loc) !== optimistic.id));
         setActiveId(previousActiveId);
-        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== optimistic.id);
-        pendingDefaultPromotionKeys.current.delete(optimistic.id!);
+        pendingLocations.clearRemoved(optimistic.id!);
+        pendingLocations.clearDefaultPromotion(optimistic.id!);
       }
     },
-    [activeId, locations, reloadLocations],
+    [activeId, locations, pendingLocations, reloadLocations],
   );
 
   const removeLocation = useCallback(
@@ -367,33 +402,28 @@ export default function App() {
       const previousLocations = locations;
       const previousActiveId = activeId;
       const key = locationKey(loc);
-      pendingRemovalKeys.current = [...pendingRemovalKeys.current, key].slice(-50);
-      const remaining = locations.filter((l) => locationKey(l) !== key);
-      const shouldPromoteDefault = loc.is_default === true && !remaining.some((l) => l.is_default);
-      const nextLocations = shouldPromoteDefault && remaining[0]
-        ? remaining.map((item, index) => index === 0 ? { ...item, is_default: true } : item)
-        : remaining;
-      const promotedLocalKey = shouldPromoteDefault && remaining[0] ? locationKey(remaining[0]) : null;
-      if (promotedLocalKey?.startsWith("local-")) {
-        pendingDefaultPromotionKeys.current.add(promotedLocalKey);
+      pendingLocations.markRemoved(key);
+      const { nextLocations, promotedKey } = planLocationRemoval(locations, key, loc.is_default === true);
+      if (promotedKey?.startsWith("local-")) {
+        pendingLocations.markDefaultPromotion(promotedKey);
       }
       setLocations(nextLocations);
       const db = window.MatrixOS?.db;
       if (!db) {
         await writeAppData(LOCATIONS_KEY, storedLocations(nextLocations));
-        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
+        pendingLocations.clearRemoved(key);
         setError(null);
         return;
       }
       if (!loc.id || loc.id.startsWith("local-")) {
-        pendingDefaultPromotionKeys.current.delete(key);
+        pendingLocations.clearDefaultPromotion(key);
         return;
       }
       try {
         await db.delete(LOCATIONS_TABLE, loc.id);
       } catch (err: unknown) {
-        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
-        if (promotedLocalKey) pendingDefaultPromotionKeys.current.delete(promotedLocalKey);
+        pendingLocations.clearRemoved(key);
+        if (promotedKey) pendingLocations.clearDefaultPromotion(promotedKey);
         console.warn("[weather] location delete failed:", errMsg(err));
         setError("Location could not be removed.");
         setLocations(previousLocations);
@@ -401,7 +431,7 @@ export default function App() {
         return;
       }
       let promotionFailed = false;
-      const promoted = shouldPromoteDefault ? nextLocations[0] : null;
+      const promoted = promotedKey ? nextLocations[0] : null;
       if (promoted?.id && !promoted.id.startsWith("local-")) {
         try {
           await db.update(LOCATIONS_TABLE, promoted.id, { is_default: true });
@@ -410,14 +440,14 @@ export default function App() {
           console.warn("[weather] default location promotion failed:", errMsg(err));
         }
       }
-      if (promotedLocalKey && !promotedLocalKey.startsWith("local-")) {
-        pendingDefaultPromotionKeys.current.delete(promotedLocalKey);
+      if (promotedKey && !promotedKey.startsWith("local-")) {
+        pendingLocations.clearDefaultPromotion(promotedKey);
       }
-      pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
+      pendingLocations.clearRemoved(key);
       await reloadLocations();
       setError(promotionFailed ? "Default location could not be updated." : null);
     },
-    [activeId, locations, reloadLocations],
+    [activeId, locations, pendingLocations, reloadLocations],
   );
 
   const nowIso = forecast?.current?.time;

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -1,0 +1,506 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Droplets,
+  MapPin,
+  Plus,
+  Search,
+  Trash2,
+  Wind,
+  X,
+} from "lucide-react";
+import {
+  buildDaily,
+  buildHourly,
+  coerceLocation,
+  DEMO_LOCATION,
+  demoForecast,
+  formatDay,
+  formatHour,
+  formatTemp,
+  isDaytime,
+  tempSpan,
+  weatherVisual,
+  type OpenMeteoForecast,
+  type SavedLocation,
+  type Unit,
+} from "./weather-model";
+import { fetchForecast, geocode, type GeoResult } from "./weather-api";
+import { WeatherIcon } from "./WeatherIcon";
+import "./styles.css";
+
+const LOCATIONS_TABLE = "locations";
+const LS_KEY = "matrix-weather-locations";
+const LS_UNIT = "matrix-weather-unit";
+
+type LoadStatus = "loading" | "live" | "demo";
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function readLocalLocations(): SavedLocation[] {
+  try {
+    const raw = window.localStorage.getItem(LS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(coerceLocation).filter((l): l is SavedLocation => l !== null);
+  } catch (err: unknown) {
+    console.warn("[weather] local locations read failed:", errMsg(err));
+    return [];
+  }
+}
+
+function writeLocalLocations(locations: SavedLocation[]): void {
+  try {
+    window.localStorage.setItem(LS_KEY, JSON.stringify(locations));
+  } catch (err: unknown) {
+    console.warn("[weather] local locations write failed:", errMsg(err));
+  }
+}
+
+export default function App() {
+  const [locations, setLocations] = useState<SavedLocation[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [forecast, setForecast] = useState<OpenMeteoForecast | null>(null);
+  const [status, setStatus] = useState<LoadStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [unit, setUnit] = useState<Unit>(() => {
+    try {
+      return window.localStorage.getItem(LS_UNIT) === "f" ? "f" : "c";
+    } catch {
+      return "c";
+    }
+  });
+
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<GeoResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const searchSeq = useRef(0);
+
+  const reloadLocations = useCallback(async () => {
+    const db = window.MatrixOS?.db;
+    if (!db) {
+      setLocations(readLocalLocations());
+      return;
+    }
+    try {
+      const rows = await db.find(LOCATIONS_TABLE, { orderBy: { created_at: "asc" } });
+      const parsed = rows.map(coerceLocation).filter((l): l is SavedLocation => l !== null);
+      setLocations(parsed);
+    } catch (err: unknown) {
+      console.warn("[weather] location load failed:", errMsg(err));
+      setError("Saved locations could not be loaded.");
+      setLocations(readLocalLocations());
+    }
+  }, []);
+
+  useEffect(() => {
+    void reloadLocations();
+    const db = window.MatrixOS?.db;
+    if (!db?.onChange) return undefined;
+    try {
+      return db.onChange(LOCATIONS_TABLE, () => void reloadLocations());
+    } catch (err: unknown) {
+      console.warn("[weather] onChange subscribe failed:", errMsg(err));
+      return undefined;
+    }
+  }, [reloadLocations]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(LS_UNIT, unit);
+    } catch (err: unknown) {
+      console.warn("[weather] unit persist failed:", errMsg(err));
+    }
+  }, [unit]);
+
+  // Keep an active selection in sync with the available locations.
+  useEffect(() => {
+    if (locations.length === 0) {
+      setActiveId(null);
+      return;
+    }
+    const stillThere = activeId && locations.some((l) => (l.id ?? l.name) === activeId);
+    if (!stillThere) {
+      const def = locations.find((l) => l.is_default) ?? locations[0];
+      setActiveId(def.id ?? def.name);
+    }
+  }, [locations, activeId]);
+
+  const active = useMemo<SavedLocation | null>(() => {
+    if (locations.length === 0) return null;
+    return locations.find((l) => (l.id ?? l.name) === activeId) ?? locations[0];
+  }, [locations, activeId]);
+
+  // Load forecast for the active location with graceful demo fallback.
+  useEffect(() => {
+    if (!active) {
+      setForecast(null);
+      setStatus("loading");
+      return;
+    }
+    let cancelled = false;
+    setStatus("loading");
+    setError(null);
+    (async () => {
+      try {
+        const data = await fetchForecast(active);
+        if (cancelled) return;
+        setForecast(data);
+        setStatus("live");
+      } catch (err: unknown) {
+        if (cancelled) return;
+        console.warn("[weather] forecast fetch failed:", errMsg(err));
+        setForecast(demoForecast());
+        setStatus("demo");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [active]);
+
+  // Debounced geocode search.
+  useEffect(() => {
+    if (!searchOpen) return undefined;
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      setSearchError(null);
+      setSearching(false);
+      return undefined;
+    }
+    const seq = ++searchSeq.current;
+    setSearching(true);
+    const handle = window.setTimeout(async () => {
+      try {
+        const found = await geocode(q);
+        if (seq !== searchSeq.current) return;
+        setResults(found);
+        setSearchError(found.length === 0 ? "No matching places." : null);
+      } catch (err: unknown) {
+        if (seq !== searchSeq.current) return;
+        console.warn("[weather] geocode failed:", errMsg(err));
+        setSearchError("Search is unavailable right now.");
+        setResults([]);
+      } finally {
+        if (seq === searchSeq.current) setSearching(false);
+      }
+    }, 280);
+    return () => window.clearTimeout(handle);
+  }, [query, searchOpen]);
+
+  const addLocation = useCallback(
+    async (geo: GeoResult) => {
+      const label = geo.admin1 && geo.admin1 !== geo.name ? `${geo.name}` : geo.name;
+      const candidate: SavedLocation = {
+        name: label,
+        latitude: geo.latitude,
+        longitude: geo.longitude,
+        is_default: locations.length === 0,
+      };
+      // Optimistic add.
+      const optimistic: SavedLocation = { ...candidate, id: `local-${Date.now()}` };
+      setLocations((curr) => [...curr, optimistic]);
+      setActiveId(optimistic.id!);
+      setSearchOpen(false);
+      setQuery("");
+      setResults([]);
+
+      const db = window.MatrixOS?.db;
+      if (!db) {
+        writeLocalLocations([...locations, candidate]);
+        return;
+      }
+      try {
+        const { id } = await db.insert(LOCATIONS_TABLE, {
+          name: candidate.name,
+          latitude: candidate.latitude,
+          longitude: candidate.longitude,
+          is_default: candidate.is_default ?? false,
+        });
+        setActiveId(id);
+        await reloadLocations();
+      } catch (err: unknown) {
+        console.warn("[weather] location save failed:", errMsg(err));
+        setError("Location could not be saved.");
+      }
+    },
+    [locations, reloadLocations],
+  );
+
+  const removeLocation = useCallback(
+    async (loc: SavedLocation) => {
+      setLocations((curr) => curr.filter((l) => (l.id ?? l.name) !== (loc.id ?? loc.name)));
+      const db = window.MatrixOS?.db;
+      if (!db) {
+        writeLocalLocations(locations.filter((l) => (l.id ?? l.name) !== (loc.id ?? loc.name)));
+        return;
+      }
+      if (!loc.id || loc.id.startsWith("local-")) return;
+      try {
+        await db.delete(LOCATIONS_TABLE, loc.id);
+        await reloadLocations();
+      } catch (err: unknown) {
+        console.warn("[weather] location delete failed:", errMsg(err));
+        setError("Location could not be removed.");
+      }
+    },
+    [locations, reloadLocations],
+  );
+
+  const nowIso = forecast?.current?.time;
+  const code = forecast?.current?.weather_code ?? 0;
+  const visual = weatherVisual(code);
+  const sunrise = forecast?.daily?.sunrise?.[0];
+  const sunset = forecast?.daily?.sunset?.[0];
+  const day = forecast?.current?.is_day != null
+    ? forecast.current.is_day === 1
+    : isDaytime(nowIso ?? new Date().toISOString(), sunrise, sunset);
+  const gradient = day ? visual.gradientDay : visual.gradientNight;
+
+  const hourly = useMemo(
+    () => (forecast ? buildHourly(forecast, nowIso, 24) : []),
+    [forecast, nowIso],
+  );
+  const daily = useMemo(() => (forecast ? buildDaily(forecast, 7) : []), [forecast]);
+  const span = useMemo(() => tempSpan(daily), [daily]);
+
+  const currentTemp = forecast?.current?.temperature_2m ?? 0;
+  const feels = forecast?.current?.apparent_temperature ?? currentTemp;
+  const todayDaily = daily[0];
+
+  const hasLocations = locations.length > 0;
+
+  return (
+    <main className="weather-app" data-tone={visual.tone}>
+      <aside className="sidebar">
+        <header className="sidebar__head">
+          <h1>Weather</h1>
+          <button
+            type="button"
+            className="add-btn"
+            aria-label="Add location"
+            onClick={() => setSearchOpen(true)}
+          >
+            <Plus size={18} />
+          </button>
+        </header>
+
+        <div className="location-list" role="list">
+          {locations.map((loc) => {
+            const id = loc.id ?? loc.name;
+            const isActive = (active?.id ?? active?.name) === id;
+            return (
+              <button
+                key={id}
+                type="button"
+                role="listitem"
+                data-testid="location-item"
+                className={isActive ? "loc-chip loc-chip--active" : "loc-chip"}
+                onClick={() => setActiveId(id)}
+              >
+                <MapPin size={15} />
+                <span className="loc-chip__name">{loc.name}</span>
+                {loc.is_default ? <span className="loc-chip__badge">Default</span> : null}
+                <span
+                  className="loc-chip__remove"
+                  role="button"
+                  tabIndex={-1}
+                  aria-label={`Remove ${loc.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void removeLocation(loc);
+                  }}
+                >
+                  <Trash2 size={14} />
+                </span>
+              </button>
+            );
+          })}
+          {!hasLocations ? <p className="sidebar__hint">No saved places yet.</p> : null}
+        </div>
+      </aside>
+
+      <section className="stage">
+        {!hasLocations ? (
+          <div className="empty-state" data-testid="empty-state">
+            <div className="empty-state__mark">
+              <WeatherIcon name="cloud-sun" size={40} />
+            </div>
+            <h2>Add your first location</h2>
+            <p>Search any city to see live conditions, an hourly strip, and a 7-day forecast.</p>
+            <button type="button" className="primary-action" onClick={() => setSearchOpen(true)}>
+              <Search size={16} /> Search a city
+            </button>
+          </div>
+        ) : (
+          <div className="weather-scroll">
+            <div className="hero" style={{ backgroundImage: gradient }} data-testid="weather-hero">
+              <div className={`hero__sky hero__sky--${visual.kind}`} aria-hidden="true">
+                <span className="hero__orb" />
+                <span className="hero__cloud hero__cloud--a" />
+                <span className="hero__cloud hero__cloud--b" />
+              </div>
+              <div className="hero__content">
+                <div className="hero__loc" data-testid="hero-location">
+                  <MapPin size={16} /> {active?.name ?? "—"}
+                </div>
+                <div className="hero__temp" data-testid="hero-temp">
+                  {status === "loading" ? "—" : formatTemp(currentTemp, unit)}
+                </div>
+                <div className="hero__condition" data-testid="hero-condition">
+                  <WeatherIcon name={visual.icon} size={22} /> {visual.label}
+                </div>
+                <div className="hero__meta">
+                  <span>Feels {formatTemp(feels, unit)}</span>
+                  {todayDaily ? (
+                    <span>
+                      H:{formatTemp(todayDaily.highC, unit)} · L:{formatTemp(todayDaily.lowC, unit)}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="hero__chips">
+                  {forecast?.current?.relative_humidity_2m != null ? (
+                    <span className="hero__chip">
+                      <Droplets size={13} /> {Math.round(forecast.current.relative_humidity_2m)}%
+                    </span>
+                  ) : null}
+                  {forecast?.current?.wind_speed_10m != null ? (
+                    <span className="hero__chip">
+                      <Wind size={13} /> {Math.round(forecast.current.wind_speed_10m)} km/h
+                    </span>
+                  ) : null}
+                  <button
+                    type="button"
+                    className="unit-toggle"
+                    onClick={() => setUnit((u) => (u === "c" ? "f" : "c"))}
+                    aria-label="Toggle temperature unit"
+                  >
+                    °{unit === "c" ? "C" : "F"}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {status === "demo" ? (
+              <div className="demo-notice" data-testid="demo-notice">
+                Showing demo data — live forecast is unavailable right now.
+              </div>
+            ) : null}
+            {error ? <div className="error-notice">{error}</div> : null}
+
+            <div className="panel">
+              <h3 className="panel__title">Hourly forecast</h3>
+              <div className="hourly-strip" data-testid="hourly-strip">
+                {hourly.map((h, i) => (
+                  <div className="hourly-cell" data-testid="hourly-cell" key={`${h.time}-${i}`}>
+                    <span className="hourly-cell__time">{formatHour(h.time, h.isNow)}</span>
+                    <WeatherIcon name={weatherVisual(h.code).icon} size={20} />
+                    <span className="hourly-cell__temp">{formatTemp(h.tempC, unit)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="panel">
+              <h3 className="panel__title">7-day forecast</h3>
+              <div className="daily-list" data-testid="daily-list">
+                {daily.map((d) => {
+                  const range = span.max - span.min || 1;
+                  const left = ((d.lowC - span.min) / range) * 100;
+                  const width = ((d.highC - d.lowC) / range) * 100;
+                  return (
+                    <div className="daily-row" data-testid="daily-row" key={d.date}>
+                      <span className="daily-row__day">{formatDay(d.date, nowIso)}</span>
+                      <span className="daily-row__icon">
+                        <WeatherIcon name={weatherVisual(d.code).icon} size={20} />
+                      </span>
+                      <span className="daily-row__low">{formatTemp(d.lowC, unit)}</span>
+                      <span className="daily-row__bar">
+                        <span
+                          className="daily-row__bar-fill"
+                          style={{ left: `${left}%`, width: `${Math.max(8, width)}%` }}
+                        />
+                      </span>
+                      <span className="daily-row__high">{formatTemp(d.highC, unit)}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {searchOpen ? (
+        <div
+          className="search-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Search locations"
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget) setSearchOpen(false);
+          }}
+        >
+          <div className="search-panel">
+            <form
+              className="search-bar"
+              onSubmit={(e) => {
+                e.preventDefault();
+              }}
+            >
+              <Search size={18} />
+              <input
+                data-testid="search-input"
+                autoFocus
+                placeholder="Search city or place"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") setSearchOpen(false);
+                }}
+              />
+              <button
+                type="button"
+                className="search-close"
+                aria-label="Close search"
+                onClick={() => setSearchOpen(false)}
+              >
+                <X size={16} />
+              </button>
+            </form>
+            <div className="search-results">
+              {searching ? <p className="search-hint">Searching…</p> : null}
+              {!searching && searchError ? <p className="search-hint">{searchError}</p> : null}
+              {results.map((r, i) => (
+                <button
+                  key={`${r.name}-${r.latitude}-${r.longitude}-${i}`}
+                  type="button"
+                  data-testid="search-result"
+                  className="search-result"
+                  onClick={() => void addLocation(r)}
+                >
+                  <MapPin size={15} />
+                  <span className="search-result__name">{r.name}</span>
+                  <span className="search-result__meta">
+                    {[r.admin1, r.country].filter(Boolean).join(", ")}
+                  </span>
+                </button>
+              ))}
+              {!searching && !searchError && query.trim().length < 2 ? (
+                <p className="search-hint">Type at least two characters.</p>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </main>
+  );
+}
+
+// Re-export to keep DEMO_LOCATION referenced for tree-shake clarity / tooling.
+export { DEMO_LOCATION };

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -336,6 +336,7 @@ export default function App() {
         const existing = await readStoredLocations();
         await writeAppData(LOCATIONS_KEY, storedLocations([...existing, candidate]));
         await reloadLocations();
+        setActiveId(candidate.name);
         setError(null);
         return;
       }

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -29,8 +29,8 @@ import { WeatherIcon } from "./WeatherIcon";
 import "./styles.css";
 
 const LOCATIONS_TABLE = "locations";
-const LS_KEY = "matrix-weather-locations";
-const LS_UNIT = "matrix-weather-unit";
+const LOCATIONS_KEY = "matrix-weather-locations";
+const UNIT_KEY = "matrix-weather-unit";
 
 type LoadStatus = "loading" | "live" | "demo";
 
@@ -38,25 +38,55 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-function readLocalLocations(): SavedLocation[] {
+const fallbackData: Record<string, unknown> = {};
+
+async function readAppData<T>(key: string, fallback: T): Promise<T> {
   try {
-    const raw = window.localStorage.getItem(LS_KEY);
-    if (!raw) return [];
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.map(coerceLocation).filter((l): l is SavedLocation => l !== null);
+    if (window.MatrixOS?.readData) {
+      const value = await window.MatrixOS.readData(key);
+      return value === undefined || value === null ? fallback : (value as T);
+    }
   } catch (err: unknown) {
-    console.warn("[weather] local locations read failed:", errMsg(err));
-    return [];
+    console.warn("[weather] app data read failed:", errMsg(err));
   }
+  return Object.prototype.hasOwnProperty.call(fallbackData, key) ? (fallbackData[key] as T) : fallback;
 }
 
-function writeLocalLocations(locations: SavedLocation[]): void {
+async function writeAppData<T>(key: string, value: T): Promise<void> {
   try {
-    window.localStorage.setItem(LS_KEY, JSON.stringify(locations));
+    if (window.MatrixOS?.writeData) {
+      await window.MatrixOS.writeData(key, value);
+      return;
+    }
   } catch (err: unknown) {
-    console.warn("[weather] local locations write failed:", errMsg(err));
+    console.warn("[weather] app data write failed:", errMsg(err));
   }
+  fallbackData[key] = value;
+}
+
+async function readStoredLocations(): Promise<SavedLocation[]> {
+  const parsed = await readAppData<unknown>(LOCATIONS_KEY, []);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map(coerceLocation).filter((l): l is SavedLocation => l !== null);
+}
+
+function locationKey(loc: SavedLocation): string {
+  return loc.id ?? `${loc.name}:${loc.latitude}:${loc.longitude}`;
+}
+
+function sameLocations(a: SavedLocation[], b: SavedLocation[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((loc, index) => {
+    const other = b[index];
+    return (
+      !!other &&
+      locationKey(loc) === locationKey(other) &&
+      loc.name === other.name &&
+      loc.latitude === other.latitude &&
+      loc.longitude === other.longitude &&
+      loc.is_default === other.is_default
+    );
+  });
 }
 
 export default function App() {
@@ -65,13 +95,8 @@ export default function App() {
   const [forecast, setForecast] = useState<OpenMeteoForecast | null>(null);
   const [status, setStatus] = useState<LoadStatus>("loading");
   const [error, setError] = useState<string | null>(null);
-  const [unit, setUnit] = useState<Unit>(() => {
-    try {
-      return window.localStorage.getItem(LS_UNIT) === "f" ? "f" : "c";
-    } catch {
-      return "c";
-    }
-  });
+  const [unit, setUnit] = useState<Unit>("c");
+  const [unitReady, setUnitReady] = useState(false);
 
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -79,21 +104,28 @@ export default function App() {
   const [searching, setSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const searchSeq = useRef(0);
+  const pendingRemovalKeys = useRef<string[]>([]);
 
   const reloadLocations = useCallback(async () => {
     const db = window.MatrixOS?.db;
     if (!db) {
-      setLocations(readLocalLocations());
+      const stored = await readStoredLocations();
+      setLocations((current) => (sameLocations(current, stored) ? current : stored));
       return;
     }
     try {
       const rows = await db.find(LOCATIONS_TABLE, { orderBy: { created_at: "asc" } });
-      const parsed = rows.map(coerceLocation).filter((l): l is SavedLocation => l !== null);
-      setLocations(parsed);
+      const pending = pendingRemovalKeys.current;
+      const parsed = rows
+        .map(coerceLocation)
+        .filter((l): l is SavedLocation => l !== null)
+        .filter((l) => !pending.includes(locationKey(l)));
+      setLocations((current) => (sameLocations(current, parsed) ? current : parsed));
     } catch (err: unknown) {
       console.warn("[weather] location load failed:", errMsg(err));
       setError("Saved locations could not be loaded.");
-      setLocations(readLocalLocations());
+      const stored = await readStoredLocations();
+      setLocations((current) => (sameLocations(current, stored) ? current : stored));
     }
   }, []);
 
@@ -110,12 +142,21 @@ export default function App() {
   }, [reloadLocations]);
 
   useEffect(() => {
-    try {
-      window.localStorage.setItem(LS_UNIT, unit);
-    } catch (err: unknown) {
-      console.warn("[weather] unit persist failed:", errMsg(err));
-    }
-  }, [unit]);
+    let cancelled = false;
+    void readAppData<Unit>(UNIT_KEY, "c").then((stored) => {
+      if (cancelled) return;
+      setUnit(stored === "f" ? "f" : "c");
+      setUnitReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!unitReady) return;
+    void writeAppData(UNIT_KEY, unit);
+  }, [unit, unitReady]);
 
   // Keep an active selection in sync with the available locations.
   useEffect(() => {
@@ -135,9 +176,20 @@ export default function App() {
     return locations.find((l) => (l.id ?? l.name) === activeId) ?? locations[0];
   }, [locations, activeId]);
 
+  const activeForecastLocation = useMemo<SavedLocation | null>(() => {
+    if (!active) return null;
+    return {
+      id: active.id,
+      name: active.name,
+      latitude: active.latitude,
+      longitude: active.longitude,
+      is_default: active.is_default,
+    };
+  }, [active?.id, active?.name, active?.latitude, active?.longitude, active?.is_default]);
+
   // Load forecast for the active location with graceful demo fallback.
   useEffect(() => {
-    if (!active) {
+    if (!activeForecastLocation) {
       setForecast(null);
       setStatus("loading");
       return;
@@ -147,7 +199,7 @@ export default function App() {
     setError(null);
     (async () => {
       try {
-        const data = await fetchForecast(active);
+        const data = await fetchForecast(activeForecastLocation);
         if (cancelled) return;
         setForecast(data);
         setStatus("live");
@@ -161,7 +213,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [active]);
+  }, [activeForecastLocation]);
 
   // Debounced geocode search.
   useEffect(() => {
@@ -195,6 +247,7 @@ export default function App() {
 
   const addLocation = useCallback(
     async (geo: GeoResult) => {
+      const previousActiveId = activeId;
       const label = geo.admin1 && geo.admin1 !== geo.name ? `${geo.name}` : geo.name;
       const candidate: SavedLocation = {
         name: label,
@@ -212,7 +265,7 @@ export default function App() {
 
       const db = window.MatrixOS?.db;
       if (!db) {
-        writeLocalLocations([...locations, candidate]);
+        await writeAppData(LOCATIONS_KEY, [...locations, optimistic]);
         return;
       }
       try {
@@ -222,34 +275,53 @@ export default function App() {
           longitude: candidate.longitude,
           is_default: candidate.is_default ?? false,
         });
+        const saved: SavedLocation = { ...candidate, id };
+        setLocations((curr) =>
+          curr.map((loc) => (locationKey(loc) === optimistic.id ? saved : loc)),
+        );
         setActiveId(id);
         await reloadLocations();
       } catch (err: unknown) {
         console.warn("[weather] location save failed:", errMsg(err));
         setError("Location could not be saved.");
+        setLocations((curr) => curr.filter((loc) => locationKey(loc) !== optimistic.id));
+        setActiveId(previousActiveId);
       }
     },
-    [locations, reloadLocations],
+    [activeId, locations, reloadLocations],
   );
 
   const removeLocation = useCallback(
     async (loc: SavedLocation) => {
-      setLocations((curr) => curr.filter((l) => (l.id ?? l.name) !== (loc.id ?? loc.name)));
+      const previousLocations = locations;
+      const previousActiveId = activeId;
+      const key = locationKey(loc);
+      pendingRemovalKeys.current = [...pendingRemovalKeys.current, key].slice(-50);
+      const remaining = locations.filter((l) => locationKey(l) !== key);
+      setLocations(remaining);
       const db = window.MatrixOS?.db;
       if (!db) {
-        writeLocalLocations(locations.filter((l) => (l.id ?? l.name) !== (loc.id ?? loc.name)));
+        await writeAppData(LOCATIONS_KEY, remaining);
+        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
         return;
       }
-      if (!loc.id || loc.id.startsWith("local-")) return;
+      if (!loc.id || loc.id.startsWith("local-")) {
+        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
+        return;
+      }
       try {
         await db.delete(LOCATIONS_TABLE, loc.id);
+        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
         await reloadLocations();
       } catch (err: unknown) {
+        pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
         console.warn("[weather] location delete failed:", errMsg(err));
         setError("Location could not be removed.");
+        setLocations(previousLocations);
+        setActiveId(previousActiveId);
       }
     },
-    [locations, reloadLocations],
+    [activeId, locations, reloadLocations],
   );
 
   const nowIso = forecast?.current?.time;

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -331,10 +331,14 @@ export default function App() {
       const key = locationKey(loc);
       pendingRemovalKeys.current = [...pendingRemovalKeys.current, key].slice(-50);
       const remaining = locations.filter((l) => locationKey(l) !== key);
-      setLocations(remaining);
+      const shouldPromoteDefault = loc.is_default === true && !remaining.some((l) => l.is_default);
+      const nextLocations = shouldPromoteDefault && remaining[0]
+        ? remaining.map((item, index) => index === 0 ? { ...item, is_default: true } : item)
+        : remaining;
+      setLocations(nextLocations);
       const db = window.MatrixOS?.db;
       if (!db) {
-        await writeAppData(LOCATIONS_KEY, storedLocations(remaining));
+        await writeAppData(LOCATIONS_KEY, storedLocations(nextLocations));
         pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
         setError(null);
         return;
@@ -345,6 +349,10 @@ export default function App() {
       }
       try {
         await db.delete(LOCATIONS_TABLE, loc.id);
+        const promoted = shouldPromoteDefault ? nextLocations[0] : null;
+        if (promoted?.id && !promoted.id.startsWith("local-")) {
+          await db.update(LOCATIONS_TABLE, promoted.id, { is_default: true });
+        }
         pendingRemovalKeys.current = pendingRemovalKeys.current.filter((k) => k !== key);
         await reloadLocations();
         setError(null);

--- a/home/apps/weather/src/App.tsx
+++ b/home/apps/weather/src/App.tsx
@@ -275,6 +275,7 @@ export default function App() {
           latitude: candidate.latitude,
           longitude: candidate.longitude,
           is_default: candidate.is_default ?? false,
+          created_at: new Date().toISOString(),
         });
         const saved: SavedLocation = { ...candidate, id };
         setLocations((curr) =>

--- a/home/apps/weather/src/WeatherIcon.tsx
+++ b/home/apps/weather/src/WeatherIcon.tsx
@@ -1,0 +1,31 @@
+import {
+  Cloud,
+  CloudDrizzle,
+  CloudFog,
+  CloudLightning,
+  CloudRain,
+  CloudRainWind,
+  CloudSnow,
+  CloudSun,
+  Snowflake,
+  Sun,
+  type LucideProps,
+} from "lucide-react";
+
+const MAP: Record<string, React.ComponentType<LucideProps>> = {
+  sun: Sun,
+  "cloud-sun": CloudSun,
+  cloud: Cloud,
+  "cloud-fog": CloudFog,
+  "cloud-drizzle": CloudDrizzle,
+  "cloud-rain": CloudRain,
+  "cloud-rain-wind": CloudRainWind,
+  "cloud-snow": CloudSnow,
+  snowflake: Snowflake,
+  "cloud-lightning": CloudLightning,
+};
+
+export function WeatherIcon({ name, size = 20, ...rest }: { name: string } & LucideProps) {
+  const Icon = MAP[name] ?? Cloud;
+  return <Icon size={size} {...rest} />;
+}

--- a/home/apps/weather/src/main.tsx
+++ b/home/apps/weather/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("weather" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/weather/src/matrix-os.d.ts
+++ b/home/apps/weather/src/matrix-os.d.ts
@@ -1,0 +1,27 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+  /** Proxy a GET to an allowlisted external API via the gateway (apps cannot fetch cross-origin). */
+  proxyFetch?(url: string): Promise<unknown>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/weather/src/styles.css
+++ b/home/apps/weather/src/styles.css
@@ -1,0 +1,596 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  color: var(--app-fg);
+  background: var(--app-bg);
+}
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.weather-app {
+  height: 100vh;
+  width: 100%;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 248px minmax(0, 1fr);
+  background: var(--app-bg);
+}
+
+/* ---------- Sidebar ---------- */
+.sidebar {
+  height: 100vh;
+  overflow-y: auto;
+  border-right: 1px solid var(--app-border);
+  padding: 18px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.sidebar__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.sidebar__head h1 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.add-btn {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 12px;
+  background: var(--app-muted);
+  color: var(--app-fg);
+  transition: all 0.15s ease;
+}
+.add-btn:hover {
+  background: color-mix(in srgb, var(--app-fg) 8%, transparent);
+}
+.location-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.loc-chip {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid transparent;
+  border-radius: 14px;
+  padding: 11px 12px;
+  background: transparent;
+  color: var(--app-fg);
+  text-align: left;
+  transition: all 0.15s ease;
+}
+.loc-chip:hover {
+  background: color-mix(in srgb, var(--app-fg) 4%, transparent);
+}
+.loc-chip--active {
+  background: var(--app-card);
+  border-color: var(--app-border);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+.loc-chip__name {
+  flex: 1;
+  font-weight: 650;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.loc-chip__badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--app-muted-fg);
+}
+.loc-chip__remove {
+  display: grid;
+  place-items: center;
+  color: var(--app-muted-fg);
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease;
+}
+.loc-chip:hover .loc-chip__remove {
+  opacity: 1;
+}
+.loc-chip__remove:hover {
+  color: var(--app-danger);
+}
+.sidebar__hint {
+  color: var(--app-muted-fg);
+  font-size: 13px;
+  padding: 4px 8px;
+}
+
+/* ---------- Stage ---------- */
+.stage {
+  height: 100vh;
+  overflow: hidden;
+  position: relative;
+}
+.weather-scroll {
+  height: 100vh;
+  overflow-y: auto;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ---------- Hero ---------- */
+.hero {
+  position: relative;
+  border-radius: 28px;
+  overflow: hidden;
+  min-height: 320px;
+  padding: 26px;
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(50, 53, 46, 0.18);
+  background-size: cover;
+}
+.weather-app[data-tone="dark"] .hero {
+  color: #1b1d20;
+}
+.hero__content {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  height: 100%;
+}
+.hero__loc {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 650;
+  font-size: 15px;
+  opacity: 0.95;
+}
+.hero__temp {
+  font-size: 76px;
+  font-weight: 250;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
+  margin-top: 4px;
+}
+.hero__condition {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 17px;
+  font-weight: 600;
+}
+.hero__meta {
+  display: flex;
+  gap: 14px;
+  font-size: 14px;
+  opacity: 0.92;
+  margin-top: 2px;
+}
+.hero__chips {
+  display: flex;
+  gap: 8px;
+  margin-top: auto;
+  padding-top: 18px;
+  align-items: center;
+}
+.hero__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 12.5px;
+  font-weight: 600;
+  backdrop-filter: blur(6px);
+}
+.weather-app[data-tone="dark"] .hero__chip {
+  background: rgba(0, 0, 0, 0.12);
+}
+.unit-toggle {
+  margin-left: auto;
+  border: 0;
+  border-radius: 999px;
+  padding: 5px 12px;
+  font-size: 13px;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.22);
+  color: inherit;
+  backdrop-filter: blur(6px);
+  transition: background 0.15s ease;
+}
+.unit-toggle:hover {
+  background: rgba(255, 255, 255, 0.34);
+}
+
+/* Hero ambient motion */
+.hero__sky {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: hidden;
+}
+.hero__orb {
+  position: absolute;
+  top: -40px;
+  right: -30px;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0) 70%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+.hero__sky--clear .hero__orb {
+  opacity: 1;
+  animation: orb-pulse 6s ease-in-out infinite;
+}
+.hero__cloud {
+  position: absolute;
+  height: 60px;
+  width: 160px;
+  border-radius: 60px;
+  background: rgba(255, 255, 255, 0.22);
+  filter: blur(8px);
+  opacity: 0;
+}
+.hero__sky--cloudy .hero__cloud,
+.hero__sky--rain .hero__cloud,
+.hero__sky--drizzle .hero__cloud,
+.hero__sky--snow .hero__cloud,
+.hero__sky--fog .hero__cloud,
+.hero__sky--thunder .hero__cloud {
+  opacity: 1;
+}
+.hero__cloud--a {
+  top: 30px;
+  left: -60px;
+  animation: drift 26s linear infinite;
+}
+.hero__cloud--b {
+  top: 90px;
+  left: -120px;
+  width: 120px;
+  height: 44px;
+  animation: drift 38s linear infinite;
+}
+@keyframes drift {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(140%);
+  }
+}
+@keyframes orb-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+}
+
+/* ---------- Notices ---------- */
+.demo-notice,
+.error-notice {
+  border-radius: 14px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 600;
+}
+.demo-notice {
+  background: color-mix(in srgb, var(--app-warning) 18%, var(--app-card));
+  color: color-mix(in srgb, var(--app-warning) 60%, var(--app-fg));
+  border: 1px solid color-mix(in srgb, var(--app-warning) 40%, transparent);
+}
+.error-notice {
+  background: color-mix(in srgb, var(--app-danger) 12%, var(--app-card));
+  color: var(--app-danger);
+  border: 1px solid color-mix(in srgb, var(--app-danger) 30%, transparent);
+}
+
+/* ---------- Panels ---------- */
+.panel {
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 22px;
+  padding: 16px 18px;
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.06);
+}
+.panel__title {
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--app-muted-fg);
+}
+
+.hourly-strip {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
+}
+.hourly-cell {
+  flex: 0 0 auto;
+  min-width: 62px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 8px;
+  border-radius: 16px;
+  color: var(--app-fg);
+  transition: background 0.15s ease;
+}
+.hourly-cell:hover {
+  background: color-mix(in srgb, var(--app-fg) 4%, transparent);
+}
+.hourly-cell__time {
+  font-size: 12.5px;
+  font-weight: 650;
+  color: var(--app-muted-fg);
+}
+.hourly-cell__temp {
+  font-size: 15px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.daily-list {
+  display: flex;
+  flex-direction: column;
+}
+.daily-row {
+  display: grid;
+  grid-template-columns: 52px 28px 40px minmax(80px, 1fr) 40px;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 2px;
+  border-bottom: 1px solid color-mix(in srgb, var(--app-border) 60%, transparent);
+}
+.daily-row:last-child {
+  border-bottom: 0;
+}
+.daily-row__day {
+  font-weight: 650;
+  font-size: 14px;
+}
+.daily-row__icon {
+  display: grid;
+  place-items: center;
+  color: var(--app-muted-fg);
+}
+.daily-row__low {
+  text-align: right;
+  color: var(--app-muted-fg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.daily-row__high {
+  text-align: right;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.daily-row__bar {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--app-muted);
+  overflow: hidden;
+}
+.daily-row__bar-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--app-accent) 55%, #58a7e0),
+    var(--app-accent)
+  );
+}
+
+/* ---------- Empty state ---------- */
+.empty-state {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  text-align: center;
+  padding: 24px;
+}
+.empty-state__mark {
+  width: 84px;
+  height: 84px;
+  display: grid;
+  place-items: center;
+  border-radius: 26px;
+  background: var(--app-muted);
+  color: var(--app-accent);
+  margin-bottom: 6px;
+}
+.empty-state h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+}
+.empty-state p {
+  margin: 0;
+  max-width: 360px;
+  color: var(--app-muted-fg);
+  line-height: 1.5;
+}
+.primary-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  border: 0;
+  border-radius: 14px;
+  padding: 11px 18px;
+  font-weight: 700;
+  background: var(--app-accent);
+  color: #fff;
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--app-accent) 35%, transparent);
+  transition: transform 0.15s ease;
+}
+.primary-action:hover {
+  transform: translateY(-1px);
+}
+
+/* ---------- Search overlay ---------- */
+.search-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(30, 30, 28, 0.32);
+  backdrop-filter: blur(3px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 14vh;
+}
+.search-panel {
+  width: min(480px, 92vw);
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 20px;
+  box-shadow: 0 20px 60px rgba(50, 53, 46, 0.28);
+  overflow: hidden;
+}
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--app-border);
+  color: var(--app-muted-fg);
+}
+.search-bar input {
+  flex: 1;
+  border: 0;
+  outline: none;
+  background: transparent;
+  font-size: 16px;
+  color: var(--app-fg);
+}
+.search-close {
+  border: 0;
+  background: transparent;
+  color: var(--app-muted-fg);
+  display: grid;
+  place-items: center;
+}
+.search-results {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 6px;
+}
+.search-result {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  background: transparent;
+  color: var(--app-fg);
+  text-align: left;
+  padding: 11px 12px;
+  border-radius: 12px;
+  transition: background 0.15s ease;
+}
+.search-result:hover {
+  background: color-mix(in srgb, var(--app-fg) 5%, transparent);
+}
+.search-result__name {
+  font-weight: 650;
+}
+.search-result__meta {
+  margin-left: auto;
+  font-size: 12.5px;
+  color: var(--app-muted-fg);
+}
+.search-hint {
+  margin: 0;
+  padding: 14px 12px;
+  color: var(--app-muted-fg);
+  font-size: 13.5px;
+}
+
+button:focus-visible,
+.loc-chip:focus-visible,
+.search-result:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 720px) {
+  .weather-app {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero__orb,
+  .hero__cloud--a,
+  .hero__cloud--b {
+    animation: none !important;
+  }
+  * {
+    transition: none !important;
+  }
+}

--- a/home/apps/weather/src/styles.css
+++ b/home/apps/weather/src/styles.css
@@ -91,14 +91,14 @@ button {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 8px;
   border: 1px solid transparent;
   border-radius: 14px;
-  padding: 11px 12px;
+  padding: 0;
   background: transparent;
   color: var(--app-fg);
   text-align: left;
   transition: all 0.15s ease;
+  overflow: hidden;
 }
 .loc-chip:hover {
   background: color-mix(in srgb, var(--app-fg) 4%, transparent);
@@ -107,6 +107,18 @@ button {
   background: var(--app-card);
   border-color: var(--app-border);
   box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+.loc-chip__select {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  padding: 11px 0 11px 12px;
 }
 .loc-chip__name {
   flex: 1;
@@ -125,11 +137,18 @@ button {
 .loc-chip__remove {
   display: grid;
   place-items: center;
+  align-self: stretch;
+  width: 34px;
+  border: 0;
+  border-radius: 10px;
+  margin: 4px;
+  background: transparent;
   color: var(--app-muted-fg);
   opacity: 0;
   transition: opacity 0.15s ease, color 0.15s ease;
 }
-.loc-chip:hover .loc-chip__remove {
+.loc-chip:hover .loc-chip__remove,
+.loc-chip:focus-within .loc-chip__remove {
   opacity: 1;
 }
 .loc-chip__remove:hover {

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -32,7 +32,12 @@ async function proxyJson<T>(url: string): Promise<T> {
     const detail = String((data as Record<string, unknown>).error);
     throw new Error(`proxy request failed: ${detail}`);
   }
-  const hasExpectedShape = "current" in data || "hourly" in data || "daily" in data || "results" in data;
+  const hasExpectedShape =
+    Object.keys(data as Record<string, unknown>).length === 0 ||
+    "current" in data ||
+    "hourly" in data ||
+    "daily" in data ||
+    "results" in data;
   if (!hasExpectedShape) {
     throw new Error("proxy request failed: unexpected response shape");
   }

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -21,7 +21,21 @@ async function proxyJson<T>(url: string): Promise<T> {
     if (!res.ok) throw new Error(`request failed: ${res.status}`);
     return (await res.json()) as T;
   }
-  return (await proxy(url)) as T;
+  return (await withTimeout(proxy(url), 12_000)) as T;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: number | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = window.setTimeout(() => reject(new Error("proxy request timed out")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) window.clearTimeout(timeout);
+  }
 }
 
 export async function geocode(query: string): Promise<GeoResult[]> {

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -12,7 +12,7 @@ export interface GeoResult {
   admin1?: string;
 }
 
-async function proxyJson<T>(url: string): Promise<T> {
+async function proxyJson<T>(url: string, opts: { allowEmptyObject?: boolean } = {}): Promise<T> {
   const proxy = window.MatrixOS?.proxyFetch;
   if (!proxy) {
     // No bridge (e.g. unit tests / no shell): allow a direct fetch so tests can
@@ -33,7 +33,7 @@ async function proxyJson<T>(url: string): Promise<T> {
     throw new Error(`proxy request failed: ${detail}`);
   }
   const hasExpectedShape =
-    Object.keys(data as Record<string, unknown>).length === 0 ||
+    (opts.allowEmptyObject === true && Object.keys(data as Record<string, unknown>).length === 0) ||
     "current" in data ||
     "hourly" in data ||
     "daily" in data ||
@@ -65,7 +65,7 @@ export async function geocode(query: string): Promise<GeoResult[]> {
   url.searchParams.set("language", "en");
   url.searchParams.set("format", "json");
 
-  const data = await proxyJson<{ results?: GeoResult[] }>(url.toString());
+  const data = await proxyJson<{ results?: GeoResult[] }>(url.toString(), { allowEmptyObject: true });
   const results = Array.isArray(data.results) ? data.results : [];
   return results
     .filter(

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -1,0 +1,66 @@
+// Network layer for Open-Meteo. Apps run in a null-origin sandboxed iframe with
+// CSP connect-src 'self', so we CANNOT fetch third-party APIs directly. We go
+// through window.MatrixOS.proxyFetch, which forwards the request (via postMessage)
+// to the shell, which calls the gateway's allowlisted /api/bridge/proxy endpoint.
+import type { OpenMeteoForecast, SavedLocation } from "./weather-model";
+
+export interface GeoResult {
+  name: string;
+  latitude: number;
+  longitude: number;
+  country?: string;
+  admin1?: string;
+}
+
+async function proxyJson<T>(url: string): Promise<T> {
+  const proxy = window.MatrixOS?.proxyFetch;
+  if (!proxy) {
+    // No bridge (e.g. unit tests / no shell): allow a direct fetch so tests can
+    // mock global fetch. In the real shell proxyFetch is always present.
+    const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) throw new Error(`request failed: ${res.status}`);
+    return (await res.json()) as T;
+  }
+  return (await proxy(url)) as T;
+}
+
+export async function geocode(query: string): Promise<GeoResult[]> {
+  const url = new URL("https://geocoding-api.open-meteo.com/v1/search");
+  url.searchParams.set("name", query);
+  url.searchParams.set("count", "8");
+  url.searchParams.set("language", "en");
+  url.searchParams.set("format", "json");
+
+  const data = await proxyJson<{ results?: GeoResult[] }>(url.toString());
+  const results = Array.isArray(data.results) ? data.results : [];
+  return results
+    .filter(
+      (r) =>
+        typeof r.name === "string" &&
+        Number.isFinite(r.latitude) &&
+        Number.isFinite(r.longitude),
+    )
+    .map((r) => ({
+      name: r.name,
+      latitude: r.latitude,
+      longitude: r.longitude,
+      country: r.country,
+      admin1: r.admin1,
+    }));
+}
+
+export async function fetchForecast(loc: SavedLocation): Promise<OpenMeteoForecast> {
+  const url = new URL("https://api.open-meteo.com/v1/forecast");
+  url.searchParams.set("latitude", String(loc.latitude));
+  url.searchParams.set("longitude", String(loc.longitude));
+  url.searchParams.set(
+    "current",
+    "temperature_2m,apparent_temperature,weather_code,is_day,relative_humidity_2m,wind_speed_10m",
+  );
+  url.searchParams.set("hourly", "temperature_2m,weather_code");
+  url.searchParams.set("daily", "weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset");
+  url.searchParams.set("forecast_days", "7");
+  url.searchParams.set("timezone", "auto");
+
+  return proxyJson<OpenMeteoForecast>(url.toString());
+}

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -25,11 +25,12 @@ async function proxyJson<T>(url: string): Promise<T> {
   if (data == null) {
     throw new Error("proxy request failed: empty response");
   }
-  if (
-    typeof data === "object" &&
-    "error" in data
-  ) {
-    throw new Error("proxy request failed");
+  if (typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("proxy request failed: invalid response");
+  }
+  if ("error" in data) {
+    const detail = String((data as Record<string, unknown>).error);
+    throw new Error(`proxy request failed: ${detail}`);
   }
   return data as T;
 }
@@ -63,7 +64,11 @@ export async function geocode(query: string): Promise<GeoResult[]> {
         typeof r.name === "string" &&
         r.name.trim().length > 0 &&
         Number.isFinite(r.latitude) &&
-        Number.isFinite(r.longitude),
+        Number.isFinite(r.longitude) &&
+        r.latitude >= -90 &&
+        r.latitude <= 90 &&
+        r.longitude >= -180 &&
+        r.longitude <= 180,
     )
     .map((r) => ({
       name: r.name.trim(),

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -22,8 +22,10 @@ async function proxyJson<T>(url: string): Promise<T> {
     return (await res.json()) as T;
   }
   const data = await withTimeout(proxy(url), 12_000);
+  if (data == null) {
+    throw new Error("proxy request failed: empty response");
+  }
   if (
-    data &&
     typeof data === "object" &&
     "error" in data
   ) {

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -32,6 +32,10 @@ async function proxyJson<T>(url: string): Promise<T> {
     const detail = String((data as Record<string, unknown>).error);
     throw new Error(`proxy request failed: ${detail}`);
   }
+  const hasExpectedShape = "current" in data || "hourly" in data || "daily" in data || "results" in data;
+  if (!hasExpectedShape) {
+    throw new Error("proxy request failed: unexpected response shape");
+  }
   return data as T;
 }
 

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -61,11 +61,12 @@ export async function geocode(query: string): Promise<GeoResult[]> {
     .filter(
       (r) =>
         typeof r.name === "string" &&
+        r.name.trim().length > 0 &&
         Number.isFinite(r.latitude) &&
         Number.isFinite(r.longitude),
     )
     .map((r) => ({
-      name: r.name,
+      name: r.name.trim(),
       latitude: r.latitude,
       longitude: r.longitude,
       country: r.country,

--- a/home/apps/weather/src/weather-api.ts
+++ b/home/apps/weather/src/weather-api.ts
@@ -21,7 +21,15 @@ async function proxyJson<T>(url: string): Promise<T> {
     if (!res.ok) throw new Error(`request failed: ${res.status}`);
     return (await res.json()) as T;
   }
-  return (await withTimeout(proxy(url), 12_000)) as T;
+  const data = await withTimeout(proxy(url), 12_000);
+  if (
+    data &&
+    typeof data === "object" &&
+    "error" in data
+  ) {
+    throw new Error("proxy request failed");
+  }
+  return data as T;
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {

--- a/home/apps/weather/src/weather-model.ts
+++ b/home/apps/weather/src/weather-model.ts
@@ -143,6 +143,12 @@ export function formatTemp(celsius: number, unit: Unit = "c"): string {
   return `${Math.round(toUnit(celsius, unit))}°`;
 }
 
+/** Format a wind-speed value from Open-Meteo km/h for the requested unit system. */
+export function formatWindSpeed(kmh: number, unit: Unit = "c"): string {
+  if (!Number.isFinite(kmh)) return unit === "f" ? "0 mph" : "0 km/h";
+  return unit === "f" ? `${Math.round(kmh * 0.621371)} mph` : `${Math.round(kmh)} km/h`;
+}
+
 /** Convert a Celsius value to the requested unit (numeric, unrounded). */
 export function toUnit(celsius: number, unit: Unit): number {
   if (!Number.isFinite(celsius)) return 0;

--- a/home/apps/weather/src/weather-model.ts
+++ b/home/apps/weather/src/weather-model.ts
@@ -294,6 +294,18 @@ export function tempSpan(days: DayPoint[]): { min: number; max: number } {
   return { min, max };
 }
 
+/** Compute a bounded range-bar position for daily high/low temperatures. */
+export function dailyTemperatureBar(day: DayPoint, span: { min: number; max: number }): { left: number; width: number } {
+  const range = span.max - span.min || 1;
+  const rawLeft = ((day.lowC - span.min) / range) * 100;
+  const rawWidth = ((day.highC - day.lowC) / range) * 100;
+  const width = Math.min(100, Math.max(8, rawWidth));
+  return {
+    left: Math.min(100 - width, Math.max(0, rawLeft)),
+    width,
+  };
+}
+
 export interface SavedLocation {
   id?: string;
   name: string;

--- a/home/apps/weather/src/weather-model.ts
+++ b/home/apps/weather/src/weather-model.ts
@@ -162,23 +162,25 @@ export function formatHour(iso: string, isNow = false): string {
 
 /** Short weekday label, e.g. "Mon", or "Today" for the current day. */
 export function formatDay(iso: string, todayIso?: string): string {
+  const todayKey = todayIso?.slice(0, 10) ?? localDateKey(new Date());
   if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
-    const todayKey = todayIso?.slice(0, 10) ?? new Date().toISOString().slice(0, 10);
     if (iso === todayKey) return "Today";
     const [year, month, day] = iso.split("-").map(Number);
     return new Date(year, month - 1, day).toLocaleDateString("en-US", { weekday: "short" });
   }
+  const isoKey = iso.match(/^\d{4}-\d{2}-\d{2}/)?.[0];
+  if (isoKey === todayKey) return "Today";
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "--";
-  const ref = todayIso ? new Date(todayIso) : new Date();
-  if (
-    d.getFullYear() === ref.getFullYear() &&
-    d.getMonth() === ref.getMonth() &&
-    d.getDate() === ref.getDate()
-  ) {
-    return "Today";
-  }
   return d.toLocaleDateString("en-US", { weekday: "short" });
+}
+
+function localDateKey(date: Date): string {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
 }
 
 export interface HourPoint {

--- a/home/apps/weather/src/weather-model.ts
+++ b/home/apps/weather/src/weather-model.ts
@@ -82,7 +82,7 @@ const GRADIENTS: Record<WeatherKind, { day: string; night: string; tone: "light"
   fog: {
     day: "linear-gradient(160deg, #8d97a1 0%, #b3bbc3 55%, #d6dbe0 100%)",
     night: "linear-gradient(160deg, #232a31 0%, #3a444d 60%, #545f69 100%)",
-    tone: "light",
+    tone: "dark",
   },
   drizzle: {
     day: "linear-gradient(160deg, #5b7d99 0%, #7c9bb4 55%, #a7c0d3 100%)",
@@ -97,7 +97,7 @@ const GRADIENTS: Record<WeatherKind, { day: string; night: string; tone: "light"
   snow: {
     day: "linear-gradient(160deg, #7f93a8 0%, #aebfce 55%, #e2ebf4 100%)",
     night: "linear-gradient(160deg, #1d2733 0%, #36475a 60%, #5b7088 100%)",
-    tone: "light",
+    tone: "dark",
   },
   thunder: {
     day: "linear-gradient(160deg, #3a3f55 0%, #545a78 55%, #7d83a3 100%)",
@@ -187,6 +187,16 @@ function localDateKey(date: Date): string {
     String(date.getMonth() + 1).padStart(2, "0"),
     String(date.getDate()).padStart(2, "0"),
   ].join("-");
+}
+
+function localDateTime(date: Date): string {
+  const dateKey = localDateKey(date);
+  const timeKey = [
+    String(date.getHours()).padStart(2, "0"),
+    String(date.getMinutes()).padStart(2, "0"),
+    String(date.getSeconds()).padStart(2, "0"),
+  ].join(":");
+  return `${dateKey}T${timeKey}`;
 }
 
 export interface HourPoint {
@@ -313,7 +323,7 @@ export function demoForecast(baseIso?: string): OpenMeteoForecast {
   const hourlyCode: number[] = [];
   for (let i = 0; i < 24; i += 1) {
     const t = new Date(base.getTime() + i * 3_600_000);
-    hourlyTime.push(t.toISOString());
+    hourlyTime.push(localDateTime(t));
     // Mild diurnal curve peaking mid-afternoon.
     const hour = t.getHours();
     const temp = 14 + 6 * Math.sin(((hour - 6) / 24) * Math.PI * 2);
@@ -332,22 +342,23 @@ export function demoForecast(baseIso?: string): OpenMeteoForecast {
   const lows = [11, 10, 9, 9, 10, 12, 13];
   for (let i = 0; i < 7; i += 1) {
     const d = new Date(dayStart.getTime() + i * 86_400_000);
-    dayDate.push(d.toISOString().slice(0, 10));
+    dayDate.push(localDateKey(d));
     dayMax.push(highs[i]);
     dayMin.push(lows[i]);
     dayCode.push(dailyCodes[i]);
   }
 
-  const sunrise = new Date(dayStart.getTime() + 6.5 * 3_600_000).toISOString();
-  const sunset = new Date(dayStart.getTime() + 19.5 * 3_600_000).toISOString();
+  const sunrise = localDateTime(new Date(dayStart.getTime() + 6.5 * 3_600_000));
+  const sunset = localDateTime(new Date(dayStart.getTime() + 19.5 * 3_600_000));
+  const currentTime = localDateTime(base);
 
   return {
     current: {
-      time: base.toISOString(),
+      time: currentTime,
       temperature_2m: hourlyTemp[0],
       apparent_temperature: hourlyTemp[0] - 1.5,
       weather_code: hourlyCode[0],
-      is_day: isDaytime(base.toISOString(), sunrise, sunset) ? 1 : 0,
+      is_day: isDaytime(currentTime, sunrise, sunset) ? 1 : 0,
       relative_humidity_2m: 68,
       wind_speed_10m: 12,
     },
@@ -368,8 +379,8 @@ export function coerceLocation(row: unknown): SavedLocation | null {
   if (!row || typeof row !== "object") return null;
   const r = row as Record<string, unknown>;
   const name = typeof r.name === "string" ? r.name.trim() : "";
-  const latitude = typeof r.latitude === "number" ? r.latitude : Number(r.latitude);
-  const longitude = typeof r.longitude === "number" ? r.longitude : Number(r.longitude);
+  const latitude = typeof r.latitude === "number" ? r.latitude : (r.latitude == null ? NaN : Number(r.latitude));
+  const longitude = typeof r.longitude === "number" ? r.longitude : (r.longitude == null ? NaN : Number(r.longitude));
   if (!name) return null;
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
   if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) return null;

--- a/home/apps/weather/src/weather-model.ts
+++ b/home/apps/weather/src/weather-model.ts
@@ -1,0 +1,369 @@
+// Pure, UI-free weather helpers. Unit tested in tests/default-apps/weather-model.test.ts
+// Open-Meteo WMO weather code mapping + formatting + grouping utilities.
+
+export type WeatherKind =
+  | "clear"
+  | "cloudy"
+  | "fog"
+  | "drizzle"
+  | "rain"
+  | "snow"
+  | "thunder";
+
+export interface WeatherVisual {
+  /** WMO code that produced this visual. */
+  code: number;
+  /** Short human label, e.g. "Partly Cloudy". */
+  label: string;
+  /** Coarse condition family used for icon + gradient selection. */
+  kind: WeatherKind;
+  /** Lucide icon name to render. */
+  icon: string;
+  /** CSS gradient string for the hero, day variant. */
+  gradientDay: string;
+  /** CSS gradient string for the hero, night variant. */
+  gradientNight: string;
+  /** Foreground text tone that reads on the gradient. */
+  tone: "light" | "dark";
+}
+
+interface CodeSpec {
+  label: string;
+  kind: WeatherKind;
+  icon: string;
+}
+
+// WMO weather interpretation codes used by Open-Meteo.
+// https://open-meteo.com/en/docs
+const CODE_TABLE: Record<number, CodeSpec> = {
+  0: { label: "Clear Sky", kind: "clear", icon: "sun" },
+  1: { label: "Mainly Clear", kind: "clear", icon: "sun" },
+  2: { label: "Partly Cloudy", kind: "cloudy", icon: "cloud-sun" },
+  3: { label: "Overcast", kind: "cloudy", icon: "cloud" },
+  45: { label: "Fog", kind: "fog", icon: "cloud-fog" },
+  48: { label: "Rime Fog", kind: "fog", icon: "cloud-fog" },
+  51: { label: "Light Drizzle", kind: "drizzle", icon: "cloud-drizzle" },
+  53: { label: "Drizzle", kind: "drizzle", icon: "cloud-drizzle" },
+  55: { label: "Heavy Drizzle", kind: "drizzle", icon: "cloud-drizzle" },
+  56: { label: "Freezing Drizzle", kind: "drizzle", icon: "cloud-drizzle" },
+  57: { label: "Freezing Drizzle", kind: "drizzle", icon: "cloud-drizzle" },
+  61: { label: "Light Rain", kind: "rain", icon: "cloud-rain" },
+  63: { label: "Rain", kind: "rain", icon: "cloud-rain" },
+  65: { label: "Heavy Rain", kind: "rain", icon: "cloud-rain-wind" },
+  66: { label: "Freezing Rain", kind: "rain", icon: "cloud-rain" },
+  67: { label: "Freezing Rain", kind: "rain", icon: "cloud-rain-wind" },
+  71: { label: "Light Snow", kind: "snow", icon: "cloud-snow" },
+  73: { label: "Snow", kind: "snow", icon: "cloud-snow" },
+  75: { label: "Heavy Snow", kind: "snow", icon: "snowflake" },
+  77: { label: "Snow Grains", kind: "snow", icon: "snowflake" },
+  80: { label: "Light Showers", kind: "rain", icon: "cloud-rain" },
+  81: { label: "Showers", kind: "rain", icon: "cloud-rain" },
+  82: { label: "Violent Showers", kind: "rain", icon: "cloud-rain-wind" },
+  85: { label: "Snow Showers", kind: "snow", icon: "cloud-snow" },
+  86: { label: "Snow Showers", kind: "snow", icon: "cloud-snow" },
+  95: { label: "Thunderstorm", kind: "thunder", icon: "cloud-lightning" },
+  96: { label: "Thunderstorm", kind: "thunder", icon: "cloud-lightning" },
+  99: { label: "Severe Thunderstorm", kind: "thunder", icon: "cloud-lightning" },
+};
+
+const FALLBACK: CodeSpec = { label: "Unknown", kind: "cloudy", icon: "cloud" };
+
+const GRADIENTS: Record<WeatherKind, { day: string; night: string; tone: "light" | "dark" }> = {
+  clear: {
+    day: "linear-gradient(160deg, #4aa3df 0%, #7cc6f0 55%, #bfe3f7 100%)",
+    night: "linear-gradient(160deg, #0f1f3d 0%, #1d335c 60%, #2c4a7e 100%)",
+    tone: "light",
+  },
+  cloudy: {
+    day: "linear-gradient(160deg, #6f8398 0%, #9aabbc 55%, #c4cfd9 100%)",
+    night: "linear-gradient(160deg, #1c2530 0%, #313e4d 60%, #4a5a6b 100%)",
+    tone: "light",
+  },
+  fog: {
+    day: "linear-gradient(160deg, #8d97a1 0%, #b3bbc3 55%, #d6dbe0 100%)",
+    night: "linear-gradient(160deg, #232a31 0%, #3a444d 60%, #545f69 100%)",
+    tone: "light",
+  },
+  drizzle: {
+    day: "linear-gradient(160deg, #5b7d99 0%, #7c9bb4 55%, #a7c0d3 100%)",
+    night: "linear-gradient(160deg, #131f2c 0%, #243646 60%, #38516a 100%)",
+    tone: "light",
+  },
+  rain: {
+    day: "linear-gradient(160deg, #44617a 0%, #5d7e99 55%, #88a6bd 100%)",
+    night: "linear-gradient(160deg, #0d1620 0%, #1c2c3b 60%, #2d4359 100%)",
+    tone: "light",
+  },
+  snow: {
+    day: "linear-gradient(160deg, #7f93a8 0%, #aebfce 55%, #e2ebf4 100%)",
+    night: "linear-gradient(160deg, #1d2733 0%, #36475a 60%, #5b7088 100%)",
+    tone: "light",
+  },
+  thunder: {
+    day: "linear-gradient(160deg, #3a3f55 0%, #545a78 55%, #7d83a3 100%)",
+    night: "linear-gradient(160deg, #0c0d16 0%, #1f2236 60%, #383c5c 100%)",
+    tone: "light",
+  },
+};
+
+/** Map an Open-Meteo WMO weather code to a visual descriptor. */
+export function weatherVisual(code: number): WeatherVisual {
+  const spec = CODE_TABLE[code] ?? FALLBACK;
+  const g = GRADIENTS[spec.kind];
+  return {
+    code,
+    label: spec.label,
+    kind: spec.kind,
+    icon: spec.icon,
+    gradientDay: g.day,
+    gradientNight: g.night,
+    tone: g.tone,
+  };
+}
+
+/** Whether a given ISO timestamp is during daytime given sunrise/sunset bounds. */
+export function isDaytime(iso: string, sunrise?: string, sunset?: string): boolean {
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return true;
+  if (sunrise && sunset) {
+    const rise = new Date(sunrise).getTime();
+    const set = new Date(sunset).getTime();
+    if (Number.isFinite(rise) && Number.isFinite(set)) {
+      return t >= rise && t < set;
+    }
+  }
+  const hour = new Date(iso).getHours();
+  return hour >= 6 && hour < 19;
+}
+
+export type Unit = "c" | "f";
+
+/** Format a temperature value (always stored in Celsius) for display. */
+export function formatTemp(celsius: number, unit: Unit = "c"): string {
+  return `${Math.round(toUnit(celsius, unit))}°`;
+}
+
+/** Convert a Celsius value to the requested unit (numeric, unrounded). */
+export function toUnit(celsius: number, unit: Unit): number {
+  if (!Number.isFinite(celsius)) return 0;
+  return unit === "f" ? celsius * 1.8 + 32 : celsius;
+}
+
+/** Short hour label, e.g. "3 PM" or "Now" when isNow. */
+export function formatHour(iso: string, isNow = false): string {
+  if (isNow) return "Now";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "--";
+  const h = d.getHours();
+  const period = h >= 12 ? "PM" : "AM";
+  const display = h % 12 === 0 ? 12 : h % 12;
+  return `${display} ${period}`;
+}
+
+/** Short weekday label, e.g. "Mon", or "Today" for the current day. */
+export function formatDay(iso: string, todayIso?: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "--";
+  const ref = todayIso ? new Date(todayIso) : new Date();
+  if (
+    d.getFullYear() === ref.getFullYear() &&
+    d.getMonth() === ref.getMonth() &&
+    d.getDate() === ref.getDate()
+  ) {
+    return "Today";
+  }
+  return d.toLocaleDateString("en-US", { weekday: "short" });
+}
+
+export interface HourPoint {
+  time: string;
+  tempC: number;
+  code: number;
+  isNow: boolean;
+}
+
+export interface DayPoint {
+  date: string;
+  highC: number;
+  lowC: number;
+  code: number;
+}
+
+export interface OpenMeteoForecast {
+  current?: {
+    time?: string;
+    temperature_2m?: number;
+    apparent_temperature?: number;
+    weather_code?: number;
+    is_day?: number;
+    relative_humidity_2m?: number;
+    wind_speed_10m?: number;
+  };
+  hourly?: {
+    time?: string[];
+    temperature_2m?: number[];
+    weather_code?: number[];
+  };
+  daily?: {
+    time?: string[];
+    weather_code?: number[];
+    temperature_2m_max?: number[];
+    temperature_2m_min?: number[];
+    sunrise?: string[];
+    sunset?: string[];
+  };
+}
+
+/**
+ * Build the next ~24h of hourly points starting at (or just after) `nowIso`.
+ * Marks the first slot at/after now as "Now".
+ */
+export function buildHourly(forecast: OpenMeteoForecast, nowIso?: string, count = 24): HourPoint[] {
+  const times = forecast.hourly?.time ?? [];
+  const temps = forecast.hourly?.temperature_2m ?? [];
+  const codes = forecast.hourly?.weather_code ?? [];
+  if (times.length === 0) return [];
+
+  const now = nowIso ? new Date(nowIso).getTime() : Date.now();
+  let startIdx = times.findIndex((t) => new Date(t).getTime() >= now);
+  if (startIdx < 0) startIdx = 0;
+
+  const out: HourPoint[] = [];
+  for (let i = startIdx; i < times.length && out.length < count; i += 1) {
+    out.push({
+      time: times[i],
+      tempC: temps[i] ?? 0,
+      code: codes[i] ?? 0,
+      isNow: out.length === 0,
+    });
+  }
+  return out;
+}
+
+/** Build daily points (next `count` days) from the daily block. */
+export function buildDaily(forecast: OpenMeteoForecast, count = 7): DayPoint[] {
+  const days = forecast.daily?.time ?? [];
+  const codes = forecast.daily?.weather_code ?? [];
+  const max = forecast.daily?.temperature_2m_max ?? [];
+  const min = forecast.daily?.temperature_2m_min ?? [];
+  const out: DayPoint[] = [];
+  for (let i = 0; i < days.length && out.length < count; i += 1) {
+    out.push({
+      date: days[i],
+      highC: max[i] ?? 0,
+      lowC: min[i] ?? 0,
+      code: codes[i] ?? 0,
+    });
+  }
+  return out;
+}
+
+/** Compute the high/low temperature span across daily points (for the range bars). */
+export function tempSpan(days: DayPoint[]): { min: number; max: number } {
+  if (days.length === 0) return { min: 0, max: 0 };
+  let min = Infinity;
+  let max = -Infinity;
+  for (const d of days) {
+    if (d.lowC < min) min = d.lowC;
+    if (d.highC > max) max = d.highC;
+  }
+  return { min, max };
+}
+
+export interface SavedLocation {
+  id?: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+  is_default?: boolean;
+}
+
+export const DEMO_LOCATION: SavedLocation = {
+  name: "San Francisco",
+  latitude: 37.7749,
+  longitude: -122.4194,
+  is_default: true,
+};
+
+/**
+ * Generate a deterministic, plausible demo forecast for offline/no-network
+ * fallback. Anchored to `baseIso` so the "Now" slot lines up with reality.
+ */
+export function demoForecast(baseIso?: string): OpenMeteoForecast {
+  const base = baseIso ? new Date(baseIso) : new Date();
+  base.setMinutes(0, 0, 0);
+  const codeCycle = [1, 2, 3, 2, 61, 80, 3, 1];
+
+  const hourlyTime: string[] = [];
+  const hourlyTemp: number[] = [];
+  const hourlyCode: number[] = [];
+  for (let i = 0; i < 24; i += 1) {
+    const t = new Date(base.getTime() + i * 3_600_000);
+    hourlyTime.push(t.toISOString());
+    // Mild diurnal curve peaking mid-afternoon.
+    const hour = t.getHours();
+    const temp = 14 + 6 * Math.sin(((hour - 6) / 24) * Math.PI * 2);
+    hourlyTemp.push(Math.round(temp * 10) / 10);
+    hourlyCode.push(codeCycle[hour % codeCycle.length]);
+  }
+
+  const dayDate: string[] = [];
+  const dayMax: number[] = [];
+  const dayMin: number[] = [];
+  const dayCode: number[] = [];
+  const dayStart = new Date(base);
+  dayStart.setHours(0, 0, 0, 0);
+  const dailyCodes = [1, 2, 3, 61, 80, 2, 1];
+  const highs = [19, 18, 16, 15, 17, 20, 21];
+  const lows = [11, 10, 9, 9, 10, 12, 13];
+  for (let i = 0; i < 7; i += 1) {
+    const d = new Date(dayStart.getTime() + i * 86_400_000);
+    dayDate.push(d.toISOString().slice(0, 10));
+    dayMax.push(highs[i]);
+    dayMin.push(lows[i]);
+    dayCode.push(dailyCodes[i]);
+  }
+
+  const sunrise = new Date(dayStart.getTime() + 6.5 * 3_600_000).toISOString();
+  const sunset = new Date(dayStart.getTime() + 19.5 * 3_600_000).toISOString();
+
+  return {
+    current: {
+      time: base.toISOString(),
+      temperature_2m: hourlyTemp[0],
+      apparent_temperature: hourlyTemp[0] - 1.5,
+      weather_code: hourlyCode[0],
+      is_day: isDaytime(base.toISOString(), sunrise, sunset) ? 1 : 0,
+      relative_humidity_2m: 68,
+      wind_speed_10m: 12,
+    },
+    hourly: { time: hourlyTime, temperature_2m: hourlyTemp, weather_code: hourlyCode },
+    daily: {
+      time: dayDate,
+      weather_code: dayCode,
+      temperature_2m_max: dayMax,
+      temperature_2m_min: dayMin,
+      sunrise: [sunrise],
+      sunset: [sunset],
+    },
+  };
+}
+
+/** Normalize a possibly-untrusted DB/localStorage row into a SavedLocation. */
+export function coerceLocation(row: unknown): SavedLocation | null {
+  if (!row || typeof row !== "object") return null;
+  const r = row as Record<string, unknown>;
+  const name = typeof r.name === "string" ? r.name.trim() : "";
+  const latitude = typeof r.latitude === "number" ? r.latitude : Number(r.latitude);
+  const longitude = typeof r.longitude === "number" ? r.longitude : Number(r.longitude);
+  if (!name) return null;
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+  if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) return null;
+  return {
+    id: typeof r.id === "string" ? r.id : undefined,
+    name,
+    latitude,
+    longitude,
+    is_default: r.is_default === true,
+  };
+}

--- a/home/apps/weather/src/weather-model.ts
+++ b/home/apps/weather/src/weather-model.ts
@@ -162,6 +162,12 @@ export function formatHour(iso: string, isNow = false): string {
 
 /** Short weekday label, e.g. "Mon", or "Today" for the current day. */
 export function formatDay(iso: string, todayIso?: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
+    const todayKey = todayIso?.slice(0, 10) ?? new Date().toISOString().slice(0, 10);
+    if (iso === todayKey) return "Today";
+    const [year, month, day] = iso.split("-").map(Number);
+    return new Date(year, month - 1, day).toLocaleDateString("en-US", { weekday: "short" });
+  }
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return "--";
   const ref = todayIso ? new Date(todayIso) : new Date();
@@ -349,7 +355,7 @@ export function demoForecast(baseIso?: string): OpenMeteoForecast {
   };
 }
 
-/** Normalize a possibly-untrusted DB/localStorage row into a SavedLocation. */
+/** Normalize a possibly-untrusted DB or bridge-KV row into a SavedLocation. */
 export function coerceLocation(row: unknown): SavedLocation | null {
   if (!row || typeof row !== "object") return null;
   const r = row as Record<string, unknown>;

--- a/tests/default-apps/weather-api.test.ts
+++ b/tests/default-apps/weather-api.test.ts
@@ -53,6 +53,21 @@ describe("weather api proxy", () => {
     })).rejects.toThrow("proxy request failed: invalid response");
   });
 
+  it("rejects unexpected proxy objects instead of treating them as forecast data", async () => {
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        proxyFetch: vi.fn(async () => ({ reason: "rate limited" })),
+      },
+    });
+
+    await expect(fetchForecast({
+      name: "Berlin",
+      latitude: 52.52,
+      longitude: 13.405,
+    })).rejects.toThrow("proxy request failed: unexpected response shape");
+  });
+
   it("drops blank geocode names before returning search results", async () => {
     Object.defineProperty(window, "MatrixOS", {
       configurable: true,

--- a/tests/default-apps/weather-api.test.ts
+++ b/tests/default-apps/weather-api.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchForecast } from "../../home/apps/weather/src/weather-api";
+import { fetchForecast, geocode } from "../../home/apps/weather/src/weather-api";
 
 describe("weather api proxy", () => {
   afterEach(() => {
@@ -36,5 +36,23 @@ describe("weather api proxy", () => {
       latitude: 52.52,
       longitude: 13.405,
     })).rejects.toThrow("proxy request failed: empty response");
+  });
+
+  it("drops blank geocode names before returning search results", async () => {
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        proxyFetch: vi.fn(async () => ({
+          results: [
+            { name: "", latitude: 52.52, longitude: 13.405 },
+            { name: "  Berlin  ", latitude: 52.52, longitude: 13.405, country: "Germany" },
+          ],
+        })),
+      },
+    });
+
+    await expect(geocode("Berlin")).resolves.toEqual([
+      { name: "Berlin", latitude: 52.52, longitude: 13.405, country: "Germany", admin1: undefined },
+    ]);
   });
 });

--- a/tests/default-apps/weather-api.test.ts
+++ b/tests/default-apps/weather-api.test.ts
@@ -22,4 +22,19 @@ describe("weather api proxy", () => {
       longitude: 13.405,
     })).rejects.toThrow("proxy request failed");
   });
+
+  it("rejects empty proxy responses instead of treating them as forecast data", async () => {
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        proxyFetch: vi.fn(async () => null),
+      },
+    });
+
+    await expect(fetchForecast({
+      name: "Berlin",
+      latitude: 52.52,
+      longitude: 13.405,
+    })).rejects.toThrow("proxy request failed: empty response");
+  });
 });

--- a/tests/default-apps/weather-api.test.ts
+++ b/tests/default-apps/weather-api.test.ts
@@ -20,7 +20,7 @@ describe("weather api proxy", () => {
       name: "Berlin",
       latitude: 52.52,
       longitude: 13.405,
-    })).rejects.toThrow("proxy request failed");
+    })).rejects.toThrow("proxy request failed: upstream request failed");
   });
 
   it("rejects empty proxy responses instead of treating them as forecast data", async () => {
@@ -38,6 +38,21 @@ describe("weather api proxy", () => {
     })).rejects.toThrow("proxy request failed: empty response");
   });
 
+  it("rejects primitive proxy responses instead of treating them as forecast data", async () => {
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        proxyFetch: vi.fn(async () => "Rate limit exceeded"),
+      },
+    });
+
+    await expect(fetchForecast({
+      name: "Berlin",
+      latitude: 52.52,
+      longitude: 13.405,
+    })).rejects.toThrow("proxy request failed: invalid response");
+  });
+
   it("drops blank geocode names before returning search results", async () => {
     Object.defineProperty(window, "MatrixOS", {
       configurable: true,
@@ -46,6 +61,25 @@ describe("weather api proxy", () => {
           results: [
             { name: "", latitude: 52.52, longitude: 13.405 },
             { name: "  Berlin  ", latitude: 52.52, longitude: 13.405, country: "Germany" },
+          ],
+        })),
+      },
+    });
+
+    await expect(geocode("Berlin")).resolves.toEqual([
+      { name: "Berlin", latitude: 52.52, longitude: 13.405, country: "Germany", admin1: undefined },
+    ]);
+  });
+
+  it("drops out-of-range geocode coordinates", async () => {
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        proxyFetch: vi.fn(async () => ({
+          results: [
+            { name: "Bad Latitude", latitude: 120, longitude: 13.405 },
+            { name: "Bad Longitude", latitude: 52.52, longitude: -200 },
+            { name: "Berlin", latitude: 52.52, longitude: 13.405, country: "Germany" },
           ],
         })),
       },

--- a/tests/default-apps/weather-api.test.ts
+++ b/tests/default-apps/weather-api.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchForecast } from "../../home/apps/weather/src/weather-api";
+
+describe("weather api proxy", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+  });
+
+  it("rejects proxy error payloads instead of treating them as forecast data", async () => {
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        proxyFetch: vi.fn(async () => ({ error: "upstream request failed" })),
+      },
+    });
+
+    await expect(fetchForecast({
+      name: "Berlin",
+      latitude: 52.52,
+      longitude: 13.405,
+    })).rejects.toThrow("proxy request failed");
+  });
+});

--- a/tests/default-apps/weather-api.test.ts
+++ b/tests/default-apps/weather-api.test.ts
@@ -86,6 +86,17 @@ describe("weather api proxy", () => {
     ]);
   });
 
+  it("treats empty geocode proxy objects as no matching places", async () => {
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        proxyFetch: vi.fn(async () => ({})),
+      },
+    });
+
+    await expect(geocode("no-such-place")).resolves.toEqual([]);
+  });
+
   it("drops out-of-range geocode coordinates", async () => {
     Object.defineProperty(window, "MatrixOS", {
       configurable: true,

--- a/tests/default-apps/weather-api.test.ts
+++ b/tests/default-apps/weather-api.test.ts
@@ -68,6 +68,21 @@ describe("weather api proxy", () => {
     })).rejects.toThrow("proxy request failed: unexpected response shape");
   });
 
+  it("rejects empty forecast proxy objects instead of treating them as live data", async () => {
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        proxyFetch: vi.fn(async () => ({})),
+      },
+    });
+
+    await expect(fetchForecast({
+      name: "Berlin",
+      latitude: 52.52,
+      longitude: 13.405,
+    })).rejects.toThrow("proxy request failed: unexpected response shape");
+  });
+
   it("drops blank geocode names before returning search results", async () => {
     Object.defineProperty(window, "MatrixOS", {
       configurable: true,

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -9,11 +9,12 @@ type DbRow = Record<string, unknown>;
 function installMatrixDb(initialRows: DbRow[] = []) {
   const rows = [...initialRows];
   let changeHandler: (() => void) | null = null;
+  let insertCount = 0;
   const db = {
     find: vi.fn(async () => rows),
     findOne: vi.fn(async () => null),
     insert: vi.fn(async (_table: string, data: DbRow) => {
-      const id = "loc-new";
+      const id = `loc-new-${++insertCount}`;
       rows.push({ id, created_at: new Date().toISOString(), ...data });
       changeHandler?.();
       return { id };
@@ -215,7 +216,7 @@ describe("Weather app", () => {
 
     render(<App />);
     await vi.waitFor(() => {
-      expect(screen.getByText("Berlin")).toBeTruthy();
+      expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
     });
 
     fireEvent.click(screen.getByLabelText(/remove berlin/i));
@@ -223,7 +224,7 @@ describe("Weather app", () => {
     await vi.waitFor(() => {
       expect(screen.getByText(/location could not be removed/i)).toBeTruthy();
     });
-    expect(screen.getByText("Berlin")).toBeTruthy();
+    expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
   });
 
   it("stores fallback locations through MatrixOS data bridge", async () => {
@@ -243,11 +244,11 @@ describe("Weather app", () => {
     });
     fireEvent.click(screen.getByTestId("search-result"));
 
-    await waitFor(() => {
-      expect(bridge.writeData).toHaveBeenCalledWith(
-        "matrix-weather-locations",
-        expect.arrayContaining([expect.objectContaining({ name: "Berlin" })]),
-      );
+    await vi.waitFor(() => {
+      expect(bridge.writeData.mock.calls.some(([key]) => key === "matrix-weather-locations")).toBe(true);
     });
+    const stored = bridge.writeData.mock.calls.find(([key]) => key === "matrix-weather-locations")?.[1] as Array<Record<string, unknown>>;
+    expect(stored).toEqual([expect.objectContaining({ name: "Berlin" })]);
+    expect(String(stored[0].id ?? "")).not.toMatch(/^local-/);
   });
 });

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -15,7 +15,7 @@ function installMatrixDb(initialRows: DbRow[] = []) {
     findOne: vi.fn(async () => null),
     insert: vi.fn(async (_table: string, data: DbRow) => {
       const id = `loc-new-${++insertCount}`;
-      rows.push({ id, created_at: new Date().toISOString(), ...data });
+      rows.push({ id, ...data });
       changeHandler?.();
       return { id };
     }),
@@ -198,6 +198,8 @@ describe("Weather app", () => {
     const [table, payload] = db.insert.mock.calls[0];
     expect(table).toBe("locations");
     expect(payload).toMatchObject({ name: "Berlin", latitude: 52.52, longitude: 13.405 });
+    expect(typeof payload.created_at).toBe("string");
+    expect(Number.isNaN(Date.parse(payload.created_at as string))).toBe(false);
   });
 
   it("rolls back optimistic add when DB insert fails", async () => {

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -238,7 +238,9 @@ describe("Weather app", () => {
       expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
     });
 
-    fireEvent.click(screen.getByLabelText(/remove berlin/i));
+    const removeButton = screen.getByRole("button", { name: /remove berlin/i });
+    expect(removeButton.getAttribute("tabindex")).not.toBe("-1");
+    fireEvent.click(removeButton);
 
     await vi.waitFor(() => {
       expect(screen.getByText(/location could not be removed/i)).toBeTruthy();

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -11,7 +11,18 @@ function installMatrixDb(initialRows: DbRow[] = []) {
   let changeHandler: (() => void) | null = null;
   let insertCount = 0;
   const db = {
-    find: vi.fn(async () => rows),
+    find: vi.fn(async (_table: string, opts?: { orderBy?: Record<string, "asc" | "desc"> }) => {
+      const result = [...rows];
+      const [key, dir] = Object.entries(opts?.orderBy ?? {})[0] ?? [];
+      if (key) {
+        result.sort((a, b) => {
+          const left = String(a[key] ?? "");
+          const right = String(b[key] ?? "");
+          return dir === "desc" ? right.localeCompare(left) : left.localeCompare(right);
+        });
+      }
+      return result;
+    }),
     findOne: vi.fn(async () => null),
     insert: vi.fn(async (_table: string, data: DbRow) => {
       const id = `loc-new-${++insertCount}`;
@@ -39,8 +50,9 @@ function installMatrixDb(initialRows: DbRow[] = []) {
       };
     }),
   };
+  Object.assign(db, { rows });
   Object.defineProperty(window, "MatrixOS", { configurable: true, value: { db } });
-  return db;
+  return db as typeof db & { rows: DbRow[] };
 }
 
 function installMatrixDataBridge(data = new Map<string, unknown>()) {
@@ -137,6 +149,22 @@ describe("Weather app", () => {
     expect(within(daily).getAllByTestId("daily-row").length).toBe(3);
   });
 
+  it("orders saved locations by creation time", async () => {
+    installMatrixDb([
+      { id: "loc-2", name: "Paris", latitude: 48.8566, longitude: 2.3522, is_default: false, created_at: "2026-05-31T11:00:00.000Z" },
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true, created_at: "2026-05-31T10:00:00.000Z" },
+    ]);
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+
+    await vi.waitFor(() => {
+      const items = screen.getAllByTestId("location-item");
+      expect(within(items[0]).getByText("Berlin")).toBeTruthy();
+      expect(within(items[1]).getByText("Paris")).toBeTruthy();
+    });
+  });
+
   it("converts wind speed to mph when Fahrenheit is selected", async () => {
     installMatrixDb([
       { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
@@ -219,6 +247,123 @@ describe("Weather app", () => {
     expect(screen.getAllByTestId("location-item")).toHaveLength(1);
   });
 
+  it("only shows the search spinner when the debounced geocode request starts", async () => {
+    installMatrixDb([]);
+    const fetchMock = mockFetchOk();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /search a city/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Berlin" } });
+
+    expect(screen.queryByText("Searching…")).toBeNull();
+    await vi.advanceTimersByTimeAsync(279);
+    expect(screen.queryByText("Searching…")).toBeNull();
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes("geocoding-api"))).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+  });
+
+  it("clears a stale search error as soon as a new debounced query starts", async () => {
+    installMatrixDb([]);
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("geocode unavailable"))
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => GEOCODE_JSON,
+      } as Response);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /search a city/i }));
+    const input = screen.getByTestId("search-input");
+    fireEvent.change(input, { target: { value: "Berlin" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByText("Search is unavailable right now.")).toBeTruthy();
+    });
+
+    fireEvent.change(input, { target: { value: "Paris" } });
+
+    expect(screen.queryByText("Search is unavailable right now.")).toBeNull();
+    expect(screen.queryByText("Searching…")).toBeNull();
+  });
+
+  it("does not show stale geocode results after the query becomes too short", async () => {
+    installMatrixDb([]);
+    let resolveGeocode: ((response: Response) => void) | null = null;
+    const fetchMock = vi.fn(() => new Promise<Response>((resolve) => {
+      resolveGeocode = resolve;
+    }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /search a city/i }));
+    const input = screen.getByTestId("search-input");
+    fireEvent.change(input, { target: { value: "Berlin" } });
+    await vi.advanceTimersByTimeAsync(280);
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(input, { target: { value: "B" } });
+    expect(screen.queryByTestId("search-result")).toBeNull();
+
+    resolveGeocode?.({
+      ok: true,
+      status: 200,
+      json: async () => GEOCODE_JSON,
+    } as Response);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(screen.queryByTestId("search-result")).toBeNull();
+    expect(screen.getByText("Type at least two characters.")).toBeTruthy();
+  });
+
+  it("does not refetch an identical forecast when an optimistic id resolves", async () => {
+    installMatrixDb([]);
+    const fetchMock = mockFetchOk();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /search a city/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Berlin" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("hero-location").textContent).toContain("Berlin");
+    });
+    const forecastCalls = fetchMock.mock.calls.filter(([input]) => (
+      String(input).includes("api.open-meteo.com/v1/forecast")
+    ));
+    expect(forecastCalls).toHaveLength(1);
+  });
+
   it("rolls back optimistic add when DB insert fails", async () => {
     const db = installMatrixDb([]);
     db.insert.mockRejectedValueOnce(new Error("insert failed"));
@@ -289,6 +434,127 @@ describe("Weather app", () => {
     );
     expect(parisItem).toBeTruthy();
     expect(within(parisItem as HTMLElement).getByText("Default")).toBeTruthy();
+  });
+
+  it("promotes a pending inserted location when removing the default", async () => {
+    const db = installMatrixDb([
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+    ]);
+    let resolveInsert: (() => void) | null = null;
+    db.insert.mockImplementationOnce(async (_table: string, data: DbRow) => {
+      await new Promise<void>((resolve) => {
+        resolveInsert = resolve;
+      });
+      const id = "loc-new-1";
+      db.rows.push({ id, ...data });
+      return { id };
+    });
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const body = url.includes("geocoding-api")
+        ? {
+            results: [
+              { name: "Paris", latitude: 48.8566, longitude: 2.3522, country: "France", admin1: "Ile-de-France" },
+            ],
+          }
+        : FORECAST_JSON;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add location/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Paris" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await vi.waitFor(() => {
+      expect(screen.getAllByText("Paris, Ile-de-France").length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getByRole("button", { name: /remove berlin/i }));
+
+    await vi.waitFor(() => {
+      expect(db.delete).toHaveBeenCalledWith("locations", "loc-1");
+      expect(screen.queryByText("Berlin")).toBeNull();
+    });
+
+    resolveInsert?.();
+
+    await vi.waitFor(() => {
+      expect(db.update).toHaveBeenCalledWith("locations", "loc-new-1", { is_default: true });
+    });
+    const parisItem = screen.getAllByTestId("location-item").find((item) =>
+      within(item).queryByText("Paris, Ile-de-France"),
+    );
+    expect(parisItem).toBeTruthy();
+    expect(within(parisItem as HTMLElement).getByText("Default")).toBeTruthy();
+  });
+
+  it("does not re-add a pending inserted location after it was removed", async () => {
+    const db = installMatrixDb([
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+    ]);
+    let resolveInsert: (() => void) | null = null;
+    db.insert.mockImplementationOnce(async (_table: string, data: DbRow) => {
+      await new Promise<void>((resolve) => {
+        resolveInsert = resolve;
+      });
+      const id = "loc-new-1";
+      db.rows.push({ id, ...data });
+      return { id };
+    });
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const body = url.includes("geocoding-api")
+        ? {
+            results: [
+              { name: "Paris", latitude: 48.8566, longitude: 2.3522, country: "France", admin1: "Ile-de-France" },
+            ],
+          }
+        : FORECAST_JSON;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add location/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Paris" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await vi.waitFor(() => {
+      expect(screen.getAllByText("Paris, Ile-de-France").length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getByRole("button", { name: /remove paris/i }));
+    expect(screen.queryByText("Paris, Ile-de-France")).toBeNull();
+
+    resolveInsert?.();
+
+    await vi.waitFor(() => {
+      expect(db.delete).toHaveBeenCalledWith("locations", "loc-new-1");
+    });
+    expect(screen.queryByText("Paris, Ile-de-France")).toBeNull();
+    expect(db.rows.some((row) => row.id === "loc-new-1")).toBe(false);
   });
 
   it("keeps the removed location deleted when default promotion fails", async () => {

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -132,6 +132,23 @@ describe("Weather app", () => {
     expect(within(daily).getAllByTestId("daily-row").length).toBe(3);
   });
 
+  it("converts wind speed to mph when Fahrenheit is selected", async () => {
+    installMatrixDb([
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+    ]);
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText("11 km/h")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /toggle temperature unit/i }));
+
+    expect(screen.getByText("7 mph")).toBeTruthy();
+    expect(screen.queryByText("11 km/h")).toBeNull();
+  });
+
   it("falls back to seeded demo data with a notice when fetch fails", async () => {
     installMatrixDb([
       { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -251,4 +251,46 @@ describe("Weather app", () => {
     expect(stored).toEqual([expect.objectContaining({ name: "Berlin" })]);
     expect(String(stored[0].id ?? "")).not.toMatch(/^local-/);
   });
+
+  it("does not persist optimistic local ids when adding fallback locations repeatedly", async () => {
+    const bridge = installMatrixDataBridge();
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /search a city/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Berlin" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await vi.waitFor(() => {
+      const stored = bridge.writeData.mock.calls.find(
+        ([key]) => key === "matrix-weather-locations",
+      )?.[1] as Array<Record<string, unknown>> | undefined;
+      expect(stored?.length).toBe(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add location/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Berlin" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await vi.waitFor(() => {
+      const writes = bridge.writeData.mock.calls.filter(
+        ([key]) => key === "matrix-weather-locations",
+      );
+      const stored = writes.at(-1)?.[1] as Array<Record<string, unknown>> | undefined;
+      expect(stored?.length).toBe(2);
+      expect(stored?.some((loc) => String(loc.id ?? "").startsWith("local-"))).toBe(false);
+    });
+  });
 });

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -19,7 +19,12 @@ function installMatrixDb(initialRows: DbRow[] = []) {
       changeHandler?.();
       return { id };
     }),
-    update: vi.fn(async () => ({ ok: true })),
+    update: vi.fn(async (_table: string, id: string, data: DbRow) => {
+      const row = rows.find((item) => item.id === id);
+      if (row) Object.assign(row, data);
+      changeHandler?.();
+      return { ok: true };
+    }),
     delete: vi.fn(async (_table: string, id: string) => {
       const index = rows.findIndex((row) => row.id === id);
       if (index >= 0) rows.splice(index, 1);
@@ -258,6 +263,32 @@ describe("Weather app", () => {
       expect(screen.getByText(/location could not be removed/i)).toBeTruthy();
     });
     expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
+  });
+
+  it("promotes the next location when removing the default", async () => {
+    const db = installMatrixDb([
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+      { id: "loc-2", name: "Paris", latitude: 48.8566, longitude: 2.3522, is_default: false },
+    ]);
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Paris").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /remove berlin/i }));
+
+    await vi.waitFor(() => {
+      expect(db.delete).toHaveBeenCalledWith("locations", "loc-1");
+      expect(db.update).toHaveBeenCalledWith("locations", "loc-2", { is_default: true });
+    });
+    const parisItem = screen.getAllByTestId("location-item").find((item) =>
+      within(item).queryByText("Paris"),
+    );
+    expect(parisItem).toBeTruthy();
+    expect(within(parisItem as HTMLElement).getByText("Default")).toBeTruthy();
   });
 
   it("stores fallback locations through MatrixOS data bridge", async () => {

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -6,18 +6,46 @@ import App from "../../home/apps/weather/src/App";
 
 type DbRow = Record<string, unknown>;
 
-function installMatrixDb(rows: DbRow[] = []) {
+function installMatrixDb(initialRows: DbRow[] = []) {
+  const rows = [...initialRows];
+  let changeHandler: (() => void) | null = null;
   const db = {
     find: vi.fn(async () => rows),
     findOne: vi.fn(async () => null),
-    insert: vi.fn(async () => ({ id: "loc-new" })),
+    insert: vi.fn(async (_table: string, data: DbRow) => {
+      const id = "loc-new";
+      rows.push({ id, created_at: new Date().toISOString(), ...data });
+      changeHandler?.();
+      return { id };
+    }),
     update: vi.fn(async () => ({ ok: true })),
-    delete: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async (_table: string, id: string) => {
+      const index = rows.findIndex((row) => row.id === id);
+      if (index >= 0) rows.splice(index, 1);
+      changeHandler?.();
+      return { ok: true };
+    }),
     count: vi.fn(async () => rows.length),
-    onChange: vi.fn(() => () => undefined),
+    onChange: vi.fn((_table: string, callback: () => void) => {
+      changeHandler = callback;
+      return () => {
+        changeHandler = null;
+      };
+    }),
   };
   Object.defineProperty(window, "MatrixOS", { configurable: true, value: { db } });
   return db;
+}
+
+function installMatrixDataBridge(data = new Map<string, unknown>()) {
+  const bridge = {
+    readData: vi.fn(async (key: string) => data.get(key) ?? null),
+    writeData: vi.fn(async (key: string, value: unknown) => {
+      data.set(key, value);
+    }),
+  };
+  Object.defineProperty(window, "MatrixOS", { configurable: true, value: bridge });
+  return bridge;
 }
 
 const FORECAST_JSON = {
@@ -152,5 +180,74 @@ describe("Weather app", () => {
     const [table, payload] = db.insert.mock.calls[0];
     expect(table).toBe("locations");
     expect(payload).toMatchObject({ name: "Berlin", latitude: 52.52, longitude: 13.405 });
+  });
+
+  it("rolls back optimistic add when DB insert fails", async () => {
+    const db = installMatrixDb([]);
+    db.insert.mockRejectedValueOnce(new Error("insert failed"));
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /search a city/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Berlin" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/location could not be saved/i)).toBeTruthy();
+    });
+    expect(screen.getByTestId("empty-state")).toBeTruthy();
+  });
+
+  it("rolls back optimistic remove when DB delete fails", async () => {
+    const db = installMatrixDb([
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+    ]);
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByText("Berlin")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByLabelText(/remove berlin/i));
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/location could not be removed/i)).toBeTruthy();
+    });
+    expect(screen.getByText("Berlin")).toBeTruthy();
+  });
+
+  it("stores fallback locations through MatrixOS data bridge", async () => {
+    const bridge = installMatrixDataBridge();
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /search a city/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Berlin" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await waitFor(() => {
+      expect(bridge.writeData).toHaveBeenCalledWith(
+        "matrix-weather-locations",
+        expect.arrayContaining([expect.objectContaining({ name: "Berlin" })]),
+      );
+    });
   });
 });

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/weather/src/App";
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const db = {
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async () => ({ id: "loc-new" })),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => rows.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", { configurable: true, value: { db } });
+  return db;
+}
+
+const FORECAST_JSON = {
+  current: {
+    time: "2026-05-31T10:00:00",
+    temperature_2m: 18.4,
+    apparent_temperature: 16.9,
+    weather_code: 2,
+    is_day: 1,
+    relative_humidity_2m: 70,
+    wind_speed_10m: 11,
+  },
+  hourly: {
+    time: Array.from({ length: 24 }, (_, i) => `2026-05-31T${String(i).padStart(2, "0")}:00:00`),
+    temperature_2m: Array.from({ length: 24 }, (_, i) => 12 + i * 0.3),
+    weather_code: Array.from({ length: 24 }, () => 2),
+  },
+  daily: {
+    time: ["2026-05-31", "2026-06-01", "2026-06-02"],
+    weather_code: [2, 61, 0],
+    temperature_2m_max: [21, 18, 24],
+    temperature_2m_min: [11, 9, 13],
+    sunrise: ["2026-05-31T06:00:00"],
+    sunset: ["2026-05-31T20:00:00"],
+  },
+};
+
+const GEOCODE_JSON = {
+  results: [
+    { name: "Berlin", latitude: 52.52, longitude: 13.405, country: "Germany", admin1: "Berlin" },
+  ],
+};
+
+function mockFetchOk() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const body = url.includes("geocoding-api") ? GEOCODE_JSON : FORECAST_JSON;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as Response;
+  });
+}
+
+describe("Weather app", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-31T10:00:00"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+    Reflect.deleteProperty(globalThis, "fetch");
+    window.localStorage.clear();
+  });
+
+  it("loads a default location and renders the hero, hourly strip, and daily forecast", async () => {
+    installMatrixDb([
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+    ]);
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("hero-temp").textContent).toBe("18°");
+    });
+    // condition label from code 2 → Partly Cloudy
+    expect(screen.getByTestId("hero-condition").textContent).toContain("Partly Cloudy");
+    // current location name
+    expect(screen.getByTestId("hero-location").textContent).toContain("Berlin");
+
+    // hourly strip rendered with at least several hours
+    const hourly = screen.getByTestId("hourly-strip");
+    expect(within(hourly).getAllByTestId("hourly-cell").length).toBeGreaterThan(5);
+    expect(within(hourly).getByText("Now")).toBeTruthy();
+
+    // daily forecast rendered with our 3 days
+    const daily = screen.getByTestId("daily-list");
+    expect(within(daily).getAllByTestId("daily-row").length).toBe(3);
+  });
+
+  it("falls back to seeded demo data with a notice when fetch fails", async () => {
+    installMatrixDb([
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+    ]);
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    render(<App />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("demo-notice")).toBeTruthy();
+    });
+    // still shows a hero (never a blank screen)
+    expect(screen.getByTestId("hero-temp")).toBeTruthy();
+    const hourly = screen.getByTestId("hourly-strip");
+    expect(within(hourly).getAllByTestId("hourly-cell").length).toBeGreaterThan(5);
+  });
+
+  it("searches and saves a new location via the DB bridge", async () => {
+    const db = installMatrixDb([]);
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+
+    // empty state onboarding when no locations
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeTruthy();
+    });
+
+    // open the search overlay from the empty-state CTA
+    fireEvent.click(screen.getByRole("button", { name: /search a city/i }));
+
+    const input = screen.getByTestId("search-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Berlin" } });
+    // advance the debounce timer so geocode fires
+    await vi.advanceTimersByTimeAsync(400);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await vi.waitFor(() => {
+      expect(db.insert).toHaveBeenCalled();
+    });
+    const [table, payload] = db.insert.mock.calls[0];
+    expect(table).toBe("locations");
+    expect(payload).toMatchObject({ name: "Berlin", latitude: 52.52, longitude: 13.405 });
+  });
+});

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -598,6 +598,7 @@ describe("Weather app", () => {
     await vi.waitFor(() => {
       expect(screen.getByTestId("search-result")).toBeTruthy();
     });
+    bridge.readData.mockClear();
     fireEvent.click(screen.getByTestId("search-result"));
 
     await vi.waitFor(() => {
@@ -606,6 +607,7 @@ describe("Weather app", () => {
     const stored = bridge.writeData.mock.calls.find(([key]) => key === "matrix-weather-locations")?.[1] as Array<Record<string, unknown>>;
     expect(stored).toEqual([expect.objectContaining({ name: "Berlin" })]);
     expect(String(stored[0].id ?? "")).not.toMatch(/^local-/);
+    expect(bridge.readData.mock.calls.filter(([key]) => key === "matrix-weather-locations").length).toBeGreaterThanOrEqual(2);
   });
 
   it("does not persist duplicates or optimistic local ids when adding fallback locations repeatedly", async () => {

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -652,6 +652,47 @@ describe("Weather app", () => {
     });
   });
 
+  it("keeps a newly added fallback location active after storage reload", async () => {
+    installMatrixDataBridge(new Map<string, unknown>([[
+      "matrix-weather-locations",
+      [
+        { name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+      ],
+    ]]));
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const body = url.includes("geocoding-api")
+        ? {
+            results: [
+              { name: "Paris", latitude: 48.8566, longitude: 2.3522, country: "France", admin1: "Ile-de-France" },
+            ],
+          }
+        : FORECAST_JSON;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("hero-location").textContent).toContain("Berlin");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add location/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Paris" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("hero-location").textContent).toContain("Paris, Ile-de-France");
+    });
+  });
+
   it("strips optimistic local ids when removing fallback locations", async () => {
     const bridge = installMatrixDataBridge(new Map<string, unknown>([[
       "matrix-weather-locations",

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -291,6 +291,32 @@ describe("Weather app", () => {
     expect(within(parisItem as HTMLElement).getByText("Default")).toBeTruthy();
   });
 
+  it("keeps the removed location deleted when default promotion fails", async () => {
+    const db = installMatrixDb([
+      { id: "loc-1", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+      { id: "loc-2", name: "Paris", latitude: 48.8566, longitude: 2.3522, is_default: false },
+    ]);
+    db.update.mockRejectedValueOnce(new Error("update failed"));
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Paris").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /remove berlin/i }));
+
+    await vi.waitFor(() => {
+      expect(db.delete).toHaveBeenCalledWith("locations", "loc-1");
+      expect(db.update).toHaveBeenCalledWith("locations", "loc-2", { is_default: true });
+      expect(screen.getByText(/default location could not be updated/i)).toBeTruthy();
+    });
+    expect(screen.queryByText(/location could not be removed/i)).toBeNull();
+    expect(screen.queryByText("Berlin")).toBeNull();
+    expect(screen.getAllByText("Paris").length).toBeGreaterThan(0);
+  });
+
   it("stores fallback locations through MatrixOS data bridge", async () => {
     const bridge = installMatrixDataBridge();
     globalThis.fetch = mockFetchOk() as unknown as typeof fetch;

--- a/tests/default-apps/weather-app.test.tsx
+++ b/tests/default-apps/weather-app.test.tsx
@@ -200,6 +200,18 @@ describe("Weather app", () => {
     expect(payload).toMatchObject({ name: "Berlin", latitude: 52.52, longitude: 13.405 });
     expect(typeof payload.created_at).toBe("string");
     expect(Number.isNaN(Date.parse(payload.created_at as string))).toBe(false);
+
+    db.insert.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: /add location/i }));
+    fireEvent.change(screen.getByTestId("search-input"), { target: { value: "Berlin" } });
+    await vi.advanceTimersByTimeAsync(400);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("search-result")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("search-result"));
+
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId("location-item")).toHaveLength(1);
   });
 
   it("rolls back optimistic add when DB insert fails", async () => {
@@ -273,7 +285,7 @@ describe("Weather app", () => {
     expect(String(stored[0].id ?? "")).not.toMatch(/^local-/);
   });
 
-  it("does not persist optimistic local ids when adding fallback locations repeatedly", async () => {
+  it("does not persist duplicates or optimistic local ids when adding fallback locations repeatedly", async () => {
     const bridge = installMatrixDataBridge();
     globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
 
@@ -310,7 +322,33 @@ describe("Weather app", () => {
         ([key]) => key === "matrix-weather-locations",
       );
       const stored = writes.at(-1)?.[1] as Array<Record<string, unknown>> | undefined;
-      expect(stored?.length).toBe(2);
+      expect(stored?.length).toBe(1);
+      expect(stored?.some((loc) => String(loc.id ?? "").startsWith("local-"))).toBe(false);
+    });
+  });
+
+  it("strips optimistic local ids when removing fallback locations", async () => {
+    const bridge = installMatrixDataBridge(new Map<string, unknown>([[
+      "matrix-weather-locations",
+      [
+        { id: "local-stale", name: "Paris", latitude: 48.8566, longitude: 2.3522 },
+        { id: "stored-berlin", name: "Berlin", latitude: 52.52, longitude: 13.405, is_default: true },
+      ],
+    ]]));
+    globalThis.fetch = mockFetchOk() as unknown as typeof fetch;
+
+    render(<App />);
+    await vi.waitFor(() => {
+      expect(screen.getAllByText("Berlin").length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getByRole("button", { name: /remove berlin/i }));
+
+    await vi.waitFor(() => {
+      const writes = bridge.writeData.mock.calls.filter(
+        ([key]) => key === "matrix-weather-locations",
+      );
+      const stored = writes.at(-1)?.[1] as Array<Record<string, unknown>> | undefined;
+      expect(stored).toEqual([expect.objectContaining({ name: "Paris" })]);
       expect(stored?.some((loc) => String(loc.id ?? "").startsWith("local-"))).toBe(false);
     });
   });

--- a/tests/default-apps/weather-model.test.ts
+++ b/tests/default-apps/weather-model.test.ts
@@ -27,8 +27,10 @@ describe("weatherVisual code mapping", () => {
   it("maps rain and snow and thunder families", () => {
     expect(weatherVisual(63).kind).toBe("rain");
     expect(weatherVisual(75).kind).toBe("snow");
+    expect(weatherVisual(75).tone).toBe("dark");
     expect(weatherVisual(95).kind).toBe("thunder");
     expect(weatherVisual(45).kind).toBe("fog");
+    expect(weatherVisual(45).tone).toBe("dark");
     expect(weatherVisual(51).kind).toBe("drizzle");
     expect(weatherVisual(3).kind).toBe("cloudy");
   });
@@ -151,6 +153,8 @@ describe("coerceLocation", () => {
     expect(coerceLocation({ name: "", latitude: 1, longitude: 1 })).toBeNull();
     expect(coerceLocation({ name: "X", latitude: 200, longitude: 1 })).toBeNull();
     expect(coerceLocation({ name: "X", latitude: 1, longitude: "abc" })).toBeNull();
+    expect(coerceLocation({ name: "Null Island", latitude: null, longitude: 0 })).toBeNull();
+    expect(coerceLocation({ name: "Null Island", latitude: 0, longitude: null })).toBeNull();
   });
 });
 
@@ -162,5 +166,15 @@ describe("demoForecast", () => {
     expect(typeof f.current?.temperature_2m).toBe("number");
     const hours = buildHourly(f, "2026-05-31T10:00:00");
     expect(hours[0].isNow).toBe(true);
+  });
+
+  it("uses local Open-Meteo timestamp strings instead of UTC strings", () => {
+    const f = demoForecast("2026-05-31T00:30:00+14:00");
+    expect(f.current?.time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:00:00$/);
+    expect(f.current?.time).not.toContain("Z");
+    expect(f.hourly?.time?.[0]).not.toContain("Z");
+    expect(f.daily?.time?.[0]).toBe(f.current?.time?.slice(0, 10));
+    expect(f.daily?.sunrise?.[0]).not.toContain("Z");
+    expect(formatDay(f.daily?.time?.[0] ?? "", f.current?.time)).toBe("Today");
   });
 });

--- a/tests/default-apps/weather-model.test.ts
+++ b/tests/default-apps/weather-model.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDaily,
+  buildHourly,
+  coerceLocation,
+  demoForecast,
+  formatDay,
+  formatHour,
+  formatTemp,
+  isDaytime,
+  tempSpan,
+  toUnit,
+  weatherVisual,
+  type OpenMeteoForecast,
+} from "../../home/apps/weather/src/weather-model";
+
+describe("weatherVisual code mapping", () => {
+  it("maps clear sky", () => {
+    const v = weatherVisual(0);
+    expect(v.label).toBe("Clear Sky");
+    expect(v.kind).toBe("clear");
+    expect(v.icon).toBe("sun");
+    expect(v.gradientDay).toContain("linear-gradient");
+    expect(v.gradientNight).toContain("linear-gradient");
+  });
+
+  it("maps rain and snow and thunder families", () => {
+    expect(weatherVisual(63).kind).toBe("rain");
+    expect(weatherVisual(75).kind).toBe("snow");
+    expect(weatherVisual(95).kind).toBe("thunder");
+    expect(weatherVisual(45).kind).toBe("fog");
+    expect(weatherVisual(51).kind).toBe("drizzle");
+    expect(weatherVisual(3).kind).toBe("cloudy");
+  });
+
+  it("falls back gracefully for unknown codes", () => {
+    const v = weatherVisual(1234);
+    expect(v.label).toBe("Unknown");
+    expect(v.icon).toBe("cloud");
+  });
+});
+
+describe("temperature formatting", () => {
+  it("rounds celsius", () => {
+    expect(formatTemp(14.6, "c")).toBe("15°");
+    expect(formatTemp(-0.4, "c")).toBe("0°");
+  });
+
+  it("converts to fahrenheit", () => {
+    expect(Math.round(toUnit(0, "f"))).toBe(32);
+    expect(Math.round(toUnit(100, "f"))).toBe(212);
+    expect(formatTemp(20, "f")).toBe("68°");
+  });
+
+  it("handles non-finite input", () => {
+    expect(toUnit(Number.NaN, "c")).toBe(0);
+  });
+});
+
+describe("hour and day labels", () => {
+  it("labels now and pm/am", () => {
+    expect(formatHour("2026-05-31T15:00:00", true)).toBe("Now");
+    expect(formatHour("2026-05-31T15:00:00")).toBe("3 PM");
+    expect(formatHour("2026-05-31T00:00:00")).toBe("12 AM");
+    expect(formatHour("2026-05-31T09:00:00")).toBe("9 AM");
+  });
+
+  it("labels today vs weekday", () => {
+    const today = "2026-05-31T10:00:00";
+    expect(formatDay("2026-05-31", today)).toBe("Today");
+    expect(formatDay("2026-06-01", today)).toBe("Mon");
+  });
+});
+
+describe("isDaytime", () => {
+  it("uses sunrise/sunset window when given", () => {
+    const sunrise = "2026-05-31T06:00:00.000Z";
+    const sunset = "2026-05-31T20:00:00.000Z";
+    expect(isDaytime("2026-05-31T12:00:00.000Z", sunrise, sunset)).toBe(true);
+    expect(isDaytime("2026-05-31T22:00:00.000Z", sunrise, sunset)).toBe(false);
+  });
+});
+
+const FORECAST: OpenMeteoForecast = {
+  current: { time: "2026-05-31T10:00:00", temperature_2m: 18, weather_code: 2 },
+  hourly: {
+    time: [
+      "2026-05-31T09:00:00",
+      "2026-05-31T10:00:00",
+      "2026-05-31T11:00:00",
+      "2026-05-31T12:00:00",
+    ],
+    temperature_2m: [16, 18, 19, 20],
+    weather_code: [3, 2, 1, 0],
+  },
+  daily: {
+    time: ["2026-05-31", "2026-06-01", "2026-06-02"],
+    weather_code: [2, 61, 0],
+    temperature_2m_max: [21, 18, 24],
+    temperature_2m_min: [11, 9, 13],
+  },
+};
+
+describe("buildHourly", () => {
+  it("starts at the slot at/after now and marks it", () => {
+    const hours = buildHourly(FORECAST, "2026-05-31T10:00:00", 10);
+    expect(hours[0].time).toBe("2026-05-31T10:00:00");
+    expect(hours[0].isNow).toBe(true);
+    expect(hours[1].isNow).toBe(false);
+    expect(hours).toHaveLength(3);
+  });
+
+  it("returns empty when no hourly data", () => {
+    expect(buildHourly({}, "2026-05-31T10:00:00")).toEqual([]);
+  });
+});
+
+describe("buildDaily + tempSpan", () => {
+  it("builds day points", () => {
+    const days = buildDaily(FORECAST, 7);
+    expect(days).toHaveLength(3);
+    expect(days[1]).toMatchObject({ date: "2026-06-01", highC: 18, lowC: 9, code: 61 });
+  });
+
+  it("computes span across days", () => {
+    const span = tempSpan(buildDaily(FORECAST));
+    expect(span.min).toBe(9);
+    expect(span.max).toBe(24);
+  });
+});
+
+describe("coerceLocation", () => {
+  it("accepts a valid row", () => {
+    expect(coerceLocation({ name: "Paris", latitude: 48.85, longitude: 2.35 })).toMatchObject({
+      name: "Paris",
+      latitude: 48.85,
+      longitude: 2.35,
+    });
+  });
+
+  it("rejects invalid rows", () => {
+    expect(coerceLocation(null)).toBeNull();
+    expect(coerceLocation({ name: "", latitude: 1, longitude: 1 })).toBeNull();
+    expect(coerceLocation({ name: "X", latitude: 200, longitude: 1 })).toBeNull();
+    expect(coerceLocation({ name: "X", latitude: 1, longitude: "abc" })).toBeNull();
+  });
+});
+
+describe("demoForecast", () => {
+  it("produces 24 hourly and 7 daily points anchored to base", () => {
+    const f = demoForecast("2026-05-31T10:00:00");
+    expect(f.hourly?.time).toHaveLength(24);
+    expect(f.daily?.time).toHaveLength(7);
+    expect(typeof f.current?.temperature_2m).toBe("number");
+    const hours = buildHourly(f, "2026-05-31T10:00:00");
+    expect(hours[0].isNow).toBe(true);
+  });
+});

--- a/tests/default-apps/weather-model.test.ts
+++ b/tests/default-apps/weather-model.test.ts
@@ -74,6 +74,10 @@ describe("hour and day labels", () => {
   it("compares Open-Meteo date-only days without timezone rollover", () => {
     expect(formatDay("2026-06-01", "2026-06-01T00:30:00-07:00")).toBe("Today");
   });
+
+  it("compares timestamp days by date prefix when today has an offset", () => {
+    expect(formatDay("2026-06-01T00:30:00", "2026-06-01T00:30:00-07:00")).toBe("Today");
+  });
 });
 
 describe("isDaytime", () => {

--- a/tests/default-apps/weather-model.test.ts
+++ b/tests/default-apps/weather-model.test.ts
@@ -3,6 +3,7 @@ import {
   buildDaily,
   buildHourly,
   coerceLocation,
+  dailyTemperatureBar,
   demoForecast,
   formatDay,
   formatHour,
@@ -136,6 +137,16 @@ describe("buildDaily + tempSpan", () => {
     const span = tempSpan(buildDaily(FORECAST));
     expect(span.min).toBe(9);
     expect(span.max).toBe(24);
+  });
+
+  it("keeps minimum daily bar width inside the track", () => {
+    const bar = dailyTemperatureBar(
+      { date: "2026-06-03", highC: 39, lowC: 38, code: 0 },
+      { min: 25, max: 39 },
+    );
+    expect(bar.width).toBe(8);
+    expect(bar.left + bar.width).toBeLessThanOrEqual(100);
+    expect(bar.left).toBe(92);
   });
 });
 

--- a/tests/default-apps/weather-model.test.ts
+++ b/tests/default-apps/weather-model.test.ts
@@ -70,6 +70,10 @@ describe("hour and day labels", () => {
     expect(formatDay("2026-05-31", today)).toBe("Today");
     expect(formatDay("2026-06-01", today)).toBe("Mon");
   });
+
+  it("compares Open-Meteo date-only days without timezone rollover", () => {
+    expect(formatDay("2026-06-01", "2026-06-01T00:30:00-07:00")).toBe("Today");
+  });
 });
 
 describe("isDaytime", () => {


### PR DESCRIPTION
Stack: 8/22
Branch: stack/default-apps-weather

Scope: Weather app model, Open-Meteo proxy usage, UI, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.