### PR TITLE
feat(tetris): add guideline block game

### DIFF
--- a/home/apps/games/tetris/matrix.json
+++ b/home/apps/games/tetris/matrix.json
@@ -3,7 +3,7 @@
   "description": "Classic block-stacking puzzle",
   "runtime": "vite",
   "category": "games",
-  "icon": "game-center",
+  "icon": "tetris",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -13,6 +13,20 @@
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
   "slug": "tetris",
+  "storage": {
+    "tables": {
+      "scores": {
+        "columns": {
+          "score": "integer",
+          "lines": "integer",
+          "level": "integer"
+        },
+        "indexes": [
+          "score"
+        ]
+      }
+    }
+  },
   "build": {
     "install": "true",
     "command": "vite build --base ./ --outDir dist",

--- a/home/apps/games/tetris/matrix.json
+++ b/home/apps/games/tetris/matrix.json
@@ -3,7 +3,7 @@
   "description": "Classic block-stacking puzzle",
   "runtime": "vite",
   "category": "games",
-  "icon": "tetris",
+  "icon": "game-center",
   "author": "system",
   "version": "1.0.0",
   "tags": [

--- a/home/apps/games/tetris/src/App.tsx
+++ b/home/apps/games/tetris/src/App.tsx
@@ -288,8 +288,9 @@ export default function App() {
               title: "Game over",
               body: `You cleared ${game.lines} lines and scored ${game.score.toLocaleString()}.`,
               cta: "Play again",
-            }
+          }
           : null;
+  const overlayAction = phase === "paused" ? togglePause : startGame;
 
   return (
     <main className={reduced ? "tetris-app tetris-app--reduced" : "tetris-app"}>
@@ -325,7 +326,7 @@ export default function App() {
                     <Trophy size={16} /> Best {best.toLocaleString()}
                   </div>
                 )}
-                <button type="button" className="primary-action" onClick={startGame}>
+                <button type="button" className="primary-action" onClick={overlayAction}>
                   <Play size={18} /> {overlay.cta}
                 </button>
                 {saveNote && phase === "over" && <span className="overlay__note">{saveNote}</span>}

--- a/home/apps/games/tetris/src/App.tsx
+++ b/home/apps/games/tetris/src/App.tsx
@@ -1,0 +1,405 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Gauge, Layers, Pause, Play, RotateCcw, Trophy } from "lucide-react";
+import {
+  COLS,
+  ROWS,
+  HIDDEN_ROWS,
+  PIECE_COLORS,
+  type GameState,
+  type PieceType,
+  createGame,
+  cellsFor,
+  tryMove,
+  tryRotate,
+  softDrop,
+  hardDrop,
+  holdPiece,
+  step,
+  ghostRow,
+  gravityMs,
+} from "./tetris-model";
+import "./styles.css";
+
+const SCORES_TABLE = "scores";
+const BEST_KEY = "matrix-tetris-best";
+
+type Phase = "ready" | "playing" | "paused" | "over";
+
+interface ScoreRow {
+  score: number;
+  lines: number;
+  level: number;
+}
+
+function prefersReducedMotion(): boolean {
+  try {
+    return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+  } catch {
+    return false;
+  }
+}
+
+function readLocalBest(): number {
+  try {
+    const raw = window.localStorage?.getItem(BEST_KEY);
+    const n = raw ? Number.parseInt(raw, 10) : 0;
+    return Number.isFinite(n) ? n : 0;
+  } catch (err: unknown) {
+    console.warn("[tetris] local best read failed:", err instanceof Error ? err.message : String(err));
+    return 0;
+  }
+}
+
+function writeLocalBest(value: number): void {
+  try {
+    window.localStorage?.setItem(BEST_KEY, String(value));
+  } catch (err: unknown) {
+    console.warn("[tetris] local best write failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function loadBest(): Promise<number> {
+  if (!window.MatrixOS?.db) return readLocalBest();
+  const rows = await window.MatrixOS.db.find(SCORES_TABLE, {
+    orderBy: { score: "desc" },
+    limit: 1,
+  });
+  const top = rows[0];
+  const dbBest = top && typeof top.score === "number" ? top.score : 0;
+  return Math.max(dbBest, readLocalBest());
+}
+
+async function persistScore(row: ScoreRow): Promise<void> {
+  writeLocalBest(Math.max(readLocalBest(), row.score));
+  if (!window.MatrixOS?.db) return;
+  await window.MatrixOS.db.insert(SCORES_TABLE, {
+    score: row.score,
+    lines: row.lines,
+    level: row.level,
+  });
+}
+
+// A small static mini-grid renderer for next / hold previews.
+function PiecePreview({ type, label }: { type: PieceType | null; label: string }) {
+  // Render a 4x4 box; map the spawn-rotation cells of the piece into it.
+  const cells = Array.from({ length: 16 }, () => false as boolean);
+  if (type) {
+    const offsets = cellsFor({ type, rotation: 0, row: 0, col: 0 });
+    for (const [r, c] of offsets) {
+      const idx = r * 4 + c;
+      if (idx >= 0 && idx < 16) cells[idx] = true;
+    }
+  }
+  return (
+    <div className="preview" aria-label={`${label}${type ? `: ${type}` : ": empty"}`}>
+      <span className="preview__label">{label}</span>
+      <div className="preview__grid">
+        {cells.map((on, i) => (
+          <span
+            key={i}
+            className="preview__cell"
+            style={on && type ? { background: PIECE_COLORS[type], boxShadow: "inset 0 0 0 1px rgba(255,255,255,.25)" } : undefined}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  const [game, setGame] = useState<GameState>(() => createGame());
+  const [phase, setPhase] = useState<Phase>("ready");
+  const [best, setBest] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [saveNote, setSaveNote] = useState<string | null>(null);
+  const reduced = useMemo(() => prefersReducedMotion(), []);
+  const savedForGameRef = useRef(false);
+
+  const reload = useCallback(async () => {
+    try {
+      setError(null);
+      setBest(await loadBest());
+    } catch (err: unknown) {
+      console.warn("[tetris] best score load failed:", err instanceof Error ? err.message : String(err));
+      setBest(readLocalBest());
+      setError("High score history could not be loaded.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+    const unsub = window.MatrixOS?.db?.onChange?.(SCORES_TABLE, () => void reload());
+    return () => {
+      if (typeof unsub === "function") unsub();
+    };
+  }, [reload]);
+
+  const startGame = useCallback(() => {
+    savedForGameRef.current = false;
+    setSaveNote(null);
+    setGame(createGame());
+    setPhase("playing");
+  }, []);
+
+  const togglePause = useCallback(() => {
+    setPhase((p) => (p === "playing" ? "paused" : p === "paused" ? "playing" : p));
+  }, []);
+
+  // Gravity loop.
+  useEffect(() => {
+    if (phase !== "playing") return undefined;
+    const interval = gravityMs(game.level);
+    const timer = window.setInterval(() => {
+      setGame((g) => step(g));
+    }, interval);
+    return () => window.clearInterval(timer);
+  }, [phase, game.level]);
+
+  // Persist score once when the game ends.
+  useEffect(() => {
+    if (!game.over) return;
+    setPhase("over");
+    if (savedForGameRef.current) return;
+    savedForGameRef.current = true;
+    const row: ScoreRow = { score: game.score, lines: game.lines, level: game.level };
+    setBest((b) => Math.max(b, game.score));
+    void (async () => {
+      try {
+        await persistScore(row);
+        setSaveNote(window.MatrixOS?.db ? "Saved to Matrix Postgres" : "Saved locally");
+      } catch (err: unknown) {
+        console.warn("[tetris] score save failed:", err instanceof Error ? err.message : String(err));
+        setSaveNote("Score could not be saved.");
+        setError("Score could not be saved.");
+      }
+    })();
+  }, [game.over, game.score, game.lines, game.level]);
+
+  // Keyboard controls.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "p" || e.key === "P") {
+        e.preventDefault();
+        togglePause();
+        return;
+      }
+      if ((e.key === "Enter" || e.key === " ") && (phase === "ready" || phase === "over")) {
+        e.preventDefault();
+        startGame();
+        return;
+      }
+      if (phase !== "playing") return;
+      switch (e.key) {
+        case "ArrowLeft":
+          e.preventDefault();
+          setGame((g) => tryMove(g, -1, 0));
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          setGame((g) => tryMove(g, 1, 0));
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setGame((g) => softDrop(g));
+          break;
+        case "ArrowUp":
+        case "x":
+        case "X":
+          e.preventDefault();
+          setGame((g) => tryRotate(g, 1));
+          break;
+        case "z":
+        case "Z":
+        case "Control":
+          e.preventDefault();
+          setGame((g) => tryRotate(g, -1));
+          break;
+        case "c":
+        case "C":
+        case "Shift":
+          e.preventDefault();
+          setGame((g) => holdPiece(g));
+          break;
+        case " ":
+          e.preventDefault();
+          setGame((g) => hardDrop(g));
+          break;
+        default:
+          break;
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [phase, startGame, togglePause]);
+
+  // Build the visible 10x20 render grid with the active piece + ghost overlaid.
+  const renderGrid = useMemo(() => {
+    const grid: Array<{ color: string | null; active: boolean; ghost: boolean }> = Array.from(
+      { length: ROWS * COLS },
+      () => ({ color: null, active: false, ghost: false }),
+    );
+
+    // Locked cells.
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        const cell = game.board[r + HIDDEN_ROWS][c];
+        if (cell) grid[r * COLS + c].color = PIECE_COLORS[cell];
+      }
+    }
+
+    // Ghost piece.
+    if (game.active && phase === "playing") {
+      const gRow = ghostRow(game);
+      if (gRow !== null) {
+        const ghost = { ...game.active, row: gRow };
+        for (const [r, c] of cellsFor(ghost)) {
+          const vr = r - HIDDEN_ROWS;
+          if (vr >= 0 && vr < ROWS && c >= 0 && c < COLS) {
+            grid[vr * COLS + c].ghost = true;
+          }
+        }
+      }
+    }
+
+    // Active piece.
+    if (game.active) {
+      const color = PIECE_COLORS[game.active.type];
+      for (const [r, c] of cellsFor(game.active)) {
+        const vr = r - HIDDEN_ROWS;
+        if (vr >= 0 && vr < ROWS && c >= 0 && c < COLS) {
+          grid[vr * COLS + c] = { color, active: true, ghost: false };
+        }
+      }
+    }
+    return grid;
+  }, [game, phase]);
+
+  const overlay =
+    phase === "ready"
+      ? {
+          title: "Matrix Tetris",
+          body: "Stack tetrominoes, clear lines, chase your best. Arrow keys to move, Up/Z to rotate, Space to hard drop.",
+          cta: "Play",
+        }
+      : phase === "paused"
+        ? { title: "Paused", body: "Take a breath. Press P or Resume to continue.", cta: "Resume" }
+        : phase === "over"
+          ? {
+              title: "Game over",
+              body: `You cleared ${game.lines} lines and scored ${game.score.toLocaleString()}.`,
+              cta: "Play again",
+            }
+          : null;
+
+  return (
+    <main className={reduced ? "tetris-app tetris-app--reduced" : "tetris-app"}>
+      <section className="play-area">
+        <div className="board-wrap">
+          <div className="board" data-testid="tetris-board" role="grid" aria-label="Tetris playfield">
+            {renderGrid.map((cell, i) => (
+              <span
+                key={i}
+                data-testid="tetris-cell"
+                data-active={cell.active ? "true" : "false"}
+                className={
+                  cell.ghost
+                    ? "cell cell--ghost"
+                    : cell.color
+                      ? cell.active
+                        ? "cell cell--active"
+                        : "cell cell--locked"
+                      : "cell"
+                }
+                style={cell.color ? { background: cell.color } : undefined}
+              />
+            ))}
+          </div>
+
+          {overlay && (
+            <div className="overlay" role="dialog" aria-label={overlay.title}>
+              <div className="overlay__card">
+                <h1>{overlay.title}</h1>
+                <p>{overlay.body}</p>
+                {phase === "over" && (
+                  <div className="overlay__stat">
+                    <Trophy size={16} /> Best {best.toLocaleString()}
+                  </div>
+                )}
+                <button type="button" className="primary-action" onClick={startGame}>
+                  <Play size={18} /> {overlay.cta}
+                </button>
+                {saveNote && phase === "over" && <span className="overlay__note">{saveNote}</span>}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <aside className="side-rail" aria-label="Game info">
+        <div className="brand">
+          <span className="brand__mark" aria-hidden="true">
+            <Layers size={16} />
+          </span>
+          Matrix Tetris
+        </div>
+
+        <div className="stat-grid">
+          <div className="stat">
+            <span>Score</span>
+            <strong data-testid="tetris-score">{game.score.toLocaleString()}</strong>
+          </div>
+          <div className="stat">
+            <span>Best</span>
+            <strong data-testid="tetris-best">{best.toLocaleString()}</strong>
+          </div>
+          <div className="stat">
+            <span>Lines</span>
+            <strong>{game.lines}</strong>
+          </div>
+          <div className="stat">
+            <span>Level</span>
+            <strong>{game.level}</strong>
+          </div>
+        </div>
+
+        <PiecePreview type={game.hold} label="Hold" />
+
+        <div className="next-stack">
+          <span className="preview__label">Next</span>
+          <div className="next-stack__list">
+            {game.queue.slice(0, 3).map((type, i) => (
+              <PiecePreview key={`${type}-${i}`} type={type} label={`Up ${i + 1}`} />
+            ))}
+          </div>
+        </div>
+
+        <div className="controls">
+          {phase === "playing" || phase === "paused" ? (
+            <button type="button" className="secondary-action" onClick={togglePause}>
+              {phase === "paused" ? <Play size={16} /> : <Pause size={16} />}
+              {phase === "paused" ? "Resume" : "Pause"}
+            </button>
+          ) : (
+            <button type="button" className="secondary-action" onClick={startGame}>
+              <Play size={16} /> Play
+            </button>
+          )}
+          <button type="button" className="icon-action" title="Restart" onClick={startGame}>
+            <RotateCcw size={16} />
+          </button>
+        </div>
+
+        <div className="hints">
+          <Gauge size={14} />
+          <span>
+            <kbd>←</kbd>
+            <kbd>→</kbd> move · <kbd>↓</kbd> soft · <kbd>Space</kbd> drop · <kbd>↑</kbd>/<kbd>Z</kbd> rotate ·{" "}
+            <kbd>C</kbd> hold · <kbd>P</kbd> pause
+          </span>
+        </div>
+
+        {error && <div className="error-note">{error}</div>}
+      </aside>
+    </main>
+  );
+}

--- a/home/apps/games/tetris/src/App.tsx
+++ b/home/apps/games/tetris/src/App.tsx
@@ -137,6 +137,7 @@ export default function App() {
   const startGame = useCallback(() => {
     savedForGameRef.current = false;
     setSaveNote(null);
+    setError(null);
     setGame(createGame());
     setPhase("playing");
   }, []);

--- a/home/apps/games/tetris/src/App.tsx
+++ b/home/apps/games/tetris/src/App.tsx
@@ -31,6 +31,12 @@ interface ScoreRow {
   level: number;
 }
 
+function numericScore(row: Record<string, unknown> | undefined): number {
+  if (!row) return 0;
+  const score = typeof row.score === "number" ? row.score : Number(row.score);
+  return Number.isFinite(score) && score > 0 ? score : 0;
+}
+
 function prefersReducedMotion(): boolean {
   try {
     return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
@@ -58,25 +64,50 @@ function writeLocalBest(value: number): void {
   }
 }
 
-async function loadBest(): Promise<number> {
+export async function loadBest(): Promise<number> {
   if (!window.MatrixOS?.db) return readLocalBest();
   const rows = await window.MatrixOS.db.find(SCORES_TABLE, {
     orderBy: { score: "desc" },
     limit: 1,
   });
-  const top = rows[0];
-  const dbBest = top && typeof top.score === "number" ? top.score : 0;
-  return Math.max(dbBest, readLocalBest());
+  return numericScore(rows[0]);
 }
 
-async function persistScore(row: ScoreRow): Promise<void> {
-  writeLocalBest(Math.max(readLocalBest(), row.score));
-  if (!window.MatrixOS?.db) return;
-  await window.MatrixOS.db.insert(SCORES_TABLE, {
-    score: row.score,
-    lines: row.lines,
-    level: row.level,
+export async function persistScore(row: ScoreRow): Promise<void> {
+  if (!window.MatrixOS?.db) {
+    writeLocalBest(Math.max(readLocalBest(), row.score));
+    return;
+  }
+  const db = window.MatrixOS.db;
+  const rows = await db.find(SCORES_TABLE, {
+    orderBy: { score: "desc" },
+    limit: 10000,
   });
+  const [bestRow, ...staleRows] = rows;
+  const bestId = typeof bestRow?.id === "string" ? bestRow.id : null;
+  const bestScore = numericScore(bestRow);
+  const nextBest = {
+    score: Math.max(bestScore, row.score),
+    lines: row.score > bestScore ? row.lines : (bestRow?.lines ?? row.lines),
+    level: row.score > bestScore ? row.level : (bestRow?.level ?? row.level),
+  };
+
+  if (bestId) {
+    if (row.score > bestScore) {
+      await db.update(SCORES_TABLE, bestId, nextBest);
+    }
+  } else {
+    await db.insert(SCORES_TABLE, nextBest);
+  }
+
+  await Promise.all(
+    staleRows
+      .map((stale) => (typeof stale.id === "string" ? stale.id : null))
+      .filter((id): id is string => id !== null)
+      .map((id) => db.delete(SCORES_TABLE, id).catch((err: unknown) => {
+        console.warn("[tetris] stale score cleanup failed:", err instanceof Error ? err.message : String(err));
+      })),
+  );
 }
 
 // A small static mini-grid renderer for next / hold previews.

--- a/home/apps/games/tetris/src/main.tsx
+++ b/home/apps/games/tetris/src/main.tsx
@@ -1,9 +1,3 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App";
+import { renderDefaultApp } from "../../../_shared/default-apps";
 
-createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+renderDefaultApp("tetris" as const);

--- a/home/apps/games/tetris/src/main.tsx
+++ b/home/apps/games/tetris/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("tetris" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/tetris/src/matrix-os.d.ts
+++ b/home/apps/games/tetris/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/games/tetris/src/styles.css
+++ b/home/apps/games/tetris/src/styles.css
@@ -1,0 +1,367 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+  --app-mono: var(--matrix-font-mono, "JetBrains Mono", monospace);
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  background: var(--app-bg);
+  color: var(--app-fg);
+  font-family: var(--app-font);
+}
+
+.tetris-app {
+  height: 100vh;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 20px;
+  padding: 22px;
+  background:
+    radial-gradient(circle at 14% 8%, color-mix(in srgb, var(--app-accent) 12%, transparent), transparent 40%),
+    radial-gradient(circle at 92% 96%, color-mix(in srgb, var(--app-primary) 10%, transparent), transparent 42%),
+    var(--app-bg);
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: 0;
+  color: inherit;
+}
+
+button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--app-accent) 55%, transparent);
+  outline-offset: 2px;
+}
+
+/* ---------- Playfield ---------- */
+.play-area {
+  display: grid;
+  place-items: center;
+  min-width: 0;
+}
+
+.board-wrap {
+  position: relative;
+  height: 100%;
+  display: grid;
+  place-items: center;
+}
+
+.board {
+  --cols: 10;
+  --rows: 20;
+  display: grid;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  grid-template-rows: repeat(var(--rows), 1fr);
+  gap: 2px;
+  aspect-ratio: 10 / 20;
+  height: min(100%, calc((100vh - 44px)));
+  max-height: calc(100vh - 44px);
+  padding: 10px;
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--app-fg) 8%, var(--app-card));
+  box-shadow:
+    inset 0 2px 10px color-mix(in srgb, var(--app-fg) 16%, transparent),
+    0 10px 28px rgba(50, 53, 46, 0.14);
+}
+
+.cell {
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--app-fg) 5%, transparent);
+  transition: background 0.12s ease;
+}
+
+.tetris-app--reduced .cell {
+  transition: none;
+}
+
+.cell--locked {
+  box-shadow:
+    inset 0 2px 3px rgba(255, 255, 255, 0.32),
+    inset 0 -3px 4px rgba(0, 0, 0, 0.22);
+}
+
+.cell--active {
+  box-shadow:
+    inset 0 2px 4px rgba(255, 255, 255, 0.45),
+    inset 0 -3px 5px rgba(0, 0, 0, 0.24);
+}
+
+.cell--ghost {
+  background: transparent;
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--app-fg) 22%, transparent);
+}
+
+/* ---------- Overlays ---------- */
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--app-bg) 72%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.overlay__card {
+  display: grid;
+  justify-items: center;
+  gap: 12px;
+  max-width: 320px;
+  padding: 28px 26px;
+  text-align: center;
+  border-radius: var(--app-radius);
+  background: var(--app-card);
+  box-shadow: 0 18px 44px rgba(50, 53, 46, 0.2);
+}
+
+.overlay__card h1 {
+  margin: 0;
+  font-size: 28px;
+  letter-spacing: -0.01em;
+}
+
+.overlay__card p {
+  margin: 0;
+  color: var(--app-muted-fg);
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+.overlay__stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--app-accent);
+  font-weight: 800;
+}
+
+.overlay__note {
+  font-size: 12px;
+  color: var(--app-muted-fg);
+}
+
+/* ---------- Side rail ---------- */
+.side-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 850;
+  font-size: 15px;
+}
+
+.brand__mark {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 11px;
+  color: var(--app-primary-fg);
+  background: linear-gradient(145deg, var(--app-accent), color-mix(in srgb, var(--app-accent) 60%, var(--app-warning)));
+  box-shadow: 0 6px 14px color-mix(in srgb, var(--app-accent) 40%, transparent);
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.stat {
+  display: grid;
+  gap: 2px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: var(--app-card);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+
+.stat span {
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--app-muted-fg);
+}
+
+.stat strong {
+  font-size: 22px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- Previews ---------- */
+.preview {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: var(--app-card);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+
+.preview__label {
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--app-muted-fg);
+}
+
+.preview__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  gap: 3px;
+  width: 72px;
+  aspect-ratio: 1;
+}
+
+.preview__cell {
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--app-fg) 6%, transparent);
+}
+
+.next-stack {
+  display: grid;
+  gap: 8px;
+}
+
+.next-stack__list {
+  display: grid;
+  gap: 10px;
+}
+
+.next-stack .preview {
+  padding: 10px 12px;
+}
+
+/* ---------- Controls ---------- */
+.controls {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.primary-action,
+.secondary-action,
+.icon-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  border-radius: 14px;
+  font-weight: 800;
+  transition: transform 0.14s ease, box-shadow 0.14s ease;
+}
+
+.tetris-app--reduced .primary-action,
+.tetris-app--reduced .secondary-action,
+.tetris-app--reduced .icon-action {
+  transition: none;
+}
+
+.primary-action {
+  padding: 0 22px;
+  color: var(--app-primary-fg);
+  background: var(--app-accent);
+  box-shadow: 0 10px 22px color-mix(in srgb, var(--app-accent) 38%, transparent);
+}
+
+.secondary-action {
+  flex: 1;
+  background: var(--app-card);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+
+.icon-action {
+  width: 44px;
+  background: var(--app-card);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+
+.primary-action:hover,
+.secondary-action:hover,
+.icon-action:hover {
+  transform: translateY(-1px);
+}
+
+/* ---------- Hints & errors ---------- */
+.hints {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  color: var(--app-muted-fg);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.hints kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  margin: 0 1px;
+  border-radius: 6px;
+  background: var(--app-muted);
+  font-family: var(--app-mono);
+  font-size: 11px;
+  color: var(--app-fg);
+}
+
+.error-note {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--app-danger) 12%, var(--app-card));
+  color: var(--app-danger);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+@media (max-width: 760px) {
+  .tetris-app {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) auto;
+  }
+
+  .side-rail {
+    flex-direction: row;
+    flex-wrap: wrap;
+    overflow: visible;
+  }
+}

