### PR TITLE
feat(platform): add Cloud Run image workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ node_modules
 .git
 .gitignore
 Dockerfile*
+!Dockerfile.platform
 .dockerignore
 *.log*
 .env*

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -1,0 +1,157 @@
+name: Platform Cloud Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment to deploy
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+      promote:
+        description: Promote the deployed revision to 100% traffic
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: platform-cloud-run-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy platform
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ vars.GCP_REGION }}
+      ARTIFACT_REPOSITORY: ${{ vars.ARTIFACT_REPOSITORY }}
+      CLOUD_RUN_SERVICE: ${{ vars.CLOUD_RUN_SERVICE }}
+      CLOUD_RUN_SERVICE_ACCOUNT: ${{ vars.CLOUD_RUN_SERVICE_ACCOUNT }}
+      PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL }}
+      MATRIX_APP_URL: ${{ vars.MATRIX_APP_URL }}
+      MATRIX_APP_DOMAIN_HOSTS: ${{ vars.MATRIX_APP_DOMAIN_HOSTS }}
+      MATRIX_CODE_DOMAIN_HOSTS: ${{ vars.MATRIX_CODE_DOMAIN_HOSTS }}
+      CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}
+      POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
+      POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || 'https://neo.matrix-os.com' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate deployment configuration
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            GCP_PROJECT_ID \
+            GCP_REGION \
+            ARTIFACT_REPOSITORY \
+            CLOUD_RUN_SERVICE \
+            CLOUD_RUN_SERVICE_ACCOUNT \
+            PLATFORM_PUBLIC_URL \
+            MATRIX_APP_URL \
+            MATRIX_APP_DOMAIN_HOSTS \
+            MATRIX_CODE_DOMAIN_HOSTS \
+            CUSTOMER_VPS_IMAGE_VERSION; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing required GitHub environment variable(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v4
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v4
+
+      - name: Build platform image
+        run: |
+          set -euo pipefail
+          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:${GITHUB_SHA::12}"
+          echo "IMAGE=$image" >> "$GITHUB_ENV"
+          gcloud builds submit . \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --config cloudbuild.platform.yaml \
+            --substitutions "_IMAGE=$image" \
+            --timeout=1200s
+
+      - name: Deploy tagged revision
+        run: |
+          set -euo pipefail
+          service_exists=0
+          if gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" >/dev/null 2>&1; then
+            service_exists=1
+          fi
+
+          traffic_flags=(--tag candidate)
+          if [ "$service_exists" = "1" ]; then
+            traffic_flags+=(--no-traffic)
+          fi
+
+          gcloud run deploy "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --image "$IMAGE" \
+            --service-account "$CLOUD_RUN_SERVICE_ACCOUNT" \
+            --platform managed \
+            --port 8080 \
+            --cpu 1 \
+            --memory 1Gi \
+            --concurrency 30 \
+            --timeout 300 \
+            --min-instances 0 \
+            --max-instances 10 \
+            --ingress all \
+            --allow-unauthenticated \
+            "${traffic_flags[@]}" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=true,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest"
+
+      - name: Smoke candidate revision
+        run: |
+          set -euo pipefail
+          candidate_url=$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format 'value(status.traffic[?tag=="candidate"].url)')
+          if [ -z "$candidate_url" ]; then
+            echo "No tagged candidate Cloud Run URL found; refusing to smoke the live service URL." >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error --max-time 10 "$candidate_url/health" >/dev/null
+
+      - name: Promote revision
+        if: ${{ inputs.promote }}
+        run: |
+          set -euo pipefail
+          revision=$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format 'value(status.traffic[?tag=="candidate"].revisionName)')
+          if [ -z "$revision" ]; then
+            echo "No candidate revision found" >&2
+            exit 1
+          fi
+          gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --to-revisions "$revision=100"

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -1,0 +1,51 @@
+FROM node:24-alpine AS base
+
+RUN apk add --no-cache ca-certificates g++ linux-headers make python3
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY packages/observability/package.json packages/observability/package.json
+COPY packages/platform/package.json packages/platform/package.json
+COPY scripts/fix-node-pty-perms.mjs scripts/fix-node-pty-perms.mjs
+
+FROM base AS deps
+
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter '@matrix-os/platform...'
+
+FROM deps AS builder
+
+COPY . .
+RUN pnpm --filter '@matrix-os/observability' build
+RUN pnpm --filter '@matrix-os/platform' build
+
+FROM base AS prod-deps
+
+RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/platform...'
+
+FROM node:24-alpine AS runtime
+
+RUN apk add --no-cache ca-certificates
+
+WORKDIR /app
+
+RUN adduser -D -u 1001 -h /home/matrix-platform -s /sbin/nologin matrix-platform && \
+    chown matrix-platform:matrix-platform /app /home/matrix-platform
+
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/node_modules ./node_modules
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/observability/package.json ./packages/observability/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/platform/package.json ./packages/platform/package.json
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/platform/dist ./packages/platform/dist
+COPY --chown=matrix-platform:matrix-platform distro/customer-vps ./distro/customer-vps
+
+ENV NODE_ENV=production
+ENV PLATFORM_PORT=8080
+ENV CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml
+
+EXPOSE 8080
+
+USER matrix-platform
+
+CMD ["node", "packages/platform/dist/main.js"]

