### PR TITLE
feat(chess): add playable board UI

### DIFF
--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -110,10 +110,15 @@ export default function App() {
   const [gamesPlayed, setGamesPlayed] = useState<number>(0);
   const savedResultRef = useRef(false);
   const errorRef = useRef<string | null>(null);
+  const saveStateRef = useRef(saveState);
 
   useEffect(() => {
     errorRef.current = error;
   }, [error]);
+
+  useEffect(() => {
+    saveStateRef.current = saveState;
+  }, [saveState]);
 
   // AI opponent configuration. `humanColor` is the side the user plays in
   // vs-computer mode; the engine plays the other side. `thinking` disables input
@@ -348,7 +353,7 @@ export default function App() {
   );
 
   const undo = useCallback(() => {
-    if (pendingPromotion) return;
+    if (pendingPromotion || saveStateRef.current === "saving") return;
     cancelAiMove();
     // In vs-computer mode an "undo" should take back the full human+AI pair so
     // the human is the side to move again (unless only one ply exists).
@@ -373,7 +378,7 @@ export default function App() {
         else clearSelection();
       } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "z") {
         e.preventDefault();
-        if (!pendingPromotion) undo();
+        if (!pendingPromotion && !inputLockedRef.current && saveStateRef.current !== "saving") undo();
       }
     };
     window.addEventListener("keydown", onKey);
@@ -619,7 +624,7 @@ export default function App() {
             type="button"
             className="secondary-action"
             onClick={undo}
-            disabled={sanHistory.length === 0 || thinking || aiToMove || Boolean(pendingPromotion)}
+            disabled={sanHistory.length === 0 || thinking || aiToMove || Boolean(pendingPromotion) || saveState === "saving"}
           >
             <RotateCcw size={16} /> Undo
           </button>

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -79,6 +79,7 @@ async function persistGame(pgn: string, result: string): Promise<void> {
     await db.insert(GAMES_TABLE, { pgn, result });
     return;
   }
+  if (window.MatrixOS) return;
   // localStorage fallback when the DB bridge is unavailable.
   const raw = window.localStorage.getItem(LS_KEY);
   let prior: unknown[] = [];
@@ -140,6 +141,10 @@ export default function App() {
       if (db) {
         const n = await db.count(GAMES_TABLE);
         setGamesPlayed(typeof n === "number" ? n : 0);
+        return;
+      }
+      if (window.MatrixOS) {
+        setGamesPlayed(0);
         return;
       }
       const raw = window.localStorage.getItem(LS_KEY);

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -199,7 +199,6 @@ export default function App() {
       try {
         await persistGame(gameRef.current.pgn(), result);
         setSaveState("saved");
-        await reloadStats();
       } catch (err: unknown) {
         console.warn("[chess] could not save game:", err instanceof Error ? err.message : String(err));
         setSaveState("error");
@@ -207,7 +206,7 @@ export default function App() {
         setError(SAVE_ERROR);
       }
     },
-    [reloadStats],
+    [],
   );
 
   const applyMove = useCallback(

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -620,7 +620,7 @@ export default function App() {
             type="button"
             className="secondary-action"
             onClick={undo}
-            disabled={sanHistory.length === 0 || thinking || Boolean(pendingPromotion)}
+            disabled={sanHistory.length === 0 || thinking || aiToMove || Boolean(pendingPromotion)}
           >
             <RotateCcw size={16} /> Undo
           </button>

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -322,6 +322,8 @@ export default function App() {
     setLastMove(null);
     setPendingPromotion(null);
     setSaveState("idle");
+    errorRef.current = null;
+    setError(null);
     clearSelection();
     bump();
   }, [bump, cancelAiMove, clearSelection]);

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -138,20 +138,25 @@ export default function App() {
     const db = window.MatrixOS?.db;
     try {
       setError(null);
+      const clearStatsError = () => setSaveState((current) => current === "error" ? "idle" : current);
       if (db) {
         const n = await db.count(GAMES_TABLE);
         setGamesPlayed(typeof n === "number" ? n : 0);
+        clearStatsError();
         return;
       }
       if (window.MatrixOS) {
         setGamesPlayed(0);
+        clearStatsError();
         return;
       }
       const raw = window.localStorage.getItem(LS_KEY);
       const parsed = raw ? JSON.parse(raw) : [];
       setGamesPlayed(Array.isArray(parsed) ? parsed.length : 0);
+      clearStatsError();
     } catch (err: unknown) {
       console.warn("[chess] could not load game stats:", err instanceof Error ? err.message : String(err));
+      setSaveState("error");
       setError("Saved games could not be loaded.");
     }
   }, []);

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -18,6 +18,8 @@ import "./styles.css";
 const GAMES_TABLE = "games";
 const LS_KEY = "matrixos.chess.games";
 const PROMOTION_PIECES: PieceType[] = ["q", "r", "b", "n"];
+const STATS_ERROR = "Saved games could not be loaded.";
+const SAVE_ERROR = "This game could not be saved.";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 type GameMode = "two-player" | "vs-computer";
@@ -107,6 +109,11 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
   const [gamesPlayed, setGamesPlayed] = useState<number>(0);
   const savedResultRef = useRef(false);
+  const errorRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    errorRef.current = error;
+  }, [error]);
 
   // AI opponent configuration. `humanColor` is the side the user plays in
   // vs-computer mode; the engine plays the other side. `thinking` disables input
@@ -137,8 +144,12 @@ export default function App() {
   const reloadStats = useCallback(async () => {
     const db = window.MatrixOS?.db;
     try {
-      setError(null);
-      const clearStatsError = () => setSaveState((current) => current === "error" ? "idle" : current);
+      const clearStatsError = () => {
+        if (errorRef.current !== STATS_ERROR) return;
+        errorRef.current = null;
+        setError(null);
+        setSaveState((current) => current === "error" ? "idle" : current);
+      };
       if (db) {
         const n = await db.count(GAMES_TABLE);
         setGamesPlayed(typeof n === "number" ? n : 0);
@@ -157,7 +168,8 @@ export default function App() {
     } catch (err: unknown) {
       console.warn("[chess] could not load game stats:", err instanceof Error ? err.message : String(err));
       setSaveState("error");
-      setError("Saved games could not be loaded.");
+      errorRef.current = STATS_ERROR;
+      setError(STATS_ERROR);
     }
   }, []);
 
@@ -191,7 +203,8 @@ export default function App() {
       } catch (err: unknown) {
         console.warn("[chess] could not save game:", err instanceof Error ? err.message : String(err));
         setSaveState("error");
-        setError("This game could not be saved.");
+        errorRef.current = SAVE_ERROR;
+        setError(SAVE_ERROR);
       }
     },
     [reloadStats],

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -173,6 +173,7 @@ export default function App() {
     } catch (err: unknown) {
       console.warn("[chess] could not load game stats:", err instanceof Error ? err.message : String(err));
       setSaveState((current) => current === "saving" || current === "saved" ? current : "error");
+      if (errorRef.current === SAVE_ERROR) return;
       errorRef.current = STATS_ERROR;
       setError(STATS_ERROR);
     }

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -383,8 +383,13 @@ export default function App() {
       const cfg = aiConfigRef.current;
       try {
         const best = findBestMove(gameRef.current as unknown as ChessLike, DIFFICULTY_DEPTH[cfg.difficulty]);
-        if (best && aiRunIdRef.current === runId) {
+        if (aiRunIdRef.current !== runId) return;
+        if (best) {
           applyMove(best.from, best.to, best.promotion);
+        } else {
+          setMode("two-player");
+          setSaveState("error");
+          setError("The computer could not find a move. Continuing as local two-player.");
         }
       } catch (err: unknown) {
         if (aiRunIdRef.current !== runId) return;

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -387,8 +387,11 @@ export default function App() {
           applyMove(best.from, best.to, best.promotion);
         }
       } catch (err: unknown) {
+        if (aiRunIdRef.current !== runId) return;
         console.warn("[chess] AI search failed:", err instanceof Error ? err.message : String(err));
-        setError("The computer could not find a move.");
+        setMode("two-player");
+        setSaveState("error");
+        setError("The computer could not find a move. Continuing as local two-player.");
       } finally {
         if (aiRunIdRef.current === runId) setThinking(false);
       }

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -320,6 +320,7 @@ export default function App() {
   }, []);
 
   const newGame = useCallback(() => {
+    if (saveStateRef.current === "saving") return;
     cancelAiMove();
     gameRef.current.reset();
     savedResultRef.current = false;
@@ -617,7 +618,7 @@ export default function App() {
         </div>
 
         <div className="board-actions">
-          <button type="button" className="primary-action" onClick={newGame}>
+          <button type="button" className="primary-action" onClick={newGame} disabled={saveState === "saving"}>
             <Sparkles size={16} /> New game
           </button>
           <button

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -334,6 +334,7 @@ export default function App() {
   );
 
   const undo = useCallback(() => {
+    if (pendingPromotion) return;
     cancelAiMove();
     // In vs-computer mode an "undo" should take back the full human+AI pair so
     // the human is the side to move again (unless only one ply exists).
@@ -348,7 +349,7 @@ export default function App() {
     setLastMove(null);
     clearSelection();
     bump();
-  }, [bump, cancelAiMove, clearSelection]);
+  }, [bump, cancelAiMove, clearSelection, pendingPromotion]);
 
   // Keyboard: Esc clears selection / dismisses promotion, Cmd/Ctrl+Z undoes.
   useEffect(() => {
@@ -358,7 +359,7 @@ export default function App() {
         else clearSelection();
       } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "z") {
         e.preventDefault();
-        undo();
+        if (!pendingPromotion) undo();
       }
     };
     window.addEventListener("keydown", onKey);
@@ -602,7 +603,7 @@ export default function App() {
             type="button"
             className="secondary-action"
             onClick={undo}
-            disabled={sanHistory.length === 0 || thinking}
+            disabled={sanHistory.length === 0 || thinking || Boolean(pendingPromotion)}
           >
             <RotateCcw size={16} /> Undo
           </button>

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -393,16 +393,17 @@ export default function App() {
   // resets or undoes while a search is queued.
   useEffect(() => {
     if (!aiToMove) return undefined;
+    let active = true;
     const runId = aiRunIdRef.current;
     setThinking(true);
     aiTimerRef.current = setTimeout(() => {
       aiTimerRef.current = null;
       // Bail if a reset/undo invalidated this run while it was queued.
-      if (aiRunIdRef.current !== runId) return;
+      if (!active || aiRunIdRef.current !== runId) return;
       const cfg = aiConfigRef.current;
       try {
         const best = findBestMove(gameRef.current as unknown as ChessLike, DIFFICULTY_DEPTH[cfg.difficulty]);
-        if (aiRunIdRef.current !== runId) return;
+        if (!active || aiRunIdRef.current !== runId) return;
         if (best) {
           applyMove(best.from, best.to, best.promotion);
         } else {
@@ -411,16 +412,17 @@ export default function App() {
           setError("The computer could not find a move. Continuing as local two-player.");
         }
       } catch (err: unknown) {
-        if (aiRunIdRef.current !== runId) return;
+        if (!active || aiRunIdRef.current !== runId) return;
         console.warn("[chess] AI search failed:", err instanceof Error ? err.message : String(err));
         setMode("two-player");
         setSaveState("error");
         setError("The computer could not find a move. Continuing as local two-player.");
       } finally {
-        if (aiRunIdRef.current === runId) setThinking(false);
+        if (active && aiRunIdRef.current === runId) setThinking(false);
       }
     }, 220);
     return () => {
+      active = false;
       if (aiTimerRef.current !== null) {
         clearTimeout(aiTimerRef.current);
         aiTimerRef.current = null;

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -1,0 +1,687 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Chess } from "chess.js";
+import { Bot, Brain, FlipVertical2, RotateCcw, Save, Sparkles, Swords, Trophy, Users } from "lucide-react";
+import {
+  PIECE_GLYPHS,
+  capturedFromHistory,
+  groupMovesIntoPairs,
+  materialDelta,
+  squareColor,
+  squaresOfBoard,
+  type PieceColor,
+  type PieceLike,
+  type PieceType,
+} from "./chess-model";
+import { DIFFICULTY_DEPTH, findBestMove, type ChessLike, type Difficulty } from "./chess-ai";
+import "./styles.css";
+
+const GAMES_TABLE = "games";
+const LS_KEY = "matrixos.chess.games";
+const PROMOTION_PIECES: PieceType[] = ["q", "r", "b", "n"];
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+type GameMode = "two-player" | "vs-computer";
+
+const DIFFICULTY_LABEL: Record<Difficulty, string> = {
+  easy: "Easy",
+  medium: "Medium",
+  hard: "Hard",
+};
+
+interface VerboseMove {
+  from: string;
+  to: string;
+  san: string;
+  color: PieceColor;
+  piece: PieceType;
+  captured?: PieceType;
+  promotion?: PieceType;
+}
+
+interface PendingPromotion {
+  from: string;
+  to: string;
+  color: PieceColor;
+}
+
+interface StatusInfo {
+  text: string;
+  tone: "turn" | "check" | "win" | "draw";
+  result: string | null;
+}
+
+function colorName(color: PieceColor): string {
+  return color === "w" ? "White" : "Black";
+}
+
+/** Decide game status from the chess.js engine. */
+function deriveStatus(game: Chess): StatusInfo {
+  const turn = game.turn() as PieceColor;
+  if (game.isCheckmate()) {
+    const winner = turn === "w" ? "Black" : "White";
+    return { text: `Checkmate — ${winner} wins`, tone: "win", result: turn === "w" ? "0-1" : "1-0" };
+  }
+  if (game.isStalemate()) {
+    return { text: "Stalemate — draw", tone: "draw", result: "1/2-1/2" };
+  }
+  if (game.isDraw()) {
+    return { text: "Draw", tone: "draw", result: "1/2-1/2" };
+  }
+  if (game.isCheck()) {
+    return { text: `${colorName(turn)} is in check`, tone: "check", result: null };
+  }
+  return { text: `${colorName(turn)} to move`, tone: "turn", result: null };
+}
+
+async function persistGame(pgn: string, result: string): Promise<void> {
+  const db = window.MatrixOS?.db;
+  if (db) {
+    await db.insert(GAMES_TABLE, { pgn, result });
+    return;
+  }
+  // localStorage fallback when the DB bridge is unavailable.
+  const raw = window.localStorage.getItem(LS_KEY);
+  let prior: unknown[] = [];
+  try {
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (Array.isArray(parsed)) prior = parsed;
+  } catch (err: unknown) {
+    console.warn("[chess] could not parse saved games:", err instanceof Error ? err.message : String(err));
+  }
+  prior.unshift({ pgn, result, created_at: new Date().toISOString() });
+  window.localStorage.setItem(LS_KEY, JSON.stringify(prior.slice(0, 50)));
+}
+
+export default function App() {
+  const gameRef = useRef(new Chess());
+  const [, forceVersion] = useState(0);
+  const bump = useCallback(() => forceVersion((v) => v + 1), []);
+
+  const [selected, setSelected] = useState<string | null>(null);
+  const [legalTargets, setLegalTargets] = useState<Set<string>>(new Set());
+  const [lastMove, setLastMove] = useState<{ from: string; to: string } | null>(null);
+  const [flipped, setFlipped] = useState(false);
+  const [pendingPromotion, setPendingPromotion] = useState<PendingPromotion | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [gamesPlayed, setGamesPlayed] = useState<number>(0);
+  const savedResultRef = useRef(false);
+
+  // AI opponent configuration. `humanColor` is the side the user plays in
+  // vs-computer mode; the engine plays the other side. `thinking` disables input
+  // while the AI search runs.
+  const [mode, setMode] = useState<GameMode>("two-player");
+  const [humanColor, setHumanColor] = useState<PieceColor>("w");
+  const [difficulty, setDifficulty] = useState<Difficulty>("medium");
+  const [thinking, setThinking] = useState(false);
+  // Latest settings, read inside the deferred AI callback without re-subscribing.
+  const aiConfigRef = useRef({ mode, humanColor, difficulty });
+  aiConfigRef.current = { mode, humanColor, difficulty };
+  // Guards against double-scheduling and lets New game / Undo cancel a pending move.
+  const aiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const aiRunIdRef = useRef(0);
+  // Mirrors whether human input is currently locked, so the move callbacks can
+  // read it without being re-created on every think tick.
+  const inputLockedRef = useRef(false);
+
+  const game = gameRef.current;
+  const status = deriveStatus(game);
+  const verbose = game.history({ verbose: true }) as unknown as VerboseMove[];
+  const sanHistory = verbose.map((m) => m.san);
+  const pairs = groupMovesIntoPairs(sanHistory);
+  const captured = capturedFromHistory(verbose);
+  const delta = materialDelta(captured.byWhite, captured.byBlack);
+
+  // Load prior game count (DB or localStorage) for the stats rail.
+  const reloadStats = useCallback(async () => {
+    const db = window.MatrixOS?.db;
+    try {
+      setError(null);
+      if (db) {
+        const n = await db.count(GAMES_TABLE);
+        setGamesPlayed(typeof n === "number" ? n : 0);
+        return;
+      }
+      const raw = window.localStorage.getItem(LS_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      setGamesPlayed(Array.isArray(parsed) ? parsed.length : 0);
+    } catch (err: unknown) {
+      console.warn("[chess] could not load game stats:", err instanceof Error ? err.message : String(err));
+      setError("Saved games could not be loaded.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void reloadStats();
+    const db = window.MatrixOS?.db;
+    if (!db?.onChange) return undefined;
+    return db.onChange(GAMES_TABLE, () => void reloadStats());
+  }, [reloadStats]);
+
+  const clearSelection = useCallback(() => {
+    setSelected(null);
+    setLegalTargets(new Set());
+  }, []);
+
+  const refreshLegal = useCallback((square: string) => {
+    const moves = gameRef.current.moves({ square: square as never, verbose: true }) as unknown as VerboseMove[];
+    setLegalTargets(new Set(moves.map((m) => m.to)));
+  }, []);
+
+  // Persist the finished game exactly once when it ends.
+  const maybePersistResult = useCallback(
+    async (result: string | null) => {
+      if (!result || savedResultRef.current) return;
+      savedResultRef.current = true;
+      setSaveState("saving");
+      try {
+        await persistGame(gameRef.current.pgn(), result);
+        setSaveState("saved");
+        await reloadStats();
+      } catch (err: unknown) {
+        console.warn("[chess] could not save game:", err instanceof Error ? err.message : String(err));
+        setSaveState("error");
+        setError("This game could not be saved.");
+      }
+    },
+    [reloadStats],
+  );
+
+  const applyMove = useCallback(
+    (from: string, to: string, promotion?: PieceType) => {
+      let move: VerboseMove | null = null;
+      try {
+        move = gameRef.current.move({ from, to, promotion }) as unknown as VerboseMove | null;
+      } catch (err: unknown) {
+        // chess.js throws on illegal moves in some versions; treat as rejected.
+        console.warn("[chess] rejected move:", err instanceof Error ? err.message : String(err));
+        move = null;
+      }
+      if (!move) {
+        clearSelection();
+        return false;
+      }
+      setLastMove({ from, to });
+      clearSelection();
+      setSaveState("idle");
+      bump();
+      const next = deriveStatus(gameRef.current);
+      void maybePersistResult(next.result);
+      return true;
+    },
+    [bump, clearSelection, maybePersistResult],
+  );
+
+  // Attempt a move, opening the promotion picker if a pawn reaches the last rank.
+  const attemptMove = useCallback(
+    (from: string, to: string): boolean => {
+      const piece = gameRef.current.get(from as never) as PieceLike | undefined;
+      const promotionRank = to[1] === "8" || to[1] === "1";
+      if (piece && piece.type === "p" && promotionRank) {
+        const legal = (gameRef.current.moves({ square: from as never, verbose: true }) as unknown as VerboseMove[]).some(
+          (m) => m.to === to,
+        );
+        if (legal) {
+          setPendingPromotion({ from, to, color: piece.color });
+          return true;
+        }
+      }
+      return applyMove(from, to);
+    },
+    [applyMove],
+  );
+
+  const handleSquareClick = useCallback(
+    (square: string) => {
+      if (pendingPromotion || inputLockedRef.current) return;
+      const piece = gameRef.current.get(square as never) as PieceLike | undefined;
+      const turn = gameRef.current.turn() as PieceColor;
+
+      if (selected) {
+        if (square === selected) {
+          clearSelection();
+          return;
+        }
+        if (legalTargets.has(square)) {
+          attemptMove(selected, square);
+          return;
+        }
+        // Reselect another own piece, otherwise clear.
+        if (piece && piece.color === turn) {
+          setSelected(square);
+          refreshLegal(square);
+        } else {
+          clearSelection();
+        }
+        return;
+      }
+
+      if (piece && piece.color === turn) {
+        setSelected(square);
+        refreshLegal(square);
+      }
+    },
+    [attemptMove, clearSelection, legalTargets, pendingPromotion, refreshLegal, selected],
+  );
+
+  const handleDrop = useCallback(
+    (from: string, to: string) => {
+      if (pendingPromotion || from === to || inputLockedRef.current) return;
+      attemptMove(from, to);
+    },
+    [attemptMove, pendingPromotion],
+  );
+
+  const completePromotion = useCallback(
+    (type: PieceType) => {
+      if (!pendingPromotion) return;
+      applyMove(pendingPromotion.from, pendingPromotion.to, type);
+      setPendingPromotion(null);
+    },
+    [applyMove, pendingPromotion],
+  );
+
+  // Cancel any scheduled/in-flight AI reply so resets and undos can't be raced
+  // by a stale engine move.
+  const cancelAiMove = useCallback(() => {
+    if (aiTimerRef.current !== null) {
+      clearTimeout(aiTimerRef.current);
+      aiTimerRef.current = null;
+    }
+    aiRunIdRef.current += 1; // invalidate any deferred run already queued
+    setThinking(false);
+  }, []);
+
+  const newGame = useCallback(() => {
+    cancelAiMove();
+    gameRef.current.reset();
+    savedResultRef.current = false;
+    setLastMove(null);
+    setPendingPromotion(null);
+    setSaveState("idle");
+    clearSelection();
+    bump();
+  }, [bump, cancelAiMove, clearSelection]);
+
+  // Switching mode or side starts a fresh game so the engine plays a coherent
+  // game from the new configuration (and never has to "take over" mid-game).
+  const startMode = useCallback(
+    (next: GameMode) => {
+      setMode(next);
+      newGame();
+    },
+    [newGame],
+  );
+
+  const chooseColor = useCallback(
+    (color: PieceColor) => {
+      setHumanColor(color);
+      // Flip the board so the human's pieces sit at the bottom.
+      setFlipped(color === "b");
+      newGame();
+    },
+    [newGame],
+  );
+
+  const undo = useCallback(() => {
+    cancelAiMove();
+    // In vs-computer mode an "undo" should take back the full human+AI pair so
+    // the human is the side to move again (unless only one ply exists).
+    const config = aiConfigRef.current;
+    const takeBackPair =
+      config.mode === "vs-computer" && gameRef.current.turn() === config.humanColor;
+    const undone = gameRef.current.undo();
+    if (!undone) return;
+    if (takeBackPair) gameRef.current.undo();
+    savedResultRef.current = false;
+    setSaveState("idle");
+    setLastMove(null);
+    clearSelection();
+    bump();
+  }, [bump, cancelAiMove, clearSelection]);
+
+  // Keyboard: Esc clears selection / dismisses promotion, Cmd/Ctrl+Z undoes.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (pendingPromotion) setPendingPromotion(null);
+        else clearSelection();
+      } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "z") {
+        e.preventDefault();
+        undo();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [clearSelection, pendingPromotion, undo]);
+
+  const aiColor: PieceColor = humanColor === "w" ? "b" : "w";
+  const aiToMove =
+    mode === "vs-computer" && !pendingPromotion && game.turn() === aiColor && status.result === null;
+  // Lock human input while the engine is to move or actively searching.
+  const inputLocked = thinking || aiToMove;
+  inputLockedRef.current = inputLocked;
+
+  // Schedule the AI reply whenever it becomes the engine's turn. We defer the
+  // (synchronous, CPU-bound) negamax search behind a setTimeout so the human's
+  // move paints first and the UI never freezes mid-interaction; `thinking`
+  // disables input meanwhile. A run-id guards against stale moves after the user
+  // resets or undoes while a search is queued.
+  useEffect(() => {
+    if (!aiToMove) return undefined;
+    const runId = aiRunIdRef.current;
+    setThinking(true);
+    aiTimerRef.current = setTimeout(() => {
+      aiTimerRef.current = null;
+      // Bail if a reset/undo invalidated this run while it was queued.
+      if (aiRunIdRef.current !== runId) return;
+      const cfg = aiConfigRef.current;
+      try {
+        const best = findBestMove(gameRef.current as unknown as ChessLike, DIFFICULTY_DEPTH[cfg.difficulty]);
+        if (best && aiRunIdRef.current === runId) {
+          applyMove(best.from, best.to, best.promotion);
+        }
+      } catch (err: unknown) {
+        console.warn("[chess] AI search failed:", err instanceof Error ? err.message : String(err));
+        setError("The computer could not find a move.");
+      } finally {
+        if (aiRunIdRef.current === runId) setThinking(false);
+      }
+    }, 220);
+    return () => {
+      if (aiTimerRef.current !== null) {
+        clearTimeout(aiTimerRef.current);
+        aiTimerRef.current = null;
+      }
+    };
+  }, [aiToMove, applyMove]);
+
+  const squares = useMemo(() => squaresOfBoard(flipped), [flipped]);
+  const ranksForCoords = flipped ? ["1", "2", "3", "4", "5", "6", "7", "8"] : ["8", "7", "6", "5", "4", "3", "2", "1"];
+  const filesForCoords = flipped ? ["h", "g", "f", "e", "d", "c", "b", "a"] : ["a", "b", "c", "d", "e", "f", "g", "h"];
+
+  const turn = game.turn() as PieceColor;
+  const gameOver = status.tone === "win" || status.tone === "draw";
+
+  return (
+    <main className="chess-app">
+      <section className="board-stage" aria-label="Chess board">
+        <header className="stage-head">
+          <div className="product-mark" aria-hidden="true">
+            <Swords size={18} />
+          </div>
+          <div className="stage-title">
+            <span className="eyebrow">Matrix Chess</span>
+            <h1>{mode === "vs-computer" ? "Play the computer" : "Local two-player"}</h1>
+          </div>
+          <button
+            type="button"
+            className="ghost-btn"
+            onClick={() => setFlipped((v) => !v)}
+            title="Flip board"
+            aria-label="Flip board"
+          >
+            <FlipVertical2 size={16} />
+          </button>
+        </header>
+
+        <div className="setup-bar" data-testid="setup-bar">
+          <div className="seg" role="group" aria-label="Game mode">
+            <button
+              type="button"
+              className={`seg-btn${mode === "two-player" ? " seg-btn--on" : ""}`}
+              aria-pressed={mode === "two-player"}
+              data-testid="mode-two-player"
+              onClick={() => startMode("two-player")}
+            >
+              <Users size={14} /> Two players
+            </button>
+            <button
+              type="button"
+              className={`seg-btn${mode === "vs-computer" ? " seg-btn--on" : ""}`}
+              aria-pressed={mode === "vs-computer"}
+              data-testid="mode-vs-computer"
+              onClick={() => startMode("vs-computer")}
+            >
+              <Bot size={14} /> vs Computer
+            </button>
+          </div>
+
+          {mode === "vs-computer" && (
+            <div className="setup-options">
+              <div className="seg" role="group" aria-label="Your color">
+                <button
+                  type="button"
+                  className={`seg-btn${humanColor === "w" ? " seg-btn--on" : ""}`}
+                  aria-pressed={humanColor === "w"}
+                  data-testid="color-white"
+                  onClick={() => chooseColor("w")}
+                >
+                  White
+                </button>
+                <button
+                  type="button"
+                  className={`seg-btn${humanColor === "b" ? " seg-btn--on" : ""}`}
+                  aria-pressed={humanColor === "b"}
+                  data-testid="color-black"
+                  onClick={() => chooseColor("b")}
+                >
+                  Black
+                </button>
+              </div>
+              <label className="difficulty">
+                <Brain size={14} aria-hidden="true" />
+                <select
+                  aria-label="Difficulty"
+                  data-testid="difficulty"
+                  value={difficulty}
+                  onChange={(e) => setDifficulty(e.target.value as Difficulty)}
+                >
+                  {(Object.keys(DIFFICULTY_LABEL) as Difficulty[]).map((d) => (
+                    <option key={d} value={d}>
+                      {DIFFICULTY_LABEL[d]}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          )}
+        </div>
+
+        <div
+          className={`status-pill status-pill--${thinking ? "thinking" : status.tone}`}
+          role="status"
+          data-testid="status"
+          data-tone={thinking ? "thinking" : status.tone}
+          aria-live="polite"
+        >
+          {thinking ? (
+            <>
+              <Bot size={15} className="thinking-spin" />
+              <span data-testid="thinking">Computer is thinking…</span>
+            </>
+          ) : (
+            <>
+              {gameOver ? <Trophy size={15} /> : <Sparkles size={15} />}
+              <span>{status.text}</span>
+            </>
+          )}
+        </div>
+
+        <div className="board-frame">
+          <div className="rank-coords" aria-hidden="true">
+            {ranksForCoords.map((r) => (
+              <span key={r}>{r}</span>
+            ))}
+          </div>
+          <div className="board" data-testid="board" role="grid" aria-label="Chess board">
+            {squares.map((sq) => {
+              const piece = game.get(sq as never) as PieceLike | undefined;
+              const isLegal = legalTargets.has(sq);
+              const isSelected = selected === sq;
+              const isLast = lastMove?.from === sq || lastMove?.to === sq;
+              return (
+                <button
+                  key={sq}
+                  type="button"
+                  role="gridcell"
+                  data-testid={`square-${sq}`}
+                  data-square={sq}
+                  data-legal={isLegal ? "true" : "false"}
+                  data-selected={isSelected ? "true" : "false"}
+                  aria-label={`${sq}${piece ? ` ${colorName(piece.color)} ${piece.type}` : " empty"}`}
+                  className={[
+                    "square",
+                    `square--${squareColor(sq)}`,
+                    isSelected ? "square--selected" : "",
+                    isLast ? "square--last" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  onClick={() => handleSquareClick(sq)}
+                  draggable={Boolean(piece && piece.color === turn && !gameOver && !inputLocked)}
+                  onDragStart={(e) => {
+                    if (!piece || piece.color !== turn || inputLocked) {
+                      e.preventDefault();
+                      return;
+                    }
+                    e.dataTransfer.setData("text/plain", sq);
+                    setSelected(sq);
+                    refreshLegal(sq);
+                  }}
+                  onDragOver={(e) => {
+                    if (legalTargets.has(sq)) e.preventDefault();
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const from = e.dataTransfer.getData("text/plain");
+                    if (from) handleDrop(from, sq);
+                  }}
+                >
+                  {isLegal && !piece && <span className="legal-dot" aria-hidden="true" />}
+                  {isLegal && piece && <span className="legal-ring" aria-hidden="true" />}
+                  {piece && (
+                    <span className={`piece piece--${piece.color}`} aria-hidden="true">
+                      {PIECE_GLYPHS[piece.color][piece.type]}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          <div className="file-coords" aria-hidden="true">
+            {filesForCoords.map((f) => (
+              <span key={f}>{f}</span>
+            ))}
+          </div>
+        </div>
+
+        <div className="board-actions">
+          <button type="button" className="primary-action" onClick={newGame}>
+            <Sparkles size={16} /> New game
+          </button>
+          <button
+            type="button"
+            className="secondary-action"
+            onClick={undo}
+            disabled={sanHistory.length === 0 || thinking}
+          >
+            <RotateCcw size={16} /> Undo
+          </button>
+        </div>
+      </section>
+
+      <aside className="side-panel" aria-label="Game information">
+        <div className="capture-tray">
+          <CaptureRow label="Black captured" pieces={captured.byBlack} edge={delta.advantage === "black" ? delta.amount : 0} />
+          <CaptureRow label="White captured" pieces={captured.byWhite} edge={delta.advantage === "white" ? delta.amount : 0} />
+        </div>
+
+        <div className="history-card">
+          <div className="section-heading">
+            <p className="eyebrow">Move history</p>
+            <h2>SAN notation</h2>
+          </div>
+          <div className="move-history" data-testid="move-history">
+            {pairs.length === 0 ? (
+              <div className="empty-history">
+                <Swords size={22} />
+                <strong>No moves yet</strong>
+                <span>White to move. Click a piece to see its legal squares, then click a target.</span>
+              </div>
+            ) : (
+              <ol className="move-list">
+                {pairs.map((p) => (
+                  <li key={p.number} className="move-row">
+                    <span className="move-no">{p.number}.</span>
+                    <span className="move-san">{p.white}</span>
+                    <span className="move-san">{p.black ?? ""}</span>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        </div>
+
+        <div className={`save-strip${saveState === "error" ? " save-strip--error" : ""}`}>
+          <Save size={14} />
+          <span>
+            {saveState === "saving" && "Saving game to Matrix Postgres…"}
+            {saveState === "saved" && "Game saved"}
+            {saveState === "error" && (error ?? "Game could not be saved.")}
+            {saveState === "idle" && `${gamesPlayed} game${gamesPlayed === 1 ? "" : "s"} on record`}
+          </span>
+        </div>
+
+        <p className="note">
+          {mode === "vs-computer"
+            ? `Playing ${colorName(humanColor)} vs the computer (${DIFFICULTY_LABEL[difficulty]}).`
+            : "Two-player mode. Switch to vs Computer to play the engine."}
+        </p>
+      </aside>
+
+      {pendingPromotion && (
+        <div className="promo-overlay" role="dialog" aria-modal="true" aria-label="Choose promotion piece">
+          <div className="promo-card">
+            <p>Promote to</p>
+            <div className="promo-options">
+              {PROMOTION_PIECES.map((type) => (
+                <button
+                  key={type}
+                  type="button"
+                  className="promo-btn"
+                  data-testid={`promote-${type}`}
+                  onClick={() => completePromotion(type)}
+                >
+                  <span className={`piece piece--${pendingPromotion.color}`}>
+                    {PIECE_GLYPHS[pendingPromotion.color][type]}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+function CaptureRow({ label, pieces, edge }: { label: string; pieces: PieceLike[]; edge: number }) {
+  return (
+    <div className="capture-row">
+      <span className="capture-label">{label}</span>
+      <div className="capture-pieces">
+        {pieces.length === 0 ? (
+          <span className="capture-empty">—</span>
+        ) : (
+          pieces.map((p, i) => (
+            <span key={`${p.type}-${i}`} className={`capture-glyph capture-glyph--${p.color}`}>
+              {PIECE_GLYPHS[p.color][p.type]}
+            </span>
+          ))
+        )}
+        {edge > 0 && <span className="capture-edge">+{edge}</span>}
+      </div>
+    </div>
+  );
+}

--- a/home/apps/games/chess/src/App.tsx
+++ b/home/apps/games/chess/src/App.tsx
@@ -172,7 +172,7 @@ export default function App() {
       clearStatsError();
     } catch (err: unknown) {
       console.warn("[chess] could not load game stats:", err instanceof Error ? err.message : String(err));
-      setSaveState("error");
+      setSaveState((current) => current === "saving" || current === "saved" ? current : "error");
       errorRef.current = STATS_ERROR;
       setError(STATS_ERROR);
     }

--- a/home/apps/games/chess/src/main.tsx
+++ b/home/apps/games/chess/src/main.tsx
@@ -1,9 +1,3 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import App from "./App";
+import { renderDefaultApp } from "../../../_shared/default-apps";
 
-createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+renderDefaultApp("chess" as const);

--- a/home/apps/games/chess/src/main.tsx
+++ b/home/apps/games/chess/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("chess" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/chess/src/styles.css
+++ b/home/apps/games/chess/src/styles.css
@@ -1,0 +1,557 @@
+:root {
+  --app-bg: var(--matrix-bg, #fafaf5);
+  --app-fg: var(--matrix-fg, #32352e);
+  --app-card: var(--matrix-card, #ffffff);
+  --app-muted: var(--matrix-muted, #f0ede4);
+  --app-muted-fg: var(--matrix-muted-fg, #7a7768);
+  --app-border: var(--matrix-border, #d6d3c8);
+  --app-primary: var(--matrix-primary, #434e3f);
+  --app-primary-fg: var(--matrix-primary-fg, #fafaf5);
+  --app-accent: var(--matrix-accent, #d06f25);
+  --app-success: var(--matrix-success, #3a7d44);
+  --app-warning: var(--matrix-warning, #d49b2a);
+  --app-danger: var(--matrix-destructive, #c4342d);
+  --app-radius: var(--matrix-radius, 22px);
+  --app-font: var(--matrix-font-sans, "Inter", system-ui, sans-serif);
+  --app-mono: var(--matrix-font-mono, "JetBrains Mono", monospace);
+
+  /* board palette derived from theme tones */
+  --sq-light: color-mix(in srgb, var(--app-card) 78%, var(--app-warning) 22%);
+  --sq-dark: color-mix(in srgb, var(--app-primary) 62%, var(--app-card) 38%);
+  --sq-select: color-mix(in srgb, var(--app-accent) 55%, transparent);
+  --sq-last: color-mix(in srgb, var(--app-warning) 40%, transparent);
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+body {
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+.chess-app {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 22px;
+  height: 100vh;
+  padding: 22px;
+  background: var(--app-bg);
+  color: var(--app-fg);
+  font-family: var(--app-font);
+  overflow: hidden;
+}
+
+/* ---- board stage ---- */
+.board-stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+}
+
+.stage-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 560px;
+}
+.product-mark {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--app-primary);
+  color: var(--app-primary-fg);
+}
+.stage-title {
+  flex: 1;
+}
+.eyebrow {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--app-muted-fg);
+}
+.stage-title h1 {
+  margin: 2px 0 0;
+  font-size: 19px;
+}
+.ghost-btn {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  border: 1px solid var(--app-border);
+  background: var(--app-card);
+  color: var(--app-fg);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.ghost-btn:hover {
+  background: color-mix(in srgb, var(--app-fg) 4%, transparent);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  background: var(--app-card);
+  color: var(--app-fg);
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+.status-pill--check {
+  color: var(--app-warning);
+}
+.status-pill--win {
+  background: var(--app-success);
+  color: #fff;
+}
+.status-pill--draw {
+  color: var(--app-muted-fg);
+}
+.status-pill--thinking {
+  color: var(--app-accent);
+}
+.thinking-spin {
+  animation: thinking-pulse 1.1s ease-in-out infinite;
+}
+@keyframes thinking-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: scale(0.92);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
+/* ---- setup bar (mode / color / difficulty) ---- */
+.setup-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  max-width: 560px;
+}
+.setup-options {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+.seg {
+  display: inline-flex;
+  padding: 3px;
+  border-radius: 12px;
+  background: var(--app-muted);
+  gap: 2px;
+}
+.seg-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 13px;
+  border: none;
+  background: transparent;
+  border-radius: 9px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--app-muted-fg);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: var(--app-font);
+}
+.seg-btn:hover {
+  color: var(--app-fg);
+}
+.seg-btn--on {
+  background: var(--app-card);
+  color: var(--app-fg);
+  box-shadow: 0 2px 6px rgba(50, 53, 46, 0.1);
+}
+.seg-btn:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 1px;
+}
+.difficulty {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  color: var(--app-muted-fg);
+}
+.difficulty select {
+  border: none;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--app-fg);
+  font-family: var(--app-font);
+  cursor: pointer;
+  outline: none;
+}
+
+.board-frame {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) 22px;
+  grid-template-areas:
+    "ranks board"
+    ".     files";
+  gap: 6px;
+  width: 100%;
+  max-width: 560px;
+  aspect-ratio: 1 / 1;
+}
+.rank-coords {
+  grid-area: ranks;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  font-size: 11px;
+  color: var(--app-muted-fg);
+  font-family: var(--app-mono);
+}
+.file-coords {
+  grid-area: files;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  font-size: 11px;
+  color: var(--app-muted-fg);
+  font-family: var(--app-mono);
+}
+
+.board {
+  grid-area: board;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(8, 1fr);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(50, 53, 46, 0.16);
+}
+
+.square {
+  position: relative;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 0.12s ease;
+}
+.square--light {
+  background: var(--sq-light);
+}
+.square--dark {
+  background: var(--sq-dark);
+}
+.square--last::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--sq-last);
+  pointer-events: none;
+}
+.square--selected {
+  box-shadow: inset 0 0 0 4px var(--sq-select);
+}
+.square:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 3px var(--app-accent);
+}
+
+.piece {
+  font-size: clamp(26px, 7vw, 46px);
+  line-height: 1;
+  user-select: none;
+  pointer-events: none;
+  filter: drop-shadow(0 1px 1px rgba(50, 53, 46, 0.35));
+}
+.piece--w {
+  color: #fbfaf5;
+}
+.piece--b {
+  color: #2a2c26;
+}
+
+.legal-dot {
+  width: 26%;
+  height: 26%;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--app-primary) 45%, transparent);
+}
+.legal-ring {
+  position: absolute;
+  inset: 8%;
+  border-radius: 50%;
+  border: 4px solid color-mix(in srgb, var(--app-accent) 70%, transparent);
+}
+
+.board-actions {
+  display: flex;
+  gap: 12px;
+  width: 100%;
+  max-width: 560px;
+}
+.primary-action,
+.secondary-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 18px;
+  border-radius: 13px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.15s ease;
+}
+.primary-action {
+  background: var(--app-accent);
+  color: #fff;
+}
+.primary-action:hover {
+  filter: brightness(0.96);
+}
+.secondary-action {
+  background: var(--app-card);
+  border-color: var(--app-border);
+  color: var(--app-fg);
+}
+.secondary-action:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--app-fg) 4%, transparent);
+}
+.secondary-action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ---- side panel ---- */
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.capture-tray {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--app-card);
+  border-radius: 16px;
+  padding: 12px 14px;
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+.capture-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.capture-label {
+  font-size: 11px;
+  color: var(--app-muted-fg);
+  width: 96px;
+  flex-shrink: 0;
+}
+.capture-pieces {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  flex-wrap: wrap;
+}
+.capture-glyph {
+  font-size: 20px;
+  line-height: 1;
+}
+.capture-glyph--w {
+  color: #c9c6bb;
+}
+.capture-glyph--b {
+  color: #3a3c34;
+}
+.capture-empty {
+  color: var(--app-muted-fg);
+}
+.capture-edge {
+  margin-left: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--app-success);
+  font-family: var(--app-mono);
+}
+
+.history-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--app-card);
+  border-radius: 16px;
+  padding: 14px 16px;
+  box-shadow: 0 4px 12px rgba(50, 53, 46, 0.08);
+}
+.section-heading h2 {
+  margin: 2px 0 0;
+  font-size: 15px;
+}
+.move-history {
+  margin-top: 10px;
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+.empty-history {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 6px;
+  padding: 26px 8px;
+  color: var(--app-muted-fg);
+}
+.empty-history strong {
+  color: var(--app-fg);
+  font-size: 14px;
+}
+.empty-history span {
+  font-size: 12px;
+  max-width: 220px;
+}
+.move-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: var(--app-mono);
+  font-size: 13px;
+}
+.move-row {
+  display: grid;
+  grid-template-columns: 34px 1fr 1fr;
+  align-items: center;
+  padding: 4px 6px;
+  border-radius: 8px;
+}
+.move-row:nth-child(odd) {
+  background: color-mix(in srgb, var(--app-fg) 3%, transparent);
+}
+.move-no {
+  color: var(--app-muted-fg);
+}
+
+.save-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 13px;
+  background: var(--app-muted);
+  color: var(--app-muted-fg);
+  font-size: 12px;
+}
+.save-strip--error {
+  background: color-mix(in srgb, var(--app-danger) 14%, transparent);
+  color: var(--app-danger);
+}
+.note {
+  margin: 0;
+  font-size: 11px;
+  color: var(--app-muted-fg);
+  text-align: center;
+}
+
+/* ---- promotion overlay ---- */
+.promo-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--app-fg) 32%, transparent);
+  backdrop-filter: blur(3px);
+  z-index: 20;
+}
+.promo-card {
+  background: var(--app-card);
+  border-radius: 18px;
+  padding: 18px 20px;
+  box-shadow: 0 18px 48px rgba(50, 53, 46, 0.3);
+  text-align: center;
+}
+.promo-card p {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--app-muted-fg);
+}
+.promo-options {
+  display: flex;
+  gap: 10px;
+}
+.promo-btn {
+  width: 56px;
+  height: 56px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  border: 1px solid var(--app-border);
+  background: var(--app-muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.promo-btn:hover {
+  background: color-mix(in srgb, var(--app-accent) 18%, transparent);
+}
+.promo-btn .piece {
+  font-size: 34px;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .square,
+  .ghost-btn,
+  .primary-action,
+  .secondary-action,
+  .seg-btn,
+  .promo-btn {
+    transition: none;
+  }
+  .thinking-spin {
+    animation: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .chess-app {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
+    overflow-y: auto;
+  }
+}

--- a/home/apps/games/chess/tsconfig.json
+++ b/home/apps/games/chess/tsconfig.json
@@ -1,1 +1,17 @@
-{"compilerOptions":{"target":"ES2022","useDefineForClassFields":true,"lib":["DOM","DOM.Iterable","ES2022"],"allowJs":false,"skipLibCheck":true,"esModuleInterop":true,"allowSyntheticDefaultImports":true,"strict":true,"forceConsistentCasingInFileNames":true,"module":"ESNext","moduleResolution":"Bundler","resolveJsonModule":true,"isolatedModules":true,"noEmit":true,"jsx":"react-jsx"},"include":["src","../../_shared/**/*.tsx"]}
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/home/apps/games/chess/tsconfig.json
+++ b/home/apps/games/chess/tsconfig.json
@@ -11,7 +11,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src"]
 }

--- a/home/apps/games/chess/vite.config.ts
+++ b/home/apps/games/chess/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  plugins: [react()],
   base: "./",
   build: {
     outDir: "dist",

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -155,6 +155,13 @@ describe("Chess app", () => {
     });
 
     expect(await screen.findByText("Game saved")).toBeTruthy();
+    await act(async () => {
+      db.emitChange();
+      await Promise.resolve();
+    });
+
+    expect(db.count).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("Game saved")).toBeTruthy();
     expect(screen.queryByText("Saved games could not be loaded.")).toBeNull();
   });
 

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -4,7 +4,12 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findBestMove } from "../../home/apps/games/chess/src/chess-ai";
 
-// vitest.config.ts aliases app-local chess.js to a faithful test double.
+type DbRow = Record<string, unknown>;
+type ChessMockControls = {
+  __setNextBoard(board: Record<string, { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" }>, turn?: "w" | "b"): void;
+  __setNextCheckmate(value?: boolean): void;
+};
+
 let App: React.ComponentType;
 
 vi.mock("../../home/apps/games/chess/src/chess-ai", async (importOriginal) => {
@@ -14,11 +19,6 @@ vi.mock("../../home/apps/games/chess/src/chess-ai", async (importOriginal) => {
     findBestMove: vi.fn(actual.findBestMove),
   };
 });
-
-type DbRow = Record<string, unknown>;
-type ChessMockControls = {
-  __setNextBoard(board: Record<string, { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" }>, turn?: "w" | "b"): void;
-};
 
 function installMatrixDb(rows: DbRow[] = []) {
   const listeners: Array<() => void> = [];
@@ -93,6 +93,34 @@ describe("Chess app", () => {
     await waitFor(() => expect(screen.queryByText("Saved games could not be loaded.")).toBeNull());
     expect(screen.queryByText("Game could not be saved.")).toBeNull();
     expect(screen.getByText("1 game on record")).toBeTruthy();
+  });
+
+  it("keeps a save error visible during stats change reloads", async () => {
+    const { __setNextCheckmate } = await import("chess.js") as unknown as ChessMockControls;
+    __setNextCheckmate();
+    const db = installMatrixDb([]);
+    db.insert.mockRejectedValueOnce(new Error("save failed"));
+    db.count.mockResolvedValue(1);
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("This game could not be saved.")).toBeTruthy();
+
+    await act(async () => {
+      db.emitChange();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("This game could not be saved.")).toBeTruthy();
+    expect(screen.queryByText("1 game on record")).toBeNull();
   });
 
   it("highlights legal destinations when a pawn is selected", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -243,6 +243,39 @@ describe("Chess app", () => {
     expect(within(screen.getByTestId("move-history")).getByText("h6")).toBeTruthy();
   });
 
+  it("renders the selected piece after a pawn promotion", async () => {
+    installMatrixDb([]);
+    const { __setNextBoard } = await import("chess.js") as unknown as ChessMockControls;
+    __setNextBoard({
+      a7: { color: "w", type: "p" },
+      g1: { color: "w", type: "n" },
+      h7: { color: "b", type: "p" },
+    });
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-g1"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-f3"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-h7"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-h6"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-a7"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-a8"));
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTestId("promote-q"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("square-a8").getAttribute("aria-label")).toBe("a8 White q");
+    });
+  });
+
   it("falls back to local play when the computer search fails", async () => {
     installMatrixDb([]);
     vi.mocked(findBestMove).mockImplementationOnce(() => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findBestMove } from "../../home/apps/games/chess/src/chess-ai";
@@ -56,12 +56,14 @@ describe("Chess app", () => {
   });
 
   afterEach(async () => {
+    cleanup();
     const { __reset } = await import("chess.js") as unknown as ChessMockControls;
     __reset();
     vi.restoreAllMocks();
     vi.mocked(findBestMove).mockClear();
     Reflect.deleteProperty(window, "MatrixOS");
     window.localStorage.clear();
+    vi.resetModules();
   });
 
   it("renders an 8x8 board with 64 squares", async () => {
@@ -125,6 +127,11 @@ describe("Chess app", () => {
 
     expect(screen.getByText("This game could not be saved.")).toBeTruthy();
     expect(screen.queryByText("1 game on record")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+
+    expect(screen.queryByText("This game could not be saved.")).toBeNull();
+    expect(screen.getByText("1 game on record")).toBeTruthy();
   });
 
   it("highlights legal destinations when a pawn is selected", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -8,6 +8,7 @@ type DbRow = Record<string, unknown>;
 type ChessMockControls = {
   __setNextBoard(board: Record<string, { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" }>, turn?: "w" | "b"): void;
   __setNextCheckmate(value?: boolean): void;
+  Chess: new () => { moves(opts: { square: string }): string[] };
 };
 
 let App: React.ComponentType;
@@ -139,6 +140,29 @@ describe("Chess app", () => {
       expect(screen.getByTestId("square-e3").getAttribute("data-legal")).toBe("true");
       expect(screen.getByTestId("square-e4").getAttribute("data-legal")).toBe("true");
     });
+  });
+
+  it("mock chess legal moves cover sliding pieces and kings", async () => {
+    const { Chess, __setNextBoard } = await import("chess.js") as unknown as ChessMockControls;
+
+    __setNextBoard({
+      d4: { color: "w", type: "r" },
+      d6: { color: "b", type: "p" },
+      f4: { color: "w", type: "p" },
+    });
+    const rookMoves = new Chess().moves({ square: "d4" });
+    expect(rookMoves).toEqual(expect.arrayContaining(["d5", "d6", "c4", "e4"]));
+    expect(rookMoves).not.toContain("d7");
+    expect(rookMoves).not.toContain("g4");
+
+    __setNextBoard({ d4: { color: "w", type: "b" } });
+    expect(new Chess().moves({ square: "d4" })).toEqual(expect.arrayContaining(["e5", "f6", "c5", "e3"]));
+
+    __setNextBoard({ d4: { color: "w", type: "q" } });
+    expect(new Chess().moves({ square: "d4" })).toEqual(expect.arrayContaining(["d5", "e4", "e5", "c3"]));
+
+    __setNextBoard({ d4: { color: "w", type: "k" } });
+    expect(new Chess().moves({ square: "d4" })).toEqual(expect.arrayContaining(["d5", "e5", "e4", "c3"]));
   });
 
   it("records a legal move in the SAN history", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -16,6 +16,9 @@ vi.mock("../../home/apps/games/chess/src/chess-ai", async (importOriginal) => {
 });
 
 type DbRow = Record<string, unknown>;
+type ChessMockControls = {
+  __setNextBoard(board: Record<string, { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" }>, turn?: "w" | "b"): void;
+};
 
 function installMatrixDb(rows: DbRow[] = []) {
   const listeners: Array<() => void> = [];
@@ -201,6 +204,43 @@ describe("Chess app", () => {
       expect(screen.getByTestId("square-e2").getAttribute("aria-label")).toBe("e2 White p");
       expect(screen.getByTestId("square-e4").getAttribute("aria-label")).toBe("e4 empty");
     });
+  });
+
+  it("keeps undo disabled while a promotion choice is pending", async () => {
+    installMatrixDb([]);
+    const { __setNextBoard } = await import("chess.js") as unknown as ChessMockControls;
+    __setNextBoard({
+      a7: { color: "w", type: "p" },
+      g1: { color: "w", type: "n" },
+      h7: { color: "b", type: "p" },
+    });
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-g1"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-f3"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-h7"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-h6"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-a7"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-a8"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("dialog", { name: /choose promotion piece/i })).toBeTruthy();
+    const undoButton = screen.getByRole("button", { name: /undo/i }) as HTMLButtonElement;
+    expect(undoButton.disabled).toBe(true);
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+
+    expect(screen.getByRole("dialog", { name: /choose promotion piece/i })).toBeTruthy();
+    expect(within(screen.getByTestId("move-history")).getByText("Nf3")).toBeTruthy();
+    expect(within(screen.getByTestId("move-history")).getByText("h6")).toBeTruthy();
   });
 
   it("falls back to local play when the computer search fails", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -158,7 +158,7 @@ describe("Chess app", () => {
     expect(screen.queryByText("Saved games could not be loaded.")).toBeNull();
   });
 
-  it("keeps undo locked while a finished game save is pending", async () => {
+  it("keeps reset and undo locked while a finished game save is pending", async () => {
     const { __setNextCheckmate } = await import("chess.js") as unknown as ChessMockControls;
     __setNextCheckmate();
     const db = installMatrixDb([]);
@@ -181,9 +181,12 @@ describe("Chess app", () => {
     });
 
     expect(await screen.findByText("Saving game to Matrix Postgres…")).toBeTruthy();
+    const newGameButton = screen.getByRole("button", { name: /new game/i }) as HTMLButtonElement;
     const undoButton = screen.getByRole("button", { name: /undo/i }) as HTMLButtonElement;
+    expect(newGameButton.disabled).toBe(true);
     expect(undoButton.disabled).toBe(true);
 
+    fireEvent.click(newGameButton);
     fireEvent.keyDown(window, { key: "z", ctrlKey: true });
 
     expect(screen.getByTestId("square-e4").getAttribute("aria-label")).toBe("e4 White p");

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -202,4 +202,39 @@ describe("Chess app", () => {
       expect(screen.getByTestId("square-e6").getAttribute("data-legal")).toBe("true");
     });
   });
+
+  it("falls back to local play when the computer returns no move", async () => {
+    installMatrixDb([]);
+    vi.mocked(findBestMove).mockReturnValueOnce(null);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mode-vs-computer"));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await new Promise((resolve) => setTimeout(resolve, 260));
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(findBestMove)).toHaveBeenCalled();
+      expect(screen.getByTestId("mode-two-player").getAttribute("aria-pressed")).toBe("true");
+      expect(screen.getByText("The computer could not find a move. Continuing as local two-player.")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e7"));
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("square-e6").getAttribute("data-legal")).toBe("true");
+    });
+  });
 });

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -138,6 +138,35 @@ describe("Chess app", () => {
     expect(screen.getByText("1 game on record")).toBeTruthy();
   });
 
+  it("keeps a save error visible when a later stats reload fails", async () => {
+    const { __setNextCheckmate } = await import("chess.js") as unknown as ChessMockControls;
+    __setNextCheckmate();
+    const db = installMatrixDb([]);
+    db.insert.mockRejectedValueOnce(new Error("save failed"));
+    db.count.mockResolvedValueOnce(0).mockRejectedValueOnce(new Error("count failed"));
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("This game could not be saved.")).toBeTruthy();
+
+    await act(async () => {
+      db.emitChange();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(db.count).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("This game could not be saved.")).toBeTruthy();
+    expect(screen.queryByText("Saved games could not be loaded.")).toBeNull();
+  });
+
   it("keeps a successful save visible when a later stats reload would fail", async () => {
     const { __setNextCheckmate } = await import("chess.js") as unknown as ChessMockControls;
     __setNextCheckmate();

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -12,7 +12,10 @@ type ChessMockControls = {
   __reset(): void;
   Chess: new () => {
     moves(opts: { square: string }): string[];
-    moves(opts: { square: string; verbose: true }): Array<{ to: string; promotion?: string }>;
+    moves(opts: { square: string; verbose: true }): Array<{ to: string; promotion?: string; captured?: string }>;
+    move(move: { from: string; to: string; promotion?: string }): unknown;
+    reset(): void;
+    isCheckmate(): boolean;
   };
 };
 
@@ -301,6 +304,39 @@ describe("Chess app", () => {
     const moves = new Chess().moves({ square: "a7", verbose: true });
 
     expect(moves.filter((move) => move.to === "a8").map((move) => move.promotion)).toEqual(["q", "r", "b", "n"]);
+  });
+
+  it("mock chess verbose moves include captured pieces for non-pawns", async () => {
+    const { Chess, __setNextBoard } = await import("chess.js") as unknown as ChessMockControls;
+
+    __setNextBoard({
+      d4: { color: "w", type: "r" },
+      d6: { color: "b", type: "n" },
+      f5: { color: "w", type: "n" },
+      e7: { color: "b", type: "q" },
+    });
+    const rookMoves = new Chess().moves({ square: "d4", verbose: true });
+    expect(rookMoves).toContainEqual(expect.objectContaining({ to: "d6", captured: "n" }));
+
+    __setNextBoard({
+      f5: { color: "w", type: "n" },
+      e7: { color: "b", type: "q" },
+    });
+    const knightMoves = new Chess().moves({ square: "f5", verbose: true });
+    expect(knightMoves).toContainEqual(expect.objectContaining({ to: "e7", captured: "q" }));
+  });
+
+  it("mock chess reset clears forced checkmate state", async () => {
+    const { Chess, __setNextCheckmate } = await import("chess.js") as unknown as ChessMockControls;
+
+    __setNextCheckmate();
+    const game = new Chess();
+    expect(game.move({ from: "e2", to: "e4" })).toBeTruthy();
+    expect(game.isCheckmate()).toBe(true);
+
+    game.reset();
+    expect(game.move({ from: "e2", to: "e4" })).toBeTruthy();
+    expect(game.isCheckmate()).toBe(false);
   });
 
   it("records a legal move in the SAN history", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "../../home/apps/games/chess/src/App";
 import { findBestMove } from "../../home/apps/games/chess/src/chess-ai";
 
 type DbRow = Record<string, unknown>;
@@ -14,8 +15,6 @@ type ChessMockControls = {
     moves(opts: { square: string; verbose: true }): Array<{ to: string; promotion?: string }>;
   };
 };
-
-let App: React.ComponentType;
 
 vi.mock("../../home/apps/games/chess/src/chess-ai", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../home/apps/games/chess/src/chess-ai")>();
@@ -54,8 +53,11 @@ function installMatrixDb(rows: DbRow[] = []) {
 
 describe("Chess app", () => {
   beforeEach(async () => {
+    const actualChessAi = await vi.importActual<typeof import("../../home/apps/games/chess/src/chess-ai")>(
+      "../../home/apps/games/chess/src/chess-ai",
+    );
+    vi.mocked(findBestMove).mockImplementation(actualChessAi.findBestMove);
     window.localStorage.clear();
-    ({ default: App } = await import("../../home/apps/games/chess/src/App"));
   });
 
   afterEach(async () => {
@@ -63,7 +65,7 @@ describe("Chess app", () => {
     const { __reset } = await import("chess.js") as unknown as ChessMockControls;
     __reset();
     vi.restoreAllMocks();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
     window.localStorage.clear();
   });

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -173,6 +173,24 @@ describe("Chess app", () => {
 
     __setNextBoard({ d4: { color: "w", type: "k" } });
     expect(new Chess().moves({ square: "d4" })).toEqual(expect.arrayContaining(["d5", "e5", "e4", "c3"]));
+
+    __setNextBoard({
+      e4: { color: "w", type: "p" },
+      d5: { color: "b", type: "p" },
+      f5: { color: "w", type: "p" },
+    });
+    const whitePawnMoves = new Chess().moves({ square: "e4" });
+    expect(whitePawnMoves).toEqual(expect.arrayContaining(["e5", "d5"]));
+    expect(whitePawnMoves).not.toContain("f5");
+
+    __setNextBoard({
+      d5: { color: "b", type: "p" },
+      e4: { color: "w", type: "p" },
+      c4: { color: "b", type: "p" },
+    }, "b");
+    const blackPawnMoves = new Chess().moves({ square: "d5" });
+    expect(blackPawnMoves).toEqual(expect.arrayContaining(["d4", "e4"]));
+    expect(blackPawnMoves).not.toContain("c4");
   });
 
   it("records a legal move in the SAN history", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -8,6 +8,7 @@ type DbRow = Record<string, unknown>;
 type ChessMockControls = {
   __setNextBoard(board: Record<string, { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" }>, turn?: "w" | "b"): void;
   __setNextCheckmate(value?: boolean): void;
+  __reset(): void;
   Chess: new () => { moves(opts: { square: string }): string[] };
 };
 
@@ -54,7 +55,9 @@ describe("Chess app", () => {
     ({ default: App } = await import("../../home/apps/games/chess/src/App"));
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const { __reset } = await import("chess.js") as unknown as ChessMockControls;
+    __reset();
     vi.restoreAllMocks();
     vi.mocked(findBestMove).mockClear();
     Reflect.deleteProperty(window, "MatrixOS");

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -9,7 +9,10 @@ type ChessMockControls = {
   __setNextBoard(board: Record<string, { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" }>, turn?: "w" | "b"): void;
   __setNextCheckmate(value?: boolean): void;
   __reset(): void;
-  Chess: new () => { moves(opts: { square: string }): string[] };
+  Chess: new () => {
+    moves(opts: { square: string }): string[];
+    moves(opts: { square: string; verbose: true }): Array<{ to: string; promotion?: string }>;
+  };
 };
 
 let App: React.ComponentType;
@@ -191,6 +194,15 @@ describe("Chess app", () => {
     const blackPawnMoves = new Chess().moves({ square: "d5" });
     expect(blackPawnMoves).toEqual(expect.arrayContaining(["d4", "e4"]));
     expect(blackPawnMoves).not.toContain("c4");
+  });
+
+  it("mock chess verbose pawn moves include promotion choices", async () => {
+    const { Chess, __setNextBoard } = await import("chess.js") as unknown as ChessMockControls;
+
+    __setNextBoard({ a7: { color: "w", type: "p" } });
+    const moves = new Chess().moves({ square: "a7", verbose: true });
+
+    expect(moves.filter((move) => move.to === "a8").map((move) => move.promotion)).toEqual(["q", "r", "b", "n"]);
   });
 
   it("records a legal move in the SAN history", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// chess.js is an app-local dependency (home/apps/games/chess/node_modules).
+// The root vitest runner cannot be relied upon to resolve it, and chess.js is
+// itself a trusted, separately-tested library — its legality logic is not what
+// this UI test verifies. We therefore mock a faithful subset of the chess.js
+// API that the App consumes, seeded from the real standard opening position.
+// The pure board/material/SAN helpers are exercised by chess-model.test.ts.
+// ---------------------------------------------------------------------------
+type Piece = { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" };
+
+function startingBoard(): Record<string, Piece> {
+  const b: Record<string, Piece> = {};
+  const back: Piece["type"][] = ["r", "n", "b", "q", "k", "b", "n", "r"];
+  const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
+  files.forEach((f, i) => {
+    b[`${f}1`] = { color: "w", type: back[i] };
+    b[`${f}2`] = { color: "w", type: "p" };
+    b[`${f}7`] = { color: "b", type: "p" };
+    b[`${f}8`] = { color: "b", type: back[i] };
+  });
+  return b;
+}
+
+class FakeChess {
+  private board: Record<string, Piece> = startingBoard();
+  private turnColor: "w" | "b" = "w";
+  private moveSans: string[] = [];
+
+  reset() {
+    this.board = startingBoard();
+    this.turnColor = "w";
+    this.moveSans = [];
+  }
+
+  turn() {
+    return this.turnColor;
+  }
+
+  get(square: string): Piece | undefined {
+    return this.board[square];
+  }
+
+  // verbose moves for a specific square (only pawn double/single push needed)
+  moves(opts?: { square?: string; verbose?: boolean }) {
+    if (opts?.square) {
+      const piece = this.board[opts.square];
+      if (!piece || piece.color !== this.turnColor) return [];
+      const file = opts.square[0];
+      const rank = Number(opts.square[1]);
+      const out: { from: string; to: string; piece: string; color: string }[] = [];
+      if (piece.type === "p") {
+        const dir = piece.color === "w" ? 1 : -1;
+        const one = `${file}${rank + dir}`;
+        const two = `${file}${rank + dir * 2}`;
+        if (!this.board[one]) out.push({ from: opts.square, to: one, piece: "p", color: piece.color });
+        const homeRank = piece.color === "w" ? 2 : 7;
+        if (rank === homeRank && !this.board[one] && !this.board[two]) {
+          out.push({ from: opts.square, to: two, piece: "p", color: piece.color });
+        }
+      }
+      if (piece.type === "n") {
+        // knight from b1 / g1 etc. — enumerate a couple of legal jumps
+        const targets = piece.color === "w" ? ["a3", "c3", "f3", "h3"] : ["a6", "c6", "f6", "h6"];
+        for (const t of targets) {
+          if (!this.board[t]) out.push({ from: opts.square, to: t, piece: "n", color: piece.color });
+        }
+      }
+      return opts.verbose ? out : out.map((m) => m.to);
+    }
+    return [];
+  }
+
+  move(m: { from: string; to: string; promotion?: string }) {
+    const piece = this.board[m.from];
+    if (!piece || piece.color !== this.turnColor) return null;
+    const legal = (this.moves({ square: m.from, verbose: true }) as { to: string }[]).some(
+      (x) => x.to === m.to,
+    );
+    if (!legal) return null;
+    delete this.board[m.from];
+    this.board[m.to] = piece;
+    // crude SAN: pawn pushes are the destination square; pieces prefix letter
+    const san = piece.type === "p" ? m.to : `${piece.type.toUpperCase()}${m.to}`;
+    this.moveSans.push(san);
+    this.turnColor = this.turnColor === "w" ? "b" : "w";
+    return { from: m.from, to: m.to, san, color: piece.color, piece: piece.type, captured: undefined };
+  }
+
+  history(_opts?: { verbose?: boolean }) {
+    return this.moveSans.slice();
+  }
+
+  fen() {
+    return `fake ${this.moveSans.length} ${this.turnColor}`;
+  }
+
+  pgn() {
+    return this.moveSans.join(" ");
+  }
+
+  isCheck() {
+    return false;
+  }
+  isCheckmate() {
+    return false;
+  }
+  isStalemate() {
+    return false;
+  }
+  isDraw() {
+    return false;
+  }
+  isGameOver() {
+    return false;
+  }
+  undo() {
+    if (this.moveSans.length === 0) return null;
+    this.moveSans.pop();
+    this.turnColor = this.turnColor === "w" ? "b" : "w";
+    return {};
+  }
+}
+
+vi.mock("chess.js", () => ({ Chess: FakeChess }));
+
+// Import App AFTER the mock is registered.
+let App: React.ComponentType;
+
+type DbRow = Record<string, unknown>;
+
+function installMatrixDb(rows: DbRow[] = []) {
+  const db = {
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    insert: vi.fn(async () => ({ id: "game-new" })),
+    update: vi.fn(async () => ({ ok: true })),
+    delete: vi.fn(async () => ({ ok: true })),
+    count: vi.fn(async () => rows.length),
+    onChange: vi.fn(() => () => undefined),
+  };
+  Object.defineProperty(window, "MatrixOS", {
+    configurable: true,
+    value: { db },
+  });
+  return db;
+}
+
+describe("Chess app", () => {
+  beforeEach(async () => {
+    window.localStorage.clear();
+    ({ default: App } = await import("../../home/apps/games/chess/src/App"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, "MatrixOS");
+    window.localStorage.clear();
+  });
+
+  it("renders an 8x8 board with 64 squares", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    const board = await screen.findByTestId("board");
+    expect(board.querySelectorAll("[data-square]").length).toBe(64);
+    expect(within(board).getAllByRole("gridcell").length).toBe(64);
+  });
+
+  it("highlights legal destinations when a pawn is selected", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    // select the e2 pawn
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+    });
+
+    // e3 and e4 should be marked as legal targets
+    await waitFor(() => {
+      expect(screen.getByTestId("square-e3").getAttribute("data-legal")).toBe("true");
+      expect(screen.getByTestId("square-e4").getAttribute("data-legal")).toBe("true");
+    });
+  });
+
+  it("records a legal move in the SAN history", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await Promise.resolve();
+    });
+
+    const history = await screen.findByTestId("move-history");
+    expect(within(history).getByText("e4")).toBeTruthy();
+  });
+
+  it("toggles between two-player and vs-computer modes", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    // Defaults to two-player; computer options are hidden.
+    expect(screen.queryByTestId("difficulty")).toBeNull();
+    expect(screen.getByTestId("mode-two-player").getAttribute("aria-pressed")).toBe("true");
+
+    // Switch to vs Computer — color + difficulty controls appear.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mode-vs-computer"));
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("mode-vs-computer").getAttribute("aria-pressed")).toBe("true");
+      expect(screen.getByTestId("difficulty")).toBeTruthy();
+      expect(screen.getByTestId("color-white")).toBeTruthy();
+      expect(screen.getByTestId("color-black")).toBeTruthy();
+    });
+
+    // Difficulty is selectable.
+    await act(async () => {
+      fireEvent.change(screen.getByTestId("difficulty"), { target: { value: "hard" } });
+      await Promise.resolve();
+    });
+    expect((screen.getByTestId("difficulty") as HTMLSelectElement).value).toBe("hard");
+
+    // Back to two-player hides the options again.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mode-two-player"));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.queryByTestId("difficulty")).toBeNull());
+  });
+
+  it("New game resets the move history", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /new game/i }));
+
+    const history = screen.getByTestId("move-history");
+    expect(within(history).queryByText("e4")).toBeNull();
+  });
+});

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -18,6 +18,7 @@ vi.mock("../../home/apps/games/chess/src/chess-ai", async (importOriginal) => {
 type DbRow = Record<string, unknown>;
 
 function installMatrixDb(rows: DbRow[] = []) {
+  const listeners: Array<() => void> = [];
   const db = {
     find: vi.fn(async () => rows),
     findOne: vi.fn(async () => null),
@@ -25,7 +26,16 @@ function installMatrixDb(rows: DbRow[] = []) {
     update: vi.fn(async () => ({ ok: true })),
     delete: vi.fn(async () => ({ ok: true })),
     count: vi.fn(async () => rows.length),
-    onChange: vi.fn(() => () => undefined),
+    onChange: vi.fn((_table: string, cb: () => void) => {
+      listeners.push(cb);
+      return () => {
+        const index = listeners.indexOf(cb);
+        if (index >= 0) listeners.splice(index, 1);
+      };
+    }),
+    emitChange: () => {
+      for (const cb of [...listeners]) cb();
+    },
   };
   Object.defineProperty(window, "MatrixOS", {
     configurable: true,
@@ -53,6 +63,33 @@ describe("Chess app", () => {
     const board = await screen.findByTestId("board");
     expect(board.querySelectorAll("[data-square]").length).toBe(64);
     expect(within(board).getAllByRole("gridcell").length).toBe(64);
+  });
+
+  it("shows a save-strip error when saved game stats fail to load", async () => {
+    const db = installMatrixDb([]);
+    db.count.mockRejectedValueOnce(new Error("count failed"));
+
+    render(<App />);
+
+    expect(await screen.findByText("Saved games could not be loaded.")).toBeTruthy();
+  });
+
+  it("clears a stats load error after a successful db change reload", async () => {
+    const db = installMatrixDb([{}]);
+    db.count.mockRejectedValueOnce(new Error("count failed")).mockResolvedValueOnce(1);
+
+    render(<App />);
+
+    expect(await screen.findByText("Saved games could not be loaded.")).toBeTruthy();
+
+    await act(async () => {
+      db.emitChange();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.queryByText("Saved games could not be loaded.")).toBeNull());
+    expect(screen.queryByText("Game could not be saved.")).toBeNull();
+    expect(screen.getByText("1 game on record")).toBeTruthy();
   });
 
   it("highlights legal destinations when a pawn is selected", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -136,6 +136,26 @@ describe("Chess app", () => {
     expect(screen.getByText("1 game on record")).toBeTruthy();
   });
 
+  it("keeps a successful save visible when a later stats reload would fail", async () => {
+    const { __setNextCheckmate } = await import("chess.js") as unknown as ChessMockControls;
+    __setNextCheckmate();
+    const db = installMatrixDb([]);
+    db.count.mockResolvedValueOnce(0).mockRejectedValueOnce(new Error("count failed"));
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Game saved")).toBeTruthy();
+    expect(screen.queryByText("Saved games could not be loaded.")).toBeNull();
+  });
+
   it("highlights legal destinations when a pawn is selected", async () => {
     installMatrixDb([]);
     render(<App />);

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -63,10 +63,9 @@ describe("Chess app", () => {
     const { __reset } = await import("chess.js") as unknown as ChessMockControls;
     __reset();
     vi.restoreAllMocks();
-    vi.mocked(findBestMove).mockClear();
+    vi.clearAllMocks();
     Reflect.deleteProperty(window, "MatrixOS");
     window.localStorage.clear();
-    vi.resetModules();
   });
 
   it("renders an 8x8 board with 64 squares", async () => {

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -3,132 +3,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// ---------------------------------------------------------------------------
-// chess.js is an app-local dependency (home/apps/games/chess/node_modules).
-// The root vitest runner cannot be relied upon to resolve it, and chess.js is
-// itself a trusted, separately-tested library — its legality logic is not what
-// this UI test verifies. We therefore mock a faithful subset of the chess.js
-// API that the App consumes, seeded from the real standard opening position.
-// The pure board/material/SAN helpers are exercised by chess-model.test.ts.
-// ---------------------------------------------------------------------------
-type Piece = { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" };
-
-function startingBoard(): Record<string, Piece> {
-  const b: Record<string, Piece> = {};
-  const back: Piece["type"][] = ["r", "n", "b", "q", "k", "b", "n", "r"];
-  const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
-  files.forEach((f, i) => {
-    b[`${f}1`] = { color: "w", type: back[i] };
-    b[`${f}2`] = { color: "w", type: "p" };
-    b[`${f}7`] = { color: "b", type: "p" };
-    b[`${f}8`] = { color: "b", type: back[i] };
-  });
-  return b;
-}
-
-class FakeChess {
-  private board: Record<string, Piece> = startingBoard();
-  private turnColor: "w" | "b" = "w";
-  private moveSans: string[] = [];
-
-  reset() {
-    this.board = startingBoard();
-    this.turnColor = "w";
-    this.moveSans = [];
-  }
-
-  turn() {
-    return this.turnColor;
-  }
-
-  get(square: string): Piece | undefined {
-    return this.board[square];
-  }
-
-  // verbose moves for a specific square (only pawn double/single push needed)
-  moves(opts?: { square?: string; verbose?: boolean }) {
-    if (opts?.square) {
-      const piece = this.board[opts.square];
-      if (!piece || piece.color !== this.turnColor) return [];
-      const file = opts.square[0];
-      const rank = Number(opts.square[1]);
-      const out: { from: string; to: string; piece: string; color: string }[] = [];
-      if (piece.type === "p") {
-        const dir = piece.color === "w" ? 1 : -1;
-        const one = `${file}${rank + dir}`;
-        const two = `${file}${rank + dir * 2}`;
-        if (!this.board[one]) out.push({ from: opts.square, to: one, piece: "p", color: piece.color });
-        const homeRank = piece.color === "w" ? 2 : 7;
-        if (rank === homeRank && !this.board[one] && !this.board[two]) {
-          out.push({ from: opts.square, to: two, piece: "p", color: piece.color });
-        }
-      }
-      if (piece.type === "n") {
-        // knight from b1 / g1 etc. — enumerate a couple of legal jumps
-        const targets = piece.color === "w" ? ["a3", "c3", "f3", "h3"] : ["a6", "c6", "f6", "h6"];
-        for (const t of targets) {
-          if (!this.board[t]) out.push({ from: opts.square, to: t, piece: "n", color: piece.color });
-        }
-      }
-      return opts.verbose ? out : out.map((m) => m.to);
-    }
-    return [];
-  }
-
-  move(m: { from: string; to: string; promotion?: string }) {
-    const piece = this.board[m.from];
-    if (!piece || piece.color !== this.turnColor) return null;
-    const legal = (this.moves({ square: m.from, verbose: true }) as { to: string }[]).some(
-      (x) => x.to === m.to,
-    );
-    if (!legal) return null;
-    delete this.board[m.from];
-    this.board[m.to] = piece;
-    // crude SAN: pawn pushes are the destination square; pieces prefix letter
-    const san = piece.type === "p" ? m.to : `${piece.type.toUpperCase()}${m.to}`;
-    this.moveSans.push(san);
-    this.turnColor = this.turnColor === "w" ? "b" : "w";
-    return { from: m.from, to: m.to, san, color: piece.color, piece: piece.type, captured: undefined };
-  }
-
-  history(_opts?: { verbose?: boolean }) {
-    return this.moveSans.slice();
-  }
-
-  fen() {
-    return `fake ${this.moveSans.length} ${this.turnColor}`;
-  }
-
-  pgn() {
-    return this.moveSans.join(" ");
-  }
-
-  isCheck() {
-    return false;
-  }
-  isCheckmate() {
-    return false;
-  }
-  isStalemate() {
-    return false;
-  }
-  isDraw() {
-    return false;
-  }
-  isGameOver() {
-    return false;
-  }
-  undo() {
-    if (this.moveSans.length === 0) return null;
-    this.moveSans.pop();
-    this.turnColor = this.turnColor === "w" ? "b" : "w";
-    return {};
-  }
-}
-
-vi.mock("chess.js", () => ({ Chess: FakeChess }));
-
-// Import App AFTER the mock is registered.
+// vitest.config.ts aliases app-local chess.js to a faithful test double.
 let App: React.ComponentType;
 
 type DbRow = Record<string, unknown>;
@@ -258,5 +133,26 @@ describe("Chess app", () => {
 
     const history = screen.getByTestId("move-history");
     expect(within(history).queryByText("e4")).toBeNull();
+  });
+
+  it("Undo restores the previous board position", async () => {
+    installMatrixDb([]);
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("square-e4").getAttribute("aria-label")).toBe("e4 White p");
+    fireEvent.click(screen.getByRole("button", { name: /undo/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("square-e2").getAttribute("aria-label")).toBe("e2 White p");
+      expect(screen.getByTestId("square-e4").getAttribute("aria-label")).toBe("e4 empty");
+    });
   });
 });

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -156,6 +156,44 @@ describe("Chess app", () => {
     expect(screen.queryByText("Saved games could not be loaded.")).toBeNull();
   });
 
+  it("keeps undo locked while a finished game save is pending", async () => {
+    const { __setNextCheckmate } = await import("chess.js") as unknown as ChessMockControls;
+    __setNextCheckmate();
+    const db = installMatrixDb([]);
+    let resolveInsert: ((value: { id: string }) => void) | null = null;
+    db.insert.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveInsert = resolve;
+        }),
+    );
+
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Saving game to Matrix Postgres…")).toBeTruthy();
+    const undoButton = screen.getByRole("button", { name: /undo/i }) as HTMLButtonElement;
+    expect(undoButton.disabled).toBe(true);
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+
+    expect(screen.getByTestId("square-e4").getAttribute("aria-label")).toBe("e4 White p");
+    expect(screen.getByTestId("square-e2").getAttribute("aria-label")).toBe("e2 empty");
+    expect(db.insert).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveInsert?.({ id: "game-new" });
+      await Promise.resolve();
+    });
+  });
+
   it("highlights legal destinations when a pawn is selected", async () => {
     installMatrixDb([]);
     render(<App />);

--- a/tests/default-apps/chess-app.test.tsx
+++ b/tests/default-apps/chess-app.test.tsx
@@ -2,9 +2,18 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { findBestMove } from "../../home/apps/games/chess/src/chess-ai";
 
 // vitest.config.ts aliases app-local chess.js to a faithful test double.
 let App: React.ComponentType;
+
+vi.mock("../../home/apps/games/chess/src/chess-ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../home/apps/games/chess/src/chess-ai")>();
+  return {
+    ...actual,
+    findBestMove: vi.fn(actual.findBestMove),
+  };
+});
 
 type DbRow = Record<string, unknown>;
 
@@ -33,6 +42,7 @@ describe("Chess app", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.mocked(findBestMove).mockClear();
     Reflect.deleteProperty(window, "MatrixOS");
     window.localStorage.clear();
   });
@@ -153,6 +163,43 @@ describe("Chess app", () => {
     await waitFor(() => {
       expect(screen.getByTestId("square-e2").getAttribute("aria-label")).toBe("e2 White p");
       expect(screen.getByTestId("square-e4").getAttribute("aria-label")).toBe("e4 empty");
+    });
+  });
+
+  it("falls back to local play when the computer search fails", async () => {
+    installMatrixDb([]);
+    vi.mocked(findBestMove).mockImplementationOnce(() => {
+      throw new Error("engine down");
+    });
+    render(<App />);
+    await screen.findByTestId("board");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mode-vs-computer"));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e2"));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e4"));
+      await new Promise((resolve) => setTimeout(resolve, 260));
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(findBestMove)).toHaveBeenCalled();
+      expect(screen.getByTestId("mode-two-player").getAttribute("aria-pressed")).toBe("true");
+      expect(screen.getByText("The computer could not find a move. Continuing as local two-player.")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("square-e7"));
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("square-e6").getAttribute("data-legal")).toBe("true");
     });
   });
 });

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -6,6 +6,7 @@ type VerboseMove = {
   color: Piece["color"];
   piece: Piece["type"];
   captured?: Piece["type"];
+  promotion?: Piece["type"];
 };
 type MoveRecord = VerboseMove & {
   moved: Piece;
@@ -82,6 +83,15 @@ export class Chess {
       const rank = Number(opts.square[1]);
       const fileIdx = FILES.indexOf(file);
       const out: Omit<VerboseMove, "san">[] = [];
+      const addPawnMove = (to: string, captured?: Piece["type"]) => {
+        const promotionRank = piece.color === "w" ? "8" : "1";
+        const base = { from: opts.square as string, to, piece: "p" as const, color: piece.color, captured };
+        if (to[1] !== promotionRank) {
+          out.push(base);
+          return;
+        }
+        for (const promotion of ["q", "r", "b", "n"] as const) out.push({ ...base, promotion });
+      };
       const addTarget = (targetFileIdx: number, targetRank: number): boolean => {
         const targetFile = FILES[targetFileIdx];
         if (!targetFile || targetRank < 1 || targetRank > 8) return false;
@@ -108,10 +118,10 @@ export class Chess {
         const dir = piece.color === "w" ? 1 : -1;
         const one = `${file}${rank + dir}`;
         const two = `${file}${rank + dir * 2}`;
-        if (!this.boardState[one]) out.push({ from: opts.square, to: one, piece: "p", color: piece.color });
+        if (!this.boardState[one]) addPawnMove(one);
         const homeRank = piece.color === "w" ? 2 : 7;
         if (rank === homeRank && !this.boardState[one] && !this.boardState[two]) {
-          out.push({ from: opts.square, to: two, piece: "p", color: piece.color });
+          addPawnMove(two);
         }
         for (const dc of [-1, 1]) {
           const targetFile = FILES[fileIdx + dc];
@@ -120,7 +130,7 @@ export class Chess {
           const target = `${targetFile}${targetRank}`;
           const occupant = this.boardState[target];
           if (occupant && occupant.color !== piece.color) {
-            out.push({ from: opts.square, to: target, piece: "p", color: piece.color, captured: occupant.type });
+            addPawnMove(target, occupant.type);
           }
         }
       }
@@ -185,6 +195,7 @@ export class Chess {
       color: piece.color,
       piece: piece.type,
       captured: capturedPiece?.type,
+      promotion: m.promotion as Piece["type"] | undefined,
       moved: piece,
       capturedPiece,
     };
@@ -195,13 +206,14 @@ export class Chess {
 
   history(opts?: { verbose?: boolean }) {
     if (opts?.verbose) {
-      return this.moveStack.map(({ from, to, san, color, piece, captured }) => ({
+      return this.moveStack.map(({ from, to, san, color, piece, captured, promotion }) => ({
         from,
         to,
         san,
         color,
         piece,
         captured,
+        promotion,
       }));
     }
     return this.moveStack.map((move) => move.san);

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -27,22 +27,30 @@ function startingBoard(): Record<string, Piece> {
 
 let nextBoardState: Record<string, Piece> | null = null;
 let nextTurnColor: Piece["color"] = "w";
+let nextCheckmate = false;
 
 export function __setNextBoard(board: Record<string, Piece>, turn: Piece["color"] = "w") {
   nextBoardState = Object.fromEntries(Object.entries(board).map(([square, piece]) => [square, { ...piece }]));
   nextTurnColor = turn;
 }
 
+export function __setNextCheckmate(value = true) {
+  nextCheckmate = value;
+}
+
 export class Chess {
   private boardState: Record<string, Piece>;
   private turnColor: Piece["color"];
   private moveStack: MoveRecord[] = [];
+  private forceCheckmate: boolean;
 
   constructor() {
     this.boardState = nextBoardState ?? startingBoard();
     this.turnColor = nextTurnColor;
+    this.forceCheckmate = nextCheckmate;
     nextBoardState = null;
     nextTurnColor = "w";
+    nextCheckmate = false;
   }
 
   reset() {
@@ -173,7 +181,7 @@ export class Chess {
     return false;
   }
   isCheckmate() {
-    return false;
+    return this.forceCheckmate && this.moveStack.length > 0;
   }
   isStalemate() {
     return false;

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -118,7 +118,7 @@ export class Chess {
 
     const capturedPiece = this.boardState[m.to];
     delete this.boardState[m.from];
-    this.boardState[m.to] = piece;
+    this.boardState[m.to] = m.promotion ? { color: piece.color, type: m.promotion as Piece["type"] } : piece;
     const san = piece.type === "p" ? m.to : `${piece.type.toUpperCase()}${m.to}`;
     const record: MoveRecord = {
       from: m.from,

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -65,6 +65,7 @@ export class Chess {
     this.boardState = startingBoard();
     this.turnColor = "w";
     this.moveStack = [];
+    this.forceCheckmate = false;
   }
 
   turn() {
@@ -102,7 +103,7 @@ export class Chess {
           return true;
         }
         if (occupant.color !== piece.color) {
-          out.push({ from: opts.square as string, to: target, piece: piece.type, color: piece.color });
+          out.push({ from: opts.square as string, to: target, piece: piece.type, color: piece.color, captured: occupant.type });
         }
         return false;
       };
@@ -150,8 +151,9 @@ export class Chess {
           const targetRank = rank + dr;
           if (!targetFile || targetRank < 1 || targetRank > 8) continue;
           const target = `${targetFile}${targetRank}`;
-          if (!this.boardState[target] || this.boardState[target]!.color !== piece.color) {
-            out.push({ from: opts.square, to: target, piece: "n", color: piece.color });
+          const occupant = this.boardState[target];
+          if (!occupant || occupant.color !== piece.color) {
+            out.push({ from: opts.square, to: target, piece: "n", color: piece.color, captured: occupant?.type });
           }
         }
       }

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -1,0 +1,169 @@
+type Piece = { color: "w" | "b"; type: "p" | "n" | "b" | "r" | "q" | "k" };
+type VerboseMove = {
+  from: string;
+  to: string;
+  san: string;
+  color: Piece["color"];
+  piece: Piece["type"];
+  captured?: Piece["type"];
+};
+type MoveRecord = VerboseMove & {
+  moved: Piece;
+  capturedPiece?: Piece;
+};
+
+function startingBoard(): Record<string, Piece> {
+  const board: Record<string, Piece> = {};
+  const back: Piece["type"][] = ["r", "n", "b", "q", "k", "b", "n", "r"];
+  const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
+  files.forEach((file, i) => {
+    board[`${file}1`] = { color: "w", type: back[i] };
+    board[`${file}2`] = { color: "w", type: "p" };
+    board[`${file}7`] = { color: "b", type: "p" };
+    board[`${file}8`] = { color: "b", type: back[i] };
+  });
+  return board;
+}
+
+export class Chess {
+  private boardState: Record<string, Piece> = startingBoard();
+  private turnColor: Piece["color"] = "w";
+  private moveStack: MoveRecord[] = [];
+
+  reset() {
+    this.boardState = startingBoard();
+    this.turnColor = "w";
+    this.moveStack = [];
+  }
+
+  turn() {
+    return this.turnColor;
+  }
+
+  get(square: string): Piece | undefined {
+    return this.boardState[square];
+  }
+
+  moves(opts?: { square?: string; verbose?: boolean }) {
+    if (opts?.square) {
+      const piece = this.boardState[opts.square];
+      if (!piece || piece.color !== this.turnColor) return [];
+      const file = opts.square[0];
+      const rank = Number(opts.square[1]);
+      const out: Omit<VerboseMove, "san">[] = [];
+      if (piece.type === "p") {
+        const dir = piece.color === "w" ? 1 : -1;
+        const one = `${file}${rank + dir}`;
+        const two = `${file}${rank + dir * 2}`;
+        if (!this.boardState[one]) out.push({ from: opts.square, to: one, piece: "p", color: piece.color });
+        const homeRank = piece.color === "w" ? 2 : 7;
+        if (rank === homeRank && !this.boardState[one] && !this.boardState[two]) {
+          out.push({ from: opts.square, to: two, piece: "p", color: piece.color });
+        }
+      }
+      if (piece.type === "n") {
+        const targets = piece.color === "w" ? ["a3", "c3", "f3", "h3"] : ["a6", "c6", "f6", "h6"];
+        for (const target of targets) {
+          if (!this.boardState[target]) {
+            out.push({ from: opts.square, to: target, piece: "n", color: piece.color });
+          }
+        }
+      }
+      return opts.verbose ? out : out.map((move) => move.to);
+    }
+
+    const out: Omit<VerboseMove, "san">[] = [];
+    for (const square of Object.keys(this.boardState)) {
+      const piece = this.boardState[square];
+      if (piece?.color !== this.turnColor) continue;
+      out.push(...(this.moves({ square, verbose: true }) as Omit<VerboseMove, "san">[]));
+    }
+    return opts?.verbose ? out : out.map((move) => move.to);
+  }
+
+  move(m: { from: string; to: string; promotion?: string }) {
+    const piece = this.boardState[m.from];
+    if (!piece || piece.color !== this.turnColor) return null;
+    const legal = (this.moves({ square: m.from, verbose: true }) as { to: string }[]).some((move) => move.to === m.to);
+    if (!legal) return null;
+
+    const capturedPiece = this.boardState[m.to];
+    delete this.boardState[m.from];
+    this.boardState[m.to] = piece;
+    const san = piece.type === "p" ? m.to : `${piece.type.toUpperCase()}${m.to}`;
+    const record: MoveRecord = {
+      from: m.from,
+      to: m.to,
+      san,
+      color: piece.color,
+      piece: piece.type,
+      captured: capturedPiece?.type,
+      moved: piece,
+      capturedPiece,
+    };
+    this.moveStack.push(record);
+    this.turnColor = this.turnColor === "w" ? "b" : "w";
+    return record;
+  }
+
+  history(opts?: { verbose?: boolean }) {
+    if (opts?.verbose) {
+      return this.moveStack.map(({ from, to, san, color, piece, captured }) => ({
+        from,
+        to,
+        san,
+        color,
+        piece,
+        captured,
+      }));
+    }
+    return this.moveStack.map((move) => move.san);
+  }
+
+  board() {
+    const files = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    const ranks = ["8", "7", "6", "5", "4", "3", "2", "1"];
+    return ranks.map((rank) =>
+      files.map((file) => {
+        const square = `${file}${rank}`;
+        const piece = this.boardState[square];
+        return piece ? { square, ...piece } : null;
+      }),
+    );
+  }
+
+  fen() {
+    return `fake ${this.moveStack.length} ${this.turnColor}`;
+  }
+
+  pgn() {
+    return this.moveStack.map((move) => move.san).join(" ");
+  }
+
+  isCheck() {
+    return false;
+  }
+  isCheckmate() {
+    return false;
+  }
+  isStalemate() {
+    return false;
+  }
+  isDraw() {
+    return false;
+  }
+  isGameOver() {
+    return false;
+  }
+  undo() {
+    const last = this.moveStack.pop();
+    if (!last) return null;
+    delete this.boardState[last.to];
+    this.boardState[last.from] = last.moved;
+    if (last.capturedPiece) {
+      this.boardState[last.to] = last.capturedPiece;
+    }
+    this.turnColor = this.turnColor === "w" ? "b" : "w";
+    return last;
+  }
+}

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -62,9 +62,23 @@ export class Chess {
         }
       }
       if (piece.type === "n") {
-        const targets = piece.color === "w" ? ["a3", "c3", "f3", "h3"] : ["a6", "c6", "f6", "h6"];
-        for (const target of targets) {
-          if (!this.boardState[target]) {
+        const fileIdx = "abcdefgh".indexOf(file);
+        const knightDeltas = [
+          [-2, -1],
+          [-2, 1],
+          [-1, -2],
+          [-1, 2],
+          [1, -2],
+          [1, 2],
+          [2, -1],
+          [2, 1],
+        ];
+        for (const [dr, dc] of knightDeltas) {
+          const targetFile = "abcdefgh"[fileIdx + dc];
+          const targetRank = rank + dr;
+          if (!targetFile || targetRank < 1 || targetRank > 8) continue;
+          const target = `${targetFile}${targetRank}`;
+          if (!this.boardState[target] || this.boardState[target]!.color !== piece.color) {
             out.push({ from: opts.square, to: target, piece: "n", color: piece.color });
           }
         }

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -28,6 +28,7 @@ function startingBoard(): Record<string, Piece> {
 let nextBoardState: Record<string, Piece> | null = null;
 let nextTurnColor: Piece["color"] = "w";
 let nextCheckmate = false;
+const FILES = "abcdefgh";
 
 export function __setNextBoard(board: Record<string, Piece>, turn: Piece["color"] = "w") {
   nextBoardState = Object.fromEntries(Object.entries(board).map(([square, piece]) => [square, { ...piece }]));
@@ -73,7 +74,30 @@ export class Chess {
       if (!piece || piece.color !== this.turnColor) return [];
       const file = opts.square[0];
       const rank = Number(opts.square[1]);
+      const fileIdx = FILES.indexOf(file);
       const out: Omit<VerboseMove, "san">[] = [];
+      const addTarget = (targetFileIdx: number, targetRank: number): boolean => {
+        const targetFile = FILES[targetFileIdx];
+        if (!targetFile || targetRank < 1 || targetRank > 8) return false;
+        const target = `${targetFile}${targetRank}`;
+        const occupant = this.boardState[target];
+        if (!occupant) {
+          out.push({ from: opts.square as string, to: target, piece: piece.type, color: piece.color });
+          return true;
+        }
+        if (occupant.color !== piece.color) {
+          out.push({ from: opts.square as string, to: target, piece: piece.type, color: piece.color });
+        }
+        return false;
+      };
+      const addRay = (dr: number, dc: number) => {
+        let nextFileIdx = fileIdx + dc;
+        let nextRank = rank + dr;
+        while (addTarget(nextFileIdx, nextRank)) {
+          nextFileIdx += dc;
+          nextRank += dr;
+        }
+      };
       if (piece.type === "p") {
         const dir = piece.color === "w" ? 1 : -1;
         const one = `${file}${rank + dir}`;
@@ -85,7 +109,6 @@ export class Chess {
         }
       }
       if (piece.type === "n") {
-        const fileIdx = "abcdefgh".indexOf(file);
         const knightDeltas = [
           [-2, -1],
           [-2, 1],
@@ -104,6 +127,17 @@ export class Chess {
           if (!this.boardState[target] || this.boardState[target]!.color !== piece.color) {
             out.push({ from: opts.square, to: target, piece: "n", color: piece.color });
           }
+        }
+      }
+      if (piece.type === "b" || piece.type === "q") {
+        for (const [dr, dc] of [[1, 1], [1, -1], [-1, 1], [-1, -1]]) addRay(dr, dc);
+      }
+      if (piece.type === "r" || piece.type === "q") {
+        for (const [dr, dc] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) addRay(dr, dc);
+      }
+      if (piece.type === "k") {
+        for (const [dr, dc] of [[1, 1], [1, 0], [1, -1], [0, 1], [0, -1], [-1, 1], [-1, 0], [-1, -1]]) {
+          addTarget(fileIdx + dc, rank + dr);
         }
       }
       return opts.verbose ? out : out.map((move) => move.to);

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -113,6 +113,16 @@ export class Chess {
         if (rank === homeRank && !this.boardState[one] && !this.boardState[two]) {
           out.push({ from: opts.square, to: two, piece: "p", color: piece.color });
         }
+        for (const dc of [-1, 1]) {
+          const targetFile = FILES[fileIdx + dc];
+          const targetRank = rank + dir;
+          if (!targetFile || targetRank < 1 || targetRank > 8) continue;
+          const target = `${targetFile}${targetRank}`;
+          const occupant = this.boardState[target];
+          if (occupant && occupant.color !== piece.color) {
+            out.push({ from: opts.square, to: target, piece: "p", color: piece.color, captured: occupant.type });
+          }
+        }
       }
       if (piece.type === "n") {
         const knightDeltas = [

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -25,10 +25,25 @@ function startingBoard(): Record<string, Piece> {
   return board;
 }
 
+let nextBoardState: Record<string, Piece> | null = null;
+let nextTurnColor: Piece["color"] = "w";
+
+export function __setNextBoard(board: Record<string, Piece>, turn: Piece["color"] = "w") {
+  nextBoardState = Object.fromEntries(Object.entries(board).map(([square, piece]) => [square, { ...piece }]));
+  nextTurnColor = turn;
+}
+
 export class Chess {
-  private boardState: Record<string, Piece> = startingBoard();
-  private turnColor: Piece["color"] = "w";
+  private boardState: Record<string, Piece>;
+  private turnColor: Piece["color"];
   private moveStack: MoveRecord[] = [];
+
+  constructor() {
+    this.boardState = nextBoardState ?? startingBoard();
+    this.turnColor = nextTurnColor;
+    nextBoardState = null;
+    nextTurnColor = "w";
+  }
 
   reset() {
     this.boardState = startingBoard();

--- a/tests/default-apps/mocks/chess-js.ts
+++ b/tests/default-apps/mocks/chess-js.ts
@@ -39,6 +39,12 @@ export function __setNextCheckmate(value = true) {
   nextCheckmate = value;
 }
 
+export function __reset() {
+  nextBoardState = null;
+  nextTurnColor = "w";
+  nextCheckmate = false;
+}
+
 export class Chess {
   private boardState: Record<string, Piece>;
   private turnColor: Piece["color"];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,12 @@ export default defineConfig({
       resolveId(source, importer) {
         if (source !== "chess.js" || !importer) return null;
         const normalized = importer.split(path.sep).join("/");
-        if (normalized.endsWith("/tests/default-apps/chess-app.test.tsx") || normalized.includes("/home/apps/games/chess/src/")) {
+        // Keep FakeChess scoped to the chess app integration test and the
+        // component it renders so lower-level chess unit tests opt in explicitly.
+        if (
+          normalized.endsWith("/tests/default-apps/chess-app.test.tsx") ||
+          normalized.endsWith("/home/apps/games/chess/src/App.tsx")
+        ) {
           return path.resolve(__dirname, "tests/default-apps/mocks/chess-js.ts");
         }
         return null;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       react: path.resolve(__dirname, "node_modules/react"),
       "react-dom": path.resolve(__dirname, "node_modules/react-dom"),
       "@aws-sdk/client-s3": path.resolve(__dirname, "node_modules/@aws-sdk/client-s3"),
+      "chess.js": path.resolve(__dirname, "tests/default-apps/mocks/chess-js.ts"),
     },
   },
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,23 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  plugins: [
+    {
+      name: "chess-app-test-mock",
+      enforce: "pre",
+      resolveId(source, importer) {
+        if (source !== "chess.js" || !importer) return null;
+        const normalized = importer.split(path.sep).join("/");
+        if (
+          normalized.endsWith("/tests/default-apps/chess-app.test.tsx") ||
+          normalized.endsWith("/home/apps/games/chess/src/App.tsx")
+        ) {
+          return path.resolve(__dirname, "tests/default-apps/mocks/chess-js.ts");
+        }
+        return null;
+      },
+    },
+  ],
   resolve: {
     conditions: ["node"],
     alias: {
@@ -26,7 +43,6 @@ export default defineConfig({
       react: path.resolve(__dirname, "node_modules/react"),
       "react-dom": path.resolve(__dirname, "node_modules/react-dom"),
       "@aws-sdk/client-s3": path.resolve(__dirname, "node_modules/@aws-sdk/client-s3"),
-      "chess.js": path.resolve(__dirname, "tests/default-apps/mocks/chess-js.ts"),
     },
   },
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,10 +9,7 @@ export default defineConfig({
       resolveId(source, importer) {
         if (source !== "chess.js" || !importer) return null;
         const normalized = importer.split(path.sep).join("/");
-        if (
-          normalized.endsWith("/tests/default-apps/chess-app.test.tsx") ||
-          normalized.endsWith("/home/apps/games/chess/src/App.tsx")
-        ) {
+        if (normalized.endsWith("/tests/default-apps/chess-app.test.tsx") || normalized.includes("/home/apps/games/chess/src/")) {
           return path.resolve(__dirname, "tests/default-apps/mocks/chess-js.ts");
         }
         return null;


### PR DESCRIPTION
Stack: 18/22
Branch: stack/default-apps-chess-ui

Scope: Playable chess board UI and app-level tests.

Review notes:
This is one layer from the PR #303 split. Review with its downstack dependencies; the full app/runtime stack through #326 matches the rebased PR #303 source exactly. Shared icon polish lands in #325, Whiteboard cleanup in #326, and the reusable review-monitor command in #327.

Verification:
- Rebased source branch onto current main successfully.
- Top-of-stack parity check against the rebased source branch was empty in both directions before adding the command-only #327 layer.
- git diff --check main..HEAD passed before adding the command-only #327 layer.
- Focused shell tests previously passed on the PR source: pnpm test tests/shell/canvas-toolbar.test.ts tests/shell/app-launch.test.ts tests/shell/dock-icon-resolution.test.ts -- --runInBand.

Invariants:
- Source of truth: app code and manifests live under home/apps/**, shipped icons live under home/system/icons/**, shell launch defaults live in home/system/desktop.json, and user app data remains owner-controlled Postgres via the MatrixOS bridge.
- Lock/transaction scope: this stack does not move app data writes into client-local storage; default apps use the bridge and the gateway owns schema provisioning. Multi-step user data persistence remains inside gateway/DB boundaries, not inside iframe app code.
- Acceptable orphan states: layers may be temporarily incomplete until their stack dependencies land. Runtime/app code can exist before icon polish, and failed/generated icon paths fall back to shipped assets or existing shell fallback behavior.
- Auth source of truth: existing Clerk/session gateway auth and MatrixOS bridge authorization remain authoritative; iframe apps do not gain direct authenticated fetch access.
- Deferred scope: widget mode, per-app ideal launch sizes, broader app product depth, and production rollout are intentionally outside this split and should be handled in follow-up PRs.