### PR TITLE
fix(shell): defer offscreen canvas app hydration

### DIFF
--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -16,9 +16,36 @@ import { autoArrangeWindows } from "./canvas-auto-arrange";
 import { CanvasMinimap } from "./CanvasMinimap";
 
 const GROUP_COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"];
+const APP_HYDRATION_MARGIN_PX = 320;
 
 interface CanvasRendererProps {
   children?: ReactNode;
+}
+
+export function shouldHydrateCanvasWindow(input: {
+  window: { x: number; y: number; width: number; height: number; path: string; minimized?: boolean };
+  focusedWindowId: string | null;
+  windowId: string;
+  zoom: number;
+  panX: number;
+  panY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}): boolean {
+  if (input.window.minimized) return false;
+  if (input.window.path.startsWith("__")) return true;
+  if (input.focusedWindowId === input.windowId) return true;
+
+  const left = (input.window.x + input.panX) * input.zoom;
+  const top = (input.window.y + input.panY) * input.zoom;
+  const right = left + input.window.width * input.zoom;
+  const bottom = top + input.window.height * input.zoom;
+  return (
+    right >= -APP_HYDRATION_MARGIN_PX &&
+    bottom >= -APP_HYDRATION_MARGIN_PX &&
+    left <= input.viewportWidth + APP_HYDRATION_MARGIN_PX &&
+    top <= input.viewportHeight + APP_HYDRATION_MARGIN_PX
+  );
 }
 
 export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
@@ -26,10 +53,16 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
   const focusedWindowId = useWindowManager((s) => s.focusedWindowId);
   const clearFocus = useWindowManager((s) => s.clearFocus);
   const fitAll = useCanvasTransform((s) => s.fitAll);
+  const zoom = useCanvasTransform((s) => s.zoom);
+  const panX = useCanvasTransform((s) => s.panX);
+  const panY = useCanvasTransform((s) => s.panY);
+  const containerRect = useCanvasTransform((s) => s.containerRect);
   const groups = useCanvasGroups((s) => s.groups);
   const createGroup = useCanvasGroups((s) => s.createGroup);
   const addToGroup = useCanvasGroups((s) => s.addToGroup);
   const labels = useCanvasLabels((s) => s.labels);
+  const viewportWidth = containerRect?.width ?? (typeof window !== "undefined" ? window.innerWidth : 0);
+  const viewportHeight = containerRect?.height ?? (typeof window !== "undefined" ? window.innerHeight : 0);
 
   const onSelect = (windowIds: string[]) => {
     if (windowIds.length < 2) return;
@@ -117,9 +150,26 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
           </div>
         )}
         {children}
-        {windows.map((win) => (
-          <CanvasWindow key={win.id} win={win} hidden={win.minimized} />
-        ))}
+        {windows.map((win) => {
+          const hydrateContent = shouldHydrateCanvasWindow({
+            window: win,
+            windowId: win.id,
+            focusedWindowId,
+            zoom,
+            panX,
+            panY,
+            viewportWidth,
+            viewportHeight,
+          });
+          return (
+            <CanvasWindow
+              key={win.id}
+              win={win}
+              hidden={win.minimized}
+              deferAppContent={!hydrateContent}
+            />
+          );
+        })}
       </CanvasTransform>
       <WorkspaceCanvas />
       <CanvasMinimap />

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState } from "react";
 import type { ReactNode } from "react";
 import { useWindowManager } from "@/hooks/useWindowManager";
+import type { AppWindow } from "@/hooks/useWindowManager";
 import { useCanvasTransform } from "@/hooks/useCanvasTransform";
 import { useCanvasGroups } from "@/stores/canvas-groups";
 import { useCanvasLabels } from "@/stores/canvas-labels";
@@ -22,6 +23,16 @@ interface CanvasRendererProps {
   children?: ReactNode;
 }
 
