### PR TITLE
fix(release): support jurisdictional R2 bundle endpoint

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -258,6 +258,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_BUNDLES_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BUNDLES_SECRET_ACCESS_KEY || secrets.R2_SECRET_ACCESS_KEY }}
       R2_BUCKET: ${{ vars.R2_BUNDLES_BUCKET || vars.R2_BUCKET || 'matrixos-sync' }}
+      R2_ENDPOINT: ${{ vars.R2_BUNDLES_ENDPOINT || vars.R2_ENDPOINT || format('https://{0}.r2.cloudflarestorage.com', secrets.R2_BUNDLES_ACCOUNT_ID || secrets.R2_ACCOUNT_ID) }}
       PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
       PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
     steps:

--- a/scripts/publish-release-r2.mjs
+++ b/scripts/publish-release-r2.mjs
@@ -191,11 +191,13 @@ if (dryRun) {
   process.exit(0);
 }
 
-const accountId = required("R2_ACCOUNT_ID");
+const accountId = process.env.R2_ACCOUNT_ID;
 const accessKeyId = process.env.AWS_ACCESS_KEY_ID || required("R2_ACCESS_KEY_ID");
 const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY || required("R2_SECRET_ACCESS_KEY");
 const platformSecret = required("PLATFORM_SECRET");
