### PR TITLE
fix(platform): support native shell auth callbacks

### DIFF
--- a/packages/gateway/src/shell/names.ts
+++ b/packages/gateway/src/shell/names.ts
@@ -2,7 +2,7 @@ import { realpath } from "node:fs/promises";
 import { isAbsolute, resolve, sep } from "node:path";
 import { shellError } from "./errors.js";
 
-const SESSION_SLUG = /^[a-z0-9][a-z0-9-]{0,30}$/;
+const SESSION_SLUG = /^[a-z0-9][a-z0-9_-]{0,63}$/;
 const PROFILE_SLUG = /^[a-z][a-z0-9-]{0,30}$/;
 const LONG_SLUG = /^[a-z][a-z0-9-]{0,63}$/;
 

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -126,6 +126,7 @@ function approvalPage(
   csrf: string,
   publishableKey: string | null,
   scriptNonce: string,
+  nativeRedirectUri: string | null,
 ): string {
   // Renders an HTML page that lets a Clerk-authenticated user confirm the
   // device pairing. The Clerk widget is loaded for sign-in if needed; once a
@@ -137,6 +138,7 @@ function approvalPage(
   const escapedPublishableKey = publishableKey
     ? escapeHtmlAttr(publishableKey)
     : null;
+  const escapedNativeRedirectUri = nativeRedirectUri ? escapeHtmlAttr(nativeRedirectUri) : '';
   const clerkScript = publishableKey
     ? `
   <script nonce="${scriptNonce}">
@@ -361,6 +363,8 @@ function approvalPage(
         }
 
         var body = new URLSearchParams({ userCode: userCode, csrf: csrf });
+        var nativeRedirectUri = document.getElementById('native-redirect-uri')?.value || '';
+        if (nativeRedirectUri) body.set('redirectUri', nativeRedirectUri);
         var res = await fetchWithTimeout('/auth/device/approve', {
           method: 'POST',
           headers: {
@@ -557,6 +561,7 @@ function approvalPage(
       <form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">
         <input type="hidden" name="userCode" value="${escapedCode}">
         <input type="hidden" name="csrf" value="${escapedCsrf}">
+        <input id="native-redirect-uri" type="hidden" name="redirectUri" value="${escapedNativeRedirectUri}">
         <button id="confirm-button" type="submit" disabled>approve login</button>
       </form>
       <p id="status" class="status" role="status" aria-live="polite">${publishableKey ? '' : 'Sign-in is unavailable. Refresh and try again.'}</p>
@@ -568,11 +573,34 @@ function approvalPage(
 </html>`;
 }
 
-function approvalSuccessPage(): string {
+function approvalSuccessPage(nativeRedirectUri: string | null = null): string {
+  const redirectMeta = nativeRedirectUri
+    ? `<meta http-equiv="refresh" content="0; url=${escapeHtmlAttr(nativeRedirectUri)}">`
+    : '';
+  const redirectLink = nativeRedirectUri
+    ? `<p><a href="${escapeHtmlAttr(nativeRedirectUri)}">Return to Matrix OS</a></p>`
+    : '';
   return `<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><title>Authorized</title>
+<html lang="en"><head><meta charset="utf-8">${redirectMeta}<title>Authorized</title>
 <style>body{font-family:-apple-system,sans-serif;background:#0a0a0a;color:#eee;min-height:100vh;display:flex;align-items:center;justify-content:center}.card{max-width:380px;padding:2rem;background:#141414;border:1px solid #222;border-radius:8px;text-align:center}</style></head>
-<body><div class="card"><h1>Login successful</h1><p>You can close this tab and return to your terminal.</p></div></body></html>`;
+<body><div class="card"><h1>Login successful</h1><p>You can close this tab and return to Matrix OS.</p>${redirectLink}</div></body></html>`;
+}
+
+function normalizeNativeRedirectUri(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length > 512) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'matrixos:' || url.hostname !== 'auth') return null;
+    return url.toString();
+  } catch (err: unknown) {
+    if (!(err instanceof TypeError)) {
+      console.error(
+        '[device-flow] Native redirect URI parse failed:',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    return null;
+  }
 }
 
 function applyNoFrameHeaders(
@@ -664,7 +692,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       // Read body to engage bodyLimit and validate the clientId. RFC 8628
       // doesn't require a clientId, but we keep one for usage analytics
       // and to lay the groundwork for per-client policy.
-      let body: { clientId?: unknown };
+      let body: { clientId?: unknown; redirectUri?: unknown };
       try {
         body = await c.req.json();
       } catch (err: unknown) {
@@ -680,13 +708,18 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
 
       try {
         const issued = await flow.createDeviceCode();
+        const nativeRedirectUri = normalizeNativeRedirectUri(body.redirectUri);
+        const verificationUrl = new URL(issued.verificationUri);
+        if (nativeRedirectUri && body.clientId === 'matrix-os-macos') {
+          verificationUrl.searchParams.set('redirect_uri', nativeRedirectUri);
+        }
         captureAuthEvent("cli_device_code_created", {
           client_id: body.clientId,
         });
         return c.json({
           deviceCode: issued.deviceCode,
           userCode: issued.userCode,
-          verificationUri: issued.verificationUri,
+          verificationUri: verificationUrl.toString(),
           expiresIn: issued.expiresIn,
           interval: issued.interval,
         });
@@ -748,6 +781,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
   // GET /auth/device?user_code=ABCD-EFGH -- public; renders approval HTML.
   app.get('/auth/device', (c) => {
     const userCodeRaw = c.req.query('user_code') ?? '';
+    const nativeRedirectUri = normalizeNativeRedirectUri(c.req.query('redirect_uri'));
     if (!userCodeRaw) {
       return c.text('Missing user_code', 400);
     }
@@ -763,7 +797,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       `device_csrf=${csrf}; Path=/auth/device; Max-Age=900; HttpOnly; SameSite=Strict${secure}`,
     );
     applyNoFrameHeaders(c, scriptNonce, { allowClerkCaptcha: true });
-    return c.html(approvalPage(userCodeRaw, csrf, publishableKey, scriptNonce));
+    return c.html(approvalPage(userCodeRaw, csrf, publishableKey, scriptNonce, nativeRedirectUri));
   });
 
   // POST /auth/device/approve -- requires Clerk session + CSRF cookie/form match.
@@ -795,10 +829,12 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       const cookieCsrf = readCsrfCookie(c.req.header('cookie'));
       let formCsrf: string | undefined;
       let userCode: string | undefined;
+      let nativeRedirectUri: string | null = null;
       try {
         const form = await c.req.parseBody();
         formCsrf = typeof form.csrf === 'string' ? form.csrf : undefined;
         userCode = typeof form.userCode === 'string' ? form.userCode : undefined;
+        nativeRedirectUri = normalizeNativeRedirectUri(form.redirectUri);
       } catch (err: unknown) {
         console.error(
           '[device-flow] Form parse failed:',
@@ -830,7 +866,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       }
 
       applyNoFrameHeaders(c);
-      return c.html(approvalSuccessPage());
+      return c.html(approvalSuccessPage(nativeRedirectUri));
     },
   );
 

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { createHmac, randomBytes } from 'node:crypto';
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import {
@@ -105,6 +105,28 @@ function readCsrfCookie(cookieHeader: string | undefined): string | null {
   return m ? m[1] : null;
 }
 
+function signNativeRedirectUri(secret: string, userCode: string, redirectUri: string): string {
+  return createHmac('sha256', secret)
+    .update(normalizeUserCode(userCode))
+    .update('\0')
+    .update(redirectUri)
+    .digest('base64url');
+}
+
+function verifiedNativeRedirectUri(
+  secret: string,
+  userCode: string,
+  redirectUriValue: unknown,
+  signatureValue: unknown,
+): string | null {
+  const redirectUri = normalizeNativeRedirectUri(redirectUriValue);
+  if (!redirectUri || typeof signatureValue !== 'string' || signatureValue.length > 128) {
+    return null;
+  }
+  const expected = signNativeRedirectUri(secret, userCode, redirectUri);
+  return timingSafeTokenEquals(expected, signatureValue) ? redirectUri : null;
+}
+
 function escapeHtmlAttr(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -127,6 +149,7 @@ function approvalPage(
   publishableKey: string | null,
   scriptNonce: string,
   nativeRedirectUri: string | null,
+  nativeRedirectSig: string | null,
 ): string {
   // Renders an HTML page that lets a Clerk-authenticated user confirm the
   // device pairing. The Clerk widget is loaded for sign-in if needed; once a
@@ -139,6 +162,7 @@ function approvalPage(
     ? escapeHtmlAttr(publishableKey)
     : null;
   const escapedNativeRedirectUri = nativeRedirectUri ? escapeHtmlAttr(nativeRedirectUri) : '';
+  const escapedNativeRedirectSig = nativeRedirectSig ? escapeHtmlAttr(nativeRedirectSig) : '';
   const clerkScript = publishableKey
     ? `
   <script nonce="${scriptNonce}">
@@ -364,7 +388,9 @@ function approvalPage(
 
         var body = new URLSearchParams({ userCode: userCode, csrf: csrf });
         var nativeRedirectUri = document.getElementById('native-redirect-uri')?.value || '';
+        var nativeRedirectSig = document.getElementById('native-redirect-sig')?.value || '';
         if (nativeRedirectUri) body.set('redirectUri', nativeRedirectUri);
+        if (nativeRedirectSig) body.set('redirectSig', nativeRedirectSig);
         var res = await fetchWithTimeout('/auth/device/approve', {
           method: 'POST',
           headers: {
@@ -562,6 +588,7 @@ function approvalPage(
         <input type="hidden" name="userCode" value="${escapedCode}">
         <input type="hidden" name="csrf" value="${escapedCsrf}">
         <input id="native-redirect-uri" type="hidden" name="redirectUri" value="${escapedNativeRedirectUri}">
+        <input id="native-redirect-sig" type="hidden" name="redirectSig" value="${escapedNativeRedirectSig}">
         <button id="confirm-button" type="submit" disabled>approve login</button>
       </form>
       <p id="status" class="status" role="status" aria-live="polite">${publishableKey ? '' : 'Sign-in is unavailable. Refresh and try again.'}</p>
@@ -712,6 +739,10 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
         const verificationUrl = new URL(issued.verificationUri);
         if (nativeRedirectUri && body.clientId === 'matrix-os-macos') {
           verificationUrl.searchParams.set('redirect_uri', nativeRedirectUri);
+          verificationUrl.searchParams.set(
+            'redirect_sig',
+            signNativeRedirectUri(config.jwtSecret, issued.userCode, nativeRedirectUri),
+          );
         }
         captureAuthEvent("cli_device_code_created", {
           client_id: body.clientId,
@@ -781,7 +812,13 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
   // GET /auth/device?user_code=ABCD-EFGH -- public; renders approval HTML.
   app.get('/auth/device', (c) => {
     const userCodeRaw = c.req.query('user_code') ?? '';
-    const nativeRedirectUri = normalizeNativeRedirectUri(c.req.query('redirect_uri'));
+    const nativeRedirectUri = verifiedNativeRedirectUri(
+      config.jwtSecret,
+      userCodeRaw,
+      c.req.query('redirect_uri'),
+      c.req.query('redirect_sig'),
+    );
+    const nativeRedirectSig = nativeRedirectUri ? c.req.query('redirect_sig') ?? null : null;
     if (!userCodeRaw) {
       return c.text('Missing user_code', 400);
     }
@@ -797,7 +834,14 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       `device_csrf=${csrf}; Path=/auth/device; Max-Age=900; HttpOnly; SameSite=Strict${secure}`,
     );
     applyNoFrameHeaders(c, scriptNonce, { allowClerkCaptcha: true });
-    return c.html(approvalPage(userCodeRaw, csrf, publishableKey, scriptNonce, nativeRedirectUri));
+    return c.html(approvalPage(
+      userCodeRaw,
+      csrf,
+      publishableKey,
+      scriptNonce,
+      nativeRedirectUri,
+      nativeRedirectSig,
+    ));
   });
 
   // POST /auth/device/approve -- requires Clerk session + CSRF cookie/form match.
@@ -829,12 +873,15 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       const cookieCsrf = readCsrfCookie(c.req.header('cookie'));
       let formCsrf: string | undefined;
       let userCode: string | undefined;
+      let formRedirectUri: unknown;
+      let formRedirectSig: unknown;
       let nativeRedirectUri: string | null = null;
       try {
         const form = await c.req.parseBody();
         formCsrf = typeof form.csrf === 'string' ? form.csrf : undefined;
         userCode = typeof form.userCode === 'string' ? form.userCode : undefined;
-        nativeRedirectUri = normalizeNativeRedirectUri(form.redirectUri);
+        formRedirectUri = form.redirectUri;
+        formRedirectSig = form.redirectSig;
       } catch (err: unknown) {
         console.error(
           '[device-flow] Form parse failed:',
@@ -853,6 +900,12 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
       if (!userCode || normalizeUserCode(userCode).length !== 8) {
         return c.json({ error: 'invalid_request' }, 400);
       }
+      nativeRedirectUri = verifiedNativeRedirectUri(
+        config.jwtSecret,
+        userCode,
+        formRedirectUri,
+        formRedirectSig,
+      );
 
       try {
         await flow.approveDeviceCode(userCode, verifyResult.userId);

--- a/tests/gateway/shell-names.test.ts
+++ b/tests/gateway/shell-names.test.ts
@@ -26,6 +26,7 @@ describe("shell name and path validation", () => {
     expect(validateSessionName("main")).toBe("main");
     expect(validateSessionName("1")).toBe("1");
     expect(validateSessionName("matrix-sess_abc123")).toBe("matrix-sess_abc123");
+    expect(validateSessionName("a".repeat(64))).toBe("a".repeat(64));
     expect(validateLayoutName("dev-workspace-1")).toBe("dev-workspace-1");
     expect(validateProfileName("local")).toBe("local");
   });

--- a/tests/gateway/shell-names.test.ts
+++ b/tests/gateway/shell-names.test.ts
@@ -25,6 +25,7 @@ describe("shell name and path validation", () => {
   it("accepts safe session, layout, and profile slugs", () => {
     expect(validateSessionName("main")).toBe("main");
     expect(validateSessionName("1")).toBe("1");
+    expect(validateSessionName("matrix-sess_abc123")).toBe("matrix-sess_abc123");
     expect(validateLayoutName("dev-workspace-1")).toBe("dev-workspace-1");
     expect(validateProfileName("local")).toBe("local");
   });
@@ -34,11 +35,13 @@ describe("shell name and path validation", () => {
   });
 
   it("rejects unsafe identifiers", () => {
-    for (const value of ["Main", "-main", "main_", "../main", "a".repeat(65)]) {
+    for (const value of ["Main", "-main", "../main", "a".repeat(65)]) {
       expect(() => validateSessionName(value)).toThrow("Invalid request");
       expect(() => validateLayoutName(value)).toThrow("Invalid request");
       expect(() => validateProfileName(value)).toThrow("Invalid request");
     }
+    expect(() => validateLayoutName("main_")).toThrow("Invalid request");
+    expect(() => validateProfileName("main_")).toThrow("Invalid request");
   });
 
   it("resolves cwd inside the owner home", async () => {

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -87,6 +87,48 @@ describe("device routes", () => {
       });
     });
 
+    it("includes a validated native callback for the macOS client", async () => {
+      const res = await app.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "matrix-os-macos",
+          redirectUri: "matrixos://auth?status=approved",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const verificationUri = new URL(body.verificationUri);
+      expect(verificationUri.searchParams.get("redirect_uri")).toBe(
+        "matrixos://auth?status=approved",
+      );
+    });
+
+    it("ignores native callbacks for other clients or invalid schemes", async () => {
+      const cliRes = await app.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "matrixos-cli",
+          redirectUri: "matrixos://auth?status=approved",
+        }),
+      });
+      const invalidRes = await app.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "matrix-os-macos",
+          redirectUri: "https://evil.example/callback",
+        }),
+      });
+
+      const cliBody = await cliRes.json();
+      const invalidBody = await invalidRes.json();
+      expect(new URL(cliBody.verificationUri).searchParams.has("redirect_uri")).toBe(false);
+      expect(new URL(invalidBody.verificationUri).searchParams.has("redirect_uri")).toBe(false);
+    });
+
     it("rejects oversized body with 413", async () => {
       const huge = "x".repeat(8192);
       const body = JSON.stringify({ clientId: huge });
@@ -364,6 +406,47 @@ describe("device routes", () => {
         body: new URLSearchParams({ userCode: code.userCode, csrf }).toString(),
       });
       expect(res.status).toBe(401);
+    });
+
+    it("returns a native callback handoff page after approval when requested", async () => {
+      const code = await app
+        .request("/api/auth/device/code", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            clientId: "matrix-os-macos",
+            redirectUri: "matrixos://auth?status=approved",
+          }),
+        })
+        .then((r) => r.json());
+
+      const setCookieRes = await app.request(code.verificationUri);
+      const csrf = (setCookieRes.headers.get("set-cookie") ?? "").match(
+        /device_csrf=([^;]+)/,
+      )![1];
+      const html = await setCookieRes.text();
+      expect(html).toContain('id="native-redirect-uri"');
+      expect(html).toContain("matrixos://auth?status=approved");
+
+      const approveRes = await app.request("/auth/device/approve", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          authorization: "Bearer clerk-alice",
+          cookie: `device_csrf=${csrf}`,
+        },
+        body: new URLSearchParams({
+          userCode: code.userCode,
+          csrf,
+          redirectUri: "matrixos://auth?status=approved",
+        }).toString(),
+      });
+
+      expect(approveRes.status).toBe(200);
+      const successHtml = await approveRes.text();
+      expect(successHtml).toContain("Return to Matrix OS");
+      expect(successHtml).toContain("matrixos://auth?status=approved");
+      expect(successHtml).toContain('http-equiv="refresh"');
     });
 
     it("leaves the device code pending when approval only carries the CSRF cookie", async () => {

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -103,6 +103,7 @@ describe("device routes", () => {
       expect(verificationUri.searchParams.get("redirect_uri")).toBe(
         "matrixos://auth?status=approved",
       );
+      expect(verificationUri.searchParams.get("redirect_sig")).toEqual(expect.any(String));
     });
 
     it("ignores native callbacks for other clients or invalid schemes", async () => {
@@ -424,9 +425,53 @@ describe("device routes", () => {
       const csrf = (setCookieRes.headers.get("set-cookie") ?? "").match(
         /device_csrf=([^;]+)/,
       )![1];
+      const verificationUri = new URL(code.verificationUri);
+      const redirectSig = verificationUri.searchParams.get("redirect_sig");
       const html = await setCookieRes.text();
       expect(html).toContain('id="native-redirect-uri"');
+      expect(html).toContain('id="native-redirect-sig"');
       expect(html).toContain("matrixos://auth?status=approved");
+      expect(redirectSig).toEqual(expect.any(String));
+
+      const approveRes = await app.request("/auth/device/approve", {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          authorization: "Bearer clerk-alice",
+          cookie: `device_csrf=${csrf}`,
+        },
+        body: new URLSearchParams({
+          userCode: code.userCode,
+          csrf,
+          redirectUri: "matrixos://auth?status=approved",
+          redirectSig: redirectSig ?? "",
+        }).toString(),
+      });
+
+      expect(approveRes.status).toBe(200);
+      const successHtml = await approveRes.text();
+      expect(successHtml).toContain("Return to Matrix OS");
+      expect(successHtml).toContain("matrixos://auth?status=approved");
+      expect(successHtml).toContain('http-equiv="refresh"');
+    });
+
+    it("ignores manually appended native callbacks without the macOS signature", async () => {
+      const code = await app
+        .request("/api/auth/device/code", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ clientId: "matrixos-cli" }),
+        })
+        .then((r) => r.json());
+
+      const setCookieRes = await app.request(
+        `/auth/device?user_code=${code.userCode}&redirect_uri=${encodeURIComponent("matrixos://auth?status=approved")}`,
+      );
+      const csrf = (setCookieRes.headers.get("set-cookie") ?? "").match(
+        /device_csrf=([^;]+)/,
+      )![1];
+      const html = await setCookieRes.text();
+      expect(html).not.toContain("matrixos://auth?status=approved");
 
       const approveRes = await app.request("/auth/device/approve", {
         method: "POST",
@@ -444,9 +489,8 @@ describe("device routes", () => {
 
       expect(approveRes.status).toBe(200);
       const successHtml = await approveRes.text();
-      expect(successHtml).toContain("Return to Matrix OS");
-      expect(successHtml).toContain("matrixos://auth?status=approved");
-      expect(successHtml).toContain('http-equiv="refresh"');
+      expect(successHtml).not.toContain("matrixos://auth?status=approved");
+      expect(successHtml).not.toContain('http-equiv="refresh"');
     });
 
     it("leaves the device code pending when approval only carries the CSRF cookie", async () => {


### PR DESCRIPTION
## Summary
- add an allowlisted `matrixos://auth` redirect handoff to the device approval flow for the macOS shell client
- preserve the native redirect through the Clerk approval page and success page so the browser can return control to the desktop app
- allow generated zellij session names with underscores in gateway terminal session validation while keeping profile/layout names stricter

## Invariants
- Source of truth: the device-code flow state remains the existing platform auth flow store; the native callback is only an allowlisted handoff URL attached to verification and approval pages.
- Lock/transaction scope: this change does not add database writes or multi-step persistence. Device approval continues to use the existing flow approval path.
- Acceptable orphan states: if the custom URL handoff is blocked or unsupported, the approval still succeeds and the page shows a manual Return to Matrix OS link. The desktop app can keep polling device status.
- Auth source of truth: Clerk remains the source of truth for approving device codes. The custom redirect never authenticates by itself and is only accepted for `clientId=matrix-os-macos` with `matrixos://auth`.
- Deferred scope: this PR does not ship the native macOS UI changes or deploy the platform/app-shell service; those are separate follow-up slices.

## Validation
- `pnpm test tests/platform/device-routes.test.ts`
- `pnpm test tests/gateway/shell-names.test.ts`
- `pnpm run check:patterns` (0 violations; existing warning buckets only)
