### PR TITLE
fix(onboarding): route CLI signup through billing gate

### DIFF
--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -144,13 +144,6 @@ function approvalPage(
     var csrf = "${escapedCsrf}";
     var approvalUrl = window.location.href;
     var authMode = new URL(window.location.href).searchParams.get('mode') === 'sign-in' ? 'sign-in' : 'sign-up';
-    var checkoutAttemptStorageKey = 'matrix.device.billing.checkoutAttemptAt.' + userCode;
-    var checkoutAttemptMaxAgeMs = 30 * 60 * 1000;
-    var provisioningStarted = false;
-    var provisioningPolls = 0;
-    var maxProvisioningPolls = 60;
-    var billingConfirmationPolls = 0;
-    var maxBillingConfirmationPolls = 60;
     var runtimeReady = false;
 
     function deviceReturnPath() {
@@ -160,6 +153,16 @@ function approvalPage(
       return url.pathname + url.search;
     }
 
+    function billingSetupPath() {
+      var url = new URL('/', window.location.origin);
+      url.searchParams.set('device_return', deviceReturnPath());
+      return url.pathname + url.search;
+    }
+
+    function redirectToBillingSetup() {
+      window.location.assign(billingSetupPath());
+    }
+
     function deviceAuthUrl(mode) {
       var url = new URL(approvalUrl);
       url.searchParams.delete('billing');
@@ -167,41 +170,6 @@ function approvalPage(
       url.searchParams.set('mode', mode);
       return url.toString();
     }
-
-    function hasTrustedCheckoutReturn() {
-      try {
-        var rawAttemptAt = window.sessionStorage.getItem(checkoutAttemptStorageKey);
-        if (!rawAttemptAt) return false;
-        var attemptAt = Number(rawAttemptAt);
-        return Number.isFinite(attemptAt) && Date.now() - attemptAt <= checkoutAttemptMaxAgeMs;
-      } catch (err) {
-        console.warn('[matrix] Unable to read device checkout attempt state', err instanceof Error ? err.message : String(err));
-        return false;
-      }
-    }
-
-    function rememberBillingCheckoutAttempt() {
-      try {
-        window.sessionStorage.setItem(checkoutAttemptStorageKey, String(Date.now()));
-      } catch (err) {
-        console.warn('[matrix] Unable to write device checkout attempt state', err instanceof Error ? err.message : String(err));
-      }
-    }
-
-    function stripCheckoutReturnParams() {
-      try {
-        var currentUrl = new URL(window.location.href);
-        currentUrl.searchParams.delete('checkout');
-        currentUrl.searchParams.delete('billing');
-        window.history.replaceState(null, '', currentUrl.pathname + currentUrl.search + currentUrl.hash);
-      } catch (err) {
-        console.warn('[matrix] Unable to clear device checkout return state', err instanceof Error ? err.message : String(err));
-      }
-    }
-
-    var checkoutReturnRequested = new URLSearchParams(window.location.search || '').get('checkout') === 'success';
-    var checkoutJustCompleted = checkoutReturnRequested && hasTrustedCheckoutReturn();
-    if (checkoutReturnRequested) stripCheckoutReturnParams();
 
     function fetchWithTimeout(url, options) {
       var controller = new AbortController();
@@ -269,28 +237,6 @@ function approvalPage(
       renderActionState('Setting up Matrix CLI', message, 'Working...', function() {});
       var button = document.querySelector('#signin-area button');
       if (button) button.disabled = true;
-    }
-
-    function showRuntimeRequiredState() {
-      runtimeReady = false;
-      setConfirmReady(false);
-      renderActionState(
-        'Finish Matrix setup',
-        'Create your Matrix computer before connecting this terminal.',
-        'Provision Matrix computer',
-        startProvisioningFromClerkSession
-      );
-    }
-
-    function showBillingRequiredState() {
-      runtimeReady = false;
-      setConfirmReady(false);
-      renderActionState(
-        'Start hosted trial',
-        'Billing starts the hosted Matrix computer trial, then this CLI login can continue.',
-        'Start checkout',
-        startBillingCheckoutFromClerkSession
-      );
     }
 
     function showSignedInRecoveryState() {
@@ -364,122 +310,6 @@ function approvalPage(
       return await window.Clerk.session.getToken();
     }
 
-    function pollProvisioningSession() {
-      provisioningPolls += 1;
-      if (provisioningPolls > maxProvisioningPolls) {
-        provisioningStarted = false;
-        checkoutJustCompleted = false;
-        billingConfirmationPolls = 0;
-        showSignedInRecoveryState();
-        return;
-      }
-      window.setTimeout(continueDeviceOnboarding, 8000);
-    }
-
-    function retryProvisioningAfterBillingDelay() {
-      billingConfirmationPolls += 1;
-      if (billingConfirmationPolls > maxBillingConfirmationPolls) {
-        provisioningStarted = false;
-        checkoutJustCompleted = false;
-        showBillingRequiredState();
-        return;
-      }
-      provisioningStarted = false;
-      showLoadingState('Confirming billing...');
-      window.setTimeout(startProvisioningFromClerkSession, 8000);
-    }
-
-    async function startBillingCheckoutFromClerkSession() {
-      showLoadingState('Opening secure checkout...');
-      try {
-        var token = await clerkTokenOrNull();
-        if (!token) {
-          showAuth();
-          return;
-        }
-        var res = await fetchWithTimeout('/billing/checkout', {
-          method: 'POST',
-          headers: {
-            Authorization: \`Bearer \${token}\`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-          body: JSON.stringify({
-            planSlug: 'matrix_builder',
-            interval: 'monthly',
-            regionSlug: 'region_fsn1',
-            returnPath: deviceReturnPath(),
-          }),
-          credentials: 'same-origin',
-        });
-        var body = await res.json().catch(function(err) {
-          console.warn('[matrix] Unable to parse device checkout response', err instanceof Error ? err.message : String(err));
-          return null;
-        });
-        if (!res.ok || !body || typeof body.url !== 'string') {
-          showBillingRequiredState();
-          return;
-        }
-        rememberBillingCheckoutAttempt();
-        window.location.assign(body.url);
-      } catch (err) {
-        console.error('[matrix] Device checkout failed', err instanceof Error ? err.message : String(err));
-        showBillingRequiredState();
-      }
-    }
-
-    async function startProvisioningFromClerkSession() {
-      if (provisioningStarted) return;
-      provisioningStarted = true;
-      try {
-        var token = await clerkTokenOrNull();
-        if (!token) {
-          provisioningStarted = false;
-          showAuth();
-          return;
-        }
-        showLoadingState('Starting your Matrix computer...');
-        var res = await fetchWithTimeout('/api/auth/provision-runtime', {
-          method: 'POST',
-          headers: {
-            Authorization: \`Bearer \${token}\`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({}),
-          credentials: 'same-origin',
-        });
-        if (res.ok) {
-          billingConfirmationPolls = 0;
-          provisioningPolls = 0;
-          showLoadingState('Preparing your Matrix computer...');
-          pollProvisioningSession();
-          return;
-        }
-        if (res.status === 402) {
-          if (checkoutJustCompleted) {
-            retryProvisioningAfterBillingDelay();
-            return;
-          }
-          provisioningStarted = false;
-          showBillingRequiredState();
-          return;
-        }
-        if (res.status === 409) {
-          provisioningPolls = 0;
-          billingConfirmationPolls = 0;
-          showLoadingState('Preparing your Matrix computer...');
-          pollProvisioningSession();
-          return;
-        }
-        provisioningStarted = false;
-        showSignedInRecoveryState();
-      } catch (err) {
-        console.error('[matrix] Device runtime provisioning failed', err instanceof Error ? err.message : String(err));
-        provisioningStarted = false;
-        showSignedInRecoveryState();
-      }
-    }
-
     async function continueDeviceOnboarding() {
       try {
         var token = await clerkTokenOrNull();
@@ -498,23 +328,11 @@ function approvalPage(
           credentials: 'same-origin',
         });
         if (res.ok) {
-          provisioningStarted = false;
-          billingConfirmationPolls = 0;
-          provisioningPolls = 0;
           showConfirm();
           return;
         }
         if (res.status === 404) {
-          if (provisioningStarted) {
-            showLoadingState('Preparing your Matrix computer...');
-            pollProvisioningSession();
-            return;
-          }
-          if (checkoutJustCompleted) {
-            startProvisioningFromClerkSession();
-            return;
-          }
-          showRuntimeRequiredState();
+          redirectToBillingSetup();
           return;
         }
         showSignedInRecoveryState();

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -3363,7 +3363,7 @@ export function createApp(deps: {
     let singleMachineRuntimeSlot: string | null = null;
 
     const isGatewayPath = isAppDomain && isAppDomainGatewayPath(path);
-    const allowAuthShellUnroutedIdentity = shouldProxyAuthShellForUnroutedUser({
+    const allowAuthShellUnroutedIdentity = !legacyContainerRoutingEnabled && shouldProxyAuthShellForUnroutedUser({
       isAppDomain,
       method: c.req.method,
       path,

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -562,6 +562,29 @@ function shouldProxyShellForBillingGate(input: {
   );
 }
 
+function shouldProxyAuthShellForUnroutedUser(input: {
+  isAppDomain: boolean;
+  method: string;
+  path: string;
+}): boolean {
+  return (
+    input.isAppDomain &&
+    (input.method === 'GET' || input.method === 'HEAD') &&
+    !input.path.startsWith('/api/') &&
+    !input.path.startsWith('/vps') &&
+    !input.path.startsWith('/internal/') &&
+    !input.path.startsWith('/billing/') &&
+    !input.path.startsWith('/ws') &&
+    input.path !== '/metrics'
+  );
+}
+
+function getAuthShellOrigin(env: NodeJS.ProcessEnv): string {
+  const host = env.AUTH_SHELL_HOST?.trim() || '127.0.0.1';
+  const port = env.AUTH_SHELL_PORT?.trim() || '3200';
+  return `http://${host}:${port}`;
+}
+
 interface ExplicitVmRoute {
   handle: string;
   upstreamPath: string;
@@ -2672,6 +2695,39 @@ export function createApp(deps: {
   }
   app.capturePlatformEvent = capturePlatformEvent;
 
+  async function proxyAuthShell(c: Context, host: string): Promise<Response> {
+    const upstream = new URL(c.req.url);
+    const targetUrl = `${getAuthShellOrigin(appEnv)}${upstream.pathname}${upstream.search}`;
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(c.req.header())) {
+      const lowerKey = key.toLowerCase();
+      if (lowerKey !== 'host' && value) {
+        headers.set(key, value);
+      }
+    }
+    headers.set('host', new URL(getAuthShellOrigin(appEnv)).host);
+    headers.set('x-forwarded-host', host);
+    headers.set('x-forwarded-proto', 'https');
+    headers.set('accept-encoding', 'identity');
+    headers.set('connection', 'close');
+
+    try {
+      const response = await fetch(targetUrl, {
+        method: c.req.method,
+        headers,
+        redirect: 'manual',
+        signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
+      });
+      return new Response(response.body, {
+        status: response.status,
+        headers: sanitizeProxyResponseHeaders(response.headers),
+      });
+    } catch (err: unknown) {
+      logPlatformRouteError('app-domain auth-shell proxy', err);
+      return c.text('Matrix OS shell unavailable', 502);
+    }
+  }
+
   async function resolveBillingClerkUserId(c: Context): Promise<string | null> {
     try {
       if (!clerkAuth) return null;
@@ -3307,6 +3363,11 @@ export function createApp(deps: {
     let singleMachineRuntimeSlot: string | null = null;
 
     const isGatewayPath = isAppDomain && isAppDomainGatewayPath(path);
+    const allowAuthShellUnroutedIdentity = shouldProxyAuthShellForUnroutedUser({
+      isAppDomain,
+      method: c.req.method,
+      path,
+    });
     const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
     const authMode = path.startsWith('/sign-up') ? 'sign-up' : 'sign-in';
     const requestedRouteHandle = !explicitVmRoute && isAppDomain
@@ -3319,7 +3380,7 @@ export function createApp(deps: {
       clerkAuth,
       db,
       platformJwtSecret,
-      allowUnroutedClerkIdentity: Boolean(explicitVmRoute),
+      allowUnroutedClerkIdentity: Boolean(explicitVmRoute) || allowAuthShellUnroutedIdentity,
       requestedHandle: requestedRouteHandle,
       runtimeSlot: requestRuntimeSlot,
     });
@@ -3674,6 +3735,9 @@ export function createApp(deps: {
       applyNoStoreHeaders(c);
       if (isCodeDomain || isGatewayPath) {
         return c.json({ error: 'Matrix computer unavailable' }, 503);
+      }
+      if (allowAuthShellUnroutedIdentity && identity.handle === '') {
+        return proxyAuthShell(c, host);
       }
       return c.html(getNoContainerPage(), 503);
     }

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 import { useAuth } from "@clerk/nextjs";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Loader2Icon, LogInIcon } from "lucide-react";
+import { AlertCircleIcon, Loader2Icon, LogInIcon } from "lucide-react";
 import {
   getMatrixBillingSuccessRedirectUrl,
 } from "@/lib/billing";
@@ -144,7 +144,19 @@ function SignInRedirecting() {
   );
 }
 
-function SubscriptionConfirmationPending() {
+function reloadCurrentPage(): void {
+  window.location.assign(window.location.href);
+}
+
+function SubscriptionConfirmationPending({
+  status = "preparing",
+  onRefresh = () => window.location.assign(getMatrixBillingSuccessRedirectUrl()),
+}: {
+  status?: "preparing" | "failed";
+  onRefresh?: () => void;
+}) {
+  const failed = status === "failed";
+
   return (
     <div className="fixed inset-0 z-[80] flex items-center justify-center bg-deep/30 px-4 py-8 text-deep backdrop-blur-md">
       <section className="relative flex w-full max-w-md flex-col overflow-hidden rounded-3xl border border-forest/15 bg-page-bg/95 shadow-[0_40px_120px_rgba(50,53,46,0.35)]">
@@ -159,26 +171,31 @@ function SubscriptionConfirmationPending() {
 
         <div className="relative flex flex-col items-center gap-5 p-8 text-center">
           <div className="flex size-14 items-center justify-center rounded-2xl border border-forest/15 bg-white shadow-sm">
-            <Loader2Icon className="size-6 animate-spin text-ember" aria-hidden="true" />
+            {failed ? (
+              <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
+            ) : (
+              <Loader2Icon className="size-6 animate-spin text-ember" aria-hidden="true" />
+            )}
           </div>
           <div className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-forest/60">
               Matrix OS · Billing
             </p>
             <h1 className="text-2xl font-semibold tracking-tight text-deep">
-              Confirming your subscription
+              {failed ? "Matrix setup needs attention" : "Confirming your subscription"}
             </h1>
             <p className="mx-auto max-w-xs text-sm leading-6 text-forest/75">
-              Stripe is activating billing for your Matrix computer. This usually takes a few
-              seconds — your shell will open automatically.
+              {failed
+                ? "Billing is active, but your Matrix computer did not finish starting. Try again to continue CLI login."
+                : "Stripe is activating billing for your Matrix computer. This usually takes a few seconds — your shell will open automatically."}
             </p>
           </div>
           <button
             type="button"
-            onClick={() => window.location.assign(getMatrixBillingSuccessRedirectUrl())}
+            onClick={onRefresh}
             className="inline-flex h-10 items-center rounded-xl border border-forest/15 bg-white px-5 text-sm font-semibold text-forest transition-colors hover:bg-cream/60"
           >
-            Refresh status
+            {failed ? "Try again" : "Refresh status"}
           </button>
         </div>
       </section>
@@ -220,7 +237,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
   const billingChecking = isSignedIn && billingActive === null;
   const [checkoutJustCompleted, setCheckoutJustCompleted] = useState(false);
   const [checkoutAttemptChecked, setCheckoutAttemptChecked] = useState(false);
-  const [, setDeviceSetupStatus] = useState<"idle" | "preparing" | "failed">("idle");
+  const [deviceSetupStatus, setDeviceSetupStatus] = useState<"idle" | "preparing" | "failed">("idle");
   const lastTrackedState = useRef<string | null>(null);
   const deviceSetupStarted = useRef(false);
 
@@ -287,12 +304,13 @@ function BillingGateInner({ children }: { children: ReactNode }) {
         headers: await authHeaders(),
         body: JSON.stringify({ redirectTo: deviceReturnPath }),
       });
+      if (disposed) return;
 
       if (!sessionResponse.ok) {
         pollTimeout = window.setTimeout(() => {
           void pollRuntimeReady().catch((error: unknown) => {
             console.warn("[billing] device runtime poll failed", error instanceof Error ? error.name : typeof error);
-            setDeviceSetupStatus("failed");
+            if (!disposed) setDeviceSetupStatus("failed");
           });
         }, DEVICE_SETUP_POLL_MS);
         return;
@@ -304,6 +322,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
         cache: "no-store",
         headers: { Accept: "text/html" },
       });
+      if (disposed) return;
 
       if (readyResponse.ok) {
         window.location.replace(deviceReturnPath);
@@ -313,7 +332,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
       pollTimeout = window.setTimeout(() => {
         void pollRuntimeReady().catch((error: unknown) => {
           console.warn("[billing] device runtime readiness failed", error instanceof Error ? error.name : typeof error);
-          setDeviceSetupStatus("failed");
+          if (!disposed) setDeviceSetupStatus("failed");
         });
       }, DEVICE_SETUP_POLL_MS);
     }
@@ -326,6 +345,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
         headers: await authHeaders(),
         body: JSON.stringify({}),
       });
+      if (disposed) return;
       if (!provisionResponse.ok && provisionResponse.status !== 409) {
         if (provisionResponse.status === 402) {
           deviceSetupStarted.current = false;
@@ -340,7 +360,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
 
     void startDeviceRuntimeSetup().catch((error: unknown) => {
       console.warn("[billing] device runtime setup failed", error instanceof Error ? error.name : typeof error);
-      setDeviceSetupStatus("failed");
+      if (!disposed) setDeviceSetupStatus("failed");
     });
 
     return () => {
@@ -425,7 +445,10 @@ function BillingGateInner({ children }: { children: ReactNode }) {
         <div className="min-h-screen pointer-events-none select-none blur-[1px] brightness-90">
           {children}
         </div>
-        <SubscriptionConfirmationPending />
+        <SubscriptionConfirmationPending
+          status={deviceSetupStatus === "failed" ? "failed" : "preparing"}
+          onRefresh={reloadCurrentPage}
+        />
       </>
     );
   }

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -349,7 +349,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
       if (!provisionResponse.ok && provisionResponse.status !== 409) {
         if (provisionResponse.status === 402) {
           deviceSetupStarted.current = false;
-          setDeviceSetupStatus("idle");
+          setDeviceSetupStatus("failed");
           return;
         }
         setDeviceSetupStatus("failed");

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -365,6 +365,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
 
     return () => {
       disposed = true;
+      deviceSetupStarted.current = false;
       if (pollTimeout !== undefined) window.clearTimeout(pollTimeout);
     };
   }, [deviceReturnPath, getToken, hasBillingAccess, isLoaded, isSignedIn]);

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -15,6 +15,9 @@ const e2eBillingBypass = process.env.NEXT_PUBLIC_E2E_TEST_BYPASS === "1";
 const CHECKOUT_ATTEMPT_STORAGE_KEY = "matrix.billing.checkoutAttemptAt";
 const CHECKOUT_ATTEMPT_MAX_AGE_MS = 30 * 60 * 1000;
 const DEFAULT_SIGN_IN_URL = "https://matrix-os.com/login";
+const DEVICE_SETUP_POLL_MS = 8_000;
+const DEVICE_SETUP_MAX_POLLS = 60;
+const DEVICE_SETUP_TIMEOUT_MS = 10_000;
 
 function logCheckoutStorageError(action: "read" | "write", error: unknown): void {
   if (error instanceof Error) {
@@ -54,7 +57,31 @@ function hasRecentBillingCheckoutAttempt(): boolean {
   }
 }
 
-function BillingRequired() {
+function normalizeDeviceReturnPath(value: string | null): string | null {
+  if (!value || value.length > 2048 || !value.startsWith("/") || value.startsWith("//")) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value, "https://app.matrix-os.com");
+    if (url.pathname !== "/auth/device") return null;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch (error) {
+    console.warn("[billing] invalid device return path", error instanceof Error ? error.name : typeof error);
+    return null;
+  }
+}
+
+function getBillingCheckoutReturnPath(deviceReturnPath: string | null): string | undefined {
+  if (!deviceReturnPath || typeof window === "undefined") return undefined;
+  const url = new URL(window.location.href);
+  url.searchParams.delete("billing");
+  url.searchParams.delete("checkout");
+  url.searchParams.set("device_return", deviceReturnPath);
+  return `${url.pathname}${url.search}`;
+}
+
+function BillingRequired({ checkoutReturnPath }: { checkoutReturnPath?: string }) {
   return (
     <Settings
       open
@@ -65,6 +92,7 @@ function BillingRequired() {
       closeDisabled
       billingMode="provisioning"
       onBillingCheckoutIntent={rememberBillingCheckoutAttempt}
+      billingCheckoutReturnPath={checkoutReturnPath}
     />
   );
 }
@@ -181,16 +209,20 @@ export function BillingGate({ children }: { children: ReactNode }) {
 }
 
 function BillingGateInner({ children }: { children: ReactNode }) {
-  const { isLoaded, isSignedIn } = useAuth();
+  const { isLoaded, isSignedIn, getToken } = useAuth();
   const { active: billingActive } = useMatrixBillingAccess();
   const router = useRouter();
   const searchParams = useSearchParams();
   const checkoutReturnRequested = searchParams.get("checkout") === "success";
+  const deviceReturnPath = normalizeDeviceReturnPath(searchParams.get("device_return"));
+  const billingCheckoutReturnPath = getBillingCheckoutReturnPath(deviceReturnPath);
   const hasBillingAccess = isSignedIn ? billingActive === true : false;
   const billingChecking = isSignedIn && billingActive === null;
   const [checkoutJustCompleted, setCheckoutJustCompleted] = useState(false);
   const [checkoutAttemptChecked, setCheckoutAttemptChecked] = useState(false);
+  const [, setDeviceSetupStatus] = useState<"idle" | "preparing" | "failed">("idle");
   const lastTrackedState = useRef<string | null>(null);
+  const deviceSetupStarted = useRef(false);
 
   // react-doctor-disable-next-line react-doctor/no-cascading-set-state -- not a cascade: this is a single post-hydration resolution of the checkout-return state. The two setStates batch in one render pass and only re-run when `checkoutReturnRequested` changes; they cannot be derived in render because hasRecentBillingCheckoutAttempt() reads sessionStorage, which is client-only and would break SSR/hydration.
   useEffect(() => {
@@ -206,7 +238,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
   }, [checkoutReturnRequested]);
 
   useEffect(() => {
-    if (hasBillingAccess && checkoutReturnRequested) {
+    if (hasBillingAccess && checkoutReturnRequested && !deviceReturnPath) {
       capturePostHogEvent("billing_checkout_confirmed", {
         surface: "shell",
         source: "billing_gate",
@@ -214,7 +246,108 @@ function BillingGateInner({ children }: { children: ReactNode }) {
       // react-doctor-disable-next-line react-doctor/nextjs-no-client-side-redirect -- legit post-action client redirect: once billing access is confirmed for a returning Stripe checkout, this strips the `?checkout=success` query so a reload does not re-trigger the confirmation flow. It must run client-side after the async billing-access check resolves (a server redirect() cannot observe client billing state), and it is gated on hasBillingAccess && checkoutReturnRequested so it fires once, not on every render.
       router.replace("/");
     }
-  }, [checkoutReturnRequested, hasBillingAccess, router]);
+  }, [checkoutReturnRequested, deviceReturnPath, hasBillingAccess, router]);
+
+  useEffect(() => {
+    if (!deviceReturnPath || !hasBillingAccess || !isLoaded || !isSignedIn) return;
+    if (deviceSetupStarted.current) return;
+    deviceSetupStarted.current = true;
+    let disposed = false;
+    let pollCount = 0;
+    let pollTimeout: number | undefined;
+
+    async function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), DEVICE_SETUP_TIMEOUT_MS);
+      return fetch(url, { ...options, signal: controller.signal }).finally(() => {
+        window.clearTimeout(timeoutId);
+      });
+    }
+
+    async function authHeaders(): Promise<HeadersInit> {
+      const token = await getToken();
+      return {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      };
+    }
+
+    async function pollRuntimeReady(): Promise<void> {
+      if (disposed) return;
+      pollCount += 1;
+      if (pollCount > DEVICE_SETUP_MAX_POLLS) {
+        setDeviceSetupStatus("failed");
+        return;
+      }
+
+      const sessionResponse = await fetchWithTimeout("/api/auth/app-session", {
+        method: "POST",
+        credentials: "include",
+        headers: await authHeaders(),
+        body: JSON.stringify({ redirectTo: deviceReturnPath }),
+      });
+
+      if (!sessionResponse.ok) {
+        pollTimeout = window.setTimeout(() => {
+          void pollRuntimeReady().catch((error: unknown) => {
+            console.warn("[billing] device runtime poll failed", error instanceof Error ? error.name : typeof error);
+            setDeviceSetupStatus("failed");
+          });
+        }, DEVICE_SETUP_POLL_MS);
+        return;
+      }
+
+      const readyResponse = await fetchWithTimeout("/", {
+        method: "GET",
+        credentials: "include",
+        cache: "no-store",
+        headers: { Accept: "text/html" },
+      });
+
+      if (readyResponse.ok) {
+        window.location.replace(deviceReturnPath);
+        return;
+      }
+
+      pollTimeout = window.setTimeout(() => {
+        void pollRuntimeReady().catch((error: unknown) => {
+          console.warn("[billing] device runtime readiness failed", error instanceof Error ? error.name : typeof error);
+          setDeviceSetupStatus("failed");
+        });
+      }, DEVICE_SETUP_POLL_MS);
+    }
+
+    async function startDeviceRuntimeSetup(): Promise<void> {
+      setDeviceSetupStatus("preparing");
+      const provisionResponse = await fetchWithTimeout("/api/auth/provision-runtime", {
+        method: "POST",
+        credentials: "include",
+        headers: await authHeaders(),
+        body: JSON.stringify({}),
+      });
+      if (!provisionResponse.ok && provisionResponse.status !== 409) {
+        if (provisionResponse.status === 402) {
+          deviceSetupStarted.current = false;
+          setDeviceSetupStatus("idle");
+          return;
+        }
+        setDeviceSetupStatus("failed");
+        return;
+      }
+      await pollRuntimeReady();
+    }
+
+    void startDeviceRuntimeSetup().catch((error: unknown) => {
+      console.warn("[billing] device runtime setup failed", error instanceof Error ? error.name : typeof error);
+      setDeviceSetupStatus("failed");
+    });
+
+    return () => {
+      disposed = true;
+      if (pollTimeout !== undefined) window.clearTimeout(pollTimeout);
+    };
+  }, [deviceReturnPath, getToken, hasBillingAccess, isLoaded, isSignedIn]);
 
   useEffect(() => {
     if (!isLoaded) return;
@@ -281,7 +414,18 @@ function BillingGateInner({ children }: { children: ReactNode }) {
         <div className="min-h-screen pointer-events-none select-none blur-[1px] brightness-90">
           {children}
         </div>
-        <BillingRequired />
+        <BillingRequired checkoutReturnPath={billingCheckoutReturnPath} />
+      </>
+    );
+  }
+
+  if (deviceReturnPath) {
+    return (
+      <>
+        <div className="min-h-screen pointer-events-none select-none blur-[1px] brightness-90">
+          {children}
+        </div>
+        <SubscriptionConfirmationPending />
       </>
     );
   }

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -90,6 +90,7 @@ interface SettingsProps {
   closeDisabled?: boolean;
   billingMode?: "settings" | "provisioning";
   onBillingCheckoutIntent?: () => void;
+  billingCheckoutReturnPath?: string;
 }
 
 export function Settings({
@@ -101,6 +102,7 @@ export function Settings({
   closeDisabled = false,
   billingMode = "settings",
   onBillingCheckoutIntent,
+  billingCheckoutReturnPath,
 }: SettingsProps) {
   const [activeSection, setActiveSection] = useState<SectionId>(defaultSection);
   // Tracks the prior `open` value so the render-time section adjustment below
@@ -249,6 +251,7 @@ export function Settings({
                 <BillingSection
                   mode={billingMode}
                   onCheckoutIntent={onBillingCheckoutIntent}
+                  checkoutReturnPath={billingCheckoutReturnPath}
                 />
               )}
               {activeSection === "plugins" && <PluginsSection />}

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -82,6 +82,7 @@ function captureBillingTelemetry(
 function CheckoutPanel({
   mode,
   onCheckoutIntent,
+  checkoutReturnPath,
   telemetryProperties,
   planSlug,
   regionSlug,
@@ -90,6 +91,7 @@ function CheckoutPanel({
 }: {
   mode: BillingPanelMode;
   onCheckoutIntent?: () => void;
+  checkoutReturnPath?: string;
   telemetryProperties: BillingTelemetryProperties;
   planSlug: string;
   regionSlug: string;
@@ -125,7 +127,12 @@ function CheckoutPanel({
           "content-type": "application/json",
           accept: "application/json",
         },
-        body: JSON.stringify({ planSlug, interval: billingInterval, regionSlug }),
+        body: JSON.stringify({
+          planSlug,
+          interval: billingInterval,
+          regionSlug,
+          ...(checkoutReturnPath ? { returnPath: checkoutReturnPath } : {}),
+        }),
       });
       const body = (await response.json().catch((err: unknown) => {
         captureBillingTelemetry("checkout_response_parse_error", {
@@ -716,12 +723,14 @@ export function BillingPanel({
   accessReason,
   mode = "settings",
   onCheckoutIntent,
+  checkoutReturnPath,
 }: {
   active: boolean | null;
   entitlement?: BillingEntitlementSummary | null;
   accessReason?: string | null;
   mode?: BillingPanelMode;
   onCheckoutIntent?: () => void;
+  checkoutReturnPath?: string;
 }) {
   const [selectedProfileSlug, setSelectedProfileSlug] = useState<string>(
     MATRIX_BILLING_SERVER_PROFILES[1]?.featureSlug ??
@@ -847,6 +856,7 @@ export function BillingPanel({
         <CheckoutPanel
           mode={mode}
           onCheckoutIntent={onCheckoutIntent}
+          checkoutReturnPath={checkoutReturnPath}
           telemetryProperties={telemetryProperties}
           planSlug={selectedProfile.planSlug}
           regionSlug={selectedRegion.featureSlug}

--- a/shell/src/components/settings/sections/BillingSection.tsx
+++ b/shell/src/components/settings/sections/BillingSection.tsx
@@ -7,9 +7,11 @@ import { BillingPanel, type BillingPanelMode } from "./BillingPanel";
 export function BillingSection({
   mode = "settings",
   onCheckoutIntent,
+  checkoutReturnPath,
 }: {
   mode?: BillingPanelMode;
   onCheckoutIntent?: () => void;
+  checkoutReturnPath?: string;
 }) {
   const { active, entitlement, accessReason } = useMatrixBillingAccess();
 
@@ -44,6 +46,7 @@ export function BillingSection({
         accessReason={accessReason}
         mode={mode}
         onCheckoutIntent={onCheckoutIntent}
+        checkoutReturnPath={checkoutReturnPath}
       />
     </div>
   );

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -494,7 +494,7 @@ describe("device routes", () => {
       expect(html).toContain('id="instance-line"');
     });
 
-    it("starts signed-out CLI approval on signup and defers approval until runtime readiness", async () => {
+    it("starts signed-out CLI approval on signup and sends runtime setup to the shell billing tab", async () => {
       const res = await app.request("/auth/device?user_code=BCDF-GHJK");
       const html = await res.text();
 
@@ -504,19 +504,16 @@ describe("device routes", () => {
       expect(html).toContain("signUpUrl: deviceAuthUrl('sign-up')");
       expect(html).toContain("fallbackRedirectUrl: approvalUrl");
       expect(html).toContain("fetchWithTimeout('/api/auth/app-session'");
-      expect(html).toContain("fetchWithTimeout('/api/auth/provision-runtime'");
-      expect(html).toContain("fetchWithTimeout('/billing/checkout'");
-      expect(html).toContain("returnPath: deviceReturnPath");
-      expect(html).toContain("showRuntimeRequiredState()");
-      expect(html).toContain("showBillingRequiredState()");
+      expect(html).toContain("redirectToBillingSetup()");
+      expect(html).toContain("device_return");
+      expect(html).not.toContain("fetchWithTimeout('/api/auth/provision-runtime'");
+      expect(html).not.toContain("fetchWithTimeout('/billing/checkout'");
+      expect(html).not.toContain("Provision Matrix computer");
+      expect(html).not.toContain("Start checkout");
       expect(html).toContain("confirm.disabled = true;");
       expect(html).toContain("button.disabled = isBusy || !runtimeReady;");
       expect(html).toContain("delete signin.dataset.mounted;");
-      const provisioningStart = html.indexOf("async function startProvisioningFromClerkSession");
       const continueStart = html.indexOf("async function continueDeviceOnboarding");
-      expect(html.indexOf("var token = await clerkTokenOrNull();", provisioningStart)).toBeLessThan(
-        html.indexOf("showLoadingState('Starting your Matrix computer...');", provisioningStart),
-      );
       expect(html.indexOf("var token = await clerkTokenOrNull();", continueStart)).toBeLessThan(
         html.indexOf("showLoadingState('Checking your Matrix computer...');", continueStart),
       );

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1838,6 +1838,42 @@ describe("platform proxy routing", () => {
     delete process.env.AUTH_SHELL_PORT;
   });
 
+  it("keeps legacy no-container app-domain users on the platform auth page", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "true";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
+    await deleteContainer(db, "alice");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("auth shell", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: "__session=clerk-new",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("fetch('/api/auth/provision-runtime'");
+    expect(html).toContain("Billing required");
+    expect(html).not.toBe("auth shell");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does not trust a stale app session cookie over a different Clerk session", async () => {
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -104,6 +104,8 @@ describe("platform proxy routing", () => {
     delete process.env.MATRIX_STRIPE_BILLING_ENABLED;
     delete process.env.HETZNER_SERVER_TYPE;
     delete process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED;
+    delete process.env.AUTH_SHELL_HOST;
+    delete process.env.AUTH_SHELL_PORT;
   });
 
   it("escapes JSON embedded in auth page inline scripts", () => {
@@ -1791,6 +1793,49 @@ describe("platform proxy routing", () => {
     expect(html).toContain("Loading your Matrix computer");
     expect(html).not.toContain("ask the operator to provision this account");
     expect(html).not.toContain("You are already signed in");
+  });
+
+  it("serves the shell billing gate from auth-shell for signed-in users before a VPS exists", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    await deleteContainer(db, "alice");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("auth shell", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: "__session=clerk-new",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("auth shell");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "http://auth-shell.test:3200/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        method: "GET",
+        redirect: "manual",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    delete process.env.AUTH_SHELL_HOST;
+    delete process.env.AUTH_SHELL_PORT;
   });
 
   it("does not trust a stale app session cookie over a different Clerk session", async () => {

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -9,6 +9,7 @@ const clerkState = vi.hoisted(() => ({
   isSignedIn: true,
   userId: "user_123",
   activePlan: null as string | null,
+  getToken: vi.fn(async () => "clerk-token"),
 }));
 const navigationState = vi.hoisted(() => ({
   replace: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock("@clerk/nextjs", () => ({
     isSignedIn: clerkState.isSignedIn,
     userId: clerkState.userId,
     has: ({ plan }: { plan: string }) => plan === clerkState.activePlan,
+    getToken: clerkState.getToken,
   }),
 }));
 
@@ -43,6 +45,7 @@ describe("BillingGate", () => {
     );
     resetMatrixBillingAccessCacheForTests();
     vi.restoreAllMocks();
+    clerkState.getToken.mockResolvedValue("clerk-token");
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response(JSON.stringify({ access: { runtimeProxyAllowed: false } }), {
         status: 200,
@@ -234,6 +237,67 @@ describe("BillingGate", () => {
 
     expect(await screen.findByText("Matrix workspace")).toBeTruthy();
     expect(navigationState.replace).toHaveBeenCalledWith("/");
+  });
+
+  it("provisions and polls with the CLI device return path once billing is active", async () => {
+    vi.unstubAllEnvs();
+    window.history.replaceState(
+      {},
+      "",
+      "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    );
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = true;
+    clerkState.activePlan = null;
+    clerkState.getToken.mockResolvedValue("clerk-token");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      if (input === "/billing/status") {
+        return new Response(JSON.stringify({ access: { runtimeProxyAllowed: true } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (input === "/api/auth/provision-runtime") {
+        return new Response("{}", { status: 202, headers: { "content-type": "application/json" } });
+      }
+      if (input === "/api/auth/app-session") {
+        return new Response(JSON.stringify({ error: "Matrix computer unavailable" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("", { status: 503 });
+    });
+    vi.resetModules();
+
+    const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    expect(await screen.findByText("Confirming your subscription")).toBeTruthy();
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/auth/provision-runtime",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({}),
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/auth/app-session",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ redirectTo: "/auth/device?user_code=BCDF-GHJK" }),
+        }),
+      ),
+    );
+    expect(navigationState.replace).not.toHaveBeenCalled();
   });
 
   it("keeps direct checkout success navigation on the checkout panel", async () => {

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -300,6 +300,44 @@ describe("BillingGate", () => {
     expect(navigationState.replace).not.toHaveBeenCalled();
   });
 
+  it("surfaces a retry state when CLI device runtime provisioning fails", async () => {
+    vi.unstubAllEnvs();
+    window.history.replaceState(
+      {},
+      "",
+      "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    );
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = true;
+    clerkState.activePlan = null;
+    clerkState.getToken.mockResolvedValue("clerk-token");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      if (input === "/billing/status") {
+        return new Response(JSON.stringify({ access: { runtimeProxyAllowed: true } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (input === "/api/auth/provision-runtime") {
+        return new Response("{}", { status: 500, headers: { "content-type": "application/json" } });
+      }
+      return new Response("", { status: 503 });
+    });
+    vi.resetModules();
+
+    const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    expect(await screen.findByText("Matrix setup needs attention")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+    expect(screen.queryByText("Confirming your subscription")).toBeNull();
+  });
+
   it("keeps direct checkout success navigation on the checkout panel", async () => {
     vi.unstubAllEnvs();
     window.history.replaceState({}, "", "/?checkout=success");

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -338,6 +338,44 @@ describe("BillingGate", () => {
     expect(screen.queryByText("Confirming your subscription")).toBeNull();
   });
 
+  it("surfaces a retry state when CLI device billing has not propagated to provisioning", async () => {
+    vi.unstubAllEnvs();
+    window.history.replaceState(
+      {},
+      "",
+      "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+    );
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = true;
+    clerkState.activePlan = null;
+    clerkState.getToken.mockResolvedValue("clerk-token");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      if (input === "/billing/status") {
+        return new Response(JSON.stringify({ access: { runtimeProxyAllowed: true } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (input === "/api/auth/provision-runtime") {
+        return new Response("{}", { status: 402, headers: { "content-type": "application/json" } });
+      }
+      return new Response("", { status: 503 });
+    });
+    vi.resetModules();
+
+    const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    expect(await screen.findByText("Matrix setup needs attention")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+    expect(screen.queryByText("Confirming your subscription")).toBeNull();
+  });
+
   it("keeps direct checkout success navigation on the checkout panel", async () => {
     vi.unstubAllEnvs();
     window.history.replaceState({}, "", "/?checkout=success");

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -134,6 +134,44 @@ describe("BillingSection", () => {
     );
   });
 
+  it("includes a safe return path when checkout is launched from CLI device setup", async () => {
+    clerkState.isLoaded = true;
+    clerkState.activePlan = null;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ url: "https://checkout.stripe.test/session" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const { BillingSection } = await import(
+      "../../shell/src/components/settings/sections/BillingSection.js"
+    );
+
+    render(
+      <BillingSection
+        mode="provisioning"
+        checkoutReturnPath="/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("Not active")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "Continue to pay" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/billing/checkout",
+        expect.objectContaining({
+          body: JSON.stringify({
+            planSlug: "matrix_builder",
+            interval: "monthly",
+            regionSlug: "region_fsn1",
+            returnPath: "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK",
+          }),
+        }),
+      ),
+    );
+  });
+
   it("uses provisioning copy when billing is shown before the hosted computer exists", async () => {
     clerkState.isLoaded = true;
     clerkState.activePlan = null;


### PR DESCRIPTION
## Summary
- route signed-in CLI device signup users without a runtime into the shell billing Settings tab instead of rendering the device page provisioning UI
- carry the device return path through billing checkout, start runtime provisioning after billing access is active, then return to `/auth/device` once the app session and shell route are ready
- proxy unrouted signed-in app-domain users to the auth-shell billing gate before their first VPS exists

## Tests
- `bun run test tests/platform/device-routes.test.ts tests/shell/billing-section.test.tsx tests/shell/billing-gate.test.tsx tests/platform/proxy-routing.test.ts` (130 passed)
- `bun run typecheck`
- `bun run check:patterns` (0 violations; warnings only)
- `npx react-doctor@latest shell` (no new BillingGate findings; pre-existing MarkdownViewer findings remain)
- `bun run test` (524 passed, 3 skipped; 5994 passed, 20 skipped)

## Review/Monitoring
- Opened from manual worktree `/home/deploy/matrix-os.worktrees/cli-first-device-signup`.
- Needs current-head CI and Greptile 5/5 before merge.

## Invariants
- **Source of truth**: Clerk session identity plus platform billing entitlement remain canonical. The shell billing gate owns plan/region checkout UI; the device page owns device approval only.
- **Lock/transaction scope**: this change adds no direct DB writes. Provisioning remains delegated to existing `/api/auth/provision-runtime`; checkout remains delegated to existing `/billing/checkout`.
- **Acceptable orphan states**: billing may become active before the VPS is live. The billing gate keeps the user in a pending setup state, retries app-session/runtime readiness, and returns to `/auth/device` only after readiness is confirmed. A 402 returns control to the billing gate.
- **Auth source of truth**: Clerk bearer token/cookies authorize billing, provisioning, app-session exchange, and auth-shell routing. Device approval still requires Clerk bearer plus CSRF.
- **Deferred scope**: the landing/app `getAuthPage` still has separate custom provisioning UI. This PR targets CLI device signup and the auth-shell no-runtime billing gate path.