### PR TITLE
fix(platform): allow Clerk captcha on device auth page

### DIFF
--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -760,14 +760,21 @@ function approvalSuccessPage(): string {
 function applyNoFrameHeaders(
   c: import('hono').Context,
   scriptNonce?: string,
+  options: { allowClerkCaptcha?: boolean } = {},
 ): void {
   c.header('X-Frame-Options', 'DENY');
   const scriptSrc = scriptNonce
     ? `'self' 'nonce-${scriptNonce}' https://clerk.matrix-os.com`
     : `'self' https://clerk.matrix-os.com`;
+  const captchaSrc = options.allowClerkCaptcha
+    ? ' https://challenges.cloudflare.com'
+    : '';
+  const captchaDirectives = options.allowClerkCaptcha
+    ? " worker-src 'self' blob:; frame-src https://challenges.cloudflare.com;"
+    : '';
   c.header(
     'Content-Security-Policy',
-    `frame-ancestors 'none'; script-src ${scriptSrc}; object-src 'none'; base-uri 'none'`,
+    `frame-ancestors 'none'; script-src ${scriptSrc}${captchaSrc};${captchaDirectives} object-src 'none'; base-uri 'none'`,
   );
 }
 
@@ -937,7 +944,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       'Set-Cookie',
       `device_csrf=${csrf}; Path=/auth/device; Max-Age=900; HttpOnly; SameSite=Strict${secure}`,
     );
-    applyNoFrameHeaders(c, scriptNonce);
+    applyNoFrameHeaders(c, scriptNonce, { allowClerkCaptcha: true });
     return c.html(approvalPage(userCodeRaw, csrf, publishableKey, scriptNonce));
   });
 

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -247,6 +247,12 @@ describe("device routes", () => {
         }).toString(),
       });
       expect(approveRes.status).toBe(200);
+      const successCsp = approveRes.headers.get("content-security-policy") ?? "";
+      expect(successCsp).toContain("frame-ancestors 'none'");
+      expect(successCsp).toContain("script-src 'self' https://clerk.matrix-os.com");
+      expect(successCsp).not.toContain("https://challenges.cloudflare.com");
+      expect(successCsp).not.toContain("worker-src");
+      expect(successCsp).not.toContain("frame-src");
 
       const tokenRes = await app.request("/api/auth/device/token", {
         method: "POST",
@@ -475,6 +481,9 @@ describe("device routes", () => {
       expect(res.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
       expect(res.headers.get("content-security-policy")).toContain("script-src");
       expect(res.headers.get("content-security-policy")).toContain("'nonce-");
+      expect(res.headers.get("content-security-policy")).toContain("https://challenges.cloudflare.com");
+      expect(res.headers.get("content-security-policy")).toContain("worker-src 'self' blob:");
+      expect(res.headers.get("content-security-policy")).toContain("frame-src https://challenges.cloudflare.com");
       expect(res.headers.get("content-security-policy")).not.toContain("'unsafe-inline'");
       const cookie = res.headers.get("set-cookie") ?? "";
       expect(cookie).toMatch(/device_csrf=[A-Fa-f0-9]+/);

--- a/tests/platform/middleware-shortcircuit.test.ts
+++ b/tests/platform/middleware-shortcircuit.test.ts
@@ -66,6 +66,9 @@ describe("container-proxy middleware short-circuit for device-flow paths", () =>
     // route registered by createAuthRoutes.
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("content-security-policy")).toContain("https://challenges.cloudflare.com");
+    expect(res.headers.get("content-security-policy")).toContain("worker-src 'self' blob:");
+    expect(res.headers.get("content-security-policy")).toContain("frame-src https://challenges.cloudflare.com");
     // device-flow's GET handler sets a CSRF cookie.
     const cookie = res.headers.get("set-cookie") ?? "";
     expect(cookie).toMatch(/device_csrf=[A-Fa-f0-9]+/);


### PR DESCRIPTION
## Summary
- Allow Clerk CAPTCHA/Cloudflare Turnstile assets on the CLI device authorization page CSP.
- Keep the static device approval success page on the narrower non-CAPTCHA CSP.
- Cover both direct `/auth/device` rendering and the `app.matrix-os.com` middleware short-circuit path.

## Tests
- `flox activate -- bun run test tests/platform/device-routes.test.ts`
- `flox activate -- bun run test tests/platform/middleware-shortcircuit.test.ts`
- `flox activate -- bun run typecheck`
- `flox activate -- bun run check:patterns`
- `flox activate -- bun run test` (5990 passed, 1 unrelated timeout in `tests/gateway/app-runtime/install-flow.test.ts`; targeted rerun below passed)
- `flox activate -- bun run test tests/gateway/app-runtime/install-flow.test.ts -t "rejects on hash mismatch for community tier"`

## Review/Monitoring
- Greptile reviewed the first commit at 4/5 and noted the shared CSP helper broadened the static approval success page.
- This update narrows the success page CSP while preserving CAPTCHA allowances for pages that mount Clerk signup/sign-in.
- Awaiting latest CI and Greptile rereview for the updated commit.

## Invariants
- Source of truth: Clerk session remains the browser auth source; platform device-flow state remains the CLI authorization source.
- Lock/transaction scope: unchanged; this only adjusts response CSP headers and adds assertions.
- Acceptable orphan states: unchanged; failed runtime provisioning, billing, or device approval behavior is not modified.
- Auth source of truth: existing Clerk bearer/session token plus device CSRF approval flow.
- Deferred scope: no Clerk dashboard settings, billing/provisioning flow, or customer VPS host-bundle changes.
"")