+interface CanvasWindowMountProps {
+  win: AppWindow;
+  focusedWindowId: string | null;
+  zoom: number;
+  panX: number;
+  panY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
 export function shouldHydrateCanvasWindow(input: {
   window: { x: number; y: number; width: number; height: number; path: string; minimized?: boolean };
   focusedWindowId: string | null;
@@ -31,7 +42,9 @@ export function shouldHydrateCanvasWindow(input: {
   panY: number;
   viewportWidth: number;
   viewportHeight: number;
+  hydratedOnce?: boolean;
 }): boolean {
+  if (input.hydratedOnce) return true;
   if (input.window.path.startsWith("__")) return true;
   if (input.focusedWindowId === input.windowId) return true;
 
@@ -151,22 +164,16 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
         )}
         {children}
         {windows.map((win) => {
-          const hydrateContent = shouldHydrateCanvasWindow({
-            window: win,
-            windowId: win.id,
-            focusedWindowId,
-            zoom,
-            panX,
-            panY,
-            viewportWidth,
-            viewportHeight,
-          });
           return (
-            <CanvasWindow
+            <CanvasWindowMount
               key={win.id}
               win={win}
-              hidden={win.minimized}
-              deferAppContent={!hydrateContent}
+              focusedWindowId={focusedWindowId}
+              zoom={zoom}
+              panX={panX}
+              panY={panY}
+              viewportWidth={viewportWidth}
+              viewportHeight={viewportHeight}
             />
           );
         })}
@@ -174,5 +181,38 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
       <WorkspaceCanvas />
       <CanvasMinimap />
     </div>
+  );
+}
+
+function CanvasWindowMount({
+  win,
+  focusedWindowId,
+  zoom,
+  panX,
+  panY,
+  viewportWidth,
+  viewportHeight,
+}: CanvasWindowMountProps) {
+  const shouldHydrateNow = shouldHydrateCanvasWindow({
+    window: win,
+    windowId: win.id,
+    focusedWindowId,
+    zoom,
+    panX,
+    panY,
+    viewportWidth,
+    viewportHeight,
+  });
+  const [hydratedOnce, setHydratedOnce] = useState(shouldHydrateNow);
+  if (shouldHydrateNow && !hydratedOnce) {
+    setHydratedOnce(true);
+  }
+
+  return (
+    <CanvasWindow
+      win={win}
+      hidden={win.minimized}
+      deferAppContent={!(shouldHydrateNow || hydratedOnce)}
+    />
   );
 }

