### PR TITLE
fix(onboarding): force cloud profile for first-run login

### DIFF
--- a/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
+++ b/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
@@ -14,6 +14,7 @@ Guide the human through a complete developer onboarding path without collecting 
 - Use Matrix shell sessions for interactive work. Do not invent SSH instructions.
 - Use Docker only when the target repo already needs containers or cannot run directly with its normal dev command. Production Matrix OS customer runtime is VPS-native, not Docker Compose.
 - If the current repo contains `www/public/skills.md`, read it first for the latest Matrix CLI commands. Otherwise use `https://matrix-os.com/skills.md` as the canonical command reference.
+- First-run hosted onboarding must use the cloud profile. Do not use `--dev`, `--profile local`, `matrix profile use local`, localhost URLs, `MATRIXOS_PLATFORM_URL`, or `MATRIXOS_GATEWAY_URL` unless the human explicitly asks for Matrix local-stack development.
 
 ## Workflow
 
@@ -25,12 +26,12 @@ Guide the human through a complete developer onboarding path without collecting 
 2. **Verify local prerequisites**
    - Check `git --version`, `gh --version`, and `matrix --version` when available.
    - If GitHub CLI is not authenticated, guide `gh auth login --hostname github.com --git-protocol ssh --web`, then verify with `gh auth status`.
-   - If Matrix CLI is missing, install using the latest `skills.md` instructions, then run `matrix login`.
+   - If Matrix CLI is missing, install using the latest `skills.md` instructions, then run `matrix login --profile cloud`.
 
 3. **Bring up Matrix**
    - Run `matrix status`, `matrix instance info`, and `matrix doctor`.
    - If `matrix doctor` reports a sync daemon issue, run `matrix sync` and then `matrix doctor` again.
-   - If no Matrix instance exists, send the human to `https://app.matrix-os.com`, wait for provisioning, then retry `matrix login`.
+   - If no Matrix instance exists, send the human to `https://app.matrix-os.com`, wait for provisioning, then retry `matrix login --profile cloud`.
 
 4. **Create or reuse the setup shell**
    - Prefer a named shell so the human, web terminal, and agent can reattach:

--- a/skills/matrix-os/SKILL.md
+++ b/skills/matrix-os/SKILL.md
@@ -25,7 +25,8 @@ Matrix OS gives each developer their own cloud computer: browser desktop, files,
 
 - Only send Matrix credentials to `https://app.matrix-os.com` or `https://matrix-os.com`.
 - Do not paste Matrix tokens, Clerk tokens, GitHub tokens, Claude keys, Codex keys, or OAuth codes into third-party websites.
-- Prefer `matrix login` and browser/device flows over copying secrets into chat.
+- Prefer hosted `matrix login --profile cloud` and browser/device flows over copying secrets into chat.
+- For first-run hosted onboarding, use the `cloud` profile explicitly. Do not use `--dev`, `--profile local`, `matrix profile use local`, localhost URLs, `MATRIXOS_PLATFORM_URL`, or `MATRIXOS_GATEWAY_URL` unless the human explicitly asks for Matrix local-stack development.
 - Treat the Matrix VPS as the user's computer. Ask before deleting files, resetting sessions, or installing global packages that may change their environment.
 - Use named shell sessions for setup so the human can reattach from the Matrix web terminal.
 
@@ -51,7 +52,7 @@ Tell the human:
 Read https://matrix-os.com/skills.md and follow the instructions to set up Matrix OS.
 
 1. Install the Matrix CLI.
-2. Run matrix login and send me the browser/device claim link if prompted.
+2. Run matrix login --profile cloud and send me the browser/device claim link if prompted.
 3. Once the Matrix VPS is ready, I can attach to the same shell session and finish setup.
 ```
 
@@ -68,12 +69,12 @@ curl -fsSL https://get.matrix-os.com | sh
 Authenticate:
 
 ```bash
