### PR TITLE
fix(task-manager): satisfy strict bundle build

### DIFF
--- a/home/apps/task-manager/src/App.tsx
+++ b/home/apps/task-manager/src/App.tsx
@@ -281,25 +281,27 @@ function App() {
           resolveCreatedCardId(created.id);
           return;
         }
-        const liveColumnExists = boardRef.current?.columns.some((column) => column.id === liveCard.columnId) ?? false;
+        const liveColumnId = liveCard.columnId;
+        const liveColumnExists = boardRef.current?.columns.some((column) => column.id === liveColumnId) ?? false;
         if (!liveColumnExists) {
           resolveCreatedCardId(created.id);
           return;
         }
-        const pendingColumnId = liveCard.columnId;
+        const pendingColumnId = liveColumnId;
         let columnId = await (pendingColumnIdsRef.current[pendingColumnId] ?? Promise.resolve(pendingColumnId));
         liveCard = boardRef.current?.cards.find((card) => card.id === created.id);
         if (!liveCard) {
           resolveCreatedCardId(created.id);
           return;
         }
-        const latestColumnExists = boardRef.current?.columns.some((column) => column.id === liveCard.columnId) ?? false;
+        const latestColumnId = liveCard.columnId;
+        const latestColumnExists = boardRef.current?.columns.some((column) => column.id === latestColumnId) ?? false;
         if (!latestColumnExists) {
           resolveCreatedCardId(created.id);
           return;
         }
-        if (liveCard.columnId !== pendingColumnId) {
-          columnId = await (pendingColumnIdsRef.current[liveCard.columnId] ?? Promise.resolve(liveCard.columnId));
+        if (latestColumnId !== pendingColumnId) {
+          columnId = await (pendingColumnIdsRef.current[latestColumnId] ?? Promise.resolve(latestColumnId));
         }
         const result = await bridge.insert(CARDS_TABLE, cardToRow({ ...liveCard, columnId }, liveCard.order));
         resolveCreatedCardId(result.id);
@@ -1065,10 +1067,11 @@ function CardDetail({
   const [assignee, setAssignee] = useState(card.assignee);
   const [labelInput, setLabelInput] = useState("");
   const [checklistInput, setChecklistInput] = useState("");
-  const previousCardRef = useRef(card);
-  useEffect(() => {
-    const previous = previousCardRef.current;
+  const [previousCard, setPreviousCard] = useState(card);
+  if (previousCard !== card) {
+    const previous = previousCard;
     const sameCard = previous.id === card.id || pendingSwapFromId === previous.id;
+    setPreviousCard(card);
     if (!sameCard || title === previous.title) setTitle(card.title);
     if (!sameCard || description === previous.description) setDescription(card.description);
     if (!sameCard || assignee === previous.assignee) setAssignee(card.assignee);
@@ -1076,8 +1079,7 @@ function CardDetail({
       setLabelInput("");
       setChecklistInput("");
     }
-    previousCardRef.current = card;
-  }, [assignee, card, description, pendingSwapFromId, title]);
+  }
 
   const progress = checklistProgress(card.checklist);
 


### PR DESCRIPTION
## Summary
- Fix task-manager strict TypeScript narrowing that broke the host-bundle build.
- Move detail-card prop synchronization out of an effect to remove React Doctor errors in the touched file.

## Validation
- pnpm --dir home/apps/task-manager build
- bun run test tests/default-apps/task-manager-app.test.tsx tests/default-apps/task-board-model.test.ts
- npx react-doctor@latest home/apps/task-manager --diff origin/main --no-score
- bun run check:patterns
- git diff --check

## Invariants
- Source of truth: task-manager board data remains the existing MatrixOS bridge/Postgres tables; this PR changes only client-side render/build safety.
- Lock/transaction scope: no database writes, locks, or transactions are added or changed.
- Acceptable orphan states: unchanged from the existing optimistic persistence and reload-on-failure behavior.
- Auth source of truth: unchanged; app data access continues through the injected MatrixOS bridge.
- Deferred scope: optional React Doctor warnings in the task-manager app remain out of scope for this release unblock.