--- a/shell/src/components/canvas/CanvasRenderer.tsx
+++ b/shell/src/components/canvas/CanvasRenderer.tsx
@@ -32,7 +32,6 @@ export function shouldHydrateCanvasWindow(input: {
   viewportWidth: number;
   viewportHeight: number;
 }): boolean {
-  if (input.window.minimized) return false;
   if (input.window.path.startsWith("__")) return true;
   if (input.focusedWindowId === input.windowId) return true;
 
@@ -84,8 +83,9 @@ export function CanvasRenderer({ children }: CanvasRendererProps = {}) {
   };
 
   // Minimized windows stay mounted (display:none in CanvasWindow) so their
-  // iframe / terminal state survives a minimize -> restore round-trip. We
-  // still derive a visible-windows list for empty-state and fit-all logic.
+  // iframe / terminal state survives a minimize -> restore round-trip. Offscreen
+  // non-built-in app windows can still defer at boot via shouldHydrateCanvasWindow.
+  // We still derive a visible-windows list for empty-state and fit-all logic.
   const visibleWindows = windows.filter((w) => !w.minimized);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity required: this handler is a dependency of the keydown-listener effect below and re-binds the global window keydown listener on identity change. Inlining would detach/reattach the listener every render.

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -46,10 +46,12 @@ interface CanvasWindowProps {
   /** When true, the window stays mounted but is visually hidden so iframe
       state, terminal sockets, and React state survive minimize -> restore. */
   hidden?: boolean;
+  /** Defers expensive app iframe hydration for offscreen Canvas windows. */
+  deferAppContent?: boolean;
 }
 
 // react-doctor-disable-next-line react-doctor/no-giant-component -- cohesive single-window renderer: the bulk is two theme-specific title-bar JSX trees (mac vs win98) plus drag/resize/fullscreen pointer handlers that all share the same window state and refs. Splitting would require threading every handler and ref through props with no readability or reuse gain.
-export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
+export function CanvasWindow({ win, hidden = false, deferAppContent = false }: CanvasWindowProps) {
   const chatState = useChatContext();
   const zoom = useCanvasTransform((s) => s.zoom);
   const panX = useCanvasTransform((s) => s.panX);
@@ -453,6 +455,20 @@ export function CanvasWindow({ win, hidden = false }: CanvasWindowProps) {
               onSubmit={chatState.submitMessage}
               mobile={isMobile}
             />
+          )}
+        </div>
+      ) : deferAppContent ? (
+        <div
+          className="h-full w-full flex items-center justify-center bg-card"
+          aria-label={`${win.title} will load when visible`}
+        >
+          {iconUrl ? (
+            // react-doctor-disable-next-line react-doctor/nextjs-no-img-element -- app icon served from a runtime gateway host (/icons/{slug}.png with ?v=etag) that cannot be statically configured for next/image
+            <img src={iconUrl} alt="" className="size-16 rounded-2xl object-cover opacity-45" draggable={false} />
+          ) : (
+            <span className="text-3xl font-semibold text-muted-foreground/20">
+              {win.title.charAt(0).toUpperCase()}
+            </span>
           )}
         </div>
       ) : (

--- a/shell/src/components/preview-window/MarkdownViewer.tsx
+++ b/shell/src/components/preview-window/MarkdownViewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ComponentPropsWithoutRef } from "react";
+import { useMemo, useState, type ComponentPropsWithoutRef } from "react";
 import ReactMarkdown, { defaultUrlTransform, type UrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -83,11 +83,9 @@ function MarkdownSvgPreview({
     () => resolveSvgPreviewSource(src, sourcePath),
     [src, sourcePath],
   );
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    setFailed(false);
-  }, [resolved.ok ? resolved.src : src]);
+  const resolvedKey = resolved.ok ? resolved.src : src;
+  const [failedSrc, setFailedSrc] = useState<string | undefined>();
+  const failed = failedSrc === resolvedKey;
 
   if (!resolved.ok || failed) {
     return <SvgPreviewFallback alt={alt} />;
@@ -102,7 +100,7 @@ function MarkdownSvgPreview({
         decoding="async"
         draggable={false}
         loading="lazy"
-        onError={() => setFailed(true)}
+        onError={() => setFailedSrc(resolved.src)}
         referrerPolicy="no-referrer"
         src={resolved.src}
         title={title}

--- a/tests/shell/canvas-renderer.test.ts
+++ b/tests/shell/canvas-renderer.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { shouldHydrateCanvasWindow } from "../../shell/src/components/canvas/CanvasRenderer.js";
 import { useWindowManager } from "../../shell/src/hooks/useWindowManager.js";
 import { useCanvasTransform, INTERACTION_THRESHOLD } from "../../shell/src/hooks/useCanvasTransform.js";
 import { useDesktopMode } from "../../shell/src/stores/desktop-mode.js";
@@ -90,5 +91,41 @@ describe("Canvas Renderer Integration", () => {
     // Simulating a 100px screen drag at 2x zoom = 50px canvas movement
     useWindowManager.getState().moveWindow(winId, origX + 50, 20);
     expect(useWindowManager.getState().windows[0].x).toBe(origX + 50);
+  });
+
+  it("defers offscreen Canvas app hydration while keeping visible apps and built-ins eager", () => {
+    const base = {
+      focusedWindowId: null,
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      viewportWidth: 1200,
+      viewportHeight: 800,
+    };
+
+    expect(shouldHydrateCanvasWindow({
+      ...base,
+      windowId: "visible-app",
+      window: { path: "apps/notes/index.html", x: 100, y: 100, width: 640, height: 480 },
+    })).toBe(true);
+
+    expect(shouldHydrateCanvasWindow({
+      ...base,
+      windowId: "offscreen-app",
+      window: { path: "apps/legacy/index.html", x: 5000, y: 100, width: 640, height: 480 },
+    })).toBe(false);
+
+    expect(shouldHydrateCanvasWindow({
+      ...base,
+      windowId: "terminal",
+      window: { path: "__terminal__:restored", x: 5000, y: 100, width: 640, height: 480 },
+    })).toBe(true);
+
+    expect(shouldHydrateCanvasWindow({
+      ...base,
+      focusedWindowId: "focused-app",
+      windowId: "focused-app",
+      window: { path: "apps/legacy/index.html", x: 5000, y: 100, width: 640, height: 480 },
+    })).toBe(true);
   });
 });

--- a/tests/shell/canvas-renderer.test.ts
+++ b/tests/shell/canvas-renderer.test.ts
@@ -123,6 +123,13 @@ describe("Canvas Renderer Integration", () => {
 
     expect(shouldHydrateCanvasWindow({
       ...base,
+      hydratedOnce: true,
+      windowId: "hydrated-offscreen-app",
+      window: { path: "apps/legacy/index.html", x: 5000, y: 100, width: 640, height: 480 },
+    })).toBe(true);
+
+    expect(shouldHydrateCanvasWindow({
+      ...base,
       windowId: "terminal",
       window: { path: "__terminal__:restored", x: 5000, y: 100, width: 640, height: 480 },
     })).toBe(true);

--- a/tests/shell/canvas-renderer.test.ts
+++ b/tests/shell/canvas-renderer.test.ts
@@ -111,6 +111,12 @@ describe("Canvas Renderer Integration", () => {
 
     expect(shouldHydrateCanvasWindow({
       ...base,
+      windowId: "minimized-app",
+      window: { path: "apps/notes/index.html", x: 100, y: 100, width: 640, height: 480, minimized: true },
+    })).toBe(true);
+
+    expect(shouldHydrateCanvasWindow({
+      ...base,
       windowId: "offscreen-app",
       window: { path: "apps/legacy/index.html", x: 5000, y: 100, width: 640, height: 480 },
     })).toBe(false);

--- a/tests/shell/canvas-window-terminal-overlay.test.tsx
+++ b/tests/shell/canvas-window-terminal-overlay.test.tsx
@@ -6,12 +6,17 @@ import { CanvasWindow } from "../../shell/src/components/canvas/CanvasWindow.js"
 import { useCanvasTransform } from "../../shell/src/hooks/useCanvasTransform.js";
 import { useWindowManager, type AppWindow } from "../../shell/src/hooks/useWindowManager.js";
 
+const appViewerRender = vi.hoisted(() => vi.fn());
+
 vi.mock("../../shell/src/components/terminal/TerminalApp.js", () => ({
   TerminalApp: () => <button type="button">Terminal tab one</button>,
 }));
 
 vi.mock("../../shell/src/components/AppViewer.js", () => ({
-  AppViewer: () => <iframe title="App iframe" />,
+  AppViewer: (props: { path: string }) => {
+    appViewerRender(props);
+    return <iframe title="App iframe" />;
+  },
 }));
 
 vi.mock("../../shell/src/components/file-browser/FileBrowser.js", () => ({
@@ -55,6 +60,7 @@ const iframeWindow: AppWindow = {
 
 describe("CanvasWindow terminal interactivity", () => {
   beforeEach(() => {
+    appViewerRender.mockClear();
     useCanvasTransform.setState({ zoom: 1, panX: 0, panY: 0, isAnimating: false, isScrolling: false });
     useWindowManager.setState({
       windows: [],
@@ -77,6 +83,15 @@ describe("CanvasWindow terminal interactivity", () => {
   it("keeps the click shield for iframe app windows", () => {
     const { container } = render(<CanvasWindow win={iframeWindow} />);
 
+    expect(container.querySelector("[data-canvas-interaction-overlay]")).toBeTruthy();
+  });
+
+  it("does not mount AppViewer when Canvas defers offscreen app content", () => {
+    const { container } = render(<CanvasWindow win={iframeWindow} deferAppContent />);
+
+    expect(appViewerRender).not.toHaveBeenCalled();
+    expect(screen.queryByTitle("App iframe")).toBeNull();
+    expect(screen.getByLabelText("Notes will load when visible")).toBeTruthy();
     expect(container.querySelector("[data-canvas-interaction-overlay]")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- defer Canvas app iframe hydration when restored app windows are offscreen or minimized
- keep built-ins/terminals and focused app windows eager so active workflows still restore immediately
- remove a React Doctor error in MarkdownViewer by keying SVG load failures to the resolved URL instead of syncing state in an effect

## Why
A live hamedmp regression showed old restored Canvas app windows (`matrix-beta-crm`, `games/snake`, `todo`) were mounting iframes during shell boot. After signed srcdoc asset routing fixed app asset loading, those previously failing iframes started loading real app bundles, making Matrix boot and app opening feel slow.

## Invariants
- Source of truth: `system/layout.json` remains the persisted window source; this only changes client hydration behavior.
- Lock/transaction scope: no persistence or DB writes are introduced.
- Acceptable orphan states: offscreen app windows can show placeholder chrome until they enter the viewport or receive focus; no app data is mutated while deferred.
- Auth source of truth: unchanged; app iframe/session auth remains handled by existing AppViewer and gateway/platform session routes once content hydrates.
- Deferred scope: this does not delete user-installed apps or reset user layout data; it prevents hidden/offscreen restored app windows from eagerly loading.

## Validation
- `bun run test tests/shell/canvas-renderer.test.ts tests/shell/canvas-window-terminal-overlay.test.tsx tests/shell/markdown-viewer-svg.test.tsx`
- `npx react-doctor@latest shell` (0 errors; existing warnings only)
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check`
- `bun run test` (530 files passed, 6010 tests passed; 3 files/20 tests skipped)
