### PR TITLE
feat(snake): add canvas arcade game

### DIFF
--- a/home/apps/games/snake/matrix.json
+++ b/home/apps/games/snake/matrix.json
@@ -3,7 +3,7 @@
   "description": "Classic snake game with increasing speed",
   "runtime": "vite",
   "category": "games",
-  "icon": "snake",
+  "icon": "game-center",
   "author": "system",
   "version": "1.0.0",
   "tags": [

--- a/home/apps/games/snake/matrix.json
+++ b/home/apps/games/snake/matrix.json
@@ -3,7 +3,7 @@
   "description": "Classic snake game with increasing speed",
   "runtime": "vite",
   "category": "games",
-  "icon": "game-center",
+  "icon": "snake",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -12,6 +12,19 @@
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
   "slug": "snake",
+  "storage": {
+    "tables": {
+      "scores": {
+        "columns": {
+          "score": "integer",
+          "best": "integer"
+        },
+        "indexes": [
+          "best"
+        ]
+      }
+    }
+  },
   "build": {
     "install": "true",
     "command": "vite build --base ./ --outDir dist",

--- a/home/apps/games/snake/src/App.tsx
+++ b/home/apps/games/snake/src/App.tsx
@@ -14,6 +14,7 @@ import {
 
 const SCORES_TABLE = "scores";
 const LS_BEST_KEY = "matrix-snake-best";
+const DATA_BEST_KEY = "matrix-snake-best";
 
 type Difficulty = "chill" | "classic" | "fast";
 
@@ -49,17 +50,38 @@ function coerceBest(row: unknown): number {
   return Number.isFinite(score) && score > 0 ? score : 0;
 }
 
-function readLocalBest(): number {
+function coercePositiveNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+async function readFallbackBest(): Promise<number> {
+  if (window.MatrixOS?.readData) {
+    try {
+      return coercePositiveNumber(await window.MatrixOS.readData(DATA_BEST_KEY));
+    } catch (err: unknown) {
+      console.warn("[snake] app data best read failed:", err instanceof Error ? err.message : String(err));
+      return 0;
+    }
+  }
   try {
     const raw = localStorage.getItem(LS_BEST_KEY);
-    const n = raw ? Number(raw) : 0;
-    return Number.isFinite(n) && n > 0 ? n : 0;
+    return coercePositiveNumber(raw);
   } catch {
     return 0;
   }
 }
 
-function writeLocalBest(value: number): void {
+async function writeFallbackBest(value: number): Promise<void> {
+  if (window.MatrixOS?.writeData) {
+    try {
+      await window.MatrixOS.writeData(DATA_BEST_KEY, value);
+      return;
+    } catch (err: unknown) {
+      console.warn("[snake] app data best save failed:", err instanceof Error ? err.message : String(err));
+      return;
+    }
+  }
   try {
     localStorage.setItem(LS_BEST_KEY, String(value));
   } catch (err: unknown) {
@@ -68,7 +90,7 @@ function writeLocalBest(value: number): void {
 }
 
 async function loadBest(): Promise<number> {
-  const local = readLocalBest();
+  const local = await readFallbackBest();
   const db = window.MatrixOS?.db;
   if (!db) return local;
   const rows = await db.find(SCORES_TABLE, { orderBy: { best: "desc" }, limit: 1 });
@@ -111,7 +133,7 @@ export default function App() {
       setBest(await loadBest());
     } catch (err: unknown) {
       console.warn("[snake] best load failed:", err instanceof Error ? err.message : String(err));
-      setBest(readLocalBest());
+      setBest(await readFallbackBest());
       setError("High score could not be loaded.");
     }
   }, []);
@@ -130,13 +152,13 @@ export default function App() {
     setLastGameWasBest(wasNewBest);
     if (wasNewBest) {
       setBest(newBest);
-      writeLocalBest(newBest);
+      await writeFallbackBest(newBest);
     }
     try {
       await persistScore(finalScore, newBest);
     } catch (err: unknown) {
       console.warn("[snake] score save failed:", err instanceof Error ? err.message : String(err));
-      if (wasNewBest) writeLocalBest(newBest);
+      if (wasNewBest) await writeFallbackBest(newBest);
       setError("Score could not be synced.");
     }
   }, []);

--- a/home/apps/games/snake/src/App.tsx
+++ b/home/apps/games/snake/src/App.tsx
@@ -13,7 +13,6 @@ import {
 } from "./snake-model";
 
 const SCORES_TABLE = "scores";
-const LS_BEST_KEY = "matrix-snake-best";
 const DATA_BEST_KEY = "matrix-snake-best";
 
 type Difficulty = "chill" | "classic" | "fast";
@@ -64,12 +63,7 @@ async function readFallbackBest(): Promise<number> {
       return 0;
     }
   }
-  try {
-    const raw = localStorage.getItem(LS_BEST_KEY);
-    return coercePositiveNumber(raw);
-  } catch {
-    return 0;
-  }
+  return 0;
 }
 
 async function writeFallbackBest(value: number): Promise<void> {
@@ -81,11 +75,6 @@ async function writeFallbackBest(value: number): Promise<void> {
       console.warn("[snake] app data best save failed:", err instanceof Error ? err.message : String(err));
       return;
     }
-  }
-  try {
-    localStorage.setItem(LS_BEST_KEY, String(value));
-  } catch (err: unknown) {
-    console.warn("[snake] local best save failed:", err instanceof Error ? err.message : String(err));
   }
 }
 

--- a/home/apps/games/snake/src/App.tsx
+++ b/home/apps/games/snake/src/App.tsx
@@ -164,7 +164,6 @@ export default function App() {
       await persistScore(finalScore, newBest);
     } catch (err: unknown) {
       console.warn("[snake] score save failed:", err instanceof Error ? err.message : String(err));
-      if (wasNewBest) await writeFallbackBest(newBest);
       setError("Score could not be synced.");
     }
   }, []);