--- a/home/apps/games/tetris/src/tetris-model.ts
+++ b/home/apps/games/tetris/src/tetris-model.ts
@@ -1,0 +1,432 @@
+// Pure, UI-free Tetris engine. Deterministic with an injectable RNG / bag.
+// Guideline-style: 10x20 visible field, 7-bag randomizer, SRS rotation with
+// basic wall kicks, lock, line clears, scoring, levels, top-out.
+
+export const COLS = 10;
+export const ROWS = 20;
+// Two hidden rows above the visible field where pieces spawn.
+export const HIDDEN_ROWS = 2;
+export const TOTAL_ROWS = ROWS + HIDDEN_ROWS;
+
+export type PieceType = "I" | "O" | "T" | "S" | "Z" | "J" | "L";
+
+export const PIECES: PieceType[] = ["I", "O", "T", "S", "Z", "J", "L"];
+
+// Guideline tetromino colors.
+export const PIECE_COLORS: Record<PieceType, string> = {
+  I: "#3FC4D6", // cyan
+  O: "#F2C94C", // yellow
+  T: "#A064D4", // purple
+  S: "#52C26B", // green
+  Z: "#E5564B", // red
+  J: "#4C7DE0", // blue
+  L: "#E58A3C", // orange
+};
+
+// Cell value: null = empty, otherwise the PieceType that occupies it (for color).
+export type Cell = PieceType | null;
+export type Board = Cell[][];
+
+// Rotation states 0..3. Each piece is described by the filled cell offsets in
+// a local box. We use canonical SRS spawn shapes.
+type Offsets = ReadonlyArray<readonly [number, number]>;
+
+// Each piece: rotation state -> list of [row, col] offsets within a 4x4 (I) or
+// 3x3 (others) bounding box. O is rotation-invariant.
+const SHAPES: Record<PieceType, ReadonlyArray<Offsets>> = {
+  I: [
+    [[1, 0], [1, 1], [1, 2], [1, 3]],
+    [[0, 2], [1, 2], [2, 2], [3, 2]],
+    [[2, 0], [2, 1], [2, 2], [2, 3]],
+    [[0, 1], [1, 1], [2, 1], [3, 1]],
+  ],
+  O: [
+    [[0, 1], [0, 2], [1, 1], [1, 2]],
+    [[0, 1], [0, 2], [1, 1], [1, 2]],
+    [[0, 1], [0, 2], [1, 1], [1, 2]],
+    [[0, 1], [0, 2], [1, 1], [1, 2]],
+  ],
+  T: [
+    [[0, 1], [1, 0], [1, 1], [1, 2]],
+    [[0, 1], [1, 1], [1, 2], [2, 1]],
+    [[1, 0], [1, 1], [1, 2], [2, 1]],
+    [[0, 1], [1, 0], [1, 1], [2, 1]],
+  ],
+  S: [
+    [[0, 1], [0, 2], [1, 0], [1, 1]],
+    [[0, 1], [1, 1], [1, 2], [2, 2]],
+    [[1, 1], [1, 2], [2, 0], [2, 1]],
+    [[0, 0], [1, 0], [1, 1], [2, 1]],
+  ],
+  Z: [
+    [[0, 0], [0, 1], [1, 1], [1, 2]],
+    [[0, 2], [1, 1], [1, 2], [2, 1]],
+    [[1, 0], [1, 1], [2, 1], [2, 2]],
+    [[0, 1], [1, 0], [1, 1], [2, 0]],
+  ],
+  J: [
+    [[0, 0], [1, 0], [1, 1], [1, 2]],
+    [[0, 1], [0, 2], [1, 1], [2, 1]],
+    [[1, 0], [1, 1], [1, 2], [2, 2]],
+    [[0, 1], [1, 1], [2, 0], [2, 1]],
+  ],
+  L: [
+    [[0, 2], [1, 0], [1, 1], [1, 2]],
+    [[0, 1], [1, 1], [2, 1], [2, 2]],
+    [[1, 0], [1, 1], [1, 2], [2, 0]],
+    [[0, 0], [0, 1], [1, 1], [2, 1]],
+  ],
+};
+
+// SRS wall-kick offsets. JLSTZ share one table, I has its own. Index by
+// from->to transition. Each entry is the ordered list of [dx, dy] to try
+// (dx = column shift, dy = row shift; positive dy = downward).
+type KickKey = `${0 | 1 | 2 | 3}>${0 | 1 | 2 | 3}`;
+
+type KickTable = Partial<Record<KickKey, ReadonlyArray<readonly [number, number]>>>;
+
+const KICKS_JLSTZ: KickTable = {
+  "0>1": [[0, 0], [-1, 0], [-1, -1], [0, 2], [-1, 2]],
+  "1>0": [[0, 0], [1, 0], [1, 1], [0, -2], [1, -2]],
+  "1>2": [[0, 0], [1, 0], [1, 1], [0, -2], [1, -2]],
+  "2>1": [[0, 0], [-1, 0], [-1, -1], [0, 2], [-1, 2]],
+  "2>3": [[0, 0], [1, 0], [1, -1], [0, 2], [1, 2]],
+  "3>2": [[0, 0], [-1, 0], [-1, 1], [0, -2], [-1, -2]],
+  "3>0": [[0, 0], [-1, 0], [-1, 1], [0, -2], [-1, -2]],
+  "0>3": [[0, 0], [1, 0], [1, -1], [0, 2], [1, 2]],
+};
+
+const KICKS_I: KickTable = {
+  "0>1": [[0, 0], [-2, 0], [1, 0], [-2, 1], [1, -2]],
+  "1>0": [[0, 0], [2, 0], [-1, 0], [2, -1], [-1, 2]],
+  "1>2": [[0, 0], [-1, 0], [2, 0], [-1, -2], [2, 1]],
+  "2>1": [[0, 0], [1, 0], [-2, 0], [1, 2], [-2, -1]],
+  "2>3": [[0, 0], [2, 0], [-1, 0], [2, -1], [-1, 2]],
+  "3>2": [[0, 0], [-2, 0], [1, 0], [-2, 1], [1, -2]],
+  "3>0": [[0, 0], [1, 0], [-2, 0], [1, 2], [-2, -1]],
+  "0>3": [[0, 0], [-1, 0], [2, 0], [-1, -2], [2, 1]],
+};
+
+export interface ActivePiece {
+  type: PieceType;
+  rotation: 0 | 1 | 2 | 3;
+  row: number; // top-left of bounding box, in TOTAL_ROWS coordinates
+  col: number;
+}
+
+export interface GameState {
+  board: Board; // TOTAL_ROWS x COLS, includes hidden rows at the top
+  active: ActivePiece | null;
+  queue: PieceType[]; // upcoming pieces (next-queue preview)
+  bag: PieceType[]; // remaining pieces in the current 7-bag
+  hold: PieceType | null;
+  canHold: boolean;
+  score: number;
+  lines: number;
+  level: number;
+  over: boolean;
+  // Transient: rows cleared on the most recent lock (for animation).
+  lastCleared: number[];
+}
+
+export type Rng = () => number;
+
+export function createBoard(): Board {
+  return Array.from({ length: TOTAL_ROWS }, () => Array<Cell>(COLS).fill(null));
+}
+
+// Fisher-Yates shuffle of the 7 pieces using an injectable RNG.
+export function newBag(rng: Rng = Math.random): PieceType[] {
+  const bag = [...PIECES];
+  for (let i = bag.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [bag[i], bag[j]] = [bag[j], bag[i]];
+  }
+  return bag;
+}
+
+// Pull the next piece from the bag, refilling from a fresh 7-bag when empty.
+export function nextFromBag(
+  bag: PieceType[],
+  rng: Rng = Math.random,
+): { piece: PieceType; bag: PieceType[] } {
+  let working = bag.length > 0 ? [...bag] : newBag(rng);
+  const piece = working[0];
+  working = working.slice(1);
+  return { piece, bag: working };
+}
+
+// Absolute cells a piece occupies, in TOTAL_ROWS coordinates.
+export function cellsFor(piece: ActivePiece): Array<[number, number]> {
+  const shape = SHAPES[piece.type][piece.rotation];
+  return shape.map(([dr, dc]) => [piece.row + dr, piece.col + dc]);
+}
+
+export function isValid(board: Board, piece: ActivePiece): boolean {
+  for (const [r, c] of cellsFor(piece)) {
+    if (c < 0 || c >= COLS) return false;
+    if (r < 0 || r >= TOTAL_ROWS) return false;
+    if (board[r][c] !== null) return false;
+  }
+  return true;
+}
+
+function spawnPiece(type: PieceType): ActivePiece {
+  // Spawn horizontally centered. Row HIDDEN_ROWS-1 straddles the hidden/visible
+  // boundary so the piece's lower cells are immediately visible at the top of
+  // the playfield while still leaving a hidden row for top-out detection.
+  return { type, rotation: 0, row: HIDDEN_ROWS - 1, col: 3 };
+}
+
+const PREVIEW_COUNT = 5;
+
+function ensureQueue(
+  queue: PieceType[],
+  bag: PieceType[],
+  rng: Rng,
+): { queue: PieceType[]; bag: PieceType[] } {
+  let q = [...queue];
+  let b = [...bag];
+  while (q.length < PREVIEW_COUNT) {
+    const pulled = nextFromBag(b, rng);
+    q.push(pulled.piece);
+    b = pulled.bag;
+  }
+  return { queue: q, bag: b };
+}
+
+export function createGame(rng: Rng = Math.random): GameState {
+  const filled = ensureQueue([], newBag(rng), rng);
+  const first = filled.queue[0];
+  const queue = filled.queue.slice(1);
+  const refilled = ensureQueue(queue, filled.bag, rng);
+  const active = spawnPiece(first);
+  return {
+    board: createBoard(),
+    active,
+    queue: refilled.queue,
+    bag: refilled.bag,
+    hold: null,
+    canHold: true,
+    score: 0,
+    lines: 0,
+    level: 1,
+    over: false,
+    lastCleared: [],
+  };
+}
+
+// Take the next piece from the queue and refill from the bag.
+function pullNext(
+  state: GameState,
+  rng: Rng,
+): { type: PieceType; queue: PieceType[]; bag: PieceType[] } {
+  const type = state.queue[0];
+  const rest = state.queue.slice(1);
+  const refilled = ensureQueue(rest, state.bag, rng);
+  return { type, queue: refilled.queue, bag: refilled.bag };
+}
+
+export function tryMove(state: GameState, dCol: number, dRow: number): GameState {
+  if (state.over || !state.active) return state;
+  const moved: ActivePiece = {
+    ...state.active,
+    col: state.active.col + dCol,
+    row: state.active.row + dRow,
+  };
+  if (isValid(state.board, moved)) {
+    return { ...state, active: moved };
+  }
+  return state;
+}
+
+export function tryRotate(state: GameState, dir: 1 | -1): GameState {
+  if (state.over || !state.active) return state;
+  const piece = state.active;
+  if (piece.type === "O") return state; // O does not rotate visibly
+  const from = piece.rotation;
+  const to = (((from + dir) % 4) + 4) % 4 as 0 | 1 | 2 | 3;
+  const key = `${from}>${to}` as KickKey;
+  const table = piece.type === "I" ? KICKS_I : KICKS_JLSTZ;
+  const kicks = table[key] ?? [[0, 0]];
+  for (const [dx, dy] of kicks) {
+    const candidate: ActivePiece = {
+      ...piece,
+      rotation: to,
+      col: piece.col + dx,
+      row: piece.row + dy,
+    };
+    if (isValid(state.board, candidate)) {
+      return { ...state, active: candidate };
+    }
+  }
+  return state;
+}
+
+// Scan board, remove full rows, return the cleared row indices and a new board.
+export function clearLines(board: Board): { board: Board; cleared: number[] } {
+  const cleared: number[] = [];
+  for (let r = 0; r < TOTAL_ROWS; r++) {
+    if (board[r].every((cell) => cell !== null)) cleared.push(r);
+  }
+  if (cleared.length === 0) return { board, cleared };
+  const kept = board.filter((_, r) => !cleared.includes(r));
+  const newRows = Array.from({ length: cleared.length }, () => Array<Cell>(COLS).fill(null));
+  return { board: [...newRows, ...kept], cleared };
+}
+
+// Guideline-ish line scoring per the cleared count and current level.
+const LINE_SCORE = [0, 100, 300, 500, 800];
+
+export function scoreForLines(count: number, level: number): number {
+  const base = LINE_SCORE[Math.min(count, 4)] ?? 0;
+  return base * level;
+}
+
+export function levelForLines(lines: number): number {
+  return Math.floor(lines / 10) + 1;
+}
+
+// Gravity interval in milliseconds for a given level (classic-ish curve).
+export function gravityMs(level: number): number {
+  const table = [0, 800, 720, 630, 550, 470, 380, 300, 220, 130, 100, 80, 80, 70, 70, 50];
+  return table[Math.min(level, table.length - 1)] ?? 50;
+}
+
+// Settle the active piece into the board, clear lines, update score/level, and
+// spawn the next piece. Sets `over` on top-out.
+export function lockPiece(state: GameState, rng: Rng = Math.random): GameState {
+  if (!state.active || state.over) return state;
+  const board = state.board.map((row) => [...row]);
+  for (const [r, c] of cellsFor(state.active)) {
+    if (r >= 0 && r < TOTAL_ROWS && c >= 0 && c < COLS) {
+      board[r][c] = state.active.type;
+    }
+  }
+  const { board: clearedBoard, cleared } = clearLines(board);
+  const lines = state.lines + cleared.length;
+  const level = levelForLines(lines);
+  const score = state.score + scoreForLines(cleared.length, state.level);
+
+  const { type, queue, bag } = pullNext(state, rng);
+  const next = spawnPiece(type);
+
+  // Top-out: if the freshly spawned piece overlaps existing blocks.
+  if (!isValid(clearedBoard, next)) {
+    return {
+      ...state,
+      board: clearedBoard,
+      active: null,
+      queue,
+      bag,
+      score,
+      lines,
+      level,
+      canHold: true,
+      over: true,
+      lastCleared: cleared,
+    };
+  }
+
+  return {
+    ...state,
+    board: clearedBoard,
+    active: next,
+    queue,
+    bag,
+    score,
+    lines,
+    level,
+    canHold: true,
+    over: false,
+    lastCleared: cleared,
+  };
+}
+
+// Apply one gravity step: move down if possible, otherwise lock.
+export function step(state: GameState, rng: Rng = Math.random): GameState {
+  if (state.over || !state.active) return state;
+  const moved: ActivePiece = { ...state.active, row: state.active.row + 1 };
+  if (isValid(state.board, moved)) {
+    return { ...state, active: moved };
+  }
+  return lockPiece(state, rng);
+}
+
+// Soft drop: move down one, award 1 point per cell if it moved.
+export function softDrop(state: GameState): GameState {
+  if (state.over || !state.active) return state;
+  const moved: ActivePiece = { ...state.active, row: state.active.row + 1 };
+  if (isValid(state.board, moved)) {
+    return { ...state, active: moved, score: state.score + 1 };
+  }
+  return state;
+}
+
+// Hard drop: drop to the bottom, award 2 points per cell, then lock.
+export function hardDrop(state: GameState, rng: Rng = Math.random): GameState {
+  if (state.over || !state.active) return state;
+  let piece = state.active;
+  let dropped = 0;
+  while (true) {
+    const moved: ActivePiece = { ...piece, row: piece.row + 1 };
+    if (!isValid(state.board, moved)) break;
+    piece = moved;
+    dropped++;
+  }
+  const withPiece: GameState = {
+    ...state,
+    active: piece,
+    score: state.score + dropped * 2,
+  };
+  return lockPiece(withPiece, rng);
+}
+
+// Hold the current piece, swapping with a previously held one if present.
+export function holdPiece(state: GameState, rng: Rng = Math.random): GameState {
+  if (state.over || !state.active || !state.canHold) return state;
+  const current = state.active.type;
+  if (state.hold === null) {
+    const { type, queue, bag } = pullNext(state, rng);
+    const next = spawnPiece(type);
+    return {
+      ...state,
+      active: isValid(state.board, next) ? next : next,
+      hold: current,
+      queue,
+      bag,
+      canHold: false,
+    };
+  }
+  const swapped = spawnPiece(state.hold);
+  return {
+    ...state,
+    active: swapped,
+    hold: current,
+    canHold: false,
+  };
+}
+
+// Ghost piece position (where the active piece would hard-drop to).
+export function ghostRow(state: GameState): number | null {
+  if (!state.active) return null;
+  let piece = state.active;
+  while (true) {
+    const moved: ActivePiece = { ...piece, row: piece.row + 1 };
+    if (!isValid(state.board, moved)) break;
+    piece = moved;
+  }
+  return piece.row;
+}
+
+// A seedable RNG for deterministic tests / reproducible games (mulberry32).
+export function seededRng(seed: number): Rng {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/home/apps/games/tetris/src/tetris-model.ts
+++ b/home/apps/games/tetris/src/tetris-model.ts
@@ -389,9 +389,21 @@ export function holdPiece(state: GameState, rng: Rng = Math.random): GameState {
   if (state.hold === null) {
     const { type, queue, bag } = pullNext(state, rng);
     const next = spawnPiece(type);
+    if (!isValid(state.board, next)) {
+      return {
+        ...state,
+        active: null,
+        hold: current,
+        queue,
+        bag,
+        canHold: false,
+        over: true,
+        lastCleared: [],
+      };
+    }
     return {
       ...state,
-      active: isValid(state.board, next) ? next : next,
+      active: next,
       hold: current,
       queue,
       bag,
@@ -399,6 +411,16 @@ export function holdPiece(state: GameState, rng: Rng = Math.random): GameState {
     };
   }
   const swapped = spawnPiece(state.hold);
+  if (!isValid(state.board, swapped)) {
+    return {
+      ...state,
+      active: null,
+      hold: current,
+      canHold: false,
+      over: true,
+      lastCleared: [],
+    };
+  }
   return {
     ...state,
     active: swapped,

--- a/tests/default-apps/tetris-app.test.tsx
+++ b/tests/default-apps/tetris-app.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/games/tetris/src/App";
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const db = {
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async () => ({ id: "score-new" })),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => rows.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+describe("Tetris app", () => {
+  beforeEach(() => {
+    // Fake timers keep the gravity interval from firing async state updates
+    // after a test finishes (which would log act() warnings).
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // matchMedia is referenced for prefers-reduced-motion.
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+  });
+
+  it("renders a 10x20 playfield and loads the best score from Matrix Postgres", async () => {
+    const db = installMatrixDb([
+      { id: "s1", score: 4200, lines: 12, level: 2, created_at: "2026-05-31T10:00:00.000Z" },
+    ]);
+
+    render(<App />);
+
+    // The board renders 200 visible cells.
+    const board = await screen.findByTestId("tetris-board");
+    expect(within(board).getAllByTestId("tetris-cell")).toHaveLength(200);
+
+    // Best score loaded from the DB is shown.
+    expect(await screen.findByText(/4,?200/)).toBeTruthy();
+    expect(db.find).toHaveBeenCalledWith("scores", expect.anything());
+  });
+
+  it("shows a start overlay and begins the game when the player starts", async () => {
+    installMatrixDb([]);
+    render(<App />);
+
+    const dialog = await screen.findByRole("dialog");
+    const startBtn = within(dialog).getByRole("button", { name: /play|start/i });
+    await act(async () => {
+      fireEvent.click(startBtn);
+      await Promise.resolve();
+    });
+
+    // After starting, the status should reflect a running game (score 0).
+    expect(screen.getByTestId("tetris-score").textContent).toContain("0");
+  });
+
+  it("moves the active piece when an arrow key is pressed", async () => {
+    installMatrixDb([]);
+    vi.useFakeTimers();
+    render(<App />);
+
+    // Start the game from the overlay dialog.
+    const dialog = screen.getByRole("dialog");
+    const startBtn = within(dialog).getByRole("button", { name: /play|start/i });
+    act(() => {
+      fireEvent.click(startBtn);
+    });
+
+    // Capture which cells are occupied by the active piece before/after move.
+    function activeCols(): number[] {
+      const cells = screen.getAllByTestId("tetris-cell");
+      return cells
+        .map((el, i) => ({ i, active: el.getAttribute("data-active") === "true" }))
+        .filter((c) => c.active)
+        .map((c) => c.i % 10);
+    }
+
+    const before = activeCols();
+    // At least part of the active piece is visible at the top of the field.
+    expect(before.length).toBeGreaterThan(0);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+    });
+    const after = activeCols();
+
+    // Moving right shifts every visible active column by exactly +1.
+    expect(after.length).toBe(before.length);
+    expect([...after].sort()).toEqual([...before].map((c) => c + 1).sort());
+
+    vi.useRealTimers();
+  });
+});

--- a/tests/default-apps/tetris-app.test.tsx
+++ b/tests/default-apps/tetris-app.test.tsx
@@ -4,17 +4,38 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import App from "../../home/apps/games/tetris/src/App";
+import App, { persistScore } from "../../home/apps/games/tetris/src/App";
 
 type DbRow = Record<string, unknown>;
 
 function installMatrixDb(rows: DbRow[] = []) {
   const db = {
-    find: vi.fn(async () => rows),
+    find: vi.fn(async (_table: string, opts?: { orderBy?: Record<string, "asc" | "desc">; limit?: number }) => {
+      let result = [...rows];
+      if (opts?.orderBy?.score) {
+        result = result.sort((a, b) => {
+          const left = Number(a.score) || 0;
+          const right = Number(b.score) || 0;
+          return opts.orderBy?.score === "desc" ? right - left : left - right;
+        });
+      }
+      return typeof opts?.limit === "number" ? result.slice(0, opts.limit) : result;
+    }),
     findOne: vi.fn(async () => null),
-    insert: vi.fn(async () => ({ id: "score-new" })),
-    update: vi.fn(async () => ({ ok: true })),
-    delete: vi.fn(async () => ({ ok: true })),
+    insert: vi.fn(async (_table: string, data: DbRow) => {
+      rows.push({ id: "score-new", ...data });
+      return { id: "score-new" };
+    }),
+    update: vi.fn(async (_table: string, id: string, data: DbRow) => {
+      const row = rows.find((item) => item.id === id);
+      if (row) Object.assign(row, data);
+      return { ok: true };
+    }),
+    delete: vi.fn(async (_table: string, id: string) => {
+      const index = rows.findIndex((item) => item.id === id);
+      if (index >= 0) rows.splice(index, 1);
+      return { ok: true };
+    }),
     count: vi.fn(async () => rows.length),
     onChange: vi.fn(() => () => undefined),
   };
@@ -64,6 +85,7 @@ describe("Tetris app", () => {
   });
 
   it("renders a 10x20 playfield and loads the best score from Matrix Postgres", async () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem");
     const db = installMatrixDb([
       { id: "s1", score: 4200, lines: 12, level: 2, created_at: "2026-05-31T10:00:00.000Z" },
     ]);
@@ -77,6 +99,65 @@ describe("Tetris app", () => {
     // Best score loaded from the DB is shown.
     expect(await screen.findByText(/4,?200/)).toBeTruthy();
     expect(db.find).toHaveBeenCalledWith("scores", expect.anything());
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  it("does not write localStorage when saving a score through Matrix Postgres", async () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    const db = installMatrixDb([]);
+
+    await persistScore({ score: 1600, lines: 4, level: 1 });
+
+    expect(db.insert).toHaveBeenCalledWith("scores", expect.any(Object));
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("reuses the best score row instead of appending lower scores", async () => {
+    const db = installMatrixDb([
+      { id: "best", score: 3200, lines: 9, level: 2 },
+      { id: "stale", score: 400, lines: 1, level: 1 },
+    ]);
+
+    await persistScore({ score: 1600, lines: 4, level: 1 });
+
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.delete).toHaveBeenCalledWith("scores", "stale");
+  });
+
+  it("updates the singleton best score row when saving a higher score", async () => {
+    const db = installMatrixDb([
+      { id: "best", score: 3200, lines: 9, level: 2 },
+      { id: "stale", score: 400, lines: 1, level: 1 },
+    ]);
+
+    await persistScore({ score: 6400, lines: 18, level: 3 });
+
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.update).toHaveBeenCalledWith("scores", "best", {
+      score: 6400,
+      lines: 18,
+      level: 3,
+    });
+    expect(db.delete).toHaveBeenCalledWith("scores", "stale");
+  });
+
+  it("does not fail score persistence when stale score cleanup fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const db = installMatrixDb([
+      { id: "best", score: 3200, lines: 9, level: 2 },
+      { id: "stale", score: 400, lines: 1, level: 1 },
+    ]);
+    db.delete.mockRejectedValueOnce(new Error("cleanup failed"));
+
+    await expect(persistScore({ score: 6400, lines: 18, level: 3 })).resolves.toBeUndefined();
+
+    expect(db.update).toHaveBeenCalledWith("scores", "best", {
+      score: 6400,
+      lines: 18,
+      level: 3,
+    });
+    expect(warn).toHaveBeenCalledWith("[tetris] stale score cleanup failed:", "cleanup failed");
   });
 
   it("shows a start overlay and begins the game when the player starts", async () => {

--- a/tests/default-apps/tetris-app.test.tsx
+++ b/tests/default-apps/tetris-app.test.tsx
@@ -94,6 +94,22 @@ describe("Tetris app", () => {
     expect(screen.getByTestId("tetris-score").textContent).toContain("0");
   });
 
+  it("clears stale error banners when starting a new game", async () => {
+    const db = installMatrixDb([]);
+    db.find.mockRejectedValueOnce(new Error("load failed"));
+    render(<App />);
+
+    expect(await screen.findByText("High score history could not be loaded.")).toBeTruthy();
+    const dialog = await screen.findByRole("dialog");
+    const startBtn = within(dialog).getByRole("button", { name: /play|start/i });
+    await act(async () => {
+      fireEvent.click(startBtn);
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText("High score history could not be loaded.")).toBeNull();
+  });
+
   it("moves the active piece when an arrow key is pressed", async () => {
     installMatrixDb([]);
     vi.useFakeTimers();

--- a/tests/default-apps/tetris-app.test.tsx
+++ b/tests/default-apps/tetris-app.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/games/tetris/src/App";
@@ -49,6 +51,16 @@ describe("Tetris app", () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
+  });
+
+  it("uses the shipped shared game icon", () => {
+    const repoRoot = join(__dirname, "..", "..");
+    const manifest = JSON.parse(
+      readFileSync(join(repoRoot, "home/apps/games/tetris/matrix.json"), "utf-8"),
+    ) as { icon?: string };
+
+    expect(manifest.icon).toBe("game-center");
+    expect(existsSync(join(repoRoot, "home/system/icons/game-center.png"))).toBe(true);
   });
 
   it("renders a 10x20 playfield and loads the best score from Matrix Postgres", async () => {

--- a/tests/default-apps/tetris-app.test.tsx
+++ b/tests/default-apps/tetris-app.test.tsx
@@ -118,4 +118,33 @@ describe("Tetris app", () => {
 
     vi.useRealTimers();
   });
+
+  it("resumes from the pause overlay without restarting the board", async () => {
+    installMatrixDb([]);
+    render(<App />);
+
+    const startBtn = within(screen.getByRole("dialog")).getByRole("button", { name: /play|start/i });
+    act(() => {
+      fireEvent.click(startBtn);
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      fireEvent.keyDown(window, { key: "p" });
+    });
+
+    function activeCols(): number[] {
+      return screen
+        .getAllByTestId("tetris-cell")
+        .map((el, i) => ({ i, active: el.getAttribute("data-active") === "true" }))
+        .filter((c) => c.active)
+        .map((c) => c.i % 10);
+    }
+
+    const pausedCols = activeCols();
+    const resumeBtn = within(screen.getByRole("dialog", { name: /paused/i })).getByRole("button", { name: /resume/i });
+    act(() => {
+      fireEvent.click(resumeBtn);
+    });
+
+    expect(screen.queryByRole("dialog", { name: /paused/i })).toBeNull();
+    expect(activeCols()).toEqual(pausedCols);
+  });
 });

--- a/tests/default-apps/tetris-model.test.ts
+++ b/tests/default-apps/tetris-model.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+import {
+  COLS,
+  TOTAL_ROWS,
+  PIECES,
+  PIECE_COLORS,
+  type Board,
+  type Cell,
+  type PieceType,
+  createBoard,
+  newBag,
+  nextFromBag,
+  createGame,
+  cellsFor,
+  isValid,
+  tryMove,
+  tryRotate,
+  clearLines,
+  scoreForLines,
+  levelForLines,
+  gravityMs,
+  lockPiece,
+  step,
+  softDrop,
+  hardDrop,
+  holdPiece,
+  ghostRow,
+  seededRng,
+} from "../../home/apps/games/tetris/src/tetris-model";
+
+// Deterministic RNG factory for reproducible tests.
+const rng = () => seededRng(12345);
+
+function emptyBoard(): Board {
+  return createBoard();
+}
+
+// Fill all columns of a row except one, so a single piece can complete it.
+function fillRowExcept(board: Board, row: number, gapCol: number, fill: PieceType = "I"): void {
+  for (let c = 0; c < COLS; c++) {
+    board[row][c] = c === gapCol ? null : fill;
+  }
+}
+
+describe("7-bag randomizer", () => {
+  it("newBag yields each of the 7 pieces exactly once", () => {
+    const bag = newBag(rng());
+    expect(bag).toHaveLength(7);
+    const sorted = [...bag].sort();
+    expect(sorted).toEqual([...PIECES].sort());
+  });
+
+  it("is a permutation (no duplicates, no missing)", () => {
+    const bag = newBag(rng());
+    expect(new Set(bag).size).toBe(7);
+  });
+
+  it("nextFromBag refills with a fresh bag when empty", () => {
+    const empty: PieceType[] = [];
+    const { piece, bag } = nextFromBag(empty, rng());
+    expect(PIECES).toContain(piece);
+    expect(bag).toHaveLength(6); // a fresh 7-bag minus the pulled piece
+  });
+
+  it("every piece type has a defined color", () => {
+    for (const p of PIECES) {
+      expect(PIECE_COLORS[p]).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+
+  it("across many draws each piece appears at the expected 7-bag frequency", () => {
+    const counts: Record<string, number> = {};
+    let bag = newBag(rng());
+    const r = rng();
+    for (let i = 0; i < 70; i++) {
+      const pulled = nextFromBag(bag, r);
+      bag = pulled.bag;
+      counts[pulled.piece] = (counts[pulled.piece] ?? 0) + 1;
+    }
+    // 70 draws over 7-bags => each piece exactly 10 times.
+    for (const p of PIECES) {
+      expect(counts[p]).toBe(10);
+    }
+  });
+});
+
+describe("piece geometry & rotation", () => {
+  it("an active piece always occupies exactly 4 cells", () => {
+    const game = createGame(rng());
+    expect(cellsFor(game.active!)).toHaveLength(4);
+  });
+
+  it("rotation keeps the piece valid inside the field for a T piece", () => {
+    let game = createGame(rng());
+    // Force a T piece in a clean position.
+    game = {
+      ...game,
+      active: { type: "T", rotation: 0, row: 5, col: 3 },
+    };
+    const rotated = tryRotate(game, 1);
+    expect(rotated.active!.rotation).toBe(1);
+    expect(isValid(rotated.board, rotated.active!)).toBe(true);
+  });
+
+  it("CCW rotation is the inverse of CW for a T piece", () => {
+    let game = createGame(rng());
+    game = { ...game, active: { type: "T", rotation: 0, row: 5, col: 3 } };
+    const cw = tryRotate(game, 1);
+    const back = tryRotate(cw, -1);
+    expect(back.active!.rotation).toBe(0);
+  });
+
+  it("O piece rotation does not change occupied cells", () => {
+    let game = createGame(rng());
+    game = { ...game, active: { type: "O", rotation: 0, row: 5, col: 3 } };
+    const before = cellsFor(game.active!).map(String).sort();
+    const rotated = tryRotate(game, 1);
+    const after = cellsFor(rotated.active!).map(String).sort();
+    expect(after).toEqual(before);
+  });
+});
+
+describe("collision & walls", () => {
+  it("blocks horizontal move past the left wall", () => {
+    let game = createGame(rng());
+    game = { ...game, active: { type: "O", rotation: 0, row: 5, col: -1 } };
+    // O occupies cols 1,2 of its box, so col -1 puts cells at 0,1 (valid).
+    // Move further left should hit the wall eventually.
+    let moved = game;
+    for (let i = 0; i < 5; i++) moved = tryMove(moved, -1, 0);
+    for (const [, c] of cellsFor(moved.active!)) {
+      expect(c).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("blocks horizontal move past the right wall", () => {
+    let game = createGame(rng());
+    game = { ...game, active: { type: "O", rotation: 0, row: 5, col: 3 } };
+    let moved = game;
+    for (let i = 0; i < 20; i++) moved = tryMove(moved, 1, 0);
+    for (const [, c] of cellsFor(moved.active!)) {
+      expect(c).toBeLessThan(COLS);
+    }
+  });
+
+  it("rejects a piece overlapping a filled cell", () => {
+    const board = emptyBoard();
+    board[6][4] = "Z";
+    const piece = { type: "O" as PieceType, rotation: 0 as const, row: 5, col: 3 };
+    // O occupies (5,4),(5,5),(6,4),(6,5) -> (6,4) is filled.
+    expect(isValid(board, piece)).toBe(false);
+  });
+
+  it("step locks the piece when it cannot move down further", () => {
+    let game = createGame(rng());
+    // Place an O just above the floor.
+    game = { ...game, active: { type: "O", rotation: 0, row: TOTAL_ROWS - 2, col: 3 } };
+    const after = step(game, rng());
+    // Piece should have locked; a new active piece spawned at the top.
+    expect(after.active!.row).toBeLessThan(5);
+    // The bottom rows should now contain locked O cells.
+    const filledBottom = after.board[TOTAL_ROWS - 1].some((c) => c !== null);
+    expect(filledBottom).toBe(true);
+  });
+});
+
+describe("line clears", () => {
+  it("clears a single completed row and reports it", () => {
+    const board = emptyBoard();
+    const row = TOTAL_ROWS - 1;
+    for (let c = 0; c < COLS; c++) board[row][c] = "I";
+    const { board: cleared, cleared: rows } = clearLines(board);
+    expect(rows).toEqual([row]);
+    expect(cleared[row].every((c) => c === null)).toBe(true);
+  });
+
+  it("clears four rows simultaneously (a tetris)", () => {
+    const board = emptyBoard();
+    for (let r = TOTAL_ROWS - 4; r < TOTAL_ROWS; r++) {
+      for (let c = 0; c < COLS; c++) board[r][c] = "I";
+    }
+    const { cleared } = clearLines(board);
+    expect(cleared).toHaveLength(4);
+  });
+
+  it("does not clear an incomplete row", () => {
+    const board = emptyBoard();
+    fillRowExcept(board, TOTAL_ROWS - 1, 3);
+    const { cleared } = clearLines(board);
+    expect(cleared).toHaveLength(0);
+  });
+
+  it("locking a piece that completes a row increments the line counter", () => {
+    let game = createGame(rng());
+    const board = emptyBoard();
+    // Fill the bottom row leaving a 1-wide gap at col 0 across two stacked cells
+    // so a vertical placement can fill it. Simpler: fill bottom row except col 4-5
+    // and drop an O there.
+    fillRowExcept(board, TOTAL_ROWS - 1, 4);
+    board[TOTAL_ROWS - 1][5] = null;
+    game = {
+      ...game,
+      board,
+      active: { type: "O", rotation: 0, row: TOTAL_ROWS - 2, col: 3 },
+      lines: 0,
+    };
+    const after = lockPiece(game, rng());
+    expect(after.lines).toBe(1);
+  });
+});
+
+describe("scoring & level", () => {
+  it("scores 100/300/500/800 times level for 1/2/3/4 lines", () => {
+    expect(scoreForLines(1, 1)).toBe(100);
+    expect(scoreForLines(2, 1)).toBe(300);
+    expect(scoreForLines(3, 1)).toBe(500);
+    expect(scoreForLines(4, 1)).toBe(800);
+    expect(scoreForLines(4, 3)).toBe(2400);
+  });
+
+  it("zero lines scores zero", () => {
+    expect(scoreForLines(0, 5)).toBe(0);
+  });
+
+  it("level increases every 10 lines", () => {
+    expect(levelForLines(0)).toBe(1);
+    expect(levelForLines(9)).toBe(1);
+    expect(levelForLines(10)).toBe(2);
+    expect(levelForLines(25)).toBe(3);
+  });
+
+  it("gravity gets faster as level rises", () => {
+    expect(gravityMs(1)).toBeGreaterThan(gravityMs(5));
+    expect(gravityMs(5)).toBeGreaterThan(gravityMs(10));
+  });
+
+  it("soft drop awards a point per cell", () => {
+    let game = createGame(rng());
+    game = { ...game, active: { type: "O", rotation: 0, row: 5, col: 3 }, score: 0 };
+    const after = softDrop(game);
+    expect(after.score).toBe(1);
+    expect(after.active!.row).toBe(6);
+  });
+
+  it("hard drop awards two points per dropped cell and locks", () => {
+    let game = createGame(rng());
+    game = { ...game, board: emptyBoard(), active: { type: "O", rotation: 0, row: 0, col: 3 }, score: 0 };
+    const after = hardDrop(game, rng());
+    expect(after.score).toBeGreaterThan(0);
+    // After lock, a new piece spawns at the top.
+    expect(after.active!.row).toBeLessThan(5);
+  });
+});
+
+describe("hold piece", () => {
+  it("first hold stashes the current piece and pulls the next", () => {
+    let game = createGame(rng());
+    const current = game.active!.type;
+    const after = holdPiece(game, rng());
+    expect(after.hold).toBe(current);
+    expect(after.canHold).toBe(false);
+    expect(after.active).not.toBeNull();
+  });
+
+  it("does not allow holding twice in a row", () => {
+    let game = createGame(rng());
+    const once = holdPiece(game, rng());
+    const twice = holdPiece(once, rng());
+    expect(twice).toBe(once); // unchanged because canHold is false
+  });
+});
+
+describe("ghost & top-out", () => {
+  it("ghost row is at or below the active piece row", () => {
+    let game = createGame(rng());
+    game = { ...game, board: emptyBoard(), active: { type: "O", rotation: 0, row: 0, col: 3 } };
+    const g = ghostRow(game);
+    expect(g).not.toBeNull();
+    expect(g!).toBeGreaterThanOrEqual(game.active!.row);
+  });
+
+  it("sets game over when a newly spawned piece collides", () => {
+    let game = createGame(rng());
+    const board = emptyBoard();
+    // Fill the top rows so any spawn collides, but leave col 0 empty in each so
+    // these rows are NOT complete lines (otherwise they would be cleared first).
+    for (let r = 0; r < 4; r++) {
+      for (let c = 1; c < COLS; c++) board[r][c] = "Z";
+    }
+    // Place an active piece low and lock it; the next spawn must top out.
+    // First clear the bottom so lockPiece won't clear lines.
+    game = {
+      ...game,
+      board,
+      active: { type: "O", rotation: 0, row: 10, col: 3 },
+    };
+    const after = lockPiece(game, rng());
+    expect(after.over).toBe(true);
+    expect(after.active).toBeNull();
+  });
+});
+
+describe("determinism", () => {
+  it("two games with the same seed produce the same first piece", () => {
+    const a = createGame(seededRng(99));
+    const b = createGame(seededRng(99));
+    expect(a.active!.type).toBe(b.active!.type);
+    expect(a.queue).toEqual(b.queue);
+  });
+});

--- a/tests/default-apps/tetris-model.test.ts
+++ b/tests/default-apps/tetris-model.test.ts
@@ -268,6 +268,34 @@ describe("hold piece", () => {
     const twice = holdPiece(once, rng());
     expect(twice).toBe(once); // unchanged because canHold is false
   });
+
+  it("sets game over when first hold spawns into blocked top rows", () => {
+    const game = createGame(rng());
+    const board = emptyBoard();
+    for (let r = 0; r < 4; r++) {
+      fillRowExcept(board, r, 0, "Z");
+    }
+
+    const after = holdPiece({ ...game, board }, rng());
+
+    expect(after.over).toBe(true);
+    expect(after.active).toBeNull();
+    expect(after.hold).toBe(game.active!.type);
+  });
+
+  it("sets game over when swapping hold into blocked top rows", () => {
+    const game = createGame(rng());
+    const board = emptyBoard();
+    for (let r = 0; r < 4; r++) {
+      fillRowExcept(board, r, 0, "Z");
+    }
+
+    const after = holdPiece({ ...game, board, hold: "I", canHold: true }, rng());
+
+    expect(after.over).toBe(true);
+    expect(after.active).toBeNull();
+    expect(after.hold).toBe(game.active!.type);
+  });
 });
 
 describe("ghost & top-out", () => {


### PR DESCRIPTION
Stack: 13/22
Branch: stack/default-apps-tetris

Scope: Tetris model, UI, manifest, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.