### PR TITLE
fix(vps): unblock first boot before optional tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,6 +219,7 @@ COPY --from=builder /app/skills ./skills
 COPY --from=builder /app/scripts/build-default-apps.mjs ./scripts/build-default-apps.mjs
 COPY --from=builder /app/scripts/install-hermes-matrix-skills.sh ./scripts/install-hermes-matrix-skills.sh
 COPY --from=builder /app/scripts/sync-matrix-agent-skills.sh ./scripts/sync-matrix-agent-skills.sh
+COPY scripts/cloudflared-ws-watchdog.mjs ./scripts/cloudflared-ws-watchdog.mjs
 COPY --from=builder /app/package.json ./
 COPY distro/customer-vps /app/distro/customer-vps
 COPY distro/zshrc /app/distro/zshrc

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -7,7 +7,7 @@ users:
   - name: matrix
     primary_group: matrix
     system: true
-    home: /home/matrix
+    homedir: /home/matrix
     shell: /bin/bash
     groups:
       - docker
@@ -117,6 +117,7 @@ write_files:
       Requires=matrix-restore.service
       ConditionPathExists=/opt/matrix/restore-complete
       ConditionPathExists=/opt/matrix/bin/matrix-code
+      ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server
 
       [Service]
       User=matrix
@@ -147,6 +148,28 @@ write_files:
       ExecStart=/opt/matrix/bin/matrix-sync-agent
       Restart=on-failure
       RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/matrix-hermes.service
+    owner: root:root
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Install Matrix OS optional Hermes agent
+      After=network-online.target
+      Wants=network-online.target
+      ConditionPathExists=/opt/matrix/bin/matrix-install-hermes
+
+      [Service]
+      Type=oneshot
+      User=root
+      Group=root
+      ExecStart=/opt/matrix/bin/matrix-install-hermes
+      ExecStartPost=-/bin/systemctl start matrix-code.service
+      Restart=on-failure
+      RestartSec=10m
+      TimeoutStartSec=1800
 
       [Install]
       WantedBy=multi-user.target
@@ -836,7 +859,6 @@ runcmd:
     if [ -x /opt/matrix/bin/zellij ]; then
       ln -sf /opt/matrix/bin/zellij /usr/local/bin/zellij
     fi
-    /opt/matrix/bin/matrix-install-hermes
     openssl req -x509 -newkey rsa:2048 -nodes -days 30 -subj "/CN=customer-vps.matrix-os.local" -keyout /opt/matrix/tls/key.pem -out /opt/matrix/tls/cert.pem
     chown root:matrix /opt/matrix/tls/key.pem /opt/matrix/tls/cert.pem
     chmod 0640 /opt/matrix/tls/key.pem
@@ -862,8 +884,9 @@ runcmd:
     systemctl daemon-reload
     loginctl enable-linger matrix
     systemctl start "user@$(id -u matrix).service"
-    systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-linux-tools.service matrix-db-backup.timer nginx
+    systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-linux-tools.service matrix-db-backup.timer nginx
     systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service
+    systemctl start --no-block matrix-hermes.service || echo "matrix-host: optional Hermes install will retry via systemd" >&2
     systemctl start --no-block matrix-linux-tools.service || echo "matrix-host: optional Linux tools install will retry via systemd" >&2
     if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then
       systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service

--- a/distro/docker-compose.platform.yml
+++ b/distro/docker-compose.platform.yml
@@ -68,6 +68,39 @@ services:
     networks:
       - matrixos-net
 
