### PR TITLE
fix(onboarding): harden first-run CLI setup flow

### DIFF
--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -22,6 +22,7 @@ import {
 import type { ClerkAuth } from './clerk-auth.js';
 
 const DEVICE_BODY_LIMIT = 4096;
+const DEVICE_EXPIRES_IN_SEC = 2700;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 100;
 const RATE_LIMIT_MAX_KEYS = 10_000;
@@ -142,6 +143,73 @@ function approvalPage(
     var userCode = "${escapedCode}";
     var csrf = "${escapedCsrf}";
     var approvalUrl = window.location.href;
+    var authMode = new URL(window.location.href).searchParams.get('mode') === 'sign-in' ? 'sign-in' : 'sign-up';
+    var checkoutAttemptStorageKey = 'matrix.device.billing.checkoutAttemptAt.' + userCode;
+    var checkoutAttemptMaxAgeMs = 30 * 60 * 1000;
+    var provisioningStarted = false;
+    var provisioningPolls = 0;
+    var maxProvisioningPolls = 60;
+    var billingConfirmationPolls = 0;
+    var maxBillingConfirmationPolls = 60;
+    var runtimeReady = false;
+
+    function deviceReturnPath() {
+      var url = new URL(window.location.href);
+      url.searchParams.delete('billing');
+      url.searchParams.delete('checkout');
+      return url.pathname + url.search;
+    }
+
+    function deviceAuthUrl(mode) {
+      var url = new URL(approvalUrl);
+      url.searchParams.delete('billing');
+      url.searchParams.delete('checkout');
+      url.searchParams.set('mode', mode);
+      return url.toString();
+    }
+
+    function hasTrustedCheckoutReturn() {
+      try {
+        var rawAttemptAt = window.sessionStorage.getItem(checkoutAttemptStorageKey);
+        if (!rawAttemptAt) return false;
+        var attemptAt = Number(rawAttemptAt);
+        return Number.isFinite(attemptAt) && Date.now() - attemptAt <= checkoutAttemptMaxAgeMs;
+      } catch (err) {
+        console.warn('[matrix] Unable to read device checkout attempt state', err instanceof Error ? err.message : String(err));
+        return false;
+      }
+    }
+
+    function rememberBillingCheckoutAttempt() {
+      try {
+        window.sessionStorage.setItem(checkoutAttemptStorageKey, String(Date.now()));
+      } catch (err) {
+        console.warn('[matrix] Unable to write device checkout attempt state', err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    function stripCheckoutReturnParams() {
+      try {
+        var currentUrl = new URL(window.location.href);
+        currentUrl.searchParams.delete('checkout');
+        currentUrl.searchParams.delete('billing');
+        window.history.replaceState(null, '', currentUrl.pathname + currentUrl.search + currentUrl.hash);
+      } catch (err) {
+        console.warn('[matrix] Unable to clear device checkout return state', err instanceof Error ? err.message : String(err));
+      }
+    }
+
+    var checkoutReturnRequested = new URLSearchParams(window.location.search || '').get('checkout') === 'success';
+    var checkoutJustCompleted = checkoutReturnRequested && hasTrustedCheckoutReturn();
+    if (checkoutReturnRequested) stripCheckoutReturnParams();
+
+    function fetchWithTimeout(url, options) {
+      var controller = new AbortController();
+      var timeoutId = window.setTimeout(function() { controller.abort(); }, 10000);
+      return fetch(url, Object.assign({}, options, { signal: controller.signal })).finally(function() {
+        window.clearTimeout(timeoutId);
+      });
+    }
 
     function setStatus(message) {
       var status = document.getElementById('status');
@@ -156,12 +224,303 @@ function approvalPage(
       }
     }
 
+    function setConfirmReady(isReady) {
+      var form = document.getElementById('confirm-area');
+      var confirm = document.getElementById('confirm-button');
+      if (form) form.style.display = isReady ? 'block' : 'none';
+      if (confirm) {
+        confirm.disabled = true;
+        if (isReady) confirm.disabled = false;
+      }
+    }
+
     function updateSignedInInstance() {
       var instance = document.getElementById('instance-line');
       if (!instance || !window.Clerk || !window.Clerk.user) return;
       var user = window.Clerk.user;
       var handle = user.username || user.primaryEmailAddress?.emailAddress || user.id;
       instance.textContent = 'signed in: @' + handle + ' on app.matrix-os.com';
+    }
+
+    function renderActionState(title, detail, primaryLabel, primaryHandler) {
+      var signin = document.getElementById('signin-area');
+      if (!signin) return;
+      signin.style.display = 'block';
+      signin.innerHTML = '';
+      var state = document.createElement('div');
+      state.className = 'device-state';
+      var heading = document.createElement('h2');
+      heading.textContent = title;
+      state.appendChild(heading);
+      var copy = document.createElement('p');
+      copy.textContent = detail;
+      state.appendChild(copy);
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = primaryLabel;
+      button.addEventListener('click', primaryHandler);
+      state.appendChild(button);
+      signin.appendChild(state);
+    }
+
+    function showLoadingState(message) {
+      setConfirmReady(false);
+      renderActionState('Setting up Matrix CLI', message, 'Working...', function() {});
+      var button = document.querySelector('#signin-area button');
+      if (button) button.disabled = true;
+    }
+
+    function showRuntimeRequiredState() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      renderActionState(
+        'Finish Matrix setup',
+        'Create your Matrix computer before connecting this terminal.',
+        'Provision Matrix computer',
+        startProvisioningFromClerkSession
+      );
+    }
+
+    function showBillingRequiredState() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      renderActionState(
+        'Start hosted trial',
+        'Billing starts the hosted Matrix computer trial, then this CLI login can continue.',
+        'Start checkout',
+        startBillingCheckoutFromClerkSession
+      );
+    }
+
+    function showSignedInRecoveryState() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      renderActionState(
+        'Session needs a refresh',
+        'Matrix could not finish connecting this terminal. Try again after a moment.',
+        'Try again',
+        continueDeviceOnboarding
+      );
+    }
+
+    function showConfirm() {
+      runtimeReady = true;
+      var signin = document.getElementById('signin-area');
+      if (signin) {
+        signin.style.display = 'none';
+        signin.innerHTML = '';
+      }
+      setStatus('');
+      setConfirmReady(true);
+    }
+
+    function showSignUp() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      var signin = document.getElementById('signin-area');
+      if (signin) signin.style.display = 'block';
+      if (signin && !signin.dataset.mounted) {
+        signin.dataset.mounted = 'true';
+        window.Clerk.mountSignUp(signin, {
+          signInUrl: deviceAuthUrl('sign-in'),
+          forceRedirectUrl: approvalUrl,
+          fallbackRedirectUrl: approvalUrl,
+          signInForceRedirectUrl: approvalUrl,
+          signInFallbackRedirectUrl: approvalUrl,
+          oauthFlow: 'redirect',
+        });
+      }
+    }
+
+    function showSignIn() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      var signin = document.getElementById('signin-area');
+      if (signin) signin.style.display = 'block';
+      if (signin && !signin.dataset.mounted) {
+        signin.dataset.mounted = 'true';
+        window.Clerk.mountSignIn(signin, {
+          signUpUrl: deviceAuthUrl('sign-up'),
+          forceRedirectUrl: approvalUrl,
+          fallbackRedirectUrl: approvalUrl,
+          signUpForceRedirectUrl: approvalUrl,
+          signUpFallbackRedirectUrl: approvalUrl,
+          oauthFlow: 'redirect',
+        });
+      }
+    }
+
+    function showAuth() {
+      if (authMode === 'sign-in') {
+        showSignIn();
+        return;
+      }
+      showSignUp();
+    }
+
+    async function clerkTokenOrNull() {
+      if (!window.Clerk || !window.Clerk.session) return null;
+      return await window.Clerk.session.getToken();
+    }
+
+    function pollProvisioningSession() {
+      provisioningPolls += 1;
+      if (provisioningPolls > maxProvisioningPolls) {
+        provisioningStarted = false;
+        checkoutJustCompleted = false;
+        billingConfirmationPolls = 0;
+        showSignedInRecoveryState();
+        return;
+      }
+      window.setTimeout(continueDeviceOnboarding, 8000);
+    }
+
+    function retryProvisioningAfterBillingDelay() {
+      billingConfirmationPolls += 1;
+      if (billingConfirmationPolls > maxBillingConfirmationPolls) {
+        provisioningStarted = false;
+        checkoutJustCompleted = false;
+        showBillingRequiredState();
+        return;
+      }
+      provisioningStarted = false;
+      showLoadingState('Confirming billing...');
+      window.setTimeout(startProvisioningFromClerkSession, 8000);
+    }
+
+    async function startBillingCheckoutFromClerkSession() {
+      showLoadingState('Opening secure checkout...');
+      try {
+        var token = await clerkTokenOrNull();
+        if (!token) {
+          showAuth();
+          return;
+        }
+        var res = await fetchWithTimeout('/billing/checkout', {
+          method: 'POST',
+          headers: {
+            Authorization: \`Bearer \${token}\`,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({
+            planSlug: 'matrix_builder',
+            interval: 'monthly',
+            regionSlug: 'region_fsn1',
+            returnPath: deviceReturnPath(),
+          }),
+          credentials: 'same-origin',
+        });
+        var body = await res.json().catch(function(err) {
+          console.warn('[matrix] Unable to parse device checkout response', err instanceof Error ? err.message : String(err));
+          return null;
+        });
+        if (!res.ok || !body || typeof body.url !== 'string') {
+          showBillingRequiredState();
+          return;
+        }
+        rememberBillingCheckoutAttempt();
+        window.location.assign(body.url);
+      } catch (err) {
+        console.error('[matrix] Device checkout failed', err instanceof Error ? err.message : String(err));
+        showBillingRequiredState();
+      }
+    }
+
+    async function startProvisioningFromClerkSession() {
+      if (provisioningStarted) return;
+      provisioningStarted = true;
+      showLoadingState('Starting your Matrix computer...');
+      try {
+        var token = await clerkTokenOrNull();
+        if (!token) {
+          provisioningStarted = false;
+          showAuth();
+          return;
+        }
+        var res = await fetchWithTimeout('/api/auth/provision-runtime', {
+          method: 'POST',
+          headers: {
+            Authorization: \`Bearer \${token}\`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({}),
+          credentials: 'same-origin',
+        });
+        if (res.ok) {
+          billingConfirmationPolls = 0;
+          provisioningPolls = 0;
+          showLoadingState('Preparing your Matrix computer...');
+          pollProvisioningSession();
+          return;
+        }
+        if (res.status === 402) {
+          if (checkoutJustCompleted) {
+            retryProvisioningAfterBillingDelay();
+            return;
+          }
+          provisioningStarted = false;
+          showBillingRequiredState();
+          return;
+        }
+        if (res.status === 409) {
+          provisioningPolls = 0;
+          billingConfirmationPolls = 0;
+          showLoadingState('Preparing your Matrix computer...');
+          pollProvisioningSession();
+          return;
+        }
+        provisioningStarted = false;
+        showSignedInRecoveryState();
+      } catch (err) {
+        console.error('[matrix] Device runtime provisioning failed', err instanceof Error ? err.message : String(err));
+        provisioningStarted = false;
+        showSignedInRecoveryState();
+      }
+    }
+
+    async function continueDeviceOnboarding() {
+      showLoadingState('Checking your Matrix computer...');
+      try {
+        var token = await clerkTokenOrNull();
+        if (!token) {
+          showAuth();
+          return;
+        }
+        var res = await fetchWithTimeout('/api/auth/app-session', {
+          method: 'POST',
+          headers: {
+            Authorization: \`Bearer \${token}\`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ redirectTo: deviceReturnPath() }),
+          credentials: 'same-origin',
+        });
+        if (res.ok) {
+          provisioningStarted = false;
+          billingConfirmationPolls = 0;
+          provisioningPolls = 0;
+          showConfirm();
+          return;
+        }
+        if (res.status === 404) {
+          if (provisioningStarted) {
+            showLoadingState('Preparing your Matrix computer...');
+            pollProvisioningSession();
+            return;
+          }
+          if (checkoutJustCompleted) {
+            startProvisioningFromClerkSession();
+            return;
+          }
+          showRuntimeRequiredState();
+          return;
+        }
+        showSignedInRecoveryState();
+      } catch (err) {
+        console.error('[matrix] Device session exchange failed', err instanceof Error ? err.message : String(err));
+        showSignedInRecoveryState();
+      }
     }
 
     async function submitApproval(event) {
@@ -171,21 +530,19 @@ function approvalPage(
       setBusy(true);
 
       try {
-        if (!window.Clerk.session) {
-          setStatus('Sign in before authorizing this device.');
-          showSignIn();
+        if (!runtimeReady) {
+          await continueDeviceOnboarding();
           return;
         }
 
-        var token = await window.Clerk.session.getToken();
+        var token = await clerkTokenOrNull();
         if (!token) {
-          setStatus('Sign in before authorizing this device.');
-          showSignIn();
+          showAuth();
           return;
         }
 
         var body = new URLSearchParams({ userCode: userCode, csrf: csrf });
-        var res = await fetch('/auth/device/approve', {
+        var res = await fetchWithTimeout('/auth/device/approve', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
@@ -204,34 +561,11 @@ function approvalPage(
         }
 
         setStatus('Could not authorize this device. Refresh and try again.');
-      } catch (_) {
+      } catch (err) {
+        console.error('[matrix] Device approval failed', err instanceof Error ? err.message : String(err));
         setStatus('Could not authorize this device. Refresh and try again.');
       } finally {
         setBusy(false);
-      }
-    }
-
-    function showConfirm() {
-      var signin = document.getElementById('signin-area');
-      var confirm = document.getElementById('confirm-area');
-      if (signin) signin.style.display = 'none';
-      if (confirm) confirm.style.display = 'block';
-    }
-
-    function showSignIn() {
-      var signin = document.getElementById('signin-area');
-      var confirm = document.getElementById('confirm-area');
-      if (signin) signin.style.display = 'block';
-      if (confirm) confirm.style.display = 'block';
-      if (signin && !signin.dataset.mounted) {
-        signin.dataset.mounted = 'true';
-        window.Clerk.mountSignIn(signin, {
-          forceRedirectUrl: approvalUrl,
-          fallbackRedirectUrl: approvalUrl,
-          signUpForceRedirectUrl: approvalUrl,
-          signUpFallbackRedirectUrl: approvalUrl,
-          oauthFlow: 'redirect',
-        });
       }
     }
 
@@ -239,12 +573,12 @@ function approvalPage(
       window.Clerk.load().then(function() {
         updateSignedInInstance();
         if (window.Clerk.user && window.Clerk.session) {
-          showConfirm();
+          continueDeviceOnboarding();
         } else {
-          showSignIn();
+          showAuth();
         }
       }).catch(function() {
-        setStatus('Could not load sign-in. Refresh and try again.');
+        setStatus('Could not load signup. Refresh and try again.');
       });
     }
 
@@ -291,10 +625,10 @@ function approvalPage(
       padding: 24px;
     }
     main {
-      width: min(920px, 100%);
+      width: min(1120px, 100%);
       display: grid;
-      grid-template-columns: minmax(0, 1fr) 280px;
-      gap: 20px;
+      grid-template-columns: minmax(0, 1fr) minmax(360px, 440px);
+      gap: 24px;
       align-items: stretch;
     }
     .terminal {
@@ -342,12 +676,13 @@ function approvalPage(
       color: #25332d;
       border: 1px solid #ddd4c3;
       border-radius: 8px;
-      padding: 20px;
+      padding: 24px;
       display: flex;
       flex-direction: column;
       gap: 16px;
     }
     h1 { margin: 0; font-size: 20px; line-height: 1.2; }
+    h2 { margin: 0; font-size: 18px; line-height: 1.2; }
     p { margin: 0; color: #516158; line-height: 1.5; }
     button {
       width: 100%;
@@ -362,6 +697,13 @@ function approvalPage(
     button:disabled { opacity: 0.65; cursor: wait; }
     .status { min-height: 1.25rem; color: #9f2d2d; }
     #signin-area { min-width: 0; }
+    .device-state {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      border-top: 1px solid #ded7c9;
+      padding-top: 16px;
+    }
     @media (max-width: 760px) {
       main { grid-template-columns: 1fr; }
       .terminal { min-height: 360px; }
@@ -393,10 +735,10 @@ function approvalPage(
         <p>Authorize this terminal to connect to your Matrix OS cloud computer.</p>
       </div>
       <div id="signin-area" style="display:none"></div>
-      <form id="confirm-area" method="POST" action="/auth/device/approve" style="display:block">
+      <form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">
         <input type="hidden" name="userCode" value="${escapedCode}">
         <input type="hidden" name="csrf" value="${escapedCsrf}">
-        <button id="confirm-button" type="submit">approve login</button>
+        <button id="confirm-button" type="submit" disabled>approve login</button>
       </form>
       <p id="status" class="status" role="status" aria-live="polite">${publishableKey ? '' : 'Sign-in is unavailable. Refresh and try again.'}</p>
     </section>
@@ -461,6 +803,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
   const flow: DeviceFlow = createDeviceFlow({
     db: config.db,
     verificationBase: config.platformUrl,
+    expiresInSec: DEVICE_EXPIRES_IN_SEC,
     now: config.now,
     issueToken: async ({ clerkUserId }) => {
       const container = await getContainerByClerkId(config.db, clerkUserId);

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -247,6 +247,7 @@ function approvalPage(
       if (!signin) return;
       signin.style.display = 'block';
       signin.innerHTML = '';
+      delete signin.dataset.mounted;
       var state = document.createElement('div');
       state.className = 'device-state';
       var heading = document.createElement('h2');
@@ -430,7 +431,6 @@ function approvalPage(
     async function startProvisioningFromClerkSession() {
       if (provisioningStarted) return;
       provisioningStarted = true;
-      showLoadingState('Starting your Matrix computer...');
       try {
         var token = await clerkTokenOrNull();
         if (!token) {
@@ -438,6 +438,7 @@ function approvalPage(
           showAuth();
           return;
         }
+        showLoadingState('Starting your Matrix computer...');
         var res = await fetchWithTimeout('/api/auth/provision-runtime', {
           method: 'POST',
           headers: {
@@ -480,13 +481,13 @@ function approvalPage(
     }
 
     async function continueDeviceOnboarding() {
-      showLoadingState('Checking your Matrix computer...');
       try {
         var token = await clerkTokenOrNull();
         if (!token) {
           showAuth();
           return;
         }
+        showLoadingState('Checking your Matrix computer...');
         var res = await fetchWithTimeout('/api/auth/app-session', {
           method: 'POST',
           headers: {

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -219,7 +219,7 @@ function approvalPage(
     function setBusy(isBusy) {
       var button = document.getElementById('confirm-button');
       if (button) {
-        button.disabled = isBusy;
+        button.disabled = isBusy || !runtimeReady;
         button.textContent = isBusy ? 'authorizing...' : 'approve login';
       }
     }

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -245,8 +245,8 @@ function resolvePriceId(
 function isSafeBillingReturnPath(value: string): boolean {
   if (!value.startsWith('/') || value.startsWith('//')) return false;
   try {
-    const url = new URL(value, 'https://app.matrix-os.com');
-    return url.origin === 'https://app.matrix-os.com' && url.pathname.startsWith('/');
+    const url = new URL(value, 'https://matrix-os-return.invalid');
+    return url.pathname.startsWith('/');
   } catch (err: unknown) {
     if (err instanceof TypeError || err instanceof Error) return false;
     return false;

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -36,6 +36,10 @@ const CheckoutRequestSchema = z.object({
   planSlug: z.enum(['matrix_starter', 'matrix_builder', 'matrix_max']),
   interval: z.enum(['monthly', 'annual']).default('monthly'),
   regionSlug: z.enum(['region_fsn1', 'region_nbg1', 'region_ash', 'region_hil']).default('region_fsn1'),
+  returnPath: z.string().min(1).max(2048).optional().refine(
+    (value) => value === undefined || isSafeBillingReturnPath(value),
+    { message: 'Invalid return path' },
+  ),
 });
 
 export interface StripeCheckoutSessionInput {
@@ -121,8 +125,8 @@ export function createBillingRoutes(options: {
         automaticTax: true,
         allowPromotionCodes: true,
         regionSlug: parsed.data.regionSlug,
-        successUrl: resolveBillingReturnUrl(env, 'success'),
-        cancelUrl: resolveBillingReturnUrl(env, 'canceled'),
+        successUrl: resolveBillingReturnUrl(env, 'success', parsed.data.returnPath),
+        cancelUrl: resolveBillingReturnUrl(env, 'canceled', parsed.data.returnPath),
       });
       return c.json({ url: session.url }, 200);
     } catch (err: unknown) {
@@ -238,11 +242,33 @@ function resolvePriceId(
   return env[key];
 }
 
-function resolveBillingReturnUrl(env: NodeJS.ProcessEnv, state: 'success' | 'canceled' | 'portal'): string {
+function isSafeBillingReturnPath(value: string): boolean {
+  if (!value.startsWith('/') || value.startsWith('//')) return false;
+  try {
+    const url = new URL(value, 'https://app.matrix-os.com');
+    return url.origin === 'https://app.matrix-os.com' && url.pathname.startsWith('/');
+  } catch (err: unknown) {
+    if (err instanceof TypeError || err instanceof Error) return false;
+    return false;
+  }
+}
+
+function resolveBillingReturnUrl(
+  env: NodeJS.ProcessEnv,
+  state: 'success' | 'canceled' | 'portal',
+  returnPath?: string,
+): string {
+  const appUrl = env.NEXT_PUBLIC_MATRIX_APP_URL ?? env.PLATFORM_PUBLIC_URL ?? 'https://app.matrix-os.com';
+  if (returnPath && state !== 'portal') {
+    const appBase = new URL(appUrl);
+    const url = new URL(returnPath, appBase.origin);
+    url.searchParams.set('billing', state);
+    if (state === 'success') url.searchParams.set('checkout', 'success');
+    return url.toString();
+  }
   if (state === 'success' && env.STRIPE_CHECKOUT_SUCCESS_URL) return env.STRIPE_CHECKOUT_SUCCESS_URL;
   if (state === 'canceled' && env.STRIPE_CHECKOUT_CANCEL_URL) return env.STRIPE_CHECKOUT_CANCEL_URL;
   if (state === 'portal' && env.STRIPE_PORTAL_RETURN_URL) return env.STRIPE_PORTAL_RETURN_URL;
-  const appUrl = env.NEXT_PUBLIC_MATRIX_APP_URL ?? env.PLATFORM_PUBLIC_URL ?? 'https://app.matrix-os.com';
   const url = new URL(appUrl);
   url.searchParams.set('billing', state);
   if (state === 'success') url.searchParams.set('checkout', 'success');

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -105,6 +105,29 @@ describe('platform billing routes', () => {
     }));
   });
 
+  it('resolves a safe checkout returnPath against the configured app origin', async () => {
+    const app = createApp('user_123', {
+      ...env,
+      NEXT_PUBLIC_MATRIX_APP_URL: 'https://staging.matrix-os.com',
+    });
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        returnPath: '/auth/device?user_code=BCDF-GHJK',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
+      successUrl: 'https://staging.matrix-os.com/auth/device?user_code=BCDF-GHJK&billing=success&checkout=success',
+      cancelUrl: 'https://staging.matrix-os.com/auth/device?user_code=BCDF-GHJK&billing=canceled',
+    }));
+  });
+
   it('prefers a safe checkout returnPath over configured checkout return URLs', async () => {
     const app = createApp('user_123', {
       ...env,

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -46,12 +46,12 @@ describe('platform billing routes', () => {
     await destroyTestPlatformDb(db);
   });
 
-  function createApp(userId: string | null = 'user_123') {
+  function createApp(userId: string | null = 'user_123', routeEnv: NodeJS.ProcessEnv = env) {
     const app = new Hono();
     app.route('/billing', createBillingRoutes({
       db,
       stripe,
-      env,
+      env: routeEnv,
       resolveClerkUserId: () => Promise.resolve(userId),
       now: () => new Date('2026-05-30T00:00:00.000Z'),
     }));
@@ -83,6 +83,73 @@ describe('platform billing routes', () => {
     expect(stripe.createCheckoutSession).toHaveBeenCalledWith(
       expect.not.objectContaining({ payment_method_types: expect.anything() }),
     );
+  });
+
+  it('uses a validated same-origin returnPath for checkout return URLs', async () => {
+    const app = createApp();
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        returnPath: '/auth/device?user_code=BCDF-GHJK',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
+      successUrl: 'https://app.matrix-os.com/auth/device?user_code=BCDF-GHJK&billing=success&checkout=success',
+      cancelUrl: 'https://app.matrix-os.com/auth/device?user_code=BCDF-GHJK&billing=canceled',
+    }));
+  });
+
+  it('prefers a safe checkout returnPath over configured checkout return URLs', async () => {
+    const app = createApp('user_123', {
+      ...env,
+      STRIPE_CHECKOUT_SUCCESS_URL: 'https://app.matrix-os.com/after-success',
+      STRIPE_CHECKOUT_CANCEL_URL: 'https://app.matrix-os.com/after-cancel',
+    });
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        returnPath: '/auth/device?user_code=BCDF-GHJK',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
+      successUrl: 'https://app.matrix-os.com/auth/device?user_code=BCDF-GHJK&billing=success&checkout=success',
+      cancelUrl: 'https://app.matrix-os.com/auth/device?user_code=BCDF-GHJK&billing=canceled',
+    }));
+  });
+
+  it.each([
+    ['external URL', 'https://evil.example/auth/device?user_code=BCDF-GHJK'],
+    ['protocol-relative URL', '//evil.example/auth/device?user_code=BCDF-GHJK'],
+    ['missing leading slash', 'auth/device?user_code=BCDF-GHJK'],
+    ['oversized path', `/${'x'.repeat(2049)}`],
+  ])('rejects unsafe checkout returnPath values: %s', async (_label, returnPath) => {
+    const app = createApp();
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        planSlug: 'matrix_builder',
+        interval: 'monthly',
+        returnPath,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid request' });
+    expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
   });
 
   it('reuses an existing Stripe customer link when one is already known', async () => {

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -502,6 +502,15 @@ describe("device routes", () => {
       expect(html).toContain("showBillingRequiredState()");
       expect(html).toContain("confirm.disabled = true;");
       expect(html).toContain("button.disabled = isBusy || !runtimeReady;");
+      expect(html).toContain("delete signin.dataset.mounted;");
+      const provisioningStart = html.indexOf("async function startProvisioningFromClerkSession");
+      const continueStart = html.indexOf("async function continueDeviceOnboarding");
+      expect(html.indexOf("var token = await clerkTokenOrNull();", provisioningStart)).toBeLessThan(
+        html.indexOf("showLoadingState('Starting your Matrix computer...');", provisioningStart),
+      );
+      expect(html.indexOf("var token = await clerkTokenOrNull();", continueStart)).toBeLessThan(
+        html.indexOf("showLoadingState('Checking your Matrix computer...');", continueStart),
+      );
       expect(html).toContain(
         '<form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">',
       );

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -501,6 +501,7 @@ describe("device routes", () => {
       expect(html).toContain("showRuntimeRequiredState()");
       expect(html).toContain("showBillingRequiredState()");
       expect(html).toContain("confirm.disabled = true;");
+      expect(html).toContain("button.disabled = isBusy || !runtimeReady;");
       expect(html).toContain(
         '<form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">',
       );

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -82,7 +82,7 @@ describe("device routes", () => {
         deviceCode: expect.any(String),
         userCode: expect.stringMatching(/^[A-Z]{4}-[A-Z]{4}$/),
         verificationUri: expect.stringContaining("/auth/device?user_code="),
-        expiresIn: 900,
+        expiresIn: 2700,
         interval: 5,
       });
     });
@@ -485,6 +485,27 @@ describe("device routes", () => {
       expect(html).toContain('id="instance-line"');
     });
 
+    it("starts signed-out CLI approval on signup and defers approval until runtime readiness", async () => {
+      const res = await app.request("/auth/device?user_code=BCDF-GHJK");
+      const html = await res.text();
+
+      expect(html).toContain("window.Clerk.mountSignUp");
+      expect(html).toContain("signInUrl: deviceAuthUrl('sign-in')");
+      expect(html).toContain("window.Clerk.mountSignIn");
+      expect(html).toContain("signUpUrl: deviceAuthUrl('sign-up')");
+      expect(html).toContain("fallbackRedirectUrl: approvalUrl");
+      expect(html).toContain("fetchWithTimeout('/api/auth/app-session'");
+      expect(html).toContain("fetchWithTimeout('/api/auth/provision-runtime'");
+      expect(html).toContain("fetchWithTimeout('/billing/checkout'");
+      expect(html).toContain("returnPath: deviceReturnPath");
+      expect(html).toContain("showRuntimeRequiredState()");
+      expect(html).toContain("showBillingRequiredState()");
+      expect(html).toContain("confirm.disabled = true;");
+      expect(html).toContain(
+        '<form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">',
+      );
+    });
+
     it("submits approval with an explicit Clerk bearer token", async () => {
       const res = await app.request("/auth/device?user_code=BCDF-GHJK");
       const html = await res.text();
@@ -499,7 +520,7 @@ describe("device routes", () => {
         html.indexOf("event.preventDefault();"),
       );
       expect(html).toContain(
-        '<form id="confirm-area" method="POST" action="/auth/device/approve" style="display:block">',
+        '<form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">',
       );
       expect(html).toContain("var html = await res.text();");
       expect(html.indexOf("var html = await res.text();")).toBeLessThan(
@@ -510,7 +531,7 @@ describe("device routes", () => {
       expect(html).not.toContain('onload="initClerk()"');
       expect(html).toContain("forceRedirectUrl: approvalUrl");
       expect(html).toContain("fallbackRedirectUrl: approvalUrl");
-      expect(html).toContain("signUpForceRedirectUrl: approvalUrl");
+      expect(html).toContain("signInForceRedirectUrl: approvalUrl");
       expect(html).not.toContain("afterSignInUrl");
     });
 

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -40,6 +40,8 @@ matrix whoami                # confirms handle, gateway, token expiry
 matrix shell new main        # creates and attaches to your "main" session
 ```
 
+If you do not have a Matrix account yet, `matrix login` keeps waiting while the browser walks you through signup, hosted trial checkout, and provisioning your Matrix computer. When setup finishes, approve the CLI in that same browser tab and return to your terminal.
+
 `Ctrl-\ Ctrl-\` detaches from a session without killing it. Reattach any time with `matrix shell connect main`.
 
 ## Profiles


### PR DESCRIPTION
fix(onboarding): harden first-run CLI setup flow

Summary:
- Make CLI device approval start with signup for signed-out users and keep
  approval gated until a Matrix runtime is ready.
- Preserve device return paths through billing checkout and extend platform
  device-code expiry to 45 minutes.
- Cover the device flow, checkout return-path handling, and default device-flow
  expiry with focused tests, plus update the CLI guide.

Rationale:
- First-run users coming from `matrix login` need one continuous browser
  handoff through signup, billing, provisioning, and final CLI approval.
- Checkout returns must stay on the original device URL so the pending CLI
  command can complete without losing the user code.

Tests:
- flox activate -- bun run typecheck
- flox activate -- bun run check:patterns
- flox activate -- bun run test

Co-authored-by: Codex <codex@openai.com>

fix(onboarding): address device login review findings

Summary:
- Keep the hidden approval button disabled while runtime readiness is false.
- Make checkout returnPath validation rely on the relative-path guard instead
  of comparing against a production-origin parser base.
- Add regressions for staging app origins and the runtime-ready button guard.

Rationale:
- Greptile found two small consistency issues in the first-run CLI onboarding
  handoff. Both fixes keep the browser flow aligned with the existing
  server-side auth and billing invariants.

Tests:
- flox activate -- bun run test -- tests/platform/device-routes.test.ts tests/platform/billing-routes.test.ts tests/platform/device-flow.test.ts
- flox activate -- bun run typecheck
- flox activate -- bun run check:patterns
- flox activate -- bun run test

Co-authored-by: Codex <codex@openai.com>