### PR TITLE
feat(whiteboard): add board persistence model

### DIFF
--- a/home/apps/whiteboard/matrix.json
+++ b/home/apps/whiteboard/matrix.json
@@ -1,7 +1,7 @@
 {
   "name": "Whiteboard",
   "slug": "whiteboard",
-  "description": "Excalidraw sketching and diagramming canvas",
+  "description": "Infinite sketching and diagramming canvas with shapes, sticky notes, and export.",
   "category": "productivity",
   "icon": "whiteboard",
   "author": "system",
@@ -9,11 +9,28 @@
   "runtime": "vite",
   "runtimeVersion": "^1.0.0",
   "scope": "personal",
+  "storage": {
+    "tables": {
+      "scenes": {
+        "columns": {
+          "name": "text",
+          "doc": "jsonb"
+        }
+      }
+    }
+  },
   "build": {
-    "install": "pnpm install --ignore-workspace --prefer-offline",
-    "command": "pnpm build",
+    "install": "true",
+    "command": "vite build --base ./ --outDir dist",
     "output": "dist",
-    "timeout": 180
+    "timeout": 180,
+    "sourceGlobs": [
+      "src/**",
+      "../_shared/**",
+      "index.html",
+      "matrix.json",
+      "vite.config.ts"
+    ]
   },
   "listingTrust": "first_party"
 }

--- a/home/apps/whiteboard/matrix.json
+++ b/home/apps/whiteboard/matrix.json
@@ -20,8 +20,8 @@
     }
   },
   "build": {
-    "install": "true",
-    "command": "vite build --base ./ --outDir dist",
+    "install": "pnpm install --frozen-lockfile",
+    "command": "pnpm build",
     "output": "dist",
     "timeout": 180,
     "sourceGlobs": [

--- a/home/apps/whiteboard/matrix.json
+++ b/home/apps/whiteboard/matrix.json
@@ -15,8 +15,8 @@
         "columns": {
           "name": "text",
           "doc": "jsonb",
-          "created_at": "text",
-          "updated_at": "text"
+          "created_at": "timestamptz",
+          "updated_at": "timestamptz"
         }
       }
     }

--- a/home/apps/whiteboard/matrix.json
+++ b/home/apps/whiteboard/matrix.json
@@ -14,7 +14,9 @@
       "scenes": {
         "columns": {
           "name": "text",
-          "doc": "jsonb"
+          "doc": "jsonb",
+          "created_at": "text",
+          "updated_at": "text"
         }
       }
     }

