### PR TITLE
feat(chess): add AI move engine

### DIFF
--- a/home/.template-manifest.json
+++ b/home/.template-manifest.json
@@ -34,7 +34,7 @@
   "apps/games/backgammon/index.html": "c99ae8f3cd68ea93da15f9d5c083d44322c21afdb3de97ae25c31cc887d2e2d1",
   "apps/games/backgammon/matrix.json": "d4511a2eb829ecc19bf912c9c458c57062a353f3c334612138c38f87577b26b2",
   "apps/games/chess/index.html": "6a29bb619257b55485ff6a300dee6415b62a580da74933fc8f478af524acc8a5",
-  "apps/games/chess/matrix.json": "84fa73cefa8364634e731e7227dc1510a803fc6d61b20b54da79af7fcb00a8ac",
+  "apps/games/chess/matrix.json": "6508cf470d3f11ef1367fa8a1383641c04b6638c67eb55308f8dac09ef84a735",
   "apps/games/index.html": "5f41943bf1244390ca1ac78ea1bd647eb1fd680ab8cdae27e2738c170b456153",
   "apps/games/matrix.json": "b4e01e0780cb5d5bfbd742dcd9c350cf65c7d99ced8711c6569a995d65b12a8e",
   "apps/games/minesweeper/index.html": "14c82d3a7f7d83fff9029a3d14a7af42c5a19dea1e11d85362da0cea1e6a430f",
@@ -112,4 +112,3 @@
   "apps/_shared/default-apps.tsx": "10f6a540ac219424769732b5952b586bcc0029674915eb22af7bb1b5cc9864d9",
   "apps/_shared/theme.css": "382355577a00e4744b823fda818f1c4cdb40d782609eb90adc9950492bccaa5b"
 }
-

--- a/home/apps/games/chess/matrix.json
+++ b/home/apps/games/chess/matrix.json
@@ -26,7 +26,7 @@
     }
   },
   "build": {
-    "install": "true",
+    "install": "pnpm install --ignore-workspace --prefer-offline",
     "command": "vite build --base ./ --outDir dist",
     "output": "dist",
     "timeout": 180,

--- a/home/apps/games/chess/matrix.json
+++ b/home/apps/games/chess/matrix.json
@@ -1,9 +1,9 @@
 {
   "name": "Chess",
-  "description": "Classic chess with AI opponent",
+  "description": "Local two-player chess with full legal-move validation, SAN history, and saved games.",
   "runtime": "vite",
   "category": "games",
-  "icon": "game-center",
+  "icon": "chess",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -13,18 +13,29 @@
   "runtimeVersion": "^1.0.0",
   "listingTrust": "first_party",
   "slug": "chess",
+  "scope": "personal",
+  "storage": {
+    "tables": {
+      "games": {
+        "columns": {
+          "pgn": "text",
+          "result": "text"
+        }
+      }
+    }
+  },
   "build": {
-    "install": "true",
-    "command": "vite build --base ./ --outDir dist",
+    "install": "pnpm install --ignore-workspace --prefer-offline",
+    "command": "pnpm build",
     "output": "dist",
     "timeout": 180,
     "sourceGlobs": [
       "src/**",
-      "../_shared/**",
-      "../../_shared/**",
       "index.html",
       "matrix.json",
-      "vite.config.ts"
+      "package.json",
+      "vite.config.ts",
+      "tsconfig.json"
     ]
   }
 }

--- a/home/apps/games/chess/matrix.json
+++ b/home/apps/games/chess/matrix.json
@@ -3,7 +3,7 @@
   "description": "Local two-player chess with full legal-move validation, SAN history, and saved games.",
   "runtime": "vite",
   "category": "games",
-  "icon": "chess",
+  "icon": "game-center",
   "author": "system",
   "version": "1.0.0",
   "tags": [
@@ -19,7 +19,8 @@
       "games": {
         "columns": {
           "pgn": "text",
-          "result": "text"
+          "result": "text",
+          "created_at": "timestamptz"
         }
       }
     }
@@ -34,6 +35,7 @@
       "index.html",
       "matrix.json",
       "package.json",
+      "pnpm-lock.yaml",
       "vite.config.ts",
       "tsconfig.json"
     ]

--- a/home/apps/games/chess/matrix.json
+++ b/home/apps/games/chess/matrix.json
@@ -26,12 +26,14 @@
     }
   },
   "build": {
-    "install": "pnpm install --ignore-workspace --prefer-offline",
-    "command": "pnpm build",
+    "install": "true",
+    "command": "vite build --base ./ --outDir dist",
     "output": "dist",
     "timeout": 180,
     "sourceGlobs": [
       "src/**",
+      "../_shared/**",
+      "../../_shared/**",
       "index.html",
       "matrix.json",
       "package.json",

--- a/home/apps/games/chess/package.json
+++ b/home/apps/games/chess/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@matrixos/chess",
+  "private": true,
+  "version": "1.0.0",
+  "packageManager": "pnpm@10.33.4",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 3108",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "chess.js": "^1.0.0",
+    "lucide-react": "^0.563.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^4.4.1",
+    "typescript": "~5.8.3",
+    "vite": "^6.3.2"
+  }
+}

