### PR TITLE
fix(shell): scope dark default to terminal

### DIFF
--- a/shell/src/hooks/useTheme.ts
+++ b/shell/src/hooks/useTheme.ts
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useFileWatcher } from "./useFileWatcher";
 import { getGatewayUrl } from "@/lib/gateway";
-import { getPreset } from "@/lib/theme-presets";
 
 export interface Theme {
   name: string;
@@ -45,8 +44,6 @@ export const DEFAULT_THEME: Theme = {
   radius: "0.75rem",
 };
 
-const SHELL_FALLBACK_THEME: Theme = getPreset("dark") ?? DEFAULT_THEME;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -58,17 +55,18 @@ function stringEntries(value: unknown): Record<string, string> {
   );
 }
 
-export function normalizeTheme(value: unknown, fallbackTheme: Theme = SHELL_FALLBACK_THEME): Theme {
+export function normalizeTheme(value: unknown, fallbackTheme: Theme = DEFAULT_THEME): Theme {
   if (!isRecord(value)) return fallbackTheme;
   if (Object.keys(value).length === 0) return fallbackTheme;
 
-  const { mode: _fallbackMode, ...fallbackWithoutMode } = fallbackTheme;
-
   return {
-    ...fallbackWithoutMode,
     name: typeof value.name === "string" && value.name.trim() ? value.name : fallbackTheme.name,
     ...(value.mode === "light" || value.mode === "dark" ? { mode: value.mode } : {}),
-    ...(value.style === "flat" || value.style === "neumorphic" ? { style: value.style } : {}),
+    ...(value.style === "flat" || value.style === "neumorphic"
+      ? { style: value.style }
+      : fallbackTheme.style
+        ? { style: fallbackTheme.style }
+        : {}),
     colors: {
       ...fallbackTheme.colors,
       ...stringEntries(value.colors),
@@ -120,9 +118,9 @@ function inferMode(theme: Theme): "light" | "dark" {
 }
 
 export function getThemeFallback(): Theme {
-  // First-run shell fallback is intentionally dark on every surface.
-  // Explicit saved themes, including light themes, still override this.
-  return SHELL_FALLBACK_THEME;
+  // First-run shell fallback stays light. Terminal readability is handled by
+  // terminal-specific settings, not by changing global shell theme tokens.
+  return DEFAULT_THEME;
 }
 
 export function useTheme() {
@@ -157,7 +155,7 @@ export async function saveTheme(theme: Theme): Promise<void> {
   });
 }
 
-async function fetchTheme(defaultTheme: Theme = SHELL_FALLBACK_THEME): Promise<Theme> {
+async function fetchTheme(defaultTheme: Theme = DEFAULT_THEME): Promise<Theme> {
   try {
     const gatewayUrl = getGatewayUrl();
     const res = await fetch(`${gatewayUrl}/api/settings/theme`, {

--- a/shell/src/stores/terminal-defaults.ts
+++ b/shell/src/stores/terminal-defaults.ts
@@ -1,0 +1,13 @@
+export type TerminalThemeId =
+  | "system"
+  | "one-dark"
+  | "one-light"
+  | "catppuccin-mocha"
+  | "dracula"
+  | "solarized-dark"
+  | "solarized-light"
+  | "nord"
+  | "github-dark"
+  | "github-light";
+
+export const DEFAULT_TERMINAL_THEME_ID: TerminalThemeId = "one-dark";

--- a/shell/src/stores/terminal-settings.ts
+++ b/shell/src/stores/terminal-settings.ts
@@ -1,22 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { DEFAULT_TERMINAL_THEME_ID, type TerminalThemeId } from "./terminal-defaults";
 
-export type TerminalThemeId =
-  | "system"
-  | "one-dark"
-  | "one-light"
-  | "catppuccin-mocha"
-  | "dracula"
-  | "solarized-dark"
-  | "solarized-light"
-  | "nord"
-  | "github-dark"
-  | "github-light";
+export { DEFAULT_TERMINAL_THEME_ID, type TerminalThemeId } from "./terminal-defaults";
 
 export const TERMINAL_FONT_FAMILIES = ["MesloLGS NF", "Berkeley Mono", "JetBrains Mono", "Fira Code"] as const;
 export type TerminalFontFamily = (typeof TERMINAL_FONT_FAMILIES)[number];
 export type TerminalCursorStyle = "block" | "bar" | "underline";
-export const DEFAULT_TERMINAL_THEME_ID: TerminalThemeId = "one-dark";
 
 interface TerminalSettings {
   themeId: TerminalThemeId;

--- a/shell/src/stores/terminal-settings.ts
+++ b/shell/src/stores/terminal-settings.ts
@@ -16,6 +16,7 @@ export type TerminalThemeId =
 export const TERMINAL_FONT_FAMILIES = ["MesloLGS NF", "Berkeley Mono", "JetBrains Mono", "Fira Code"] as const;
 export type TerminalFontFamily = (typeof TERMINAL_FONT_FAMILIES)[number];
 export type TerminalCursorStyle = "block" | "bar" | "underline";
+export const DEFAULT_TERMINAL_THEME_ID: TerminalThemeId = "one-dark";
 
 interface TerminalSettings {
   themeId: TerminalThemeId;
@@ -37,7 +38,7 @@ interface TerminalSettings {
 export const useTerminalSettings = create<TerminalSettings>()(
   persist(
     (set) => ({
-      themeId: "system",
+      themeId: DEFAULT_TERMINAL_THEME_ID,
       fontSize: 13,
       fontFamily: "MesloLGS NF",
       ligatures: true,

--- a/tests/shell/terminal-settings.test.ts
+++ b/tests/shell/terminal-settings.test.ts
@@ -1,12 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { readFile } from "node:fs/promises";
+import { DEFAULT_TERMINAL_THEME_ID } from "../../shell/src/stores/terminal-defaults.js";
 
 describe("terminal settings defaults", () => {
-  it("defaults new terminal settings to a dark terminal theme", async () => {
-    const source = await readFile(new URL("../../shell/src/stores/terminal-settings.ts", import.meta.url), "utf8");
-
-    expect(source).toContain('export const DEFAULT_TERMINAL_THEME_ID: TerminalThemeId = "one-dark";');
-    expect(source).toContain("themeId: DEFAULT_TERMINAL_THEME_ID");
-    expect(source).toContain('| "system"');
+  it("defaults new terminal settings to a dark terminal theme", () => {
+    expect(DEFAULT_TERMINAL_THEME_ID).toBe("one-dark");
   });
 });

--- a/tests/shell/terminal-settings.test.ts
+++ b/tests/shell/terminal-settings.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+
+describe("terminal settings defaults", () => {
+  it("defaults new terminal settings to a dark terminal theme", async () => {
+    const source = await readFile(new URL("../../shell/src/stores/terminal-settings.ts", import.meta.url), "utf8");
+
+    expect(source).toContain('export const DEFAULT_TERMINAL_THEME_ID: TerminalThemeId = "one-dark";');
+    expect(source).toContain("themeId: DEFAULT_TERMINAL_THEME_ID");
+    expect(source).toContain('| "system"');
+  });
+});

--- a/tests/shell/useTheme.test.ts
+++ b/tests/shell/useTheme.test.ts
@@ -52,18 +52,18 @@ describe("theme system", () => {
     expect(DEFAULT_THEME.fonts.sans).toBeDefined();
   });
 
-  it("uses a dark fallback theme for desktop and mobile first-run shell state", () => {
+  it("uses the light default theme for first-run shell state", () => {
     const theme = getThemeFallback();
 
-    expect(theme.mode).toBe("dark");
-    expect(theme.colors.background).not.toBe(DEFAULT_THEME.colors.background);
+    expect(theme).toBe(DEFAULT_THEME);
+    expect(theme.colors.background).toBe("#FAFAF9");
   });
 
-  it("normalizes empty first-run theme responses against the dark shell fallback", () => {
+  it("normalizes empty first-run theme responses against the light shell fallback", () => {
     const fallback = getThemeFallback();
     const theme = normalizeTheme({}, fallback);
 
-    expect(theme.mode).toBe("dark");
+    expect(theme.mode).toBeUndefined();
     expect(theme.colors.background).toBe(fallback.colors.background);
   });
 
@@ -74,7 +74,7 @@ describe("theme system", () => {
     expect(normalizeTheme([], fallback)).toBe(fallback);
   });
 
-  it("preserves explicit saved light themes over the dark shell fallback", () => {
+  it("preserves explicit saved light themes over the shell fallback", () => {
     const theme = normalizeTheme({
       name: "saved-light",
       mode: "light",
@@ -87,6 +87,21 @@ describe("theme system", () => {
     expect(theme.mode).toBe("light");
     expect(theme.colors.background).toBe("#ffffff");
     expect(theme.colors.foreground).toBe("#111111");
+  });
+
+  it("preserves explicit saved dark themes over the shell fallback", () => {
+    const theme = normalizeTheme({
+      name: "saved-dark",
+      mode: "dark",
+      colors: {
+        background: "#111111",
+        foreground: "#ffffff",
+      },
+    });
+
+    expect(theme.mode).toBe("dark");
+    expect(theme.colors.background).toBe("#111111");
+    expect(theme.colors.foreground).toBe("#ffffff");
   });
 
   it("preserves legacy saved light themes that omit mode", () => {


### PR DESCRIPTION
## Summary

- Restores the shell first-run/fetch-failure fallback to the light `DEFAULT_THEME` so Settings, Billing, and other shell UI no longer inherit the dark preset by default.
- Scopes the dark default to the terminal by changing new terminal settings from `themeId: "system"` to `themeId: "one-dark"`.
- Keeps `Match OS` available and preserves existing persisted terminal settings, including explicit `system` preferences.
- Moves the terminal default constant into a dependency-free module so tests can import the real default without loading the Zustand store.

## Tests

- `/home/nima/matrix-os/node_modules/.bin/vitest run tests/shell/useTheme.test.ts tests/shell/terminal-settings.test.ts --config /home/nima/matrix-os/vitest.config.ts` passed: 15 tests.
- `./scripts/review/check-patterns.sh --diff origin/main` passed: no violations or warnings.
- GitHub PR checks passed: Vercel, Vercel Preview Comments, and `check`.

## Review/Monitoring

- Latest commit: `6070ba387ee10ec5aa82ccad072c730c5f3059bc`.
- Greptile latest trusted review: 5/5 on latest commit.
- Review threads: stale Greptile source-inspection thread resolved after the direct-import fix.

## Invariants

- **Source of truth**: saved shell themes still come from `system/theme.json`; terminal appearance defaults come from terminal-specific settings.
- **Lock/transaction scope**: no database, filesystem write path, or multi-step mutation changed.
- **Acceptable orphan states**: if shell theme fetch fails, shell renders with `DEFAULT_THEME`; terminal still defaults to `one-dark` unless a terminal preference is already persisted.
- **Auth source of truth**: unchanged existing gateway auth for `/api/settings/theme`.
- **Deferred scope**: no migration of existing terminal settings, no Settings/Billing redesign, and no global theme preset changes.
