### PR TITLE
feat(shell): add account controls to billing settings

### DIFF
--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -84,7 +84,7 @@ function TrafficLights({ onClose, closeDisabled = false }: { onClose: () => void
 
 function SettingsAccountFooter() {
   return (
-    <div
+    <section
       aria-label="Account"
       className="sticky bottom-0 z-10 mt-2 flex shrink-0 items-center justify-between gap-3 border-t border-border/40 bg-card/95 px-2 py-2 backdrop-blur sm:static sm:mt-auto sm:justify-center sm:bg-transparent sm:px-0 sm:pt-3 sm:backdrop-blur-none"
     >
@@ -92,7 +92,7 @@ function SettingsAccountFooter() {
         <p className="text-xs font-semibold text-foreground">Account</p>
       </div>
       <AccountButton />
-    </div>
+    </section>
   );
 }
 
@@ -218,8 +218,11 @@ export function Settings({
           </header>
 
           <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
-            <aside className="flex w-full shrink-0 flex-col border-b border-border/40 bg-card/50 p-2 sm:w-52 sm:border-b-0 sm:border-r sm:overflow-y-auto">
-              <nav className="flex gap-1 overflow-x-auto pb-1 sm:flex-col sm:gap-0.5 sm:overflow-x-visible sm:pb-0">
+            <aside className="flex w-full shrink-0 flex-col border-b border-border/40 bg-card/50 p-2 sm:w-52 sm:border-b-0 sm:border-r">
+              <nav
+                aria-label="Settings sections"
+                className="flex gap-1 overflow-x-auto pb-1 sm:min-h-0 sm:flex-1 sm:flex-col sm:gap-0.5 sm:overflow-x-visible sm:overflow-y-auto sm:pb-0"
+              >
                 {sections.map((section) => {
                   const Icon = section.icon;
                   const active = activeSection === section.id;

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -24,6 +24,7 @@ import { PluginsSection } from "./settings/sections/PluginsSection";
 import { SystemSection } from "./settings/sections/SystemSection";
 import { BillingSection } from "./settings/sections/BillingSection";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
+import { UserButton as AccountButton } from "./UserButton";
 
 
 const sections = [
@@ -77,6 +78,20 @@ function TrafficLights({ onClose, closeDisabled = false }: { onClose: () => void
         aria-label="Maximize"
         disabled
       />
+    </div>
+  );
+}
+
+function SettingsAccountFooter() {
+  return (
+    <div
+      aria-label="Account"
+      className="sticky bottom-0 z-10 mt-2 flex shrink-0 items-center justify-between gap-3 border-t border-border/40 bg-card/95 px-2 py-2 backdrop-blur sm:static sm:mt-auto sm:justify-center sm:bg-transparent sm:px-0 sm:pt-3 sm:backdrop-blur-none"
+    >
+      <div className="min-w-0 sm:hidden">
+        <p className="text-xs font-semibold text-foreground">Account</p>
+      </div>
+      <AccountButton />
     </div>
   );
 }
@@ -203,7 +218,7 @@ export function Settings({
           </header>
 
           <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
-            <aside className="w-full shrink-0 border-b border-border/40 bg-card/50 p-2 sm:w-48 sm:border-b-0 sm:border-r sm:overflow-y-auto">
+            <aside className="flex w-full shrink-0 flex-col border-b border-border/40 bg-card/50 p-2 sm:w-52 sm:border-b-0 sm:border-r sm:overflow-y-auto">
               <nav className="flex gap-1 overflow-x-auto pb-1 sm:flex-col sm:gap-0.5 sm:overflow-x-visible sm:pb-0">
                 {sections.map((section) => {
                   const Icon = section.icon;
@@ -237,9 +252,10 @@ export function Settings({
                   );
                 })}
               </nav>
+              <SettingsAccountFooter />
             </aside>
 
-            <main className="min-w-0 flex-1 overflow-y-auto">
+            <main className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain">
               {activeSection === "appearance" && <AppearanceSection />}
               {activeSection === "agent" && <AgentSection />}
               {activeSection === "channels" && <ChannelsSection />}

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -159,7 +159,7 @@ function CheckoutPanel({
   }
 
   return (
-    <div className="rounded-2xl border border-forest/15 bg-card p-4">
+    <div className="rounded-2xl border border-forest/15 bg-card p-3 sm:p-4">
       {mode === "provisioning" && (
         <div className="mb-2">
           <p className="text-sm font-semibold text-deep">Start checkout &amp; provision</p>
@@ -487,7 +487,7 @@ function ServerProfileGrid({
   onSelect: (featureSlug: string) => void;
 }) {
   return (
-    <div className="grid gap-3 lg:grid-cols-3">
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
       {MATRIX_BILLING_SERVER_PROFILES.map((profile, index) => {
         const selected = profile.featureSlug === selectedFeature;
         return (
@@ -496,14 +496,14 @@ function ServerProfileGrid({
           key={profile.featureSlug}
           aria-pressed={selected}
           onClick={() => onSelect(profile.featureSlug)}
-          className={`group flex min-h-[154px] flex-col rounded-2xl border p-3 text-left transition-all ${
+          className={`group flex min-h-[154px] min-w-0 flex-col rounded-2xl border p-3 text-left transition-all ${
             selected
               ? "border-ember bg-[#fff7ec] shadow-[0_18px_50px_rgba(83,68,48,0.16)]"
               : "border-forest/12 bg-white hover:-translate-y-0.5 hover:border-forest/25 hover:shadow-[0_14px_34px_rgba(83,68,48,0.08)]"
           }`}
         >
           <div className="flex items-start justify-between gap-3">
-            <div>
+            <div className="min-w-0">
               <span
                 className={`inline-flex rounded-full px-2.5 py-1 text-[11px] font-semibold ${
                   selected ? "bg-ember text-ember-foreground" : "bg-forest/8 text-forest/70"
@@ -511,13 +511,13 @@ function ServerProfileGrid({
               >
                 {profileLabels[index] ?? "Plan"}
               </span>
-              <p className="mt-2 text-lg font-semibold tracking-tight text-deep">
+              <p className="mt-2 truncate text-lg font-semibold tracking-tight text-deep">
                 {profile.label}
               </p>
               <p className="text-xs font-medium text-forest/45">{profile.hetznerType}</p>
             </div>
-            <div className="text-right">
-              <p className="text-2xl font-semibold tracking-tight text-deep">
+            <div className="shrink-0 text-right">
+              <p className="text-xl font-semibold tracking-tight text-deep sm:text-2xl">
                 ${profilePrice(profile, billingInterval)}
               </p>
               <p className="text-xs text-forest/50">
@@ -545,7 +545,7 @@ function ServerProfileGrid({
           </div>
 
           <div className="mt-auto flex items-center justify-between pt-2.5">
-            <span className="text-xs text-forest/50">
+            <span className="min-w-0 truncate text-xs text-forest/50">
               {profileSpec(profile)}
             </span>
             <span
@@ -573,7 +573,7 @@ function RegionList({
   onSelect: (featureSlug: string) => void;
 }) {
   return (
-    <div className="grid gap-2 sm:grid-cols-4">
+    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
       {MATRIX_BILLING_REGIONS.map((region) => (
         <button
           type="button"
@@ -620,12 +620,12 @@ function PlanSummary({
   billingInterval: BillingInterval;
 }) {
   return (
-    <div className="rounded-2xl border border-forest/15 bg-white p-5 shadow-sm">
+    <div className="rounded-2xl border border-forest/15 bg-white p-4 shadow-sm sm:p-5">
       <p className="text-xs font-semibold uppercase tracking-[0.18em] text-forest/55">
         Plan summary
       </p>
       <div className="mt-4 rounded-2xl bg-[#f4efe3] p-4">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <p className="text-lg font-semibold tracking-tight text-deep">
               {selectedProfile.label}
@@ -634,7 +634,7 @@ function PlanSummary({
               {profileSpec(selectedProfile)}
             </p>
           </div>
-          <p className="text-3xl font-semibold tracking-tight text-deep">
+          <p className="text-2xl font-semibold tracking-tight text-deep sm:text-3xl">
             ${profilePrice(selectedProfile, billingInterval)}
           </p>
         </div>
@@ -671,7 +671,7 @@ function HeroSelectionPreview({
   billingInterval: BillingInterval;
 }) {
   return (
-    <div className="mt-4 grid max-w-2xl gap-3 sm:grid-cols-2">
+    <div className="mt-4 grid max-w-2xl gap-3 md:grid-cols-2">
       <div className="rounded-2xl border border-forest/10 bg-white/60 p-3">
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -833,12 +833,12 @@ export function BillingPanel({
 
   return (
     <div className="space-y-3">
-      <section className="grid gap-4 rounded-[22px] border border-forest/15 bg-[#fbf7ed] p-4 lg:grid-cols-[minmax(0,1fr)_340px]">
+      <section className="grid gap-4 rounded-[22px] border border-forest/15 bg-[#fbf7ed] p-3 sm:p-4 xl:grid-cols-[minmax(0,1fr)_340px]">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-forest/60">
             {mode === "provisioning" ? "Provisioning" : "Billing"}
           </p>
-          <h3 className="mt-2 max-w-3xl text-2xl font-semibold tracking-tight text-deep sm:text-3xl">
+          <h3 className="mt-2 max-w-3xl text-xl font-semibold tracking-tight text-deep sm:text-2xl lg:text-3xl">
             {mode === "provisioning"
               ? "Pick the cloud computer Matrix boots on"
               : "Manage your hosted Matrix computer"}
@@ -865,8 +865,8 @@ export function BillingPanel({
         />
       </section>
 
-      <section className="rounded-[22px] border border-forest/12 bg-white p-3.5">
-        <div className="mb-3 flex items-center justify-between gap-4 px-1">
+      <section className="rounded-[22px] border border-forest/12 bg-white p-3 sm:p-3.5">
+        <div className="mb-3 flex flex-col gap-1 px-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <h4 className="text-sm font-semibold text-deep">Computer</h4>
           <p className="text-xs text-forest/45">Launch tiers: CPX22 / CPX32 / CPX52</p>
         </div>
@@ -877,8 +877,8 @@ export function BillingPanel({
         />
       </section>
 
-      <section className="rounded-[22px] border border-forest/12 bg-white p-3.5">
-        <div className="mb-3 flex items-center justify-between gap-4 px-1">
+      <section className="rounded-[22px] border border-forest/12 bg-white p-3 sm:p-3.5">
+        <div className="mb-3 flex flex-col gap-1 px-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <h4 className="text-sm font-semibold text-deep">Region</h4>
           <p className="text-xs text-forest/45">
             Closest location is selected automatically

--- a/shell/src/components/settings/sections/BillingSection.tsx
+++ b/shell/src/components/settings/sections/BillingSection.tsx
@@ -16,7 +16,7 @@ export function BillingSection({
   const { active, entitlement, accessReason } = useMatrixBillingAccess();
 
   return (
-    <div className="mx-auto max-w-5xl space-y-3 p-3 sm:p-4">
+    <div className="mx-auto max-w-5xl space-y-3 p-2 sm:p-4">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
         <div className="min-w-0">
           <h2 className="text-lg font-semibold">Billing</h2>

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -22,6 +22,19 @@ vi.mock("@clerk/nextjs", () => ({
   SignUp: () => (
     <div data-testid="sign-up-component">Mock SignUp</div>
   ),
+  UserButton: Object.assign(
+    ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="clerk-user-button">{children}</div>
+    ),
+    {
+      MenuItems: ({ children }: { children?: React.ReactNode }) => (
+        <div data-testid="clerk-user-button-menu">{children}</div>
+      ),
+      Link: ({ label }: { label: string }) => (
+        <a href="/runtime">{label}</a>
+      ),
+    },
+  ),
   useAuth: () => ({
     isLoaded: clerkState.isLoaded,
     isSignedIn: clerkState.isSignedIn,

--- a/tests/shell/settings-panel.test.tsx
+++ b/tests/shell/settings-panel.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const billingState = vi.hoisted(() => ({
@@ -67,9 +68,9 @@ describe("Settings panel", () => {
 
     render(<Settings open onOpenChange={() => {}} />);
 
-    const accountRegion = screen.getByLabelText("Account");
-    expect(accountRegion).toBeTruthy();
-    expect(screen.getByTestId("settings-clerk-user-button")).toBeTruthy();
+    const accountRegion = screen.getByRole("region", { name: "Account" });
+    await waitFor(() => expect(accountRegion).toBeVisible());
+    expect(screen.getByTestId("settings-clerk-user-button")).toBeVisible();
     expect(accountRegion.className).toContain("sm:mt-auto");
   });
 
@@ -89,16 +90,21 @@ describe("Settings panel", () => {
     );
 
     expect(screen.getByText("Billing settings provisioning")).toBeTruthy();
-    expect(screen.getByLabelText("Account")).toBeTruthy();
-    expect(screen.getByTestId("settings-clerk-user-button")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.getByRole("region", { name: "Account" })).toBeVisible(),
+    );
+    expect(screen.getByTestId("settings-clerk-user-button")).toBeVisible();
   });
 
-  it("uses the mobile sticky account footer placement below the settings tabs", async () => {
+  it("keeps the account footer visible outside the desktop navigation scroll area", async () => {
     const { Settings } = await import("../../shell/src/components/Settings.js");
 
     render(<Settings open onOpenChange={() => {}} />);
 
-    const accountRegion = screen.getByLabelText("Account");
+    const nav = screen.getByRole("navigation", { name: "Settings sections" });
+    const accountRegion = screen.getByRole("region", { name: "Account" });
+    expect(nav).not.toContainElement(accountRegion);
+    expect(nav.className).toContain("sm:overflow-y-auto");
     expect(accountRegion.className).toContain("sticky");
     expect(accountRegion.className).toContain("sm:static");
   });

--- a/tests/shell/settings-panel.test.tsx
+++ b/tests/shell/settings-panel.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const billingState = vi.hoisted(() => ({
+  active: true as boolean | null,
+}));
+
+vi.mock("@/hooks/useMatrixBillingAccess", () => ({
+  useMatrixBillingAccess: () => ({
+    active: billingState.active,
+    entitlement: null,
+    accessReason: null,
+  }),
+}));
+
+vi.mock("../../shell/src/components/UserButton.js", () => ({
+  UserButton: () => (
+    <button type="button" data-testid="settings-clerk-user-button">
+      Account menu
+    </button>
+  ),
+}));
+
+vi.mock("../../shell/src/components/settings/sections/AppearanceSection.js", () => ({
+  AppearanceSection: () => <div>Appearance settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/AgentSection.js", () => ({
+  AgentSection: () => <div>Agent settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/ChannelsSection.js", () => ({
+  ChannelsSection: () => <div>Channel settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/IntegrationsSection.js", () => ({
+  IntegrationsSection: () => <div>Integration settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/SkillsSection.js", () => ({
+  SkillsSection: () => <div>Skill settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/CronSection.js", () => ({
+  CronSection: () => <div>Cron settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/SecuritySection.js", () => ({
+  SecuritySection: () => <div>Security settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/PluginsSection.js", () => ({
+  PluginsSection: () => <div>Plugin settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/SystemSection.js", () => ({
+  SystemSection: () => <div>System settings</div>,
+}));
+vi.mock("../../shell/src/components/settings/sections/BillingSection.js", () => ({
+  BillingSection: ({ mode }: { mode?: string }) => (
+    <div>Billing settings {mode ?? "settings"}</div>
+  ),
+}));
+
+describe("Settings panel", () => {
+  beforeEach(() => {
+    billingState.active = true;
+  });
+
+  it("renders the Clerk account button in the settings navigation footer", async () => {
+    const { Settings } = await import("../../shell/src/components/Settings.js");
+
+    render(<Settings open onOpenChange={() => {}} />);
+
+    const accountRegion = screen.getByLabelText("Account");
+    expect(accountRegion).toBeTruthy();
+    expect(screen.getByTestId("settings-clerk-user-button")).toBeTruthy();
+    expect(accountRegion.className).toContain("sm:mt-auto");
+  });
+
+  it("keeps account controls available while billing is locked for provisioning", async () => {
+    billingState.active = false;
+    const { Settings } = await import("../../shell/src/components/Settings.js");
+
+    render(
+      <Settings
+        open
+        onOpenChange={() => {}}
+        lockedSection="billing"
+        closeDisabled
+        billingActiveOverride={false}
+        billingMode="provisioning"
+      />,
+    );
+
+    expect(screen.getByText("Billing settings provisioning")).toBeTruthy();
+    expect(screen.getByLabelText("Account")).toBeTruthy();
+    expect(screen.getByTestId("settings-clerk-user-button")).toBeTruthy();
+  });
+
+  it("uses the mobile sticky account footer placement below the settings tabs", async () => {
+    const { Settings } = await import("../../shell/src/components/Settings.js");
+
+    render(<Settings open onOpenChange={() => {}} />);
+
+    const accountRegion = screen.getByLabelText("Account");
+    expect(accountRegion.className).toContain("sticky");
+    expect(accountRegion.className).toContain("sm:static");
+  });
+});

--- a/tests/shell/settings-panel.test.tsx
+++ b/tests/shell/settings-panel.test.tsx
@@ -60,6 +60,7 @@ vi.mock("../../shell/src/components/settings/sections/BillingSection.js", () => 
 
 describe("Settings panel", () => {
   beforeEach(() => {
+    vi.resetModules();
     billingState.active = true;
   });
 


### PR DESCRIPTION
## Summary
- Add the Clerk account menu to the Settings sidebar footer so users can manage their account and sign out during billing setup.
- Improve the mobile layout for Settings and the billing plan/region selector.
- Cover the locked billing state, account footer placement, and Clerk mock shape with shell tests.
- Address Greptile review feedback by using a named account section, keeping the footer outside the desktop scroll container, and isolating Settings panel module imports in tests.

## Tests
- flox activate -- bun run test tests/shell/billing-gate.test.tsx tests/shell/settings-panel.test.tsx tests/shell/billing-section.test.tsx
- flox activate -- bun run typecheck
- flox activate -- bun run check:patterns (0 violations; existing scanner warnings only)
- flox activate -- npx react-doctor@latest shell
- flox activate -- npx react-doctor@latest shell --verbose --diff (No issues found)

## Review/Monitoring
- PR title check: pass
- Vercel preview: pass
- Greptile: 5/5 on commit 6ac8f847fabd878b89e211267190fc3f00422bbe
- Greptile review threads: resolved

## Notes
- Frontend-only shell/settings change; no backend invariants section required.
- Full bun run test was attempted earlier and only failed in tests/scripts/cleanup-local-artifacts.test.ts due this macOS environment returning /private/var/folders realpaths while the test expects /var/folders paths; unrelated to this PR.