### PR TITLE
feat(whiteboard): add canvas board UI

### DIFF
--- a/home/apps/whiteboard/index.html
+++ b/home/apps/whiteboard/index.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Whiteboard</title>
-    <script>
-      window.EXCALIDRAW_ASSET_PATH = "./excalidraw-assets/";
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -1,193 +1,1549 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Excalidraw, MainMenu } from "@excalidraw/excalidraw";
-import "@excalidraw/excalidraw/index.css";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  ArrowUpRight,
+  Check,
+  Circle,
+  Download,
+  FilePlus2,
+  MousePointer2,
+  Minus,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Pen,
+  Pencil,
+  Redo2,
+  Square,
+  StickyNote,
+  Trash2,
+  Type,
+  Undo2,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import "./styles.css";
+import {
+  addElement,
+  boardIndexFromRows,
+  boundsOf,
+  canRedo,
+  canUndo,
+  cloneScene,
+  commit,
+  createHistory,
+  deleteElements,
+  deserializeScene,
+  docFromRow,
+  elementsInRect,
+  emptyScene,
+  hitTestScene,
+  makeId,
+  moveElement,
+  normalizeBoardName,
+  redo,
+  rowToBoardMeta,
+  serializeScene,
+  undo,
+  updateElement,
+  type BoardMeta,
+  type BoxElement,
+  type History,
+  type LineElement,
+  type PenElement,
+  type Point,
+  type Scene,
+  type SceneElement,
+  type ToolKind,
+} from "./whiteboard-model";
 
-const APP_ID = "whiteboard";
-const STORAGE_KEY = "default-scene";
-const FETCH_TIMEOUT_MS = 10_000;
-const SAVE_DELAY_MS = 600;
+const SCENES_TABLE = "scenes";
+const LS_KEY = "matrix-whiteboard-scene-v1";
+const LS_NAME_KEY = "matrix-whiteboard-name-v1";
+const AUTOSAVE_MS = 800;
 
-type ExcalidrawProps = React.ComponentProps<typeof Excalidraw>;
-type OnChangeArgs = Parameters<NonNullable<ExcalidrawProps["onChange"]>>;
-type Elements = OnChangeArgs[0];
-type AppState = OnChangeArgs[1];
-type BinaryFiles = OnChangeArgs[2];
+const PALETTE = ["#32352E", "#C4342D", "#D06F25", "#3A7D44", "#2D6CDF", "#7A4FD0", "#9A8C66"];
+const STROKE_WIDTHS = [2, 4, 8];
+const STICKY_FILL = "#FFE9A8";
 
