### PR TITLE
fix(platform): unregister app-domain service worker

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -739,6 +739,42 @@ function applyNoStoreHeaders(c: import('hono').Context): void {
   c.header('Expires', '0');
 }
 
+const APP_DOMAIN_UNREGISTER_SERVICE_WORKER = `
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys
+      .filter((key) => key.startsWith("matrix-os-"))
+      .map((key) => caches.delete(key)));
+    await self.clients.claim();
+    await self.registration.unregister();
+  })());
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(fetch(event.request));
+});
+`.trim();
+
+function appDomainServiceWorkerResponse(): Response {
+  return new Response(APP_DOMAIN_UNREGISTER_SERVICE_WORKER, {
+    status: 200,
+    headers: {
+      'content-type': 'text/javascript; charset=utf-8',
+      'cache-control': 'no-store, private',
+      'cdn-cache-control': 'no-store',
+      'cloudflare-cdn-cache-control': 'no-store',
+      'pragma': 'no-cache',
+      'expires': '0',
+      'service-worker-allowed': '/',
+    },
+  });
+}
+
 function isPostgresUniqueViolation(err: unknown): boolean {
   return err instanceof Error && (err as Error & { code?: unknown }).code === '23505';
 }
@@ -3495,6 +3531,9 @@ export function createApp(deps: {
     // but we short-circuit explicitly so a misconfigured PLATFORM_JWT_SECRET or
     // a future refactor can't accidentally proxy them into a user container.
     const reqPath = c.req.path;
+    if (isAppDomain && reqPath === '/service-worker.js') {
+      return appDomainServiceWorkerResponse();
+    }
     if (isAppDomain && (
       reqPath === '/auth/device' ||
       reqPath.startsWith('/auth/device/') ||

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -3337,6 +3337,41 @@ describe("platform proxy routing", () => {
     }
   });
 
+  it("serves an unregistering app-domain service worker without auth", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("wrong target", { status: 200 }),
+    );
+    const verifyToken = vi.fn().mockResolvedValue({ authenticated: false });
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken,
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_123";
+    try {
+      const res = await app.request("/service-worker.js", {
+        headers: {
+          host: "app.matrix-os.com",
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/javascript");
+      expect(res.headers.get("cache-control")).toBe("no-store, private");
+      expect(res.headers.get("cdn-cache-control")).toBe("no-store");
+      expect(res.headers.get("service-worker-allowed")).toBe("/");
+      expect(await res.text()).toContain("registration.unregister()");
+      expect(verifyToken).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    }
+  });
+
   it("routes app-domain shell static assets with the short-lived shell route cookie", async () => {
     await insertUserMachine(db, {
       machineId: "machine-alice",


### PR DESCRIPTION
## Source of truth

The platform owns the shared `app.matrix-os.com/service-worker.js` response. Customer VPS shell bundles remain the source of truth for per-runtime shell assets, but the shared app domain must not allow a stale runtime service worker to control all app-domain requests.

## Lock/transaction scope

No database writes and no transaction scope. This is a deterministic GET response for the app-domain service worker path.

## Acceptable orphan states

A browser may keep an old service worker until its next navigation or service worker update check. The new worker uses `skipWaiting`, `clients.claim`, deletes Matrix OS caches, and unregisters itself so stale cache-first handlers stop intercepting static chunks.

## Auth source of truth

This route is intentionally public on `app.matrix-os.com` and does not consult Clerk. It returns no user data and exists only to retire stale service worker state. Authenticated runtime/API/static routes keep their existing Clerk, app-session, route-cookie, and platform-token behavior.

## Deferred scope

This does not redesign PWA behavior for customer VPS shells. Re-enabling a scoped PWA worker should happen only after the Cloudflare direct runtime router defines a per-runtime scope that cannot control platform auth or shared app-domain assets.

## Rollback plan

Revert this commit. Browsers that already received the unregistering worker will keep operating without the app-domain service worker; runtime shell asset serving continues through normal network routing.

## Verification

- `pnpm exec vitest run tests/platform/proxy-routing.test.ts --testNamePattern 'unregistering app-domain service worker'`
- `pnpm exec vitest run tests/platform/proxy-routing.test.ts`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns`

## PostHog events/errors

No PostHog events added. This route intentionally avoids user/session context and has no provider call or failure category to report.
