### PR TITLE
feat(minesweeper): add flood-fill puzzle game

### DIFF
--- a/home/apps/games/minesweeper/matrix.json
+++ b/home/apps/games/minesweeper/matrix.json
@@ -3,7 +3,7 @@
   "description": "Classic mine-clearing puzzle",
   "runtime": "vite",
   "category": "games",
-  "icon": "minesweeper",
+  "icon": "game-center",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -17,9 +17,12 @@
       "times": {
         "columns": {
           "difficulty": "text",
+          "rows": "integer",
+          "cols": "integer",
+          "mines": "integer",
           "seconds": "integer"
         },
-        "indexes": ["difficulty"]
+        "indexes": ["difficulty", "rows", "cols", "mines"]
       }
     }
   },

--- a/home/apps/games/minesweeper/matrix.json
+++ b/home/apps/games/minesweeper/matrix.json
@@ -3,7 +3,7 @@
   "description": "Classic mine-clearing puzzle",
   "runtime": "vite",
   "category": "games",
-  "icon": "game-center",
+  "icon": "minesweeper",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -12,6 +12,17 @@
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
   "slug": "minesweeper",
+  "storage": {
+    "tables": {
+      "times": {
+        "columns": {
+          "difficulty": "text",
+          "seconds": "integer"
+        },
+        "indexes": ["difficulty"]
+      }
+    }
+  },
   "build": {
     "install": "true",
     "command": "vite build --base ./ --outDir dist",

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -207,6 +207,11 @@ export default function App(): React.ReactElement {
   const persistBestTime = useCallback(
     async (diff: Difficulty, bestSpec: DifficultySpec, secs: number) => {
       const key = bestKeyFor(diff, bestSpec);
+      const db = window.MatrixOS?.db;
+      if (!db) {
+        setStatusMsg("Best time sync unavailable");
+        return;
+      }
       let previousBest: number | undefined;
       setBestTimes((prev) => {
         const current = prev[key];
@@ -215,11 +220,6 @@ export default function App(): React.ReactElement {
         return { ...prev, [key]: secs };
       });
 
-      const db = window.MatrixOS?.db;
-      if (!db) {
-        setStatusMsg("Best time sync unavailable");
-        return;
-      }
       try {
         const inserted = await db.insert("times", {
           difficulty: diff,

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -36,11 +36,19 @@ const NUMBER_COLORS: Record<number, string> = {
   8: "#6b7280",
 };
 
-const LS_KEY = "matrix-minesweeper-best-times";
+const BEST_TIME_QUERY_LIMIT = 500;
 
 function specFor(difficulty: Difficulty, custom: DifficultySpec): DifficultySpec {
   if (difficulty === "custom") return clampCustom(custom);
   return difficultyConfig(difficulty);
+}
+
+function bestKeyFor(difficulty: Difficulty, spec: DifficultySpec): string {
+  return `${difficulty}:${spec.rows}x${spec.cols}:${spec.mines}`;
+}
+
+function isDifficulty(value: unknown): value is Difficulty {
+  return value === "beginner" || value === "intermediate" || value === "expert" || value === "custom";
 }
 
 function pad3(n: number): string {
@@ -49,25 +57,17 @@ function pad3(n: number): string {
   return String(clamped).padStart(3, "0");
 }
 
-function readLocalBest(): Record<string, number> {
-  try {
-    const raw = window.localStorage?.getItem(LS_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object") return parsed as Record<string, number>;
-    return {};
-  } catch (err) {
-    console.warn("[minesweeper] failed to read local best times", err);
-    return {};
+function rowBestKey(row: Record<string, unknown>): string | null {
+  const difficulty = isDifficulty(row.difficulty) ? row.difficulty : null;
+  if (!difficulty) return null;
+  const rows = typeof row.rows === "number" ? row.rows : Number(row.rows);
+  const cols = typeof row.cols === "number" ? row.cols : Number(row.cols);
+  const mines = typeof row.mines === "number" ? row.mines : Number(row.mines);
+  if (Number.isFinite(rows) && Number.isFinite(cols) && Number.isFinite(mines)) {
+    return bestKeyFor(difficulty, clampCustom({ rows, cols, mines }));
   }
-}
-
-function writeLocalBest(best: Record<string, number>): void {
-  try {
-    window.localStorage?.setItem(LS_KEY, JSON.stringify(best));
-  } catch (err) {
-    console.warn("[minesweeper] failed to persist local best times", err);
-  }
+  if (difficulty === "custom") return null;
+  return bestKeyFor(difficulty, difficultyConfig(difficulty));
 }
 
 export default function App(): React.ReactElement {
@@ -81,9 +81,9 @@ export default function App(): React.ReactElement {
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const savedThisGame = useRef(false);
-  const dbAvailable = useRef(false);
 
   const spec = useMemo(() => specFor(difficulty, custom), [difficulty, custom]);
+  const bestKey = useMemo(() => bestKeyFor(difficulty, spec), [difficulty, spec.rows, spec.cols, spec.mines]);
 
   // --- Responsive board sizing --------------------------------------------
   // The board area flexes to fill the remaining window space; we measure it
@@ -152,25 +152,23 @@ export default function App(): React.ReactElement {
   const loadBestTimes = useCallback(async () => {
     const db = window.MatrixOS?.db;
     if (!db) {
-      dbAvailable.current = false;
-      setBestTimes(readLocalBest());
+      setBestTimes({});
       return;
     }
-    dbAvailable.current = true;
     try {
-      const rows = await db.find("times", { orderBy: { seconds: "asc" } });
+      const rows = await db.find("times", { orderBy: { seconds: "asc" }, limit: BEST_TIME_QUERY_LIMIT });
       const best: Record<string, number> = {};
       for (const row of rows) {
-        const diff = typeof row.difficulty === "string" ? row.difficulty : null;
+        const key = rowBestKey(row);
         const secs = typeof row.seconds === "number" ? row.seconds : Number(row.seconds);
-        if (!diff || Number.isNaN(secs)) continue;
-        if (best[diff] === undefined || secs < best[diff]) best[diff] = secs;
+        if (!key || Number.isNaN(secs)) continue;
+        if (best[key] === undefined || secs < best[key]) best[key] = secs;
       }
       setBestTimes(best);
     } catch (err) {
       console.warn("[minesweeper] failed to load best times from DB", err);
       setStatusMsg("Could not load best times");
-      setBestTimes(readLocalBest());
+      setBestTimes({});
     }
   }, []);
 
@@ -198,32 +196,47 @@ export default function App(): React.ReactElement {
   }, [loadBestTimes]);
 
   const persistBestTime = useCallback(
-    async (diff: Difficulty, secs: number) => {
-      // Optimistic local update.
+    async (diff: Difficulty, bestSpec: DifficultySpec, secs: number) => {
+      const key = bestKeyFor(diff, bestSpec);
       setBestTimes((prev) => {
-        const current = prev[diff];
+        const current = prev[key];
         if (current !== undefined && current <= secs) return prev;
-        const next = { ...prev, [diff]: secs };
-        if (!dbAvailable.current) writeLocalBest(next);
-        return next;
+        return { ...prev, [key]: secs };
       });
 
       const db = window.MatrixOS?.db;
       if (!db) {
+        setStatusMsg("Best time sync unavailable");
         return;
       }
       try {
-        await db.insert("times", { difficulty: diff, seconds: secs });
+        const inserted = await db.insert("times", {
+          difficulty: diff,
+          rows: bestSpec.rows,
+          cols: bestSpec.cols,
+          mines: bestSpec.mines,
+          seconds: secs,
+        });
+        void (async () => {
+          try {
+            const rows = await db.find("times", {
+              where: { difficulty: diff, rows: bestSpec.rows, cols: bestSpec.cols, mines: bestSpec.mines },
+              orderBy: { seconds: "asc" },
+              limit: BEST_TIME_QUERY_LIMIT,
+            });
+            await Promise.all(
+              rows
+                .filter((row) => typeof row.id === "string" && row.id !== inserted.id && Number(row.seconds) >= secs)
+                .map((row) => db.delete("times", row.id as string)),
+            );
+          } catch (err) {
+            console.warn("[minesweeper] failed to prune stale best times", err);
+          }
+        })();
         setStatusMsg("Best time saved to Matrix Postgres");
       } catch (err) {
         console.warn("[minesweeper] failed to persist best time", err);
         setStatusMsg("Could not save best time");
-        // Fall back to localStorage so the record is not lost.
-        const local = readLocalBest();
-        if (local[diff] === undefined || secs < local[diff]) {
-          local[diff] = secs;
-          writeLocalBest(local);
-        }
       }
     },
     [],
@@ -248,36 +261,30 @@ export default function App(): React.ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [difficulty, spec.rows, spec.cols, spec.mines]);
 
-  const handleResult = useCallback(
-    (next: Board) => {
-      if (next.status === "won") {
-        setFace("win");
-        if (!savedThisGame.current) {
-          savedThisGame.current = true;
-          // seconds may lag the final tick; ensure at least 1.
-          const finalSecs = Math.max(1, seconds);
-          const current = bestTimes[difficulty];
-          if (current === undefined || finalSecs < current) {
-            void persistBestTime(difficulty, finalSecs);
-          }
+  useEffect(() => {
+    if (board.status === "won") {
+      setFace("win");
+      if (!savedThisGame.current) {
+        savedThisGame.current = true;
+        const finalSecs = Math.max(1, seconds);
+        const current = bestTimes[bestKey];
+        if (current === undefined || finalSecs < current) {
+          void persistBestTime(difficulty, spec, finalSecs);
         }
-      } else if (next.status === "lost") {
-        setFace("dead");
       }
-    },
-    [seconds, bestTimes, difficulty, persistBestTime],
-  );
+    } else if (board.status === "lost") {
+      setFace("dead");
+    }
+  }, [bestKey, bestTimes, board.status, difficulty, persistBestTime, seconds, spec]);
 
   const onReveal = useCallback(
     (r: number, c: number) => {
       setBoard((prev) => {
         if (prev.status === "won" || prev.status === "lost") return prev;
-        const next = reveal(prev, r, c);
-        handleResult(next);
-        return next;
+        return reveal(prev, r, c);
       });
     },
-    [handleResult],
+    [],
   );
 
   const onFlag = useCallback((r: number, c: number) => {
@@ -288,12 +295,10 @@ export default function App(): React.ReactElement {
     (r: number, c: number) => {
       setBoard((prev) => {
         if (prev.status !== "playing") return prev;
-        const next = chord(prev, r, c);
-        handleResult(next);
-        return next;
+        return chord(prev, r, c);
       });
     },
-    [handleResult],
+    [],
   );
 
   // --- Pointer handling (left reveal, right flag, both = chord) ------------
@@ -382,9 +387,13 @@ export default function App(): React.ReactElement {
     [board, clearLongPress, onChord, onReveal],
   );
 
+  const onTouchCancelCell = useCallback(() => {
+    clearLongPress();
+  }, [clearLongPress]);
+
   const remaining = minesRemaining(board);
   const flags = flagsPlaced(board);
-  const best = bestTimes[difficulty];
+  const best = bestTimes[bestKey];
 
   const faceGlyph =
     face === "win" ? "😎" : face === "dead" ? "😵" : face === "scared" ? "😮" : "🙂";
@@ -437,6 +446,7 @@ export default function App(): React.ReactElement {
               <input
                 type="number"
                 min={1}
+                max={custom.rows * custom.cols - 9}
                 value={custom.mines}
                 onChange={(e) => setCustom((p) => ({ ...p, mines: Number(e.target.value) }))}
               />
@@ -510,6 +520,7 @@ export default function App(): React.ReactElement {
                   onContextMenu={(e) => onContextMenuCell(e, r, c)}
                   onTouchStart={() => onTouchStartCell(r, c)}
                   onTouchEnd={() => onTouchEndCell(r, c)}
+                  onTouchCancel={onTouchCancelCell}
                 >
                   {showNumber ? cell.adjacent : null}
                   {showMine ? <Bomb size={14} aria-hidden="true" /> : null}

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -226,7 +226,7 @@ export default function App(): React.ReactElement {
             });
             await Promise.all(
               rows
-                .filter((row) => typeof row.id === "string" && row.id !== inserted.id && Number(row.seconds) >= secs)
+                .filter((row) => typeof row.id === "string" && row.id !== inserted.id && Number(row.seconds) > secs)
                 .map((row) => db.delete("times", row.id as string)),
             );
           } catch (err) {
@@ -547,7 +547,9 @@ export default function App(): React.ReactElement {
           </div>
           <output className="ms-status" aria-live="polite">
             {board.status === "won"
-              ? "Cleared! 🎉"
+              ? statusMsg
+                ? `Cleared! ${statusMsg}`
+                : "Cleared! 🎉"
               : board.status === "lost"
                 ? "Boom — try again"
                 : statusMsg}

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -294,6 +294,10 @@ export default function App(): React.ReactElement {
       setFace("win");
       if (savedGameId.current !== gameMeta.id) {
         savedGameId.current = gameMeta.id;
+        // Persist against the game metadata from the render that observed the
+        // win. A difficulty/custom change can schedule a reset effect in the
+        // same commit; using live difficulty/spec here would save the completed
+        // game's time under the next board's key.
         const finalSecs = Math.max(1, latestSecondsRef.current);
         const gameBestKey = bestKeyFor(gameMeta.difficulty, gameMeta.spec);
         const current = bestTimesRef.current[gameBestKey];

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -1,0 +1,548 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Bomb, Flag, RotateCcw } from "lucide-react";
+import {
+  CELL,
+  chord,
+  clampCustom,
+  createBoard,
+  difficultyConfig,
+  flagsPlaced,
+  minesRemaining,
+  reveal,
+  toggleFlag,
+  type Board,
+  type Difficulty,
+  type DifficultySpec,
+} from "./minesweeper-model";
+
+type Face = "happy" | "scared" | "win" | "dead";
+
+const DIFFICULTIES: Array<{ id: Difficulty; label: string }> = [
+  { id: "beginner", label: "Beginner" },
+  { id: "intermediate", label: "Intermediate" },
+  { id: "expert", label: "Expert" },
+  { id: "custom", label: "Custom" },
+];
+
+// Number colors matching classic Minesweeper.
+const NUMBER_COLORS: Record<number, string> = {
+  1: "#1d4ed8",
+  2: "#15803d",
+  3: "#dc2626",
+  4: "#1e3a8a",
+  5: "#7f1d1d",
+  6: "#0e7490",
+  7: "#1f2937",
+  8: "#6b7280",
+};
+
+const LS_KEY = "matrix-minesweeper-best-times";
+
+function specFor(difficulty: Difficulty, custom: DifficultySpec): DifficultySpec {
+  if (difficulty === "custom") return clampCustom(custom);
+  return difficultyConfig(difficulty);
+}
+
+function pad3(n: number): string {
+  const clamped = Math.max(-99, Math.min(999, n));
+  if (clamped < 0) return `-${String(Math.abs(clamped)).padStart(2, "0")}`;
+  return String(clamped).padStart(3, "0");
+}
+
+function readLocalBest(): Record<string, number> {
+  try {
+    const raw = window.localStorage?.getItem(LS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object") return parsed as Record<string, number>;
+    return {};
+  } catch (err) {
+    console.warn("[minesweeper] failed to read local best times", err);
+    return {};
+  }
+}
+
+function writeLocalBest(best: Record<string, number>): void {
+  try {
+    window.localStorage?.setItem(LS_KEY, JSON.stringify(best));
+  } catch (err) {
+    console.warn("[minesweeper] failed to persist local best times", err);
+  }
+}
+
+export default function App(): React.ReactElement {
+  const [difficulty, setDifficulty] = useState<Difficulty>("beginner");
+  const [custom, setCustom] = useState<DifficultySpec>({ rows: 16, cols: 16, mines: 40 });
+  const [board, setBoard] = useState<Board>(() => createBoard(difficultyConfig("beginner")));
+  const [seconds, setSeconds] = useState(0);
+  const [face, setFace] = useState<Face>("happy");
+  const [bestTimes, setBestTimes] = useState<Record<string, number>>({});
+  const [statusMsg, setStatusMsg] = useState<string>("");
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const savedThisGame = useRef(false);
+  const dbAvailable = useRef(false);
+
+  const spec = useMemo(() => specFor(difficulty, custom), [difficulty, custom]);
+
+  // --- Responsive board sizing --------------------------------------------
+  // The board area flexes to fill the remaining window space; we measure it
+  // and derive a per-cell size so every difficulty (incl. Expert 30x16) fits
+  // without clipping or scroll. Cells stay within a comfortable min/max range.
+  const boardAreaRef = useRef<HTMLDivElement | null>(null);
+  const [cellSize, setCellSize] = useState(30);
+
+  useEffect(() => {
+    const el = boardAreaRef.current;
+    if (!el) return;
+
+    const MIN_CELL = 12;
+    const MAX_CELL = 34;
+    const GRID_PADDING = 12; // .ms-grid padding (6px) on each side
+    const CELL_MARGIN = 2; // .ms-cell margin (1px) on each side
+
+    const recompute = () => {
+      const node = boardAreaRef.current;
+      if (!node) return;
+      const availW = node.clientWidth;
+      const availH = node.clientHeight;
+      if (availW <= 0 || availH <= 0) return;
+      const perCellExtra = CELL_MARGIN;
+      const usableW = availW - GRID_PADDING;
+      const usableH = availH - GRID_PADDING;
+      const byW = Math.floor(usableW / board.cols) - perCellExtra;
+      const byH = Math.floor(usableH / board.rows) - perCellExtra;
+      const next = Math.max(MIN_CELL, Math.min(MAX_CELL, Math.min(byW, byH)));
+      setCellSize((prev) => (prev === next ? prev : next));
+    };
+
+    recompute();
+    const RO = (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+    if (!RO) {
+      window.addEventListener("resize", recompute);
+      return () => window.removeEventListener("resize", recompute);
+    }
+    const ro = new RO(recompute);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [board.rows, board.cols]);
+
+  // --- Timer ---------------------------------------------------------------
+  const stopTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (board.status === "playing") {
+      if (timerRef.current === null) {
+        timerRef.current = setInterval(() => {
+          setSeconds((s) => Math.min(999, s + 1));
+        }, 1000);
+      }
+    } else {
+      stopTimer();
+    }
+    return stopTimer;
+  }, [board.status, stopTimer]);
+
+  // --- Best-time persistence ----------------------------------------------
+  const loadBestTimes = useCallback(async () => {
+    const db = window.MatrixOS?.db;
+    if (!db) {
+      dbAvailable.current = false;
+      setBestTimes(readLocalBest());
+      return;
+    }
+    dbAvailable.current = true;
+    try {
+      const rows = await db.find("times", { orderBy: { seconds: "asc" } });
+      const best: Record<string, number> = {};
+      for (const row of rows) {
+        const diff = typeof row.difficulty === "string" ? row.difficulty : null;
+        const secs = typeof row.seconds === "number" ? row.seconds : Number(row.seconds);
+        if (!diff || Number.isNaN(secs)) continue;
+        if (best[diff] === undefined || secs < best[diff]) best[diff] = secs;
+      }
+      setBestTimes(best);
+    } catch (err) {
+      console.warn("[minesweeper] failed to load best times from DB", err);
+      setStatusMsg("Could not load best times");
+      setBestTimes(readLocalBest());
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadBestTimes();
+    const db = window.MatrixOS?.db;
+    if (!db) return;
+    let unsub: (() => void) | undefined;
+    try {
+      unsub = db.onChange("times", () => {
+        void loadBestTimes();
+      });
+    } catch (err) {
+      console.warn("[minesweeper] failed to subscribe to best-time changes", err);
+    }
+    return () => {
+      if (unsub) {
+        try {
+          unsub();
+        } catch (err) {
+          console.warn("[minesweeper] failed to unsubscribe", err);
+        }
+      }
+    };
+  }, [loadBestTimes]);
+
+  const persistBestTime = useCallback(
+    async (diff: Difficulty, secs: number) => {
+      // Optimistic local update.
+      setBestTimes((prev) => {
+        const current = prev[diff];
+        if (current !== undefined && current <= secs) return prev;
+        const next = { ...prev, [diff]: secs };
+        if (!dbAvailable.current) writeLocalBest(next);
+        return next;
+      });
+
+      const db = window.MatrixOS?.db;
+      if (!db) {
+        return;
+      }
+      try {
+        await db.insert("times", { difficulty: diff, seconds: secs });
+        setStatusMsg("Best time saved to Matrix Postgres");
+      } catch (err) {
+        console.warn("[minesweeper] failed to persist best time", err);
+        setStatusMsg("Could not save best time");
+        // Fall back to localStorage so the record is not lost.
+        const local = readLocalBest();
+        if (local[diff] === undefined || secs < local[diff]) {
+          local[diff] = secs;
+          writeLocalBest(local);
+        }
+      }
+    },
+    [],
+  );
+
+  // --- Game lifecycle ------------------------------------------------------
+  const newGame = useCallback(
+    (nextSpec: DifficultySpec) => {
+      stopTimer();
+      setBoard(createBoard(nextSpec));
+      setSeconds(0);
+      setFace("happy");
+      setStatusMsg("");
+      savedThisGame.current = false;
+    },
+    [stopTimer],
+  );
+
+  // Re-create the board when difficulty/custom spec changes.
+  useEffect(() => {
+    newGame(spec);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [difficulty, spec.rows, spec.cols, spec.mines]);
+
+  const handleResult = useCallback(
+    (next: Board) => {
+      if (next.status === "won") {
+        setFace("win");
+        if (!savedThisGame.current) {
+          savedThisGame.current = true;
+          // seconds may lag the final tick; ensure at least 1.
+          const finalSecs = Math.max(1, seconds);
+          const current = bestTimes[difficulty];
+          if (current === undefined || finalSecs < current) {
+            void persistBestTime(difficulty, finalSecs);
+          }
+        }
+      } else if (next.status === "lost") {
+        setFace("dead");
+      }
+    },
+    [seconds, bestTimes, difficulty, persistBestTime],
+  );
+
+  const onReveal = useCallback(
+    (r: number, c: number) => {
+      setBoard((prev) => {
+        if (prev.status === "won" || prev.status === "lost") return prev;
+        const next = reveal(prev, r, c);
+        handleResult(next);
+        return next;
+      });
+    },
+    [handleResult],
+  );
+
+  const onFlag = useCallback((r: number, c: number) => {
+    setBoard((prev) => toggleFlag(prev, r, c));
+  }, []);
+
+  const onChord = useCallback(
+    (r: number, c: number) => {
+      setBoard((prev) => {
+        if (prev.status !== "playing") return prev;
+        const next = chord(prev, r, c);
+        handleResult(next);
+        return next;
+      });
+    },
+    [handleResult],
+  );
+
+  // --- Pointer handling (left reveal, right flag, both = chord) ------------
+  const pressed = useRef<{ left: boolean; right: boolean }>({ left: false, right: false });
+  const longPress = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearLongPress = useCallback(() => {
+    if (longPress.current !== null) {
+      clearTimeout(longPress.current);
+      longPress.current = null;
+    }
+  }, []);
+
+  // Tracks whether the most recent mouseup was a both-button chord, so the
+  // synthetic click that follows knows to chord instead of reveal.
+  const chordOnClick = useRef(false);
+
+  const onMouseDownCell = useCallback(
+    (e: React.MouseEvent) => {
+      if (board.status === "won" || board.status === "lost") return;
+      if (e.button === 0) pressed.current.left = true;
+      if (e.button === 2) pressed.current.right = true;
+      if (e.button === 0 || (pressed.current.left && pressed.current.right)) {
+        setFace("scared");
+      }
+    },
+    [board.status],
+  );
+
+  const onMouseUpCell = useCallback((e: React.MouseEvent) => {
+    chordOnClick.current = pressed.current.left && pressed.current.right;
+    if (e.button === 0) pressed.current.left = false;
+    if (e.button === 2) pressed.current.right = false;
+  }, []);
+
+  // The click handler is the source of truth for left-button reveals so it
+  // works with both real pointer input and synthetic test clicks.
+  const onClickCell = useCallback(
+    (r: number, c: number) => {
+      if (board.status === "won" || board.status === "lost") return;
+      setFace((f) => (f === "scared" ? "happy" : f));
+      const cell = board.cells[r]?.[c];
+      if (!cell) return;
+      if (chordOnClick.current || cell.state === CELL.REVEALED) {
+        chordOnClick.current = false;
+        onChord(r, c);
+        return;
+      }
+      onReveal(r, c);
+    },
+    [board, onChord, onReveal],
+  );
+
+  const onContextMenuCell = useCallback(
+    (e: React.MouseEvent, r: number, c: number) => {
+      e.preventDefault();
+      // Reset the right-press flag so a right-click alone flags rather than chords.
+      pressed.current.right = false;
+      onFlag(r, c);
+    },
+    [onFlag],
+  );
+
+  // Long-press on touch toggles a flag.
+  const onTouchStartCell = useCallback(
+    (r: number, c: number) => {
+      clearLongPress();
+      longPress.current = setTimeout(() => {
+        onFlag(r, c);
+        longPress.current = null;
+      }, 350);
+    },
+    [clearLongPress, onFlag],
+  );
+
+  const onTouchEndCell = useCallback(
+    (r: number, c: number) => {
+      if (longPress.current !== null) {
+        // Was a short tap -> reveal.
+        clearLongPress();
+        const cell = board.cells[r]?.[c];
+        if (cell && cell.state === CELL.REVEALED) onChord(r, c);
+        else onReveal(r, c);
+      }
+    },
+    [board, clearLongPress, onChord, onReveal],
+  );
+
+  const remaining = minesRemaining(board);
+  const flags = flagsPlaced(board);
+  const best = bestTimes[difficulty];
+
+  const faceGlyph =
+    face === "win" ? "😎" : face === "dead" ? "😵" : face === "scared" ? "😮" : "🙂";
+
+  return (
+    <div className="ms-root">
+      <div className="ms-frame">
+        <header className="ms-header">
+          <h1 className="ms-title">Minesweeper</h1>
+          <div className="ms-difficulty" role="tablist" aria-label="Difficulty">
+            {DIFFICULTIES.map((d) => (
+              <button
+                key={d.id}
+                type="button"
+                role="tab"
+                aria-selected={difficulty === d.id}
+                className={`ms-diff-btn${difficulty === d.id ? " is-active" : ""}`}
+                onClick={() => setDifficulty(d.id)}
+              >
+                {d.label}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        {difficulty === "custom" ? (
+          <div className="ms-custom">
+            <label>
+              Width
+              <input
+                type="number"
+                min={5}
+                max={48}
+                value={custom.cols}
+                onChange={(e) => setCustom((p) => ({ ...p, cols: Number(e.target.value) }))}
+              />
+            </label>
+            <label>
+              Height
+              <input
+                type="number"
+                min={5}
+                max={30}
+                value={custom.rows}
+                onChange={(e) => setCustom((p) => ({ ...p, rows: Number(e.target.value) }))}
+              />
+            </label>
+            <label>
+              Mines
+              <input
+                type="number"
+                min={1}
+                value={custom.mines}
+                onChange={(e) => setCustom((p) => ({ ...p, mines: Number(e.target.value) }))}
+              />
+            </label>
+          </div>
+        ) : null}
+
+        <div className="ms-panel">
+          <div className="ms-readout" data-testid="mine-counter" aria-label="Mines remaining">
+            {pad3(remaining)}
+          </div>
+          <button
+            type="button"
+            className="ms-reset"
+            data-testid="reset"
+            aria-label="New game"
+            onClick={() => newGame(spec)}
+          >
+            <span className="ms-face" aria-hidden="true">
+              {faceGlyph}
+            </span>
+            <RotateCcw className="ms-reset-icon" size={14} aria-hidden="true" />
+          </button>
+          <div className="ms-readout" data-testid="timer" aria-label="Elapsed time">
+            {pad3(seconds)}
+          </div>
+        </div>
+
+        <div className="ms-board-area" ref={boardAreaRef}>
+          <div
+            className="ms-grid"
+            style={{
+              gridTemplateColumns: `repeat(${board.cols}, ${cellSize}px)`,
+              ["--ms-cell" as string]: `${cellSize}px`,
+            }}
+            onContextMenu={(e) => e.preventDefault()}
+            role="grid"
+            tabIndex={-1}
+            aria-label="Minefield"
+          >
+          {board.cells.map((row, r) =>
+            row.map((cell, c) => {
+              const idx = r * board.cols + c;
+              const revealed = cell.state === CELL.REVEALED;
+              const exploded = cell.state === CELL.EXPLODED;
+              const flagged = cell.state === CELL.FLAGGED;
+              const showNumber = revealed && !cell.mine && cell.adjacent > 0;
+              const showMine = (revealed || exploded) && cell.mine;
+              return (
+                <button
+                  key={idx}
+                  type="button"
+                  data-testid={`cell-${idx}`}
+                  data-state={cell.state}
+                  className={`ms-cell${revealed || exploded ? " is-open" : ""}${
+                    exploded ? " is-exploded" : ""
+                  }`}
+                  style={showNumber ? { color: NUMBER_COLORS[cell.adjacent] } : undefined}
+                  aria-label={
+                    flagged
+                      ? "Flagged cell"
+                      : revealed
+                        ? showNumber
+                          ? `${cell.adjacent} adjacent mines`
+                          : "Empty cell"
+                        : "Hidden cell"
+                  }
+                  onMouseDown={onMouseDownCell}
+                  onMouseUp={onMouseUpCell}
+                  onClick={() => onClickCell(r, c)}
+                  onContextMenu={(e) => onContextMenuCell(e, r, c)}
+                  onTouchStart={() => onTouchStartCell(r, c)}
+                  onTouchEnd={() => onTouchEndCell(r, c)}
+                >
+                  {showNumber ? cell.adjacent : null}
+                  {showMine ? <Bomb size={14} aria-hidden="true" /> : null}
+                  {flagged ? <Flag size={13} className="ms-flag" aria-hidden="true" /> : null}
+                </button>
+              );
+            }),
+          )}
+          </div>
+        </div>
+
+        <footer className="ms-footer">
+          <div className="ms-stat" data-testid="best-time">
+            <span className="ms-stat-label">Best</span>
+            <span className="ms-stat-value">
+              {best !== undefined ? `${best}s` : "—"}
+            </span>
+          </div>
+          <div className="ms-stat">
+            <span className="ms-stat-label">Flags</span>
+            <span className="ms-stat-value">
+              {flags}/{board.mines}
+            </span>
+          </div>
+          <output className="ms-status" aria-live="polite">
+            {board.status === "won"
+              ? "Cleared! 🎉"
+              : board.status === "lost"
+                ? "Boom — try again"
+                : statusMsg}
+          </output>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -17,6 +17,12 @@ import {
 
 type Face = "happy" | "scared" | "win" | "dead";
 
+interface GameMeta {
+  id: number;
+  difficulty: Difficulty;
+  spec: DifficultySpec;
+}
+
 const DIFFICULTIES: Array<{ id: Difficulty; label: string }> = [
   { id: "beginner", label: "Beginner" },
   { id: "intermediate", label: "Intermediate" },
@@ -78,12 +84,17 @@ export default function App(): React.ReactElement {
   const [face, setFace] = useState<Face>("happy");
   const [bestTimes, setBestTimes] = useState<Record<string, number>>({});
   const [statusMsg, setStatusMsg] = useState<string>("");
+  const [gameMeta, setGameMeta] = useState<GameMeta>(() => ({
+    id: 0,
+    difficulty: "beginner",
+    spec: difficultyConfig("beginner"),
+  }));
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const savedThisGame = useRef(false);
+  const savedGameId = useRef<number | null>(null);
 
   const spec = useMemo(() => specFor(difficulty, custom), [difficulty, custom]);
-  const bestKey = useMemo(() => bestKeyFor(difficulty, spec), [difficulty, spec.rows, spec.cols, spec.mines]);
+  const bestKey = useMemo(() => bestKeyFor(difficulty, spec), [difficulty, spec]);
 
   // --- Responsive board sizing --------------------------------------------
   // The board area flexes to fill the remaining window space; we measure it
@@ -152,7 +163,6 @@ export default function App(): React.ReactElement {
   const loadBestTimes = useCallback(async () => {
     const db = window.MatrixOS?.db;
     if (!db) {
-      setBestTimes({});
       return;
     }
     try {
@@ -168,7 +178,6 @@ export default function App(): React.ReactElement {
     } catch (err) {
       console.warn("[minesweeper] failed to load best times from DB", err);
       setStatusMsg("Could not load best times");
-      setBestTimes({});
     }
   }, []);
 
@@ -198,8 +207,10 @@ export default function App(): React.ReactElement {
   const persistBestTime = useCallback(
     async (diff: Difficulty, bestSpec: DifficultySpec, secs: number) => {
       const key = bestKeyFor(diff, bestSpec);
+      let previousBest: number | undefined;
       setBestTimes((prev) => {
         const current = prev[key];
+        previousBest = current;
         if (current !== undefined && current <= secs) return prev;
         return { ...prev, [key]: secs };
       });
@@ -237,6 +248,13 @@ export default function App(): React.ReactElement {
       } catch (err) {
         console.warn("[minesweeper] failed to persist best time", err);
         setStatusMsg("Could not save best time");
+        setBestTimes((prev) => {
+          if (prev[key] !== secs) return prev;
+          const next = { ...prev };
+          if (previousBest === undefined) delete next[key];
+          else next[key] = previousBest;
+          return next;
+        });
       }
     },
     [],
@@ -244,38 +262,43 @@ export default function App(): React.ReactElement {
 
   // --- Game lifecycle ------------------------------------------------------
   const newGame = useCallback(
-    (nextSpec: DifficultySpec) => {
+    (nextSpec: DifficultySpec, nextDifficulty: Difficulty = difficulty) => {
       stopTimer();
       setBoard(createBoard(nextSpec));
+      setGameMeta((current) => ({
+        id: current.id + 1,
+        difficulty: nextDifficulty,
+        spec: nextSpec,
+      }));
       setSeconds(0);
       setFace("happy");
       setStatusMsg("");
-      savedThisGame.current = false;
     },
-    [stopTimer],
+    [difficulty, stopTimer],
   );
 
   // Re-create the board when difficulty/custom spec changes.
   useEffect(() => {
-    newGame(spec);
+    newGame(spec, difficulty);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [difficulty, spec.rows, spec.cols, spec.mines]);
 
   useEffect(() => {
     if (board.status === "won") {
       setFace("win");
-      if (!savedThisGame.current) {
-        savedThisGame.current = true;
+      if (savedGameId.current !== gameMeta.id) {
+        savedGameId.current = gameMeta.id;
         const finalSecs = Math.max(1, seconds);
-        const current = bestTimes[bestKey];
+        const gameBestKey = bestKeyFor(gameMeta.difficulty, gameMeta.spec);
+        const current = bestTimes[gameBestKey];
         if (current === undefined || finalSecs < current) {
-          void persistBestTime(difficulty, spec, finalSecs);
+          void persistBestTime(gameMeta.difficulty, gameMeta.spec, finalSecs);
         }
       }
     } else if (board.status === "lost") {
       setFace("dead");
     }
-  }, [bestKey, bestTimes, board.status, difficulty, persistBestTime, seconds, spec]);
+  }, [bestTimes, board.status, gameMeta, persistBestTime, seconds]);
 
   const onReveal = useCallback(
     (r: number, c: number) => {
@@ -319,6 +342,7 @@ export default function App(): React.ReactElement {
   const onMouseDownCell = useCallback(
     (e: React.MouseEvent) => {
       if (board.status === "won" || board.status === "lost") return;
+      if (!pressed.current.left && !pressed.current.right) chordOnClick.current = false;
       if (e.button === 0) pressed.current.left = true;
       if (e.button === 2) pressed.current.right = true;
       if (e.button === 0 || (pressed.current.left && pressed.current.right)) {
@@ -329,7 +353,7 @@ export default function App(): React.ReactElement {
   );
 
   const onMouseUpCell = useCallback((e: React.MouseEvent) => {
-    chordOnClick.current = pressed.current.left && pressed.current.right;
+    if (pressed.current.left && pressed.current.right) chordOnClick.current = true;
     if (e.button === 0) pressed.current.left = false;
     if (e.button === 2) pressed.current.right = false;
   }, []);
@@ -463,7 +487,7 @@ export default function App(): React.ReactElement {
             className="ms-reset"
             data-testid="reset"
             aria-label="New game"
-            onClick={() => newGame(spec)}
+            onClick={() => newGame(spec, difficulty)}
           >
             <span className="ms-face" aria-hidden="true">
               {faceGlyph}

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -92,6 +92,11 @@ export default function App(): React.ReactElement {
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const savedGameId = useRef<number | null>(null);
+  const bestTimesRef = useRef(bestTimes);
+
+  useEffect(() => {
+    bestTimesRef.current = bestTimes;
+  }, [bestTimes]);
 
   const spec = useMemo(() => specFor(difficulty, custom), [difficulty, custom]);
   const bestKey = useMemo(() => bestKeyFor(difficulty, spec), [difficulty, spec]);
@@ -290,7 +295,7 @@ export default function App(): React.ReactElement {
         savedGameId.current = gameMeta.id;
         const finalSecs = Math.max(1, seconds);
         const gameBestKey = bestKeyFor(gameMeta.difficulty, gameMeta.spec);
-        const current = bestTimes[gameBestKey];
+        const current = bestTimesRef.current[gameBestKey];
         if (current === undefined || finalSecs < current) {
           void persistBestTime(gameMeta.difficulty, gameMeta.spec, finalSecs);
         }
@@ -298,7 +303,7 @@ export default function App(): React.ReactElement {
     } else if (board.status === "lost") {
       setFace("dead");
     }
-  }, [bestTimes, board.status, gameMeta, persistBestTime, seconds]);
+  }, [board.status, gameMeta, persistBestTime, seconds]);
 
   const onReveal = useCallback(
     (r: number, c: number) => {

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -23,6 +23,11 @@ interface GameMeta {
   spec: DifficultySpec;
 }
 
+interface PendingBestSave {
+  secs: number;
+  count: number;
+}
+
 const DIFFICULTIES: Array<{ id: Difficulty; label: string }> = [
   { id: "beginner", label: "Beginner" },
   { id: "intermediate", label: "Intermediate" },
@@ -94,6 +99,7 @@ export default function App(): React.ReactElement {
   const savedGameId = useRef<number | null>(null);
   const latestSecondsRef = useRef(seconds);
   const bestTimesRef = useRef(bestTimes);
+  const pendingBestSavesRef = useRef<Record<string, PendingBestSave>>({});
 
   useEffect(() => {
     latestSecondsRef.current = seconds;
@@ -223,8 +229,18 @@ export default function App(): React.ReactElement {
         return;
       }
       const previousBest = bestTimesRef.current[key];
-      if (previousBest !== undefined && previousBest <= secs) return;
-      setBestTimes((prev) => ({ ...prev, [key]: secs }));
+      const pendingForKey = pendingBestSavesRef.current[key];
+      if (previousBest !== undefined && previousBest < secs) return;
+      if (previousBest === secs && pendingForKey?.secs !== secs) return;
+      pendingBestSavesRef.current[key] = {
+        secs,
+        count: pendingForKey?.secs === secs ? pendingForKey.count + 1 : 1,
+      };
+      setBestTimes((prev) => {
+        const current = prev[key];
+        if (current !== undefined && current < secs) return prev;
+        return { ...prev, [key]: secs };
+      });
 
       try {
         const inserted = await db.insert("times", {
@@ -254,13 +270,20 @@ export default function App(): React.ReactElement {
       } catch (err) {
         console.warn("[minesweeper] failed to persist best time", err);
         setStatusMsg("Could not save best time");
+        const hasEqualPendingSave = (pendingBestSavesRef.current[key]?.count ?? 0) > 1;
         setBestTimes((prev) => {
+          if (hasEqualPendingSave) return prev;
           if (prev[key] !== secs) return prev;
           const next = { ...prev };
           if (previousBest === undefined) delete next[key];
           else next[key] = previousBest;
           return next;
         });
+      } finally {
+        const pending = pendingBestSavesRef.current[key];
+        if (pending?.secs !== secs) return;
+        if (pending.count <= 1) delete pendingBestSavesRef.current[key];
+        else pendingBestSavesRef.current[key] = { secs, count: pending.count - 1 };
       }
     },
     [],
@@ -299,11 +322,7 @@ export default function App(): React.ReactElement {
         // same commit; using live difficulty/spec here would save the completed
         // game's time under the next board's key.
         const finalSecs = Math.max(1, latestSecondsRef.current);
-        const gameBestKey = bestKeyFor(gameMeta.difficulty, gameMeta.spec);
-        const current = bestTimesRef.current[gameBestKey];
-        if (current === undefined || finalSecs < current) {
-          void persistBestTime(gameMeta.difficulty, gameMeta.spec, finalSecs);
-        }
+        void persistBestTime(gameMeta.difficulty, gameMeta.spec, finalSecs);
       }
     } else if (board.status === "lost") {
       setFace("dead");

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -92,7 +92,12 @@ export default function App(): React.ReactElement {
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const savedGameId = useRef<number | null>(null);
+  const latestSecondsRef = useRef(seconds);
   const bestTimesRef = useRef(bestTimes);
+
+  useEffect(() => {
+    latestSecondsRef.current = seconds;
+  }, [seconds]);
 
   useEffect(() => {
     bestTimesRef.current = bestTimes;
@@ -289,7 +294,7 @@ export default function App(): React.ReactElement {
       setFace("win");
       if (savedGameId.current !== gameMeta.id) {
         savedGameId.current = gameMeta.id;
-        const finalSecs = Math.max(1, seconds);
+        const finalSecs = Math.max(1, latestSecondsRef.current);
         const gameBestKey = bestKeyFor(gameMeta.difficulty, gameMeta.spec);
         const current = bestTimesRef.current[gameBestKey];
         if (current === undefined || finalSecs < current) {
@@ -299,7 +304,7 @@ export default function App(): React.ReactElement {
     } else if (board.status === "lost") {
       setFace("dead");
     }
-  }, [board.status, gameMeta, persistBestTime, seconds]);
+  }, [board.status, gameMeta, persistBestTime]);
 
   const onReveal = useCallback(
     (r: number, c: number) => {

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -476,7 +476,7 @@ export default function App(): React.ReactElement {
               <input
                 type="number"
                 min={1}
-                max={custom.rows * custom.cols - 9}
+                max={spec.rows * spec.cols - 9}
                 value={custom.mines}
                 onChange={(e) => setCustom((p) => ({ ...p, mines: Number(e.target.value) }))}
               />
@@ -523,6 +523,7 @@ export default function App(): React.ReactElement {
               const revealed = cell.state === CELL.REVEALED;
               const exploded = cell.state === CELL.EXPLODED;
               const flagged = cell.state === CELL.FLAGGED;
+              const wrongFlag = cell.state === CELL.WRONG_FLAG;
               const showNumber = revealed && !cell.mine && cell.adjacent > 0;
               const showMine = (revealed || exploded) && cell.mine;
               return (
@@ -533,10 +534,12 @@ export default function App(): React.ReactElement {
                   data-state={cell.state}
                   className={`ms-cell${revealed || exploded ? " is-open" : ""}${
                     exploded ? " is-exploded" : ""
-                  }`}
+                  }${wrongFlag ? " is-wrong-flag" : ""}`}
                   style={showNumber ? { color: NUMBER_COLORS[cell.adjacent] } : undefined}
                   aria-label={
-                    flagged
+                    wrongFlag
+                      ? "Incorrect flag"
+                      : flagged
                       ? "Flagged cell"
                       : revealed
                         ? showNumber
@@ -555,6 +558,7 @@ export default function App(): React.ReactElement {
                   {showNumber ? cell.adjacent : null}
                   {showMine ? <Bomb size={14} aria-hidden="true" /> : null}
                   {flagged ? <Flag size={13} className="ms-flag" aria-hidden="true" /> : null}
+                  {wrongFlag ? <span className="ms-wrong-flag" aria-hidden="true">x</span> : null}
                 </button>
               );
             }),

--- a/home/apps/games/minesweeper/src/App.tsx
+++ b/home/apps/games/minesweeper/src/App.tsx
@@ -217,13 +217,9 @@ export default function App(): React.ReactElement {
         setStatusMsg("Best time sync unavailable");
         return;
       }
-      let previousBest: number | undefined;
-      setBestTimes((prev) => {
-        const current = prev[key];
-        previousBest = current;
-        if (current !== undefined && current <= secs) return prev;
-        return { ...prev, [key]: secs };
-      });
+      const previousBest = bestTimesRef.current[key];
+      if (previousBest !== undefined && previousBest <= secs) return;
+      setBestTimes((prev) => ({ ...prev, [key]: secs }));
 
       try {
         const inserted = await db.insert("times", {
@@ -233,22 +229,22 @@ export default function App(): React.ReactElement {
           mines: bestSpec.mines,
           seconds: secs,
         });
-        void (async () => {
-          try {
-            const rows = await db.find("times", {
-              where: { difficulty: diff, rows: bestSpec.rows, cols: bestSpec.cols, mines: bestSpec.mines },
-              orderBy: { seconds: "asc" },
-              limit: BEST_TIME_QUERY_LIMIT,
-            });
-            await Promise.all(
-              rows
-                .filter((row) => typeof row.id === "string" && row.id !== inserted.id && Number(row.seconds) > secs)
-                .map((row) => db.delete("times", row.id as string)),
-            );
-          } catch (err) {
-            console.warn("[minesweeper] failed to prune stale best times", err);
-          }
-        })();
+        try {
+          const rows = await db.find("times", {
+            where: { difficulty: diff, rows: bestSpec.rows, cols: bestSpec.cols, mines: bestSpec.mines },
+            orderBy: { seconds: "asc" },
+            limit: BEST_TIME_QUERY_LIMIT,
+          });
+          await Promise.all(
+            rows
+              .filter((row) => typeof row.id === "string" && row.id !== inserted.id && Number(row.seconds) > secs)
+              .map((row) => db.delete("times", row.id as string)),
+          );
+        } catch (err) {
+          console.warn("[minesweeper] failed to prune stale best times", err);
+          setStatusMsg("Best time saved; cleanup pending");
+          return;
+        }
         setStatusMsg("Best time saved to Matrix Postgres");
       } catch (err) {
         console.warn("[minesweeper] failed to persist best time", err);

--- a/home/apps/games/minesweeper/src/main.tsx
+++ b/home/apps/games/minesweeper/src/main.tsx
@@ -1,10 +1,3 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App";
-import "./styles.css";
+import { renderDefaultApp } from "../../../_shared/default-apps";
 
-createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+renderDefaultApp("minesweeper" as const);

--- a/home/apps/games/minesweeper/src/main.tsx
+++ b/home/apps/games/minesweeper/src/main.tsx
@@ -1,3 +1,10 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
 
-renderDefaultApp("minesweeper" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/minesweeper/src/matrix-os.d.ts
+++ b/home/apps/games/minesweeper/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/games/minesweeper/src/minesweeper-model.ts
+++ b/home/apps/games/minesweeper/src/minesweeper-model.ts
@@ -260,7 +260,7 @@ export function chord(board: Board, r: number, c: number, rng: () => number = Ma
     const ncell = working.cells[nr][nc];
     if (ncell.state === CELL.HIDDEN) {
       working = reveal(working, nr, nc, rng);
-      if (working.status === "lost") return working;
+      if (working.status === "lost" || working.status === "won") return working;
     }
   }
   return working;

--- a/home/apps/games/minesweeper/src/minesweeper-model.ts
+++ b/home/apps/games/minesweeper/src/minesweeper-model.ts
@@ -1,0 +1,283 @@
+// Pure, UI-free Minesweeper engine. Deterministic given an injectable RNG.
+// All board operations return a NEW board (no in-place mutation of inputs).
+
+export const CELL = {
+  HIDDEN: "hidden",
+  REVEALED: "revealed",
+  FLAGGED: "flagged",
+  EXPLODED: "exploded",
+} as const;
+
+export type CellState = (typeof CELL)[keyof typeof CELL];
+
+export type GameStatus = "ready" | "playing" | "won" | "lost";
+
+export interface Cell {
+  mine: boolean;
+  adjacent: number; // count of neighboring mines
+  state: CellState;
+}
+
+export interface Board {
+  rows: number;
+  cols: number;
+  mines: number;
+  status: GameStatus;
+  cells: Cell[][];
+}
+
+export type Difficulty = "beginner" | "intermediate" | "expert" | "custom";
+
+export interface DifficultySpec {
+  rows: number;
+  cols: number;
+  mines: number;
+}
+
+// Classic Windows Minesweeper geometries. Expert is 30 wide x 16 tall.
+export function difficultyConfig(difficulty: Exclude<Difficulty, "custom">): DifficultySpec {
+  switch (difficulty) {
+    case "beginner":
+      return { rows: 9, cols: 9, mines: 10 };
+    case "intermediate":
+      return { rows: 16, cols: 16, mines: 40 };
+    case "expert":
+      return { rows: 16, cols: 30, mines: 99 };
+  }
+}
+
+export function clampCustom(spec: DifficultySpec): DifficultySpec {
+  const rows = Math.max(5, Math.min(30, Math.floor(spec.rows) || 9));
+  const cols = Math.max(5, Math.min(48, Math.floor(spec.cols) || 9));
+  // At least one safe cell + its 8 neighbors must remain mine-free.
+  const maxMines = Math.max(1, rows * cols - 9);
+  const mines = Math.max(1, Math.min(maxMines, Math.floor(spec.mines) || 10));
+  return { rows, cols, mines };
+}
+
+function emptyCell(): Cell {
+  return { mine: false, adjacent: 0, state: CELL.HIDDEN };
+}
+
+export function createBoard(spec: DifficultySpec): Board {
+  const { rows, cols, mines } = spec;
+  const cells: Cell[][] = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => emptyCell()),
+  );
+  return { rows, cols, mines, status: "ready", cells };
+}
+
+export function inBounds(r: number, c: number, rows: number, cols: number): boolean {
+  return r >= 0 && r < rows && c >= 0 && c < cols;
+}
+
+export function neighbors(r: number, c: number, rows: number, cols: number): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  for (let dr = -1; dr <= 1; dr += 1) {
+    for (let dc = -1; dc <= 1; dc += 1) {
+      if (dr === 0 && dc === 0) continue;
+      const nr = r + dr;
+      const nc = c + dc;
+      if (inBounds(nr, nc, rows, cols)) out.push([nr, nc]);
+    }
+  }
+  return out;
+}
+
+// Choose `mines` distinct flat indices in [0, rows*cols), excluding `forbidden`.
+export function generateMines(
+  rows: number,
+  cols: number,
+  mines: number,
+  forbidden: Set<number>,
+  rng: () => number = Math.random,
+): Set<number> {
+  const total = rows * cols;
+  const available = total - forbidden.size;
+  const count = Math.max(0, Math.min(mines, available));
+  const picked = new Set<number>();
+  // Rejection sampling; fall back to a deterministic scan if RNG is degenerate.
+  let guard = 0;
+  const maxGuard = total * 50;
+  while (picked.size < count && guard < maxGuard) {
+    const idx = Math.floor(rng() * total) % total;
+    guard += 1;
+    if (forbidden.has(idx) || picked.has(idx)) continue;
+    picked.add(idx);
+  }
+  if (picked.size < count) {
+    for (let idx = 0; idx < total && picked.size < count; idx += 1) {
+      if (!forbidden.has(idx) && !picked.has(idx)) picked.add(idx);
+    }
+  }
+  return picked;
+}
+
+function computeAdjacency(cells: Cell[][], rows: number, cols: number): void {
+  for (let r = 0; r < rows; r += 1) {
+    for (let c = 0; c < cols; c += 1) {
+      if (cells[r][c].mine) {
+        cells[r][c].adjacent = 0;
+        continue;
+      }
+      let count = 0;
+      for (const [nr, nc] of neighbors(r, c, rows, cols)) {
+        if (cells[nr][nc].mine) count += 1;
+      }
+      cells[r][c].adjacent = count;
+    }
+  }
+}
+
+function cloneCells(cells: Cell[][]): Cell[][] {
+  return cells.map((row) => row.map((c) => ({ ...c })));
+}
+
+// Place mines for a board, guaranteeing the first-click cell and its neighbors are safe.
+export function placeMinesAvoiding(
+  board: Board,
+  safeR: number,
+  safeC: number,
+  rng: () => number = Math.random,
+): Board {
+  const { rows, cols, mines } = board;
+  const forbidden = new Set<number>();
+  forbidden.add(safeR * cols + safeC);
+  for (const [nr, nc] of neighbors(safeR, safeC, rows, cols)) {
+    forbidden.add(nr * cols + nc);
+  }
+  const minePositions = generateMines(rows, cols, mines, forbidden, rng);
+  const cells = cloneCells(board.cells);
+  for (const idx of minePositions) {
+    const r = Math.floor(idx / cols);
+    const c = idx % cols;
+    cells[r][c].mine = true;
+  }
+  computeAdjacency(cells, rows, cols);
+  return { ...board, cells, status: board.status === "ready" ? "playing" : board.status };
+}
+
+function floodReveal(cells: Cell[][], r: number, c: number, rows: number, cols: number): void {
+  const stack: Array<[number, number]> = [[r, c]];
+  while (stack.length > 0) {
+    const [cr, cc] = stack.pop() as [number, number];
+    const cell = cells[cr][cc];
+    if (cell.state === CELL.REVEALED || cell.state === CELL.FLAGGED) continue;
+    if (cell.mine) continue;
+    cell.state = CELL.REVEALED;
+    if (cell.adjacent === 0) {
+      for (const [nr, nc] of neighbors(cr, cc, rows, cols)) {
+        const ncell = cells[nr][nc];
+        if (ncell.state === CELL.HIDDEN && !ncell.mine) stack.push([nr, nc]);
+      }
+    }
+  }
+}
+
+function exposeAllMines(cells: Cell[][]): void {
+  for (const row of cells) {
+    for (const cell of row) {
+      if (cell.mine && cell.state !== CELL.EXPLODED && cell.state !== CELL.FLAGGED) {
+        cell.state = CELL.REVEALED;
+      }
+    }
+  }
+}
+
+function checkWin(board: Board): Board {
+  // Win when every non-mine cell is revealed.
+  for (const row of board.cells) {
+    for (const cell of row) {
+      if (!cell.mine && cell.state !== CELL.REVEALED) return board;
+    }
+  }
+  // Auto-flag all mines on win.
+  const cells = cloneCells(board.cells);
+  for (const row of cells) {
+    for (const cell of row) {
+      if (cell.mine) cell.state = CELL.FLAGGED;
+    }
+  }
+  return { ...board, cells, status: "won" };
+}
+
+export function reveal(board: Board, r: number, c: number, rng: () => number = Math.random): Board {
+  if (board.status === "won" || board.status === "lost") return board;
+  if (!inBounds(r, c, board.rows, board.cols)) return board;
+
+  // Lazily place mines on the first reveal so the first click is always safe.
+  let working = board;
+  if (working.status === "ready") {
+    working = placeMinesAvoiding(working, r, c, rng);
+  }
+
+  const target = working.cells[r][c];
+  if (target.state === CELL.FLAGGED || target.state === CELL.REVEALED) return working;
+
+  const cells = cloneCells(working.cells);
+  const hit = cells[r][c];
+
+  if (hit.mine) {
+    hit.state = CELL.EXPLODED;
+    exposeAllMines(cells);
+    return { ...working, cells, status: "lost" };
+  }
+
+  floodReveal(cells, r, c, working.rows, working.cols);
+  const next: Board = { ...working, cells, status: "playing" };
+  return checkWin(next);
+}
+
+export function toggleFlag(board: Board, r: number, c: number): Board {
+  if (board.status === "won" || board.status === "lost") return board;
+  if (!inBounds(r, c, board.rows, board.cols)) return board;
+  const cell = board.cells[r][c];
+  if (cell.state === CELL.REVEALED || cell.state === CELL.EXPLODED) return board;
+  const cells = cloneCells(board.cells);
+  cells[r][c].state = cell.state === CELL.FLAGGED ? CELL.HIDDEN : CELL.FLAGGED;
+  return { ...board, cells };
+}
+
+// Chord: when clicking a revealed number whose adjacent flags equal its value,
+// reveal all non-flagged neighbors (which loses the game if a flag is wrong).
+export function chord(board: Board, r: number, c: number, rng: () => number = Math.random): Board {
+  if (board.status === "won" || board.status === "lost") return board;
+  if (!inBounds(r, c, board.rows, board.cols)) return board;
+  const cell = board.cells[r][c];
+  if (cell.state !== CELL.REVEALED || cell.adjacent === 0) return board;
+
+  const ns = neighbors(r, c, board.rows, board.cols);
+  let flagged = 0;
+  for (const [nr, nc] of ns) {
+    if (board.cells[nr][nc].state === CELL.FLAGGED) flagged += 1;
+  }
+  if (flagged !== cell.adjacent) return board;
+
+  let working = board;
+  for (const [nr, nc] of ns) {
+    const ncell = working.cells[nr][nc];
+    if (ncell.state === CELL.HIDDEN) {
+      working = reveal(working, nr, nc, rng);
+      if (working.status === "lost") return working;
+    }
+  }
+  return working;
+}
+
+export function flagsPlaced(board: Board): number {
+  let n = 0;
+  for (const row of board.cells) for (const c of row) if (c.state === CELL.FLAGGED) n += 1;
+  return n;
+}
+
+export function minesRemaining(board: Board): number {
+  return board.mines - flagsPlaced(board);
+}
+
+export function isWon(board: Board): boolean {
+  return board.status === "won";
+}
+
+export function isLost(board: Board): boolean {
+  return board.status === "lost";
+}

--- a/home/apps/games/minesweeper/src/minesweeper-model.ts
+++ b/home/apps/games/minesweeper/src/minesweeper-model.ts
@@ -6,6 +6,7 @@ export const CELL = {
   REVEALED: "revealed",
   FLAGGED: "flagged",
   EXPLODED: "exploded",
+  WRONG_FLAG: "wrong-flag",
 } as const;
 
 export type CellState = (typeof CELL)[keyof typeof CELL];
@@ -159,8 +160,10 @@ export function placeMinesAvoiding(
 
 function floodReveal(cells: Cell[][], r: number, c: number, rows: number, cols: number): void {
   const stack: Array<[number, number]> = [[r, c]];
+  const queued = new Set<number>([r * cols + c]);
   while (stack.length > 0) {
     const [cr, cc] = stack.pop() as [number, number];
+    queued.delete(cr * cols + cc);
     const cell = cells[cr][cc];
     if (cell.state === CELL.REVEALED || cell.state === CELL.FLAGGED) continue;
     if (cell.mine) continue;
@@ -168,7 +171,11 @@ function floodReveal(cells: Cell[][], r: number, c: number, rows: number, cols: 
     if (cell.adjacent === 0) {
       for (const [nr, nc] of neighbors(cr, cc, rows, cols)) {
         const ncell = cells[nr][nc];
-        if (ncell.state === CELL.HIDDEN && !ncell.mine) stack.push([nr, nc]);
+        const key = nr * cols + nc;
+        if (ncell.state === CELL.HIDDEN && !ncell.mine && !queued.has(key)) {
+          queued.add(key);
+          stack.push([nr, nc]);
+        }
       }
     }
   }
@@ -177,6 +184,10 @@ function floodReveal(cells: Cell[][], r: number, c: number, rows: number, cols: 
 function exposeAllMines(cells: Cell[][]): void {
   for (const row of cells) {
     for (const cell of row) {
+      if (!cell.mine && cell.state === CELL.FLAGGED) {
+        cell.state = CELL.WRONG_FLAG;
+        continue;
+      }
       if (cell.mine && cell.state !== CELL.EXPLODED && cell.state !== CELL.FLAGGED) {
         cell.state = CELL.REVEALED;
       }

--- a/home/apps/games/minesweeper/src/minesweeper-model.ts
+++ b/home/apps/games/minesweeper/src/minesweeper-model.ts
@@ -213,9 +213,6 @@ export function reveal(board: Board, r: number, c: number, rng: () => number = M
     working = placeMinesAvoiding(working, r, c, rng);
   }
 
-  const target = working.cells[r][c];
-  if (target.state === CELL.FLAGGED || target.state === CELL.REVEALED) return working;
-
   const cells = cloneCells(working.cells);
   const hit = cells[r][c];
 

--- a/home/apps/games/minesweeper/src/minesweeper-model.ts
+++ b/home/apps/games/minesweeper/src/minesweeper-model.ts
@@ -204,6 +204,8 @@ function checkWin(board: Board): Board {
 export function reveal(board: Board, r: number, c: number, rng: () => number = Math.random): Board {
   if (board.status === "won" || board.status === "lost") return board;
   if (!inBounds(r, c, board.rows, board.cols)) return board;
+  const initial = board.cells[r][c];
+  if (initial.state === CELL.FLAGGED || initial.state === CELL.REVEALED) return board;
 
   // Lazily place mines on the first reveal so the first click is always safe.
   let working = board;

--- a/home/apps/games/minesweeper/src/styles.css
+++ b/home/apps/games/minesweeper/src/styles.css
@@ -300,6 +300,13 @@ button {
   color: var(--app-danger);
 }
 
+.ms-wrong-flag {
+  color: var(--app-danger);
+  font-size: clamp(10px, calc(var(--ms-cell) * 0.62), 16px);
+  font-weight: 800;
+  line-height: 1;
+}
+
 .ms-footer {
   display: flex;
   align-items: center;

--- a/home/apps/games/minesweeper/src/styles.css
+++ b/home/apps/games/minesweeper/src/styles.css
@@ -1,0 +1,349 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+  --app-mono: var(--matrix-font-mono, "JetBrains Mono", monospace);
+  --ms-cell: 30px;
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  color: var(--app-fg);
+  background: var(--app-bg);
+}
+
+button {
+  font: inherit;
+}
+
+.ms-root {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  overflow: hidden;
+  padding: 12px;
+  background:
+    radial-gradient(circle at 16% 12%, color-mix(in srgb, var(--app-accent) 12%, transparent), transparent 30%),
+    radial-gradient(circle at 88% 84%, color-mix(in srgb, var(--app-primary) 10%, transparent), transparent 32%),
+    var(--app-bg);
+}
+
+.ms-frame {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  background: var(--app-card);
+  border-radius: var(--app-radius);
+  box-shadow: 0 18px 50px rgba(50, 53, 46, 0.16);
+}
+
+.ms-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  flex: 0 0 auto;
+}
+
+.ms-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.ms-difficulty {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  background: var(--app-muted);
+  padding: 4px;
+  border-radius: 14px;
+}
+
+.ms-diff-btn {
+  border: none;
+  background: transparent;
+  color: var(--app-muted-fg);
+  padding: 6px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  transition: all 0.15s ease;
+}
+
+.ms-diff-btn:hover {
+  background: color-mix(in srgb, var(--app-fg) 4%, transparent);
+  color: var(--app-fg);
+}
+
+.ms-diff-btn.is-active {
+  background: var(--app-card);
+  color: var(--app-fg);
+  box-shadow: 0 2px 6px rgba(50, 53, 46, 0.12);
+}
+
+.ms-diff-btn:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 1px;
+}
+
+.ms-custom {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  flex: 0 0 auto;
+}
+
+.ms-custom label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--app-muted-fg);
+}
+
+.ms-custom input {
+  width: 80px;
+  padding: 6px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--app-border);
+  background: var(--app-bg);
+  color: var(--app-fg);
+  font: inherit;
+}
+
+.ms-custom input:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 1px;
+  border-color: var(--app-accent);
+}
+
+.ms-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 14px;
+  background: var(--app-muted);
+  border-radius: 16px;
+  flex: 0 0 auto;
+}
+
+.ms-readout {
+  font-family: var(--app-mono);
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--app-danger);
+  background: #211c17;
+  padding: 4px 10px;
+  border-radius: 10px;
+  min-width: 64px;
+  text-align: center;
+  text-shadow: 0 0 6px color-mix(in srgb, var(--app-danger) 60%, transparent);
+}
+
+.ms-reset {
+  position: relative;
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  border: 1px solid var(--app-border);
+  background: var(--app-card);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 3px 8px rgba(50, 53, 46, 0.12);
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.ms-reset:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(50, 53, 46, 0.18);
+}
+
+.ms-reset:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 5px rgba(50, 53, 46, 0.16);
+}
+
+.ms-reset:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+.ms-face {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.ms-reset-icon {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  color: var(--app-muted-fg);
+  opacity: 0.6;
+}
+
+.ms-board-area {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.ms-grid {
+  display: grid;
+  gap: 0;
+  padding: 6px;
+  background: color-mix(in srgb, var(--app-border) 60%, var(--app-muted));
+  border-radius: 12px;
+  user-select: none;
+  touch-action: manipulation;
+}
+
+.ms-cell {
+  width: var(--ms-cell);
+  height: var(--ms-cell);
+  margin: 1px;
+  border: none;
+  border-radius: max(3px, calc(var(--ms-cell) * 0.18));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--app-mono);
+  font-size: clamp(9px, calc(var(--ms-cell) * 0.55), 18px);
+  font-weight: 800;
+  line-height: 1;
+  cursor: pointer;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--app-card) 92%, white),
+    var(--app-muted)
+  );
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
+    0 1px 2px rgba(50, 53, 46, 0.12);
+  color: var(--app-fg);
+  transition:
+    background 0.12s ease,
+    transform 0.06s ease;
+}
+
+.ms-cell:hover:not(.is-open) {
+  background: color-mix(in srgb, var(--app-accent) 14%, var(--app-muted));
+}
+
+.ms-cell:active:not(.is-open) {
+  transform: scale(0.96);
+}
+
+.ms-cell:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: -2px;
+}
+
+.ms-cell.is-open {
+  background: var(--app-bg);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--app-border) 70%, transparent);
+  cursor: default;
+}
+
+.ms-cell.is-exploded {
+  background: color-mix(in srgb, var(--app-danger) 35%, var(--app-bg));
+  color: var(--app-card);
+}
+
+/* Scale lucide icons to the responsive cell size so they never overflow. */
+.ms-cell svg {
+  width: clamp(8px, calc(var(--ms-cell) * 0.6), 16px);
+  height: clamp(8px, calc(var(--ms-cell) * 0.6), 16px);
+}
+
+.ms-flag {
+  color: var(--app-danger);
+}
+
+.ms-footer {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 2px 6px;
+  flex-wrap: wrap;
+  flex: 0 0 auto;
+}
+
+.ms-stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.ms-stat-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--app-muted-fg);
+  font-weight: 700;
+}
+
+.ms-stat-value {
+  font-size: 15px;
+  font-weight: 700;
+  font-family: var(--app-mono);
+}
+
+.ms-status {
+  margin-left: auto;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--app-success);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ms-cell,
+  .ms-reset,
+  .ms-diff-btn {
+    transition: none;
+  }
+  .ms-cell:active:not(.is-open),
+  .ms-reset:hover,
+  .ms-reset:active {
+    transform: none;
+  }
+}

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -87,17 +87,27 @@ describe("Minesweeper app", () => {
     ]);
     render(<App />);
     await screen.findAllByTestId(/^cell-/);
-    expect(db.find).toHaveBeenCalledWith("times", expect.any(Object));
+    expect(db.find).toHaveBeenCalledWith("times", { orderBy: { seconds: "asc" }, limit: 500 });
     const best = await screen.findByTestId("best-time");
     expect(within(best).getByText(/42/)).toBeTruthy();
   });
 
-  it("falls back to localStorage when the DB bridge is unavailable", async () => {
+  it("works without a DB bridge", async () => {
     // No MatrixOS injected.
     render(<App />);
     const cells = await screen.findAllByTestId(/^cell-/);
     expect(cells.length).toBe(81);
     // Should not crash; mine counter still renders.
     expect(screen.getByTestId("mine-counter").textContent).toBe("010");
+  });
+
+  it("sets a native max for custom mine counts", async () => {
+    installMatrixDb([]);
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Custom" }));
+
+    const mines = screen.getByLabelText("Mines");
+    expect(mines.getAttribute("max")).toBe("247");
   });
 });

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -191,6 +191,32 @@ describe("Minesweeper app", () => {
     expect(within(best).getByText(/42/)).toBeTruthy();
   });
 
+  it("does not keep an optimistic best time when DB sync is unavailable", async () => {
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Custom" }));
+    fireEvent.change(screen.getByLabelText("Width"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Height"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Mines"), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+    expect(await screen.findAllByTestId(/^cell-/)).toHaveLength(25);
+
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    fireEvent.click(screen.getByTestId("cell-12"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(7_000);
+    });
+
+    for (let index = 1; index < 25; index += 1) {
+      fireEvent.click(screen.getByTestId(`cell-${index}`));
+    }
+
+    expect(screen.getByText(/Cleared! Best time sync unavailable/)).toBeTruthy();
+    expect(within(screen.getByTestId("best-time")).getByText("—")).toBeTruthy();
+  });
+
   it("works without a DB bridge", async () => {
     // No MatrixOS injected.
     render(<App />);

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -257,6 +257,46 @@ describe("Minesweeper app", () => {
     expect(within(screen.getByTestId("best-time")).getByText("1s")).toBeTruthy();
   });
 
+  it("saves best time under the completed game key when difficulty changes after win", async () => {
+    const db = installMatrixDb([]);
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Custom" }));
+    fireEvent.change(screen.getByLabelText("Width"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Height"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Mines"), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+    expect(await screen.findAllByTestId(/^cell-/)).toHaveLength(25);
+
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    fireEvent.click(screen.getByTestId("cell-12"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+
+    await act(async () => {
+      for (let index = 1; index < 25; index += 1) {
+        fireEvent.click(screen.getByTestId(`cell-${index}`));
+      }
+      fireEvent.click(screen.getByRole("tab", { name: "Beginner" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(db.insert).toHaveBeenCalledWith(
+      "times",
+      expect.objectContaining({
+        difficulty: "custom",
+        rows: 5,
+        cols: 5,
+        mines: 1,
+        seconds: expect.any(Number),
+      }),
+    );
+  });
+
   it("works without a DB bridge", async () => {
     // No MatrixOS injected.
     render(<App />);

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -298,6 +298,55 @@ describe("Minesweeper app", () => {
     );
   });
 
+  it("persists an equal best time while the previous equal save is still pending", async () => {
+    const db = installMatrixDb([]);
+    const insertResolvers: Array<(value: { id: string }) => void> = [];
+    db.insert.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          insertResolvers.push(resolve);
+        }),
+    );
+
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Custom" }));
+    fireEvent.change(screen.getByLabelText("Width"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Height"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Mines"), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+    expect(await screen.findAllByTestId(/^cell-/)).toHaveLength(25);
+
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    fireEvent.click(screen.getByTestId("cell-12"));
+    for (let index = 1; index < 25; index += 1) {
+      fireEvent.click(screen.getByTestId(`cell-${index}`));
+    }
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(db.insert).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+    expect(await screen.findAllByTestId(/^cell-/)).toHaveLength(25);
+    fireEvent.click(screen.getByTestId("cell-12"));
+    for (let index = 1; index < 25; index += 1) {
+      fireEvent.click(screen.getByTestId(`cell-${index}`));
+    }
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(db.insert).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      insertResolvers.forEach((resolve, index) => resolve({ id: `time-${index}` }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
   it("works without a DB bridge", async () => {
     // No MatrixOS injected.
     render(<App />);

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/games/minesweeper/src/App";
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const db = {
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async () => ({ id: "time-new" })),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => rows.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+describe("Minesweeper app", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+    try {
+      window.localStorage.clear();
+    } catch {
+      /* jsdom localStorage may be unavailable */
+    }
+  });
+
+  it("renders the grid, mine counter, timer, and difficulty controls", async () => {
+    installMatrixDb([]);
+    render(<App />);
+
+    // Beginner default: 9x9 = 81 cells.
+    const cells = await screen.findAllByTestId(/^cell-/);
+    expect(cells.length).toBe(81);
+
+    // Mine counter shows 010 (3-digit Windows style) and timer 000.
+    expect(screen.getByTestId("mine-counter").textContent).toBe("010");
+    expect(screen.getByTestId("timer").textContent).toBe("000");
+
+    // Smiley reset is present.
+    expect(screen.getByTestId("reset")).toBeTruthy();
+  });
+
+  it("reveals a cell on left-click and starts play", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    const cells = await screen.findAllByTestId(/^cell-/);
+
+    fireEvent.click(screen.getByTestId("cell-40")); // center-ish 9x9
+
+    const revealed = (await screen.findAllByTestId(/^cell-/)).filter((el) =>
+      el.getAttribute("data-state") === "revealed",
+    );
+    expect(revealed.length).toBeGreaterThan(0);
+  });
+
+  it("toggles a flag on right-click and updates the mine counter", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+
+    const cell = screen.getByTestId("cell-0");
+    fireEvent.contextMenu(cell);
+
+    expect(screen.getByTestId("cell-0").getAttribute("data-state")).toBe("flagged");
+    // 10 mines - 1 flag = 9
+    expect(screen.getByTestId("mine-counter").textContent).toBe("009");
+
+    // Right-click again removes it.
+    fireEvent.contextMenu(screen.getByTestId("cell-0"));
+    expect(screen.getByTestId("cell-0").getAttribute("data-state")).toBe("hidden");
+    expect(screen.getByTestId("mine-counter").textContent).toBe("010");
+  });
+
+  it("loads best times from the Matrix DB on mount", async () => {
+    const db = installMatrixDb([
+      { id: "t1", difficulty: "beginner", seconds: 42, created_at: "2026-05-31T10:00:00.000Z" },
+    ]);
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+    expect(db.find).toHaveBeenCalledWith("times", expect.any(Object));
+    const best = await screen.findByTestId("best-time");
+    expect(within(best).getByText(/42/)).toBeTruthy();
+  });
+
+  it("falls back to localStorage when the DB bridge is unavailable", async () => {
+    // No MatrixOS injected.
+    render(<App />);
+    const cells = await screen.findAllByTestId(/^cell-/);
+    expect(cells.length).toBe(81);
+    // Should not crash; mine counter still renders.
+    expect(screen.getByTestId("mine-counter").textContent).toBe("010");
+  });
+});

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/games/minesweeper/src/App";
@@ -7,6 +9,7 @@ import App from "../../home/apps/games/minesweeper/src/App";
 type DbRow = Record<string, unknown>;
 
 function installMatrixDb(rows: DbRow[] = []) {
+  const listeners: Record<string, Array<() => void>> = {};
   const db = {
     find: vi.fn(async () => rows),
     findOne: vi.fn(async () => null),
@@ -14,7 +17,15 @@ function installMatrixDb(rows: DbRow[] = []) {
     update: vi.fn(async () => ({ ok: true })),
     delete: vi.fn(async () => ({ ok: true })),
     count: vi.fn(async () => rows.length),
-    onChange: vi.fn(() => () => undefined),
+    onChange: vi.fn((table: string, callback: () => void) => {
+      (listeners[table] ??= []).push(callback);
+      return () => {
+        listeners[table] = (listeners[table] ?? []).filter((listener) => listener !== callback);
+      };
+    }),
+    emitChange: (table: string) => {
+      for (const callback of listeners[table] ?? []) callback();
+    },
   };
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
@@ -25,6 +36,7 @@ function installMatrixDb(rows: DbRow[] = []) {
 
 describe("Minesweeper app", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
     try {
@@ -32,6 +44,14 @@ describe("Minesweeper app", () => {
     } catch {
       /* jsdom localStorage may be unavailable */
     }
+  });
+
+  it("uses the shipped shared game icon", () => {
+    const manifestPath = resolve(process.cwd(), "home/apps/games/minesweeper/matrix.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as { icon?: string };
+
+    expect(manifest.icon).toBe("game-center");
+    expect(existsSync(resolve(process.cwd(), "home/system/icons/game-center.png"))).toBe(true);
   });
 
   it("renders the grid, mine counter, timer, and difficulty controls", async () => {
@@ -81,6 +101,54 @@ describe("Minesweeper app", () => {
     expect(screen.getByTestId("mine-counter").textContent).toBe("010");
   });
 
+  it("keeps both-button chord intent when the right button is released first", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+
+    const cell = screen.getByTestId("cell-0");
+    fireEvent.mouseDown(cell, { button: 0 });
+    fireEvent.mouseDown(cell, { button: 2 });
+    fireEvent.mouseUp(cell, { button: 2 });
+    fireEvent.mouseUp(cell, { button: 0 });
+    fireEvent.click(cell);
+
+    expect(screen.getByTestId("cell-0").getAttribute("data-state")).toBe("hidden");
+  });
+
+  it("reveals a cell on a short touch tap", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+
+    const cell = screen.getByTestId("cell-40");
+    fireEvent.touchStart(cell);
+    fireEvent.touchEnd(cell);
+
+    const revealed = (await screen.findAllByTestId(/^cell-/)).filter((el) =>
+      el.getAttribute("data-state") === "revealed",
+    );
+    expect(revealed.length).toBeGreaterThan(0);
+  });
+
+  it("does not toggle a flag when a touch long press is canceled", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+    vi.useFakeTimers();
+
+    const cell = screen.getByTestId("cell-0");
+    fireEvent.touchStart(cell);
+    fireEvent.touchCancel(cell);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(screen.getByTestId("cell-0").getAttribute("data-state")).toBe("hidden");
+    expect(screen.getByTestId("mine-counter").textContent).toBe("010");
+  });
+
   it("loads best times from the Matrix DB on mount", async () => {
     const db = installMatrixDb([
       { id: "t1", difficulty: "beginner", seconds: 42, created_at: "2026-05-31T10:00:00.000Z" },
@@ -89,6 +157,37 @@ describe("Minesweeper app", () => {
     await screen.findAllByTestId(/^cell-/);
     expect(db.find).toHaveBeenCalledWith("times", { orderBy: { seconds: "asc" }, limit: 500 });
     const best = await screen.findByTestId("best-time");
+    expect(within(best).getByText(/42/)).toBeTruthy();
+  });
+
+  it("keeps loaded best times when an onChange reload fails", async () => {
+    const db = installMatrixDb([
+      { id: "t1", difficulty: "beginner", seconds: 42, created_at: "2026-05-31T10:00:00.000Z" },
+    ]);
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+    const best = await screen.findByTestId("best-time");
+    expect(within(best).getByText(/42/)).toBeTruthy();
+
+    db.find.mockRejectedValueOnce(new Error("transient reload failure"));
+    db.emitChange("times");
+
+    expect(await screen.findByText("Could not load best times")).toBeTruthy();
+    expect(within(best).getByText(/42/)).toBeTruthy();
+  });
+
+  it("keeps loaded best times when the DB bridge disappears before onChange", async () => {
+    const db = installMatrixDb([
+      { id: "t1", difficulty: "beginner", seconds: 42, created_at: "2026-05-31T10:00:00.000Z" },
+    ]);
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+    const best = await screen.findByTestId("best-time");
+    expect(within(best).getByText(/42/)).toBeTruthy();
+
+    Reflect.deleteProperty(window, "MatrixOS");
+    db.emitChange("times");
+
     expect(within(best).getByText(/42/)).toBeTruthy();
   });
 

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -208,6 +208,7 @@ describe("Minesweeper app", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(7_000);
     });
+    vi.useRealTimers();
 
     for (let index = 1; index < 25; index += 1) {
       fireEvent.click(screen.getByTestId(`cell-${index}`));
@@ -215,6 +216,45 @@ describe("Minesweeper app", () => {
 
     expect(screen.getByText(/Cleared! Best time sync unavailable/)).toBeTruthy();
     expect(within(screen.getByTestId("best-time")).getByText("—")).toBeTruthy();
+  });
+
+  it("surfaces stale best-time cleanup failures after saving", async () => {
+    const db = installMatrixDb([]);
+    db.find
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: "old-best", difficulty: "custom", rows: 5, cols: 5, mines: 1, seconds: 20 },
+      ]);
+    db.delete.mockRejectedValueOnce(new Error("delete failed"));
+
+    render(<App />);
+    await screen.findAllByTestId(/^cell-/);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Custom" }));
+    fireEvent.change(screen.getByLabelText("Width"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Height"), { target: { value: "5" } });
+    fireEvent.change(screen.getByLabelText("Mines"), { target: { value: "1" } });
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+    expect(await screen.findAllByTestId(/^cell-/)).toHaveLength(25);
+
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    fireEvent.click(screen.getByTestId("cell-12"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(7_000);
+    });
+
+    for (let index = 1; index < 25; index += 1) {
+      fireEvent.click(screen.getByTestId(`cell-${index}`));
+    }
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/Best time saved; cleanup pending/)).toBeTruthy();
+    expect(db.delete).toHaveBeenCalledWith("times", "old-best");
+    expect(within(screen.getByTestId("best-time")).getByText("1s")).toBeTruthy();
   });
 
   it("works without a DB bridge", async () => {

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -274,5 +274,8 @@ describe("Minesweeper app", () => {
 
     const mines = screen.getByLabelText("Mines");
     expect(mines.getAttribute("max")).toBe("247");
+
+    fireEvent.change(screen.getByLabelText("Width"), { target: { value: "3" } });
+    expect(mines.getAttribute("max")).toBe("71");
   });
 });

--- a/tests/default-apps/minesweeper-app.test.tsx
+++ b/tests/default-apps/minesweeper-app.test.tsx
@@ -206,6 +206,9 @@ describe("Minesweeper app", () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
     fireEvent.click(screen.getByTestId("cell-12"));
     await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
       await vi.advanceTimersByTimeAsync(7_000);
     });
     vi.useRealTimers();
@@ -237,12 +240,8 @@ describe("Minesweeper app", () => {
     fireEvent.click(screen.getByRole("button", { name: /new game/i }));
     expect(await screen.findAllByTestId(/^cell-/)).toHaveLength(25);
 
-    vi.useFakeTimers();
     vi.spyOn(Math, "random").mockReturnValue(0);
     fireEvent.click(screen.getByTestId("cell-12"));
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(7_000);
-    });
 
     for (let index = 1; index < 25; index += 1) {
       fireEvent.click(screen.getByTestId(`cell-${index}`));
@@ -254,6 +253,8 @@ describe("Minesweeper app", () => {
 
     expect(screen.getByText(/Best time saved; cleanup pending/)).toBeTruthy();
     expect(db.delete).toHaveBeenCalledWith("times", "old-best");
+    // The win completes before a timer tick is committed in this immediate-win
+    // path, so finalSecs clamps the saved best time to 1 second.
     expect(within(screen.getByTestId("best-time")).getByText("1s")).toBeTruthy();
   });
 

--- a/tests/default-apps/minesweeper-model.test.ts
+++ b/tests/default-apps/minesweeper-model.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  CELL,
+  chord,
+  createBoard,
+  difficultyConfig,
+  flagsPlaced,
+  generateMines,
+  isLost,
+  isWon,
+  minesRemaining,
+  neighbors,
+  placeMinesAvoiding,
+  reveal,
+  toggleFlag,
+  type Board,
+} from "../../home/apps/games/minesweeper/src/minesweeper-model";
+
+// Deterministic RNG: returns values from a fixed queue, looping.
+function seededRng(values: number[]): () => number {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i += 1;
+    return v;
+  };
+}
+
+function countMines(board: Board): number {
+  let n = 0;
+  for (const row of board.cells) for (const c of row) if (c.mine) n += 1;
+  return n;
+}
+
+describe("minesweeper difficulty config", () => {
+  it("defines classic Windows difficulties", () => {
+    expect(difficultyConfig("beginner")).toEqual({ rows: 9, cols: 9, mines: 10 });
+    expect(difficultyConfig("intermediate")).toEqual({ rows: 16, cols: 16, mines: 40 });
+    expect(difficultyConfig("expert")).toEqual({ rows: 16, cols: 30, mines: 99 });
+  });
+});
+
+describe("createBoard", () => {
+  it("creates a fully hidden board with no mines until first click", () => {
+    const board = createBoard({ rows: 9, cols: 9, mines: 10 });
+    expect(board.rows).toBe(9);
+    expect(board.cols).toBe(9);
+    expect(board.mines).toBe(10);
+    expect(board.status).toBe("ready");
+    expect(countMines(board)).toBe(0);
+    for (const row of board.cells) {
+      for (const c of row) {
+        expect(c.state).toBe(CELL.HIDDEN);
+        expect(c.mine).toBe(false);
+      }
+    }
+  });
+});
+
+describe("generateMines / placeMinesAvoiding (first-click safety)", () => {
+  it("places exactly the requested number of mines", () => {
+    const positions = generateMines(9, 9, 10, new Set<number>(), seededRng([0.0, 0.99, 0.5, 0.25, 0.75, 0.1, 0.3, 0.6, 0.8, 0.4, 0.2, 0.7]));
+    expect(positions.size).toBe(10);
+  });
+
+  it("never places a mine on the safe cell or its neighbors", () => {
+    const board = createBoard({ rows: 9, cols: 9, mines: 10 });
+    // first click at center 4,4
+    const placed = placeMinesAvoiding(board, 4, 4, seededRng([0.01, 0.5, 0.9, 0.2, 0.7, 0.3, 0.6, 0.15, 0.85, 0.45]));
+    const safeIndex = 4 * 9 + 4;
+    const safeZone = new Set<number>([safeIndex, ...neighbors(4, 4, 9, 9).map(([r, c]) => r * 9 + c)]);
+    expect(countMines(placed)).toBe(10);
+    for (const idx of safeZone) {
+      const r = Math.floor(idx / 9);
+      const c = idx % 9;
+      expect(placed.cells[r][c].mine).toBe(false);
+    }
+  });
+
+  it("computes adjacency counts correctly", () => {
+    const board = createBoard({ rows: 3, cols: 3, mines: 1 });
+    // force a single mine at (0,0) by avoiding everywhere else
+    const placed = placeMinesAvoiding(board, 2, 2, seededRng([0.0]));
+    // mine should be away from (2,2) safe zone -> at (0,0)
+    expect(placed.cells[0][0].mine).toBe(true);
+    expect(placed.cells[0][1].adjacent).toBe(1);
+    expect(placed.cells[1][0].adjacent).toBe(1);
+    expect(placed.cells[1][1].adjacent).toBe(1);
+    expect(placed.cells[2][2].adjacent).toBe(0);
+  });
+});
+
+describe("reveal + flood fill", () => {
+  it("flood-fills connected zero cells on first click and stays playing", () => {
+    const board = createBoard({ rows: 9, cols: 9, mines: 10 });
+    const next = reveal(board, 4, 4, seededRng([0.01, 0.5, 0.9, 0.2, 0.7, 0.3, 0.6, 0.15, 0.85, 0.45]));
+    expect(next.status).toBe("playing");
+    // The clicked cell is revealed.
+    expect(next.cells[4][4].state).toBe(CELL.REVEALED);
+    // First click should open at least a region (more than just one cell).
+    let revealed = 0;
+    for (const row of next.cells) for (const c of row) if (c.state === CELL.REVEALED) revealed += 1;
+    expect(revealed).toBeGreaterThan(1);
+  });
+
+  it("does not reveal flagged cells", () => {
+    let board = createBoard({ rows: 5, cols: 5, mines: 1 });
+    board = reveal(board, 4, 4, seededRng([0.0])); // initialize mines
+    board = toggleFlag(board, 0, 0);
+    const before = board.cells[0][0].state;
+    const after = reveal(board, 0, 0).cells[0][0].state;
+    expect(before).toBe(CELL.FLAGGED);
+    expect(after).toBe(CELL.FLAGGED);
+  });
+
+  it("loses when revealing a mine and exposes all mines", () => {
+    let board = createBoard({ rows: 3, cols: 3, mines: 1 });
+    board = placeMinesAvoiding(board, 2, 2, seededRng([0.0])); // mine at (0,0)
+    const dead = reveal(board, 0, 0);
+    expect(dead.status).toBe("lost");
+    expect(isLost(dead)).toBe(true);
+    expect(dead.cells[0][0].state).toBe(CELL.EXPLODED);
+  });
+});
+
+describe("flagging", () => {
+  it("toggles flag on hidden cells and counts mines remaining", () => {
+    let board = createBoard({ rows: 9, cols: 9, mines: 10 });
+    board = reveal(board, 4, 4, seededRng([0.5, 0.1, 0.9, 0.2, 0.7, 0.3, 0.6, 0.15, 0.85, 0.45]));
+    expect(minesRemaining(board)).toBe(10);
+    board = toggleFlag(board, 0, 0);
+    expect(board.cells[0][0].state).toBe(CELL.FLAGGED);
+    expect(flagsPlaced(board)).toBe(1);
+    expect(minesRemaining(board)).toBe(9);
+    board = toggleFlag(board, 0, 0);
+    expect(board.cells[0][0].state).toBe(CELL.HIDDEN);
+    expect(minesRemaining(board)).toBe(10);
+  });
+
+  it("cannot flag a revealed cell", () => {
+    let board = createBoard({ rows: 5, cols: 5, mines: 1 });
+    board = reveal(board, 4, 4, seededRng([0.0]));
+    // (4,4) is revealed; flagging it is a no-op
+    const flagged = toggleFlag(board, 4, 4);
+    expect(flagged.cells[4][4].state).toBe(CELL.REVEALED);
+  });
+});
+
+describe("chord", () => {
+  it("reveals neighbors when flag count matches the number", () => {
+    let board = createBoard({ rows: 3, cols: 3, mines: 1 });
+    board = placeMinesAvoiding(board, 2, 2, seededRng([0.0])); // mine at (0,0)
+    board = reveal(board, 1, 1); // reveal the "1" at center
+    expect(board.cells[1][1].state).toBe(CELL.REVEALED);
+    expect(board.cells[1][1].adjacent).toBe(1);
+    board = toggleFlag(board, 0, 0); // correctly flag the mine
+    const after = chord(board, 1, 1);
+    // All non-mine neighbors should now be revealed.
+    for (const [r, c] of neighbors(1, 1, 3, 3)) {
+      if (!after.cells[r][c].mine) {
+        expect(after.cells[r][c].state).toBe(CELL.REVEALED);
+      }
+    }
+    expect(after.status).not.toBe("lost");
+  });
+
+  it("explodes on chord if a flag is wrong", () => {
+    let board = createBoard({ rows: 3, cols: 3, mines: 1 });
+    board = placeMinesAvoiding(board, 2, 2, seededRng([0.0])); // mine at (0,0)
+    board = reveal(board, 1, 1);
+    board = toggleFlag(board, 0, 1); // wrong flag (not the mine)
+    const after = chord(board, 1, 1);
+    expect(after.status).toBe("lost");
+  });
+});
+
+describe("win detection", () => {
+  it("wins when all non-mine cells are revealed", () => {
+    let board = createBoard({ rows: 3, cols: 3, mines: 1 });
+    board = placeMinesAvoiding(board, 2, 2, seededRng([0.0])); // mine at (0,0)
+    // reveal every non-mine cell
+    for (let r = 0; r < 3; r += 1) {
+      for (let c = 0; c < 3; c += 1) {
+        if (!board.cells[r][c].mine) {
+          board = reveal(board, r, c);
+        }
+      }
+    }
+    expect(isWon(board)).toBe(true);
+    expect(board.status).toBe("won");
+    // remaining mines display goes to 0 when won (all mines auto-flagged)
+    expect(minesRemaining(board)).toBe(0);
+  });
+});

--- a/tests/default-apps/minesweeper-model.test.ts
+++ b/tests/default-apps/minesweeper-model.test.ts
@@ -113,6 +113,17 @@ describe("reveal + flood fill", () => {
     expect(after).toBe(CELL.FLAGGED);
   });
 
+  it("does not place mines when the first clicked cell is flagged", () => {
+    let board = createBoard({ rows: 5, cols: 5, mines: 1 });
+    board = toggleFlag(board, 0, 0);
+
+    const after = reveal(board, 0, 0, seededRng([0.0]));
+
+    expect(after).toBe(board);
+    expect(after.status).toBe("ready");
+    expect(after.cells.flat().some((cell) => cell.mine)).toBe(false);
+  });
+
   it("loses when revealing a mine and exposes all mines", () => {
     let board = createBoard({ rows: 3, cols: 3, mines: 1 });
     board = placeMinesAvoiding(board, 2, 2, seededRng([0.0])); // mine at (0,0)

--- a/tests/default-apps/minesweeper-model.test.ts
+++ b/tests/default-apps/minesweeper-model.test.ts
@@ -182,6 +182,7 @@ describe("chord", () => {
     board = toggleFlag(board, 0, 1); // wrong flag (not the mine)
     const after = chord(board, 1, 1);
     expect(after.status).toBe("lost");
+    expect(after.cells[0][1].state).toBe(CELL.WRONG_FLAG);
   });
 });
 


### PR DESCRIPTION
Stack: 14/22
Branch: stack/default-apps-minesweeper

Scope: Minesweeper flood-fill model, UI, manifest, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.