### PR TITLE
fix(cli): keep interactive JSON stdout clean

### DIFF
--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -84,9 +84,7 @@ export async function createOrAttachRunSession(
   if (input.mouse !== undefined) {
     attachOptions.mouse = input.mouse;
   }
-  return Object.keys(attachOptions).length === 0
-    ? await client.attachSession(input.name)
-    : await client.attachSession(input.name, attachOptions);
+  return await client.attachSession(input.name, attachOptions);
 }
 
 function isInteractive(args: Record<string, unknown>, rawArgs: string[] | undefined): boolean {

--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -2,7 +2,7 @@ import { defineCommand } from "citty";
 import { randomUUID } from "node:crypto";
 import { resolveCliProfile } from "../profiles.js";
 import { formatCliError, formatCliErrorMessage, formatCliSuccess } from "../output.js";
-import { createShellClient, type ShellClient } from "../shell-client.js";
+import { createShellClient, type ShellAttachOptions, type ShellClient } from "../shell-client.js";
 import { requireCliAuthToken } from "../auth-state.js";
 
 const RUN_USAGE = "Usage: matrix run -it [--session <name>] [-C <dir>] -- <command>";
@@ -66,6 +66,7 @@ export async function createOrAttachRunSession(
     cwd?: string;
     sessionProvided: boolean;
     mouse?: boolean;
+    attachOptions?: ShellAttachOptions;
   },
 ): Promise<{ detached: boolean }> {
   try {
@@ -79,9 +80,13 @@ export async function createOrAttachRunSession(
       throw err;
     }
   }
-  return input.mouse === undefined
+  const attachOptions: ShellAttachOptions = { ...input.attachOptions };
+  if (input.mouse !== undefined) {
+    attachOptions.mouse = input.mouse;
+  }
+  return Object.keys(attachOptions).length === 0
     ? await client.attachSession(input.name)
-    : await client.attachSession(input.name, { mouse: input.mouse });
+    : await client.attachSession(input.name, attachOptions);
 }
 
 function isInteractive(args: Record<string, unknown>, rawArgs: string[] | undefined): boolean {
@@ -179,6 +184,7 @@ export const runCommand = defineCommand({
         command,
         sessionProvided,
         mouse: args.noMouse === true ? false : undefined,
+        attachOptions: json ? { output: process.stderr } : undefined,
       });
       console.log(
         json

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -119,6 +119,9 @@ function attachOptionsFromArgs(args: Record<string, unknown>) {
   const options: ShellAttachOptions = {
     fromSeq: parseFromSeq(args.fromSeq),
   };
+  if (args.json === true) {
+    options.output = process.stderr;
+  }
   if (args.noMouse === true) {
     options.mouse = false;
   }

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -66,7 +66,7 @@ async function runMatrixCli(args: string[]) {
       signal: NodeJS.Signals | null;
       stdout: string;
       stderr: string;
-    }>((resolve) => {
+    }>((resolve, reject) => {
       const child = spawn(process.execPath, [bin, ...args], {
         cwd: process.cwd(),
         env: { ...process.env, HOME: home, FORCE_COLOR: "0", NO_COLOR: "1" },
@@ -76,6 +76,9 @@ async function runMatrixCli(args: string[]) {
       const stderr: Buffer[] = [];
       child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
       child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+      child.on("error", (err) => {
+        reject(err);
+      });
       child.on("close", (status, signal) => {
         resolve({
           status,
@@ -128,7 +131,7 @@ describe("run CLI command", () => {
         sessionProvided: true,
       }),
     ).resolves.toEqual({ detached: true });
-    expect(client.attachSession).toHaveBeenCalledWith("setup");
+    expect(client.attachSession).toHaveBeenCalledWith("setup", {});
   });
 
   it("passes no-mouse mode through interactive run attach", async () => {

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -1,4 +1,10 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
 import {
   createOrAttachRunSession,
   parseRunCommand,
@@ -6,6 +12,83 @@ import {
   runCommand,
 } from "../../packages/sync-client/src/cli/commands/run.js";
 import { PUBLISHED_CLI_COMMANDS, resolvePublishedCliRedirect } from "../../packages/cli/src/index.js";
+
+async function createFakeRunGateway() {
+  let createRequests = 0;
+  let wsConnections = 0;
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/api/terminal/sessions") {
+      createRequests += 1;
+      req.resume();
+      res.writeHead(201, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ name: "run-session", created: true }));
+      return;
+    }
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: { code: "not_found" } }));
+  });
+  const wss = new WebSocketServer({ server, path: "/ws/terminal/session" });
+  wss.on("connection", (ws) => {
+    wsConnections += 1;
+    ws.send(JSON.stringify({ type: "attached" }));
+    setTimeout(() => ws.close(), 10).unref?.();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fake gateway did not bind a TCP port");
+  }
+
+  return {
+    gatewayUrl: `http://127.0.0.1:${address.port}`,
+    get createRequests() {
+      return createRequests;
+    },
+    get wsConnections() {
+      return wsConnections;
+    },
+    async close() {
+      wss.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function runMatrixCli(args: string[]) {
+  const home = await mkdtemp(join(tmpdir(), "matrix-run-cli-"));
+  const bin = join(process.cwd(), "packages/sync-client/bin/matrix.mjs");
+  try {
+    return await new Promise<{
+      status: number | null;
+      signal: NodeJS.Signals | null;
+      stdout: string;
+      stderr: string;
+    }>((resolve) => {
+      const child = spawn(process.execPath, [bin, ...args], {
+        cwd: process.cwd(),
+        env: { ...process.env, HOME: home, FORCE_COLOR: "0", NO_COLOR: "1" },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+      child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+      child.on("close", (status, signal) => {
+        resolve({
+          status,
+          signal,
+          stdout: Buffer.concat(stdout).toString("utf8"),
+          stderr: Buffer.concat(stderr).toString("utf8"),
+        });
+      });
+    });
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}
 
 describe("run CLI command", () => {
   it("exports the developer run command", () => {
@@ -63,6 +146,40 @@ describe("run CLI command", () => {
       }),
     ).resolves.toEqual({ detached: true });
     expect(client.attachSession).toHaveBeenCalledWith("setup", { mouse: false });
+  });
+
+  it("keeps stdout JSON-only for run -it --json", async () => {
+    const gateway = await createFakeRunGateway();
+    try {
+      const result = await runMatrixCli([
+        "run",
+        "-it",
+        "--session",
+        "run-session",
+        "--gateway",
+        gateway.gatewayUrl,
+        "--token",
+        "tok",
+        "--json",
+        "--",
+        "echo",
+        "ok",
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).not.toContain("\u001b[");
+      expect(JSON.parse(result.stdout)).toEqual({
+        v: 1,
+        ok: true,
+        data: { detached: true, session: "run-session" },
+      });
+      expect(result.stderr).toContain("\u001b[?1000l");
+      expect(gateway.createRequests).toBe(1);
+      expect(gateway.wsConnections).toBe(1);
+    } finally {
+      await gateway.close();
+    }
   });
 
   it("does not reuse an accidental ephemeral session collision", async () => {

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -58,7 +58,7 @@ async function runMatrixCli(args: string[]) {
     signal: NodeJS.Signals | null;
     stdout: string;
     stderr: string;
-  }>((resolve) => {
+  }>((resolve, reject) => {
     const child = spawn(process.execPath, [bin, ...args], {
       cwd: process.cwd(),
       env: { ...process.env, HOME: process.env.HOME ?? "", FORCE_COLOR: "0", NO_COLOR: "1" },
@@ -68,6 +68,9 @@ async function runMatrixCli(args: string[]) {
     const stderr: Buffer[] = [];
     child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("error", (err) => {
+      reject(err);
+    });
     child.on("close", (status, signal) => {
       resolve({
         status,

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -1,7 +1,9 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import http from "node:http";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { WebSocketServer } from "ws";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveProfileAuth } from "../../packages/sync-client/src/auth/token-store.js";
 import { shellCommand } from "../../packages/sync-client/src/cli/commands/shell.js";
@@ -14,6 +16,67 @@ async function tempHome() {
   roots.push(root);
   process.env.HOME = root;
   return root;
+}
+
+async function createFakeAttachGateway() {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: { code: "not_found" } }));
+  });
+  const wss = new WebSocketServer({ server, path: "/ws/terminal/session" });
+  let wsConnections = 0;
+  wss.on("connection", (ws) => {
+    wsConnections += 1;
+    ws.send(JSON.stringify({ type: "attached" }));
+    setTimeout(() => ws.close(), 10).unref?.();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fake gateway did not bind a TCP port");
+  }
+
+  return {
+    gatewayUrl: `http://127.0.0.1:${address.port}`,
+    get wsConnections() {
+      return wsConnections;
+    },
+    async close() {
+      wss.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function runMatrixCli(args: string[]) {
+  const bin = join(process.cwd(), "packages/sync-client/bin/matrix.mjs");
+  return await new Promise<{
+    status: number | null;
+    signal: NodeJS.Signals | null;
+    stdout: string;
+    stderr: string;
+  }>((resolve) => {
+    const child = spawn(process.execPath, [bin, ...args], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: process.env.HOME ?? "", FORCE_COLOR: "0", NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("close", (status, signal) => {
+      resolve({
+        status,
+        signal,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+  });
 }
 
 beforeEach(async () => {
@@ -268,6 +331,35 @@ describe("shell CLI command", () => {
       { v: 1, ok: true, data: { name: "main", created: true } },
       { v: 1, ok: true, data: { ok: true } },
     ]);
+  });
+
+  it.each(["connect", "attach"])("keeps stdout JSON-only for shell %s --json", async (verb) => {
+    const gateway = await createFakeAttachGateway();
+    try {
+      const result = await runMatrixCli([
+        "shell",
+        verb,
+        "main",
+        "--gateway",
+        gateway.gatewayUrl,
+        "--token",
+        "tok",
+        "--json",
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).not.toContain("\u001b[");
+      expect(JSON.parse(result.stdout)).toEqual({
+        v: 1,
+        ok: true,
+        data: { detached: true },
+      });
+      expect(result.stderr).toContain("\u001b[?1000l");
+      expect(gateway.wsConnections).toBe(1);
+    } finally {
+      await gateway.close();
+    }
   });
 
   it("creates shell sessions without attaching by default", async () => {


### PR DESCRIPTION
## Summary
- Route interactive terminal stream/control output to stderr when `--json` is used for `matrix shell connect`, `matrix shell attach`, and `matrix run -it`.
- Keep stdout reserved for the versioned JSON success envelope in those interactive JSON flows.
- Add process-level regression tests with local fake HTTP/WebSocket gateways to assert stdout remains parseable JSON and escape-free.

## Tests
- `pnpm exec vitest run tests/cli/shell.test.ts tests/cli/run.test.ts tests/cli/shell-client.test.ts`
- `pnpm --filter @finnaai/matrix test`
- `pnpm run check:patterns` (0 violations, existing broad warnings only)
- `pnpm --filter @finnaai/matrix exec tsc --noEmit`

## Review/Monitoring
- Greptile should verify that `--json` stdout is machine-readable while non-json interactive behavior remains unchanged.
- CI should cover the focused process-level CLI regressions plus the sync-client package suite.
- Reviewer requested: Nima-Naderi if GitHub permits it.

## Invariants
- **Source of truth**: The CLI command layer owns the stdout/stderr contract. `shell-client` continues to own terminal attach behavior and stream writing.
- **Lock/transaction scope**: No database or shared-state writes are introduced. No transaction scope applies.
- **Acceptable orphan states**: No persistent state is created by this change. If attach fails, existing error handling still emits the JSON error on stderr for `--json` and sets a non-zero exit code.
- **Auth source of truth**: Existing CLI profile/token resolution remains unchanged; fake gateways are test-only and use explicit `--token` arguments.
- **Deferred scope**: This does not change remote terminal protocol semantics, non-json terminal output behavior, or gateway WebSocket handling.
