### PR TITLE
fix(shell): harden account menu sign out

### DIFF
--- a/shell/src/components/MenuBar.tsx
+++ b/shell/src/components/MenuBar.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useEffect, useEffectEvent, useRef } from "react";
-import { UserButton as ClerkUserButton, useAuth } from "@clerk/nextjs";
+import { useAuth } from "@clerk/nextjs";
 import { useWindowManager } from "@/hooks/useWindowManager";
 import { useIsClient } from "@/hooks/useIsClient";
-import { CreditCardIcon, SearchIcon, ServerIcon, UserIcon } from "lucide-react";
+import { CreditCardIcon, SearchIcon, UserIcon } from "lucide-react";
 import { AppSettingsDialog } from "./AppSettingsDialog";
 import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
+import { UserButton } from "./UserButton";
 
 const FALLBACK_APP_ICON = "/icon-192.png";
 
@@ -75,7 +76,7 @@ function MenuBarUser() {
   }
 
   return (
-    <div className="flex items-center gap-1.5 [&_.cl-avatarBox]:!size-[18px] [&_.cl-userButtonTrigger]:!p-0 [&_.cl-userButtonTrigger]:!rounded-full [&_.cl-userButtonTrigger]:!shadow-none [&_.cl-userButtonTrigger]:!border-0">
+    <div className="flex items-center gap-1.5">
       <span
         className={`hidden items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium sm:inline-flex ${
           billingActive === true
@@ -86,23 +87,7 @@ function MenuBarUser() {
         <CreditCardIcon className="size-3" aria-hidden="true" />
         {billingActive === true ? "Active" : "Billing"}
       </span>
-      <ClerkUserButton
-        appearance={{
-          elements: {
-            avatarBox: "!w-[18px] !h-[18px] !min-w-[18px] !min-h-[18px]",
-            userButtonTrigger: "!p-0 !rounded-full !shadow-none !border-0",
-          },
-        }}
-        afterSignOutUrl="https://app.matrix-os.com/sign-in"
-      >
-        <ClerkUserButton.MenuItems>
-          <ClerkUserButton.Link
-            label="Switch computer"
-            labelIcon={<ServerIcon className="size-4" aria-hidden="true" />}
-            href="/runtime"
-          />
-        </ClerkUserButton.MenuItems>
-      </ClerkUserButton>
+      <UserButton variant="menubar" />
     </div>
   );
 }

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -86,12 +86,9 @@ function SettingsAccountFooter() {
   return (
     <section
       aria-label="Account"
-      className="sticky bottom-0 z-10 mt-2 flex shrink-0 items-center justify-between gap-3 border-t border-border/40 bg-card/95 px-2 py-2 backdrop-blur sm:static sm:mt-auto sm:justify-center sm:bg-transparent sm:px-0 sm:pt-3 sm:backdrop-blur-none"
+      className="sticky bottom-0 z-10 mt-2 flex shrink-0 items-center border-t border-border/40 bg-card/95 px-2 py-2 backdrop-blur sm:static sm:mt-auto sm:bg-transparent sm:px-0 sm:pt-3 sm:backdrop-blur-none"
     >
-      <div className="min-w-0 sm:hidden">
-        <p className="text-xs font-semibold text-foreground">Account</p>
-      </div>
-      <AccountButton />
+      <AccountButton variant="settings" />
     </section>
   );
 }

--- a/shell/src/components/UserButton.tsx
+++ b/shell/src/components/UserButton.tsx
@@ -27,15 +27,45 @@ async function clearMatrixAppSession(): Promise<void> {
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), SIGN_OUT_TIMEOUT_MS);
   try {
-    await fetch("/api/auth/app-session", {
+    const response = await fetch("/api/auth/app-session", {
       method: "DELETE",
       credentials: "include",
       signal: controller.signal,
     });
+    if (!response.ok) {
+      console.warn("[auth] Matrix app session clear returned non-OK status", response.status);
+    }
   } catch (error: unknown) {
     console.warn("[auth] Matrix app session clear failed", error instanceof Error ? error.name : typeof error);
   } finally {
     window.clearTimeout(timeoutId);
+  }
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
+
+async function clerkSignOutWithTimeout(
+  signOut: (options: { redirectUrl: string }) => Promise<unknown> | unknown,
+  redirectUrl: string,
+): Promise<void> {
+  let timeoutId: number | undefined;
+  try {
+    await Promise.race([
+      Promise.resolve(signOut({ redirectUrl })),
+      new Promise<never>((_, reject) => {
+        timeoutId = window.setTimeout(() => {
+          const error = new Error("Clerk sign-out timed out");
+          error.name = "TimeoutError";
+          reject(error);
+        }, SIGN_OUT_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      window.clearTimeout(timeoutId);
+    }
   }
 }
 
@@ -103,8 +133,13 @@ function MountedUserButton({ variant }: { variant: UserButtonVariant }) {
     const redirectUrl = getSignInRedirectUrl();
     await clearMatrixAppSession();
     try {
-      await clerk.signOut({ redirectUrl });
+      await clerkSignOutWithTimeout(clerk.signOut, redirectUrl);
     } catch (error: unknown) {
+      setSigningOut(false);
+      if (isTimeoutError(error)) {
+        console.warn("[auth] Clerk sign-out timed out");
+        return;
+      }
       console.error("[auth] Clerk sign-out failed", error instanceof Error ? error.name : typeof error);
       window.location.replace(redirectUrl);
     }

--- a/shell/src/components/UserButton.tsx
+++ b/shell/src/components/UserButton.tsx
@@ -1,21 +1,60 @@
 "use client";
 
-import { UserButton as ClerkUserButton, useAuth } from "@clerk/nextjs";
+import { useAuth, useClerk, useUser } from "@clerk/nextjs";
 import { useIsClient } from "@/hooks/useIsClient";
-import { useMatrixBillingAccess } from "@/hooks/useMatrixBillingAccess";
+import { cn } from "@/lib/utils";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { CreditCardIcon, ServerIcon, UserIcon } from "lucide-react";
+import { LogOutIcon, ServerIcon, SettingsIcon, UserIcon } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import { useState } from "react";
 
-function Placeholder() {
+const SIGN_OUT_TIMEOUT_MS = 10_000;
+
+type UserButtonVariant = "dock" | "menubar" | "settings";
+
+function getSignInRedirectUrl(): string {
+  const configured = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL ?? "/sign-in";
+  return new URL(configured, window.location.origin).toString();
+}
+
+async function clearMatrixAppSession(): Promise<void> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), SIGN_OUT_TIMEOUT_MS);
+  try {
+    await fetch("/api/auth/app-session", {
+      method: "DELETE",
+      credentials: "include",
+      signal: controller.signal,
+    });
+  } catch (error: unknown) {
+    console.warn("[auth] Matrix app session clear failed", error instanceof Error ? error.name : typeof error);
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+function Placeholder({ variant = "dock" }: { variant?: UserButtonVariant }) {
+  const isSettings = variant === "settings";
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className="flex size-10 items-center justify-center rounded-xl border border-border/60 bg-card shadow-sm">
-          <UserIcon className="size-4" />
+        <div
+          className={cn(
+            "flex items-center justify-center rounded-xl border border-border/60 bg-card shadow-sm",
+            variant === "menubar" ? "size-[18px] rounded-full border-0 shadow-none" : "size-10",
+            isSettings && "min-h-12 w-full justify-start gap-3 rounded-2xl px-2",
+          )}
+        >
+          <UserIcon className={cn("size-4", variant === "menubar" && "size-[14px]")} />
+          {isSettings ? (
+            <span className="min-w-0 truncate text-sm font-semibold text-foreground">Account</span>
+          ) : null}
         </div>
       </TooltipTrigger>
       <TooltipContent side="right" sideOffset={8}>
@@ -25,57 +64,155 @@ function Placeholder() {
   );
 }
 
-export function UserButton() {
+export function UserButton({ variant = "dock" }: { variant?: UserButtonVariant }) {
   // SSR hydration guard: useIsClient is false on the server and during the first client render
   // (so the static Placeholder renders during SSR/first paint), then true on the client, so the
-  // Clerk <UserButton> -- which reads browser-only auth state -- mounts without a hydration
+  // Clerk hooks -- which read browser-only auth state -- mount without a hydration
   // mismatch or a setState-in-effect cascade.
   const mounted = useIsClient();
 
   if (!mounted) {
-    return <Placeholder />;
+    return <Placeholder variant={variant} />;
   }
 
-  return <MountedUserButton />;
+  return <MountedUserButton variant={variant} />;
 }
 
-function MountedUserButton() {
+function MountedUserButton({ variant }: { variant: UserButtonVariant }) {
   const { isLoaded, isSignedIn } = useAuth();
-  const { active: billingActive } = useMatrixBillingAccess();
+  const { user } = useUser();
+  const clerk = useClerk();
+  const [signingOut, setSigningOut] = useState(false);
 
   if (!isLoaded || !isSignedIn) {
-    return <Placeholder />;
+    return <Placeholder variant={variant} />;
+  }
+
+  const displayName =
+    user?.fullName ??
+    user?.username ??
+    user?.primaryEmailAddress?.emailAddress ??
+    "Account";
+  const avatarUrl = user?.imageUrl || null;
+  const isSettings = variant === "settings";
+  const isMenubar = variant === "menubar";
+
+  async function handleSignOut() {
+    if (signingOut) return;
+    setSigningOut(true);
+    const redirectUrl = getSignInRedirectUrl();
+    await clearMatrixAppSession();
+    try {
+      await clerk.signOut({ redirectUrl });
+    } catch (error: unknown) {
+      console.error("[auth] Clerk sign-out failed", error instanceof Error ? error.name : typeof error);
+      window.location.replace(redirectUrl);
+    }
   }
 
   return (
-    <div className="flex flex-col items-center gap-1">
-      <ClerkUserButton
-        appearance={{
-          elements: {
-            avatarBox: "size-10 rounded-xl",
-            userButtonTrigger: "rounded-xl shadow-sm border border-border/60",
-          },
-        }}
-        afterSignOutUrl="https://app.matrix-os.com/sign-in"
-      >
-        <ClerkUserButton.MenuItems>
-          <ClerkUserButton.Link
-            label="Switch computer"
-            labelIcon={<ServerIcon className="size-4" aria-hidden="true" />}
-            href="/runtime"
+    <DropdownMenuPrimitive.Root>
+      <DropdownMenuPrimitive.Trigger asChild>
+        <button
+          type="button"
+          aria-label={`Account menu for ${displayName}`}
+          className={cn(
+            "flex items-center justify-center rounded-xl border border-border/60 bg-card text-foreground shadow-sm transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            isMenubar ? "size-[18px] rounded-full border-0 bg-transparent shadow-none" : "size-10",
+            isSettings && "min-h-12 w-full justify-start gap-3 rounded-2xl px-2",
+          )}
+        >
+          <AccountAvatar
+            avatarUrl={avatarUrl}
+            displayName={displayName}
+            compact={isMenubar}
           />
-        </ClerkUserButton.MenuItems>
-      </ClerkUserButton>
-      <div
-        className={`flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${
-          billingActive === true
-            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-            : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-        }`}
-      >
-        <CreditCardIcon className="size-3" aria-hidden="true" />
-        {billingActive === true ? "Active" : "Billing"}
-      </div>
-    </div>
+          {isSettings ? (
+            <span className="min-w-0 truncate text-left text-sm font-semibold">
+              {displayName}
+            </span>
+          ) : null}
+        </button>
+      </DropdownMenuPrimitive.Trigger>
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.Content
+          align={isMenubar ? "end" : "start"}
+          side={isMenubar ? "bottom" : "top"}
+          sideOffset={10}
+          className="z-50 w-[280px] overflow-hidden rounded-2xl border border-border/70 bg-popover text-popover-foreground shadow-2xl"
+        >
+          <div className="flex items-center gap-3 border-b border-border/60 px-4 py-4">
+            <AccountAvatar avatarUrl={avatarUrl} displayName={displayName} />
+            <span className="min-w-0 truncate text-sm font-semibold">{displayName}</span>
+          </div>
+          <DropdownMenuPrimitive.Item
+            className="flex cursor-default items-center gap-3 px-4 py-3 text-sm font-medium outline-none transition-colors hover:bg-muted/70 focus:bg-muted/70"
+            onSelect={() => {
+              clerk.openUserProfile();
+            }}
+          >
+            <SettingsIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+            Manage account
+          </DropdownMenuPrimitive.Item>
+          <DropdownMenuPrimitive.Item asChild>
+            <Link
+              className="flex cursor-default items-center gap-3 border-t border-border/60 px-4 py-3 text-sm font-medium outline-none transition-colors hover:bg-muted/70 focus:bg-muted/70"
+              href="/runtime"
+            >
+              <ServerIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+              Switch computer
+            </Link>
+          </DropdownMenuPrimitive.Item>
+          <DropdownMenuPrimitive.Item
+            className="flex cursor-default items-center gap-3 border-t border-border/60 px-4 py-3 text-sm font-medium outline-none transition-colors hover:bg-muted/70 focus:bg-muted/70"
+            disabled={signingOut}
+            onSelect={(event) => {
+              event.preventDefault();
+              void handleSignOut();
+            }}
+          >
+            <LogOutIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+            {signingOut ? "Signing out..." : "Sign out"}
+          </DropdownMenuPrimitive.Item>
+          <div className="border-t border-border/60 px-4 py-3 text-center text-xs font-semibold text-muted-foreground">
+            Secured by Clerk
+          </div>
+        </DropdownMenuPrimitive.Content>
+      </DropdownMenuPrimitive.Portal>
+    </DropdownMenuPrimitive.Root>
+  );
+}
+
+function AccountAvatar({
+  avatarUrl,
+  displayName,
+  compact = false,
+}: {
+  avatarUrl: string | null;
+  displayName: string;
+  compact?: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#4b3b86] text-white",
+        compact ? "size-[18px]" : "size-10",
+      )}
+    >
+      {avatarUrl ? (
+        <Image
+          src={avatarUrl}
+          alt=""
+          width={compact ? 18 : 40}
+          height={compact ? 18 : 40}
+          className="size-full object-cover"
+          referrerPolicy="no-referrer"
+          unoptimized
+        />
+      ) : (
+        <UserIcon className={cn("size-5", compact && "size-3")} aria-hidden="true" />
+      )}
+      <span className="sr-only">{displayName}</span>
+    </span>
   );
 }

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -42,6 +42,18 @@ vi.mock("@clerk/nextjs", () => ({
     has: ({ plan }: { plan: string }) => plan === clerkState.activePlan,
     getToken: clerkState.getToken,
   }),
+  useUser: () => ({
+    user: {
+      fullName: null,
+      username: "test-user",
+      imageUrl: "",
+      primaryEmailAddress: { emailAddress: "test@example.com" },
+    },
+  }),
+  useClerk: () => ({
+    signOut: vi.fn(async () => undefined),
+    openUserProfile: vi.fn(),
+  }),
 }));
 
 vi.mock("next/navigation", () => ({

--- a/tests/shell/menu-bar-focus.test.tsx
+++ b/tests/shell/menu-bar-focus.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWindowManager } from "../../shell/src/hooks/useWindowManager.js";
 
@@ -8,6 +8,18 @@ let MenuBar: typeof import("../../shell/src/components/MenuBar.js").MenuBar;
 
 vi.mock("@clerk/nextjs", () => ({
   useAuth: () => ({ isLoaded: true, isSignedIn: true }),
+  useUser: () => ({
+    user: {
+      fullName: null,
+      username: "test-user",
+      imageUrl: "",
+      primaryEmailAddress: { emailAddress: "test@example.com" },
+    },
+  }),
+  useClerk: () => ({
+    signOut: vi.fn(async () => undefined),
+    openUserProfile: vi.fn(),
+  }),
   UserButton: Object.assign(
     ({ children }: { children?: React.ReactNode }) => <div data-testid="clerk-user-button">{children}</div>,
     {
@@ -71,7 +83,7 @@ describe("MenuBar focus display", () => {
     expect(screen.queryByRole("button", { name: "Matrix OS" })).toBeNull();
   });
 
-  it("puts switch-computer under the Clerk user button instead of the top menu", () => {
+  it("puts switch-computer under the account menu instead of the top menu", async () => {
     render(
       <MenuBar onOpenCommandPalette={() => {}} onNewWindow={() => {}}>
         <button type="button">Fit</button>
@@ -79,6 +91,10 @@ describe("MenuBar focus display", () => {
     );
 
     expect(screen.queryByRole("button", { name: "Computer" })).toBeNull();
-    expect(screen.getByRole("link", { name: "Switch computer" }).getAttribute("href")).toBe("/runtime");
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Account menu for test-user" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    expect((await screen.findByRole("menuitem", { name: "Switch computer" })).getAttribute("href")).toBe("/runtime");
   });
 });

--- a/tests/shell/mobile-shell.test.tsx
+++ b/tests/shell/mobile-shell.test.tsx
@@ -21,6 +21,18 @@ vi.mock("@clerk/nextjs", () => ({
     isSignedIn: true,
     has: () => false,
   }),
+  useUser: () => ({
+    user: {
+      fullName: null,
+      username: "test-user",
+      imageUrl: "",
+      primaryEmailAddress: { emailAddress: "test@example.com" },
+    },
+  }),
+  useClerk: () => ({
+    signOut: vi.fn(async () => undefined),
+    openUserProfile: vi.fn(),
+  }),
   UserButton: Object.assign(
     ({ children }: { children?: React.ReactNode }) => <div data-testid="clerk-user-button">{children}</div>,
     {

--- a/tests/shell/user-button-hydration.test.tsx
+++ b/tests/shell/user-button-hydration.test.tsx
@@ -4,6 +4,18 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@clerk/nextjs", () => ({
   useAuth: () => ({ isLoaded: true, isSignedIn: true }),
+  useUser: () => ({
+    user: {
+      fullName: null,
+      username: "test-user",
+      imageUrl: "",
+      primaryEmailAddress: { emailAddress: "test@example.com" },
+    },
+  }),
+  useClerk: () => ({
+    signOut: vi.fn(async () => undefined),
+    openUserProfile: vi.fn(),
+  }),
   UserButton: () => <div data-testid="clerk-user-button" data-clerk-component="UserButton" />,
 }));
 

--- a/tests/shell/user-button.test.tsx
+++ b/tests/shell/user-button.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const clerkState = vi.hoisted(() => ({
+  isLoaded: true,
+  isSignedIn: true,
+  user: {
+    fullName: null as string | null,
+    username: "kongfupanda13",
+    imageUrl: "",
+    primaryEmailAddress: { emailAddress: "kongfupanda13@example.com" },
+  },
+  signOut: vi.fn(async () => undefined),
+  openUserProfile: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({
+    isLoaded: clerkState.isLoaded,
+    isSignedIn: clerkState.isSignedIn,
+  }),
+  useUser: () => ({
+    user: clerkState.user,
+  }),
+  useClerk: () => ({
+    signOut: clerkState.signOut,
+    openUserProfile: clerkState.openUserProfile,
+  }),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("UserButton", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = true;
+    clerkState.user.username = "kongfupanda13";
+    clerkState.user.fullName = null;
+    clerkState.signOut.mockResolvedValue(undefined);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ cleared: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+
+  it("renders the settings account control as a left-aligned row with the user's name", async () => {
+    const { UserButton } = await import("../../shell/src/components/UserButton.js");
+
+    render(<UserButton variant="settings" />);
+
+    const trigger = screen.getByRole("button", { name: "Account menu for kongfupanda13" });
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain("kongfupanda13");
+    expect(screen.queryByText("Billing")).toBeNull();
+  });
+
+  it("clears the Matrix app session before signing out through Clerk", async () => {
+    const { UserButton } = await import("../../shell/src/components/UserButton.js");
+
+    render(<UserButton variant="settings" />);
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Account menu for kongfupanda13" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Sign out" }));
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/auth/app-session",
+        expect.objectContaining({
+          method: "DELETE",
+          credentials: "include",
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      expect(clerkState.signOut).toHaveBeenCalledWith({
+        redirectUrl: "http://localhost:3000/sign-in",
+      });
+    });
+  });
+});

--- a/tests/shell/user-button.test.tsx
+++ b/tests/shell/user-button.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clerkState = vi.hoisted(() => ({
   isLoaded: true,
@@ -40,6 +40,7 @@ vi.mock("@/components/ui/tooltip", () => ({
 describe("UserButton", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     clerkState.isLoaded = true;
     clerkState.isSignedIn = true;
     clerkState.user.username = "kongfupanda13";
@@ -52,6 +53,18 @@ describe("UserButton", () => {
       }),
     );
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function openAccountMenu() {
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Account menu for kongfupanda13" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    return screen.findByRole("menuitem", { name: "Sign out" });
+  }
 
   it("renders the settings account control as a left-aligned row with the user's name", async () => {
     const { UserButton } = await import("../../shell/src/components/UserButton.js");
@@ -69,11 +82,7 @@ describe("UserButton", () => {
 
     render(<UserButton variant="settings" />);
 
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Account menu for kongfupanda13" }), {
-      button: 0,
-      ctrlKey: false,
-    });
-    fireEvent.click(await screen.findByRole("menuitem", { name: "Sign out" }));
+    fireEvent.click(await openAccountMenu());
 
     await waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -88,5 +97,54 @@ describe("UserButton", () => {
         redirectUrl: "http://localhost:3000/sign-in",
       });
     });
+  });
+
+  it("logs non-OK Matrix app-session cleanup responses before Clerk sign-out", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "Session unavailable" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const { UserButton } = await import("../../shell/src/components/UserButton.js");
+
+    render(<UserButton variant="settings" />);
+
+    fireEvent.click(await openAccountMenu());
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[auth] Matrix app session clear returned non-OK status",
+        503,
+      );
+      expect(clerkState.signOut).toHaveBeenCalled();
+    });
+  });
+
+  it("re-enables sign out when Clerk sign-out does not settle", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    clerkState.signOut.mockImplementation(() => new Promise(() => {}));
+    const { UserButton } = await import("../../shell/src/components/UserButton.js");
+
+    render(<UserButton variant="settings" />);
+
+    const signOutItem = await openAccountMenu();
+    vi.useFakeTimers();
+    fireEvent.click(signOutItem);
+
+    expect(screen.getByText("Signing out...")).toBeTruthy();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(clerkState.signOut).toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith("[auth] Clerk sign-out timed out");
+    expect(screen.getByRole("menuitem", { name: "Sign out" })).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- replace the Settings footer account control with a left-aligned row that shows the signed-in user's name directly
- remove the confusing billing status chip from the footer account button
- route account-menu sign-out through Matrix app-session cleanup before Clerk sign-out, and reuse that safe menu in the top menu bar
- bound Clerk sign-out failures with a timeout recovery path and log non-OK Matrix app-session cleanup responses

## Tests

- `flox activate -- bun run test -- tests/shell/user-button.test.tsx tests/shell/menu-bar-focus.test.tsx tests/shell/settings-panel.test.tsx tests/shell/billing-gate.test.tsx tests/shell/mobile-shell.test.tsx tests/shell/user-button-hydration.test.tsx`
- `flox activate -- bun run typecheck`
- `flox activate -- npx react-doctor@latest shell --diff --verbose`
- `flox activate -- bun run check:patterns`

## Review/Monitoring

- CI/Vercel checks are being monitored on PR #365.
- Greptile initial review was 3/5; the two reported sign-out resilience findings were fixed in `fix(shell): bound account sign out failures`.
- Waiting for the latest Greptile review to confirm 5/5.

## Invariants

- Source of truth: Clerk remains the account identity source; Matrix platform app-session cookie remains the platform routing/session source for app.matrix-os.com.
- Lock/transaction scope: no database writes or multi-step server transactions are introduced; client sign-out performs app-session cookie cleanup before invoking Clerk sign-out.
- Acceptable orphan states: if app-session cleanup fails or times out, the failure is logged and Clerk sign-out still runs; if Clerk sign-out times out, the account menu re-enables sign-out so the user has an in-page retry path.
- Auth source of truth: Clerk controls user authentication, while `/api/auth/app-session` clears Matrix's platform session cookie for routed shell access.
- Deferred scope: this does not change billing entitlement logic, VPS provisioning, or the existing top-bar billing status indicator.
