### PR TITLE
fix(cli): keep JSON subcommand output clean

### DIFF
--- a/packages/sync-client/src/cli/commands/instance.ts
+++ b/packages/sync-client/src/cli/commands/instance.ts
@@ -5,7 +5,14 @@ import { requireCliAuthToken } from "../auth-state.js";
 
 const INSTANCE_USAGE = "Usage: matrix instance info|restart|logs";
 const INSTANCE_SUBCOMMANDS = new Set(["info", "restart", "logs"]);
-const INSTANCE_VALUE_OPTIONS = new Set(["--profile", "--platform", "--token"]);
+const INSTANCE_STRING_ARGS = {
+  profile: { type: "string", required: false },
+  platform: { type: "string", required: false },
+  token: { type: "string", required: false },
+} as const;
+const INSTANCE_VALUE_OPTIONS = new Set(
+  Object.keys(INSTANCE_STRING_ARGS).map((name) => `--${name}`),
+);
 
 interface InstanceRequestOptions {
   method?: "GET" | "POST";
@@ -76,10 +83,10 @@ async function runInstanceCommand(
 }
 
 const commonArgs = {
-  profile: { type: "string", required: false },
+  profile: INSTANCE_STRING_ARGS.profile,
   dev: { type: "boolean", required: false, default: false },
-  platform: { type: "string", required: false },
-  token: { type: "string", required: false },
+  platform: INSTANCE_STRING_ARGS.platform,
+  token: INSTANCE_STRING_ARGS.token,
   json: { type: "boolean", required: false, default: false },
 } as const;
 

--- a/packages/sync-client/src/cli/commands/instance.ts
+++ b/packages/sync-client/src/cli/commands/instance.ts
@@ -3,8 +3,30 @@ import { formatCliError, formatCliSuccess } from "../output.js";
 import { resolveCliProfile } from "../profiles.js";
 import { requireCliAuthToken } from "../auth-state.js";
 
+const INSTANCE_USAGE = "Usage: matrix instance info|restart|logs";
+const INSTANCE_SUBCOMMANDS = new Set(["info", "restart", "logs"]);
+const INSTANCE_VALUE_OPTIONS = new Set(["--profile", "--platform", "--token"]);
+
 interface InstanceRequestOptions {
   method?: "GET" | "POST";
+}
+
+function hasInstanceSubCommand(rawArgs: string[] | undefined): boolean {
+  if (!Array.isArray(rawArgs)) {
+    return false;
+  }
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (arg.startsWith("--")) {
+      const [option] = arg.split("=", 1);
+      if (INSTANCE_VALUE_OPTIONS.has(option) && !arg.includes("=")) {
+        i += 1;
+      }
+      continue;
+    }
+    return INSTANCE_SUBCOMMANDS.has(arg);
+  }
+  return false;
 }
 
 function writeError(err: unknown, json: boolean): void {
@@ -84,7 +106,9 @@ export const instanceCommand = defineCommand({
       run: async ({ args }) => runInstanceCommand(args, "/api/instance/logs"),
     }),
   },
-  run: () => {
-    console.log("Usage: matrix instance info|restart|logs");
+  run: ({ rawArgs }) => {
+    if (!hasInstanceSubCommand(rawArgs)) {
+      console.log(INSTANCE_USAGE);
+    }
   },
 });

--- a/packages/sync-client/src/cli/commands/profile.ts
+++ b/packages/sync-client/src/cli/commands/profile.ts
@@ -7,9 +7,25 @@ import {
 } from "../../lib/profiles.js";
 import { formatCliError, formatCliSuccess } from "../output.js";
 
+const PROFILE_USAGE = "Usage: matrix profile ls|show|use|set";
+const PROFILE_SUBCOMMANDS = new Set(["ls", "show", "use", "set"]);
+
 interface ProfileView extends Profile {
   name: string;
   active: boolean;
+}
+
+function hasProfileSubCommand(rawArgs: string[] | undefined): boolean {
+  if (!Array.isArray(rawArgs)) {
+    return false;
+  }
+  for (const arg of rawArgs) {
+    if (arg.startsWith("--")) {
+      continue;
+    }
+    return PROFILE_SUBCOMMANDS.has(arg);
+  }
+  return false;
 }
 
 function profileView(name: string, profile: Profile, active: string): ProfileView {
@@ -157,7 +173,9 @@ export const profileCommand = defineCommand({
       }),
     }),
   },
-  run: () => {
-    console.log("Usage: matrix profile ls|show|use|set");
+  run: ({ rawArgs }) => {
+    if (!hasProfileSubCommand(rawArgs)) {
+      console.log(PROFILE_USAGE);
+    }
   },
 });

--- a/tests/cli/instance.test.ts
+++ b/tests/cli/instance.test.ts
@@ -1,4 +1,7 @@
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
 import { mkdtemp, rm } from "node:fs/promises";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,6 +23,81 @@ function captureLogs() {
     logs.push(String(line));
   });
   return logs;