-matrix login
+matrix login --profile cloud
 matrix status
 matrix instance info
 ```
 
-If `matrix login` says no Matrix instance exists yet, ask the human to sign up at `https://app.matrix-os.com`, wait for provisioning, then run `matrix login` again.
+If `matrix login --profile cloud` says no Matrix instance exists yet, ask the human to sign up at `https://app.matrix-os.com`, wait for provisioning, then run `matrix login --profile cloud` again.
 
 ## Interactive Setup
 

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -35,12 +35,12 @@ matrix doctor
 ## First run
 
 ```bash
-matrix login                 # opens a browser, completes the device flow
+matrix login --profile cloud # opens a browser, completes the hosted device flow
 matrix whoami                # confirms handle, gateway, token expiry
 matrix shell new main        # creates and attaches to your "main" session
 ```
 
-If you do not have a Matrix account yet, `matrix login` keeps waiting while the browser walks you through signup, hosted trial checkout, and provisioning your Matrix computer. When setup finishes, approve the CLI in that same browser tab and return to your terminal.
+If you do not have a Matrix account yet, `matrix login --profile cloud` keeps waiting while the browser walks you through signup, hosted trial checkout, and provisioning your Matrix computer. When setup finishes, approve the CLI in that same browser tab and return to your terminal.
 
 `Ctrl-\ Ctrl-\` detaches from a session without killing it. Reattach any time with `matrix shell connect main`.
 

--- a/www/content/docs/guide/developer-workflow.mdx
+++ b/www/content/docs/guide/developer-workflow.mdx
@@ -40,14 +40,14 @@ npx skills add HamedMP/matrix-os --skill matrix-os
 Then show me this checklist:
 
 1. Install or update the Matrix CLI
-2. Run `matrix login` and wait for my Matrix instance to be ready
+2. Run `matrix login --profile cloud` and wait for my Matrix instance to be ready
 3. Start my preferred coding agent on Matrix with `matrix run`
 4. Explain the reconnect and recovery commands only after the main path works
 
 Then proceed step by step. Keep the happy path to two Matrix commands:
 
 ```bash
-matrix login
+matrix login --profile cloud
 matrix run -it -- claude
 ```
 
@@ -75,7 +75,7 @@ install command from `skills.md`.
 Run:
 
 ```bash
-matrix login
+matrix login --profile cloud
 ```
 
 Pause while I complete the browser login flow. If Matrix says no instance
@@ -85,7 +85,7 @@ exists yet, send me to:
 https://app.matrix-os.com
 ```
 
-Wait for provisioning, then run `matrix login` again.
+Wait for provisioning, then run `matrix login --profile cloud` again.
 
 ## Step 3: Run agents inside Matrix
 
@@ -126,7 +126,7 @@ matrix shell attach setup
 
 Summarize:
 
-- whether `matrix login` succeeded;
+- whether `matrix login --profile cloud` succeeded;
 - whether the Matrix instance is ready;
 - the exact command to start Claude, Codex, or my preferred agent in Matrix.
 ````
@@ -170,7 +170,7 @@ Examples include Claude Code, Codex CLI, Gemini CLI, Cline CLI, and Devin for Te
 
 ```bash
 npm i -g @finnaai/matrix
-matrix login
+matrix login --profile cloud
 matrix run -it -- claude
 ```
 
@@ -219,7 +219,7 @@ This works especially well when Matrix keeps the terminal output, review notes, 
 
     ```bash
     npm i -g @finnaai/matrix
-    matrix login
+    matrix login --profile cloud
     matrix whoami
     ```
   </Step>

--- a/www/public/skills.md
+++ b/www/public/skills.md
@@ -39,7 +39,8 @@ Or just read this URL and follow the steps.
 
 - Only send Matrix credentials to `https://app.matrix-os.com` or `https://matrix-os.com`.
 - Do not paste Matrix tokens, Clerk tokens, GitHub tokens, Claude keys, Codex keys, or OAuth codes into third-party websites.
