### PR TITLE
feat(onboarding): ask users to choose coding agent

### DIFF
--- a/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
+++ b/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
@@ -20,7 +20,8 @@ Guide the human through a complete developer onboarding path without collecting 
 
 1. **Identify the path**
    - Determine whether you are running locally, inside Matrix, or inside another remote environment.
-   - Default the preferred coding agent to the one currently being used locally. If unknown, ask which one they want: Codex, Claude, another terminal agent, or Hermes.
+   - Detect the coding agent currently being used locally. If detected, suggest it, but always ask the human to confirm before launching or signing in.
+   - If unknown, ask which coding agent Matrix should set up: Claude Code, Codex, OpenCode, Gemini CLI, OpenClaw, Cursor/Cline, Shell only, or Custom. Hermes remains the Matrix system agent, not the coding-agent choice.
    - Identify the target repo URL and desired project name. If a repo is already open, use it as the starting point.
 
 2. **Verify local prerequisites**

--- a/shell/src/components/onboarding/ManualSetupStickers.tsx
+++ b/shell/src/components/onboarding/ManualSetupStickers.tsx
@@ -125,15 +125,19 @@ function parseSuggestedAgent(value: unknown): CodingAgentChoiceId | null {
     return null;
   }
   const agents = (value as { agents: unknown[] }).agents;
-  for (const candidate of ["claude", "codex", "opencode"] as const) {
+  const detectableCandidates = CODING_AGENT_CHOICES.filter(
+    (choice): choice is CodingAgentChoice & { launchAction: TerminalLaunchAction } =>
+      Boolean(choice.launchAction) && choice.id !== "shell",
+  );
+  for (const candidate of detectableCandidates) {
     const match = agents.find((agent) =>
       agent &&
       typeof agent === "object" &&
-      (agent as { id?: unknown }).id === candidate &&
+      (agent as { id?: unknown }).id === candidate.id &&
       (agent as { installed?: unknown }).installed === true &&
       ((agent as { authState?: unknown }).authState === "ok" || (agent as { authState?: unknown }).authState === "required")
     );
-    if (match) return candidate;
+    if (match) return candidate.id;
   }
   return null;
 }

--- a/shell/src/components/onboarding/ManualSetupStickers.tsx
+++ b/shell/src/components/onboarding/ManualSetupStickers.tsx
@@ -2,9 +2,9 @@
 
 import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
-import { CheckCircle2Icon, GithubIcon, MessageCircleIcon, SparklesIcon, TerminalIcon, XIcon } from "lucide-react";
+import { CheckCircle2Icon, GithubIcon, MessageCircleIcon, XIcon } from "lucide-react";
 import { useCanvasTransform } from "@/hooks/useCanvasTransform";
