### PR TITLE
docs(agents): align shipped Matrix skills

### DIFF
--- a/docs/dev/agent-matrix-skills.md
+++ b/docs/dev/agent-matrix-skills.md
@@ -2,15 +2,19 @@
 
 Matrix ships an Agent-installable skill pack under `skills/matrix/`. These skills teach Agent how to build and debug Matrix apps, use the Matrix design system, work with Matrix integrations, and operate on a dev VPS.
 
+`skills/matrix/` is the source of truth for Matrix-hosted coding agents. Runtime sync projects every skill directory with a `SKILL.md` into the tool-specific locations for Matrix, Claude Code, Codex, and Hermes.
+
 ## Skills
 
 | Skill | Purpose |
 | --- | --- |
 | `matrix-app-builder` | Build Matrix apps as Vite React TypeScript projects with `matrix.json` and verified `dist/` output. |
+| `matrix-app-ui-patterns` | Build stable app interiors for windowed, mobile, dashboard, data, and canvas contexts. |
 | `matrix-design-system` | Apply Matrix theme, shadcn-style component patterns, icon quality rules, and iframe-safe app layouts. |
 | `matrix-integrations` | Use platform-owned Matrix integrations without copying provider secrets into Agent or customer VPSes. |
 | `matrix-dev-vps` | Develop Matrix from inside a user/dev VPS with hot reload, previews, and auth-aware tunnels. |
 | `matrix-debug-app` | Fix `needs_build`, manifest problems, bundle/icon 404s, console errors, and integration proxy issues. |
+| `matrix-landing-design` | Build public Matrix OS marketing and landing surfaces without mixing those patterns into apps. |
 
 ## Install Into Agent
 
@@ -22,7 +26,7 @@ From a Matrix checkout:
 ./scripts/install-agent-matrix-skills.sh
 ```
 
-The script installs all five skills from `HamedMP/matrix-os` by default. To install from a local path or another tap/source:
+The script installs the shipped Matrix app skills from `HamedMP/matrix-os` by default. To install from a local path or another tap/source:
 
 ```bash
 ./scripts/install-agent-matrix-skills.sh /home/matrix/projects/matrix-os
@@ -33,7 +37,7 @@ AGENT_BIN=/opt/matrix/runtime/node/bin/agent ./scripts/install-agent-matrix-skil
 Equivalent manual command:
 
 ```bash
-for skill in app-builder design-system integrations dev-vps debug-app; do
+for skill in app-builder app-ui-patterns design-system integrations dev-vps debug-app landing-design; do
   agent skills install "HamedMP/matrix-os/skills/matrix/$skill"
 done
 ```
@@ -44,10 +48,12 @@ From a running Agent environment with GitHub skill install support:
 
 ```bash
 agent skills install HamedMP/matrix-os/skills/matrix/app-builder
+agent skills install HamedMP/matrix-os/skills/matrix/app-ui-patterns
 agent skills install HamedMP/matrix-os/skills/matrix/design-system
 agent skills install HamedMP/matrix-os/skills/matrix/integrations
 agent skills install HamedMP/matrix-os/skills/matrix/dev-vps
 agent skills install HamedMP/matrix-os/skills/matrix/debug-app
+agent skills install HamedMP/matrix-os/skills/matrix/landing-design
 ```
 
 If Agent is running from a local checkout, install from the local path or add the repo as a tap:
@@ -79,13 +85,15 @@ Recommended target state:
 
 1. The Matrix image includes Agent or installs it during first boot as the `matrix` user.
 2. First boot runs `scripts/install-agent-matrix-skills.sh`.
-3. Agent config sets Matrix's local gateway URL:
+3. Gateway startup runs `scripts/sync-matrix-agent-skills.sh` so Matrix, Claude Code, Codex, and Hermes see
+   the same canonical skill pack.
+4. Agent config sets Matrix's local gateway URL:
 
    ```bash
    agent config set skills.config.matrix.gateway_url http://localhost:4000
    ```
 