-interface SavedScene {
-  elements: Elements;
-  appState?: Record<string, unknown>;
-  files?: BinaryFiles;
-  savedAt: string;
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+interface ToolDef {
+  kind: ToolKind;
+  label: string;
+  shortcut: string;
+  icon: typeof MousePointer2;
 }
 
-function pickPersistedAppState(appState: AppState): Record<string, unknown> {
-  const source = appState as unknown as Record<string, unknown>;
-  const keys = [
-    "viewBackgroundColor",
-    "theme",
-    "currentItemStrokeColor",
-    "currentItemBackgroundColor",
-    "currentItemFillStyle",
-    "currentItemStrokeWidth",
-    "currentItemStrokeStyle",
-    "currentItemRoughness",
-    "currentItemOpacity",
-    "currentItemFontFamily",
-    "currentItemFontSize",
-    "currentItemTextAlign",
-    "gridSize",
-  ];
+const TOOLS: ToolDef[] = [
+  { kind: "select", label: "Select", shortcut: "V", icon: MousePointer2 },
+  { kind: "pen", label: "Pen", shortcut: "P", icon: Pen },
+  { kind: "rect", label: "Rectangle", shortcut: "R", icon: Square },
+  { kind: "ellipse", label: "Ellipse", shortcut: "O", icon: Circle },
+  { kind: "arrow", label: "Arrow", shortcut: "A", icon: ArrowUpRight },
+  { kind: "line", label: "Line", shortcut: "L", icon: Minus },
+  { kind: "text", label: "Text", shortcut: "T", icon: Type },
+  { kind: "sticky", label: "Sticky note", shortcut: "N", icon: StickyNote },
+];
 
-  const result: Record<string, unknown> = {};
-  for (const key of keys) {
-    if (source[key] !== undefined) result[key] = source[key];
-  }
-  return result;
+interface Viewport {
+  x: number;
+  y: number;
+  zoom: number;
 }
 
-async function readScene(): Promise<SavedScene | null> {
-  const params = new URLSearchParams({ app: APP_ID, key: STORAGE_KEY });
-  const res = await fetch(`/api/bridge/data?${params.toString()}`, {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
-  if (!res.ok) return null;
+interface DragState {
+  mode: "draw" | "move" | "marquee" | "pan";
+  startScene: Point;
+  lastScene: Point;
+  startScreen: Point;
+  startViewport: Viewport;
+  draftId?: string;
+  movedIds?: string[];
+  baseScene?: Scene;
+}
 
-  const payload = (await res.json()) as { value?: string | null };
-  if (!payload.value) return null;
-
+function reduceMotion(): boolean {
   try {
-    return JSON.parse(payload.value) as SavedScene;
+    return typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+  } catch {
+    return false;
+  }
+}
+
+const LOCAL_BOARD_ID = "__local__";
+
+// ---- persistence helpers --------------------------------------------------
+// localStorage is a guarded test/no-DB-only fallback. In the sandboxed shell
+// it can throw SecurityError, so every access is wrapped. In the shell the
+// MatrixOS DB bridge is the canonical transport (see agent-brief §2).
+
+function loadLocal(): Scene | null {
+  try {
+    const raw = window.localStorage.getItem(LS_KEY);
+    if (!raw) return null;
+    return deserializeScene(raw);
   } catch (err: unknown) {
-    console.warn("[whiteboard] ignored invalid saved scene:", err instanceof Error ? err.message : String(err));
+    console.warn("[whiteboard] localStorage read failed:", err instanceof Error ? err.message : String(err));
     return null;
   }
 }
 
-async function writeScene(scene: SavedScene): Promise<void> {
-  await fetch("/api/bridge/data", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    body: JSON.stringify({
-      action: "write",
-      app: APP_ID,
-      key: STORAGE_KEY,
-      value: JSON.stringify(scene),
-    }),
-  });
+function loadLocalName(): string {
+  try {
+    const raw = window.localStorage.getItem(LS_NAME_KEY);
+    return normalizeBoardName(raw);
+  } catch {
+    return normalizeBoardName(null);
+  }
 }
 
-export default function App() {
-  const [scene, setScene] = useState<SavedScene | null>(null);
-  const [loaded, setLoaded] = useState(false);
-  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingSceneRef = useRef<SavedScene | null>(null);
+function saveLocal(scene: Scene): void {
+  try {
+    window.localStorage.setItem(LS_KEY, JSON.stringify(serializeScene(scene)));
+  } catch (err: unknown) {
+    console.warn("[whiteboard] localStorage write failed:", err instanceof Error ? err.message : String(err));
+  }
+}
 
+function saveLocalName(name: string): void {
+  try {
+    window.localStorage.setItem(LS_NAME_KEY, name);
+  } catch (err: unknown) {
+    console.warn("[whiteboard] localStorage name write failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+function nextUntitledName(boards: readonly BoardMeta[]): string {
+  const base = "Untitled board";
+  const taken = new Set(boards.map((b) => b.name.toLowerCase()));
+  if (!taken.has(base.toLowerCase())) return base;
+  for (let i = 2; i < 1000; i += 1) {
+    const candidate = `${base} ${i}`;
+    if (!taken.has(candidate.toLowerCase())) return candidate;
+  }
+  return `${base} ${Date.now()}`;
+}
+
+// ---- main component -------------------------------------------------------
+
+export default function App() {
+  const [tool, setTool] = useState<ToolKind>("select");
+  const [color, setColor] = useState(PALETTE[0]);
+  const [strokeWidth, setStrokeWidth] = useState(STROKE_WIDTHS[0]);
+  const [history, setHistory] = useState<History>(() => createHistory(emptyScene()));
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [viewport, setViewport] = useState<Viewport>({ x: 0, y: 0, zoom: 1 });
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [draft, setDraft] = useState<SceneElement | null>(null);
+  const [marquee, setMarquee] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
+  const [editing, setEditing] = useState<{ id: string; value: string } | null>(null);
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  // -- multi-board ("files") state -----------------------------------------
+  const [boards, setBoards] = useState<BoardMeta[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [loadingBoard, setLoadingBoard] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [renaming, setRenaming] = useState<{ id: string; value: string } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<BoardMeta | null>(null);
+
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const draftRef = useRef<SceneElement | null>(null);
+  const activeIdRef = useRef<string | null>(null);
+  const saveTimerRef = useRef<number | null>(null);
+  const dirtyRef = useRef(false);
+
+  // Keep a ref of the active board id so debounced/async saves target the
+  // board that was active when the edit happened, not a stale closure value.
+  useEffect(() => {
+    activeIdRef.current = activeId;
+  }, [activeId]);
+
+  const scene = history.present;
+  const elements = scene.elements;
+
+  // Keep draft in a ref so synchronous pointer handlers (down→move→up in one
+  // event batch) see the latest value without waiting for a re-render. The ref
+  // is the source of truth and is updated synchronously; setDraft only drives
+  // rendering. (Updating the ref inside the setState updater is unreliable
+  // because React may defer the updater past the next pointer event.)
+  const updateDraft = useCallback((next: SceneElement | null | ((c: SceneElement | null) => SceneElement | null)) => {
+    const value = typeof next === "function" ? next(draftRef.current) : next;
+    draftRef.current = value;
+    setDraft(value);
+  }, []);
+
+  // -- load a single board's doc into the canvas ---------------------------
+  const openBoard = useCallback(async (id: string) => {
+    const db = window.MatrixOS?.db;
+    dirtyRef.current = false;
+    setActiveId(id);
+    activeIdRef.current = id;
+    setSelected(new Set());
+    setEditing(null);
+    setDraft(null);
+    setViewport({ x: 0, y: 0, zoom: 1 });
+
+    if (!db || id === LOCAL_BOARD_ID) {
+      const local = loadLocal();
+      setHistory(createHistory(local ?? emptyScene()));
+      setLoadingBoard(false);
+      return;
+    }
+    setLoadingBoard(true);
+    try {
+      setError(null);
+      const rows = await db.find(SCENES_TABLE, { where: { id }, limit: 1 });
+      const row = rows[0] ?? null;
+      // Ignore the result if the user switched away while we were loading.
+      if (activeIdRef.current !== id) return;
+      setHistory(createHistory(deserializeScene(docFromRow(row))));
+    } catch (err: unknown) {
+      console.warn("[whiteboard] board load failed:", err instanceof Error ? err.message : String(err));
+      if (activeIdRef.current === id) setError("Could not load that board.");
+    } finally {
+      if (activeIdRef.current === id) setLoadingBoard(false);
+    }
+  }, []);
+
+  // -- refresh the board index (sidebar list) -------------------------------
+  const refreshIndex = useCallback(async (): Promise<BoardMeta[]> => {
+    const db = window.MatrixOS?.db;
+    if (!db) {
+      const local: BoardMeta = { id: LOCAL_BOARD_ID, name: loadLocalName(), updatedAt: 0 };
+      setBoards([local]);
+      return [local];
+    }
+    try {
+      const rows = await db.find(SCENES_TABLE, { orderBy: { created_at: "desc" } });
+      const index = boardIndexFromRows(rows);
+      setBoards(index);
+      return index;
+    } catch (err: unknown) {
+      console.warn("[whiteboard] board list failed:", err instanceof Error ? err.message : String(err));
+      setError("Could not load your boards.");
+      return [];
+    }
+  }, []);
+
+  // -- create a board -------------------------------------------------------
+  const createBoard = useCallback(
+    async (name?: string): Promise<string | null> => {
+      const db = window.MatrixOS?.db;
+      const boardName = normalizeBoardName(name ?? nextUntitledName(boards));
+      const doc = serializeScene(emptyScene());
+      if (!db) {
+        // No DB: a single local board only.
+        saveLocal(emptyScene());
+        saveLocalName(boardName);
+        await refreshIndex();
+        await openBoard(LOCAL_BOARD_ID);
+        return LOCAL_BOARD_ID;
+      }
+      try {
+        setError(null);
+        const res = await db.insert(SCENES_TABLE, { name: boardName, doc });
+        const id = res && typeof res.id === "string" ? res.id : null;
+        await refreshIndex();
+        if (id) await openBoard(id);
+        return id;
+      } catch (err: unknown) {
+        console.warn("[whiteboard] create board failed:", err instanceof Error ? err.message : String(err));
+        setError("Could not create a board.");
+        return null;
+      }
+    },
+    [boards, openBoard, refreshIndex],
+  );
+
+  // -- initial load: pick most recent board, or create the first one --------
   useEffect(() => {
     let cancelled = false;
-    readScene()
-      .then((saved) => {
-        if (cancelled) return;
-        setScene(saved);
-      })
-      .catch((err: unknown) => {
-        console.warn("[whiteboard] failed to load scene:", err instanceof Error ? err.message : String(err));
-      })
-      .finally(() => {
-        if (!cancelled) setLoaded(true);
-      });
+    void (async () => {
+      const index = await refreshIndex();
+      if (cancelled) return;
+      if (index.length > 0) {
+        await openBoard(index[0].id);
+      } else if (window.MatrixOS?.db) {
+        await createBoard("Untitled board");
+      } else {
+        await openBoard(LOCAL_BOARD_ID);
+      }
+    })();
+    const db = window.MatrixOS?.db;
+    const unsubscribe = db?.onChange?.(SCENES_TABLE, () => {
+      // Reconcile the list; reload the active board only when not mid-edit.
+      void refreshIndex();
+      const id = activeIdRef.current;
+      if (id && !dirtyRef.current) void openBoard(id);
+    });
     return () => {
       cancelled = true;
+      if (unsubscribe) unsubscribe();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // -- debounced autosave to the ACTIVE board's row -------------------------
+  const persist = useCallback(async (toSave: Scene, boardId: string | null) => {
+    const db = window.MatrixOS?.db;
+    const doc = serializeScene(toSave);
+    if (!db || boardId === LOCAL_BOARD_ID) {
+      saveLocal(toSave);
+      setSaveState("saved");
+      dirtyRef.current = false;
+      return;
+    }
+    if (!boardId) return;
+    setSaveState("saving");
+    try {
+      await db.update(SCENES_TABLE, boardId, { doc });
+      setSaveState("saved");
+      setError(null);
+      dirtyRef.current = false;
+      // Bump this board to the top of the recency-sorted list locally.
+      setBoards((prev) =>
+        [...prev]
+          .map((b) => (b.id === boardId ? { ...b, updatedAt: Date.now() } : b))
+          .sort((a, b) => b.updatedAt - a.updatedAt),
+      );
+    } catch (err: unknown) {
+      console.warn("[whiteboard] scene save failed:", err instanceof Error ? err.message : String(err));
+      setSaveState("error");
+      setError("Changes could not be saved.");
+      saveLocal(toSave);
+    }
+  }, []);
+
+  const scheduleSave = useCallback(
+    (toSave: Scene) => {
+      dirtyRef.current = true;
+      const boardId = activeIdRef.current;
+      if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = window.setTimeout(() => {
+        saveTimerRef.current = null;
+        void persist(toSave, boardId);
+      }, AUTOSAVE_MS);
+    },
+    [persist],
+  );
 
   useEffect(() => {
     return () => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
     };
   }, []);
 
-  const scheduleSave = useCallback((nextScene: SavedScene) => {
-    pendingSceneRef.current = nextScene;
-    setSaveState("saving");
+  // -- switch boards (flush a pending save first) ---------------------------
+  const switchBoard = useCallback(
+    (id: string) => {
+      if (id === activeIdRef.current) return;
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+        if (dirtyRef.current) void persist(history.present, activeIdRef.current);
+      }
+      void openBoard(id);
+    },
+    [history, openBoard, persist],
+  );
 
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(() => {
-      const pending = pendingSceneRef.current;
-      if (!pending) return;
-
-      writeScene(pending)
-        .then(() => setSaveState("saved"))
-        .catch((err: unknown) => {
-          console.warn("[whiteboard] failed to save scene:", err instanceof Error ? err.message : String(err));
-          setSaveState("error");
-        });
-    }, SAVE_DELAY_MS);
-  }, []);
-
-  const initialData = useMemo<ExcalidrawProps["initialData"]>(() => {
-    if (!scene) {
-      return {
-        appState: {
-          viewBackgroundColor: "#f8fafc",
-        },
-        scrollToContent: true,
-      };
+  // -- rename a board -------------------------------------------------------
+  const commitRename = useCallback(async () => {
+    const r = renaming;
+    setRenaming(null);
+    if (!r) return;
+    const name = normalizeBoardName(r.value);
+    setBoards((prev) => prev.map((b) => (b.id === r.id ? { ...b, name } : b)));
+    const db = window.MatrixOS?.db;
+    if (!db || r.id === LOCAL_BOARD_ID) {
+      saveLocalName(name);
+      return;
     }
+    try {
+      await db.update(SCENES_TABLE, r.id, { name });
+    } catch (err: unknown) {
+      console.warn("[whiteboard] rename failed:", err instanceof Error ? err.message : String(err));
+      setError("Could not rename the board.");
+      void refreshIndex();
+    }
+  }, [refreshIndex, renaming]);
 
-    return {
-      elements: scene.elements,
-      appState: {
-        viewBackgroundColor: "#f8fafc",
-        ...scene.appState,
-      },
-      files: scene.files,
-      scrollToContent: true,
-    };
-  }, [scene]);
+  // -- delete a board -------------------------------------------------------
+  const deleteBoard = useCallback(
+    async (board: BoardMeta) => {
+      setConfirmDelete(null);
+      const db = window.MatrixOS?.db;
+      if (!db || board.id === LOCAL_BOARD_ID) {
+        saveLocal(emptyScene());
+        setHistory(createHistory(emptyScene()));
+        return;
+      }
+      try {
+        setError(null);
+        await db.delete(SCENES_TABLE, board.id);
+        const index = await refreshIndex();
+        if (board.id === activeIdRef.current) {
+          if (index.length > 0) await openBoard(index[0].id);
+          else await createBoard("Untitled board");
+        }
+      } catch (err: unknown) {
+        console.warn("[whiteboard] delete board failed:", err instanceof Error ? err.message : String(err));
+        setError("Could not delete the board.");
+      }
+    },
+    [createBoard, openBoard, refreshIndex],
+  );
 
-  const onChange = useCallback<NonNullable<ExcalidrawProps["onChange"]>>(
-    (elements, appState, files) => {
-      scheduleSave({
-        elements,
-        appState: pickPersistedAppState(appState),
-        files,
-        savedAt: new Date().toISOString(),
-      });
+  // -- commit + autosave wrapper -------------------------------------------
+  const apply = useCallback(
+    (next: Scene) => {
+      setHistory((h) => commit(h, next));
+      scheduleSave(next);
     },
     [scheduleSave],
   );
 
-  if (!loaded) {
-    return (
-      <div className="app-loading" role="status">
-        Opening canvas
-      </div>
-    );
-  }
+  // -- coordinate transform -------------------------------------------------
+  const toScene = useCallback(
+    (clientX: number, clientY: number): Point => {
+      const rect = svgRef.current?.getBoundingClientRect();
+      const left = rect?.left ?? 0;
+      const top = rect?.top ?? 0;
+      return {
+        x: (clientX - left - viewport.x) / viewport.zoom,
+        y: (clientY - top - viewport.y) / viewport.zoom,
+      };
+    },
+    [viewport],
+  );
+
+  // -- new-element factory --------------------------------------------------
+  const makeElementAt = useCallback(
+    (kind: ToolKind, p: Point): SceneElement => {
+      const id = makeId();
+      const base = { id, stroke: color, strokeWidth };
+      if (kind === "pen") {
+        return { ...base, kind: "pen", fill: "transparent", points: [{ ...p }] } as PenElement;
+      }
+      if (kind === "line" || kind === "arrow") {
+        return { ...base, kind, fill: "transparent", x1: p.x, y1: p.y, x2: p.x, y2: p.y } as LineElement;
+      }
+      if (kind === "sticky") {
+        return { ...base, kind: "sticky", fill: STICKY_FILL, x: p.x, y: p.y, width: 0, height: 0, text: "" } as BoxElement;
+      }
+      if (kind === "text") {
+        return { ...base, kind: "text", fill: "transparent", x: p.x, y: p.y, width: 0, height: 0, text: "" } as BoxElement;
+      }
+      return { ...base, kind: kind as "rect" | "ellipse", fill: "transparent", x: p.x, y: p.y, width: 0, height: 0 } as BoxElement;
+    },
+    [color, strokeWidth],
+  );
+
+  // -- pointer handling -----------------------------------------------------
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      if (e.button === 1 || (e.button === 0 && tool === "select" && e.altKey)) {
+        dragRef.current = {
+          mode: "pan",
+          startScene: { x: 0, y: 0 },
+          lastScene: { x: 0, y: 0 },
+          startScreen: { x: e.clientX, y: e.clientY },
+          startViewport: { ...viewport },
+        };
+        (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+        return;
+      }
+      if (e.button !== 0) return;
+      const p = toScene(e.clientX, e.clientY);
+      (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+
+      if (tool === "select") {
+        const hit = hitTestScene(scene, p.x, p.y, 6 / viewport.zoom);
+        if (hit) {
+          const nextSel = new Set(selected);
+          if (e.shiftKey) {
+            if (nextSel.has(hit.id)) nextSel.delete(hit.id);
+            else nextSel.add(hit.id);
+          } else if (!nextSel.has(hit.id)) {
+            nextSel.clear();
+            nextSel.add(hit.id);
+          }
+          setSelected(nextSel);
+          dragRef.current = {
+            mode: "move",
+            startScene: p,
+            lastScene: p,
+            startScreen: { x: e.clientX, y: e.clientY },
+            startViewport: { ...viewport },
+            movedIds: Array.from(nextSel),
+            baseScene: cloneScene(scene),
+          };
+        } else {
+          if (!e.shiftKey) setSelected(new Set());
+          dragRef.current = {
+            mode: "marquee",
+            startScene: p,
+            lastScene: p,
+            startScreen: { x: e.clientX, y: e.clientY },
+            startViewport: { ...viewport },
+          };
+          setMarquee({ x: p.x, y: p.y, w: 0, h: 0 });
+        }
+        return;
+      }
+
+      const el = makeElementAt(tool, p);
+      updateDraft(el);
+      dragRef.current = {
+        mode: "draw",
+        startScene: p,
+        lastScene: p,
+        startScreen: { x: e.clientX, y: e.clientY },
+        startViewport: { ...viewport },
+        draftId: el.id,
+      };
+    },
+    [makeElementAt, scene, selected, tool, toScene, viewport],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      if (drag.mode === "pan") {
+        const dx = e.clientX - drag.startScreen.x;
+        const dy = e.clientY - drag.startScreen.y;
+        setViewport({ ...drag.startViewport, x: drag.startViewport.x + dx, y: drag.startViewport.y + dy });
+        return;
+      }
+      const p = toScene(e.clientX, e.clientY);
+
+      if (drag.mode === "draw") {
+        updateDraft((curr) => {
+          if (!curr) return curr;
+          if (curr.kind === "pen") {
+            return { ...curr, points: [...curr.points, { ...p }] };
+          }
+          if (curr.kind === "line" || curr.kind === "arrow") {
+            return { ...curr, x2: p.x, y2: p.y };
+          }
+          const b = curr as BoxElement;
+          return { ...b, width: p.x - drag.startScene.x, height: p.y - drag.startScene.y };
+        });
+        return;
+      }
+
+      if (drag.mode === "move" && drag.movedIds && drag.baseScene) {
+        const dx = p.x - drag.startScene.x;
+        const dy = p.y - drag.startScene.y;
+        let next = drag.baseScene;
+        for (const id of drag.movedIds) next = moveElement(next, id, dx, dy);
+        setHistory((h) => ({ ...h, present: next }));
+        drag.lastScene = p;
+        return;
+      }
+
+      if (drag.mode === "marquee") {
+        drag.lastScene = p;
+        setMarquee({
+          x: drag.startScene.x,
+          y: drag.startScene.y,
+          w: p.x - drag.startScene.x,
+          h: p.y - drag.startScene.y,
+        });
+      }
+    },
+    [toScene, updateDraft],
+  );
+
+  const finishDraft = useCallback(
+    (el: SceneElement) => {
+      let final = el;
+      if (el.kind === "rect" || el.kind === "ellipse" || el.kind === "sticky" || el.kind === "text") {
+        const b = el as BoxElement;
+        let { x, y, width, height } = b;
+        if (Math.abs(width) < 4 && Math.abs(height) < 4) {
+          if (el.kind === "sticky") {
+            width = 160;
+            height = 160;
+          } else if (el.kind === "text") {
+            width = 160;
+            height = 40;
+          } else {
+            width = 120;
+            height = 90;
+          }
+        }
+        if (width < 0) {
+          x += width;
+          width = -width;
+        }
+        if (height < 0) {
+          y += height;
+          height = -height;
+        }
+        final = { ...b, x, y, width, height };
+      }
+      apply(addElement(scene, final));
+      if (final.kind === "text" || final.kind === "sticky") {
+        setEditing({ id: final.id, value: (final as BoxElement).text ?? "" });
+      }
+      if (tool !== "pen") setTool("select");
+    },
+    [apply, scene, tool],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const drag = dragRef.current;
+      dragRef.current = null;
+      (e.currentTarget as Element).releasePointerCapture?.(e.pointerId);
+      if (!drag) return;
+
+      const currentDraft = draftRef.current;
+      if (drag.mode === "draw" && currentDraft) {
+        finishDraft(currentDraft);
+        updateDraft(null);
+        return;
+      }
+      if (drag.mode === "move") {
+        setHistory((h) => {
+          if (drag.baseScene && h.present !== drag.baseScene) {
+            const moved = h.present;
+            scheduleSave(moved);
+            return commit({ ...h, present: drag.baseScene }, moved);
+          }
+          return h;
+        });
+        return;
+      }
+      if (drag.mode === "marquee") {
+        const mx = drag.startScene.x;
+        const my = drag.startScene.y;
+        const mw = drag.lastScene.x - drag.startScene.x;
+        const mh = drag.lastScene.y - drag.startScene.y;
+        const found = elementsInRect(scene, mx, my, mw, mh);
+        setSelected((prev) => {
+          const next = new Set(e.shiftKey ? prev : []);
+          for (const el of found) next.add(el.id);
+          return next;
+        });
+        setMarquee(null);
+      }
+    },
+    [finishDraft, scene, scheduleSave, updateDraft],
+  );
+
+  // -- selection ops --------------------------------------------------------
+  const deleteSelected = useCallback(() => {
+    if (selected.size === 0) return;
+    apply(deleteElements(scene, selected));
+    setSelected(new Set());
+  }, [apply, scene, selected]);
+
+  const doUndo = useCallback(() => {
+    setHistory((h) => {
+      if (!canUndo(h)) return h;
+      const next = undo(h);
+      scheduleSave(next.present);
+      return next;
+    });
+    setSelected(new Set());
+  }, [scheduleSave]);
+
+  const doRedo = useCallback(() => {
+    setHistory((h) => {
+      if (!canRedo(h)) return h;
+      const next = redo(h);
+      scheduleSave(next.present);
+      return next;
+    });
+    setSelected(new Set());
+  }, [scheduleSave]);
+
+  const clearBoard = useCallback(() => {
+    apply(emptyScene());
+    setSelected(new Set());
+    setConfirmClear(false);
+  }, [apply]);
+
+  const commitEditing = useCallback(() => {
+    if (!editing) return;
+    apply(updateElement(scene, editing.id, { text: editing.value } as Partial<BoxElement>));
+    setEditing(null);
+  }, [apply, editing, scene]);
+
+  // -- keyboard shortcuts ---------------------------------------------------
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+        return;
+      }
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "z" && !e.shiftKey) {
+        e.preventDefault();
+        doUndo();
+        return;
+      }
+      if (mod && (e.key.toLowerCase() === "y" || (e.key.toLowerCase() === "z" && e.shiftKey))) {
+        e.preventDefault();
+        doRedo();
+        return;
+      }
+      if (e.key === "Delete" || e.key === "Backspace") {
+        if (selected.size > 0) {
+          e.preventDefault();
+          deleteSelected();
+        }
+        return;
+      }
+      if (e.key === "Escape") {
+        setSelected(new Set());
+        setEditing(null);
+        setConfirmClear(false);
+        return;
+      }
+      const match = TOOLS.find((t) => t.shortcut.toLowerCase() === e.key.toLowerCase());
+      if (match) setTool(match.kind);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [deleteSelected, doRedo, doUndo, selected]);
+
+  // -- zoom -----------------------------------------------------------------
+  const zoomBy = useCallback((factor: number) => {
+    setViewport((v) => ({ ...v, zoom: Math.max(0.2, Math.min(4, v.zoom * factor)) }));
+  }, []);
+
+  const onWheel = useCallback((e: React.WheelEvent<SVGSVGElement>) => {
+    if (!(e.ctrlKey || e.metaKey)) return;
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    const cx = e.clientX - (rect?.left ?? 0);
+    const cy = e.clientY - (rect?.top ?? 0);
+    setViewport((v) => {
+      const factor = e.deltaY < 0 ? 1.1 : 0.9;
+      const zoom = Math.max(0.2, Math.min(4, v.zoom * factor));
+      const sx = (cx - v.x) / v.zoom;
+      const sy = (cy - v.y) / v.zoom;
+      return { x: cx - sx * zoom, y: cy - sy * zoom, zoom };
+    });
+  }, []);
+
+  // -- PNG export -----------------------------------------------------------
+  const exportPng = useCallback(() => {
+    const all = scene.elements;
+    const canvas = document.createElement("canvas");
+    const padding = 40;
+    let minX = 0;
+    let minY = 0;
+    let maxX = 800;
+    let maxY = 600;
+    if (all.length > 0) {
+      minX = Infinity;
+      minY = Infinity;
+      maxX = -Infinity;
+      maxY = -Infinity;
+      for (const el of all) {
+        const b = boundsOf(el);
+        minX = Math.min(minX, b.x);
+        minY = Math.min(minY, b.y);
+        maxX = Math.max(maxX, b.x + b.width);
+        maxY = Math.max(maxY, b.y + b.height);
+      }
+    }
+    const width = Math.max(1, maxX - minX + padding * 2);
+    const height = Math.max(1, maxY - minY + padding * 2);
+    canvas.width = Math.round(width);
+    canvas.height = Math.round(height);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      setError("Export is not supported here.");
+      return;
+    }
+    const styles = getComputedStyle(document.documentElement);
+    ctx.fillStyle = (styles.getPropertyValue("--app-bg") || "#FAFAF5").trim() || "#FAFAF5";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.translate(padding - minX, padding - minY);
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    for (const el of all) drawToCanvas(ctx, el);
+    try {
+      const url = canvas.toDataURL("image/png");
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `whiteboard-${new Date().toISOString().slice(0, 10)}.png`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } catch (err: unknown) {
+      console.warn("[whiteboard] PNG export failed:", err instanceof Error ? err.message : String(err));
+      setError("Could not export the board.");
+    }
+  }, [scene]);
+
+  // -- render ---------------------------------------------------------------
+  const renderElements = useMemo(() => {
+    const list = draft ? [...elements, draft] : elements;
+    return list.map((el) => (
+      <ElementView key={el.id} el={el} selected={selected.has(el.id)} editing={editing?.id === el.id} />
+    ));
+  }, [draft, editing, elements, selected]);
+
+  const motion = reduceMotion();
+  const gridUnit = 24 * viewport.zoom;
+
+  const activeName = boards.find((b) => b.id === activeId)?.name ?? "Whiteboard";
 
   return (
-    <div className="whiteboard-shell">
-      <Excalidraw
-        initialData={initialData}
-        onChange={onChange}
-        name="Matrix Whiteboard"
-      >
-        <MainMenu>
-          <MainMenu.DefaultItems.LoadScene />
-          <MainMenu.DefaultItems.SaveToActiveFile />
-          <MainMenu.DefaultItems.Export />
-          <MainMenu.DefaultItems.SaveAsImage />
-          <MainMenu.DefaultItems.Help />
-          <MainMenu.DefaultItems.ClearCanvas />
-          <MainMenu.DefaultItems.ToggleTheme />
-          <MainMenu.DefaultItems.ChangeCanvasBackground />
-        </MainMenu>
-      </Excalidraw>
-      <div className={`save-pill save-pill--${saveState}`} aria-live="polite">
-        {saveState === "saving" ? "Saving" : saveState === "error" ? "Save failed" : "Saved"}
+    <div className={`wb-app${motion ? " wb-app--reduced" : ""}`}>
+      <Toolbar
+        tool={tool}
+        setTool={setTool}
+        color={color}
+        setColor={setColor}
+        strokeWidth={strokeWidth}
+        setStrokeWidth={setStrokeWidth}
+        canUndo={canUndo(history)}
+        canRedo={canRedo(history)}
+        onUndo={doUndo}
+        onRedo={doRedo}
+        onDelete={deleteSelected}
+        hasSelection={selected.size > 0}
+        onExport={exportPng}
+        onClear={() => setConfirmClear(true)}
+        saveState={saveState}
+        sidebarOpen={sidebarOpen}
+        onToggleSidebar={() => setSidebarOpen((v) => !v)}
+        boardName={activeName}
+      />
+
+      <div className="wb-body">
+        <BoardSidebar
+          open={sidebarOpen}
+          boards={boards}
+          activeId={activeId}
+          renaming={renaming}
+          onSelect={switchBoard}
+          onNew={() => void createBoard()}
+          onStartRename={(b) => setRenaming({ id: b.id, value: b.name })}
+          onRenameChange={(value) => setRenaming((r) => (r ? { ...r, value } : r))}
+          onCommitRename={() => void commitRename()}
+          onCancelRename={() => setRenaming(null)}
+          onRequestDelete={(b) => setConfirmDelete(b)}
+        />
+
+        <div className="wb-stage">
+        <svg
+          ref={svgRef}
+          className="wb-canvas"
+          data-testid="whiteboard-canvas"
+          role="application"
+          aria-label="Whiteboard canvas"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onWheel={onWheel}
+          style={{ cursor: tool === "select" ? "default" : "crosshair" }}
+        >
+          <defs>
+            <pattern
+              id="wb-grid"
+              width={gridUnit || 24}
+              height={gridUnit || 24}
+              patternUnits="userSpaceOnUse"
+              patternTransform={`translate(${viewport.x % (gridUnit || 24)} ${viewport.y % (gridUnit || 24)})`}
+            >
+              <circle cx="1" cy="1" r="1" className="wb-grid-dot" />
+            </pattern>
+            <marker id="wb-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+              <path d="M0,0 L10,5 L0,10 z" fill="context-stroke" />
+            </marker>
+          </defs>
+          <rect className="wb-grid-bg" x="0" y="0" width="100%" height="100%" fill="url(#wb-grid)" />
+          <g transform={`translate(${viewport.x} ${viewport.y}) scale(${viewport.zoom})`}>
+            {renderElements}
+            {selected.size > 0 &&
+              elements
+                .filter((el) => selected.has(el.id))
+                .map((el) => {
+                  const b = boundsOf(el);
+                  return (
+                    <rect key={`sel-${el.id}`} className="wb-selbox" x={b.x - 4} y={b.y - 4} width={b.width + 8} height={b.height + 8} />
+                  );
+                })}
+            {marquee && (
+              <rect
+                className="wb-marquee"
+                x={Math.min(marquee.x, marquee.x + marquee.w)}
+                y={Math.min(marquee.y, marquee.y + marquee.h)}
+                width={Math.abs(marquee.w)}
+                height={Math.abs(marquee.h)}
+              />
+            )}
+          </g>
+        </svg>
+
+        {elements.length === 0 && !draft && !loadingBoard && (
+          <div className="wb-empty" data-testid="whiteboard-empty">
+            <div className="wb-empty__mark" aria-hidden="true">
+              <Pen size={26} />
+            </div>
+            <h2>Your canvas is empty</h2>
+            <p>Pick a tool and start sketching. Try the pen, drop a sticky note, or draw a shape.</p>
+            <button type="button" className="wb-empty__cta" onClick={() => setTool("pen")}>
+              <Pen size={16} /> Start drawing
+            </button>
+          </div>
+        )}
+
+        {editing && (
+          <TextEditorOverlay
+            editing={editing}
+            element={elements.find((el) => el.id === editing.id) as BoxElement | undefined}
+            viewport={viewport}
+            onChange={(value) => setEditing({ ...editing, value })}
+            onCommit={commitEditing}
+            onCancel={() => setEditing(null)}
+          />
+        )}
+
+        <div className="wb-zoom">
+          <button type="button" aria-label="Zoom out" title="Zoom out" onClick={() => zoomBy(0.9)}>
+            <ZoomOut size={16} />
+          </button>
+          <button type="button" className="wb-zoom__level" onClick={() => setViewport({ x: 0, y: 0, zoom: 1 })} title="Reset zoom">
+            {Math.round(viewport.zoom * 100)}%
+          </button>
+          <button type="button" aria-label="Zoom in" title="Zoom in" onClick={() => zoomBy(1.1)}>
+            <ZoomIn size={16} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="wb-toast wb-toast--error" role="alert">
+            {error}
+          </div>
+        )}
+        </div>
       </div>
+
+      {confirmClear && (
+        <div className="wb-modal" role="dialog" aria-modal="true" aria-label="Clear board">
+          <div className="wb-modal__card">
+            <h3>Clear the whole board?</h3>
+            <p>This removes every element. You can undo right after.</p>
+            <div className="wb-modal__actions">
+              <button type="button" className="wb-btn-ghost" onClick={() => setConfirmClear(false)}>
+                Cancel
+              </button>
+              <button type="button" className="wb-btn-danger" onClick={clearBoard}>
+                Clear board
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confirmDelete && (
+        <div className="wb-modal" role="dialog" aria-modal="true" aria-label="Delete board">
+          <div className="wb-modal__card">
+            <h3>Delete “{confirmDelete.name}”?</h3>
+            <p>This permanently removes the board and everything on it. This cannot be undone.</p>
+            <div className="wb-modal__actions">
+              <button type="button" className="wb-btn-ghost" onClick={() => setConfirmDelete(null)}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="wb-btn-danger"
+                onClick={() => void deleteBoard(confirmDelete)}
+              >
+                Delete board
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Toolbar
+// ---------------------------------------------------------------------------
+
+interface ToolbarProps {
+  tool: ToolKind;
+  setTool: (t: ToolKind) => void;
+  color: string;
+  setColor: (c: string) => void;
+  strokeWidth: number;
+  setStrokeWidth: (w: number) => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  onDelete: () => void;
+  hasSelection: boolean;
+  onExport: () => void;
+  onClear: () => void;
+  saveState: SaveState;
+  sidebarOpen: boolean;
+  onToggleSidebar: () => void;
+  boardName: string;
+}
+
+function Toolbar(props: ToolbarProps) {
+  const {
+    tool, setTool, color, setColor, strokeWidth, setStrokeWidth,
+    canUndo: canU, canRedo: canR, onUndo, onRedo, onDelete, hasSelection, onExport, onClear, saveState,
+    sidebarOpen, onToggleSidebar, boardName,
+  } = props;
+  return (
+    <header className="wb-toolbar">
+      <button
+        type="button"
+        className="wb-tool wb-tool--panel"
+        aria-label={sidebarOpen ? "Hide boards" : "Show boards"}
+        aria-pressed={sidebarOpen}
+        title={sidebarOpen ? "Hide boards" : "Show boards"}
+        onClick={onToggleSidebar}
+      >
+        {sidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
+      </button>
+      <span className="wb-boardname" title={boardName}>{boardName}</span>
+
+      <div className="wb-divider" aria-hidden="true" />
+
+      <div className="wb-toolgroup" role="toolbar" aria-label="Tools">
+        {TOOLS.map((t) => {
+          const Icon = t.icon;
+          const active = tool === t.kind;
+          return (
+            <button
+              key={t.kind}
+              type="button"
+              className={active ? "wb-tool wb-tool--active" : "wb-tool"}
+              aria-label={`${t.label} (${t.shortcut})`}
+              aria-pressed={active}
+              title={`${t.label} — ${t.shortcut}`}
+              onClick={() => setTool(t.kind)}
+            >
+              <Icon size={18} />
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="wb-divider" aria-hidden="true" />
+
+      <div className="wb-palette" role="group" aria-label="Color">
+        {PALETTE.map((c) => (
+          <button
+            key={c}
+            type="button"
+            className={c === color ? "wb-swatch wb-swatch--active" : "wb-swatch"}
+            style={{ background: c }}
+            aria-label={`Color ${c}`}
+            aria-pressed={c === color}
+            onClick={() => setColor(c)}
+          />
+        ))}
+      </div>
+
+      <div className="wb-strokes" role="group" aria-label="Stroke width">
+        {STROKE_WIDTHS.map((w) => (
+          <button
+            key={w}
+            type="button"
+            className={w === strokeWidth ? "wb-stroke wb-stroke--active" : "wb-stroke"}
+            aria-label={`Stroke ${w} pixels`}
+            aria-pressed={w === strokeWidth}
+            onClick={() => setStrokeWidth(w)}
+          >
+            <span style={{ height: w }} />
+          </button>
+        ))}
+      </div>
+
+      <div className="wb-divider" aria-hidden="true" />
+
+      <div className="wb-toolgroup">
+        <button type="button" className="wb-tool" aria-label="Undo" title="Undo — Cmd/Ctrl+Z" disabled={!canU} onClick={onUndo}>
+          <Undo2 size={18} />
+        </button>
+        <button type="button" className="wb-tool" aria-label="Redo" title="Redo — Cmd/Ctrl+Y" disabled={!canR} onClick={onRedo}>
+          <Redo2 size={18} />
+        </button>
+        <button type="button" className="wb-tool" aria-label="Delete selection" title="Delete — Del" disabled={!hasSelection} onClick={onDelete}>
+          <Trash2 size={18} />
+        </button>
+      </div>
+
+      <div className="wb-toolbar__spacer" />
+
+      <div className="wb-save" aria-live="polite">
+        {saveState === "saving" && "Saving…"}
+        {saveState === "saved" && "Saved"}
+        {saveState === "error" && "Save failed"}
+      </div>
+
+      <div className="wb-toolgroup">
+        <button type="button" className="wb-action" onClick={onExport} title="Export PNG">
+          <Download size={16} /> <span>PNG</span>
+        </button>
+        <button type="button" className="wb-action wb-action--ghost" onClick={onClear} title="Clear board">
+          Clear
+        </button>
+      </div>
+    </header>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Board sidebar (files / switcher)
+// ---------------------------------------------------------------------------
+
+interface BoardSidebarProps {
+  open: boolean;
+  boards: BoardMeta[];
+  activeId: string | null;
+  renaming: { id: string; value: string } | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  onStartRename: (b: BoardMeta) => void;
+  onRenameChange: (value: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onRequestDelete: (b: BoardMeta) => void;
+}
+
+function relativeTime(ms: number): string {
+  if (!ms) return "";
+  const diff = Date.now() - ms;
+  if (diff < 60_000) return "just now";
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+function RenameInput({
+  value,
+  label,
+  onChange,
+  onCommit,
+  onCancel,
+}: {
+  value: string;
+  label: string;
+  onChange: (v: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+}) {
+  const ref = useRef<HTMLInputElement | null>(null);
+  // Focus on mount instead of `autoFocus` (which react-doctor flags for a11y).
+  useLayoutEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+  return (
+    <input
+      ref={ref}
+      className="wb-rename-input"
+      value={value}
+      aria-label={label}
+      onChange={(e) => onChange(e.target.value)}
+      onBlur={onCommit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onCommit();
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
+    />
+  );
+}
+
+function BoardSidebar(props: BoardSidebarProps) {
+  const {
+    open, boards, activeId, renaming,
+    onSelect, onNew, onStartRename, onRenameChange, onCommitRename, onCancelRename, onRequestDelete,
+  } = props;
+  if (!open) return null;
+  return (
+    <aside className="wb-sidebar" aria-label="Boards">
+      <div className="wb-sidebar__head">
+        <span className="wb-sidebar__title">Boards</span>
+        <button type="button" className="wb-newboard" onClick={onNew} title="New board">
+          <FilePlus2 size={15} /> <span>New board</span>
+        </button>
+      </div>
+
+      {boards.length === 0 ? (
+        <div className="wb-sidebar__empty">
+          <p>No boards yet.</p>
+          <button type="button" className="wb-newboard wb-newboard--cta" onClick={onNew}>
+            <FilePlus2 size={15} /> Create your first board
+          </button>
+        </div>
+      ) : (
+        <ul className="wb-boardlist">
+          {boards.map((b) => {
+            const active = b.id === activeId;
+            const isRenaming = renaming?.id === b.id;
+            return (
+              <li key={b.id} className={active ? "wb-boarditem wb-boarditem--active" : "wb-boarditem"}>
+                {isRenaming ? (
+                  <RenameInput
+                    value={renaming.value}
+                    label={`Rename ${b.name}`}
+                    onChange={onRenameChange}
+                    onCommit={onCommitRename}
+                    onCancel={onCancelRename}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    className="wb-boarditem__open"
+                    aria-current={active ? "true" : undefined}
+                    onClick={() => onSelect(b.id)}
+                    onDoubleClick={() => onStartRename(b)}
+                  >
+                    <span className="wb-boarditem__name">{b.name}</span>
+                    {b.updatedAt > 0 && (
+                      <span className="wb-boarditem__time">{relativeTime(b.updatedAt)}</span>
+                    )}
+                  </button>
+                )}
+
+                {isRenaming ? (
+                  <button
+                    type="button"
+                    className="wb-boarditem__action"
+                    aria-label="Confirm rename"
+                    title="Save name"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={onCommitRename}
+                  >
+                    <Check size={14} />
+                  </button>
+                ) : (
+                  <div className="wb-boarditem__actions">
+                    <button
+                      type="button"
+                      className="wb-boarditem__action"
+                      aria-label={`Rename board ${b.name}`}
+                      title="Rename"
+                      onClick={() => onStartRename(b)}
+                    >
+                      <Pencil size={14} />
+                    </button>
+                    <button
+                      type="button"
+                      className="wb-boarditem__action wb-boarditem__action--danger"
+                      aria-label={`Delete board ${b.name}`}
+                      title="Delete"
+                      onClick={() => onRequestDelete(b)}
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </aside>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Element rendering
+// ---------------------------------------------------------------------------
+
+function penPath(points: Point[]): string {
+  if (points.length === 0) return "";
+  if (points.length === 1) {
+    const p = points[0];
+    return `M ${p.x} ${p.y} L ${p.x + 0.1} ${p.y + 0.1}`;
+  }
+  let d = `M ${points[0].x} ${points[0].y}`;
+  for (let i = 1; i < points.length; i += 1) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    const mx = (prev.x + curr.x) / 2;
+    const my = (prev.y + curr.y) / 2;
+    d += ` Q ${prev.x} ${prev.y} ${mx} ${my}`;
+  }
+  return d;
+}
+
+function ElementView({ el, selected, editing }: { el: SceneElement; selected: boolean; editing: boolean }) {
+  const className = selected ? "wb-el wb-el--selected" : "wb-el";
+  if (el.kind === "pen") {
+    return (
+      <path
+        d={penPath((el as PenElement).points)}
+        fill="none"
+        stroke={el.stroke}
+        strokeWidth={el.strokeWidth}
+        className={className}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    );
+  }
+  if (el.kind === "line" || el.kind === "arrow") {
+    const l = el as LineElement;
+    return (
+      <line
+        x1={l.x1}
+        y1={l.y1}
+        x2={l.x2}
+        y2={l.y2}
+        stroke={l.stroke}
+        strokeWidth={l.strokeWidth}
+        strokeLinecap="round"
+        className={className}
+        markerEnd={el.kind === "arrow" ? "url(#wb-arrow)" : undefined}
+      />
+    );
+  }
+  const b = el as BoxElement;
+  const x = b.width < 0 ? b.x + b.width : b.x;
+  const y = b.height < 0 ? b.y + b.height : b.y;
+  const w = Math.abs(b.width);
+  const h = Math.abs(b.height);
+  const stroke = el.stroke;
+  const fill = el.fill === "transparent" ? "none" : el.fill;
+  if (el.kind === "ellipse") {
+    return <ellipse cx={x + w / 2} cy={y + h / 2} rx={w / 2} ry={h / 2} stroke={stroke} strokeWidth={el.strokeWidth} fill={fill} className={className} />;
+  }
+  if (el.kind === "sticky") {
+    return (
+      <g className={className}>
+        <rect x={x} y={y} width={w} height={h} rx={6} fill={b.fill} stroke="rgba(50,53,46,0.14)" strokeWidth={1} className="wb-sticky" />
+        {!editing && b.text ? (
+          <foreignObject x={x} y={y} width={w} height={h}>
+            <div className="wb-sticky-text">{b.text}</div>
+          </foreignObject>
+        ) : null}
+      </g>
+    );
+  }
+  if (el.kind === "text") {
+    if (editing) return null;
+    return (
+      <foreignObject x={x} y={y} width={Math.max(w, 40)} height={Math.max(h, 24)} className={className}>
+        <div className="wb-text" style={{ color: el.stroke, fontSize: 18 + el.strokeWidth * 2 }}>
+          {b.text || ""}
+        </div>
+      </foreignObject>
+    );
+  }
+  return <rect x={x} y={y} width={w} height={h} rx={8} stroke={stroke} strokeWidth={el.strokeWidth} fill={fill} className={className} />;
+}
+
+// ---------------------------------------------------------------------------
+// Text editing overlay
+// ---------------------------------------------------------------------------
+
+function TextEditorOverlay({
+  editing,
+  element,
+  viewport,
+  onChange,
+  onCommit,
+  onCancel,
+}: {
+  editing: { id: string; value: string };
+  element: BoxElement | undefined;
+  viewport: Viewport;
+  onChange: (v: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+}) {
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+  useLayoutEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+  if (!element) return null;
+  const left = element.x * viewport.zoom + viewport.x;
+  const top = element.y * viewport.zoom + viewport.y;
+  const width = Math.max(Math.abs(element.width) * viewport.zoom, 120);
+  const height = Math.max(Math.abs(element.height) * viewport.zoom, 36);
+  return (
+    <textarea
+      ref={ref}
+      className="wb-text-editor"
+      aria-label="Edit text"
+      value={editing.value}
+      style={{ left, top, width, height }}
+      onChange={(e) => onChange(e.target.value)}
+      onBlur={onCommit}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          onCancel();
+        }
+        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          onCommit();
+        }
+      }}
+      placeholder="Type…"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Canvas drawing for PNG export
+// ---------------------------------------------------------------------------
+
+function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
+  ctx.strokeStyle = el.stroke;
+  ctx.lineWidth = el.strokeWidth;
+  if (el.kind === "pen") {
+    const pen = el as PenElement;
+    if (pen.points.length === 0) return;
+    ctx.beginPath();
+    ctx.moveTo(pen.points[0].x, pen.points[0].y);
+    for (let i = 1; i < pen.points.length; i += 1) ctx.lineTo(pen.points[i].x, pen.points[i].y);
+    ctx.stroke();
+    return;
+  }
+  if (el.kind === "line" || el.kind === "arrow") {
+    const l = el as LineElement;
+    ctx.beginPath();
+    ctx.moveTo(l.x1, l.y1);
+    ctx.lineTo(l.x2, l.y2);
+    ctx.stroke();
+    if (el.kind === "arrow") {
+      const angle = Math.atan2(l.y2 - l.y1, l.x2 - l.x1);
+      const size = 8 + el.strokeWidth;
+      ctx.beginPath();
+      ctx.moveTo(l.x2, l.y2);
+      ctx.lineTo(l.x2 - size * Math.cos(angle - Math.PI / 6), l.y2 - size * Math.sin(angle - Math.PI / 6));
+      ctx.moveTo(l.x2, l.y2);
+      ctx.lineTo(l.x2 - size * Math.cos(angle + Math.PI / 6), l.y2 - size * Math.sin(angle + Math.PI / 6));
+      ctx.stroke();
+    }
+    return;
+  }
+  const b = el as BoxElement;
+  const x = b.width < 0 ? b.x + b.width : b.x;
+  const y = b.height < 0 ? b.y + b.height : b.y;
+  const w = Math.abs(b.width);
+  const h = Math.abs(b.height);
+  if (el.kind === "ellipse") {
+    ctx.beginPath();
+    ctx.ellipse(x + w / 2, y + h / 2, w / 2, h / 2, 0, 0, Math.PI * 2);
+    ctx.stroke();
+    return;
+  }
+  if (el.kind === "sticky") {
+    ctx.fillStyle = b.fill;
+    ctx.fillRect(x, y, w, h);
+    if (b.text) {
+      ctx.fillStyle = "#32352E";
+      ctx.font = "16px Inter, system-ui, sans-serif";
+      wrapText(ctx, b.text, x + 10, y + 24, w - 20, 20);
+    }
+    return;
+  }
+  if (el.kind === "text") {
+    if (b.text) {
+      ctx.fillStyle = el.stroke;
+      ctx.font = `${18 + el.strokeWidth * 2}px Inter, system-ui, sans-serif`;
+      wrapText(ctx, b.text, x, y + 20, Math.max(w, 120), 22);
+    }
+    return;
+  }
+  ctx.strokeRect(x, y, w, h);
+}
+
+function wrapText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  lineHeight: number,
+): void {
+  const words = text.split(/\s+/);
+  let line = "";
+  let cursorY = y;
+  for (const word of words) {
+    const test = line ? `${line} ${word}` : word;
+    if (ctx.measureText(test).width > maxWidth && line) {
+      ctx.fillText(line, x, cursorY);
+      line = word;
+      cursorY += lineHeight;
+    } else {
+      line = test;
+    }
+  }
+  if (line) ctx.fillText(line, x, cursorY);
 }

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -871,6 +871,17 @@ export default function App() {
     setEditing(null);
   }, [activeId, apply, editing, scene]);
 
+  useEffect(() => {
+    if (!editing) editingCommitIdRef.current = null;
+  }, [editing]);
+
+  const startEditingElement = useCallback((el: SceneElement) => {
+    if (el.kind !== "text" && el.kind !== "sticky") return;
+    const box = el as BoxElement;
+    setSelected(new Set([el.id]));
+    setEditing({ id: el.id, value: box.text ?? "" });
+  }, []);
+
   // -- keyboard shortcuts ---------------------------------------------------
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -989,9 +1000,16 @@ export default function App() {
   const renderElements = useMemo(() => {
     const list = draft ? [...elements, draft] : elements;
     return list.map((el) => (
-      <ElementView key={el.id} el={el} selected={selected.has(el.id)} editing={editing?.id === el.id} arrowId={arrowId} />
+      <ElementView
+        key={el.id}
+        el={el}
+        selected={selected.has(el.id)}
+        editing={editing?.id === el.id}
+        arrowId={arrowId}
+        onEdit={startEditingElement}
+      />
     ));
-  }, [arrowId, draft, editing, elements, selected]);
+  }, [arrowId, draft, editing, elements, selected, startEditingElement]);
 
   const motion = reduceMotion();
   const gridUnit = 24 * viewport.zoom;
@@ -1516,7 +1534,19 @@ function penPath(points: Point[]): string {
   return d;
 }
 
-function ElementView({ el, selected, editing, arrowId }: { el: SceneElement; selected: boolean; editing: boolean; arrowId: string }) {
+function ElementView({
+  el,
+  selected,
+  editing,
+  arrowId,
+  onEdit,
+}: {
+  el: SceneElement;
+  selected: boolean;
+  editing: boolean;
+  arrowId: string;
+  onEdit: (el: SceneElement) => void;
+}) {
   const className = selected ? "wb-el wb-el--selected" : "wb-el";
   if (el.kind === "pen") {
     return (
@@ -1559,7 +1589,7 @@ function ElementView({ el, selected, editing, arrowId }: { el: SceneElement; sel
   }
   if (el.kind === "sticky") {
     return (
-      <g className={className}>
+      <g className={className} onDoubleClick={() => onEdit(el)}>
         <rect x={x} y={y} width={w} height={h} rx={6} fill={b.fill} stroke="rgba(50,53,46,0.14)" strokeWidth={1} className="wb-sticky" />
         {!editing && b.text ? (
           <foreignObject x={x} y={y} width={w} height={h}>
@@ -1572,7 +1602,14 @@ function ElementView({ el, selected, editing, arrowId }: { el: SceneElement; sel
   if (el.kind === "text") {
     if (editing) return null;
     return (
-      <foreignObject x={x} y={y} width={Math.max(w, 40)} height={Math.max(h, 24)} className={className}>
+      <foreignObject
+        x={x}
+        y={y}
+        width={Math.max(w, 40)}
+        height={Math.max(h, 24)}
+        className={className}
+        onDoubleClick={() => onEdit(el)}
+      >
         <div className="wb-text" style={{ color: el.stroke, fontSize: 18 + el.strokeWidth * 2 }}>
           {b.text || ""}
         </div>

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -742,6 +742,24 @@ export default function App() {
     [finishDraft, scene, scheduleSave, updateDraft],
   );
 
+  const onPointerCancel = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const drag = dragRef.current;
+      dragRef.current = null;
+      (e.currentTarget as Element).releasePointerCapture?.(e.pointerId);
+      updateDraft(null);
+      setMarquee(null);
+      if (drag?.mode === "move" && drag.baseScene) {
+        setHistory((current) => {
+          const nextHistory = { ...current, present: drag.baseScene as Scene };
+          historyRef.current = nextHistory;
+          return nextHistory;
+        });
+      }
+    },
+    [updateDraft],
+  );
+
   // -- selection ops --------------------------------------------------------
   const deleteSelected = useCallback(() => {
     if (selected.size === 0) return;
@@ -956,7 +974,7 @@ export default function App() {
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}
-          onPointerCancel={onPointerUp}
+          onPointerCancel={onPointerCancel}
           onWheel={onWheel}
           style={{ cursor: tool === "select" ? "default" : "crosshair" }}
         >

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -435,11 +435,8 @@ export default function App() {
     const r = renaming;
     if (!r) return;
     const name = normalizeBoardName(r.value);
-    let snapshot: BoardMeta[] | null = null;
-    setBoards((prev) => {
-      snapshot = prev;
-      return prev.map((b) => (b.id === r.id ? { ...b, name } : b));
-    });
+    const snapshot = boards;
+    setBoards((prev) => prev.map((b) => (b.id === r.id ? { ...b, name } : b)));
     const db = window.MatrixOS?.db;
     if (!db || r.id === LOCAL_BOARD_ID) {
       saveLocalName(name);
@@ -451,13 +448,13 @@ export default function App() {
       setRenaming(null);
     } catch (err: unknown) {
       console.warn("[whiteboard] rename failed:", err instanceof Error ? err.message : String(err));
-      if (snapshot) setBoards(snapshot);
+      setBoards(snapshot);
       setError("Could not rename the board.");
       void refreshIndex().then((result) => {
         setError(result.ok ? null : "Could not rename the board.");
       });
     }
-  }, [refreshIndex, renaming]);
+  }, [boards, refreshIndex, renaming]);
 
   // -- delete a board -------------------------------------------------------
   const deleteBoard = useCallback(

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -211,6 +211,8 @@ export default function App() {
   const saveTimerRef = useRef<number | null>(null);
   const dirtyRef = useRef(false);
   const historyRef = useRef<History>(history);
+  const renameCommitKeyRef = useRef<string | null>(null);
+  const editingCommitIdRef = useRef<string | null>(null);
 
   // Keep a ref of the active board id so debounced/async saves target the
   // board that was active when the edit happened, not a stale closure value.
@@ -245,6 +247,7 @@ export default function App() {
     activeIdRef.current = id;
     setSelected(new Set());
     setEditing(null);
+    setRenaming(null);
     setDraft(null);
     setViewport({ x: 0, y: 0, zoom: 1 });
 
@@ -349,10 +352,10 @@ export default function App() {
     })();
     const db = window.MatrixOS?.db;
     const unsubscribe = db?.onChange?.(SCENES_TABLE, () => {
-      // Reconcile the list; reload the active board only when not mid-edit.
+      // Reconcile the list without reopening the active board. The bridge
+      // notification is table-wide, so reopening would reset viewport,
+      // selection, and in-progress edits for unrelated board writes.
       void refreshIndex();
-      const id = activeIdRef.current;
-      if (id && !dirtyRef.current) void openBoard(id);
     });
     return () => {
       cancelled = true;
@@ -399,9 +402,9 @@ export default function App() {
   }, []);
 
   const scheduleSave = useCallback(
-    (toSave: Scene) => {
+    (toSave: Scene, targetBoardId: string | null = activeIdRef.current) => {
       dirtyRef.current = true;
-      const boardId = activeIdRef.current;
+      const boardId = targetBoardId;
       if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
       saveTimerRef.current = window.setTimeout(() => {
         saveTimerRef.current = null;
@@ -436,6 +439,9 @@ export default function App() {
     const r = renaming;
     if (!r) return;
     const name = normalizeBoardName(r.value);
+    const commitKey = `${r.id}:${name}`;
+    if (renameCommitKeyRef.current === commitKey) return;
+    renameCommitKeyRef.current = commitKey;
     const snapshot = boards;
     setBoards((prev) => prev.map((b) => (b.id === r.id ? { ...b, name } : b)));
     const db = window.MatrixOS?.db;
@@ -449,6 +455,7 @@ export default function App() {
       setRenaming(null);
     } catch (err: unknown) {
       console.warn("[whiteboard] rename failed:", err instanceof Error ? err.message : String(err));
+      renameCommitKeyRef.current = null;
       setBoards(snapshot);
       setError("Could not rename the board.");
       void refreshIndex().then((result) => {
@@ -493,13 +500,13 @@ export default function App() {
 
   // -- commit + autosave wrapper -------------------------------------------
   const apply = useCallback(
-    (next: Scene) => {
+    (next: Scene, targetBoardId: string | null = activeIdRef.current) => {
       setHistory((h) => {
         const nextHistory = commit(h, next);
         historyRef.current = nextHistory;
         return nextHistory;
       });
-      scheduleSave(next);
+      scheduleSave(next, targetBoardId);
     },
     [scheduleSave],
   );
@@ -692,6 +699,7 @@ export default function App() {
       }
       apply(addElement(scene, final));
       if (final.kind === "text" || final.kind === "sticky") {
+        editingCommitIdRef.current = null;
         setEditing({ id: final.id, value: (final as BoxElement).text ?? "" });
       }
       if (tool !== "pen") setTool("select");
@@ -747,6 +755,9 @@ export default function App() {
       (e.currentTarget as Element).releasePointerCapture?.(e.pointerId);
       updateDraft(null);
       setMarquee(null);
+      if (drag?.mode === "draw" && tool !== "pen") {
+        setTool("select");
+      }
       if (drag?.mode === "move" && drag.baseScene) {
         setHistory((current) => {
           const nextHistory = { ...current, present: drag.baseScene as Scene };
@@ -755,7 +766,7 @@ export default function App() {
         });
       }
     },
-    [updateDraft],
+    [tool, updateDraft],
   );
 
   // -- selection ops --------------------------------------------------------
@@ -793,9 +804,11 @@ export default function App() {
 
   const commitEditing = useCallback(() => {
     if (!editing) return;
-    apply(updateElement(scene, editing.id, { text: editing.value } as Partial<BoxElement>));
+    if (editingCommitIdRef.current === editing.id) return;
+    editingCommitIdRef.current = editing.id;
+    apply(updateElement(scene, editing.id, { text: editing.value } as Partial<BoxElement>), activeId);
     setEditing(null);
-  }, [apply, editing, scene]);
+  }, [activeId, apply, editing, scene]);
 
   // -- keyboard shortcuts ---------------------------------------------------
   useEffect(() => {
@@ -955,7 +968,10 @@ export default function App() {
           renaming={renaming}
           onSelect={switchBoard}
           onNew={() => void createBoard()}
-          onStartRename={(b) => setRenaming({ id: b.id, value: b.name })}
+          onStartRename={(b) => {
+            renameCommitKeyRef.current = null;
+            setRenaming({ id: b.id, value: b.name });
+          }}
           onRenameChange={(value) => setRenaming((r) => (r ? { ...r, value } : r))}
           onCommitRename={() => void commitRename()}
           onCancelRename={() => setRenaming(null)}
@@ -1277,6 +1293,12 @@ function RenameInput({
 }) {
   const ref = useRef<HTMLInputElement | null>(null);
   const cancelledRef = useRef(false);
+  const committedRef = useRef(false);
+  const commitOnce = () => {
+    if (committedRef.current) return;
+    committedRef.current = true;
+    onCommit();
+  };
   // Focus on mount instead of `autoFocus` (which react-doctor flags for a11y).
   useLayoutEffect(() => {
     ref.current?.focus();
@@ -1294,12 +1316,13 @@ function RenameInput({
           cancelledRef.current = false;
           return;
         }
-        onCommit();
+        if (committedRef.current) return;
+        commitOnce();
       }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           e.preventDefault();
-          onCommit();
+          commitOnce();
         } else if (e.key === "Escape") {
           e.preventDefault();
           cancelledRef.current = true;
@@ -1511,6 +1534,13 @@ function TextEditorOverlay({
   onCancel: () => void;
 }) {
   const ref = useRef<HTMLTextAreaElement | null>(null);
+  const cancelledRef = useRef(false);
+  const committedRef = useRef(false);
+  const commitOnce = () => {
+    if (committedRef.current) return;
+    committedRef.current = true;
+    onCommit();
+  };
   useLayoutEffect(() => {
     ref.current?.focus();
     ref.current?.select();
@@ -1529,15 +1559,23 @@ function TextEditorOverlay({
       value={editing.value}
       style={{ left, top, width, height, color: element.stroke, fontSize, lineHeight: 1.35 }}
       onChange={(e) => onChange(e.target.value)}
-      onBlur={onCommit}
+      onBlur={() => {
+        if (cancelledRef.current) {
+          cancelledRef.current = false;
+          return;
+        }
+        if (committedRef.current) return;
+        commitOnce();
+      }}
       onKeyDown={(e) => {
         if (e.key === "Escape") {
           e.preventDefault();
+          cancelledRef.current = true;
           onCancel();
         }
         if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
           e.preventDefault();
-          onCommit();
+          commitOnce();
         }
       }}
       placeholder="Type…"
@@ -1599,6 +1637,10 @@ function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
   if (el.kind === "ellipse") {
     ctx.beginPath();
     ctx.ellipse(x + w / 2, y + h / 2, w / 2, h / 2, 0, 0, Math.PI * 2);
+    if (el.fill !== "transparent") {
+      ctx.fillStyle = el.fill;
+      ctx.fill();
+    }
     ctx.stroke();
     return;
   }

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -68,6 +68,7 @@ const SCENES_TABLE = "scenes";
 const LS_KEY = "matrix-whiteboard-scene-v1";
 const LS_NAME_KEY = "matrix-whiteboard-name-v1";
 const AUTOSAVE_MS = 800;
+const BOARD_LIST_ERROR = "Could not load your boards.";
 
 const PALETTE = ["#32352E", "#C4342D", "#D06F25", "#3A7D44", "#2D6CDF", "#7A4FD0", "#9A8C66"];
 const STROKE_WIDTHS = [2, 4, 8];
@@ -332,7 +333,7 @@ export default function App() {
   }, []);
 
   // -- refresh the board index (sidebar list) -------------------------------
-  const refreshIndex = useCallback(async (): Promise<BoardIndexResult> => {
+  const refreshIndex = useCallback(async (opts: { reportError?: boolean } = {}): Promise<BoardIndexResult> => {
     const db = window.MatrixOS?.db;
     if (!db) {
       const local: BoardMeta = { id: LOCAL_BOARD_ID, name: loadLocalName(), updatedAt: 0 };
@@ -343,10 +344,11 @@ export default function App() {
       const rows = await db.find(SCENES_TABLE, { orderBy: { created_at: "desc" } });
       const index = boardIndexFromRows(rows);
       setBoards(index);
+      setError((prev) => (prev === BOARD_LIST_ERROR ? null : prev));
       return { boards: index, ok: true };
     } catch (err: unknown) {
       console.warn("[whiteboard] board list failed:", err instanceof Error ? err.message : String(err));
-      setError("Could not load your boards.");
+      if (opts.reportError !== false) setError(BOARD_LIST_ERROR);
       return { boards: [], ok: false };
     }
   }, []);
@@ -416,7 +418,7 @@ export default function App() {
       // Reconcile the list without reopening the active board. The bridge
       // notification is table-wide, so reopening would reset viewport,
       // selection, and in-progress edits for unrelated board writes.
-      void refreshIndex();
+      void refreshIndex({ reportError: false });
     });
     return () => {
       cancelled = true;
@@ -1758,6 +1760,9 @@ function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
     ctx.fillStyle = b.fill;
     roundedRectPath(ctx, x, y, w, h, 6);
     ctx.fill();
+    ctx.strokeStyle = "rgba(50,53,46,0.14)";
+    ctx.lineWidth = 1;
+    ctx.stroke();
     if (b.text) {
       ctx.fillStyle = "#32352E";
       ctx.font = "16px Inter, system-ui, sans-serif";

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -1276,6 +1276,7 @@ function RenameInput({
   onCancel: () => void;
 }) {
   const ref = useRef<HTMLInputElement | null>(null);
+  const cancelledRef = useRef(false);
   // Focus on mount instead of `autoFocus` (which react-doctor flags for a11y).
   useLayoutEffect(() => {
     ref.current?.focus();
@@ -1288,13 +1289,20 @@ function RenameInput({
       value={value}
       aria-label={label}
       onChange={(e) => onChange(e.target.value)}
-      onBlur={onCommit}
+      onBlur={() => {
+        if (cancelledRef.current) {
+          cancelledRef.current = false;
+          return;
+        }
+        onCommit();
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           e.preventDefault();
           onCommit();
         } else if (e.key === "Escape") {
           e.preventDefault();
+          cancelledRef.current = true;
           onCancel();
         }
       }}

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -306,6 +306,7 @@ export default function App() {
     setRenaming(null);
     setDraft(null);
     setViewport({ x: 0, y: 0, zoom: 1 });
+    setError(null);
 
     if (!db || id === LOCAL_BOARD_ID) {
       const local = loadLocal();
@@ -317,7 +318,6 @@ export default function App() {
     }
     setLoadingBoard(true);
     try {
-      setError(null);
       const rows = await db.find(SCENES_TABLE, { where: { id }, limit: 1 });
       const row = rows[0] ?? null;
       // Ignore the result if the user switched away while we were loading.
@@ -342,7 +342,7 @@ export default function App() {
       return { boards: [local], ok: true };
     }
     try {
-      const rows = await db.find(SCENES_TABLE, { orderBy: { created_at: "desc" } });
+      const rows = await db.find(SCENES_TABLE, { orderBy: { updated_at: "desc" } });
       const index = boardIndexFromRows(rows);
       setBoards(index);
       setError((prev) => (prev === BOARD_LIST_ERROR ? null : prev));
@@ -487,7 +487,17 @@ export default function App() {
 
   useEffect(() => {
     return () => {
-      if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+      const pending = pendingSaveRef.current;
+      pendingSaveRef.current = null;
+      if (pending) {
+        saveLocal(pending.scene);
+      } else if (dirtyRef.current) {
+        saveLocal(historyRef.current.present);
+      }
     };
   }, []);
 
@@ -924,6 +934,7 @@ export default function App() {
         e.preventDefault();
         setSelected(new Set());
         setEditing(null);
+        setRenaming(null);
         setConfirmClear(false);
         setConfirmDelete(null);
         return;

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -1080,7 +1080,7 @@ export default function App() {
             setRenaming({ id: b.id, value: b.name });
           }}
           onRenameChange={(value) => setRenaming((r) => (r ? { ...r, value } : r))}
-          onCommitRename={() => void commitRename()}
+          onCommitRename={() => commitRename()}
           onCancelRename={() => setRenaming(null)}
           onRequestDelete={(b) => setConfirmDelete(b)}
         />

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -128,7 +128,8 @@ interface BoardIndexResult {
 function reduceMotion(): boolean {
   try {
     return typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
-  } catch {
+  } catch (err: unknown) {
+    console.warn("[whiteboard] matchMedia check failed:", err instanceof Error ? err.message : String(err));
     return false;
   }
 }

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -1766,15 +1766,18 @@ function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
     if (b.text) {
       ctx.fillStyle = "#32352E";
       ctx.font = "16px Inter, system-ui, sans-serif";
+      ctx.textBaseline = "alphabetic";
       wrapText(ctx, b.text, x + 10, y + 24, w - 20, 20);
     }
     return;
   }
   if (el.kind === "text") {
     if (b.text) {
+      const fontSize = 18 + el.strokeWidth * 2;
       ctx.fillStyle = el.stroke;
-      ctx.font = `${18 + el.strokeWidth * 2}px Inter, system-ui, sans-serif`;
-      wrapText(ctx, b.text, x, y + 20, Math.max(w, 120), 22);
+      ctx.font = `${fontSize}px Inter, system-ui, sans-serif`;
+      ctx.textBaseline = "top";
+      wrapText(ctx, b.text, x, y, Math.max(w, 120), Math.ceil(fontSize * 1.35));
     }
     return;
   }

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -589,11 +589,9 @@ export default function App() {
   // -- commit + autosave wrapper -------------------------------------------
   const apply = useCallback(
     (next: Scene, targetBoardId: string | null = activeIdRef.current) => {
-      setHistory((h) => {
-        const nextHistory = commit(h, next);
-        historyRef.current = nextHistory;
-        return nextHistory;
-      });
+      const nextHistory = commit(historyRef.current, next);
+      historyRef.current = nextHistory;
+      setHistory(nextHistory);
       scheduleSave(next, targetBoardId);
     },
     [scheduleSave],
@@ -735,11 +733,9 @@ export default function App() {
         const dy = p.y - drag.startScene.y;
         let next = drag.baseScene;
         for (const id of drag.movedIds) next = moveElement(next, id, dx, dy);
-        setHistory((h) => {
-          const nextHistory = { ...h, present: next };
-          historyRef.current = nextHistory;
-          return nextHistory;
-        });
+        const nextHistory = { ...historyRef.current, present: next };
+        historyRef.current = nextHistory;
+        setHistory(nextHistory);
         drag.lastScene = p;
         return;
       }
@@ -847,11 +843,9 @@ export default function App() {
         setTool("select");
       }
       if (drag?.mode === "move" && drag.baseScene) {
-        setHistory((current) => {
-          const nextHistory = { ...current, present: drag.baseScene as Scene };
-          historyRef.current = nextHistory;
-          return nextHistory;
-        });
+        const nextHistory = { ...historyRef.current, present: drag.baseScene };
+        historyRef.current = nextHistory;
+        setHistory(nextHistory);
       }
     },
     [tool, updateDraft],

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -109,6 +109,11 @@ interface DragState {
   baseScene?: Scene;
 }
 
+interface BoardIndexResult {
+  boards: BoardMeta[];
+  ok: boolean;
+}
+
 function reduceMotion(): boolean {
   try {
     return typeof window !== "undefined" && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
@@ -205,12 +210,17 @@ export default function App() {
   const activeIdRef = useRef<string | null>(null);
   const saveTimerRef = useRef<number | null>(null);
   const dirtyRef = useRef(false);
+  const historyRef = useRef<History>(history);
 
   // Keep a ref of the active board id so debounced/async saves target the
   // board that was active when the edit happened, not a stale closure value.
   useEffect(() => {
     activeIdRef.current = activeId;
   }, [activeId]);
+
+  useEffect(() => {
+    historyRef.current = history;
+  }, [history]);
 
   const scene = history.present;
   const elements = scene.elements;
@@ -239,7 +249,9 @@ export default function App() {
 
     if (!db || id === LOCAL_BOARD_ID) {
       const local = loadLocal();
-      setHistory(createHistory(local ?? emptyScene()));
+      const nextHistory = createHistory(local ?? emptyScene());
+      historyRef.current = nextHistory;
+      setHistory(nextHistory);
       setLoadingBoard(false);
       return;
     }
@@ -250,7 +262,9 @@ export default function App() {
       const row = rows[0] ?? null;
       // Ignore the result if the user switched away while we were loading.
       if (activeIdRef.current !== id) return;
-      setHistory(createHistory(deserializeScene(docFromRow(row))));
+      const nextHistory = createHistory(deserializeScene(docFromRow(row)));
+      historyRef.current = nextHistory;
+      setHistory(nextHistory);
     } catch (err: unknown) {
       console.warn("[whiteboard] board load failed:", err instanceof Error ? err.message : String(err));
       if (activeIdRef.current === id) setError("Could not load that board.");
@@ -260,22 +274,22 @@ export default function App() {
   }, []);
 
   // -- refresh the board index (sidebar list) -------------------------------
-  const refreshIndex = useCallback(async (): Promise<BoardMeta[]> => {
+  const refreshIndex = useCallback(async (): Promise<BoardIndexResult> => {
     const db = window.MatrixOS?.db;
     if (!db) {
       const local: BoardMeta = { id: LOCAL_BOARD_ID, name: loadLocalName(), updatedAt: 0 };
       setBoards([local]);
-      return [local];
+      return { boards: [local], ok: true };
     }
     try {
       const rows = await db.find(SCENES_TABLE, { orderBy: { created_at: "desc" } });
       const index = boardIndexFromRows(rows);
       setBoards(index);
-      return index;
+      return { boards: index, ok: true };
     } catch (err: unknown) {
       console.warn("[whiteboard] board list failed:", err instanceof Error ? err.message : String(err));
       setError("Could not load your boards.");
-      return [];
+      return { boards: [], ok: false };
     }
   }, []);
 
@@ -298,7 +312,13 @@ export default function App() {
         const res = await db.insert(SCENES_TABLE, { name: boardName, doc });
         const id = res && typeof res.id === "string" ? res.id : null;
         await refreshIndex();
-        if (id) await openBoard(id);
+        if (!id) {
+          console.warn("[whiteboard] create board response did not include an id");
+          setError("Could not create a board.");
+          setLoadingBoard(false);
+          return null;
+        }
+        await openBoard(id);
         return id;
       } catch (err: unknown) {
         console.warn("[whiteboard] create board failed:", err instanceof Error ? err.message : String(err));
@@ -316,8 +336,10 @@ export default function App() {
     void (async () => {
       const index = await refreshIndex();
       if (cancelled) return;
-      if (index.length > 0) {
-        await openBoard(index[0].id);
+      if (!index.ok) {
+        setLoadingBoard(false);
+      } else if (index.boards.length > 0) {
+        await openBoard(index.boards[0].id);
       } else if (window.MatrixOS?.db) {
         await createBoard("Untitled board");
       } else {
@@ -401,11 +423,11 @@ export default function App() {
       if (saveTimerRef.current !== null) {
         window.clearTimeout(saveTimerRef.current);
         saveTimerRef.current = null;
-        if (dirtyRef.current) void persist(history.present, activeIdRef.current);
+        if (dirtyRef.current) void persist(historyRef.current.present, activeIdRef.current);
       }
       void openBoard(id);
     },
-    [history, openBoard, persist],
+    [openBoard, persist],
   );
 
   // -- rename a board -------------------------------------------------------
@@ -431,7 +453,9 @@ export default function App() {
       console.warn("[whiteboard] rename failed:", err instanceof Error ? err.message : String(err));
       if (snapshot) setBoards(snapshot);
       setError("Could not rename the board.");
-      void refreshIndex().finally(() => setError("Could not rename the board."));
+      void refreshIndex().then((result) => {
+        setError(result.ok ? null : "Could not rename the board.");
+      });
     }
   }, [refreshIndex, renaming]);
 
@@ -441,7 +465,9 @@ export default function App() {
       const db = window.MatrixOS?.db;
       if (!db || board.id === LOCAL_BOARD_ID) {
         saveLocal(emptyScene());
-        setHistory(createHistory(emptyScene()));
+        const nextHistory = createHistory(emptyScene());
+        historyRef.current = nextHistory;
+        setHistory(nextHistory);
         setConfirmDelete(null);
         return;
       }
@@ -450,8 +476,13 @@ export default function App() {
         await db.delete(SCENES_TABLE, board.id);
         const index = await refreshIndex();
         if (board.id === activeIdRef.current) {
-          if (index.length > 0) await openBoard(index[0].id);
-          else await createBoard("Untitled board");
+          if (!index.ok) {
+            setLoadingBoard(false);
+          } else if (index.boards.length > 0) {
+            await openBoard(index.boards[0].id);
+          } else {
+            await createBoard("Untitled board");
+          }
         }
         setConfirmDelete(null);
       } catch (err: unknown) {
@@ -465,7 +496,11 @@ export default function App() {
   // -- commit + autosave wrapper -------------------------------------------
   const apply = useCallback(
     (next: Scene) => {
-      setHistory((h) => commit(h, next));
+      setHistory((h) => {
+        const nextHistory = commit(h, next);
+        historyRef.current = nextHistory;
+        return nextHistory;
+      });
       scheduleSave(next);
     },
     [scheduleSave],
@@ -607,7 +642,11 @@ export default function App() {
         const dy = p.y - drag.startScene.y;
         let next = drag.baseScene;
         for (const id of drag.movedIds) next = moveElement(next, id, dx, dy);
-        setHistory((h) => ({ ...h, present: next }));
+        setHistory((h) => {
+          const nextHistory = { ...h, present: next };
+          historyRef.current = nextHistory;
+          return nextHistory;
+        });
         drag.lastScene = p;
         return;
       }
@@ -676,14 +715,14 @@ export default function App() {
         return;
       }
       if (drag.mode === "move") {
-        setHistory((h) => {
-          if (drag.baseScene && h.present !== drag.baseScene) {
-            const moved = h.present;
-            scheduleSave(moved);
-            return commit({ ...h, present: drag.baseScene }, moved);
-          }
-          return h;
-        });
+        const current = historyRef.current;
+        if (drag.baseScene && current.present !== drag.baseScene) {
+          const moved = current.present;
+          const nextHistory = commit({ ...current, present: drag.baseScene }, moved);
+          historyRef.current = nextHistory;
+          setHistory(nextHistory);
+          scheduleSave(moved);
+        }
         return;
       }
       if (drag.mode === "marquee") {
@@ -711,22 +750,22 @@ export default function App() {
   }, [apply, scene, selected]);
 
   const doUndo = useCallback(() => {
-    setHistory((h) => {
-      if (!canUndo(h)) return h;
-      const next = undo(h);
-      scheduleSave(next.present);
-      return next;
-    });
+    const current = historyRef.current;
+    if (!canUndo(current)) return;
+    const next = undo(current);
+    historyRef.current = next;
+    setHistory(next);
+    scheduleSave(next.present);
     setSelected(new Set());
   }, [scheduleSave]);
 
   const doRedo = useCallback(() => {
-    setHistory((h) => {
-      if (!canRedo(h)) return h;
-      const next = redo(h);
-      scheduleSave(next.present);
-      return next;
-    });
+    const current = historyRef.current;
+    if (!canRedo(current)) return;
+    const next = redo(current);
+    historyRef.current = next;
+    setHistory(next);
+    scheduleSave(next.present);
     setSelected(new Set());
   }, [scheduleSave]);
 

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -196,6 +197,9 @@ export default function App() {
   const [confirmDelete, setConfirmDelete] = useState<BoardMeta | null>(null);
 
   const svgRef = useRef<SVGSVGElement | null>(null);
+  const svgIdPrefix = useId().replace(/:/g, "");
+  const gridId = `${svgIdPrefix}-wb-grid`;
+  const arrowId = `${svgIdPrefix}-wb-arrow`;
   const dragRef = useRef<DragState | null>(null);
   const draftRef = useRef<SceneElement | null>(null);
   const activeIdRef = useRef<string | null>(null);
@@ -400,17 +404,18 @@ export default function App() {
   // -- rename a board -------------------------------------------------------
   const commitRename = useCallback(async () => {
     const r = renaming;
-    setRenaming(null);
     if (!r) return;
     const name = normalizeBoardName(r.value);
     setBoards((prev) => prev.map((b) => (b.id === r.id ? { ...b, name } : b)));
     const db = window.MatrixOS?.db;
     if (!db || r.id === LOCAL_BOARD_ID) {
       saveLocalName(name);
+      setRenaming(null);
       return;
     }
     try {
       await db.update(SCENES_TABLE, r.id, { name });
+      setRenaming(null);
     } catch (err: unknown) {
       console.warn("[whiteboard] rename failed:", err instanceof Error ? err.message : String(err));
       setError("Could not rename the board.");
@@ -838,9 +843,9 @@ export default function App() {
   const renderElements = useMemo(() => {
     const list = draft ? [...elements, draft] : elements;
     return list.map((el) => (
-      <ElementView key={el.id} el={el} selected={selected.has(el.id)} editing={editing?.id === el.id} />
+      <ElementView key={el.id} el={el} selected={selected.has(el.id)} editing={editing?.id === el.id} arrowId={arrowId} />
     ));
-  }, [draft, editing, elements, selected]);
+  }, [arrowId, draft, editing, elements, selected]);
 
   const motion = reduceMotion();
   const gridUnit = 24 * viewport.zoom;
@@ -901,7 +906,7 @@ export default function App() {
         >
           <defs>
             <pattern
-              id="wb-grid"
+              id={gridId}
               width={gridUnit || 24}
               height={gridUnit || 24}
               patternUnits="userSpaceOnUse"
@@ -909,11 +914,11 @@ export default function App() {
             >
               <circle cx="1" cy="1" r="1" className="wb-grid-dot" />
             </pattern>
-            <marker id="wb-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <marker id={arrowId} viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
               <path d="M0,0 L10,5 L0,10 z" fill="context-stroke" />
             </marker>
           </defs>
-          <rect className="wb-grid-bg" x="0" y="0" width="100%" height="100%" fill="url(#wb-grid)" />
+          <rect className="wb-grid-bg" x="0" y="0" width="100%" height="100%" fill={`url(#${gridId})`} />
           <g transform={`translate(${viewport.x} ${viewport.y}) scale(${viewport.zoom})`}>
             {renderElements}
             {selected.size > 0 &&
@@ -1340,7 +1345,7 @@ function penPath(points: Point[]): string {
   return d;
 }
 
-function ElementView({ el, selected, editing }: { el: SceneElement; selected: boolean; editing: boolean }) {
+function ElementView({ el, selected, editing, arrowId }: { el: SceneElement; selected: boolean; editing: boolean; arrowId: string }) {
   const className = selected ? "wb-el wb-el--selected" : "wb-el";
   if (el.kind === "pen") {
     return (
@@ -1367,7 +1372,7 @@ function ElementView({ el, selected, editing }: { el: SceneElement; selected: bo
         strokeWidth={l.strokeWidth}
         strokeLinecap="round"
         className={className}
-        markerEnd={el.kind === "arrow" ? "url(#wb-arrow)" : undefined}
+        markerEnd={el.kind === "arrow" ? `url(#${arrowId})` : undefined}
       />
     );
   }

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -1465,12 +1465,24 @@ function TextEditorOverlay({
 function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
   ctx.strokeStyle = el.stroke;
   ctx.lineWidth = el.strokeWidth;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
   if (el.kind === "pen") {
     const pen = el as PenElement;
     if (pen.points.length === 0) return;
     ctx.beginPath();
-    ctx.moveTo(pen.points[0].x, pen.points[0].y);
-    for (let i = 1; i < pen.points.length; i += 1) ctx.lineTo(pen.points[i].x, pen.points[i].y);
+    if (pen.points.length === 1) {
+      const p = pen.points[0];
+      ctx.moveTo(p.x, p.y);
+      ctx.lineTo(p.x + 0.1, p.y + 0.1);
+    } else {
+      ctx.moveTo(pen.points[0].x, pen.points[0].y);
+      for (let i = 1; i < pen.points.length; i += 1) {
+        const prev = pen.points[i - 1];
+        const curr = pen.points[i];
+        ctx.quadraticCurveTo(prev.x, prev.y, (prev.x + curr.x) / 2, (prev.y + curr.y) / 2);
+      }
+    }
     ctx.stroke();
     return;
   }
@@ -1505,7 +1517,8 @@ function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
   }
   if (el.kind === "sticky") {
     ctx.fillStyle = b.fill;
-    ctx.fillRect(x, y, w, h);
+    roundedRectPath(ctx, x, y, w, h, 6);
+    ctx.fill();
     if (b.text) {
       ctx.fillStyle = "#32352E";
       ctx.font = "16px Inter, system-ui, sans-serif";
@@ -1521,7 +1534,38 @@ function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
     }
     return;
   }
-  ctx.strokeRect(x, y, w, h);
+  roundedRectPath(ctx, x, y, w, h, 8);
+  if (el.fill !== "transparent") {
+    ctx.fillStyle = el.fill;
+    ctx.fill();
+  }
+  ctx.stroke();
+}
+
+function roundedRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  radius: number,
+): void {
+  const r = Math.min(radius, Math.abs(w) / 2, Math.abs(h) / 2);
+  ctx.beginPath();
+  if (typeof ctx.roundRect === "function") {
+    ctx.roundRect(x, y, w, h, r);
+    return;
+  }
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.arcTo(x + w, y, x + w, y + r, r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+  ctx.lineTo(x + r, y + h);
+  ctx.arcTo(x, y + h, x, y + h - r, r);
+  ctx.lineTo(x, y + r);
+  ctx.arcTo(x, y, x + r, y, r);
+  ctx.closePath();
 }
 
 function wrapText(

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -1860,10 +1860,10 @@ function wrapText(
   let cursorY = y;
   const paragraphs = text.replace(/\r\n/g, "\n").split("\n");
   for (const [index, paragraph] of paragraphs.entries()) {
-    const words = paragraph.split(/[ \t]+/).filter((word) => word.length > 0);
+    const words = paragraph.split(/([ \t]+)/).filter((word) => word.length > 0);
     let line = "";
     for (const word of words) {
-      const test = line ? `${line} ${word}` : word;
+      const test = `${line}${word}`;
       if (ctx.measureText(test).width > maxWidth && line) {
         ctx.fillText(line, x, cursorY);
         line = word;

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -240,6 +240,7 @@ export default function App() {
   const openBoard = useCallback(async (id: string) => {
     const db = window.MatrixOS?.db;
     dirtyRef.current = false;
+    setSaveState("idle");
     setActiveId(id);
     activeIdRef.current = id;
     setSelected(new Set());
@@ -1511,13 +1512,14 @@ function TextEditorOverlay({
   const top = element.y * viewport.zoom + viewport.y;
   const width = Math.max(Math.abs(element.width) * viewport.zoom, 120);
   const height = Math.max(Math.abs(element.height) * viewport.zoom, 36);
+  const fontSize = (18 + element.strokeWidth * 2) * viewport.zoom;
   return (
     <textarea
       ref={ref}
       className="wb-text-editor"
       aria-label="Edit text"
       value={editing.value}
-      style={{ left, top, width, height }}
+      style={{ left, top, width, height, color: element.stroke, fontSize, lineHeight: 1.35 }}
       onChange={(e) => onChange(e.target.value)}
       onBlur={onCommit}
       onKeyDown={(e) => {

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -166,9 +166,10 @@ function saveLocalName(name: string): void {
   }
 }
 
-function nextUntitledName(boards: readonly BoardMeta[]): string {
+function nextUntitledName(boards: readonly BoardMeta[], reservedNames: ReadonlySet<string> = new Set()): string {
   const base = "Untitled board";
   const taken = new Set(boards.map((b) => b.name.toLowerCase()));
+  for (const name of reservedNames) taken.add(name.toLowerCase());
   if (!taken.has(base.toLowerCase())) return base;
   for (let i = 2; i < 1000; i += 1) {
     const candidate = `${base} ${i}`;
@@ -212,6 +213,7 @@ export default function App() {
   const dirtyRef = useRef(false);
   const historyRef = useRef<History>(history);
   const renameCommitKeyRef = useRef<string | null>(null);
+  const pendingBoardNamesRef = useRef<Set<string>>(new Set());
   const editingCommitIdRef = useRef<string | null>(null);
 
   // Keep a ref of the active board id so debounced/async saves target the
@@ -301,34 +303,41 @@ export default function App() {
   const createBoard = useCallback(
     async (name?: string): Promise<string | null> => {
       const db = window.MatrixOS?.db;
-      const boardName = normalizeBoardName(name ?? nextUntitledName(boards));
+      const isGeneratedName = name == null;
+      const boardName = normalizeBoardName(name ?? nextUntitledName(boards, pendingBoardNamesRef.current));
+      const reservedName = isGeneratedName ? boardName.toLowerCase() : null;
+      if (reservedName) pendingBoardNamesRef.current.add(reservedName);
       const doc = serializeScene(emptyScene());
-      if (!db) {
-        // No DB: a single local board only.
-        saveLocal(emptyScene());
-        saveLocalName(boardName);
-        await refreshIndex();
-        await openBoard(LOCAL_BOARD_ID);
-        return LOCAL_BOARD_ID;
-      }
       try {
-        setError(null);
-        const res = await db.insert(SCENES_TABLE, { name: boardName, doc });
-        const id = res && typeof res.id === "string" ? res.id : null;
-        await refreshIndex();
-        if (!id) {
-          console.warn("[whiteboard] create board response did not include an id");
+        if (!db) {
+          // No DB: a single local board only.
+          saveLocal(emptyScene());
+          saveLocalName(boardName);
+          await refreshIndex();
+          await openBoard(LOCAL_BOARD_ID);
+          return LOCAL_BOARD_ID;
+        }
+        try {
+          setError(null);
+          const res = await db.insert(SCENES_TABLE, { name: boardName, doc });
+          const id = res && typeof res.id === "string" ? res.id : null;
+          await refreshIndex();
+          if (!id) {
+            console.warn("[whiteboard] create board response did not include an id");
+            setError("Could not create a board.");
+            setLoadingBoard(false);
+            return null;
+          }
+          await openBoard(id);
+          return id;
+        } catch (err: unknown) {
+          console.warn("[whiteboard] create board failed:", err instanceof Error ? err.message : String(err));
           setError("Could not create a board.");
           setLoadingBoard(false);
           return null;
         }
-        await openBoard(id);
-        return id;
-      } catch (err: unknown) {
-        console.warn("[whiteboard] create board failed:", err instanceof Error ? err.message : String(err));
-        setError("Could not create a board.");
-        setLoadingBoard(false);
-        return null;
+      } finally {
+        if (reservedName) pendingBoardNamesRef.current.delete(reservedName);
       }
     },
     [boards, openBoard, refreshIndex],
@@ -1620,12 +1629,17 @@ function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
     if (el.kind === "arrow") {
       const angle = Math.atan2(l.y2 - l.y1, l.x2 - l.x1);
       const size = 8 + el.strokeWidth;
+      const leftX = l.x2 - size * Math.cos(angle - Math.PI / 6);
+      const leftY = l.y2 - size * Math.sin(angle - Math.PI / 6);
+      const rightX = l.x2 - size * Math.cos(angle + Math.PI / 6);
+      const rightY = l.y2 - size * Math.sin(angle + Math.PI / 6);
       ctx.beginPath();
       ctx.moveTo(l.x2, l.y2);
-      ctx.lineTo(l.x2 - size * Math.cos(angle - Math.PI / 6), l.y2 - size * Math.sin(angle - Math.PI / 6));
-      ctx.moveTo(l.x2, l.y2);
-      ctx.lineTo(l.x2 - size * Math.cos(angle + Math.PI / 6), l.y2 - size * Math.sin(angle + Math.PI / 6));
-      ctx.stroke();
+      ctx.lineTo(leftX, leftY);
+      ctx.lineTo(rightX, rightY);
+      ctx.closePath();
+      ctx.fillStyle = el.stroke;
+      ctx.fill();
     }
     return;
   }
@@ -1705,18 +1719,26 @@ function wrapText(
   maxWidth: number,
   lineHeight: number,
 ): void {
-  const words = text.split(/\s+/);
-  let line = "";
   let cursorY = y;
-  for (const word of words) {
-    const test = line ? `${line} ${word}` : word;
-    if (ctx.measureText(test).width > maxWidth && line) {
+  const paragraphs = text.replace(/\r\n/g, "\n").split("\n");
+  for (const [index, paragraph] of paragraphs.entries()) {
+    const words = paragraph.split(/[ \t]+/).filter((word) => word.length > 0);
+    let line = "";
+    for (const word of words) {
+      const test = line ? `${line} ${word}` : word;
+      if (ctx.measureText(test).width > maxWidth && line) {
+        ctx.fillText(line, x, cursorY);
+        line = word;
+        cursorY += lineHeight;
+      } else {
+        line = test;
+      }
+    }
+    if (line) {
       ctx.fillText(line, x, cursorY);
-      line = word;
+    }
+    if (index < paragraphs.length - 1 || !line) {
       cursorY += lineHeight;
-    } else {
-      line = test;
     }
   }
-  if (line) ctx.fillText(line, x, cursorY);
 }

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -263,6 +263,7 @@ export default function App() {
   const draftRef = useRef<SceneElement | null>(null);
   const activeIdRef = useRef<string | null>(null);
   const saveTimerRef = useRef<number | null>(null);
+  const pendingSaveRef = useRef<{ scene: Scene; boardId: string | null } | null>(null);
   const dirtyRef = useRef(false);
   const historyRef = useRef<History>(history);
   const renameCommitKeyRef = useRef<string | null>(null);
@@ -414,11 +415,16 @@ export default function App() {
       }
     })();
     const db = window.MatrixOS?.db;
+    let refreshPending = false;
     const unsubscribe = db?.onChange?.(SCENES_TABLE, () => {
       // Reconcile the list without reopening the active board. The bridge
       // notification is table-wide, so reopening would reset viewport,
       // selection, and in-progress edits for unrelated board writes.
-      void refreshIndex({ reportError: false });
+      if (refreshPending) return;
+      refreshPending = true;
+      void refreshIndex({ reportError: false }).finally(() => {
+        refreshPending = false;
+      });
     });
     return () => {
       cancelled = true;
@@ -468,9 +474,11 @@ export default function App() {
     (toSave: Scene, targetBoardId: string | null = activeIdRef.current) => {
       dirtyRef.current = true;
       const boardId = targetBoardId;
+      pendingSaveRef.current = { scene: toSave, boardId };
       if (saveTimerRef.current !== null) window.clearTimeout(saveTimerRef.current);
       saveTimerRef.current = window.setTimeout(() => {
         saveTimerRef.current = null;
+        pendingSaveRef.current = null;
         void persist(toSave, boardId);
       }, AUTOSAVE_MS);
     },
@@ -490,7 +498,10 @@ export default function App() {
       if (saveTimerRef.current !== null) {
         window.clearTimeout(saveTimerRef.current);
         saveTimerRef.current = null;
-        if (dirtyRef.current) void persist(historyRef.current.present, activeIdRef.current);
+        const pending = pendingSaveRef.current;
+        pendingSaveRef.current = null;
+        if (pending) void persist(pending.scene, pending.boardId);
+        else if (dirtyRef.current) void persist(historyRef.current.present, activeIdRef.current);
       }
       void openBoard(id);
     },

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -545,7 +545,7 @@ export default function App() {
       renameCommitKeyRef.current = null;
       setBoards(snapshot);
       setError("Could not rename the board.");
-      void refreshIndex().then((result) => {
+      void refreshIndex({ reportError: false }).then((result) => {
         setError(result.ok ? null : "Could not rename the board.");
       });
       return false;
@@ -1797,10 +1797,11 @@ function drawToCanvas(ctx: CanvasRenderingContext2D, el: SceneElement): void {
     ctx.lineWidth = 1;
     ctx.stroke();
     if (b.text) {
+      const stickyFontSize = 15;
       ctx.fillStyle = "#32352E";
-      ctx.font = "16px Inter, system-ui, sans-serif";
-      ctx.textBaseline = "alphabetic";
-      wrapText(ctx, b.text, x + 10, y + 24, w - 20, 20);
+      ctx.font = `${stickyFontSize}px Inter, system-ui, sans-serif`;
+      ctx.textBaseline = "top";
+      wrapText(ctx, b.text, x + 10, y + 8, w - 20, Math.ceil(stickyFontSize * 1.35));
     }
     return;
   }

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -49,7 +49,6 @@ import {
   moveElement,
   normalizeBoardName,
   redo,
-  rowToBoardMeta,
   serializeScene,
   undo,
   updateElement,
@@ -140,7 +139,8 @@ function loadLocalName(): string {
   try {
     const raw = window.localStorage.getItem(LS_NAME_KEY);
     return normalizeBoardName(raw);
-  } catch {
+  } catch (err: unknown) {
+    console.warn("[whiteboard] localStorage name read failed:", err instanceof Error ? err.message : String(err));
     return normalizeBoardName(null);
   }
 }
@@ -303,6 +303,7 @@ export default function App() {
       } catch (err: unknown) {
         console.warn("[whiteboard] create board failed:", err instanceof Error ? err.message : String(err));
         setError("Could not create a board.");
+        setLoadingBoard(false);
         return null;
       }
     },
@@ -343,17 +344,21 @@ export default function App() {
     const doc = serializeScene(toSave);
     if (!db || boardId === LOCAL_BOARD_ID) {
       saveLocal(toSave);
-      setSaveState("saved");
-      dirtyRef.current = false;
+      if (activeIdRef.current === boardId) {
+        setSaveState("saved");
+        dirtyRef.current = false;
+      }
       return;
     }
     if (!boardId) return;
-    setSaveState("saving");
+    if (activeIdRef.current === boardId) setSaveState("saving");
     try {
       await db.update(SCENES_TABLE, boardId, { doc });
-      setSaveState("saved");
-      setError(null);
-      dirtyRef.current = false;
+      if (activeIdRef.current === boardId) {
+        setSaveState("saved");
+        setError(null);
+        dirtyRef.current = false;
+      }
       // Bump this board to the top of the recency-sorted list locally.
       setBoards((prev) =>
         [...prev]
@@ -362,8 +367,10 @@ export default function App() {
       );
     } catch (err: unknown) {
       console.warn("[whiteboard] scene save failed:", err instanceof Error ? err.message : String(err));
-      setSaveState("error");
-      setError("Changes could not be saved.");
+      if (activeIdRef.current === boardId) {
+        setSaveState("error");
+        setError("Changes could not be saved.");
+      }
       saveLocal(toSave);
     }
   }, []);
@@ -431,11 +438,11 @@ export default function App() {
   // -- delete a board -------------------------------------------------------
   const deleteBoard = useCallback(
     async (board: BoardMeta) => {
-      setConfirmDelete(null);
       const db = window.MatrixOS?.db;
       if (!db || board.id === LOCAL_BOARD_ID) {
         saveLocal(emptyScene());
         setHistory(createHistory(emptyScene()));
+        setConfirmDelete(null);
         return;
       }
       try {
@@ -446,6 +453,7 @@ export default function App() {
           if (index.length > 0) await openBoard(index[0].id);
           else await createBoard("Untitled board");
         }
+        setConfirmDelete(null);
       } catch (err: unknown) {
         console.warn("[whiteboard] delete board failed:", err instanceof Error ? err.message : String(err));
         setError("Could not delete the board.");
@@ -760,9 +768,11 @@ export default function App() {
         return;
       }
       if (e.key === "Escape") {
+        e.preventDefault();
         setSelected(new Set());
         setEditing(null);
         setConfirmClear(false);
+        setConfirmDelete(null);
         return;
       }
       const match = TOOLS.find((t) => t.shortcut.toLowerCase() === e.key.toLowerCase());

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -406,7 +406,11 @@ export default function App() {
     const r = renaming;
     if (!r) return;
     const name = normalizeBoardName(r.value);
-    setBoards((prev) => prev.map((b) => (b.id === r.id ? { ...b, name } : b)));
+    let snapshot: BoardMeta[] | null = null;
+    setBoards((prev) => {
+      snapshot = prev;
+      return prev.map((b) => (b.id === r.id ? { ...b, name } : b));
+    });
     const db = window.MatrixOS?.db;
     if (!db || r.id === LOCAL_BOARD_ID) {
       saveLocalName(name);
@@ -418,8 +422,9 @@ export default function App() {
       setRenaming(null);
     } catch (err: unknown) {
       console.warn("[whiteboard] rename failed:", err instanceof Error ? err.message : String(err));
+      if (snapshot) setBoards(snapshot);
       setError("Could not rename the board.");
-      void refreshIndex();
+      void refreshIndex().finally(() => setError("Could not rename the board."));
     }
   }, [refreshIndex, renaming]);
 

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -928,14 +928,14 @@ export default function App() {
         setConfirmDelete(null);
         return;
       }
-      if (!mod) {
+      if (!mod && !confirmClear && !confirmDelete) {
         const match = TOOLS.find((t) => t.shortcut.toLowerCase() === e.key.toLowerCase());
         if (match) setTool(match.kind);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [deleteSelected, doRedo, doUndo, selected]);
+  }, [confirmClear, confirmDelete, deleteSelected, doRedo, doUndo, selected]);
 
   // -- zoom -----------------------------------------------------------------
   const zoomBy = useCallback((factor: number) => {

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -521,10 +521,10 @@ export default function App() {
   // -- rename a board -------------------------------------------------------
   const commitRename = useCallback(async () => {
     const r = renaming;
-    if (!r) return;
+    if (!r) return false;
     const name = normalizeBoardName(r.value);
     const commitKey = `${r.id}:${name}`;
-    if (renameCommitKeyRef.current === commitKey) return;
+    if (renameCommitKeyRef.current === commitKey) return false;
     renameCommitKeyRef.current = commitKey;
     const snapshot = boards;
     setBoards((prev) => prev.map((b) => (b.id === r.id ? { ...b, name } : b)));
@@ -532,11 +532,14 @@ export default function App() {
     if (!db || r.id === LOCAL_BOARD_ID) {
       saveLocalName(name);
       setRenaming(null);
-      return;
+      setError(null);
+      return true;
     }
     try {
       await db.update(SCENES_TABLE, r.id, { name });
       setRenaming(null);
+      setError(null);
+      return true;
     } catch (err: unknown) {
       console.warn("[whiteboard] rename failed:", err instanceof Error ? err.message : String(err));
       renameCommitKeyRef.current = null;
@@ -545,6 +548,7 @@ export default function App() {
       void refreshIndex().then((result) => {
         setError(result.ok ? null : "Could not rename the board.");
       });
+      return false;
     }
   }, [boards, refreshIndex, renaming]);
 
@@ -1359,7 +1363,7 @@ interface BoardSidebarProps {
   onNew: () => void;
   onStartRename: (b: BoardMeta) => void;
   onRenameChange: (value: string) => void;
-  onCommitRename: () => void;
+  onCommitRename: () => Promise<boolean> | boolean | void;
   onCancelRename: () => void;
   onRequestDelete: (b: BoardMeta) => void;
 }
@@ -1387,7 +1391,7 @@ function RenameInput({
   value: string;
   label: string;
   onChange: (v: string) => void;
-  onCommit: () => void;
+  onCommit: () => Promise<boolean> | boolean | void;
   onCancel: () => void;
 }) {
   const ref = useRef<HTMLInputElement | null>(null);
@@ -1396,7 +1400,14 @@ function RenameInput({
   const commitOnce = () => {
     if (committedRef.current) return;
     committedRef.current = true;
-    onCommit();
+    void Promise.resolve(onCommit())
+      .then((committed) => {
+        if (committed === false) committedRef.current = false;
+      })
+      .catch((err: unknown) => {
+        console.warn("[whiteboard] rename commit handler failed:", err instanceof Error ? err.message : String(err));
+        committedRef.current = false;
+      });
   };
   // Focus on mount instead of `autoFocus` (which react-doctor flags for a11y).
   useLayoutEffect(() => {

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -493,6 +493,7 @@ export default function App() {
   const onPointerDown = useCallback(
     (e: React.PointerEvent<SVGSVGElement>) => {
       if (e.button === 1 || (e.button === 0 && tool === "select" && e.altKey)) {
+        e.preventDefault();
         dragRef.current = {
           mode: "pan",
           startScene: { x: 0, y: 0 },

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -814,8 +814,10 @@ export default function App() {
         setConfirmDelete(null);
         return;
       }
-      const match = TOOLS.find((t) => t.shortcut.toLowerCase() === e.key.toLowerCase());
-      if (match) setTool(match.kind);
+      if (!mod) {
+        const match = TOOLS.find((t) => t.shortcut.toLowerCase() === e.key.toLowerCase());
+        if (match) setTool(match.kind);
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);

--- a/home/apps/whiteboard/src/App.tsx
+++ b/home/apps/whiteboard/src/App.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import {
   ArrowUpRight,
@@ -74,6 +75,15 @@ const STICKY_FILL = "#FFE9A8";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
+const MODAL_FOCUS_SELECTOR = [
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "a[href]",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
 interface ToolDef {
   kind: ToolKind;
   label: string;
@@ -120,6 +130,48 @@ function reduceMotion(): boolean {
   } catch {
     return false;
   }
+}
+
+function ModalDialog({ label, children }: { label: string; children: ReactNode }) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    const first = cardRef.current?.querySelector<HTMLElement>(MODAL_FOCUS_SELECTOR);
+    first?.focus();
+  }, []);
+
+  return (
+    <div className="wb-modal" role="dialog" aria-modal="true" aria-label={label}>
+      <div
+        ref={cardRef}
+        className="wb-modal__card"
+        onKeyDown={(event) => {
+          if (event.key !== "Tab") return;
+          const card = cardRef.current;
+          if (!card) return;
+          const focusable = Array.from(card.querySelectorAll<HTMLElement>(MODAL_FOCUS_SELECTOR)).filter(
+            (element) => element.tabIndex !== -1,
+          );
+          if (focusable.length === 0) {
+            event.preventDefault();
+            return;
+          }
+          const active = document.activeElement;
+          const activeIndex = focusable.findIndex((element) => element === active);
+          event.preventDefault();
+          if (event.shiftKey) {
+            const previousIndex = activeIndex <= 0 ? focusable.length - 1 : activeIndex - 1;
+            focusable[previousIndex]?.focus();
+            return;
+          }
+          const nextIndex = activeIndex < 0 || activeIndex === focusable.length - 1 ? 0 : activeIndex + 1;
+          focusable[nextIndex]?.focus();
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
 }
 
 const LOCAL_BOARD_ID = "__local__";
@@ -1084,8 +1136,7 @@ export default function App() {
       </div>
 
       {confirmClear && (
-        <div className="wb-modal" role="dialog" aria-modal="true" aria-label="Clear board">
-          <div className="wb-modal__card">
+        <ModalDialog label="Clear board">
             <h3>Clear the whole board?</h3>
             <p>This removes every element. You can undo right after.</p>
             <div className="wb-modal__actions">
@@ -1096,13 +1147,11 @@ export default function App() {
                 Clear board
               </button>
             </div>
-          </div>
-        </div>
+        </ModalDialog>
       )}
 
       {confirmDelete && (
-        <div className="wb-modal" role="dialog" aria-modal="true" aria-label="Delete board">
-          <div className="wb-modal__card">
+        <ModalDialog label="Delete board">
             <h3>Delete “{confirmDelete.name}”?</h3>
             <p>This permanently removes the board and everything on it. This cannot be undone.</p>
             <div className="wb-modal__actions">
@@ -1117,8 +1166,7 @@ export default function App() {
                 Delete board
               </button>
             </div>
-          </div>
-        </div>
+        </ModalDialog>
       )}
     </div>
   );
@@ -1347,6 +1395,13 @@ function BoardSidebar(props: BoardSidebarProps) {
     open, boards, activeId, renaming,
     onSelect, onNew, onStartRename, onRenameChange, onCommitRename, onCancelRename, onRequestDelete,
   } = props;
+  const activeItemRef = useRef<HTMLLIElement | null>(null);
+
+  useEffect(() => {
+    if (!open || !activeId) return;
+    activeItemRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [activeId, open]);
+
   if (!open) return null;
   return (
     <aside className="wb-sidebar" aria-label="Boards">
@@ -1370,7 +1425,11 @@ function BoardSidebar(props: BoardSidebarProps) {
             const active = b.id === activeId;
             const isRenaming = renaming?.id === b.id;
             return (
-              <li key={b.id} className={active ? "wb-boarditem wb-boarditem--active" : "wb-boarditem"}>
+              <li
+                key={b.id}
+                ref={active ? activeItemRef : undefined}
+                className={active ? "wb-boarditem wb-boarditem--active" : "wb-boarditem"}
+              >
                 {isRenaming ? (
                   <RenameInput
                     value={renaming.value}

--- a/home/apps/whiteboard/src/styles.css
+++ b/home/apps/whiteboard/src/styles.css
@@ -1,11 +1,18 @@
 :root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
   color-scheme: light;
-  font-family: 'Inter', system-ui, sans-serif;
-  background: #F7F1E7;
-  color: #32352E;
-  --matrix-primary: #434E3F;
-  --matrix-border: #D6D3C8;
-  --matrix-muted: #F3EAE0;
 }
 
 * {
@@ -18,63 +25,686 @@ body,
   width: 100%;
   height: 100%;
   margin: 0;
-  overflow: hidden;
 }
 
 body {
-  background: linear-gradient(170deg, #F7F1E7 0%, #F3EAE0 30%, #F7F3ED 60%, #F7F1E7 100%);
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  color: var(--app-fg);
+  background: var(--app-bg);
 }
 
-.whiteboard-shell {
-  position: fixed;
-  inset: 0;
-  min-width: 0;
+.wb-app {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--app-bg);
+  color: var(--app-fg);
+}
+
+/* ---- Toolbar ---- */
+.wb-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--app-card);
+  border-bottom: 1px solid color-mix(in srgb, var(--app-border) 70%, transparent);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.06);
+  z-index: 5;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+}
+
+.wb-toolbar__spacer {
+  flex: 1;
+}
+
+.wb-toolgroup {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.wb-divider {
+  width: 1px;
+  height: 26px;
+  background: color-mix(in srgb, var(--app-border) 70%, transparent);
+  margin: 0 2px;
+  flex: none;
+}
+
+.wb-tool,
+.wb-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: none;
+  background: transparent;
+  color: var(--app-fg);
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.wb-action {
+  width: auto;
+  padding: 0 14px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.wb-tool:hover:not(:disabled),
+.wb-action:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--app-fg) 6%, transparent);
+}
+
+.wb-tool:disabled,
+.wb-action:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.wb-tool--active {
+  background: var(--app-primary);
+  color: var(--app-primary-fg);
+  box-shadow: 0 2px 6px rgba(50, 53, 46, 0.18);
+}
+
+.wb-tool:focus-visible,
+.wb-action:focus-visible,
+.wb-swatch:focus-visible,
+.wb-stroke:focus-visible,
+.wb-zoom button:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+.wb-action {
+  background: var(--app-accent);
+  color: #fff;
+  height: 38px;
+}
+
+.wb-action:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--app-accent) 88%, #000);
+}
+
+.wb-action--ghost {
+  background: transparent;
+  color: var(--app-muted-fg);
+  border: 1px solid color-mix(in srgb, var(--app-border) 80%, transparent);
+}
+
+.wb-action--ghost:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--app-fg) 6%, transparent);
+  color: var(--app-fg);
+}
+
+/* color palette */
+.wb-palette {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.wb-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+}
+
+.wb-swatch:hover {
+  transform: scale(1.12);
+}
+
+.wb-swatch--active {
+  border-color: var(--app-card);
+  box-shadow: 0 0 0 2px var(--app-fg);
+}
+
+/* stroke widths */
+.wb-strokes {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.wb-stroke {
+  width: 34px;
+  height: 32px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+}
+
+.wb-stroke span {
+  display: block;
+  width: 18px;
+  border-radius: 999px;
+  background: var(--app-fg);
+}
+
+.wb-stroke:hover {
+  background: color-mix(in srgb, var(--app-fg) 6%, transparent);
+}
+
+.wb-stroke--active {
+  background: color-mix(in srgb, var(--app-fg) 8%, transparent);
+  border-color: color-mix(in srgb, var(--app-border) 80%, transparent);
+}
+
+.wb-save {
+  font-size: 12px;
+  color: var(--app-muted-fg);
+  min-width: 56px;
+  text-align: right;
+}
+
+.wb-tool--panel {
+  flex: none;
+}
+
+.wb-boardname {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--app-fg);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: none;
+}
+
+/* ---- Body layout (sidebar + stage) ---- */
+.wb-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ---- Board sidebar ---- */
+.wb-sidebar {
+  width: 232px;
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  background: var(--app-card);
+  border-right: 1px solid color-mix(in srgb, var(--app-border) 70%, transparent);
+  overflow: hidden;
+}
+
+.wb-sidebar__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 14px 10px;
+}
+
+.wb-sidebar__title {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--app-muted-fg);
+}
+
+.wb-newboard {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 10px;
+  background: var(--app-accent);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  box-shadow: 0 2px 8px rgba(208, 111, 37, 0.28);
+}
+
+.wb-newboard:hover {
+  background: color-mix(in srgb, var(--app-accent) 88%, #000);
+}
+
+.wb-newboard--cta {
+  margin-top: 10px;
+}
+
+.wb-sidebar__empty {
+  padding: 18px 16px;
+  text-align: center;
+  color: var(--app-muted-fg);
+  font-size: 13px;
+}
+
+.wb-boardlist {
+  list-style: none;
+  margin: 0;
+  padding: 4px 8px 12px;
+  overflow-y: auto;
+  flex: 1;
   min-height: 0;
 }
 
-.whiteboard-shell .excalidraw {
-  --color-primary: #434E3F;
-  --color-primary-darker: #32352E;
-  --color-primary-darkest: #2a2d26;
-  --color-primary-light: #E0E1CA;
-  font-family: 'Inter', system-ui, sans-serif;
+.wb-boarditem {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 12px;
+  padding: 2px 4px 2px 0;
+  transition: background 0.15s ease;
 }
 
-.app-loading {
-  display: grid;
+.wb-boarditem + .wb-boarditem {
+  margin-top: 2px;
+}
+
+.wb-boarditem:hover {
+  background: color-mix(in srgb, var(--app-fg) 5%, transparent);
+}
+
+.wb-boarditem--active {
+  background: color-mix(in srgb, var(--app-accent) 14%, transparent);
+}
+
+.wb-boarditem--active:hover {
+  background: color-mix(in srgb, var(--app-accent) 18%, transparent);
+}
+
+.wb-boarditem__open {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 8px 10px;
+  border-radius: 10px;
+  text-align: left;
+  color: var(--app-fg);
+}
+
+.wb-boarditem__open:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: -2px;
+}
+
+.wb-boarditem__name {
+  font-size: 13px;
+  font-weight: 600;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wb-boarditem--active .wb-boarditem__name {
+  color: color-mix(in srgb, var(--app-accent) 70%, var(--app-fg));
+}
+
+.wb-boarditem__time {
+  font-size: 11px;
+  color: var(--app-muted-fg);
+}
+
+.wb-boarditem__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.wb-boarditem:hover .wb-boarditem__actions,
+.wb-boarditem--active .wb-boarditem__actions {
+  opacity: 1;
+}
+
+.wb-boarditem__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  color: var(--app-muted-fg);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.wb-boarditem__action:hover {
+  background: color-mix(in srgb, var(--app-fg) 8%, transparent);
+  color: var(--app-fg);
+}
+
+.wb-boarditem__action--danger:hover {
+  background: color-mix(in srgb, var(--app-danger) 14%, transparent);
+  color: var(--app-danger);
+}
+
+.wb-boarditem__action:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 1px;
+}
+
+.wb-rename-input {
+  flex: 1;
+  min-width: 0;
+  margin: 4px 4px 4px 6px;
+  padding: 6px 8px;
+  border: 1px solid var(--app-accent);
+  border-radius: 8px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  font-family: var(--app-font);
+  font-size: 13px;
+  font-weight: 600;
+  outline: none;
+}
+
+/* ---- Stage / canvas ---- */
+.wb-stage {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.wb-canvas {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
-  place-items: center;
-  background: linear-gradient(170deg, #F7F1E7 0%, #F3EAE0 30%, #F7F3ED 60%, #F7F1E7 100%);
-  color: #7A7768;
-  font-size: 0.875rem;
-  letter-spacing: 0;
+  touch-action: none;
+  display: block;
 }
 
-.save-pill {
-  position: fixed;
-  right: 1rem;
-  bottom: 1rem;
-  z-index: 10;
-  min-width: 5.5rem;
-  border: 1px solid rgba(214,211,200,0.35);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.65);
-  box-shadow: 0 10px 30px rgba(50,53,46,0.12);
-  color: #32352E;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1;
-  padding: 0.55rem 0.75rem;
+.wb-grid-dot {
+  fill: color-mix(in srgb, var(--app-fg) 16%, transparent);
+}
+
+.wb-grid-bg {
+  pointer-events: none;
+}
+
+.wb-el {
+  transition: opacity 0.12s ease;
+}
+
+.wb-selbox {
+  fill: none;
+  stroke: var(--app-accent);
+  stroke-width: 1.5;
+  stroke-dasharray: 5 4;
+  pointer-events: none;
+}
+
+.wb-marquee {
+  fill: color-mix(in srgb, var(--app-accent) 12%, transparent);
+  stroke: var(--app-accent);
+  stroke-width: 1;
+  stroke-dasharray: 4 3;
+  pointer-events: none;
+}
+
+.wb-sticky {
+  filter: drop-shadow(0 4px 10px rgba(50, 53, 46, 0.16));
+}
+
+.wb-sticky-text,
+.wb-text {
+  width: 100%;
+  height: 100%;
+  padding: 8px 10px;
+  font-family: var(--app-font);
+  font-size: 15px;
+  line-height: 1.35;
+  color: #32352e;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.wb-text {
+  padding: 0;
+}
+
+/* ---- Empty state ---- */
+.wb-empty {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   text-align: center;
-  backdrop-filter: blur(14px);
+  max-width: 360px;
+  padding: 28px;
+  pointer-events: none;
 }
 
-.save-pill--saving {
-  color: #434E3F;
+.wb-empty__mark {
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 18px;
+  display: grid;
+  place-items: center;
+  border-radius: 20px;
+  background: var(--app-card);
+  color: var(--app-accent);
+  box-shadow: 0 8px 22px rgba(50, 53, 46, 0.12);
 }
 
-.save-pill--error {
-  color: #C4342D;
+.wb-empty h2 {
+  margin: 0 0 6px;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.wb-empty p {
+  margin: 0 0 18px;
+  color: var(--app-muted-fg);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.wb-empty__cta {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border: none;
+  border-radius: 12px;
+  background: var(--app-accent);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  box-shadow: 0 4px 12px rgba(208, 111, 37, 0.3);
+}
+
+.wb-empty__cta:hover {
+  background: color-mix(in srgb, var(--app-accent) 88%, #000);
+}
+
+/* ---- Zoom control ---- */
+.wb-zoom {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--app-card);
+  border: 1px solid color-mix(in srgb, var(--app-border) 70%, transparent);
+  border-radius: 12px;
+  padding: 4px;
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.1);
+}
+
+.wb-zoom button {
+  border: none;
+  background: transparent;
+  color: var(--app-fg);
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+}
+
+.wb-zoom button:hover {
+  background: color-mix(in srgb, var(--app-fg) 6%, transparent);
+}
+
+.wb-zoom__level {
+  width: auto !important;
+  padding: 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- Text editor overlay ---- */
+.wb-text-editor {
+  position: absolute;
+  z-index: 20;
+  border: 2px solid var(--app-accent);
+  border-radius: 8px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  font-family: var(--app-font);
+  font-size: 15px;
+  line-height: 1.35;
+  padding: 6px 8px;
+  resize: none;
+  outline: none;
+  box-shadow: 0 8px 22px rgba(50, 53, 46, 0.18);
+}
+
+/* ---- Toast ---- */
+.wb-toast {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 10px 16px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: 0 8px 22px rgba(50, 53, 46, 0.18);
+}
+
+.wb-toast--error {
+  background: var(--app-danger);
+  color: #fff;
+}
+
+/* ---- Modal ---- */
+.wb-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  background: rgba(50, 53, 46, 0.32);
+  backdrop-filter: blur(2px);
+}
+
+.wb-modal__card {
+  width: min(360px, 90vw);
+  background: var(--app-card);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 18px 48px rgba(50, 53, 46, 0.28);
+}
+
+.wb-modal__card h3 {
+  margin: 0 0 8px;
+  font-size: 18px;
+}
+
+.wb-modal__card p {
+  margin: 0 0 20px;
+  color: var(--app-muted-fg);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.wb-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.wb-btn-ghost,
+.wb-btn-danger {
+  padding: 9px 16px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.15s ease;
+}
+
+.wb-btn-ghost {
+  background: transparent;
+  color: var(--app-fg);
+  border-color: color-mix(in srgb, var(--app-border) 80%, transparent);
+}
+
+.wb-btn-ghost:hover {
+  background: color-mix(in srgb, var(--app-fg) 6%, transparent);
+}
+
+.wb-btn-danger {
+  background: var(--app-danger);
+  color: #fff;
+}
+
+.wb-btn-danger:hover {
+  background: color-mix(in srgb, var(--app-danger) 88%, #000);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
+.wb-app--reduced * {
+  transition: none !important;
+  animation: none !important;
 }

--- a/home/apps/whiteboard/src/styles.css
+++ b/home/apps/whiteboard/src/styles.css
@@ -602,11 +602,8 @@ body {
   border: 2px solid var(--app-accent);
   border-radius: 8px;
   background: var(--app-card);
-  color: var(--app-fg);
   font-family: var(--app-font);
-  font-size: 15px;
-  line-height: 1.35;
-  padding: 6px 8px;
+  padding: 0;
   resize: none;
   outline: none;
   box-shadow: 0 8px 22px rgba(50, 53, 46, 0.18);

--- a/home/apps/whiteboard/tsconfig.json
+++ b/home/apps/whiteboard/tsconfig.json
@@ -1,13 +1,20 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "esModuleInterop": true,
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
   },
-  "include": ["src", "scripts"]
+  "include": ["src"]
 }

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -322,6 +322,37 @@ describe("Whiteboard app", () => {
 
     expect(screen.queryByText("Committed text")).toBeNull();
   });
+
+  it("reopens placed text for editing and commits a second edit", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Text (T)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 120, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    const editor = screen.getByLabelText("Edit text") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "Initial text" } });
+    fireEvent.keyDown(editor, { key: "Enter", metaKey: true });
+
+    fireEvent.doubleClick(screen.getByText("Initial text"));
+    const reopened = screen.getByLabelText("Edit text") as HTMLTextAreaElement;
+    expect(reopened.value).toBe("Initial text");
+    fireEvent.change(reopened, { target: { value: "Revised text" } });
+    fireEvent.keyDown(reopened, { key: "Enter", metaKey: true });
+
+    expect(screen.getByText("Revised text")).toBeTruthy();
+    expect(screen.queryByText("Initial text")).toBeNull();
+  });
 });
 
 describe("Whiteboard app — multi-board files", () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -94,6 +94,25 @@ describe("Whiteboard app", () => {
     expect(screen.getByRole("button", { name: "Undo" })).toBeTruthy();
   });
 
+  it("does not switch drawing tools for browser modifier shortcuts", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const select = screen.getByRole("button", { name: "Select (V)" });
+    const pen = screen.getByRole("button", { name: "Pen (P)" });
+    expect(select.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.keyDown(window, { key: "p", ctrlKey: true });
+    expect(select.getAttribute("aria-pressed")).toBe("true");
+    expect(pen.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.keyDown(window, { key: "p" });
+    expect(pen.getAttribute("aria-pressed")).toBe("true");
+  });
+
   it("shows an empty-state onboarding affordance when the board is blank", async () => {
     installMatrixDb([]);
     render(<App />);

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -167,6 +167,7 @@ describe("Whiteboard app — multi-board files", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    db.insert.mockClear();
 
     const newBtn = screen.getByRole("button", { name: /new board/i });
     await act(async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -243,16 +243,22 @@ describe("Whiteboard app — multi-board files", () => {
       await Promise.resolve();
     });
 
+    db.find.mockRejectedValueOnce(new Error("list failed"));
     fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
     const input = screen.getByLabelText(/rename sprint plan/i);
     fireEvent.change(input, { target: { value: "Launch plan" } });
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
       await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     expect(screen.getByText("Could not rename the board.")).toBeTruthy();
     expect(screen.getByDisplayValue("Launch plan")).toBeTruthy();
+    fireEvent.keyDown(screen.getByDisplayValue("Launch plan"), { key: "Escape" });
+    expect(screen.getAllByText("Sprint plan").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Launch plan")).toBeNull();
   });
 
   it("loads the active board's doc when switching boards", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/whiteboard/src/App";
@@ -347,6 +347,39 @@ describe("Whiteboard app — multi-board files", () => {
     // the toolbar, so use getAllByText for the active one).
     expect(screen.getByText("Sprint plan")).toBeTruthy();
     expect(screen.getAllByText("Wireframe").length).toBeGreaterThan(0);
+  });
+
+  it("scrolls the active board into view after selection", async () => {
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+      board("b2", "Wireframe", "2026-03-03T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    scrollIntoView.mockClear();
+
+    const sprintButton = screen.getByText("Sprint plan").closest("button");
+    if (!sprintButton) throw new Error("Expected Sprint plan board button");
+    fireEvent.click(sprintButton);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    if (originalScrollIntoView) {
+      Object.defineProperty(Element.prototype, "scrollIntoView", {
+        configurable: true,
+        value: originalScrollIntoView,
+      });
+    } else {
+      Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+    }
   });
 
   it("creates a new board via db.insert when New board is clicked", async () => {
@@ -955,6 +988,34 @@ describe("Whiteboard app — multi-board files", () => {
 
     expect(screen.getByText("Could not delete the board.")).toBeTruthy();
     expect(screen.getByRole("dialog", { name: /delete board/i })).toBeTruthy();
+  });
+
+  it("traps keyboard focus inside delete confirmation", async () => {
+    installMatrixDb([
+      board("b1", "Keep me", "2026-02-02T00:00:00.000Z"),
+      board("b2", "Delete me", "2026-03-03T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /delete board delete me/i }));
+    const dialog = screen.getByRole("dialog", { name: /delete board/i });
+    const cancel = within(dialog).getByRole("button", { name: /cancel/i });
+    const confirm = within(dialog).getByRole("button", { name: /^delete board$/i });
+
+    expect(document.activeElement).toBe(cancel);
+
+    fireEvent.keyDown(cancel, { key: "Tab" });
+    expect(document.activeElement).toBe(confirm);
+
+    fireEvent.keyDown(confirm, { key: "Tab" });
+    expect(document.activeElement).toBe(cancel);
+
+    fireEvent.keyDown(cancel, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(confirm);
   });
 
   it("dismisses delete confirmation with Escape", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -902,8 +902,53 @@ describe("Whiteboard app — multi-board files", () => {
 
     fireEvent.click(screen.getByTitle("Export PNG"));
 
-    expect(ctx.fillText).toHaveBeenCalledWith("First line", 40, 70);
-    expect(ctx.fillText).toHaveBeenCalledWith("Second line", 40, 92);
+    expect(ctx.fillText).toHaveBeenCalledWith("First line", 40, 50);
+    expect(ctx.fillText).toHaveBeenCalledWith("Second line", 40, 77);
+  });
+
+  it("spaces exported text lines from the rendered font size", async () => {
+    installMatrixDb([
+      {
+        ...board("b1", "Sketch", "2026-02-02T00:00:00.000Z"),
+        doc: {
+          version: 1,
+          elements: [
+            { id: "t1", kind: "text", x: 40, y: 50, width: 200, height: 120, stroke: "#111", fill: "transparent", strokeWidth: 8, text: "First line\nSecond line" },
+          ],
+        },
+      },
+    ]);
+    const fonts: string[] = [];
+    const baselines: string[] = [];
+    const ctx = {
+      fillRect: vi.fn(),
+      fillText: vi.fn(),
+      measureText: vi.fn((value: string) => ({ width: value.length * 8 })),
+      translate: vi.fn(),
+      set fillStyle(_value: string) {},
+      set font(value: string) { fonts.push(value); },
+      set lineCap(_value: string) {},
+      set lineJoin(_value: string) {},
+      set lineWidth(_value: number) {},
+      set strokeStyle(_value: string) {},
+      set textBaseline(value: CanvasTextBaseline) { baselines.push(value); },
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/png;base64,stub");
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTitle("Export PNG"));
+
+    expect(fonts).toContain("34px Inter, system-ui, sans-serif");
+    expect(baselines).toContain("top");
+    expect(ctx.fillText).toHaveBeenCalledWith("First line", 40, 50);
+    expect(ctx.fillText).toHaveBeenCalledWith("Second line", 40, 96);
   });
 
   it("does not reset the active canvas selection for table-wide change notifications", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -1231,6 +1231,27 @@ describe("Whiteboard app — multi-board files", () => {
     expect(document.activeElement).toBe(confirm);
   });
 
+  it("does not switch tools from shortcuts while delete confirmation is open", async () => {
+    installMatrixDb([
+      board("b1", "Keep me", "2026-02-02T00:00:00.000Z"),
+      board("b2", "Delete me", "2026-03-03T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /delete board delete me/i }));
+    const dialog = screen.getByRole("dialog", { name: /delete board/i });
+    const cancel = within(dialog).getByRole("button", { name: /cancel/i });
+
+    fireEvent.keyDown(cancel, { key: "r" });
+
+    expect(screen.getByRole("button", { name: "Select (V)" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Rectangle (R)" }).getAttribute("aria-pressed")).toBe("false");
+  });
+
   it("dismisses delete confirmation with Escape", async () => {
     installMatrixDb([
       board("b1", "Keep me", "2026-02-02T00:00:00.000Z"),

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -202,6 +202,36 @@ describe("Whiteboard app", () => {
     const sawRect = allCalls.some((call) => JSON.stringify(call).includes("rect"));
     expect(sawRect).toBe(true);
   });
+
+  it("discards in-progress rectangles when the pointer is canceled", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Rectangle (R)" }));
+
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 220, clientY: 180, pointerId: 1 });
+      fireEvent.pointerCancel(canvas, { clientX: 220, clientY: 180, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("whiteboard-empty")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1200);
+    });
+
+    const allCalls = [...db.insert.mock.calls, ...db.update.mock.calls];
+    const sawRect = allCalls.some((call) => JSON.stringify(call).includes("rect"));
+    expect(sawRect).toBe(false);
+  });
 });
 
 describe("Whiteboard app — multi-board files", () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -11,6 +11,7 @@ function installMatrixDb(rows: DbRow[] = []) {
   // and find() can be filtered/sorted like the bridge calls the app relies on.
   const store: DbRow[] = rows.map((r) => ({ ...r }));
   let seq = 0;
+  let onChangeHandler: (() => void) | null = null;
   const db = {
     find: vi.fn(async (_table: string, opts?: { where?: Record<string, unknown>; orderBy?: Record<string, "asc" | "desc"> }) => {
       const where = opts?.where;
@@ -48,7 +49,15 @@ function installMatrixDb(rows: DbRow[] = []) {
       return { ok: true };
     }),
     count: vi.fn(async () => store.length),
-    onChange: vi.fn(() => () => undefined),
+    onChange: vi.fn((_table: string, callback: () => void) => {
+      onChangeHandler = callback;
+      return () => {
+        onChangeHandler = null;
+      };
+    }),
+    emitChange: () => {
+      onChangeHandler?.();
+    },
   };
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
@@ -223,6 +232,8 @@ describe("Whiteboard app", () => {
     });
 
     expect(screen.getByTestId("whiteboard-empty")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Select (V)" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Rectangle (R)" }).getAttribute("aria-pressed")).toBe("false");
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1200);
@@ -253,6 +264,63 @@ describe("Whiteboard app", () => {
     const editor = screen.getByLabelText("Edit text") as HTMLTextAreaElement;
     expect(editor.style.fontSize).toBe("22px");
     expect(editor.style.lineHeight).toBe("1.35");
+  });
+
+  it("does not commit cancelled text edits when Escape is followed by blur", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Text (T)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 120, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    const editor = screen.getByLabelText("Edit text") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "Draft text" } });
+    fireEvent.keyDown(editor, { key: "Escape" });
+    fireEvent.blur(editor);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1200);
+    });
+
+    expect(JSON.stringify(db.update.mock.calls)).not.toContain("Draft text");
+    expect(screen.queryByLabelText("Edit text")).toBeNull();
+  });
+
+  it("does not add a duplicate undo entry when a committed text edit blurs after unmount", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Text (T)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 120, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    const editor = screen.getByLabelText("Edit text") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "Committed text" } });
+    fireEvent.keyDown(editor, { key: "Enter", metaKey: true });
+    fireEvent.blur(editor);
+
+    expect(screen.getByText("Committed text")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+
+    expect(screen.queryByText("Committed text")).toBeNull();
   });
 });
 
@@ -384,6 +452,34 @@ describe("Whiteboard app — multi-board files", () => {
     expect(screen.queryByText("Launch plan")).toBeNull();
   });
 
+  it("clears a failed rename editor when switching boards", async () => {
+    const db = installMatrixDb([
+      board("board-a", "Board A", "2026-04-04T00:00:00.000Z"),
+      board("board-b", "Board B", "2026-02-02T00:00:00.000Z"),
+    ]);
+    db.update.mockRejectedValueOnce(new Error("rename failed"));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board board a/i }));
+    const input = screen.getByLabelText(/rename board a/i);
+    fireEvent.change(input, { target: { value: "Renamed A" } });
+    await act(async () => {
+      fireEvent.blur(input);
+      fireEvent.click(screen.getByText("Board B"));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.update).toHaveBeenCalledWith("scenes", "board-a", expect.objectContaining({ name: "Renamed A" }));
+    expect(screen.queryByDisplayValue("Renamed A")).toBeNull();
+    expect(screen.getAllByText("Board B").length).toBeGreaterThan(0);
+  });
+
   it("does not commit a cancelled board rename when Escape is followed by blur", async () => {
     const db = installMatrixDb([
       board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
@@ -406,6 +502,32 @@ describe("Whiteboard app — multi-board files", () => {
     expect(db.update).not.toHaveBeenCalledWith("scenes", "b1", expect.objectContaining({ name: "Launch plan" }));
     expect(screen.getAllByText("Sprint plan").length).toBeGreaterThan(0);
     expect(screen.queryByText("Launch plan")).toBeNull();
+  });
+
+  it("does not commit a board rename twice when Enter is followed by blur", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
+    const input = screen.getByLabelText(/rename sprint plan/i);
+    fireEvent.change(input, { target: { value: "Launch plan" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.blur(input);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const renameCalls = db.update.mock.calls.filter(
+      ([table, id, data]) => table === "scenes" && id === "b1" && data.name === "Launch plan",
+    );
+    expect(renameCalls).toHaveLength(1);
   });
 
   it("clears the rename error after a recovery refresh succeeds", async () => {
@@ -476,6 +598,90 @@ describe("Whiteboard app — multi-board files", () => {
     expect(loadedById || loadedOne).toBe(true);
   });
 
+  it("fills ellipses when exporting PNGs", async () => {
+    installMatrixDb([
+      {
+        ...board("b1", "Sketch", "2026-02-02T00:00:00.000Z"),
+        doc: {
+          version: 1,
+          elements: [
+            { id: "e1", kind: "ellipse", x: 20, y: 30, width: 80, height: 50, stroke: "#000", fill: "#F87171", strokeWidth: 2 },
+          ],
+        },
+      },
+    ]);
+    const ctx = {
+      beginPath: vi.fn(),
+      ellipse: vi.fn(),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      stroke: vi.fn(),
+      translate: vi.fn(),
+      set fillStyle(_value: string) {},
+      set lineCap(_value: string) {},
+      set lineJoin(_value: string) {},
+      set lineWidth(_value: number) {},
+      set strokeStyle(_value: string) {},
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/png;base64,stub");
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTitle("Export PNG"));
+
+    expect(ctx.ellipse).toHaveBeenCalled();
+    expect(ctx.fill).toHaveBeenCalled();
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it("does not reset the active canvas selection for table-wide change notifications", async () => {
+    const db = installMatrixDb([
+      {
+        id: "b1",
+        name: "Sketch",
+        doc: {
+          version: 1,
+          elements: [
+            { id: "r1", kind: "rect", x: 10, y: 10, width: 80, height: 50, stroke: "#000", fill: "transparent", strokeWidth: 2 },
+          ],
+        },
+        created_at: "2026-02-02T00:00:00.000Z",
+        updated_at: "2026-02-02T00:00:00.000Z",
+      },
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 20, clientY: 20, button: 0, pointerId: 1 });
+      await Promise.resolve();
+    });
+    expect(document.querySelector(".wb-el--selected")).toBeTruthy();
+
+    db.find.mockClear();
+    await act(async () => {
+      db.emitChange();
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector(".wb-el--selected")).toBeTruthy();
+    expect(db.find.mock.calls.some(
+      ([table, opts]) =>
+        table === "scenes" &&
+        (opts as { where?: Record<string, unknown> } | undefined)?.where?.id === "b1",
+    )).toBe(false);
+  });
+
   it("clears a flushed save indicator when switching boards", async () => {
     const db = installMatrixDb([
       board("old-board", "Old board", "2026-02-02T00:00:00.000Z"),
@@ -504,6 +710,56 @@ describe("Whiteboard app — multi-board files", () => {
     });
 
     expect(screen.queryByText("Saving…")).toBeNull();
+  });
+
+  it("does not save a blurred text editor to the next board during switch", async () => {
+    const db = installMatrixDb([
+      board("board-a", "Board A", "2026-04-04T00:00:00.000Z"),
+      board("board-b", "Board B", "2026-02-02T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Text (T)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 120, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    const editor = screen.getByLabelText("Edit text") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "Hello from A" } });
+    db.update.mockClear();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Board B"));
+      fireEvent.blur(editor);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1200);
+    });
+
+    const corruptedB = db.update.mock.calls.some(
+      ([table, id, data]) =>
+        table === "scenes" &&
+        id === "board-b" &&
+        JSON.stringify((data as Record<string, unknown>).doc).includes("Hello from A"),
+    );
+    const savedA = db.update.mock.calls.some(
+      ([table, id, data]) =>
+        table === "scenes" &&
+        id === "board-a" &&
+        JSON.stringify((data as Record<string, unknown>).doc).includes("Hello from A"),
+    );
+    expect(corruptedB).toBe(false);
+    expect(savedA).toBe(true);
   });
 
   it("autosaves edits to the ACTIVE board's row via db.update", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -232,6 +232,28 @@ describe("Whiteboard app", () => {
     const sawRect = allCalls.some((call) => JSON.stringify(call).includes("rect"));
     expect(sawRect).toBe(false);
   });
+
+  it("matches the text editor font metrics to rendered text", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Text (T)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 120, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 260, clientY: 150, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    const editor = screen.getByLabelText("Edit text") as HTMLTextAreaElement;
+    expect(editor.style.fontSize).toBe("22px");
+    expect(editor.style.lineHeight).toBe("1.35");
+  });
 });
 
 describe("Whiteboard app — multi-board files", () => {
@@ -428,6 +450,36 @@ describe("Whiteboard app — multi-board files", () => {
     );
     const loadedOne = db.findOne.mock.calls.some(([table, id]) => table === "scenes" && id === "b1");
     expect(loadedById || loadedOne).toBe(true);
+  });
+
+  it("clears a flushed save indicator when switching boards", async () => {
+    const db = installMatrixDb([
+      board("old-board", "Old board", "2026-02-02T00:00:00.000Z"),
+      board("new-board", "New board", "2026-04-04T00:00:00.000Z"),
+    ]);
+    db.update.mockImplementationOnce(async () => new Promise(() => undefined));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Rectangle (R)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 200, clientY: 160, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 200, clientY: 160, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Old board"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("Saving…")).toBeNull();
   });
 
   it("autosaves edits to the ACTIVE board's row via db.update", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -371,6 +371,39 @@ describe("Whiteboard app — multi-board files", () => {
     expect(typeof inserted.name).toBe("string");
   });
 
+  it("reserves generated board names during rapid consecutive creates", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    const resolvers: Array<() => void> = [];
+    db.insert.mockImplementation(async (_table: string, data: Record<string, unknown>) => {
+      const id = `scene-new-${resolvers.length + 1}`;
+      await new Promise<void>((resolve) => {
+        resolvers.push(resolve);
+      });
+      return { id, ...data };
+    });
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    db.insert.mockClear();
+
+    const newBtn = screen.getByRole("button", { name: /new board/i });
+    fireEvent.click(newBtn);
+    fireEvent.click(newBtn);
+
+    expect(db.insert).toHaveBeenNthCalledWith(1, "scenes", expect.objectContaining({ name: "Untitled board" }));
+    expect(db.insert).toHaveBeenNthCalledWith(2, "scenes", expect.objectContaining({ name: "Untitled board 2" }));
+
+    await act(async () => {
+      for (const resolve of resolvers) resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
   it("recovers the initial loading state when first board creation fails", async () => {
     const db = installMatrixDb([]);
     db.insert.mockRejectedValueOnce(new Error("create failed"));
@@ -638,6 +671,89 @@ describe("Whiteboard app — multi-board files", () => {
     expect(ctx.ellipse).toHaveBeenCalled();
     expect(ctx.fill).toHaveBeenCalled();
     expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it("fills arrowheads when exporting PNGs", async () => {
+    installMatrixDb([
+      {
+        ...board("b1", "Sketch", "2026-02-02T00:00:00.000Z"),
+        doc: {
+          version: 1,
+          elements: [
+            { id: "a1", kind: "arrow", x1: 20, y1: 30, x2: 100, y2: 90, stroke: "#000", strokeWidth: 2 },
+          ],
+        },
+      },
+    ]);
+    const ctx = {
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      lineTo: vi.fn(),
+      moveTo: vi.fn(),
+      stroke: vi.fn(),
+      translate: vi.fn(),
+      set fillStyle(_value: string) {},
+      set lineCap(_value: string) {},
+      set lineJoin(_value: string) {},
+      set lineWidth(_value: number) {},
+      set strokeStyle(_value: string) {},
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/png;base64,stub");
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTitle("Export PNG"));
+
+    expect(ctx.closePath).toHaveBeenCalled();
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  it("preserves explicit text newlines when exporting PNGs", async () => {
+    installMatrixDb([
+      {
+        ...board("b1", "Sketch", "2026-02-02T00:00:00.000Z"),
+        doc: {
+          version: 1,
+          elements: [
+            { id: "t1", kind: "text", x: 40, y: 50, width: 200, height: 80, stroke: "#111", fill: "transparent", strokeWidth: 1, text: "First line\nSecond line" },
+          ],
+        },
+      },
+    ]);
+    const ctx = {
+      fillRect: vi.fn(),
+      fillText: vi.fn(),
+      measureText: vi.fn((value: string) => ({ width: value.length * 8 })),
+      translate: vi.fn(),
+      set fillStyle(_value: string) {},
+      set font(_value: string) {},
+      set lineCap(_value: string) {},
+      set lineJoin(_value: string) {},
+      set lineWidth(_value: number) {},
+      set strokeStyle(_value: string) {},
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/png;base64,stub");
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTitle("Export PNG"));
+
+    expect(ctx.fillText).toHaveBeenCalledWith("First line", 40, 70);
+    expect(ctx.fillText).toHaveBeenCalledWith("Second line", 40, 92);
   });
 
   it("does not reset the active canvas selection for table-wide change notifications", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -1086,7 +1086,7 @@ describe("Whiteboard app — multi-board files", () => {
         doc: {
           version: 1,
           elements: [
-            { id: "t1", kind: "text", x: 40, y: 50, width: 200, height: 80, stroke: "#111", fill: "transparent", strokeWidth: 1, text: "First line\nSecond line" },
+            { id: "t1", kind: "text", x: 40, y: 50, width: 200, height: 80, stroke: "#111", fill: "transparent", strokeWidth: 1, text: "  First line\nSecond line" },
           ],
         },
       },
@@ -1115,7 +1115,7 @@ describe("Whiteboard app — multi-board files", () => {
 
     fireEvent.click(screen.getByTitle("Export PNG"));
 
-    expect(ctx.fillText).toHaveBeenCalledWith("First line", 40, 50);
+    expect(ctx.fillText).toHaveBeenCalledWith("  First line", 40, 50);
     expect(ctx.fillText).toHaveBeenCalledWith("Second line", 40, 77);
   });
 

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -500,29 +500,32 @@ describe("Whiteboard app — multi-board files", () => {
       configurable: true,
       value: scrollIntoView,
     });
-    installMatrixDb([
-      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
-      board("b2", "Wireframe", "2026-03-03T00:00:00.000Z"),
-    ]);
-    render(<App />);
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    scrollIntoView.mockClear();
-
-    const sprintButton = screen.getByText("Sprint plan").closest("button");
-    if (!sprintButton) throw new Error("Expected Sprint plan board button");
-    fireEvent.click(sprintButton);
-
-    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
-    if (originalScrollIntoView) {
-      Object.defineProperty(Element.prototype, "scrollIntoView", {
-        configurable: true,
-        value: originalScrollIntoView,
+    try {
+      installMatrixDb([
+        board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+        board("b2", "Wireframe", "2026-03-03T00:00:00.000Z"),
+      ]);
+      render(<App />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
       });
-    } else {
-      Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+      scrollIntoView.mockClear();
+
+      const sprintButton = screen.getByText("Sprint plan").closest("button");
+      if (!sprintButton) throw new Error("Expected Sprint plan board button");
+      fireEvent.click(sprintButton);
+
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    } finally {
+      if (originalScrollIntoView) {
+        Object.defineProperty(Element.prototype, "scrollIntoView", {
+          configurable: true,
+          value: originalScrollIntoView,
+        });
+      } else {
+        Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+      }
     }
   });
 

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/whiteboard/src/App";
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  // Mutable backing store so insert/update/delete + find reflect each other,
+  // and find() can be filtered by `where` (the app loads a board by id).
+  const store: DbRow[] = rows.map((r) => ({ ...r }));
+  let seq = 0;
+  const db = {
+    find: vi.fn(async (_table: string, opts?: { where?: Record<string, unknown> }) => {
+      const where = opts?.where;
+      const matched = where
+        ? store.filter((r) => Object.entries(where).every(([k, v]) => r[k] === v))
+        : store;
+      return matched.map((r) => ({ ...r }));
+    }),
+    findOne: vi.fn(async (_table: string, id: string) => {
+      const row = store.find((r) => r.id === id);
+      return row ? { ...row } : null;
+    }),
+    insert: vi.fn(async (_table: string, data: Record<string, unknown>) => {
+      seq += 1;
+      const id = `scene-${seq}`;
+      store.push({ id, created_at: new Date().toISOString(), ...data });
+      return { id };
+    }),
+    update: vi.fn(async (_table: string, id: string, data: Record<string, unknown>) => {
+      const row = store.find((r) => r.id === id);
+      if (row) Object.assign(row, data);
+      return { ok: true };
+    }),
+    delete: vi.fn(async (_table: string, id: string) => {
+      const i = store.findIndex((r) => r.id === id);
+      if (i >= 0) store.splice(i, 1);
+      return { ok: true };
+    }),
+    count: vi.fn(async () => store.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+// jsdom lacks these canvas/SVG APIs the app touches defensively.
+beforeEach(() => {
+  vi.useFakeTimers();
+  // pointer capture is a no-op in jsdom
+  if (!(Element.prototype as { setPointerCapture?: unknown }).setPointerCapture) {
+    (Element.prototype as unknown as Record<string, unknown>).setPointerCapture = () => undefined;
+    (Element.prototype as unknown as Record<string, unknown>).releasePointerCapture = () => undefined;
+  }
+  // getBoundingClientRect returns zeros in jsdom by default; give the canvas a size
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+    x: 0, y: 0, top: 0, left: 0, right: 1000, bottom: 700, width: 1000, height: 700, toJSON: () => ({}),
+  } as DOMRect);
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(window, "MatrixOS");
+});
+
+describe("Whiteboard app", () => {
+  it("renders the toolbar with the core drawing tools", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Tool buttons expose accessible names via aria-label.
+    expect(screen.getByRole("button", { name: "Select (V)" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Pen (P)" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Rectangle (R)" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Ellipse (O)" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Undo" })).toBeTruthy();
+  });
+
+  it("shows an empty-state onboarding affordance when the board is blank", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("whiteboard-empty")).toBeTruthy();
+  });
+
+  it("draws a rectangle which adds an element and autosaves to the DB", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+    // Init: empty store -> a first board is created and opened.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Pick the rectangle tool.
+    fireEvent.click(screen.getByRole("button", { name: "Rectangle (R)" }));
+
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    // Drag to draw a rectangle.
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 220, clientY: 180, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 220, clientY: 180, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    // One element now exists -> empty state is gone.
+    expect(screen.queryByTestId("whiteboard-empty")).toBeNull();
+
+    // Debounced autosave fires after the timer elapses.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1200);
+    });
+
+    // The board row is persisted through the bridge (insert on create, then
+    // update for the drawn rect) — never via a raw fetch.
+    const persisted = db.insert.mock.calls.length + db.update.mock.calls.length;
+    expect(persisted).toBeGreaterThan(0);
+    const allCalls = [...db.insert.mock.calls, ...db.update.mock.calls];
+    const sawRect = allCalls.some((call) => JSON.stringify(call).includes("rect"));
+    expect(sawRect).toBe(true);
+  });
+});
+
+describe("Whiteboard app — multi-board files", () => {
+  const board = (id: string, name: string, updatedAt: string): DbRow => ({
+    id,
+    name,
+    doc: { version: 1, elements: [] },
+    created_at: updatedAt,
+    updated_at: updatedAt,
+  });
+
+  it("lists existing boards by name in the file sidebar", async () => {
+    installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+      board("b2", "Wireframe", "2026-03-03T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // Names render in the sidebar list (the active board's name also shows in
+    // the toolbar, so use getAllByText for the active one).
+    expect(screen.getByText("Sprint plan")).toBeTruthy();
+    expect(screen.getAllByText("Wireframe").length).toBeGreaterThan(0);
+  });
+
+  it("creates a new board via db.insert when New board is clicked", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const newBtn = screen.getByRole("button", { name: /new board/i });
+    await act(async () => {
+      fireEvent.click(newBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).toHaveBeenCalled();
+    expect(db.insert.mock.calls[0][0]).toBe("scenes");
+    const inserted = db.insert.mock.calls[0][1] as Record<string, unknown>;
+    expect(typeof inserted.name).toBe("string");
+  });
+
+  it("loads the active board's doc when switching boards", async () => {
+    const db = installMatrixDb([
+      board("b1", "Empty one", "2026-02-02T00:00:00.000Z"),
+    ]);
+    // Give b2 a real element so we can assert its doc loads on switch.
+    db.insert.mockClear();
+    // Seed a second board directly in the store via insert mock semantics:
+    await db.insert("scenes", {
+      name: "Has a rect",
+      doc: {
+        version: 1,
+        elements: [
+          { id: "r1", kind: "rect", x: 10, y: 10, width: 40, height: 30, stroke: "#000", fill: "transparent", strokeWidth: 2 },
+        ],
+      },
+      updated_at: "2026-04-04T00:00:00.000Z",
+    });
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Switch to the board named "Empty one" (the other one is active first since newer).
+    const target = screen.getByText("Empty one");
+    db.find.mockClear();
+    await act(async () => {
+      fireEvent.click(target);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Switching loads that board's row by id.
+    const loadedById = db.find.mock.calls.some(
+      ([table, opts]) =>
+        table === "scenes" &&
+        (opts as { where?: Record<string, unknown> } | undefined)?.where?.id === "b1",
+    );
+    const loadedOne = db.findOne.mock.calls.some(([table, id]) => table === "scenes" && id === "b1");
+    expect(loadedById || loadedOne).toBe(true);
+  });
+
+  it("autosaves edits to the ACTIVE board's row via db.update", async () => {
+    const db = installMatrixDb([
+      board("active-board", "My board", "2026-05-05T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Rectangle (R)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 200, clientY: 160, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 200, clientY: 160, pointerId: 1 });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1200);
+    });
+
+    const updatedActive = db.update.mock.calls.some(
+      ([table, id]) => table === "scenes" && id === "active-board",
+    );
+    expect(updatedActive).toBe(true);
+  });
+
+  it("deletes a board via db.delete after confirmation", async () => {
+    const db = installMatrixDb([
+      board("b1", "Keep me", "2026-02-02T00:00:00.000Z"),
+      board("b2", "Delete me", "2026-03-03T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Open the delete affordance for "Delete me".
+    const delBtn = screen.getByRole("button", { name: /delete board delete me/i });
+    await act(async () => {
+      fireEvent.click(delBtn);
+      await Promise.resolve();
+    });
+    // Confirm in the dialog.
+    const confirm = screen.getByRole("button", { name: /^delete board$/i });
+    await act(async () => {
+      fireEvent.click(confirm);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.delete).toHaveBeenCalledWith("scenes", "b2");
+  });
+});

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -384,6 +384,30 @@ describe("Whiteboard app — multi-board files", () => {
     expect(screen.queryByText("Launch plan")).toBeNull();
   });
 
+  it("does not commit a cancelled board rename when Escape is followed by blur", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
+    const input = screen.getByLabelText(/rename sprint plan/i);
+    fireEvent.change(input, { target: { value: "Launch plan" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    fireEvent.blur(input);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(db.update).not.toHaveBeenCalledWith("scenes", "b1", expect.objectContaining({ name: "Launch plan" }));
+    expect(screen.getAllByText("Sprint plan").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Launch plan")).toBeNull();
+  });
+
   it("clears the rename error after a recovery refresh succeeds", async () => {
     const db = installMatrixDb([
       board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -334,7 +334,11 @@ describe("Whiteboard app — multi-board files", () => {
       board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
     ]);
     db.update.mockRejectedValueOnce(new Error("rename failed"));
-    render(<App />);
+    render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>,
+    );
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -66,6 +66,25 @@ function installMatrixDb(rows: DbRow[] = []) {
   return db;
 }
 
+function persistedElementTypes(db: ReturnType<typeof installMatrixDb>) {
+  const calls = [...db.insert.mock.calls, ...db.update.mock.calls] as Array<unknown[]>;
+  return calls.flatMap((call) => {
+    const data = call.at(-1);
+    const doc = typeof data === "object" && data !== null && "doc" in data
+      ? (data as { doc?: unknown }).doc
+      : null;
+    const elements = typeof doc === "object" && doc !== null && "elements" in doc
+      ? (doc as { elements?: unknown }).elements
+      : null;
+    if (!Array.isArray(elements)) return [];
+    return elements
+      .map((element) => typeof element === "object" && element !== null && "kind" in element
+        ? (element as { kind?: unknown }).kind
+        : null)
+      .filter((kind): kind is string => typeof kind === "string");
+  });
+}
+
 // jsdom lacks these canvas/SVG APIs the app touches defensively.
 beforeEach(() => {
   vi.useFakeTimers();
@@ -208,9 +227,7 @@ describe("Whiteboard app", () => {
     // update for the drawn rect) — never via a raw fetch.
     const persisted = db.insert.mock.calls.length + db.update.mock.calls.length;
     expect(persisted).toBeGreaterThan(0);
-    const allCalls = [...db.insert.mock.calls, ...db.update.mock.calls];
-    const sawRect = allCalls.some((call) => JSON.stringify(call).includes("rect"));
-    expect(sawRect).toBe(true);
+    expect(persistedElementTypes(db)).toContain("rect");
   });
 
   it("keeps a local backup of pending autosaves on unmount", async () => {
@@ -310,9 +327,7 @@ describe("Whiteboard app", () => {
       await vi.advanceTimersByTimeAsync(1200);
     });
 
-    const allCalls = [...db.insert.mock.calls, ...db.update.mock.calls];
-    const sawRect = allCalls.some((call) => JSON.stringify(call).includes("rect"));
-    expect(sawRect).toBe(false);
+    expect(persistedElementTypes(db)).not.toContain("rect");
   });
 
   it("matches the text editor font metrics to rendered text", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -232,6 +232,20 @@ describe("Whiteboard app — multi-board files", () => {
     expect(typeof inserted.name).toBe("string");
   });
 
+  it("recovers the initial loading state when first board creation fails", async () => {
+    const db = installMatrixDb([]);
+    db.insert.mockRejectedValueOnce(new Error("create failed"));
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Could not create a board.")).toBeTruthy();
+    expect(screen.getByTestId("whiteboard-empty")).toBeTruthy();
+  });
+
   it("keeps rename editing open when the db update fails", async () => {
     const db = installMatrixDb([
       board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
@@ -358,5 +372,47 @@ describe("Whiteboard app — multi-board files", () => {
     });
 
     expect(db.delete).toHaveBeenCalledWith("scenes", "b2");
+  });
+
+  it("keeps delete confirmation open when deleting a board fails", async () => {
+    const db = installMatrixDb([
+      board("b1", "Keep me", "2026-02-02T00:00:00.000Z"),
+      board("b2", "Delete me", "2026-03-03T00:00:00.000Z"),
+    ]);
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /delete board delete me/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^delete board$/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Could not delete the board.")).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: /delete board/i })).toBeTruthy();
+  });
+
+  it("dismisses delete confirmation with Escape", async () => {
+    installMatrixDb([
+      board("b1", "Keep me", "2026-02-02T00:00:00.000Z"),
+      board("b2", "Delete me", "2026-03-03T00:00:00.000Z"),
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /delete board delete me/i }));
+    expect(screen.getByRole("dialog", { name: /delete board/i })).toBeTruthy();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog", { name: /delete board/i })).toBeNull();
   });
 });

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -8,15 +8,23 @@ type DbRow = Record<string, unknown>;
 
 function installMatrixDb(rows: DbRow[] = []) {
   // Mutable backing store so insert/update/delete + find reflect each other,
-  // and find() can be filtered by `where` (the app loads a board by id).
+  // and find() can be filtered/sorted like the bridge calls the app relies on.
   const store: DbRow[] = rows.map((r) => ({ ...r }));
   let seq = 0;
   const db = {
-    find: vi.fn(async (_table: string, opts?: { where?: Record<string, unknown> }) => {
+    find: vi.fn(async (_table: string, opts?: { where?: Record<string, unknown>; orderBy?: Record<string, "asc" | "desc"> }) => {
       const where = opts?.where;
-      const matched = where
+      let matched = where
         ? store.filter((r) => Object.entries(where).every(([k, v]) => r[k] === v))
         : store;
+      if (opts?.orderBy) {
+        const [field, dir] = Object.entries(opts.orderBy)[0] as [string, "asc" | "desc"];
+        matched = [...matched].sort((a, b) => {
+          const av = String(a[field] ?? "");
+          const bv = String(b[field] ?? "");
+          return dir === "desc" ? bv.localeCompare(av) : av.localeCompare(bv);
+        });
+      }
       return matched.map((r) => ({ ...r }));
     }),
     findOne: vi.fn(async (_table: string, id: string) => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -103,6 +103,29 @@ describe("Whiteboard app", () => {
     expect(screen.getByTestId("whiteboard-empty")).toBeTruthy();
   });
 
+  it("uses unique svg definition ids for multiple instances", async () => {
+    installMatrixDb([]);
+    const { container } = render(
+      <>
+        <App />
+        <App />
+      </>,
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const gridIds = [...container.querySelectorAll("pattern")].map((node) => node.id);
+    const markerIds = [...container.querySelectorAll("marker")].map((node) => node.id);
+    expect(gridIds).toHaveLength(2);
+    expect(markerIds).toHaveLength(2);
+    expect(new Set(gridIds).size).toBe(2);
+    expect(new Set(markerIds).size).toBe(2);
+    expect(gridIds).not.toContain("wb-grid");
+    expect(markerIds).not.toContain("wb-arrow");
+  });
+
   it("prevents native autoscroll when starting a middle-button pan", async () => {
     installMatrixDb([]);
     render(<App />);
@@ -207,6 +230,29 @@ describe("Whiteboard app — multi-board files", () => {
     expect(db.insert.mock.calls[0][0]).toBe("scenes");
     const inserted = db.insert.mock.calls[0][1] as Record<string, unknown>;
     expect(typeof inserted.name).toBe("string");
+  });
+
+  it("keeps rename editing open when the db update fails", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    db.update.mockRejectedValueOnce(new Error("rename failed"));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
+    const input = screen.getByLabelText(/rename sprint plan/i);
+    fireEvent.change(input, { target: { value: "Launch plan" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Could not rename the board.")).toBeTruthy();
+    expect(screen.getByDisplayValue("Launch plan")).toBeTruthy();
   });
 
   it("loads the active board's doc when switching boards", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -731,6 +731,45 @@ describe("Whiteboard app — multi-board files", () => {
     expect(screen.queryByText("Could not rename the board.")).toBeNull();
   });
 
+  it("allows a failed board rename submitted with Enter to be retried", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    db.update.mockRejectedValueOnce(new Error("rename failed"));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
+    const input = screen.getByLabelText(/rename sprint plan/i);
+    fireEvent.change(input, { target: { value: "Launch plan" } });
+    db.find.mockRejectedValueOnce(new Error("list failed"));
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Could not rename the board.")).toBeTruthy();
+    expect(screen.getByDisplayValue("Launch plan")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.keyDown(screen.getByDisplayValue("Launch plan"), { key: "Enter" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const renameCalls = db.update.mock.calls.filter(
+      ([table, id, data]) => table === "scenes" && id === "b1" && data.name === "Launch plan",
+    );
+    expect(renameCalls).toHaveLength(2);
+    expect(screen.queryByDisplayValue("Launch plan")).toBeNull();
+    expect(screen.queryByText("Could not rename the board.")).toBeNull();
+  });
+
   it("clears stale errors when switching to the local board path", async () => {
     const db = installMatrixDb([
       board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -103,6 +103,25 @@ describe("Whiteboard app", () => {
     expect(screen.getByTestId("whiteboard-empty")).toBeTruthy();
   });
 
+  it("prevents native autoscroll when starting a middle-button pan", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    const wasNotCanceled = fireEvent.pointerDown(canvas, {
+      clientX: 100,
+      clientY: 100,
+      button: 1,
+      pointerId: 1,
+    });
+
+    expect(wasNotCanceled).toBe(false);
+  });
+
   it("draws a rectangle which adds an element and autosaves to the DB", async () => {
     const db = installMatrixDb([]);
     render(<App />);

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -993,6 +993,56 @@ describe("Whiteboard app — multi-board files", () => {
     )).toBe(false);
   });
 
+  it("coalesces background index refreshes while one is in flight", async () => {
+    const db = installMatrixDb([
+      {
+        id: "b1",
+        name: "Sketch",
+        doc: { version: 1, elements: [] },
+        created_at: "2026-02-02T00:00:00.000Z",
+        updated_at: "2026-02-02T00:00:00.000Z",
+      },
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const originalFind = db.find.getMockImplementation();
+    let releaseRefresh: (() => void) | null = null;
+    let finishRefresh: (() => void) | null = null;
+    const refreshFinished = new Promise<void>((resolve) => {
+      finishRefresh = resolve;
+    });
+    const refreshStarted = new Promise<void>((resolve) => {
+      db.find.mockImplementationOnce(async (table, opts) => {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseRefresh = release;
+        });
+        const rows = originalFind ? await originalFind(table, opts) : [];
+        finishRefresh?.();
+        return rows;
+      });
+    });
+    db.find.mockClear();
+
+    await act(async () => {
+      db.emitChange();
+      await refreshStarted;
+      db.emitChange();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      expect(db.find).toHaveBeenCalledTimes(1);
+      releaseRefresh?.();
+      await refreshFinished;
+      await Promise.resolve();
+    });
+  });
+
   it("clears a flushed save indicator when switching boards", async () => {
     const db = installMatrixDb([
       board("old-board", "Old board", "2026-02-02T00:00:00.000Z"),
@@ -1048,8 +1098,9 @@ describe("Whiteboard app — multi-board files", () => {
     db.update.mockClear();
 
     await act(async () => {
-      fireEvent.click(screen.getByText("Board B"));
+      // Browsers move focus before dispatching the click target action.
       fireEvent.blur(editor);
+      fireEvent.click(screen.getByText("Board B"));
       await Promise.resolve();
       await Promise.resolve();
     });

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -40,7 +40,7 @@ function installMatrixDb(rows: DbRow[] = []) {
     }),
     update: vi.fn(async (_table: string, id: string, data: Record<string, unknown>) => {
       const row = store.find((r) => r.id === id);
-      if (row) Object.assign(row, data);
+      if (row) Object.assign(row, data, { updated_at: new Date().toISOString() });
       return { ok: true };
     }),
     delete: vi.fn(async (_table: string, id: string) => {
@@ -84,6 +84,7 @@ afterEach(() => {
   vi.runOnlyPendingTimers();
   vi.useRealTimers();
   vi.restoreAllMocks();
+  window.localStorage.clear();
   Reflect.deleteProperty(window, "MatrixOS");
 });
 
@@ -210,6 +211,36 @@ describe("Whiteboard app", () => {
     const allCalls = [...db.insert.mock.calls, ...db.update.mock.calls];
     const sawRect = allCalls.some((call) => JSON.stringify(call).includes("rect"));
     expect(sawRect).toBe(true);
+  });
+
+  it("keeps a local backup of pending autosaves on unmount", async () => {
+    installMatrixDb([
+      {
+        id: "b1",
+        name: "Sketch",
+        doc: { version: 1, elements: [] },
+        created_at: "2026-02-02T00:00:00.000Z",
+        updated_at: "2026-02-02T00:00:00.000Z",
+      },
+    ]);
+    const { unmount } = render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Rectangle (R)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 220, clientY: 180, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 220, clientY: 180, pointerId: 1 });
+      await Promise.resolve();
+    });
+
+    unmount();
+
+    expect(window.localStorage.getItem("matrix-whiteboard-scene-v1")).toContain("\"kind\":\"rect\"");
   });
 
   it("does not let background board refresh failures overwrite save errors", async () => {
@@ -420,6 +451,33 @@ describe("Whiteboard app — multi-board files", () => {
     expect(screen.getAllByText("Wireframe").length).toBeGreaterThan(0);
   });
 
+  it("requests the board index in last-edited order", async () => {
+    const db = installMatrixDb([
+      {
+        ...board("old-created", "Edited recently", "2026-04-04T00:00:00.000Z"),
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        ...board("new-created", "Created recently", "2026-02-02T00:00:00.000Z"),
+        created_at: "2026-05-05T00:00:00.000Z",
+      },
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      db.find.mock.calls.some(
+        ([table, opts]) =>
+          table === "scenes" &&
+          (opts as { orderBy?: Record<string, string> } | undefined)?.orderBy?.updated_at === "desc",
+      ),
+    ).toBe(true);
+    expect(screen.getAllByText("Edited recently").length).toBeGreaterThan(0);
+  });
+
   it("scrolls the active board into view after selection", async () => {
     const originalScrollIntoView = Element.prototype.scrollIntoView;
     const scrollIntoView = vi.fn();
@@ -575,6 +633,7 @@ describe("Whiteboard app — multi-board files", () => {
     fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
     const input = screen.getByLabelText(/rename sprint plan/i);
     fireEvent.change(input, { target: { value: "Launch plan" } });
+    db.find.mockRejectedValueOnce(new Error("list failed"));
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
       await Promise.resolve();
@@ -587,6 +646,67 @@ describe("Whiteboard app — multi-board files", () => {
     fireEvent.keyDown(screen.getByDisplayValue("Launch plan"), { key: "Escape" });
     expect(screen.getAllByText("Sprint plan").length).toBeGreaterThan(0);
     expect(screen.queryByText("Launch plan")).toBeNull();
+  });
+
+  it("dismisses a failed rename row with global Escape", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    db.update.mockRejectedValueOnce(new Error("rename failed"));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
+    const input = screen.getByLabelText(/rename sprint plan/i);
+    fireEvent.change(input, { target: { value: "Launch plan" } });
+    db.find.mockRejectedValueOnce(new Error("list failed"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Could not rename the board.")).toBeTruthy();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(screen.queryByDisplayValue("Launch plan")).toBeNull();
+    expect(screen.getAllByText("Sprint plan").length).toBeGreaterThan(0);
+  });
+
+  it("clears stale errors when switching to the local board path", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    db.update.mockRejectedValueOnce(new Error("rename failed"));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
+    const input = screen.getByLabelText(/rename sprint plan/i);
+    fireEvent.change(input, { target: { value: "Launch plan" } });
+    db.find.mockRejectedValueOnce(new Error("list failed"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Could not rename the board.")).toBeTruthy();
+
+    Reflect.deleteProperty(window, "MatrixOS");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /new board/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("Could not rename the board.")).toBeNull();
   });
 
   it("clears a failed rename editor when switching boards", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -246,6 +246,40 @@ describe("Whiteboard app — multi-board files", () => {
     expect(screen.getByTestId("whiteboard-empty")).toBeTruthy();
   });
 
+  it("does not create a first board when loading the board index fails", async () => {
+    const db = installMatrixDb([]);
+    db.find.mockRejectedValueOnce(new Error("list failed"));
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Could not load your boards.")).toBeTruthy();
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("reports a create failure when the bridge insert omits the new board id", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    db.insert.mockResolvedValueOnce({} as { id: string });
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /new board/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Could not create a board.")).toBeTruthy();
+  });
+
   it("keeps rename editing open when the db update fails", async () => {
     const db = installMatrixDb([
       board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
@@ -273,6 +307,31 @@ describe("Whiteboard app — multi-board files", () => {
     fireEvent.keyDown(screen.getByDisplayValue("Launch plan"), { key: "Escape" });
     expect(screen.getAllByText("Sprint plan").length).toBeGreaterThan(0);
     expect(screen.queryByText("Launch plan")).toBeNull();
+  });
+
+  it("clears the rename error after a recovery refresh succeeds", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    db.update.mockRejectedValueOnce(new Error("rename failed"));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
+    const input = screen.getByLabelText(/rename sprint plan/i);
+    fireEvent.change(input, { target: { value: "Launch plan" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("Could not rename the board.")).toBeNull();
+    expect(screen.getAllByText("Sprint plan").length).toBeGreaterThan(0);
   });
 
   it("loads the active board's doc when switching boards", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -212,6 +212,46 @@ describe("Whiteboard app", () => {
     expect(sawRect).toBe(true);
   });
 
+  it("does not let background board refresh failures overwrite save errors", async () => {
+    const db = installMatrixDb([
+      {
+        id: "b1",
+        name: "Sketch",
+        doc: { version: 1, elements: [] },
+        created_at: "2026-02-02T00:00:00.000Z",
+        updated_at: "2026-02-02T00:00:00.000Z",
+      },
+    ]);
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    db.update.mockRejectedValueOnce(new Error("save failed"));
+    fireEvent.click(screen.getByRole("button", { name: "Rectangle (R)" }));
+    const canvas = screen.getByTestId("whiteboard-canvas");
+    await act(async () => {
+      fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, button: 0, pointerId: 1 });
+      fireEvent.pointerMove(canvas, { clientX: 220, clientY: 180, pointerId: 1 });
+      fireEvent.pointerUp(canvas, { clientX: 220, clientY: 180, pointerId: 1 });
+      await vi.advanceTimersByTimeAsync(1200);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Changes could not be saved.")).toBeTruthy();
+
+    db.find.mockRejectedValueOnce(new Error("background refresh failed"));
+    await act(async () => {
+      db.emitChange();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Changes could not be saved.")).toBeTruthy();
+    expect(screen.queryByText("Could not load your boards.")).toBeNull();
+  });
+
   it("discards in-progress rectangles when the pointer is canceled", async () => {
     const db = installMatrixDb([]);
     render(<App />);
@@ -735,6 +775,52 @@ describe("Whiteboard app — multi-board files", () => {
     expect(ctx.ellipse).toHaveBeenCalled();
     expect(ctx.fill).toHaveBeenCalled();
     expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it("strokes sticky note borders when exporting PNGs", async () => {
+    installMatrixDb([
+      {
+        ...board("b1", "Sketch", "2026-02-02T00:00:00.000Z"),
+        doc: {
+          version: 1,
+          elements: [
+            { id: "s1", kind: "sticky", x: 20, y: 30, width: 120, height: 80, stroke: "#000", fill: "#FFE9A8", strokeWidth: 2, text: "" },
+          ],
+        },
+      },
+    ]);
+    const strokeStyles: string[] = [];
+    const lineWidths: number[] = [];
+    const ctx = {
+      beginPath: vi.fn(),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      roundRect: vi.fn(),
+      stroke: vi.fn(),
+      translate: vi.fn(),
+      set fillStyle(_value: string) {},
+      set lineCap(_value: string) {},
+      set lineJoin(_value: string) {},
+      set lineWidth(value: number) { lineWidths.push(value); },
+      set strokeStyle(value: string) { strokeStyles.push(value); },
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/png;base64,stub");
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTitle("Export PNG"));
+
+    expect(ctx.roundRect).toHaveBeenCalled();
+    expect(ctx.fill).toHaveBeenCalled();
+    expect(ctx.stroke).toHaveBeenCalled();
+    expect(strokeStyles).toContain("rgba(50,53,46,0.14)");
+    expect(lineWidths).toContain(1);
   });
 
   it("fills arrowheads when exporting PNGs", async () => {

--- a/tests/default-apps/whiteboard-app.test.tsx
+++ b/tests/default-apps/whiteboard-app.test.tsx
@@ -677,6 +677,45 @@ describe("Whiteboard app — multi-board files", () => {
     expect(screen.getAllByText("Sprint plan").length).toBeGreaterThan(0);
   });
 
+  it("allows a failed board rename to be retried", async () => {
+    const db = installMatrixDb([
+      board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),
+    ]);
+    db.update.mockRejectedValueOnce(new Error("rename failed"));
+    render(<App />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /rename board sprint plan/i }));
+    const input = screen.getByLabelText(/rename sprint plan/i);
+    fireEvent.change(input, { target: { value: "Launch plan" } });
+    db.find.mockRejectedValueOnce(new Error("list failed"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Could not rename the board.")).toBeTruthy();
+    expect(screen.getByDisplayValue("Launch plan")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm rename/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const renameCalls = db.update.mock.calls.filter(
+      ([table, id, data]) => table === "scenes" && id === "b1" && data.name === "Launch plan",
+    );
+    expect(renameCalls).toHaveLength(2);
+    expect(screen.queryByDisplayValue("Launch plan")).toBeNull();
+    expect(screen.queryByText("Could not rename the board.")).toBeNull();
+  });
+
   it("clears stale errors when switching to the local board path", async () => {
     const db = installMatrixDb([
       board("b1", "Sprint plan", "2026-02-02T00:00:00.000Z"),


### PR DESCRIPTION
Stack: 10/22
Branch: stack/default-apps-whiteboard-ui

Scope: Whiteboard canvas UI, styles, and app tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.