### PR TITLE
fix(apps): route sandboxed app assets with signed urls

### DIFF
--- a/packages/gateway/src/app-runtime/app-session-middleware.ts
+++ b/packages/gateway/src/app-runtime/app-session-middleware.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
-import { timingSafeEqual } from "node:crypto";
 import { join } from "node:path";
 import type { MiddlewareHandler } from "hono";
+import { timingSafeStringEquals } from "../security/timing-safe.js";
 import { verifyAppSession, type AppSessionPayloadType } from "./app-session.js";
 import { SAFE_SLUG } from "./manifest-schema.js";
 
@@ -23,17 +23,6 @@ function isReadOnlyViteAssetRequest(method: string, path: string, slug: string):
     (method === "GET" || method === "HEAD") &&
     path.startsWith(`/apps/${slug}/assets/`)
   );
-}
-
-function timingSafeStringEquals(actual: string, expected: string): boolean {
-  const actualBuffer = Buffer.from(actual);
-  const expectedBuffer = Buffer.from(expected);
-  const compareLength = Math.max(actualBuffer.length, expectedBuffer.length, 1);
-  const paddedActual = Buffer.alloc(compareLength);
-  const paddedExpected = Buffer.alloc(compareLength);
-  actualBuffer.copy(paddedActual);
-  expectedBuffer.copy(paddedExpected);
-  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(paddedActual, paddedExpected);
 }
 
 function hasPlatformAssetAuthorization(authHeader: string | undefined): boolean {

--- a/packages/gateway/src/app-runtime/app-session-middleware.ts
+++ b/packages/gateway/src/app-runtime/app-session-middleware.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { timingSafeEqual } from "node:crypto";
 import { join } from "node:path";
 import type { MiddlewareHandler } from "hono";
 import { verifyAppSession, type AppSessionPayloadType } from "./app-session.js";
@@ -16,6 +17,32 @@ const SECURITY_HEADERS = {
   "Content-Security-Policy":
     "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; frame-ancestors 'self'",
 };
+
+function isReadOnlyViteAssetRequest(method: string, path: string, slug: string): boolean {
+  return (
+    (method === "GET" || method === "HEAD") &&
+    path.startsWith(`/apps/${slug}/assets/`)
+  );
+}
+
+function timingSafeStringEquals(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  const compareLength = Math.max(actualBuffer.length, expectedBuffer.length, 1);
+  const paddedActual = Buffer.alloc(compareLength);
+  const paddedExpected = Buffer.alloc(compareLength);
+  actualBuffer.copy(paddedActual);
+  expectedBuffer.copy(paddedExpected);
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(paddedActual, paddedExpected);
+}
+
+function hasPlatformAssetAuthorization(authHeader: string | undefined): boolean {
+  const matrixAuthToken = process.env.MATRIX_AUTH_TOKEN;
+  if (!matrixAuthToken || !authHeader?.startsWith("Bearer ")) {
+    return false;
+  }
+  return timingSafeStringEquals(authHeader.slice("Bearer ".length), matrixAuthToken);
+}
 
 function sessionExpiredResponse(
   slug: string,
@@ -58,6 +85,14 @@ export function appSessionMiddleware(
     const slug = c.req.param("slug");
     if (!slug || !SAFE_SLUG.test(slug)) {
       return c.json({ error: "invalid slug" }, 400);
+    }
+
+    if (
+      isReadOnlyViteAssetRequest(c.req.method, c.req.path, slug) &&
+      hasPlatformAssetAuthorization(c.req.header("authorization"))
+    ) {
+      await next();
+      return;
     }
 
     const correlationId = crypto.randomUUID();

--- a/packages/gateway/src/security/timing-safe.ts
+++ b/packages/gateway/src/security/timing-safe.ts
@@ -1,0 +1,20 @@
+import { timingSafeEqual } from "node:crypto";
+
+export function timingSafeStringEquals(
+  actual: string | null | undefined,
+  expected: string,
+): boolean {
+  if (!actual) return false;
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  const compareLength = Math.max(actualBuffer.length, expectedBuffer.length);
+  if (compareLength === 0) return false;
+  const paddedActual = Buffer.alloc(compareLength);
+  const paddedExpected = Buffer.alloc(compareLength);
+  actualBuffer.copy(paddedActual);
+  expectedBuffer.copy(paddedExpected);
+  return (
+    actualBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(paddedActual, paddedExpected)
+  );
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -6,7 +6,7 @@ import {
   stat as statAsync,
   writeFile as writeFileAsync,
 } from "node:fs/promises";
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { dirname, extname, join, normalize, resolve, relative } from "node:path";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { cors } from "hono/cors";
@@ -45,6 +45,7 @@ import { createSessionRuntimeBridge } from "./session-runtime-bridge.js";
 import { createWorkspaceStartupRecovery } from "./workspace-startup-recovery.js";
 import { createChannelManager, type ChannelManager } from "./channels/manager.js";
 import { createOutboundQueue } from "./security/outbound-queue.js";
+import { timingSafeStringEquals } from "./security/timing-safe.js";
 import { createTelegramAdapter, type TelegramAdapter } from "./channels/telegram.js";
 import { createTelegramStream } from "./channels/telegram-stream.js";
 import { createPushAdapter } from "./channels/push.js";
@@ -295,18 +296,6 @@ export async function resetVolatilePtySessionList(persistPath: string): Promise<
 
 const INTEGRATION_PROXY_BODY_LIMIT = 64 * 1024;
 const HANDLE_PATTERN = /^[a-z][a-z0-9-]{2,30}$/;
-
-function timingSafeStringEquals(actual: string | null | undefined, expected: string): boolean {
-  if (!actual) return false;
-  const actualBuffer = Buffer.from(actual);
-  const expectedBuffer = Buffer.from(expected);
-  const maxLength = Math.max(actualBuffer.length, expectedBuffer.length);
-  const paddedActual = Buffer.alloc(maxLength);
-  const paddedExpected = Buffer.alloc(maxLength);
-  actualBuffer.copy(paddedActual);
-  expectedBuffer.copy(paddedExpected);
-  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(paddedActual, paddedExpected);
-}
 
 export interface GatewayConfig {
   homePath: string;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1062,7 +1062,7 @@ function rewriteSandboxedViteAppAssetUrls(
 function rewriteSandboxedViteJsAssetImports(js: string, assetToken: string | null): string {
   if (!assetToken) return js;
   return js.replace(
-    /(\b(?:from|import)\s*(?:\(\s*)?)(["'])(\.\/[^"']+\.(?:js|css)(?:\?[^"'#]*)?(?:#[^"']*)?)\2/g,
+    /((?:\bimport\s*\(\s*)|(?:\bimport\s*)|(?:\b(?:import|export)[^"']*?\bfrom\s*))(["'])(\.\/[^"']+\.(?:js|css)(?:\?[^"'#]*)?(?:#[^"']*)?)\2/g,
     (match: string, prefix: string, quote: string, value: string) => {
       if (value.includes(`${APP_ASSET_ROUTE_TOKEN_PARAM}=`)) return match;
       return `${prefix}${quote}${appendQueryParamToPath(value, APP_ASSET_ROUTE_TOKEN_PARAM, assetToken)}${quote}`;
@@ -3520,6 +3520,15 @@ export function createApp(deps: {
     const cookieHeader = c.req.header('cookie');
     const path = c.req.path;
     const explicitVmRoute = isAppDomain ? readExplicitVmRoute(path) : null;
+    const explicitVmRouteHasValidAppAssetToken = Boolean(
+      explicitVmRoute &&
+      hasValidExplicitVmAppAssetToken({
+        method: c.req.method,
+        rawUrl: c.req.url,
+        route: explicitVmRoute,
+        platformSecret,
+      }),
+    );
     const runtimeSelection = readRuntimeSlotSelection(c.req.url);
     const requestRuntimeSlot = runtimeSelection.slot;
     let singleMachineRuntimeSlot: string | null = null;
@@ -3556,12 +3565,7 @@ export function createApp(deps: {
     if (
       !identity &&
       explicitVmRoute &&
-      hasValidExplicitVmAppAssetToken({
-        method: c.req.method,
-        rawUrl: c.req.url,
-        route: explicitVmRoute,
-        platformSecret,
-      })
+      explicitVmRouteHasValidAppAssetToken
     ) {
       identity = {
         handle: explicitVmRoute.handle,
@@ -3625,13 +3629,7 @@ export function createApp(deps: {
       return c.text('Invalid Matrix OS computer', 400);
     }
     if (isAppDomain && explicitVmRoute) {
-      const isExplicitSignedAppAsset = hasValidExplicitVmAppAssetToken({
-        method: c.req.method,
-        rawUrl: c.req.url,
-        route: explicitVmRoute,
-        platformSecret,
-      });
-      if ((!identity.userId || identity.source === 'mobile-session' || identity.source === 'static-route') && !isExplicitSignedAppAsset) {
+      if ((!identity.userId || identity.source === 'mobile-session' || identity.source === 'static-route') && !explicitVmRouteHasValidAppAssetToken) {
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);
       }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -110,6 +110,8 @@ const APP_SESSION_COOKIE = 'matrix_app_session';
 const APP_ROUTE_COOKIE = 'matrix_app_route';
 const SHELL_ROUTE_COOKIE = 'matrix_shell_route';
 const CODE_SESSION_EXPIRES_IN_SEC = 12 * 60 * 60;
+const APP_ASSET_ROUTE_TOKEN_PARAM = 'matrix_asset_token';
+const APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS = [APP_ASSET_ROUTE_TOKEN_PARAM] as const;
 const HOST_BUNDLE_READ_TIMEOUT_MS = 30_000;
 const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const HOST_BUNDLE_FILES = new Set([
@@ -482,7 +484,7 @@ function readRuntimeSlot(rawUrl: string): string {
   return readRuntimeSlotSelection(rawUrl).slot;
 }
 
-function buildForwardedQueryString(rawUrl: string): string {
+function buildForwardedQueryString(rawUrl: string, omittedParams: readonly string[] = []): string {
   const queryStart = rawUrl.indexOf('?');
   if (queryStart === -1) return '';
   // Browser HTTP requests do not include fragments, but synthetic proxy tests
@@ -498,7 +500,7 @@ function buildForwardedQueryString(rawUrl: string): string {
       // `%72untime=staging` cannot leak the platform-only runtime selector to
       // a customer VPS.
       const parsedKey = new URLSearchParams(`${rawKey}=`).keys().next().value ?? rawKey;
-      return parsedKey !== 'runtime';
+      return parsedKey !== 'runtime' && !omittedParams.includes(parsedKey);
     })
     .join('&');
   return forwarded ? `?${forwarded}` : '';
@@ -575,6 +577,29 @@ function readExplicitVmRoute(path: string): ExplicitVmRoute | null {
     handle: match[1],
     upstreamPath: rest ? `/${rest}` : '/',
   };
+}
+
+function hasValidExplicitVmAppAssetToken(input: {
+  method: string;
+  rawUrl: string;
+  route: ExplicitVmRoute;
+  platformSecret: string;
+}): boolean {
+  if (input.method !== 'GET' && input.method !== 'HEAD') return false;
+  const slug = getViteAppAssetSlug(input.route.upstreamPath);
+  if (!slug) return false;
+  try {
+    const url = new URL(input.rawUrl, 'https://app.matrix-os.com');
+    return verifyAppAssetRouteToken({
+      token: url.searchParams.get(APP_ASSET_ROUTE_TOKEN_PARAM),
+      expectedHandle: input.route.handle,
+      expectedSlug: slug,
+      platformSecret: input.platformSecret,
+    });
+  } catch (err: unknown) {
+    console.warn('[platform] Failed to parse explicit VM asset URL:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
 }
 
 function readGatewayRouteCookie(path: string, cookieHeader: string | undefined): string | null {
@@ -855,8 +880,9 @@ function addVaryHeader(headers: Headers, values: string[]): void {
 
 function applySandboxedAppAssetCorsHeaders(headers: Headers, path: string, origin: string | undefined): void {
   if (!isViteAppAssetPath(path) || origin !== 'null') return;
-  // Credentialed null-origin asset CORS is intentionally limited to shell-route cookies,
-  // which must remain SameSite=Lax so arbitrary sandboxed iframes cannot send them.
+  // Runtime apps execute from a sandboxed srcdoc iframe with an opaque null
+  // origin. Asset requests use explicit /vm/{handle}/apps/... URLs so they do
+  // not need relaxed SameSite cookies to cross that sandbox boundary.
   headers.set('access-control-allow-origin', 'null');
   headers.set('access-control-allow-credentials', 'true');
   addVaryHeader(headers, ['Origin']);
@@ -884,6 +910,198 @@ function isAppDomainStaticAssetPath(path: string): boolean {
 
 function isViteAppAssetPath(path: string): boolean {
   return /^\/apps\/[a-z0-9][a-z0-9-]{0,63}\/assets\/.+/.test(path);
+}
+
+function getViteAppAssetSlug(path: string): string | null {
+  const match = path.match(/^\/apps\/([a-z0-9][a-z0-9-]{0,63})\/assets\/.+/);
+  return match?.[1] ?? null;
+}
+
+function getViteAppHtmlSlug(path: string): string | null {
+  const match = path.match(/^\/apps\/([a-z0-9][a-z0-9-]{0,63})(?:\/(?:index\.html)?)?$/);
+  return match?.[1] ?? null;
+}
+
+interface AppAssetRouteTokenPayload {
+  v: 1;
+  handle: string;
+  slug: string;
+}
+
+function signAppAssetRouteToken(
+  payload: AppAssetRouteTokenPayload,
+  platformSecret: string,
+): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = createHmac('sha256', platformSecret)
+    .update(encodedPayload)
+    .digest('base64url');
+  return `${encodedPayload}.${signature}`;
+}
+
+function buildAppAssetRouteToken(
+  handle: string,
+  slug: string,
+  platformSecret: string,
+): string {
+  // Vite can lazy-load chunks long after initial HTML render, and browser
+  // module imports cannot refresh query tokens without a full page reload. The
+  // token therefore gates static app bundle assets by handle+slug, not time.
+  return signAppAssetRouteToken({
+    v: 1,
+    handle,
+    slug,
+  }, platformSecret);
+}
+
+function verifyAppAssetRouteToken(input: {
+  token: string | null;
+  expectedHandle: string;
+  expectedSlug: string;
+  platformSecret: string;
+}): boolean {
+  if (!input.token || !input.platformSecret) return false;
+  const [encodedPayload, signature, extra] = input.token.split('.');
+  if (!encodedPayload || !signature || extra !== undefined) return false;
+  const expectedSignature = createHmac('sha256', input.platformSecret)
+    .update(encodedPayload)
+    .digest('base64url');
+  if (!timingSafeTokenEquals(signature, expectedSignature)) return false;
+
+  try {
+    const parsed = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as Partial<AppAssetRouteTokenPayload>;
+    return (
+      parsed.v === 1 &&
+      parsed.handle === input.expectedHandle &&
+      parsed.slug === input.expectedSlug
+    );
+  } catch (err: unknown) {
+    console.warn('[platform] Failed to parse app asset route token:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+function appendQueryParamToPath(path: string, key: string, value: string): string {
+  const hashStart = path.indexOf('#');
+  const pathAndQuery = hashStart === -1 ? path : path.slice(0, hashStart);
+  const hash = hashStart === -1 ? '' : path.slice(hashStart);
+  const separator = pathAndQuery.includes('?') ? '&' : '?';
+  return `${pathAndQuery}${separator}${encodeURIComponent(key)}=${encodeURIComponent(value)}${hash}`;
+}
+
+function readAppAssetRouteToken(rawUrl: string): string | null {
+  try {
+    const url = new URL(rawUrl, 'https://app.matrix-os.com');
+    return url.searchParams.get(APP_ASSET_ROUTE_TOKEN_PARAM);
+  } catch (err: unknown) {
+    console.warn('[platform] Failed to read app asset route token:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+function rewriteSandboxedViteAppAssetUrls(
+  html: string,
+  handle: string,
+  path: string,
+  platformSecret: string,
+): string {
+  const slug = getViteAppHtmlSlug(path);
+  if (!slug || !platformSecret) return html;
+  const assetToken = buildAppAssetRouteToken(handle, slug, platformSecret);
+  const appAssetPrefix = `/apps/${slug}/assets/`;
+  const rewriteTag = (tag: string): string => tag.replace(
+    /\b(src|href)=(["'])([^"']+)\2/g,
+    (match: string, attr: string, quote: string, value: string) => {
+      const assetRemainder = value.startsWith('./assets/')
+        ? value.slice('./assets/'.length)
+        : value.startsWith(appAssetPrefix)
+          ? value.slice(appAssetPrefix.length)
+          : null;
+      if (!assetRemainder) return match;
+      const explicitAssetPath = appendQueryParamToPath(
+        `/vm/${handle}/apps/${slug}/assets/${assetRemainder}`,
+        APP_ASSET_ROUTE_TOKEN_PARAM,
+        assetToken,
+      );
+      return `${attr}=${quote}${explicitAssetPath}${quote}`;
+    },
+  );
+
+  let rewritten = '';
+  let cursor = 0;
+  while (cursor < html.length) {
+    const tagStart = html.indexOf('<', cursor);
+    if (tagStart === -1) {
+      rewritten += html.slice(cursor);
+      break;
+    }
+    const tagEnd = html.indexOf('>', tagStart + 1);
+    if (tagEnd === -1) {
+      rewritten += html.slice(cursor);
+      break;
+    }
+    rewritten += html.slice(cursor, tagStart);
+    const tag = html.slice(tagStart, tagEnd + 1);
+    const tagName = tag.match(/^<\s*([a-zA-Z][a-zA-Z0-9-]*)\b/)?.[1]?.toLowerCase();
+    const shouldRewriteTag = tagName === 'script' || tagName === 'link';
+    rewritten += shouldRewriteTag ? rewriteTag(tag) : tag;
+    cursor = tagEnd + 1;
+
+    if (tagName === 'script' && !/\/\s*>$/.test(tag)) {
+      const scriptCloseStart = html.toLowerCase().indexOf('</script', cursor);
+      if (scriptCloseStart === -1) continue;
+      const scriptCloseEnd = html.indexOf('>', scriptCloseStart + '</script'.length);
+      if (scriptCloseEnd === -1) continue;
+      rewritten += html.slice(cursor, scriptCloseEnd + 1);
+      cursor = scriptCloseEnd + 1;
+    }
+  }
+  return rewritten;
+}
+
+function rewriteSandboxedViteJsAssetImports(js: string, assetToken: string | null): string {
+  if (!assetToken) return js;
+  return js.replace(
+    /(\b(?:from|import)\s*(?:\(\s*)?)(["'])(\.\/[^"']+\.(?:js|css)(?:\?[^"'#]*)?(?:#[^"']*)?)\2/g,
+    (match: string, prefix: string, quote: string, value: string) => {
+      if (value.includes(`${APP_ASSET_ROUTE_TOKEN_PARAM}=`)) return match;
+      return `${prefix}${quote}${appendQueryParamToPath(value, APP_ASSET_ROUTE_TOKEN_PARAM, assetToken)}${quote}`;
+    },
+  );
+}
+
+async function buildAppDomainProxyResponse(input: {
+  upstream: Response;
+  responseHeaders: Headers;
+  path: string;
+  handle: string;
+  platformSecret: string;
+  assetRouteToken?: string | null;
+}): Promise<Response> {
+  if (getViteAppHtmlSlug(input.path) && input.responseHeaders.get('content-type')?.includes('text/html')) {
+    const html = await input.upstream.text();
+    input.responseHeaders.delete('content-length');
+    return new Response(rewriteSandboxedViteAppAssetUrls(html, input.handle, input.path, input.platformSecret), {
+      status: input.upstream.status,
+      headers: input.responseHeaders,
+    });
+  }
+  if (
+    getViteAppAssetSlug(input.path) &&
+    input.assetRouteToken &&
+    input.responseHeaders.get('content-type')?.includes('javascript')
+  ) {
+    const js = await input.upstream.text();
+    input.responseHeaders.delete('content-length');
+    return new Response(rewriteSandboxedViteJsAssetImports(js, input.assetRouteToken), {
+      status: input.upstream.status,
+      headers: input.responseHeaders,
+    });
+  }
+  return new Response(input.upstream.body, {
+    status: input.upstream.status,
+    headers: input.responseHeaders,
+  });
 }
 
 function buildCodeDomainProxyHeaders(
@@ -3256,7 +3474,7 @@ export function createApp(deps: {
         return c.json({ error: 'VPS unavailable' }, 404);
       }
 
-      const qs = buildForwardedQueryString(c.req.url);
+      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
       const targetUrl = buildCustomerVpsProxyUrl(runningMachine, reqPath, qs);
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
@@ -3335,6 +3553,22 @@ export function createApp(deps: {
         };
       }
     }
+    if (
+      !identity &&
+      explicitVmRoute &&
+      hasValidExplicitVmAppAssetToken({
+        method: c.req.method,
+        rawUrl: c.req.url,
+        route: explicitVmRoute,
+        platformSecret,
+      })
+    ) {
+      identity = {
+        handle: explicitVmRoute.handle,
+        userId: '',
+        source: 'static-route',
+      };
+    }
     if (!identity && isAppDomain && isAppDomainStaticAssetPath(path)) {
       const shellRouteHandle = readShellRouteCookie(path, cookieHeader);
       if (shellRouteHandle) {
@@ -3357,6 +3591,10 @@ export function createApp(deps: {
     if (!identity) {
       console.log(`[${isCodeDomain ? 'code' : 'app'}] no token path=${path}`);
       if (isCodeDomain && isCodeDomainStaticAssetPath(path)) {
+        applyNoStoreHeaders(c);
+        return c.text('Unauthorized', 401);
+      }
+      if (isAppDomain && explicitVmRoute && isViteAppAssetPath(explicitVmRoute.upstreamPath)) {
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);
       }
@@ -3387,12 +3625,18 @@ export function createApp(deps: {
       return c.text('Invalid Matrix OS computer', 400);
     }
     if (isAppDomain && explicitVmRoute) {
-      if (!identity.userId || identity.source === 'mobile-session' || identity.source === 'static-route') {
+      const isExplicitSignedAppAsset = hasValidExplicitVmAppAssetToken({
+        method: c.req.method,
+        rawUrl: c.req.url,
+        route: explicitVmRoute,
+        platformSecret,
+      });
+      if ((!identity.userId || identity.source === 'mobile-session' || identity.source === 'static-route') && !isExplicitSignedAppAsset) {
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);
       }
       const machine = await getActiveUserMachineByHandle(db, explicitVmRoute.handle);
-      if (!machine || machine.clerkUserId !== identity.userId) {
+      if (!machine || (identity.userId && machine.clerkUserId !== identity.userId)) {
         applyNoStoreHeaders(c);
         return c.text('Matrix OS computer unavailable', 404);
       }
@@ -3419,7 +3663,7 @@ export function createApp(deps: {
         applyNoStoreHeaders(c);
         return c.html(getVpsBootPage({ status: machine.status }), 503);
       }
-      const qs = buildForwardedQueryString(c.req.url);
+      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
       const targetUrl = buildCustomerVpsProxyUrl(machine, explicitVmRoute.upstreamPath, qs);
       if (!targetUrl) {
         return c.json({ error: 'VPS unreachable' }, 502);
@@ -3446,8 +3690,10 @@ export function createApp(deps: {
       headers.set('connection', 'close');
       if (platformSecret) {
         headers.set('authorization', `Bearer ${buildPlatformVerificationToken(machine.handle, platformSecret)}`);
-        headers.set('x-platform-user-id', identity.userId);
-        headers.set('x-platform-verified', buildPlatformUserProof(machine.handle, identity.userId, platformSecret));
+        if (identity.userId) {
+          headers.set('x-platform-user-id', identity.userId);
+          headers.set('x-platform-verified', buildPlatformUserProof(machine.handle, identity.userId, platformSecret));
+        }
       }
 
       try {
@@ -3463,9 +3709,13 @@ export function createApp(deps: {
         const responseHeaders = sanitizeProxyResponseHeaders(upstream.headers);
         applySandboxedAppAssetCorsHeaders(responseHeaders, explicitVmRoute.upstreamPath, c.req.header('origin'));
         responseHeaders.append('set-cookie', buildShellRouteCookie(machine.handle));
-        return new Response(upstream.body, {
-          status: upstream.status,
-          headers: responseHeaders,
+        return await buildAppDomainProxyResponse({
+          upstream,
+          responseHeaders,
+          path: explicitVmRoute.upstreamPath,
+          handle: machine.handle,
+          platformSecret,
+          assetRouteToken: readAppAssetRouteToken(c.req.url),
         });
       } catch (err: unknown) {
         logPlatformRouteError('app-domain explicit vps proxy', err);
@@ -3543,7 +3793,7 @@ export function createApp(deps: {
         ? await getRuntimeEntitlementDecisionForUser(db, requestedActiveMachine.clerkUserId, appEnv)
       : getRuntimeEntitlementDecision(appEnv);
     if (runningMachine) {
-      const qs = buildForwardedQueryString(c.req.url);
+      const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
       if (
         !entitlement.runtimeProxyAllowed &&
         !shouldProxyShellForBillingGate({
@@ -3634,6 +3884,16 @@ export function createApp(deps: {
           responseHeaders.append('set-cookie', buildCodeSessionCookie(issued.token));
         }
 
+        if (isAppDomain) {
+          return await buildAppDomainProxyResponse({
+            upstream,
+            responseHeaders,
+            path,
+            handle: runningMachine.handle,
+            platformSecret,
+            assetRouteToken: readAppAssetRouteToken(c.req.url),
+          });
+        }
         return new Response(upstream.body, {
           status: upstream.status,
           headers: responseHeaders,
@@ -3704,7 +3964,7 @@ export function createApp(deps: {
 
     await updateLastActive(db, record.handle);
 
-    const qs = buildForwardedQueryString(c.req.url);
+    const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
     const targetPort = isCodeDomain ? CODE_SERVER_PORT : (isGatewayPath || path === '/apps' || path.startsWith('/apps/')) ? 4000 : 3000;
     const body = ['GET', 'HEAD'].includes(c.req.method) ? undefined : await c.req.blob();
     const headers = isCodeDomain
@@ -3796,6 +4056,16 @@ export function createApp(deps: {
           responseHeaders.append('set-cookie', buildCodeSessionCookie(issued.token));
         }
 
+        if (isAppDomain) {
+          return await buildAppDomainProxyResponse({
+            upstream,
+            responseHeaders,
+            path,
+            handle: record.handle,
+            platformSecret,
+            assetRouteToken: readAppAssetRouteToken(c.req.url),
+          });
+        }
         return new Response(upstream.body, {
           status: upstream.status,
           headers: responseHeaders,
@@ -4265,7 +4535,7 @@ export function createApp(deps: {
       return c.json({ error: 'Invalid handle' }, 400);
     }
     const path = c.req.path.replace(`/proxy/${handle}`, '') || '/';
-    const qs = buildForwardedQueryString(c.req.url);
+    const qs = buildForwardedQueryString(c.req.url, APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS);
     const runningMachine = await getRunningUserMachineByHandle(db, handle);
     if (runningMachine) {
       const targetUrl = buildCustomerVpsProxyUrl(runningMachine, path, qs);

--- a/tests/gateway/app-runtime/app-session-middleware.test.ts
+++ b/tests/gateway/app-runtime/app-session-middleware.test.ts
@@ -17,6 +17,10 @@ function createTestApp() {
     return c.json({ ok: true, slug: c.req.param("slug") });
   });
 
+  app.post("/apps/:slug/*", (c) => {
+    return c.json({ ok: true, slug: c.req.param("slug") });
+  });
+
   return app;
 }
 
@@ -36,6 +40,47 @@ function makeValidCookie(slug: string, overrides?: Partial<AppSessionPayloadType
 }
 
 describe("appSessionMiddleware", () => {
+  it("rejects read-only Vite asset requests without an app-session cookie or platform authorization", async () => {
+    const app = createTestApp();
+    const res = await app.request("/apps/notes/assets/index.js", {
+      headers: { Accept: "application/json" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("session_expired");
+  });
+
+  it("allows read-only Vite asset requests with platform authorization", async () => {
+    const previousMatrixAuthToken = process.env.MATRIX_AUTH_TOKEN;
+    try {
+      process.env.MATRIX_AUTH_TOKEN = MASTER_SECRET;
+      const app = createTestApp();
+      const res = await app.request("/apps/notes/assets/index.js", {
+        headers: { Authorization: `Bearer ${MASTER_SECRET}` },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.slug).toBe("notes");
+    } finally {
+      process.env.MATRIX_AUTH_TOKEN = previousMatrixAuthToken;
+    }
+  });
+
+  it("still requires an app-session cookie for mutating asset-path requests", async () => {
+    const app = createTestApp();
+    const res = await app.request("/apps/notes/assets/index.js", {
+      method: "POST",
+      headers: { Accept: "application/json" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("session_expired");
+  });
+
   it("401 without cookie + Accept: text/html returns HTML interstitial with postMessage script", async () => {
     const app = createTestApp();
     const res = await app.request("/apps/notes/index.html", {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -794,6 +794,54 @@ describe("platform proxy routing", () => {
     expect(res.headers.get("vary")).toContain("Accept-Encoding");
   });
 
+  it("rewrites proxied Vite app HTML to signed explicit VM asset URLs for srcdoc iframes", async () => {
+    await insertUserMachine(db, {
+      machineId: "machine-alice-vite-html",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      hetznerServerId: 128,
+      publicIPv4: "203.0.113.16",
+      status: "running",
+      imageVersion: "matrix-os-host-dev",
+      provisionedAt: "2026-05-06T00:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        '<!doctype html><script>const fixture = \'src="./assets/not-a-real-import.js"\';</script><script type="module" src="./assets/index.js"></script><link rel="stylesheet" href="./assets/index.css">',
+        {
+          status: 200,
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+          },
+        },
+      ),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/apps/chess/", {
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.16:443/apps/chess/");
+    const html = await res.text();
+    expect(html).toMatch(/src="\/vm\/alice\/apps\/chess\/assets\/index\.js\?matrix_asset_token=[^"]+"/);
+    expect(html).toMatch(/href="\/vm\/alice\/apps\/chess\/assets\/index\.css\?matrix_asset_token=[^"]+"/);
+    expect(html).toContain('src="./assets/not-a-real-import.js"');
+    expect(res.headers.get("set-cookie")).toContain("matrix_shell_route=alice");
+    expect(res.headers.get("set-cookie")).toContain("SameSite=Lax");
+  });
+
   it("routes code.matrix-os.com to the authenticated user's VPS gateway first", async () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     await insertUserMachine(db, {
@@ -1998,7 +2046,7 @@ describe("platform proxy routing", () => {
     expect(claims.runtime_slot).toBe("staging");
   });
 
-  it("routes explicit VM Vite app assets with null-origin CORS", async () => {
+  it("routes signed explicit VM Vite app assets with null-origin CORS without browser cookies", async () => {
     await deleteContainer(db, "alice");
     await insertUserMachine(db, {
       machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff140",
@@ -2011,15 +2059,27 @@ describe("platform proxy routing", () => {
       imageVersion: "matrix-os-host-2026.04.26-1",
       provisionedAt: "2026-04-26T12:00:00.000Z",
     });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("console.log('chess')", {
-        status: 200,
-        headers: {
-          "content-type": "application/javascript",
-          vary: "Accept-Encoding",
-        },
-      }),
-    );
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          '<!doctype html><script type="module" src="./assets/index.js"></script>',
+          {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response('import{a}from"./react.js";import("./editor.js");console.log("chess")', {
+          status: 200,
+          headers: {
+            "content-type": "application/javascript",
+            vary: "Accept-Encoding",
+          },
+        }),
+      );
     const app = createApp({
       db,
       orchestrator: stubOrchestrator(),
@@ -2029,24 +2089,72 @@ describe("platform proxy routing", () => {
       platformSecret: "platform-secret-123",
     });
 
-    const res = await app.request("/vm/alice/apps/chess/assets/index.js", {
+    const htmlRes = await app.request("/apps/chess/", {
       headers: {
         host: "app.matrix-os.com",
         authorization: "Bearer clerk-session",
+      },
+    });
+    expect(htmlRes.status).toBe(200);
+    const html = await htmlRes.text();
+    const assetPath = html.match(/src="([^"]+)"/)?.[1];
+    expect(assetPath).toMatch(/^\/vm\/alice\/apps\/chess\/assets\/index\.js\?matrix_asset_token=/);
+
+    const res = await app.request(assetPath ?? "/invalid", {
+      headers: {
+        host: "app.matrix-os.com",
         origin: "null",
       },
     });
 
     expect(res.status).toBe(200);
-    const [assetUrl, assetInit] = fetchMock.mock.calls[0]!;
+    const [assetUrl, assetInit] = fetchMock.mock.calls[1]!;
     expect(assetUrl).toBe("https://203.0.113.34:443/apps/chess/assets/index.js");
     const assetHeaders = assetInit?.headers as Headers;
     expect(assetHeaders.get("origin")).toBe("null");
     expect(assetHeaders.get("accept-encoding")).toBe("identity");
+    expect(assetHeaders.get("cookie")).toBeNull();
+    expect(assetHeaders.get("x-platform-user-id")).toBeNull();
     expect(res.headers.get("access-control-allow-origin")).toBe("null");
     expect(res.headers.get("access-control-allow-credentials")).toBe("true");
     expect(res.headers.get("vary")).toContain("Origin");
     expect(res.headers.get("set-cookie")).toContain("matrix_shell_route=alice");
+    const js = await res.text();
+    expect(js).toMatch(/from"\.\/react\.js\?matrix_asset_token=[^"]+"/);
+    expect(js).toMatch(/import\("\.\/editor\.js\?matrix_asset_token=[^"]+"\)/);
+  });
+
+  it("rejects unsigned explicit VM Vite app assets before probing a handle", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff14a",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      runtimeSlot: "primary",
+      status: "running",
+      hetznerServerId: 123494,
+      publicIPv4: "203.0.113.44",
+      imageVersion: "matrix-os-host-2026.04.26-1",
+      provisionedAt: "2026-04-26T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("console.log('chess')", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/vm/alice/apps/chess/assets/index.js", {
+      headers: {
+        host: "app.matrix-os.com",
+        origin: "null",
+      },
+    });
+
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("routes authenticated shell static assets through the selected VM handle cookie", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2072,7 +2072,7 @@ describe("platform proxy routing", () => {
         ),
       )
       .mockResolvedValueOnce(
-        new Response('import{a}from"./react.js";import("./editor.js");console.log("chess")', {
+        new Response('import{a}from"./react.js";import("./editor.js");const untouched=Array.from("./plain.js");console.log("chess")', {
           status: 200,
           headers: {
             "content-type": "application/javascript",
@@ -2122,6 +2122,7 @@ describe("platform proxy routing", () => {
     const js = await res.text();
     expect(js).toMatch(/from"\.\/react\.js\?matrix_asset_token=[^"]+"/);
     expect(js).toMatch(/import\("\.\/editor\.js\?matrix_asset_token=[^"]+"\)/);
+    expect(js).toContain('Array.from("./plain.js")');
   });
 
   it("rejects unsigned explicit VM Vite app assets before probing a handle", async () => {


### PR DESCRIPTION
## Summary
- keep app-session cookies `SameSite=Strict` and platform route cookies `SameSite=Lax`
- let the gateway serve read-only Vite asset files (`GET`/`HEAD /apps/{slug}/assets/*`) without an app-session cookie while keeping app HTML and mutating requests session-gated
- rewrite proxied Vite app HTML so `srcdoc` iframes load assets from explicit `/vm/{handle}/apps/{slug}/assets/*` URLs that do not depend on null-origin cookies
- allow explicit VM Vite asset routes to proxy with null-origin CORS without browser cookies

## Why
Default Vite apps render from a sandboxed `srcdoc` iframe with origin `null`. Browser cookie SameSite rules prevent the iframe from sending the route/session cookies on module script and stylesheet loads, so assets return 401 and the app opens white. Relaxing auth cookies to `SameSite=None` would fix the symptom but broaden CSRF/null-origin exposure. This keeps cookies protected and removes the cookie dependency only for static built asset files.

## Invariants
- Source of truth: app access remains the gateway-signed `matrix_app_session__{slug}` cookie for app HTML, APIs, and mutating app paths; runtime selection remains platform machine records plus explicit `/vm/{handle}` routing.
- Lock/transaction scope: no database writes or transactions changed.
- Acceptable orphan states: already-rendered old srcdoc HTML may still reference `/apps/{slug}/assets/*`; re-opening or refreshing the app fetches rewritten HTML. Static built assets contain app code, not owner app data.
- Auth source of truth: app data/API/mutation access remains app-session protected; only read-only built Vite assets bypass the app-session middleware. Explicit VM asset routing does not attach a platform user identity when no user is authenticated.
- Deferred scope: this does not change app sandbox CSP, MatrixOS bridge permissions, app data APIs, or release-channel UI.

## Validation
- bun run test tests/gateway/app-runtime/app-session.test.ts tests/gateway/app-runtime/app-session-middleware.test.ts tests/platform/proxy-routing.test.ts
- bun run typecheck
- bun run check:patterns
- git diff --check