### PR TITLE
feat(2048): add merge game engine

### DIFF
--- a/home/apps/games/2048/matrix.json
+++ b/home/apps/games/2048/matrix.json
@@ -3,7 +3,7 @@
   "description": "Merge tiles to reach 2048",
   "runtime": "vite",
   "category": "games",
-  "icon": "game-center",
+  "icon": "2048",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -12,6 +12,16 @@
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
   "slug": "2048",
+  "storage": {
+    "tables": {
+      "scores": {
+        "columns": {
+          "score": "integer",
+          "best": "integer"
+        }
+      }
+    }
+  },
   "build": {
     "install": "true",
     "command": "vite build --base ./ --outDir dist",

--- a/home/apps/games/2048/matrix.json
+++ b/home/apps/games/2048/matrix.json
@@ -17,7 +17,8 @@
       "scores": {
         "columns": {
           "score": "integer",
-          "best": "integer"
+          "best": "integer",
+          "created_at": "timestamptz"
         }
       }
     }

--- a/home/apps/games/2048/matrix.json
+++ b/home/apps/games/2048/matrix.json
@@ -3,7 +3,7 @@
   "description": "Merge tiles to reach 2048",
   "runtime": "vite",
   "category": "games",
-  "icon": "2048",
+  "icon": "game-center",
   "author": "system",
   "version": "1.0.0",
   "tags": [

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -44,12 +44,29 @@ type Action =
   | { type: "undo" }
   | { type: "load-best"; best: number };
 
-function tilesFromBoard(board: Board): Tile[] {
+function tilesFromBoard(
+  board: Board,
+  previous: Tile[] = [],
+  spawned: { row: number; col: number; value: number } | null = null,
+): Tile[] {
   const tiles: Tile[] = [];
+  const used = new Set<number>();
   for (let r = 0; r < board.length; r += 1) {
     for (let c = 0; c < board[r].length; c += 1) {
       if (board[r][c] !== 0) {
-        tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: true });
+        if (spawned && spawned.row === r && spawned.col === c && spawned.value === board[r][c]) {
+          tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: true });
+          continue;
+        }
+        const match = previous
+          .filter((tile) => tile.value === board[r][c] && !used.has(tile.id))
+          .sort((a, b) => Math.abs(a.row - r) + Math.abs(a.col - c) - (Math.abs(b.row - r) + Math.abs(b.col - c)))[0];
+        if (match) {
+          used.add(match.id);
+          tiles.push({ ...match, row: r, col: c, spawned: false, merged: false });
+        } else {
+          tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: false, merged: true });
+        }
       }
     }
   }
