### PR TITLE
fix(onboarding): force cloud profile for first-run login

### DIFF
--- a/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
+++ b/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
@@ -14,6 +14,7 @@ Guide the human through a complete developer onboarding path without collecting 
 - Use Matrix shell sessions for interactive work. Do not invent SSH instructions.
 - Use Docker only when the target repo already needs containers or cannot run directly with its normal dev command. Production Matrix OS customer runtime is VPS-native, not Docker Compose.
 - If the current repo contains `www/public/skills.md`, read it first for the latest Matrix CLI commands. Otherwise use `https://matrix-os.com/skills.md` as the canonical command reference.
+- First-run hosted onboarding must use the cloud profile. Do not use `--dev`, `--profile local`, `matrix profile use local`, localhost URLs, `MATRIXOS_PLATFORM_URL`, or `MATRIXOS_GATEWAY_URL` unless the human explicitly asks for Matrix local-stack development.
 
 ## Workflow
 
@@ -25,12 +26,12 @@ Guide the human through a complete developer onboarding path without collecting 
 2. **Verify local prerequisites**
    - Check `git --version`, `gh --version`, and `matrix --version` when available.
    - If GitHub CLI is not authenticated, guide `gh auth login --hostname github.com --git-protocol ssh --web`, then verify with `gh auth status`.
-   - If Matrix CLI is missing, install using the latest `skills.md` instructions, then run `matrix login`.
+   - If Matrix CLI is missing, install using the latest `skills.md` instructions, then run `matrix login --profile cloud`.
 
 3. **Bring up Matrix**
    - Run `matrix status`, `matrix instance info`, and `matrix doctor`.
    - If `matrix doctor` reports a sync daemon issue, run `matrix sync` and then `matrix doctor` again.
-   - If no Matrix instance exists, send the human to `https://app.matrix-os.com`, wait for provisioning, then retry `matrix login`.
+   - If no Matrix instance exists, send the human to `https://app.matrix-os.com`, wait for provisioning, then retry `matrix login --profile cloud`.
 
 4. **Create or reuse the setup shell**
    - Prefer a named shell so the human, web terminal, and agent can reattach:

--- a/skills/matrix-os/SKILL.md
+++ b/skills/matrix-os/SKILL.md
@@ -25,7 +25,8 @@ Matrix OS gives each developer their own cloud computer: browser desktop, files,
 
 - Only send Matrix credentials to `https://app.matrix-os.com` or `https://matrix-os.com`.
 - Do not paste Matrix tokens, Clerk tokens, GitHub tokens, Claude keys, Codex keys, or OAuth codes into third-party websites.
-- Prefer `matrix login` and browser/device flows over copying secrets into chat.
+- Prefer hosted `matrix login --profile cloud` and browser/device flows over copying secrets into chat.
+- For first-run hosted onboarding, use the `cloud` profile explicitly. Do not use `--dev`, `--profile local`, `matrix profile use local`, localhost URLs, `MATRIXOS_PLATFORM_URL`, or `MATRIXOS_GATEWAY_URL` unless the human explicitly asks for Matrix local-stack development.
 - Treat the Matrix VPS as the user's computer. Ask before deleting files, resetting sessions, or installing global packages that may change their environment.
 - Use named shell sessions for setup so the human can reattach from the Matrix web terminal.
 
@@ -51,7 +52,7 @@ Tell the human:
 Read https://matrix-os.com/skills.md and follow the instructions to set up Matrix OS.
 
 1. Install the Matrix CLI.
-2. Run matrix login and send me the browser/device claim link if prompted.
+2. Run matrix login --profile cloud and send me the browser/device claim link if prompted.
 3. Once the Matrix VPS is ready, I can attach to the same shell session and finish setup.
 ```
 
@@ -68,12 +69,12 @@ curl -fsSL https://get.matrix-os.com | sh
 Authenticate:
 
 ```bash
-matrix login
+matrix login --profile cloud
 matrix status
 matrix instance info
 ```
 
-If `matrix login` says no Matrix instance exists yet, ask the human to sign up at `https://app.matrix-os.com`, wait for provisioning, then run `matrix login` again.
+If `matrix login --profile cloud` says no Matrix instance exists yet, ask the human to sign up at `https://app.matrix-os.com`, wait for provisioning, then run `matrix login --profile cloud` again.
 
 ## Interactive Setup
 

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -35,12 +35,12 @@ matrix doctor
 ## First run
 
 ```bash
-matrix login                 # opens a browser, completes the device flow
+matrix login --profile cloud # opens a browser, completes the hosted device flow
 matrix whoami                # confirms handle, gateway, token expiry
 matrix shell new main        # creates and attaches to your "main" session
 ```
 