+  cloudflared-watchdog:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}
+        - NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY:-}
+        - NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=${NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN:-}
+        - NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST:-}
+        - NEXT_PUBLIC_POSTHOG_API_HOST=${NEXT_PUBLIC_POSTHOG_API_HOST:-}
+    entrypoint: ["node"]
+    command: ["scripts/cloudflared-ws-watchdog.mjs"]
+    environment:
+      - PLATFORM_INTERNAL_URL=http://platform:9000
+      - PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL:-https://app.matrix-os.com}
+      - PLATFORM_SECRET=${PLATFORM_SECRET}
+      - PLATFORM_JWT_SECRET=${PLATFORM_JWT_SECRET}
+      - CLOUDFLARED_WATCHDOG_INTERVAL_MS=${CLOUDFLARED_WATCHDOG_INTERVAL_MS:-60000}
+      - CLOUDFLARED_WATCHDOG_PROBE_TIMEOUT_MS=${CLOUDFLARED_WATCHDOG_PROBE_TIMEOUT_MS:-10000}
+      - CLOUDFLARED_WATCHDOG_FAILURE_THRESHOLD=${CLOUDFLARED_WATCHDOG_FAILURE_THRESHOLD:-3}
+      - CLOUDFLARED_WATCHDOG_RESTART_COOLDOWN_MS=${CLOUDFLARED_WATCHDOG_RESTART_COOLDOWN_MS:-300000}
+      - CLOUDFLARED_WATCHDOG_TERMINAL_SESSION=${CLOUDFLARED_WATCHDOG_TERMINAL_SESSION:-main}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      platform:
+        condition: service_healthy
+      cloudflared:
+        condition: service_started
+    restart: unless-stopped
+    networks:
+      - matrixos-net
+
   platform:
     build:
       context: ..

--- a/docs/dev/vps-deployment.md
+++ b/docs/dev/vps-deployment.md
@@ -1016,6 +1016,25 @@ sudo systemctl status cloudflared.service
 ls /etc/cloudflared/credentials.json
 ```
 
+### Shell reconnects while HTTP stays healthy
+
+Split the incident by layer before changing runtime code: direct customer VPS
+health, local platform websocket upgrade, then public `app.matrix-os.com`
+websocket upgrade. Public `/ws` or `/ws/terminal/session` failures while direct
+origin probes succeed usually mean the Cloudflare tunnel is wedged.
+
+The production platform compose runs `cloudflared-watchdog`, which polls
+`/vps/fleet`, selects a healthy running customer VPS, mints a short-lived
+websocket token, and probes public `/ws` plus `/ws/terminal/session`. After
+three consecutive public websocket failures it restarts only the Cloudflared
+container through the Docker socket, then resumes probing. Tune it with:
+
+```bash
+CLOUDFLARED_WATCHDOG_INTERVAL_MS=60000
+CLOUDFLARED_WATCHDOG_FAILURE_THRESHOLD=3
+CLOUDFLARED_WATCHDOG_RESTART_COOLDOWN_MS=300000
+```
+
 ### Customer VPS provisioning fails
 
 ```bash