@@ -92,13 +109,7 @@ function reducer(state: InternalState, action: Action): InternalState {
       const spawn = addRandomTile(result.board, Math.random);
       const nextBoard = spawn.board;
       const nextScore = state.score + result.gained;
-      const tiles = tilesFromBoard(nextBoard).map((t) => {
-        // Mark the freshly spawned tile so only it pops in.
-        if (spawn.spawned && t.row === spawn.spawned.row && t.col === spawn.spawned.col) {
-          return { ...t, spawned: true, merged: false };
-        }
-        return { ...t, spawned: false };
-      });
+      const tiles = tilesFromBoard(nextBoard, state.tiles, spawn.spawned);
 
       return {
         board: nextBoard,
@@ -144,6 +155,7 @@ export default function App() {
   const [keepPlaying, setKeepPlaying] = useState(false);
   const dbRowId = useRef<string | null>(null);
   const dbRowInsertRef = useRef<Promise<string> | null>(null);
+  const pendingBestRef = useRef(0);
   const boardRef = useRef<HTMLDivElement | null>(null);
 
   const persistScore = useCallback((score: number) => {
@@ -241,13 +253,18 @@ export default function App() {
     }
     const db = window.MatrixOS?.db;
     if (!db) return;
+    pendingBestRef.current = Math.max(pendingBestRef.current, newBest);
     (async () => {
       try {
         if (dbRowId.current) {
-          await db.update(SCORES_TABLE, dbRowId.current, { best: newBest });
+          await db.update(SCORES_TABLE, dbRowId.current, { best: Math.max(newBest, pendingBestRef.current) });
         } else {
           if (!dbRowInsertRef.current) {
-            dbRowInsertRef.current = db.insert(SCORES_TABLE, { score: 0, best: newBest })
+            dbRowInsertRef.current = db.insert(SCORES_TABLE, {
+              score: newBest,
+              best: pendingBestRef.current,
+              created_at: new Date().toISOString(),
+            })
               .then((res) => {
                 dbRowId.current = res.id;
                 return res.id;
@@ -257,7 +274,7 @@ export default function App() {
               });
           }
           const id = await dbRowInsertRef.current;
-          await db.update(SCORES_TABLE, id, { best: newBest });
+          await db.update(SCORES_TABLE, id, { best: Math.max(newBest, pendingBestRef.current) });
         }
       } catch (err) {
         console.warn("[2048] failed to persist best score", err);
@@ -279,6 +296,9 @@ export default function App() {
     persistScore(state.score);
   }, [persistScore, state.score]);
 
+  const showWin = state.won && !keepPlaying;
+  const showOver = state.over && (!state.won || keepPlaying);
+
   // ---- Keyboard input ------------------------------------------------------
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -292,12 +312,13 @@ export default function App() {
       const dir = KEY_TO_DIR[e.key];
       if (dir) {
         e.preventDefault();
+        if (showWin) return;
         dispatch({ type: "move", direction: dir });
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [state.history]);
+  }, [showWin, state.history]);
 
   // ---- Touch swipe ---------------------------------------------------------
   useEffect(() => {
@@ -325,6 +346,7 @@ export default function App() {
       let dir: Direction;
       if (absX > absY) dir = dx > 0 ? "right" : "left";
       else dir = dy > 0 ? "down" : "up";
+      if (showWin) return;
       dispatch({ type: "move", direction: dir });
     };
 
@@ -334,10 +356,7 @@ export default function App() {
       el.removeEventListener("touchstart", onStart);
       el.removeEventListener("touchend", onEnd);
     };
-  }, []);
-
-  const showWin = state.won && !keepPlaying;
-  const showOver = state.over && (!state.won || keepPlaying);
+  }, [showWin]);
 
   const newGameClick = useCallback(() => {
     setKeepPlaying(false);

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { RotateCcw, Undo2, Trophy, Sparkles } from "lucide-react";
+import { RotateCcw, Undo2, Trophy, Sparkles, X } from "lucide-react";
 import {
   type Board,
   type Direction,
@@ -41,8 +41,7 @@ interface InternalState extends GameState {
 type Action =
   | { type: "reset" }
   | { type: "move"; direction: Direction }
-  | { type: "undo" }
-  | { type: "load-best"; best: number };
+  | { type: "undo" };
 
 function cellKey(row: number, col: number): string {
   return `${row}:${col}`;
@@ -110,7 +109,7 @@ export function tilesFromBoard(
           used.add(match.id);
           tiles.push({ ...match, row: r, col: c, spawned: false, merged: false });
         } else {
-          tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: false, merged: true });
+          tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: false, merged: false });
         }
       }
     }
@@ -176,9 +175,6 @@ function reducer(state: InternalState, action: Action): InternalState {
       };
     }
 
-    case "load-best":
-      return state;
-
     default:
       return state;
   }
@@ -210,6 +206,7 @@ export default function App() {
   const [keepPlaying, setKeepPlaying] = useState(false);
   const dbRowId = useRef<string | null>(null);
   const dbRowInsertRef = useRef<Promise<string> | null>(null);
+  const dbInitialLoadRef = useRef<Promise<void> | null>(null);
   const pendingBestRef = useRef(0);
   const boardRef = useRef<HTMLDivElement | null>(null);
 
@@ -234,8 +231,10 @@ export default function App() {
       try {
         const raw = window.localStorage.getItem(BEST_KEY);
         if (raw && active) setBest(Number(raw) || 0);
-      } catch {
-        // localStorage may be unavailable (privacy mode); ignore safely.
+      } catch (err) {
+        if (!(err instanceof DOMException && err.name === "SecurityError")) {
+          console.warn("[2048] unexpected localStorage read error", err);
+        }
       }
     };
 
@@ -246,24 +245,30 @@ export default function App() {
       };
     }
 
-    (async () => {
+    const load = (async () => {
       try {
         const rows = await db.find(SCORES_TABLE, { orderBy: { created_at: "desc" }, limit: 1 });
         if (!active) return;
         const row = rows[0];
         if (row) {
+          const loadedBest = Number(row.best) || 0;
           dbRowId.current = (row.id as string) ?? null;
-          setBest(Number(row.best) || 0);
+          pendingBestRef.current = Math.max(pendingBestRef.current, loadedBest);
+          setBest((prev) => Math.max(prev, loadedBest));
         } else {
           fromLocal();
         }
+        setError(null);
       } catch (err) {
         if (!active) return;
         console.warn("[2048] failed to load best score from MatrixOS.db", err);
         setError("Couldn't load your best score; playing locally.");
         fromLocal();
+      } finally {
+        dbInitialLoadRef.current = null;
       }
     })();
+    dbInitialLoadRef.current = load;
 
     return () => {
       active = false;
@@ -284,6 +289,7 @@ export default function App() {
             if (row) {
               dbRowId.current = (row.id as string) ?? dbRowId.current;
               setBest((prev) => Math.max(prev, Number(row.best) || 0));
+              setError(null);
             }
           } catch (err) {
             console.warn("[2048] onChange reload failed", err);
@@ -303,14 +309,19 @@ export default function App() {
     // Optimistic local fallback always.
     try {
       window.localStorage.setItem(BEST_KEY, String(newBest));
-    } catch {
-      // ignore; non-fatal
+    } catch (err) {
+      if (!(err instanceof DOMException && err.name === "SecurityError")) {
+        console.warn("[2048] unexpected localStorage write error", err);
+      }
     }
     const db = window.MatrixOS?.db;
     if (!db) return;
     pendingBestRef.current = Math.max(pendingBestRef.current, newBest);
     (async () => {
       try {
+        if (!dbRowId.current && dbInitialLoadRef.current) {
+          await dbInitialLoadRef.current;
+        }
         if (dbRowId.current) {
           await db.update(SCORES_TABLE, dbRowId.current, { best: Math.max(newBest, pendingBestRef.current) });
         } else {
@@ -321,7 +332,7 @@ export default function App() {
               created_at: new Date().toISOString(),
             })
               .then((res) => {
-                dbRowId.current = res.id;
+                if (!dbRowId.current) dbRowId.current = res.id;
                 return res.id;
               })
               .finally(() => {
@@ -329,8 +340,9 @@ export default function App() {
               });
           }
           const id = await dbRowInsertRef.current;
-          await db.update(SCORES_TABLE, id, { best: Math.max(newBest, pendingBestRef.current) });
+          await db.update(SCORES_TABLE, dbRowId.current ?? id, { best: Math.max(newBest, pendingBestRef.current) });
         }
+        setError(null);
       } catch (err) {
         console.warn("[2048] failed to persist best score", err);
         setError("Best score saved locally; sync failed.");
@@ -353,6 +365,10 @@ export default function App() {
 
   const showWin = state.won && !keepPlaying;
   const showOver = state.over && (!state.won || keepPlaying);
+  const undoMove = useCallback(() => {
+    setKeepPlaying(false);
+    dispatch({ type: "undo" });
+  }, []);
 
   // ---- Keyboard input ------------------------------------------------------
   useEffect(() => {
@@ -360,7 +376,7 @@ export default function App() {
       if (e.metaKey || e.ctrlKey) {
         if ((e.key === "z" || e.key === "Z") && state.history) {
           e.preventDefault();
-          dispatch({ type: "undo" });
+          undoMove();
         }
         return;
       }
@@ -373,7 +389,7 @@ export default function App() {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [showWin, state.history]);
+  }, [showWin, state.history, undoMove]);
 
   // ---- Touch swipe ---------------------------------------------------------
   useEffect(() => {
@@ -446,7 +462,7 @@ export default function App() {
         </header>
 
         <div className="controls">
-          <button type="button" className="btn ghost" onClick={() => dispatch({ type: "undo" })} disabled={!state.history}>
+          <button type="button" className="btn ghost" onClick={undoMove} disabled={!state.history}>
             <Undo2 size={15} aria-hidden /> Undo
           </button>
           <button type="button" className="btn primary" onClick={newGameClick}>
@@ -528,7 +544,10 @@ export default function App() {
 
         {error && (
           <div className="banner" role="status">
-            {error}
+            <span>{error}</span>
+            <button type="button" className="banner-dismiss" aria-label="Dismiss sync message" onClick={() => setError(null)}>
+              <X size={13} aria-hidden />
+            </button>
           </div>
         )}
       </div>

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -209,6 +209,7 @@ export default function App() {
   const dbInitialLoadRef = useRef<Promise<void> | null>(null);
   const pendingBestRef = useRef(0);
   const latestScoreRef = useRef(0);
+  const sessionRef = useRef(0);
   const boardRef = useRef<HTMLDivElement | null>(null);
   latestScoreRef.current = state.score;
 
@@ -238,9 +239,11 @@ export default function App() {
   const persistScore = useCallback((score: number) => {
     const db = window.MatrixOS?.db;
     if (!db) return;
+    const session = sessionRef.current;
     (async () => {
       try {
         const id = await ensureScoreRow(db, score);
+        if (session !== sessionRef.current) return;
         await db.update(SCORES_TABLE, id, { score: Math.max(score, latestScoreRef.current) });
       } catch (err) {
         console.warn("[2048] failed to update current score", err);
@@ -443,6 +446,7 @@ export default function App() {
   }, [showWin]);
 
   const newGameClick = useCallback(() => {
+    sessionRef.current += 1;
     setKeepPlaying(false);
     dispatch({ type: "reset" });
   }, []);

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -5,37 +5,17 @@ import {
   type Direction,
   type GameState,
   addRandomTile,
+  animationCellsForMove,
   cloneBoard,
   hasWon,
   isGameOver,
   move,
   newGame,
 } from "./game-2048";
+import { nextTileId, tilesFromBoard, type Tile } from "./tile-animation";
 
 const BEST_KEY = "matrixos.2048.best";
 const SCORES_TABLE = "scores";
-
-// ---- Tile identity for animation ------------------------------------------
-// We keep a parallel grid of stable tile ids so React can animate slides/merges
-// via CSS transforms keyed by id rather than re-rendering whole cells.
-interface Tile {
-  id: number;
-  value: number;
-  row: number;
-  col: number;
-  merged?: boolean; // pulse on merge
-  spawned?: boolean; // pop-in on spawn
-}
-
-let TILE_SEQ = 1;
-function nextId(): number {
-  TILE_SEQ += 1;
-  return TILE_SEQ;
-}
-
-export function resetTileIdsForTest(): void {
-  TILE_SEQ = 1;
-}
 
 interface InternalState extends GameState {
   tiles: Tile[];
@@ -47,98 +27,6 @@ type Action =
   | { type: "move"; direction: Direction }
   | { type: "undo" };
 
-function cellKey(row: number, col: number): string {
-  return `${row}:${col}`;
-}
-
-function animationCellsForMove(board: Board, direction: Direction): { merged: Set<string>; consumed: Set<string> } {
-  const merged = new Set<string>();
-  const consumed = new Set<string>();
-  for (let line = 0; line < board.length; line += 1) {
-    const values: Array<{ value: number; row: number; col: number }> = [];
-    for (let offset = 0; offset < board.length; offset += 1) {
-      const row = direction === "up" ? offset : direction === "down" ? board.length - 1 - offset : line;
-      const col = direction === "left" ? offset : direction === "right" ? board.length - 1 - offset : line;
-      const value = board[row][col];
-      if (value !== 0) values.push({ value, row, col });
-    }
-
-    let target = 0;
-    for (let index = 0; index < values.length; index += 1) {
-      const current = values[index];
-      const next = values[index + 1];
-      const isMerge = Boolean(next && current.value === next.value);
-      const row = direction === "up" ? target : direction === "down" ? board.length - 1 - target : line;
-      const col = direction === "left" ? target : direction === "right" ? board.length - 1 - target : line;
-      if (isMerge) {
-        // `merged` is keyed by post-move output cells; `consumed` is keyed by
-        // pre-move source cells so survivor selection cannot reuse merged tiles.
-        merged.add(cellKey(row, col));
-        consumed.add(cellKey(current.row, current.col));
-        if (next) consumed.add(cellKey(next.row, next.col));
-        index += 1;
-      }
-      target += 1;
-    }
-  }
-  return { merged, consumed };
-}
-
-export function tilesFromBoard(
-  board: Board,
-  previous: Tile[] = [],
-  spawned: { row: number; col: number; value: number } | null = null,
-  mergedCells = new Set<string>(),
-  consumedCells = new Set<string>(),
-  direction?: Direction,
-): Tile[] {
-  const tiles: Tile[] = [];
-  const used = new Set(
-    previous
-      .filter((tile) => consumedCells.has(cellKey(tile.row, tile.col)))
-      .map((tile) => tile.id),
-  );
-  for (let r = 0; r < board.length; r += 1) {
-    for (let c = 0; c < board[r].length; c += 1) {
-      if (board[r][c] !== 0) {
-        if (spawned && spawned.row === r && spawned.col === c && spawned.value === board[r][c]) {
-          tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: true });
-          continue;
-        }
-        if (mergedCells.has(cellKey(r, c))) {
-          tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: false, merged: true });
-          continue;
-        }
-        const lineMatch = direction
-          ? previous
-            .filter((tile) =>
-              tile.value === board[r][c] &&
-              !used.has(tile.id) &&
-              (direction === "left" || direction === "right" ? tile.row === r : tile.col === c),
-            )
-            .sort((a, b) => (direction === "left" || direction === "right" ? a.col - b.col : a.row - b.row))[0]
-          : null;
-        const match = previous
-          .filter((tile) => tile.value === board[r][c] && !used.has(tile.id))
-          .sort((a, b) => {
-            const distance = Math.abs(a.row - r) + Math.abs(a.col - c) - (Math.abs(b.row - r) + Math.abs(b.col - c));
-            if (distance !== 0) return distance;
-            if (a.row !== b.row) return a.row - b.row;
-            return a.col - b.col;
-          })[0];
-        const resolved = lineMatch ?? match;
-        if (resolved) {
-          used.add(resolved.id);
-          tiles.push({ ...resolved, row: r, col: c, spawned: false, merged: false });
-        } else {
-          tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: false, merged: false });
-        }
-      }
-    }
-  }
-  return tiles;
-}
-
 function freshGame(): InternalState {
   const g = newGame();
   const tiles: Tile[] = [];
@@ -146,7 +34,7 @@ function freshGame(): InternalState {
     for (let col = 0; col < g.board[row].length; col += 1) {
       const value = g.board[row][col];
       if (value !== 0) {
-        tiles.push({ id: nextId(), value, row, col, spawned: true, merged: false });
+        tiles.push({ id: nextTileId(), value, row, col, spawned: true, merged: false });
       }
     }
   }

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -84,6 +84,7 @@ export function tilesFromBoard(
   spawned: { row: number; col: number; value: number } | null = null,
   mergedCells = new Set<string>(),
   consumedCells = new Set<string>(),
+  direction?: Direction,
 ): Tile[] {
   const tiles: Tile[] = [];
   const used = new Set(
@@ -102,12 +103,27 @@ export function tilesFromBoard(
           tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: false, merged: true });
           continue;
         }
+        const lineMatch = direction
+          ? previous
+            .filter((tile) =>
+              tile.value === board[r][c] &&
+              !used.has(tile.id) &&
+              (direction === "left" || direction === "right" ? tile.row === r : tile.col === c),
+            )
+            .sort((a, b) => (direction === "left" || direction === "right" ? a.col - b.col : a.row - b.row))[0]
+          : null;
         const match = previous
           .filter((tile) => tile.value === board[r][c] && !used.has(tile.id))
-          .sort((a, b) => Math.abs(a.row - r) + Math.abs(a.col - c) - (Math.abs(b.row - r) + Math.abs(b.col - c)))[0];
-        if (match) {
-          used.add(match.id);
-          tiles.push({ ...match, row: r, col: c, spawned: false, merged: false });
+          .sort((a, b) => {
+            const distance = Math.abs(a.row - r) + Math.abs(a.col - c) - (Math.abs(b.row - r) + Math.abs(b.col - c));
+            if (distance !== 0) return distance;
+            if (a.row !== b.row) return a.row - b.row;
+            return a.col - b.col;
+          })[0];
+        const resolved = lineMatch ?? match;
+        if (resolved) {
+          used.add(resolved.id);
+          tiles.push({ ...resolved, row: r, col: c, spawned: false, merged: false });
         } else {
           tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: false, merged: false });
         }
@@ -163,7 +179,7 @@ function reducer(state: InternalState, action: Action): InternalState {
       const nextBoard = spawn.board;
       const nextScore = state.score + result.gained;
       const animationCells = animationCellsForMove(state.board, action.direction);
-      const tiles = tilesFromBoard(nextBoard, state.tiles, spawn.spawned, animationCells.merged, animationCells.consumed);
+      const tiles = tilesFromBoard(nextBoard, state.tiles, spawn.spawned, animationCells.merged, animationCells.consumed, action.direction);
 
       return {
         board: nextBoard,
@@ -285,9 +301,15 @@ export default function App() {
         const row = rows[0];
         if (row) {
           const loadedBest = Number(row.best) || 0;
-          dbRowId.current = (row.id as string) ?? null;
+          const rowId = (row.id as string) ?? null;
+          dbRowId.current = rowId;
           pendingBestRef.current = Math.max(pendingBestRef.current, loadedBest);
           setBest((prev) => Math.max(prev, loadedBest));
+          if (rowId && latestScoreRef.current === 0) {
+            void db.update(SCORES_TABLE, rowId, { score: 0 }).catch((err) => {
+              console.warn("[2048] failed to sync loaded score row", err);
+            });
+          }
         } else {
           fromLocal();
         }
@@ -351,9 +373,11 @@ export default function App() {
     const db = window.MatrixOS?.db;
     if (!db) return;
     pendingBestRef.current = Math.max(pendingBestRef.current, newBest);
+    const session = sessionRef.current;
     (async () => {
       try {
         const id = await ensureScoreRow(db, newBest);
+        if (session !== sessionRef.current) return;
         await db.update(SCORES_TABLE, id, {
           score: latestScoreRef.current,
           best: Math.max(newBest, pendingBestRef.current),

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -445,8 +445,7 @@ export default function App() {
   const newGameClick = useCallback(() => {
     setKeepPlaying(false);
     dispatch({ type: "reset" });
-    persistScore(0);
-  }, [persistScore]);
+  }, []);
 
   return (
     <div className="app">

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import React, { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { RotateCcw, Undo2, Trophy, Sparkles } from "lucide-react";
 import {
   type Board,
@@ -44,10 +44,43 @@ type Action =
   | { type: "undo" }
   | { type: "load-best"; best: number };
 
-function tilesFromBoard(
+function cellKey(row: number, col: number): string {
+  return `${row}:${col}`;
+}
+
+function mergeCellsForMove(board: Board, direction: Direction): Set<string> {
+  const merged = new Set<string>();
+  for (let line = 0; line < board.length; line += 1) {
+    const values: Array<{ value: number; row: number; col: number }> = [];
+    for (let offset = 0; offset < board.length; offset += 1) {
+      const row = direction === "up" ? offset : direction === "down" ? board.length - 1 - offset : line;
+      const col = direction === "left" ? offset : direction === "right" ? board.length - 1 - offset : line;
+      const value = board[row][col];
+      if (value !== 0) values.push({ value, row, col });
+    }
+
+    let target = 0;
+    for (let index = 0; index < values.length; index += 1) {
+      const current = values[index];
+      const next = values[index + 1];
+      const isMerge = Boolean(next && current.value === next.value);
+      const row = direction === "up" ? target : direction === "down" ? board.length - 1 - target : line;
+      const col = direction === "left" ? target : direction === "right" ? board.length - 1 - target : line;
+      if (isMerge) {
+        merged.add(cellKey(row, col));
+        index += 1;
+      }
+      target += 1;
+    }
+  }
+  return merged;
+}
+
+export function tilesFromBoard(
   board: Board,
   previous: Tile[] = [],
   spawned: { row: number; col: number; value: number } | null = null,
+  mergedCells = new Set<string>(),
 ): Tile[] {
   const tiles: Tile[] = [];
   const used = new Set<number>();
@@ -56,6 +89,10 @@ function tilesFromBoard(
       if (board[r][c] !== 0) {
         if (spawned && spawned.row === r && spawned.col === c && spawned.value === board[r][c]) {
           tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: true });
+          continue;
+        }
+        if (mergedCells.has(cellKey(r, c))) {
+          tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: false, merged: true });
           continue;
         }
         const match = previous
@@ -118,7 +155,7 @@ function reducer(state: InternalState, action: Action): InternalState {
       const spawn = addRandomTile(result.board, Math.random);
       const nextBoard = spawn.board;
       const nextScore = state.score + result.gained;
-      const tiles = tilesFromBoard(nextBoard, state.tiles, spawn.spawned);
+      const tiles = tilesFromBoard(nextBoard, state.tiles, spawn.spawned, mergeCellsForMove(state.board, action.direction));
 
       return {
         board: nextBoard,

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -1,0 +1,447 @@
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { RotateCcw, Undo2, Trophy, Sparkles } from "lucide-react";
+import {
+  type Board,
+  type Direction,
+  type GameState,
+  addRandomTile,
+  cloneBoard,
+  hasWon,
+  isGameOver,
+  move,
+  newGame,
+} from "./game-2048";
+
+const BEST_KEY = "matrixos.2048.best";
+const SCORES_TABLE = "scores";
+
+// ---- Tile identity for animation ------------------------------------------
+// We keep a parallel grid of stable tile ids so React can animate slides/merges
+// via CSS transforms keyed by id rather than re-rendering whole cells.
+interface Tile {
+  id: number;
+  value: number;
+  row: number;
+  col: number;
+  merged?: boolean; // pulse on merge
+  spawned?: boolean; // pop-in on spawn
+}
+
+let TILE_SEQ = 1;
+function nextId(): number {
+  TILE_SEQ += 1;
+  return TILE_SEQ;
+}
+
+interface InternalState extends GameState {
+  tiles: Tile[];
+  history: { board: Board; score: number; tiles: Tile[] } | null;
+}
+
+type Action =
+  | { type: "reset" }
+  | { type: "move"; direction: Direction }
+  | { type: "undo" }
+  | { type: "load-best"; best: number };
+
+function tilesFromBoard(board: Board): Tile[] {
+  const tiles: Tile[] = [];
+  for (let r = 0; r < board.length; r += 1) {
+    for (let c = 0; c < board[r].length; c += 1) {
+      if (board[r][c] !== 0) {
+        tiles.push({ id: nextId(), value: board[r][c], row: r, col: c, spawned: true });
+      }
+    }
+  }
+  return tiles;
+}
+
+function freshGame(): InternalState {
+  const g = newGame();
+  return { ...g, tiles: tilesFromBoard(g.board), history: null };
+}
+
+function reducer(state: InternalState, action: Action): InternalState {
+  switch (action.type) {
+    case "reset":
+      return freshGame();
+
+    case "undo": {
+      if (!state.history) return state;
+      return {
+        board: cloneBoard(state.history.board),
+        score: state.history.score,
+        won: hasWon(state.history.board),
+        over: false,
+        tiles: state.history.tiles.map((t) => ({ ...t, merged: false, spawned: false })),
+        history: null,
+      };
+    }
+
+    case "move": {
+      if (state.over) return state;
+      const result = move(state.board, action.direction);
+      if (!result.moved) return state;
+
+      const history = {
+        board: cloneBoard(state.board),
+        score: state.score,
+        tiles: state.tiles.map((t) => ({ ...t })),
+      };
+
+      const spawn = addRandomTile(result.board, Math.random);
+      const nextBoard = spawn.board;
+      const nextScore = state.score + result.gained;
+      const tiles = tilesFromBoard(nextBoard).map((t) => {
+        // Mark the freshly spawned tile so only it pops in.
+        if (spawn.spawned && t.row === spawn.spawned.row && t.col === spawn.spawned.col) {
+          return { ...t, spawned: true, merged: false };
+        }
+        return { ...t, spawned: false };
+      });
+
+      return {
+        board: nextBoard,
+        score: nextScore,
+        won: hasWon(nextBoard),
+        over: isGameOver(nextBoard),
+        tiles,
+        history,
+      };
+    }
+
+    case "load-best":
+      return state;
+
+    default:
+      return state;
+  }
+}
+
+const KEY_TO_DIR: Record<string, Direction> = {
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  ArrowUp: "up",
+  ArrowDown: "down",
+  a: "left",
+  d: "right",
+  w: "up",
+  s: "down",
+  A: "left",
+  D: "right",
+  W: "up",
+  S: "down",
+  h: "left",
+  l: "right",
+  k: "up",
+  j: "down",
+};
+
+export default function App() {
+  const [state, dispatch] = useReducer(reducer, undefined, freshGame);
+  const [best, setBest] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [keepPlaying, setKeepPlaying] = useState(false);
+  const dbRowId = useRef<string | null>(null);
+  const boardRef = useRef<HTMLDivElement | null>(null);
+
+  // ---- Load best score: DB first, localStorage fallback -------------------
+  useEffect(() => {
+    let active = true;
+    const db = window.MatrixOS?.db;
+
+    const fromLocal = () => {
+      try {
+        const raw = window.localStorage.getItem(BEST_KEY);
+        if (raw && active) setBest(Number(raw) || 0);
+      } catch {
+        // localStorage may be unavailable (privacy mode); ignore safely.
+      }
+    };
+
+    if (!db) {
+      fromLocal();
+      return () => {
+        active = false;
+      };
+    }
+
+    (async () => {
+      try {
+        const rows = await db.find(SCORES_TABLE, { orderBy: { created_at: "desc" }, limit: 1 });
+        if (!active) return;
+        const row = rows[0];
+        if (row) {
+          dbRowId.current = (row.id as string) ?? null;
+          setBest(Number(row.best) || 0);
+        } else {
+          fromLocal();
+        }
+      } catch (err) {
+        if (!active) return;
+        console.warn("[2048] failed to load best score from MatrixOS.db", err);
+        setError("Couldn't load your best score; playing locally.");
+        fromLocal();
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // ---- onChange subscription: reconcile best when DB changes --------------
+  useEffect(() => {
+    const db = window.MatrixOS?.db;
+    if (!db?.onChange) return;
+    let unsub: (() => void) | undefined;
+    try {
+      unsub = db.onChange(SCORES_TABLE, () => {
+        (async () => {
+          try {
+            const rows = await db.find(SCORES_TABLE, { orderBy: { created_at: "desc" }, limit: 1 });
+            const row = rows[0];
+            if (row) {
+              dbRowId.current = (row.id as string) ?? dbRowId.current;
+              setBest((prev) => Math.max(prev, Number(row.best) || 0));
+            }
+          } catch (err) {
+            console.warn("[2048] onChange reload failed", err);
+          }
+        })();
+      });
+    } catch (err) {
+      console.warn("[2048] failed to subscribe to scores changes", err);
+    }
+    return () => {
+      if (unsub) unsub();
+    };
+  }, []);
+
+  // ---- Persist a new best (optimistic local, background DB) ---------------
+  const persistBest = useCallback((newBest: number) => {
+    // Optimistic local fallback always.
+    try {
+      window.localStorage.setItem(BEST_KEY, String(newBest));
+    } catch {
+      // ignore; non-fatal
+    }
+    const db = window.MatrixOS?.db;
+    if (!db) return;
+    (async () => {
+      try {
+        if (dbRowId.current) {
+          await db.update(SCORES_TABLE, dbRowId.current, { best: newBest });
+        } else {
+          const res = await db.insert(SCORES_TABLE, { score: 0, best: newBest });
+          dbRowId.current = res.id;
+        }
+      } catch (err) {
+        console.warn("[2048] failed to persist best score", err);
+        setError("Best score saved locally; sync failed.");
+      }
+    })();
+  }, []);
+
+  // Update best whenever current score beats it.
+  useEffect(() => {
+    if (state.score > best) {
+      setBest(state.score);
+      persistBest(state.score);
+    }
+  }, [state.score, best, persistBest]);
+
+  // Persist the current score onto the score row too (so DB.score is live).
+  useEffect(() => {
+    const db = window.MatrixOS?.db;
+    if (!db || !dbRowId.current || state.score === 0) return;
+    (async () => {
+      try {
+        await db.update(SCORES_TABLE, dbRowId.current as string, { score: state.score });
+      } catch (err) {
+        console.warn("[2048] failed to update current score", err);
+      }
+    })();
+  }, [state.score]);
+
+  // ---- Keyboard input ------------------------------------------------------
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey) {
+        if ((e.key === "z" || e.key === "Z") && state.history) {
+          e.preventDefault();
+          dispatch({ type: "undo" });
+        }
+        return;
+      }
+      const dir = KEY_TO_DIR[e.key];
+      if (dir) {
+        e.preventDefault();
+        dispatch({ type: "move", direction: dir });
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [state.history]);
+
+  // ---- Touch swipe ---------------------------------------------------------
+  useEffect(() => {
+    const el = boardRef.current;
+    if (!el) return;
+    let startX = 0;
+    let startY = 0;
+    let tracking = false;
+
+    const onStart = (e: TouchEvent) => {
+      const t = e.touches[0];
+      startX = t.clientX;
+      startY = t.clientY;
+      tracking = true;
+    };
+    const onEnd = (e: TouchEvent) => {
+      if (!tracking) return;
+      tracking = false;
+      const t = e.changedTouches[0];
+      const dx = t.clientX - startX;
+      const dy = t.clientY - startY;
+      const absX = Math.abs(dx);
+      const absY = Math.abs(dy);
+      if (Math.max(absX, absY) < 24) return; // ignore taps
+      let dir: Direction;
+      if (absX > absY) dir = dx > 0 ? "right" : "left";
+      else dir = dy > 0 ? "down" : "up";
+      dispatch({ type: "move", direction: dir });
+    };
+
+    el.addEventListener("touchstart", onStart, { passive: true });
+    el.addEventListener("touchend", onEnd, { passive: true });
+    return () => {
+      el.removeEventListener("touchstart", onStart);
+      el.removeEventListener("touchend", onEnd);
+    };
+  }, []);
+
+  const showWin = state.won && !keepPlaying;
+  const showOver = state.over && !state.won;
+
+  const newGameClick = useCallback(() => {
+    setKeepPlaying(false);
+    dispatch({ type: "reset" });
+  }, []);
+
+  return (
+    <div className="app">
+      <div className="shell">
+        <header className="topbar">
+          <div className="title-block">
+            <h1 className="title">2048</h1>
+            <p className="subtitle">Join the tiles, reach 2048.</p>
+          </div>
+          <div className="scores">
+            <div className="score-card">
+              <span className="score-label">Score</span>
+              <span className="score-value" data-testid="score">
+                {state.score}
+              </span>
+            </div>
+            <div className="score-card">
+              <span className="score-label">
+                <Trophy size={11} aria-hidden /> Best
+              </span>
+              <span className="score-value" data-testid="best">
+                {best}
+              </span>
+            </div>
+          </div>
+        </header>
+
+        <div className="controls">
+          <button type="button" className="btn ghost" onClick={() => dispatch({ type: "undo" })} disabled={!state.history}>
+            <Undo2 size={15} aria-hidden /> Undo
+          </button>
+          <button type="button" className="btn primary" onClick={newGameClick}>
+            <RotateCcw size={15} aria-hidden /> New game
+          </button>
+        </div>
+
+        <div className="board-wrap">
+          <div className="board" data-testid="board" ref={boardRef} aria-label="2048 board">
+            {Array.from({ length: 16 }).map((_, i) => (
+              <div key={`bg-${i}`} className="cell" data-testid="cell" aria-hidden />
+            ))}
+
+            {state.tiles.map((tile) => (
+              <div
+                key={tile.id}
+                className={[
+                  "tile",
+                  `tile-${tile.value > 2048 ? "super" : tile.value}`,
+                  tile.merged ? "is-merged" : "",
+                  tile.spawned ? "is-new" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+                style={
+                  {
+                    "--col": tile.col,
+                    "--row": tile.row,
+                  } as React.CSSProperties
+                }
+                data-testid="tile"
+                data-value={tile.value}
+              >
+                <span className="tile-inner">{tile.value}</span>
+              </div>
+            ))}
+
+            {showWin && (
+              <div className="overlay win" role="dialog" aria-label="You win">
+                <Sparkles size={28} aria-hidden />
+                <h2>You made 2048!</h2>
+                <p>Keep going for a higher score.</p>
+                <div className="overlay-actions">
+                  <button type="button" className="btn primary" onClick={() => setKeepPlaying(true)}>
+                    Keep playing
+                  </button>
+                  <button type="button" className="btn ghost" onClick={newGameClick}>
+                    New game
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {showOver && (
+              <div className="overlay over" role="dialog" aria-label="Game over">
+                <h2>Game over</h2>
+                <p>No more moves. Final score {state.score}.</p>
+                <div className="overlay-actions">
+                  <button type="button" className="btn primary" onClick={newGameClick}>
+                    Try again
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <footer className="hints">
+          <span className="hint">
+            <kbd>←</kbd>
+            <kbd>↑</kbd>
+            <kbd>→</kbd>
+            <kbd>↓</kbd> or <kbd>WASD</kbd> to move
+          </span>
+          <span className="hint">
+            <kbd>⌘Z</kbd> undo · swipe on touch
+          </span>
+        </footer>
+
+        {error && (
+          <div className="banner" role="status">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -48,8 +48,9 @@ function cellKey(row: number, col: number): string {
   return `${row}:${col}`;
 }
 
-function mergeCellsForMove(board: Board, direction: Direction): Set<string> {
+function animationCellsForMove(board: Board, direction: Direction): { merged: Set<string>; consumed: Set<string> } {
   const merged = new Set<string>();
+  const consumed = new Set<string>();
   for (let line = 0; line < board.length; line += 1) {
     const values: Array<{ value: number; row: number; col: number }> = [];
     for (let offset = 0; offset < board.length; offset += 1) {
@@ -68,12 +69,14 @@ function mergeCellsForMove(board: Board, direction: Direction): Set<string> {
       const col = direction === "left" ? target : direction === "right" ? board.length - 1 - target : line;
       if (isMerge) {
         merged.add(cellKey(row, col));
+        consumed.add(cellKey(current.row, current.col));
+        if (next) consumed.add(cellKey(next.row, next.col));
         index += 1;
       }
       target += 1;
     }
   }
-  return merged;
+  return { merged, consumed };
 }
 
 export function tilesFromBoard(
@@ -81,9 +84,14 @@ export function tilesFromBoard(
   previous: Tile[] = [],
   spawned: { row: number; col: number; value: number } | null = null,
   mergedCells = new Set<string>(),
+  consumedCells = new Set<string>(),
 ): Tile[] {
   const tiles: Tile[] = [];
-  const used = new Set<number>();
+  const used = new Set(
+    previous
+      .filter((tile) => consumedCells.has(cellKey(tile.row, tile.col)))
+      .map((tile) => tile.id),
+  );
   for (let r = 0; r < board.length; r += 1) {
     for (let c = 0; c < board[r].length; c += 1) {
       if (board[r][c] !== 0) {
@@ -155,7 +163,8 @@ function reducer(state: InternalState, action: Action): InternalState {
       const spawn = addRandomTile(result.board, Math.random);
       const nextBoard = spawn.board;
       const nextScore = state.score + result.gained;
-      const tiles = tilesFromBoard(nextBoard, state.tiles, spawn.spawned, mergeCellsForMove(state.board, action.direction));
+      const animationCells = animationCellsForMove(state.board, action.direction);
+      const tiles = tilesFromBoard(nextBoard, state.tiles, spawn.spawned, animationCells.merged, animationCells.consumed);
 
       return {
         board: nextBoard,

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -376,6 +376,7 @@ export default function App() {
 
   // Persist the current score onto the score row too (so DB.score is live).
   useEffect(() => {
+    if (state.score === 0 && !dbRowId.current) return;
     persistScore(state.score);
   }, [persistScore, state.score]);
 

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -440,8 +440,8 @@ export default function App() {
 
   const newGameClick = useCallback(() => {
     setKeepPlaying(false);
-    persistScore(0);
     dispatch({ type: "reset" });
+    persistScore(0);
   }, [persistScore]);
 
   return (

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -256,7 +256,11 @@ export default function App() {
     const fromLocal = () => {
       try {
         const raw = window.localStorage.getItem(BEST_KEY);
-        if (raw && active) setBest(Number(raw) || 0);
+        if (raw && active) {
+          const localBest = Number(raw) || 0;
+          pendingBestRef.current = Math.max(pendingBestRef.current, localBest);
+          setBest(localBest);
+        }
       } catch (err) {
         if (!(err instanceof DOMException && err.name === "SecurityError")) {
           console.warn("[2048] unexpected localStorage read error", err);

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -33,6 +33,10 @@ function nextId(): number {
   return TILE_SEQ;
 }
 
+export function resetTileIdsForTest(): void {
+  TILE_SEQ = 1;
+}
+
 interface InternalState extends GameState {
   tiles: Tile[];
   history: { board: Board; score: number; tiles: Tile[] } | null;
@@ -67,6 +71,8 @@ function animationCellsForMove(board: Board, direction: Direction): { merged: Se
       const row = direction === "up" ? target : direction === "down" ? board.length - 1 - target : line;
       const col = direction === "left" ? target : direction === "right" ? board.length - 1 - target : line;
       if (isMerge) {
+        // `merged` is keyed by post-move output cells; `consumed` is keyed by
+        // pre-move source cells so survivor selection cannot reuse merged tiles.
         merged.add(cellKey(row, col));
         consumed.add(cellKey(current.row, current.col));
         if (next) consumed.add(cellKey(next.row, next.col));

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -75,7 +75,16 @@ function tilesFromBoard(
 
 function freshGame(): InternalState {
   const g = newGame();
-  return { ...g, tiles: tilesFromBoard(g.board), history: null };
+  const tiles: Tile[] = [];
+  for (let row = 0; row < g.board.length; row += 1) {
+    for (let col = 0; col < g.board[row].length; col += 1) {
+      const value = g.board[row][col];
+      if (value !== 0) {
+        tiles.push({ id: nextId(), value, row, col, spawned: true, merged: false });
+      }
+    }
+  }
+  return { ...g, tiles, history: null };
 }
 
 function reducer(state: InternalState, action: Action): InternalState {

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -172,7 +172,7 @@ export default function App() {
         if (raw && active) {
           const localBest = Number(raw) || 0;
           pendingBestRef.current = Math.max(pendingBestRef.current, localBest);
-          setBest(localBest);
+          setBest((prev) => Math.max(prev, localBest));
         }
       } catch (err) {
         if (!(err instanceof DOMException && err.name === "SecurityError")) {

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -236,7 +236,9 @@ export default function App() {
             const rows = await db.find(SCORES_TABLE, { orderBy: { created_at: "desc" }, limit: 1 });
             const row = rows[0];
             if (row) {
-              dbRowId.current = (row.id as string) ?? dbRowId.current;
+              const rowId = typeof row.id === "string" ? row.id : null;
+              if (dbRowId.current && rowId && rowId !== dbRowId.current) return;
+              dbRowId.current = rowId ?? dbRowId.current;
               pendingBestRef.current = Math.max(pendingBestRef.current, Number(row.best) || 0);
               setBest((prev) => Math.max(prev, Number(row.best) || 0));
               setError(null);

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -205,22 +205,48 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
   const [keepPlaying, setKeepPlaying] = useState(false);
   const dbRowId = useRef<string | null>(null);
-  const dbRowInsertRef = useRef<Promise<string> | null>(null);
+  const scoreRowEnsureRef = useRef<Promise<string> | null>(null);
   const dbInitialLoadRef = useRef<Promise<void> | null>(null);
   const pendingBestRef = useRef(0);
+  const latestScoreRef = useRef(0);
   const boardRef = useRef<HTMLDivElement | null>(null);
+  latestScoreRef.current = state.score;
+
+  const ensureScoreRow = useCallback(async (db: MatrixOSDb, scoreHint: number): Promise<string> => {
+    if (dbRowId.current) return dbRowId.current;
+    if (dbInitialLoadRef.current) {
+      await dbInitialLoadRef.current;
+    }
+    if (dbRowId.current) return dbRowId.current;
+    if (!scoreRowEnsureRef.current) {
+      scoreRowEnsureRef.current = db.insert(SCORES_TABLE, {
+        score: Math.max(scoreHint, latestScoreRef.current),
+        best: Math.max(pendingBestRef.current, latestScoreRef.current),
+        created_at: new Date().toISOString(),
+      })
+        .then((res) => {
+          dbRowId.current = res.id;
+          return res.id;
+        })
+        .finally(() => {
+          scoreRowEnsureRef.current = null;
+        });
+    }
+    return scoreRowEnsureRef.current;
+  }, []);
 
   const persistScore = useCallback((score: number) => {
     const db = window.MatrixOS?.db;
-    if (!db || !dbRowId.current) return;
+    if (!db) return;
     (async () => {
       try {
-        await db.update(SCORES_TABLE, dbRowId.current as string, { score });
+        const id = await ensureScoreRow(db, score);
+        await db.update(SCORES_TABLE, id, { score: Math.max(score, latestScoreRef.current) });
       } catch (err) {
         console.warn("[2048] failed to update current score", err);
       }
     })();
-  }, []);
+  }, [ensureScoreRow]);
 
   // ---- Load best score: DB first, localStorage fallback -------------------
   useEffect(() => {
@@ -288,6 +314,7 @@ export default function App() {
             const row = rows[0];
             if (row) {
               dbRowId.current = (row.id as string) ?? dbRowId.current;
+              pendingBestRef.current = Math.max(pendingBestRef.current, Number(row.best) || 0);
               setBest((prev) => Math.max(prev, Number(row.best) || 0));
               setError(null);
             }
@@ -319,36 +346,18 @@ export default function App() {
     pendingBestRef.current = Math.max(pendingBestRef.current, newBest);
     (async () => {
       try {
-        if (!dbRowId.current && dbInitialLoadRef.current) {
-          await dbInitialLoadRef.current;
-        }
-        if (dbRowId.current) {
-          await db.update(SCORES_TABLE, dbRowId.current, { best: Math.max(newBest, pendingBestRef.current) });
-        } else {
-          if (!dbRowInsertRef.current) {
-            dbRowInsertRef.current = db.insert(SCORES_TABLE, {
-              score: newBest,
-              best: pendingBestRef.current,
-              created_at: new Date().toISOString(),
-            })
-              .then((res) => {
-                if (!dbRowId.current) dbRowId.current = res.id;
-                return res.id;
-              })
-              .finally(() => {
-                dbRowInsertRef.current = null;
-              });
-          }
-          const id = await dbRowInsertRef.current;
-          await db.update(SCORES_TABLE, dbRowId.current ?? id, { best: Math.max(newBest, pendingBestRef.current) });
-        }
+        const id = await ensureScoreRow(db, newBest);
+        await db.update(SCORES_TABLE, id, {
+          score: latestScoreRef.current,
+          best: Math.max(newBest, pendingBestRef.current),
+        });
         setError(null);
       } catch (err) {
         console.warn("[2048] failed to persist best score", err);
         setError("Best score saved locally; sync failed.");
       }
     })();
-  }, []);
+  }, [ensureScoreRow]);
 
   // Update best whenever current score beats it.
   useEffect(() => {

--- a/home/apps/games/2048/src/App.tsx
+++ b/home/apps/games/2048/src/App.tsx
@@ -143,7 +143,20 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
   const [keepPlaying, setKeepPlaying] = useState(false);
   const dbRowId = useRef<string | null>(null);
+  const dbRowInsertRef = useRef<Promise<string> | null>(null);
   const boardRef = useRef<HTMLDivElement | null>(null);
+
+  const persistScore = useCallback((score: number) => {
+    const db = window.MatrixOS?.db;
+    if (!db || !dbRowId.current) return;
+    (async () => {
+      try {
+        await db.update(SCORES_TABLE, dbRowId.current as string, { score });
+      } catch (err) {
+        console.warn("[2048] failed to update current score", err);
+      }
+    })();
+  }, []);
 
   // ---- Load best score: DB first, localStorage fallback -------------------
   useEffect(() => {
@@ -233,8 +246,18 @@ export default function App() {
         if (dbRowId.current) {
           await db.update(SCORES_TABLE, dbRowId.current, { best: newBest });
         } else {
-          const res = await db.insert(SCORES_TABLE, { score: 0, best: newBest });
-          dbRowId.current = res.id;
+          if (!dbRowInsertRef.current) {
+            dbRowInsertRef.current = db.insert(SCORES_TABLE, { score: 0, best: newBest })
+              .then((res) => {
+                dbRowId.current = res.id;
+                return res.id;
+              })
+              .finally(() => {
+                dbRowInsertRef.current = null;
+              });
+          }
+          const id = await dbRowInsertRef.current;
+          await db.update(SCORES_TABLE, id, { best: newBest });
         }
       } catch (err) {
         console.warn("[2048] failed to persist best score", err);
@@ -253,16 +276,8 @@ export default function App() {
 
   // Persist the current score onto the score row too (so DB.score is live).
   useEffect(() => {
-    const db = window.MatrixOS?.db;
-    if (!db || !dbRowId.current || state.score === 0) return;
-    (async () => {
-      try {
-        await db.update(SCORES_TABLE, dbRowId.current as string, { score: state.score });
-      } catch (err) {
-        console.warn("[2048] failed to update current score", err);
-      }
-    })();
-  }, [state.score]);
+    persistScore(state.score);
+  }, [persistScore, state.score]);
 
   // ---- Keyboard input ------------------------------------------------------
   useEffect(() => {
@@ -322,12 +337,13 @@ export default function App() {
   }, []);
 
   const showWin = state.won && !keepPlaying;
-  const showOver = state.over && !state.won;
+  const showOver = state.over && (!state.won || keepPlaying);
 
   const newGameClick = useCallback(() => {
     setKeepPlaying(false);
+    persistScore(0);
     dispatch({ type: "reset" });
-  }, []);
+  }, [persistScore]);
 
   return (
     <div className="app">

--- a/home/apps/games/2048/src/game-2048.ts
+++ b/home/apps/games/2048/src/game-2048.ts
@@ -26,6 +26,11 @@ export interface GameState {
   over: boolean;
 }
 
+export interface MoveAnimationCells {
+  merged: string[];
+  consumed: string[];
+}
+
 export function createEmptyBoard(): Board {
   return Array.from({ length: SIZE }, () => Array.from({ length: SIZE }, () => 0));
 }
@@ -52,23 +57,44 @@ export function hasWon(board: Board): boolean {
   return maxTile(board) >= WIN_VALUE;
 }
 
-// Slide + merge a single row to the left. Returns the new row and points gained.
-function collapseRow(row: number[]): { row: number[]; gained: number } {
-  const tiles = row.filter((v) => v !== 0);
+function cellKey(row: number, col: number): string {
+  return `${row}:${col}`;
+}
+
+function lineCell(line: number, offset: number, direction: Direction): { row: number; col: number } {
+  if (direction === "up") return { row: offset, col: line };
+  if (direction === "down") return { row: SIZE - 1 - offset, col: line };
+  if (direction === "right") return { row: line, col: SIZE - 1 - offset };
+  return { row: line, col: offset };
+}
+
+// Slide + merge a single normalized row to the left. The merge trace is used by
+// UI animation so it cannot drift from the scoring/move semantics.
+function collapseRow(row: number[]): {
+  row: number[];
+  gained: number;
+  merges: Array<{ targetIndex: number; sourceIndexes: [number, number] }>;
+} {
+  const tiles = row
+    .map((value, index) => ({ value, index }))
+    .filter((tile) => tile.value !== 0);
   const out: number[] = [];
+  const merges: Array<{ targetIndex: number; sourceIndexes: [number, number] }> = [];
   let gained = 0;
   for (let i = 0; i < tiles.length; i += 1) {
-    if (i + 1 < tiles.length && tiles[i] === tiles[i + 1]) {
-      const merged = tiles[i] * 2;
+    if (i + 1 < tiles.length && tiles[i].value === tiles[i + 1].value) {
+      const targetIndex = out.length;
+      const merged = tiles[i].value * 2;
       out.push(merged);
       gained += merged;
+      merges.push({ targetIndex, sourceIndexes: [tiles[i].index, tiles[i + 1].index] });
       i += 1; // skip the consumed tile so it cannot merge again this move
     } else {
-      out.push(tiles[i]);
+      out.push(tiles[i].value);
     }
   }
   while (out.length < SIZE) out.push(0);
-  return { row: out, gained };
+  return { row: out, gained, merges };
 }
 
 function rowsEqual(a: number[], b: number[]): boolean {
@@ -119,6 +145,28 @@ export function move(board: Board, direction: Direction): MoveResult {
   }
 
   return { board: result, moved, gained };
+}
+
+export function animationCellsForMove(board: Board, direction: Direction): MoveAnimationCells {
+  const merged: string[] = [];
+  const consumed: string[] = [];
+  for (let line = 0; line < SIZE; line += 1) {
+    const normalizedRow: number[] = [];
+    for (let offset = 0; offset < SIZE; offset += 1) {
+      const { row, col } = lineCell(line, offset, direction);
+      normalizedRow.push(board[row][col]);
+    }
+    const collapsed = collapseRow(normalizedRow);
+    for (const merge of collapsed.merges) {
+      const target = lineCell(line, merge.targetIndex, direction);
+      merged.push(cellKey(target.row, target.col));
+      for (const sourceIndex of merge.sourceIndexes) {
+        const source = lineCell(line, sourceIndex, direction);
+        consumed.push(cellKey(source.row, source.col));
+      }
+    }
+  }
+  return { merged, consumed };
 }
 
 export function emptyCells(board: Board): { row: number; col: number }[] {

--- a/home/apps/games/2048/src/game-2048.ts
+++ b/home/apps/games/2048/src/game-2048.ts
@@ -1,0 +1,167 @@
+// Pure, UI-free 2048 board engine. Deterministic with an injectable RNG.
+// A board is a 4x4 grid of tile values; 0 represents an empty cell.
+
+export const SIZE = 4;
+export const WIN_VALUE = 2048;
+
+export type Board = number[][];
+export type Direction = "left" | "right" | "up" | "down";
+export type Rng = () => number;
+
+export interface MoveResult {
+  board: Board;
+  moved: boolean;
+  gained: number;
+}
+
+export interface SpawnResult {
+  board: Board;
+  spawned: { row: number; col: number; value: number } | null;
+}
+
+export interface GameState {
+  board: Board;
+  score: number;
+  won: boolean;
+  over: boolean;
+}
+
+export function createEmptyBoard(): Board {
+  return Array.from({ length: SIZE }, () => Array.from({ length: SIZE }, () => 0));
+}
+
+export function cloneBoard(board: Board): Board {
+  return board.map((row) => [...row]);
+}
+
+export function countEmpty(board: Board): number {
+  let n = 0;
+  for (const row of board) {
+    for (const cell of row) if (cell === 0) n += 1;
+  }
+  return n;
+}
+
+export function maxTile(board: Board): number {
+  let m = 0;
+  for (const row of board) for (const cell of row) if (cell > m) m = cell;
+  return m;
+}
+
+export function hasWon(board: Board): boolean {
+  return maxTile(board) >= WIN_VALUE;
+}
+
+// Slide + merge a single row to the left. Returns the new row and points gained.
+function collapseRow(row: number[]): { row: number[]; gained: number } {
+  const tiles = row.filter((v) => v !== 0);
+  const out: number[] = [];
+  let gained = 0;
+  for (let i = 0; i < tiles.length; i += 1) {
+    if (i + 1 < tiles.length && tiles[i] === tiles[i + 1]) {
+      const merged = tiles[i] * 2;
+      out.push(merged);
+      gained += merged;
+      i += 1; // skip the consumed tile so it cannot merge again this move
+    } else {
+      out.push(tiles[i]);
+    }
+  }
+  while (out.length < SIZE) out.push(0);
+  return { row: out, gained };
+}
+
+function rowsEqual(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+function transpose(board: Board): Board {
+  const out = createEmptyBoard();
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      out[c][r] = board[r][c];
+    }
+  }
+  return out;
+}
+
+function reverseRows(board: Board): Board {
+  return board.map((row) => [...row].reverse());
+}
+
+// Move the board in `direction`. Pure: never mutates `board`.
+export function move(board: Board, direction: Direction): MoveResult {
+  let work = cloneBoard(board);
+
+  // Normalize so we always collapse "to the left", then transform back.
+  if (direction === "right") work = reverseRows(work);
+  else if (direction === "up") work = transpose(work);
+  else if (direction === "down") work = reverseRows(transpose(work));
+
+  let gained = 0;
+  const collapsed = work.map((row) => {
+    const res = collapseRow(row);
+    gained += res.gained;
+    return res.row;
+  });
+
+  let result = collapsed;
+  if (direction === "right") result = reverseRows(result);
+  else if (direction === "up") result = transpose(result);
+  else if (direction === "down") result = transpose(reverseRows(result));
+
+  let moved = false;
+  for (let r = 0; r < SIZE; r += 1) {
+    if (!rowsEqual(result[r], board[r])) {
+      moved = true;
+      break;
+    }
+  }
+
+  return { board: result, moved, gained };
+}
+
+export function emptyCells(board: Board): { row: number; col: number }[] {
+  const cells: { row: number; col: number }[] = [];
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      if (board[r][c] === 0) cells.push({ row: r, col: c });
+    }
+  }
+  return cells;
+}
+
+// Add a 2 (90%) or 4 (10%) to a random empty cell. Pure: returns a new board.
+export function addRandomTile(board: Board, rng: Rng = Math.random): SpawnResult {
+  const cells = emptyCells(board);
+  if (cells.length === 0) return { board: cloneBoard(board), spawned: null };
+  const idx = Math.min(cells.length - 1, Math.floor(rng() * cells.length));
+  const { row, col } = cells[idx];
+  const value = rng() < 0.9 ? 2 : 4;
+  const next = cloneBoard(board);
+  next[row][col] = value;
+  return { board: next, spawned: { row, col, value } };
+}
+
+export function canMove(board: Board): boolean {
+  if (countEmpty(board) > 0) return true;
+  for (let r = 0; r < SIZE; r += 1) {
+    for (let c = 0; c < SIZE; c += 1) {
+      const v = board[r][c];
+      if (c + 1 < SIZE && board[r][c + 1] === v) return true;
+      if (r + 1 < SIZE && board[r + 1][c] === v) return true;
+    }
+  }
+  return false;
+}
+
+export function isGameOver(board: Board): boolean {
+  return !canMove(board);
+}
+
+export function newGame(rng: Rng = Math.random): GameState {
+  let board = createEmptyBoard();
+  board = addRandomTile(board, rng).board;
+  board = addRandomTile(board, rng).board;
+  return { board, score: 0, won: false, over: false };
+}

--- a/home/apps/games/2048/src/main.tsx
+++ b/home/apps/games/2048/src/main.tsx
@@ -1,10 +1,3 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App";
-import "./styles.css";
+import { renderDefaultApp } from "../../../_shared/default-apps";
 
-createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+renderDefaultApp("2048" as const);

--- a/home/apps/games/2048/src/main.tsx
+++ b/home/apps/games/2048/src/main.tsx
@@ -1,3 +1,10 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
 
-renderDefaultApp("2048" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/2048/src/matrix-os.d.ts
+++ b/home/apps/games/2048/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/games/2048/src/styles.css
+++ b/home/apps/games/2048/src/styles.css
@@ -369,12 +369,33 @@ kbd {
   color: var(--app-fg);
 }
 .banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   font-size: 12px;
   text-align: center;
   color: var(--app-danger);
   background: color-mix(in srgb, var(--app-danger) 10%, transparent);
   border-radius: 10px;
   padding: 8px 12px;
+}
+.banner-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  color: var(--app-danger);
+  background: color-mix(in srgb, var(--app-danger) 12%, transparent);
+  cursor: pointer;
+}
+.banner-dismiss:focus-visible {
+  outline: 2px solid var(--app-danger);
+  outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/home/apps/games/2048/src/styles.css
+++ b/home/apps/games/2048/src/styles.css
@@ -1,0 +1,390 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+
+  /* Board geometry */
+  --gap: 2.6%;
+  --tile-radius: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  color: var(--app-fg);
+  background: var(--app-bg);
+}
+
+.app {
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(12px, 3vw, 28px);
+  background:
+    radial-gradient(120% 120% at 50% -10%, color-mix(in srgb, var(--app-accent) 6%, transparent), transparent 60%),
+    var(--app-bg);
+}
+
+.shell {
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ---- Top bar ------------------------------------------------------------ */
+.topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.title {
+  margin: 0;
+  font-size: clamp(34px, 8vw, 48px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--app-fg);
+}
+.subtitle {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: var(--app-muted-fg);
+}
+.scores {
+  display: flex;
+  gap: 8px;
+}
+.score-card {
+  min-width: 78px;
+  background: var(--app-card);
+  border-radius: 14px;
+  padding: 8px 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+.score-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--app-muted-fg);
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.score-value {
+  font-size: 22px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: var(--app-fg);
+}
+
+/* ---- Controls ----------------------------------------------------------- */
+.controls {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  border-radius: 12px;
+  padding: 9px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.btn.primary {
+  background: var(--app-accent);
+  color: #fff;
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--app-accent) 30%, transparent);
+}
+.btn.primary:hover {
+  filter: brightness(1.05);
+}
+.btn.ghost {
+  background: var(--app-muted);
+  color: var(--app-fg);
+}
+.btn.ghost:hover {
+  background: color-mix(in srgb, var(--app-fg) 8%, var(--app-muted));
+}
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.btn:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+/* ---- Board -------------------------------------------------------------- */
+.board-wrap {
+  width: 100%;
+}
+.board {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background: color-mix(in srgb, var(--app-fg) 10%, var(--app-muted));
+  border-radius: var(--app-radius);
+  padding: var(--gap);
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  gap: var(--gap);
+  box-shadow: 0 8px 24px rgba(50, 53, 46, 0.12);
+  touch-action: none;
+  user-select: none;
+}
+.cell {
+  border-radius: var(--tile-radius);
+  background: color-mix(in srgb, var(--app-card) 55%, transparent);
+}
+
+/* Tiles are absolutely positioned for smooth sliding. The board's inner area
+   (inside padding) holds 4 cells + 3 gaps; positions resolve against the board
+   width via left/top percentages so the slide animation stays smooth. */
+.tile {
+  --track: calc(100% - 2 * var(--gap)); /* inner width inside padding */
+  --cell-size: calc((var(--track) - 3 * var(--gap)) / 4);
+  --step: calc(var(--cell-size) + var(--gap));
+  position: absolute;
+  width: var(--cell-size);
+  height: var(--cell-size);
+  left: calc(var(--gap) + var(--col) * var(--step));
+  top: calc(var(--gap) + var(--row) * var(--step));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: left 0.12s ease-in-out, top 0.12s ease-in-out;
+  will-change: left, top;
+}
+.tile-inner {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--tile-radius);
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(20px, 6vw, 34px);
+  color: #776e65;
+  background: #eee4da;
+  box-shadow: 0 2px 6px rgba(50, 53, 46, 0.12);
+}
+
+/* Color ramp — classic 2048 palette, warmed to match clay language */
+.tile-2 .tile-inner {
+  background: #eee4da;
+  color: #776e65;
+}
+.tile-4 .tile-inner {
+  background: #ede0c8;
+  color: #776e65;
+}
+.tile-8 .tile-inner {
+  background: #f2b179;
+  color: #fff;
+}
+.tile-16 .tile-inner {
+  background: #f59563;
+  color: #fff;
+}
+.tile-32 .tile-inner {
+  background: #f67c5f;
+  color: #fff;
+}
+.tile-64 .tile-inner {
+  background: #f65e3b;
+  color: #fff;
+}
+.tile-128 .tile-inner {
+  background: #edcf72;
+  color: #fff;
+  font-size: clamp(18px, 5.2vw, 30px);
+}
+.tile-256 .tile-inner {
+  background: #edcc61;
+  color: #fff;
+  font-size: clamp(18px, 5.2vw, 30px);
+}
+.tile-512 .tile-inner {
+  background: #edc850;
+  color: #fff;
+  font-size: clamp(18px, 5.2vw, 30px);
+}
+.tile-1024 .tile-inner {
+  background: #edc53f;
+  color: #fff;
+  font-size: clamp(15px, 4.4vw, 26px);
+}
+.tile-2048 .tile-inner {
+  background: var(--app-accent);
+  color: #fff;
+  font-size: clamp(15px, 4.4vw, 26px);
+  box-shadow: 0 0 20px color-mix(in srgb, var(--app-accent) 55%, transparent);
+}
+.tile-super .tile-inner {
+  background: #3c3a32;
+  color: #fff;
+  font-size: clamp(13px, 3.8vw, 22px);
+}
+
+/* ---- Animations --------------------------------------------------------- */
+@keyframes pop-in {
+  0% {
+    transform: scale(0);
+  }
+  60% {
+    transform: scale(1.12);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@keyframes merge-pulse {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(1.18);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+.tile.is-new .tile-inner {
+  animation: pop-in 0.16s ease;
+}
+.tile.is-merged .tile-inner {
+  animation: merge-pulse 0.16s ease;
+}
+
+/* ---- Overlays ----------------------------------------------------------- */
+.overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--app-radius);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  text-align: center;
+  padding: 24px;
+  backdrop-filter: blur(3px);
+  background: color-mix(in srgb, var(--app-bg) 78%, transparent);
+  animation: fade-in 0.2s ease;
+}
+.overlay h2 {
+  margin: 4px 0 0;
+  font-size: 26px;
+  font-weight: 800;
+}
+.overlay p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--app-muted-fg);
+}
+.overlay.win {
+  color: var(--app-accent);
+}
+.overlay-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* ---- Hints + banner ----------------------------------------------------- */
+.hints {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--app-muted-fg);
+}
+.hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 1px 5px;
+  border-radius: 6px;
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--app-fg);
+}
+.banner {
+  font-size: 12px;
+  text-align: center;
+  color: var(--app-danger);
+  background: color-mix(in srgb, var(--app-danger) 10%, transparent);
+  border-radius: 10px;
+  padding: 8px 12px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tile {
+    transition: none;
+    will-change: auto;
+  }
+  .tile.is-new .tile-inner,
+  .tile.is-merged .tile-inner,
+  .overlay {
+    animation: none;
+  }
+}

--- a/home/apps/games/2048/src/tile-animation.ts
+++ b/home/apps/games/2048/src/tile-animation.ts
@@ -1,0 +1,78 @@
+import type { Board, Direction } from "./game-2048";
+
+export interface Tile {
+  id: number;
+  value: number;
+  row: number;
+  col: number;
+  merged?: boolean;
+  spawned?: boolean;
+}
+
+let TILE_SEQ = 1;
+
+export function nextTileId(): number {
+  TILE_SEQ += 1;
+  return TILE_SEQ;
+}
+
+export function resetTileIdsForTest(): void {
+  TILE_SEQ = 1;
+}
+
+function cellKey(row: number, col: number): string {
+  return `${row}:${col}`;
+}
+
+export function tilesFromBoard(
+  board: Board,
+  previous: Tile[] = [],
+  spawned: { row: number; col: number; value: number } | null = null,
+  mergedCells: readonly string[] = [],
+  consumedCells: readonly string[] = [],
+  direction?: Direction,
+): Tile[] {
+  const tiles: Tile[] = [];
+  const used = previous
+    .filter((tile) => consumedCells.includes(cellKey(tile.row, tile.col)))
+    .map((tile) => tile.id);
+  for (let r = 0; r < board.length; r += 1) {
+    for (let c = 0; c < board[r].length; c += 1) {
+      if (board[r][c] !== 0) {
+        if (spawned && spawned.row === r && spawned.col === c && spawned.value === board[r][c]) {
+          tiles.push({ id: nextTileId(), value: board[r][c], row: r, col: c, spawned: true });
+          continue;
+        }
+        if (mergedCells.includes(cellKey(r, c))) {
+          tiles.push({ id: nextTileId(), value: board[r][c], row: r, col: c, spawned: false, merged: true });
+          continue;
+        }
+        const lineMatch = direction
+          ? previous
+            .filter((tile) =>
+              tile.value === board[r][c] &&
+              !used.includes(tile.id) &&
+              (direction === "left" || direction === "right" ? tile.row === r : tile.col === c),
+            )
+            .sort((a, b) => (direction === "left" || direction === "right" ? a.col - b.col : a.row - b.row))[0]
+          : null;
+        const match = previous
+          .filter((tile) => tile.value === board[r][c] && !used.includes(tile.id))
+          .sort((a, b) => {
+            const distance = Math.abs(a.row - r) + Math.abs(a.col - c) - (Math.abs(b.row - r) + Math.abs(b.col - c));
+            if (distance !== 0) return distance;
+            if (a.row !== b.row) return a.row - b.row;
+            return a.col - b.col;
+          })[0];
+        const resolved = lineMatch ?? match;
+        if (resolved) {
+          used.push(resolved.id);
+          tiles.push({ ...resolved, row: r, col: c, spawned: false, merged: false });
+        } else {
+          tiles.push({ id: nextTileId(), value: board[r][c], row: r, col: c, spawned: false, merged: false });
+        }
+      }
+    }
+  }
+  return tiles;
+}

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -2,7 +2,7 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import App, { tilesFromBoard } from "../../home/apps/games/2048/src/App";
+import App, { resetTileIdsForTest, tilesFromBoard } from "../../home/apps/games/2048/src/App";
 
 type DbRow = Record<string, unknown>;
 
@@ -25,6 +25,7 @@ function installMatrixDb(rows: DbRow[] = []) {
 
 describe("2048 app", () => {
   beforeEach(() => {
+    resetTileIdsForTest();
     window.localStorage.clear();
   });
 

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -247,6 +247,22 @@ describe("2048 app", () => {
     await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("7777"));
   });
 
+  it("preserves a localStorage best score when creating the first DB score row", async () => {
+    window.localStorage.setItem("matrixos.2048.best", "7777");
+    const db = installMatrixDb([]);
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await waitFor(() =>
+      expect(db.insert).toHaveBeenCalledWith(
+        "scores",
+        expect.objectContaining({ best: 7777 }),
+      ),
+    );
+    await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("7777"));
+  });
+
   it("logs unexpected localStorage read failures", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -85,6 +85,17 @@ describe("2048 app", () => {
     expect(screen.getByTestId("score").textContent).toBe("0");
   });
 
+  it("persists a zero live score when starting a new game", async () => {
+    const db = installMatrixDb([{ id: "s1", score: 1234, best: 5000, created_at: "2026-05-31T00:00:00.000Z" }]);
+    render(<App />);
+    await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("5000"));
+    db.update.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
+  });
+
   it("falls back to localStorage best score when MatrixOS.db is undefined", async () => {
     window.localStorage.setItem("matrixos.2048.best", "7777");
     render(<App />);

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -8,6 +8,7 @@ import { resetTileIdsForTest, tilesFromBoard } from "../../home/apps/games/2048/
 type DbRow = Record<string, unknown>;
 
 function installMatrixDb(rows: DbRow[] = []) {
+  let onChangeHandler: (() => void) | null = null;
   const db = {
     find: vi.fn(async () => rows),
     findOne: vi.fn(async () => null),
@@ -15,7 +16,15 @@ function installMatrixDb(rows: DbRow[] = []) {
     update: vi.fn(async () => ({ ok: true })),
     delete: vi.fn(async () => ({ ok: true })),
     count: vi.fn(async () => rows.length),
-    onChange: vi.fn(() => () => undefined),
+    onChange: vi.fn((_table: string, handler: () => void) => {
+      onChangeHandler = handler;
+      return () => {
+        if (onChangeHandler === handler) onChangeHandler = null;
+      };
+    }),
+    emitChange: () => {
+      onChangeHandler?.();
+    },
   };
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
@@ -222,6 +231,33 @@ describe("2048 app", () => {
 
     await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", expect.objectContaining({ score: 0 })));
     expect(db.update).not.toHaveBeenCalledWith("scores", "s1", { score: 4 });
+  });
+
+  it("keeps writes on the loaded score row after a foreign score change", async () => {
+    vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValueOnce(0.1).mockReturnValueOnce(0).mockReturnValueOnce(0.1).mockReturnValue(0.1);
+    const db = installMatrixDb([{ id: "s1", score: 0, best: 0, created_at: "2026-05-31T00:00:00.000Z" }]);
+    db.find
+      .mockResolvedValueOnce([{ id: "s1", score: 0, best: 0, created_at: "2026-05-31T00:00:00.000Z" }])
+      .mockResolvedValueOnce([{ id: "s2", score: 0, best: 4096, created_at: "2026-06-01T00:00:00.000Z" }]);
+    render(<App />);
+    await screen.findByTestId("board");
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
+    db.update.mockClear();
+
+    await act(async () => {
+      db.emitChange();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(db.find).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 4 }));
+    expect(db.update).not.toHaveBeenCalledWith("scores", "s2", expect.anything());
   });
 
   it("does not persist an in-flight previous score after starting a new game", async () => {

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -163,14 +163,41 @@ describe("2048 app", () => {
   });
 
   it("persists a zero live score when starting a new game", async () => {
+    vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValueOnce(0.1).mockReturnValueOnce(0).mockReturnValueOnce(0.1).mockReturnValue(0.1);
     const db = installMatrixDb([{ id: "s1", score: 1234, best: 5000, created_at: "2026-05-31T00:00:00.000Z" }]);
     render(<App />);
     await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("5000"));
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId("score").textContent).toBe("4"));
     db.update.mockClear();
 
     fireEvent.click(screen.getByRole("button", { name: /new game/i }));
 
     await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
+  });
+
+  it("does not persist the previous live score when starting a new game", async () => {
+    vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValueOnce(0.1).mockReturnValueOnce(0).mockReturnValueOnce(0.1).mockReturnValue(0.1);
+    const db = installMatrixDb([{ id: "s1", score: 0, best: 0, created_at: "2026-05-31T00:00:00.000Z" }]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId("score").textContent).toBe("4"));
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 4 }));
+    db.update.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
+    expect(db.update).not.toHaveBeenCalledWith("scores", "s1", { score: 4 });
   });
 
   it("creates the initial DB score row with the latest early-move score", async () => {

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -2,7 +2,8 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import App, { resetTileIdsForTest, tilesFromBoard } from "../../home/apps/games/2048/src/App";
+import App from "../../home/apps/games/2048/src/App";
+import { resetTileIdsForTest, tilesFromBoard } from "../../home/apps/games/2048/src/tile-animation";
 
 type DbRow = Record<string, unknown>;
 
@@ -75,8 +76,8 @@ describe("2048 app", () => {
         { id: 3, value: 4, row: 0, col: 3 },
       ],
       null,
-      new Set(["0:0"]),
-      new Set(["0:0", "0:1"]),
+      ["0:0"],
+      ["0:0", "0:1"],
     );
 
     const merged = tiles.find((tile) => tile.row === 0 && tile.col === 0);
@@ -100,8 +101,8 @@ describe("2048 app", () => {
         { id: 3, value: 4, row: 0, col: 2 },
       ],
       null,
-      new Set(["0:0"]),
-      new Set(["0:0", "0:1"]),
+      ["0:0"],
+      ["0:0", "0:1"],
     );
 
     const merged = tiles.find((tile) => tile.row === 0 && tile.col === 0);
@@ -123,8 +124,8 @@ describe("2048 app", () => {
         { id: 2, value: 2, row: 0, col: 1 },
       ],
       null,
-      new Set(),
-      new Set(),
+      [],
+      [],
       "up",
     );
 

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -46,6 +46,20 @@ describe("2048 app", () => {
     await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("5000"));
   });
 
+  it("marks initial tiles as newly spawned rather than merged", async () => {
+    installMatrixDb([]);
+    render(<App />);
+
+    const board = await screen.findByTestId("board");
+    const tiles = within(board).getAllByTestId("tile");
+
+    expect(tiles).toHaveLength(2);
+    for (const tile of tiles) {
+      expect(tile.className).toContain("is-new");
+      expect(tile.className).not.toContain("is-merged");
+    }
+  });
+
   it("an arrow key produces a move and increases score on a merge", async () => {
     const db = installMatrixDb([]);
     render(<App />);

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -109,6 +109,28 @@ describe("2048 app", () => {
     expect(survivor).toMatchObject({ id: 3, value: 4, merged: false });
   });
 
+  it("keeps same-value survivor identities within their slide line", () => {
+    const tiles = tilesFromBoard(
+      [
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ],
+      [
+        { id: 1, value: 2, row: 3, col: 0 },
+        { id: 2, value: 2, row: 0, col: 1 },
+      ],
+      null,
+      new Set(),
+      new Set(),
+      "up",
+    );
+
+    expect(tiles.find((tile) => tile.row === 0 && tile.col === 0)).toMatchObject({ id: 1 });
+    expect(tiles.find((tile) => tile.row === 0 && tile.col === 1)).toMatchObject({ id: 2 });
+  });
+
   it("does not mark unmatched fallback tiles as merged", () => {
     const tiles = tilesFromBoard(
       [

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -367,6 +367,38 @@ describe("2048 app", () => {
     await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("7777"));
   });
 
+  it("keeps a newer in-memory best when db load falls back to stale localStorage", async () => {
+    const randomValues = [0, 0.1, 0, 0.1, 0, 0.1];
+    vi.spyOn(Math, "random").mockImplementation(() => randomValues.shift() ?? 0.1);
+    window.localStorage.setItem("matrixos.2048.best", "2");
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("write failed");
+    });
+    const db = installMatrixDb([]);
+    let rejectFind: (error: Error) => void = () => undefined;
+    db.find.mockImplementation(async () => new Promise<DbRow[]>((_resolve, reject) => {
+      rejectFind = reject;
+    }));
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("4"));
+
+    await act(async () => {
+      rejectFind(new Error("load failed"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("4"));
+  });
+
   it("waits for actual play before creating the first DB score row", async () => {
     const randomValues = [0, 0.1, 0, 0.1, 0, 0.1];
     vi.spyOn(Math, "random").mockImplementation(() => randomValues.shift() ?? 0.1);

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -200,6 +200,37 @@ describe("2048 app", () => {
     expect(db.update).not.toHaveBeenCalledWith("scores", "s1", { score: 4 });
   });
 
+  it("does not persist an in-flight previous score after starting a new game", async () => {
+    vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValueOnce(0.1).mockReturnValueOnce(0).mockReturnValueOnce(0.1).mockReturnValue(0.1);
+    const db = installMatrixDb([]);
+    let resolveFind: (rows: DbRow[]) => void = () => undefined;
+    db.find.mockImplementation(async () => new Promise<DbRow[]>((resolve) => {
+      resolveFind = resolve;
+    }));
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId("score").textContent).toBe("4"));
+
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+    expect(screen.getByTestId("score").textContent).toBe("0");
+
+    await act(async () => {
+      resolveFind([{ id: "s1", score: 0, best: 0, created_at: "2026-05-31T00:00:00.000Z" }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
+    expect(db.update).not.toHaveBeenCalledWith("scores", "s1", { score: 4 });
+  });
+
   it("creates the initial DB score row with the latest early-move score", async () => {
     const randomValues = [0, 0.1, 0, 0.1, 0, 0.1];
     vi.spyOn(Math, "random").mockImplementation(() => randomValues.shift() ?? 0.1);

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -109,6 +109,20 @@ describe("2048 app", () => {
     expect(survivor).toMatchObject({ id: 3, value: 4, merged: false });
   });
 
+  it("does not mark unmatched fallback tiles as merged", () => {
+    const tiles = tilesFromBoard(
+      [
+        [16, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ],
+      [{ id: 1, value: 2, row: 0, col: 0 }],
+    );
+
+    expect(tiles[0]).toMatchObject({ value: 16, spawned: false, merged: false });
+  });
+
   it("an arrow key produces a move and increases score on a merge", async () => {
     const db = installMatrixDb([]);
     render(<App />);
@@ -159,10 +173,89 @@ describe("2048 app", () => {
     await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
   });
 
+  it("waits for the initial score row before persisting an early best", async () => {
+    const randomValues = [0, 0.1, 0, 0.1, 0, 0.1];
+    vi.spyOn(Math, "random").mockImplementation(() => randomValues.shift() ?? 0.1);
+    const db = installMatrixDb([]);
+    let resolveFind: (rows: DbRow[]) => void = () => undefined;
+    db.find.mockImplementation(async () => new Promise<DbRow[]>((resolve) => {
+      resolveFind = resolve;
+    }));
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveFind([{ id: "s1", score: 0, best: 5000, created_at: "2026-05-31T00:00:00.000Z" }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith("scores", "s1", expect.objectContaining({ best: 5000 })),
+    );
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(screen.getByTestId("best").textContent).toBe("5000");
+  });
+
   it("falls back to localStorage best score when MatrixOS.db is undefined", async () => {
     window.localStorage.setItem("matrixos.2048.best", "7777");
     render(<App />);
     await screen.findByTestId("board");
     await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("7777"));
+  });
+
+  it("logs unexpected localStorage read failures", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("read failed");
+    });
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    expect(warn).toHaveBeenCalledWith("[2048] unexpected localStorage read error", expect.any(Error));
+  });
+
+  it("logs unexpected localStorage write failures", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("write failed");
+    });
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(warn).toHaveBeenCalledWith("[2048] unexpected localStorage write error", expect.any(Error)),
+    );
+  });
+
+  it("lets the player dismiss a transient sync error banner", async () => {
+    const db = installMatrixDb([]);
+    db.find.mockRejectedValueOnce(new Error("load failed"));
+
+    render(<App />);
+    await screen.findByTestId("board");
+    expect(await screen.findByText("Couldn't load your best score; playing locally.")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss sync message/i }));
+
+    expect(screen.queryByText("Couldn't load your best score; playing locally.")).toBeNull();
   });
 });

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -2,7 +2,7 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import App from "../../home/apps/games/2048/src/App";
+import App, { tilesFromBoard } from "../../home/apps/games/2048/src/App";
 
 type DbRow = Record<string, unknown>;
 
@@ -58,6 +58,30 @@ describe("2048 app", () => {
       expect(tile.className).toContain("is-new");
       expect(tile.className).not.toContain("is-merged");
     }
+  });
+
+  it("marks the merged target instead of a slid same-value tile", () => {
+    const tiles = tilesFromBoard(
+      [
+        [4, 4, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ],
+      [
+        { id: 1, value: 2, row: 0, col: 0 },
+        { id: 2, value: 2, row: 0, col: 1 },
+        { id: 3, value: 4, row: 0, col: 3 },
+      ],
+      null,
+      new Set(["0:0"]),
+    );
+
+    const merged = tiles.find((tile) => tile.row === 0 && tile.col === 0);
+    const slid = tiles.find((tile) => tile.row === 0 && tile.col === 1);
+    expect(merged?.merged).toBe(true);
+    expect(merged?.id).not.toBe(3);
+    expect(slid).toMatchObject({ id: 3, merged: false });
   });
 
   it("an arrow key produces a move and increases score on a merge", async () => {

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -177,7 +177,7 @@ describe("2048 app", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /new game/i }));
 
-    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", expect.objectContaining({ score: 0 })));
   });
 
   it("does not persist the previous live score when starting a new game", async () => {
@@ -196,7 +196,7 @@ describe("2048 app", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /new game/i }));
 
-    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", expect.objectContaining({ score: 0 })));
     expect(db.update).not.toHaveBeenCalledWith("scores", "s1", { score: 4 });
   });
 
@@ -227,7 +227,9 @@ describe("2048 app", () => {
       await Promise.resolve();
     });
 
-    await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
+    await waitFor(() =>
+      expect(db.update).toHaveBeenCalledWith("scores", "s1", expect.objectContaining({ score: 0 })),
+    );
     expect(db.update).not.toHaveBeenCalledWith("scores", "s1", { score: 4 });
   });
 
@@ -305,20 +307,50 @@ describe("2048 app", () => {
     await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("7777"));
   });
 
-  it("preserves a localStorage best score when creating the first DB score row", async () => {
+  it("waits for actual play before creating the first DB score row", async () => {
+    const randomValues = [0, 0.1, 0, 0.1, 0, 0.1];
+    vi.spyOn(Math, "random").mockImplementation(() => randomValues.shift() ?? 0.1);
     window.localStorage.setItem("matrixos.2048.best", "7777");
     const db = installMatrixDb([]);
 
     render(<App />);
     await screen.findByTestId("board");
+    await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("7777"));
+    expect(db.insert).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
 
     await waitFor(() =>
       expect(db.insert).toHaveBeenCalledWith(
         "scores",
-        expect.objectContaining({ best: 7777 }),
+        expect.objectContaining({ score: 4, best: 7777 }),
       ),
     );
-    await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("7777"));
+  });
+
+  it("does not create a best-zero score row after fast unmount", async () => {
+    window.localStorage.setItem("matrixos.2048.best", "7777");
+    const db = installMatrixDb([]);
+    let resolveFind: (rows: DbRow[]) => void = () => undefined;
+    db.find.mockImplementation(async () => new Promise<DbRow[]>((resolve) => {
+      resolveFind = resolve;
+    }));
+
+    const { unmount } = render(<App />);
+    await screen.findByTestId("board");
+
+    unmount();
+    await act(async () => {
+      resolveFind([]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).not.toHaveBeenCalled();
   });
 
   it("logs unexpected localStorage read failures", async () => {

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -75,6 +75,7 @@ describe("2048 app", () => {
       ],
       null,
       new Set(["0:0"]),
+      new Set(["0:0", "0:1"]),
     );
 
     const merged = tiles.find((tile) => tile.row === 0 && tile.col === 0);
@@ -82,6 +83,30 @@ describe("2048 app", () => {
     expect(merged?.merged).toBe(true);
     expect(merged?.id).not.toBe(3);
     expect(slid).toMatchObject({ id: 3, merged: false });
+  });
+
+  it("does not reuse consumed merge-source ids for surviving same-value tiles", () => {
+    const tiles = tilesFromBoard(
+      [
+        [8, 4, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ],
+      [
+        { id: 1, value: 4, row: 0, col: 0 },
+        { id: 2, value: 4, row: 0, col: 1 },
+        { id: 3, value: 4, row: 0, col: 2 },
+      ],
+      null,
+      new Set(["0:0"]),
+      new Set(["0:0", "0:1"]),
+    );
+
+    const merged = tiles.find((tile) => tile.row === 0 && tile.col === 0);
+    const survivor = tiles.find((tile) => tile.row === 0 && tile.col === 1);
+    expect(merged?.merged).toBe(true);
+    expect(survivor).toMatchObject({ id: 3, value: 4, merged: false });
   });
 
   it("an arrow key produces a move and increases score on a merge", async () => {

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -173,6 +173,40 @@ describe("2048 app", () => {
     await waitFor(() => expect(db.update).toHaveBeenCalledWith("scores", "s1", { score: 0 }));
   });
 
+  it("creates the initial DB score row with the latest early-move score", async () => {
+    const randomValues = [0, 0.1, 0, 0.1, 0, 0.1];
+    vi.spyOn(Math, "random").mockImplementation(() => randomValues.shift() ?? 0.1);
+    const db = installMatrixDb([]);
+    let resolveFind: (rows: DbRow[]) => void = () => undefined;
+    db.find.mockImplementation(async () => new Promise<DbRow[]>((resolve) => {
+      resolveFind = resolve;
+    }));
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveFind([]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(db.insert).toHaveBeenCalledWith(
+        "scores",
+        expect.objectContaining({ score: 4, best: 4 }),
+      ),
+    );
+  });
+
   it("waits for the initial score row before persisting an early best", async () => {
     const randomValues = [0, 0.1, 0, 0.1, 0, 0.1];
     vi.spyOn(Math, "random").mockImplementation(() => randomValues.shift() ?? 0.1);

--- a/tests/default-apps/2048-app.test.tsx
+++ b/tests/default-apps/2048-app.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/games/2048/src/App";
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const db = {
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async () => ({ id: "score-new" })),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => rows.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+describe("2048 app", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+    window.localStorage.clear();
+  });
+
+  it("renders a 16-cell board, score, and best-score readouts", async () => {
+    installMatrixDb([{ id: "s1", score: 1234, best: 5000, created_at: "2026-05-31T00:00:00.000Z" }]);
+    render(<App />);
+
+    const board = await screen.findByTestId("board");
+    // 16 grid cells
+    expect(within(board).getAllByTestId("cell").length).toBe(16);
+    expect(screen.getByTestId("score").textContent).toBe("0");
+    // best score loaded from DB
+    await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("5000"));
+  });
+
+  it("an arrow key produces a move and increases score on a merge", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    const scoreBefore = Number(screen.getByTestId("score").textContent);
+
+    // Press arrows in every direction; with two starting tiles at least one
+    // direction will eventually merge or move. We assert the board reacts:
+    // pressing keys must not throw and the score is a number that can only grow.
+    await act(async () => {
+      for (const key of ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"]) {
+        fireEvent.keyDown(window, { key });
+        await Promise.resolve();
+      }
+    });
+
+    const scoreAfter = Number(screen.getByTestId("score").textContent);
+    expect(scoreAfter).toBeGreaterThanOrEqual(scoreBefore);
+    // there must still be a board with 16 cells after moves
+    expect(within(screen.getByTestId("board")).getAllByTestId("cell").length).toBe(16);
+  });
+
+  it("New game button resets the score to 0", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      for (const key of ["ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown"]) {
+        fireEvent.keyDown(window, { key });
+        await Promise.resolve();
+      }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+    expect(screen.getByTestId("score").textContent).toBe("0");
+  });
+
+  it("falls back to localStorage best score when MatrixOS.db is undefined", async () => {
+    window.localStorage.setItem("matrixos.2048.best", "7777");
+    render(<App />);
+    await screen.findByTestId("board");
+    await waitFor(() => expect(screen.getByTestId("best").textContent).toBe("7777"));
+  });
+});

--- a/tests/default-apps/2048-model.test.ts
+++ b/tests/default-apps/2048-model.test.ts
@@ -3,6 +3,7 @@ import {
   type Board,
   type Direction,
   addRandomTile,
+  animationCellsForMove,
   canMove,
   cloneBoard,
   countEmpty,
@@ -151,6 +152,21 @@ describe("2048 engine — slide + merge per direction", () => {
     const snapshot = flat(b);
     move(b, "left");
     expect(flat(b)).toEqual(snapshot);
+  });
+
+  it("reports merge animation cells from the engine collapse path", () => {
+    const b = grid([
+      [2, 2, 4, 4],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+
+    expect(move(b, "right").board[0]).toEqual([0, 0, 4, 8]);
+    expect(animationCellsForMove(b, "right")).toEqual({
+      merged: ["0:3", "0:2"],
+      consumed: ["0:3", "0:2", "0:1", "0:0"],
+    });
   });
 });
 

--- a/tests/default-apps/2048-model.test.ts
+++ b/tests/default-apps/2048-model.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import {
+  type Board,
+  type Direction,
+  addRandomTile,
+  canMove,
+  cloneBoard,
+  countEmpty,
+  createEmptyBoard,
+  hasWon,
+  isGameOver,
+  move,
+  newGame,
+} from "../../home/apps/games/2048/src/game-2048";
+
+// A deterministic RNG returning the values in `seq`, cycling if exhausted.
+function seqRng(seq: number[]): () => number {
+  let i = 0;
+  return () => {
+    const v = seq[i % seq.length];
+    i += 1;
+    return v;
+  };
+}
+
+// Build a board from a 4x4 grid of numbers (0 = empty).
+function grid(rows: number[][]): Board {
+  return rows.map((r) => [...r]);
+}
+
+function flat(b: Board): number[] {
+  return b.flat();
+}
+
+describe("2048 engine — empty board + helpers", () => {
+  it("creates an empty 4x4 board", () => {
+    const b = createEmptyBoard();
+    expect(b.length).toBe(4);
+    expect(b.every((r) => r.length === 4)).toBe(true);
+    expect(countEmpty(b)).toBe(16);
+  });
+
+  it("cloneBoard makes an independent copy", () => {
+    const b = grid([
+      [2, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    const c = cloneBoard(b);
+    c[0][0] = 4;
+    expect(b[0][0]).toBe(2);
+  });
+});
+
+describe("2048 engine — slide + merge per direction", () => {
+  it("slides tiles left and merges equal neighbors once", () => {
+    const b = grid([
+      [2, 2, 2, 2],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    const r = move(b, "left");
+    expect(r.board[0]).toEqual([4, 4, 0, 0]);
+    expect(r.moved).toBe(true);
+    expect(r.gained).toBe(8); // two merges of 2+2 -> 4 + 4
+  });
+
+  it("slides and merges right", () => {
+    const b = grid([
+      [2, 2, 4, 4],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    const r = move(b, "right");
+    expect(r.board[0]).toEqual([0, 0, 4, 8]);
+    expect(r.gained).toBe(12);
+  });
+
+  it("slides and merges up", () => {
+    const b = grid([
+      [2, 0, 0, 0],
+      [2, 0, 0, 0],
+      [2, 0, 0, 0],
+      [2, 0, 0, 0],
+    ]);
+    const r = move(b, "up");
+    expect(r.board.map((row) => row[0])).toEqual([4, 4, 0, 0]);
+    expect(r.gained).toBe(8);
+  });
+
+  it("slides and merges down", () => {
+    const b = grid([
+      [2, 0, 0, 0],
+      [2, 0, 0, 0],
+      [4, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    const r = move(b, "down");
+    expect(r.board.map((row) => row[0])).toEqual([0, 0, 4, 4]);
+    expect(r.gained).toBe(4);
+  });
+
+  it("does not double-merge in a single move (8 not 16)", () => {
+    // [2,2,4,0] left -> first 2+2 merge into 4, then existing 4 stays separate
+    const b = grid([
+      [2, 2, 4, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    const r = move(b, "left");
+    expect(r.board[0]).toEqual([4, 4, 0, 0]);
+    expect(r.gained).toBe(4);
+  });
+
+  it("merges only the outer pair for four-of-a-kind in correct order (left)", () => {
+    const b = grid([
+      [4, 4, 2, 2],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    const r = move(b, "left");
+    expect(r.board[0]).toEqual([8, 4, 0, 0]);
+    expect(r.gained).toBe(12);
+  });
+
+  it("reports moved=false when nothing changes", () => {
+    const b = grid([
+      [2, 4, 8, 16],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    const r = move(b, "left");
+    expect(r.moved).toBe(false);
+    expect(r.gained).toBe(0);
+    expect(r.board).toEqual(b);
+  });
+
+  it("does not mutate the input board", () => {
+    const b = grid([
+      [2, 2, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    const snapshot = flat(b);
+    move(b, "left");
+    expect(flat(b)).toEqual(snapshot);
+  });
+});
+
+describe("2048 engine — spawn", () => {
+  it("addRandomTile fills exactly one empty cell", () => {
+    const b = createEmptyBoard();
+    // rng: first value picks the empty-cell index, second picks 2-vs-4
+    const r = addRandomTile(b, seqRng([0, 0]));
+    expect(countEmpty(r.board)).toBe(15);
+    expect(r.spawned).not.toBeNull();
+  });
+
+  it("spawns a 4 roughly 10% of the time (rng >= 0.9 -> 4)", () => {
+    const b = createEmptyBoard();
+    const r = addRandomTile(b, seqRng([0, 0.95]));
+    expect(r.spawned).not.toBeNull();
+    expect(r.board[r.spawned!.row][r.spawned!.col]).toBe(4);
+  });
+
+  it("spawns a 2 when rng < 0.9", () => {
+    const b = createEmptyBoard();
+    const r = addRandomTile(b, seqRng([0, 0.1]));
+    expect(r.board[r.spawned!.row][r.spawned!.col]).toBe(2);
+  });
+
+  it("returns null spawn when board is full", () => {
+    const full = grid([
+      [2, 4, 2, 4],
+      [4, 2, 4, 2],
+      [2, 4, 2, 4],
+      [4, 2, 4, 2],
+    ]);
+    const r = addRandomTile(full, seqRng([0, 0]));
+    expect(r.spawned).toBeNull();
+    expect(r.board).toEqual(full);
+  });
+});
+
+describe("2048 engine — win + game over", () => {
+  it("hasWon true when a 2048 tile exists", () => {
+    const b = grid([
+      [2048, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+    expect(hasWon(b)).toBe(true);
+  });
+
+  it("hasWon false otherwise", () => {
+    expect(hasWon(createEmptyBoard())).toBe(false);
+  });
+
+  it("canMove true when an empty cell exists", () => {
+    const b = grid([
+      [2, 4, 8, 16],
+      [4, 8, 16, 32],
+      [8, 16, 32, 64],
+      [16, 32, 64, 0],
+    ]);
+    expect(canMove(b)).toBe(true);
+    expect(isGameOver(b)).toBe(false);
+  });
+
+  it("canMove true when an adjacent merge is available even with full board", () => {
+    const b = grid([
+      [2, 2, 8, 16],
+      [4, 8, 16, 32],
+      [8, 16, 32, 64],
+      [16, 32, 64, 128],
+    ]);
+    expect(canMove(b)).toBe(true);
+  });
+
+  it("isGameOver true on a full board with no merges", () => {
+    const b = grid([
+      [2, 4, 2, 4],
+      [4, 2, 4, 2],
+      [2, 4, 2, 4],
+      [4, 2, 4, 2],
+    ]);
+    expect(canMove(b)).toBe(false);
+    expect(isGameOver(b)).toBe(true);
+  });
+});
+
+describe("2048 engine — newGame", () => {
+  it("starts with exactly two tiles", () => {
+    const g = newGame(seqRng([0, 0, 0.5, 0, 0]));
+    expect(countEmpty(g.board)).toBe(14);
+    expect(g.score).toBe(0);
+    expect(g.won).toBe(false);
+    expect(g.over).toBe(false);
+  });
+
+  it("is deterministic given a fixed RNG", () => {
+    const a = newGame(seqRng([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]));
+    const b = newGame(seqRng([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]));
+    expect(a.board).toEqual(b.board);
+  });
+});
+
+describe("2048 engine — move directions exhaustive", () => {
+  const dirs: Direction[] = ["left", "right", "up", "down"];
+  it("every direction is a pure function returning a fresh board", () => {
+    const b = grid([
+      [2, 0, 2, 0],
+      [0, 4, 0, 4],
+      [8, 0, 8, 0],
+      [0, 0, 0, 0],
+    ]);
+    for (const d of dirs) {
+      const r = move(b, d);
+      expect(r.board).not.toBe(b);
+      expect(r.board.length).toBe(4);
+    }
+  });
+});

--- a/tests/default-apps/2048-model.test.ts
+++ b/tests/default-apps/2048-model.test.ts
@@ -116,7 +116,7 @@ describe("2048 engine — slide + merge per direction", () => {
     expect(r.gained).toBe(4);
   });
 
-  it("merges only the outer pair for four-of-a-kind in correct order (left)", () => {
+  it("merges both adjacent pairs in correct order (left)", () => {
     const b = grid([
       [4, 4, 2, 2],
       [0, 0, 0, 0],


### PR DESCRIPTION
Stack: 11/22
Branch: stack/default-apps-2048

Scope: 2048 game engine, UI, manifest, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.