### PR TITLE
fix(cli): make peers profile-aware

### DIFF
--- a/packages/sync-client/src/cli/commands/peers.ts
+++ b/packages/sync-client/src/cli/commands/peers.ts
@@ -1,41 +1,73 @@
 import { defineCommand } from "citty";
-import { loadAuth } from "../../auth/token-store.js";
-import { loadConfig } from "../../lib/config.js";
+import { requireCliAuthToken } from "../auth-state.js";
+import { formatCliError, formatCliSuccess } from "../output.js";
+import { resolveCliProfile } from "../profiles.js";
+
+interface PeerStatus {
+  peers?: { peerId: string; hostname: string; connectedAt: number }[];
+}
+
+function writeError(err: unknown, json: boolean): void {
+  const code =
+    err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
+      ? (err as { code: string }).code
+      : "peers_request_failed";
+  const safeMessage =
+    (code === "not_authenticated" || code === "auth_expired") && err instanceof Error
+      ? err.message
+      : undefined;
+  console.error(json ? formatCliError(code, safeMessage) : safeMessage ?? `Error: Request failed (${code})`);
+}
 
 export const peersCommand = defineCommand({
   meta: { name: "peers", description: "List connected peers" },
-  run: async () => {
-    const config = await loadConfig();
-    const auth = await loadAuth();
+  args: {
+    profile: { type: "string", required: false },
+    dev: { type: "boolean", required: false, default: false },
+    gateway: { type: "string", required: false },
+    token: { type: "string", required: false },
+    json: { type: "boolean", required: false, default: false },
+  },
+  run: async ({ args }) => {
+    const json = args.json === true;
+    try {
+      const profile = await resolveCliProfile(args);
+      const token = await requireCliAuthToken(profile);
 
-    if (!config || !auth) {
-      console.error("Not configured. Run 'matrixos login' and 'matrixos sync' first.");
-      process.exit(1);
-    }
+      const res = await fetch(`${profile.gatewayUrl}/api/sync/status`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(10_000),
+      });
 
-    const res = await fetch(`${config.gatewayUrl}/api/sync/status`, {
-      headers: { authorization: `Bearer ${auth.accessToken}` },
-      signal: AbortSignal.timeout(10_000),
-    });
+      if (!res.ok) {
+        throw Object.assign(new Error("peers_request_failed"), { code: "peers_request_failed" });
+      }
 
-    if (!res.ok) {
-      console.error(`Failed to fetch peer status: ${res.status}`);
-      process.exit(1);
-    }
+      const data = (await res.json()) as PeerStatus;
+      const peers = data.peers ?? [];
 
-    const data = (await res.json()) as {
-      peers?: { peerId: string; hostname: string; connectedAt: number }[];
-    };
+      if (json) {
+        console.log(formatCliSuccess({
+          profile: profile.name,
+          gatewayUrl: profile.gatewayUrl,
+          peers,
+        }));
+        return;
+      }
 
-    if (!data.peers || data.peers.length === 0) {
-      console.log("No peers connected.");
-      return;
-    }
+      if (peers.length === 0) {
+        console.log("No peers connected.");
+        return;
+      }
 
-    console.log("Connected peers:");
-    for (const peer of data.peers) {
-      const since = new Date(peer.connectedAt).toISOString();
-      console.log(`  ${peer.peerId} (${peer.hostname}) — since ${since}`);
+      console.log("Connected peers:");
+      for (const peer of peers) {
+        const since = new Date(peer.connectedAt).toISOString();
+        console.log(`  ${peer.peerId} (${peer.hostname}) — since ${since}`);
+      }
+    } catch (err: unknown) {
+      writeError(err, json);
+      process.exitCode = 1;
     }
   },
 });

--- a/packages/sync-client/src/cli/profiles.ts
+++ b/packages/sync-client/src/cli/profiles.ts
@@ -25,7 +25,7 @@ export async function resolveCliProfile(
     flags.dev === true ? "local" : typeof flags.profile === "string" ? flags.profile : profiles.active;
   const profile = profiles.profiles[explicitProfile];
   if (!profile) {
-    throw new Error("profile_not_found");
+    throw Object.assign(new Error("profile_not_found"), { code: "profile_not_found" });
   }
 
   return {

--- a/tests/cli/peers.test.ts
+++ b/tests/cli/peers.test.ts
@@ -1,0 +1,168 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveProfileAuth } from "../../packages/sync-client/src/auth/token-store.js";
+import { loginCommand } from "../../packages/sync-client/src/cli/commands/login.js";
+import { peersCommand } from "../../packages/sync-client/src/cli/commands/peers.js";
+
+const roots: string[] = [];
+const originalHome = process.env.HOME;
+const originalGatewayUrl = process.env.MATRIXOS_GATEWAY_URL;
+const originalPlatformUrl = process.env.MATRIXOS_PLATFORM_URL;
+
+async function tempHome(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "matrix-peers-cli-"));
+  roots.push(root);
+  process.env.HOME = root;
+  return root;
+}
+
+function captureLogs(): string[] {
+  const logs: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+    logs.push(String(line));
+  });
+  return logs;
+}
+
+function captureErrors(): string[] {
+  const errors: string[] = [];
+  vi.spyOn(console, "error").mockImplementation((line?: unknown) => {
+    errors.push(String(line));
+  });
+  return errors;
+}
+
+beforeEach(async () => {
+  process.exitCode = undefined;
+  process.env.MATRIXOS_GATEWAY_URL = "http://localhost:4010";
+  process.env.MATRIXOS_PLATFORM_URL = "http://localhost:9010";
+  await tempHome();
+});
+
+afterEach(async () => {
+  process.env.HOME = originalHome;
+  process.env.MATRIXOS_GATEWAY_URL = originalGatewayUrl;
+  process.env.MATRIXOS_PLATFORM_URL = originalPlatformUrl;
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("peers CLI command", () => {
+  it("uses profile-scoped dev login auth without legacy sync config", async () => {
+    await loginCommand.run!({ args: { dev: true } } as never);
+    await rm(join(process.env.HOME!, ".matrixos", "config.json"), { force: true });
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          peers: [{ peerId: "peer-1", hostname: "devhost", connectedAt: 1700000000000 }],
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+    const logs = captureLogs();
+
+    await peersCommand.run!({ args: {} } as never);
+
+    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:4010/api/sync/status", {
+      headers: { Authorization: "Bearer dev-token" },
+      signal: expect.any(AbortSignal),
+    });
+    expect(logs).toEqual([
+      "Connected peers:",
+      "  peer-1 (devhost) \u2014 since 2023-11-14T22:13:20.000Z",
+    ]);
+  });
+
+  it("honors explicit profile, gateway, and token overrides", async () => {
+    await mkdir(join(process.env.HOME!, ".matrixos"), { recursive: true });
+    await writeFile(
+      join(process.env.HOME!, ".matrixos", "profiles.json"),
+      JSON.stringify({
+        active: "cloud",
+        profiles: {
+          cloud: {
+            platformUrl: "https://platform.example",
+            gatewayUrl: "https://gateway.example",
+          },
+          local: {
+            platformUrl: "http://localhost:9000",
+            gatewayUrl: "http://localhost:4000",
+          },
+        },
+      }),
+      { flag: "wx" },
+    );
+    await saveProfileAuth("cloud", {
+      accessToken: "cloud-token",
+      expiresAt: Date.now() + 60_000,
+      userId: "user_cloud",
+      handle: "cloud",
+    });
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ peers: [] })));
+    vi.stubGlobal("fetch", fetchImpl);
+    const logs = captureLogs();
+
+    await peersCommand.run!({
+      args: {
+        profile: "cloud",
+        gateway: "https://override.example",
+        token: "operator-token",
+      },
+    } as never);
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://override.example/api/sync/status", {
+      headers: { Authorization: "Bearer operator-token" },
+      signal: expect.any(AbortSignal),
+    });
+    expect(logs).toEqual(["No peers connected."]);
+  });
+
+  it("prints JSON output when requested", async () => {
+    await loginCommand.run!({ args: { dev: true } } as never);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            peers: [{ peerId: "peer-1", hostname: "devhost", connectedAt: 1700000000000 }],
+          }),
+        ),
+      ),
+    );
+    const logs = captureLogs();
+
+    await peersCommand.run!({ args: { json: true } } as never);
+
+    expect(JSON.parse(logs[0]!)).toEqual({
+      v: 1,
+      ok: true,
+      data: {
+        profile: "local",
+        gatewayUrl: "http://localhost:4010",
+        peers: [{ peerId: "peer-1", hostname: "devhost", connectedAt: 1700000000000 }],
+      },
+    });
+  });
+
+  it("emits safe JSON errors without exposing gateway response bodies", async () => {
+    await loginCommand.run!({ args: { dev: true } } as never);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("provider exploded", { status: 502 })),
+    );
+    const errors = captureErrors();
+
+    await peersCommand.run!({ args: { json: true } } as never);
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(errors[0]!)).toEqual({
+      v: 1,
+      error: { code: "peers_request_failed", message: "Request failed" },
+    });
+    expect(errors[0]).not.toContain("provider exploded");
+  });
+});