--- a/home/apps/games/chess/pnpm-lock.yaml
+++ b/home/apps/games/chess/pnpm-lock.yaml
@@ -1,0 +1,1154 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      chess.js:
+        specifier: ^1.0.0
+        version: 1.4.0
+      lucide-react:
+        specifier: ^0.563.0
+        version: 0.563.0(react@19.2.6)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.2
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.7.0(vite@6.4.2)
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^6.3.2
+        version: 6.4.2
+
+packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chess.js@1.4.0:
+    resolution: {integrity: sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  electron-to-chromium@1.5.364:
+    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.563.0:
+    resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/estree@1.0.8': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.32: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.364
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001793: {}
+
+  chess.js@1.4.0: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  electron-to-chromium@1.5.364: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lucide-react@0.563.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  node-releases@2.0.46: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.6: {}
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.8.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@6.4.2:
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}

--- a/home/apps/games/chess/src/chess-ai.ts
+++ b/home/apps/games/chess/src/chess-ai.ts
@@ -1,0 +1,260 @@
+// Pure, UI-free chess engine: depth-limited negamax with alpha-beta pruning.
+//
+// Design notes:
+// - Dependency-injected. We do NOT import chess.js here; instead the engine
+//   operates on any object matching the small `ChessLike` surface (the real
+//   `Chess` instance satisfies it). This keeps the module unit-testable from the
+//   root vitest runner, which cannot resolve the app-local "chess.js" specifier,
+//   and keeps the engine deterministic given a position + depth.
+// - chess.js handles all legality (move generation, check/mate/stalemate). The
+//   engine only searches and scores.
+// - Evaluation = material (standard piece values) + piece-square tables
+//   (positional) + a small mobility term. Scores are from the perspective of the
+//   side to move (negamax convention).
+
+import type { PieceColor, PieceType } from "./chess-model";
+import { PIECE_VALUES } from "./chess-model";
+
+/** A single legal move as produced by chess.js `moves({ verbose: true })`. */
+export interface VerboseMove {
+  from: string;
+  to: string;
+  san?: string;
+  color: PieceColor;
+  piece: PieceType;
+  captured?: PieceType;
+  promotion?: PieceType;
+}
+
+export interface BoardSquare {
+  square: string;
+  type: PieceType;
+  color: PieceColor;
+}
+
+/**
+ * The minimal subset of the chess.js `Chess` API the engine relies on. Both the
+ * real library instance and any faithful test double satisfy this.
+ */
+export interface ChessLike {
+  moves(opts: { verbose: true }): VerboseMove[];
+  move(m: { from: string; to: string; promotion?: PieceType }): unknown;
+  undo(): unknown;
+  turn(): PieceColor;
+  board(): (BoardSquare | null)[][];
+  isCheckmate(): boolean;
+  isStalemate(): boolean;
+  isDraw(): boolean;
+}
+
+export type AiMove = Pick<VerboseMove, "from" | "to"> & { promotion?: PieceType };
+
+// Centipawn material values (queen = 900, etc.). Derived from the shared
+// PIECE_VALUES so material scoring stays consistent with the UI tray.
+const MATERIAL: Record<PieceType, number> = {
+  p: PIECE_VALUES.p * 100,
+  n: PIECE_VALUES.n * 100,
+  b: PIECE_VALUES.b * 100,
+  r: PIECE_VALUES.r * 100,
+  q: PIECE_VALUES.q * 100,
+  k: 0,
+};
+
+// Large but finite mate score. Adjusted by ply so the engine prefers faster
+// mates and delays getting mated.
+const MATE = 100_000;
+
+// Piece-square tables (white's perspective, a1 = index 56 .. h8 = index 7 when
+// read rank 8 -> rank 1). We index by [rankIndexFromTop][fileIndex]; black uses
+// the vertically mirrored value. Values are small positional nudges in
+// centipawns — material always dominates.
+// prettier-ignore
+const PST: Record<PieceType, number[][]> = {
+  p: [
+    [  0,  0,  0,  0,  0,  0,  0,  0],
+    [ 50, 50, 50, 50, 50, 50, 50, 50],
+    [ 10, 10, 20, 30, 30, 20, 10, 10],
+    [  5,  5, 10, 25, 25, 10,  5,  5],
+    [  0,  0,  0, 20, 20,  0,  0,  0],
+    [  5, -5,-10,  0,  0,-10, -5,  5],
+    [  5, 10, 10,-20,-20, 10, 10,  5],
+    [  0,  0,  0,  0,  0,  0,  0,  0],
+  ],
+  n: [
+    [-50,-40,-30,-30,-30,-30,-40,-50],
+    [-40,-20,  0,  0,  0,  0,-20,-40],
+    [-30,  0, 10, 15, 15, 10,  0,-30],
+    [-30,  5, 15, 20, 20, 15,  5,-30],
+    [-30,  0, 15, 20, 20, 15,  0,-30],
+    [-30,  5, 10, 15, 15, 10,  5,-30],
+    [-40,-20,  0,  5,  5,  0,-20,-40],
+    [-50,-40,-30,-30,-30,-30,-40,-50],
+  ],
+  b: [
+    [-20,-10,-10,-10,-10,-10,-10,-20],
+    [-10,  0,  0,  0,  0,  0,  0,-10],
+    [-10,  0,  5, 10, 10,  5,  0,-10],
+    [-10,  5,  5, 10, 10,  5,  5,-10],
+    [-10,  0, 10, 10, 10, 10,  0,-10],
+    [-10, 10, 10, 10, 10, 10, 10,-10],
+    [-10,  5,  0,  0,  0,  0,  5,-10],
+    [-20,-10,-10,-10,-10,-10,-10,-20],
+  ],
+  r: [
+    [  0,  0,  0,  0,  0,  0,  0,  0],
+    [  5, 10, 10, 10, 10, 10, 10,  5],
+    [ -5,  0,  0,  0,  0,  0,  0, -5],
+    [ -5,  0,  0,  0,  0,  0,  0, -5],
+    [ -5,  0,  0,  0,  0,  0,  0, -5],
+    [ -5,  0,  0,  0,  0,  0,  0, -5],
+    [ -5,  0,  0,  0,  0,  0,  0, -5],
+    [  0,  0,  0,  5,  5,  0,  0,  0],
+  ],
+  q: [
+    [-20,-10,-10, -5, -5,-10,-10,-20],
+    [-10,  0,  0,  0,  0,  0,  0,-10],
+    [-10,  0,  5,  5,  5,  5,  0,-10],
+    [ -5,  0,  5,  5,  5,  5,  0, -5],
+    [  0,  0,  5,  5,  5,  5,  0, -5],
+    [-10,  5,  5,  5,  5,  5,  0,-10],
+    [-10,  0,  5,  0,  0,  0,  0,-10],
+    [-20,-10,-10, -5, -5,-10,-10,-20],
+  ],
+  k: [
+    [-30,-40,-40,-50,-50,-40,-40,-30],
+    [-30,-40,-40,-50,-50,-40,-40,-30],
+    [-30,-40,-40,-50,-50,-40,-40,-30],
+    [-30,-40,-40,-50,-50,-40,-40,-30],
+    [-20,-30,-30,-40,-40,-30,-30,-20],
+    [-10,-20,-20,-20,-20,-20,-20,-10],
+    [ 20, 20,  0,  0,  0,  0, 20, 20],
+    [ 20, 30, 10,  0,  0, 10, 30, 20],
+  ],
+};
+
+/**
+ * Static evaluation of a position, in centipawns, from the perspective of the
+ * side to move (positive = good for the side to move). Material dominates;
+ * piece-square tables and a small mobility term break ties positionally.
+ */
+export function evaluatePosition(game: ChessLike): number {
+  if (game.isCheckmate()) {
+    // Side to move is mated -> worst possible.
+    return -MATE;
+  }
+  if (game.isStalemate() || game.isDraw()) {
+    return 0;
+  }
+
+  const board = game.board();
+  let whiteScore = 0;
+  // board() is rank 8 (index 0) down to rank 1 (index 7), file a..h (0..7).
+  for (let r = 0; r < 8; r += 1) {
+    const row = board[r];
+    for (let f = 0; f < 8; f += 1) {
+      const sq = row[f];
+      if (!sq) continue;
+      const material = MATERIAL[sq.type];
+      // White reads the table directly; black reads the vertically mirrored row.
+      const positional = sq.color === "w" ? PST[sq.type][r][f] : PST[sq.type][7 - r][f];
+      const contribution = material + positional;
+      whiteScore += sq.color === "w" ? contribution : -contribution;
+    }
+  }
+
+  // Small mobility term: count of legal moves for the side to move. Bounded so it
+  // never outweighs a pawn.
+  const mobility = game.moves({ verbose: true }).length;
+  whiteScore += (game.turn() === "w" ? mobility : -mobility) * 2;
+
+  // Convert to side-to-move perspective for negamax.
+  return game.turn() === "w" ? whiteScore : -whiteScore;
+}
+
+// Order moves so captures (most-valuable-victim) are searched first; better
+// move ordering makes alpha-beta prune far more aggressively.
+function orderMoves(moves: VerboseMove[]): VerboseMove[] {
+  // toSorted() (ES2023) would be cleaner, but the app's tsconfig lib target
+  // predates it; a copy-then-sort keeps the input array immutable.
+  return [...moves].sort((a, b) => captureScore(b) - captureScore(a));
+}
+
+function captureScore(m: VerboseMove): number {
+  if (!m.captured) return 0;
+  // MVV-LVA-ish: prize the victim, lightly discount the attacker.
+  return MATERIAL[m.captured] - MATERIAL[m.piece] / 10 + 1;
+}
+
+/**
+ * Negamax with alpha-beta pruning. Returns the score (centipawns) of `game` for
+ * the side to move, searching `depth` plies deep. `ply` tracks distance from the
+ * root so mate scores prefer the quickest mate.
+ */
+function negamax(game: ChessLike, depth: number, alpha: number, beta: number, ply: number): number {
+  if (game.isCheckmate()) {
+    // Being mated now is bad; the deeper (later) the mate, the less bad.
+    return -MATE + ply;
+  }
+  if (game.isStalemate() || game.isDraw()) {
+    return 0;
+  }
+  if (depth === 0) {
+    return evaluatePosition(game);
+  }
+
+  const moves = orderMoves(game.moves({ verbose: true }));
+  if (moves.length === 0) {
+    // No legal moves but not flagged mate/stalemate above: treat as draw.
+    return 0;
+  }
+
+  let best = -Infinity;
+  let a = alpha;
+  for (const m of moves) {
+    game.move({ from: m.from, to: m.to, promotion: m.promotion });
+    const score = -negamax(game, depth - 1, -beta, -a, ply + 1);
+    game.undo();
+    if (score > best) best = score;
+    if (best > a) a = best;
+    if (a >= beta) break; // beta cutoff
+  }
+  return best;
+}
+
+/**
+ * Pick the best move for the side to move at the given search depth. Returns
+ * `null` when there are no legal moves (checkmate/stalemate). Deterministic for a
+ * fixed position + depth: ties keep the first move in the (stable) ordering.
+ */
+export function findBestMove(game: ChessLike, depth: number): AiMove | null {
+  const moves = orderMoves(game.moves({ verbose: true }));
+  if (moves.length === 0) return null;
+
+  const searchDepth = Math.max(1, Math.floor(depth));
+  let bestMove: VerboseMove = moves[0];
+  let bestScore = -Infinity;
+  let alpha = -Infinity;
+  const beta = Infinity;
+
+  for (const m of moves) {
+    game.move({ from: m.from, to: m.to, promotion: m.promotion });
+    const score = -negamax(game, searchDepth - 1, -beta, -alpha, 1);
+    game.undo();
+    if (score > bestScore) {
+      bestScore = score;
+      bestMove = m;
+    }
+    if (bestScore > alpha) alpha = bestScore;
+  }
+
+  return { from: bestMove.from, to: bestMove.to, promotion: bestMove.promotion };
+}
+
+/** Map a difficulty label to a search depth. */
+export type Difficulty = "easy" | "medium" | "hard";
+
+export const DIFFICULTY_DEPTH: Record<Difficulty, number> = {
+  easy: 1,
+  medium: 2,
+  hard: 3,
+};

