### PR TITLE
fix(cli): emit JSON for sync control commands

### DIFF
--- a/bin/matrixos.ts
+++ b/bin/matrixos.ts
@@ -327,8 +327,10 @@ function runSyncCli(subArgs: string[]): Promise<void> {
       env: process.env,
     });
     child.on("exit", (code) => {
-      if (code === 0 || code === null) resolve();
-      else reject(new Error(`Sync CLI exited with code ${code}`));
+      if (code !== null && code !== 0) {
+        process.exitCode = code;
+      }
+      resolve();
     });
     child.on("error", reject);
   });

--- a/packages/sync-client/src/cli/commands/sync.ts
+++ b/packages/sync-client/src/cli/commands/sync.ts
@@ -169,7 +169,7 @@ export const syncCommand = defineCommand({
       try {
         switch (first) {
           case "status":
-            return runStatus(json);
+            return await runStatus(json);
           case "pause":
             await sendCommand("pause");
             console.log(json ? formatCliSuccess({ paused: true }) : "Sync paused.");

--- a/packages/sync-client/src/cli/commands/sync.ts
+++ b/packages/sync-client/src/cli/commands/sync.ts
@@ -2,19 +2,39 @@ import { defineCommand } from "citty";
 import { resolve } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { loadConfig, saveConfig, defaultSyncPath, generatePeerId } from "../../lib/config.js";
-import { sendCommand, isDaemonRunning } from "../daemon-client.js";
+import {
+  isDaemonClientError,
+  sendCommand,
+  isDaemonRunning,
+} from "../daemon-client.js";
 import { installService, startService } from "../../daemon/service.js";
 import { resolveCliProfile } from "../profiles.js";
+import { formatCliError, formatCliSuccess } from "../output.js";
 
 const SUBCOMMANDS = new Set(["status", "pause", "resume"]);
 
-async function runStatus(): Promise<void> {
+function writeSyncError(err: unknown, json: boolean): void {
+  const code = isDaemonClientError(err) ? err.code : "sync_failed";
+  const message = isDaemonClientError(err) ? err.message : "Sync command failed.";
+  console.error(json ? formatCliError(code, message) : `Error: ${message}`);
+  process.exitCode = 1;
+}
+
+async function runStatus(json: boolean): Promise<void> {
   const running = await isDaemonRunning();
   if (!running) {
+    if (json) {
+      console.log(formatCliSuccess({ running: false }));
+      return;
+    }
     console.log("Sync daemon is not running.");
     return;
   }
   const status = await sendCommand("status");
+  if (json) {
+    console.log(formatCliSuccess({ ...status, running: true }));
+    return;
+  }
   console.log("Sync status:");
   console.log(`  Syncing: ${status.syncing ? "yes" : "paused"}`);
   console.log(`  Manifest version: ${status.manifestVersion}`);
@@ -121,6 +141,12 @@ export const syncCommand = defineCommand({
       description: "Override bearer token for this command",
       required: false,
     },
+    json: {
+      type: "boolean",
+      description: "Emit machine-readable JSON output",
+      required: false,
+      default: false,
+    },
     path: {
       type: "string",
       alias: "p",
@@ -137,19 +163,25 @@ export const syncCommand = defineCommand({
   },
   run: async ({ args, rawArgs }) => {
     const first = rawArgs?.find((a) => !a.startsWith("-"));
+    const json = args.json === true;
 
     if (first && SUBCOMMANDS.has(first)) {
-      switch (first) {
-        case "status":
-          return runStatus();
-        case "pause":
-          await sendCommand("pause");
-          console.log("Sync paused.");
-          return;
-        case "resume":
-          await sendCommand("resume");
-          console.log("Sync resumed.");
-          return;
+      try {
+        switch (first) {
+          case "status":
+            return runStatus(json);
+          case "pause":
+            await sendCommand("pause");
+            console.log(json ? formatCliSuccess({ paused: true }) : "Sync paused.");
+            return;
+          case "resume":
+            await sendCommand("resume");
+            console.log(json ? formatCliSuccess({ resumed: true }) : "Sync resumed.");
+            return;
+        }
+      } catch (err: unknown) {
+        writeSyncError(err, json);
+        return;
       }
     }
 

--- a/packages/sync-client/src/cli/daemon-client.ts
+++ b/packages/sync-client/src/cli/daemon-client.ts
@@ -82,7 +82,7 @@ export async function sendCommand(
     };
 
     const timer = setTimeout(() => {
-      fail(new Error("IPC request timed out"));
+      fail(new DaemonClientError("daemon_timeout", "Sync daemon timed out."));
     }, timeout);
 
     socket.on("connect", () => {

--- a/packages/sync-client/src/cli/daemon-client.ts
+++ b/packages/sync-client/src/cli/daemon-client.ts
@@ -4,6 +4,22 @@ import { getConfigDir } from "../lib/config.js";
 import { DAEMON_IPC_VERSION } from "../daemon/types.js";
 
 export const IPC_MAX_RESPONSE_BYTES = 256 * 1024;
+export const DAEMON_UNAVAILABLE_CODE = "daemon_unavailable";
+export const DAEMON_UNAVAILABLE_MESSAGE = "Sync daemon is not running.";
+
+export class DaemonClientError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DaemonClientError";
+  }
+}
+
+export function isDaemonClientError(err: unknown): err is DaemonClientError {
+  return err instanceof DaemonClientError;
+}
 
 function socketPath(): string {
   return join(getConfigDir(), "daemon.sock");
@@ -108,11 +124,16 @@ export async function sendCommand(
     });
 
     socket.on("error", (err) => {
-      fail(
-        new Error(
-          `Cannot connect to daemon. Is it running? (${err.message})`,
-        ),
-      );
+      if (
+        "code" in err &&
+        ["ENOENT", "ECONNREFUSED", "EPERM", "EACCES"].includes(
+          String((err as NodeJS.ErrnoException).code),
+        )
+      ) {
+        fail(new DaemonClientError(DAEMON_UNAVAILABLE_CODE, DAEMON_UNAVAILABLE_MESSAGE));
+        return;
+      }
+      fail(new DaemonClientError("daemon_ipc_failed", "Sync daemon request failed."));
     });
   });
 }

--- a/packages/sync-client/tests/unit/daemon-client.test.ts
+++ b/packages/sync-client/tests/unit/daemon-client.test.ts
@@ -4,6 +4,8 @@ import { createServer, type Server, type Socket } from "node:net";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  DAEMON_UNAVAILABLE_CODE,
+  DAEMON_UNAVAILABLE_MESSAGE,
   IPC_MAX_RESPONSE_BYTES,
   probeDaemonSocket,
   sendCommand,
@@ -90,6 +92,13 @@ describe("sendCommand", () => {
       for (const socket of sockets) socket.destroy();
       await closeServer(server);
     }
+  });
+
+  it("rejects missing daemon sockets with a safe stable error", async () => {
+    await expect(sendCommand("pause", {}, 100)).rejects.toMatchObject({
+      code: DAEMON_UNAVAILABLE_CODE,
+      message: DAEMON_UNAVAILABLE_MESSAGE,
+    });
   });
 
   it("rejects oversized daemon responses before timing out", async () => {

--- a/packages/sync-client/tests/unit/daemon-client.test.ts
+++ b/packages/sync-client/tests/unit/daemon-client.test.ts
@@ -101,6 +101,26 @@ describe("sendCommand", () => {
     });
   });
 
+  it("rejects timed out daemon commands with a safe stable error", async () => {
+    const sock = join(tempDir, ".matrixos", "daemon.sock");
+    const sockets = new Set<Socket>();
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    await listen(server, sock);
+
+    try {
+      await expect(sendCommand("status", {}, 50)).rejects.toMatchObject({
+        code: "daemon_timeout",
+        message: "Sync daemon timed out.",
+      });
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await closeServer(server);
+    }
+  });
+
   it("rejects oversized daemon responses before timing out", async () => {
     const sock = join(tempDir, ".matrixos", "daemon.sock");
     const sockets = new Set<Socket>();

--- a/tests/cli/sync-json.test.ts
+++ b/tests/cli/sync-json.test.ts
@@ -1,0 +1,192 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const roots: string[] = [];
+const bin = join(process.cwd(), "packages/sync-client/bin/matrix.mjs");
+const rootBin = join(process.cwd(), "bin/matrixos.mjs");
+
+async function tempHome(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "matrix-sync-json-cli-"));
+  roots.push(root);
+  return root;
+}
+
+async function runCli(
+  home: string,
+  args: string[],
+  commandBin = bin,
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [commandBin, ...args], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+    child.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+    child.on("exit", (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
+async function listen(server: Server, socketPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function startDaemon(home: string): Promise<Server> {
+  const configDir = join(home, ".matrixos");
+  await mkdir(configDir, { recursive: true });
+  const server = createServer((socket) => {
+    let buffer = "";
+    socket.on("data", (data) => {
+      buffer += data.toString();
+      const idx = buffer.indexOf("\n");
+      if (idx === -1) return;
+      const msg = JSON.parse(buffer.slice(0, idx)) as { command?: string };
+      const result = msg.command === "status"
+        ? { syncing: true, manifestVersion: 7, fileCount: 3, lastSyncAt: 1_710_000_000_000 }
+        : {};
+      socket.write(`${JSON.stringify({ v: 1, result })}\n`);
+    });
+  });
+  await listen(server, join(configDir, "daemon.sock"));
+  return server;
+}
+
+function expectSafeNoDaemonStderr(stderr: string, home: string): void {
+  expect(stderr).not.toContain(home);
+  expect(stderr).not.toContain(".matrixos");
+  expect(stderr).not.toContain("daemon.sock");
+  expect(stderr).not.toContain(" at ");
+  expect(stderr).not.toContain("Socket.");
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("sync CLI JSON output", () => {
+  it("emits a versioned status envelope when the daemon is not running", async () => {
+    const home = await tempHome();
+
+    const result = await runCli(home, ["sync", "status", "--json"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({
+      v: 1,
+      ok: true,
+      data: { running: false },
+    });
+  });
+
+  it("emits versioned success envelopes for daemon-backed sync commands", async () => {
+    const home = await tempHome();
+    const server = await startDaemon(home);
+
+    try {
+      const status = await runCli(home, ["sync", "status", "--json"]);
+      const pause = await runCli(home, ["sync", "pause", "--json"]);
+      const resume = await runCli(home, ["sync", "resume", "--json"]);
+
+      expect(status.status).toBe(0);
+      expect(JSON.parse(status.stdout)).toEqual({
+        v: 1,
+        ok: true,
+        data: {
+          running: true,
+          syncing: true,
+          manifestVersion: 7,
+          fileCount: 3,
+          lastSyncAt: 1_710_000_000_000,
+        },
+      });
+      expect(status.stderr).toBe("");
+
+      expect(pause.status).toBe(0);
+      expect(JSON.parse(pause.stdout)).toEqual({
+        v: 1,
+        ok: true,
+        data: { paused: true },
+      });
+      expect(pause.stderr).toBe("");
+
+      expect(resume.status).toBe(0);
+      expect(JSON.parse(resume.stdout)).toEqual({
+        v: 1,
+        ok: true,
+        data: { resumed: true },
+      });
+      expect(resume.stderr).toBe("");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("emits safe JSON errors for no-daemon pause and resume", async () => {
+    const home = await tempHome();
+
+    for (const command of ["pause", "resume"]) {
+      const result = await runCli(home, ["sync", command, "--json"]);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expectSafeNoDaemonStderr(result.stderr, home);
+      expect(JSON.parse(result.stderr)).toEqual({
+        v: 1,
+        error: {
+          code: "daemon_unavailable",
+          message: "Sync daemon is not running.",
+        },
+      });
+    }
+  });
+
+  it("emits safe human errors for no-daemon pause and resume", async () => {
+    const home = await tempHome();
+
+    for (const command of ["pause", "resume"]) {
+      const result = await runCli(home, ["sync", command]);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expectSafeNoDaemonStderr(result.stderr, home);
+      expect(result.stderr.trim()).toBe("Error: Sync daemon is not running.");
+    }
+  });
+
+  it("does not append wrapper errors after forwarded JSON sync failures", async () => {
+    const home = await tempHome();
+
+    const result = await runCli(home, ["sync", "pause", "--json"], rootBin);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expectSafeNoDaemonStderr(result.stderr, home);
+    expect(JSON.parse(result.stderr)).toEqual({
+      v: 1,
+      error: {
+        code: "daemon_unavailable",
+        message: "Sync daemon is not running.",
+      },
+    });
+  });
+});

--- a/tests/cli/sync-json.test.ts
+++ b/tests/cli/sync-json.test.ts
@@ -71,6 +71,18 @@ async function startDaemon(home: string): Promise<Server> {
   return server;
 }
 
+async function startInvalidStatusDaemon(home: string): Promise<Server> {
+  const configDir = join(home, ".matrixos");
+  await mkdir(configDir, { recursive: true });
+  const server = createServer((socket) => {
+    socket.on("data", () => {
+      socket.write("not-json\n");
+    });
+  });
+  await listen(server, join(configDir, "daemon.sock"));
+  return server;
+}
+
 function expectSafeNoDaemonStderr(stderr: string, home: string): void {
   expect(stderr).not.toContain(home);
   expect(stderr).not.toContain(".matrixos");
@@ -157,6 +169,28 @@ describe("sync CLI JSON output", () => {
           message: "Sync daemon is not running.",
         },
       });
+    }
+  });
+
+  it("emits safe JSON when status IPC fails after the daemon probe", async () => {
+    const home = await tempHome();
+    const server = await startInvalidStatusDaemon(home);
+
+    try {
+      const result = await runCli(home, ["sync", "status", "--json"]);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expectSafeNoDaemonStderr(result.stderr, home);
+      expect(JSON.parse(result.stderr)).toEqual({
+        v: 1,
+        error: {
+          code: "sync_failed",
+          message: "Sync command failed.",
+        },
+      });
+    } finally {
+      await closeServer(server);
     }
   });
 


### PR DESCRIPTION
## Summary

- Add process-level coverage for `matrix sync status/pause/resume --json`.
- Emit versioned `formatCliSuccess` envelopes for sync status, pause, and resume.
- Emit safe `formatCliError` envelopes and safe human errors when sync daemon control commands cannot connect.
- Propagate forwarded sync CLI exit codes from the repo wrapper without appending an extra wrapper error line.

## Tests

- `pnpm exec vitest run tests/cli/sync-json.test.ts`
- `pnpm --filter @finnaai/matrix test`
- `pnpm --filter @finnaai/matrix build`
- `./scripts/review/check-patterns.sh --diff main` (0 violations; existing broad scanner warnings only)

## Review/Monitoring

- CI and Greptile will be monitored after PR creation.
- If Greptile reports below 5/5, findings will be fixed or explicitly deferred with follow-up tracking before this PR is considered ready.

## Invariants

- **Source of truth**: The sync daemon IPC response remains the source of truth for live sync status; the CLI only formats the daemon result into stable human or JSON output.
- **Lock/transaction scope**: No database, filesystem mutation, or transaction scope is introduced. Pause/resume still send one IPC command to the daemon.
- **Acceptable orphan states**: If the daemon is not reachable, the CLI reports a stable `daemon_unavailable` error and does not change daemon state. If the repo wrapper forwards a failing sync command, it propagates the child exit code without adding extra stderr.
- **Auth source of truth**: Unchanged. These sync control commands use the existing local daemon socket and do not introduce new auth behavior.
- **Deferred scope**: This PR does not change daemon pause/resume semantics, service startup, or broader CLI JSON schemas outside `sync status/pause/resume`.