--- a/tests/cli/peers.test.ts
+++ b/tests/cli/peers.test.ts
@@ -165,4 +165,31 @@ describe("peers CLI command", () => {
     });
     expect(errors[0]).not.toContain("provider exploded");
   });
+
+  it("emits the profile_not_found code in JSON for a missing profile", async () => {
+    const fetchImpl = vi.fn();
+    vi.stubGlobal("fetch", fetchImpl);
+    const errors = captureErrors();
+
+    await peersCommand.run!({ args: { profile: "missing", json: true } } as never);
+
+    expect(process.exitCode).toBe(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(JSON.parse(errors[0]!)).toEqual({
+      v: 1,
+      error: { code: "profile_not_found", message: "Request failed" },
+    });
+  });
+
+  it("emits the profile_not_found code in human mode for a missing profile", async () => {
+    const fetchImpl = vi.fn();
+    vi.stubGlobal("fetch", fetchImpl);
+    const errors = captureErrors();
+
+    await peersCommand.run!({ args: { profile: "missing" } } as never);
+
+    expect(process.exitCode).toBe(1);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(errors).toEqual(["Error: Request failed (profile_not_found)"]);
+  });
 });


### PR DESCRIPTION
## Summary

- Make `matrix peers` resolve the active or requested CLI profile instead of reading legacy top-level `~/.matrixos/auth.json` and sync config.
- Add `--profile`, `--dev`, `--gateway`, `--token`, and `--json` support to align peers with newer profile-aware CLI commands.
- Return generic request errors for gateway failures without exposing response bodies or provider details.