-If you do not have a Matrix account yet, `matrix login` keeps waiting while the browser walks you through signup, hosted trial checkout, and provisioning your Matrix computer. When setup finishes, approve the CLI in that same browser tab and return to your terminal.
+If you do not have a Matrix account yet, `matrix login --profile cloud` keeps waiting while the browser walks you through signup, hosted trial checkout, and provisioning your Matrix computer. When setup finishes, approve the CLI in that same browser tab and return to your terminal.
 
 `Ctrl-\ Ctrl-\` detaches from a session without killing it. Reattach any time with `matrix shell connect main`.
 

--- a/www/content/docs/guide/developer-workflow.mdx
+++ b/www/content/docs/guide/developer-workflow.mdx
@@ -40,14 +40,14 @@ npx skills add HamedMP/matrix-os --skill matrix-os
 Then show me this checklist:
 
 1. Install or update the Matrix CLI
-2. Run `matrix login` and wait for my Matrix instance to be ready
+2. Run `matrix login --profile cloud` and wait for my Matrix instance to be ready
 3. Start my preferred coding agent on Matrix with `matrix run`
 4. Explain the reconnect and recovery commands only after the main path works
 
 Then proceed step by step. Keep the happy path to two Matrix commands:
 
 ```bash
-matrix login
+matrix login --profile cloud
 matrix run -it -- claude
 ```
 
@@ -75,7 +75,7 @@ install command from `skills.md`.
 Run:
 
 ```bash
-matrix login
+matrix login --profile cloud
 ```
 
 Pause while I complete the browser login flow. If Matrix says no instance
@@ -85,7 +85,7 @@ exists yet, send me to:
 https://app.matrix-os.com
 ```
 
-Wait for provisioning, then run `matrix login` again.
+Wait for provisioning, then run `matrix login --profile cloud` again.
 
 ## Step 3: Run agents inside Matrix
 
@@ -126,7 +126,7 @@ matrix shell attach setup
 
 Summarize:
 
-- whether `matrix login` succeeded;
+- whether `matrix login --profile cloud` succeeded;
 - whether the Matrix instance is ready;
 - the exact command to start Claude, Codex, or my preferred agent in Matrix.
 ````
@@ -170,7 +170,7 @@ Examples include Claude Code, Codex CLI, Gemini CLI, Cline CLI, and Devin for Te
 
 ```bash
 npm i -g @finnaai/matrix
-matrix login
+matrix login --profile cloud
 matrix run -it -- claude
 ```
 
@@ -219,7 +219,7 @@ This works especially well when Matrix keeps the terminal output, review notes, 
 
     ```bash
     npm i -g @finnaai/matrix
-    matrix login
+    matrix login --profile cloud
     matrix whoami
     ```
   </Step>

--- a/www/public/skills.md
+++ b/www/public/skills.md
@@ -39,7 +39,8 @@ Or just read this URL and follow the steps.
 
 - Only send Matrix credentials to `https://app.matrix-os.com` or `https://matrix-os.com`.
 - Do not paste Matrix tokens, Clerk tokens, GitHub tokens, Claude keys, Codex keys, or OAuth codes into third-party websites.
-- Prefer `matrix login` and browser/device flows over copying secrets into chat.
+- Prefer hosted `matrix login --profile cloud` and browser/device flows over copying secrets into chat.
+- For first-run hosted onboarding, use the `cloud` profile explicitly. Do not use `--dev`, `--profile local`, `matrix profile use local`, localhost URLs, `MATRIXOS_PLATFORM_URL`, or `MATRIXOS_GATEWAY_URL` unless the human explicitly asks for Matrix local-stack development.
 - Treat the Matrix VPS as the user's computer. Ask before deleting files, resetting sessions, or installing global packages that may change their environment.
 - Use named shell sessions for setup so the human can reattach from the Matrix web terminal.
 
@@ -51,7 +52,7 @@ Tell the human:
 Read https://matrix-os.com/skills.md and follow the instructions to set up Matrix OS.
 
 1. Install the Matrix CLI.
-2. Run matrix login and send me the browser/device claim link if prompted.
+2. Run matrix login --profile cloud and send me the browser/device claim link if prompted.
 3. Once the Matrix VPS is ready, I can attach to the same shell session and finish setup.
 ```
 
@@ -71,18 +72,18 @@ curl -fsSL https://get.matrix-os.com | sh
 Authenticate:
 
 ```bash
-matrix login
+matrix login --profile cloud
 matrix status
 matrix instance info
 ```
 
-If `matrix login` says no Matrix instance exists yet, ask the human to sign up at:
+If `matrix login --profile cloud` says no Matrix instance exists yet, ask the human to sign up at:
 
 ```text
 https://app.matrix-os.com
 ```
 
-After the VPS is provisioned, run `matrix login` again.
+After the VPS is provisioned, run `matrix login --profile cloud` again.
 
 ## Interactive Setup
 
@@ -158,7 +159,7 @@ matrix shell connect <existing-session>
 
 `connect` may succeed even when `attach` and `run -it` fail.
 
-After `matrix login`, run:
+After `matrix login --profile cloud`, run:
 
 ```bash
 matrix doctor