-const endpoint = process.env.R2_ENDPOINT || `https://${accountId}.r2.cloudflarestorage.com`;
+const endpoint =
+  process.env.R2_ENDPOINT ||
+  (accountId ? `https://${accountId}.r2.cloudflarestorage.com` : required("R2_ACCOUNT_ID"));
 const s3 = new S3Client({
   region: "auto",
   endpoint,

--- a/scripts/publish-release-r2.mjs
+++ b/scripts/publish-release-r2.mjs
@@ -195,9 +195,10 @@ const accountId = required("R2_ACCOUNT_ID");
 const accessKeyId = process.env.AWS_ACCESS_KEY_ID || required("R2_ACCESS_KEY_ID");
 const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY || required("R2_SECRET_ACCESS_KEY");
 const platformSecret = required("PLATFORM_SECRET");
+const endpoint = process.env.R2_ENDPOINT || `https://${accountId}.r2.cloudflarestorage.com`;
 const s3 = new S3Client({
   region: "auto",
-  endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+  endpoint,
   credentials: { accessKeyId, secretAccessKey },
 });
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -77,11 +77,13 @@ if ! command -v aws >/dev/null 2>&1; then
   exec node "$ROOT_DIR/scripts/publish-release-r2.mjs" "${NODE_PUBLISH_ARGS[@]}"
 fi
 
-: "${R2_ACCOUNT_ID:?set R2_ACCOUNT_ID}"
 : "${AWS_ACCESS_KEY_ID:?set AWS_ACCESS_KEY_ID}"
 : "${AWS_SECRET_ACCESS_KEY:?set AWS_SECRET_ACCESS_KEY}"
 R2_BUCKET="${R2_BUCKET:-matrixos-sync}"
-R2_ENDPOINT="${R2_ENDPOINT:-https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com}"
+if [ -z "${R2_ENDPOINT:-}" ]; then
+  : "${R2_ACCOUNT_ID:?set R2_ACCOUNT_ID or R2_ENDPOINT}"
+  R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+fi
 PLATFORM_PUBLIC_URL="${PLATFORM_PUBLIC_URL:-https://app.matrix-os.com}"
 
 SHA256="$(sha256sum "$BUNDLE" | awk '{print $1}')"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -81,7 +81,7 @@ fi
 : "${AWS_ACCESS_KEY_ID:?set AWS_ACCESS_KEY_ID}"
 : "${AWS_SECRET_ACCESS_KEY:?set AWS_SECRET_ACCESS_KEY}"
 R2_BUCKET="${R2_BUCKET:-matrixos-sync}"
-R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+R2_ENDPOINT="${R2_ENDPOINT:-https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com}"
 PLATFORM_PUBLIC_URL="${PLATFORM_PUBLIC_URL:-https://app.matrix-os.com}"
 
 SHA256="$(sha256sum "$BUNDLE" | awk '{print $1}')"

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -182,6 +182,7 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('AWS_ACCESS_KEY_ID: ${{ secrets.R2_BUNDLES_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}');
     expect(workflow).toContain('AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BUNDLES_SECRET_ACCESS_KEY || secrets.R2_SECRET_ACCESS_KEY }}');
     expect(workflow).toContain("R2_BUCKET: ${{ vars.R2_BUNDLES_BUCKET || vars.R2_BUCKET || 'matrixos-sync' }}");
+    expect(workflow).toContain("R2_ENDPOINT: ${{ vars.R2_BUNDLES_ENDPOINT || vars.R2_ENDPOINT || format('https://{0}.r2.cloudflarestorage.com', secrets.R2_BUNDLES_ACCOUNT_ID || secrets.R2_ACCOUNT_ID) }}");
     expect(workflow).toContain('-X POST "${PLATFORM_PUBLIC_URL%/}/vps/deploy"');
     expect(workflow).not.toContain('HOST_BUNDLE_CHANNEL: ${{ steps.meta.outputs.channel }}');
     expect(workflow).not.toContain('-X POST "https://app.matrix-os.com/vps/deploy"');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -150,6 +150,8 @@ describe('customer VPS host bundle', () => {
     expect(publishScript).toContain('--metadata "sha256=$SHA256"');
     expect(publishScript).toContain('upload_immutable_object "$BUNDLE" "$BUNDLE_KEY" "application/gzip"');
     expect(publishScript).toContain('upload_immutable_object "$CHECKSUM_FILE" "$CHECKSUM_KEY" "text/plain; charset=utf-8"');
+    expect(publishScript).toContain(': "${R2_ACCOUNT_ID:?set R2_ACCOUNT_ID or R2_ENDPOINT}"');
+    expect(publishScript).toContain('if [ -z "${R2_ENDPOINT:-}" ]; then');
     expect(publishScript).not.toContain('aws s3 cp "$BUNDLE" "s3://$R2_BUCKET/$BUNDLE_KEY"');
   });
 
@@ -167,6 +169,9 @@ describe('customer VPS host bundle', () => {
     expect(nodePublisher).toContain('R2_ACCESS_KEY_ID');
     expect(nodePublisher).toContain('R2_SECRET_ACCESS_KEY');
     expect(nodePublisher).toContain('AbortSignal.timeout(30_000)');
+    expect(nodePublisher).toContain('const accountId = process.env.R2_ACCOUNT_ID;');
+    expect(nodePublisher).toContain('process.env.R2_ENDPOINT ||');
+    expect(nodePublisher).toContain('(accountId ? `https://${accountId}.r2.cloudflarestorage.com` : required("R2_ACCOUNT_ID"))');
   });
 
   it('host bundle release workflow stamps the resolved channel into release metadata before packaging', () => {


### PR DESCRIPTION
## Summary

- Allow host-bundle publishing scripts to use an explicit R2 S3 endpoint.
- Wire host-bundle release publishing to R2_BUNDLES_ENDPOINT or R2_ENDPOINT before falling back to the default global endpoint.
- Add workflow regression coverage for the endpoint env wiring.

## Invariants

- Source of truth: R2 remains the host-bundle object store; this only selects the correct S3 endpoint for jurisdictional buckets.
- Lock/transaction scope: no database writes or transactions are changed; publishing remains immutable object upload followed by existing release registration.
- Acceptable orphan states: if upload fails, release registration is not reached. Existing immutable-object verification remains unchanged.
- Auth source of truth: GitHub Actions still uses scoped R2 S3 credentials from secrets and platform release registration still uses PLATFORM_SECRET.
- Deferred scope: no bucket creation, secret rotation, Cloud Run deployment, or VPS fanout changes are included.
- Rollback plan: remove R2_BUNDLES_ENDPOINT or revert this PR to use the previous default R2 endpoint behavior.
- PostHog events/errors: intentionally unchanged; this is release plumbing only.

## Verification commands

- bash -n scripts/publish-release.sh
- node --check scripts/publish-release-r2.mjs
- pnpm exec vitest run tests/platform/customer-vps-host-bundle.test.ts
- bun run check:patterns --diff origin/main

## Operator setup

Set R2_BUNDLES_ENDPOINT=https://63a1787d41e5df7aee344eab876fffe8.eu.r2.cloudflarestorage.com for the EU matrixos-bundles bucket.