@@ -228,12 +227,25 @@ export default function App() {
   // --- Game loop ---
   useEffect(() => {
     if (game.status !== "running") return undefined;
-    const interval = Math.round(speedForScore(game.score) * DIFFICULTY[difficulty].tickMul);
-    const id = window.setInterval(() => {
+    let cancelled = false;
+    let tickTimer: number | null = null;
+    let scheduleTimer: number | null = null;
+    const schedule = () => {
+      if (cancelled || gameRef.current.status !== "running") return;
+      const interval = Math.round(speedForScore(gameRef.current.score) * DIFFICULTY[difficulty].tickMul);
+      tickTimer = window.setTimeout(tick, interval);
+    };
+    const tick = () => {
       setGame((current) => step(current, rng));
-    }, interval);
-    return () => window.clearInterval(id);
-  }, [game.status, game.score, difficulty]);
+      scheduleTimer = window.setTimeout(schedule, 0);
+    };
+    schedule();
+    return () => {
+      cancelled = true;
+      if (tickTimer !== null) window.clearTimeout(tickTimer);
+      if (scheduleTimer !== null) window.clearTimeout(scheduleTimer);
+    };
+  }, [game.status, difficulty]);
 
   // --- Eat pulse + save-on-end side effects ---
   useEffect(() => {

--- a/home/apps/games/snake/src/App.tsx
+++ b/home/apps/games/snake/src/App.tsx
@@ -271,7 +271,9 @@ export default function App() {
         canvas.width = px;
         canvas.height = px;
       }
-      const cell = canvas.width / GRID_COLS;
+      const cellW = canvas.width / GRID_COLS;
+      const cellH = canvas.height / GRID_ROWS;
+      const cell = Math.min(cellW, cellH);
       const cs = window.getComputedStyle(canvas);
       const read = (name: string, fallback: string) => {
         const v = cs.getPropertyValue(name).trim();
@@ -292,14 +294,14 @@ export default function App() {
       ctx.lineWidth = 1;
       for (let i = 1; i < GRID_COLS; i++) {
         ctx.beginPath();
-        ctx.moveTo(i * cell, 0);
-        ctx.lineTo(i * cell, canvas.height);
+        ctx.moveTo(i * cellW, 0);
+        ctx.lineTo(i * cellW, canvas.height);
         ctx.stroke();
       }
       for (let j = 1; j < GRID_ROWS; j++) {
         ctx.beginPath();
-        ctx.moveTo(0, j * cell);
-        ctx.lineTo(canvas.width, j * cell);
+        ctx.moveTo(0, j * cellH);
+        ctx.lineTo(canvas.width, j * cellH);
         ctx.stroke();
       }
 
@@ -310,8 +312,8 @@ export default function App() {
       // food with gentle pulse
       const t = prefersReducedMotion ? 0 : Date.now() / 320;
       const foodPulse = prefersReducedMotion ? 1 : 1 + Math.sin(t) * 0.06;
-      const fx = g.food.x * cell + cell / 2;
-      const fy = g.food.y * cell + cell / 2;
+      const fx = g.food.x * cellW + cellW / 2;
+      const fy = g.food.y * cellH + cellH / 2;
       ctx.fillStyle = foodColor;
       ctx.beginPath();
       ctx.arc(fx, fy, (cell / 2 - pad) * foodPulse, 0, Math.PI * 2);
@@ -323,14 +325,15 @@ export default function App() {
         const isHead = s === 0;
         ctx.fillStyle = isHead ? headColor : snakeColor;
         const grow = isHead && eatPulseRef.current > 0 ? eatPulseRef.current * pad * 0.5 : 0;
-        const x = seg.x * cell + pad - grow;
-        const y = seg.y * cell + pad - grow;
-        const w = cell - pad * 2 + grow * 2;
+        const x = seg.x * cellW + pad - grow;
+        const y = seg.y * cellH + pad - grow;
+        const w = cellW - pad * 2 + grow * 2;
+        const h = cellH - pad * 2 + grow * 2;
         ctx.beginPath();
         if (typeof ctx.roundRect === "function") {
-          ctx.roundRect(x, y, w, w, radius);
+          ctx.roundRect(x, y, w, h, radius);
         } else {
-          ctx.rect(x, y, w, w);
+          ctx.rect(x, y, w, h);
         }
         ctx.fill();
       }

--- a/home/apps/games/snake/src/App.tsx
+++ b/home/apps/games/snake/src/App.tsx
@@ -123,6 +123,7 @@ export default function App() {
   const savedForRef = useRef(false); // guard one save per game-over
   const eatPulseRef = useRef(0);
   const prevScoreRef = useRef(0);
+  const bestLoadedRef = useRef(false);
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
@@ -130,10 +131,14 @@ export default function App() {
   const reloadBest = useCallback(async () => {
     try {
       setError(null);
-      setBest(await loadBest());
+      const loadedBest = await loadBest();
+      bestLoadedRef.current = true;
+      setBest(loadedBest);
     } catch (err: unknown) {
       console.warn("[snake] best load failed:", err instanceof Error ? err.message : String(err));
-      setBest(await readFallbackBest());
+      const fallbackBest = await readFallbackBest();
+      bestLoadedRef.current = true;
+      setBest(fallbackBest);
       setError("High score could not be loaded.");
     }
   }, []);
@@ -147,8 +152,9 @@ export default function App() {
 
   // --- Persist new high score on game end ---
   const commitScore = useCallback(async (finalScore: number) => {
+    const bestLoaded = bestLoadedRef.current;
     const newBest = Math.max(bestRef.current, finalScore);
-    const wasNewBest = finalScore > bestRef.current;
+    const wasNewBest = bestLoaded && finalScore > bestRef.current;
     setLastGameWasBest(wasNewBest);
     if (wasNewBest) {
       setBest(newBest);

--- a/home/apps/games/snake/src/App.tsx
+++ b/home/apps/games/snake/src/App.tsx
@@ -1,0 +1,472 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Gauge, Pause, Play, RotateCcw, Trophy } from "lucide-react";
+import "./styles.css";
+import {
+  GRID_COLS,
+  GRID_ROWS,
+  createGame,
+  nextDirection,
+  speedForScore,
+  step,
+  type Direction,
+  type GameState,
+} from "./snake-model";
+
+const SCORES_TABLE = "scores";
+const LS_BEST_KEY = "matrix-snake-best";
+
+type Difficulty = "chill" | "classic" | "fast";
+
+const DIFFICULTY: Record<Difficulty, { label: string; tickMul: number; hint: string }> = {
+  chill: { label: "Chill", tickMul: 1.5, hint: "Relaxed pace" },
+  classic: { label: "Classic", tickMul: 1, hint: "Nokia speed" },
+  fast: { label: "Fast", tickMul: 0.65, hint: "Reflex test" },
+};
+
+const KEY_TO_DIR: Record<string, Direction> = {
+  ArrowUp: "up",
+  ArrowDown: "down",
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  w: "up",
+  W: "up",
+  s: "down",
+  S: "down",
+  a: "left",
+  A: "left",
+  d: "right",
+  D: "right",
+};
+
+const rng = () => Math.random();
+
+function coerceBest(row: unknown): number {
+  if (!row || typeof row !== "object") return 0;
+  const data = row as Record<string, unknown>;
+  const best = typeof data.best === "number" ? data.best : Number(data.best);
+  if (Number.isFinite(best) && best > 0) return best;
+  const score = typeof data.score === "number" ? data.score : Number(data.score);
+  return Number.isFinite(score) && score > 0 ? score : 0;
+}
+
+function readLocalBest(): number {
+  try {
+    const raw = localStorage.getItem(LS_BEST_KEY);
+    const n = raw ? Number(raw) : 0;
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeLocalBest(value: number): void {
+  try {
+    localStorage.setItem(LS_BEST_KEY, String(value));
+  } catch (err: unknown) {
+    console.warn("[snake] local best save failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function loadBest(): Promise<number> {
+  const local = readLocalBest();
+  const db = window.MatrixOS?.db;
+  if (!db) return local;
+  const rows = await db.find(SCORES_TABLE, { orderBy: { best: "desc" }, limit: 1 });
+  const dbBest = rows.length > 0 ? coerceBest(rows[0]) : 0;
+  return Math.max(local, dbBest);
+}
+
+async function persistScore(score: number, best: number): Promise<void> {
+  const db = window.MatrixOS?.db;
+  if (!db) return;
+  await db.insert(SCORES_TABLE, { score, best });
+}
+
+const prefersReducedMotion =
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+export default function App() {
+  const [game, setGame] = useState<GameState>(() => createGame(rng));
+  const [difficulty, setDifficulty] = useState<Difficulty>("classic");
+  const [best, setBest] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const gameRef = useRef(game);
+  gameRef.current = game;
+  const bestRef = useRef(best);
+  bestRef.current = best;
+  const savedForRef = useRef(false); // guard one save per game-over
+  const eatPulseRef = useRef(0);
+  const prevScoreRef = useRef(0);
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // --- Load persisted best score ---
+  const reloadBest = useCallback(async () => {
+    try {
+      setError(null);
+      setBest(await loadBest());
+    } catch (err: unknown) {
+      console.warn("[snake] best load failed:", err instanceof Error ? err.message : String(err));
+      setBest(readLocalBest());
+      setError("High score could not be loaded.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void reloadBest();
+    const db = window.MatrixOS?.db;
+    if (!db?.onChange) return undefined;
+    return db.onChange(SCORES_TABLE, () => void reloadBest());
+  }, [reloadBest]);
+
+  // --- Persist new high score on game end ---
+  const commitScore = useCallback(async (finalScore: number) => {
+    const newBest = Math.max(bestRef.current, finalScore);
+    if (newBest > bestRef.current) {
+      setBest(newBest);
+      writeLocalBest(newBest);
+    }
+    try {
+      await persistScore(finalScore, newBest);
+    } catch (err: unknown) {
+      console.warn("[snake] score save failed:", err instanceof Error ? err.message : String(err));
+      writeLocalBest(newBest);
+      setError("Score could not be synced; kept locally.");
+    }
+  }, []);
+
+  // --- Game controls ---
+  const startNewGame = useCallback(() => {
+    savedForRef.current = false;
+    prevScoreRef.current = 0;
+    setError(null);
+    setGame({ ...createGame(rng), status: "running" });
+  }, []);
+
+  const togglePause = useCallback(() => {
+    setGame((current) => {
+      if (current.status === "running") return { ...current, status: "paused" };
+      if (current.status === "paused") return { ...current, status: "running" };
+      if (current.status === "ready") return { ...current, status: "running" };
+      return current;
+    });
+  }, []);
+
+  const queueDirection = useCallback((dir: Direction) => {
+    setGame((current) => {
+      if (current.status === "over" || current.status === "won") return current;
+      const status = current.status === "ready" ? "running" : current.status;
+      if (status === "paused") return { ...current, status: "running" };
+      return { ...current, status, nextDir: nextDirection(current.direction, dir) };
+    });
+  }, []);
+
+  // --- Keyboard ---
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === " " || e.key === "Spacebar") {
+        e.preventDefault();
+        togglePause();
+        return;
+      }
+      if (e.key === "Enter") {
+        const status = gameRef.current.status;
+        if (status === "over" || status === "won" || status === "ready") {
+          e.preventDefault();
+          startNewGame();
+        }
+        return;
+      }
+      const dir = KEY_TO_DIR[e.key];
+      if (dir) {
+        e.preventDefault();
+        queueDirection(dir);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [queueDirection, startNewGame, togglePause]);
+
+  // --- Game loop ---
+  useEffect(() => {
+    if (game.status !== "running") return undefined;
+    const interval = Math.round(speedForScore(game.score) * DIFFICULTY[difficulty].tickMul);
+    const id = window.setInterval(() => {
+      setGame((current) => step(current, rng));
+    }, interval);
+    return () => window.clearInterval(id);
+  }, [game.status, game.score, difficulty]);
+
+  // --- Eat pulse + save-on-end side effects ---
+  useEffect(() => {
+    if (game.score > prevScoreRef.current) {
+      eatPulseRef.current = prefersReducedMotion ? 0 : 1;
+    }
+    prevScoreRef.current = game.score;
+  }, [game.score]);
+
+  useEffect(() => {
+    if ((game.status === "over" || game.status === "won") && !savedForRef.current) {
+      savedForRef.current = true;
+      void commitScore(game.score);
+    }
+  }, [game.status, game.score, commitScore]);
+
+  // --- Canvas render ---
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return undefined;
+
+    let raf = 0;
+    const draw = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const size = Math.min(canvas.clientWidth, canvas.clientHeight);
+      if (size <= 0) {
+        raf = window.requestAnimationFrame(draw);
+        return;
+      }
+      const px = Math.round(size * dpr);
+      if (canvas.width !== px || canvas.height !== px) {
+        canvas.width = px;
+        canvas.height = px;
+      }
+      const cell = canvas.width / GRID_COLS;
+      const cs = window.getComputedStyle(canvas);
+      const read = (name: string, fallback: string) => {
+        const v = cs.getPropertyValue(name).trim();
+        return v || fallback;
+      };
+      const boardBg = read("--snake-board", "#eef0e6");
+      const gridLine = read("--snake-grid", "rgba(67,78,63,0.06)");
+      const snakeColor = read("--snake-body", "#434E3F");
+      const headColor = read("--snake-head", "#3A7D44");
+      const foodColor = read("--snake-food", "#D06F25");
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = boardBg;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      // subtle grid
+      ctx.strokeStyle = gridLine;
+      ctx.lineWidth = 1;
+      for (let i = 1; i < GRID_COLS; i++) {
+        ctx.beginPath();
+        ctx.moveTo(i * cell, 0);
+        ctx.lineTo(i * cell, canvas.height);
+        ctx.stroke();
+      }
+      for (let j = 1; j < GRID_ROWS; j++) {
+        ctx.beginPath();
+        ctx.moveTo(0, j * cell);
+        ctx.lineTo(canvas.width, j * cell);
+        ctx.stroke();
+      }
+
+      const g = gameRef.current;
+      const pad = Math.max(1, cell * 0.12);
+      const radius = Math.max(2, cell * 0.28);
+
+      // food with gentle pulse
+      const t = prefersReducedMotion ? 0 : Date.now() / 320;
+      const foodPulse = prefersReducedMotion ? 1 : 1 + Math.sin(t) * 0.06;
+      const fx = g.food.x * cell + cell / 2;
+      const fy = g.food.y * cell + cell / 2;
+      ctx.fillStyle = foodColor;
+      ctx.beginPath();
+      ctx.arc(fx, fy, (cell / 2 - pad) * foodPulse, 0, Math.PI * 2);
+      ctx.fill();
+
+      // snake
+      for (let s = g.snake.length - 1; s >= 0; s--) {
+        const seg = g.snake[s];
+        const isHead = s === 0;
+        ctx.fillStyle = isHead ? headColor : snakeColor;
+        const grow = isHead && eatPulseRef.current > 0 ? eatPulseRef.current * pad * 0.5 : 0;
+        const x = seg.x * cell + pad - grow;
+        const y = seg.y * cell + pad - grow;
+        const w = cell - pad * 2 + grow * 2;
+        ctx.beginPath();
+        if (typeof ctx.roundRect === "function") {
+          ctx.roundRect(x, y, w, w, radius);
+        } else {
+          ctx.rect(x, y, w, w);
+        }
+        ctx.fill();
+      }
+
+      if (eatPulseRef.current > 0) {
+        eatPulseRef.current = Math.max(0, eatPulseRef.current - 0.08);
+      }
+      raf = window.requestAnimationFrame(draw);
+    };
+    raf = window.requestAnimationFrame(draw);
+    return () => window.cancelAnimationFrame(raf);
+  }, []);
+
+  const statusLabel = useMemo(() => {
+    switch (game.status) {
+      case "running":
+        return "Running";
+      case "paused":
+        return "Paused";
+      case "over":
+        return "Game over";
+      case "won":
+        return "Perfect game";
+      default:
+        return "Ready";
+    }
+  }, [game.status]);
+
+  const isNewBest = (game.status === "over" || game.status === "won") && game.score >= best && game.score > 0;
+  const overlayVisible = game.status === "ready" || game.status === "over" || game.status === "won";
+
+  return (
+    <main className="snake-app">
+      <section className="board-panel" aria-label="Snake game board">
+        <header className="topbar">
+          <div className="brand">
+            <span className="brand-mark" aria-hidden="true">
+              <Play size={16} />
+            </span>
+            <span>Matrix Snake</span>
+          </div>
+          <div className="scoreboard">
+            <div className="stat">
+              <span>Score</span>
+              <strong data-testid="score">{game.score}</strong>
+            </div>
+            <div className="stat stat--best">
+              <span>
+                <Trophy size={13} aria-hidden="true" /> Best
+              </span>
+              <strong data-testid="high-score">{best}</strong>
+            </div>
+          </div>
+        </header>
+
+        <div className="canvas-wrap">
+          <canvas ref={canvasRef} className="board" aria-label="Snake play area" />
+
+          {overlayVisible && (
+            <div className="overlay" role="dialog" aria-label={statusLabel}>
+              <div className="overlay-card">
+                {game.status === "ready" && (
+                  <>
+                    <span className="overlay-icon" aria-hidden="true">
+                      <Play size={28} />
+                    </span>
+                    <h1>Snake</h1>
+                    <p>Eat to grow. Avoid the walls and yourself.</p>
+                    <div className="keys-hint">
+                      <kbd>↑</kbd>
+                      <kbd>↓</kbd>
+                      <kbd>←</kbd>
+                      <kbd>→</kbd>
+                      <span>or</span>
+                      <kbd>W</kbd>
+                      <kbd>A</kbd>
+                      <kbd>S</kbd>
+                      <kbd>D</kbd>
+                      <span>·</span>
+                      <kbd>Space</kbd>
+                      <span>pause</span>
+                    </div>
+                    <button className="primary-action" type="button" onClick={startNewGame}>
+                      <Play size={18} /> Start game
+                    </button>
+                  </>
+                )}
+                {(game.status === "over" || game.status === "won") && (
+                  <>
+                    <span className="overlay-icon" aria-hidden="true">
+                      <Trophy size={28} />
+                    </span>
+                    <h1>{game.status === "won" ? "Perfect game!" : "Game over"}</h1>
+                    <p>
+                      You scored <strong>{game.score}</strong>
+                      {isNewBest ? " — a new best!" : ""}.
+                    </p>
+                    <button className="primary-action" type="button" onClick={startNewGame}>
+                      <RotateCcw size={18} /> Play again
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <aside className="side-panel">
+        <div className="control-card">
+          <p className="eyebrow">Status</p>
+          <div className="status-row">
+            <span className={`status-dot status-dot--${game.status}`} aria-hidden="true" />
+            <strong data-testid="snake-status">{statusLabel}</strong>
+          </div>
+          <div className="button-row">
+            <button
+              className="ghost-action"
+              type="button"
+              onClick={togglePause}
+              disabled={game.status === "over" || game.status === "won"}
+            >
+              {game.status === "running" ? <Pause size={16} /> : <Play size={16} />}
+              {game.status === "running" ? "Pause" : "Resume"}
+            </button>
+            <button className="ghost-action" type="button" onClick={startNewGame}>
+              <RotateCcw size={16} /> New game
+            </button>
+          </div>
+        </div>
+
+        <div className="control-card">
+          <p className="eyebrow">
+            <Gauge size={13} aria-hidden="true" /> Difficulty
+          </p>
+          <div className="difficulty-row" role="group" aria-label="Difficulty">
+            {(Object.keys(DIFFICULTY) as Difficulty[]).map((key) => (
+              <button
+                key={key}
+                type="button"
+                className={key === difficulty ? "diff-chip diff-chip--active" : "diff-chip"}
+                onClick={() => setDifficulty(key)}
+                aria-pressed={key === difficulty}
+              >
+                <strong>{DIFFICULTY[key].label}</strong>
+                <span>{DIFFICULTY[key].hint}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="control-card hints">
+          <p className="eyebrow">Controls</p>
+          <ul>
+            <li>
+              <kbd>Arrows</kbd> / <kbd>WASD</kbd> steer
+            </li>
+            <li>
+              <kbd>Space</kbd> pause &amp; resume
+            </li>
+            <li>
+              <kbd>Enter</kbd> new game
+            </li>
+          </ul>
+        </div>
+
+        {error && (
+          <div className="error-note" role="status">
+            {error}
+          </div>
+        )}
+      </aside>
+    </main>
+  );
+}

--- a/home/apps/games/snake/src/App.tsx
+++ b/home/apps/games/snake/src/App.tsx
@@ -5,7 +5,7 @@ import {
   GRID_COLS,
   GRID_ROWS,
   createGame,
-  nextDirection,
+  queuedDirection,
   speedForScore,
   step,
   type Direction,
@@ -78,7 +78,7 @@ async function loadBest(): Promise<number> {
 
 async function persistScore(score: number, best: number): Promise<void> {
   const db = window.MatrixOS?.db;
-  if (!db) return;
+  if (!db || score <= 0) return;
   await db.insert(SCORES_TABLE, { score, best });
 }
 
@@ -92,6 +92,7 @@ export default function App() {
   const [difficulty, setDifficulty] = useState<Difficulty>("classic");
   const [best, setBest] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [lastGameWasBest, setLastGameWasBest] = useState(false);
 
   const gameRef = useRef(game);
   gameRef.current = game;
@@ -125,7 +126,9 @@ export default function App() {
   // --- Persist new high score on game end ---
   const commitScore = useCallback(async (finalScore: number) => {
     const newBest = Math.max(bestRef.current, finalScore);
-    if (newBest > bestRef.current) {
+    const wasNewBest = finalScore > bestRef.current;
+    setLastGameWasBest(wasNewBest);
+    if (wasNewBest) {
       setBest(newBest);
       writeLocalBest(newBest);
     }
@@ -133,8 +136,8 @@ export default function App() {
       await persistScore(finalScore, newBest);
     } catch (err: unknown) {
       console.warn("[snake] score save failed:", err instanceof Error ? err.message : String(err));
-      writeLocalBest(newBest);
-      setError("Score could not be synced; kept locally.");
+      if (wasNewBest) writeLocalBest(newBest);
+      setError("Score could not be synced.");
     }
   }, []);
 
@@ -142,6 +145,7 @@ export default function App() {
   const startNewGame = useCallback(() => {
     savedForRef.current = false;
     prevScoreRef.current = 0;
+    setLastGameWasBest(false);
     setError(null);
     setGame({ ...createGame(rng), status: "running" });
   }, []);
@@ -159,8 +163,11 @@ export default function App() {
     setGame((current) => {
       if (current.status === "over" || current.status === "won") return current;
       const status = current.status === "ready" ? "running" : current.status;
-      if (status === "paused") return { ...current, status: "running" };
-      return { ...current, status, nextDir: nextDirection(current.direction, dir) };
+      return {
+        ...current,
+        status: status === "paused" ? "running" : status,
+        nextDir: queuedDirection(current.direction, current.nextDir, dir),
+      };
     });
   }, []);
 
@@ -323,7 +330,7 @@ export default function App() {
     }
   }, [game.status]);
 
-  const isNewBest = (game.status === "over" || game.status === "won") && game.score >= best && game.score > 0;
+  const isNewBest = (game.status === "over" || game.status === "won") && lastGameWasBest;
   const overlayVisible = game.status === "ready" || game.status === "over" || game.status === "won";
 
   return (

--- a/home/apps/games/snake/src/main.tsx
+++ b/home/apps/games/snake/src/main.tsx
@@ -1,9 +1,3 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App";
+import { renderDefaultApp } from "../../../_shared/default-apps";
 
-createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+renderDefaultApp("snake" as const);

--- a/home/apps/games/snake/src/main.tsx
+++ b/home/apps/games/snake/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("snake" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/snake/src/matrix-os.d.ts
+++ b/home/apps/games/snake/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/games/snake/src/snake-model.ts
+++ b/home/apps/games/snake/src/snake-model.ts
@@ -49,6 +49,11 @@ export function nextDirection(current: Direction, requested: Direction): Directi
   return requested;
 }
 
+export function queuedDirection(current: Direction, queued: Direction, requested: Direction): Direction {
+  if (isOpposite(current, requested) || isOpposite(queued, requested)) return queued;
+  return requested;
+}
+
 /** Pick a uniformly random free cell, or null if the board is full. */
 export function spawnFood(snake: Cell[], rng: Rng): Cell | null {
   const occupied = new Set(snake.map((c) => `${c.x},${c.y}`));

--- a/home/apps/games/snake/src/snake-model.ts
+++ b/home/apps/games/snake/src/snake-model.ts
@@ -50,6 +50,7 @@ export function nextDirection(current: Direction, requested: Direction): Directi
 }
 
 export function queuedDirection(current: Direction, queued: Direction, requested: Direction): Direction {
+  if (requested === current) return queued;
   if (isOpposite(current, requested) || isOpposite(queued, requested)) return queued;
   return requested;
 }

--- a/home/apps/games/snake/src/snake-model.ts
+++ b/home/apps/games/snake/src/snake-model.ts
@@ -1,0 +1,137 @@
+// Pure, UI-free Snake engine. Deterministic given an injectable RNG.
+
+export const GRID_COLS = 20;
+export const GRID_ROWS = 20;
+
+export type Direction = "up" | "down" | "left" | "right";
+export type Status = "ready" | "running" | "paused" | "over" | "won";
+
+export interface Cell {
+  x: number;
+  y: number;
+}
+
+export interface GameState {
+  snake: Cell[]; // head is index 0
+  direction: Direction; // current heading (the one applied last tick)
+  nextDir: Direction; // queued heading from input, applied at next step
+  food: Cell;
+  score: number;
+  status: Status;
+}
+
+export type Rng = () => number;
+
+const DELTAS: Record<Direction, Cell> = {
+  up: { x: 0, y: -1 },
+  down: { x: 0, y: 1 },
+  left: { x: -1, y: 0 },
+  right: { x: 1, y: 0 },
+};
+
+const OPPOSITE: Record<Direction, Direction> = {
+  up: "down",
+  down: "up",
+  left: "right",
+  right: "left",
+};
+
+export function isOpposite(a: Direction, b: Direction): boolean {
+  return OPPOSITE[a] === b;
+}
+
+/**
+ * Resolve the direction the snake should head, rejecting a 180-degree
+ * reversal relative to its current heading.
+ */
+export function nextDirection(current: Direction, requested: Direction): Direction {
+  if (isOpposite(current, requested)) return current;
+  return requested;
+}
+
+/** Pick a uniformly random free cell, or null if the board is full. */
+export function spawnFood(snake: Cell[], rng: Rng): Cell | null {
+  const occupied = new Set(snake.map((c) => `${c.x},${c.y}`));
+  const free: Cell[] = [];
+  for (let y = 0; y < GRID_ROWS; y++) {
+    for (let x = 0; x < GRID_COLS; x++) {
+      if (!occupied.has(`${x},${y}`)) free.push({ x, y });
+    }
+  }
+  if (free.length === 0) return null;
+  const idx = Math.min(free.length - 1, Math.floor(rng() * free.length));
+  return free[idx];
+}
+
+/** Tick interval in milliseconds; gets faster as the score rises. */
+export function speedForScore(score: number): number {
+  const base = 140;
+  const min = 60;
+  const stepDown = Math.floor(score / 4) * 8;
+  return Math.max(min, base - stepDown);
+}
+
+/** Build a fresh game with a centered length-3 snake heading right. */
+export function createGame(rng: Rng): GameState {
+  const cy = Math.floor(GRID_ROWS / 2);
+  const cx = Math.floor(GRID_COLS / 2);
+  const snake: Cell[] = [
+    { x: cx, y: cy },
+    { x: cx - 1, y: cy },
+    { x: cx - 2, y: cy },
+  ];
+  const food = spawnFood(snake, rng) ?? { x: 0, y: 0 };
+  return {
+    snake,
+    direction: "right",
+    nextDir: "right",
+    food,
+    score: 0,
+    status: "ready",
+  };
+}
+
+function outOfBounds(cell: Cell): boolean {
+  return cell.x < 0 || cell.y < 0 || cell.x >= GRID_COLS || cell.y >= GRID_ROWS;
+}
+
+/**
+ * Advance the game by one tick. Returns a new state; never mutates the input.
+ * Only advances when status is "running".
+ */
+export function step(state: GameState, rng: Rng): GameState {
+  if (state.status !== "running") return state;
+
+  const direction = nextDirection(state.direction, state.nextDir);
+  const delta = DELTAS[direction];
+  const head = state.snake[0];
+  const newHead: Cell = { x: head.x + delta.x, y: head.y + delta.y };
+
+  if (outOfBounds(newHead)) {
+    return { ...state, direction, status: "over" };
+  }
+
+  const eating = newHead.x === state.food.x && newHead.y === state.food.y;
+
+  // Body that will persist after the move. When not eating, the tail moves,
+  // so the last cell is free to step into (classic snake rule).
+  const body = eating ? state.snake : state.snake.slice(0, -1);
+  const hitSelf = body.some((c) => c.x === newHead.x && c.y === newHead.y);
+  if (hitSelf) {
+    return { ...state, direction, status: "over" };
+  }
+
+  const newSnake = [newHead, ...body];
+
+  if (!eating) {
+    return { ...state, snake: newSnake, direction };
+  }
+
+  const score = state.score + 1;
+  const nextFood = spawnFood(newSnake, rng);
+  if (nextFood === null) {
+    // Board completely filled — perfect game.
+    return { ...state, snake: newSnake, direction, score, status: "won" };
+  }
+  return { ...state, snake: newSnake, direction, food: nextFood, score };
+}

--- a/home/apps/games/snake/src/styles.css
+++ b/home/apps/games/snake/src/styles.css
@@ -1,0 +1,436 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+
+  /* board palette derived from theme tokens */
+  --snake-board: color-mix(in srgb, var(--app-muted) 70%, var(--app-card));
+  --snake-grid: color-mix(in srgb, var(--app-fg) 6%, transparent);
+  --snake-body: var(--app-primary);
+  --snake-head: var(--app-success);
+  --snake-food: var(--app-accent);
+
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  background: var(--app-bg);
+  color: var(--app-fg);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: 0;
+  color: inherit;
+}
+
+kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  padding: 2px 6px;
+  border-radius: 7px;
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  box-shadow: 0 1px 0 var(--app-border);
+  font-size: 12px;
+  font-weight: 700;
+  font-family: inherit;
+}
+
+.snake-app {
+  height: 100vh;
+  width: 100%;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 18px;
+  padding: 18px;
+  background:
+    radial-gradient(circle at 14% 12%, color-mix(in srgb, var(--app-success) 16%, transparent), transparent 30%),
+    radial-gradient(circle at 88% 16%, color-mix(in srgb, var(--app-accent) 14%, transparent), transparent 26%),
+    var(--app-bg);
+}
+
+/* ---------- Board ---------- */
+.board-panel {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--app-card);
+  border-radius: var(--app-radius);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+  padding: 18px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  font-size: 15px;
+  color: var(--app-fg);
+}
+
+.brand-mark {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  color: var(--app-primary-fg);
+  background: linear-gradient(145deg, var(--app-success), color-mix(in srgb, var(--app-success) 70%, var(--app-primary)));
+  box-shadow: 0 6px 14px color-mix(in srgb, var(--app-success) 32%, transparent);
+}
+
+.scoreboard {
+  display: inline-flex;
+  gap: 10px;
+}
+
+.stat {
+  display: grid;
+  gap: 1px;
+  min-width: 72px;
+  padding: 8px 14px;
+  border-radius: 14px;
+  background: var(--app-muted);
+  text-align: right;
+}
+
+.stat span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  color: var(--app-muted-fg);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.stat strong {
+  font-size: 24px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.stat--best strong {
+  color: var(--app-accent);
+}
+
+.canvas-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  place-items: center;
+}
+
+.board {
+  width: min(100%, calc(100vh - 130px));
+  height: min(100%, calc(100vh - 130px));
+  aspect-ratio: 1;
+  border-radius: 18px;
+  background: var(--snake-board);
+  box-shadow:
+    inset 0 2px 8px color-mix(in srgb, var(--app-fg) 10%, transparent),
+    0 4px 12px rgba(50, 53, 46, 0.08);
+}
+
+/* ---------- Overlay ---------- */
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--app-card) 72%, transparent);
+  backdrop-filter: blur(6px);
+}
+
+.overlay-card {
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  max-width: 320px;
+  padding: 26px 28px;
+  text-align: center;
+  border-radius: var(--app-radius);
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  box-shadow: 0 18px 40px rgba(50, 53, 46, 0.16);
+  animation: pop 0.18s ease;
+}
+
+.overlay-icon {
+  width: 54px;
+  height: 54px;
+  display: grid;
+  place-items: center;
+  border-radius: 18px;
+  color: var(--app-primary-fg);
+  background: linear-gradient(145deg, var(--app-accent), color-mix(in srgb, var(--app-accent) 65%, var(--app-warning)));
+  box-shadow: 0 10px 22px color-mix(in srgb, var(--app-accent) 34%, transparent);
+}
+
+.overlay-card h1 {
+  margin: 0;
+  font-size: 26px;
+}
+
+.overlay-card p {
+  margin: 0;
+  color: var(--app-muted-fg);
+  line-height: 1.5;
+}
+
+.keys-hint {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: var(--app-muted-fg);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.primary-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  padding: 11px 22px;
+  border-radius: 999px;
+  font-weight: 800;
+  color: var(--app-primary-fg);
+  background: linear-gradient(145deg, var(--app-accent), color-mix(in srgb, var(--app-accent) 78%, var(--app-warning)));
+  box-shadow: 0 10px 22px color-mix(in srgb, var(--app-accent) 32%, transparent);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-action:hover {
+  transform: translateY(-1px);
+}
+
+/* ---------- Side panel ---------- */
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.control-card {
+  background: var(--app-card);
+  border-radius: var(--app-radius);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.eyebrow {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--app-muted-fg);
+  font-size: 11px;
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 18px;
+}
+
+.status-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--app-muted-fg);
+}
+
+.status-dot--running {
+  background: var(--app-success);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--app-success) 22%, transparent);
+}
+
+.status-dot--paused {
+  background: var(--app-warning);
+}
+
+.status-dot--over {
+  background: var(--app-danger);
+}
+
+.status-dot--won {
+  background: var(--app-accent);
+}
+
+.button-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.ghost-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 8px;
+  border-radius: 12px;
+  font-weight: 750;
+  font-size: 13px;
+  background: var(--app-muted);
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.ghost-action:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--app-fg) 6%, var(--app-muted));
+  transform: translateY(-1px);
+}
+
+.ghost-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.difficulty-row {
+  display: grid;
+  gap: 8px;
+}
+
+.diff-chip {
+  display: grid;
+  gap: 1px;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 13px;
+  background: var(--app-muted);
+  transition: all 0.15s ease;
+}
+
+.diff-chip strong {
+  font-size: 14px;
+}
+
+.diff-chip span {
+  color: var(--app-muted-fg);
+  font-size: 12px;
+}
+
+.diff-chip:hover {
+  transform: translateY(-1px);
+}
+
+.diff-chip--active {
+  background: color-mix(in srgb, var(--app-accent) 16%, var(--app-card));
+  box-shadow: inset 0 0 0 2px var(--app-accent);
+}
+
+.diff-chip--active strong {
+  color: var(--app-accent);
+}
+
+.hints ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 7px;
+  color: var(--app-muted-fg);
+  font-size: 13px;
+}
+
+.error-note {
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--app-danger) 12%, var(--app-card));
+  color: var(--app-danger);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+button:focus-visible,
+.diff-chip:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--app-accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+@keyframes pop {
+  from {
+    transform: scale(0.94);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+@media (max-width: 760px) {
+  .snake-app {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) auto;
+    overflow-y: auto;
+  }
+  .board {
+    width: min(100%, 72vh);
+    height: auto;
+  }
+}

--- a/tests/default-apps/snake-app.test.tsx
+++ b/tests/default-apps/snake-app.test.tsx
@@ -82,6 +82,14 @@ describe("Snake app", () => {
     expect(screen.getByTestId("snake-status").textContent?.toLowerCase()).toContain("ready");
   });
 
+  it("ignores stale localStorage best scores in the sandbox", async () => {
+    localStorage.setItem("matrix-snake-best", "99");
+    installMatrixDb([]);
+    render(<App />);
+
+    expect((await screen.findByTestId("high-score")).textContent).toContain("0");
+  });
+
   it("starts on a direction key and advances state on ticks", async () => {
     installMatrixDb([]);
     vi.useFakeTimers();

--- a/tests/default-apps/snake-app.test.tsx
+++ b/tests/default-apps/snake-app.test.tsx
@@ -55,14 +55,12 @@ describe("Snake app", () => {
       set shadowBlur(_v: number) {},
       set shadowColor(_v: string) {},
     }));
-    localStorage.clear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
-    localStorage.clear();
   });
 
   it("uses a shipped default game icon", () => {

--- a/tests/default-apps/snake-app.test.tsx
+++ b/tests/default-apps/snake-app.test.tsx
@@ -82,8 +82,7 @@ describe("Snake app", () => {
     expect(screen.getByTestId("snake-status").textContent?.toLowerCase()).toContain("ready");
   });
 
-  it("ignores stale localStorage best scores in the sandbox", async () => {
-    localStorage.setItem("matrix-snake-best", "99");
+  it("shows 0 best when MatrixOS.readData is absent and db has no rows", async () => {
     installMatrixDb([]);
     render(<App />);
 

--- a/tests/default-apps/snake-app.test.tsx
+++ b/tests/default-apps/snake-app.test.tsx
@@ -104,6 +104,32 @@ describe("Snake app", () => {
     expect(screen.getByTestId("snake-status").textContent?.toLowerCase()).toContain("running");
   });
 
+  it("does not overwrite fallback best before the initial best load resolves", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(208 / 397);
+    const db = installMatrixDb([]);
+    db.find.mockImplementation(async () => new Promise<DbRow[]>(() => undefined));
+    const writeData = vi.fn(async () => undefined);
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        db,
+        readData: vi.fn(async () => 12),
+        writeData,
+      },
+    });
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+
+    expect(db.insert).toHaveBeenCalledWith("scores", expect.objectContaining({ score: expect.any(Number) }));
+    expect(writeData).not.toHaveBeenCalled();
+  });
+
   it("pauses and resumes with Space", async () => {
     installMatrixDb([]);
     vi.useFakeTimers();

--- a/tests/default-apps/snake-app.test.tsx
+++ b/tests/default-apps/snake-app.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/games/snake/src/App";
@@ -61,6 +63,14 @@ describe("Snake app", () => {
     vi.restoreAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
     localStorage.clear();
+  });
+
+  it("uses a shipped default game icon", () => {
+    const manifestPath = resolve(process.cwd(), "home/apps/games/snake/matrix.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as { icon?: string };
+
+    expect(manifest.icon).toBe("game-center");
+    expect(existsSync(resolve(process.cwd(), "home/system/icons/game-center.png"))).toBe(true);
   });
 
   it("renders the start screen with controls hint and a high score", async () => {

--- a/tests/default-apps/snake-app.test.tsx
+++ b/tests/default-apps/snake-app.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/games/snake/src/App";
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const db = {
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async () => ({ id: "score-new" })),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => rows.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+describe("Snake app", () => {
+  beforeEach(() => {
+    // jsdom has no canvas 2d context; stub it so the renderer does not throw.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLCanvasElement.prototype as any).getContext = vi.fn(() => ({
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      beginPath: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      roundRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      closePath: vi.fn(),
+      setTransform: vi.fn(),
+      createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      set fillStyle(_v: string) {},
+      set strokeStyle(_v: string) {},
+      set lineWidth(_v: number) {},
+      set lineJoin(_v: string) {},
+      set lineCap(_v: string) {},
+      set globalAlpha(_v: number) {},
+      set shadowBlur(_v: number) {},
+      set shadowColor(_v: string) {},
+    }));
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+    localStorage.clear();
+  });
+
+  it("renders the start screen with controls hint and a high score", async () => {
+    installMatrixDb([{ id: "s1", score: 12, best: 12, created_at: "2026-05-31T10:00:00Z" }]);
+    render(<App />);
+    // High score from the DB is reflected.
+    expect((await screen.findByTestId("high-score")).textContent).toContain("12");
+    // Start state / onboarding hint is present.
+    expect(screen.getByTestId("snake-status").textContent?.toLowerCase()).toContain("ready");
+  });
+
+  it("starts on a direction key and advances state on ticks", async () => {
+    installMatrixDb([]);
+    vi.useFakeTimers();
+    render(<App />);
+
+    const initialScore = screen.getByTestId("score").textContent;
+    expect(initialScore).toBe("0");
+
+    // Pressing an arrow key starts the game heading right.
+    act(() => {
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+    });
+    expect(screen.getByTestId("snake-status").textContent?.toLowerCase()).toContain("running");
+
+    // Advancing one tick keeps the game running (the snake moves one cell to the
+    // right, well clear of any wall) — confirms the loop is wired to the engine.
+    act(() => {
+      vi.advanceTimersByTime(220);
+    });
+    expect(screen.getByTestId("snake-status").textContent?.toLowerCase()).toContain("running");
+  });
+
+  it("pauses and resumes with Space", async () => {
+    installMatrixDb([]);
+    vi.useFakeTimers();
+    render(<App />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "ArrowUp" });
+    });
+    expect(screen.getByTestId("snake-status").textContent?.toLowerCase()).toContain("running");
+
+    act(() => {
+      fireEvent.keyDown(window, { key: " " });
+    });
+    expect(screen.getByTestId("snake-status").textContent?.toLowerCase()).toContain("paused");
+  });
+});

--- a/tests/default-apps/snake-app.test.tsx
+++ b/tests/default-apps/snake-app.test.tsx
@@ -130,6 +130,42 @@ describe("Snake app", () => {
     expect(writeData).not.toHaveBeenCalled();
   });
 
+  it("does not retry fallback best writes when score sync also fails", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(208 / 397);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const db = installMatrixDb([]);
+    db.insert.mockRejectedValueOnce(new Error("sync failed"));
+    const writeData = vi.fn(async () => {
+      throw new Error("fallback failed");
+    });
+    Object.defineProperty(window, "MatrixOS", {
+      configurable: true,
+      value: {
+        db,
+        readData: vi.fn(async () => 0),
+        writeData,
+      },
+    });
+
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      await vi.advanceTimersByTimeAsync(2_500);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).toHaveBeenCalled();
+    expect(writeData).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Score could not be synced.")).toBeTruthy();
+  });
+
   it("pauses and resumes with Space", async () => {
     installMatrixDb([]);
     vi.useFakeTimers();

--- a/tests/default-apps/snake-model.test.ts
+++ b/tests/default-apps/snake-model.test.ts
@@ -42,6 +42,11 @@ describe("snake-model: direction", () => {
     expect(queuedDirection("right", "up", "left")).toBe("up");
     expect(queuedDirection("right", "right", "up")).toBe("up");
   });
+
+  it("does not clobber an already queued turn with the current heading", () => {
+    expect(queuedDirection("right", "up", "right")).toBe("up");
+    expect(queuedDirection("up", "left", "up")).toBe("left");
+  });
 });
 
 describe("snake-model: createGame", () => {

--- a/tests/default-apps/snake-model.test.ts
+++ b/tests/default-apps/snake-model.test.ts
@@ -156,6 +156,8 @@ describe("snake-model: spawnFood", () => {
   it("returns a free cell within the grid bounds", () => {
     const snake = [{ x: 0, y: 0 }];
     const food = spawnFood(snake, seededRng([0.5, 0.5]));
+    expect(food).not.toBeNull();
+    if (!food) throw new Error("expected food to spawn");
     expect(food.x).toBeGreaterThanOrEqual(0);
     expect(food.x).toBeLessThan(GRID_COLS);
     expect(food.y).toBeGreaterThanOrEqual(0);

--- a/tests/default-apps/snake-model.test.ts
+++ b/tests/default-apps/snake-model.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  GRID_COLS,
+  GRID_ROWS,
+  createGame,
+  isOpposite,
+  nextDirection,
+  spawnFood,
+  speedForScore,
+  step,
+  type Direction,
+  type GameState,
+} from "../../home/apps/games/snake/src/snake-model";
+
+// Deterministic RNG helper: cycles through provided values then 0.
+function seededRng(values: number[]): () => number {
+  let i = 0;
+  return () => (i < values.length ? values[i++] : 0);
+}
+
+describe("snake-model: direction", () => {
+  it("detects opposite directions (180-degree reversal)", () => {
+    expect(isOpposite("up", "down")).toBe(true);
+    expect(isOpposite("down", "up")).toBe(true);
+    expect(isOpposite("left", "right")).toBe(true);
+    expect(isOpposite("right", "left")).toBe(true);
+    expect(isOpposite("up", "left")).toBe(false);
+    expect(isOpposite("up", "up")).toBe(false);
+  });
+
+  it("prevents 180-degree reversal via nextDirection", () => {
+    expect(nextDirection("right", "left")).toBe("right");
+    expect(nextDirection("right", "up")).toBe("up");
+    expect(nextDirection("up", "down")).toBe("up");
+    expect(nextDirection("up", "right")).toBe("right");
+  });
+});
+
+describe("snake-model: createGame", () => {
+  it("creates a centered snake of length 3 moving right with score 0", () => {
+    const game = createGame(seededRng([0.5, 0.5]));
+    expect(game.snake.length).toBe(3);
+    expect(game.direction).toBe("right");
+    expect(game.score).toBe(0);
+    expect(game.status).toBe("ready");
+    expect(game.food).toBeTruthy();
+  });
+
+  it("never spawns food on the snake", () => {
+    const game = createGame(seededRng([0, 0]));
+    const onSnake = game.snake.some((c) => c.x === game.food.x && c.y === game.food.y);
+    expect(onSnake).toBe(false);
+  });
+});
+
+describe("snake-model: step movement", () => {
+  it("moves the head one cell in the current direction and keeps length when no food", () => {
+    const game = createGame(seededRng([0.9, 0.9]));
+    const head = game.snake[0];
+    const running: GameState = { ...game, status: "running" };
+    const next = step(running, seededRng([0.9, 0.9]));
+    expect(next.snake[0]).toEqual({ x: head.x + 1, y: head.y });
+    expect(next.snake.length).toBe(game.snake.length);
+    expect(next.status).toBe("running");
+  });
+
+  it("does not advance when not running", () => {
+    const game = createGame(seededRng([0.5, 0.5]));
+    const next = step(game, seededRng([0.5, 0.5]));
+    expect(next).toEqual(game);
+  });
+});
+
+describe("snake-model: growth on food", () => {
+  it("grows the snake and increments score when eating food", () => {
+    const base = createGame(seededRng([0.5, 0.5]));
+    const head = base.snake[0];
+    // Place food directly in front of the head.
+    const running: GameState = {
+      ...base,
+      status: "running",
+      food: { x: head.x + 1, y: head.y },
+    };
+    const next = step(running, seededRng([0.95, 0.95]));
+    expect(next.snake.length).toBe(base.snake.length + 1);
+    expect(next.score).toBe(base.score + 1);
+    // A new food is placed somewhere not on the snake.
+    const onSnake = next.snake.some((c) => c.x === next.food.x && c.y === next.food.y);
+    expect(onSnake).toBe(false);
+  });
+});
+
+describe("snake-model: collisions", () => {
+  it("ends the game on wall collision", () => {
+    const head = { x: GRID_COLS - 1, y: 2 };
+    const running: GameState = {
+      snake: [head, { x: GRID_COLS - 2, y: 2 }, { x: GRID_COLS - 3, y: 2 }],
+      direction: "right",
+      nextDir: "right",
+      food: { x: 0, y: 0 },
+      score: 0,
+      status: "running",
+    };
+    const next = step(running, seededRng([0.5, 0.5]));
+    expect(next.status).toBe("over");
+  });
+
+  it("ends the game on self collision", () => {
+    // Snake shaped so that moving down folds onto its own body.
+    const snake = [
+      { x: 5, y: 5 },
+      { x: 4, y: 5 },
+      { x: 4, y: 6 },
+      { x: 5, y: 6 },
+      { x: 6, y: 6 },
+    ];
+    const running: GameState = {
+      snake,
+      direction: "right",
+      nextDir: "down",
+      food: { x: 0, y: 0 },
+      score: 0,
+      status: "running",
+    };
+    const next = step(running, seededRng([0.5, 0.5]));
+    expect(next.status).toBe("over");
+  });
+
+  it("applies the queued direction before moving", () => {
+    const base = createGame(seededRng([0.9, 0.9]));
+    const queued: GameState = { ...base, status: "running", nextDir: "up" };
+    const next = step(queued, seededRng([0.9, 0.9]));
+    expect(next.direction).toBe("up");
+    expect(next.snake[0].y).toBe(base.snake[0].y - 1);
+  });
+});
+
+describe("snake-model: speed", () => {
+  it("returns faster (smaller) tick interval as score rises", () => {
+    const slow = speedForScore(0);
+    const fast = speedForScore(50);
+    expect(fast).toBeLessThan(slow);
+    expect(fast).toBeGreaterThan(0);
+  });
+});
+
+describe("snake-model: spawnFood", () => {
+  it("returns a free cell within the grid bounds", () => {
+    const snake = [{ x: 0, y: 0 }];
+    const food = spawnFood(snake, seededRng([0.5, 0.5]));
+    expect(food.x).toBeGreaterThanOrEqual(0);
+    expect(food.x).toBeLessThan(GRID_COLS);
+    expect(food.y).toBeGreaterThanOrEqual(0);
+    expect(food.y).toBeLessThan(GRID_ROWS);
+    expect(food.x === 0 && food.y === 0).toBe(false);
+  });
+
+  it("returns null when the board is full", () => {
+    const full: { x: number; y: number }[] = [];
+    for (let y = 0; y < GRID_ROWS; y++) {
+      for (let x = 0; x < GRID_COLS; x++) full.push({ x, y });
+    }
+    expect(spawnFood(full, seededRng([0.5]))).toBeNull();
+  });
+
+  it("wins the game when food fills the last cell", () => {
+    // Fill the whole board except one cell in front of the head.
+    const cells: { x: number; y: number }[] = [];
+    for (let y = 0; y < GRID_ROWS; y++) {
+      for (let x = 0; x < GRID_COLS; x++) cells.push({ x, y });
+    }
+    // Head at (1,0) moving left into (0,0) which holds food; rest fills board.
+    const head = { x: 1, y: 0 };
+    const food = { x: 0, y: 0 };
+    const body = cells.filter((c) => !(c.x === food.x && c.y === food.y));
+    // Ensure head is first.
+    const snake = [head, ...body.filter((c) => !(c.x === head.x && c.y === head.y))];
+    const running: GameState = {
+      snake,
+      direction: "left",
+      nextDir: "left",
+      food,
+      score: snake.length - 3,
+      status: "running",
+    };
+    const next = step(running, seededRng([0.5, 0.5]));
+    expect(next.status).toBe("won");
+  });
+});
+
+export type { Direction };

--- a/tests/default-apps/snake-model.test.ts
+++ b/tests/default-apps/snake-model.test.ts
@@ -5,6 +5,7 @@ import {
   createGame,
   isOpposite,
   nextDirection,
+  queuedDirection,
   spawnFood,
   speedForScore,
   step,
@@ -33,6 +34,13 @@ describe("snake-model: direction", () => {
     expect(nextDirection("right", "up")).toBe("up");
     expect(nextDirection("up", "down")).toBe("up");
     expect(nextDirection("up", "right")).toBe("right");
+  });
+
+  it("does not clobber an already queued turn with its opposite", () => {
+    expect(queuedDirection("right", "up", "down")).toBe("up");
+    expect(queuedDirection("right", "right", "left")).toBe("right");
+    expect(queuedDirection("right", "up", "left")).toBe("up");
+    expect(queuedDirection("right", "right", "up")).toBe("up");
   });
 });
 


### PR DESCRIPTION
Stack: 12/22
Branch: stack/default-apps-snake

Scope: Snake game model, canvas UI, manifest, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.