### PR TITLE
feat(platform): add Cloud Run runtime mode

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -34,7 +34,7 @@ import {
   type HostBundleReleaseRecord,
   type UserMachineRecord,
 } from './db.js';
-import type { Orchestrator } from './orchestrator.js';
+import { LegacyContainerOrchestrationDisabledError, type Orchestrator } from './orchestrator.js';
 import { createSocialApi } from './social.js';
 import { createStoreApi } from './store-api.js';
 import { createSocialFeedApi } from './social-api.js';
@@ -4422,8 +4422,16 @@ export function createApp(deps: {
   });
 
   app.post('/containers/rolling-restart', async (c) => {
-    const result = await orchestrator.rollingRestart();
-    return c.json(result);
+    try {
+      const result = await orchestrator.rollingRestart();
+      return c.json(result);
+    } catch (e: unknown) {
+      if (e instanceof LegacyContainerOrchestrationDisabledError) {
+        return c.json({ error: 'Not supported in this runtime mode' }, 503);
+      }
+      logPlatformRouteError('/containers/rolling-restart', e);
+      return c.json({ error: 'Rolling restart failed' }, 500);
+    }
   });
 
   app.delete('/containers/:handle', async (c) => {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -6,7 +6,7 @@ import { installPostHogHonoErrorTracking, MATRIX_TELEMETRY_EVENTS, type MatrixTe
 import { createConnection, type Socket } from 'node:net';
 import { connect as createTlsConnection } from 'node:tls';
 import type { IncomingMessage, Server } from 'node:http';
-import Dockerode from 'dockerode';
+import type Dockerode from 'dockerode';
 import { Agent } from 'undici';
 import { z } from 'zod/v4';
 import {
@@ -88,6 +88,10 @@ import {
 import { createLaunchReadinessRoutes } from './launch-readiness-routes.js';
 import { HetznerServerTypeSchema, RuntimeSlotSchema } from './customer-vps-schema.js';
 import { shouldVerifyCustomerVpsTls } from './customer-vps-tls.js';
+import {
+  PlatformStartupConfigError,
+  loadPlatformRuntimeConfig,
+} from './runtime-mode.js';
 
 const PORT = Number(process.env.PLATFORM_PORT ?? 9000);
 const PLATFORM_SECRET = process.env.PLATFORM_SECRET ?? '';
@@ -4696,41 +4700,66 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
   if (checkUnsafeDefaultSecrets().length > 0) {
     process.exit(1);
   }
-  const platformDatabaseUrl = process.env.PLATFORM_DATABASE_URL ??
-    (process.env.POSTGRES_URL ? `${process.env.POSTGRES_URL}/matrixos_platform` : undefined);
-  const db = platformDatabaseUrl ? createPlatformDb(platformDatabaseUrl) : createPlatformDb();
+  let runtimeConfig;
+  try {
+    runtimeConfig = loadPlatformRuntimeConfig();
+  } catch (err: unknown) {
+    if (err instanceof PlatformStartupConfigError) {
+      console.error(`[platform] ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+  const db = createPlatformDb(runtimeConfig.platformDatabaseUrl);
   await db.ready;
-  const docker = new Dockerode();
 
   checkHomeMirrorS3Env();
 
-  const [{ createOrchestrator }, { createLifecycleManager }] = await Promise.all([
-    import('./orchestrator.js'),
-    import('./lifecycle.js'),
-  ]);
-  const orchestrator = createOrchestrator({
-    db,
-    docker,
-    image: process.env.PLATFORM_IMAGE,
-    dataDir: process.env.PLATFORM_DATA_DIR,
-    platformSecret: PLATFORM_SECRET,
-    publicTelemetryEnv: collectTenantPublicTelemetryEnv(),
-    postgresUrl: process.env.POSTGRES_URL,
-  });
+  let docker: Dockerode | undefined;
+  let orchestrator: Orchestrator;
+  if (runtimeConfig.legacyContainerOrchestrationEnabled) {
+    const [
+      { default: DockerodeCtor },
+      { createOrchestrator },
+      { createLifecycleManager },
+      { createStatsCollector },
+    ] = await Promise.all([
+      import('dockerode'),
+      import('./orchestrator.js'),
+      import('./lifecycle.js'),
+      import('./stats-collector.js'),
+    ]);
+    docker = new DockerodeCtor();
+    orchestrator = createOrchestrator({
+      db,
+      docker,
+      image: process.env.PLATFORM_IMAGE,
+      dataDir: process.env.PLATFORM_DATA_DIR,
+      platformSecret: PLATFORM_SECRET,
+      publicTelemetryEnv: collectTenantPublicTelemetryEnv(),
+      postgresUrl: process.env.POSTGRES_URL,
+    });
 
-  const maxRunning = Number(process.env.MAX_RUNNING_CONTAINERS) || 20;
-  const lifecycle = createLifecycleManager({ db, orchestrator, maxRunning });
-  lifecycle.start();
+    const maxRunning = Number(process.env.MAX_RUNNING_CONTAINERS) || 20;
+    const lifecycle = createLifecycleManager({ db, orchestrator, maxRunning });
+    lifecycle.start();
 
-  const { createStatsCollector } = await import('./stats-collector.js');
-  const statsCollector = createStatsCollector({
-    docker,
-    listRunning: () => listContainers(db, 'running'),
-    onResolvedContainerId: async (handle, containerId) => {
-      await updateContainerStatus(db, handle, 'running', containerId);
-    },
-  });
-  statsCollector.start();
+    const statsCollector = createStatsCollector({
+      docker,
+      listRunning: () => listContainers(db, 'running'),
+      onResolvedContainerId: async (handle, containerId) => {
+        await updateContainerStatus(db, handle, 'running', containerId);
+      },
+    });
+    statsCollector.start();
+  } else {
+    const { createDisabledOrchestrator } = await import('./orchestrator.js');
+    orchestrator = createDisabledOrchestrator({
+      db,
+      image: process.env.PLATFORM_IMAGE ?? 'customer-vps',
+    });
+    console.log('[platform] Cloud Run mode enabled; legacy Docker container orchestration is disabled');
+  }
 
   // Clerk JWT verification (optional -- only active when CLERK_SECRET_KEY is set)
   let clerkAuth: ClerkAuth | undefined;
@@ -4878,7 +4907,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
   let customerVpsService: CustomerVpsService | undefined;
   let customerVpsReconciliationInterval: ReturnType<typeof setInterval> | undefined;
   let customerVpsReconciliationPromise: Promise<void> | undefined;
-  if (process.env.CUSTOMER_VPS_ENABLED === 'true') {
+  if (runtimeConfig.customerVpsEnabled) {
     const [
       { createCustomerVpsService },
       { loadCustomerVpsConfig },

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -337,6 +337,10 @@ function isMissingContainerError(err: unknown): boolean {
   return err instanceof Error && err.message.startsWith('No container for handle:');
 }
 
+function isLegacyContainerOrchestrationUnavailable(err: unknown): boolean {
+  return err instanceof LegacyContainerOrchestrationDisabledError;
+}
+
 function logPlatformRouteError(route: string, err: unknown): void {
   console.error(
     `[platform] ${route} failed:`,
@@ -4351,6 +4355,9 @@ export function createApp(deps: {
       if (e instanceof Error && e.message === 'Invalid handle') {
         return c.json({ error: 'Invalid handle' }, 400);
       }
+      if (isLegacyContainerOrchestrationUnavailable(e)) {
+        return c.json({ error: 'Not supported in this runtime mode' }, 503);
+      }
       if (isMissingContainerError(e)) {
         return c.json({ error: 'Container not found' }, 404);
       }
@@ -4367,6 +4374,9 @@ export function createApp(deps: {
       if (e instanceof Error && e.message === 'Invalid handle') {
         return c.json({ error: 'Invalid handle' }, 400);
       }
+      if (isLegacyContainerOrchestrationUnavailable(e)) {
+        return c.json({ error: 'Not supported in this runtime mode' }, 503);
+      }
       if (isMissingContainerError(e)) {
         return c.json({ error: 'Container not found' }, 404);
       }
@@ -4382,6 +4392,9 @@ export function createApp(deps: {
     } catch (e: unknown) {
       if (e instanceof Error && e.message === 'Invalid handle') {
         return c.json({ error: 'Invalid handle' }, 400);
+      }
+      if (isLegacyContainerOrchestrationUnavailable(e)) {
+        return c.json({ error: 'Not supported in this runtime mode' }, 503);
       }
       if (isMissingContainerError(e)) {
         return c.json({ error: 'Container not found' }, 404);
@@ -4416,6 +4429,9 @@ export function createApp(deps: {
       const record = await orchestrator.upgrade(handle);
       return c.json(record);
     } catch (e: unknown) {
+      if (isLegacyContainerOrchestrationUnavailable(e)) {
+        return c.json({ error: 'Not supported in this runtime mode' }, 503);
+      }
       logPlatformRouteError('/containers/:handle/self-upgrade', e);
       return c.json({ error: 'Upgrade failed' }, 500);
     }
@@ -4426,7 +4442,7 @@ export function createApp(deps: {
       const result = await orchestrator.rollingRestart();
       return c.json(result);
     } catch (e: unknown) {
-      if (e instanceof LegacyContainerOrchestrationDisabledError) {
+      if (isLegacyContainerOrchestrationUnavailable(e)) {
         return c.json({ error: 'Not supported in this runtime mode' }, 503);
       }
       logPlatformRouteError('/containers/rolling-restart', e);
@@ -4441,6 +4457,9 @@ export function createApp(deps: {
     } catch (e: unknown) {
       if (e instanceof Error && e.message === 'Invalid handle') {
         return c.json({ error: 'Invalid handle' }, 400);
+      }
+      if (isLegacyContainerOrchestrationUnavailable(e)) {
+        return c.json({ error: 'Not supported in this runtime mode' }, 503);
       }
       if (isMissingContainerError(e)) {
         return c.json({ error: 'Container not found' }, 404);

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -4342,6 +4342,9 @@ export function createApp(deps: {
       if (e instanceof CustomerVpsError) {
         return c.json({ error: e.publicMessage }, e.status as never);
       }
+      if (isLegacyContainerOrchestrationUnavailable(e)) {
+        return c.json({ error: 'Not supported in this runtime mode' }, 503);
+      }
       logPlatformRouteError('/containers/provision', e);
       return c.json({ error: 'Provision failed' }, 500);
     }

--- a/packages/platform/src/orchestrator.ts
+++ b/packages/platform/src/orchestrator.ts
@@ -55,6 +55,42 @@ export interface Orchestrator {
   syncStates(): Promise<void>;
 }
 
+export class LegacyContainerOrchestrationDisabledError extends Error {
+  constructor() {
+    super('Legacy container orchestration is disabled in this platform runtime mode');
+    this.name = 'LegacyContainerOrchestrationDisabledError';
+  }
+}
+
+export function createDisabledOrchestrator(config: {
+  db: PlatformDB;
+  image?: string;
+}): Orchestrator {
+  const { db, image = 'customer-vps' } = config;
+  const unavailable = async (): Promise<never> => {
+    throw new LegacyContainerOrchestrationDisabledError();
+  };
+
+  return {
+    provision: unavailable,
+    start: unavailable,
+    stop: unavailable,
+    destroy: unavailable,
+    upgrade: unavailable,
+    rollingRestart: unavailable,
+    async getInfo(handle) {
+      return getContainer(db, handle);
+    },
+    getImage() {
+      return image;
+    },
+    async listAll(status?) {
+      return listContainers(db, status);
+    },
+    async syncStates() {},
+  };
+}
+
 export function createOrchestrator(config: OrchestratorConfig): Orchestrator {
   const {
     db,

--- a/packages/platform/src/runtime-mode.ts
+++ b/packages/platform/src/runtime-mode.ts
@@ -5,7 +5,6 @@ const LOCAL_DATABASE_HOSTS = new Set([
   'localhost',
   '127.0.0.1',
   '0.0.0.0',
-  '::1',
   '[::1]',
 ]);
 
@@ -15,7 +14,6 @@ export interface PlatformRuntimeConfig {
   mode: PlatformRuntimeMode;
   platformDatabaseUrl: string;
   customerVpsEnabled: boolean;
-  dockerRequired: boolean;
   legacyContainerOrchestrationEnabled: boolean;
 }
 
@@ -76,7 +74,6 @@ export function loadPlatformRuntimeConfig(env: NodeJS.ProcessEnv = process.env):
     mode,
     platformDatabaseUrl,
     customerVpsEnabled,
-    dockerRequired: mode !== 'cloud_run',
     legacyContainerOrchestrationEnabled: mode !== 'cloud_run',
   };
 }

--- a/packages/platform/src/runtime-mode.ts
+++ b/packages/platform/src/runtime-mode.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod/v4';
+
+const PlatformRuntimeModeSchema = z.enum(['cloud_run', 'compose', 'local']);
+const LOCAL_DATABASE_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '0.0.0.0',
+  '::1',
+  '[::1]',
+]);
+
+export type PlatformRuntimeMode = z.infer<typeof PlatformRuntimeModeSchema>;
+
+export interface PlatformRuntimeConfig {
+  mode: PlatformRuntimeMode;
+  platformDatabaseUrl: string;
+  customerVpsEnabled: boolean;
+  dockerRequired: boolean;
+  legacyContainerOrchestrationEnabled: boolean;
+}
+
+export class PlatformStartupConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PlatformStartupConfigError';
+  }
+}
+
+function resolvePlatformDatabaseUrl(env: NodeJS.ProcessEnv): string | undefined {
+  return env.PLATFORM_DATABASE_URL ??
+    (env.POSTGRES_URL ? `${env.POSTGRES_URL}/matrixos_platform` : undefined);
+}
+
+function isLocalDatabaseUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch (err: unknown) {
+    if (!(err instanceof TypeError)) {
+      throw err;
+    }
+    throw new PlatformStartupConfigError('PLATFORM_DATABASE_URL must be a valid Postgres URL');
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  return LOCAL_DATABASE_HOSTS.has(hostname) || hostname.startsWith('127.');
+}
+
+export function loadPlatformRuntimeConfig(env: NodeJS.ProcessEnv = process.env): PlatformRuntimeConfig {
+  const rawMode = env.PLATFORM_RUNTIME_MODE ?? 'compose';
+  const parsedMode = PlatformRuntimeModeSchema.safeParse(rawMode);
+  if (!parsedMode.success) {
+    throw new PlatformStartupConfigError('PLATFORM_RUNTIME_MODE must be one of: cloud_run, compose, local');
+  }
+
+  const mode = parsedMode.data;
+  const customerVpsEnabled = env.CUSTOMER_VPS_ENABLED === 'true';
+  const platformDatabaseUrl = resolvePlatformDatabaseUrl(env);
+
+  if (mode === 'cloud_run') {
+    if (!customerVpsEnabled) {
+      throw new PlatformStartupConfigError('CUSTOMER_VPS_ENABLED=true is required when PLATFORM_RUNTIME_MODE=cloud_run');
+    }
+    if (!env.PLATFORM_DATABASE_URL) {
+      throw new PlatformStartupConfigError('PLATFORM_DATABASE_URL is required when PLATFORM_RUNTIME_MODE=cloud_run');
+    }
+    if (isLocalDatabaseUrl(env.PLATFORM_DATABASE_URL)) {
+      throw new PlatformStartupConfigError('PLATFORM_DATABASE_URL must point at a managed Postgres host when PLATFORM_RUNTIME_MODE=cloud_run');
+    }
+  }
+
+  if (!platformDatabaseUrl) {
+    throw new PlatformStartupConfigError('Platform Postgres URL is required: set PLATFORM_DATABASE_URL or POSTGRES_URL');
+  }
+
+  return {
+    mode,
+    platformDatabaseUrl,
+    customerVpsEnabled,
+    dockerRequired: mode !== 'cloud_run',
+    legacyContainerOrchestrationEnabled: mode !== 'cloud_run',
+  };
+}

--- a/specs/085-cloud-run-platform-migration/agent-implementation-guide.md
+++ b/specs/085-cloud-run-platform-migration/agent-implementation-guide.md
@@ -1,0 +1,108 @@
+# Agent Implementation Guide
+
+Use this guide when a coding agent implements the Cloud Run platform migration. Work in a manual git worktree on a Matrix cloud instance, open a PR, and keep each change small enough for review.
+
+## Operating Rules
+
+- Start by reading `.specify/memory/constitution.md`, `AGENTS.md`, and `specs/085-cloud-run-platform-migration/spec.md`.
+- Work in a manual worktree, not directly on `main`.
+- Use TDD: add failing tests before implementation.
+- Keep each PR below 50 files and 3000 additions. Split into stacked PRs if needed.
+- Use Conventional Commit style for commits and PR titles.
+- Do not add non-Postgres persistence.
+- Do not put platform-only secrets on customer VPSes.
+- Do not ask for raw secret values. Ask for secret name, target environment, and whether it has been configured.
+- Do not print secrets, database URLs, API tokens, cookies, or signed route tokens in logs or final messages.
+
+## Worktree Setup
+
+```bash
+git fetch origin
+git worktree add -b 085-cloud-run-platform-cloud-mode ../matrix-os-cloud-mode origin/main
+cd ../matrix-os-cloud-mode
+pnpm install --frozen-lockfile
+```
+
+If split, use stacked subsystem branches:
+
+1. `085-cloud-run-mode`
+2. `085-runtime-route-token`
+3. `085-edge-router`
+4. `085-vps-token-ingress`
+5. `085-cloud-run-cicd`
+6. `085-inngest-workflows`
+7. `085-synapse-central`
+
+## Inputs Agents May Ask For
+
+Ask only for missing operator decisions or confirmation: GCP project id, Cloud Run service name, Artifact Registry repo, staging/production Neon branch names, Secret Manager secret names and configuration status, R2 bucket/prefix model, Cloudflare account id and Worker name, Clerk test/production decision, Inngest/PostHog environment names, HMAC vs asymmetric route tokens, and per-VPS vs shared tunnel routing.
+
+Do not ask for raw Neon, Clerk, Stripe, Pipedream, R2, Hetzner, PostHog, Inngest, Cloudflare, or production user secrets.
+
+## Implementation Slices
+
+### Slice 1: Cloud Run platform mode
+
+Files: `packages/platform/src/main.ts`, `packages/platform/src/orchestrator.ts`, `packages/platform/src/customer-vps-config.ts`, `packages/platform/src/db.ts`, `tests/platform/*`.
+
+Implement `PLATFORM_RUNTIME_MODE=cloud_run|compose|local`, startup validation for cloud mode, no Docker socket requirement in cloud mode, required `CUSTOMER_VPS_ENABLED=true`, localhost `PLATFORM_DATABASE_URL` rejection, and optional proxy usage behavior when the legacy `proxy` service is absent.
+
+Tests: cloud mode starts without Dockerode/Docker socket, fails if customer VPS mode is disabled, fails if platform DB URL is localhost, and compose/local mode remains compatible.
+
+### Slice 2: Runtime route-token protocol
+
+Add `packages/platform/src/runtime-route-token.ts` and `POST /runtime/routes/resolve`. Verify Clerk-authenticated route resolution, owned explicit VM resolution, generic failures, short-lived token claims, and PostHog success/failure categories.
+
+### Slice 3: Cloudflare Worker router
+
+Add `packages/edge-router` with host/path classification, Cloud Run proxying, runtime resolver calls, VPS origin forwarding, WebSocket upgrade forwarding, no-store headers, and PostHog safe-property events.
+
+### Slice 4: VPS route-token ingress
+
+Update customer VPS cloud-init/host-bin/gateway tests for cloudflared, nginx route-token gate, shell/gateway/code routing, WebSocket upgrade preservation, code proxy token validation, and safe failure events.
+
+### Slice 5: Cloud Run CI/CD
+
+Add `.github/workflows/platform-cloud-run.yml`, Cloud Run image build/push/deploy with no traffic, tagged revision smoke, gradual or manual promotion, rollback on failed smoke, and no secret echoing.
+
+### Slice 6: Inngest workflows
+
+Add platform Inngest client/functions/routes and tests for user-created provisioning, retry-safe VPS provision, deploy fanout isolation, and categorized provider failures.
+
+### Slice 7: Central Synapse
+
+Add Synapse deployment artifact, reverse proxy config, well-known config, Redis, explicit federation setting, and backup/restore notes.
+
+## Required Validation Before PR
+
+Run relevant subset first, then:
+
+```bash
+bun run typecheck
+bun run check:patterns
+bun run test
+```
+
+For Worker changes:
+
+```bash
+pnpm --filter @matrix-os/edge-router test
+pnpm --filter @matrix-os/edge-router exec wrangler deploy --dry-run
+```
+
+For platform changes:
+
+```bash
+pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json
+pnpm exec vitest run tests/platform
+```
+
+Only run deploy commands after the human confirms target environment and provider secrets are configured.
+
+## PR Body Requirements
+
+Every backend PR must include source of truth, lock/transaction scope, acceptable orphan states, auth source of truth, deferred scope, rollback plan, verification commands, and whether PostHog events/errors were added or deferred.
+
+## When to Stop and Ask
+
+Ask before creating paid cloud resources, changing production DNS, pointing Clerk/Pipedream/Stripe webhooks at new URLs, deploying to production Cloud Run, promoting production traffic, fanout deploying to all VPSes, deleting old resources, or rotating secrets.

--- a/specs/085-cloud-run-platform-migration/operator-setup-guide.md
+++ b/specs/085-cloud-run-platform-migration/operator-setup-guide.md
@@ -1,0 +1,105 @@
+# Operator Setup Guide
+
+This guide is for the human operator setting up managed services and sharing access with engineering. It complements `spec.md` and tells coding agents what has already been configured.
+
+Create one secure password-manager item named `Matrix OS Cloud Platform - Production` with non-secret metadata and links: GCP project id, Cloud Run service, Artifact Registry repository, Neon project, R2 bucket, Cloudflare account id and Worker, Clerk app, Pipedream project/environment, Inngest app/environment, PostHog project, Hetzner project, and Synapse deployment location.
+
+Store secret values only in provider secret stores and the password manager, never in GitHub issues, chats, PRs, or agent prompts.
+
+## Neon
+
+Create project `matrixos_platform`, Postgres 18, region AWS Europe Central 1 Frankfurt. Create database and role `matrixos_platform`, production branch, staging branch template, pooled connection strings for Cloud Run, production pooled URL in Google Secret Manager as `platform-database-url`, and staging pooled URLs in staging secrets.
+
+Tell agents only the Neon project name, branch name, Secret Manager secret name, and whether the secret is configured.
+
+## Google Cloud Run
+
+Create GCP project, Artifact Registry repository `matrix-os`, Cloud Run service `matrix-platform`, service account `matrix-platform-runner`, and Secret Manager secrets for all runtime secrets.
+
+Recommended production settings: `europe-west3`, min instances 1 for beta and 2 before paid users, max instances 10 initially, concurrency 20-40, CPU 1-2 vCPU, memory 1-2 GiB, timeout 60-300s, and ingress behind Cloudflare public route.
+
+Cloud Run env should include:
+
+```text
+PLATFORM_RUNTIME_MODE=cloud_run
+PLATFORM_PORT=8080
+PLATFORM_PUBLIC_URL=https://api.matrix-os.com
+CUSTOMER_VPS_ENABLED=true
+CUSTOMER_VPS_TLS_VERIFY=true
+CUSTOMER_VPS_IMAGE_VERSION=dev
+MATRIX_APP_DOMAIN_HOSTS=app.matrix-os.com
+MATRIX_CODE_DOMAIN_HOSTS=code.matrix-os.com
+NEXT_PUBLIC_MATRIX_APP_URL=https://app.matrix-os.com
+POSTHOG_HOST=https://eu.i.posthog.com
+POSTHOG_API_HOST=https://eu.i.posthog.com
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+NEXT_PUBLIC_POSTHOG_API_HOST=https://eu.i.posthog.com
+```
+
+Cloud Run secrets should include `PLATFORM_DATABASE_URL`, `PLATFORM_SECRET`, `PLATFORM_JWT_SECRET`, Clerk, Stripe, Pipedream, R2, Hetzner, Inngest, and PostHog secrets.
+
+## Cloudflare
+
+Create Worker `matrix-edge-router`, production routes for `api.matrix-os.com/*`, `app.matrix-os.com/*`, and `code.matrix-os.com/*`, staging routes for matching `*-staging` hostnames, customer VPS tunnel naming convention, and WAF/rate-limit rules.
+
+Worker vars:
+
+```text
+PLATFORM_ORIGIN=https://api.matrix-os.com
+ROUTE_RESOLVE_PATH=/runtime/routes/resolve
+RUNTIME_ROUTE_CACHE_TTL_SECONDS=60
+POSTHOG_HOST=https://eu.i.posthog.com
+```
+
+Worker secrets: `POSTHOG_PROJECT_TOKEN` and `EDGE_ROUTE_SIGNING_SECRET` if the Worker signs edge-local tokens.
+
+## R2
+
+Create production bucket `matrixos-sync` or `matrixos-prod`, staging bucket or prefix, scoped production and staging API tokens, and keep object layout for `system-bundles/`, `matrixos-sync/`, `backups/`, `exports/`, and `staging/`.
+
+Customer VPSes should receive only scoped runtime sync/backup credentials or a platform sync proxy token.
+
+## Clerk
+
+Configure production app for `matrix-os.com`, optional staging app, sign-in/sign-up URLs, redirect URL `https://app.matrix-os.com/`, and webhook events `user.created`, `user.updated`, and `user.deleted`. Prefer Inngest endpoint once implemented; otherwise use Cloud Run webhook route temporarily.
+
+## Pipedream
+
+Configure production and development/staging environments. Callback URLs point to Cloud Run/Worker public routes. Do not put Pipedream credentials on customer VPSes.
+
+## Inngest
+
+Create production app/environment `matrix-platform` and staging `matrix-platform-staging`. Store `INNGEST_EVENT_KEY` and `INNGEST_SIGNING_KEY`. Wire Clerk events, release published events, VPS provision/reconcile/deploy events, billing entitlement changes, and integration events.
+
+## PostHog
+
+Create production and staging projects/environments using EU host `https://eu.i.posthog.com`. Add dashboards and alerts for route-token failures, Worker upstream errors, VPS unreachable rate, WebSocket failures, Cloud Run 5xx, workflow failures, host bundle deploys, sync/R2 failures, and Synapse health.
+
+## Hetzner and Customer VPSes
+
+Keep the per-user VPS model. The platform provisioning flow should create the server, local Matrix user, `/opt/matrix/env/host.env`, `/opt/matrix/env/postgres.env`, `/opt/matrix/env/r2.env`, cloudflared service, nginx route-token gate, and Matrix systemd services.
+
+## Central Synapse
+
+For beta, run one central Synapse deployment in Germany/Frankfurt with Postgres and Redis. Route `matrix.matrix-os.com` through Cloudflare. Do not deploy Synapse on every VPS until there is a product requirement for per-user or per-org homeserver isolation.
+
+## GitHub Environments
+
+Create `staging` and `production`. Staging contains staging deploy credentials/tokens/URLs. Production contains production deploy credentials/tokens, `PLATFORM_SECRET`, and production platform URL. Require manual approval for production deployments.
+
+## Team Access Model
+
+| Team member type | Access |
+|------------------|--------|
+| Engineer | GitHub repo, staging Cloud Run logs, staging Neon branches, staging Worker deploy, staging PostHog |
+| Release owner | Production deploy approval, production Cloud Run, production Cloudflare routes, production Neon read/admin, production PostHog |
+| Operator | Billing/admin for GCP, Cloudflare, Neon, Clerk, Pipedream, Inngest, Hetzner |
+| Agent | No direct secrets; works through repo, tests, and human-confirmed secret names |
+
+## What to Tell Agents
+
+Provide branch/worktree name, target slice, whether staging services exist, configured secret names, target staging URLs, and whether deploy commands are allowed. Do not provide secret values.
+
+## Cutover Checklist
+
+Before switching production DNS, verify Cloud Run production revision healthy with no traffic, Neon production DB migrated, R2 host-bundle publish works, Worker staging route passes runtime tests, one disposable VPS validates shell/gateway/code WebSockets through Cloudflare, Clerk webhooks and Inngest workflows work in staging, PostHog receives events from all required surfaces, and rollback DNS path is documented.

--- a/specs/085-cloud-run-platform-migration/spec.md
+++ b/specs/085-cloud-run-platform-migration/spec.md
@@ -1,0 +1,243 @@
+# 085 Cloud Run Platform Migration
+
+Status: draft for immediate implementation
+Owner: Matrix OS platform
+Date: 2026-06-04
+
+Companion docs:
+
+- [Agent implementation guide](agent-implementation-guide.md)
+- [Operator setup guide](operator-setup-guide.md)
+
+## Goal
+
+Move the production control plane out of the current single platform Docker Compose host and into managed cloud services while keeping the Matrix OS runtime model intact.
+
+- Cloud Run runs the centralized platform API/control plane.
+- Neon stores platform Postgres data.
+- Cloudflare R2 stores host bundles, sync objects, backups, exports, and object data.
+- Clerk remains the identity provider.
+- Pipedream remains platform-owned integration infrastructure.
+- Inngest runs durable background workflows.
+- User browsers reach their assigned VPS runtime directly through Cloudflare, not through Cloud Run on the interactive hot path.
+- Each customer VPS continues to run the owner runtime gateway, shell, code service, local owner Postgres, and sync/update agents.
+- Synapse is centralized for beta rather than installed on every user VPS.
+
+Downtime is acceptable for this migration because there are no production users yet.
+
+## Non-Goals
+
+- Do not migrate owner/app/runtime data from each VPS into Neon.
+- Do not run the customer runtime on Cloud Run, Workers, or serverless functions.
+- Do not put Pipedream, Clerk, Stripe, Neon admin credentials, or global platform secrets on customer VPSes.
+- Do not make Cloudflare Workers the platform source of truth.
+- Do not deploy Synapse per VPS for beta.
+- Do not introduce D1, SQLite, or another persistence layer for platform state.
+
+## Target Services
+
+| Layer | Service | Region | Purpose |
+|-------|---------|--------|---------|
+| DNS, WAF, TLS, routing | Cloudflare | global | Public entrypoint for Matrix OS domains |
+| Edge router | Cloudflare Worker | global | Session bootstrap, runtime route token minting, dispatch to Cloud Run or selected VPS tunnel |
+| Platform API | Google Cloud Run | `europe-west3` Frankfurt | Central Hono platform/control-plane API |
+| Platform DB | Neon Postgres 18 | AWS Europe Central 1, Frankfurt | Canonical platform data |
+| Object storage | Cloudflare R2 | EU jurisdiction if available/required | Host bundles, sync objects, backups, exports |
+| Auth | Clerk | Matrix domains | User sessions and identity |
+| Integrations | Pipedream | platform-owned | OAuth/integration proxy source of truth |
+| Workflows | Inngest | hosted or self-hosted later | Provisioning, deploy fanout, reconciliation, webhook jobs |
+| User runtime | Hetzner Cloud VPS | start with `fsn1` or `nbg1` | Per-user Matrix computer |
+| Runtime DB | Local Postgres on each VPS | same VPS | Owner/app/runtime data |
+| Messaging | Central Synapse cluster | Germany/Frankfurt | Matrix homeserver for beta |
+
+## Selected Platform Database
+
+Use this Neon project for the first migration target:
+
+```text
+Project name: matrixos_platform
+Postgres version: 18
+Region: AWS Europe Central 1 (Frankfurt)
+```
+
+The production branch holds platform data only. Use Neon branches for staging and pull-request validation.
+
+## Target Request Paths
+
+Platform/API paths go through Cloudflare to Cloud Run, then to Neon, R2, Clerk, Pipedream, or Inngest. Examples include `/auth/*`, `/billing/*`, `/containers/provision`, `/vps/*`, `/system-bundles/*`, `/api/integrations/*`, internal integration routes, operator routes, and webhooks.
+
+Interactive runtime paths must not proxy through Cloud Run after the route is known:
+
+```text
+Browser -> Cloudflare DNS/WAF -> Cloudflare Worker -> selected customer VPS cloudflared tunnel
+  -> VPS nginx -> matrix-shell.service :3000
+  -> matrix-gateway.service :4000
+  -> matrix-code.service :8787
+```
+
+Matrix protocol paths go to central Synapse:
+
+```text
+Matrix client or federated homeserver -> Cloudflare -> matrix.matrix-os.com -> central Synapse reverse proxy
+```
+
+## Architecture
+
+```mermaid
+flowchart TD
+  Browser["User browser"]
+  CF["Cloudflare DNS/WAF"]
+  Worker["Cloudflare Worker router"]
+  CloudRun["Cloud Run: matrix-platform"]
+  Neon["Neon Postgres: platform DB"]
+  R2["Cloudflare R2"]
+  Clerk["Clerk"]
+  Inngest["Inngest"]
+  Pipedream["Pipedream"]
+  VpsTunnel["Customer VPS cloudflared tunnel"]
+  VpsNginx["VPS nginx"]
+  Shell["matrix-shell.service :3000"]
+  Gateway["matrix-gateway.service :4000"]
+  Code["matrix-code.service :8787"]
+  LocalPg["VPS local Postgres"]
+  Synapse["Central Synapse"]
+  SynapsePg["Synapse Postgres"]
+  Redis["Redis"]
+
+  Browser --> CF --> Worker
+  Worker -->|platform/API/auth/webhooks| CloudRun
+  CloudRun --> Neon
+  CloudRun --> R2
+  CloudRun --> Clerk
+  CloudRun --> Pipedream
+  CloudRun --> Inngest
+  Worker -->|interactive runtime route| VpsTunnel --> VpsNginx
+  VpsNginx --> Shell
+  VpsNginx --> Gateway
+  VpsNginx --> Code
+  Gateway --> LocalPg
+  Browser -->|Matrix client-server/federation| CF --> Synapse
+  Synapse --> SynapsePg
+  Synapse --> Redis
+```
+
+## Data Ownership
+
+Neon is canonical for platform-owned control-plane data: Clerk user mapping, handles, VPS/machine registry, runtime slots, entitlement projections, release metadata, deploy fanout records, integration metadata, Pipedream mapping, audit logs, and launch readiness state.
+
+Each customer VPS remains canonical for owner-owned data: `~/system/*`, `~/apps/*`, `~/agents/*`, app data in local owner Postgres, runtime sessions, terminal/code workspace state, and owner-local backups before upload. R2 mirrors or backs up owner data, but does not become the canonical owner database.
+
+## Security Model
+
+All public traffic enters through Cloudflare. Configure WAF managed rules, route-specific rate limits, bot/abuse controls for signup/onboarding, `CDN-Cache-Control: no-store` for authenticated runtime/code responses, and immutable public asset caching only where safe.
+
+Clerk remains the end-user session source of truth. Platform operator APIs use `PLATFORM_SECRET` bearer auth until an admin session model replaces it. Internal VPS calls use per-host `UPGRADE_TOKEN` or a new per-machine HMAC/JWT credential. Route-token minting must be short-lived and bound to user, machine handle, runtime slot, host class, and expiry.
+
+The VPS must reject direct browser traffic without a platform-signed route token or Cloudflare Access/service-token proof. Required Worker-to-VPS headers are `X-Matrix-Route-Token`, `X-Matrix-Handle`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and `CF-Connecting-IP`. For `code.matrix-os.com`, continue sending `X-Matrix-Code-Proxy-Token`.
+
+Never copy platform-only Pipedream, Clerk, Stripe, Hetzner, or global platform secrets into customer VPS env files.
+
+## Observability
+
+PostHog is required across Cloud Run platform, Worker router, shell client, customer VPS gateway, sync/update agent, Inngest workflows, and central Synapse coarse health. Do not send raw prompts, file contents, message bodies, provider secrets, database URLs, filesystem paths, or upstream error bodies. Use stable `matrix_*` event names and coarse error categories.
+
+## Code Changes
+
+### 1. Split platform deployment mode from legacy Docker mode
+
+Files:
+
+- `packages/platform/src/main.ts`
+- `packages/platform/src/orchestrator.ts`
+- `packages/platform/src/customer-vps-config.ts`
+- `packages/platform/src/db.ts`
+
+Changes:
+
+- Add `PLATFORM_RUNTIME_MODE=cloud_run|compose|local`.
+- In `cloud_run` mode, refuse to initialize Dockerode-dependent legacy user-container orchestration.
+- In `cloud_run` mode, require `CUSTOMER_VPS_ENABLED=true`.
+- In `cloud_run` mode, fail startup if `PLATFORM_DATABASE_URL` is missing or points at localhost.
+- Keep `/containers/provision` as a compatibility route, but route only to customer VPS provisioning.
+- Make `/api/admin/proxy-usage` optional or remove its hard dependency on `http://proxy:8080`.
+- Ensure all startup checks are Cloud Run compatible and do not require `/var/run/docker.sock`.
+
+Acceptance checks:
+
+- `PLATFORM_RUNTIME_MODE=cloud_run CUSTOMER_VPS_ENABLED=true` starts without Docker socket.
+- `PLATFORM_RUNTIME_MODE=cloud_run CUSTOMER_VPS_ENABLED=false` fails startup with a clear operator error.
+- Legacy compose local development still works.
+
+### 2. Add direct runtime route-token protocol
+
+Add `POST /runtime/routes/resolve` with Clerk auth. Resolve primary runtime and explicit owned `/vm/<handle>` routes. Mint short-lived HMAC/JWT route tokens with `sub`, `handle`, `slot`, `host`, `pathClass`, `exp`, and `jti`. Return generic unauthorized and missing-machine errors.
+
+### 3. Add Cloudflare Worker router
+
+Add `packages/edge-router`. Match host/path, send platform routes to Cloud Run, resolve interactive runtime routes through Cloud Run, forward runtime HTTP/WebSocket requests to selected VPS tunnel/origin, preserve code proxy token behavior, and apply no-store headers to authenticated/runtime/code responses.
+
+### 4. Update customer VPS ingress for route-token validation
+
+Install and run `cloudflared`, add nginx route-token validation before shell/gateway/code, preserve WebSocket upgrade headers, keep code-server proxy token validation, and expose no public HTTP ports on the VPS.
+
+### 5. Centralize Synapse
+
+Add deployment artifacts for Synapse, Postgres, Redis, and reverse proxy config. Use one central Synapse for beta.
+
+### 6. Keep host-bundle release flow
+
+Keep GitHub Actions host bundle builds and R2 immutable publishing. Register releases in Neon through Cloud Run and trigger deploy fanout through Cloud Run/Inngest.
+
+### 7. Add Inngest workflows
+
+Add workflow client, functions, routes, and tests for user lifecycle, VPS provisioning/reconciliation/deploy, release publishing, integrations, and billing entitlement changes.
+
+### 8. CI/CD changes
+
+Add Cloud Run and edge-router workflows. Deploy Cloud Run revisions with no traffic, smoke tagged revisions, shift traffic gradually or through manual blue/green approval, and roll back on failed smoke.
+
+## Migration Plan
+
+1. Freeze and backup old platform compose, platform Postgres, R2 metadata, active VPSes, and Cloudflare routes.
+2. Prepare managed services: Neon, R2, Cloud Run, Worker, Inngest, and central Synapse.
+3. Make platform Cloud Run compatible.
+4. Deploy platform to Cloud Run with no traffic and smoke `/health`, `/system-bundles/releases`, `/vps`, `/runtime/routes/resolve`, and `/billing/config`.
+5. Deploy edge router to staging, then route `app.matrix-os.com` and `code.matrix-os.com`.
+6. Migrate one disposable VPS ingress, validate HTTP/WebSocket direct paths, then roll host bundle to test VPSes.
+7. Cut over onboarding, webhooks, release registration, and deploy fanout.
+8. Retire old compose platform after rollback path is documented.
+
+## Rollback Plan
+
+Move Cloudflare routes back to old compose platform, restore old platform Postgres if Neon state is incompatible, disable Worker runtime direct routing, re-enable existing platform proxy path, and restart old platform compose. Do not roll back owner data unless a specific migration touched owner data.
+
+## Verification Checklist
+
+Platform: Cloud Run health, Neon connection, no Docker socket requirement, VPS provisioning, admin VPS routes, release metadata, and Inngest test event.
+
+Edge router: auth/device and runtime platform routes, selected VPS runtime routes, owned `/vm/<handle>` checks, WebSockets, and generic unauthorized responses.
+
+VPS: cloudflared active, nginx rejects missing/expired route token, shell/gateway/code/local Postgres active, host bundle update works, and R2 sync/backup works.
+
+Synapse: client-server API, well-known files, Postgres not SQLite, Redis configured, and explicit federation decision.
+
+## Open Decisions
+
+1. Should `app.matrix-os.com` continue to serve auth pages from auth-shell, or should platform-owned auth routes fully replace it before Cloud Run migration?
+2. Should route tokens be HMAC JWTs with `PLATFORM_JWT_SECRET` or asymmetric JWTs so VPSes only hold a public key?
+3. Should every VPS get its own Cloudflare Tunnel, or should shared tunnel connectors route by origin metadata?
+4. Should Synapse run on Cloud Run, GKE, or a VM? Recommendation today: VM or small Kubernetes deployment, not Cloud Run.
+5. Should Inngest own all provisioning steps immediately, or only reconciliation/deploy fanout first?
+
+## Implementation Order
+
+1. Cloud Run compatibility mode in platform.
+2. Neon platform database wiring.
+3. Route-token resolve endpoint.
+4. Cloudflare Worker router.
+5. VPS route-token ingress.
+6. Cloud Run CI/CD.
+7. Worker CI/CD.
+8. Inngest workflows.
+9. Central Synapse deployment.
+10. Cutover and old compose retirement.

--- a/tests/platform/api.test.ts
+++ b/tests/platform/api.test.ts
@@ -712,6 +712,26 @@ describe('platform/api', () => {
     expect(body.durationMs).toBeGreaterThanOrEqual(0);
   });
 
+  it('POST /containers/rolling-restart returns structured unsupported response in cloud mode', async () => {
+    const cloudApp = createApp({
+      db,
+      orchestrator: createDisabledOrchestrator({ db }),
+      platformSecret,
+      env: {
+        PLATFORM_RUNTIME_MODE: 'cloud_run',
+        CUSTOMER_VPS_ENABLED: 'true',
+      } as NodeJS.ProcessEnv,
+    });
+
+    const res = await cloudApp.request('/containers/rolling-restart', {
+      method: 'POST',
+      headers: adminHeaders,
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'Not supported in this runtime mode' });
+  });
+
   it('DELETE /containers/:handle destroys a container', async () => {
     await app.request('/containers/provision', {
       method: 'POST',

--- a/tests/platform/api.test.ts
+++ b/tests/platform/api.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 import { createHmac } from 'node:crypto';
 import { type PlatformDB, insertContainer, insertUserMachine, updateUserMachine } from '../../packages/platform/src/db.js';
-import { createOrchestrator } from '../../packages/platform/src/orchestrator.js';
+import { createDisabledOrchestrator, createOrchestrator } from '../../packages/platform/src/orchestrator.js';
 import { createApp } from '../../packages/platform/src/main.js';
 import { metricsRegistry } from '../../packages/platform/src/metrics.js';
 
@@ -217,6 +217,41 @@ describe('platform/api', () => {
       expect(await second.text()).toContain('matrix_vps_healthy{handle="alice"} 1');
     } finally {
       globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('serves the admin dashboard when the legacy proxy usage service is absent', async () => {
+    const cloudApp = createApp({
+      db,
+      orchestrator: createDisabledOrchestrator({ db }),
+      platformSecret,
+      env: {
+        PLATFORM_RUNTIME_MODE: 'cloud_run',
+        CUSTOMER_VPS_ENABLED: 'true',
+      } as NodeJS.ProcessEnv,
+    });
+    const originalFetch = globalThis.fetch;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+    try {
+      const res = await cloudApp.request('/admin/dashboard', { headers: adminHeaders });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        summary: {
+          total: 0,
+          running: 0,
+          stopped: 0,
+        },
+        containers: [],
+        stoppedContainers: [],
+        usageSummary: null,
+      });
+      expect(globalThis.fetch).toHaveBeenCalledWith('http://proxy:8080/usage/summary', {
+        signal: expect.any(AbortSignal),
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      warnSpy.mockRestore();
     }
   });
 

--- a/tests/platform/api.test.ts
+++ b/tests/platform/api.test.ts
@@ -712,7 +712,18 @@ describe('platform/api', () => {
     expect(body.durationMs).toBeGreaterThanOrEqual(0);
   });
 
-  it('POST /containers/rolling-restart returns structured unsupported response in cloud mode', async () => {
+  it.each([
+    ['POST', '/containers/alice/start', adminHeaders],
+    ['POST', '/containers/alice/stop', adminHeaders],
+    ['POST', '/containers/alice/upgrade', adminHeaders],
+    [
+      'POST',
+      '/containers/alice/self-upgrade',
+      { authorization: `Bearer ${createHmac('sha256', platformSecret).update('alice').digest('hex')}` },
+    ],
+    ['POST', '/containers/rolling-restart', adminHeaders],
+    ['DELETE', '/containers/alice', adminHeaders],
+  ])('%s %s returns structured unsupported response in cloud mode', async (method, path, headers) => {
     const cloudApp = createApp({
       db,
       orchestrator: createDisabledOrchestrator({ db }),
@@ -723,9 +734,9 @@ describe('platform/api', () => {
       } as NodeJS.ProcessEnv,
     });
 
-    const res = await cloudApp.request('/containers/rolling-restart', {
-      method: 'POST',
-      headers: adminHeaders,
+    const res = await cloudApp.request(path, {
+      method,
+      headers,
     });
 
     expect(res.status).toBe(503);

--- a/tests/platform/api.test.ts
+++ b/tests/platform/api.test.ts
@@ -553,6 +553,27 @@ describe('platform/api', () => {
     expect(await res.json()).toEqual({ error: 'Container already exists' });
   });
 
+  it('POST /containers/provision returns structured unsupported response when legacy orchestration is disabled', async () => {
+    const cloudApp = createApp({
+      db,
+      orchestrator: createDisabledOrchestrator({ db }),
+      platformSecret,
+      env: {
+        PLATFORM_RUNTIME_MODE: 'cloud_run',
+        CUSTOMER_VPS_ENABLED: 'true',
+      } as NodeJS.ProcessEnv,
+    });
+
+    const res = await cloudApp.request('/containers/provision', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...adminHeaders },
+      body: JSON.stringify({ handle: 'alice', clerkUserId: 'c1' }),
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'Not supported in this runtime mode' });
+  });
+
   it('fails closed when admin routes are not configured with a secret', async () => {
     const { docker } = createMockDocker();
     const orchestrator = createOrchestrator({ db, docker: docker as any });

--- a/tests/platform/orchestrator.test.ts
+++ b/tests/platform/orchestrator.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
 import pg from 'pg';
 import { type PlatformDB, getContainer } from '../../packages/platform/src/db.js';
-import { createOrchestrator, type Orchestrator } from '../../packages/platform/src/orchestrator.js';
+import {
+  LegacyContainerOrchestrationDisabledError,
+  createDisabledOrchestrator,
+  createOrchestrator,
+  type Orchestrator,
+} from '../../packages/platform/src/orchestrator.js';
 
 function createMockDocker() {
   const mockContainer = {
@@ -32,6 +37,16 @@ describe('platform/orchestrator', () => {
 
   afterEach(async () => {
     await destroyTestPlatformDb(db);
+  });
+
+  it('can disable Docker-backed orchestration while preserving read-only container views', async () => {
+    const orch = createDisabledOrchestrator({ db, image: 'customer-vps' });
+
+    await expect(orch.provision('alice', 'clerk_1')).rejects.toBeInstanceOf(
+      LegacyContainerOrchestrationDisabledError,
+    );
+    await expect(orch.listAll()).resolves.toEqual([]);
+    expect(orch.getImage()).toBe('customer-vps');
   });
 
   it('provisions a container', async () => {

--- a/tests/platform/runtime-mode.test.ts
+++ b/tests/platform/runtime-mode.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PlatformStartupConfigError,
+  loadPlatformRuntimeConfig,
+} from '../../packages/platform/src/runtime-mode.js';
+
+describe('platform/runtime-mode', () => {
+  it('defaults to compose-compatible legacy orchestration', () => {
+    const config = loadPlatformRuntimeConfig({
+      POSTGRES_URL: 'postgres://postgres:postgres@db:5432',
+    });
+
+    expect(config.mode).toBe('compose');
+    expect(config.platformDatabaseUrl).toBe('postgres://postgres:postgres@db:5432/matrixos_platform');
+    expect(config.dockerRequired).toBe(true);
+    expect(config.legacyContainerOrchestrationEnabled).toBe(true);
+  });
+
+  it('allows Cloud Run mode without Docker when customer VPS mode and a managed database are configured', () => {
+    const config = loadPlatformRuntimeConfig({
+      PLATFORM_RUNTIME_MODE: 'cloud_run',
+      CUSTOMER_VPS_ENABLED: 'true',
+      PLATFORM_DATABASE_URL: 'postgres://matrixos_platform:secret@ep-green-field.eu-central-1.aws.neon.tech/matrixos_platform',
+    });
+
+    expect(config.mode).toBe('cloud_run');
+    expect(config.dockerRequired).toBe(false);
+    expect(config.legacyContainerOrchestrationEnabled).toBe(false);
+    expect(config.platformDatabaseUrl).toContain('neon.tech/matrixos_platform');
+  });
+
+  it('rejects Cloud Run mode when customer VPS provisioning is disabled', () => {
+    expect(() => loadPlatformRuntimeConfig({
+      PLATFORM_RUNTIME_MODE: 'cloud_run',
+      CUSTOMER_VPS_ENABLED: 'false',
+      PLATFORM_DATABASE_URL: 'postgres://matrixos_platform:secret@ep-green-field.eu-central-1.aws.neon.tech/matrixos_platform',
+    })).toThrow(new PlatformStartupConfigError('CUSTOMER_VPS_ENABLED=true is required when PLATFORM_RUNTIME_MODE=cloud_run'));
+  });
+
+  it('rejects Cloud Run mode without an explicit platform database URL', () => {
+    expect(() => loadPlatformRuntimeConfig({
+      PLATFORM_RUNTIME_MODE: 'cloud_run',
+      CUSTOMER_VPS_ENABLED: 'true',
+      POSTGRES_URL: 'postgres://postgres:postgres@db:5432',
+    })).toThrow(new PlatformStartupConfigError('PLATFORM_DATABASE_URL is required when PLATFORM_RUNTIME_MODE=cloud_run'));
+  });
+
+  it('rejects localhost platform database URLs in Cloud Run mode', () => {
+    expect(() => loadPlatformRuntimeConfig({
+      PLATFORM_RUNTIME_MODE: 'cloud_run',
+      CUSTOMER_VPS_ENABLED: 'true',
+      PLATFORM_DATABASE_URL: 'postgres://matrixos_platform:secret@localhost:5432/matrixos_platform',
+    })).toThrow(new PlatformStartupConfigError('PLATFORM_DATABASE_URL must point at a managed Postgres host when PLATFORM_RUNTIME_MODE=cloud_run'));
+  });
+
+  it('rejects unknown runtime mode values', () => {
+    expect(() => loadPlatformRuntimeConfig({
+      PLATFORM_RUNTIME_MODE: 'kubernetes',
+      PLATFORM_DATABASE_URL: 'postgres://postgres:postgres@db:5432/matrixos_platform',
+    })).toThrow(new PlatformStartupConfigError('PLATFORM_RUNTIME_MODE must be one of: cloud_run, compose, local'));
+  });
+});

--- a/tests/platform/runtime-mode.test.ts
+++ b/tests/platform/runtime-mode.test.ts
@@ -12,7 +12,6 @@ describe('platform/runtime-mode', () => {
 
     expect(config.mode).toBe('compose');
     expect(config.platformDatabaseUrl).toBe('postgres://postgres:postgres@db:5432/matrixos_platform');
-    expect(config.dockerRequired).toBe(true);
     expect(config.legacyContainerOrchestrationEnabled).toBe(true);
   });
 
@@ -24,7 +23,6 @@ describe('platform/runtime-mode', () => {
     });
 
     expect(config.mode).toBe('cloud_run');
-    expect(config.dockerRequired).toBe(false);
     expect(config.legacyContainerOrchestrationEnabled).toBe(false);
     expect(config.platformDatabaseUrl).toContain('neon.tech/matrixos_platform');
   });


### PR DESCRIPTION
## Summary

- Add the 085 Cloud Run platform migration spec, agent implementation guide, and operator setup guide.
- Add `PLATFORM_RUNTIME_MODE=cloud_run|compose|local` startup validation with Cloud Run requirements for customer VPS mode and managed `PLATFORM_DATABASE_URL`.
- Skip Dockerode, legacy lifecycle, and Docker stats collector initialization in Cloud Run mode by using a disabled read-only legacy orchestrator.
- Keep the admin dashboard usable when the legacy `proxy:8080` usage service is absent.

## Invariants

- Source of truth: platform runtime mode comes from `PLATFORM_RUNTIME_MODE`; in `cloud_run`, `PLATFORM_DATABASE_URL` must be the explicit managed Postgres URL and customer VPS records remain in platform Postgres.
- Lock/transaction scope: this slice adds startup configuration and orchestration selection only; it does not add multi-write database mutations or new transaction boundaries.
- Acceptable orphan states: Cloud Run mode disables legacy container orchestration; compatibility provisioning must use `customerVpsService`, while legacy read-only container views remain available for operator visibility.
- Auth source of truth: unchanged. Clerk remains user auth, `PLATFORM_SECRET` remains operator/internal bearer auth, and no new route-token auth is introduced in this slice.
- Deferred scope: route-token resolver, Cloudflare Worker router, VPS route-token ingress, Cloud Run CI/CD, Inngest workflows, and central Synapse are documented but intentionally deferred to follow-up slices.
- Rollback plan: deploy with `PLATFORM_RUNTIME_MODE=compose`/unset to preserve legacy Docker orchestration, or revert this PR before Cloud Run rollout. No owner data migrations are included.
- PostHog events/errors: no new events in this slice; route-token and workflow event coverage is deferred to the relevant implementation slices.

## Tests

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run tests/platform/runtime-mode.test.ts`
- `pnpm exec vitest run tests/platform/runtime-mode.test.ts tests/platform/orchestrator.test.ts tests/platform/api.test.ts`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns` (0 violations, existing warnings only)
- `bun run typecheck`
- `bun run test` (531 files passed, 6024 tests passed, 20 skipped)