+}
+
+async function runMatrixCli(args: string[]): Promise<{
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  const bin = join(process.cwd(), "packages/sync-client/bin/matrix.mjs");
+  const child = spawn(process.execPath, [bin, ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: process.env.HOME ?? "",
+      MATRIX_HOME: join(process.env.HOME ?? "", "matrix-home"),
+    },
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf-8");
+  child.stderr.setEncoding("utf-8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const status = await new Promise<number | null>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("matrix_cli_timeout"));
+    }, 10_000);
+    child.once("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      resolve(code);
+    });
+  });
+  return { status, stdout, stderr };
+}
+
+function expectJsonStdout(stdout: string): unknown {
+  expect(stdout).not.toContain("Usage: matrix instance info|restart|logs");
+  return JSON.parse(stdout);
+}
+
+async function startInstanceServer(): Promise<{ server: Server; platformUrl: string }> {
+  const server = createServer((req, res) => {
+    res.setHeader("content-type", "application/json");
+    if (req.url === "/api/instance/restart") {
+      res.end(JSON.stringify({ restarted: true }));
+      return;
+    }
+    if (req.url === "/api/instance/logs") {
+      res.end(JSON.stringify({ lines: ["ready"] }));
+      return;
+    }
+    if (req.url === "/api/instance") {
+      res.end(JSON.stringify({ status: "running", handle: "cloud" }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return { server, platformUrl: `http://127.0.0.1:${address.port}` };
 }
 
 beforeEach(async () => {
@@ -48,6 +126,38 @@ describe("instance CLI command", () => {
       "logs",
       "restart",
     ]);
+  });
+
+  it("emits clean process-level JSON for instance subcommands", async () => {
+    const { server, platformUrl } = await startInstanceServer();
+    try {
+      const commands = [
+        ["instance", "info", "--platform", platformUrl, "--token", "cloud-token", "--json"],
+        ["instance", "restart", "--platform", platformUrl, "--token", "cloud-token", "--json"],
+        ["instance", "logs", "--platform", platformUrl, "--token", "cloud-token", "--json"],
+      ];
+
+      const outputs = [];
+      for (const args of commands) {
+        const result = await runMatrixCli(args);
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe("");
+        outputs.push(expectJsonStdout(result.stdout));
+      }
+
+      expect(outputs).toEqual([
+        { v: 1, ok: true, data: { status: "running", handle: "cloud" } },
+        { v: 1, ok: true, data: { restarted: true } },
+        { v: 1, ok: true, data: { lines: ["ready"] } },
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    }
   });
 
   it("calls profile-scoped instance endpoints with bounded fetches", async () => {

--- a/tests/cli/profile.test.ts
+++ b/tests/cli/profile.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -54,6 +55,25 @@ async function expectDaemonConfigPreserved(configDir: string): Promise<void> {
   await expect(pathExists(join(configDir, "profiles", "cloud", "config.json"))).resolves.toBe(false);
 }
 
+function runMatrixCli(args: string[]) {
+  const bin = join(process.cwd(), "packages/sync-client/bin/matrix.mjs");
+  return spawnSync(process.execPath, [bin, ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: process.env.HOME ?? "",
+      MATRIX_HOME: join(process.env.HOME ?? "", "matrix-home"),
+    },
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
+}
+
+function expectJsonStdout(stdout: string): unknown {
+  expect(stdout).not.toContain("Usage: matrix profile ls|show|use|set");
+  return JSON.parse(stdout);
+}
+
 beforeEach(async () => {
   process.exitCode = undefined;
   await tempHome();
@@ -102,6 +122,48 @@ describe("profile CLI command", () => {
         ],
       },
     });
+  });
+
+  it("emits clean process-level JSON for profile subcommands", () => {
+    const commands = [
+      ["profile", "ls", "--json"],
+      ["profile", "show", "--json"],
+      [
+        "profile",
+        "set",
+        "staging",
+        "--platform",
+        "https://platform.example",
+        "--gateway",
+        "https://gateway.example",
+        "--json",
+      ],
+      ["profile", "show", "staging", "--json"],
+      ["profile", "use", "staging", "--json"],
+    ];
+
+    const outputs = commands.map((args) => {
+      const result = runMatrixCli(args);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      return expectJsonStdout(result.stdout);
+    });
+
+    expect(outputs).toEqual([
+      expect.objectContaining({ v: 1, ok: true }),
+      expect.objectContaining({ v: 1, ok: true }),
+      expect.objectContaining({
+        v: 1,
+        ok: true,
+        data: expect.objectContaining({ name: "staging" }),
+      }),
+      expect.objectContaining({
+        v: 1,
+        ok: true,
+        data: expect.objectContaining({ name: "staging" }),
+      }),
+      { v: 1, ok: true, data: { active: "staging" } },
+    ]);
   });
 
   it("sets and shows a named profile", async () => {


### PR DESCRIPTION
## Summary

- Suppress `profile` and `instance` parent usage output when known subcommands have already run.
- Add process-level regressions for `profile ls/show/use/set --json` and `instance info/restart/logs --json` so the real `citty` parent/subcommand behavior is covered.
- Preserve bare parent command usage output for `matrix profile` and `matrix instance`.

## Tests

- `pnpm exec vitest run tests/cli/profile.test.ts tests/cli/instance.test.ts tests/cli/unified-command-tree.test.ts`
- `pnpm --filter @finnaai/matrix test`
- `pnpm --filter @finnaai/matrix build`
- `git diff --check`
- Not run: `bun run check:patterns` because `bun` is not installed in this worktree environment.

## Review/Monitoring

- Awaiting CI and Greptile review.
- I will monitor review/check status and follow up if Greptile reports below 5/5.

## Invariants

- Source of truth: CLI output formatting remains the command handlers' `formatCliSuccess` / `formatCliError` envelopes. The parent command only controls whether to print human usage text for bare parent invocations.
- Lock/transaction scope: no database writes or multi-step transactional state are introduced. Existing profile file writes remain unchanged.
- Acceptable orphan states: none added. Process-level tests use temporary homes and a short-lived local HTTP server that is closed in `finally`.
- Auth source of truth: unchanged. `instance` commands still resolve the selected CLI profile and token through the existing profile/auth helpers, while tests pass an explicit token to the local mock platform.
- Deferred scope: this PR does not redesign `citty` command routing, alter other command groups, or change non-JSON human output beyond suppressing duplicate parent usage after successful subcommands.
