### PR TITLE
fix(games): launch playable app entrypoints

### DIFF
--- a/home/apps/games/2048/src/main.tsx
+++ b/home/apps/games/2048/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("2048" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/chess/src/main.tsx
+++ b/home/apps/games/chess/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("chess" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/minesweeper/src/main.tsx
+++ b/home/apps/games/minesweeper/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("minesweeper" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/snake/src/main.tsx
+++ b/home/apps/games/snake/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("snake" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/solitaire/src/main.tsx
+++ b/home/apps/games/solitaire/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("solitaire" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/home/apps/games/tetris/src/main.tsx
+++ b/home/apps/games/tetris/src/main.tsx
@@ -1,3 +1,9 @@
-import { renderDefaultApp } from "../../../_shared/default-apps";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-renderDefaultApp("tetris" as const);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/tests/gateway/games.test.ts
+++ b/tests/gateway/games.test.ts
@@ -1,24 +1,42 @@
 import { describe, it, expect } from "vitest";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseAppManifest } from "../../packages/gateway/src/app-manifest.js";
 
 const GAMES_DIR = join(__dirname, "../../home/apps/games");
 const SHARED_RENDERER = join(__dirname, "../../home/apps/_shared/default-apps.tsx");
 
-const GAME_SLUGS = ["snake", "2048", "minesweeper", "tetris", "solitaire", "chess"];
+const PLAYABLE_GAME_SLUGS = readdirSync(GAMES_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .filter((slug) => existsSync(join(GAMES_DIR, slug, "src/App.tsx")))
+  .sort();
 
-function expectViteApp(appDir: string, appId: string) {
+function expectViteAppScaffold(appDir: string) {
   const html = readFileSync(join(appDir, "index.html"), "utf-8");
   expect(html.toLowerCase()).toContain("<!doctype html>");
   expect(html).toContain('id="root"');
   expect(html).toContain('type="module"');
   expect(html).toContain("/src/main.tsx");
   expect(existsSync(join(appDir, "vite.config.ts"))).toBe(true);
+}
+
+function expectSharedRendererApp(appDir: string, appId: string) {
+  expectViteAppScaffold(appDir);
 
   const source = readFileSync(join(appDir, "src/main.tsx"), "utf-8");
   expect(source).toContain("renderDefaultApp");
   expect(source).toContain(`"${appId}"`);
+}
+
+function expectPlayableGameApp(appDir: string) {
+  expectViteAppScaffold(appDir);
+  expect(existsSync(join(appDir, "src/App.tsx"))).toBe(true);
+
+  const source = readFileSync(join(appDir, "src/main.tsx"), "utf-8");
+  expect(source).toContain("createRoot");
+  expect(source).toContain('from "./App"');
+  expect(source).not.toContain("renderDefaultApp");
 }
 
 describe("T1420-T1427: Pre-installed games", () => {
@@ -32,11 +50,11 @@ describe("T1420-T1427: Pre-installed games", () => {
     });
 
     it("is a Vite app wired to the shared renderer", () => {
-      expectViteApp(GAMES_DIR, "games");
+      expectSharedRendererApp(GAMES_DIR, "games");
     });
   });
 
-  for (const slug of GAME_SLUGS) {
+  for (const slug of PLAYABLE_GAME_SLUGS) {
     describe(slug, () => {
       it("has a directory", () => {
         expect(existsSync(join(GAMES_DIR, slug))).toBe(true);
@@ -55,19 +73,17 @@ describe("T1420-T1427: Pre-installed games", () => {
         expect(manifest.build.output).toBe("dist");
       });
 
-      it("is a Vite app wired to the shared renderer", () => {
-        expectViteApp(join(GAMES_DIR, slug), slug);
+      it("is a Vite app wired to its playable App entrypoint", () => {
+        expectPlayableGameApp(join(GAMES_DIR, slug));
       });
     });
   }
 
-  it("keeps game-specific UI definitions in the shared app renderer", () => {
+  it("keeps the game launcher UI in the shared app renderer", () => {
     const shared = readFileSync(SHARED_RENDERER, "utf-8");
-    for (const slug of GAME_SLUGS) {
+    for (const slug of PLAYABLE_GAME_SLUGS) {
       expect(shared).toContain(slug);
     }
-    expect(shared).toContain("ArcadeApp");
-    expect(shared).toContain("BoardGame");
     expect(shared).toContain("gameCards");
   });
 });


### PR DESCRIPTION
## Summary

- Wire pre-installed playable games (`2048`, `chess`, `minesweeper`, `snake`, `solitaire`, `tetris`) to their real React `App` entrypoints instead of the shared placeholder renderer.
- Update the game contract test so every game directory with `src/App.tsx` must launch through `createRoot(<App />)` while the Game Center launcher remains on the shared renderer.

## Tests

- `bun run test tests/gateway/games.test.ts` (failed before the fix, passed after; now discovers all playable game dirs)
- `node scripts/build-default-apps.mjs home/apps`
- `bun run typecheck`
- `bun run check:patterns`
- `npx react-doctor@latest /tmp/matrix-react-doctor-games`
- `npx react-doctor@latest /tmp/matrix-react-doctor-games --verbose --diff` (full temp scan; reports pre-existing app-body warnings, not the changed entrypoints)
- `bun run test tests/gateway/apps.test.ts tests/gateway/games.test.ts`
- `bun run test tests/default-apps/notes-rich-editor.test.tsx`
- `bun run test tests/gateway/apps.test.ts tests/gateway/games.test.ts tests/default-apps/snake-app.test.tsx tests/default-apps/chess-app.test.tsx tests/default-apps/2048-app.test.tsx tests/default-apps/minesweeper-app.test.tsx tests/default-apps/tetris-app.test.tsx tests/default-apps/solitaire-app.test.tsx`
- `bun run test` reached 6014 passing tests and failed only `tests/default-apps/notes-rich-editor.test.tsx` because `build-default-apps` had installed ignored nested app `node_modules` under `home/apps/notes`, causing a duplicate React copy. After moving generated nested app `node_modules` out of the worktree, the failed notes test passed.

## Invariants

- Source of truth: shipped default game source remains under `home/apps/games/**`; host-bundle/default-app builds compile those sources into runtime assets.
- Lock/transaction scope: not applicable; no persistence or backend mutation behavior changed.
- Acceptable orphan states: existing ignored local build outputs may be regenerated by `scripts/build-default-apps.mjs`; they are not part of this PR.
- Auth source of truth: unchanged; app session and gateway auth behavior is not touched.
- Deferred scope: broad React Doctor cleanup in the game app bodies is out of scope for this narrow launch-entrypoint regression fix.