--- a/cloudbuild.platform.yaml
+++ b/cloudbuild.platform.yaml
@@ -1,0 +1,15 @@
+substitutions:
+  _IMAGE: europe-west3-docker.pkg.dev/matrix-os-1144/matrix-os/matrix-platform:manual
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - Dockerfile.platform
+      - -t
+      - ${_IMAGE}
+      - .
+
+images:
+  - ${_IMAGE}

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -19,6 +19,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@clerk/backend": "2.33.0",
     "@hono/node-server": "^1.19.9",
     "@matrix-os/observability": "workspace:*",
     "dockerode": "^4.0.7",
@@ -28,6 +29,7 @@
     "pg": "^8.21.0",
     "prom-client": "^15.1.3",
     "stripe": "22.1.1",
-    "ws": "^8.19.0"
+    "ws": "^8.19.0",
+    "zod": "^4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,9 @@ importers:
 
   packages/platform:
     dependencies:
+      '@clerk/backend':
+        specifier: 2.33.0
+        version: 2.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@hono/node-server':
         specifier: ^1.19.9
         version: 1.19.11(hono@4.12.8)
@@ -464,6 +467,9 @@ importers:
       ws:
         specifier: ^8.19.0
         version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@electric-sql/pglite':
         specifier: ^0.4.0


### PR DESCRIPTION
## Summary

- Add a platform-only Dockerfile for the Cloud Run control plane.
- Add a Cloud Build config that builds Dockerfile.platform instead of the customer/runtime image.
- Add a workflow-dispatch Cloud Run deploy workflow with tagged candidate smoke and optional manual promotion.

## Invariants

- Source of truth: platform Postgres remains canonical for platform records; Artifact Registry stores deployable image bytes only.
- Lock/transaction scope: no database transaction behavior changes; this PR only changes build/deploy plumbing.
- Acceptable orphan states: an image can be built without being promoted; a candidate revision can exist with zero traffic until smoke/promotion completes.
- Auth source of truth: Cloud Run runtime auth remains Clerk, PLATFORM_SECRET, and per-route checks. GitHub deployment auth uses GCP workload identity through environment secrets.
- Deferred scope: does not point production DNS to Cloud Run, does not migrate Neon data, does not add the missing Inngest/Pipedream webhook secret versions, and does not fan out deploy to VPSes.
- Rollback plan: keep the previous Cloud Run revision or route DNS back to the legacy platform; the workflow supports candidate revisions before promotion.
- PostHog events/errors: unchanged; this is deployment-image and workflow plumbing only.

## Verification commands

- git diff --check
- Manual smoke used equivalent temporary Dockerfile.platform image: Cloud Run /health returned {"status":"ok"} on matrix-platform-00003-ros