## Tests

- `pnpm exec vitest run tests/cli/peers.test.ts tests/cli/profile-auth.test.ts`
- `pnpm --filter @finnaai/matrix test`
- `pnpm --filter @finnaai/matrix exec tsc --noEmit`
- `./scripts/review/check-patterns.sh --diff main` (0 violations; broad scanner warnings are outside this diff)

## Review/Monitoring

- Requested reviewer: `Nima-Naderi` when possible.
- Monitor CI and Greptile after PR creation.
- If Greptile reports below 5/5, fix findings in this branch, rerun focused validation, commit, push, and continue monitoring.

## Invariants

- **Source of truth**: CLI profile files under `~/.matrixos/profiles/*` are canonical for profile auth and gateway configuration. Legacy top-level auth/config are not required for `matrix peers`.
- **Lock/transaction scope**: no database writes or multi-step persistence are introduced. The command reads local profile/auth files and performs one bounded gateway request.
- **Acceptable orphan states**: if the gateway request fails after profile/auth resolution, no state is mutated; the CLI returns a generic request failure.
- **Auth source of truth**: bearer token comes from `requireCliAuthToken(resolveCliProfile(args))`, including explicit token override support and profile-scoped auth expiry checks.
- **Deferred scope**: this PR does not change daemon sync config, sync lifecycle commands, or gateway peer status response schemas.