--- a/scripts/cloudflared-ws-watchdog.mjs
+++ b/scripts/cloudflared-ws-watchdog.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import os from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { SignJWT } from 'jose';
+import { WebSocket } from 'ws';
+
+const SYNC_JWT_AUDIENCE = 'matrix-os-sync';
+const SYNC_JWT_ISSUER = 'matrix-os-platform';
+const DEFAULT_WS_PATHS = ['/ws'];
+const DEFAULT_DOCKER_SOCKET = '/var/run/docker.sock';
+
+function toPositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function selectProbeMachine(fleet) {
+  const machines = Array.isArray(fleet?.machines) ? fleet.machines : [];
+  for (const machine of machines) {
+    if (!isRecord(machine)) continue;
+    if (machine.status !== 'running' || machine.healthy !== true) continue;
+    if (
+      typeof machine.handle !== 'string' ||
+      !machine.handle ||
+      typeof machine.clerkUserId !== 'string' ||
+      !machine.clerkUserId
+    ) {
+      continue;
+    }
+    return {
+      handle: machine.handle,
+      clerkUserId: machine.clerkUserId,
+      runtimeSlot: typeof machine.runtimeSlot === 'string' && machine.runtimeSlot
+        ? machine.runtimeSlot
+        : 'primary',
+    };
+  }
+  return null;
+}
+
+export function buildProbeWebSocketUrl(platformPublicUrl, path, token) {
+  const base = new URL(platformPublicUrl || 'https://app.matrix-os.com');
+  if (base.protocol === 'https:') {
+    base.protocol = 'wss:';
+  } else if (base.protocol === 'http:') {
+    base.protocol = 'ws:';
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const url = new URL(normalizedPath, `${base.origin}/`);
+  url.searchParams.set('token', token);
+  return url;
+}
+
+export function redactProbeUrl(rawUrl) {
+  try {
+    const url = new URL(rawUrl);
+    if (url.searchParams.has('token')) {
+      url.searchParams.set('token', 'REDACTED');
+    }
+    return url.toString();
+  } catch (err) {
+    if (!(err instanceof TypeError)) {
+      console.warn('[cloudflared-watchdog] Failed to redact malformed probe URL:', err instanceof Error ? err.message : String(err));
+    }
+    return '[invalid-url]';
+  }
+}
+
+export function shouldRestartCloudflared(consecutiveFailures, threshold) {
+  return consecutiveFailures >= Math.max(1, threshold);
+}
+
+function parseConfig(env = process.env) {
+  const terminalSession = env.CLOUDFLARED_WATCHDOG_TERMINAL_SESSION || 'main';
+  return {
+    platformInternalUrl: env.PLATFORM_INTERNAL_URL || 'http://platform:9000',
+    platformPublicUrl: env.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com',
+    platformSecret: env.PLATFORM_SECRET || '',
+    platformJwtSecret: env.PLATFORM_JWT_SECRET || '',
+    intervalMs: toPositiveInt(env.CLOUDFLARED_WATCHDOG_INTERVAL_MS, 60_000),
+    probeTimeoutMs: toPositiveInt(env.CLOUDFLARED_WATCHDOG_PROBE_TIMEOUT_MS, 10_000),
+    failureThreshold: toPositiveInt(env.CLOUDFLARED_WATCHDOG_FAILURE_THRESHOLD, 3),
+    restartCooldownMs: toPositiveInt(env.CLOUDFLARED_WATCHDOG_RESTART_COOLDOWN_MS, 300_000),
+    dockerSocket: env.CLOUDFLARED_WATCHDOG_DOCKER_SOCKET || DEFAULT_DOCKER_SOCKET,
+    containerName: env.CLOUDFLARED_WATCHDOG_CONTAINER || '',
+    wsPaths: [
+      ...DEFAULT_WS_PATHS,
+      `/ws/terminal/session?session=${encodeURIComponent(terminalSession)}&fromSeq=0`,
+    ],
+  };
+}
+
+async function fetchFleet(config) {
+  if (!config.platformSecret) {
+    throw new Error('PLATFORM_SECRET is required for websocket watchdog fleet probes');
+  }
+  const url = new URL('/vps/fleet', config.platformInternalUrl);
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${config.platformSecret}`,
+    },
+    signal: AbortSignal.timeout(config.probeTimeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`fleet probe failed with status ${response.status}`);
+  }
+  return response.json();
+}
+
+async function issueProbeToken(config, machine) {
+  if (config.platformJwtSecret.length < 32) {
+    throw new Error('PLATFORM_JWT_SECRET must be at least 32 characters for websocket watchdog probes');
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const claims = {
+    sub: machine.clerkUserId,
+    handle: machine.handle,
+    gateway_url: config.platformPublicUrl,
+    runtime_slot: machine.runtimeSlot,
+    aud: SYNC_JWT_AUDIENCE,
+    iat: now,
+    exp: now + 120,
+    iss: SYNC_JWT_ISSUER,
+  };
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setAudience(SYNC_JWT_AUDIENCE)
+    .sign(new TextEncoder().encode(config.platformJwtSecret));
+}
+
+async function probeWebSocket(url, timeoutMs) {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(url, { handshakeTimeout: timeoutMs });
+    const timer = setTimeout(() => {
+      ws.terminate();
+      resolve({ ok: false, reason: 'timeout' });
+    }, timeoutMs + 1_000);
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    ws.once('open', () => {
+      ws.close();
+      finish({ ok: true, reason: 'open' });
+    });
+    ws.once('unexpected-response', (_request, response) => {
+      response.resume();
+      finish({ ok: false, reason: `status_${response.statusCode}` });
+    });
+    ws.once('error', (err) => {
+      finish({ ok: false, reason: err instanceof Error ? err.message : 'websocket_error' });
+    });
+    ws.once('close', (code) => {
+      finish({ ok: false, reason: `close_${code}` });
+    });
+  });
+}
+
+async function dockerRequest(config, method, requestPath) {
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      socketPath: config.dockerSocket,
+      path: requestPath,
+      method,
+    }, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        body += chunk;
+      });
+      response.on('end', () => {
+        if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+          resolve(body);
+          return;
+        }
+        reject(new Error(`Docker API ${method} ${requestPath} failed with status ${response.statusCode}`));
+      });
+    });
+    request.setTimeout(config.probeTimeoutMs, () => {
+      request.destroy(new Error('Docker API request timed out'));
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+async function dockerJson(config, requestPath) {
+  const body = await dockerRequest(config, 'GET', requestPath);
+  return body ? JSON.parse(body) : null;
+}
+
+async function resolveCloudflaredContainer(config) {
+  if (config.containerName) return config.containerName;
+
+  let projectLabel = '';
+  try {
+    const self = await dockerJson(config, `/containers/${encodeURIComponent(os.hostname())}/json`);
+    projectLabel = self?.Config?.Labels?.['com.docker.compose.project'] || '';
+  } catch (err) {
+    console.warn('[cloudflared-watchdog] Could not inspect watchdog container:', err instanceof Error ? err.message : String(err));
+  }
+
+  const labels = ['com.docker.compose.service=cloudflared'];
+  if (projectLabel) labels.push(`com.docker.compose.project=${projectLabel}`);
+  const filters = encodeURIComponent(JSON.stringify({ label: labels }));
+  const containers = await dockerJson(config, `/containers/json?all=false&filters=${filters}`);
+  if (!Array.isArray(containers) || containers.length === 0 || typeof containers[0]?.Id !== 'string') {
+    throw new Error('Could not find running cloudflared container by Docker Compose labels');
+  }
+  return containers[0].Id;
+}
+
+async function restartCloudflared(config) {
+  const container = await resolveCloudflaredContainer(config);
+  await dockerRequest(config, 'POST', `/containers/${encodeURIComponent(container)}/restart?t=10`);
+  console.warn('[cloudflared-watchdog] Restarted cloudflared after repeated public websocket probe failures');
+}
+
+async function runProbeCycle(config) {
+  const fleet = await fetchFleet(config);
+  const machine = selectProbeMachine(fleet);
+  if (!machine) {
+    console.warn('[cloudflared-watchdog] No healthy running customer machine available; skipping websocket probe cycle');
+    return true;
+  }
+  const token = await issueProbeToken(config, machine);
+  const results = [];
+  for (const path of config.wsPaths) {
+    const url = buildProbeWebSocketUrl(config.platformPublicUrl, path, token);
+    const result = await probeWebSocket(url, config.probeTimeoutMs);
+    results.push({ path, url: url.toString(), ...result });
+  }
+  const failures = results.filter((result) => !result.ok);
+  for (const failure of failures) {
+    console.warn(
+      `[cloudflared-watchdog] Public websocket probe failed path=${failure.path} reason=${failure.reason} url=${redactProbeUrl(failure.url)}`,
+    );
+  }
+  return failures.length === 0;
+}
+
+async function runLoop(config) {
+  let consecutiveFailures = 0;
+  let lastRestartAt = 0;
+
+  for (;;) {
+    try {
+      const ok = await runProbeCycle(config);
+      consecutiveFailures = ok ? 0 : consecutiveFailures + 1;
+    } catch (err) {
+      consecutiveFailures = 0;
+      console.warn(
+        '[cloudflared-watchdog] Probe cycle could not complete; not restarting cloudflared without public websocket failure evidence:',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    if (shouldRestartCloudflared(consecutiveFailures, config.failureThreshold)) {
+      const now = Date.now();
+      if (now - lastRestartAt >= config.restartCooldownMs) {
+        await restartCloudflared(config);
+        lastRestartAt = now;
+        consecutiveFailures = 0;
+      } else {
+        console.warn('[cloudflared-watchdog] Restart threshold reached during cooldown; leaving cloudflared running');
+      }
+    }
+
+    await sleep(config.intervalMs);
+  }
+}
+
+async function assertDockerSocketReachable(config) {
+  await dockerRequest(config, 'GET', '/_ping');
+}
+
+async function main() {
+  const config = parseConfig();
+  await assertDockerSocketReachable(config);
+  console.log('[cloudflared-watchdog] Starting public websocket watchdog');
+  await runLoop(config);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((err) => {
+    console.error('[cloudflared-watchdog] Fatal startup error:', err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/tests/platform/cloudflared-ws-watchdog.test.ts
+++ b/tests/platform/cloudflared-ws-watchdog.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildProbeWebSocketUrl,
+  redactProbeUrl,
+  selectProbeMachine,
+  shouldRestartCloudflared,
+} from '../../scripts/cloudflared-ws-watchdog.mjs';
+
+describe('cloudflared websocket watchdog', () => {
+  it('selects a healthy running customer machine for public websocket probes', () => {
+    const machine = selectProbeMachine({
+      machines: [
+        {
+          handle: 'stopped',
+          clerkUserId: 'user_stopped',
+          runtimeSlot: 'primary',
+          status: 'stopped',
+          healthy: true,
+        },
+        {
+          handle: 'alice',
+          clerkUserId: 'user_alice',
+          runtimeSlot: 'primary',
+          status: 'running',
+          healthy: true,
+        },
+      ],
+    });
+
+    expect(machine).toEqual({
+      handle: 'alice',
+      clerkUserId: 'user_alice',
+      runtimeSlot: 'primary',
+    });
+  });
+
+  it('builds tokenized public websocket URLs for shell and terminal probes', () => {
+    expect(buildProbeWebSocketUrl('https://app.matrix-os.com', '/ws', 'jwt-token').toString()).toBe(
+      'wss://app.matrix-os.com/ws?token=jwt-token',
+    );
+    expect(
+      buildProbeWebSocketUrl(
+        'https://app.matrix-os.com/',
+        '/ws/terminal/session?session=main&fromSeq=0',
+        'jwt-token',
+      ).toString(),
+    ).toBe('wss://app.matrix-os.com/ws/terminal/session?session=main&fromSeq=0&token=jwt-token');
+  });
+
+  it('redacts probe tokens before logging URLs', () => {
+    expect(redactProbeUrl('wss://app.matrix-os.com/ws?token=jwt-token&fromSeq=0')).toBe(
+      'wss://app.matrix-os.com/ws?token=REDACTED&fromSeq=0',
+    );
+  });
+
+  it('restarts cloudflared only after repeated consecutive failures', () => {
+    expect(shouldRestartCloudflared(1, 3)).toBe(false);
+    expect(shouldRestartCloudflared(2, 3)).toBe(false);
+    expect(shouldRestartCloudflared(3, 3)).toBe(true);
+  });
+
+  it('ships the watchdog in the production platform compose surface', () => {
+    const root = process.cwd();
+    const compose = readFileSync(join(root, 'distro/docker-compose.platform.yml'), 'utf8');
+    const dockerfile = readFileSync(join(root, 'Dockerfile'), 'utf8');
+
+    expect(compose).toContain('cloudflared-watchdog:');
+    expect(compose).toContain('scripts/cloudflared-ws-watchdog.mjs');
+    expect(compose).toContain('/var/run/docker.sock:/var/run/docker.sock');
+    expect(compose).toContain('CLOUDFLARED_WATCHDOG_FAILURE_THRESHOLD');
+    expect(dockerfile).toContain('COPY scripts/cloudflared-ws-watchdog.mjs ./scripts/cloudflared-ws-watchdog.mjs');
+  });
+});

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -130,11 +130,40 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('chown root:matrix /opt/matrix/postgres-compose.yml');
   });
 
+  it('uses cloud-init user schema fields accepted by Ubuntu 24.04', () => {
+    const root = process.cwd();
+    const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
+
+    expect(cloudInit).toContain('homedir: /home/matrix');
+    expect(cloudInit).not.toContain('    home: /home/matrix');
+  });
+
+  it('starts Matrix services before optional Hermes install work', () => {
+    const root = process.cwd();
+    const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
+
+    expect(cloudInit).toContain('path: /etc/systemd/system/matrix-hermes.service');
+    expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-install-hermes');
+    expect(cloudInit).toContain('ExecStartPost=-/bin/systemctl start matrix-code.service');
+    expect(cloudInit).toContain('TimeoutStartSec=1800');
+    expect(cloudInit).toContain(
+      'systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-linux-tools.service matrix-db-backup.timer nginx',
+    );
+    expect(cloudInit).toContain(
+      'systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service',
+    );
+    expect(cloudInit).toContain('systemctl start --no-block matrix-hermes.service || echo "matrix-host: optional Hermes install will retry via systemd" >&2');
+    expect(cloudInit.indexOf('systemctl start matrix-restore.service matrix-gateway.service')).toBeLessThan(
+      cloudInit.indexOf('systemctl start --no-block matrix-hermes.service'),
+    );
+    expect(cloudInit).not.toContain('\n    /opt/matrix/bin/matrix-install-hermes\n');
+  });
+
   it('loads the production customer VPS cloud-init template', async () => {
     const cloudInit = await loadCustomerVpsCloudInitTemplate();
 
     expect(cloudInit).toContain('runcmd:');
-    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-linux-tools.service matrix-db-backup.timer');
+    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-linux-tools.service matrix-db-backup.timer');
     expect(cloudInit).toContain('install -o root -g root -m 0644 /opt/matrix/systemd/*.service /etc/systemd/system/');
     expect(cloudInit).toContain('/opt/matrix/messaging /opt/matrix/messaging/bin');
     expect(cloudInit).toContain('if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then');
@@ -291,6 +320,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('Description=Matrix OS customer code editor');
     expect(cloudInit).toContain('ExecStart=/opt/matrix/bin/matrix-code');
     expect(cloudInit).toContain('ConditionPathExists=/opt/matrix/bin/matrix-code');
+    expect(cloudInit).toContain('ConditionPathExists=/opt/matrix/runtime/code-server/bin/code-server');
     expect(code).toContain('MATRIX_CODE_PROXY_TOKEN');
     expect(code).toContain('code-server');
     expect(code).toContain('crypto.timingSafeEqual');
@@ -381,7 +411,7 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip');
     expect(cloudInit).toContain('/tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli');
     expect(cloudInit).toContain('docker run -d');
-    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-linux-tools.service matrix-db-backup.timer');
+    expect(cloudInit).toContain('systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service matrix-hermes.service matrix-linux-tools.service matrix-db-backup.timer');
   });
 
   it('includes a bounded matrixctl recovery wrapper', () => {


### PR DESCRIPTION
## Summary

- start core customer VPS services before optional Hermes/tooling installs can block first boot
- move Hermes install into a retrying `matrix-hermes.service` started with `--no-block`
- fix the Ubuntu 24.04 cloud-init user schema warning by using `homedir`
- gate `matrix-code.service` on the actual code-server binary and restart it after Hermes installs optional tooling
- add a platform `cloudflared-watchdog` service that probes public `/ws` and `/ws/terminal/session` and restarts only Cloudflared after repeated tunnel-only websocket failures

## Tests

- `bun run test -- tests/platform/cloudflared-ws-watchdog.test.ts`
- `bun run test -- tests/platform/cloudflared-ws-watchdog.test.ts tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts tests/deploy/customer-vps/symphony-systemd.test.ts`
- `cloud-init schema --config-file distro/customer-vps/cloud-init.yaml`
- `bun run typecheck`
- `./scripts/review/check-patterns.sh --diff origin/main`
- `git diff --check`

## Review/Monitoring

This PR should be monitored through CI and Greptile. The live first-boot incident this addresses was a new `nima` VPS staying on the Booting Matrix OS page while cloud-init was still running `matrix-install-hermes`; gateway/shell registration happened only after Hermes Python dependency installation finished.

The live reconnect incident exposed a separate platform-edge failure: direct VPS and local platform websocket upgrades were healthy, while public `app.matrix-os.com` websocket upgrades through Cloudflare failed until `distro-cloudflared-1` was restarted. The watchdog makes that exact split observable and self-healing.

## Invariants

- Source of truth: customer VPS readiness remains the platform `user_machines` row plus VPS registration through `/vps/register`; this only changes when the VPS can reach the final registration path after core services start. The websocket watchdog uses `/vps/fleet` only to choose an already-healthy probe target.
- Lock/transaction scope: no database write path changes. Provisioning row creation and registration semantics are unchanged. The watchdog does not write database state.
- Acceptable orphan states: optional Hermes and Linux tooling may still be installing or retrying after the gateway/shell/sync-agent are registered and usable. A failed optional install should not keep the user on the boot page. The watchdog restarts Cloudflared only after completed public websocket probes fail repeatedly; local platform API failures do not count toward restart.
- Auth source of truth: existing platform registration token and host verification token handling are unchanged. The watchdog mints short-lived sync JWTs from `PLATFORM_JWT_SECRET` inside the platform deployment and redacts query tokens from logs.
- Deferred scope: this does not fix the separate Symphony launcher issue seen on Nima's VPS, where the current packaged `bin/symphony` forwards CLI flags to `mix run` incorrectly. It also does not replace Cloudflare tunnel configuration management; it adds recovery for the observed wedged websocket path.
