### PR TITLE
feat(devops): add local artifact cleanup

### DIFF
--- a/docs/platform/dev/local-artifact-cleanup.md
+++ b/docs/platform/dev/local-artifact-cleanup.md
@@ -1,0 +1,79 @@
+# Local Artifact Cleanup
+
+Matrix OS production is moving toward Cloud Run for the centralized platform, but
+local engineer machines, build hosts, and any legacy compose operators can still
+fill disks with repeated host bundle builds and Docker cache. Use the local
+cleanup tool for those hosts only.
+
+This cleanup is deliberately narrow:
+
+- Removes only old `dist/host-bundle` directories under explicitly approved
+  repository or worktree roots.
+- Optionally prunes Docker images and builder cache.
+- Never prunes Docker volumes.
+- Never touches `system-bundles/`, `$MATRIX_HOME`, owner data, backups, sync
+  objects, or customer VPS runtime state.
+- Defaults to dry-run mode.
+
+## One-Off Cleanup
+
+Preview actions first:
+
+```bash
+bun run cleanup:local-artifacts -- --root /home/deploy/matrix-os.worktrees --older-than-days 3 --docker
+```
+
+Apply after reviewing the output:
+
+```bash
+bun run cleanup:local-artifacts -- --root /home/deploy/matrix-os.worktrees --older-than-days 3 --docker --apply
+```
+
+The Docker cleanup plan runs:
+
+```bash
+docker image prune --all --force --filter until=168h
+docker builder prune --all --force --keep-storage 20GB
+```
+
+It does not run `docker volume prune`, because volumes may contain databases or
+other stateful development data.
+
+## Suggested Timer
+
+For engineer VPSes or a dedicated build host, run the cleanup daily with systemd:
+
+```ini
+[Unit]
+Description=Matrix OS local artifact cleanup
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/deploy/matrix-os
+ExecStart=/usr/bin/env bun run cleanup:local-artifacts -- --root /home/deploy/matrix-os.worktrees --older-than-days 3 --docker --apply
+```
+
+```ini
+[Unit]
+Description=Run Matrix OS local artifact cleanup daily
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Keep this timer off customer runtime VPSes unless the host is also used as an
+engineer/build machine. Customer VPS release updates should continue through the
+host-bundle release flow and must not delete owner-controlled runtime data.
+
+## Cloud Run Migration Note
+
+This guardrail still fits the Cloud Run platform migration. Cloud Run removes the
+single compose platform host from the production hot path, but it does not remove
+local worktree builds, GitHub/self-hosted build artifacts, or legacy Docker cache
+from machines that engineers use to develop and validate Matrix OS. Managed cloud
+services should own platform runtime scaling; this script only keeps local
+operator machines from failing before or during migration work.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docker:logs": "docker compose -f docker-compose.dev.yml logs -f dev",
     "docker:shell": "docker compose -f docker-compose.dev.yml exec -u matrixos dev sh",
     "docker:build": "docker compose -f docker-compose.dev.yml build --no-cache",
+    "cleanup:local-artifacts": "node scripts/cleanup-local-artifacts.mjs",
     "test": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run \"$@\"' --",
     "test:watch": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest \"$@\"' --",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/scripts/cleanup-local-artifacts.mjs
+++ b/scripts/cleanup-local-artifacts.mjs
@@ -95,7 +95,9 @@ export async function collectHostBundleCandidates({ roots, olderThanDays, now = 
           path: candidate.path,
           realpath: candidate.realpath,
           mtime: candidateStat.mtime,
-          sizeBytes: candidateStat.size,
+          // Directory stat size is not recursive disk usage. Keep the field
+          // explicit so future reporting does not confuse it for freed bytes.
+          dirEntrySizeBytes: candidateStat.size,
         });
       }
     }
@@ -160,6 +162,14 @@ function parseNumber(value, name) {
   return parsed;
 }
 
+function readOptionValue(argv, index, arg) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${arg} requires a value`);
+  }
+  return value;
+}
+
 export function parseArgs(argv, env = process.env) {
   const roots = [];
   const options = {
@@ -181,15 +191,21 @@ export function parseArgs(argv, env = process.env) {
       case "--dry-run":
         options.dryRun = true;
         break;
-      case "--root":
-        roots.push(argv[++index]);
+      case "--root": {
+        roots.push(readOptionValue(argv, index, arg));
+        index += 1;
         break;
-      case "--worktrees-root":
-        roots.push(argv[++index]);
+      }
+      case "--worktrees-root": {
+        roots.push(readOptionValue(argv, index, arg));
+        index += 1;
         break;
-      case "--older-than-days":
-        options.olderThanDays = parseNumber(argv[++index], "--older-than-days");
+      }
+      case "--older-than-days": {
+        options.olderThanDays = parseNumber(readOptionValue(argv, index, arg), "--older-than-days");
+        index += 1;
         break;
+      }
       case "--docker":
         options.includeDocker = true;
         break;
@@ -202,12 +218,16 @@ export function parseArgs(argv, env = process.env) {
       case "--skip-builder":
         options.pruneBuilder = false;
         break;
-      case "--image-until":
-        options.imageUntil = argv[++index];
+      case "--image-until": {
+        options.imageUntil = readOptionValue(argv, index, arg);
+        index += 1;
         break;
-      case "--builder-keep-storage":
-        options.builderKeepStorage = argv[++index];
+      }
+      case "--builder-keep-storage": {
+        options.builderKeepStorage = readOptionValue(argv, index, arg);
+        index += 1;
         break;
+      }
       case "--help":
         options.help = true;
         break;

--- a/scripts/cleanup-local-artifacts.mjs
+++ b/scripts/cleanup-local-artifacts.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+import { readdir, realpath, rm, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_OLDER_THAN_DAYS = 3;
+const DEFAULT_IMAGE_UNTIL = "168h";
+const DEFAULT_BUILDER_KEEP_STORAGE = "20GB";
+const DEFAULT_MAX_DEPTH = 4;
+
+export function isHostBundlePath(candidatePath) {
+  const normalized = path.normalize(candidatePath);
+  const parts = normalized.split(path.sep).filter(Boolean);
+  return parts.at(-2) === "dist" && parts.at(-1) === "host-bundle";
+}
+
+function isSkippableDirectory(name) {
+  return name === ".git" || name === "node_modules" || name === ".next";
+}
+
+async function maybeRealpath(candidatePath) {
+  try {
+    return await realpath(candidatePath);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isInsideRoot(candidateRealpath, rootRealpath) {
+  const relative = path.relative(rootRealpath, candidateRealpath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function walkForHostBundles(root, rootRealpath, depth, results) {
+  if (depth > DEFAULT_MAX_DEPTH) {
+    return;
+  }
+
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || isSkippableDirectory(entry.name)) {
+      continue;
+    }
+
+    const childPath = path.join(root, entry.name);
+    const childRealpath = await maybeRealpath(childPath);
+    if (!childRealpath || !isInsideRoot(childRealpath, rootRealpath)) {
+      continue;
+    }
+
+    if (isHostBundlePath(childPath)) {
+      results.push({ path: childPath, realpath: childRealpath });
+      continue;
+    }
+
+    await walkForHostBundles(childPath, rootRealpath, depth + 1, results);
+  }
+}
+
+export async function collectHostBundleCandidates({ roots, olderThanDays, now = new Date() }) {
+  const cutoffMs = now.getTime() - olderThanDays * DAY_MS;
+  const candidates = [];
+
+  for (const root of roots) {
+    const rootRealpath = await maybeRealpath(root);
+    if (!rootRealpath) {
+      continue;
+    }
+
+    const discovered = [];
+    await walkForHostBundles(rootRealpath, rootRealpath, 0, discovered);
+
+    for (const candidate of discovered) {
+      if (!isHostBundlePath(candidate.path)) {
+        continue;
+      }
+      const candidateStat = await stat(candidate.realpath);
+      if (candidateStat.mtimeMs <= cutoffMs) {
+        candidates.push({
+          path: candidate.path,
+          realpath: candidate.realpath,
+          mtime: candidateStat.mtime,
+          sizeBytes: candidateStat.size,
+        });
+      }
+    }
+  }
+
+  return candidates.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export async function runHostBundleCleanup({
+  roots,
+  olderThanDays,
+  now = new Date(),
+  dryRun,
+  logger = () => {},
+}) {
+  const candidates = await collectHostBundleCandidates({ roots, olderThanDays, now });
+  const removed = [];
+
+  for (const candidate of candidates) {
+    logger(`${dryRun ? "Would remove" : "Removing"} ${candidate.path}`);
+    if (!dryRun) {
+      await rm(candidate.realpath, { recursive: true, force: true });
+      removed.push(candidate);
+    }
+  }
+
+  return { candidates, removed };
+}
+
+export function buildDockerCleanupPlan({
+  includeDocker,
+  pruneImages,
+  pruneBuilder,
+  imageUntil = DEFAULT_IMAGE_UNTIL,
+  builderKeepStorage = DEFAULT_BUILDER_KEEP_STORAGE,
+}) {
+  if (!includeDocker) {
+    return [];
+  }
+
+  const plan = [];
+  if (pruneImages) {
+    plan.push({
+      command: "docker",
+      args: ["image", "prune", "--all", "--force", "--filter", `until=${imageUntil}`],
+    });
+  }
+  if (pruneBuilder) {
+    plan.push({
+      command: "docker",
+      args: ["builder", "prune", "--all", "--force", "--keep-storage", builderKeepStorage],
+    });
+  }
+  return plan;
+}
+
+function parseNumber(value, name) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  return parsed;
+}
+
+export function parseArgs(argv, env = process.env) {
+  const roots = [];
+  const options = {
+    dryRun: true,
+    olderThanDays: DEFAULT_OLDER_THAN_DAYS,
+    includeDocker: false,
+    pruneImages: true,
+    pruneBuilder: true,
+    imageUntil: DEFAULT_IMAGE_UNTIL,
+    builderKeepStorage: DEFAULT_BUILDER_KEEP_STORAGE,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--apply":
+        options.dryRun = false;
+        break;
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--root":
+        roots.push(argv[++index]);
+        break;
+      case "--worktrees-root":
+        roots.push(argv[++index]);
+        break;
+      case "--older-than-days":
+        options.olderThanDays = parseNumber(argv[++index], "--older-than-days");
+        break;
+      case "--docker":
+        options.includeDocker = true;
+        break;
+      case "--skip-docker":
+        options.includeDocker = false;
+        break;
+      case "--skip-images":
+        options.pruneImages = false;
+        break;
+      case "--skip-builder":
+        options.pruneBuilder = false;
+        break;
+      case "--image-until":
+        options.imageUntil = argv[++index];
+        break;
+      case "--builder-keep-storage":
+        options.builderKeepStorage = argv[++index];
+        break;
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  const home = env.HOME || homedir();
+  return {
+    ...options,
+    roots: roots.length > 0 ? roots : [path.join(home, "matrix-os.worktrees")],
+  };
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/cleanup-local-artifacts.mjs [options]
+
+Safely remove local build artifacts that can fill engineer or legacy compose hosts.
+The script defaults to dry-run mode. Pass --apply to delete eligible artifacts.
+
+Options:
+  --apply                         Delete eligible artifacts
+  --dry-run                       Print actions without deleting (default)
+  --root <path>                   Approved root to scan; repeatable
+  --worktrees-root <path>         Alias for --root
+  --older-than-days <days>        Remove host bundles older than this (default: 3)
+  --docker                        Also run Docker image and builder prune commands
+  --skip-docker                   Do not run Docker cleanup (default)
+  --skip-images                   Skip docker image prune
+  --skip-builder                  Skip docker builder prune
+  --image-until <duration>        Docker image prune age filter (default: 168h)
+  --builder-keep-storage <size>   Docker builder cache floor (default: 20GB)
+`);
+}
+
+async function runCommand(command, args, { dryRun, logger }) {
+  logger(`${dryRun ? "Would run" : "Running"} ${[command, ...args].join(" ")}`);
+  if (dryRun) {
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with status ${code}`));
+      }
+    });
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const logger = (message) => console.log(message);
+  const hostBundles = await runHostBundleCleanup({
+    roots: options.roots,
+    olderThanDays: options.olderThanDays,
+    dryRun: options.dryRun,
+    logger,
+  });
+
+  if (hostBundles.candidates.length === 0) {
+    logger("No eligible host bundle artifacts found.");
+  }
+
+  const dockerPlan = buildDockerCleanupPlan(options);
+  for (const command of dockerPlan) {
+    await runCommand(command.command, command.args, { dryRun: options.dryRun, logger });
+  }
+
+  logger(
+    `${options.dryRun ? "Dry run complete" : "Cleanup complete"}: ` +
+      `${hostBundles.removed.length}/${hostBundles.candidates.length} host bundle directories removed.`,
+  );
+}
+
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isCli) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : "cleanup failed");
+    process.exitCode = 1;
+  });
+}

