### PR TITLE
fix(terminal): open zellij tabs by default

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "matrix-os",
+  "interface": {
+    "displayName": "Matrix OS Plugins"
+  },
+  "plugins": [
+    {
+      "name": "matrix-onboarding",
+      "source": {
+        "source": "local",
+        "path": "./plugins/matrix-onboarding"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/docs/dev/agent-matrix-skills.md
+++ b/docs/dev/agent-matrix-skills.md
@@ -86,7 +86,7 @@ matrix login
 matrix run -it -- claude
 matrix run -it -- codex
 matrix run -it --session setup -- gh auth login
-matrix shell attach setup
+matrix shell connect -c setup
 ```
 
 `matrix run -it` creates a zellij-backed Matrix shell session, starts the requested command in a pane, and attaches the local terminal over `/ws/terminal`. The local terminal is a dumb TTY: stdin is put in raw mode, Ctrl-C/Ctrl-D are forwarded to the remote process, terminal resizes are forwarded as `resize` frames, and `Ctrl-\ Ctrl-\` detaches without killing the remote session.
@@ -94,10 +94,13 @@ matrix shell attach setup
 Use named sessions for setup workflows so the user, Matrix web terminal, Claude, Codex, or Hermes can all reattach the same VPS context:
 
 ```bash
+matrix shell connect -c setup
 matrix run -it --session setup -- gh auth login
 matrix run -it --session setup -- claude
-matrix shell attach setup
+matrix shell connect setup
 ```
+
+If `matrix run -it`, `matrix shell new`, or `matrix shell attach` fails with `zellij_failed`, do not keep retrying the same command. Run `matrix shell ls`, then use `matrix shell connect <session-name>` against an existing session. `matrix shell connect -c <session-name>` is the create-if-missing path; if creation fails, ask the human to create or choose a session from the Matrix web terminal and connect to that existing session.
 
 Non-interactive `matrix run -- <command>` should return the remote command exit status once the gateway exposes status-bearing command execution on top of the same zellij session model. Until then, developer setup docs should prefer `matrix run -it -- <interactive-command>`.
 

--- a/docs/dev/agent-matrix-skills.md
+++ b/docs/dev/agent-matrix-skills.md
@@ -57,6 +57,22 @@ agent skills tap add HamedMP/matrix-os
 agent skills browse matrix
 ```
 
+## Codex Plugin
+
+Matrix also exposes a repo-scoped Codex plugin marketplace at `.agents/plugins/marketplace.json`.
+Install it from a Matrix checkout when Codex should guide the whole onboarding flow, including
+GitHub auth, Matrix login, preferred coding-agent login, repo clone, Matrix shell setup, and preview.
+
+```bash
+codex plugin marketplace add "$(pwd)"
+```
+
+After Codex refreshes the marketplace, enable the `matrix-onboarding` plugin and ask:
+
+```text
+Help me onboard this repo into Matrix OS.
+```
+
 ## Preconfigure Agent In Matrix
 
 Recommended target state:
@@ -109,9 +125,12 @@ Non-interactive `matrix run -- <command>` should return the remote command exit 
 The bootstrap step should run after the Matrix runtime user exists and before the shell is presented as ready:
 
 ```bash
-su - matrix -c 'cd /home/matrix/projects/matrix-os && ./scripts/install-agent-matrix-skills.sh'
+su - matrix -c 'if test -x /home/matrix/projects/matrix-os/scripts/install-agent-matrix-skills.sh; then cd /home/matrix/projects/matrix-os && ./scripts/install-agent-matrix-skills.sh; else echo "Matrix skills checkout not present; skipping local skill install"; fi'
 su - matrix -c 'agent config set skills.config.matrix.gateway_url http://localhost:4000'
 ```
+
+If the checkout is not present in `/home/matrix/projects/matrix-os`, skip the first command and install
+the Matrix skills from the published source or the release-bundled skill path instead.
 
 If Agent is not installed yet, install it into a user-writable prefix owned by `matrix`, not a root-owned global npm prefix.
 

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -20,10 +20,15 @@ const ShellWsDetachSchema = z.object({
   type: z.literal("detach"),
 });
 
+const ShellWsPingSchema = z.object({
+  type: z.literal("ping"),
+});
+
 const ShellWsClientMessageSchema = z.union([
   ShellWsInputSchema,
   ShellWsResizeSchema,
   ShellWsDetachSchema,
+  ShellWsPingSchema,
 ]);
 
 export { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ };
@@ -216,6 +221,10 @@ export function createShellWsHandler(options: ShellWsHandlerOptions) {
         }
 
         const msg = result.data;
+        if (msg.type === "ping") {
+          sendJson(ws, { type: "pong" });
+          return;
+        }
         if (msg.type === "detach") {
           closeSession();
           ws.close?.();

--- a/plugins/matrix-onboarding/.codex-plugin/plugin.json
+++ b/plugins/matrix-onboarding/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "matrix-onboarding",
+  "version": "0.1.0",
+  "description": "Guide a developer through GitHub, coding-agent, repo, Matrix VPS, and preview onboarding.",
+  "author": {
+    "name": "Matrix OS"
+  },
+  "homepage": "https://matrix-os.com",
+  "repository": "https://github.com/HamedMP/matrix-os",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Matrix Onboarding",
+    "shortDescription": "Onboard developers into Matrix OS",
+    "longDescription": "Helps a coding agent walk a developer through GitHub auth, Matrix login, preferred agent login, repository cloning, running work inside Matrix shell sessions, and exposing a preview.",
+    "developerName": "Matrix OS",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://matrix-os.com",
+    "brandColor": "#33AAFF",
+    "defaultPrompt": "Help me onboard this repo into Matrix OS."
+  }
+}

--- a/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
+++ b/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: matrix-onboarding
+description: "Use when a developer wants help setting up Matrix OS for coding: GitHub auth, Matrix CLI login, preferred coding-agent login, cloning a repo, running it inside a Matrix VPS shell, and opening a preview. Also use when the user asks to onboard a repo into Matrix, run their local coding agent inside Matrix, or make a Matrix-ready development preview."
+---
+
+# Matrix Onboarding
+
+Guide the human through a complete developer onboarding path without collecting secrets in chat.
+
+## Ground Rules
+
+- Prefer browser/device login flows. Never ask the human to paste Matrix, GitHub, Claude, Codex, or provider tokens into chat.
+- Treat the Matrix VPS as the human's computer. Ask before deleting files, resetting auth, installing global packages, or changing long-lived shell sessions.
+- Use Matrix shell sessions for interactive work. Do not invent SSH instructions.
+- Use Docker only when the target repo already needs containers or cannot run directly with its normal dev command. Production Matrix OS customer runtime is VPS-native, not Docker Compose.
+- If the current repo contains `www/public/skills.md`, read it first for the latest Matrix CLI commands. Otherwise use `https://matrix-os.com/skills.md` as the canonical command reference.
+
+## Workflow
+
+1. **Identify the path**
+   - Determine whether you are running locally, inside Matrix, or inside another remote environment.
+   - Default the preferred coding agent to the one currently being used locally. If unknown, ask which one they want: Codex, Claude, another terminal agent, or Hermes.
+   - Identify the target repo URL and desired project name. If a repo is already open, use it as the starting point.
+
+2. **Verify local prerequisites**
+   - Check `git --version`, `gh --version`, and `matrix --version` when available.
+   - If GitHub CLI is not authenticated, guide `gh auth login --hostname github.com --git-protocol ssh --web`, then verify with `gh auth status`.
+   - If Matrix CLI is missing, install using the latest `skills.md` instructions, then run `matrix login`.
+
+3. **Bring up Matrix**
+   - Run `matrix status`, `matrix instance info`, and `matrix doctor`.
+   - If `matrix doctor` reports a sync daemon issue, run `matrix sync` and then `matrix doctor` again.
+   - If no Matrix instance exists, send the human to `https://app.matrix-os.com`, wait for provisioning, then retry `matrix login`.
+
+4. **Create or reuse the setup shell**
+   - Prefer a named shell so the human, web terminal, and agent can reattach:
+
+```bash
+matrix shell connect -c setup
+```
+
+   - If the human already has a useful shell session, reuse it instead of forcing the `setup` name.
+   - For `zellij_failed`, do not retry the same command repeatedly. Use:
+
+```bash
+matrix shell ls
+matrix shell connect <session-name>
+```
+
+   - Set the chosen name as `<setup-session>` for every later command. Use `setup` only if that is the session actually chosen.
+
+5. **Authenticate inside Matrix**
+   - Connect GitHub inside the Matrix VPS:
+
+```bash
+matrix run -it --session <setup-session> -- gh auth login
+matrix run -it --session <setup-session> -- gh auth status
+```
+
+   - Check that the preferred coding agent exists inside Matrix before starting it:
+
+```bash
+matrix run -it --session <setup-session> -- which codex
+matrix run -it --session <setup-session> -- which claude
+```
+
+   - Start only the preferred agent, not every example command. Use its normal login flow and then verify it can start:
+
+```bash
+matrix run -it --session <setup-session> -- codex
+matrix run -it --session <setup-session> -- claude
+```
+
+   - If the preferred agent is missing, ask before installing it globally. If another terminal agent is preferred, use the agent's normal login command inside `matrix run -it --session <setup-session> -- <command>`.
+
+6. **Clone and prepare the repo inside Matrix**
+   - Use `~/projects` unless the human requests another location.
+   - Clone with the authenticated GitHub path, then inspect the repo for package manager and dev scripts.
+   - Install dependencies using the repo's lockfile and package manager. For Matrix OS itself, prefer `flox activate` or the repo's `pnpm`/`bun` guidance.
+   - If subagents are available, delegate repo inspection to one bounded subagent: ask it to identify install commands, dev commands, required env vars, ports, Docker needs, and preview instructions. Do not pass secrets to the subagent.
+
+7. **Run and preview**
+   - Run the repo's normal dev command in a named Matrix shell session.
+   - Bind dev servers to `0.0.0.0` when the framework requires an explicit host, then verify from inside the VPS:
+
+```bash
+curl -fsS http://127.0.0.1:<port>/ >/dev/null
+```
+
+   - Open `https://app.matrix-os.com`, switch to the active runtime if needed, and use the shell Preview window or workspace preview surface for the verified port/app. If the current CLI/docs expose a concrete preview command, prefer that command and report the generated URL.
+   - If the repo is container-first, build or run the smallest needed Docker target. Keep source mounts and ports explicit, avoid privileged containers, and document how to stop it.
+
+8. **Hand off clearly**
+   - Report what was authenticated, where the repo lives, which shell session is running, the preview URL or local port, and the reattach command.
+   - Include the recovery commands:
+
+```bash
+matrix doctor
+matrix shell ls
+matrix shell connect <session-name>
+```

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, Fragment, use, useEffect, useEffectEvent, useRef, useCallback, useState, type CSSProperties, type KeyboardEvent } from "react";
+import { createContext, use, useEffect, useEffectEvent, useRef, useCallback, useState, type CSSProperties, type KeyboardEvent } from "react";
 import {
   BotIcon,
   FilesIcon,
@@ -1186,13 +1186,9 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
               </button>
             </div>
           );
-          return i === 0 ? (
-            <Fragment key={tab.id}>
-              {tabNode}
-              {newTabButton}
-            </Fragment>
-          ) : tabNode;
+          return tabNode;
         })}
