### PR TITLE
feat(solitaire): add Klondike card game

### DIFF
--- a/home/apps/games/solitaire/matrix.json
+++ b/home/apps/games/solitaire/matrix.json
@@ -3,7 +3,7 @@
   "description": "Classic Klondike solitaire card game",
   "runtime": "vite",
   "category": "games",
-  "icon": "game-center",
+  "icon": "solitaire",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -12,6 +12,18 @@
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
   "slug": "solitaire",
+  "storage": {
+    "tables": {
+      "stats": {
+        "columns": {
+          "games_played": "integer",
+          "games_won": "integer",
+          "best_time": "integer",
+          "best_moves": "integer"
+        }
+      }
+    }
+  },
   "build": {
     "install": "true",
     "command": "vite build --base ./ --outDir dist",

--- a/home/apps/games/solitaire/matrix.json
+++ b/home/apps/games/solitaire/matrix.json
@@ -3,7 +3,7 @@
   "description": "Classic Klondike solitaire card game",
   "runtime": "vite",
   "category": "games",
-  "icon": "solitaire",
+  "icon": "game-center",
   "author": "system",
   "version": "1.0.0",
   "tags": [

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -144,7 +144,7 @@ export default function App({ initialState }: AppProps) {
       return;
     }
     try {
-      const rows = await db.find(STATS_TABLE, { limit: 1, orderBy: { created_at: "desc" } });
+      const rows = await db.find(STATS_TABLE, { limit: 1 });
       if (rows && rows.length > 0) {
         const loaded = coerceStats(rows[0]);
         statsRowIdRef.current = loaded.id ?? null;

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -71,6 +71,7 @@ export default function App({ initialState }: AppProps) {
   const statsLoadedRef = useRef(false);
   const statsRowIdRef = useRef<string | null>(null);
   const statsInsertRef = useRef<Promise<string> | null>(null);
+  const pendingGamesPlayedRef = useRef(0);
   const startedAtRef = useRef<number>(Date.now());
 
   const won = isWon(game);
@@ -153,7 +154,16 @@ export default function App({ initialState }: AppProps) {
       try {
         const value = await window.MatrixOS?.readData?.(DRAW_PREF_KEY);
         if (!active) return;
-        if (value === 1 || value === 3) setDraw(value);
+        if (value === 1 || value === 3) {
+          setDraw(value);
+          if (!initialState) {
+            setGame((current) => {
+              if (current.moves !== 0 || current.drawCount === value) return current;
+              startedAtRef.current = Date.now();
+              return deal(Math.random, value);
+            });
+          }
+        }
       } catch (err: unknown) {
         console.warn("[solitaire] draw preference load failed:", err instanceof Error ? err.message : String(err));
       }
@@ -161,12 +171,24 @@ export default function App({ initialState }: AppProps) {
     return () => {
       active = false;
     };
-  }, []);
+  }, [initialState]);
 
   const recordGamePlayed = useCallback(() => {
+    if (!statsLoadedRef.current) {
+      pendingGamesPlayedRef.current += 1;
+      return;
+    }
     const cur = statsRef.current;
     void persistStats({ ...cur, games_played: cur.games_played + 1 });
   }, [persistStats]);
+
+  useEffect(() => {
+    if (!statsLoadedRef.current || pendingGamesPlayedRef.current === 0) return;
+    const pending = pendingGamesPlayedRef.current;
+    pendingGamesPlayedRef.current = 0;
+    const cur = statsRef.current;
+    void persistStats({ ...cur, games_played: cur.games_played + pending });
+  }, [persistStats, stats]);
 
   useEffect(() => {
     if (countedInitialGameRef.current || !statsLoadedRef.current) return;
@@ -192,6 +214,7 @@ export default function App({ initialState }: AppProps) {
       setElapsed(0);
       setError(null);
       recordedWinRef.current = false;
+      countedInitialGameRef.current = true;
       startedAtRef.current = Date.now();
       setRunning(true);
       recordGamePlayed();
@@ -268,6 +291,8 @@ export default function App({ initialState }: AppProps) {
           if (doMove(selected, dest)) return;
           return;
         }
+        setSelected(src);
+        return;
       }
       // otherwise auto-route this source to a legal destination
       const dest = findAutoDestination(game, src);

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -66,6 +66,7 @@ export default function App({ initialState }: AppProps) {
   const [elapsed, setElapsed] = useState(0);
   const [running, setRunning] = useState(!initialState);
   const [selected, setSelected] = useState<Source | null>(null);
+  const gameRef = useRef(game);
   const recordedWinRef = useRef(false);
   const countedInitialGameRef = useRef(Boolean(initialState));
   const statsLoadedRef = useRef(false);
@@ -75,6 +76,10 @@ export default function App({ initialState }: AppProps) {
   const startedAtRef = useRef<number>(Date.now());
 
   const won = isWon(game);
+
+  useEffect(() => {
+    gameRef.current = game;
+  }, [game]);
 
   useEffect(() => {
     statsRef.current = stats;
@@ -158,11 +163,13 @@ export default function App({ initialState }: AppProps) {
         if (value === 1 || value === 3) {
           setDraw(value);
           if (!initialState) {
-            setGame((current) => {
-              if (current.moves !== 0 || current.drawCount === value) return current;
+            const current = gameRef.current;
+            if (current.moves === 0 && current.drawCount !== value) {
+              const next = deal(Math.random, value);
+              gameRef.current = next;
               startedAtRef.current = Date.now();
-              return deal(Math.random, value);
-            });
+              setGame(next);
+            }
           }
         }
       } catch (err: unknown) {

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -22,10 +22,14 @@ import { useSolitaireStats } from "./useSolitaireStats";
 const DRAW_PREF_KEY = "solitaire:draw-mode";
 
 function formatTime(seconds: number): string {
-  if (!seconds || seconds < 0) return "--:--";
+  if (seconds < 0) return "--:--";
   const m = Math.floor(seconds / 60).toString().padStart(2, "0");
   const s = Math.floor(seconds % 60).toString().padStart(2, "0");
   return `${m}:${s}`;
+}
+
+function formatBestTime(seconds: number): string {
+  return seconds === 0 ? "--:--" : formatTime(seconds);
 }
 
 interface AppProps {
@@ -461,7 +465,7 @@ export default function App({ initialState }: AppProps) {
         <span>
           Won {stats.games_won}/{stats.games_played}
         </span>
-        <span>Best time {formatTime(stats.best_time)}</span>
+        <span>Best time {formatBestTime(stats.best_time)}</span>
         <span>Best moves {stats.best_moves || "--"}</span>
         <span className="sol-hint">Double-click → foundation · Cmd/Ctrl+Z undo · N new</span>
       </footer>

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -1,0 +1,607 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { RotateCcw, Sparkles, Trophy, Undo2, Wand2 } from "lucide-react";
+import "./styles.css";
+import {
+  type Card,
+  type Destination,
+  type GameState,
+  type Source,
+  RANK_LABELS,
+  SUIT_SYMBOLS,
+  applyMove,
+  autoCompleteStep,
+  autoMoveToFoundation,
+  canAutoComplete,
+  deal,
+  drawFromStock,
+  findAutoDestination,
+  isWon,
+  suitColor,
+} from "./solitaire-model";
+
+const STATS_TABLE = "stats";
+const LS_STATS_KEY = "matrix.solitaire.stats";
+const LS_DRAW_KEY = "matrix.solitaire.draw";
+
+interface Stats {
+  id?: string;
+  games_played: number;
+  games_won: number;
+  best_time: number; // seconds, 0 = none
+  best_moves: number; // 0 = none
+}
+
+const EMPTY_STATS: Stats = { games_played: 0, games_won: 0, best_time: 0, best_moves: 0 };
+
+function coerceStats(row: unknown): Stats {
+  if (!row || typeof row !== "object") return { ...EMPTY_STATS };
+  const r = row as Record<string, unknown>;
+  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : Number(v) || 0);
+  return {
+    id: typeof r.id === "string" ? r.id : undefined,
+    games_played: num(r.games_played),
+    games_won: num(r.games_won),
+    best_time: num(r.best_time),
+    best_moves: num(r.best_moves),
+  };
+}
+
+function loadLocalStats(): Stats {
+  try {
+    const raw = localStorage.getItem(LS_STATS_KEY);
+    if (!raw) return { ...EMPTY_STATS };
+    return coerceStats(JSON.parse(raw));
+  } catch (err: unknown) {
+    console.warn("[solitaire] local stats read failed:", err instanceof Error ? err.message : String(err));
+    return { ...EMPTY_STATS };
+  }
+}
+
+function saveLocalStats(stats: Stats): void {
+  try {
+    localStorage.setItem(LS_STATS_KEY, JSON.stringify(stats));
+  } catch (err: unknown) {
+    console.warn("[solitaire] local stats write failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+function formatTime(seconds: number): string {
+  if (!seconds || seconds < 0) return "--:--";
+  const m = Math.floor(seconds / 60).toString().padStart(2, "0");
+  const s = Math.floor(seconds % 60).toString().padStart(2, "0");
+  return `${m}:${s}`;
+}
+
+interface AppProps {
+  initialState?: GameState;
+}
+
+export default function App({ initialState }: AppProps) {
+  const [draw, setDraw] = useState<1 | 3>(() => {
+    try {
+      return localStorage.getItem(LS_DRAW_KEY) === "3" ? 3 : 1;
+    } catch {
+      return 1;
+    }
+  });
+  const [game, setGame] = useState<GameState>(() => initialState ?? deal(Math.random, draw));
+  const [history, setHistory] = useState<GameState[]>([]);
+  const [stats, setStats] = useState<Stats>(EMPTY_STATS);
+  const [error, setError] = useState<string | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const [running, setRunning] = useState(!initialState);
+  const [selected, setSelected] = useState<Source | null>(null);
+  const recordedWinRef = useRef(false);
+  const startedAtRef = useRef<number>(Date.now());
+
+  const won = isWon(game);
+
+  // ---- Stats persistence (DB with localStorage fallback) -----------------
+  const persistStats = useCallback(async (next: Stats) => {
+    setStats(next);
+    saveLocalStats(next);
+    const db = window.MatrixOS?.db;
+    if (!db) return;
+    const payload = {
+      games_played: next.games_played,
+      games_won: next.games_won,
+      best_time: next.best_time,
+      best_moves: next.best_moves,
+    };
+    try {
+      if (next.id) {
+        await db.update(STATS_TABLE, next.id, payload);
+      } else {
+        const res = await db.insert(STATS_TABLE, payload);
+        if (res?.id) setStats((cur) => ({ ...cur, id: res.id }));
+      }
+    } catch (err: unknown) {
+      console.warn("[solitaire] stats save failed:", err instanceof Error ? err.message : String(err));
+      setError("Stats could not be saved to Matrix Postgres.");
+    }
+  }, []);
+
+  const loadStats = useCallback(async () => {
+    const db = window.MatrixOS?.db;
+    if (!db) {
+      setStats(loadLocalStats());
+      return;
+    }
+    try {
+      const rows = await db.find(STATS_TABLE, { limit: 1, orderBy: { created_at: "desc" } });
+      if (rows && rows.length > 0) {
+        setStats(coerceStats(rows[0]));
+      } else {
+        setStats(loadLocalStats());
+      }
+      setError(null);
+    } catch (err: unknown) {
+      console.warn("[solitaire] stats load failed:", err instanceof Error ? err.message : String(err));
+      setError("Stats could not be loaded; using local fallback.");
+      setStats(loadLocalStats());
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadStats();
+    const db = window.MatrixOS?.db;
+    return db?.onChange?.(STATS_TABLE, () => void loadStats());
+  }, [loadStats]);
+
+  // ---- Timer -------------------------------------------------------------
+  useEffect(() => {
+    if (!running || won) return undefined;
+    const id = window.setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAtRef.current) / 1000));
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [running, won]);
+
+  // ---- New game ----------------------------------------------------------
+  const startNewGame = useCallback(
+    (drawCount: 1 | 3 = draw) => {
+      setGame(deal(Math.random, drawCount));
+      setHistory([]);
+      setSelected(null);
+      setElapsed(0);
+      setError(null);
+      recordedWinRef.current = false;
+      startedAtRef.current = Date.now();
+      setRunning(true);
+      // count a played game
+      setStats((cur) => {
+        const next = { ...cur, games_played: cur.games_played + 1 };
+        void persistStats(next);
+        return next;
+      });
+    },
+    [draw, persistStats],
+  );
+
+  const setDrawMode = useCallback((mode: 1 | 3) => {
+    setDraw(mode);
+    try {
+      localStorage.setItem(LS_DRAW_KEY, String(mode));
+    } catch {
+      // non-fatal: preference persistence is best-effort
+      console.warn("[solitaire] could not persist draw preference");
+    }
+    startNewGame(mode);
+  }, [startNewGame]);
+
+  // ---- Move application with history -------------------------------------
+  const commit = useCallback((next: GameState) => {
+    setGame((prev) => {
+      setHistory((h) => [...h.slice(-200), prev]);
+      return next;
+    });
+  }, []);
+
+  const undo = useCallback(() => {
+    setHistory((h) => {
+      if (h.length === 0) return h;
+      const prev = h[h.length - 1];
+      setGame(prev);
+      setSelected(null);
+      return h.slice(0, -1);
+    });
+  }, []);
+
+  const doMove = useCallback(
+    (src: Source, dest: Destination) => {
+      const next = applyMove(game, src, dest);
+      if (next) {
+        commit(next);
+        setSelected(null);
+        return true;
+      }
+      return false;
+    },
+    [commit, game],
+  );
+
+  const sendToFoundation = useCallback(
+    (src: Source) => {
+      const next = autoMoveToFoundation(game, src);
+      if (next) {
+        commit(next);
+        setSelected(null);
+        return true;
+      }
+      return false;
+    },
+    [commit, game],
+  );
+
+  const handleDraw = useCallback(() => {
+    setSelected(null);
+    commit(drawFromStock(game));
+  }, [commit, game]);
+
+  // ---- Click-to-move (auto route) ----------------------------------------
+  const handleCardActivate = useCallback(
+    (src: Source) => {
+      // If a source is already selected, attempt to use this click as a destination.
+      if (selected) {
+        // clicking the same selection clears it
+        const dest = sourceToDestination(src);
+        if (dest && doMove(selected, dest)) return;
+      }
+      // otherwise auto-route this source to a legal destination
+      const dest = findAutoDestination(game, src);
+      if (dest) {
+        doMove(src, dest);
+        return;
+      }
+      // nothing automatic: select it (so user can pick a destination pile)
+      setSelected((cur) => (sourceEquals(cur, src) ? null : src));
+    },
+    [doMove, game, selected],
+  );
+
+  const handlePileActivate = useCallback(
+    (dest: Destination) => {
+      if (!selected) return;
+      doMove(selected, dest);
+    },
+    [doMove, selected],
+  );
+
+  // ---- Drag and drop -----------------------------------------------------
+  const dragRef = useRef<Source | null>(null);
+  const onDragStart = useCallback((src: Source) => {
+    dragRef.current = src;
+    setSelected(null);
+  }, []);
+  const onDrop = useCallback(
+    (dest: Destination) => {
+      const src = dragRef.current;
+      dragRef.current = null;
+      if (src) doMove(src, dest);
+    },
+    [doMove],
+  );
+
+  // ---- Auto-complete -----------------------------------------------------
+  const autoComplete = useCallback(() => {
+    setGame((start) => {
+      let cur: GameState | null = start;
+      let last = start;
+      let guard = 0;
+      while (cur && !isWon(cur) && guard < 80) {
+        const step = autoCompleteStep(cur);
+        if (!step) break;
+        last = step;
+        cur = step;
+        guard += 1;
+      }
+      if (last !== start) setHistory((h) => [...h.slice(-200), start]);
+      return last;
+    });
+    setSelected(null);
+  }, []);
+
+  // ---- Win handling ------------------------------------------------------
+  useEffect(() => {
+    if (!won || recordedWinRef.current) return;
+    recordedWinRef.current = true;
+    setRunning(false);
+    setStats((cur) => {
+      const time = elapsed;
+      const moves = game.moves;
+      const next: Stats = {
+        ...cur,
+        games_won: cur.games_won + 1,
+        best_time: cur.best_time === 0 ? time : Math.min(cur.best_time, time || cur.best_time),
+        best_moves: cur.best_moves === 0 ? moves : Math.min(cur.best_moves, moves || cur.best_moves),
+      };
+      void persistStats(next);
+      return next;
+    });
+  }, [won, elapsed, game.moves, persistStats]);
+
+  // ---- Keyboard ----------------------------------------------------------
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "z") {
+        e.preventDefault();
+        undo();
+      } else if (e.key === "Escape") {
+        setSelected(null);
+      } else if (e.key === " " || e.key === "Spacebar") {
+        if (game.stock.length > 0 || game.waste.length > 0) {
+          e.preventDefault();
+          handleDraw();
+        }
+      } else if (e.key.toLowerCase() === "n") {
+        startNewGame();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [game.stock.length, game.waste.length, handleDraw, startNewGame, undo]);
+
+  const showAutoComplete = useMemo(() => canAutoComplete(game), [game]);
+  const wasteTop = game.waste.length > 0 ? game.waste[game.waste.length - 1] : null;
+
+  return (
+    <main className="sol-app" data-reduced-ok>
+      <header className="sol-bar">
+        <div className="sol-brand">
+          <span className="sol-mark" aria-hidden="true">
+            <Sparkles size={16} />
+          </span>
+          <span>Matrix Solitaire</span>
+        </div>
+        <div className="sol-stats" aria-label="Game status">
+          <Stat label="Time" value={formatTime(elapsed)} />
+          <Stat label="Moves" value={String(game.moves)} />
+          <Stat label="Score" value={String(game.score)} />
+        </div>
+        <div className="sol-controls">
+          <div className="sol-segment" role="group" aria-label="Draw mode">
+            <button
+              type="button"
+              className={draw === 1 ? "seg seg--on" : "seg"}
+              onClick={() => setDrawMode(1)}
+            >
+              Draw 1
+            </button>
+            <button
+              type="button"
+              className={draw === 3 ? "seg seg--on" : "seg"}
+              onClick={() => setDrawMode(3)}
+            >
+              Draw 3
+            </button>
+          </div>
+          <button type="button" className="sol-btn" onClick={undo} disabled={history.length === 0} title="Undo (Cmd/Ctrl+Z)">
+            <Undo2 size={15} /> Undo
+          </button>
+          {showAutoComplete && !won && (
+            <button type="button" className="sol-btn sol-btn--accent" onClick={autoComplete} title="Auto-complete">
+              <Wand2 size={15} /> Auto
+            </button>
+          )}
+          <button type="button" className="sol-btn sol-btn--primary" onClick={() => startNewGame()} title="New game (N)">
+            <RotateCcw size={15} /> New game
+          </button>
+        </div>
+      </header>
+
+      {error && <div className="sol-toast" role="status">{error}</div>}
+
+      <section className="sol-table" aria-label="Solitaire board">
+        <div className="sol-top">
+          <div className="sol-deal">
+            {/* Stock */}
+            <button
+              type="button"
+              className="sol-slot sol-stock"
+              data-testid="stock"
+              aria-label={game.stock.length > 0 ? "Draw from stock" : "Recycle waste"}
+              onClick={handleDraw}
+            >
+              {game.stock.length > 0 ? (
+                <span className="sol-stock-back">{game.stock.length}</span>
+              ) : (
+                <span className="sol-recycle"><RotateCcw size={20} /></span>
+              )}
+            </button>
+            {/* Waste */}
+            <div className="sol-slot sol-waste" data-testid="waste">
+              {wasteTop ? (
+                <CardView
+                  card={wasteTop}
+                  selected={sourceEquals(selected, { type: "waste" })}
+                  draggable
+                  onActivate={() => handleCardActivate({ type: "waste" })}
+                  onSendFoundation={() => sendToFoundation({ type: "waste" })}
+                  onDragStart={() => onDragStart({ type: "waste" })}
+                />
+              ) : (
+                <span className="sol-empty-mark">♢</span>
+              )}
+            </div>
+          </div>
+
+          <div className="sol-foundations">
+            {game.foundations.map((pile, f) => {
+              const top = pile.length > 0 ? pile[pile.length - 1] : null;
+              return (
+                <div
+                  key={f}
+                  className="sol-slot sol-foundation"
+                  data-testid="foundation"
+                  onClick={() => handlePileActivate({ type: "foundation", pile: f })}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={() => onDrop({ type: "foundation", pile: f })}
+                >
+                  {top ? (
+                    <CardView
+                      card={top}
+                      draggable
+                      onActivate={() => handleCardActivate({ type: "foundation", pile: f })}
+                      onDragStart={() => onDragStart({ type: "foundation", pile: f })}
+                    />
+                  ) : (
+                    <span className="sol-empty-mark">A</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="sol-tableau">
+          {game.tableau.map((pile, t) => (
+            <div
+              key={t}
+              className="sol-col"
+              data-testid="tableau-pile"
+              onClick={() => {
+                if (pile.length === 0) handlePileActivate({ type: "tableau", pile: t });
+              }}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={() => onDrop({ type: "tableau", pile: t })}
+            >
+              {pile.length === 0 && <span className="sol-empty-mark sol-empty-mark--col">K</span>}
+              {pile.map((card, idx) => {
+                const src: Source = { type: "tableau", pile: t, index: idx };
+                return (
+                  <div
+                    className="sol-stacked"
+                    key={card.id}
+                    style={{ top: `calc(${idx} * var(--stack-step))` }}
+                  >
+                    <CardView
+                      card={card}
+                      selected={sourceEquals(selected, src)}
+                      draggable={card.faceUp}
+                      onActivate={() => card.faceUp && handleCardActivate(src)}
+                      onSendFoundation={() => idx === pile.length - 1 && sendToFoundation(src)}
+                      onDragStart={() => card.faceUp && onDragStart(src)}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {won && (
+        <div className="sol-win" role="dialog" aria-label="You won" data-testid="win-banner">
+          <div className="sol-confetti" aria-hidden="true">
+            {Array.from({ length: 24 }).map((_, i) => (
+              <i key={i} style={{ "--i": i } as React.CSSProperties} />
+            ))}
+          </div>
+          <div className="sol-win-card">
+            <Trophy size={34} />
+            <h2>You win!</h2>
+            <p>
+              {game.moves} moves · {formatTime(elapsed)} · {stats.games_won} total wins
+            </p>
+            <button type="button" className="sol-btn sol-btn--primary" onClick={() => startNewGame()}>
+              <RotateCcw size={15} /> Play again
+            </button>
+          </div>
+        </div>
+      )}
+
+      <footer className="sol-footer">
+        <span>
+          Won {stats.games_won}/{stats.games_played}
+        </span>
+        <span>Best time {formatTime(stats.best_time)}</span>
+        <span>Best moves {stats.best_moves || "--"}</span>
+        <span className="sol-hint">Double-click → foundation · Cmd/Ctrl+Z undo · N new</span>
+      </footer>
+    </main>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="sol-stat">
+      <span className="sol-stat-label">{label}</span>
+      <strong className="sol-stat-value">{value}</strong>
+    </div>
+  );
+}
+
+interface CardViewProps {
+  card: Card;
+  selected?: boolean;
+  draggable?: boolean;
+  onActivate?: () => void;
+  onSendFoundation?: () => void;
+  onDragStart?: () => void;
+}
+
+function CardView({ card, selected, draggable, onActivate, onSendFoundation, onDragStart }: CardViewProps) {
+  if (!card.faceUp) {
+    return <div className="sol-card sol-card--back" data-testid={`card-${card.id}`} aria-hidden="true" />;
+  }
+  const color = suitColor(card.suit);
+  const symbol = SUIT_SYMBOLS[card.suit];
+  const label = `${RANK_LABELS[card.rank]} of ${card.suit}`;
+  return (
+    <div
+      className={`sol-card sol-card--${color}${selected ? " sol-card--selected" : ""}`}
+      data-testid={`card-${card.id}`}
+      role="button"
+      tabIndex={0}
+      aria-label={label}
+      draggable={draggable}
+      onClick={(e) => {
+        e.stopPropagation();
+        onActivate?.();
+      }}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        onSendFoundation?.();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onActivate?.();
+        }
+      }}
+      onDragStart={(e) => {
+        e.dataTransfer?.setData("text/plain", card.id);
+        onDragStart?.();
+      }}
+    >
+      <span className="sol-corner sol-corner--tl">
+        <em>{RANK_LABELS[card.rank]}</em>
+        <i>{symbol}</i>
+      </span>
+      <span className="sol-pip" aria-hidden="true">
+        {symbol}
+      </span>
+      <span className="sol-corner sol-corner--br">
+        <em>{RANK_LABELS[card.rank]}</em>
+        <i>{symbol}</i>
+      </span>
+    </div>
+  );
+}
+
+function sourceEquals(a: Source | null, b: Source | null): boolean {
+  if (!a || !b) return false;
+  if (a.type !== b.type) return false;
+  if (a.type === "waste" && b.type === "waste") return true;
+  if (a.type === "foundation" && b.type === "foundation") return a.pile === b.pile;
+  if (a.type === "tableau" && b.type === "tableau") return a.pile === b.pile && a.index === b.index;
+  return false;
+}
+
+// When a selected source is clicked onto another card, treat that card's pile
+// as the destination.
+function sourceToDestination(src: Source): Destination | null {
+  if (src.type === "tableau") return { type: "tableau", pile: src.pile };
+  if (src.type === "foundation") return { type: "foundation", pile: src.pile };
+  return null;
+}

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -62,9 +62,11 @@ export default function App({ initialState }: AppProps) {
   const [history, setHistory] = useState<GameState[]>([]);
   const [stats, setStats] = useState<Stats>(EMPTY_STATS);
   const statsRef = useRef<Stats>(EMPTY_STATS);
+  const historyRef = useRef<GameState[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
   const [running, setRunning] = useState(!initialState);
+  const [statsLoaded, setStatsLoaded] = useState(false);
   const [selected, setSelected] = useState<Source | null>(null);
   const gameRef = useRef(game);
   const recordedWinRef = useRef(false);
@@ -72,6 +74,7 @@ export default function App({ initialState }: AppProps) {
   const statsLoadedRef = useRef(false);
   const statsRowIdRef = useRef<string | null>(null);
   const statsInsertRef = useRef<Promise<string> | null>(null);
+  const statsSaveQueueRef = useRef<Promise<void>>(Promise.resolve());
   const pendingGamesPlayedRef = useRef(0);
   const startedAtRef = useRef<number>(Date.now());
 
@@ -85,42 +88,51 @@ export default function App({ initialState }: AppProps) {
     statsRef.current = stats;
   }, [stats]);
 
+  useEffect(() => {
+    historyRef.current = history;
+  }, [history]);
+
   // ---- Stats persistence -------------------------------------------------
-  const persistStats = useCallback(async (next: Stats) => {
+  const persistStats = useCallback((next: Stats) => {
     statsRef.current = next;
     setStats(next);
     const db = window.MatrixOS?.db;
-    if (!db) return;
-    const payload = {
-      games_played: next.games_played,
-      games_won: next.games_won,
-      best_time: next.best_time,
-      best_moves: next.best_moves,
-    };
-    try {
-      const rowId = next.id ?? statsRowIdRef.current;
-      if (rowId) {
-        statsRowIdRef.current = rowId;
-        await db.update(STATS_TABLE, rowId, payload);
-      } else {
-        if (!statsInsertRef.current) {
-          statsInsertRef.current = db.insert(STATS_TABLE, payload)
-            .then((res) => {
-              statsRowIdRef.current = res.id;
-              setStats((cur) => ({ ...cur, id: res.id }));
-              return res.id;
-            })
-            .finally(() => {
-              statsInsertRef.current = null;
-            });
+    if (!db) return Promise.resolve();
+    const save = async () => {
+      const payload = {
+        games_played: next.games_played,
+        games_won: next.games_won,
+        best_time: next.best_time,
+        best_moves: next.best_moves,
+      };
+      try {
+        const rowId = next.id ?? statsRowIdRef.current;
+        if (rowId) {
+          statsRowIdRef.current = rowId;
+          await db.update(STATS_TABLE, rowId, payload);
+        } else {
+          if (!statsInsertRef.current) {
+            statsInsertRef.current = db.insert(STATS_TABLE, payload)
+              .then((res) => {
+                statsRowIdRef.current = res.id;
+                setStats((cur) => ({ ...cur, id: res.id }));
+                return res.id;
+              })
+              .finally(() => {
+                statsInsertRef.current = null;
+              });
+          }
+          const insertedId = await statsInsertRef.current;
+          await db.update(STATS_TABLE, insertedId, payload);
         }
-        const insertedId = await statsInsertRef.current;
-        await db.update(STATS_TABLE, insertedId, payload);
+      } catch (err: unknown) {
+        console.warn("[solitaire] stats save failed:", err instanceof Error ? err.message : String(err));
+        setError("Stats could not be saved to Matrix Postgres.");
       }
-    } catch (err: unknown) {
-      console.warn("[solitaire] stats save failed:", err instanceof Error ? err.message : String(err));
-      setError("Stats could not be saved to Matrix Postgres.");
-    }
+    };
+    const run = statsSaveQueueRef.current.then(save, save);
+    statsSaveQueueRef.current = run.catch(() => undefined);
+    return run;
   }, []);
 
   const loadStats = useCallback(async () => {
@@ -128,6 +140,7 @@ export default function App({ initialState }: AppProps) {
     if (!db) {
       setStats({ ...EMPTY_STATS });
       statsLoadedRef.current = true;
+      setStatsLoaded(true);
       return;
     }
     try {
@@ -146,6 +159,7 @@ export default function App({ initialState }: AppProps) {
       setStats({ ...EMPTY_STATS });
     }
     statsLoadedRef.current = true;
+    setStatsLoaded(true);
   }, []);
 
   useEffect(() => {
@@ -193,7 +207,7 @@ export default function App({ initialState }: AppProps) {
   }, [persistStats]);
 
   useEffect(() => {
-    if (!statsLoadedRef.current) return;
+    if (!statsLoaded) return;
     let increment = pendingGamesPlayedRef.current;
     pendingGamesPlayedRef.current = 0;
     if (!countedInitialGameRef.current) {
@@ -205,7 +219,7 @@ export default function App({ initialState }: AppProps) {
     const next = { ...cur, games_played: cur.games_played + increment };
     statsRef.current = next;
     void persistStats(next);
-  }, [persistStats, stats]);
+  }, [persistStats, statsLoaded]);
 
   // ---- Timer -------------------------------------------------------------
   useEffect(() => {
@@ -220,6 +234,7 @@ export default function App({ initialState }: AppProps) {
   const startNewGame = useCallback(
     (drawCount: 1 | 3 = draw) => {
       setGame(deal(Math.random, drawCount));
+      historyRef.current = [];
       setHistory([]);
       setSelected(null);
       setElapsed(0);
@@ -236,25 +251,36 @@ export default function App({ initialState }: AppProps) {
   const setDrawMode = useCallback((mode: 1 | 3) => {
     if (mode === draw) return;
     setDraw(mode);
-    void window.MatrixOS?.writeData?.(DRAW_PREF_KEY, mode).catch((err: unknown) => {
-      console.warn("[solitaire] draw preference save failed:", err instanceof Error ? err.message : String(err));
-    });
+    const writeData = window.MatrixOS?.writeData;
+    if (writeData) {
+      void writeData(DRAW_PREF_KEY, mode).catch((err: unknown) => {
+        console.warn("[solitaire] draw preference save failed:", err instanceof Error ? err.message : String(err));
+      });
+    }
     startNewGame(mode);
   }, [draw, startNewGame]);
 
   // ---- Move application with history -------------------------------------
   const commit = useCallback((next: GameState) => {
-    setHistory((h) => [...h.slice(-200), game]);
+    const nextHistory = [...historyRef.current.slice(-200), game];
+    historyRef.current = nextHistory;
+    setHistory(nextHistory);
     setGame(next);
   }, [game]);
 
   const undo = useCallback(() => {
     if (history.length === 0) return;
     const prev = history[history.length - 1];
-    setHistory(history.slice(0, -1));
+    const nextHistory = history.slice(0, -1);
+    historyRef.current = nextHistory;
+    setHistory(nextHistory);
     setGame(prev);
+    if (won) {
+      recordedWinRef.current = false;
+      setRunning(true);
+    }
     setSelected(null);
-  }, [history]);
+  }, [history, won]);
 
   const doMove = useCallback(
     (src: Source, dest: Destination) => {
@@ -354,7 +380,9 @@ export default function App({ initialState }: AppProps) {
       guard += 1;
     }
     if (last !== game) {
-      setHistory((h) => [...h.slice(-200), game]);
+      const nextHistory = [...historyRef.current.slice(-200), game];
+      historyRef.current = nextHistory;
+      setHistory(nextHistory);
       setGame(last);
     }
     setSelected(null);
@@ -496,6 +524,7 @@ export default function App({ initialState }: AppProps) {
                   {top ? (
                     <CardView
                       card={top}
+                      selected={sourceEquals(selected, { type: "foundation", pile: f })}
                       draggable
                       onActivate={() => handleCardActivate({ type: "foundation", pile: f })}
                       onDragStart={() => onDragStart({ type: "foundation", pile: f })}

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -380,6 +380,8 @@ export default function App({ initialState }: AppProps) {
       guard += 1;
     }
     if (last !== game) {
+      // Commit the whole auto-complete chain as one undo step so Undo returns
+      // to the user's pre-auto-complete board instead of each forced move.
       const nextHistory = [...historyRef.current.slice(-200), game];
       historyRef.current = nextHistory;
       setHistory(nextHistory);

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -20,8 +20,7 @@ import {
 } from "./solitaire-model";
 
 const STATS_TABLE = "stats";
-const LS_STATS_KEY = "matrix.solitaire.stats";
-const LS_DRAW_KEY = "matrix.solitaire.draw";
+const DRAW_PREF_KEY = "solitaire:draw-mode";
 
 interface Stats {
   id?: string;
@@ -46,25 +45,6 @@ function coerceStats(row: unknown): Stats {
   };
 }
 
-function loadLocalStats(): Stats {
-  try {
-    const raw = localStorage.getItem(LS_STATS_KEY);
-    if (!raw) return { ...EMPTY_STATS };
-    return coerceStats(JSON.parse(raw));
-  } catch (err: unknown) {
-    console.warn("[solitaire] local stats read failed:", err instanceof Error ? err.message : String(err));
-    return { ...EMPTY_STATS };
-  }
-}
-
-function saveLocalStats(stats: Stats): void {
-  try {
-    localStorage.setItem(LS_STATS_KEY, JSON.stringify(stats));
-  } catch (err: unknown) {
-    console.warn("[solitaire] local stats write failed:", err instanceof Error ? err.message : String(err));
-  }
-}
-
 function formatTime(seconds: number): string {
   if (!seconds || seconds < 0) return "--:--";
   const m = Math.floor(seconds / 60).toString().padStart(2, "0");
@@ -77,29 +57,31 @@ interface AppProps {
 }
 
 export default function App({ initialState }: AppProps) {
-  const [draw, setDraw] = useState<1 | 3>(() => {
-    try {
-      return localStorage.getItem(LS_DRAW_KEY) === "3" ? 3 : 1;
-    } catch {
-      return 1;
-    }
-  });
+  const [draw, setDraw] = useState<1 | 3>(1);
   const [game, setGame] = useState<GameState>(() => initialState ?? deal(Math.random, draw));
   const [history, setHistory] = useState<GameState[]>([]);
   const [stats, setStats] = useState<Stats>(EMPTY_STATS);
+  const statsRef = useRef<Stats>(EMPTY_STATS);
   const [error, setError] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
   const [running, setRunning] = useState(!initialState);
   const [selected, setSelected] = useState<Source | null>(null);
   const recordedWinRef = useRef(false);
+  const countedInitialGameRef = useRef(Boolean(initialState));
+  const statsLoadedRef = useRef(false);
+  const statsRowIdRef = useRef<string | null>(null);
+  const statsInsertRef = useRef<Promise<string> | null>(null);
   const startedAtRef = useRef<number>(Date.now());
 
   const won = isWon(game);
 
-  // ---- Stats persistence (DB with localStorage fallback) -----------------
+  useEffect(() => {
+    statsRef.current = stats;
+  }, [stats]);
+
+  // ---- Stats persistence -------------------------------------------------
   const persistStats = useCallback(async (next: Stats) => {
     setStats(next);
-    saveLocalStats(next);
     const db = window.MatrixOS?.db;
     if (!db) return;
     const payload = {
@@ -109,11 +91,24 @@ export default function App({ initialState }: AppProps) {
       best_moves: next.best_moves,
     };
     try {
-      if (next.id) {
-        await db.update(STATS_TABLE, next.id, payload);
+      const rowId = next.id ?? statsRowIdRef.current;
+      if (rowId) {
+        statsRowIdRef.current = rowId;
+        await db.update(STATS_TABLE, rowId, payload);
       } else {
-        const res = await db.insert(STATS_TABLE, payload);
-        if (res?.id) setStats((cur) => ({ ...cur, id: res.id }));
+        if (!statsInsertRef.current) {
+          statsInsertRef.current = db.insert(STATS_TABLE, payload)
+            .then((res) => {
+              statsRowIdRef.current = res.id;
+              setStats((cur) => ({ ...cur, id: res.id }));
+              return res.id;
+            })
+            .finally(() => {
+              statsInsertRef.current = null;
+            });
+        }
+        const insertedId = await statsInsertRef.current;
+        await db.update(STATS_TABLE, insertedId, payload);
       }
     } catch (err: unknown) {
       console.warn("[solitaire] stats save failed:", err instanceof Error ? err.message : String(err));
@@ -124,22 +119,26 @@ export default function App({ initialState }: AppProps) {
   const loadStats = useCallback(async () => {
     const db = window.MatrixOS?.db;
     if (!db) {
-      setStats(loadLocalStats());
+      setStats({ ...EMPTY_STATS });
+      statsLoadedRef.current = true;
       return;
     }
     try {
       const rows = await db.find(STATS_TABLE, { limit: 1, orderBy: { created_at: "desc" } });
       if (rows && rows.length > 0) {
-        setStats(coerceStats(rows[0]));
+        const loaded = coerceStats(rows[0]);
+        statsRowIdRef.current = loaded.id ?? null;
+        setStats(loaded);
       } else {
-        setStats(loadLocalStats());
+        setStats({ ...EMPTY_STATS });
       }
       setError(null);
     } catch (err: unknown) {
       console.warn("[solitaire] stats load failed:", err instanceof Error ? err.message : String(err));
-      setError("Stats could not be loaded; using local fallback.");
-      setStats(loadLocalStats());
+      setError("Stats could not be loaded.");
+      setStats({ ...EMPTY_STATS });
     }
+    statsLoadedRef.current = true;
   }, []);
 
   useEffect(() => {
@@ -147,6 +146,33 @@ export default function App({ initialState }: AppProps) {
     const db = window.MatrixOS?.db;
     return db?.onChange?.(STATS_TABLE, () => void loadStats());
   }, [loadStats]);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const value = await window.MatrixOS?.readData?.(DRAW_PREF_KEY);
+        if (!active) return;
+        if (value === 1 || value === 3) setDraw(value);
+      } catch (err: unknown) {
+        console.warn("[solitaire] draw preference load failed:", err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const recordGamePlayed = useCallback(() => {
+    const cur = statsRef.current;
+    void persistStats({ ...cur, games_played: cur.games_played + 1 });
+  }, [persistStats]);
+
+  useEffect(() => {
+    if (countedInitialGameRef.current || !statsLoadedRef.current) return;
+    countedInitialGameRef.current = true;
+    recordGamePlayed();
+  }, [recordGamePlayed, stats]);
 
   // ---- Timer -------------------------------------------------------------
   useEffect(() => {
@@ -168,44 +194,32 @@ export default function App({ initialState }: AppProps) {
       recordedWinRef.current = false;
       startedAtRef.current = Date.now();
       setRunning(true);
-      // count a played game
-      setStats((cur) => {
-        const next = { ...cur, games_played: cur.games_played + 1 };
-        void persistStats(next);
-        return next;
-      });
+      recordGamePlayed();
     },
-    [draw, persistStats],
+    [draw, recordGamePlayed],
   );
 
   const setDrawMode = useCallback((mode: 1 | 3) => {
     setDraw(mode);
-    try {
-      localStorage.setItem(LS_DRAW_KEY, String(mode));
-    } catch {
-      // non-fatal: preference persistence is best-effort
-      console.warn("[solitaire] could not persist draw preference");
-    }
+    void window.MatrixOS?.writeData?.(DRAW_PREF_KEY, mode).catch((err: unknown) => {
+      console.warn("[solitaire] draw preference save failed:", err instanceof Error ? err.message : String(err));
+    });
     startNewGame(mode);
   }, [startNewGame]);
 
   // ---- Move application with history -------------------------------------
   const commit = useCallback((next: GameState) => {
-    setGame((prev) => {
-      setHistory((h) => [...h.slice(-200), prev]);
-      return next;
-    });
-  }, []);
+    setHistory((h) => [...h.slice(-200), game]);
+    setGame(next);
+  }, [game]);
 
   const undo = useCallback(() => {
-    setHistory((h) => {
-      if (h.length === 0) return h;
-      const prev = h[h.length - 1];
-      setGame(prev);
-      setSelected(null);
-      return h.slice(0, -1);
-    });
-  }, []);
+    if (history.length === 0) return;
+    const prev = history[history.length - 1];
+    setHistory(history.slice(0, -1));
+    setGame(prev);
+    setSelected(null);
+  }, [history]);
 
   const doMove = useCallback(
     (src: Source, dest: Destination) => {
@@ -245,7 +259,10 @@ export default function App({ initialState }: AppProps) {
       if (selected) {
         // clicking the same selection clears it
         const dest = sourceToDestination(src);
-        if (dest && doMove(selected, dest)) return;
+        if (dest) {
+          if (doMove(selected, dest)) return;
+          return;
+        }
       }
       // otherwise auto-route this source to a legal destination
       const dest = findAutoDestination(game, src);
@@ -284,39 +301,36 @@ export default function App({ initialState }: AppProps) {
 
   // ---- Auto-complete -----------------------------------------------------
   const autoComplete = useCallback(() => {
-    setGame((start) => {
-      let cur: GameState | null = start;
-      let last = start;
-      let guard = 0;
-      while (cur && !isWon(cur) && guard < 80) {
-        const step = autoCompleteStep(cur);
-        if (!step) break;
-        last = step;
-        cur = step;
-        guard += 1;
-      }
-      if (last !== start) setHistory((h) => [...h.slice(-200), start]);
-      return last;
-    });
+    let cur: GameState | null = game;
+    let last = game;
+    let guard = 0;
+    while (cur && !isWon(cur) && guard < 80) {
+      const step = autoCompleteStep(cur);
+      if (!step) break;
+      last = step;
+      cur = step;
+      guard += 1;
+    }
+    if (last !== game) {
+      setHistory((h) => [...h.slice(-200), game]);
+      setGame(last);
+    }
     setSelected(null);
-  }, []);
+  }, [game]);
 
   // ---- Win handling ------------------------------------------------------
   useEffect(() => {
     if (!won || recordedWinRef.current) return;
     recordedWinRef.current = true;
     setRunning(false);
-    setStats((cur) => {
-      const time = elapsed;
-      const moves = game.moves;
-      const next: Stats = {
-        ...cur,
-        games_won: cur.games_won + 1,
-        best_time: cur.best_time === 0 ? time : Math.min(cur.best_time, time || cur.best_time),
-        best_moves: cur.best_moves === 0 ? moves : Math.min(cur.best_moves, moves || cur.best_moves),
-      };
-      void persistStats(next);
-      return next;
+    const cur = statsRef.current;
+    const time = elapsed;
+    const moves = game.moves;
+    void persistStats({
+      ...cur,
+      games_won: cur.games_won + 1,
+      best_time: cur.best_time === 0 ? time : Math.min(cur.best_time, time || cur.best_time),
+      best_moves: cur.best_moves === 0 ? moves : Math.min(cur.best_moves, moves || cur.best_moves),
     });
   }, [won, elapsed, game.moves, persistStats]);
 

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -259,6 +259,10 @@ export default function App({ initialState }: AppProps) {
       // If a source is already selected, attempt to use this click as a destination.
       if (selected) {
         // clicking the same selection clears it
+        if (sourceEquals(selected, src)) {
+          setSelected(null);
+          return;
+        }
         const dest = sourceToDestination(src);
         if (dest) {
           if (doMove(selected, dest)) return;

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -82,6 +82,7 @@ export default function App({ initialState }: AppProps) {
 
   // ---- Stats persistence -------------------------------------------------
   const persistStats = useCallback(async (next: Stats) => {
+    statsRef.current = next;
     setStats(next);
     const db = window.MatrixOS?.db;
     if (!db) return;
@@ -179,22 +180,25 @@ export default function App({ initialState }: AppProps) {
       return;
     }
     const cur = statsRef.current;
-    void persistStats({ ...cur, games_played: cur.games_played + 1 });
+    const next = { ...cur, games_played: cur.games_played + 1 };
+    statsRef.current = next;
+    void persistStats(next);
   }, [persistStats]);
 
   useEffect(() => {
-    if (!statsLoadedRef.current || pendingGamesPlayedRef.current === 0) return;
-    const pending = pendingGamesPlayedRef.current;
+    if (!statsLoadedRef.current) return;
+    let increment = pendingGamesPlayedRef.current;
     pendingGamesPlayedRef.current = 0;
+    if (!countedInitialGameRef.current) {
+      countedInitialGameRef.current = true;
+      increment += 1;
+    }
+    if (increment === 0) return;
     const cur = statsRef.current;
-    void persistStats({ ...cur, games_played: cur.games_played + pending });
+    const next = { ...cur, games_played: cur.games_played + increment };
+    statsRef.current = next;
+    void persistStats(next);
   }, [persistStats, stats]);
-
-  useEffect(() => {
-    if (countedInitialGameRef.current || !statsLoadedRef.current) return;
-    countedInitialGameRef.current = true;
-    recordGamePlayed();
-  }, [recordGamePlayed, stats]);
 
   // ---- Timer -------------------------------------------------------------
   useEffect(() => {

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -18,32 +18,8 @@ import {
   isWon,
   suitColor,
 } from "./solitaire-model";
-
-const STATS_TABLE = "stats";
+import { useSolitaireStats } from "./useSolitaireStats";
 const DRAW_PREF_KEY = "solitaire:draw-mode";
-
-interface Stats {
-  id?: string;
-  games_played: number;
-  games_won: number;
-  best_time: number; // seconds, 0 = none
-  best_moves: number; // 0 = none
-}
-
-const EMPTY_STATS: Stats = { games_played: 0, games_won: 0, best_time: 0, best_moves: 0 };
-
-function coerceStats(row: unknown): Stats {
-  if (!row || typeof row !== "object") return { ...EMPTY_STATS };
-  const r = row as Record<string, unknown>;
-  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : Number(v) || 0);
-  return {
-    id: typeof r.id === "string" ? r.id : undefined,
-    games_played: num(r.games_played),
-    games_won: num(r.games_won),
-    best_time: num(r.best_time),
-    best_moves: num(r.best_moves),
-  };
-}
 
 function formatTime(seconds: number): string {
   if (!seconds || seconds < 0) return "--:--";
@@ -60,23 +36,16 @@ export default function App({ initialState }: AppProps) {
   const [draw, setDraw] = useState<1 | 3>(1);
   const [game, setGame] = useState<GameState>(() => initialState ?? deal(Math.random, draw));
   const [history, setHistory] = useState<GameState[]>([]);
-  const [stats, setStats] = useState<Stats>(EMPTY_STATS);
-  const statsRef = useRef<Stats>(EMPTY_STATS);
   const historyRef = useRef<GameState[]>([]);
-  const [error, setError] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
   const [running, setRunning] = useState(!initialState);
-  const [statsLoaded, setStatsLoaded] = useState(false);
   const [selected, setSelected] = useState<Source | null>(null);
   const gameRef = useRef(game);
   const recordedWinRef = useRef(false);
-  const countedInitialGameRef = useRef(Boolean(initialState));
-  const statsLoadedRef = useRef(false);
-  const statsRowIdRef = useRef<string | null>(null);
-  const statsInsertRef = useRef<Promise<string> | null>(null);
-  const statsSaveQueueRef = useRef<Promise<void>>(Promise.resolve());
-  const pendingGamesPlayedRef = useRef(0);
   const startedAtRef = useRef<number>(Date.now());
+  const { stats, error, clearStatsError, recordGamePlayed, recordWin } = useSolitaireStats({
+    countInitialGame: Boolean(initialState),
+  });
 
   const won = isWon(game);
 
@@ -85,88 +54,8 @@ export default function App({ initialState }: AppProps) {
   }, [game]);
 
   useEffect(() => {
-    statsRef.current = stats;
-  }, [stats]);
-
-  useEffect(() => {
     historyRef.current = history;
   }, [history]);
-
-  // ---- Stats persistence -------------------------------------------------
-  const persistStats = useCallback((next: Stats) => {
-    statsRef.current = next;
-    setStats(next);
-    const db = window.MatrixOS?.db;
-    if (!db) return Promise.resolve();
-    const save = async () => {
-      const payload = {
-        games_played: next.games_played,
-        games_won: next.games_won,
-        best_time: next.best_time,
-        best_moves: next.best_moves,
-      };
-      try {
-        const rowId = next.id ?? statsRowIdRef.current;
-        if (rowId) {
-          statsRowIdRef.current = rowId;
-          await db.update(STATS_TABLE, rowId, payload);
-        } else {
-          if (!statsInsertRef.current) {
-            statsInsertRef.current = db.insert(STATS_TABLE, payload)
-              .then((res) => {
-                statsRowIdRef.current = res.id;
-                setStats((cur) => ({ ...cur, id: res.id }));
-                return res.id;
-              })
-              .finally(() => {
-                statsInsertRef.current = null;
-              });
-          }
-          const insertedId = await statsInsertRef.current;
-          await db.update(STATS_TABLE, insertedId, payload);
-        }
-      } catch (err: unknown) {
-        console.warn("[solitaire] stats save failed:", err instanceof Error ? err.message : String(err));
-        setError("Stats could not be saved to Matrix Postgres.");
-      }
-    };
-    const run = statsSaveQueueRef.current.then(save, save);
-    statsSaveQueueRef.current = run.catch(() => undefined);
-    return run;
-  }, []);
-
-  const loadStats = useCallback(async () => {
-    const db = window.MatrixOS?.db;
-    if (!db) {
-      setStats({ ...EMPTY_STATS });
-      statsLoadedRef.current = true;
-      setStatsLoaded(true);
-      return;
-    }
-    try {
-      const rows = await db.find(STATS_TABLE, { limit: 1 });
-      if (rows && rows.length > 0) {
-        const loaded = coerceStats(rows[0]);
-        statsRowIdRef.current = loaded.id ?? null;
-        setStats(loaded);
-      } else {
-        setStats({ ...EMPTY_STATS });
-      }
-      setError(null);
-    } catch (err: unknown) {
-      console.warn("[solitaire] stats load failed:", err instanceof Error ? err.message : String(err));
-      setError("Stats could not be loaded.");
-      setStats({ ...EMPTY_STATS });
-    }
-    statsLoadedRef.current = true;
-    setStatsLoaded(true);
-  }, []);
-
-  useEffect(() => {
-    void loadStats();
-    const db = window.MatrixOS?.db;
-    return db?.onChange?.(STATS_TABLE, () => void loadStats());
-  }, [loadStats]);
 
   useEffect(() => {
     let active = true;
@@ -195,32 +84,6 @@ export default function App({ initialState }: AppProps) {
     };
   }, [initialState]);
 
-  const recordGamePlayed = useCallback(() => {
-    if (!statsLoadedRef.current) {
-      pendingGamesPlayedRef.current += 1;
-      return;
-    }
-    const cur = statsRef.current;
-    const next = { ...cur, games_played: cur.games_played + 1 };
-    statsRef.current = next;
-    void persistStats(next);
-  }, [persistStats]);
-
-  useEffect(() => {
-    if (!statsLoaded) return;
-    let increment = pendingGamesPlayedRef.current;
-    pendingGamesPlayedRef.current = 0;
-    if (!countedInitialGameRef.current) {
-      countedInitialGameRef.current = true;
-      increment += 1;
-    }
-    if (increment === 0) return;
-    const cur = statsRef.current;
-    const next = { ...cur, games_played: cur.games_played + increment };
-    statsRef.current = next;
-    void persistStats(next);
-  }, [persistStats, statsLoaded]);
-
   // ---- Timer -------------------------------------------------------------
   useEffect(() => {
     if (!running || won) return undefined;
@@ -238,14 +101,13 @@ export default function App({ initialState }: AppProps) {
       setHistory([]);
       setSelected(null);
       setElapsed(0);
-      setError(null);
+      clearStatsError();
       recordedWinRef.current = false;
-      countedInitialGameRef.current = true;
       startedAtRef.current = Date.now();
       setRunning(true);
       recordGamePlayed();
     },
-    [draw, recordGamePlayed],
+    [clearStatsError, draw, recordGamePlayed],
   );
 
   const setDrawMode = useCallback((mode: 1 | 3) => {
@@ -400,16 +262,9 @@ export default function App({ initialState }: AppProps) {
     if (!won || recordedWinRef.current) return;
     recordedWinRef.current = true;
     setRunning(false);
-    const cur = statsRef.current;
     const time = Math.floor((Date.now() - startedAtRef.current) / 1000);
-    const moves = game.moves;
-    void persistStats({
-      ...cur,
-      games_won: cur.games_won + 1,
-      best_time: cur.best_time === 0 ? time : Math.min(cur.best_time, time || cur.best_time),
-      best_moves: cur.best_moves === 0 ? moves : Math.min(cur.best_moves, moves || cur.best_moves),
-    });
-  }, [won, game.moves, persistStats]);
+    recordWin(time, game.moves);
+  }, [won, game.moves, recordWin]);
 
   // ---- Keyboard ----------------------------------------------------------
   useEffect(() => {

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -234,12 +234,13 @@ export default function App({ initialState }: AppProps) {
   );
 
   const setDrawMode = useCallback((mode: 1 | 3) => {
+    if (mode === draw) return;
     setDraw(mode);
     void window.MatrixOS?.writeData?.(DRAW_PREF_KEY, mode).catch((err: unknown) => {
       console.warn("[solitaire] draw preference save failed:", err instanceof Error ? err.message : String(err));
     });
     startNewGame(mode);
-  }, [startNewGame]);
+  }, [draw, startNewGame]);
 
   // ---- Move application with history -------------------------------------
   const commit = useCallback((next: GameState) => {

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -311,7 +311,12 @@ export default function App({ initialState }: AppProps) {
   const handleDraw = useCallback(() => {
     setSelected(null);
     if (game.stock.length === 0 && game.waste.length === 0) return;
-    commit(drawFromStock(game));
+    const next = drawFromStock(game);
+    if (game.stock.length === 0) {
+      setGame(next);
+      return;
+    }
+    commit(next);
   }, [commit, game]);
 
   // ---- Click-to-move (auto route) ----------------------------------------
@@ -396,7 +401,7 @@ export default function App({ initialState }: AppProps) {
     recordedWinRef.current = true;
     setRunning(false);
     const cur = statsRef.current;
-    const time = elapsed;
+    const time = Math.floor((Date.now() - startedAtRef.current) / 1000);
     const moves = game.moves;
     void persistStats({
       ...cur,
@@ -404,7 +409,7 @@ export default function App({ initialState }: AppProps) {
       best_time: cur.best_time === 0 ? time : Math.min(cur.best_time, time || cur.best_time),
       best_moves: cur.best_moves === 0 ? moves : Math.min(cur.best_moves, moves || cur.best_moves),
     });
-  }, [won, elapsed, game.moves, persistStats]);
+  }, [won, game.moves, persistStats]);
 
   // ---- Keyboard ----------------------------------------------------------
   useEffect(() => {

--- a/home/apps/games/solitaire/src/App.tsx
+++ b/home/apps/games/solitaire/src/App.tsx
@@ -249,6 +249,7 @@ export default function App({ initialState }: AppProps) {
 
   const handleDraw = useCallback(() => {
     setSelected(null);
+    if (game.stock.length === 0 && game.waste.length === 0) return;
     commit(drawFromStock(game));
   }, [commit, game]);
 

--- a/home/apps/games/solitaire/src/main.tsx
+++ b/home/apps/games/solitaire/src/main.tsx
@@ -1,3 +1,12 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("solitaire" as const);
+const root = document.getElementById("root");
+if (root) {
+  createRoot(root).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/home/apps/games/solitaire/src/main.tsx
+++ b/home/apps/games/solitaire/src/main.tsx
@@ -1,12 +1,3 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App";
+import { renderDefaultApp } from "../../../_shared/default-apps";
 
-const root = document.getElementById("root");
-if (root) {
-  createRoot(root).render(
-    <StrictMode>
-      <App />
-    </StrictMode>,
-  );
-}
+renderDefaultApp("solitaire" as const);

--- a/home/apps/games/solitaire/src/matrix-os.d.ts
+++ b/home/apps/games/solitaire/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/games/solitaire/src/solitaire-model.ts
+++ b/home/apps/games/solitaire/src/solitaire-model.ts
@@ -284,9 +284,10 @@ export function applyMove(state: GameState, src: Source, dest: Destination): Gam
 // Find a legal destination for a click on a given source. Prefers foundation
 // for a single top card, then any legal tableau pile.
 export function findAutoDestination(state: GameState, src: Source): Destination | null {
+  if (src.type === "foundation") return null;
+
   const isSingleTop =
     (src.type === "waste") ||
-    (src.type === "foundation") ||
     (src.type === "tableau" && src.index === state.tableau[src.pile].length - 1);
 
   if (isSingleTop) {
@@ -329,7 +330,6 @@ export function autoMoveToFoundation(state: GameState, src: Source): GameState |
 export function canAutoComplete(state: GameState): boolean {
   if (isWon(state)) return false;
   if (state.stock.length > 0) return false;
-  if (state.waste.length > 1) return false;
   for (const pile of state.tableau) {
     for (const card of pile) {
       if (!card.faceUp) return false;

--- a/home/apps/games/solitaire/src/solitaire-model.ts
+++ b/home/apps/games/solitaire/src/solitaire-model.ts
@@ -232,9 +232,9 @@ function scoreFor(src: Source, dest: Destination): number {
 export function isLegalMove(state: GameState, src: Source, dest: Destination): boolean {
   // Foundations only accept single cards.
   if (dest.type === "foundation") {
+    if (src.type === "foundation") return false;
     let moving: Card | undefined;
     if (src.type === "waste") moving = topOf(state.waste);
-    else if (src.type === "foundation") moving = topOf(state.foundations[src.pile]);
     else {
       const pile = state.tableau[src.pile];
       // a foundation move from tableau must be the single bottom-most face-up card

--- a/home/apps/games/solitaire/src/solitaire-model.ts
+++ b/home/apps/games/solitaire/src/solitaire-model.ts
@@ -197,7 +197,7 @@ export function drawFromStock(state: GameState): GameState {
   if (s.stock.length === 0) {
     // recycle waste back into stock (reversed, face-down)
     if (s.waste.length === 0) return state; // nothing to do
-    s.stock = s.waste.reverse().map((c) => ({ ...c, faceUp: false }));
+    s.stock = s.waste.slice().reverse().map((c) => ({ ...c, faceUp: false }));
     s.waste = [];
     s.moves += 1;
     return s;

--- a/home/apps/games/solitaire/src/solitaire-model.ts
+++ b/home/apps/games/solitaire/src/solitaire-model.ts
@@ -335,7 +335,7 @@ export function canAutoComplete(state: GameState): boolean {
       if (!card.faceUp) return false;
     }
   }
-  return true;
+  return autoCompleteStep(state) !== null;
 }
 
 // Perform one auto-complete step: send the lowest available top card to a

--- a/home/apps/games/solitaire/src/solitaire-model.ts
+++ b/home/apps/games/solitaire/src/solitaire-model.ts
@@ -1,0 +1,372 @@
+// Pure Klondike Solitaire engine — UI-free, deterministic, unit-testable.
+// All randomness is injected via an RNG `() => number` (0 <= n < 1).
+
+export type Suit = "spades" | "hearts" | "diamonds" | "clubs";
+export type Color = "red" | "black";
+
+export interface Card {
+  id: string; // stable id, e.g. "spades-1"
+  suit: Suit;
+  rank: number; // 1 (Ace) .. 13 (King)
+  faceUp: boolean;
+}
+
+// Tableau piles: 7. Foundation piles: 4 (one per suit, by index but suit-agnostic).
+export interface GameState {
+  stock: Card[]; // face-down draw pile (top = last element)
+  waste: Card[]; // face-up discard (top = last element)
+  foundations: Card[][]; // 4 piles, ascending same-suit
+  tableau: Card[][]; // 7 piles
+  drawCount: 1 | 3; // draw 1 or draw 3
+  moves: number;
+  score: number;
+}
+
+export const SUITS: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+export const RED_SUITS: Suit[] = ["hearts", "diamonds"];
+
+export function suitColor(suit: Suit): Color {
+  return suit === "hearts" || suit === "diamonds" ? "red" : "black";
+}
+
+export const RANK_LABELS: Record<number, string> = {
+  1: "A",
+  2: "2",
+  3: "3",
+  4: "4",
+  5: "5",
+  6: "6",
+  7: "7",
+  8: "8",
+  9: "9",
+  10: "10",
+  11: "J",
+  12: "Q",
+  13: "K",
+};
+
+export const SUIT_SYMBOLS: Record<Suit, string> = {
+  spades: "♠",
+  hearts: "♥",
+  diamonds: "♦",
+  clubs: "♣",
+};
+
+// ---- Deck -----------------------------------------------------------------
+
+export function buildDeck(): Card[] {
+  const deck: Card[] = [];
+  for (const suit of SUITS) {
+    for (let rank = 1; rank <= 13; rank += 1) {
+      deck.push({ id: `${suit}-${rank}`, suit, rank, faceUp: false });
+    }
+  }
+  return deck;
+}
+
+// Fisher–Yates with an injectable RNG.
+export function shuffle<T>(items: T[], rng: () => number): T[] {
+  const arr = items.slice();
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr;
+}
+
+// ---- Deal -----------------------------------------------------------------
+
+// Klondike deal: 7 tableau piles, pile i gets i+1 cards, top card face-up,
+// 28 cards total in the tableau, rest into the stock face-down.
+export function deal(rng: () => number, drawCount: 1 | 3 = 1): GameState {
+  const deck = shuffle(buildDeck(), rng);
+  const tableau: Card[][] = [[], [], [], [], [], [], []];
+  let idx = 0;
+  for (let pile = 0; pile < 7; pile += 1) {
+    for (let n = 0; n <= pile; n += 1) {
+      const card = { ...deck[idx] };
+      card.faceUp = n === pile; // only last card face-up
+      tableau[pile].push(card);
+      idx += 1;
+    }
+  }
+  const stock = deck.slice(idx).map((c) => ({ ...c, faceUp: false }));
+  return {
+    stock,
+    waste: [],
+    foundations: [[], [], [], []],
+    tableau,
+    drawCount,
+    moves: 0,
+    score: 0,
+  };
+}
+
+// ---- Helpers --------------------------------------------------------------
+
+export function cloneState(s: GameState): GameState {
+  return {
+    stock: s.stock.map((c) => ({ ...c })),
+    waste: s.waste.map((c) => ({ ...c })),
+    foundations: s.foundations.map((p) => p.map((c) => ({ ...c }))),
+    tableau: s.tableau.map((p) => p.map((c) => ({ ...c }))),
+    drawCount: s.drawCount,
+    moves: s.moves,
+    score: s.score,
+  };
+}
+
+function topOf(pile: Card[]): Card | undefined {
+  return pile.length > 0 ? pile[pile.length - 1] : undefined;
+}
+
+// ---- Legality -------------------------------------------------------------
+
+// A card may stack on a tableau pile if alternating color + descending rank,
+// or the pile is empty and the moving card is a King.
+export function canStackOnTableau(moving: Card, pile: Card[]): boolean {
+  const top = topOf(pile);
+  if (!top) return moving.rank === 13; // only Kings to empty
+  if (!top.faceUp) return false;
+  return suitColor(moving.suit) !== suitColor(top.suit) && moving.rank === top.rank - 1;
+}
+
+// A card may go to a foundation pile if it is an Ace onto an empty pile, or
+// the same suit and exactly one rank higher than the foundation's top card.
+export function canMoveToFoundation(moving: Card, pile: Card[]): boolean {
+  const top = topOf(pile);
+  if (!top) return moving.rank === 1; // Ace starts a foundation
+  return moving.suit === top.suit && moving.rank === top.rank + 1;
+}
+
+// Is a run of face-up tableau cards starting at index `start` a valid movable
+// sequence (alternating color, descending)?
+export function isMovableRun(pile: Card[], start: number): boolean {
+  if (start < 0 || start >= pile.length) return false;
+  for (let i = start; i < pile.length; i += 1) {
+    if (!pile[i].faceUp) return false;
+    if (i > start) {
+      const prev = pile[i - 1];
+      const cur = pile[i];
+      if (suitColor(prev.suit) === suitColor(cur.suit) || cur.rank !== prev.rank - 1) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// ---- Move sources ---------------------------------------------------------
+
+export type Source =
+  | { type: "waste" }
+  | { type: "foundation"; pile: number }
+  | { type: "tableau"; pile: number; index: number };
+
+function flipExposed(pile: Card[]): boolean {
+  const top = topOf(pile);
+  if (top && !top.faceUp) {
+    top.faceUp = true;
+    return true;
+  }
+  return false;
+}
+
+function takeFromSource(s: GameState, src: Source): Card[] | null {
+  if (src.type === "waste") {
+    const c = s.waste.pop();
+    return c ? [c] : null;
+  }
+  if (src.type === "foundation") {
+    const c = s.foundations[src.pile].pop();
+    return c ? [c] : null;
+  }
+  // tableau run from index to end
+  const pile = s.tableau[src.pile];
+  if (src.index < 0 || src.index >= pile.length) return null;
+  if (!isMovableRun(pile, src.index)) return null;
+  return pile.splice(src.index);
+}
+
+// ---- Draw / recycle -------------------------------------------------------
+
+export function drawFromStock(state: GameState): GameState {
+  const s = cloneState(state);
+  if (s.stock.length === 0) {
+    // recycle waste back into stock (reversed, face-down)
+    if (s.waste.length === 0) return state; // nothing to do
+    s.stock = s.waste.reverse().map((c) => ({ ...c, faceUp: false }));
+    s.waste = [];
+    s.moves += 1;
+    return s;
+  }
+  const n = Math.min(s.drawCount, s.stock.length);
+  for (let i = 0; i < n; i += 1) {
+    const c = s.stock.pop();
+    if (c) {
+      c.faceUp = true;
+      s.waste.push(c);
+    }
+  }
+  s.moves += 1;
+  return s;
+}
+
+// ---- Apply a move ---------------------------------------------------------
+
+// Destination is either a tableau pile or a foundation pile.
+export type Destination =
+  | { type: "tableau"; pile: number }
+  | { type: "foundation"; pile: number };
+
+function scoreFor(src: Source, dest: Destination): number {
+  // Microsoft-style standard scoring (subset).
+  if (dest.type === "foundation") return 10;
+  if (src.type === "waste" && dest.type === "tableau") return 5;
+  if (src.type === "foundation" && dest.type === "tableau") return -15;
+  return 0;
+}
+
+export function isLegalMove(state: GameState, src: Source, dest: Destination): boolean {
+  // Foundations only accept single cards.
+  if (dest.type === "foundation") {
+    let moving: Card | undefined;
+    if (src.type === "waste") moving = topOf(state.waste);
+    else if (src.type === "foundation") moving = topOf(state.foundations[src.pile]);
+    else {
+      const pile = state.tableau[src.pile];
+      // a foundation move from tableau must be the single bottom-most face-up card
+      if (src.index !== pile.length - 1) return false;
+      moving = topOf(pile);
+    }
+    if (!moving || !moving.faceUp) return false;
+    return canMoveToFoundation(moving, state.foundations[dest.pile]);
+  }
+  // tableau destination
+  let movingFirst: Card | undefined;
+  if (src.type === "waste") movingFirst = topOf(state.waste);
+  else if (src.type === "foundation") movingFirst = topOf(state.foundations[src.pile]);
+  else {
+    const pile = state.tableau[src.pile];
+    if (!isMovableRun(pile, src.index)) return false;
+    movingFirst = pile[src.index];
+  }
+  if (!movingFirst || !movingFirst.faceUp) return false;
+  // Cannot move onto the same tableau pile
+  if (src.type === "tableau" && src.pile === dest.pile) return false;
+  return canStackOnTableau(movingFirst, state.tableau[dest.pile]);
+}
+
+// Apply a move, returning a new state, or null if illegal.
+export function applyMove(state: GameState, src: Source, dest: Destination): GameState | null {
+  if (!isLegalMove(state, src, dest)) return null;
+  const s = cloneState(state);
+  const cards = takeFromSource(s, src);
+  if (!cards) return null;
+  if (dest.type === "foundation") {
+    s.foundations[dest.pile].push(cards[0]);
+  } else {
+    s.tableau[dest.pile].push(...cards);
+  }
+  // flip the newly exposed tableau card under the source
+  if (src.type === "tableau") {
+    flipExposed(s.tableau[src.pile]);
+  }
+  s.moves += 1;
+  s.score = Math.max(0, s.score + scoreFor(src, dest));
+  return s;
+}
+
+// ---- Auto-route -----------------------------------------------------------
+
+// Find a legal destination for a click on a given source. Prefers foundation
+// for a single top card, then any legal tableau pile.
+export function findAutoDestination(state: GameState, src: Source): Destination | null {
+  const isSingleTop =
+    (src.type === "waste") ||
+    (src.type === "foundation") ||
+    (src.type === "tableau" && src.index === state.tableau[src.pile].length - 1);
+
+  if (isSingleTop) {
+    for (let f = 0; f < 4; f += 1) {
+      if (isLegalMove(state, src, { type: "foundation", pile: f })) {
+        return { type: "foundation", pile: f };
+      }
+    }
+  }
+  for (let t = 0; t < 7; t += 1) {
+    if (isLegalMove(state, src, { type: "tableau", pile: t })) {
+      // Prefer non-empty piles so we don't waste a King slot needlessly,
+      // but still allow empty as a fallback (handled by ordering below).
+      const dest: Destination = { type: "tableau", pile: t };
+      if (state.tableau[t].length > 0) return dest;
+    }
+  }
+  // empty tableau fallback
+  for (let t = 0; t < 7; t += 1) {
+    if (state.tableau[t].length === 0 && isLegalMove(state, src, { type: "tableau", pile: t })) {
+      return { type: "tableau", pile: t };
+    }
+  }
+  return null;
+}
+
+// Send a single card to a foundation if legal; returns new state or null.
+export function autoMoveToFoundation(state: GameState, src: Source): GameState | null {
+  for (let f = 0; f < 4; f += 1) {
+    const next = applyMove(state, src, { type: "foundation", pile: f });
+    if (next) return next;
+  }
+  return null;
+}
+
+// ---- Auto-complete --------------------------------------------------------
+
+// True when every card is face-up (stock+waste empty or fully exposed): the
+// game is mechanically solved and can auto-finish to the foundations.
+export function canAutoComplete(state: GameState): boolean {
+  if (isWon(state)) return false;
+  if (state.stock.length > 0) return false;
+  if (state.waste.length > 1) return false;
+  for (const pile of state.tableau) {
+    for (const card of pile) {
+      if (!card.faceUp) return false;
+    }
+  }
+  return true;
+}
+
+// Perform one auto-complete step: send the lowest available top card to a
+// foundation. Returns the next state, or null if no move is available.
+export function autoCompleteStep(state: GameState): GameState | null {
+  const candidates: Source[] = [];
+  if (state.waste.length > 0) candidates.push({ type: "waste" });
+  for (let t = 0; t < 7; t += 1) {
+    const pile = state.tableau[t];
+    if (pile.length > 0) candidates.push({ type: "tableau", pile: t, index: pile.length - 1 });
+  }
+  // choose the candidate with the lowest rank that has a legal foundation move
+  let best: { src: Source; rank: number } | null = null;
+  for (const src of candidates) {
+    let card: Card | undefined;
+    if (src.type === "waste") card = topOf(state.waste);
+    else if (src.type === "tableau") card = topOf(state.tableau[src.pile]);
+    if (!card) continue;
+    for (let f = 0; f < 4; f += 1) {
+      if (isLegalMove(state, src, { type: "foundation", pile: f })) {
+        if (!best || card.rank < best.rank) best = { src, rank: card.rank };
+        break;
+      }
+    }
+  }
+  if (!best) return null;
+  return autoMoveToFoundation(state, best.src);
+}
+
+// ---- Win ------------------------------------------------------------------
+
+export function isWon(state: GameState): boolean {
+  return state.foundations.every((pile) => pile.length === 13);
+}

--- a/home/apps/games/solitaire/src/styles.css
+++ b/home/apps/games/solitaire/src/styles.css
@@ -1,0 +1,470 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+
+  /* Card geometry */
+  --card-w: clamp(46px, 9.4vw, 86px);
+  --card-h: calc(var(--card-w) * 1.4);
+  --card-radius: clamp(6px, 1vw, 10px);
+  --stack-step: calc(var(--card-h) * 0.27);
+  --felt: #2f6b46;
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  font-family: var(--app-font);
+  color: var(--app-fg);
+  background: var(--app-bg);
+}
+
+.sol-app {
+  position: relative;
+  height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(140% 120% at 50% -20%, color-mix(in srgb, var(--app-accent) 7%, transparent), transparent 55%),
+    var(--app-bg);
+  overflow: hidden;
+}
+
+/* ---- Top bar ----------------------------------------------------------- */
+.sol-bar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px clamp(12px, 2.4vw, 22px);
+  flex-wrap: wrap;
+}
+.sol-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+.sol-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--app-accent) 16%, transparent);
+  color: var(--app-accent);
+}
+.sol-stats {
+  display: flex;
+  gap: 8px;
+  margin-left: 4px;
+}
+.sol-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 58px;
+  padding: 5px 10px;
+  background: var(--app-card);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+.sol-stat-label {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--app-muted-fg);
+}
+.sol-stat-value {
+  font-size: 17px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+.sol-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+.sol-segment {
+  display: inline-flex;
+  background: var(--app-muted);
+  border-radius: 11px;
+  padding: 2px;
+}
+.seg {
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--app-muted-fg);
+  padding: 6px 11px;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.seg--on {
+  background: var(--app-card);
+  color: var(--app-fg);
+  box-shadow: 0 2px 6px rgba(50, 53, 46, 0.1);
+}
+.sol-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  border-radius: 12px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  background: var(--app-muted);
+  color: var(--app-fg);
+  transition: all 0.15s ease;
+}
+.sol-btn:hover {
+  background: color-mix(in srgb, var(--app-fg) 8%, var(--app-muted));
+}
+.sol-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.sol-btn--primary {
+  background: var(--app-primary);
+  color: var(--app-primary-fg);
+}
+.sol-btn--primary:hover {
+  filter: brightness(1.06);
+  background: var(--app-primary);
+}
+.sol-btn--accent {
+  background: var(--app-accent);
+  color: #fff;
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--app-accent) 30%, transparent);
+}
+.sol-btn--accent:hover {
+  filter: brightness(1.06);
+  background: var(--app-accent);
+}
+.sol-btn:focus-visible,
+.seg:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+.sol-toast {
+  margin: 0 clamp(12px, 2.4vw, 22px);
+  padding: 8px 14px;
+  font-size: 12px;
+  border-radius: 12px;
+  color: var(--app-danger);
+  background: color-mix(in srgb, var(--app-danger) 10%, transparent);
+}
+
+/* ---- Felt table -------------------------------------------------------- */
+.sol-table {
+  flex: 1;
+  margin: 4px clamp(10px, 2vw, 22px) 0;
+  padding: clamp(12px, 2vw, 22px);
+  border-radius: var(--app-radius);
+  background:
+    radial-gradient(120% 80% at 50% 0%, color-mix(in srgb, #ffffff 10%, var(--felt)), transparent 60%),
+    var(--felt);
+  box-shadow: inset 0 2px 18px rgba(0, 0, 0, 0.28), 0 10px 30px rgba(50, 53, 46, 0.16);
+  overflow: auto;
+  user-select: none;
+}
+
+.sol-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: clamp(14px, 2.6vw, 26px);
+}
+.sol-deal,
+.sol-foundations {
+  display: flex;
+  gap: clamp(6px, 1.4vw, 14px);
+}
+
+.sol-slot {
+  width: var(--card-w);
+  height: var(--card-h);
+  border-radius: var(--card-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.sol-foundation,
+.sol-waste,
+.sol-stock {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1.5px solid rgba(255, 255, 255, 0.22);
+}
+.sol-stock {
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  background: rgba(255, 255, 255, 0.06);
+  transition: all 0.15s ease;
+}
+.sol-stock:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+.sol-stock-back {
+  position: absolute;
+  inset: 4px;
+  border-radius: calc(var(--card-radius) - 2px);
+  background:
+    repeating-linear-gradient(45deg, color-mix(in srgb, var(--app-primary) 80%, #1d231a) 0 6px, color-mix(in srgb, var(--app-primary) 60%, #2a3322) 6px 12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 800;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+.sol-recycle {
+  color: rgba(255, 255, 255, 0.55);
+}
+.sol-empty-mark {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: clamp(18px, 4vw, 30px);
+  font-weight: 700;
+}
+.sol-empty-mark--col {
+  margin-top: 4px;
+}
+
+.sol-foundation {
+  cursor: pointer;
+}
+
+/* ---- Tableau ----------------------------------------------------------- */
+.sol-tableau {
+  display: grid;
+  grid-template-columns: repeat(7, var(--card-w));
+  gap: clamp(6px, 1.4vw, 14px);
+  justify-content: space-between;
+}
+.sol-col {
+  position: relative;
+  width: var(--card-w);
+  min-height: var(--card-h);
+}
+.sol-col .sol-empty-mark {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1.5px dashed rgba(255, 255, 255, 0.18);
+  border-radius: var(--card-radius);
+}
+.sol-stacked {
+  position: absolute;
+  left: 0;
+  width: var(--card-w);
+}
+
+/* ---- Card -------------------------------------------------------------- */
+.sol-card {
+  position: relative;
+  width: var(--card-w);
+  height: var(--card-h);
+  border-radius: var(--card-radius);
+  background: var(--app-card);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+  overflow: hidden;
+}
+.sol-card:hover {
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.4);
+}
+.sol-card--selected {
+  outline: 2.5px solid var(--app-accent);
+  outline-offset: -1px;
+  transform: translateY(-3px);
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--app-accent) 40%, rgba(0, 0, 0, 0.4));
+}
+.sol-card:focus-visible {
+  outline: 2.5px solid var(--app-accent);
+  outline-offset: 1px;
+}
+.sol-card--red {
+  color: var(--app-danger);
+}
+.sol-card--black {
+  color: #1c1f1a;
+}
+.sol-card--back {
+  background:
+    repeating-linear-gradient(45deg, color-mix(in srgb, var(--app-primary) 78%, #1d231a) 0 6px, color-mix(in srgb, var(--app-primary) 58%, #2a3322) 6px 12px);
+  cursor: default;
+}
+.sol-corner {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 0.95;
+  font-weight: 800;
+}
+.sol-corner em {
+  font-style: normal;
+  font-size: clamp(11px, 2.4vw, 17px);
+}
+.sol-corner i {
+  font-style: normal;
+  font-size: clamp(9px, 2vw, 14px);
+}
+.sol-corner--tl {
+  top: 4px;
+  left: 5px;
+}
+.sol-corner--br {
+  bottom: 4px;
+  right: 5px;
+  transform: rotate(180deg);
+}
+.sol-pip {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(20px, 5vw, 38px);
+  opacity: 0.9;
+}
+
+/* ---- Win celebration --------------------------------------------------- */
+.sol-win {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--app-bg) 60%, transparent);
+  backdrop-filter: blur(4px);
+  z-index: 5;
+  animation: sol-fade 0.25s ease;
+}
+.sol-win-card {
+  position: relative;
+  z-index: 2;
+  background: var(--app-card);
+  border-radius: var(--app-radius);
+  padding: 28px 34px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  color: var(--app-accent);
+  box-shadow: 0 18px 50px rgba(50, 53, 46, 0.28);
+}
+.sol-win-card h2 {
+  margin: 2px 0 0;
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--app-fg);
+}
+.sol-win-card p {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--app-muted-fg);
+}
+.sol-confetti {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+.sol-confetti i {
+  position: absolute;
+  top: -12px;
+  left: calc(var(--i) * 4.16%);
+  width: 8px;
+  height: 14px;
+  border-radius: 2px;
+  background: hsl(calc(var(--i) * 37) 70% 55%);
+  animation: sol-fall 2.4s linear infinite;
+  animation-delay: calc(var(--i) * 0.08s);
+}
+@keyframes sol-fall {
+  0% {
+    transform: translateY(-20px) rotate(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(105vh) rotate(540deg);
+    opacity: 0.7;
+  }
+}
+@keyframes sol-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* ---- Footer ------------------------------------------------------------ */
+.sol-footer {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px clamp(12px, 2.4vw, 22px);
+  font-size: 12px;
+  color: var(--app-muted-fg);
+  flex-wrap: wrap;
+}
+.sol-hint {
+  margin-left: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sol-card,
+  .sol-win,
+  .sol-card--selected {
+    transition: none;
+    animation: none;
+  }
+  .sol-confetti i {
+    animation: none;
+    display: none;
+  }
+}

--- a/home/apps/games/solitaire/src/useSolitaireStats.ts
+++ b/home/apps/games/solitaire/src/useSolitaireStats.ts
@@ -34,6 +34,7 @@ export function useSolitaireStats({ countInitialGame }: { countInitialGame: bool
   const statsRowIdRef = useRef<string | null>(null);
   const statsInsertRef = useRef<Promise<string> | null>(null);
   const statsSaveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const statsWriteVersionRef = useRef(0);
   const pendingGamesPlayedRef = useRef(0);
   const countedInitialGameRef = useRef(countInitialGame);
 
@@ -46,6 +47,7 @@ export function useSolitaireStats({ countInitialGame }: { countInitialGame: bool
   }, []);
 
   const persistStats = useCallback((next: Stats) => {
+    statsWriteVersionRef.current += 1;
     statsRef.current = next;
     setStats(next);
     const db = window.MatrixOS?.db;
@@ -63,7 +65,9 @@ export function useSolitaireStats({ countInitialGame }: { countInitialGame: bool
           statsRowIdRef.current = rowId;
           await db.update(STATS_TABLE, rowId, payload);
         } else {
+          let createdForThisSave = false;
           if (!statsInsertRef.current) {
+            createdForThisSave = true;
             statsInsertRef.current = db.insert(STATS_TABLE, payload)
               .then((res) => {
                 statsRowIdRef.current = res.id;
@@ -75,7 +79,9 @@ export function useSolitaireStats({ countInitialGame }: { countInitialGame: bool
               });
           }
           const insertedId = await statsInsertRef.current;
-          await db.update(STATS_TABLE, insertedId, payload);
+          if (!createdForThisSave) {
+            await db.update(STATS_TABLE, insertedId, payload);
+          }
         }
       } catch (err: unknown) {
         console.warn("[solitaire] stats save failed:", err instanceof Error ? err.message : String(err));
@@ -89,6 +95,7 @@ export function useSolitaireStats({ countInitialGame }: { countInitialGame: bool
 
   const loadStats = useCallback(async () => {
     const db = window.MatrixOS?.db;
+    const writeVersionAtStart = statsWriteVersionRef.current;
     if (!db) {
       setStats({ ...EMPTY_STATS });
       statsLoadedRef.current = true;
@@ -100,9 +107,13 @@ export function useSolitaireStats({ countInitialGame }: { countInitialGame: bool
       if (rows && rows.length > 0) {
         const loaded = coerceStats(rows[0]);
         statsRowIdRef.current = loaded.id ?? null;
-        setStats(loaded);
+        if (statsWriteVersionRef.current === writeVersionAtStart) {
+          setStats(loaded);
+        }
       } else {
-        setStats({ ...EMPTY_STATS });
+        if (statsWriteVersionRef.current === writeVersionAtStart) {
+          setStats({ ...EMPTY_STATS });
+        }
       }
       setError(null);
     } catch (err: unknown) {

--- a/home/apps/games/solitaire/src/useSolitaireStats.ts
+++ b/home/apps/games/solitaire/src/useSolitaireStats.ts
@@ -163,8 +163,8 @@ export function useSolitaireStats({ countInitialGame }: { countInitialGame: bool
     void persistStats({
       ...cur,
       games_won: cur.games_won + 1,
-      best_time: cur.best_time === 0 ? time : Math.min(cur.best_time, time || cur.best_time),
-      best_moves: cur.best_moves === 0 ? moves : Math.min(cur.best_moves, moves || cur.best_moves),
+      best_time: cur.best_time === 0 ? time : Math.min(cur.best_time, time),
+      best_moves: cur.best_moves === 0 ? moves : Math.min(cur.best_moves, moves),
     });
   }, [persistStats]);
 

--- a/home/apps/games/solitaire/src/useSolitaireStats.ts
+++ b/home/apps/games/solitaire/src/useSolitaireStats.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const STATS_TABLE = "stats";
+
+export interface Stats {
+  id?: string;
+  games_played: number;
+  games_won: number;
+  best_time: number; // seconds, 0 = none
+  best_moves: number; // 0 = none
+}
+
+const EMPTY_STATS: Stats = { games_played: 0, games_won: 0, best_time: 0, best_moves: 0 };
+
+function coerceStats(row: unknown): Stats {
+  if (!row || typeof row !== "object") return { ...EMPTY_STATS };
+  const r = row as Record<string, unknown>;
+  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : Number(v) || 0);
+  return {
+    id: typeof r.id === "string" ? r.id : undefined,
+    games_played: num(r.games_played),
+    games_won: num(r.games_won),
+    best_time: num(r.best_time),
+    best_moves: num(r.best_moves),
+  };
+}
+
+export function useSolitaireStats({ countInitialGame }: { countInitialGame: boolean }) {
+  const [stats, setStats] = useState<Stats>(EMPTY_STATS);
+  const [error, setError] = useState<string | null>(null);
+  const [statsLoaded, setStatsLoaded] = useState(false);
+  const statsRef = useRef<Stats>(EMPTY_STATS);
+  const statsLoadedRef = useRef(false);
+  const statsRowIdRef = useRef<string | null>(null);
+  const statsInsertRef = useRef<Promise<string> | null>(null);
+  const statsSaveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const pendingGamesPlayedRef = useRef(0);
+  const countedInitialGameRef = useRef(countInitialGame);
+
+  useEffect(() => {
+    statsRef.current = stats;
+  }, [stats]);
+
+  const clearStatsError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  const persistStats = useCallback((next: Stats) => {
+    statsRef.current = next;
+    setStats(next);
+    const db = window.MatrixOS?.db;
+    if (!db) return Promise.resolve();
+    const save = async () => {
+      const payload = {
+        games_played: next.games_played,
+        games_won: next.games_won,
+        best_time: next.best_time,
+        best_moves: next.best_moves,
+      };
+      try {
+        const rowId = next.id ?? statsRowIdRef.current;
+        if (rowId) {
+          statsRowIdRef.current = rowId;
+          await db.update(STATS_TABLE, rowId, payload);
+        } else {
+          if (!statsInsertRef.current) {
+            statsInsertRef.current = db.insert(STATS_TABLE, payload)
+              .then((res) => {
+                statsRowIdRef.current = res.id;
+                setStats((cur) => ({ ...cur, id: res.id }));
+                return res.id;
+              })
+              .finally(() => {
+                statsInsertRef.current = null;
+              });
+          }
+          const insertedId = await statsInsertRef.current;
+          await db.update(STATS_TABLE, insertedId, payload);
+        }
+      } catch (err: unknown) {
+        console.warn("[solitaire] stats save failed:", err instanceof Error ? err.message : String(err));
+        setError("Stats could not be saved to Matrix Postgres.");
+      }
+    };
+    const run = statsSaveQueueRef.current.then(save, save);
+    statsSaveQueueRef.current = run.catch(() => undefined);
+    return run;
+  }, []);
+
+  const loadStats = useCallback(async () => {
+    const db = window.MatrixOS?.db;
+    if (!db) {
+      setStats({ ...EMPTY_STATS });
+      statsLoadedRef.current = true;
+      setStatsLoaded(true);
+      return;
+    }
+    try {
+      const rows = await db.find(STATS_TABLE, { limit: 1 });
+      if (rows && rows.length > 0) {
+        const loaded = coerceStats(rows[0]);
+        statsRowIdRef.current = loaded.id ?? null;
+        setStats(loaded);
+      } else {
+        setStats({ ...EMPTY_STATS });
+      }
+      setError(null);
+    } catch (err: unknown) {
+      console.warn("[solitaire] stats load failed:", err instanceof Error ? err.message : String(err));
+      setError("Stats could not be loaded.");
+      setStats({ ...EMPTY_STATS });
+    }
+    statsLoadedRef.current = true;
+    setStatsLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    void loadStats();
+    const db = window.MatrixOS?.db;
+    return db?.onChange?.(STATS_TABLE, () => void loadStats());
+  }, [loadStats]);
+
+  const recordGamePlayed = useCallback(() => {
+    countedInitialGameRef.current = true;
+    if (!statsLoadedRef.current) {
+      pendingGamesPlayedRef.current += 1;
+      return;
+    }
+    const cur = statsRef.current;
+    const next = { ...cur, games_played: cur.games_played + 1 };
+    statsRef.current = next;
+    void persistStats(next);
+  }, [persistStats]);
+
+  useEffect(() => {
+    if (!statsLoaded) return;
+    let increment = pendingGamesPlayedRef.current;
+    pendingGamesPlayedRef.current = 0;
+    if (!countedInitialGameRef.current) {
+      countedInitialGameRef.current = true;
+      increment += 1;
+    }
+    if (increment === 0) return;
+    const cur = statsRef.current;
+    const next = { ...cur, games_played: cur.games_played + increment };
+    statsRef.current = next;
+    void persistStats(next);
+  }, [persistStats, statsLoaded]);
+
+  const recordWin = useCallback((time: number, moves: number) => {
+    const cur = statsRef.current;
+    void persistStats({
+      ...cur,
+      games_won: cur.games_won + 1,
+      best_time: cur.best_time === 0 ? time : Math.min(cur.best_time, time || cur.best_time),
+      best_moves: cur.best_moves === 0 ? moves : Math.min(cur.best_moves, moves || cur.best_moves),
+    });
+  }, [persistStats]);
+
+  return { stats, error, clearStatsError, recordGamePlayed, recordWin };
+}

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -87,6 +87,35 @@ describe("Solitaire app", () => {
     expect(undoButton.disabled).toBe(true);
   });
 
+  it("clears a selected tableau card when it is clicked again", async () => {
+    installMatrixDb();
+    const state: GameState = {
+      stock: [],
+      waste: [],
+      foundations: [[], [], [], []],
+      tableau: [
+        [{ id: "spades-5", suit: "spades", rank: 5, faceUp: true }],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      drawCount: 1,
+      moves: 0,
+      score: 0,
+    };
+    render(<App initialState={state} />);
+
+    const card = await screen.findByTestId("card-spades-5");
+    fireEvent.click(card);
+    expect(card.className).toContain("sol-card--selected");
+
+    fireEvent.click(card);
+    expect(card.className).not.toContain("sol-card--selected");
+  });
+
   it("persists stats to the bridge when a game is won", async () => {
     const db = installMatrixDb([]);
     // a state one move from a win: 51 cards on foundations, last Ace... build full minus one

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/games/solitaire/src/App";
@@ -7,7 +7,10 @@ import { type GameState } from "../../home/apps/games/solitaire/src/solitaire-mo
 
 type DbRow = Record<string, unknown>;
 
-function installMatrixDb(rows: DbRow[] = []) {
+function installMatrixDb(
+  rows: DbRow[] = [],
+  bridge: { readData?: () => Promise<unknown>; writeData?: (key: string, value: unknown) => Promise<void> } = {},
+) {
   const db = {
     find: vi.fn(async () => rows),
     findOne: vi.fn(async () => null),
@@ -19,7 +22,7 @@ function installMatrixDb(rows: DbRow[] = []) {
   };
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
-    value: { db },
+    value: { db, ...bridge },
   });
   return db;
 }
@@ -114,6 +117,69 @@ describe("Solitaire app", () => {
 
     fireEvent.click(card);
     expect(card.className).not.toContain("sol-card--selected");
+  });
+
+  it("applies saved draw-three preference to the untouched initial deal", async () => {
+    installMatrixDb([], { readData: vi.fn(async () => 3) });
+    render(<App />);
+
+    const drawThree = await screen.findByRole("button", { name: /draw 3/i });
+    await waitFor(() => expect(drawThree.className).toContain("seg--on"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("stock"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("stock").textContent).toContain("21");
+  });
+
+  it("does not double-count when a new game starts before stats finish loading", async () => {
+    let resolveFind: (rows: DbRow[]) => void = () => undefined;
+    const db = installMatrixDb();
+    db.find.mockImplementation(async () => new Promise<DbRow[]>((resolve) => {
+      resolveFind = resolve;
+    }));
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole("button", { name: /new game/i }));
+
+    await act(async () => {
+      resolveFind([{ id: "stats-1", games_played: 5, games_won: 2, best_time: 90, best_moves: 30 }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith(
+      "stats",
+      "stats-1",
+      expect.objectContaining({ games_played: 6 }),
+    ));
+    expect(db.update.mock.calls.filter((call) => call[0] === "stats" && (call[2] as DbRow).games_played === 7)).toHaveLength(0);
+  });
+
+  it("does not auto-route a waste card while another source is selected", async () => {
+    installMatrixDb();
+    const state: GameState = {
+      ...seededState(),
+      tableau: [
+        [{ id: "spades-5", suit: "spades", rank: 5, faceUp: true }],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    };
+    render(<App initialState={state} />);
+
+    fireEvent.click(await screen.findByTestId("card-spades-5"));
+    fireEvent.click(screen.getByTestId("card-spades-1"));
+
+    expect(screen.getByTestId("waste").textContent).toContain("A");
+    expect(screen.getAllByTestId("foundation").some((pile) => within(pile).queryByTestId("card-spades-1"))).toBe(false);
+    expect(screen.getByTestId("card-spades-1").className).toContain("sol-card--selected");
   });
 
   it("persists stats to the bridge when a game is won", async () => {

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -148,6 +148,23 @@ describe("Solitaire app", () => {
     expect(undoButton.disabled).toBe(true);
   });
 
+  it("does not add undo history when recycling the waste", async () => {
+    installMatrixDb();
+    render(<App initialState={seededState()} />);
+
+    const undoButton = await screen.findByRole("button", { name: /undo/i }) as HTMLButtonElement;
+    expect(undoButton.disabled).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("stock"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("stock").textContent).toContain("1");
+    expect(screen.getByTestId("waste").textContent).not.toContain("A");
+    expect(undoButton.disabled).toBe(true);
+  });
+
   it("clears a selected tableau card when it is clicked again", async () => {
     installMatrixDb();
     const state: GameState = {
@@ -286,6 +303,28 @@ describe("Solitaire app", () => {
         games_won: 1,
         best_moves: 11,
       }));
+    });
+  });
+
+  it("records exact wall-clock win time even before the timer ticks", async () => {
+    const db = installMatrixDb([]);
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    render(<App initialState={oneMoveFromWinState()} />);
+
+    now = 1_005_000;
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-clubs-13"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      const statPayloads = [
+        ...db.insert.mock.calls.filter((call) => call[0] === "stats").map((call) => call[1] as DbRow),
+        ...db.update.mock.calls.filter((call) => call[0] === "stats").map((call) => call[2] as DbRow),
+      ];
+      expect(statPayloads).toContainEqual(expect.objectContaining({ best_time: 5 }));
     });
   });
 

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/games/solitaire/src/App";
+import { type GameState } from "../../home/apps/games/solitaire/src/solitaire-model";
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const db = {
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async () => ({ id: "stats-new" })),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => rows.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+// A state where the waste has an Ace ready to send to a foundation.
+function seededState(): GameState {
+  const t: GameState["tableau"] = [[], [], [], [], [], [], []];
+  return {
+    stock: [],
+    waste: [{ id: "spades-1", suit: "spades", rank: 1, faceUp: true }],
+    foundations: [[], [], [], []],
+    tableau: t,
+    drawCount: 1,
+    moves: 0,
+    score: 0,
+  };
+}
+
+describe("Solitaire app", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+  });
+
+  it("renders the board with foundations, stock, and a new game control", async () => {
+    installMatrixDb();
+    render(<App />);
+    expect(await screen.findByRole("button", { name: /new game/i })).toBeTruthy();
+    // 4 foundation slots present
+    expect(screen.getAllByTestId("foundation").length).toBe(4);
+    // 7 tableau piles present
+    expect(screen.getAllByTestId("tableau-pile").length).toBe(7);
+  });
+
+  it("double-clicking an exposed Ace sends it to a foundation (a legal move)", async () => {
+    installMatrixDb();
+    render(<App initialState={seededState()} />);
+
+    const aceCard = await screen.findByTestId("card-spades-1");
+    expect(screen.getByTestId("waste").textContent).toContain("A");
+
+    await act(async () => {
+      fireEvent.doubleClick(aceCard);
+      await Promise.resolve();
+    });
+
+    // The ace now lives in a foundation pile, not the waste.
+    const foundations = screen.getAllByTestId("foundation");
+    const inFoundation = foundations.some((f) => within(f).queryByTestId("card-spades-1"));
+    expect(inFoundation).toBe(true);
+  });
+
+  it("persists stats to the bridge when a game is won", async () => {
+    const db = installMatrixDb([]);
+    // a state one move from a win: 51 cards on foundations, last Ace... build full minus one
+    const suits = ["spades", "hearts", "diamonds", "clubs"] as const;
+    const foundations = suits.map((suit) =>
+      Array.from({ length: 13 }, (_, r) => ({ id: `${suit}-${r + 1}`, suit, rank: r + 1, faceUp: true })),
+    );
+    // remove the last card (clubs King) and place it on the waste
+    const last = foundations[3].pop()!;
+    const winState: GameState = {
+      stock: [],
+      waste: [last],
+      foundations,
+      tableau: [[], [], [], [], [], [], []],
+      drawCount: 1,
+      moves: 10,
+      score: 0,
+    };
+    render(<App initialState={winState} />);
+
+    const kingCard = await screen.findByTestId("card-clubs-13");
+    await act(async () => {
+      fireEvent.doubleClick(kingCard);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("win-banner")).toBeTruthy();
+    expect(db.insert).toHaveBeenCalled();
+    const tableArg = db.insert.mock.calls[0][0];
+    expect(tableArg).toBe("stats");
+  });
+});

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -289,6 +289,45 @@ describe("Solitaire app", () => {
     });
   });
 
+  it("preserves queued win and new-game stats when bridge updates resolve slowly", async () => {
+    const db = installMatrixDb([{ id: "stats-1", games_played: 5, games_won: 0, best_time: 0, best_moves: 0 }]);
+    const payloads: DbRow[] = [];
+    const releaseUpdates: Array<() => void> = [];
+    db.update.mockImplementation(async (_table: string, _id: string, payload: DbRow) => {
+      payloads.push(payload);
+      await new Promise<void>((resolve) => {
+        releaseUpdates.push(resolve);
+      });
+      return { ok: true };
+    });
+
+    render(<App initialState={oneMoveFromWinState()} />);
+    await screen.findByTestId("card-clubs-13");
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-clubs-13"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+      await Promise.resolve();
+    });
+
+    expect(payloads).toHaveLength(1);
+
+    for (let i = 0; i < 2; i += 1) {
+      await waitFor(() => expect(releaseUpdates.length).toBeGreaterThan(0));
+      const release = releaseUpdates.shift();
+      expect(release).toBeDefined();
+      await act(async () => {
+        release?.();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+
+    expect(payloads).toContainEqual(expect.objectContaining({ games_played: 5, games_won: 1, best_moves: 11 }));
+    expect(payloads).toContainEqual(expect.objectContaining({ games_played: 6, games_won: 1 }));
+  });
+
   it("records a second win after undoing from a won game", async () => {
     const db = installMatrixDb([]);
     render(<App initialState={oneMoveFromWinState()} />);

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -127,6 +127,15 @@ describe("Solitaire app", () => {
     expect(screen.getByTestId("card-spades-1")).toBeTruthy();
   });
 
+  it("shows zero elapsed time while preserving the empty best-time display", async () => {
+    installMatrixDb();
+    render(<App initialState={seededState()} />);
+    await screen.findByTestId("card-spades-1");
+
+    expect(within(screen.getByLabelText("Game status")).getByText("00:00")).toBeTruthy();
+    expect(screen.getByText("Best time --:--")).toBeTruthy();
+  });
+
   it("changes draw mode without throwing when the bridge has no writeData helper", async () => {
     installMatrixDb();
     render(<App initialState={seededState()} />);
@@ -349,6 +358,24 @@ describe("Solitaire app", () => {
       ];
       expect(statPayloads).toContainEqual(expect.objectContaining({ best_time: 5 }));
     });
+  });
+
+  it("allows an immediate win to replace a slower best time", async () => {
+    const db = installMatrixDb([{ id: "stats-1", games_played: 1, games_won: 0, best_time: 30, best_moves: 20 }]);
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    render(<App initialState={oneMoveFromWinState()} />);
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-clubs-13"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith(
+      "stats",
+      "stats-1",
+      expect.objectContaining({ best_time: 0, best_moves: 11 }),
+    ));
   });
 
   it("preserves queued win and new-game stats when bridge updates resolve slowly", async () => {

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -11,6 +11,7 @@ function installMatrixDb(
   rows: DbRow[] = [],
   bridge: { readData?: () => Promise<unknown>; writeData?: (key: string, value: unknown) => Promise<void> } = {},
 ) {
+  let onChangeCallback: (() => void) | undefined;
   const db = {
     find: vi.fn(async () => rows),
     findOne: vi.fn(async () => null),
@@ -18,7 +19,11 @@ function installMatrixDb(
     update: vi.fn(async () => ({ ok: true })),
     delete: vi.fn(async () => ({ ok: true })),
     count: vi.fn(async () => rows.length),
-    onChange: vi.fn(() => () => undefined),
+    onChange: vi.fn((_table: string, callback: () => void) => {
+      onChangeCallback = callback;
+      return () => undefined;
+    }),
+    emitChange: () => onChangeCallback?.(),
   };
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
@@ -306,6 +311,24 @@ describe("Solitaire app", () => {
     });
   });
 
+  it("does not issue a redundant update after the initial stats insert", async () => {
+    const db = installMatrixDb([]);
+    render(<App initialState={oneMoveFromWinState()} />);
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-clubs-13"));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.insert).toHaveBeenCalledWith(
+      "stats",
+      expect.objectContaining({ games_won: 1, best_moves: 11 }),
+    ));
+    expect(db.update.mock.calls.filter((call) => call[0] === "stats")).toHaveLength(0);
+  });
+
   it("records exact wall-clock win time even before the timer ticks", async () => {
     const db = installMatrixDb([]);
     let now = 1_000_000;
@@ -401,5 +424,53 @@ describe("Solitaire app", () => {
       ];
       expect(statPayloads).toContainEqual(expect.objectContaining({ games_won: 2 }));
     });
+  });
+
+  it("keeps in-flight win stats newer than a stale bridge reload", async () => {
+    let resolveReload: (rows: DbRow[]) => void = () => undefined;
+    const db = installMatrixDb([{ id: "stats-1", games_played: 5, games_won: 0, best_time: 0, best_moves: 0 }]);
+
+    render(<App initialState={oneMoveFromWinState()} />);
+    await screen.findByTestId("card-clubs-13");
+
+    db.find.mockImplementationOnce(async () => new Promise<DbRow[]>((resolve) => {
+      resolveReload = resolve;
+    }));
+    act(() => {
+      db.emitChange();
+    });
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-clubs-13"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith(
+      "stats",
+      "stats-1",
+      expect.objectContaining({ games_won: 1 }),
+    ));
+
+    await act(async () => {
+      resolveReload([{ id: "stats-1", games_played: 5, games_won: 0, best_time: 0, best_moves: 0 }]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-clubs-13"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.update).toHaveBeenCalledWith(
+      "stats",
+      "stats-1",
+      expect.objectContaining({ games_won: 2 }),
+    ));
   });
 });

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -57,7 +57,7 @@ describe("Solitaire app", () => {
     expect(screen.getAllByTestId("tableau-pile").length).toBe(7);
   });
 
-  it("double-clicking an exposed Ace sends it to a foundation (a legal move)", async () => {
+  it("clicking an exposed Ace sends it to a foundation (a legal move)", async () => {
     installMatrixDb();
     render(<App initialState={seededState()} />);
 
@@ -65,7 +65,7 @@ describe("Solitaire app", () => {
     expect(screen.getByTestId("waste").textContent).toContain("A");
 
     await act(async () => {
-      fireEvent.doubleClick(aceCard);
+      fireEvent.click(aceCard);
       await Promise.resolve();
     });
 
@@ -73,6 +73,17 @@ describe("Solitaire app", () => {
     const foundations = screen.getAllByTestId("foundation");
     const inFoundation = foundations.some((f) => within(f).queryByTestId("card-spades-1"));
     expect(inFoundation).toBe(true);
+  });
+
+  it("does not restart the current game when clicking the active draw mode", async () => {
+    installMatrixDb();
+    render(<App initialState={seededState()} />);
+    expect(await screen.findByTestId("card-spades-1")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /draw 1/i }));
+
+    expect(screen.getByTestId("waste").textContent).toContain("A");
+    expect(screen.getByTestId("card-spades-1")).toBeTruthy();
   });
 
   it("does not add undo history when drawing from empty stock and waste", async () => {
@@ -204,14 +215,21 @@ describe("Solitaire app", () => {
 
     const kingCard = await screen.findByTestId("card-clubs-13");
     await act(async () => {
-      fireEvent.doubleClick(kingCard);
+      fireEvent.click(kingCard);
       await Promise.resolve();
       await Promise.resolve();
     });
 
     expect(screen.getByTestId("win-banner")).toBeTruthy();
-    expect(db.insert).toHaveBeenCalled();
-    const tableArg = db.insert.mock.calls[0][0];
-    expect(tableArg).toBe("stats");
+    await waitFor(() => {
+      const statPayloads = [
+        ...db.insert.mock.calls.filter((call) => call[0] === "stats").map((call) => call[1] as DbRow),
+        ...db.update.mock.calls.filter((call) => call[0] === "stats").map((call) => call[2] as DbRow),
+      ];
+      expect(statPayloads).toContainEqual(expect.objectContaining({
+        games_won: 1,
+        best_moves: 11,
+      }));
+    });
   });
 });

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -72,6 +72,21 @@ describe("Solitaire app", () => {
     expect(inFoundation).toBe(true);
   });
 
+  it("does not add undo history when drawing from empty stock and waste", async () => {
+    installMatrixDb();
+    render(<App initialState={{ ...seededState(), waste: [] }} />);
+
+    const undoButton = await screen.findByRole("button", { name: /undo/i }) as HTMLButtonElement;
+    expect(undoButton.disabled).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("stock"));
+      await Promise.resolve();
+    });
+
+    expect(undoButton.disabled).toBe(true);
+  });
+
   it("persists stats to the bridge when a game is won", async () => {
     const db = installMatrixDb([]);
     // a state one move from a win: 51 cards on foundations, last Ace... build full minus one

--- a/tests/default-apps/solitaire-app.test.tsx
+++ b/tests/default-apps/solitaire-app.test.tsx
@@ -41,6 +41,23 @@ function seededState(): GameState {
   };
 }
 
+function oneMoveFromWinState(): GameState {
+  const suits = ["spades", "hearts", "diamonds", "clubs"] as const;
+  const foundations = suits.map((suit) =>
+    Array.from({ length: 13 }, (_, r) => ({ id: `${suit}-${r + 1}`, suit, rank: r + 1, faceUp: true })),
+  );
+  const last = foundations[3].pop()!;
+  return {
+    stock: [],
+    waste: [last],
+    foundations,
+    tableau: [[], [], [], [], [], [], []],
+    drawCount: 1,
+    moves: 10,
+    score: 0,
+  };
+}
+
 describe("Solitaire app", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -75,6 +92,25 @@ describe("Solitaire app", () => {
     expect(inFoundation).toBe(true);
   });
 
+  it("records a single undo entry per committed move under StrictMode", async () => {
+    installMatrixDb();
+    render(
+      <React.StrictMode>
+        <App initialState={seededState()} />
+      </React.StrictMode>,
+    );
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-spades-1"));
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+
+    expect(screen.getByTestId("waste").textContent).toContain("A");
+    expect((screen.getByRole("button", { name: /undo/i }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("does not restart the current game when clicking the active draw mode", async () => {
     installMatrixDb();
     render(<App initialState={seededState()} />);
@@ -84,6 +120,17 @@ describe("Solitaire app", () => {
 
     expect(screen.getByTestId("waste").textContent).toContain("A");
     expect(screen.getByTestId("card-spades-1")).toBeTruthy();
+  });
+
+  it("changes draw mode without throwing when the bridge has no writeData helper", async () => {
+    installMatrixDb();
+    render(<App initialState={seededState()} />);
+    expect(await screen.findByTestId("card-spades-1")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /draw 3/i }));
+
+    expect(screen.getByRole("button", { name: /draw 3/i }).className).toContain("seg--on");
+    expect(screen.queryByText(/draw preference save failed/i)).toBeNull();
   });
 
   it("does not add undo history when drawing from empty stock and waste", async () => {
@@ -130,6 +177,30 @@ describe("Solitaire app", () => {
     expect(card.className).not.toContain("sol-card--selected");
   });
 
+  it("shows when a foundation card is selected", async () => {
+    installMatrixDb();
+    const state: GameState = {
+      stock: [],
+      waste: [],
+      foundations: [
+        [{ id: "hearts-13", suit: "hearts", rank: 13, faceUp: true }],
+        [],
+        [],
+        [],
+      ],
+      tableau: [[], [], [], [], [], [], []],
+      drawCount: 1,
+      moves: 0,
+      score: 0,
+    };
+    render(<App initialState={state} />);
+
+    const card = await screen.findByTestId("card-hearts-13");
+    fireEvent.click(card);
+
+    expect(card.className).toContain("sol-card--selected");
+  });
+
   it("applies saved draw-three preference to the untouched initial deal", async () => {
     installMatrixDb([], { readData: vi.fn(async () => 3) });
     render(<App />);
@@ -166,6 +237,7 @@ describe("Solitaire app", () => {
       "stats-1",
       expect.objectContaining({ games_played: 6 }),
     ));
+    expect(db.update.mock.calls.filter((call) => call[0] === "stats" && (call[2] as DbRow).games_played === 6)).toHaveLength(1);
     expect(db.update.mock.calls.filter((call) => call[0] === "stats" && (call[2] as DbRow).games_played === 7)).toHaveLength(0);
   });
 
@@ -195,23 +267,7 @@ describe("Solitaire app", () => {
 
   it("persists stats to the bridge when a game is won", async () => {
     const db = installMatrixDb([]);
-    // a state one move from a win: 51 cards on foundations, last Ace... build full minus one
-    const suits = ["spades", "hearts", "diamonds", "clubs"] as const;
-    const foundations = suits.map((suit) =>
-      Array.from({ length: 13 }, (_, r) => ({ id: `${suit}-${r + 1}`, suit, rank: r + 1, faceUp: true })),
-    );
-    // remove the last card (clubs King) and place it on the waste
-    const last = foundations[3].pop()!;
-    const winState: GameState = {
-      stock: [],
-      waste: [last],
-      foundations,
-      tableau: [[], [], [], [], [], [], []],
-      drawCount: 1,
-      moves: 10,
-      score: 0,
-    };
-    render(<App initialState={winState} />);
+    render(<App initialState={oneMoveFromWinState()} />);
 
     const kingCard = await screen.findByTestId("card-clubs-13");
     await act(async () => {
@@ -230,6 +286,42 @@ describe("Solitaire app", () => {
         games_won: 1,
         best_moves: 11,
       }));
+    });
+  });
+
+  it("records a second win after undoing from a won game", async () => {
+    const db = installMatrixDb([]);
+    render(<App initialState={oneMoveFromWinState()} />);
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-clubs-13"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      const statPayloads = [
+        ...db.insert.mock.calls.filter((call) => call[0] === "stats").map((call) => call[1] as DbRow),
+        ...db.update.mock.calls.filter((call) => call[0] === "stats").map((call) => call[2] as DbRow),
+      ];
+      expect(statPayloads).toContainEqual(expect.objectContaining({ games_won: 1 }));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("card-clubs-13"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      const statPayloads = [
+        ...db.insert.mock.calls.filter((call) => call[0] === "stats").map((call) => call[1] as DbRow),
+        ...db.update.mock.calls.filter((call) => call[0] === "stats").map((call) => call[2] as DbRow),
+      ];
+      expect(statPayloads).toContainEqual(expect.objectContaining({ games_won: 2 }));
     });
   });
 });

--- a/tests/default-apps/solitaire-model.test.ts
+++ b/tests/default-apps/solitaire-model.test.ts
@@ -104,6 +104,15 @@ describe("foundation legality", () => {
     expect(canMoveToFoundation(card("hearts", 2), [card("spades", 1)])).toBe(false);
     expect(canMoveToFoundation(card("spades", 3), [card("spades", 1)])).toBe(false);
   });
+
+  it("rejects foundation-to-foundation moves", () => {
+    const s = emptyState();
+    s.foundations[0] = [card("spades", 1)];
+
+    expect(isLegalMove(s, { type: "foundation", pile: 0 }, { type: "foundation", pile: 1 })).toBe(false);
+    expect(applyMove(s, { type: "foundation", pile: 0 }, { type: "foundation", pile: 1 })).toBeNull();
+    expect(findAutoDestination(s, { type: "foundation", pile: 0 })).toBeNull();
+  });
 });
 
 describe("movable runs", () => {

--- a/tests/default-apps/solitaire-model.test.ts
+++ b/tests/default-apps/solitaire-model.test.ts
@@ -113,6 +113,15 @@ describe("foundation legality", () => {
     expect(applyMove(s, { type: "foundation", pile: 0 }, { type: "foundation", pile: 1 })).toBeNull();
     expect(findAutoDestination(s, { type: "foundation", pile: 0 })).toBeNull();
   });
+
+  it("does not auto-route foundation cards back to tableau on single click", () => {
+    const s = emptyState();
+    s.foundations[0] = [card("spades", 7)];
+    s.tableau[0] = [card("hearts", 8)];
+
+    expect(isLegalMove(s, { type: "foundation", pile: 0 }, { type: "tableau", pile: 0 })).toBe(true);
+    expect(findAutoDestination(s, { type: "foundation", pile: 0 })).toBeNull();
+  });
 });
 
 describe("movable runs", () => {
@@ -225,6 +234,16 @@ describe("auto-complete + win", () => {
     // one king got promoted
     const promoted = step!.foundations.some((p) => p.length === 13);
     expect(promoted).toBe(true);
+  });
+
+  it("can auto-complete through multiple face-up waste cards when stock is empty", () => {
+    const s = emptyState();
+    s.foundations[0] = [card("spades", 1), card("spades", 2)];
+    s.waste = [card("spades", 4), card("spades", 3)];
+
+    expect(canAutoComplete(s)).toBe(true);
+    const step = autoCompleteStep(s);
+    expect(step?.foundations[0].at(-1)?.rank).toBe(3);
   });
 
   it("does not offer auto-complete when no top card can move to a foundation", () => {

--- a/tests/default-apps/solitaire-model.test.ts
+++ b/tests/default-apps/solitaire-model.test.ts
@@ -258,10 +258,7 @@ describe("auto-complete + win", () => {
     const s = emptyState();
     const suits: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
     s.foundations = suits.map((suit) => Array.from({ length: 11 }, (_, r) => card(suit, r + 1)));
-    suits.forEach((suit, i) => {
-      s.tableau[i] = [card(suit, 12), card(suit, 13)].reverse(); // K on top of Q? fix below
-    });
-    // Lay Q then K so Q is promotable first (Q at top), then K.
+    // K at index 0, Q on top (index 1) so Q is promotable first, then K.
     suits.forEach((suit, i) => {
       s.tableau[i] = [card(suit, 13, true), card(suit, 12, true)];
     });

--- a/tests/default-apps/solitaire-model.test.ts
+++ b/tests/default-apps/solitaire-model.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+import {
+  type Card,
+  type GameState,
+  type Suit,
+  applyMove,
+  autoCompleteStep,
+  autoMoveToFoundation,
+  buildDeck,
+  canAutoComplete,
+  canMoveToFoundation,
+  canStackOnTableau,
+  cloneState,
+  deal,
+  drawFromStock,
+  findAutoDestination,
+  isLegalMove,
+  isMovableRun,
+  isWon,
+  shuffle,
+  suitColor,
+} from "../../home/apps/games/solitaire/src/solitaire-model";
+
+// Deterministic RNG cycling through a sequence.
+function seqRng(seq: number[]): () => number {
+  let i = 0;
+  return () => seq[i++ % seq.length];
+}
+
+function card(suit: Suit, rank: number, faceUp = true): Card {
+  return { id: `${suit}-${rank}`, suit, rank, faceUp };
+}
+
+function emptyState(over: Partial<GameState> = {}): GameState {
+  return {
+    stock: [],
+    waste: [],
+    foundations: [[], [], [], []],
+    tableau: [[], [], [], [], [], [], []],
+    drawCount: 1,
+    moves: 0,
+    score: 0,
+    ...over,
+  };
+}
+
+describe("deck", () => {
+  it("builds 52 unique cards face-down", () => {
+    const deck = buildDeck();
+    expect(deck).toHaveLength(52);
+    expect(new Set(deck.map((c) => c.id)).size).toBe(52);
+    expect(deck.every((c) => !c.faceUp)).toBe(true);
+  });
+
+  it("shuffle is a permutation and uses the rng", () => {
+    const deck = buildDeck();
+    const shuffled = shuffle(deck, seqRng([0.99, 0.1, 0.5, 0.3]));
+    expect(shuffled).toHaveLength(52);
+    expect(new Set(shuffled.map((c) => c.id)).size).toBe(52);
+  });
+});
+
+describe("deal", () => {
+  it("lays out 28 cards across 7 piles with only the top face-up", () => {
+    const s = deal(seqRng([0.42]));
+    expect(s.tableau).toHaveLength(7);
+    let total = 0;
+    s.tableau.forEach((pile, i) => {
+      expect(pile).toHaveLength(i + 1);
+      total += pile.length;
+      pile.forEach((c, idx) => {
+        expect(c.faceUp).toBe(idx === pile.length - 1);
+      });
+    });
+    expect(total).toBe(28);
+    expect(s.stock).toHaveLength(24);
+    expect(s.stock.every((c) => !c.faceUp)).toBe(true);
+    expect(s.waste).toHaveLength(0);
+    expect(s.foundations.flat()).toHaveLength(0);
+  });
+});
+
+describe("tableau legality", () => {
+  it("allows alternating-color descending", () => {
+    // red 7 on black 8
+    expect(canStackOnTableau(card("hearts", 7), [card("spades", 8)])).toBe(true);
+    expect(canStackOnTableau(card("diamonds", 7), [card("clubs", 8)])).toBe(true);
+  });
+  it("rejects same color or wrong rank", () => {
+    expect(canStackOnTableau(card("hearts", 7), [card("diamonds", 8)])).toBe(false);
+    expect(canStackOnTableau(card("hearts", 6), [card("spades", 8)])).toBe(false);
+  });
+  it("only a King may go to an empty pile", () => {
+    expect(canStackOnTableau(card("spades", 13), [])).toBe(true);
+    expect(canStackOnTableau(card("spades", 12), [])).toBe(false);
+  });
+});
+
+describe("foundation legality", () => {
+  it("only an Ace starts a foundation, then same-suit ascending", () => {
+    expect(canMoveToFoundation(card("spades", 1), [])).toBe(true);
+    expect(canMoveToFoundation(card("spades", 2), [])).toBe(false);
+    expect(canMoveToFoundation(card("spades", 2), [card("spades", 1)])).toBe(true);
+    expect(canMoveToFoundation(card("hearts", 2), [card("spades", 1)])).toBe(false);
+    expect(canMoveToFoundation(card("spades", 3), [card("spades", 1)])).toBe(false);
+  });
+});
+
+describe("movable runs", () => {
+  it("validates alternating descending face-up runs", () => {
+    const pile = [card("clubs", 9, false), card("hearts", 8), card("spades", 7), card("diamonds", 6)];
+    expect(isMovableRun(pile, 1)).toBe(true);
+    expect(isMovableRun(pile, 0)).toBe(false); // face-down
+  });
+  it("rejects broken runs", () => {
+    const pile = [card("hearts", 8), card("diamonds", 7)]; // same color
+    expect(isMovableRun(pile, 0)).toBe(false);
+  });
+});
+
+describe("applyMove", () => {
+  it("moves a waste card to a foundation and scores", () => {
+    const s = emptyState({ waste: [card("spades", 1)] });
+    const next = applyMove(s, { type: "waste" }, { type: "foundation", pile: 0 });
+    expect(next).not.toBeNull();
+    expect(next!.foundations[0]).toHaveLength(1);
+    expect(next!.waste).toHaveLength(0);
+    expect(next!.score).toBe(10);
+    expect(next!.moves).toBe(1);
+  });
+
+  it("moves a tableau run and flips the exposed card", () => {
+    const s = emptyState();
+    s.tableau[0] = [card("clubs", 10, false), card("hearts", 9), card("spades", 8)];
+    s.tableau[1] = [card("clubs", 10)];
+    const next = applyMove(s, { type: "tableau", pile: 0, index: 1 }, { type: "tableau", pile: 1 });
+    expect(next).not.toBeNull();
+    expect(next!.tableau[1]).toHaveLength(3);
+    expect(next!.tableau[0]).toHaveLength(1);
+    expect(next!.tableau[0][0].faceUp).toBe(true); // flipped
+  });
+
+  it("rejects an illegal move", () => {
+    const s = emptyState({ waste: [card("spades", 5)] });
+    expect(applyMove(s, { type: "waste" }, { type: "foundation", pile: 0 })).toBeNull();
+    expect(isLegalMove(s, { type: "waste" }, { type: "foundation", pile: 0 })).toBe(false);
+  });
+
+  it("does not mutate the source state", () => {
+    const s = emptyState({ waste: [card("spades", 1)] });
+    const before = cloneState(s);
+    applyMove(s, { type: "waste" }, { type: "foundation", pile: 0 });
+    expect(s).toEqual(before);
+  });
+});
+
+describe("draw / recycle", () => {
+  it("draws one card by default and turns it face-up", () => {
+    const s = emptyState({ stock: [card("spades", 5, false), card("hearts", 9, false)] });
+    const next = drawFromStock(s);
+    expect(next.waste).toHaveLength(1);
+    expect(next.waste[0].faceUp).toBe(true);
+    expect(next.stock).toHaveLength(1);
+  });
+  it("draws three when drawCount is 3", () => {
+    const stock = Array.from({ length: 5 }, (_, i) => card("clubs", i + 1, false));
+    const next = drawFromStock(emptyState({ stock, drawCount: 3 }));
+    expect(next.waste).toHaveLength(3);
+    expect(next.stock).toHaveLength(2);
+  });
+  it("recycles waste back to stock when stock is empty", () => {
+    const s = emptyState({ stock: [], waste: [card("spades", 1), card("hearts", 2)] });
+    const next = drawFromStock(s);
+    expect(next.stock).toHaveLength(2);
+    expect(next.waste).toHaveLength(0);
+    expect(next.stock.every((c) => !c.faceUp)).toBe(true);
+  });
+});
+
+describe("auto-route + auto to foundation", () => {
+  it("finds a foundation destination for an Ace", () => {
+    const s = emptyState({ waste: [card("diamonds", 1)] });
+    const dest = findAutoDestination(s, { type: "waste" });
+    expect(dest).toEqual({ type: "foundation", pile: 0 });
+  });
+  it("autoMoveToFoundation promotes a top card", () => {
+    const s = emptyState();
+    s.foundations[0] = [card("spades", 1)];
+    s.tableau[0] = [card("spades", 2)];
+    const next = autoMoveToFoundation(s, { type: "tableau", pile: 0, index: 0 });
+    expect(next).not.toBeNull();
+    expect(next!.foundations[0]).toHaveLength(2);
+  });
+});
+
+describe("auto-complete + win", () => {
+  it("detects a won game", () => {
+    const s = emptyState();
+    const suits: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+    s.foundations = suits.map((suit) => Array.from({ length: 13 }, (_, r) => card(suit, r + 1)));
+    expect(isWon(s)).toBe(true);
+    expect(canAutoComplete(s)).toBe(false);
+  });
+
+  it("canAutoComplete when all cards face-up and stock empty", () => {
+    const s = emptyState();
+    const suits: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+    // each foundation up to Q, each tableau holds the matching King face-up
+    s.foundations = suits.map((suit) => Array.from({ length: 12 }, (_, r) => card(suit, r + 1)));
+    suits.forEach((suit, i) => {
+      s.tableau[i] = [card(suit, 13)];
+    });
+    expect(canAutoComplete(s)).toBe(true);
+    const step = autoCompleteStep(s);
+    expect(step).not.toBeNull();
+    // one king got promoted
+    const promoted = step!.foundations.some((p) => p.length === 13);
+    expect(promoted).toBe(true);
+  });
+
+  it("auto-completes a near-solved game to a win", () => {
+    const s = emptyState();
+    const suits: Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+    s.foundations = suits.map((suit) => Array.from({ length: 11 }, (_, r) => card(suit, r + 1)));
+    suits.forEach((suit, i) => {
+      s.tableau[i] = [card(suit, 12), card(suit, 13)].reverse(); // K on top of Q? fix below
+    });
+    // Lay Q then K so Q is promotable first (Q at top), then K.
+    suits.forEach((suit, i) => {
+      s.tableau[i] = [card(suit, 13, true), card(suit, 12, true)];
+    });
+    let cur: GameState | null = s;
+    let guard = 0;
+    while (cur && !isWon(cur) && guard < 100) {
+      cur = autoCompleteStep(cur);
+      guard += 1;
+    }
+    expect(cur).not.toBeNull();
+    expect(isWon(cur!)).toBe(true);
+  });
+});
+
+describe("suitColor", () => {
+  it("classifies colors", () => {
+    expect(suitColor("hearts")).toBe("red");
+    expect(suitColor("diamonds")).toBe("red");
+    expect(suitColor("spades")).toBe("black");
+    expect(suitColor("clubs")).toBe("black");
+  });
+});

--- a/tests/default-apps/solitaire-model.test.ts
+++ b/tests/default-apps/solitaire-model.test.ts
@@ -227,6 +227,14 @@ describe("auto-complete + win", () => {
     expect(promoted).toBe(true);
   });
 
+  it("does not offer auto-complete when no top card can move to a foundation", () => {
+    const s = emptyState();
+    s.tableau[0] = [card("hearts", 1), card("spades", 13)];
+
+    expect(autoCompleteStep(s)).toBeNull();
+    expect(canAutoComplete(s)).toBe(false);
+  });
+
   it("auto-completes a near-solved game to a win", () => {
     const s = emptyState();
     const suits: Suit[] = ["spades", "hearts", "diamonds", "clubs"];


### PR DESCRIPTION
Stack: 15/22
Branch: stack/default-apps-solitaire

Scope: Solitaire/Klondike model, UI, manifest, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.