--- a/tests/scripts/cleanup-local-artifacts.test.ts
+++ b/tests/scripts/cleanup-local-artifacts.test.ts
@@ -7,6 +7,7 @@ import {
   buildDockerCleanupPlan,
   collectHostBundleCandidates,
   isHostBundlePath,
+  parseArgs,
   runHostBundleCleanup,
 } from "../../scripts/cleanup-local-artifacts.mjs";
 
@@ -48,6 +49,11 @@ describe("cleanup-local-artifacts", () => {
     });
 
     expect(candidates.map((candidate) => candidate.path)).toEqual([oldBundle]);
+    expect(candidates[0]).toMatchObject({
+      path: oldBundle,
+      dirEntrySizeBytes: expect.any(Number),
+    });
+    expect(candidates[0]).not.toHaveProperty("sizeBytes");
   });
 
   it("keeps dry-run cleanup non-destructive and applies only eligible bundle removals", async () => {
@@ -105,5 +111,18 @@ describe("cleanup-local-artifacts", () => {
       },
     ]);
     expect(plan.flatMap((entry) => entry.args)).not.toContain("volume");
+  });
+
+  it("rejects value-consuming CLI flags when their value is missing or another flag", () => {
+    expect(() => parseArgs(["--root"])).toThrow("--root requires a value");
+    expect(() => parseArgs(["--root", "--docker"])).toThrow("--root requires a value");
+    expect(() => parseArgs(["--worktrees-root"])).toThrow("--worktrees-root requires a value");
+    expect(() => parseArgs(["--older-than-days", "--docker"])).toThrow(
+      "--older-than-days requires a value",
+    );
+    expect(() => parseArgs(["--image-until"])).toThrow("--image-until requires a value");
+    expect(() => parseArgs(["--builder-keep-storage", "--apply"])).toThrow(
+      "--builder-keep-storage requires a value",
+    );
   });
 });