--- a/home/apps/games/chess/src/chess-model.ts
+++ b/home/apps/games/chess/src/chess-model.ts
@@ -1,0 +1,124 @@
+// Pure, UI-free chess helpers. Legal move generation/validation is delegated to
+// the chess.js library; this module only handles presentation-layer concerns:
+// board square enumeration, square coloring, piece glyphs, SAN grouping, and
+// material counting. Everything here is deterministic and unit-tested.
+
+export type PieceColor = "w" | "b";
+export type PieceType = "p" | "n" | "b" | "r" | "q" | "k";
+
+export interface PieceLike {
+  color: PieceColor;
+  type: PieceType;
+}
+
+export const FILES = ["a", "b", "c", "d", "e", "f", "g", "h"] as const;
+export const RANKS = ["8", "7", "6", "5", "4", "3", "2", "1"] as const;
+
+/**
+ * All 64 squares in render order (top-left to bottom-right). With white at the
+ * bottom (flipped=false) this runs a8..h8, a7..h7, … a1..h1. Flipping reverses
+ * the orientation so black sits at the bottom.
+ */
+export function squaresOfBoard(flipped: boolean): string[] {
+  const files = flipped ? [...FILES].reverse() : [...FILES];
+  const ranks = flipped ? [...RANKS].reverse() : [...RANKS];
+  const out: string[] = [];
+  for (const rank of ranks) {
+    for (const file of files) {
+      out.push(`${file}${rank}`);
+    }
+  }
+  return out;
+}
+
+/** Standard chessboard coloring: a1 is dark. */
+export function squareColor(square: string): "light" | "dark" {
+  const fileIndex = FILES.indexOf(square[0] as (typeof FILES)[number]);
+  const rank = Number(square[1]);
+  // a1 (fileIndex 0, rank 1) is a dark square: odd sum => dark, even => light.
+  return (fileIndex + rank) % 2 === 0 ? "light" : "dark";
+}
+
+export const PIECE_GLYPHS: Record<PieceColor, Record<PieceType, string>> = {
+  w: { k: "♔", q: "♕", r: "♖", b: "♗", n: "♘", p: "♙" },
+  b: { k: "♚", q: "♛", r: "♜", b: "♝", n: "♞", p: "♟" },
+};
+
+export const PIECE_VALUES: Record<PieceType, number> = {
+  p: 1,
+  n: 3,
+  b: 3,
+  r: 5,
+  q: 9,
+  k: 0,
+};
+
+export interface MovePair {
+  number: number;
+  white: string;
+  black: string | null;
+}
+
+/** Group a flat SAN list into numbered move pairs for a two-column history. */
+export function groupMovesIntoPairs(san: string[]): MovePair[] {
+  const pairs: MovePair[] = [];
+  for (let i = 0; i < san.length; i += 2) {
+    pairs.push({
+      number: i / 2 + 1,
+      white: san[i],
+      black: i + 1 < san.length ? san[i + 1] : null,
+    });
+  }
+  return pairs;
+}
+
+export interface MaterialDelta {
+  white: number;
+  black: number;
+  advantage: "white" | "black" | "even";
+  amount: number;
+}
+
+/**
+ * Material captured by each side. `capturedByWhite` are the black pieces white
+ * has taken; `capturedByBlack` are the white pieces black has taken.
+ */
+export function materialDelta(
+  capturedByWhite: PieceLike[],
+  capturedByBlack: PieceLike[],
+): MaterialDelta {
+  const white = capturedByWhite.reduce((sum, p) => sum + PIECE_VALUES[p.type], 0);
+  const black = capturedByBlack.reduce((sum, p) => sum + PIECE_VALUES[p.type], 0);
+  const diff = white - black;
+  return {
+    white,
+    black,
+    advantage: diff > 0 ? "white" : diff < 0 ? "black" : "even",
+    amount: Math.abs(diff),
+  };
+}
+
+export interface CapturedTray {
+  byWhite: PieceLike[];
+  byBlack: PieceLike[];
+}
+
+/**
+ * Derive captured pieces from verbose chess.js move history. Each verbose move
+ * may carry a `captured` piece type; the capturer's color is `color`.
+ */
+export function capturedFromHistory(
+  moves: { color: PieceColor; captured?: PieceType }[],
+): CapturedTray {
+  const byWhite: PieceLike[] = [];
+  const byBlack: PieceLike[] = [];
+  for (const m of moves) {
+    if (!m.captured) continue;
+    if (m.color === "w") {
+      byWhite.push({ color: "b", type: m.captured });
+    } else {
+      byBlack.push({ color: "w", type: m.captured });
+    }
+  }
+  return { byWhite, byBlack };
+}

