### PR TITLE
fix(auth): make Clerk logout authoritative

### DIFF
--- a/packages/platform/src/clerk-auth.ts
+++ b/packages/platform/src/clerk-auth.ts
@@ -1,16 +1,21 @@
 export interface ClerkTokenPayload {
   sub: string;
+  sid?: unknown;
   [key: string]: unknown;
 }
 
 export interface VerifyResult {
   authenticated: boolean;
   userId?: string;
+  sessionId?: string;
   error?: string;
 }
 
+export const CLERK_SESSION_REVOKE_TIMEOUT_MS = 10_000;
+
 export interface ClerkAuthDeps {
   verifyToken: (token: string) => Promise<ClerkTokenPayload>;
+  revokeSession?: (sessionId: string) => Promise<void>;
 }
 
 export interface ClerkAuth {
@@ -23,10 +28,46 @@ export interface ClerkAuth {
     token: string,
     expectedUserId: string,
   ): Promise<VerifyResult>;
+  revokeSession(sessionId: string): Promise<boolean>;
   isPublicPath(path: string): boolean;
 }
 
 const PUBLIC_PATHS = ["/health"];
+
+export function createClerkSessionRevoker(opts: {
+  secretKey: string;
+  apiUrl?: string;
+  fetchImpl?: typeof fetch;
+}): (sessionId: string) => Promise<void> {
+  const apiUrl = opts.apiUrl ?? "https://api.clerk.com";
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  return async (sessionId) => {
+    const response = await fetchImpl(
+      `${apiUrl}/v1/sessions/${encodeURIComponent(sessionId)}/revoke`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${opts.secretKey}`,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(CLERK_SESSION_REVOKE_TIMEOUT_MS),
+      },
+    );
+    if (!response.ok) {
+      throw new Error("Clerk session revoke failed");
+    }
+  };
+}
+
+function verifiedResultFromPayload(payload: ClerkTokenPayload): VerifyResult {
+  return {
+    authenticated: true,
+    userId: payload.sub,
+    ...(typeof payload.sid === "string" && payload.sid.length > 0
+      ? { sessionId: payload.sid }
+      : {}),
+  };
+}
 
 export function createClerkAuth(deps: ClerkAuthDeps): ClerkAuth {
   return {
@@ -48,7 +89,7 @@ export function createClerkAuth(deps: ClerkAuthDeps): ClerkAuth {
     async verify(token) {
       try {
         const payload = await deps.verifyToken(token);
-        return { authenticated: true, userId: payload.sub };
+        return verifiedResultFromPayload(payload);
       } catch (err) {
         return {
           authenticated: false,
@@ -63,13 +104,19 @@ export function createClerkAuth(deps: ClerkAuthDeps): ClerkAuth {
         if (payload.sub !== expectedUserId) {
           return { authenticated: false, error: "User mismatch" };
         }
-        return { authenticated: true, userId: payload.sub };
+        return verifiedResultFromPayload(payload);
       } catch (err) {
         return {
           authenticated: false,
           error: err instanceof Error ? err.message : "Token verification failed",
         };
       }
+    },
+
+    async revokeSession(sessionId) {
+      if (!deps.revokeSession) return false;
+      await deps.revokeSession(sessionId);
+      return true;
     },
 
     isPublicPath(path) {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2027,7 +2027,7 @@ function getAuthPage(
           }, 10000);
         })
       ]).finally(function() {
-        if (timeoutId) window.clearTimeout(timeoutId);
+        if (timeoutId !== undefined) window.clearTimeout(timeoutId);
       });
     }
     function redirectAfterSignOutIssue(err) {
@@ -3455,7 +3455,11 @@ export function createApp(deps: {
         try {
           clerkSessionRevoked = await clerkAuth.revokeSession(result.sessionId);
         } catch (err: unknown) {
-          console.warn('[auth/app-session] Clerk session revoke failed', err instanceof Error ? err.name : typeof err);
+          if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
+            console.warn('[auth/app-session] Clerk session revoke timed out', err.name);
+          } else {
+            console.warn('[auth/app-session] Clerk session revoke failed', err instanceof Error ? err.name : typeof err);
+          }
         }
       }
     }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -119,6 +119,7 @@ const CODE_SESSION_EXPIRES_IN_SEC = 12 * 60 * 60;
 const APP_ASSET_ROUTE_TOKEN_PARAM = 'matrix_asset_token';
 const APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS = [APP_ASSET_ROUTE_TOKEN_PARAM] as const;
 const SAFE_CLERK_CLEAR_COOKIE_NAME = /^(?:__session|__client_uat)_[A-Za-z0-9_-]{1,128}$/;
+const BROWSER_CLERK_SIGN_OUT_TIMEOUT_MS = 10_000;
 const HOST_BUNDLE_READ_TIMEOUT_MS = 30_000;
 const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const HOST_BUNDLE_FILES = new Set([
@@ -1960,6 +1961,7 @@ function getAuthPage(
   <script nonce="${scriptNonce}">
     var redirectTarget = ${redirectTargetJson};
     var signOutTarget = ${signOutTargetJson};
+    var SIGN_OUT_TIMEOUT_MS = ${BROWSER_CLERK_SIGN_OUT_TIMEOUT_MS};
     var requestedRuntime = new URLSearchParams(redirectTarget.split('?')[1] || '').get('runtime');
     var checkoutAttemptStorageKey = 'matrix.billing.checkoutAttemptAt';
     var checkoutAttemptMaxAgeMs = 30 * 60 * 1000;
@@ -2024,7 +2026,7 @@ function getAuthPage(
             var err = new Error('Clerk sign-out timed out');
             err.name = 'TimeoutError';
             reject(err);
-          }, 10000);
+          }, SIGN_OUT_TIMEOUT_MS);
         })
       ]).finally(function() {
         if (timeoutId !== undefined) window.clearTimeout(timeoutId);

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -38,7 +38,7 @@ import { LegacyContainerOrchestrationDisabledError, type Orchestrator } from './
 import { createSocialApi } from './social.js';
 import { createStoreApi } from './store-api.js';
 import { createSocialFeedApi } from './social-api.js';
-import { createClerkAuth, type ClerkAuth } from './clerk-auth.js';
+import { createClerkAuth, createClerkSessionRevoker, type ClerkAuth } from './clerk-auth.js';
 import type { MatrixProvisioner } from './matrix-provisioning.js';
 import { createAuthRoutes } from './auth-routes.js';
 import { issueSyncJwt, verifySyncJwt } from './sync-jwt.js';
@@ -111,11 +111,14 @@ const DOCKER_INSPECT_TIMEOUT_MS = 10_000;
 const CODE_SERVER_PORT = Number(process.env.MATRIX_CODE_SERVER_PORT ?? 8787);
 const CODE_SESSION_COOKIE = 'matrix_code_session';
 const APP_SESSION_COOKIE = 'matrix_app_session';
+const CLERK_SESSION_COOKIE = '__session';
+const CLERK_CLIENT_UAT_COOKIE = '__client_uat';
 const APP_ROUTE_COOKIE = 'matrix_app_route';
 const SHELL_ROUTE_COOKIE = 'matrix_shell_route';
 const CODE_SESSION_EXPIRES_IN_SEC = 12 * 60 * 60;
 const APP_ASSET_ROUTE_TOKEN_PARAM = 'matrix_asset_token';
 const APP_ASSET_ROUTE_OMITTED_QUERY_PARAMS = [APP_ASSET_ROUTE_TOKEN_PARAM] as const;
+const SAFE_CLERK_CLEAR_COOKIE_NAME = /^(?:__session|__client_uat)_[A-Za-z0-9_-]{1,128}$/;
 const HOST_BUNDLE_READ_TIMEOUT_MS = 30_000;
 const HOST_BUNDLE_IMAGE_VERSION_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const HOST_BUNDLE_FILES = new Set([
@@ -737,6 +740,51 @@ function buildClearAppSessionCookie(): string {
     'SameSite=Lax',
     'Max-Age=0',
   ].join('; ');
+}
+
+function buildClearBrowserCookie(name: string, domain?: string): string {
+  return [
+    `${name}=`,
+    'Path=/',
+    ...(domain ? [`Domain=${domain}`] : []),
+    'Secure',
+    'SameSite=Lax',
+    'Max-Age=0',
+  ].join('; ');
+}
+
+function matrixCookieDomainForHost(hostHeader: string | undefined): string | null {
+  const hostname = (hostHeader ?? '').split(':', 1)[0]?.toLowerCase() ?? '';
+  if (hostname === 'matrix-os.com' || hostname.endsWith('.matrix-os.com')) {
+    return 'matrix-os.com';
+  }
+  return null;
+}
+
+function clerkCookieClearNames(cookieHeader: string | undefined): string[] {
+  const names = new Set<string>([CLERK_SESSION_COOKIE, CLERK_CLIENT_UAT_COOKIE]);
+  for (const part of (cookieHeader ?? '').split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const equalsIndex = trimmed.indexOf('=');
+    const name = equalsIndex === -1 ? trimmed : trimmed.slice(0, equalsIndex);
+    if (SAFE_CLERK_CLEAR_COOKIE_NAME.test(name)) {
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+function appendSignOutClearCookies(c: import('hono').Context): void {
+  const cookieHeader = c.req.header('cookie');
+  const domain = matrixCookieDomainForHost(c.req.header('host'));
+  c.header('Set-Cookie', buildClearAppSessionCookie(), { append: true });
+  for (const name of clerkCookieClearNames(cookieHeader)) {
+    c.header('Set-Cookie', buildClearBrowserCookie(name), { append: true });
+    if (domain) {
+      c.header('Set-Cookie', buildClearBrowserCookie(name, domain), { append: true });
+    }
+  }
 }
 
 function applyNoStoreHeaders(c: import('hono').Context): void {
@@ -1967,6 +2015,25 @@ function getAuthPage(
         footerActionLink: 'font-medium'
       }
     };
+    function clerkSignOutWithTimeout() {
+      var timeoutId;
+      return Promise.race([
+        Promise.resolve(window.Clerk.signOut({ redirectUrl: signOutTarget })),
+        new Promise(function(_, reject) {
+          timeoutId = window.setTimeout(function() {
+            var err = new Error('Clerk sign-out timed out');
+            err.name = 'TimeoutError';
+            reject(err);
+          }, 10000);
+        })
+      ]).finally(function() {
+        if (timeoutId) window.clearTimeout(timeoutId);
+      });
+    }
+    function redirectAfterSignOutIssue(err) {
+      console.warn('[matrix] Clerk.signOut did not finish', err instanceof Error ? err.name : String(typeof err));
+      window.location.replace(signOutTarget);
+    }
     function renderSessionState(title, detail, primaryLabel, primaryHandler) {
       var el = document.getElementById('auth');
       el.innerHTML = '';
@@ -2006,16 +2073,12 @@ function getAuthPage(
             console.error('[matrix] App session clear failed', err instanceof Error ? err.message : String(err));
           })
           .then(function() {
-            return window.Clerk.signOut();
+            return clerkSignOutWithTimeout();
           })
           .then(function() {
             window.location.replace(signOutTarget);
           })
-          .catch(function(err) {
-            console.error('[matrix] Clerk.signOut failed', err instanceof Error ? err.message : String(err));
-            signOutButton.disabled = false;
-            signOutButton.textContent = 'Sign out';
-          });
+          .catch(redirectAfterSignOutIssue);
       });
       actions.appendChild(signOutButton);
 
@@ -3384,9 +3447,21 @@ export function createApp(deps: {
   }
 
   app.delete('/api/auth/app-session', bodyLimit({ maxSize: 1024 }), async (c) => {
+    let clerkSessionRevoked = false;
+    const clerkToken = clerkAuth?.extractToken(undefined, c.req.header('cookie'));
+    if (clerkAuth && clerkToken) {
+      const result = await clerkAuth.verify(clerkToken);
+      if (result.authenticated && result.sessionId) {
+        try {
+          clerkSessionRevoked = await clerkAuth.revokeSession(result.sessionId);
+        } catch (err: unknown) {
+          console.warn('[auth/app-session] Clerk session revoke failed', err instanceof Error ? err.name : typeof err);
+        }
+      }
+    }
     applyNoStoreHeaders(c);
-    c.header('Set-Cookie', buildClearAppSessionCookie());
-    return c.json({ cleared: true });
+    appendSignOutClearCookies(c);
+    return c.json({ cleared: true, clerkSessionRevoked });
   });
 
   app.post('/api/auth/provision-runtime', bodyLimit({ maxSize: 1024 }), async (c) => {
@@ -4836,13 +4911,15 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
 
   // Clerk JWT verification (optional -- only active when CLERK_SECRET_KEY is set)
   let clerkAuth: ClerkAuth | undefined;
-  if (process.env.CLERK_SECRET_KEY) {
+  const clerkSecretKey = process.env.CLERK_SECRET_KEY;
+  if (clerkSecretKey) {
     const { verifyToken } = await import('@clerk/backend');
     clerkAuth = createClerkAuth({
       verifyToken: async (token: string) => {
-        const payload = await verifyToken(token, { secretKey: process.env.CLERK_SECRET_KEY! });
+        const payload = await verifyToken(token, { secretKey: clerkSecretKey });
         return payload as { sub: string; [key: string]: unknown };
       },
+      revokeSession: createClerkSessionRevoker({ secretKey: clerkSecretKey }),
     });
   }
 

--- a/shell/src/components/UserButton.tsx
+++ b/shell/src/components/UserButton.tsx
@@ -109,7 +109,7 @@ export function UserButton({ variant = "dock" }: { variant?: UserButtonVariant }
 }
 
 function MountedUserButton({ variant }: { variant: UserButtonVariant }) {
-  const { isLoaded, isSignedIn } = useAuth();
+  const { isLoaded, isSignedIn, signOut } = useAuth();
   const { user } = useUser();
   const clerk = useClerk();
   const [signingOut, setSigningOut] = useState(false);
@@ -133,14 +133,13 @@ function MountedUserButton({ variant }: { variant: UserButtonVariant }) {
     const redirectUrl = getSignInRedirectUrl();
     await clearMatrixAppSession();
     try {
-      await clerkSignOutWithTimeout(clerk.signOut, redirectUrl);
+      await clerkSignOutWithTimeout(signOut, redirectUrl);
     } catch (error: unknown) {
-      setSigningOut(false);
       if (isTimeoutError(error)) {
         console.warn("[auth] Clerk sign-out timed out");
-        return;
+      } else {
+        console.error("[auth] Clerk sign-out failed", error instanceof Error ? error.name : typeof error);
       }
-      console.error("[auth] Clerk sign-out failed", error instanceof Error ? error.name : typeof error);
       window.location.replace(redirectUrl);
     }
   }

--- a/shell/src/components/UserButton.tsx
+++ b/shell/src/components/UserButton.tsx
@@ -134,6 +134,7 @@ function MountedUserButton({ variant }: { variant: UserButtonVariant }) {
     await clearMatrixAppSession();
     try {
       await clerkSignOutWithTimeout(signOut, redirectUrl);
+      window.location.replace(redirectUrl);
     } catch (error: unknown) {
       if (isTimeoutError(error)) {
         console.warn("[auth] Clerk sign-out timed out");

--- a/tests/platform/clerk-auth.test.ts
+++ b/tests/platform/clerk-auth.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+  CLERK_SESSION_REVOKE_TIMEOUT_MS,
   createClerkAuth,
+  createClerkSessionRevoker,
   type ClerkAuth,
 } from "../../packages/platform/src/clerk-auth.js";
 
@@ -76,5 +78,43 @@ describe("T800: Clerk JWT verification on subdomain proxy", () => {
   it("other paths are not public", () => {
     expect(auth.isPublicPath("/api/message")).toBe(false);
     expect(auth.isPublicPath("/ws")).toBe(false);
+  });
+
+  it("extracts the Clerk session id from verified JWT claims", async () => {
+    const verifyFn = vi.fn().mockResolvedValue({ sub: "user_abc123", sid: "sess_123" });
+    auth = createClerkAuth({ verifyToken: verifyFn });
+
+    const result = await auth.verify("tok_test");
+
+    expect(result).toEqual({
+      authenticated: true,
+      userId: "user_abc123",
+      sessionId: "sess_123",
+    });
+  });
+
+  it("revokes Clerk sessions with a bounded direct Backend API fetch", async () => {
+    const signal = AbortSignal.abort();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(signal);
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    const revokeSession = createClerkSessionRevoker({
+      secretKey: "sk_test_matrix",
+      fetchImpl: fetchMock,
+    });
+
+    await revokeSession("sess/with/slashes");
+
+    expect(timeoutSpy).toHaveBeenCalledWith(CLERK_SESSION_REVOKE_TIMEOUT_MS);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.clerk.com/v1/sessions/sess%2Fwith%2Fslashes/revoke",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer sk_test_matrix",
+          Accept: "application/json",
+        },
+        signal,
+      }),
+    );
   });
 });

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -81,6 +81,14 @@ function stubDocker(inspectInfo: { id?: string; ipAddress?: string; running?: bo
   } as unknown as Dockerode;
 }
 
+function combinedSetCookie(headers: Headers): string {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;
+  if (typeof getSetCookie === "function") {
+    return getSetCookie.call(headers).join("\n");
+  }
+  return headers.get("set-cookie") ?? "";
+}
+
 describe("platform proxy routing", () => {
   let db: PlatformDB;
 
@@ -1148,7 +1156,10 @@ describe("platform proxy routing", () => {
     expect(html).toContain('var signOutTarget = "/sign-in";');
     expect(html).toContain("continueWithClerkSession");
     expect(html).toContain("fetch('/api/auth/app-session'");
-    expect(html).toContain("[matrix] Clerk.signOut failed");
+    expect(html).toContain("function clerkSignOutWithTimeout()");
+    expect(html).toContain("window.setTimeout(function() {");
+    expect(html).toContain("window.location.replace(signOutTarget)");
+    expect(html).toContain("[matrix] Clerk.signOut did not finish");
     expect(html).not.toContain("window.location.replace(redirectTarget)");
   });
 
@@ -1390,6 +1401,82 @@ describe("platform proxy routing", () => {
     });
     expect(exchange.headers.get("set-cookie")).toContain("matrix_app_session=;");
     expect(exchange.headers.get("set-cookie")).toContain("Max-Age=0");
+  });
+
+  it("revokes the current Clerk session and clears Matrix and Clerk cookies on sign-out", async () => {
+    const revokeSession = vi.fn().mockResolvedValue(undefined);
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice", sid: "sess_123" }),
+        revokeSession,
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/api/auth/app-session", {
+      method: "DELETE",
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: [
+          "matrix_app_session=matrix-token",
+          "__session=clerk-token",
+          "__client_uat=123",
+          "__session_safeSuffix-123=clerk-token",
+          "__client_uat_safeSuffix_456=456",
+          "__session_unsafe.suffix=ignored",
+          "other=value",
+        ].join("; "),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      cleared: true,
+      clerkSessionRevoked: true,
+    });
+    expect(revokeSession).toHaveBeenCalledWith("sess_123");
+    const setCookie = combinedSetCookie(res.headers);
+    expect(setCookie).toContain("matrix_app_session=;");
+    expect(setCookie).toContain("__session=;");
+    expect(setCookie).toContain("__client_uat=;");
+    expect(setCookie).toContain("__session_safeSuffix-123=;");
+    expect(setCookie).toContain("__client_uat_safeSuffix_456=;");
+    expect(setCookie).not.toContain("__session_unsafe.suffix=;");
+    expect(setCookie).toContain("Domain=matrix-os.com");
+  });
+
+  it("returns generic sign-out success and clears cookies when Clerk revoke fails", async () => {
+    const errorSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice", sid: "sess_123" }),
+        revokeSession: vi.fn().mockRejectedValue(new Error("provider exploded")),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/api/auth/app-session", {
+      method: "DELETE",
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: "matrix_app_session=matrix-token; __session=clerk-token; __client_uat=123",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      cleared: true,
+      clerkSessionRevoked: false,
+    });
+    const setCookie = combinedSetCookie(res.headers);
+    expect(setCookie).toContain("matrix_app_session=;");
+    expect(setCookie).toContain("__session=;");
+    expect(setCookie).toContain("__client_uat=;");
+    expect(errorSpy).toHaveBeenCalledWith("[auth/app-session] Clerk session revoke failed", "Error");
   });
 
   it("lets a signed-in checkout return start hosted runtime provisioning without admin credentials", async () => {
@@ -1817,6 +1904,8 @@ describe("platform proxy routing", () => {
     const html = await res.text();
     expect(html).toContain("window.Clerk.session.getToken()");
     expect(html).toContain("fetch('/api/auth/app-session'");
+    expect(html).toContain("function clerkSignOutWithTimeout()");
+    expect(html).toContain("window.location.replace(signOutTarget)");
     expect(html).toContain("fetch('/api/auth/provision-runtime'");
     expect(html).toContain("signal: controller.signal");
     expect(html).toContain("window.clearTimeout(timeoutId);");

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1158,6 +1158,7 @@ describe("platform proxy routing", () => {
     expect(html).toContain("fetch('/api/auth/app-session'");
     expect(html).toContain("function clerkSignOutWithTimeout()");
     expect(html).toContain("window.setTimeout(function() {");
+    expect(html).toContain("if (timeoutId !== undefined) window.clearTimeout(timeoutId);");
     expect(html).toContain("window.location.replace(signOutTarget)");
     expect(html).toContain("[matrix] Clerk.signOut did not finish");
     expect(html).not.toContain("window.location.replace(redirectTarget)");
@@ -1477,6 +1478,40 @@ describe("platform proxy routing", () => {
     expect(setCookie).toContain("__session=;");
     expect(setCookie).toContain("__client_uat=;");
     expect(errorSpy).toHaveBeenCalledWith("[auth/app-session] Clerk session revoke failed", "Error");
+  });
+
+  it("logs Clerk revoke timeouts specifically while returning generic sign-out success", async () => {
+    const errorSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const timeoutError = new Error("operation timed out");
+    timeoutError.name = "TimeoutError";
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice", sid: "sess_123" }),
+        revokeSession: vi.fn().mockRejectedValue(timeoutError),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/api/auth/app-session", {
+      method: "DELETE",
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: "matrix_app_session=matrix-token; __session=clerk-token",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      cleared: true,
+      clerkSessionRevoked: false,
+    });
+    expect(combinedSetCookie(res.headers)).toContain("__session=;");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[auth/app-session] Clerk session revoke timed out",
+      "TimeoutError",
+    );
   });
 
   it("lets a signed-in checkout return start hosted runtime provisioning without admin credentials", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1157,7 +1157,9 @@ describe("platform proxy routing", () => {
     expect(html).toContain("continueWithClerkSession");
     expect(html).toContain("fetch('/api/auth/app-session'");
     expect(html).toContain("function clerkSignOutWithTimeout()");
+    expect(html).toContain("var SIGN_OUT_TIMEOUT_MS = 10000;");
     expect(html).toContain("window.setTimeout(function() {");
+    expect(html).toContain("}, SIGN_OUT_TIMEOUT_MS);");
     expect(html).toContain("if (timeoutId !== undefined) window.clearTimeout(timeoutId);");
     expect(html).toContain("window.location.replace(signOutTarget)");
     expect(html).toContain("[matrix] Clerk.signOut did not finish");

--- a/tests/shell/user-button.test.tsx
+++ b/tests/shell/user-button.test.tsx
@@ -17,10 +17,13 @@ const clerkState = vi.hoisted(() => ({
   openUserProfile: vi.fn(),
 }));
 
+const replaceMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@clerk/nextjs", () => ({
   useAuth: () => ({
     isLoaded: clerkState.isLoaded,
     isSignedIn: clerkState.isSignedIn,
+    signOut: clerkState.signOut,
   }),
   useUser: () => ({
     user: clerkState.user,
@@ -52,6 +55,14 @@ describe("UserButton", () => {
         headers: { "content-type": "application/json" },
       }),
     );
+    replaceMock.mockReset();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        origin: "http://localhost:3000",
+        replace: replaceMock,
+      },
+    });
   });
 
   afterEach(() => {
@@ -122,7 +133,7 @@ describe("UserButton", () => {
     });
   });
 
-  it("re-enables sign out when Clerk sign-out does not settle", async () => {
+  it("redirects after platform cleanup when Clerk sign-out does not settle", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     clerkState.signOut.mockImplementation(() => new Promise(() => {}));
     const { UserButton } = await import("../../shell/src/components/UserButton.js");
@@ -145,6 +156,25 @@ describe("UserButton", () => {
     });
 
     expect(warnSpy).toHaveBeenCalledWith("[auth] Clerk sign-out timed out");
-    expect(screen.getByRole("menuitem", { name: "Sign out" })).toBeTruthy();
+    expect(replaceMock).toHaveBeenCalledWith("http://localhost:3000/sign-in");
+  });
+
+  it("redirects after platform cleanup when Clerk sign-out rejects", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    clerkState.signOut.mockRejectedValue(new Error("boom"));
+    const { UserButton } = await import("../../shell/src/components/UserButton.js");
+
+    render(<UserButton variant="settings" />);
+
+    fireEvent.click(await openAccountMenu());
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/auth/app-session",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+      expect(errorSpy).toHaveBeenCalledWith("[auth] Clerk sign-out failed", "Error");
+      expect(replaceMock).toHaveBeenCalledWith("http://localhost:3000/sign-in");
+    });
   });
 });

--- a/tests/shell/user-button.test.tsx
+++ b/tests/shell/user-button.test.tsx
@@ -107,6 +107,7 @@ describe("UserButton", () => {
       expect(clerkState.signOut).toHaveBeenCalledWith({
         redirectUrl: "http://localhost:3000/sign-in",
       });
+      expect(replaceMock).toHaveBeenCalledWith("http://localhost:3000/sign-in");
     });
   });
 


### PR DESCRIPTION
## Summary

- make `DELETE /api/auth/app-session` verify the browser Clerk `__session` JWT, extract its `sid`, and revoke that Clerk session through a bounded direct Backend API request
- keep Matrix and Clerk cookie clearing as defense-in-depth, including safe request-present Clerk cookie suffix variants, while returning generic success on revoke failures
- keep both sign-out surfaces in the existing order: platform cleanup first, browser Clerk `signOut` best-effort second, with timeout/rejection redirecting to the sign-in/sign-up target

## Tests

- `flox activate -- bun run test -- tests/shell/user-button.test.tsx tests/platform/clerk-auth.test.ts tests/platform/proxy-routing.test.ts` (106 passed)
- `flox activate -- bun run typecheck`
- `flox activate -- bun run check:patterns` (5 warnings, 0 violations)
- `flox activate -- npx react-doctor@latest shell --verbose --diff` (100/100, no diff issues)
- Full-suite note: `flox activate -- bun run test` was attempted in the original PR worktree before recreating this fresh branch; it reported 6065 passed / 2 failed, both in `tests/scripts/cleanup-local-artifacts.test.ts` due to macOS temp path canonicalization (`/var/...` vs `/private/var/...`), unrelated to this auth diff.

## Review/Monitoring

- This is a follow-up PR because #365 was already merged before the authoritative logout patch was ready.
- First Greptile review was 4/5; both findings were fixed in `fix(auth): tighten Clerk logout diagnostics`.
- Second Greptile review was 4/5; both findings were fixed in `fix(auth): add sign-out redirect fallback`.
- Latest trusted Greptile review is 5/5 on commit `247651ebd`.
- Visible GitHub checks are green: PR Title, Vercel, and Vercel Preview Comments.
- Fixed Greptile review threads have been resolved.

## Invariants

- Source of truth: Clerk remains the account identity source. Authoritative logout is the server-side Clerk session revoke for the verified `__session` JWT `sid`; Matrix platform app-session and Clerk cookie clearing are defense-in-depth cleanup.
- Lock/transaction scope: no database writes or multi-step DB transactions are introduced. The route verifies the Clerk token, performs the bounded external revoke outside any DB critical section, then appends clear-cookie headers.
- Acceptable orphan states: if Clerk revoke fails, times out, is not configured, or the token has no `sid`, the platform still clears Matrix/Clerk cookies and returns generic success with `clerkSessionRevoked: false`; browser Clerk `signOut` failures redirect to the sign-in target instead of leaving the button stuck.
- Auth source of truth: the platform verifies the Clerk `__session` token server-side and uses `CLERK_SECRET_KEY` only for the direct Backend API revoke call with `AbortSignal.timeout(10_000)`. Browser Clerk `signOut` is cleanup/navigation polish, not the authority.
- Deferred scope: this does not change billing entitlement logic, VPS provisioning, session creation, or Clerk client SDK internals. `createClerkClient` is intentionally not used for revoke because this PR uses a direct abortable fetch.