-4. No Pipedream, Clerk, Gmail, GitHub, Slack, or provider secrets are written to Agent config or customer VPS env.
+5. No Pipedream, Clerk, Gmail, GitHub, Slack, or provider secrets are written to Agent config or customer VPS env.
 
 For production user VPSes, preinstalling Agent plus the Matrix skills is safe because the skills contain instructions only. Authenticated Matrix actions should still go through Matrix gateway/platform APIs.
 

--- a/docs/dev/hermes-matrix-skills.md
+++ b/docs/dev/hermes-matrix-skills.md
@@ -18,10 +18,12 @@ The sync script uses symlinked skill directories when possible, so updates to `s
 | Skill | Purpose |
 | --- | --- |
 | `matrix-app-builder` | Build Matrix apps as Vite React TypeScript projects with `matrix.json` and verified `dist/` output. |
+| `matrix-app-ui-patterns` | Build stable app interiors for windowed, mobile, dashboard, data, and canvas contexts. |
 | `matrix-design-system` | Apply Matrix theme, shadcn-style component patterns, icon quality rules, and iframe-safe app layouts. |
 | `matrix-integrations` | Use platform-owned Matrix integrations without copying provider secrets into Hermes or customer VPSes. |
 | `matrix-dev-vps` | Develop Matrix from inside a user/dev VPS with hot reload, previews, and auth-aware tunnels. |
 | `matrix-debug-app` | Fix `needs_build`, manifest problems, bundle/icon 404s, console errors, and integration proxy issues. |
+| `matrix-landing-design` | Build public Matrix OS marketing and landing surfaces without mixing those patterns into apps. |
 
 ## Install Into Hermes
 
@@ -33,7 +35,7 @@ From a Matrix checkout:
 ./scripts/install-hermes-matrix-skills.sh
 ```
 
-The script installs all five skills from `HamedMP/matrix-os` by default. To install from a local path or another tap/source:
+The script installs the shipped Matrix app skills from `HamedMP/matrix-os` by default. To install from a local path or another tap/source:
 
 ```bash
 ./scripts/install-hermes-matrix-skills.sh /home/matrix/projects/matrix-os
@@ -50,7 +52,7 @@ MATRIX_SKILL_TARGETS=matrix,claude,codex,hermes ./scripts/sync-matrix-agent-skil
 Equivalent manual command:
 
 ```bash
-for skill in app-builder design-system integrations dev-vps debug-app; do
+for skill in app-builder app-ui-patterns design-system integrations dev-vps debug-app landing-design; do
   hermes skills install "HamedMP/matrix-os/skills/matrix/$skill"
 done
 ```
@@ -61,10 +63,12 @@ From a running Hermes environment with GitHub skill install support:
 
 ```bash
 hermes skills install HamedMP/matrix-os/skills/matrix/app-builder
+hermes skills install HamedMP/matrix-os/skills/matrix/app-ui-patterns
 hermes skills install HamedMP/matrix-os/skills/matrix/design-system
 hermes skills install HamedMP/matrix-os/skills/matrix/integrations
 hermes skills install HamedMP/matrix-os/skills/matrix/dev-vps
 hermes skills install HamedMP/matrix-os/skills/matrix/debug-app