--- a/home/apps/games/chess/src/matrix-os.d.ts
+++ b/home/apps/games/chess/src/matrix-os.d.ts
@@ -1,0 +1,25 @@
+interface MatrixOSDb {
+  find(table: string, opts?: {
+    where?: Record<string, unknown>;
+    orderBy?: Record<string, "asc" | "desc">;
+    limit?: number;
+    offset?: number;
+  }): Promise<Record<string, unknown>[]>;
+  findOne(table: string, id: string): Promise<Record<string, unknown> | null>;
+  insert(table: string, data: Record<string, unknown>): Promise<{ id: string }>;
+  update(table: string, id: string, data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  delete(table: string, id: string): Promise<{ ok: boolean }>;
+  count(table: string, filter?: Record<string, unknown>): Promise<number>;
+  onChange(table: string, callback: (e: { table: string }) => void): () => void;
+}
+interface MatrixOS {
+  db?: MatrixOSDb;
+  theme?: Record<string, string>;
+  app?: { name: string };
+  readData?(key: string): Promise<unknown>;
+  writeData?(key: string, value: unknown): Promise<void>;
+}
+declare global {
+  interface Window { MatrixOS?: MatrixOS; }
+}
+export {};

--- a/tests/default-apps/chess-ai.test.ts
+++ b/tests/default-apps/chess-ai.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+// chess.js is an app-local dependency. The root vitest runner cannot resolve the
+// bare "chess.js" specifier (it lives only in home/apps/games/chess/node_modules),
+// so we import the real engine from that app-local path — exactly the same library
+// the built app uses. This exercises the AI against genuine legal-move generation.
+import { Chess } from "../../home/apps/games/chess/node_modules/chess.js/dist/esm/chess.js";
+import { findBestMove, evaluatePosition } from "../../home/apps/games/chess/src/chess-ai";
+
+// chess-ai is dependency-injected: it accepts any object matching the small
+// `ChessLike` surface it uses. The real `Chess` instance satisfies it.
+function game(fen?: string): Chess {
+  return fen ? new Chess(fen) : new Chess();
+}
+
+describe("chess-ai engine", () => {
+  it("returns a legal move from the starting position", () => {
+    const g = game();
+    const best = findBestMove(g, 2);
+    expect(best).not.toBeNull();
+    const legal = g.moves({ verbose: true }).map((m) => `${m.from}${m.to}`);
+    expect(legal).toContain(`${best!.from}${best!.to}`);
+  });
+
+  it("finds an obvious mate-in-1 (back-rank mate)", () => {
+    // White to move: Ra8 is checkmate. Black king on h8 boxed by its own pawns,
+    // white rook lifts to the back rank.
+    const g = game("6k1/5ppp/8/8/8/8/8/R6K w - - 0 1");
+    const best = findBestMove(g, 3);
+    expect(best).not.toBeNull();
+    // Apply the chosen move and confirm it is mate.
+    const probe = game(g.fen());
+    probe.move({ from: best!.from, to: best!.to, promotion: best!.promotion });
+    expect(probe.isCheckmate()).toBe(true);
+    expect(best!.to).toBe("a8");
+  });
+
+  it("captures a hanging queen when it is free", () => {
+    // White rook on a1, undefended black queen on a8, nothing else contests it.
+    // Best move must be the free queen capture Rxa8.
+    const g = game("q5k1/8/8/8/8/8/6PP/R5K1 w - - 0 1");
+    const best = findBestMove(g, 3);
+    expect(best).not.toBeNull();
+    expect(best!.from).toBe("a1");
+    expect(best!.to).toBe("a8");
+  });
+
+  it("prefers the higher-material outcome between two captures", () => {
+    // White rook on d1 can take an undefended queen on d8 or an undefended
+    // knight on a... set up so a free queen and a free rook are both available;
+    // engine must grab the queen.
+    const g = game("3q3k/8/8/8/8/8/6PP/3R2K1 w - - 0 1");
+    const best = findBestMove(g, 2);
+    expect(best).not.toBeNull();
+    expect(best!.to).toBe("d8");
+  });
+
+  it("evaluation favors the side with more material", () => {
+    // White is up a full queen.
+    const up = evaluatePosition(game("4k3/8/8/8/8/8/8/3QK3 w - - 0 1"));
+    const even = evaluatePosition(game("4k3/8/8/8/8/8/8/4K3 w - - 0 1"));
+    expect(up).toBeGreaterThan(even);
+  });
+
+  it("is deterministic for a fixed position + depth", () => {
+    const a = findBestMove(game("3q3k/8/8/8/8/8/6PP/3R2K1 w - - 0 1"), 2);
+    const b = findBestMove(game("3q3k/8/8/8/8/8/6PP/3R2K1 w - - 0 1"), 2);
+    expect(a).toEqual(b);
+  });
+
+  it("returns null when there are no legal moves (checkmated side to move)", () => {
+    // Black is already checkmated: king on g8 boxed by its own pawn on g7, white
+    // rook on h8 giving check with the white king on g6 covering the escape.
+    const mated = game("6kR/6P1/6K1/8/8/8/8/8 b - - 0 1");
+    expect(mated.moves().length).toBe(0);
+    expect(findBestMove(mated, 2)).toBeNull();
+    // sanity: a normal mid-game position still yields a move for the side to move
+    const live = game("r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3");
+    expect(findBestMove(live, 1)).not.toBeNull();
+  });
+});

--- a/tests/default-apps/chess-ai.test.ts
+++ b/tests/default-apps/chess-ai.test.ts
@@ -1,80 +1,172 @@
 import { describe, expect, it } from "vitest";
-// chess.js is an app-local dependency. The root vitest runner cannot resolve the
-// bare "chess.js" specifier (it lives only in home/apps/games/chess/node_modules),
-// so we import the real engine from that app-local path — exactly the same library
-// the built app uses. This exercises the AI against genuine legal-move generation.
-import { Chess } from "../../home/apps/games/chess/node_modules/chess.js/dist/esm/chess.js";
-import { findBestMove, evaluatePosition } from "../../home/apps/games/chess/src/chess-ai";
+import {
+  type BoardSquare,
+  type ChessLike,
+  type VerboseMove,
+  evaluatePosition,
+  findBestMove,
+} from "../../home/apps/games/chess/src/chess-ai";
 
-// chess-ai is dependency-injected: it accepts any object matching the small
-// `ChessLike` surface it uses. The real `Chess` instance satisfies it.
-function game(fen?: string): Chess {
-  return fen ? new Chess(fen) : new Chess();
+type Node = {
+  turn: "w" | "b";
+  board: (BoardSquare | null)[][];
+  moves?: VerboseMove[];
+  checkmate?: boolean;
+  stalemate?: boolean;
+  draw?: boolean;
+};
+
+function emptyBoard(): (BoardSquare | null)[][] {
+  return Array.from({ length: 8 }, () => Array<BoardSquare | null>(8).fill(null));
+}
+
+function boardWith(pieces: Array<BoardSquare & { row: number; col: number }>): (BoardSquare | null)[][] {
+  const board = emptyBoard();
+  for (const piece of pieces) {
+    board[piece.row][piece.col] = { square: piece.square, type: piece.type, color: piece.color };
+  }
+  return board;
+}
+
+class MockChess implements ChessLike {
+  private current: string;
+  private readonly history: string[] = [];
+
+  constructor(
+    private readonly nodes: Record<string, Node>,
+    start = "root",
+  ) {
+    this.current = start;
+  }
+
+  moves(): VerboseMove[] {
+    return this.nodes[this.current].moves ?? [];
+  }
+
+  move(m: { from: string; to: string }): unknown {
+    this.history.push(this.current);
+    this.current = `${m.from}${m.to}`;
+    return m;
+  }
+
+  undo(): unknown {
+    const prev = this.history.pop();
+    if (prev) this.current = prev;
+    return null;
+  }
+
+  turn(): "w" | "b" {
+    return this.nodes[this.current].turn;
+  }
+
+  board(): (BoardSquare | null)[][] {
+    return this.nodes[this.current].board;
+  }
+
+  isCheckmate(): boolean {
+    return Boolean(this.nodes[this.current].checkmate);
+  }
+
+  isStalemate(): boolean {
+    return Boolean(this.nodes[this.current].stalemate);
+  }
+
+  isDraw(): boolean {
+    return Boolean(this.nodes[this.current].draw);
+  }
+}
+
+const quietBoard = boardWith([
+  { square: "e1", row: 7, col: 4, color: "w", type: "k" },
+  { square: "e8", row: 0, col: 4, color: "b", type: "k" },
+]);
+
+function move(from: string, to: string, piece: VerboseMove["piece"], captured?: VerboseMove["captured"]): VerboseMove {
+  return { from, to, piece, captured, color: "w" };
 }
 
 describe("chess-ai engine", () => {
-  it("returns a legal move from the starting position", () => {
-    const g = game();
-    const best = findBestMove(g, 2);
+  it("returns a legal move from the current position", () => {
+    const moves = [move("a2", "a3", "p"), move("h2", "h3", "p")];
+    const game = new MockChess({
+      root: { turn: "w", board: quietBoard, moves },
+      a2a3: { turn: "b", board: quietBoard },
+      h2h3: { turn: "b", board: quietBoard },
+    });
+
+    const best = findBestMove(game, 2);
+
     expect(best).not.toBeNull();
-    const legal = g.moves({ verbose: true }).map((m) => `${m.from}${m.to}`);
-    expect(legal).toContain(`${best!.from}${best!.to}`);
+    expect(moves.map((m) => `${m.from}${m.to}`)).toContain(`${best!.from}${best!.to}`);
   });
 
-  it("finds an obvious mate-in-1 (back-rank mate)", () => {
-    // White to move: Ra8 is checkmate. Black king on h8 boxed by its own pawns,
-    // white rook lifts to the back rank.
-    const g = game("6k1/5ppp/8/8/8/8/8/R6K w - - 0 1");
-    const best = findBestMove(g, 3);
-    expect(best).not.toBeNull();
-    // Apply the chosen move and confirm it is mate.
-    const probe = game(g.fen());
-    probe.move({ from: best!.from, to: best!.to, promotion: best!.promotion });
-    expect(probe.isCheckmate()).toBe(true);
-    expect(best!.to).toBe("a8");
+  it("finds an immediate mating move", () => {
+    const game = new MockChess({
+      root: {
+        turn: "w",
+        board: quietBoard,
+        moves: [move("a1", "a8", "r"), move("a1", "a7", "r")],
+      },
+      a1a8: { turn: "b", board: quietBoard, checkmate: true },
+      a1a7: { turn: "b", board: quietBoard },
+    });
+
+    expect(findBestMove(game, 3)).toEqual({ from: "a1", to: "a8", promotion: undefined });
   });
 
-  it("captures a hanging queen when it is free", () => {
-    // White rook on a1, undefended black queen on a8, nothing else contests it.
-    // Best move must be the free queen capture Rxa8.
-    const g = game("q5k1/8/8/8/8/8/6PP/R5K1 w - - 0 1");
-    const best = findBestMove(g, 3);
-    expect(best).not.toBeNull();
-    expect(best!.from).toBe("a1");
-    expect(best!.to).toBe("a8");
-  });
+  it("captures a hanging queen before a lower-value piece", () => {
+    const queenWin = boardWith([
+      { square: "e1", row: 7, col: 4, color: "w", type: "k" },
+      { square: "e8", row: 0, col: 4, color: "b", type: "k" },
+      { square: "d8", row: 0, col: 3, color: "w", type: "r" },
+      { square: "a8", row: 0, col: 0, color: "b", type: "n" },
+    ]);
+    const knightWin = boardWith([
+      { square: "e1", row: 7, col: 4, color: "w", type: "k" },
+      { square: "e8", row: 0, col: 4, color: "b", type: "k" },
+      { square: "a8", row: 0, col: 0, color: "w", type: "r" },
+      { square: "d8", row: 0, col: 3, color: "b", type: "q" },
+    ]);
+    const game = new MockChess({
+      root: {
+        turn: "w",
+        board: quietBoard,
+        moves: [move("d1", "a8", "r", "n"), move("d1", "d8", "r", "q")],
+      },
+      d1a8: { turn: "b", board: knightWin },
+      d1d8: { turn: "b", board: queenWin },
+    });
 
-  it("prefers the higher-material outcome between two captures", () => {
-    // White rook on d1 can take an undefended queen on d8 or an undefended
-    // knight on a... set up so a free queen and a free rook are both available;
-    // engine must grab the queen.
-    const g = game("3q3k/8/8/8/8/8/6PP/3R2K1 w - - 0 1");
-    const best = findBestMove(g, 2);
-    expect(best).not.toBeNull();
-    expect(best!.to).toBe("d8");
+    expect(findBestMove(game, 2)).toEqual({ from: "d1", to: "d8", promotion: undefined });
   });
 
   it("evaluation favors the side with more material", () => {
-    // White is up a full queen.
-    const up = evaluatePosition(game("4k3/8/8/8/8/8/8/3QK3 w - - 0 1"));
-    const even = evaluatePosition(game("4k3/8/8/8/8/8/8/4K3 w - - 0 1"));
+    const up = evaluatePosition(new MockChess({
+      root: {
+        turn: "w",
+        board: boardWith([
+          { square: "e1", row: 7, col: 4, color: "w", type: "k" },
+          { square: "e8", row: 0, col: 4, color: "b", type: "k" },
+          { square: "d1", row: 7, col: 3, color: "w", type: "q" },
+        ]),
+      },
+    }));
+    const even = evaluatePosition(new MockChess({ root: { turn: "w", board: quietBoard } }));
     expect(up).toBeGreaterThan(even);
   });
 
-  it("is deterministic for a fixed position + depth", () => {
-    const a = findBestMove(game("3q3k/8/8/8/8/8/6PP/3R2K1 w - - 0 1"), 2);
-    const b = findBestMove(game("3q3k/8/8/8/8/8/6PP/3R2K1 w - - 0 1"), 2);
+  it("is deterministic for a fixed position and depth", () => {
+    const nodes = {
+      root: { turn: "w" as const, board: quietBoard, moves: [move("a2", "a3", "p"), move("h2", "h3", "p")] },
+      a2a3: { turn: "b" as const, board: quietBoard },
+      h2h3: { turn: "b" as const, board: quietBoard },
+    };
+    const a = findBestMove(new MockChess(nodes), 2);
+    const b = findBestMove(new MockChess(nodes), 2);
     expect(a).toEqual(b);
   });
 
-  it("returns null when there are no legal moves (checkmated side to move)", () => {
-    // Black is already checkmated: king on g8 boxed by its own pawn on g7, white
-    // rook on h8 giving check with the white king on g6 covering the escape.
-    const mated = game("6kR/6P1/6K1/8/8/8/8/8 b - - 0 1");
-    expect(mated.moves().length).toBe(0);
-    expect(findBestMove(mated, 2)).toBeNull();
-    // sanity: a normal mid-game position still yields a move for the side to move
-    const live = game("r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3");
-    expect(findBestMove(live, 1)).not.toBeNull();
+  it("returns null when there are no legal moves", () => {
+    expect(findBestMove(new MockChess({ root: { turn: "b", board: quietBoard, moves: [], checkmate: true } }), 2)).toBeNull();
   });
 });

--- a/tests/default-apps/chess-ai.test.ts
+++ b/tests/default-apps/chess-ai.test.ts
@@ -155,6 +155,31 @@ describe("chess-ai engine", () => {
     expect(up).toBeGreaterThan(even);
   });
 
+  it("evaluation treats terminal positions explicitly", () => {
+    expect(evaluatePosition(new MockChess({
+      root: { turn: "w", board: quietBoard, checkmate: true },
+    }))).toBeLessThan(-90_000);
+    expect(evaluatePosition(new MockChess({
+      root: { turn: "w", board: quietBoard, stalemate: true },
+    }))).toBe(0);
+    expect(evaluatePosition(new MockChess({
+      root: { turn: "w", board: quietBoard, draw: true },
+    }))).toBe(0);
+  });
+
+  it("search handles stalemate child nodes as draws", () => {
+    const game = new MockChess({
+      root: {
+        turn: "w",
+        board: quietBoard,
+        moves: [move("a2", "a3", "p")],
+      },
+      a2a3: { turn: "b", board: quietBoard, stalemate: true },
+    });
+
+    expect(findBestMove(game, 2)).toEqual({ from: "a2", to: "a3", promotion: undefined });
+  });
+
   it("is deterministic for a fixed position and depth", () => {
     const nodes = {
       root: { turn: "w" as const, board: quietBoard, moves: [move("a2", "a3", "p"), move("h2", "h3", "p")] },

--- a/tests/default-apps/chess-model.test.ts
+++ b/tests/default-apps/chess-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   PIECE_GLYPHS,
+  capturedFromHistory,
   groupMovesIntoPairs,
   materialDelta,
   squareColor,
@@ -78,5 +79,27 @@ describe("chess-model pure helpers", () => {
     );
     expect(delta.advantage).toBe("even");
     expect(delta.amount).toBe(0);
+  });
+
+  it("reports black material advantage using the absolute difference", () => {
+    const delta = materialDelta(
+      [{ color: "b", type: "p" }],
+      [{ color: "w", type: "r" }],
+    );
+    expect(delta.white).toBe(1);
+    expect(delta.black).toBe(5);
+    expect(delta.advantage).toBe("black");
+    expect(delta.amount).toBe(4);
+  });
+
+  it("derives captured trays from verbose move history", () => {
+    const tray = capturedFromHistory([
+      { color: "w", captured: "p" },
+      { color: "b", captured: "n" },
+      { color: "w" },
+    ]);
+
+    expect(tray.byWhite).toEqual([{ color: "b", type: "p" }]);
+    expect(tray.byBlack).toEqual([{ color: "w", type: "n" }]);
   });
 });

--- a/tests/default-apps/chess-model.test.ts
+++ b/tests/default-apps/chess-model.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  PIECE_GLYPHS,
+  groupMovesIntoPairs,
+  materialDelta,
+  squareColor,
+  squaresOfBoard,
+} from "../../home/apps/games/chess/src/chess-model";
+
+describe("chess-model pure helpers", () => {
+  it("enumerates all 64 squares from a8 to h1", () => {
+    const squares = squaresOfBoard(false);
+    expect(squares).toHaveLength(64);
+    expect(squares[0]).toBe("a8");
+    expect(squares[7]).toBe("h8");
+    expect(squares[56]).toBe("a1");
+    expect(squares[63]).toBe("h1");
+  });
+
+  it("flips the board orientation when requested", () => {
+    const flipped = squaresOfBoard(true);
+    expect(flipped).toHaveLength(64);
+    expect(flipped[0]).toBe("h1");
+    expect(flipped[63]).toBe("a8");
+  });
+
+  it("computes square color deterministically (a1 dark, h1 light)", () => {
+    expect(squareColor("a1")).toBe("dark");
+    expect(squareColor("h1")).toBe("light");
+    expect(squareColor("a8")).toBe("light");
+    expect(squareColor("h8")).toBe("dark");
+  });
+
+  it("maps every piece to a unicode glyph", () => {
+    expect(PIECE_GLYPHS.w.k).toBe("♔");
+    expect(PIECE_GLYPHS.b.q).toBe("♛");
+    // every color/type combination is present
+    for (const color of ["w", "b"] as const) {
+      for (const type of ["p", "n", "b", "r", "q", "k"] as const) {
+        expect(typeof PIECE_GLYPHS[color][type]).toBe("string");
+        expect(PIECE_GLYPHS[color][type].length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("groups a SAN move list into numbered white/black pairs", () => {
+    const pairs = groupMovesIntoPairs(["e4", "e5", "Nf3", "Nc6", "Bb5"]);
+    expect(pairs).toEqual([
+      { number: 1, white: "e4", black: "e5" },
+      { number: 2, white: "Nf3", black: "Nc6" },
+      { number: 3, white: "Bb5", black: null },
+    ]);
+  });
+
+  it("returns an empty pair list for no moves", () => {
+    expect(groupMovesIntoPairs([])).toEqual([]);
+  });
+
+  it("computes material delta from captured pieces", () => {
+    // white captured a black rook (5) and pawn (1) = +6; black captured a white knight (3)
+    const delta = materialDelta(
+      [
+        { color: "b", type: "r" },
+        { color: "b", type: "p" },
+      ],
+      [{ color: "w", type: "n" }],
+    );
+    expect(delta.white).toBe(6);
+    expect(delta.black).toBe(3);
+    expect(delta.advantage).toBe("white");
+    expect(delta.amount).toBe(3);
+  });
+
+  it("reports an even material balance", () => {
+    const delta = materialDelta(
+      [{ color: "b", type: "p" }],
+      [{ color: "w", type: "p" }],
+    );
+    expect(delta.advantage).toBe("even");
+    expect(delta.amount).toBe(0);
+  });
+});


### PR DESCRIPTION
Stack: 17/22
Branch: stack/default-apps-chess-engine

Scope: Chess dependency, AI move engine, game model, and tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.