### PR TITLE
fix(auth): show sign-out progress in account menu

### DIFF
--- a/shell/src/components/UserButton.tsx
+++ b/shell/src/components/UserButton.tsx
@@ -8,7 +8,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { LogOutIcon, ServerIcon, SettingsIcon, UserIcon } from "lucide-react";
+import { Loader2Icon, LogOutIcon, ServerIcon, SettingsIcon, UserIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
@@ -200,13 +200,18 @@ function MountedUserButton({ variant }: { variant: UserButtonVariant }) {
           </DropdownMenuPrimitive.Item>
           <DropdownMenuPrimitive.Item
             className="flex cursor-default items-center gap-3 border-t border-border/60 px-4 py-3 text-sm font-medium outline-none transition-colors hover:bg-muted/70 focus:bg-muted/70"
+            aria-busy={signingOut}
             disabled={signingOut}
             onSelect={(event) => {
               event.preventDefault();
               void handleSignOut();
             }}
           >
-            <LogOutIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+            {signingOut ? (
+              <Loader2Icon className="size-4 animate-spin text-muted-foreground" aria-hidden="true" />
+            ) : (
+              <LogOutIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+            )}
             {signingOut ? "Signing out..." : "Sign out"}
           </DropdownMenuPrimitive.Item>
           <div className="border-t border-border/60 px-4 py-3 text-center text-xs font-semibold text-muted-foreground">

--- a/tests/shell/user-button.test.tsx
+++ b/tests/shell/user-button.test.tsx
@@ -145,7 +145,10 @@ describe("UserButton", () => {
     vi.useFakeTimers();
     fireEvent.click(signOutItem);
 
-    expect(screen.getByText("Signing out...")).toBeTruthy();
+    const pendingSignOutItem = screen.getByRole("menuitem", { name: "Signing out..." });
+    expect(pendingSignOutItem.getAttribute("aria-disabled")).toBe("true");
+    expect(pendingSignOutItem.getAttribute("aria-busy")).toBe("true");
+    expect(pendingSignOutItem.querySelector("svg.animate-spin")).toBeTruthy();
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();


### PR DESCRIPTION
## Summary

- show a real animated spinner in the shell account menu while sign-out is pending
- keep the existing authoritative logout flow unchanged: platform cleanup first, browser Clerk signOut second, existing timeouts unchanged
- extend the UserButton regression test to cover pending row feedback, disabled state, and spinner rendering

## Tests

- `flox activate -- bun run test -- tests/shell/user-button.test.tsx` (5 passed)
- `flox activate -- bun run typecheck`
- `flox activate -- bun run check:patterns` (5 warnings, 0 violations)
- `flox activate -- npx react-doctor@latest shell --verbose --diff` (100/100, no issues)

## Review/Monitoring

- Visible GitHub checks are green: PR Title, Vercel, and Vercel Preview Comments.
- Latest trusted Greptile review is 5/5 on commit `f5d9847a`.
- No review threads are open.