--- a/home/apps/whiteboard/src/matrix-os.d.ts
+++ b/home/apps/whiteboard/src/matrix-os.d.ts
@@ -1,0 +1,28 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+  // External APIs are CSP-blocked from the iframe; proxy GETs to an allowlisted
+  // host through the gateway. Allowlist lives in the gateway (/api/bridge/proxy).
+  proxyFetch?(url: string): Promise<unknown>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/whiteboard/src/whiteboard-model.ts
+++ b/home/apps/whiteboard/src/whiteboard-model.ts
@@ -345,6 +345,10 @@ export function normalizeBoardName(raw: unknown): string {
 
 function toEpochMs(raw: unknown): number {
   if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (raw instanceof Date) {
+    const ms = raw.getTime();
+    return Number.isFinite(ms) ? ms : 0;
+  }
   if (typeof raw === "string") {
     const ms = Date.parse(raw);
     if (Number.isFinite(ms)) return ms;
@@ -412,6 +416,7 @@ function coerceElement(raw: unknown): SceneElement | null {
           )
           .filter((p): p is Point => p !== null)
       : [];
+    if (points.length === 0) return null;
     return { ...base, kind: "pen", points };
   }
   if (kind === "line" || kind === "arrow") {

--- a/home/apps/whiteboard/src/whiteboard-model.ts
+++ b/home/apps/whiteboard/src/whiteboard-model.ts
@@ -1,0 +1,464 @@
+// Pure, UI-free scene model for the whiteboard app.
+// Element types, CRUD, hit-testing, history (undo/redo), serialize/deserialize.
+
+export type ToolKind =
+  | "select"
+  | "pen"
+  | "rect"
+  | "ellipse"
+  | "arrow"
+  | "line"
+  | "text"
+  | "sticky";
+
+export type ElementKind =
+  | "pen"
+  | "rect"
+  | "ellipse"
+  | "arrow"
+  | "line"
+  | "text"
+  | "sticky";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface BaseElement {
+  id: string;
+  kind: ElementKind;
+  stroke: string;
+  fill: string;
+  strokeWidth: number;
+}
+
+export interface BoxElement extends BaseElement {
+  kind: "rect" | "ellipse" | "text" | "sticky";
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text?: string;
+}
+
+export interface LineElement extends BaseElement {
+  kind: "line" | "arrow";
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface PenElement extends BaseElement {
+  kind: "pen";
+  points: Point[];
+}
+
+export type SceneElement = BoxElement | LineElement | PenElement;
+
+export interface Scene {
+  elements: SceneElement[];
+}
+
+export interface SerializedScene {
+  version: 1;
+  elements: SceneElement[];
+}
+
+export const SCENE_VERSION = 1 as const;
+
+let idCounter = 0;
+
+/** Deterministic-ish id generator that still avoids collisions across a session. */
+export function makeId(): string {
+  idCounter += 1;
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `el-${Date.now().toString(36)}-${idCounter}-${rand}`;
+}
+
+export function emptyScene(): Scene {
+  return { elements: [] };
+}
+
+export function cloneScene(scene: Scene): Scene {
+  return { elements: scene.elements.map(cloneElement) };
+}
+
+export function cloneElement(el: SceneElement): SceneElement {
+  if (el.kind === "pen") {
+    return { ...el, points: el.points.map((p) => ({ ...p })) };
+  }
+  return { ...el };
+}
+
+/** Immutably add an element, returning a new scene. */
+export function addElement(scene: Scene, el: SceneElement): Scene {
+  return { elements: [...scene.elements, cloneElement(el)] };
+}
+
+/** Immutably update an element by id with a partial patch. No-op if missing. */
+export function updateElement(
+  scene: Scene,
+  id: string,
+  patch: Partial<SceneElement>,
+): Scene {
+  return {
+    elements: scene.elements.map((el) =>
+      el.id === id ? (mergeElement(el, patch) as SceneElement) : el,
+    ),
+  };
+}
+
+function mergeElement(el: SceneElement, patch: Partial<SceneElement>): SceneElement {
+  const merged = { ...el, ...patch, id: el.id, kind: el.kind } as SceneElement;
+  return cloneElement(merged);
+}
+
+/** Immutably move an element by (dx, dy). */
+export function moveElement(scene: Scene, id: string, dx: number, dy: number): Scene {
+  return {
+    elements: scene.elements.map((el) => (el.id === id ? translate(el, dx, dy) : el)),
+  };
+}
+
+export function translate(el: SceneElement, dx: number, dy: number): SceneElement {
+  if (el.kind === "pen") {
+    return { ...el, points: el.points.map((p) => ({ x: p.x + dx, y: p.y + dy })) };
+  }
+  if (el.kind === "line" || el.kind === "arrow") {
+    return { ...el, x1: el.x1 + dx, y1: el.y1 + dy, x2: el.x2 + dx, y2: el.y2 + dy };
+  }
+  const box = el as BoxElement;
+  return { ...box, x: box.x + dx, y: box.y + dy };
+}
+
+/** Immutably remove an element by id. */
+export function deleteElement(scene: Scene, id: string): Scene {
+  return { elements: scene.elements.filter((el) => el.id !== id) };
+}
+
+export function deleteElements(scene: Scene, ids: Iterable<string>): Scene {
+  const set = new Set(ids);
+  return { elements: scene.elements.filter((el) => !set.has(el.id)) };
+}
+
+/** Axis-aligned bounding box for any element. */
+export function boundsOf(el: SceneElement): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} {
+  if (el.kind === "pen") {
+    if (el.points.length === 0) return { x: 0, y: 0, width: 0, height: 0 };
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const p of el.points) {
+      minX = Math.min(minX, p.x);
+      minY = Math.min(minY, p.y);
+      maxX = Math.max(maxX, p.x);
+      maxY = Math.max(maxY, p.y);
+    }
+    return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+  }
+  if (el.kind === "line" || el.kind === "arrow") {
+    const x = Math.min(el.x1, el.x2);
+    const y = Math.min(el.y1, el.y2);
+    return { x, y, width: Math.abs(el.x2 - el.x1), height: Math.abs(el.y2 - el.y1) };
+  }
+  const box = el as BoxElement;
+  const x = Math.min(box.x, box.x + box.width);
+  const y = Math.min(box.y, box.y + box.height);
+  return { x, y, width: Math.abs(box.width), height: Math.abs(box.height) };
+}
+
+function distanceToSegment(p: Point, a: Point, b: Point): number {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return Math.hypot(p.x - a.x, p.y - a.y);
+  let t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  const projX = a.x + t * dx;
+  const projY = a.y + t * dy;
+  return Math.hypot(p.x - projX, p.y - projY);
+}
+
+/**
+ * Does the point (x, y) hit the element? `tolerance` widens line/stroke hits.
+ * Boxes are hit anywhere inside (plus tolerance); lines/pen near the stroke.
+ */
+export function hitTest(el: SceneElement, x: number, y: number, tolerance = 6): boolean {
+  const p = { x, y };
+  if (el.kind === "line" || el.kind === "arrow") {
+    return (
+      distanceToSegment(p, { x: el.x1, y: el.y1 }, { x: el.x2, y: el.y2 }) <=
+      tolerance + el.strokeWidth / 2
+    );
+  }
+  if (el.kind === "pen") {
+    for (let i = 1; i < el.points.length; i += 1) {
+      if (
+        distanceToSegment(p, el.points[i - 1], el.points[i]) <=
+        tolerance + el.strokeWidth / 2
+      ) {
+        return true;
+      }
+    }
+    // single dot
+    if (el.points.length === 1) {
+      return Math.hypot(x - el.points[0].x, y - el.points[0].y) <= tolerance + el.strokeWidth;
+    }
+    return false;
+  }
+  const b = boundsOf(el);
+  if (el.kind === "ellipse") {
+    const cx = b.x + b.width / 2;
+    const cy = b.y + b.height / 2;
+    const rx = b.width / 2 + tolerance;
+    const ry = b.height / 2 + tolerance;
+    if (rx <= 0 || ry <= 0) return false;
+    const nx = (x - cx) / rx;
+    const ny = (y - cy) / ry;
+    return nx * nx + ny * ny <= 1;
+  }
+  return (
+    x >= b.x - tolerance &&
+    x <= b.x + b.width + tolerance &&
+    y >= b.y - tolerance &&
+    y <= b.y + b.height + tolerance
+  );
+}
+
+/** Topmost element under the point (last drawn wins), or null. */
+export function hitTestScene(scene: Scene, x: number, y: number, tolerance = 6): SceneElement | null {
+  for (let i = scene.elements.length - 1; i >= 0; i -= 1) {
+    if (hitTest(scene.elements[i], x, y, tolerance)) return scene.elements[i];
+  }
+  return null;
+}
+
+/** All elements whose bounding box intersects the given rectangle (marquee select). */
+export function elementsInRect(
+  scene: Scene,
+  rx: number,
+  ry: number,
+  rw: number,
+  rh: number,
+): SceneElement[] {
+  const x0 = Math.min(rx, rx + rw);
+  const y0 = Math.min(ry, ry + rh);
+  const x1 = Math.max(rx, rx + rw);
+  const y1 = Math.max(ry, ry + rh);
+  return scene.elements.filter((el) => {
+    const b = boundsOf(el);
+    return b.x <= x1 && b.x + b.width >= x0 && b.y <= y1 && b.y + b.height >= y0;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// History (undo / redo)
+// ---------------------------------------------------------------------------
+
+export interface History {
+  past: Scene[];
+  present: Scene;
+  future: Scene[];
+  limit: number;
+}
+
+const DEFAULT_HISTORY_LIMIT = 100;
+
+export function createHistory(initial: Scene = emptyScene(), limit = DEFAULT_HISTORY_LIMIT): History {
+  return { past: [], present: cloneScene(initial), future: [], limit };
+}
+
+/** Push a new present scene; clears the redo stack and caps the undo stack. */
+export function commit(history: History, next: Scene): History {
+  const past = [...history.past, history.present];
+  while (past.length > history.limit) past.shift();
+  return { past, present: cloneScene(next), future: [], limit: history.limit };
+}
+
+export function canUndo(history: History): boolean {
+  return history.past.length > 0;
+}
+
+export function canRedo(history: History): boolean {
+  return history.future.length > 0;
+}
+
+export function undo(history: History): History {
+  if (!canUndo(history)) return history;
+  const past = [...history.past];
+  const previous = past.pop() as Scene;
+  return {
+    past,
+    present: previous,
+    future: [history.present, ...history.future],
+    limit: history.limit,
+  };
+}
+
+export function redo(history: History): History {
+  if (!canRedo(history)) return history;
+  const [next, ...rest] = history.future;
+  return {
+    past: [...history.past, history.present],
+    present: next,
+    future: rest,
+    limit: history.limit,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+export function serializeScene(scene: Scene): SerializedScene {
+  return { version: SCENE_VERSION, elements: scene.elements.map(cloneElement) };
+}
+
+// ---------------------------------------------------------------------------
+// Board index (multi-board: one DB row per board)
+// ---------------------------------------------------------------------------
+
+/** Lightweight metadata for a single board, derived from a `scenes` row. */
+export interface BoardMeta {
+  id: string;
+  name: string;
+  /** epoch ms, best-effort from created_at/updated_at; 0 when unknown. */
+  updatedAt: number;
+}
+
+const DEFAULT_BOARD_NAME = "Untitled board";
+
+/** Sanitize a user/board name to a non-empty trimmed string with a cap. */
+export function normalizeBoardName(raw: unknown): string {
+  const value = typeof raw === "string" ? raw.trim() : "";
+  if (!value) return DEFAULT_BOARD_NAME;
+  return value.slice(0, 120);
+}
+
+function toEpochMs(raw: unknown): number {
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw === "string") {
+    const ms = Date.parse(raw);
+    if (Number.isFinite(ms)) return ms;
+  }
+  return 0;
+}
+
+/**
+ * Turn a raw `scenes` DB row into board metadata. Returns null when the row
+ * has no usable string id (cannot be addressed for load/update/delete).
+ */
+export function rowToBoardMeta(raw: unknown): BoardMeta | null {
+  if (!raw || typeof raw !== "object") return null;
+  const data = raw as Record<string, unknown>;
+  if (typeof data.id !== "string" || data.id.length === 0) return null;
+  return {
+    id: data.id,
+    name: normalizeBoardName(data.name),
+    updatedAt: toEpochMs(data.updated_at) || toEpochMs(data.created_at),
+  };
+}
+
+/**
+ * Build the sorted board index from raw `scenes` rows (most recently updated
+ * first; name as a stable tiebreaker). Rows without a usable id are dropped.
+ */
+export function boardIndexFromRows(rows: readonly unknown[]): BoardMeta[] {
+  const metas = rows
+    .map(rowToBoardMeta)
+    .filter((m): m is BoardMeta => m !== null);
+  metas.sort((a, b) => {
+    if (b.updatedAt !== a.updatedAt) return b.updatedAt - a.updatedAt;
+    return a.name.localeCompare(b.name);
+  });
+  return metas;
+}
+
+/** Find the doc payload (jsonb or string) for a board row by id. */
+export function docFromRow(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object") return null;
+  return (raw as Record<string, unknown>).doc ?? null;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+function coerceElement(raw: unknown): SceneElement | null {
+  if (!raw || typeof raw !== "object") return null;
+  const data = raw as Record<string, unknown>;
+  const kind = data.kind;
+  const id = typeof data.id === "string" ? data.id : makeId();
+  const stroke = typeof data.stroke === "string" ? data.stroke : "#32352E";
+  const fill = typeof data.fill === "string" ? data.fill : "transparent";
+  const strokeWidth = isFiniteNumber(data.strokeWidth) ? data.strokeWidth : 2;
+  const base = { id, stroke, fill, strokeWidth };
+
+  if (kind === "pen") {
+    const points = Array.isArray(data.points)
+      ? data.points
+          .map((p) =>
+            p && typeof p === "object" && isFiniteNumber((p as Point).x) && isFiniteNumber((p as Point).y)
+              ? { x: (p as Point).x, y: (p as Point).y }
+              : null,
+          )
+          .filter((p): p is Point => p !== null)
+      : [];
+    return { ...base, kind: "pen", points };
+  }
+  if (kind === "line" || kind === "arrow") {
+    if (
+      !isFiniteNumber(data.x1) ||
+      !isFiniteNumber(data.y1) ||
+      !isFiniteNumber(data.x2) ||
+      !isFiniteNumber(data.y2)
+    ) {
+      return null;
+    }
+    return { ...base, kind, x1: data.x1, y1: data.y1, x2: data.x2, y2: data.y2 };
+  }
+  if (kind === "rect" || kind === "ellipse" || kind === "text" || kind === "sticky") {
+    if (
+      !isFiniteNumber(data.x) ||
+      !isFiniteNumber(data.y) ||
+      !isFiniteNumber(data.width) ||
+      !isFiniteNumber(data.height)
+    ) {
+      return null;
+    }
+    const text = typeof data.text === "string" ? data.text : undefined;
+    return { ...base, kind, x: data.x, y: data.y, width: data.width, height: data.height, text };
+  }
+  return null;
+}
+
+/** Parse a serialized scene from an unknown value (JSON object or string). */
+export function deserializeScene(raw: unknown): Scene {
+  let value = raw;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch (err: unknown) {
+      console.warn(
+        "[whiteboard] failed to parse scene JSON:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return emptyScene();
+    }
+  }
+  if (!value || typeof value !== "object") return emptyScene();
+  const data = value as Record<string, unknown>;
+  const list = Array.isArray(data.elements) ? data.elements : [];
+  const elements = list
+    .map(coerceElement)
+    .filter((el): el is SceneElement => el !== null);
+  return { elements };
+}

--- a/tests/default-apps/whiteboard-model.test.ts
+++ b/tests/default-apps/whiteboard-model.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import {
+  addElement,
+  boardIndexFromRows,
+  boundsOf,
+  canRedo,
+  canUndo,
+  commit,
+  createHistory,
+  deleteElement,
+  deserializeScene,
+  docFromRow,
+  elementsInRect,
+  emptyScene,
+  hitTest,
+  hitTestScene,
+  makeId,
+  moveElement,
+  normalizeBoardName,
+  redo,
+  rowToBoardMeta,
+  serializeScene,
+  undo,
+  updateElement,
+  type BoxElement,
+  type LineElement,
+  type PenElement,
+} from "../../home/apps/whiteboard/src/whiteboard-model";
+
+function rect(id: string, x: number, y: number, w: number, h: number): BoxElement {
+  return { id, kind: "rect", x, y, width: w, height: h, stroke: "#000", fill: "transparent", strokeWidth: 2 };
+}
+
+describe("whiteboard model — CRUD", () => {
+  it("adds an element immutably", () => {
+    const s0 = emptyScene();
+    const s1 = addElement(s0, rect("a", 0, 0, 10, 10));
+    expect(s0.elements).toHaveLength(0);
+    expect(s1.elements).toHaveLength(1);
+    expect(s1.elements[0].id).toBe("a");
+  });
+
+  it("updates an element by id with a partial patch", () => {
+    const s1 = addElement(emptyScene(), rect("a", 0, 0, 10, 10));
+    const s2 = updateElement(s1, "a", { stroke: "#f00" } as Partial<BoxElement>);
+    expect((s2.elements[0] as BoxElement).stroke).toBe("#f00");
+    // original untouched
+    expect((s1.elements[0] as BoxElement).stroke).toBe("#000");
+  });
+
+  it("moves an element by delta", () => {
+    const s1 = addElement(emptyScene(), rect("a", 5, 5, 10, 10));
+    const s2 = moveElement(s1, "a", 3, -2);
+    const b = boundsOf(s2.elements[0]);
+    expect(b.x).toBe(8);
+    expect(b.y).toBe(3);
+  });
+
+  it("moves a line element by translating both endpoints", () => {
+    const line: LineElement = {
+      id: "l", kind: "line", x1: 0, y1: 0, x2: 10, y2: 10,
+      stroke: "#000", fill: "transparent", strokeWidth: 2,
+    };
+    const s = moveElement(addElement(emptyScene(), line), "l", 5, 5);
+    const moved = s.elements[0] as LineElement;
+    expect([moved.x1, moved.y1, moved.x2, moved.y2]).toEqual([5, 5, 15, 15]);
+  });
+
+  it("deletes an element by id", () => {
+    const s1 = addElement(addElement(emptyScene(), rect("a", 0, 0, 1, 1)), rect("b", 5, 5, 1, 1));
+    const s2 = deleteElement(s1, "a");
+    expect(s2.elements.map((e) => e.id)).toEqual(["b"]);
+  });
+});
+
+describe("whiteboard model — hit testing", () => {
+  it("hits inside a rectangle", () => {
+    const r = rect("a", 0, 0, 20, 20);
+    expect(hitTest(r, 10, 10)).toBe(true);
+    expect(hitTest(r, 100, 100)).toBe(false);
+  });
+
+  it("hits near a line stroke within tolerance", () => {
+    const line: LineElement = {
+      id: "l", kind: "line", x1: 0, y1: 0, x2: 100, y2: 0,
+      stroke: "#000", fill: "transparent", strokeWidth: 2,
+    };
+    expect(hitTest(line, 50, 2)).toBe(true);
+    expect(hitTest(line, 50, 40)).toBe(false);
+  });
+
+  it("hits a pen stroke near its path", () => {
+    const pen: PenElement = {
+      id: "p", kind: "pen",
+      points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 20, y: 0 }],
+      stroke: "#000", fill: "transparent", strokeWidth: 2,
+    };
+    expect(hitTest(pen, 15, 1)).toBe(true);
+    expect(hitTest(pen, 15, 50)).toBe(false);
+  });
+
+  it("returns the topmost element under a point", () => {
+    const s = addElement(addElement(emptyScene(), rect("under", 0, 0, 50, 50)), rect("over", 0, 0, 50, 50));
+    expect(hitTestScene(s, 25, 25)?.id).toBe("over");
+    expect(hitTestScene(s, 500, 500)).toBeNull();
+  });
+
+  it("selects elements intersecting a marquee rectangle", () => {
+    const s = addElement(addElement(emptyScene(), rect("a", 0, 0, 10, 10)), rect("b", 100, 100, 10, 10));
+    const inside = elementsInRect(s, -5, -5, 30, 30).map((e) => e.id);
+    expect(inside).toEqual(["a"]);
+  });
+});
+
+describe("whiteboard model — history (undo/redo)", () => {
+  it("undoes and redoes committed scenes", () => {
+    let h = createHistory(emptyScene());
+    expect(canUndo(h)).toBe(false);
+
+    const s1 = addElement(h.present, rect("a", 0, 0, 1, 1));
+    h = commit(h, s1);
+    const s2 = addElement(h.present, rect("b", 1, 1, 1, 1));
+    h = commit(h, s2);
+
+    expect(h.present.elements).toHaveLength(2);
+    expect(canUndo(h)).toBe(true);
+
+    h = undo(h);
+    expect(h.present.elements.map((e) => e.id)).toEqual(["a"]);
+    expect(canRedo(h)).toBe(true);
+
+    h = undo(h);
+    expect(h.present.elements).toHaveLength(0);
+    expect(canUndo(h)).toBe(false);
+
+    h = redo(h);
+    expect(h.present.elements.map((e) => e.id)).toEqual(["a"]);
+    h = redo(h);
+    expect(h.present.elements.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("clears the redo stack after a new commit", () => {
+    let h = createHistory(emptyScene());
+    h = commit(h, addElement(h.present, rect("a", 0, 0, 1, 1)));
+    h = undo(h);
+    expect(canRedo(h)).toBe(true);
+    h = commit(h, addElement(h.present, rect("c", 2, 2, 1, 1)));
+    expect(canRedo(h)).toBe(false);
+    expect(h.present.elements.map((e) => e.id)).toEqual(["c"]);
+  });
+
+  it("caps the undo stack at the configured limit", () => {
+    let h = createHistory(emptyScene(), 3);
+    for (let i = 0; i < 10; i += 1) {
+      h = commit(h, addElement(h.present, rect(`r${i}`, i, i, 1, 1)));
+    }
+    expect(h.past.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("whiteboard model — serialization", () => {
+  it("round-trips a scene through serialize/deserialize", () => {
+    let s = emptyScene();
+    s = addElement(s, rect("a", 1, 2, 3, 4));
+    s = addElement(s, {
+      id: "l", kind: "arrow", x1: 0, y1: 0, x2: 5, y2: 5,
+      stroke: "#abc", fill: "transparent", strokeWidth: 4,
+    } as LineElement);
+    s = addElement(s, {
+      id: "p", kind: "pen", points: [{ x: 1, y: 1 }, { x: 2, y: 2 }],
+      stroke: "#def", fill: "transparent", strokeWidth: 3,
+    } as PenElement);
+    s = addElement(s, {
+      id: "n", kind: "sticky", x: 10, y: 10, width: 80, height: 80,
+      text: "hello", stroke: "#111", fill: "#ff0", strokeWidth: 1,
+    } as BoxElement);
+
+    const serialized = serializeScene(s);
+    expect(serialized.version).toBe(1);
+
+    const restored = deserializeScene(JSON.parse(JSON.stringify(serialized)));
+    expect(restored.elements).toHaveLength(4);
+    expect(restored.elements.map((e) => e.id)).toEqual(["a", "l", "p", "n"]);
+    expect((restored.elements[3] as BoxElement).text).toBe("hello");
+    expect((restored.elements[2] as PenElement).points).toHaveLength(2);
+  });
+
+  it("deserializes from a JSON string and drops malformed elements", () => {
+    const json = JSON.stringify({
+      version: 1,
+      elements: [
+        { id: "ok", kind: "rect", x: 0, y: 0, width: 5, height: 5, stroke: "#000", fill: "transparent", strokeWidth: 2 },
+        { id: "bad", kind: "rect", x: "nope", y: 0, width: 5, height: 5 },
+        { kind: "mystery" },
+      ],
+    });
+    const scene = deserializeScene(json);
+    expect(scene.elements).toHaveLength(1);
+    expect(scene.elements[0].id).toBe("ok");
+  });
+
+  it("returns an empty scene for invalid input", () => {
+    expect(deserializeScene("not json {{{").elements).toHaveLength(0);
+    expect(deserializeScene(null).elements).toHaveLength(0);
+    expect(deserializeScene(42).elements).toHaveLength(0);
+  });
+
+  it("generates unique ids", () => {
+    const ids = new Set(Array.from({ length: 200 }, () => makeId()));
+    expect(ids.size).toBe(200);
+  });
+});
+
+describe("whiteboard model — board index", () => {
+  it("normalizes board names (trims, falls back, caps length)", () => {
+    expect(normalizeBoardName("  Plan  ")).toBe("Plan");
+    expect(normalizeBoardName("")).toBe("Untitled board");
+    expect(normalizeBoardName("   ")).toBe("Untitled board");
+    expect(normalizeBoardName(null)).toBe("Untitled board");
+    expect(normalizeBoardName("x".repeat(300)).length).toBe(120);
+  });
+
+  it("maps a raw row to board metadata", () => {
+    const meta = rowToBoardMeta({
+      id: "row-1",
+      name: "Sketch",
+      doc: { version: 1, elements: [] },
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-02-01T00:00:00.000Z",
+    });
+    expect(meta).not.toBeNull();
+    expect(meta?.id).toBe("row-1");
+    expect(meta?.name).toBe("Sketch");
+    expect(meta?.updatedAt).toBe(Date.parse("2026-02-01T00:00:00.000Z"));
+  });
+
+  it("rejects rows without a usable id", () => {
+    expect(rowToBoardMeta({ name: "x" })).toBeNull();
+    expect(rowToBoardMeta({ id: "", name: "x" })).toBeNull();
+    expect(rowToBoardMeta(null)).toBeNull();
+  });
+
+  it("builds a sorted index (most recent first) and drops bad rows", () => {
+    const index = boardIndexFromRows([
+      { id: "a", name: "Old", updated_at: "2026-01-01T00:00:00.000Z" },
+      { id: "b", name: "New", updated_at: "2026-03-01T00:00:00.000Z" },
+      { name: "missing id" },
+    ]);
+    expect(index.map((m) => m.id)).toEqual(["b", "a"]);
+    expect(index).toHaveLength(2);
+  });
+
+  it("extracts the doc payload from a row", () => {
+    expect(docFromRow({ id: "x", doc: { version: 1, elements: [] } })).toEqual({
+      version: 1,
+      elements: [],
+    });
+    expect(docFromRow({ id: "x" })).toBeNull();
+    expect(docFromRow(null)).toBeNull();
+  });
+});

--- a/tests/default-apps/whiteboard-model.test.ts
+++ b/tests/default-apps/whiteboard-model.test.ts
@@ -66,6 +66,19 @@ describe("whiteboard model — CRUD", () => {
     expect([moved.x1, moved.y1, moved.x2, moved.y2]).toEqual([5, 5, 15, 15]);
   });
 
+  it("moves a pen element by translating every point", () => {
+    const pen: PenElement = {
+      id: "p", kind: "pen",
+      points: [{ x: 0, y: 0 }, { x: 10, y: 5 }, { x: 20, y: 0 }],
+      stroke: "#000", fill: "transparent", strokeWidth: 2,
+    };
+    const s = moveElement(addElement(emptyScene(), pen), "p", 3, -4);
+    const moved = s.elements[0] as PenElement;
+
+    expect(moved.points).toEqual([{ x: 3, y: -4 }, { x: 13, y: 1 }, { x: 23, y: -4 }]);
+    expect(pen.points).toEqual([{ x: 0, y: 0 }, { x: 10, y: 5 }, { x: 20, y: 0 }]);
+  });
+
   it("deletes an element by id", () => {
     const s1 = addElement(addElement(emptyScene(), rect("a", 0, 0, 1, 1)), rect("b", 5, 5, 1, 1));
     const s2 = deleteElement(s1, "a");
@@ -87,6 +100,17 @@ describe("whiteboard model — hit testing", () => {
     };
     expect(hitTest(line, 50, 2)).toBe(true);
     expect(hitTest(line, 50, 40)).toBe(false);
+  });
+
+  it("hits inside an ellipse using normalized coordinates", () => {
+    const ellipse: BoxElement = {
+      id: "e", kind: "ellipse", x: 10, y: 20, width: 80, height: 40,
+      stroke: "#000", fill: "transparent", strokeWidth: 2,
+    };
+
+    expect(hitTest(ellipse, 50, 40, 0)).toBe(true);
+    expect(hitTest(ellipse, 85, 40, 0)).toBe(true);
+    expect(hitTest(ellipse, 95, 40, 0)).toBe(false);
   });
 
   it("hits a pen stroke near its path", () => {

--- a/tests/default-apps/whiteboard-model.test.ts
+++ b/tests/default-apps/whiteboard-model.test.ts
@@ -217,6 +217,7 @@ describe("whiteboard model — serialization", () => {
       elements: [
         { id: "ok", kind: "rect", x: 0, y: 0, width: 5, height: 5, stroke: "#000", fill: "transparent", strokeWidth: 2 },
         { id: "bad", kind: "rect", x: "nope", y: 0, width: 5, height: 5 },
+        { id: "ghost", kind: "pen", points: [{ x: "nope", y: 1 }, null] },
         { kind: "mystery" },
       ],
     });
@@ -245,8 +246,8 @@ describe("whiteboard model — board index", () => {
     ) as { storage?: { tables?: { scenes?: { columns?: Record<string, string> } } } };
 
     expect(manifest.storage?.tables?.scenes?.columns).toMatchObject({
-      created_at: "text",
-      updated_at: "text",
+      created_at: "timestamptz",
+      updated_at: "timestamptz",
     });
   });
 
@@ -286,6 +287,14 @@ describe("whiteboard model — board index", () => {
     ]);
     expect(index.map((m) => m.id)).toEqual(["b", "a"]);
     expect(index).toHaveLength(2);
+  });
+
+  it("builds a sorted index from Postgres timestamp objects", () => {
+    const index = boardIndexFromRows([
+      { id: "a", name: "Old", updated_at: new Date("2026-01-01T00:00:00.000Z") },
+      { id: "b", name: "New", updated_at: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    expect(index.map((m) => m.id)).toEqual(["b", "a"]);
   });
 
   it("extracts the doc payload from a row", () => {

--- a/tests/default-apps/whiteboard-model.test.ts
+++ b/tests/default-apps/whiteboard-model.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   addElement,
@@ -236,6 +238,18 @@ describe("whiteboard model — serialization", () => {
 });
 
 describe("whiteboard model — board index", () => {
+  it("declares timestamp columns needed for recency sorting", () => {
+    const repoRoot = join(__dirname, "..", "..");
+    const manifest = JSON.parse(
+      readFileSync(join(repoRoot, "home/apps/whiteboard/matrix.json"), "utf-8"),
+    ) as { storage?: { tables?: { scenes?: { columns?: Record<string, string> } } } };
+
+    expect(manifest.storage?.tables?.scenes?.columns).toMatchObject({
+      created_at: "text",
+      updated_at: "text",
+    });
+  });
+
   it("normalizes board names (trims, falls back, caps length)", () => {
     expect(normalizeBoardName("  Plan  ")).toBe("Plan");
     expect(normalizeBoardName("")).toBe("Untitled board");


### PR DESCRIPTION
Stack: 9/22
Branch: stack/default-apps-whiteboard-model

Scope: Whiteboard persistence model, manifest updates, bridge types, and model tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.