-import { createTerminalLaunchPath } from "@/lib/terminal-launch";
+import { createTerminalLaunchPath, type TerminalLaunchAction } from "@/lib/terminal-launch";
 
 interface ManualSetupStickersProps {
   onOpenTerminal: (path: string) => void;
@@ -29,6 +29,46 @@ interface StickerProps {
 }
 
 type StickerId = "agent" | "github" | "hermes" | "finish";
+
+type CodingAgentChoiceId =
+  | "claude"
+  | "codex"
+  | "opencode"
+  | "gemini"
+  | "openclaw"
+  | "cursor-cline"
+  | "shell"
+  | "custom";
+
+interface CodingAgentChoice {
+  id: CodingAgentChoiceId;
+  label: string;
+  launchAction?: TerminalLaunchAction;
+  manualCopy?: string;
+}
+
+const CODING_AGENT_CHOICES: CodingAgentChoice[] = [
+  { id: "claude", label: "Claude Code", launchAction: "agent-claude" },
+  { id: "codex", label: "Codex", launchAction: "agent-codex" },
+  { id: "opencode", label: "OpenCode", launchAction: "agent-opencode" },
+  { id: "gemini", label: "Gemini CLI", launchAction: "agent-gemini" },
+  {
+    id: "openclaw",
+    label: "OpenClaw",
+    manualCopy: "Use OpenClaw from its normal terminal or editor flow, then keep Matrix as the shared shell and project workspace.",
+  },
+  {
+    id: "cursor-cline",
+    label: "Cursor/Cline",
+    manualCopy: "Use Cursor or Cline from your editor, then connect Matrix for the remote shell, GitHub auth, and preview workflow.",
+  },
+  { id: "shell", label: "Shell only", launchAction: "agent-shell" },
+  {
+    id: "custom",
+    label: "Custom",
+    manualCopy: "Run your custom terminal agent with matrix run -it --session setup -- <your-command> after Matrix login finishes.",
+  },
+];
 
 const DEFAULT_POSITIONS: Record<StickerId, { x: number; y: number }> = {
   agent: { x: 34, y: 0 },
@@ -78,6 +118,24 @@ function writeStoredPositions(positions: Record<StickerId, { x: number; y: numbe
   } catch (error) {
     console.warn("Failed to save onboarding sticker positions", error);
   }
+}
+
+function parseSuggestedAgent(value: unknown): CodingAgentChoiceId | null {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { agents?: unknown }).agents)) {
+    return null;
+  }
+  const agents = (value as { agents: unknown[] }).agents;
+  for (const candidate of ["claude", "codex", "opencode"] as const) {
+    const match = agents.find((agent) =>
+      agent &&
+      typeof agent === "object" &&
+      (agent as { id?: unknown }).id === candidate &&
+      (agent as { installed?: unknown }).installed === true &&
+      ((agent as { authState?: unknown }).authState === "ok" || (agent as { authState?: unknown }).authState === "required")
+    );
+    if (match) return candidate;
+  }
+  return null;
 }
 
 function StickerButton({
@@ -153,6 +211,8 @@ function SetupSticker({
 export function ManualSetupStickers({ onOpenTerminal, onAskHermes, onClose }: ManualSetupStickersProps) {
   const [positions, setPositions] = useState(readStoredPositions);
   const [spatial, setSpatial] = useState(() => typeof window === "undefined" || window.innerWidth >= 1100);
+  const [suggestedAgent, setSuggestedAgent] = useState<CodingAgentChoiceId | null>(null);
+  const [selectedManualCopy, setSelectedManualCopy] = useState<string | null>(null);
   const positionsRef = useRef(positions);
   const dragRef = useRef<{
     id: StickerId;
@@ -170,6 +230,42 @@ export function ManualSetupStickers({ onOpenTerminal, onAskHermes, onClose }: Ma
     window.addEventListener("resize", updateSpatialLayout);
     return () => window.removeEventListener("resize", updateSpatialLayout);
   }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 10_000);
+    let mounted = true;
+    void fetch("/api/agents", {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return response.json() as Promise<unknown>;
+      })
+      .then((body) => {
+        if (mounted) setSuggestedAgent(parseSuggestedAgent(body));
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        console.warn("[onboarding] failed to detect coding agents:", error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => window.clearTimeout(timeout));
+    return () => {
+      mounted = false;
+      controller.abort();
+      window.clearTimeout(timeout);
+    };
+  }, []);
+
+  function chooseCodingAgent(choice: CodingAgentChoice) {
+    if (choice.launchAction) {
+      setSelectedManualCopy(null);
+      onOpenTerminal(createTerminalLaunchPath(choice.launchAction));
+      return;
+    }
+    setSelectedManualCopy(choice.manualCopy ?? "Use your agent's normal setup flow, then return to Matrix when it is ready.");
+  }
 
   const onDragStart = (id: StickerId, event: ReactPointerEvent<HTMLElement>) => {
     if (!spatial || event.button !== 0) return;
@@ -241,19 +337,35 @@ export function ManualSetupStickers({ onOpenTerminal, onAskHermes, onClose }: Ma
           {...dragProps}
         >
           <p>
-            Matrix is bring-your-own-agent. Sign in to Claude, Codex, or any agent you trust for specialist work.
-            Hermes keeps Matrix useful even when no external agent is connected.
+            Matrix is bring-your-own-agent. Pick one coding agent before opening a setup terminal. Hermes keeps Matrix
+            useful even when no external agent is connected.
           </p>
-          <div className="mt-5 flex flex-wrap gap-2">
-            <StickerButton onClick={() => onOpenTerminal(createTerminalLaunchPath("claude-login"))}>
-              <TerminalIcon className="size-4" aria-hidden="true" />
-              Open Claude login
-            </StickerButton>
-            <StickerButton variant="light" onClick={() => onOpenTerminal(createTerminalLaunchPath("codex-login"))}>
-              <SparklesIcon className="size-4" aria-hidden="true" />
-              Open Codex login
-            </StickerButton>
+          <p className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] opacity-65">Choose your coding agent</p>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            {CODING_AGENT_CHOICES.map((choice) => (
+              <button
+                key={choice.id}
+                type="button"
+                onClick={() => chooseCodingAgent(choice)}
+                onPointerDown={(event) => event.stopPropagation()}
+                className="min-h-10 rounded-md border border-current/15 bg-white/46 px-2.5 text-left text-sm font-semibold transition hover:-translate-y-0.5 hover:bg-white/70 active:translate-y-0"
+              >
+                <span className="flex items-center justify-between gap-2">
+                  <span>{choice.label}</span>
+                  {suggestedAgent === choice.id && (
+                    <span className="rounded-full bg-[#17281f]/10 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.12em]">
+                      Suggested
+                    </span>
+                  )}
+                </span>
+              </button>
+            ))}
           </div>
+          {selectedManualCopy && (
+            <p className="mt-3 rounded-md border border-current/12 bg-white/42 p-3 text-sm leading-5">
+              {selectedManualCopy}
+            </p>
+          )}
         </SetupSticker>
 
         <SetupSticker

--- a/shell/src/components/preview-window/MarkdownViewer.tsx
+++ b/shell/src/components/preview-window/MarkdownViewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ComponentPropsWithoutRef } from "react";
+import { useMemo, useState, type ComponentPropsWithoutRef } from "react";
 import ReactMarkdown, { defaultUrlTransform, type UrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -83,11 +83,12 @@ function MarkdownSvgPreview({
     () => resolveSvgPreviewSource(src, sourcePath),
     [src, sourcePath],
   );
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    setFailed(false);
-  }, [resolved.ok ? resolved.src : src]);
+  const resolvedKey = resolved.ok ? resolved.src : src ?? "";
+  const [failure, setFailure] = useState(() => ({ key: resolvedKey, failed: false }));
+  if (failure.key !== resolvedKey) {
+    setFailure({ key: resolvedKey, failed: false });
+  }
+  const failed = failure.key === resolvedKey ? failure.failed : false;
 
   if (!resolved.ok || failed) {
     return <SvgPreviewFallback alt={alt} />;
@@ -102,7 +103,7 @@ function MarkdownSvgPreview({
         decoding="async"
         draggable={false}
         loading="lazy"
-        onError={() => setFailed(true)}
+        onError={() => setFailure({ key: resolvedKey, failed: true })}
         referrerPolicy="no-referrer"
         src={resolved.src}
         title={title}

--- a/shell/src/lib/terminal-launch.ts
+++ b/shell/src/lib/terminal-launch.ts
@@ -1,4 +1,10 @@
-export type TerminalLaunchAction = "claude-login" | "codex-login" | "github-ssh-login";
+export type TerminalLaunchAction =
+  | "agent-claude"
+  | "agent-codex"
+  | "agent-opencode"
+  | "agent-gemini"
+  | "agent-shell"
+  | "github-ssh-login";
 
 export interface TerminalLaunchConfig {
   action: TerminalLaunchAction;
@@ -8,16 +14,31 @@ export interface TerminalLaunchConfig {
 }
 
 const TERMINAL_ACTIONS: Record<TerminalLaunchAction, TerminalLaunchConfig> = {
-  "claude-login": {
-    action: "claude-login",
-    label: "Claude login",
+  "agent-claude": {
+    action: "agent-claude",
+    label: "Claude Code setup",
     command: "claude",
     claudeMode: true,
   },
-  "codex-login": {
-    action: "codex-login",
-    label: "Codex login",
+  "agent-codex": {
+    action: "agent-codex",
+    label: "Codex setup",
     command: "codex",
+  },
+  "agent-opencode": {
+    action: "agent-opencode",
+    label: "OpenCode setup",
+    command: "opencode",
+  },
+  "agent-gemini": {
+    action: "agent-gemini",
+    label: "Gemini CLI setup",
+    command: "gemini",
+  },
+  "agent-shell": {
+    action: "agent-shell",
+    label: "Shell setup",
+    command: "bash",
   },
   "github-ssh-login": {
     action: "github-ssh-login",
@@ -41,7 +62,7 @@ export function createTerminalLaunchPath(action: TerminalLaunchAction): string {
 
 export function parseTerminalLaunchPath(path: string): TerminalLaunchConfig | null {
   if (!path.startsWith("__terminal__:setup-")) return null;
-  const match = path.match(/^__terminal__:setup-(claude-login|codex-login|github-ssh-login)(?:-[A-Za-z0-9]+)?$/);
+  const match = path.match(/^__terminal__:setup-(agent-claude|agent-codex|agent-opencode|agent-gemini|agent-shell|github-ssh-login)(?:-[A-Za-z0-9]+)?$/);
   if (!match) return null;
   return TERMINAL_ACTIONS[match[1] as TerminalLaunchAction];
 }

--- a/skills/matrix-os/SKILL.md
+++ b/skills/matrix-os/SKILL.md
@@ -53,7 +53,8 @@ Read https://matrix-os.com/skills.md and follow the instructions to set up Matri
 
 1. Install the Matrix CLI.
 2. Run matrix login --profile cloud and send me the browser/device claim link if prompted.
-3. Once the Matrix VPS is ready, I can attach to the same shell session and finish setup.
+3. Detect the coding agent I am using locally, then ask me to confirm which agent to set up on Matrix.
+4. Once the Matrix VPS is ready, I can attach to the same shell session and finish setup.
 ```
 
 Then run:
@@ -92,8 +93,7 @@ Use named sessions:
 
 ```bash
 matrix run -it --session setup -- gh auth login
-matrix run -it --session setup -- claude
-matrix run -it --session setup -- codex
+matrix run -it --session setup -- <chosen-agent-command>
 matrix shell attach setup
 ```
 
@@ -137,17 +137,38 @@ gh auth login --hostname github.com --git-protocol ssh --web
 
 Do not ask the human to paste GitHub tokens into chat. Use the browser flow.
 
-## Claude, Codex, And Hermes
+## Choose A Coding Agent
 
 Matrix is bring-your-own-agent.
 
-Preferred setup order:
+First detect the agent environment you are running in. If it is clear, suggest that agent, but always ask the human to confirm before launching or signing in:
 
-1. If the human uses Claude, run `matrix run -it --session setup -- claude` and complete Claude login in the remote terminal.
-2. If the human uses Codex, run `matrix run -it --session setup -- codex` and complete Codex login in the remote terminal.
-3. If neither Claude nor Codex is available, use Hermes inside Matrix as the system agent for building apps and completing tasks.
+```text
+Which coding agent should Matrix set up?
 
-Hermes must continue to work even when Claude or Codex are connected. Claude/Codex are developer tools; Hermes is the Matrix-native assistant for app building, email summaries, calendar tasks, integrations, and everyday actions.
+- Claude Code
+- Codex
+- OpenCode
+- Gemini CLI
+- OpenClaw
+- Cursor/Cline
+- Shell only
+- Custom
+```
+
+Use explicit Matrix commands for the confirmed choice:
+
+```bash
+matrix run -it --session setup -- claude
+matrix run -it --session setup -- codex
+matrix run -it --session setup -- opencode
+matrix run -it --session setup -- gemini
+matrix run -it --session setup -- bash
+```
+
+For OpenClaw, Cursor/Cline, or Custom, use the agent's normal terminal/editor setup flow and keep Matrix as the shared shell, GitHub auth, project workspace, and preview surface. Do not claim Matrix can verify an agent that has no supported CLI probe yet.
+
+Hermes must continue to work regardless of the coding-agent choice. Coding agents are developer tools; Hermes is the Matrix-native system assistant for app building, email summaries, calendar tasks, integrations, and everyday actions.
 
 ## Build A Matrix App
 

--- a/tests/gateway/onboarding-tool-packs.test.ts
+++ b/tests/gateway/onboarding-tool-packs.test.ts
@@ -279,7 +279,7 @@ describe("onboarding tool packs", () => {
       const installer = createHostToolPackInstaller({
         scriptPath,
         timeoutMs: 50,
-        linuxToolsTimeoutMs: 500,
+        linuxToolsTimeoutMs: 2_000,
       });
 
       await installer.install(testPrincipal.userId, "linux-tools");

--- a/tests/shell/manual-setup-stickers.test.tsx
+++ b/tests/shell/manual-setup-stickers.test.tsx
@@ -70,6 +70,27 @@ describe("ManualSetupStickers", () => {
     expect(onOpenTerminal).not.toHaveBeenCalled();
   });
 
+  it("marks Gemini CLI as suggested when detected", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      agents: [
+        { id: "gemini", installed: true, authState: "required" },
+      ],
+    }), {
+      headers: { "Content-Type": "application/json" },
+    })));
+    render(
+      <ManualSetupStickers
+        onOpenTerminal={vi.fn()}
+        onAskHermes={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const badge = await screen.findByText("Suggested");
+    const suggestedButton = badge.closest("button");
+    expect(suggestedButton?.textContent).toContain("Gemini CLI");
+  });
+
   it("shows manual setup guidance for unsupported agent choices", () => {
     const onOpenTerminal = vi.fn();
     render(

--- a/tests/shell/manual-setup-stickers.test.tsx
+++ b/tests/shell/manual-setup-stickers.test.tsx
@@ -2,18 +2,25 @@
 
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
 import { ManualSetupStickers } from "../../shell/src/components/onboarding/ManualSetupStickers.js";
 
 describe("ManualSetupStickers", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ agents: [] }), {
+      headers: { "Content-Type": "application/json" },
+    })));
+  });
+
   afterEach(() => {
+    vi.unstubAllGlobals();
     window.localStorage.clear();
     useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, isAnimating: false });
   });
 
-  it("opens only explicit terminal setup actions", () => {
+  it("asks the user to choose a coding agent before opening terminal setup", () => {
     const onOpenTerminal = vi.fn();
     render(
       <ManualSetupStickers
@@ -23,12 +30,60 @@ describe("ManualSetupStickers", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /open claude login/i }));
+    expect(screen.getByText("Choose your coding agent")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Claude Code/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Codex/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /OpenCode/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Gemini CLI/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /OpenClaw/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Cursor\/Cline/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Shell only/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Custom/i })).toBeTruthy();
+    expect(onOpenTerminal).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Claude Code/i }));
     fireEvent.click(screen.getByRole("button", { name: /run gh auth login/i }));
 
     expect(onOpenTerminal).toHaveBeenCalledTimes(2);
-    expect(onOpenTerminal.mock.calls[0]?.[0]).toMatch(/^__terminal__:setup-claude-login-/);
+    expect(onOpenTerminal.mock.calls[0]?.[0]).toMatch(/^__terminal__:setup-agent-claude-/);
     expect(onOpenTerminal.mock.calls[1]?.[0]).toMatch(/^__terminal__:setup-github-ssh-login-/);
+  });
+
+  it("marks a detected coding agent as suggested without selecting it", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      agents: [
+        { id: "codex", installed: true, authState: "ok" },
+      ],
+    }), {
+      headers: { "Content-Type": "application/json" },
+    })));
+    const onOpenTerminal = vi.fn();
+    render(
+      <ManualSetupStickers
+        onOpenTerminal={onOpenTerminal}
+        onAskHermes={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("Suggested")).toBeTruthy();
+    expect(onOpenTerminal).not.toHaveBeenCalled();
+  });
+
+  it("shows manual setup guidance for unsupported agent choices", () => {
+    const onOpenTerminal = vi.fn();
+    render(
+      <ManualSetupStickers
+        onOpenTerminal={onOpenTerminal}
+        onAskHermes={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Cursor\/Cline/i }));
+
+    expect(onOpenTerminal).not.toHaveBeenCalled();
+    expect(screen.getByText(/Use Cursor or Cline from your editor/i)).toBeTruthy();
   });
 
   it("opens Hermes instead of the old voice onboarding", () => {

--- a/tests/shell/terminal-launch.test.ts
+++ b/tests/shell/terminal-launch.test.ts
@@ -17,14 +17,22 @@ describe("terminal launch paths", () => {
   it("maps onboarding setup actions to startup commands", () => {
     vi.spyOn(Date, "now").mockReturnValue(1_779_788_800_000);
 
-    expect(parseTerminalLaunchPath(createTerminalLaunchPath("claude-login"))).toMatchObject({
-      label: "Claude login",
+    expect(parseTerminalLaunchPath(createTerminalLaunchPath("agent-claude"))).toMatchObject({
+      label: "Claude Code setup",
       command: "claude",
       claudeMode: true,
     });
-    expect(parseTerminalLaunchPath(createTerminalLaunchPath("codex-login"))).toMatchObject({
-      label: "Codex login",
+    expect(parseTerminalLaunchPath(createTerminalLaunchPath("agent-codex"))).toMatchObject({
+      label: "Codex setup",
       command: "codex",
+    });
+    expect(parseTerminalLaunchPath(createTerminalLaunchPath("agent-opencode"))).toMatchObject({
+      label: "OpenCode setup",
+      command: "opencode",
+    });
+    expect(parseTerminalLaunchPath(createTerminalLaunchPath("agent-gemini"))).toMatchObject({
+      label: "Gemini CLI setup",
+      command: "gemini",
     });
     expect(parseTerminalLaunchPath(createTerminalLaunchPath("github-ssh-login"))?.command).toContain("gh auth login --hostname github.com --git-protocol ssh --web");
   });
@@ -35,27 +43,27 @@ describe("terminal launch paths", () => {
   });
 
   it("queues setup actions so an existing terminal can open them as tabs", () => {
-    enqueueTerminalLaunch(createTerminalLaunchPath("claude-login"));
-    enqueueTerminalLaunch(createTerminalLaunchPath("codex-login"));
+    enqueueTerminalLaunch(createTerminalLaunchPath("agent-claude"));
+    enqueueTerminalLaunch(createTerminalLaunchPath("agent-codex"));
 
     expect(drainTerminalLaunchQueue().map((launch) => launch.action)).toEqual([
-      "claude-login",
-      "codex-login",
+      "agent-claude",
+      "agent-codex",
     ]);
     expect(drainTerminalLaunchQueue()).toEqual([]);
   });
 
   it("drains only launches targeted at the active terminal window", () => {
-    enqueueTerminalLaunch(createTerminalLaunchPath("claude-login"), "terminal-a");
-    enqueueTerminalLaunch(createTerminalLaunchPath("codex-login"), "terminal-b");
+    enqueueTerminalLaunch(createTerminalLaunchPath("agent-claude"), "terminal-a");
+    enqueueTerminalLaunch(createTerminalLaunchPath("agent-codex"), "terminal-b");
     enqueueTerminalLaunch(createTerminalLaunchPath("github-ssh-login"));
 
     expect(drainTerminalLaunchQueue("terminal-a").map((launch) => launch.action)).toEqual([
-      "claude-login",
+      "agent-claude",
       "github-ssh-login",
     ]);
     expect(drainTerminalLaunchQueue("terminal-b").map((launch) => launch.action)).toEqual([
-      "codex-login",
+      "agent-codex",
     ]);
     expect(drainTerminalLaunchQueue()).toEqual([]);
   });

--- a/tests/shell/terminal-launch.test.ts
+++ b/tests/shell/terminal-launch.test.ts
@@ -34,6 +34,10 @@ describe("terminal launch paths", () => {
       label: "Gemini CLI setup",
       command: "gemini",
     });
+    expect(parseTerminalLaunchPath(createTerminalLaunchPath("agent-shell"))).toMatchObject({
+      label: "Shell setup",
+      command: "bash",
+    });
     expect(parseTerminalLaunchPath(createTerminalLaunchPath("github-ssh-login"))?.command).toContain("gh auth login --hostname github.com --git-protocol ssh --web");
   });
 

--- a/www/content/docs/guide/developer-workflow.mdx
+++ b/www/content/docs/guide/developer-workflow.mdx
@@ -41,17 +41,17 @@ Then show me this checklist:
 
 1. Install or update the Matrix CLI
 2. Run `matrix login --profile cloud` and wait for my Matrix instance to be ready
-3. Start my preferred coding agent on Matrix with `matrix run`
+3. Detect which coding agent I am using locally, then ask me to confirm which one to set up on Matrix
 4. Explain the reconnect and recovery commands only after the main path works
 
 Then proceed step by step. Keep the happy path to two Matrix commands:
 
 ```bash
 matrix login --profile cloud
-matrix run -it -- claude
+matrix run -it --session setup -- <confirmed-agent-command>
 ```
 
-Use `codex`, `gemini`, or another terminal agent instead of `claude` if I ask for it.
+If you detect my current agent, suggest it, but always ask me to confirm in one click/message before launching it. If you cannot detect it confidently, ask me to choose: Claude Code, Codex, OpenCode, Gemini CLI, OpenClaw, Cursor/Cline, Shell only, or Custom.
 
 ## Step 1: Install or update the Matrix CLI
 

--- a/www/public/skills.md
+++ b/www/public/skills.md
@@ -53,7 +53,8 @@ Read https://matrix-os.com/skills.md and follow the instructions to set up Matri
 
 1. Install the Matrix CLI.
 2. Run matrix login --profile cloud and send me the browser/device claim link if prompted.
-3. Once the Matrix VPS is ready, I can attach to the same shell session and finish setup.
+3. Detect the coding agent I am using locally, then ask me to confirm which agent to set up on Matrix.
+4. Once the Matrix VPS is ready, I can attach to the same shell session and finish setup.
 ```
 
 Then run:
@@ -100,14 +101,10 @@ local terminal
 Use these commands:
 
 ```bash
-# Bring your own agent: Claude, Codex, or another terminal agent.
-matrix run -it -- claude
-matrix run -it -- codex
-
 # Use a named setup session so the human and web terminal can reattach.
 matrix shell connect -c setup
 matrix run -it --session setup -- gh auth login
-matrix run -it --session setup -- claude
+matrix run -it --session setup -- <chosen-agent-command>
 ```
 
 `matrix shell connect -c setup` creates the named session if it does not exist, then connects to it. If the human already has a working web terminal or CLI session, reuse that session instead of requiring a new one named `setup`.
@@ -210,17 +207,38 @@ gh auth login --hostname github.com --git-protocol ssh --web
 
 Do not ask the human to paste GitHub tokens into chat. Use the browser flow.
 
-## Claude, Codex, And Hermes
+## Choose A Coding Agent
 
 Matrix is bring-your-own-agent.
 
-Preferred setup order:
+First detect the agent environment you are running in. If it is clear, suggest that agent, but always ask the human to confirm before launching or signing in:
 
-1. If the human uses Claude, run `matrix run -it --session setup -- claude` and complete Claude login in the remote terminal.
-2. If the human uses Codex, run `matrix run -it --session setup -- codex` and complete Codex login in the remote terminal.
-3. If neither Claude nor Codex is available, use Hermes inside Matrix as the system agent for building apps and completing tasks.
+```text
+Which coding agent should Matrix set up?
 
-Hermes should continue to work even when Claude or Codex are connected. Claude/Codex are developer tools; Hermes is the Matrix-native assistant for app building, email summaries, calendar tasks, integrations, and everyday actions.
+- Claude Code
+- Codex
+- OpenCode
+- Gemini CLI
+- OpenClaw
+- Cursor/Cline
+- Shell only
+- Custom
+```
+
+Use explicit Matrix commands for the confirmed choice:
+
+```bash
+matrix run -it --session setup -- claude
+matrix run -it --session setup -- codex
+matrix run -it --session setup -- opencode
+matrix run -it --session setup -- gemini
+matrix run -it --session setup -- bash
+```
+
+For OpenClaw, Cursor/Cline, or Custom, use the agent's normal terminal/editor setup flow and keep Matrix as the shared shell, GitHub auth, project workspace, and preview surface. Do not claim Matrix can verify an agent that has no supported CLI probe yet.
+
+Hermes should continue to work regardless of the coding-agent choice. Coding agents are developer tools; Hermes is the Matrix-native system assistant for app building, email summaries, calendar tasks, integrations, and everyday actions.
 
 ## Build A Matrix App
 

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -88,7 +88,7 @@ https://matrix-os.com/skills.md
 
 Then install the Matrix CLI, help me sign in with matrix login --profile cloud, and start my preferred coding agent with matrix run.
 
-Use Claude Code, Codex, OpenCode, Pi, Cursor, Gemini CLI, or another terminal agent if I ask for it.`;
+Before starting an agent, detect which coding agent I am using locally. Always ask me to confirm the choice in one click/message. If you cannot detect it confidently, ask me to choose: Claude Code, Codex, OpenCode, Gemini CLI, OpenClaw, Cursor/Cline, Shell only, or Custom.`;
 
 const agentBrands = [
   { name: "Claude Code", logo: "/agents/claude-code.svg" },


### PR DESCRIPTION
Summary:
- replace fixed Claude/Codex setup shortcuts with an explicit coding-agent chooser in onboarding notes
- extend setup terminal actions for Claude, Codex, OpenCode, Gemini CLI, and shell-only setup while showing manual guidance for unsupported choices
- align the landing prompt, public skills.md, local Matrix skill, onboarding plugin skill, and developer workflow docs around detect + confirm behavior
- fix a React Doctor finding in MarkdownViewer and harden a flaky onboarding tool-pack timeout test

Tests:
- flox activate -- bun run typecheck
- flox activate -- bun run check:patterns
- flox activate -- npx react-doctor@latest shell
- flox activate -- bun run test tests/gateway/onboarding-tool-packs.test.ts
- flox activate -- bun run test tests/shell/manual-setup-stickers.test.tsx tests/shell/terminal-launch.test.ts tests/shell/markdown-viewer-svg.test.tsx
- flox activate -- bun run test

Invariants:
- Source of truth: matrix run remains command-explicit; the onboarding chooser only drives guided UI/copy, not a saved CLI default.
- Lock/transaction scope: no database writes or transactions are introduced by the onboarding agent-choice flow.
- Acceptable orphan states: unsupported agent choices show manual setup guidance and do not claim launch or verification support.
- Auth source of truth: installed/auth-needed suggestions still come from the existing /api/agents signal; no credentials or provider secrets are accepted in the UI.
- Deferred scope: full auth/probe integrations for OpenClaw, Cursor/Cline, Custom, and other non-terminal agents remain out of scope.