+        {newTabButton}
       </div>
       {!ctx.mobile && (
       <div

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1584,6 +1584,7 @@ function LocalTerminalSidebar() {
     setDeletingShellNames(Array.from(deletingShellsRef.current!));
     setShellsError(null);
     const previousShells = shells;
+    const deletedShell = previousShells.find((shell) => shell.name === name);
     setShells((prev) => prev.filter((shell) => shell.name !== name));
     // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler cannot lower the try/finally below into memoized form; the async delete flow is correct as written
     try {
@@ -1593,14 +1594,14 @@ function LocalTerminalSidebar() {
       });
       if (!res.ok) {
         setShellsError("Failed to remove shell");
-        setShells((prev) => prev.some((shell) => shell.name === name) ? prev : previousShells);
+        setShells((prev) => prev.some((shell) => shell.name === name) || !deletedShell ? prev : [...prev, deletedShell]);
         return;
       }
       await fetchShells({ silent: true });
     } catch (err: unknown) {
       console.warn("Failed to remove shell session:", err instanceof Error ? err.message : err);
       setShellsError("Could not remove shell");
-      setShells((prev) => prev.some((shell) => shell.name === name) ? prev : previousShells);
+      setShells((prev) => prev.some((shell) => shell.name === name) || !deletedShell ? prev : [...prev, deletedShell]);
     } finally {
       deletingShellsRef.current!.delete(name);
       setDeletingShellNames(Array.from(deletingShellsRef.current!));

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -87,7 +87,7 @@ const SIDEBAR_RAIL_BUTTON_BASE_STYLE: CSSProperties = {
 
 const SHELL_CARD_NAME_BUTTON_STYLE: CSSProperties = {
   color: "var(--foreground)",
-  fontSize: 12,
+  fontSize: 13,
   fontWeight: 650,
   fontFamily: "var(--font-mono, ui-monospace, monospace)",
   background: "transparent",
@@ -96,6 +96,8 @@ const SHELL_CARD_NAME_BUTTON_STYLE: CSSProperties = {
   textAlign: "left",
   cursor: "copy",
 };
+
+const SHELLS_REFRESH_INTERVAL_MS = 5_000;
 
 const PROJECT_BRANCH_BADGE_STYLE: CSSProperties = {
   padding: "1px 5px",
@@ -1140,13 +1142,15 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
               className="flex items-center gap-1.5 cursor-pointer whitespace-nowrap transition-colors"
               style={{
                 ...TAB_ITEM_BASE_STYLE,
-                background: active ? "var(--background)" : "transparent",
+                background: active ? "var(--background)" : "color-mix(in srgb, var(--background) 42%, transparent)",
                 color: active ? "var(--foreground)" : "var(--muted-foreground)",
-                border: `1px solid ${active ? "var(--border)" : "transparent"}`,
-                padding: ctx.mobile ? "0 8px" : "0 10px",
-                fontWeight: active ? 500 : 400,
-                minWidth: ctx.mobile ? 112 : 136,
-                maxWidth: ctx.mobile ? 168 : 220,
+                border: `1px solid ${active ? "var(--border)" : "color-mix(in srgb, var(--border) 55%, transparent)"}`,
+                padding: ctx.mobile ? "0 7px" : "0 8px",
+                fontWeight: active ? 600 : 450,
+                flex: ctx.mobile ? "0 1 148px" : "0 1 168px",
+                minWidth: ctx.mobile ? 96 : 108,
+                maxWidth: ctx.mobile ? 160 : 190,
+                boxShadow: active ? "0 1px 0 rgba(0,0,0,0.08)" : "none",
               }}
               draggable
               onClick={() => ctx.setActiveTab(tab.id)}
@@ -1302,6 +1306,20 @@ function shellSessionsEqual(left: ShellSessionSummary[], right: ShellSessionSumm
   });
 }
 
+function getShellTabCount(shell: ShellSessionSummary): number | null {
+  if (!Array.isArray(shell.tabs)) return null;
+  return shell.tabs.reduce((count, tab) => {
+    const indexedCount = Number.isInteger(tab.idx) && tab.idx >= 0 ? tab.idx + 1 : 0;
+    return Math.max(count, indexedCount);
+  }, shell.tabs.length);
+}
+
+function formatShellTabCount(shell: ShellSessionSummary): string {
+  const count = getShellTabCount(shell);
+  if (count === null) return "tabs unknown";
+  return `${count} tab${count === 1 ? "" : "s"}`;
+}
+
 function workspaceSessionsEqual(left: WorkspaceSessionSummary[], right: WorkspaceSessionSummary[]): boolean {
   if (left.length !== right.length) return false;
   const sortedLeft = [...left].sort((a, b) => a.id.localeCompare(b.id));
@@ -1328,7 +1346,7 @@ function workspaceSessionsEqual(left: WorkspaceSessionSummary[], right: Workspac
 // react-doctor-disable-next-line react-doctor/no-giant-component, react-doctor/prefer-useReducer -- no-giant-component: cohesive core terminal sidebar component; extraction tracked separately. prefer-useReducer: the 15 useState fields are several independent clusters, not one related cluster: projects/shells/sessions/files each carry their own data+loading+error triplet with separate fetch lifecycles, plus orthogonal tab/filter/rootPath/tree UI state; collapsing them into one reducer would obscure the independent update sites and would not be a mechanical, behavior-identical change.
 function LocalTerminalSidebar() {
   const ctx = useTerminalAppContext();
-  const [tab, setTab] = useState<SidebarTab>("sessions");
+  const [tab, setTab] = useState<SidebarTab>("shells");
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [projectsLoading, setProjectsLoading] = useState(true);
   const [projectsError, setProjectsError] = useState<string | null>(null);
@@ -1385,16 +1403,18 @@ function LocalTerminalSidebar() {
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity for effect dep: `fetchShells` is in the dependency array of the shells-tab load useEffect below and command handlers.
   const fetchShells = useCallback(async (options: { silent?: boolean; signal?: AbortSignal } = {}) => {
-    if (!options.silent) setShellsLoading(true);
-    if (!options.silent) setShellsError(null);
+    const silent = options.silent === true;
+    if (!silent) setShellsLoading(true);
+    if (!silent) setShellsError(null);
     // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler cannot lower the try/finally below into memoized form; the async load is correct as written
     try {
       const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions`, {
         signal: options.signal ?? AbortSignal.timeout(10_000),
       });
       if (!res.ok) {
-        setShellsError("Failed to load shells");
-        if (!options.silent) setShells([]);
+        if (!silent) {
+          setShellsError("Failed to load shells");
+        }
         return;
       }
       const data = (await res.json()) as { sessions?: ShellSessionSummary[] };
@@ -1402,18 +1422,27 @@ function LocalTerminalSidebar() {
       setShells((prev) => shellSessionsEqual(prev, nextShells) ? prev : nextShells);
       setShellsError(null);
     } catch (err: unknown) {
-      if (options.silent && err instanceof DOMException && err.name === "AbortError") return;
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      if (silent) return;
       console.warn("Failed to load shell sessions:", err instanceof Error ? err.message : err);
       setShellsError("Could not reach gateway");
-      if (!options.silent) setShells([]);
     } finally {
-      if (!options.silent) setShellsLoading(false);
+      if (!silent) setShellsLoading(false);
     }
   }, []);
 
   useEffect(() => {
+    if (tab !== "shells") return;
+    const controller = new AbortController();
     // react-doctor-disable-next-line react-hooks-js/set-state-in-effect, react-doctor/no-event-handler -- async network load of the shell-session list when the Shells tab becomes active; `tab` is live derived state that can change from many sources (restore, programmatic nav, deep link), not a single DOM click handler, so the fetch belongs in the effect and cannot be hoisted to one parent handler
-    if (tab === "shells") void fetchShells();
+    void fetchShells({ signal: controller.signal });
+    const refreshTimer = window.setInterval(() => {
+      void fetchShells({ silent: true });
+    }, SHELLS_REFRESH_INTERVAL_MS);
+    return () => {
+      controller.abort();
+      window.clearInterval(refreshTimer);
+    };
   }, [fetchShells, tab]);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity for effect dep: `fetchSessions` is in the dependency array of the sessions-tab useEffect below.
@@ -1554,6 +1583,8 @@ function LocalTerminalSidebar() {
     deletingShellsRef.current!.add(name);
     setDeletingShellNames(Array.from(deletingShellsRef.current!));
     setShellsError(null);
+    const previousShells = shells;
+    setShells((prev) => prev.filter((shell) => shell.name !== name));
     // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler cannot lower the try/finally below into memoized form; the async delete flow is correct as written
     try {
       const res = await fetch(`${getGatewayUrl()}/api/terminal/sessions/${encodeURIComponent(name)}?force=1`, {
@@ -1562,12 +1593,14 @@ function LocalTerminalSidebar() {
       });
       if (!res.ok) {
         setShellsError("Failed to remove shell");
+        setShells((prev) => prev.some((shell) => shell.name === name) ? prev : previousShells);
         return;
       }
-      await fetchShells();
+      await fetchShells({ silent: true });
     } catch (err: unknown) {
       console.warn("Failed to remove shell session:", err instanceof Error ? err.message : err);
       setShellsError("Could not remove shell");
+      setShells((prev) => prev.some((shell) => shell.name === name) ? prev : previousShells);
     } finally {
       deletingShellsRef.current!.delete(name);
       setDeletingShellNames(Array.from(deletingShellsRef.current!));
@@ -1663,9 +1696,9 @@ function LocalTerminalSidebar() {
           background: "color-mix(in srgb, var(--background) 62%, var(--card))",
         }}
       >
+        <SidebarRailButton label="Shells" icon={<TerminalIcon size={16} strokeWidth={1.8} />} active={tab === "shells"} onClick={() => selectSidebarTab("shells")} />
         <SidebarRailButton label="Sessions" icon={<BotIcon size={16} strokeWidth={1.8} />} active={tab === "sessions"} onClick={() => selectSidebarTab("sessions")} />
         <SidebarRailButton label="Projects" icon={<FolderIcon size={16} strokeWidth={1.8} />} active={tab === "projects"} onClick={() => selectSidebarTab("projects")} />
-        <SidebarRailButton label="Shells" icon={<TerminalIcon size={16} strokeWidth={1.8} />} active={tab === "shells"} onClick={() => selectSidebarTab("shells")} />
         <SidebarRailButton label="Files" icon={<FilesIcon size={16} strokeWidth={1.8} />} active={tab === "files"} onClick={() => selectSidebarTab("files")} />
         <div style={{ flex: 1 }} />
         <button
@@ -1957,6 +1990,7 @@ function ShellCard({
 }) {
   const tabs = shell.tabs ?? [];
   const focusedTab = tabs.find((tab) => tab.focused) ?? tabs[0];
+  const tabCountLabel = formatShellTabCount(shell);
   const statusColor =
     shell.status === "active" || !shell.status
       ? "var(--success)"
@@ -1976,21 +2010,23 @@ function ShellCard({
   return (
     <div
       style={{
-        margin: "5px 8px",
-        padding: "9px 10px",
+        margin: "6px 8px",
+        padding: "10px",
         borderRadius: 8,
         border: "1px solid var(--border)",
-        background: "var(--background)",
+        background: "color-mix(in srgb, var(--background) 84%, var(--card))",
+        boxShadow: "0 1px 0 rgba(0,0,0,0.05)",
       }}
     >
-      <div className="flex items-center gap-2" style={{ marginBottom: 5 }}>
+      <div className="flex items-center gap-2" style={{ marginBottom: 7 }}>
         <span
           style={{
-            width: 7,
-            height: 7,
+            width: 8,
+            height: 8,
             borderRadius: "50%",
             background: statusColor,
             flexShrink: 0,
+            boxShadow: "0 0 0 2px color-mix(in srgb, var(--background) 80%, transparent)",
           }}
         />
         <button
@@ -2003,12 +2039,26 @@ function ShellCard({
         >
           {shell.name}
         </button>
-        <span style={{ color: "var(--muted-foreground)", fontSize: 12, whiteSpace: "nowrap" }}>
-          {shell.attachedClients ?? 0} attached
+        <span
+          style={{
+            color: "var(--foreground)",
+            fontSize: 11,
+            whiteSpace: "nowrap",
+            border: "1px solid var(--border)",
+            borderRadius: 999,
+            background: "var(--card)",
+            padding: "1px 7px",
+            lineHeight: "18px",
+            flexShrink: 0,
+          }}
+        >
+          {tabCountLabel}
         </span>
       </div>
-      <div className="truncate" style={{ color: "var(--muted-foreground)", fontSize: 12, paddingLeft: 15 }}>
-        {shell.status ?? "active"} · {tabs.length} zellij tab{tabs.length === 1 ? "" : "s"}
+      <div className="flex min-w-0 items-center gap-2" style={{ color: "var(--muted-foreground)", fontSize: 12, paddingLeft: 16 }}>
+        <span className="truncate">{shell.status ?? "active"}</span>
+        <span aria-hidden="true">·</span>
+        <span className="truncate">{shell.attachedClients ?? 0} attached</span>
       </div>
       {focusedTab ? (
         <div
@@ -2016,15 +2066,15 @@ function ShellCard({
           style={{
             color: "var(--muted-foreground)",
             fontSize: 12,
-            paddingLeft: 15,
-            marginTop: 2,
+            paddingLeft: 16,
+            marginTop: 4,
             fontFamily: "var(--font-mono, ui-monospace, monospace)",
           }}
         >
           {focusedTab.idx}: {focusedTab.name ?? "tab"}
         </div>
       ) : null}
-      <div className="flex items-center gap-1" style={{ marginTop: 8, paddingLeft: 15 }}>
+      <div className="flex items-center gap-1" style={{ marginTop: 9, paddingLeft: 16 }}>
         <SessionActionBtn label="Open" sessionId={shell.name} onClick={onOpen} />
         <SessionActionBtn
           label={deleting ? "Deleting" : "Delete"}

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -56,12 +56,13 @@ const TAB_ITEM_BASE_STYLE: CSSProperties = {
 const TAB_CLOSE_BUTTON_STYLE: CSSProperties = {
   width: 16,
   height: 16,
+  flexShrink: 0,
   borderRadius: 3,
   border: "none",
   background: "transparent",
   color: "var(--muted-foreground)",
   opacity: 0.5,
-  marginLeft: 2,
+  marginLeft: "auto",
 };
 
 const SHELL_NEW_BUTTON_BASE_STYLE: CSSProperties = {
@@ -818,7 +819,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (!e.ctrlKey || !e.shiftKey) return;
     switch (e.key.toUpperCase()) {
-      case "T": e.preventDefault(); addTab(getCwd()); break;
+      case "T": e.preventDefault(); void createShellSessionTab("Zellij", getCwd()); break;
       case "W": e.preventDefault(); if (focusedPaneId) closePane(focusedPaneId); break;
       case "D": e.preventDefault(); if (focusedPaneId) splitPane(focusedPaneId, "horizontal"); break;
       case "E": e.preventDefault(); if (focusedPaneId) splitPane(focusedPaneId, "vertical"); break;
@@ -888,7 +889,7 @@ export function TerminalApp({ initialCommand, initialLabel, initialClaudeMode = 
                   type="button"
                   className="text-xs px-3 py-1.5 rounded cursor-pointer"
                   style={{ background: "var(--primary)", color: "var(--primary-foreground)" }}
-                  onClick={() => addTab(DEFAULT_CWD)}
+                  onClick={() => { void createShellSessionTab("Zellij", DEFAULT_CWD); }}
                 >
                   New Terminal
                 </button>
@@ -1071,7 +1072,7 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
   const getCwd = () => ctx.sidebarSelectedPath ?? defaultCwd;
   const newTabButton = (
     <ToolbarBtn
-      onClick={() => ctx.addTab(getCwd())}
+      onClick={() => { void ctx.createShellSessionTab("Zellij", getCwd()); }}
       title="New tab (Ctrl+Shift+T)"
       ariaLabel="New tab"
     >
@@ -1158,6 +1159,7 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
                 style={{
                   width: 6,
                   height: 6,
+                  flexShrink: 0,
                   borderRadius: "50%",
                   background: active ? "var(--success)" : "var(--muted-foreground)",
                   opacity: active ? 1 : 0.5,
@@ -1165,7 +1167,7 @@ function LocalTerminalTabBar({ defaultCwd }: { defaultCwd: string }) {
               />
               <span
                 className="min-w-0 truncate"
-                style={{ overflow: "hidden" }}
+                style={{ flex: "1 1 auto", overflow: "hidden" }}
               >
                 <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{tab.label}</span>
               </span>
@@ -1807,7 +1809,7 @@ function LocalTerminalSidebar() {
               <ProjectCard
                 key={p.path}
                 project={p}
-                onOpenShell={() => ctx.addTab(p.path, p.name)}
+                onOpenShell={() => { void ctx.createShellSessionTab(p.name, p.path); }}
                 onOpenClaude={() => ctx.addTab(p.path, `${p.name} · claude`, true)}
                 onOpenZellij={() => { void ctx.createShellSessionTab(`${p.name} · zellij`, p.path); }}
                 onSelect={() => ctx.setSidebarSelectedPath(p.path)}
@@ -1899,7 +1901,7 @@ function LocalTerminalSidebar() {
                 selectedPath={ctx.sidebarSelectedPath}
                 onToggle={toggleExpand}
                 onSelect={(n) => { if (n.type === "directory") ctx.setSidebarSelectedPath(n.path); }}
-                onOpenTerminal={(path) => ctx.addTab(path)}
+                onOpenTerminal={(path) => { void ctx.createShellSessionTab("Zellij", path); }}
               />
             ))}
             {filteredTree.length === 0 && (

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -1437,7 +1437,7 @@ function LocalTerminalSidebar() {
     // react-doctor-disable-next-line react-hooks-js/set-state-in-effect, react-doctor/no-event-handler -- async network load of the shell-session list when the Shells tab becomes active; `tab` is live derived state that can change from many sources (restore, programmatic nav, deep link), not a single DOM click handler, so the fetch belongs in the effect and cannot be hoisted to one parent handler
     void fetchShells({ signal: controller.signal });
     const refreshTimer = window.setInterval(() => {
-      void fetchShells({ silent: true });
+      void fetchShells({ silent: true, signal: controller.signal });
     }, SHELLS_REFRESH_INTERVAL_MS);
     return () => {
       controller.abort();

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -114,6 +114,25 @@ describe("zellij terminal WebSocket", () => {
     expect(ws.sent).toContainEqual({ type: "exit", code: 101 });
   });
 
+  it("answers heartbeat pings without forwarding them to zellij", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+    });
+
+    const session = await handler.open({ ws, session: "main", fromSeq: 0 });
+    session.onMessage(JSON.stringify({ type: "ping" }));
+
+    expect(ws.sent).toContainEqual({ type: "pong" });
+    expect(pty.writes).toEqual([]);
+  });
+
   it("maps live-tail attach to a bounded recent replay window", async () => {
     const pty = new FakePty();
     const secondPty = new FakePty();

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -138,7 +138,7 @@ describe("TerminalApp", () => {
     });
   });
 
-  it("places the new-tab control immediately after the first terminal tab", async () => {
+  it("places the new-tab control immediately after the last terminal tab", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -147,12 +147,20 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "New tab" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
     const tablist = screen.getByRole("tablist", { name: "Terminal tabs" });
-    const firstTab = screen.getAllByRole("tab")[0];
+    const tabs = screen.getAllByRole("tab");
     const newTabButton = screen.getByRole("button", { name: "New tab" });
 
-    expect(tablist.children[0]).toBe(firstTab);
-    expect(tablist.children[1]).toBe(newTabButton);
+    expect(tabs).toHaveLength(2);
+    expect(tablist.children[0]).toBe(tabs[0]);
+    expect(tablist.children[1]).toBe(tabs[1]);
+    expect(tablist.children[2]).toBe(newTabButton);
   });
 
   it("opens zellij-backed shell sessions from the new-tab control", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -155,6 +155,52 @@ describe("TerminalApp", () => {
     expect(tablist.children[1]).toBe(newTabButton);
   });
 
+  it("opens zellij-backed shell sessions from the new-tab control", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "New tab" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const createCalls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([input, init]: [RequestInfo | URL, RequestInit | undefined]) => (
+        String(input).endsWith("/api/terminal/sessions") &&
+        init?.method === "POST" &&
+        typeof init.body === "string"
+      ))
+      .map(([, init]: [RequestInfo | URL, RequestInit]) => JSON.parse(String(init.body)) as { name: string });
+
+    expect(createCalls.some((body) => /^zellij-/.test(body.name))).toBe(true);
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      paneTree: {
+        sessionId: expect.stringMatching(/^zellij-/),
+      },
+    });
+  });
+
+  it("keeps the tab close button pinned to the tab edge for short labels", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const closeButton = screen.getByRole("button", { name: "Close tab" });
+
+    expect(closeButton.style.marginLeft).toBe("auto");
+    expect(closeButton.style.flexShrink).toBe("0");
+  });
+
   it("opens the left terminal panel on Sessions first", async () => {
     render(<TerminalApp />);
 
@@ -191,6 +237,60 @@ describe("TerminalApp", () => {
     const openButton = screen.getByTitle("Open sidebar (Ctrl+Shift+B)");
     expect(openButton.parentElement?.className).toContain("absolute");
     expect(openButton.parentElement?.style.width).not.toBe("44px");
+  });
+
+  it("opens zellij-backed shell sessions from Ctrl+Shift+T", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(screen.getByRole("application", { name: "Terminal" }), {
+        key: "T",
+        ctrlKey: true,
+        shiftKey: true,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      paneTree: {
+        sessionId: expect.stringMatching(/^zellij-/),
+      },
+    });
+  });
+
+  it("opens zellij-backed shell sessions from the empty terminal state", async () => {
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Close tab" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "New Terminal" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(paneGridSpy.mock.lastCall?.[0]).toMatchObject({
+      paneTree: {
+        sessionId: expect.stringMatching(/^zellij-/),
+      },
+    });
   });
 
   it("copies a local CLI attach command when clicking a shell session name", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -209,7 +209,7 @@ describe("TerminalApp", () => {
     expect(closeButton.style.flexShrink).toBe("0");
   });
 
-  it("opens the left terminal panel on Sessions first", async () => {
+  it("opens the left terminal panel on Shells first", async () => {
     render(<TerminalApp />);
 
     await act(async () => {
@@ -223,13 +223,13 @@ describe("TerminalApp", () => {
     });
 
     expect(railButtons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Shells",
       "Sessions",
       "Projects",
-      "Shells",
       "Files",
     ]);
-    expect(screen.getByText("Sessions")).toBeTruthy();
-    expect(screen.getByLabelText("Search sessions")).toBeTruthy();
+    expect(screen.getByText("Shells")).toBeTruthy();
+    expect(screen.getByLabelText("Search shells")).toBeTruthy();
   });
 
   it("fully removes the sidebar from layout flow when hidden", async () => {
@@ -851,6 +851,9 @@ describe("TerminalApp", () => {
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
+      fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     await act(async () => {
@@ -1029,6 +1032,7 @@ describe("TerminalApp", () => {
   });
 
   it("manages canonical zellij shells from a dedicated sidebar surface", async () => {
+    let mainDeleted = false;
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/files/tree")) {
@@ -1041,6 +1045,7 @@ describe("TerminalApp", () => {
         return Promise.resolve({ ok: true, json: async () => ({}) });
       }
       if (url.includes("/api/terminal/sessions/main") && init?.method === "DELETE") {
+        mainDeleted = true;
         return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
       }
       if (url.includes("/api/terminal/sessions") && init?.method === "POST") {
@@ -1050,16 +1055,18 @@ describe("TerminalApp", () => {
         return Promise.resolve({
           ok: true,
           json: async () => ({
-            sessions: [{
-              name: "main",
-              status: "active",
-              attachedClients: 1,
-              tabs: [{ idx: 0, name: "dev", focused: true }],
-            }, {
+            sessions: [
+              ...(mainDeleted ? [] : [{
+                name: "main",
+                status: "active",
+                attachedClients: 1,
+                tabs: [{ idx: 0, name: "dev", focused: true }],
+              }]),
+              {
               name: "bench",
               status: "degraded",
               attachedClients: 0,
-              tabs: [{ idx: 0, name: "latency", focused: true }, { idx: 1, name: "load" }],
+              tabs: [{ idx: 0, name: "latency", focused: true }, { idx: 3, name: "load" }],
             }],
           }),
         });
@@ -1090,8 +1097,8 @@ describe("TerminalApp", () => {
     });
 
     expect(screen.getByLabelText("Search shells")).toHaveProperty("value", "");
-    expect(screen.getByText("active · 1 zellij tab")).toBeTruthy();
-    expect(screen.getByText("degraded · 2 zellij tabs")).toBeTruthy();
+    expect(screen.getByText("1 tab")).toBeTruthy();
+    expect(screen.getByText("4 tabs")).toBeTruthy();
     expect(screen.getByText("0: dev")).toBeTruthy();
     expect(screen.getByText("0: latency")).toBeTruthy();
 
@@ -1123,6 +1130,7 @@ describe("TerminalApp", () => {
       String(input).includes("/api/terminal/sessions/main?force=1") && init?.method === "DELETE"
     ));
     expect(deleteCalls).toHaveLength(1);
+    expect(screen.queryByText("0: dev")).toBeNull();
   });
 
   it("keeps the Shells sidebar synchronized after manual refresh", async () => {
@@ -1162,7 +1170,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getAllByText("main").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Copy attach command for main" })).toBeTruthy();
     expect(screen.queryByText("bench")).toBeNull();
 
     await act(async () => {
@@ -1216,7 +1224,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getAllByText("main").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Copy attach command for main" })).toBeTruthy();
     shellListMode = "fail";
 
     await act(async () => {
@@ -1225,7 +1233,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getAllByText("main").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Copy attach command for main" })).toBeTruthy();
     expect(screen.getByText("Failed to load shells")).toBeTruthy();
 
     await act(async () => {
@@ -1238,7 +1246,8 @@ describe("TerminalApp", () => {
     expect(screen.queryByText("Failed to load shells")).toBeNull();
   });
 
-  it("does not poll shell sessions while the Shells sidebar is open", async () => {
+  it("refreshes the Shells sidebar while open so exited zellij sessions disappear", async () => {
+    let shellList = [{ name: "main", status: "active" }];
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/api/files/tree")) {
@@ -1253,7 +1262,7 @@ describe("TerminalApp", () => {
       if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ sessions: [{ name: "main", status: "active" }] }),
+          json: async () => ({ sessions: shellList }),
         });
       }
       return Promise.resolve({ ok: true, json: async () => ({}) });
@@ -1265,7 +1274,6 @@ describe("TerminalApp", () => {
       await Promise.resolve();
       await Promise.resolve();
       await Promise.resolve();
-      fireEvent.click(screen.getByRole("button", { name: "Shells" }));
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -1275,7 +1283,8 @@ describe("TerminalApp", () => {
     )).length;
 
     await act(async () => {
-      vi.advanceTimersByTime(20_000);
+      shellList = [];
+      vi.advanceTimersByTime(5_000);
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -1283,7 +1292,8 @@ describe("TerminalApp", () => {
     const shellListCallsAfterWait = vi.mocked(global.fetch).mock.calls.filter(([input, init]) => (
       String(input).endsWith("/api/terminal/sessions") && init?.method !== "POST"
     )).length;
-    expect(shellListCallsAfterWait).toBe(shellListCallsBeforeWait);
+    expect(shellListCallsAfterWait).toBeGreaterThan(shellListCallsBeforeWait);
+    expect(screen.queryByRole("button", { name: "Copy attach command for main" })).toBeNull();
   });
 
   it("surfaces shell creation failures in the Shells sidebar", async () => {

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -1296,6 +1296,69 @@ describe("TerminalApp", () => {
     expect(screen.queryByRole("button", { name: "Copy attach command for main" })).toBeNull();
   });
 
+  it("does not clobber a concurrent Shells refresh when delete rollback runs", async () => {
+    let shellList = [{ name: "main", status: "active" }];
+    let resolveDelete: ((value: { ok: boolean; status: number; json: () => Promise<object> }) => void) | undefined;
+    const deletePromise = new Promise<{ ok: boolean; status: number; json: () => Promise<object> }>((resolve) => {
+      resolveDelete = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/files/tree")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      if (url.includes("/api/terminal/layout") && init?.method === "PUT") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) });
+      }
+      if (url.includes("/api/terminal/layout")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      }
+      if (url.includes("/api/terminal/sessions/main?force=1") && init?.method === "DELETE") {
+        return deletePromise;
+      }
+      if (url.endsWith("/api/terminal/sessions") && init?.method !== "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ sessions: shellList }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }));
+
+    render(<TerminalApp />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("button", { name: "Copy attach command for main" })).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /delete main/i }));
+      await Promise.resolve();
+    });
+    expect(screen.queryByRole("button", { name: "Copy attach command for main" })).toBeNull();
+
+    await act(async () => {
+      shellList = [{ name: "bench", status: "active" }];
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("bench")).toBeTruthy();
+
+    await act(async () => {
+      resolveDelete?.({ ok: false, status: 503, json: async () => ({ ok: false }) });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("bench")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy attach command for main" })).toBeTruthy();
+    expect(screen.getByText("Failed to remove shell")).toBeTruthy();
+  });
+
   it("surfaces shell creation failures in the Shells sidebar", async () => {
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);

--- a/www/public/skills.md
+++ b/www/public/skills.md
@@ -156,10 +156,10 @@ matrix shell ls
 matrix shell connect <existing-session>
 ```
 
-Known working example:
+Known working pattern:
 
 ```bash
-matrix shell connect nima
+matrix shell connect <existing-session>
 ```
 
 `connect` may succeed even when `attach` and `run -it` fail.

--- a/www/public/skills.md
+++ b/www/public/skills.md
@@ -156,12 +156,6 @@ matrix shell ls
 matrix shell connect <existing-session>
 ```
 
-Known working pattern:
-
-```bash
-matrix shell connect <existing-session>
-```
-
 `connect` may succeed even when `attach` and `run -it` fail.
 
 After `matrix login`, run:

--- a/www/public/skills.md
+++ b/www/public/skills.md
@@ -1,6 +1,6 @@
 ---
 name: matrix-os
-version: 0.82.0
+version: 0.83.0
 description: Set up and operate a developer-owned Matrix OS cloud computer from an AI coding agent.
 homepage: https://matrix-os.com
 metadata: {"matrix":{"category":"cloud-computer","app_url":"https://app.matrix-os.com","skill_url":"https://matrix-os.com/skills.md","cli_package":"@finnaai/matrix"}}
@@ -104,10 +104,12 @@ matrix run -it -- claude
 matrix run -it -- codex
 
 # Use a named setup session so the human and web terminal can reattach.
+matrix shell connect -c setup
 matrix run -it --session setup -- gh auth login
 matrix run -it --session setup -- claude
-matrix shell attach setup
 ```
+
+`matrix shell connect -c setup` creates the named session if it does not exist, then connects to it. If the human already has a working web terminal or CLI session, reuse that session instead of requiring a new one named `setup`.
 
 Detach from an interactive session with:
 
@@ -118,8 +120,64 @@ Ctrl-\ Ctrl-\
 Detaching leaves the remote zellij session alive. Reattach with:
 
 ```bash
-matrix shell attach setup
+matrix shell connect setup
 ```
+
+## Terminal Session Fallbacks
+
+If `matrix run -it -- ...`, `matrix shell new`, or `matrix shell attach` returns:
+
+```text
+Error: Request failed (zellij_failed)
+```
+
+do not keep retrying the same command. First list existing sessions:
+
+```bash
+matrix shell ls
+```
+
+Then connect to an existing session:
+
+```bash
+matrix shell connect <session-name>
+```
+
+For setup, prefer an existing human-created session if one is available. If no setup session exists, create-or-connect with:
+
+```bash
+matrix shell connect -c setup
+```
+
+`connect -c <session-name>` creates the session if missing and then connects to it. If creation still fails with `zellij_failed`, ask the human to create or choose a session from the Matrix web terminal, then connect to that existing session:
+
+```bash
+matrix shell ls
+matrix shell connect <existing-session>
+```
+
+Known working example:
+
+```bash
+matrix shell connect nima
+```
+
+`connect` may succeed even when `attach` and `run -it` fail.
+
+After `matrix login`, run:
+
+```bash
+matrix doctor
+```
+
+If the sync daemon fails, run:
+
+```bash
+matrix sync
+matrix doctor
+```
+
+If `matrix doctor` passes but terminal commands still return `zellij_failed`, switch to `matrix shell connect`.
 
 ## GitHub Setup For Coding
 
@@ -203,7 +261,8 @@ matrix instance info
 matrix instance logs
 matrix shell ls
 matrix shell new setup --cmd bash
-matrix shell attach setup
+matrix shell connect setup
+matrix shell connect -c setup
 matrix run -it --session setup -- claude
 matrix run -it --session setup -- codex
 matrix run -it --session setup -- gh auth login
@@ -232,10 +291,16 @@ matrix instance logs
 matrix shell ls
 ```
 
-If an interactive command looks stuck, detach with `Ctrl-\ Ctrl-\`, then reattach:
+If an interactive command looks stuck, detach with `Ctrl-\ Ctrl-\`, then reconnect:
 
 ```bash
-matrix shell attach setup
+matrix shell connect setup
+```
+
+If the named session is missing and should be created, use:
+
+```bash
+matrix shell connect -c setup
 ```
 
 If the VPS is not ready yet, wait for provisioning in `https://app.matrix-os.com`, then retry `matrix login`.


### PR DESCRIPTION
## Summary
- Route the terminal tab + button, Ctrl+Shift+T, empty-state terminal CTA, project shell open, and file-tree terminal open through canonical zellij session creation.
- Keep the new-tab + control after the last visible terminal tab.
- Keep Claude/command launch paths on the existing startup-command tab flow.
- Pin the tab close button to the right edge for short labels like `main` and tighten the tab sizing for dense multi-tab use.
- Make the left terminal panel open on zellij Shells first, polish Shell cards, count sparse zellij tab indices correctly, optimistically remove deleted shells, and silently refresh the Shells list while open so exited sessions disappear.
- Answer heartbeat pings on named zellij WebSocket sessions so the client does not periodically reconnect from missing pongs.
- Update the public Matrix skills doc to prefer `matrix shell connect`, document `connect -c <session>`, and handle `zellij_failed` fallback paths.

## Tests
- `bun run test -- tests/shell/terminal-app-component.test.tsx`
- `bun run test -- tests/gateway/terminal-zellij-ws.test.ts tests/shell/terminal-app-component.test.tsx`
- `bun run check:patterns:diff`
- `bun run typecheck`
- `git diff --check`

## Invariants
- **Source of truth**: canonical terminal tabs and the Shells sidebar use gateway-managed zellij shell sessions; saved terminal layout remains the shell UI restore source. Public agent setup guidance is served from `www/public/skills.md`.
- **Lock/transaction scope**: no database writes or multi-step transactions are introduced; session creation remains one gateway POST per user action, and shell deletion remains one gateway DELETE with client-side optimistic removal and rollback on failure.
- **Acceptable orphan states**: if a zellij session is created but the component unmounts before attaching, existing cleanup destroys the just-created session. Named zellij WebSocket ping/pong is connection-local and does not mutate session state. Silent Shells refresh failures keep the last known list visible.
- **Auth source of truth**: unchanged browser session/gateway auth applies to `/api/terminal/sessions` and terminal WebSocket routes.
- **Deferred scope**: this does not change Claude/command-launch tabs or zellij runtime internals beyond the named terminal WebSocket health protocol.