--- a/tests/scripts/cleanup-local-artifacts.test.ts
+++ b/tests/scripts/cleanup-local-artifacts.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, mkdir, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDockerCleanupPlan,
+  collectHostBundleCandidates,
+  isHostBundlePath,
+  runHostBundleCleanup,
+} from "../../scripts/cleanup-local-artifacts.mjs";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function touchOld(path: string, now: Date, ageDays: number) {
+  const timestamp = new Date(now.getTime() - ageDays * DAY_MS);
+  await utimes(path, timestamp, timestamp);
+}
+
+describe("cleanup-local-artifacts", () => {
+  it("only treats dist/host-bundle paths as removable host bundle artifacts", () => {
+    expect(isHostBundlePath("/repo/dist/host-bundle")).toBe(true);
+    expect(isHostBundlePath("/repo/dist/host-bundle/")).toBe(true);
+    expect(isHostBundlePath("/repo/system-bundles/v1")).toBe(false);
+    expect(isHostBundlePath("/repo/dist/not-host-bundle")).toBe(false);
+    expect(isHostBundlePath("/repo/home/system/host-bundle")).toBe(false);
+  });
+
+  it("collects old host bundles under approved roots and skips newer or unrelated paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-cleanup-"));
+    const now = new Date("2026-06-04T12:00:00.000Z");
+    const oldBundle = join(root, "matrix-os-a", "dist", "host-bundle");
+    const newBundle = join(root, "matrix-os-b", "dist", "host-bundle");
+    const unrelated = join(root, "matrix-os-c", "system-bundles", "v1");
+
+    await mkdir(oldBundle, { recursive: true });
+    await mkdir(newBundle, { recursive: true });
+    await mkdir(unrelated, { recursive: true });
+    await writeFile(join(oldBundle, "matrix-host-bundle.tar.gz"), "old");
+    await writeFile(join(newBundle, "matrix-host-bundle.tar.gz"), "new");
+    await touchOld(oldBundle, now, 8);
+    await touchOld(newBundle, now, 1);
+
+    const candidates = await collectHostBundleCandidates({
+      roots: [root],
+      olderThanDays: 3,
+      now,
+    });
+
+    expect(candidates.map((candidate) => candidate.path)).toEqual([oldBundle]);
+  });
+
+  it("keeps dry-run cleanup non-destructive and applies only eligible bundle removals", async () => {
+    const root = await mkdtemp(join(tmpdir(), "matrix-cleanup-"));
+    const now = new Date("2026-06-04T12:00:00.000Z");
+    const oldBundle = join(root, "matrix-os-a", "dist", "host-bundle");
+    const newBundle = join(root, "matrix-os-b", "dist", "host-bundle");
+
+    await mkdir(oldBundle, { recursive: true });
+    await mkdir(newBundle, { recursive: true });
+    await writeFile(join(oldBundle, "matrix-host-bundle.tar.gz"), "old");
+    await writeFile(join(newBundle, "matrix-host-bundle.tar.gz"), "new");
+    await touchOld(oldBundle, now, 8);
+    await touchOld(newBundle, now, 1);
+
+    const dryRun = await runHostBundleCleanup({
+      roots: [root],
+      olderThanDays: 3,
+      now,
+      dryRun: true,
+    });
+
+    expect(dryRun.removed).toEqual([]);
+    await expect(stat(oldBundle)).resolves.toBeTruthy();
+
+    const applied = await runHostBundleCleanup({
+      roots: [root],
+      olderThanDays: 3,
+      now,
+      dryRun: false,
+    });
+
+    expect(applied.removed.map((candidate) => candidate.path)).toEqual([oldBundle]);
+    await expect(stat(oldBundle)).rejects.toThrow();
+    await expect(stat(newBundle)).resolves.toBeTruthy();
+  });
+
+  it("plans Docker image and builder cleanup without volume pruning", () => {
+    const plan = buildDockerCleanupPlan({
+      includeDocker: true,
+      pruneImages: true,
+      pruneBuilder: true,
+      imageUntil: "168h",
+      builderKeepStorage: "20GB",
+    });
+
+    expect(plan).toEqual([
+      {
+        command: "docker",
+        args: ["image", "prune", "--all", "--force", "--filter", "until=168h"],
+      },
+      {
+        command: "docker",
+        args: ["builder", "prune", "--all", "--force", "--keep-storage", "20GB"],
+      },
+    ]);
+    expect(plan.flatMap((entry) => entry.args)).not.toContain("volume");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a dry-run-first `cleanup:local-artifacts` tool for engineer/build/legacy compose hosts.
- Restrict filesystem cleanup to old `dist/host-bundle` directories under explicit roots and keep Docker cleanup to images plus builder cache only.
- Harden value-consuming CLI flags after Greptile review so missing option values fail loudly instead of being silently consumed.
- Document one-off use, a suggested systemd timer, and why this still matters during the Cloud Run platform migration.

## Cloud Run migration note

This is intentionally an operational guardrail, not the full `085 Cloud Run Platform Migration` implementation. It still fits the migration because Cloud Run removes the production compose platform host, but engineer worktrees, local host-bundle builds, self-hosted build hosts, and legacy compose operators can still accumulate bundles and Docker cache. Customer VPS owner data and runtime state stay out of scope.

## Tests

- `bun run test tests/scripts/cleanup-local-artifacts.test.ts`
- `bun run cleanup:local-artifacts -- --root /home/deploy/matrix-os.worktrees --older-than-days 3 --docker`
- `bun run typecheck`
- `bun run check:patterns` (0 violations, existing warnings only)
- Pre-review full suite on the initial PR head: `bun run test` (531 files passed, 6020 tests passed, 3 files / 20 tests skipped)

## Invariants

- **Source of truth**: local build artifacts remain local filesystem/Docker state; platform release metadata, R2 objects, and owner runtime data are not modified.
- **Lock/transaction scope**: no database writes or transactions. Filesystem deletion is per discovered `dist/host-bundle` candidate after realpath/root containment checks.
- **Acceptable orphan states**: Docker image/builder pruning and host-bundle directory removal are independent; a Docker prune failure can leave cache behind without affecting release metadata or owner data.
- **Auth source of truth**: local operator CLI only; no network route or privileged API auth is introduced.
- **Deferred scope**: full Cloud Run/Neon/Worker/Inngest migration implementation, customer VPS route-token ingress, and CI/CD rollout changes are intentionally deferred to follow-up PRs.
