### PR TITLE
feat(backgammon): add legal move board game

### DIFF
--- a/home/apps/games/backgammon/matrix.json
+++ b/home/apps/games/backgammon/matrix.json
@@ -3,7 +3,7 @@
   "description": "Local two-player backgammon with a full legal-move engine, dice, hitting and bearing off.",
   "runtime": "vite",
   "category": "games",
-  "icon": "backgammon",
+  "icon": "game-center",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -17,7 +17,8 @@
       "matches": {
         "columns": {
           "winner": "text",
-          "points": "integer"
+          "points": "integer",
+          "created_at": "timestamptz"
         }
       }
     }

--- a/home/apps/games/backgammon/matrix.json
+++ b/home/apps/games/backgammon/matrix.json
@@ -1,9 +1,9 @@
 {
   "name": "Backgammon",
-  "description": "Classic board game with dice",
+  "description": "Local two-player backgammon with a full legal-move engine, dice, hitting and bearing off.",
   "runtime": "vite",
   "category": "games",
-  "icon": "game-center",
+  "icon": "backgammon",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -12,6 +12,16 @@
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
   "slug": "backgammon",
+  "storage": {
+    "tables": {
+      "matches": {
+        "columns": {
+          "winner": "text",
+          "points": "integer"
+        }
+      }
+    }
+  },
   "build": {
     "install": "true",
     "command": "vite build --base ./ --outDir dist",

--- a/home/apps/games/backgammon/src/App.tsx
+++ b/home/apps/games/backgammon/src/App.tsx
@@ -49,7 +49,11 @@ async function saveMatch(record: MatchRecord, setError: (s: string | null) => vo
   const db = window.MatrixOS?.db;
   if (db) {
     try {
-      await db.insert(MATCHES_TABLE, { winner: record.winner, points: record.points });
+      await db.insert(MATCHES_TABLE, {
+        winner: record.winner,
+        points: record.points,
+        created_at: new Date().toISOString(),
+      });
       return true;
     } catch (err) {
       console.warn("[backgammon] failed to persist match to DB", err);
@@ -460,6 +464,8 @@ export default function App() {
           {state.dice.length === 0 ? (
             <span className="bg-note">tap roll</span>
           ) : (
+            // Doubles still render as the two rolled dice; movesLeft carries
+            // four consumable die plays and drives the used/available state.
             state.dice.map((d, i) => {
               const used = !diceStillAvailable(state, d, i);
               return <DieFace key={i} value={d} used={used} rolling={rolling} />;

--- a/home/apps/games/backgammon/src/App.tsx
+++ b/home/apps/games/backgammon/src/App.tsx
@@ -26,6 +26,10 @@ interface MatchRecord {
   points: number;
 }
 
+export function movesForTarget(moves: Move[], to: number): Move[] {
+  return moves.filter((m) => m.to === to);
+}
+
 // ---- persistence -----------------------------------------------------------
 
 async function loadMatches(setError: (s: string | null) => void): Promise<MatchRecord[] | null> {
@@ -202,6 +206,7 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string>("Roll the dice to begin.");
   const [result, setResult] = useState<WinResult | null>(null);
+  const [dieChoice, setDieChoice] = useState<Move[] | null>(null);
   const savedRef = useRef(false);
 
   // load history + subscribe
@@ -284,6 +289,7 @@ export default function App() {
     setState(next);
     setRolled(true);
     setSelected(null);
+    setDieChoice(null);
     setError(null);
     setStatus(`${PLAYER_NAME[next.turn]} rolled ${roll.values[0]} & ${roll.values[1]}.`);
     window.setTimeout(() => setRolling(false), 420);
@@ -293,11 +299,13 @@ export default function App() {
     setState((prev) => ({ ...prev, turn: other(prev.turn), movesLeft: [], dice: [], history: [] }));
     setRolled(false);
     setSelected(null);
+    setDieChoice(null);
   }, []);
 
   const doMove = useCallback((move: Move) => {
     setState((prev) => applyMove(prev, move));
     setSelected(null);
+    setDieChoice(null);
   }, []);
 
   useEffect(() => {
@@ -312,6 +320,7 @@ export default function App() {
     (point: number) => {
       if (!rolled || result) return;
       if (!sourcesWithMoves.has(point)) return;
+      setDieChoice(null);
       setSelected((cur) => (cur === point ? null : point));
     },
     [rolled, result, sourcesWithMoves],
@@ -320,9 +329,14 @@ export default function App() {
   const handleTarget = useCallback(
     (to: number) => {
       if (selected === null) return;
-      const move = legalFromSelected.find((m) => m.to === to);
-      if (!move) return;
-      doMove(move);
+      const targetMoves = movesForTarget(legalFromSelected, to);
+      if (targetMoves.length === 0) return;
+      if (to === OFF && targetMoves.length > 1) {
+        setDieChoice(targetMoves);
+        setStatus(`Choose a die to bear off from point ${selected}.`);
+        return;
+      }
+      doMove(targetMoves[0]);
     },
     [selected, legalFromSelected, doMove],
   );
@@ -331,11 +345,13 @@ export default function App() {
     if (result) return;
     setState((prev) => undoMove(prev));
     setSelected(null);
+    setDieChoice(null);
   }, [result]);
 
   const handleNewGame = useCallback(() => {
     setState(createInitialState());
     setSelected(null);
+    setDieChoice(null);
     setRolled(false);
     setResult(null);
     savedRef.current = false;
@@ -663,7 +679,16 @@ export default function App() {
 
       {/* ---------- footer ---------- */}
       <footer className="bg-status">
-        {error ? (
+        {dieChoice ? (
+          <span className="die-choice">
+            Choose die
+            {dieChoice.map((move) => (
+              <button key={move.die} type="button" className="bg-btn" onClick={() => doMove(move)}>
+                {move.die}
+              </button>
+            ))}
+          </span>
+        ) : error ? (
           <span className="err">{error}</span>
         ) : status === "Saved to Matrix Postgres" ? (
           <span className="ok">{status}</span>

--- a/home/apps/games/backgammon/src/App.tsx
+++ b/home/apps/games/backgammon/src/App.tsx
@@ -324,9 +324,10 @@ export default function App() {
   );
 
   const handleUndo = useCallback(() => {
+    if (result) return;
     setState((prev) => undoMove(prev));
     setSelected(null);
-  }, []);
+  }, [result]);
 
   const handleNewGame = useCallback(() => {
     setState(createInitialState());
@@ -503,7 +504,7 @@ export default function App() {
             type="button"
             className="bg-btn icon"
             onClick={handleUndo}
-            disabled={state.history.length === 0}
+            disabled={!!result || state.history.length === 0}
             title="Undo (U)"
             aria-label="Undo"
           >

--- a/home/apps/games/backgammon/src/App.tsx
+++ b/home/apps/games/backgammon/src/App.tsx
@@ -1,0 +1,702 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Dices, RotateCcw, Undo2 } from "lucide-react";
+import "./styles.css";
+import {
+  BAR,
+  OFF,
+  type GameState,
+  type Move,
+  type Player,
+  type WinResult,
+  applyMove,
+  createInitialState,
+  generateLegalMoves,
+  isGameOver,
+  pipCount,
+  rollDice,
+  startTurn,
+  undo as undoMove,
+  winnerResult,
+} from "./backgammon-model";
+
+const MATCHES_TABLE = "matches";
+const LS_KEY = "matrixos.backgammon.matches";
+
+interface MatchRecord {
+  winner: string;
+  points: number;
+}
+
+// ---- persistence -----------------------------------------------------------
+
+async function loadMatches(setError: (s: string | null) => void): Promise<MatchRecord[]> {
+  const db = window.MatrixOS?.db;
+  if (db) {
+    try {
+      const rows = await db.find(MATCHES_TABLE, { orderBy: { created_at: "desc" }, limit: 50 });
+      return rows.map((r) => ({
+        winner: String(r.winner ?? ""),
+        points: Number(r.points ?? 0),
+      }));
+    } catch (err) {
+      console.warn("[backgammon] failed to load matches from DB", err);
+      setError("Could not load match history.");
+      // fall through to localStorage as a best-effort fallback
+    }
+  }
+  try {
+    const raw = window.localStorage.getItem(LS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((r) => ({
+      winner: String((r as MatchRecord).winner ?? ""),
+      points: Number((r as MatchRecord).points ?? 0),
+    }));
+  } catch (err) {
+    console.warn("[backgammon] failed to read localStorage matches", err);
+    return [];
+  }
+}
+
+async function saveMatch(record: MatchRecord, setError: (s: string | null) => void): Promise<boolean> {
+  const db = window.MatrixOS?.db;
+  if (db) {
+    try {
+      await db.insert(MATCHES_TABLE, { winner: record.winner, points: record.points });
+      return true;
+    } catch (err) {
+      console.warn("[backgammon] failed to persist match to DB", err);
+      setError("Could not save the result to Matrix Postgres.");
+      return false;
+    }
+  }
+  try {
+    const raw = window.localStorage.getItem(LS_KEY);
+    const list: MatchRecord[] = raw ? (JSON.parse(raw) as MatchRecord[]) : [];
+    list.unshift(record);
+    window.localStorage.setItem(LS_KEY, JSON.stringify(list.slice(0, 50)));
+    return true;
+  } catch (err) {
+    console.warn("[backgammon] failed to persist match to localStorage", err);
+    setError("Could not save the result.");
+    return false;
+  }
+}
+
+// ---- board geometry --------------------------------------------------------
+// Single responsive SVG. viewBox units; the SVG scales to fit its container
+// via CSS (width/height 100%, preserveAspectRatio). All coordinates below are
+// in these abstract units.
+
+const VB_W = 1000;
+const VB_H = 640;
+const FRAME = 16; // outer wood frame thickness
+const PLAY_X = FRAME; // left edge of the felt play area
+const PLAY_Y = FRAME;
+const TRAY_W = 96; // bear-off tray on the right
+const BAR_W = 56; // central bar
+const PLAY_W = VB_W - FRAME * 2 - TRAY_W; // width of the two felt halves + bar
+const PLAY_H = VB_H - FRAME * 2;
+const HALF_W = (PLAY_W - BAR_W) / 2; // width of one 6-point half
+const POINT_W = HALF_W / 6;
+const POINT_H = PLAY_H * 0.42; // triangle height
+const CHK_R = POINT_W * 0.42; // checker radius
+const CHK_GAP = CHK_R * 1.78; // vertical spacing between stacked checkers
+const MAX_VISIBLE = 5;
+
+const leftHalfX = PLAY_X;
+const barX = PLAY_X + HALF_W;
+const rightHalfX = barX + BAR_W;
+const trayX = rightHalfX + HALF_W;
+
+// Map a board point (1..24) to its column slot.
+// Visual standard layout:
+//   top row L->R:    13 14 15 16 17 18 | 19 20 21 22 23 24
+//   bottom row L->R: 12 11 10  9  8  7 |  6  5  4  3  2  1
+interface Slot {
+  cx: number; // center X of the point column
+  baseY: number; // Y at the open edge (where checker stack starts)
+  dir: 1 | -1; // +1 stacks downward (top points), -1 stacks upward (bottom points)
+  top: boolean;
+}
+
+function pointSlot(point: number): Slot {
+  // top points: 13..24
+  if (point >= 13) {
+    const idx = point - 13; // 0..11 left to right
+    const half = idx < 6 ? 0 : 1;
+    const within = half === 0 ? idx : idx - 6;
+    const halfStart = half === 0 ? leftHalfX : rightHalfX;
+    const cx = halfStart + within * POINT_W + POINT_W / 2;
+    return { cx, baseY: PLAY_Y, dir: 1, top: true };
+  }
+  // bottom points: 1..12. bottom-left (L->R) = 12 11 10 9 8 7, bottom-right = 6 5 4 3 2 1
+  const idx = 12 - point; // point 12 -> idx 0 (leftmost), point 1 -> idx 11 (rightmost)
+  const half = idx < 6 ? 0 : 1;
+  const within = half === 0 ? idx : idx - 6;
+  const halfStart = half === 0 ? leftHalfX : rightHalfX;
+  const cx = halfStart + within * POINT_W + POINT_W / 2;
+  return { cx, baseY: PLAY_Y + PLAY_H, dir: -1, top: false };
+}
+
+// Stacked checker centers for a point, clamped to MAX_VISIBLE.
+function stackCenters(slot: Slot, count: number): { cy: number }[] {
+  const n = Math.min(count, MAX_VISIBLE);
+  const out: { cy: number }[] = [];
+  const first = slot.baseY + slot.dir * (CHK_R + 4);
+  for (let i = 0; i < n; i++) {
+    out.push({ cy: first + slot.dir * i * CHK_GAP });
+  }
+  return out;
+}
+
+// Bar checker stack: vertical column from the top or bottom row toward center.
+function barCenters(count: number, fromTop: boolean): number[] {
+  const n = Math.min(count, MAX_VISIBLE);
+  const out: number[] = [];
+  const dir = fromTop ? 1 : -1;
+  const start = fromTop ? PLAY_Y + CHK_R + 6 : PLAY_Y + PLAY_H - CHK_R - 6;
+  for (let i = 0; i < n; i++) out.push(start + dir * i * CHK_GAP);
+  return out;
+}
+
+const barCx = barX + BAR_W / 2;
+const trayCx = trayX + TRAY_W / 2;
+const TRAY_INNER_W = TRAY_W - 18;
+const BORNE_H = 13;
+
+const PLAYER_NAME: Record<Player, string> = { white: "White", black: "Black" };
+
+// pip positions for die faces 1..6 on a 3x3 grid (cell indices 0..8)
+const DIE_PIPS: Record<number, number[]> = {
+  1: [4],
+  2: [0, 8],
+  3: [0, 4, 8],
+  4: [0, 2, 6, 8],
+  5: [0, 2, 4, 6, 8],
+  6: [0, 2, 3, 5, 6, 8],
+};
+
+function DieFace({ value, used, rolling }: { value: number; used: boolean; rolling: boolean }) {
+  const on = new Set(DIE_PIPS[value] ?? []);
+  return (
+    <div className={`die${used ? " used" : ""}${rolling ? " rolling" : ""}`} aria-label={`die ${value}`}>
+      {Array.from({ length: 9 }).map((_, i) => (
+        <span key={i} className={`pip${on.has(i) ? "" : " off"}`} />
+      ))}
+    </div>
+  );
+}
+
+// Bear-off tray fill: each borne checker is a thin stacked horizontal bar.
+function TrayStack({ count, player, fromTop }: { count: number; player: Player; fromTop: boolean }) {
+  const dir = fromTop ? 1 : -1;
+  const start = fromTop ? PLAY_Y + 20 : PLAY_Y + PLAY_H - 20 - BORNE_H;
+  return (
+    <>
+      {Array.from({ length: count }, (_, i) => (
+        <rect
+          key={`${player}-${i}`}
+          className={`borne ${player}`}
+          x={trayCx - TRAY_INNER_W / 2}
+          y={start + dir * i * (BORNE_H + 2)}
+          width={TRAY_INNER_W}
+          height={BORNE_H}
+          rx={3}
+        />
+      ))}
+    </>
+  );
+}
+
+export default function App() {
+  const [state, setState] = useState<GameState>(() => createInitialState());
+  const [selected, setSelected] = useState<number | null>(null);
+  const [rolled, setRolled] = useState(false);
+  const [rolling, setRolling] = useState(false);
+  const [matches, setMatches] = useState<MatchRecord[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string>("Roll the dice to begin.");
+  const [result, setResult] = useState<WinResult | null>(null);
+  const savedRef = useRef(false);
+
+  // load history + subscribe
+  useEffect(() => {
+    let active = true;
+    loadMatches(setError).then((rows) => {
+      if (active) setMatches(rows);
+    });
+    const db = window.MatrixOS?.db;
+    let unsub: (() => void) | undefined;
+    if (db) {
+      try {
+        unsub = db.onChange(MATCHES_TABLE, () => {
+          loadMatches(setError).then((rows) => setMatches(rows));
+        });
+      } catch (err) {
+        console.warn("[backgammon] onChange subscription failed", err);
+      }
+    }
+    return () => {
+      active = false;
+      if (unsub) unsub();
+    };
+  }, []);
+
+  const legalMoves = useMemo<Move[]>(() => {
+    if (!rolled || result) return [];
+    return generateLegalMoves(state);
+  }, [state, rolled, result]);
+
+  const legalFromSelected = useMemo<Move[]>(() => {
+    if (selected === null) return [];
+    return legalMoves.filter((m) => m.from === selected);
+  }, [legalMoves, selected]);
+
+  const legalTargets = useMemo(() => new Set(legalFromSelected.map((m) => m.to)), [legalFromSelected]);
+  const sourcesWithMoves = useMemo(() => new Set(legalMoves.map((m) => m.from)), [legalMoves]);
+
+  const pips = useMemo(
+    () => ({ white: pipCount(state, "white"), black: pipCount(state, "black") }),
+    [state],
+  );
+
+  // end-of-game detection + persistence
+  useEffect(() => {
+    if (!isGameOver(state)) return;
+    const res = winnerResult(state);
+    setResult(res);
+    if (res && !savedRef.current) {
+      savedRef.current = true;
+      const record: MatchRecord = { winner: res.winner, points: res.points };
+      saveMatch(record, setError).then((ok) => {
+        if (ok) {
+          setStatus("Saved to Matrix Postgres");
+          setMatches((prev) => [record, ...prev]);
+        }
+      });
+    }
+  }, [state]);
+
+  useEffect(() => {
+    if (!rolled || result) return;
+    if (legalMoves.length === 0) {
+      if (state.movesLeft.length === 0) {
+        setStatus(`${PLAYER_NAME[state.turn]} finished. ${PLAYER_NAME[other(state.turn)]} to roll.`);
+      } else {
+        setStatus(`No legal moves for ${PLAYER_NAME[state.turn]} — pass.`);
+      }
+    }
+  }, [legalMoves, rolled, result, state.movesLeft.length, state.turn]);
+
+  const handleRoll = useCallback(() => {
+    if (rolled || result) return;
+    const roll = rollDice();
+    setRolling(true);
+    const next = startTurn(state, roll);
+    setState(next);
+    setRolled(true);
+    setSelected(null);
+    setError(null);
+    setStatus(`${PLAYER_NAME[next.turn]} rolled ${roll.values[0]} & ${roll.values[1]}.`);
+    window.setTimeout(() => setRolling(false), 420);
+  }, [state, rolled, result]);
+
+  const endTurn = useCallback(() => {
+    setState((prev) => ({ ...prev, turn: other(prev.turn), movesLeft: [], dice: [], history: [] }));
+    setRolled(false);
+    setSelected(null);
+  }, []);
+
+  const doMove = useCallback((move: Move) => {
+    setState((prev) => applyMove(prev, move));
+    setSelected(null);
+  }, []);
+
+  useEffect(() => {
+    if (!rolled || result) return;
+    if (state.movesLeft.length === 0 && state.dice.length > 0) {
+      const timer = window.setTimeout(endTurn, 250);
+      return () => window.clearTimeout(timer);
+    }
+  }, [state.movesLeft.length, state.dice.length, rolled, result, endTurn]);
+
+  const handleSource = useCallback(
+    (point: number) => {
+      if (!rolled || result) return;
+      if (!sourcesWithMoves.has(point)) return;
+      setSelected((cur) => (cur === point ? null : point));
+    },
+    [rolled, result, sourcesWithMoves],
+  );
+
+  const handleTarget = useCallback(
+    (to: number) => {
+      if (selected === null) return;
+      const move = legalFromSelected.find((m) => m.to === to);
+      if (!move) return;
+      doMove(move);
+    },
+    [selected, legalFromSelected, doMove],
+  );
+
+  const handleUndo = useCallback(() => {
+    setState((prev) => undoMove(prev));
+    setSelected(null);
+  }, []);
+
+  const handleNewGame = useCallback(() => {
+    setState(createInitialState());
+    setSelected(null);
+    setRolled(false);
+    setResult(null);
+    savedRef.current = false;
+    setError(null);
+    setStatus("Roll the dice to begin.");
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      if (e.key === "r" || e.key === "R") handleRoll();
+      else if ((e.key === "z" && (e.metaKey || e.ctrlKey)) || e.key === "u" || e.key === "U") {
+        e.preventDefault();
+        handleUndo();
+      } else if (e.key === "n" || e.key === "N") handleNewGame();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [handleRoll, handleUndo, handleNewGame]);
+
+  const onBar = state.turn === "white" ? state.bar.white > 0 : state.bar.black > 0;
+  const canRoll = !rolled && !result;
+  const canPass = rolled && !result && legalMoves.length === 0 && state.movesLeft.length > 0;
+
+  // -- click routing for a point: prefer landing if it's a legal target --------
+  const onPointClick = useCallback(
+    (point: number) => {
+      if (legalTargets.has(point)) handleTarget(point);
+      else handleSource(point);
+    },
+    [legalTargets, handleTarget, handleSource],
+  );
+
+  const offTargetable = (player: Player) =>
+    selected !== null && legalTargets.has(OFF) && state.turn === player;
+
+  // ---- SVG point rendering ---------------------------------------------------
+  const renderPoint = (point: number) => {
+    const pt = state.points[point];
+    const slot = pointSlot(point);
+    const isLegalTarget = legalTargets.has(point);
+    const isSelected = selected === point;
+    const movable = sourcesWithMoves.has(point);
+    const odd = point % 2 === 1;
+
+    // triangle apex points toward the center of the board
+    const apexY = slot.baseY + slot.dir * POINT_H;
+    const x0 = slot.cx - POINT_W / 2 + 1.5;
+    const x1 = slot.cx + POINT_W / 2 - 1.5;
+    const tri = `${x0},${slot.baseY} ${x1},${slot.baseY} ${slot.cx},${apexY}`;
+
+    const centers = stackCenters(slot, pt.count);
+    const extra = pt.count - MAX_VISIBLE;
+    // label position for the +N count: just inside the apex of the last checker
+    const lastCy = centers.length ? centers[centers.length - 1].cy : slot.baseY;
+
+    return (
+      <g
+        key={point}
+        data-testid={`point-${point}`}
+        data-owner={pt.player ?? "none"}
+        data-count={pt.count}
+        data-legal={isLegalTarget ? "true" : "false"}
+        data-selected={isSelected ? "true" : "false"}
+        data-movable={movable ? "true" : "false"}
+        className={`pt${isLegalTarget ? " legal" : ""}${isSelected ? " selected" : ""}${movable ? " movable" : ""}`}
+        role="button"
+        tabIndex={0}
+        aria-label={`point ${point}${pt.player ? `, ${pt.count} ${pt.player}` : ", empty"}`}
+        onClick={() => onPointClick(point)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onPointClick(point);
+          }
+        }}
+      >
+        <polygon className={`tri ${odd ? "tri-a" : "tri-b"}`} points={tri} />
+        {isLegalTarget ? <polygon className="tri-target" points={tri} /> : null}
+        {isSelected ? <polygon className="tri-selected" points={tri} /> : null}
+        {centers.map((c, i) => {
+          const top = i === centers.length - 1;
+          return (
+            <circle
+              key={i}
+              className={`chk ${pt.player}${movable && top ? " movable-top" : ""}`}
+              cx={slot.cx}
+              cy={c.cy}
+              r={CHK_R}
+            />
+          );
+        })}
+        {extra > 0 ? (
+          <text className="chk-count" x={slot.cx} y={lastCy} dominantBaseline="central" textAnchor="middle">
+            +{extra}
+          </text>
+        ) : null}
+        {/* invisible hit area so the whole column is clickable */}
+        <rect
+          className="hit"
+          x={slot.cx - POINT_W / 2}
+          y={slot.top ? PLAY_Y : PLAY_Y + PLAY_H / 2}
+          width={POINT_W}
+          height={PLAY_H / 2}
+          fill="transparent"
+        />
+      </g>
+    );
+  };
+
+  // black hit checkers sit on the top of the bar, white on the bottom (mirrors home dirs)
+  const blackBarLegal = onBar && state.turn === "black" && sourcesWithMoves.has(BAR);
+  const whiteBarLegal = onBar && state.turn === "white" && sourcesWithMoves.has(BAR);
+
+  return (
+    <div className="bg-app">
+      {/* ---------- header ---------- */}
+      <header className="bg-topbar">
+        <div className="bg-title">
+          <Dices size={18} />
+          <span>Backgammon</span>
+        </div>
+
+        <div className="bg-turn" data-testid="turn-indicator">
+          <span className={`dot ${state.turn}`} />
+          {PLAYER_NAME[state.turn]} to {rolled ? "move" : "roll"}
+        </div>
+
+        <div className="bg-dice" data-testid="dice">
+          {state.dice.length === 0 ? (
+            <span className="bg-note">tap roll</span>
+          ) : (
+            state.dice.map((d, i) => {
+              const used = !diceStillAvailable(state, d, i);
+              return <DieFace key={i} value={d} used={used} rolling={rolling} />;
+            })
+          )}
+        </div>
+
+        <div className="bg-spacer" />
+
+        <div className="bg-pips">
+          <div className="bg-pip">
+            <span className="label">White</span>
+            <span className="value" data-testid="pip-white">
+              {pips.white}
+            </span>
+          </div>
+          <div className="bg-pip">
+            <span className="label">Black</span>
+            <span className="value" data-testid="pip-black">
+              {pips.black}
+            </span>
+          </div>
+        </div>
+
+        <div className="bg-actions">
+          <button type="button" className="bg-btn primary" onClick={handleRoll} disabled={!canRoll}>
+            <Dices size={15} /> Roll
+          </button>
+          {canPass ? (
+            <button type="button" className="bg-btn" onClick={endTurn}>
+              Pass
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="bg-btn icon"
+            onClick={handleUndo}
+            disabled={state.history.length === 0}
+            title="Undo (U)"
+            aria-label="Undo"
+          >
+            <Undo2 size={15} />
+          </button>
+          <button
+            type="button"
+            className="bg-btn icon"
+            onClick={handleNewGame}
+            title="New game (N)"
+            aria-label="New game"
+          >
+            <RotateCcw size={15} />
+          </button>
+        </div>
+      </header>
+
+      {/* ---------- board ---------- */}
+      <div className="bg-board-wrap">
+        <div className="bg-board" data-testid="board">
+          <svg
+            className="bg-svg"
+            viewBox={`0 0 ${VB_W} ${VB_H}`}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            aria-label="Backgammon board"
+          >
+            {/* wood frame */}
+            <rect className="frame" x={0} y={0} width={VB_W} height={VB_H} rx={20} />
+            {/* felt halves */}
+            <rect className="felt" x={leftHalfX} y={PLAY_Y} width={HALF_W} height={PLAY_H} />
+            <rect className="felt" x={rightHalfX} y={PLAY_Y} width={HALF_W} height={PLAY_H} />
+            {/* center bar */}
+            <rect className="bar" x={barX} y={PLAY_Y} width={BAR_W} height={PLAY_H} rx={6} />
+            {/* bear-off tray */}
+            <rect className="tray" x={trayX + 4} y={PLAY_Y} width={TRAY_W - 8} height={PLAY_H} rx={8} />
+            <line
+              className="tray-divider"
+              x1={trayX + 12}
+              y1={PLAY_Y + PLAY_H / 2}
+              x2={trayX + TRAY_W - 12}
+              y2={PLAY_Y + PLAY_H / 2}
+            />
+
+            {/* points */}
+            {Array.from({ length: 24 }, (_, i) => renderPoint(i + 1))}
+
+            {/* bar: hit checkers + click targets */}
+            <g
+              data-testid="bar-black"
+              data-legal={blackBarLegal ? "true" : "false"}
+              data-selected={selected === BAR && state.turn === "black" ? "true" : "false"}
+              className={`bar-slot${blackBarLegal ? " legal" : ""}${selected === BAR && state.turn === "black" ? " selected" : ""}`}
+              onClick={() => {
+                if (state.turn === "black" && onBar) handleSource(BAR);
+              }}
+            >
+              <rect
+                className="bar-hit"
+                x={barX}
+                y={PLAY_Y}
+                width={BAR_W}
+                height={PLAY_H / 2}
+                fill="transparent"
+              />
+              {barCenters(state.bar.black, true).map((cy, i) => (
+                <circle key={i} className="chk black" cx={barCx} cy={cy} r={CHK_R} />
+              ))}
+            </g>
+            <g
+              data-testid="bar-white"
+              data-legal={whiteBarLegal ? "true" : "false"}
+              data-selected={selected === BAR && state.turn === "white" ? "true" : "false"}
+              className={`bar-slot${whiteBarLegal ? " legal" : ""}${selected === BAR && state.turn === "white" ? " selected" : ""}`}
+              onClick={() => {
+                if (state.turn === "white" && onBar) handleSource(BAR);
+              }}
+            >
+              <rect
+                className="bar-hit"
+                x={barX}
+                y={PLAY_Y + PLAY_H / 2}
+                width={BAR_W}
+                height={PLAY_H / 2}
+                fill="transparent"
+              />
+              {barCenters(state.bar.white, false).map((cy, i) => (
+                <circle key={i} className="chk white" cx={barCx} cy={cy} r={CHK_R} />
+              ))}
+            </g>
+
+            {/* off trays (black top, white bottom — matches home-board sides) */}
+            <g
+              data-testid="off-black"
+              data-legal={offTargetable("black") ? "true" : "false"}
+              className={`tray-slot${offTargetable("black") ? " legal" : ""}`}
+              onClick={() => offTargetable("black") && handleTarget(OFF)}
+            >
+              <rect
+                className="tray-hit"
+                x={trayX + 4}
+                y={PLAY_Y}
+                width={TRAY_W - 8}
+                height={PLAY_H / 2}
+                fill="transparent"
+              />
+              <TrayStack count={state.off.black} player="black" fromTop />
+            </g>
+            <g
+              data-testid="off-white"
+              data-legal={offTargetable("white") ? "true" : "false"}
+              className={`tray-slot${offTargetable("white") ? " legal" : ""}`}
+              onClick={() => offTargetable("white") && handleTarget(OFF)}
+            >
+              <rect
+                className="tray-hit"
+                x={trayX + 4}
+                y={PLAY_Y + PLAY_H / 2}
+                width={TRAY_W - 8}
+                height={PLAY_H / 2}
+                fill="transparent"
+              />
+              <TrayStack count={state.off.white} player="white" fromTop={false} />
+            </g>
+
+            <text className="tray-tag" x={trayCx} y={PLAY_Y + PLAY_H / 2 - 4} textAnchor="middle">
+              {state.off.black}
+            </text>
+            <text className="tray-tag" x={trayCx} y={PLAY_Y + PLAY_H / 2 + 16} textAnchor="middle">
+              {state.off.white}
+            </text>
+          </svg>
+
+          {result ? (
+            <div className="bg-overlay">
+              <h2>{PLAYER_NAME[result.winner]} wins!</h2>
+              <p>
+                {result.label === "single"
+                  ? "Single game"
+                  : result.label === "gammon"
+                    ? "Gammon"
+                    : "Backgammon"}{" "}
+                · {result.points} point{result.points > 1 ? "s" : ""}
+              </p>
+              <button type="button" className="bg-btn primary" onClick={handleNewGame}>
+                New game
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {/* ---------- footer ---------- */}
+      <footer className="bg-status">
+        {error ? (
+          <span className="err">{error}</span>
+        ) : status === "Saved to Matrix Postgres" ? (
+          <span className="ok">{status}</span>
+        ) : (
+          <span>{status}</span>
+        )}
+        <span className="bg-records" data-testid="match-count">
+          {matches.length} match{matches.length === 1 ? "" : "es"} recorded
+        </span>
+      </footer>
+    </div>
+  );
+}
+
+function other(p: Player): Player {
+  return p === "white" ? "black" : "white";
+}
+
+// Determine whether the i-th rolled die is still unconsumed (for grey-out).
+function diceStillAvailable(state: GameState, value: number, index: number): boolean {
+  const rolledCount = state.dice.filter((d) => d === value).length;
+  const leftCount = state.movesLeft.filter((d) => d === value).length;
+  const occurrenceIndex = state.dice.slice(0, index + 1).filter((d) => d === value).length;
+  return occurrenceIndex <= leftCount && rolledCount > 0;
+}

--- a/home/apps/games/backgammon/src/App.tsx
+++ b/home/apps/games/backgammon/src/App.tsx
@@ -28,11 +28,12 @@ interface MatchRecord {
 
 // ---- persistence -----------------------------------------------------------
 
-async function loadMatches(setError: (s: string | null) => void): Promise<MatchRecord[]> {
+async function loadMatches(setError: (s: string | null) => void): Promise<MatchRecord[] | null> {
   const db = window.MatrixOS?.db;
   if (db) {
     try {
       const rows = await db.find(MATCHES_TABLE, { orderBy: { created_at: "desc" }, limit: 50 });
+      setError(null);
       return rows.map((r) => ({
         winner: String(r.winner ?? ""),
         points: Number(r.points ?? 0),
@@ -40,6 +41,7 @@ async function loadMatches(setError: (s: string | null) => void): Promise<MatchR
     } catch (err) {
       console.warn("[backgammon] failed to load matches from DB", err);
       setError("Could not load match history.");
+      return null;
     }
   }
   return [];
@@ -206,14 +208,16 @@ export default function App() {
   useEffect(() => {
     let active = true;
     loadMatches(setError).then((rows) => {
-      if (active) setMatches(rows);
+      if (active && rows) setMatches(rows);
     });
     const db = window.MatrixOS?.db;
     let unsub: (() => void) | undefined;
     if (db) {
       try {
         unsub = db.onChange(MATCHES_TABLE, () => {
-          loadMatches(setError).then((rows) => setMatches(rows));
+          loadMatches(setError).then((rows) => {
+            if (rows) setMatches(rows);
+          });
         });
       } catch (err) {
         console.warn("[backgammon] onChange subscription failed", err);

--- a/home/apps/games/backgammon/src/App.tsx
+++ b/home/apps/games/backgammon/src/App.tsx
@@ -20,7 +20,6 @@ import {
 } from "./backgammon-model";
 
 const MATCHES_TABLE = "matches";
-const LS_KEY = "matrixos.backgammon.matches";
 
 interface MatchRecord {
   winner: string;
@@ -41,22 +40,9 @@ async function loadMatches(setError: (s: string | null) => void): Promise<MatchR
     } catch (err) {
       console.warn("[backgammon] failed to load matches from DB", err);
       setError("Could not load match history.");
-      // fall through to localStorage as a best-effort fallback
     }
   }
-  try {
-    const raw = window.localStorage.getItem(LS_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.map((r) => ({
-      winner: String((r as MatchRecord).winner ?? ""),
-      points: Number((r as MatchRecord).points ?? 0),
-    }));
-  } catch (err) {
-    console.warn("[backgammon] failed to read localStorage matches", err);
-    return [];
-  }
+  return [];
 }
 
 async function saveMatch(record: MatchRecord, setError: (s: string | null) => void): Promise<boolean> {
@@ -71,17 +57,8 @@ async function saveMatch(record: MatchRecord, setError: (s: string | null) => vo
       return false;
     }
   }
-  try {
-    const raw = window.localStorage.getItem(LS_KEY);
-    const list: MatchRecord[] = raw ? (JSON.parse(raw) as MatchRecord[]) : [];
-    list.unshift(record);
-    window.localStorage.setItem(LS_KEY, JSON.stringify(list.slice(0, 50)));
-    return true;
-  } catch (err) {
-    console.warn("[backgammon] failed to persist match to localStorage", err);
-    setError("Could not save the result.");
-    return false;
-  }
+  setError("Match history sync is unavailable.");
+  return false;
 }
 
 // ---- board geometry --------------------------------------------------------
@@ -270,9 +247,10 @@ export default function App() {
     if (res && !savedRef.current) {
       savedRef.current = true;
       const record: MatchRecord = { winner: res.winner, points: res.points };
+      const usedDb = Boolean(window.MatrixOS?.db);
       saveMatch(record, setError).then((ok) => {
         if (ok) {
-          setStatus("Saved to Matrix Postgres");
+          setStatus(usedDb ? "Saved to Matrix Postgres" : "Saved");
           setMatches((prev) => [record, ...prev]);
         }
       });

--- a/home/apps/games/backgammon/src/backgammon-model.ts
+++ b/home/apps/games/backgammon/src/backgammon-model.ts
@@ -1,0 +1,410 @@
+// Pure, UI-free backgammon engine. Deterministic with injectable dice.
+//
+// Board numbering (standard, 1..24):
+//   - White moves from high points toward 1 and bears off past point 1.
+//     White home board = points 1..6. White enters from the bar onto 19..24.
+//   - Black moves from low points toward 24 and bears off past point 24.
+//     Black home board = points 19..24. Black enters from the bar onto 1..6.
+//
+// Special destinations:
+export const BAR = -1; // a checker sitting on the bar (used as move.from)
+export const OFF = 0; // borne off (used as move.to)
+
+export type Player = "white" | "black";
+
+export interface Point {
+  player: Player | null;
+  count: number;
+}
+
+export interface GameState {
+  // points[1..24]; index 0 is unused padding.
+  points: Point[];
+  bar: { white: number; black: number };
+  off: { white: number; black: number };
+  turn: Player;
+  dice: number[]; // the raw roll (2 values; doubles repeat)
+  movesLeft: number[]; // remaining die pips that can still be played this turn
+  history: HistorySnapshot[]; // for undo within the current turn
+}
+
+export interface HistorySnapshot {
+  points: Point[];
+  bar: { white: number; black: number };
+  off: { white: number; black: number };
+  movesLeft: number[];
+}
+
+export interface Move {
+  from: number; // 1..24 or BAR
+  to: number; // 1..24 or OFF
+  die: number;
+  hit?: boolean;
+  bearOff?: boolean;
+}
+
+export interface Roll {
+  values: [number, number];
+}
+
+export interface WinResult {
+  winner: Player;
+  multiplier: 1 | 2 | 3;
+  points: number;
+  label: "single" | "gammon" | "backgammon";
+}
+
+function clonePoints(points: Point[]): Point[] {
+  return points.map((p) => ({ player: p.player, count: p.count }));
+}
+
+export function createInitialState(): GameState {
+  const points: Point[] = [];
+  for (let i = 0; i <= 24; i++) points.push({ player: null, count: 0 });
+
+  // White (moves 24 -> 1)
+  points[24] = { player: "white", count: 2 };
+  points[13] = { player: "white", count: 5 };
+  points[8] = { player: "white", count: 3 };
+  points[6] = { player: "white", count: 5 };
+  // Black (mirror, moves 1 -> 24)
+  points[1] = { player: "black", count: 2 };
+  points[12] = { player: "black", count: 5 };
+  points[17] = { player: "black", count: 3 };
+  points[19] = { player: "black", count: 5 };
+
+  return {
+    points,
+    bar: { white: 0, black: 0 },
+    off: { white: 0, black: 0 },
+    turn: "white",
+    dice: [],
+    movesLeft: [],
+    history: [],
+  };
+}
+
+export function rollFromValues(a: number, b: number): Roll {
+  return { values: [a, b] };
+}
+
+export function rollDice(rng: () => number = Math.random): Roll {
+  const d = () => Math.floor(rng() * 6) + 1;
+  return { values: [d(), d()] };
+}
+
+// Begin a turn with a given roll: sets dice + movesLeft, clears undo history.
+export function startTurn(state: GameState, roll: Roll): GameState {
+  const [a, b] = roll.values;
+  const movesLeft = a === b ? [a, a, a, a] : [a, b];
+  return {
+    ...state,
+    points: clonePoints(state.points),
+    bar: { ...state.bar },
+    off: { ...state.off },
+    dice: [a, b],
+    movesLeft: [...movesLeft],
+    history: [],
+  };
+}
+
+function opponent(p: Player): Player {
+  return p === "white" ? "black" : "white";
+}
+
+// The destination point for a checker leaving `from` using `die`, in board coords.
+// Returns OFF when the checker would bear off, or a number outside 1..24 when illegal.
+function targetPoint(state: GameState, from: number, die: number): number {
+  const player = state.turn;
+  if (from === BAR) {
+    // entry point
+    return player === "white" ? 25 - die : die;
+  }
+  return player === "white" ? from - die : from + die;
+}
+
+function inHomeBoard(state: GameState, player: Player): boolean {
+  if (player === "white") {
+    if (state.bar.white > 0) return false;
+    for (let i = 7; i <= 24; i++) {
+      if (state.points[i].player === "white" && state.points[i].count > 0) return false;
+    }
+    return true;
+  }
+  if (state.bar.black > 0) return false;
+  for (let i = 1; i <= 18; i++) {
+    if (state.points[i].player === "black" && state.points[i].count > 0) return false;
+  }
+  return true;
+}
+
+// Highest point distance from bearing-off edge that the player still occupies.
+// For white, that's the largest point index in 1..6. For black, smallest index in 19..24
+// expressed as a "pip from edge" (25 - index).
+function highestHomePip(state: GameState, player: Player): number {
+  if (player === "white") {
+    for (let i = 6; i >= 1; i--) {
+      if (state.points[i].player === "white" && state.points[i].count > 0) return i;
+    }
+    return 0;
+  }
+  for (let i = 19; i <= 24; i++) {
+    if (state.points[i].player === "black" && state.points[i].count > 0) return 25 - i;
+  }
+  return 0;
+}
+
+// distance to bear off from a home point for the current player
+function bearOffPip(player: Player, from: number): number {
+  return player === "white" ? from : 25 - from;
+}
+
+function canLandOn(state: GameState, to: number): { ok: boolean; hit: boolean } {
+  if (to < 1 || to > 24) return { ok: false, hit: false };
+  const pt = state.points[to];
+  const opp = opponent(state.turn);
+  if (pt.player === opp && pt.count >= 2) return { ok: false, hit: false };
+  const hit = pt.player === opp && pt.count === 1;
+  return { ok: true, hit };
+}
+
+// All single-die legal moves from a given source for the current movesLeft set.
+export function legalDestinations(state: GameState, from: number): Move[] {
+  const player = state.turn;
+  const moves: Move[] = [];
+  const dice = uniqueDice(state.movesLeft);
+
+  // If on the bar, only bar entries are legal.
+  const onBar = player === "white" ? state.bar.white > 0 : state.bar.black > 0;
+  if (onBar && from !== BAR) return [];
+  if (!onBar && from === BAR) return [];
+
+  // Source must hold a checker of the current player (unless it's the bar).
+  if (from !== BAR) {
+    const src = state.points[from];
+    if (src.player !== player || src.count <= 0) return [];
+  }
+
+  for (const die of dice) {
+    if (from === BAR) {
+      const entry = targetPoint(state, BAR, die);
+      const land = canLandOn(state, entry);
+      if (land.ok) moves.push({ from: BAR, to: entry, die, hit: land.hit });
+      continue;
+    }
+
+    const to = targetPoint(state, from, die);
+    if (to >= 1 && to <= 24) {
+      const land = canLandOn(state, to);
+      if (land.ok) moves.push({ from, to, die, hit: land.hit });
+      continue;
+    }
+
+    // Off the edge: possible bear-off.
+    if (!inHomeBoard(state, player)) continue;
+    const pip = bearOffPip(player, from);
+    if (die === pip) {
+      moves.push({ from, to: OFF, die, bearOff: true });
+    } else if (die > pip) {
+      // Overshoot only allowed if no checker sits on a higher point.
+      if (highestHomePip(state, player) <= pip) {
+        moves.push({ from, to: OFF, die, bearOff: true });
+      }
+    }
+  }
+
+  return moves;
+}
+
+function uniqueDice(movesLeft: number[]): number[] {
+  return Array.from(new Set(movesLeft));
+}
+
+function ownSources(state: GameState): number[] {
+  const player = state.turn;
+  const onBar = player === "white" ? state.bar.white > 0 : state.bar.black > 0;
+  if (onBar) return [BAR];
+  const sources: number[] = [];
+  for (let i = 1; i <= 24; i++) {
+    if (state.points[i].player === player && state.points[i].count > 0) sources.push(i);
+  }
+  return sources;
+}
+
+// All legal single moves available right now (raw, before the "must use both dice" filter).
+function rawLegalMoves(state: GameState): Move[] {
+  const moves: Move[] = [];
+  for (const src of ownSources(state)) {
+    moves.push(...legalDestinations(state, src));
+  }
+  return moves;
+}
+
+// Apply a single move and consume one matching die. Returns a new state.
+// Pushes a snapshot for undo.
+export function applyMove(state: GameState, move: Move): GameState {
+  const next: GameState = {
+    ...state,
+    points: clonePoints(state.points),
+    bar: { ...state.bar },
+    off: { ...state.off },
+    movesLeft: [...state.movesLeft],
+    history: [
+      ...state.history,
+      {
+        points: clonePoints(state.points),
+        bar: { ...state.bar },
+        off: { ...state.off },
+        movesLeft: [...state.movesLeft],
+      },
+    ],
+  };
+  const player = state.turn;
+  const opp = opponent(player);
+
+  // remove from source
+  if (move.from === BAR) {
+    next.bar[player] -= 1;
+  } else {
+    const src = next.points[move.from];
+    src.count -= 1;
+    if (src.count === 0) src.player = null;
+  }
+
+  // place at destination
+  if (move.to === OFF) {
+    next.off[player] += 1;
+  } else {
+    const dest = next.points[move.to];
+    if (move.hit || (dest.player === opp && dest.count === 1)) {
+      // send opponent blot to the bar
+      next.bar[opp] += 1;
+      dest.player = player;
+      dest.count = 1;
+    } else {
+      dest.player = player;
+      dest.count += 1;
+    }
+  }
+
+  // consume the die
+  const idx = next.movesLeft.indexOf(move.die);
+  if (idx >= 0) next.movesLeft.splice(idx, 1);
+
+  return next;
+}
+
+// Undo the last move within the current turn. No-op if no history.
+export function undo(state: GameState): GameState {
+  if (state.history.length === 0) return state;
+  const history = [...state.history];
+  const snap = history.pop()!;
+  return {
+    ...state,
+    points: clonePoints(snap.points),
+    bar: { ...snap.bar },
+    off: { ...snap.off },
+    movesLeft: [...snap.movesLeft],
+    history,
+  };
+}
+
+// Whether the current player has any legal move with the remaining dice.
+export function hasAnyMove(state: GameState): boolean {
+  return rawLegalMoves(state).length > 0;
+}
+
+// Max number of die-plays the player could make from this position (search).
+function maxPlayable(state: GameState, depth = 0): number {
+  if (state.movesLeft.length === 0) return 0;
+  const moves = rawLegalMoves(state);
+  if (moves.length === 0) return 0;
+  let best = 0;
+  for (const m of moves) {
+    const after = applyMove(state, m);
+    const sub = 1 + maxPlayable(after, depth + 1);
+    if (sub > best) best = sub;
+  }
+  return best;
+}
+
+// Legal moves enforcing the "must use both dice if possible / larger die if only one" rule.
+export function generateLegalMoves(state: GameState): Move[] {
+  const raw = rawLegalMoves(state);
+  if (raw.length === 0) return [];
+
+  // Doubles or already-partial turns: still enforce maximal usage.
+  const maxUse = maxPlayable(state);
+
+  // Keep only moves that allow the player to reach the maximum number of die-plays.
+  let filtered = raw.filter((m) => {
+    const after = applyMove(state, m);
+    return 1 + maxPlayable(after) >= maxUse;
+  });
+
+  // Special rule: when only ONE die can be played (maxUse === 1) and the two dice differ,
+  // the player must play the larger die if a choice exists.
+  const distinctDice = uniqueDice(state.movesLeft);
+  if (maxUse === 1 && distinctDice.length === 2) {
+    const larger = Math.max(...distinctDice);
+    const hasLarger = filtered.some((m) => m.die === larger);
+    if (hasLarger) {
+      filtered = filtered.filter((m) => m.die === larger);
+    }
+  }
+
+  return filtered;
+}
+
+export function pipCount(state: GameState, player: Player): number {
+  let total = 0;
+  for (let i = 1; i <= 24; i++) {
+    const pt = state.points[i];
+    if (pt.player !== player) continue;
+    const pip = player === "white" ? i : 25 - i;
+    total += pip * pt.count;
+  }
+  total += state.bar[player] * 25;
+  return total;
+}
+
+export function isGameOver(state: GameState): boolean {
+  return state.off.white >= 15 || state.off.black >= 15;
+}
+
+export function winnerResult(state: GameState): WinResult | null {
+  if (!isGameOver(state)) return null;
+  const winner: Player = state.off.white >= 15 ? "white" : "black";
+  const loser = opponent(winner);
+
+  if (state.off[loser] > 0) {
+    return { winner, multiplier: 1, points: 1, label: "single" };
+  }
+
+  // Loser has borne off nothing -> at least a gammon.
+  // Backgammon if the loser still has a checker on the bar or in the winner's home board.
+  const loserOnBarOrWinnerHome = (() => {
+    if (state.bar[loser] > 0) return true;
+    // winner's home board: white -> 1..6, black -> 19..24
+    if (winner === "white") {
+      for (let i = 1; i <= 6; i++) {
+        if (state.points[i].player === loser && state.points[i].count > 0) return true;
+      }
+    } else {
+      for (let i = 19; i <= 24; i++) {
+        if (state.points[i].player === loser && state.points[i].count > 0) return true;
+      }
+    }
+    return false;
+  })();
+
+  if (loserOnBarOrWinnerHome) {
+    return { winner, multiplier: 3, points: 3, label: "backgammon" };
+  }
+  return { winner, multiplier: 2, points: 2, label: "gammon" };
+}
+
+// Convenience: bear-off readiness for UI badges.
+export function canBearOff(state: GameState, player: Player): boolean {
+  return inHomeBoard(state, player);
+}

--- a/home/apps/games/backgammon/src/backgammon-model.ts
+++ b/home/apps/games/backgammon/src/backgammon-model.ts
@@ -315,14 +315,14 @@ export function hasAnyMove(state: GameState): boolean {
 }
 
 // Max number of die-plays the player could make from this position (search).
-function maxPlayable(state: GameState, depth = 0): number {
+function maxPlayable(state: GameState): number {
   if (state.movesLeft.length === 0) return 0;
   const moves = rawLegalMoves(state);
   if (moves.length === 0) return 0;
   let best = 0;
   for (const m of moves) {
     const after = applyMove(state, m);
-    const sub = 1 + maxPlayable(after, depth + 1);
+    const sub = 1 + maxPlayable(after);
     if (sub > best) best = sub;
   }
   return best;

--- a/home/apps/games/backgammon/src/backgammon-model.ts
+++ b/home/apps/games/backgammon/src/backgammon-model.ts
@@ -315,16 +315,32 @@ export function hasAnyMove(state: GameState): boolean {
 }
 
 // Max number of die-plays the player could make from this position (search).
-function maxPlayable(state: GameState): number {
+function maxPlayableKey(state: GameState): string {
+  const points = state.points
+    .slice(1)
+    .map((point) => `${point.player?.[0] ?? "-"}${point.count}`)
+    .join(",");
+  return `${state.turn}|${state.movesLeft.join(",")}|${state.bar.white},${state.bar.black}|${state.off.white},${state.off.black}|${points}`;
+}
+
+function maxPlayable(state: GameState, memo = new Map<string, number>()): number {
   if (state.movesLeft.length === 0) return 0;
+  const key = maxPlayableKey(state);
+  const cached = memo.get(key);
+  if (cached !== undefined) return cached;
   const moves = rawLegalMoves(state);
-  if (moves.length === 0) return 0;
+  if (moves.length === 0) {
+    memo.set(key, 0);
+    return 0;
+  }
   let best = 0;
   for (const m of moves) {
     const after = applyMove(state, m);
-    const sub = 1 + maxPlayable(after);
+    const sub = 1 + maxPlayable(after, memo);
     if (sub > best) best = sub;
+    if (best >= state.movesLeft.length) break;
   }
+  memo.set(key, best);
   return best;
 }
 
@@ -334,12 +350,13 @@ export function generateLegalMoves(state: GameState): Move[] {
   if (raw.length === 0) return [];
 
   // Doubles or already-partial turns: still enforce maximal usage.
-  const maxUse = maxPlayable(state);
+  const maxPlayableMemo = new Map<string, number>();
+  const maxUse = maxPlayable(state, maxPlayableMemo);
 
   // Keep only moves that allow the player to reach the maximum number of die-plays.
   let filtered = raw.filter((m) => {
     const after = applyMove(state, m);
-    return 1 + maxPlayable(after) >= maxUse;
+    return 1 + maxPlayable(after, maxPlayableMemo) >= maxUse;
   });
 
   // Special rule: when only ONE die can be played (maxUse === 1) and the two dice differ,

--- a/home/apps/games/backgammon/src/main.tsx
+++ b/home/apps/games/backgammon/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("backgammon" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/backgammon/src/matrix-os.d.ts
+++ b/home/apps/games/backgammon/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/home/apps/games/backgammon/src/styles.css
+++ b/home/apps/games/backgammon/src/styles.css
@@ -396,6 +396,17 @@ body {
   color: var(--app-danger);
   font-weight: 600;
 }
+.die-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+}
+.die-choice .bg-btn {
+  min-width: 32px;
+  justify-content: center;
+  padding: 5px 9px;
+}
 .bg-records {
   margin-left: auto;
   font-size: 12px;

--- a/home/apps/games/backgammon/src/styles.css
+++ b/home/apps/games/backgammon/src/styles.css
@@ -1,0 +1,415 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+  --app-mono: var(--matrix-font-mono, "JetBrains Mono", monospace);
+
+  /* board tones derived from the warm theme */
+  --frame: color-mix(in srgb, var(--app-primary) 78%, #2a2117);
+  --felt: color-mix(in srgb, var(--app-accent) 8%, #f3ead9);
+  --bar-tone: color-mix(in srgb, var(--app-primary) 60%, #2a2117);
+  --tray-tone: color-mix(in srgb, var(--app-primary) 40%, #2a2117);
+  --tri-a: color-mix(in srgb, var(--app-accent) 78%, #f3ead9);
+  --tri-b: color-mix(in srgb, var(--app-primary) 70%, #f3ead9);
+  --checker-white: #f4f1e8;
+  --checker-white-edge: #c8c0aa;
+  --checker-black: #34322d;
+  --checker-black-edge: #16150f;
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+.bg-app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--app-bg);
+  color: var(--app-fg);
+  font-family: var(--app-font);
+  padding: 12px 14px;
+  gap: 10px;
+  overflow: hidden;
+}
+
+/* ---------- header ---------- */
+.bg-topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+.bg-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: 650;
+  font-size: 15px;
+}
+.bg-title svg {
+  color: var(--app-accent);
+}
+.bg-spacer {
+  flex: 1;
+}
+
+.bg-turn {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 11px;
+  border-radius: 11px;
+  background: var(--app-card);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+  font-weight: 600;
+  font-size: 12.5px;
+}
+.bg-turn .dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 1px solid var(--app-border);
+}
+.dot.white {
+  background: var(--checker-white);
+}
+.dot.black {
+  background: var(--checker-black);
+}
+
+.bg-pips {
+  display: flex;
+  gap: 6px;
+}
+.bg-pip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 11px;
+  background: var(--app-muted);
+  min-width: 52px;
+}
+.bg-pip .label {
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--app-muted-fg);
+}
+.bg-pip .value {
+  font-family: var(--app-mono);
+  font-weight: 700;
+  font-size: 15px;
+}
+
+.bg-actions {
+  display: flex;
+  gap: 6px;
+}
+.bg-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 11px;
+  background: var(--app-card);
+  color: var(--app-fg);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+  transition: all 0.15s ease;
+}
+.bg-btn.icon {
+  padding: 8px 9px;
+}
+.bg-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--app-fg) 4%, var(--app-card));
+}
+.bg-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.bg-btn.primary {
+  background: var(--app-accent);
+  color: #fff;
+}
+.bg-btn.primary:hover:not(:disabled) {
+  background: color-mix(in srgb, #000 8%, var(--app-accent));
+}
+.bg-btn:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+/* ---------- dice ---------- */
+.bg-dice {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  min-width: 34px;
+}
+.die {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--checker-white);
+  border: 1px solid var(--checker-white-edge);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  padding: 4px;
+  box-shadow: 0 2px 6px rgba(50, 53, 46, 0.16);
+  transition: transform 0.15s ease;
+}
+.die.used {
+  opacity: 0.32;
+}
+.die.rolling {
+  animation: bg-tumble 0.4s ease;
+}
+@keyframes bg-tumble {
+  0% {
+    transform: rotate(0) scale(0.85);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.1);
+  }
+  100% {
+    transform: rotate(360deg) scale(1);
+  }
+}
+.die .pip {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--checker-black);
+  align-self: center;
+  justify-self: center;
+}
+.die .pip.off {
+  background: transparent;
+}
+
+/* ---------- board ---------- */
+.bg-board-wrap {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  min-width: 0;
+}
+.bg-board {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-width: min(100%, calc((100vh - 120px) * 1.5625));
+  aspect-ratio: 1000 / 640;
+  margin: 0 auto;
+  display: flex;
+  filter: drop-shadow(0 12px 28px rgba(50, 53, 46, 0.22));
+}
+.bg-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: var(--app-radius);
+}
+
+/* board structure */
+.frame {
+  fill: var(--frame);
+}
+.felt {
+  fill: var(--felt);
+}
+.bar {
+  fill: var(--bar-tone);
+}
+.tray {
+  fill: var(--tray-tone);
+}
+.tray-divider {
+  stroke: rgba(0, 0, 0, 0.28);
+  stroke-width: 2;
+}
+.tray-tag {
+  fill: rgba(255, 255, 255, 0.55);
+  font-family: var(--app-mono);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+/* points */
+.tri-a {
+  fill: var(--tri-a);
+}
+.tri-b {
+  fill: var(--tri-b);
+}
+.tri {
+  stroke: rgba(0, 0, 0, 0.08);
+  stroke-width: 0.5;
+}
+.tri-target {
+  fill: none;
+  stroke: var(--app-success);
+  stroke-width: 3;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--app-success) 60%, transparent));
+}
+.tri-selected {
+  fill: none;
+  stroke: var(--app-accent);
+  stroke-width: 3;
+  stroke-linejoin: round;
+}
+.pt {
+  cursor: default;
+}
+.pt.legal,
+.pt.movable {
+  cursor: pointer;
+}
+
+/* checkers */
+.chk {
+  stroke-width: 1.5;
+}
+.chk.white {
+  fill: var(--checker-white);
+  stroke: var(--checker-white-edge);
+}
+.chk.black {
+  fill: var(--checker-black);
+  stroke: var(--checker-black-edge);
+}
+.chk.movable-top {
+  stroke: var(--app-accent);
+  stroke-width: 3;
+}
+.chk-count {
+  fill: var(--app-fg);
+  font-family: var(--app-mono);
+  font-size: 14px;
+  font-weight: 700;
+  paint-order: stroke;
+  stroke: var(--checker-white);
+  stroke-width: 3;
+}
+
+/* bar + tray interaction outlines */
+.bar-slot.legal .bar-hit,
+.tray-slot.legal .tray-hit {
+  stroke: var(--app-success);
+  stroke-width: 3;
+  fill: color-mix(in srgb, var(--app-success) 14%, transparent) !important;
+  rx: 6;
+}
+.bar-slot.selected .bar-hit {
+  stroke: var(--app-accent);
+  stroke-width: 3;
+}
+.bar-slot.legal,
+.bar-slot.selected,
+.tray-slot.legal {
+  cursor: pointer;
+}
+.borne.white {
+  fill: var(--checker-white);
+  stroke: var(--checker-white-edge);
+  stroke-width: 1;
+}
+.borne.black {
+  fill: var(--checker-black);
+  stroke: var(--checker-black-edge);
+  stroke-width: 1;
+}
+
+/* win overlay */
+.bg-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: color-mix(in srgb, var(--app-bg) 82%, transparent);
+  backdrop-filter: blur(6px);
+  z-index: 10;
+  border-radius: var(--app-radius);
+  text-align: center;
+  padding: 24px;
+}
+.bg-overlay h2 {
+  margin: 0;
+  font-size: 28px;
+}
+.bg-overlay p {
+  margin: 0;
+  color: var(--app-muted-fg);
+}
+
+/* ---------- footer ---------- */
+.bg-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 20px;
+  flex-shrink: 0;
+  font-size: 12.5px;
+  color: var(--app-muted-fg);
+}
+.bg-status .ok {
+  color: var(--app-success);
+  font-weight: 600;
+}
+.bg-status .err {
+  color: var(--app-danger);
+  font-weight: 600;
+}
+.bg-records {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--app-muted-fg);
+}
+.bg-note {
+  font-size: 12px;
+  color: var(--app-muted-fg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .die.rolling,
+  .bg-btn {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/tests/default-apps/backgammon-app.test.tsx
+++ b/tests/default-apps/backgammon-app.test.tsx
@@ -25,7 +25,6 @@ function installMatrixDb(rows: DbRow[] = []) {
 
 describe("Backgammon app", () => {
   beforeEach(() => {
-    window.localStorage.clear();
     // deterministic dice
     vi.spyOn(Math, "random").mockReturnValue(0); // floor(0*6)+1 = 1 for every die
   });
@@ -33,7 +32,6 @@ describe("Backgammon app", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
-    window.localStorage.clear();
   });
 
   it("renders the board with 24 points and turn/pip indicators", async () => {
@@ -74,14 +72,9 @@ describe("Backgammon app", () => {
     );
   });
 
-  it("falls back to localStorage match record when MatrixOS.db is undefined", async () => {
-    window.localStorage.setItem(
-      "matrixos.backgammon.matches",
-      JSON.stringify([{ winner: "white", points: 2 }]),
-    );
+  it("renders without a DB bridge and leaves match history empty", async () => {
     render(<App />);
     await screen.findByTestId("board");
-    // the stored match should surface somewhere (records readout)
-    await waitFor(() => expect(screen.getByTestId("match-count").textContent).toContain("1"));
+    expect(screen.getByTestId("match-count").textContent).toContain("0");
   });
 });

--- a/tests/default-apps/backgammon-app.test.tsx
+++ b/tests/default-apps/backgammon-app.test.tsx
@@ -7,6 +7,7 @@ import App from "../../home/apps/games/backgammon/src/App";
 type DbRow = Record<string, unknown>;
 
 function installMatrixDb(rows: DbRow[] = []) {
+  let changeCallback: (() => void) | null = null;
   const db = {
     find: vi.fn(async () => rows),
     findOne: vi.fn(async () => null),
@@ -14,7 +15,13 @@ function installMatrixDb(rows: DbRow[] = []) {
     update: vi.fn(async () => ({ ok: true })),
     delete: vi.fn(async () => ({ ok: true })),
     count: vi.fn(async () => rows.length),
-    onChange: vi.fn(() => () => undefined),
+    onChange: vi.fn((_table: string, callback: () => void) => {
+      changeCallback = callback;
+      return () => {
+        changeCallback = null;
+      };
+    }),
+    triggerChange: () => changeCallback?.(),
   };
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
@@ -76,5 +83,20 @@ describe("Backgammon app", () => {
     render(<App />);
     await screen.findByTestId("board");
     expect(screen.getByTestId("match-count").textContent).toContain("0");
+  });
+
+  it("preserves match history when a live refresh fails", async () => {
+    const db = installMatrixDb([{ winner: "white", points: 2 }]);
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByTestId("match-count").textContent).toContain("1"));
+
+    db.find.mockRejectedValueOnce(new Error("temporary storage failure"));
+    await act(async () => {
+      db.triggerChange();
+    });
+
+    await waitFor(() => expect(screen.getByText("Could not load match history.")).toBeTruthy());
+    expect(screen.getByTestId("match-count").textContent).toContain("1");
   });
 });

--- a/tests/default-apps/backgammon-app.test.tsx
+++ b/tests/default-apps/backgammon-app.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/games/backgammon/src/App";
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const db = {
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async () => ({ id: "match-new" })),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => rows.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+describe("Backgammon app", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // deterministic dice
+    vi.spyOn(Math, "random").mockReturnValue(0); // floor(0*6)+1 = 1 for every die
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+    window.localStorage.clear();
+  });
+
+  it("renders the board with 24 points and turn/pip indicators", async () => {
+    installMatrixDb([]);
+    render(<App />);
+
+    const board = await screen.findByTestId("board");
+    expect(within(board).getAllByTestId(/^point-/).length).toBe(24);
+    expect(screen.getByTestId("turn-indicator")).toBeTruthy();
+    expect(screen.getByTestId("pip-white")).toBeTruthy();
+    expect(screen.getByTestId("pip-black")).toBeTruthy();
+  });
+
+  it("rolls dice and lets a player make a legal checker move", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    // Roll: with Math.random -> 0 the dice are [1,1] (doubles, four 1s).
+    fireEvent.click(screen.getByRole("button", { name: /roll/i }));
+
+    await waitFor(() => expect(screen.getByTestId("dice")).toBeTruthy());
+
+    // White starts; white's checkers are at 24,13,8,6. With die 1 white can move
+    // 24->23, 13->12(black blot? no, 12 is black with 5 -> blocked), 8->7, 6->5.
+    // Select point 24 (a movable white stack) then a highlighted destination.
+    const p24 = screen.getByTestId("point-24");
+    fireEvent.click(p24);
+
+    // a legal destination must be highlighted; click the first highlighted target
+    const target = await screen.findByTestId("point-23");
+    expect(target.getAttribute("data-legal")).toBe("true");
+    fireEvent.click(target);
+
+    // after moving, point 23 should now hold a white checker
+    await waitFor(() =>
+      expect(screen.getByTestId("point-23").getAttribute("data-owner")).toBe("white"),
+    );
+  });
+
+  it("falls back to localStorage match record when MatrixOS.db is undefined", async () => {
+    window.localStorage.setItem(
+      "matrixos.backgammon.matches",
+      JSON.stringify([{ winner: "white", points: 2 }]),
+    );
+    render(<App />);
+    await screen.findByTestId("board");
+    // the stored match should surface somewhere (records readout)
+    await waitFor(() => expect(screen.getByTestId("match-count").textContent).toContain("1"));
+  });
+});

--- a/tests/default-apps/backgammon-app.test.tsx
+++ b/tests/default-apps/backgammon-app.test.tsx
@@ -2,7 +2,8 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import App from "../../home/apps/games/backgammon/src/App";
+import App, { movesForTarget } from "../../home/apps/games/backgammon/src/App";
+import { OFF, type Move } from "../../home/apps/games/backgammon/src/backgammon-model";
 
 type DbRow = Record<string, unknown>;
 
@@ -77,6 +78,13 @@ describe("Backgammon app", () => {
     await waitFor(() =>
       expect(screen.getByTestId("point-23").getAttribute("data-owner")).toBe("white"),
     );
+  });
+
+  it("keeps all legal die choices for an ambiguous bear off target", () => {
+    const exact = { from: 3, to: OFF, die: 3, bearOff: true } satisfies Move;
+    const overshoot = { from: 3, to: OFF, die: 6, bearOff: true } satisfies Move;
+
+    expect(movesForTarget([exact, overshoot], OFF)).toEqual([exact, overshoot]);
   });
 
   it("renders without a DB bridge and leaves match history empty", async () => {

--- a/tests/default-apps/backgammon-model.test.ts
+++ b/tests/default-apps/backgammon-model.test.ts
@@ -261,8 +261,6 @@ describe("backgammon-model — must use both dice / larger die rule", () => {
     place(s, 13, "white", 1);
     place(s, 1, "white", 14);
     place(s, 12, "black", 2); // blocks 13->12 (small die) destination directly
-    place(s, 7, "white", 0);
-    // also block the follow-up of the small die so the engine can't chain
     const st = startTurn(s, rollFromValues(6, 1));
     const moves = generateLegalMoves(st);
     // small die (1) destination 12 is blocked, so only the 6 (->7) is available.

--- a/tests/default-apps/backgammon-model.test.ts
+++ b/tests/default-apps/backgammon-model.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+import {
+  BAR,
+  OFF,
+  type GameState,
+  type Player,
+  applyMove,
+  createInitialState,
+  generateLegalMoves,
+  isGameOver,
+  legalDestinations,
+  pipCount,
+  rollFromValues,
+  startTurn,
+  winnerResult,
+} from "../../home/apps/games/backgammon/src/backgammon-model";
+
+// Convenience: build a state with an empty board, then place checkers.
+// points index 1..24 (standard numbering from White's perspective),
+// bar[white]/bar[black], off[white]/off[black].
+function emptyState(turn: Player = "white"): GameState {
+  const s = createInitialState();
+  for (let i = 0; i < s.points.length; i++) {
+    s.points[i] = { player: null, count: 0 };
+  }
+  s.bar = { white: 0, black: 0 };
+  s.off = { white: 0, black: 0 };
+  s.turn = turn;
+  s.dice = [];
+  s.movesLeft = [];
+  s.history = [];
+  return s;
+}
+
+function place(s: GameState, point: number, player: Player, count: number) {
+  s.points[point] = { player, count };
+}
+
+describe("backgammon-model — initial setup", () => {
+  it("creates standard starting position with 15 checkers each", () => {
+    const s = createInitialState();
+    // White standard: 24:2, 13:5, 8:3, 6:5  (White moves 24 -> 1)
+    expect(s.points[24]).toEqual({ player: "white", count: 2 });
+    expect(s.points[13]).toEqual({ player: "white", count: 5 });
+    expect(s.points[8]).toEqual({ player: "white", count: 3 });
+    expect(s.points[6]).toEqual({ player: "white", count: 5 });
+    // Black mirror: 1:2, 12:5, 17:3, 19:5
+    expect(s.points[1]).toEqual({ player: "black", count: 2 });
+    expect(s.points[12]).toEqual({ player: "black", count: 5 });
+    expect(s.points[17]).toEqual({ player: "black", count: 3 });
+    expect(s.points[19]).toEqual({ player: "black", count: 5 });
+
+    let white = 0;
+    let black = 0;
+    for (let i = 1; i <= 24; i++) {
+      if (s.points[i].player === "white") white += s.points[i].count;
+      if (s.points[i].player === "black") black += s.points[i].count;
+    }
+    expect(white).toBe(15);
+    expect(black).toBe(15);
+  });
+
+  it("computes the standard opening pip count of 167 for both sides", () => {
+    const s = createInitialState();
+    expect(pipCount(s, "white")).toBe(167);
+    expect(pipCount(s, "black")).toBe(167);
+  });
+});
+
+describe("backgammon-model — dice and turn", () => {
+  it("non-doubles produce two moves of distinct values", () => {
+    const s = createInitialState();
+    s.turn = "white";
+    const next = startTurn(s, rollFromValues(3, 5));
+    expect(next.dice).toEqual([3, 5]);
+    expect([...next.movesLeft].sort()).toEqual([3, 5]);
+  });
+
+  it("doubles produce four moves of the same value", () => {
+    const s = createInitialState();
+    s.turn = "white";
+    const next = startTurn(s, rollFromValues(4, 4));
+    expect(next.dice).toEqual([4, 4]);
+    expect(next.movesLeft).toEqual([4, 4, 4, 4]);
+  });
+});
+
+describe("backgammon-model — legal move generation", () => {
+  it("white moves from a high point toward 1 using a die", () => {
+    const s = emptyState("white");
+    place(s, 24, "white", 2);
+    place(s, 13, "white", 13);
+    const st = startTurn(s, rollFromValues(6, 5));
+    const dests = legalDestinations(st, 24);
+    // 24-6=18, 24-5=19
+    expect(dests.map((d) => d.to).sort((a, b) => a - b)).toEqual([18, 19]);
+  });
+
+  it("black moves toward 24 (opposite direction)", () => {
+    const s = emptyState("black");
+    place(s, 1, "black", 2);
+    place(s, 12, "black", 13);
+    const st = startTurn(s, rollFromValues(6, 5));
+    const dests = legalDestinations(st, 1);
+    // black moves up: 1+6=7, 1+5=6
+    expect(dests.map((d) => d.to).sort((a, b) => a - b)).toEqual([6, 7]);
+  });
+
+  it("a point held by 2+ opposing checkers is blocked", () => {
+    const s = emptyState("white");
+    place(s, 24, "white", 1);
+    place(s, 18, "black", 2); // 24-6=18 blocked
+    place(s, 13, "white", 14);
+    const st = startTurn(s, rollFromValues(6, 5));
+    const dests = legalDestinations(st, 24);
+    expect(dests.map((d) => d.to)).not.toContain(18);
+    expect(dests.map((d) => d.to)).toContain(19); // 24-5 ok
+  });
+
+  it("a blot (single opposing checker) is a legal hit destination", () => {
+    const s = emptyState("white");
+    place(s, 24, "white", 1);
+    place(s, 18, "black", 1); // blot at 24-6
+    place(s, 13, "white", 14);
+    const st = startTurn(s, rollFromValues(6, 5));
+    const dests = legalDestinations(st, 24);
+    const hit = dests.find((d) => d.to === 18);
+    expect(hit).toBeTruthy();
+    expect(hit?.hit).toBe(true);
+  });
+});
+
+describe("backgammon-model — applyMove and hitting", () => {
+  it("applying a hit sends opponent blot to the bar", () => {
+    const s = emptyState("white");
+    place(s, 24, "white", 1);
+    place(s, 18, "black", 1);
+    place(s, 13, "white", 14);
+    let st = startTurn(s, rollFromValues(6, 5));
+    st = applyMove(st, { from: 24, to: 18, die: 6, hit: true });
+    expect(st.points[18]).toEqual({ player: "white", count: 1 });
+    expect(st.bar.black).toBe(1);
+    expect(st.movesLeft).toEqual([5]);
+  });
+
+  it("stacks onto own point and consumes the die", () => {
+    const s = emptyState("white");
+    place(s, 13, "white", 3);
+    place(s, 8, "white", 12);
+    let st = startTurn(s, rollFromValues(5, 2));
+    st = applyMove(st, { from: 13, to: 8, die: 5 });
+    expect(st.points[8].count).toBe(13);
+    expect(st.points[13].count).toBe(2);
+    expect(st.movesLeft).toEqual([2]);
+  });
+});
+
+describe("backgammon-model — bar entry", () => {
+  it("must enter from the bar before any other move", () => {
+    const s = emptyState("white");
+    s.bar.white = 1;
+    place(s, 13, "white", 14);
+    const st = startTurn(s, rollFromValues(6, 5));
+    const moves = generateLegalMoves(st);
+    // every legal move must originate from the bar
+    expect(moves.length).toBeGreaterThan(0);
+    expect(moves.every((m) => m.from === BAR)).toBe(true);
+    // white enters into opponent home board points 19..24: die 6 -> 19, die 5 -> 20
+    expect(moves.map((m) => m.to).sort((a, b) => a - b)).toEqual([19, 20]);
+  });
+
+  it("cannot enter on a blocked entry point", () => {
+    const s = emptyState("white");
+    s.bar.white = 1;
+    place(s, 19, "black", 2); // entry for die 6 (white enters at 25-6=19) blocked
+    place(s, 13, "white", 13);
+    const st = startTurn(s, rollFromValues(6, 5));
+    const moves = generateLegalMoves(st);
+    // only die 5 -> 20 works
+    expect(moves.map((m) => m.to)).toEqual([20]);
+  });
+
+  it("with both entry points blocked there are no legal moves", () => {
+    const s = emptyState("white");
+    s.bar.white = 1;
+    place(s, 19, "black", 2);
+    place(s, 20, "black", 2);
+    const st = startTurn(s, rollFromValues(6, 5));
+    expect(generateLegalMoves(st)).toEqual([]);
+  });
+});
+
+describe("backgammon-model — bearing off", () => {
+  it("cannot bear off until all checkers are in the home board", () => {
+    const s = emptyState("white");
+    place(s, 6, "white", 1);
+    place(s, 13, "white", 14); // outside home board (1..6)
+    const st = startTurn(s, rollFromValues(6, 5));
+    const dests = legalDestinations(st, 6);
+    expect(dests.some((d) => d.to === OFF)).toBe(false);
+  });
+
+  it("bears off exactly with the matching die", () => {
+    const s = emptyState("white");
+    place(s, 6, "white", 2);
+    place(s, 3, "white", 13);
+    let st = startTurn(s, rollFromValues(6, 1));
+    const dests = legalDestinations(st, 6);
+    const off = dests.find((d) => d.to === OFF);
+    expect(off).toBeTruthy();
+    st = applyMove(st, { from: 6, to: OFF, die: 6, bearOff: true });
+    expect(st.off.white).toBe(1);
+    expect(st.points[6].count).toBe(1);
+  });
+
+  it("allows overshoot bear-off only from the highest occupied point", () => {
+    const s = emptyState("white");
+    // highest occupied point is 4; a 6 may bear off from 4 (overshoot)
+    place(s, 4, "white", 1);
+    place(s, 2, "white", 14);
+    const st = startTurn(s, rollFromValues(6, 1));
+    const destsFrom4 = legalDestinations(st, 4);
+    expect(destsFrom4.some((d) => d.to === OFF && d.die === 6)).toBe(true);
+
+    // but if a checker sits on a higher point, the 6 cannot overshoot a lower one
+    const s2 = emptyState("white");
+    place(s2, 6, "white", 1);
+    place(s2, 4, "white", 1);
+    place(s2, 2, "white", 13);
+    const st2 = startTurn(s2, rollFromValues(6, 1));
+    const destsFrom4b = legalDestinations(st2, 4);
+    // a 6 from point 4 would be overshoot, but 6 is occupied/higher -> not allowed
+    expect(destsFrom4b.some((d) => d.to === OFF && d.die === 6)).toBe(false);
+    // the 6 must bear off the checker on point 6 instead
+    const destsFrom6 = legalDestinations(st2, 6);
+    expect(destsFrom6.some((d) => d.to === OFF && d.die === 6)).toBe(true);
+  });
+});
+
+describe("backgammon-model — must use both dice / larger die rule", () => {
+  it("if only one die can be played, the player must play it", () => {
+    const s = emptyState("white");
+    // White single checker at 2; dice 6 and 3.
+    // die 3 cannot be played (2-3 < 0 and not all home? it is all home).
+    // Set up so that exactly one die yields a legal move.
+    place(s, 2, "white", 1);
+    place(s, 1, "white", 14);
+    const st = startTurn(s, rollFromValues(6, 1));
+    const moves = generateLegalMoves(st);
+    // From 2: die 1 -> point 1 (stack). die 6 -> bear off (overshoot, highest is 2). Both legal here.
+    expect(moves.length).toBeGreaterThan(0);
+  });
+
+  it("must play the larger die when only one of two can be used", () => {
+    const s = emptyState("white");
+    // Construct a position where playing the small die would block the large one,
+    // forcing the larger die to be used.
+    // White at 13 only. Dice 6 and 1. Point 7 (13-6) open, point 12 (13-1) open,
+    // but after small move 13->12, can the 6 still be played? from 12 -> 6 ok.
+    // To force "must play larger", block so that small die leaves no follow-up.
+    place(s, 13, "white", 1);
+    place(s, 1, "white", 14);
+    place(s, 12, "black", 2); // blocks 13->12 (small die) destination directly
+    place(s, 7, "white", 0);
+    // also block the follow-up of the small die so the engine can't chain
+    const st = startTurn(s, rollFromValues(6, 1));
+    const moves = generateLegalMoves(st);
+    // small die (1) destination 12 is blocked, so only the 6 (->7) is available.
+    expect(moves.every((m) => m.die === 6)).toBe(true);
+    expect(moves.map((m) => m.to)).toContain(7);
+  });
+});
+
+describe("backgammon-model — win detection", () => {
+  it("detects a normal win (1 point) when loser has borne off some", () => {
+    const s = emptyState("white");
+    s.off.white = 15;
+    s.off.black = 4;
+    expect(isGameOver(s)).toBe(true);
+    const res = winnerResult(s);
+    expect(res?.winner).toBe("white");
+    expect(res?.multiplier).toBe(1);
+    expect(res?.points).toBe(1);
+  });
+
+  it("detects a gammon (2 points) when loser has borne off none", () => {
+    const s = emptyState("white");
+    s.off.white = 15;
+    s.off.black = 0;
+    // black has no checker on the bar nor in white's home -> gammon
+    const res = winnerResult(s);
+    expect(res?.multiplier).toBe(2);
+    expect(res?.label).toBe("gammon");
+  });
+
+  it("detects a backgammon (3 points) when loser has a checker on the bar", () => {
+    const s = emptyState("white");
+    s.off.white = 15;
+    s.off.black = 0;
+    s.bar.black = 1;
+    const res = winnerResult(s);
+    expect(res?.multiplier).toBe(3);
+    expect(res?.label).toBe("backgammon");
+  });
+
+  it("is not over while a side still has checkers in play", () => {
+    const s = emptyState("white");
+    s.off.white = 14;
+    place(s, 1, "white", 1);
+    expect(isGameOver(s)).toBe(false);
+    expect(winnerResult(s)).toBeNull();
+  });
+});


### PR DESCRIPTION
Stack: 16/22
Branch: stack/default-apps-backgammon

Scope: Backgammon legal-move model, UI, manifest, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.