### PR TITLE
fix(gateway): start zellij shell sessions through pty

### DIFF
--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -46,6 +46,10 @@ export interface ZellijAdapterDeps {
   spawn?: unknown;
   spawnPty?: PtySpawn;
   timeoutMs?: number;
+  startupDelayMs?: number;
+  retainedPtyTtlMs?: number;
+  maxRetainedPtys?: number;
+  nowMs?: () => number;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
 }
@@ -97,6 +101,15 @@ const ZELLIJ_CONTEXT_ENV_KEYS = new Set([
   "ZELLIJ_SESSION_NAME",
   "ZELLIJ_PANE_ID",
 ]);
+const DEFAULT_STARTUP_DELAY_MS = 500;
+const DEFAULT_RETAINED_PTY_TTL_MS = 4 * 60 * 60 * 1000;
+const DEFAULT_MAX_RETAINED_PTYS = 128;
+
+type RetainedCreatePty = {
+  process: ShellAttachProcess;
+  startedAtMs: number;
+  exitDisposable: Disposable | null;
+};
 
 function attachEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
   const env: Record<string, string> = {};
@@ -153,6 +166,32 @@ export function classifyZellijFailure(err: unknown, stderr: string): ZellijFailu
   return diagnostic;
 }
 
+function safeZellijError(
+  err: unknown,
+  stderr = "",
+): ShellSafeError & {
+  cause?: unknown;
+  stderr?: string;
+  diagnostic?: ZellijFailureDiagnostic;
+} {
+  const safe = shellError("zellij_failed", "Shell operation failed", 500) as ShellSafeError & {
+    cause?: unknown;
+    stderr?: string;
+    diagnostic?: ZellijFailureDiagnostic;
+  };
+  safe.cause = err;
+  safe.stderr = sanitizeZellijError(stderr);
+  safe.diagnostic = classifyZellijFailure(err, stderr);
+  return safe;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
 function isNoActiveSessionsFailure(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false;
@@ -164,8 +203,46 @@ function isNoActiveSessionsFailure(err: unknown): boolean {
 export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter {
   const execFile = deps.execFile ?? nodeExecFile;
   const timeoutMs = deps.timeoutMs ?? 10_000;
+  const startupDelayMs = deps.startupDelayMs ?? DEFAULT_STARTUP_DELAY_MS;
+  const retainedPtyTtlMs = deps.retainedPtyTtlMs ?? DEFAULT_RETAINED_PTY_TTL_MS;
+  const maxRetainedPtys = deps.maxRetainedPtys ?? DEFAULT_MAX_RETAINED_PTYS;
+  const nowMs = deps.nowMs ?? Date.now;
   const cwd = deps.cwd ?? process.cwd();
   const spawnPty = deps.spawnPty ?? defaultPtySpawn();
+  const retainedCreatePtys = new Map<string, RetainedCreatePty>();
+
+  function releaseRetainedCreatePty(name: string, options: { kill?: boolean } = {}): void {
+    const retained = retainedCreatePtys.get(name);
+    if (!retained) {
+      return;
+    }
+    retainedCreatePtys.delete(name);
+    retained.exitDisposable?.dispose();
+    retained.exitDisposable = null;
+    if (options.kill) {
+      retained.process.kill();
+    }
+  }
+
+  function sweepRetainedCreatePtys(): void {
+    const cutoff = nowMs() - retainedPtyTtlMs;
+    for (const [name, retained] of retainedCreatePtys) {
+      if (retained.startedAtMs > cutoff) {
+        continue;
+      }
+      releaseRetainedCreatePty(name, { kill: true });
+    }
+  }
+
+  function evictRetainedCreatePtyIfNeeded(nextName: string): void {
+    if (retainedCreatePtys.has(nextName) || retainedCreatePtys.size < maxRetainedPtys) {
+      return;
+    }
+    const oldest = retainedCreatePtys.keys().next().value as string | undefined;
+    if (oldest) {
+      releaseRetainedCreatePty(oldest, { kill: true });
+    }
+  }
 
   function run(args: string[], timeout = timeoutMs, runCwd?: string): Promise<string> {
     const controller = new AbortController();
@@ -181,14 +258,7 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         },
         (err, stdout, stderr) => {
           if (err) {
-            const safe = shellError("zellij_failed", "Shell operation failed", 500);
-            (safe as ShellSafeError & { cause?: unknown; stderr?: string }).cause = err;
-            (safe as ShellSafeError & { stderr?: string }).stderr = sanitizeZellijError(
-              typeof stderr === "string" ? stderr : String(stderr ?? ""),
-            );
-            (safe as ShellSafeError & { diagnostic?: ZellijFailureDiagnostic }).diagnostic =
-              classifyZellijFailure(err, typeof stderr === "string" ? stderr : String(stderr ?? ""));
-            reject(safe);
+            reject(safeZellijError(err, typeof stderr === "string" ? stderr : String(stderr ?? "")));
             return;
           }
           resolve(String(stdout));
@@ -215,16 +285,51 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         .filter(Boolean);
     },
     async createSession(options) {
+      sweepRetainedCreatePtys();
+      evictRetainedCreatePtyIfNeeded(options.name);
+      releaseRetainedCreatePty(options.name, { kill: true });
+
       const args = ["--session", options.name];
       if (options.cmd) {
         args.push("--layout-string", initialCommandLayout(options.cmd, options.cwd));
       } else if (options.layout) {
         args.push("--layout", options.layout);
       }
-      args.push("attach", "--create-background", options.name);
-      await run(args, timeoutMs, options.cwd);
+      let pty: ShellAttachProcess;
+      try {
+        pty = spawnPty("zellij", args, {
+          name: "xterm-256color",
+          cols: 120,
+          rows: 40,
+          cwd: options.cwd ?? cwd,
+          env: attachEnv(deps.env),
+        });
+      } catch (err: unknown) {
+        throw safeZellijError(err);
+      }
+      const startup = { exited: null as PtyExitEvent | null };
+      const exitDisposable = pty.onExit((event) => {
+        startup.exited = event;
+        releaseRetainedCreatePty(options.name);
+      });
+      retainedCreatePtys.set(options.name, {
+        process: pty,
+        startedAtMs: nowMs(),
+        exitDisposable,
+      });
+
+      await delay(startupDelayMs);
+      if (startup.exited) {
+        releaseRetainedCreatePty(options.name);
+        const err = Object.assign(new Error("zellij exited during startup"), {
+          code: startup.exited.exitCode,
+          signal: startup.exited.signal,
+        });
+        throw safeZellijError(err);
+      }
     },
     async deleteSession(name, options = {}) {
+      releaseRetainedCreatePty(name, { kill: true });
       const args = ["delete-session", name];
       if (options.force) args.push("--force");
       await run(args);

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -69,29 +69,28 @@ describe("zellij adapter", () => {
     await expect(adapter.listSessions()).resolves.toEqual([]);
   });
 
-  it("sanitizes stderr before surfacing errors", async () => {
+  it("sanitizes stderr before surfacing execFile errors", async () => {
     const execFile = vi.fn((_file, _args, _opts, cb) => {
       cb(new Error("boom"), "", "failed in /home/alice/.ssh with zellij internals");
       return childProcess();
     });
     const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
 
-    await expect(adapter.createSession({ name: "main" })).rejects.toMatchObject({
+    await expect(adapter.createTab("main", { name: "tools" })).rejects.toMatchObject({
       code: "zellij_failed",
       safeMessage: "Shell operation failed",
     });
   });
 
-  it("classifies a missing zellij binary for server diagnostics", async () => {
+  it("classifies a missing zellij binary during session creation for server diagnostics", async () => {
     const missing = Object.assign(new Error("spawn zellij ENOENT"), {
       code: "ENOENT",
       syscall: "spawn zellij",
     });
-    const execFile = vi.fn((_file, _args, _opts, cb) => {
-      cb(missing, "", "");
-      return childProcess();
+    const spawnPty = vi.fn(() => {
+      throw missing;
     });
-    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+    const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25 });
 
     await expect(adapter.createSession({ name: "main" })).rejects.toMatchObject({
       code: "zellij_failed",
@@ -227,22 +226,28 @@ describe("zellij adapter", () => {
     expect(pty.resize).toHaveBeenCalledWith(140, 50);
   });
 
-  it("creates sessions in the requested cwd using headless attach", async () => {
-    const child = childProcess();
-    const execFile = vi.fn((_file, _args, _opts, cb) => {
-      cb(null, "", "");
-      return child;
+  it("creates sessions in the requested cwd using a retained PTY", async () => {
+    const pty = ptyProcess();
+    const execFile = vi.fn();
+    const spawnPty = vi.fn(() => pty);
+    const adapter = createZellijAdapter({
+      execFile,
+      spawnPty,
+      timeoutMs: 25,
+      startupDelayMs: 1,
     });
-    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
 
     await adapter.createSession({ name: "main", cwd: "/home/alice/work" });
 
-    expect(execFile).toHaveBeenCalledWith(
+    expect(execFile).not.toHaveBeenCalled();
+    expect(spawnPty).toHaveBeenCalledWith(
       "zellij",
-      ["--session", "main", "attach", "--create-background", "main"],
+      ["--session", "main"],
       expect.objectContaining({
-        timeout: 25,
         cwd: "/home/alice/work",
+        name: "xterm-256color",
+        cols: 120,
+        rows: 40,
         env: expect.objectContaining({
           TERM: "xterm-256color",
           COLORTERM: "truecolor",
@@ -250,17 +255,13 @@ describe("zellij adapter", () => {
           FORCE_COLOR: "3",
         }),
       }),
-      expect.any(Function),
     );
   });
 
   it("creates command sessions with the command as the initial focused pane", async () => {
-    const child = childProcess();
-    const execFile = vi.fn((_file, _args, _opts, cb) => {
-      cb(null, "", "");
-      return child;
-    });
-    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+    const pty = ptyProcess();
+    const spawnPty = vi.fn(() => pty);
+    const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25, startupDelayMs: 1 });
 
     await adapter.createSession({
       name: "bench",
@@ -268,20 +269,79 @@ describe("zellij adapter", () => {
       cmd: "node -e 'process.stdout.write(\"MATRIX_BENCH_READY\\n\")'",
     });
 
-    expect(execFile).toHaveBeenCalledTimes(1);
-    const args = execFile.mock.calls[0]?.[1];
+    expect(spawnPty).toHaveBeenCalledTimes(1);
+    const args = spawnPty.mock.calls[0]?.[1];
     expect(args).toEqual([
       "--session",
       "bench",
       "--layout-string",
       expect.stringContaining('command="node"'),
-      "attach",
-      "--create-background",
-      "bench",
     ]);
     expect(String(args?.[3])).toContain('cwd="/home/alice/work"');
     expect(String(args?.[3])).toContain('args "-e"');
     expect(String(args?.[3])).toContain("MATRIX_BENCH_READY");
+  });
+
+  it("rejects session creation when the retained PTY exits during startup", async () => {
+    const pty = ptyProcess();
+    const spawnPty = vi.fn(() => {
+      setTimeout(() => pty.emitExit(1), 0);
+      return pty;
+    });
+    const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25, startupDelayMs: 10 });
+
+    await expect(adapter.createSession({ name: "broken" })).rejects.toMatchObject({
+      code: "zellij_failed",
+      safeMessage: "Shell operation failed",
+      diagnostic: {
+        binary: "zellij",
+        kind: "process_failed",
+        exitCode: 1,
+      },
+    });
+  });
+
+  it("kills retained creation PTYs when deleting sessions", async () => {
+    const pty = ptyProcess();
+    const child = childProcess();
+    const execFile = vi.fn((_file, _args, _opts, cb) => {
+      cb(null, "", "");
+      return child;
+    });
+    const spawnPty = vi.fn(() => pty);
+    const adapter = createZellijAdapter({ execFile, spawnPty, timeoutMs: 25, startupDelayMs: 1 });
+
+    await adapter.createSession({ name: "main" });
+    await adapter.deleteSession("main", { force: true });
+
+    expect(pty.kill).toHaveBeenCalledTimes(1);
+    expect(execFile).toHaveBeenCalledWith(
+      "zellij",
+      ["delete-session", "main", "--force"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("evicts the oldest retained creation PTY when the cap is reached", async () => {
+    const first = ptyProcess();
+    const second = ptyProcess();
+    const spawnPty = vi.fn()
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second);
+    const adapter = createZellijAdapter({
+      execFile: vi.fn(),
+      spawnPty,
+      timeoutMs: 25,
+      startupDelayMs: 1,
+      maxRetainedPtys: 1,
+    });
+
+    await adapter.createSession({ name: "first" });
+    await adapter.createSession({ name: "second" });
+
+    expect(first.kill).toHaveBeenCalledTimes(1);
+    expect(second.kill).not.toHaveBeenCalled();
   });
 
   it("creates tabs and panes with terminal-capable environment at process launch", async () => {


### PR DESCRIPTION
## Summary

- Start Zellij shell sessions through a retained PTY instead of the timeout-prone headless `attach --create-background` exec path.
- Preserve existing attach/action behavior while adding bounded cleanup for retained creation PTYs.
- Add gateway tests for PTY startup, startup failure diagnostics, delete cleanup, and retained PTY cap eviction.

## Tests

- `pnpm test tests/gateway/shell-zellij.test.ts`
- `pnpm test tests/cli/run.test.ts`
- `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- `pnpm run check:patterns`
- `git diff --check`

## Invariants

- **Source of truth**: Live Zellij sessions remain the canonical terminal runtime; `system/shell-sessions.json` remains registry metadata reconciled from live sessions.
- **Lock/transaction scope**: No database writes are introduced. Session creation is still serialized by the existing `ShellRegistry` mutation queue; the adapter only changes how Zellij is started.
- **Acceptable orphan states**: If metadata persistence fails after Zellij startup, the existing registry rollback path deletes the session. Retained bootstrap PTYs are killed on delete, duplicate create, TTL sweep, or cap eviction.
- **Auth source of truth**: Existing gateway auth and `/api/terminal` route validation are unchanged.
- **Deferred scope**: Non-interactive `matrix run -- <command>` exit-status support remains out of scope.