@@ -297,4 +298,4 @@ If the named session is missing and should be created, use:
 matrix shell connect -c setup
 ```
 
-If the VPS is not ready yet, wait for provisioning in `https://app.matrix-os.com`, then retry `matrix login`.
+If the VPS is not ready yet, wait for provisioning in `https://app.matrix-os.com`, then retry `matrix login --profile cloud`.

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { SignedIn, SignedOut } from "@clerk/nextjs";
 import { ScrollScreenshot, BodyOverflow } from "@/components/landing/ScrollScreenshot";
@@ -85,7 +86,7 @@ const COPYABLE_AGENT_SETUP_PROMPT = `Set up Matrix OS so I can use my own cloud 
 First, read the official Matrix agent skill:
 https://matrix-os.com/skills.md
 
-Then install the Matrix CLI, help me sign in with matrix login, and start my preferred coding agent with matrix run.
+Then install the Matrix CLI, help me sign in with matrix login --profile cloud, and start my preferred coding agent with matrix run.
 
 Use Claude Code, Codex, OpenCode, Pi, Cursor, Gemini CLI, or another terminal agent if I ask for it.`;
 
@@ -314,7 +315,7 @@ function AgentSetupSection() {
               Paste one message. Let your agent install Matrix.
             </h2>
             <p className="max-w-xl text-[15px] leading-[1.9]" style={{ color: c.mutedFg }}>
-              Matrix publishes a setup skill at <code>matrix-os.com/skills.md</code>. Give it to Claude Code, Codex, Pi, OpenCode, Cursor, Gemini CLI, or another coding agent so it can install the CLI, guide <code>matrix login</code>, and start work on your cloud computer with <code>matrix run</code>.
+              Matrix publishes a setup skill at <code>matrix-os.com/skills.md</code>. Give it to Claude Code, Codex, Pi, OpenCode, Cursor, Gemini CLI, or another coding agent so it can install the CLI, guide <code>matrix login --profile cloud</code>, and start work on your cloud computer with <code>matrix run</code>.
             </p>
             <div className="mt-7 flex flex-wrap gap-3" aria-label="Supported coding agents">
               {agentBrands.map((brand) => (
@@ -323,13 +324,14 @@ function AgentSetupSection() {
                   className="inline-flex min-h-11 items-center gap-2.5 rounded-full px-3.5 text-[12px] font-medium"
                   style={{ border: `1px solid ${c.border}`, backgroundColor: "rgba(250,250,245,0.36)", color: c.forest }}
                 >
-                  <img
+                  <Image
                     src={brand.logo}
                     alt=""
                     aria-hidden="true"
                     width={24}
                     height={24}
                     className="size-6 shrink-0 rounded-md object-contain"
+                    unoptimized
                   />
                   {brand.name}
                 </div>
@@ -595,10 +597,10 @@ function FeaturesSection() {
               Built around you.
             </h2>
             <p className="text-[15px] leading-[1.9] mb-5" style={{ color: c.mutedFg }}>
-              Your Matrix instance runs 24/7 in the cloud, always on and always yours. Connect from your phone on the train, your laptop at home, or a friend&apos;s computer at a cafe. Every device sees the same workspace, instantly.
+              Your Matrix instance runs 24/7 in the cloud: always on, always yours. Connect from your phone on the train, your laptop at home, or a friend&apos;s computer at a cafe. Every device sees the same workspace, instantly.
             </p>
             <p className="text-[15px] leading-[1.9]" style={{ color: c.subtle }}>
-              Devices come and go. Your instance never stops. Close your laptop and pick up on your phone, with everything exactly where you left it. No syncing, no waiting, no setup.
+              Devices come and go. Your instance never stops. Close your laptop and pick up on your phone; everything is exactly where you left it. No syncing, no waiting, no setup.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Replaces the accidentally parent-branch-merged #343 with a clean PR targeting main.
- Forces first-run hosted onboarding guidance to use `matrix login --profile cloud`.
- Keeps local-profile guidance available only for explicit local-stack development.
- Cleans up the landing-page prompt wording and keeps the Agent Setup brand logos on Next Image.

## Parent Branch Cleanup
- #343 was merged into `codex/fix-cli-device-onboarding` instead of `main`.
- The parent branch was cleaned up with additive revert commit `ed4bb8a37` so no history rewrite was needed.
- This PR is the replacement intended for `main`.

## Tests
- `bun run check:patterns` (0 violations; existing warnings only)
- `flox activate -- bun run typecheck`
- `flox activate -- npx react-doctor@latest www --verbose --diff`
- `git diff --check`

## Review/Monitoring
- Please wait for CI and Greptile; Matrix OS merge policy requires Greptile 5/5 before merge.

## Invariants
- Source of truth: onboarding and public skill markdown for first-run agent guidance.
- Lock/transaction scope: not applicable; no backend persistence or runtime write path changed.
- Acceptable orphan states: not applicable; docs/skill and landing prompt copy only.
- Auth source of truth: unchanged; PR 341 remains responsible for hosted device approval, signup, billing, and provisioning return paths.
- Deferred scope: this PR does not remove the CLI local profile or change local-stack developer workflows.