### PR TITLE
fix(cli): honor shell new attach JSON

### DIFF
--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -251,13 +251,24 @@ export const shellCommand = defineCommand({
         try {
           const client = await clientFromArgs(args);
           const data = await client.createSession(sessionCreateInput(args));
-          if (json || args.attach !== true) {
+          if (args.attach !== true) {
             console.log(json ? formatCliSuccess(data) : `Created shell session ${args.name}`);
             return;
           }
-          console.log(`Created shell session ${args.name}. Attaching...`);
-          await client.attachSession(String(args.name), attachOptionsFromArgs(args));
-          console.log(`Detached. Reattach: matrix shell connect ${args.name}`);
+          if (!json) {
+            console.log(`Created shell session ${args.name}. Attaching...`);
+          }
+          const attachOptions = attachOptionsFromArgs(args);
+          if (json) {
+            attachOptions.output = process.stderr;
+            attachOptions.errorOutput = process.stderr;
+          }
+          const result = await client.attachSession(String(args.name), attachOptions);
+          console.log(
+            json
+              ? formatCliSuccess({ created: data, detached: result.detached })
+              : `Detached. Reattach: matrix shell connect ${args.name}`,
+          );
         } catch (err) {
           writeError(err, json);
           process.exitCode = 1;

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -128,6 +128,15 @@ function attachOptionsFromArgs(args: Record<string, unknown>) {
   return options;
 }
 
+function attachOptionsForOutput(args: Record<string, unknown>, json: boolean) {
+  const options = attachOptionsFromArgs(args);
+  if (json) {
+    options.output = process.stderr;
+    options.errorOutput = process.stderr;
+  }
+  return options;
+}
+
 function sessionCreateInput(args: Record<string, unknown>) {
   return {
     name: String(args.name),
@@ -191,7 +200,7 @@ function attachCommand(name: string, description: string) {
         const client = await clientFromArgs(args);
         let result: { detached: boolean };
         try {
-          result = await client.attachSession(String(args.name), attachOptionsFromArgs(args));
+          result = await client.attachSession(String(args.name), attachOptionsForOutput(args, json));
         } catch (err) {
           const code = err instanceof Error && "code" in err
             ? (err as { code?: unknown }).code
@@ -201,11 +210,12 @@ function attachCommand(name: string, description: string) {
           }
           const data = await client.createSession(sessionCreateInput(args));
           if (json) {
-            console.log(formatCliSuccess({ created: data, attached: false }));
+            result = await client.attachSession(String(args.name), attachOptionsForOutput(args, json));
+            console.log(formatCliSuccess({ created: data, detached: result.detached }));
             return;
           }
           console.log(`Created shell session ${args.name}. Connecting...`);
-          result = await client.attachSession(String(args.name), attachOptionsFromArgs(args));
+          result = await client.attachSession(String(args.name), attachOptionsForOutput(args, json));
         }
         console.log(
           json
@@ -258,12 +268,7 @@ export const shellCommand = defineCommand({
           if (!json) {
             console.log(`Created shell session ${args.name}. Attaching...`);
           }
-          const attachOptions = attachOptionsFromArgs(args);
-          if (json) {
-            attachOptions.output = process.stderr;
-            attachOptions.errorOutput = process.stderr;
-          }
-          const result = await client.attachSession(String(args.name), attachOptions);
+          const result = await client.attachSession(String(args.name), attachOptionsForOutput(args, json));
           console.log(
             json
               ? formatCliSuccess({ created: data, detached: result.detached })

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -394,6 +394,124 @@ describe("shell CLI command", () => {
     expect(stderrWrites.join("")).toContain("REMOTE_BYTES");
   });
 
+  it("honors connect --json without writing terminal bytes to stdout", async () => {
+    class OutputWebSocket {
+      static instances = 0;
+      constructor(_url: string, _options?: unknown) {
+        OutputWebSocket.instances += 1;
+      }
+      send() {}
+      close() {}
+      on(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void) {
+        if (event === "open") {
+          queueMicrotask(() => listener());
+        }
+        if (event === "message") {
+          queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "CONNECT_BYTES" })));
+        }
+        if (event === "close") {
+          queueMicrotask(() => listener());
+        }
+        return this;
+      }
+      off() {
+        return this;
+      }
+    }
+    const logs: string[] = [];
+    const stdoutWrites: string[] = [];
+    const stderrWrites: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await shellCommand.subCommands!.connect.run!({
+      args: { name: "main", dev: true, token: "tok", json: true, WebSocketImpl: OutputWebSocket },
+    } as never);
+
+    expect(OutputWebSocket.instances).toBe(1);
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      { v: 1, ok: true, data: { detached: true } },
+    ]);
+    expect(stdoutWrites.join("")).not.toContain("CONNECT_BYTES");
+    expect(stderrWrites.join("")).toContain("CONNECT_BYTES");
+  });
+
+  it("honors connect -c --json by creating and attaching", async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (/\/api\/(?:terminal\/)?sessions$/.test(url) && init?.method === "POST") {
+        return new Response(JSON.stringify({ name: "main", created: true }), { status: 201 });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+    class CreateThenOutputWebSocket {
+      static instances = 0;
+      private readonly instance: number;
+      constructor(_url: string, _options?: unknown) {
+        CreateThenOutputWebSocket.instances += 1;
+        this.instance = CreateThenOutputWebSocket.instances;
+      }
+      send() {}
+      close() {}
+      on(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void) {
+        if (event === "open") {
+          queueMicrotask(() => listener());
+        }
+        if (event === "message" && this.instance === 1) {
+          queueMicrotask(() => listener(JSON.stringify({ type: "error", code: "session_not_found" })));
+        }
+        if (event === "message" && this.instance === 2) {
+          queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "CREATED_CONNECT_BYTES" })));
+        }
+        if (event === "close" && this.instance === 2) {
+          queueMicrotask(() => listener());
+        }
+        return this;
+      }
+      off() {
+        return this;
+      }
+    }
+    const logs: string[] = [];
+    const stdoutWrites: string[] = [];
+    const stderrWrites: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await shellCommand.subCommands!.connect.run!({
+      args: { name: "main", create: true, dev: true, token: "tok", json: true, WebSocketImpl: CreateThenOutputWebSocket },
+    } as never);
+
+    expect(CreateThenOutputWebSocket.instances).toBe(2);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/terminal\/sessions$/),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      { v: 1, ok: true, data: { created: { name: "main", created: true }, detached: true } },
+    ]);
+    expect(stdoutWrites.join("")).not.toContain("CREATED_CONNECT_BYTES");
+    expect(stderrWrites.join("")).toContain("CREATED_CONNECT_BYTES");
+  });
+
   it("creates missing sessions with connect -c", async () => {
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.endsWith("/api/sessions") && init?.method === "POST") {

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -295,6 +295,105 @@ describe("shell CLI command", () => {
     expect(logs).toEqual(["Created shell session main"]);
   });
 
+  it("attaches new shell sessions when requested", async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (/\/api\/(?:terminal\/)?sessions$/.test(url) && init?.method === "POST") {
+        return new Response(JSON.stringify({ name: "main", created: true }), { status: 201 });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+    class ClosingWebSocket {
+      static instances = 0;
+      constructor(_url: string, _options?: unknown) {
+        ClosingWebSocket.instances += 1;
+      }
+      send() {}
+      close() {}
+      on(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void) {
+        if (event === "open" || event === "close") {
+          queueMicrotask(() => listener());
+        }
+        return this;
+      }
+      off() {
+        return this;
+      }
+    }
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+
+    await shellCommand.subCommands!.new.run!({
+      args: { name: "main", attach: true, dev: true, token: "tok", WebSocketImpl: ClosingWebSocket },
+    } as never);
+
+    expect(ClosingWebSocket.instances).toBe(1);
+    expect(logs).toEqual([
+      "Created shell session main. Attaching...",
+      "Detached. Reattach: matrix shell connect main",
+    ]);
+  });
+
+  it("honors new --attach --json without writing terminal bytes to stdout", async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (/\/api\/(?:terminal\/)?sessions$/.test(url) && init?.method === "POST") {
+        return new Response(JSON.stringify({ name: "main", created: true }), { status: 201 });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+    class OutputWebSocket {
+      static instances = 0;
+      constructor(_url: string, _options?: unknown) {
+        OutputWebSocket.instances += 1;
+      }
+      send() {}
+      close() {}
+      on(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void) {
+        if (event === "open") {
+          queueMicrotask(() => listener());
+        }
+        if (event === "message") {
+          queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "REMOTE_BYTES" })));
+        }
+        if (event === "close") {
+          queueMicrotask(() => listener());
+        }
+        return this;
+      }
+      off() {
+        return this;
+      }
+    }
+    const logs: string[] = [];
+    const stdoutWrites: string[] = [];
+    const stderrWrites: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+
+    await shellCommand.subCommands!.new.run!({
+      args: { name: "main", attach: true, dev: true, token: "tok", json: true, WebSocketImpl: OutputWebSocket },
+    } as never);
+
+    expect(OutputWebSocket.instances).toBe(1);
+    expect(logs.map((line) => JSON.parse(line))).toEqual([
+      { v: 1, ok: true, data: { created: { name: "main", created: true }, detached: true } },
+    ]);
+    expect(stdoutWrites.join("")).not.toContain("REMOTE_BYTES");
+    expect(stderrWrites.join("")).toContain("REMOTE_BYTES");
+  });
+
   it("creates missing sessions with connect -c", async () => {
     const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.endsWith("/api/sessions") && init?.method === "POST") {

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -37,7 +37,8 @@ matrix doctor
 ```bash
 matrix login --profile cloud # opens a browser, completes the hosted device flow
 matrix whoami                # confirms handle, gateway, token expiry
-matrix shell new main        # creates and attaches to your "main" session
+matrix shell new main          # creates your "main" session
+matrix shell new main --attach # creates and attaches in one step
 ```
 
 If you do not have a Matrix account yet, `matrix login --profile cloud` keeps waiting while the browser walks you through signup, hosted trial checkout, and provisioning your Matrix computer. When setup finishes, approve the CLI in that same browser tab and return to your terminal.
@@ -75,16 +76,17 @@ Every Matrix OS instance ships with [zellij](https://zellij.dev) pre-installed. 
 
 ```bash
 matrix shell ls                         # list sessions
-matrix shell new code                   # create + attach
-matrix shell new code --layout dev      # use a saved layout
-matrix shell new agent --cmd "claude"   # spawn an inline command in the session
+matrix shell new code                   # create a session
+matrix shell new code --attach          # create + attach
+matrix shell new code --layout dev      # create with a saved layout
+matrix shell new agent --cmd "claude"   # create with an inline command
 matrix shell connect code               # reattach to an existing session
 matrix shell connect -c review          # create if missing, then connect
 matrix shell rm code --force            # destroy a session
 ```
 
 <Callout type="info">
-**Detaching.** Press `Ctrl-\` twice in quick succession to leave the session running and return to your shell — the same combo whether you're in `attach` or just created a session with `new`. To kill it instead, exit the shell normally inside the session or run `matrix shell rm <name>`.
+**Detaching.** Press `Ctrl-\` twice in quick succession to leave the session running and return to your shell — the same combo whether you're in `attach`, `connect`, or just created a session with `new --attach`. To kill it instead, exit the shell normally inside the session or run `matrix shell rm <name>`.
 </Callout>
 
 ### Tabs


### PR DESCRIPTION
## Summary

- Fix `matrix shell new --attach --json` so explicit attach is honored instead of returning immediately after session creation.
- Route terminal attach output/control bytes to stderr in JSON mode for `new --attach`, `connect/attach`, and `connect -c`, so stdout remains a single final versioned JSON payload.
- Update CLI docs to describe bare `shell new` as create-only and `shell new --attach` as the create-and-attach path.

## Tests

- `pnpm exec vitest run tests/cli/shell.test.ts`
- `pnpm --filter @finnaai/matrix test`
- `pnpm --filter www build`
- `pnpm run check:patterns` (0 violations; existing repo-wide warnings only)
- `pnpm --filter @finnaai/matrix build`

## Review/Monitoring

- Attempted to request review from `Nima-Naderi`; GitHub rejected it because review cannot be requested from the PR author.
- Greptile initially reported 4/5 and flagged `connect/attach --json` stdout routing; this PR now fixes that path too.
- Will continue monitoring checks and the latest Greptile review after the follow-up commit.

## Invariants

- **Source of truth**: Shell session creation and attach remain the gateway terminal session API/WebSocket; CLI docs now match runtime semantics that bare `shell new` creates only.
- **Lock/transaction scope**: No database or multi-write transaction scope changes. The CLI still creates the session first, then attaches only when `--attach` or `connect -c` requests it.
- **Acceptable orphan states**: If create succeeds and attach fails, the session may remain created. This matches existing attach behavior and lets users reattach with `matrix shell connect <name>`.
- **Auth source of truth**: CLI auth remains profile token resolution through existing `requireCliAuthToken`; no auth behavior changes.
- **Deferred scope**: This PR does not change top-level CLI flag parsing, terminal stream protocol, or default create-only runtime behavior for bare `shell new`.
