### PR TITLE
fix(shell): unblock billing gate host bundle

### DIFF
--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -268,6 +268,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!deviceReturnPath || !hasBillingAccess || !isLoaded || !isSignedIn) return;
     if (deviceSetupStarted.current) return;
+    const activeDeviceReturnPath = deviceReturnPath;
     deviceSetupStarted.current = true;
     let disposed = false;
     let pollCount = 0;
@@ -302,7 +303,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
         method: "POST",
         credentials: "include",
         headers: await authHeaders(),
-        body: JSON.stringify({ redirectTo: deviceReturnPath }),
+        body: JSON.stringify({ redirectTo: activeDeviceReturnPath }),
       });
       if (disposed) return;
 
@@ -325,7 +326,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
       if (disposed) return;
 
       if (readyResponse.ok) {
-        window.location.replace(deviceReturnPath);
+        window.location.replace(activeDeviceReturnPath);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Capture the non-null CLI device return path before the async provisioning poll closure.
- Use that stable string for app-session creation and the final device-auth redirect.
- Unblocks the host-bundle `next build --webpack` typecheck that failed for PR #351 at `BillingGate.tsx:328`.

## Validation
- `bun run test tests/shell/billing-gate.test.tsx`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_local pnpm --filter './shell' exec next build --webpack`\n- `bun run typecheck`\n- `bun run check:patterns`\n- `npx react-doctor@latest shell` (92/100, pre-existing warnings only)\n\n## Invariants\n- Source of truth: Billing access and runtime readiness remain sourced from the existing billing status/provisioning/app-session endpoints; this PR only preserves the already-validated device return path inside the client effect.\n- Lock/transaction scope: No database writes or transactions are changed.\n- Acceptable orphan states: Existing retry/failure UI remains unchanged if provisioning, app-session creation, or readiness polling fails after billing succeeds.\n- Auth source of truth: Clerk session token retrieval through `getToken()` and existing credentialed requests remain unchanged.\n- Deferred scope: Does not change VPS deployment, seed app sync behavior, or checkout UX beyond fixing the production build blocker.