-- Prefer `matrix login` and browser/device flows over copying secrets into chat.
+- Prefer hosted `matrix login --profile cloud` and browser/device flows over copying secrets into chat.
+- For first-run hosted onboarding, use the `cloud` profile explicitly. Do not use `--dev`, `--profile local`, `matrix profile use local`, localhost URLs, `MATRIXOS_PLATFORM_URL`, or `MATRIXOS_GATEWAY_URL` unless the human explicitly asks for Matrix local-stack development.
 - Treat the Matrix VPS as the user's computer. Ask before deleting files, resetting sessions, or installing global packages that may change their environment.
 - Use named shell sessions for setup so the human can reattach from the Matrix web terminal.
 
@@ -51,7 +52,7 @@ Tell the human:
 Read https://matrix-os.com/skills.md and follow the instructions to set up Matrix OS.
 
 1. Install the Matrix CLI.
-2. Run matrix login and send me the browser/device claim link if prompted.
+2. Run matrix login --profile cloud and send me the browser/device claim link if prompted.
 3. Once the Matrix VPS is ready, I can attach to the same shell session and finish setup.
 ```
 
@@ -71,18 +72,18 @@ curl -fsSL https://get.matrix-os.com | sh
 Authenticate:
 
 ```bash
-matrix login
+matrix login --profile cloud
 matrix status
 matrix instance info
 ```
 
-If `matrix login` says no Matrix instance exists yet, ask the human to sign up at:
+If `matrix login --profile cloud` says no Matrix instance exists yet, ask the human to sign up at:
 
 ```text
 https://app.matrix-os.com
 ```
 
-After the VPS is provisioned, run `matrix login` again.
+After the VPS is provisioned, run `matrix login --profile cloud` again.
 
 ## Interactive Setup
 
@@ -158,7 +159,7 @@ matrix shell connect <existing-session>
 
 `connect` may succeed even when `attach` and `run -it` fail.
 
-After `matrix login`, run:
+After `matrix login --profile cloud`, run:
 
 ```bash
 matrix doctor