+hermes skills install HamedMP/matrix-os/skills/matrix/landing-design
 ```
 
 If Hermes is running from a local checkout, install from the local path or add the repo as a tap:

--- a/scripts/install-agent-matrix-skills.sh
+++ b/scripts/install-agent-matrix-skills.sh
@@ -4,12 +4,22 @@ set -euo pipefail
 AGENT_BIN="${AGENT_BIN:-agent}"
 MATRIX_SKILLS_SOURCE="${1:-${MATRIX_SKILLS_SOURCE:-HamedMP/matrix-os}}"
 
+if [ -d "${MATRIX_SKILLS_SOURCE}/skills/matrix" ]; then
+  MATRIX_SKILLS_ROOT="${MATRIX_SKILLS_SOURCE}/skills/matrix"
+elif [ -d "${MATRIX_SKILLS_SOURCE}/app-builder" ]; then
+  MATRIX_SKILLS_ROOT="$MATRIX_SKILLS_SOURCE"
+else
+  MATRIX_SKILLS_ROOT="${MATRIX_SKILLS_SOURCE}/skills/matrix"
+fi
+
 skills=(
   app-builder
+  app-ui-patterns
   design-system
   integrations
   dev-vps
   debug-app
+  landing-design
 )
 
 if ! command -v "$AGENT_BIN" >/dev/null 2>&1; then
@@ -19,7 +29,7 @@ if ! command -v "$AGENT_BIN" >/dev/null 2>&1; then
 fi
 
 for skill in "${skills[@]}"; do
-  "$AGENT_BIN" skills install "${MATRIX_SKILLS_SOURCE}/skills/matrix/${skill}"
+  "$AGENT_BIN" skills install "${MATRIX_SKILLS_ROOT}/${skill}"
 done
 
 echo "Installed Matrix Agent skills from ${MATRIX_SKILLS_SOURCE}."

--- a/scripts/install-hermes-matrix-skills.sh
+++ b/scripts/install-hermes-matrix-skills.sh
@@ -19,7 +19,15 @@ if [ -d "${MATRIX_SKILLS_SOURCE}/skills/matrix" ]; then
   exit 0
 fi
 
-for skill_dir in app-builder design-system integrations dev-vps debug-app; do
+if [ -d "${MATRIX_SKILLS_SOURCE}/app-builder" ]; then
+  MATRIX_SKILL_TARGETS=hermes \
+    MATRIX_SKILLS_SOURCE="$MATRIX_SKILLS_SOURCE" \
+    HERMES_HOME="$HERMES_HOME" \
+    bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sync-matrix-agent-skills.sh"
+  exit 0
+fi
+
+for skill_dir in app-builder app-ui-patterns design-system integrations dev-vps debug-app landing-design; do
   "$HERMES_BIN" skills install --force --yes "${MATRIX_SKILLS_SOURCE}/skills/matrix/${skill_dir}"
 done
 

--- a/skills/matrix/app-builder/SKILL.md
+++ b/skills/matrix/app-builder/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos]
 metadata:
   agent:
     tags: [Matrix OS, apps, Vite, React, TypeScript]
-    related_skills: [matrix-design-system, matrix-integrations, matrix-debug-app]
+    related_skills: [matrix-design-system, matrix-app-ui-patterns, matrix-integrations, matrix-debug-app]
 ---
 
 # Matrix App Builder
@@ -28,9 +28,11 @@ Use this when the user asks to build, create, fix, redesign, or publish a Matrix
 - Always run `pnpm install` when dependencies changed and `pnpm build` before saying the app works.
 - Verify `dist/index.html` exists.
 - Use Matrix theme variables and iframe-safe sizing.
-- For UI, ALWAYS load and follow the `matrix-design-system` skill. Key rules: Forest/Cream/Ember/Deep palette, gradient backgrounds (sand washes not flat), Orbitron H1/H2 only, Inter for everything else, capsule buttons/inputs (50px radius), glass cards (22px radius), inline SVG or bundled local icons (never text characters or remote icon scripts), stagger animations on mount. No exceptions.
+- For UI, ALWAYS load and follow `matrix-design-system` and `matrix-app-ui-patterns`. Key rules: Forest/Cream/Ember/Deep palette, gradient backgrounds (sand washes not flat), Orbitron H1/H2 only, Inter for everything else, capsule buttons/inputs (50px radius), glass cards (22px radius), inline SVG or bundled local icons (never text characters or remote icon scripts), stable window-sized layouts, and stagger animations on mount. No exceptions.
 - Store structured app data through Matrix/Postgres bridge APIs, not ad hoc local databases.
 - Never put provider secrets, API keys, or OAuth tokens inside the app directory.
+- Do not use browser `localStorage` as app persistence in the Matrix shell. Sandboxed iframes can throw `SecurityError`; use `window.MatrixOS.db` and keep local fallback paths test-only/no-op.
+- For default or first-party apps under `home/apps/**`, keep manifests deterministic: `runtime: "vite"`, `build.output: "dist"`, schema columns declared in `storage.tables`, and `icon` pointing to a committed asset in `home/system/icons/`.
 
 ## Standard Structure
 
@@ -118,6 +120,29 @@ injected bridge:
 - For external/third-party APIs use `window.MatrixOS.proxyFetch(url)` (allowlisted) — never a raw fetch.
 - Do NOT add a `localStorage` fallback that runs in the shell; it throws in the sandbox. A guarded
   `try/catch` localStorage path is acceptable only as a no-op for the unit-test environment.
+
+### Persistence Rules
+
+- Declare every persisted field in `matrix.json` `storage.tables`, including audit fields such as
+  `created_at`, best-score/best-time columns, and JSONB state payloads.
+- Load from bridge storage on startup; do not seed duplicate fallback rows after real rows load.
+- Roll back optimistic UI changes on failed creates, updates, deletes, and reorders. Keep pending deletes
+  filtered from visible state until the bridge confirms or rolls back.
+- Serialize dependent writes that update ordering, best scores, stats counters, or history rows. Avoid racing
+  two bridge writes that can overwrite each other's derived state.
+- Keep browser-only helpers guarded for tests. In production shell iframes, direct `localStorage` access and
+  raw bridge `fetch()` calls are not reliable persistence.
+
+## First-Party Default Apps
+
+When editing bundled default apps in this repo:
+
+- Keep app manifests and schema in `home/apps/<slug>/matrix.json`.
+- Reuse the shared default-app Vite build path; do not add stale per-app package/runtime fields unless the
+  app truly needs them.
+- Run `node scripts/build-default-apps.mjs home/apps` before host-bundle work when default app source changed.
+- Prefer the shared `game-center` icon for games unless a concrete shipped icon exists.
+- Verify app icon slugs against `home/system/icons/<slug>.svg` or `.png`; never rely on runtime icon generation.
 
 ## Scaffold Commands
 

--- a/skills/matrix/app-ui-patterns/SKILL.md
+++ b/skills/matrix/app-ui-patterns/SKILL.md
@@ -26,6 +26,8 @@ Matrix OS apps render inside iframes within window frames. The OS provides title
 - Use their own scroll containers, not body scroll
 - Never render their own title bar or window chrome
 - Never add internal margin against window edges
+- Keep fixed-format UI stable with explicit dimensions, grid tracks, aspect ratios, or min/max constraints so
+  hover states, labels, icons, tiles, and loading states do not shift layout.
 
 ## App Shell Pattern
 
@@ -178,6 +180,8 @@ For spatial apps: whiteboards, kanban boards, node editors.
 - Toolbar buttons: ghost variant, 36×36px, icon-only with tooltips
 - Zoom controls: bottom-right corner, small pill-shaped container
 - Canvas background: very subtle dot grid or topo pattern at 2-3% opacity
+- Cancellation must be explicit: Escape/cancel should suppress follow-up blur commits for inline editors.
+- Destructive actions and failed saves should not clear visible local state until the bridge/server confirms.
 
 ## Pattern: Empty State
 
@@ -234,3 +238,7 @@ Apps should be usable at 320px width (minimum window size).
 4. **One primary action per view.** The main thing the user came to do should be immediately obvious.
 5. **Never nest cards inside cards.** If you need hierarchy, use muted backgrounds or border-left accents.
 6. **Navigation: top (tabs) or left (sidebar).** Never bottom — the OS owns that space.
+7. **No layout shift under data refresh.** Loading, empty, error, and populated states should reserve compatible
+   space for the same controls.
+8. **Keyboard behavior is stateful.** Pause overlays, inline editors, and selected tools should treat Enter,
+   Escape, and arrow keys according to the current mode instead of restarting or committing unexpectedly.

--- a/skills/matrix/debug-app/SKILL.md
+++ b/skills/matrix/debug-app/SKILL.md
@@ -76,6 +76,9 @@ Avoid stale fields from old app formats such as `type: "html-app"` or `type: "re
 - `404 /icons/<slug>.png`: default icon asset missing or manifest points at a non-existent icon.
 - `404 app bundle`: `entry` or Vite `base` is wrong.
 - `CORS` from provider API: app is calling a provider directly. Use Matrix integration routes.
+- `SecurityError` from `localStorage`: app code is running inside the Matrix sandbox. Persist through
+  `window.MatrixOS.db`; keep localStorage fallback code test-only/no-op.
+- Missing or undefined saved fields: check `matrix.json` `storage.tables` declares the column and type.
 - `401 /api/auth/ws-token`: user is not authenticated or the route is being called from the wrong shell context.
 - `Clerk failed to load clerk.example.com`: stale environment or image build used placeholder Clerk config.
 
@@ -84,7 +87,18 @@ Avoid stale fields from old app formats such as `type: "html-app"` or `type: "re
 - Use committed default icon assets for built-in apps.
 - Manifest `icon` should be a slug, not an arbitrary URL.
 - Verify the resolved icon path exists in Matrix's system icons.
+- For games, prefer the shipped `game-center` asset unless the app has its own committed icon.
 - Do not rely on runtime image generation for default icons.
+
+## Data Bridge Checks
+
+- Confirm `window.MatrixOS?.db` exists before debugging state as an app bug.
+- Check the manifest declares every table and persisted column used by the app.
+- Reproduce create/update/delete failures and verify the UI rolls optimistic state back after bridge errors.
+- For ordered lists, best scores, timers, histories, and stats, look for racing writes. Serialize dependent
+  updates or use a single bridge operation when possible.
+- Avoid treating a test-only localStorage guard as production persistence. The shell sandbox should use the
+  bridge path.
 
 ## Integration Errors
 

--- a/tests/platform/matrix-agent-skills-sync.test.ts
+++ b/tests/platform/matrix-agent-skills-sync.test.ts
@@ -1,8 +1,10 @@
 import { execFileSync } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -32,6 +34,26 @@ metadata:
 # ${skillName}
 `,
   );
+}
+
+function extractAgentSkillList(script: string): string[] {
+  const match = script.match(/skills=\(\n(?<body>[\s\S]*?)\n\)/);
+  if (!match?.groups?.body) {
+    throw new Error("Agent installer skills array not found");
+  }
+  return match.groups.body
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .sort();
+}
+
+function extractHermesFallbackSkillList(script: string): string[] {
+  const match = script.match(/for skill_dir in (?<body>[^;]+); do/);
+  if (!match?.groups?.body) {
+    throw new Error("Hermes installer fallback loop not found");
+  }
+  return match.groups.body.split(/\s+/).filter(Boolean).sort();
 }
 
 describe("Matrix coding-agent skill sync", () => {
@@ -77,6 +99,99 @@ describe("Matrix coding-agent skill sync", () => {
       expect(readFileSync(join(cliHome, ".agents", "skills", "matrix-integrations", "SKILL.md"), "utf-8")).toContain(
         "name: matrix-integrations",
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps manual skill installers aligned with the shipped Matrix skill pack", () => {
+    const root = process.cwd();
+    const shippedSkillDirs = readdirSync(join(root, "skills", "matrix"), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+
+    const agentInstaller = readFileSync(join(root, "scripts/install-agent-matrix-skills.sh"), "utf-8");
+    const hermesInstaller = readFileSync(join(root, "scripts/install-hermes-matrix-skills.sh"), "utf-8");
+
+    expect(extractAgentSkillList(agentInstaller)).toEqual(shippedSkillDirs);
+    expect(extractHermesFallbackSkillList(hermesInstaller)).toEqual(shippedSkillDirs);
+  });
+
+  it("lets the Agent installer consume a direct skills/matrix source path", () => {
+    const root = resolve(mkdirSync(join(tmpdir(), `matrix-agent-install-${Date.now()}`), { recursive: true }));
+    const source = join(root, "skills", "matrix");
+    const fakeAgent = join(root, "agent");
+    const logPath = join(root, "agent.log");
+
+    try {
+      for (const skillDir of ["app-builder", "app-ui-patterns", "landing-design"]) {
+        writeSkill(source, skillDir, `matrix-${skillDir}`);
+      }
+
+      writeFileSync(
+        fakeAgent,
+        `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "${logPath}"
+`,
+      );
+      chmodSync(fakeAgent, 0o755);
+
+      execFileSync("bash", [join(process.cwd(), "scripts/install-agent-matrix-skills.sh"), source], {
+        env: {
+          ...process.env,
+          AGENT_BIN: fakeAgent,
+        },
+        stdio: "pipe",
+      });
+
+      const log = readFileSync(logPath, "utf-8");
+      expect(log).toContain(`skills install ${join(source, "app-builder")}`);
+      expect(log).toContain(`skills install ${join(source, "app-ui-patterns")}`);
+      expect(log).toContain(`skills install ${join(source, "landing-design")}`);
+      expect(log).not.toContain("skills/matrix/skills/matrix");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("lets the Hermes installer sync from a direct skills/matrix source path", () => {
+    const root = resolve(mkdirSync(join(tmpdir(), `matrix-hermes-install-${Date.now()}`), { recursive: true }));
+    const source = join(root, "skills", "matrix");
+    const cliHome = join(root, "cli-home");
+    const hermesHome = join(root, "hermes-home");
+    const fakeHermes = join(root, "hermes");
+
+    try {
+      for (const skillDir of ["app-builder", "app-ui-patterns", "landing-design"]) {
+        writeSkill(source, skillDir, `matrix-${skillDir}`);
+      }
+
+      writeFileSync(
+        fakeHermes,
+        `#!/usr/bin/env bash
+exit 0
+`,
+      );
+      chmodSync(fakeHermes, 0o755);
+
+      execFileSync("bash", [join(process.cwd(), "scripts/install-hermes-matrix-skills.sh"), source], {
+        env: {
+          ...process.env,
+          HERMES_BIN: fakeHermes,
+          HERMES_HOME: hermesHome,
+          HOME: cliHome,
+        },
+        stdio: "pipe",
+      });
+
+      for (const skillDir of ["app-builder", "app-ui-patterns", "landing-design"]) {
+        const skillName = `matrix-${skillDir}`;
+        const target = join(hermesHome, "skills", skillName);
+        expect(existsSync(join(target, "SKILL.md"))).toBe(true);
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+        expect(realpathSync(target)).toBe(realpathSync(join(source, skillDir)));
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- include every shipped `skills/matrix` skill in Agent/Hermes installer fallbacks
- document the full Matrix skill pack, including app UI patterns and landing design
- update app-building/debug skills with bridge persistence, schema, icon, and cancellation lessons from the default-app stack
- add regression coverage so installer fallbacks stay aligned with shipped skill directories

## Tests
- `pnpm exec vitest run tests/platform/matrix-agent-skills-sync.test.ts`
- `git diff --check`
- `bash -n scripts/install-agent-matrix-skills.sh`
- `bash -n scripts/install-hermes-matrix-skills.sh`

## Review/Monitoring
- New Graphite stack layer on top of #327.
- Awaiting fresh Greptile review and CI for current head `b38439a75378352e5522dfafdb52df61be77ade9`.

## Invariants
- Source of truth: `skills/matrix/` remains the canonical Matrix-hosted coding-agent skill pack; scripts project or install from that directory.
- Lock/transaction scope: not applicable, docs and install-script packaging only.
- Acceptable orphan states: manual installer fallback can fail per external Agent/Hermes CLI behavior without mutating Matrix data.
- Auth source of truth: no provider credentials are added; skills continue to route authenticated actions through Matrix gateway/platform APIs.
- Deferred scope: does not change runtime skill sync startup wiring or add a new authenticated Matrix toolset.