### PR TITLE
fix(platform): separate host bundle R2 storage

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2819,6 +2819,7 @@ export function createApp(deps: {
   internalSyncRoutes?: Hono<any>;
   customerVpsService?: CustomerVpsService;
   customerVpsObjectStore?: CustomerVpsObjectStore;
+  hostBundleObjectStore?: CustomerVpsObjectStore;
   env?: NodeJS.ProcessEnv;
 }) {
   const { db, docker, orchestrator, clerkAuth, matrixProvisioner } = deps;
@@ -3072,13 +3073,14 @@ export function createApp(deps: {
   });
 
   async function getSignedBundleUrl(release: HostBundleReleaseRecord): Promise<string> {
-    if (!deps.customerVpsObjectStore) {
+    const hostBundleObjectStore = deps.hostBundleObjectStore ?? deps.customerVpsObjectStore;
+    if (!hostBundleObjectStore) {
       throw new Error('Host bundle storage unavailable');
     }
-    if (!deps.customerVpsObjectStore.getPresignedGetUrl) {
+    if (!hostBundleObjectStore.getPresignedGetUrl) {
       throw new Error('Host bundle storage cannot create signed URLs');
     }
-    return deps.customerVpsObjectStore.getPresignedGetUrl(release.bundleKey, 3600);
+    return hostBundleObjectStore.getPresignedGetUrl(release.bundleKey, 3600);
   }
 
   function requireHostBundleAdmin(c: Context): Response | null {
@@ -3210,7 +3212,8 @@ export function createApp(deps: {
   // Public, immutable host-service bundles used by customer VPS cloud-init.
   // Metadata comes from Postgres; R2 only stores the bytes.
   app.get('/system-bundles/:imageVersion/:file', async (c) => {
-    if (!deps.customerVpsObjectStore) {
+    const hostBundleObjectStore = deps.hostBundleObjectStore ?? deps.customerVpsObjectStore;
+    if (!hostBundleObjectStore) {
       return c.json({ error: 'Host bundle storage unavailable' }, 503);
     }
 
@@ -3254,7 +3257,7 @@ export function createApp(deps: {
       return c.json({ error: 'Not found' }, 404);
     }
 
-    if (file.endsWith('.tar.gz') && deps.customerVpsObjectStore.getPresignedGetUrl) {
+    if (file.endsWith('.tar.gz') && hostBundleObjectStore.getPresignedGetUrl) {
       try {
         const url = await getSignedBundleUrl(release);
         return c.redirect(url, 302);
@@ -3298,7 +3301,7 @@ export function createApp(deps: {
     }
 
     try {
-      const object = await deps.customerVpsObjectStore.getObject(
+      const object = await hostBundleObjectStore.getObject(
         release.bundleKey,
         { signal: AbortSignal.timeout(HOST_BUNDLE_READ_TIMEOUT_MS) },
       );
@@ -3330,7 +3333,8 @@ export function createApp(deps: {
   });
 
   app.get('/system-bundles/channels/:channel', async (c) => {
-    if (!deps.customerVpsObjectStore) {
+    const hostBundleObjectStore = deps.hostBundleObjectStore ?? deps.customerVpsObjectStore;
+    if (!hostBundleObjectStore) {
       return c.json({ error: 'Host bundle storage unavailable' }, 503);
     }
 
@@ -4933,29 +4937,20 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
   }
 
   let internalSyncRoutes: Hono | undefined;
-  let customerVpsObjectStore:
-    | {
-        putObject(
-          key: string,
-          body: string | Uint8Array | ReadableStream<Uint8Array>,
-          options?: { signal?: AbortSignal },
-        ): Promise<{ etag?: string }>;
-        getObject(
-          key: string,
-          options?: { signal?: AbortSignal },
-        ): Promise<{ body: ReadableStream | null; etag?: string; contentLength?: number }>;
-      }
-    | undefined;
+  let customerVpsObjectStore: CustomerVpsObjectStore | undefined;
+  let hostBundleObjectStore: CustomerVpsObjectStore | undefined;
   const s3Endpoint = process.env.S3_ENDPOINT ?? process.env.R2_ENDPOINT;
   const s3AccessKey = process.env.S3_ACCESS_KEY_ID ?? process.env.R2_ACCESS_KEY_ID;
   const s3SecretKey = process.env.S3_SECRET_ACCESS_KEY ?? process.env.R2_SECRET_ACCESS_KEY;
   const s3Bucket = process.env.S3_BUCKET ?? process.env.R2_BUCKET ?? 'matrixos-sync';
   const s3ForcePathStyle = process.env.S3_FORCE_PATH_STYLE === 'true';
+  let createR2Client: GatewayR2ClientModule['createR2Client'] | undefined;
   if (s3AccessKey && s3SecretKey && PLATFORM_SECRET) {
-    const [{ createR2Client }, { createInternalSyncRoutes }] = await Promise.all([
+    const [r2ClientModule, { createInternalSyncRoutes }] = await Promise.all([
       importRuntimeModule<GatewayR2ClientModule>('../../gateway/src/sync/r2-client.js'),
       import('./internal-sync-routes.js'),
     ]);
+    createR2Client = r2ClientModule.createR2Client;
     const r2 = await createR2Client({
       accessKeyId: s3AccessKey,
       secretAccessKey: s3SecretKey,
@@ -4971,6 +4966,25 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       platformSecret: PLATFORM_SECRET,
     });
     customerVpsObjectStore = r2;
+    hostBundleObjectStore = r2;
+  }
+
+  const bundleS3Bucket = process.env.S3_BUNDLES_BUCKET ?? process.env.R2_BUNDLES_BUCKET;
+  const bundleS3AccessKey = process.env.S3_BUNDLES_ACCESS_KEY_ID ?? process.env.R2_BUNDLES_ACCESS_KEY_ID;
+  const bundleS3SecretKey = process.env.S3_BUNDLES_SECRET_ACCESS_KEY ?? process.env.R2_BUNDLES_SECRET_ACCESS_KEY;
+  if (bundleS3Bucket && bundleS3AccessKey && bundleS3SecretKey) {
+    createR2Client ??= (
+      await importRuntimeModule<GatewayR2ClientModule>('../../gateway/src/sync/r2-client.js')
+    ).createR2Client;
+    hostBundleObjectStore = await createR2Client({
+      accessKeyId: bundleS3AccessKey,
+      secretAccessKey: bundleS3SecretKey,
+      bucket: bundleS3Bucket,
+      endpoint: process.env.S3_BUNDLES_ENDPOINT ?? process.env.R2_BUNDLES_ENDPOINT,
+      publicEndpoint: process.env.S3_BUNDLES_PUBLIC_ENDPOINT ?? process.env.R2_BUNDLES_PUBLIC_ENDPOINT,
+      accountId: process.env.S3_BUNDLES_ACCOUNT_ID ?? process.env.R2_BUNDLES_ACCOUNT_ID ?? process.env.R2_ACCOUNT_ID,
+      forcePathStyle: process.env.S3_BUNDLES_FORCE_PATH_STYLE === 'true',
+    });
   }
 
   let customerVpsService: CustomerVpsService | undefined;
@@ -5055,6 +5069,7 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     internalSyncRoutes,
     customerVpsService,
     customerVpsObjectStore,
+    hostBundleObjectStore,
   });
 
   const server = serve({ fetch: app.fetch, port: PORT }, () => {

--- a/tests/platform/host-bundle-route.test.ts
+++ b/tests/platform/host-bundle-route.test.ts
@@ -94,6 +94,36 @@ describe('platform host bundle route', () => {
     expect(getObject).not.toHaveBeenCalled();
   });
 
+  it('uses dedicated host bundle object storage when configured', async () => {
+    await seedRelease();
+    const syncGetPresignedGetUrl = vi.fn().mockResolvedValue('https://sync.example/wrong-bucket');
+    const bundleGetPresignedGetUrl = vi.fn().mockResolvedValue('https://bundles.example/signed-host-bundle');
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: syncGetPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+      hostBundleObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: bundleGetPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const res = await app.request('/system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://bundles.example/signed-host-bundle');
+    expect(bundleGetPresignedGetUrl).toHaveBeenCalledWith(
+      'system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz',
+      3600,
+    );
+    expect(syncGetPresignedGetUrl).not.toHaveBeenCalled();
+  });
+
   it('returns JSON 502 when release metadata cannot mint a signed URL', async () => {
     await seedRelease();
     const getPresignedGetUrl = vi.fn().mockRejectedValue(new Error('r2 unavailable'));
@@ -165,6 +195,41 @@ describe('platform host bundle route', () => {
       'system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz',
       3600,
     );
+  });
+
+  it('uses dedicated host bundle object storage for channel manifests', async () => {
+    await seedRelease();
+    await promoteHostBundleChannel(db, 'stable', 'v2026.05.12-1');
+    const syncGetPresignedGetUrl = vi.fn().mockResolvedValue('https://sync.example/wrong-bucket');
+    const bundleGetPresignedGetUrl = vi.fn().mockResolvedValue('https://bundles.example/stable-host-bundle');
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: syncGetPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+      hostBundleObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: bundleGetPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+    });
+
+    const res = await app.request('/system-bundles/channels/stable.json');
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-1',
+      channel: 'stable',
+      url: 'https://bundles.example/stable-host-bundle',
+    });
+    expect(bundleGetPresignedGetUrl).toHaveBeenCalledWith(
+      'system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz',
+      3600,
+    );
+    expect(syncGetPresignedGetUrl).not.toHaveBeenCalled();
   });
 
   it('serializes the requested channel for promoted channel aliases', async () => {


### PR DESCRIPTION
## Summary

- Add a dedicated host bundle object-store dependency for platform bundle routes.
- Build that store from R2_BUNDLES_* / S3_BUNDLES_* env vars when configured.
- Keep customer VPS sync/object metadata on the existing R2_* / S3_* store and fall back to it for bundles when no dedicated bundle store is configured.

## Invariants

- Source of truth: platform Postgres remains canonical for release metadata and channel pointers; R2 only stores immutable bundle bytes.
- Lock/transaction scope: no database transaction behavior changes. Release route reads and channel lookups remain existing DB operations.
- Acceptable orphan states: if bundle storage is misconfigured, metadata can still exist but download signing returns the existing generic host-bundle unavailable response.
- Auth source of truth: release registration and promotion still use PLATFORM_SECRET bearer auth. Public bundle reads still rely on DB metadata plus object-store signed URLs.
- Deferred scope: this does not create buckets, rotate secrets, deploy Cloud Run, or fan out to customer VPSes.
- Rollback plan: remove R2_BUNDLES_* env vars or revert this PR to use the previous single R2 store behavior.
- PostHog events/errors: unchanged; this is storage routing/config plumbing only.

## Verification commands

- bun run test tests/platform/host-bundle-route.test.ts
- pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json
- bun run check:patterns

## Operator setup

Configure platform runtime with R2_BUNDLES_BUCKET=matrixos-bundles plus the matching R2_BUNDLES_* endpoint/account/key secrets. Keep R2_BUCKET=matrixos-sync for sync/user objects.