@@ -297,4 +298,4 @@ If the named session is missing and should be created, use:
 matrix shell connect -c setup
 ```
 
-If the VPS is not ready yet, wait for provisioning in `https://app.matrix-os.com`, then retry `matrix login`.
+If the VPS is not ready yet, wait for provisioning in `https://app.matrix-os.com`, then retry `matrix login --profile cloud`.

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -216,7 +216,7 @@ function HeroSection() {
             Your computer, in the cloud.
           </h1>
           <p className="text-[16px] leading-[1.8] mb-8" style={{ color: c.mutedFg }}>
-            A personal computer that lives in the cloud. Open any browser, sign in, and everything is ready — your apps, your files, your way.
+            A personal computer that lives in the cloud. Open any browser, sign in, and everything is ready: your apps, your files, your way.
           </p>
           <SignedOut>
             <a href="https://app.matrix-os.com" data-ph-event="marketing_cta_clicked" data-ph-location="hero" data-ph-target="get_started" className="inline-flex items-center gap-2 rounded-full px-8 py-3 text-[13px] tracking-[0.12em] uppercase font-medium transition-opacity duration-300 hover:opacity-80"
@@ -278,7 +278,7 @@ function PreviewSection() {
         <div className="mt-10 max-w-2xl mx-auto text-center">
           <h3 className="text-[1.1rem] font-semibold mb-3" style={{ color: c.forest }}>A real desktop, in your browser</h3>
           <p className="text-[15px] leading-[1.9]" style={{ color: c.mutedFg }}>
-            Your Matrix instance isn&apos;t just a dashboard — it&apos;s a full visual operating system. A desktop with windows, a dock, wallpapers, and all your apps arranged exactly how you like. It feels like sitting at your own computer, except it runs in the cloud and follows you everywhere.
+            Your Matrix instance isn&apos;t just a dashboard: it&apos;s a full visual operating system. A desktop with windows, a dock, wallpapers, and all your apps arranged exactly how you like. It feels like sitting at your own computer, except it runs in the cloud and follows you everywhere.
           </p>
         </div>
       </div>
@@ -299,7 +299,7 @@ function AboutSection() {
           </div>
           <div className="flex flex-col gap-6 md:pt-10">
             <p className="text-[15px] leading-[1.9]" style={{ color: c.mutedFg }}>
-              Matrix OS gives you a full personal computer that runs in the cloud. Open any browser, sign in, and you have your desktop — your apps, your files, your settings — ready to go. No installs, no setup, nothing to maintain.
+              Matrix OS gives you a full personal computer that runs in the cloud. Open any browser, sign in, and you have your desktop: your apps, your files, your settings, ready to go. No installs, no setup, nothing to maintain.
             </p>
             <p className="text-[15px] leading-[1.9]" style={{ color: c.mutedFg }}>
               Just tell it what you need. An AI assistant builds your apps, organizes your workspace, and keeps everything running. It works on any device, from anywhere, and picks up right where you left off.
@@ -374,10 +374,10 @@ function FeaturesSection() {
               Built around you.
             </h2>
             <p className="text-[15px] leading-[1.9] mb-5" style={{ color: c.mutedFg }}>
-              Your Matrix instance runs 24/7 in the cloud — always on, always yours. Connect from your phone on the train, your laptop at home, or a friend&apos;s computer at a cafe. Every device sees the same workspace, instantly.
+              Your Matrix instance runs 24/7 in the cloud: always on, always yours. Connect from your phone on the train, your laptop at home, or a friend&apos;s computer at a cafe. Every device sees the same workspace, instantly.
             </p>
             <p className="text-[15px] leading-[1.9]" style={{ color: c.subtle }}>
-              Devices come and go. Your instance never stops. Close your laptop and pick up on your phone — everything is exactly where you left it. No syncing, no waiting, no setup.
+              Devices come and go. Your instance never stops. Close your laptop and pick up on your phone; everything is exactly where you left it. No syncing, no waiting, no setup.
             </p>
           </div>
 
@@ -519,7 +519,7 @@ function DevelopersSection() {
               Give your agent the setup file.
             </h2>
             <p className="text-[15px] leading-[1.9]" style={{ color: c.mutedFg }}>
-              Matrix publishes an agent-readable skill at <code>matrix-os.com/skills.md</code>. Claude, Codex, Cursor, Cline, or another coding agent can read it, install the CLI, help you sign up with <code>matrix login</code>, and start working on your cloud computer with <code>matrix run</code>.
+              Matrix publishes an agent-readable skill at <code>matrix-os.com/skills.md</code>. Claude, Codex, Cursor, Cline, or another coding agent can read it, install the CLI, help you sign up with <code>matrix login --profile cloud</code>, and start working on your cloud computer with <code>matrix run</code>.
             </p>
           </div>
           <div className="rounded-[16px] p-6 md:p-8" style={{ backgroundColor: "rgba(67,78,63,0.06)", border: `1px solid ${c.border}` }}>
@@ -527,7 +527,7 @@ function DevelopersSection() {
               <code>{`Read https://matrix-os.com/skills.md
 
 npx skills add HamedMP/matrix-os --skill matrix-os
-matrix login
+matrix login --profile cloud
 matrix run -it -- claude`}</code>
             </pre>
             <div className="mt-6 flex flex-wrap gap-3">


### PR DESCRIPTION
Summary:
- Force first-run Matrix onboarding instructions to use `matrix login --profile cloud`.
- Add hosted-onboarding guardrails against local profiles, `--dev`, localhost URLs, and Matrix URL env overrides unless the user explicitly asks for local-stack development.
- Align the landing page prompt, public skills.md, installable Matrix skill, onboarding plugin skill, and hosted quick-start docs.

Stack:
- Child of PR #341 (`codex/fix-cli-device-onboarding`).
- This PR only changes onboarding guidance/profile selection.
- PR #341 remains responsible for device approval, signup, billing, and provisioning return paths.

Tests:
- `bun run check:patterns`
- `flox activate -- npx react-doctor@latest www --verbose --diff`
- `flox activate -- bun run typecheck`
- `flox activate -- bun run test`

Notes:
- The CLI `local` profile remains available for explicit local-stack development.
