### PR TITLE
fix(cli): honor leading global flags

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,7 @@
+import { normalizeLeadingGlobalFlags } from "../../sync-client/src/cli/global-flags.js";
+
+export { normalizeLeadingGlobalFlags } from "../../sync-client/src/cli/global-flags.js";
+
 export const PUBLISHED_CLI_COMMANDS = new Set([
   "login",
   "logout",
@@ -15,9 +19,10 @@ export const PUBLISHED_CLI_COMMANDS = new Set([
 ]);
 
 export function resolvePublishedCliRedirect(argv: string[]): string[] | null {
-  const first = argv.find((arg) => !arg.startsWith("-"));
+  const normalized = normalizeLeadingGlobalFlags(argv);
+  const first = normalized.find((arg) => !arg.startsWith("-"));
   if (!first || !PUBLISHED_CLI_COMMANDS.has(first)) {
     return null;
   }
-  return argv;
+  return normalized;
 }

--- a/packages/sync-client/src/cli/global-flags.ts
+++ b/packages/sync-client/src/cli/global-flags.ts
@@ -39,7 +39,7 @@ function consumeLeadingGlobalFlag(argv: string[], index: number): string[] | nul
   }
 
   const value = argv[index + 1];
-  if (value === undefined) {
+  if (value === undefined || value.startsWith("-")) {
     return [arg];
   }
   return [arg, value];

--- a/packages/sync-client/src/cli/global-flags.ts
+++ b/packages/sync-client/src/cli/global-flags.ts
@@ -1,0 +1,66 @@
+const LEADING_BOOLEAN_GLOBAL_FLAGS = new Set([
+  "--json",
+  "--dev",
+  "--no-color",
+  "--quiet",
+  "-q",
+  "--verbose",
+  "-v",
+]);
+
+const LEADING_VALUE_GLOBAL_FLAGS = new Set([
+  "--profile",
+  "--gateway",
+  "--platform",
+  "--token",
+]);
+
+function splitOption(arg: string): string {
+  return arg.split("=", 1)[0] ?? arg;
+}
+
+function consumeLeadingGlobalFlag(argv: string[], index: number): string[] | null {
+  const arg = argv[index];
+  if (!arg) {
+    return null;
+  }
+
+  if (LEADING_BOOLEAN_GLOBAL_FLAGS.has(arg)) {
+    return [arg];
+  }
+
+  const option = splitOption(arg);
+  if (!LEADING_VALUE_GLOBAL_FLAGS.has(option)) {
+    return null;
+  }
+
+  if (arg.includes("=")) {
+    return [arg];
+  }
+
+  const value = argv[index + 1];
+  if (value === undefined) {
+    return [arg];
+  }
+  return [arg, value];
+}
+
+export function normalizeLeadingGlobalFlags(argv: string[]): string[] {
+  const leadingFlags: string[] = [];
+  let index = 0;
+
+  while (index < argv.length) {
+    const consumed = consumeLeadingGlobalFlag(argv, index);
+    if (!consumed) {
+      break;
+    }
+    leadingFlags.push(...consumed);
+    index += consumed.length;
+  }
+
+  if (leadingFlags.length === 0 || index >= argv.length) {
+    return argv;
+  }
+
+  return [...argv.slice(index), ...leadingFlags];
+}

--- a/packages/sync-client/src/cli/global-flags.ts
+++ b/packages/sync-client/src/cli/global-flags.ts
@@ -16,7 +16,7 @@ const LEADING_VALUE_GLOBAL_FLAGS = new Set([
 ]);
 
 function splitOption(arg: string): string {
-  return arg.split("=", 1)[0] ?? arg;
+  return arg.split("=", 1)[0]!;
 }
 
 function consumeLeadingGlobalFlag(argv: string[], index: number): string[] | null {

--- a/packages/sync-client/src/cli/index.ts
+++ b/packages/sync-client/src/cli/index.ts
@@ -15,6 +15,7 @@ import { runCommand } from "./commands/run.js";
 import { uploadCommand } from "./commands/upload.js";
 import { downloadCommand } from "./commands/download.js";
 import { agentCommand } from "./commands/agent.js";
+import { normalizeLeadingGlobalFlags } from "./global-flags.js";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../../package.json") as { version: string };
@@ -45,4 +46,4 @@ const main = defineCommand({
   },
 });
 
-runMain(main);
+await runMain(main, { rawArgs: normalizeLeadingGlobalFlags(process.argv.slice(2)) });

--- a/tests/cli/global-flags.test.ts
+++ b/tests/cli/global-flags.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const roots: string[] = [];
+
+async function tempHome(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "matrix-cli-global-flags-"));
+  roots.push(root);
+  return root;
+}
+
+function runCli(entry: string, args: string[], home: string) {
+  const tsxLoader = join(process.cwd(), "node_modules/tsx/dist/loader.mjs");
+  return spawnSync(process.execPath, ["--import", tsxLoader, entry, ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: home,
+      MATRIX_HOME: join(home, "matrix-home"),
+    },
+    encoding: "utf-8",
+  });
+}
+
+function firstOutputLine(output: string): string {
+  return output.trim().split("\n")[0] ?? "";
+}
+
+function expectOutput(output: string, result: ReturnType<typeof runCli>): string {
+  const first = firstOutputLine(output);
+  expect(first, JSON.stringify({
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    error: result.error?.message,
+  })).not.toBe("");
+  return first;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("CLI leading global flags", () => {
+  it("honors --json before a published profile command", async () => {
+    const home = await tempHome();
+    const bin = join(process.cwd(), "packages/sync-client/src/cli/index.ts");
+
+    const result = runCli(bin, ["--json", "profile", "ls"], home);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(expectOutput(result.stdout, result))).toEqual({
+      v: 1,
+      ok: true,
+      data: {
+        active: "cloud",
+        profiles: [
+          {
+            name: "cloud",
+            active: true,
+            platformUrl: "https://app.matrix-os.com",
+            gatewayUrl: "https://app.matrix-os.com",
+          },
+          {
+            name: "local",
+            active: false,
+            platformUrl: "http://localhost:9000",
+            gatewayUrl: "http://localhost:4000",
+          },
+        ],
+      },
+    });
+  });
+
+  it("honors --profile before a published shell command", async () => {
+    const home = await tempHome();
+    const bin = join(process.cwd(), "packages/sync-client/src/cli/index.ts");
+
+    const result = runCli(bin, ["--profile", "local", "shell", "ls", "--json"], home);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(expectOutput(result.stderr, result))).toEqual({
+      v: 1,
+      error: {
+        code: "not_authenticated",
+        message: 'Not logged in for profile "local". Run `matrix login` first.',
+      },
+    });
+  });
+
+  it("redirects root matrixos commands with leading global flags", async () => {
+    const home = await tempHome();
+    const bin = join(process.cwd(), "bin/matrixos.ts");
+
+    const result = runCli(bin, ["--json", "profile", "ls"], home);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(expectOutput(result.stdout, result)).data.active).toBe("cloud");
+  });
+});

--- a/tests/cli/global-flags.test.ts
+++ b/tests/cli/global-flags.test.ts
@@ -22,6 +22,7 @@ function runCli(entry: string, args: string[], home: string) {
       MATRIX_HOME: join(home, "matrix-home"),
     },
     encoding: "utf-8",
+    timeout: 30_000,
   });
 }
 
@@ -53,27 +54,18 @@ describe("CLI leading global flags", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
-    expect(JSON.parse(expectOutput(result.stdout, result))).toEqual({
+    const payload = JSON.parse(expectOutput(result.stdout, result));
+    expect(payload).toMatchObject({
       v: 1,
       ok: true,
       data: {
         active: "cloud",
-        profiles: [
-          {
-            name: "cloud",
-            active: true,
-            platformUrl: "https://app.matrix-os.com",
-            gatewayUrl: "https://app.matrix-os.com",
-          },
-          {
-            name: "local",
-            active: false,
-            platformUrl: "http://localhost:9000",
-            gatewayUrl: "http://localhost:4000",
-          },
-        ],
       },
     });
+    expect(payload.data.profiles.map((profile: { name: string }) => profile.name)).toEqual([
+      "cloud",
+      "local",
+    ]);
   });
 
   it("honors --profile before a published shell command", async () => {

--- a/tests/cli/unified-command-tree.test.ts
+++ b/tests/cli/unified-command-tree.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   PUBLISHED_CLI_COMMANDS,
+  normalizeLeadingGlobalFlags,
   resolvePublishedCliRedirect,
 } from "../../packages/cli/src/index.js";
 import { completionCommand } from "../../packages/sync-client/src/cli/commands/completion.js";
@@ -18,6 +19,70 @@ describe("unified CLI command tree", () => {
       "cloud",
     ]);
     expect(resolvePublishedCliRedirect(["sh", "ls"])).toEqual(["sh", "ls"]);
+  });
+
+  it("normalizes documented leading global flags before command dispatch", () => {
+    expect(normalizeLeadingGlobalFlags(["--profile", "local", "status"])).toEqual([
+      "status",
+      "--profile",
+      "local",
+    ]);
+    expect(normalizeLeadingGlobalFlags(["--json", "profile", "ls"])).toEqual([
+      "profile",
+      "ls",
+      "--json",
+    ]);
+    expect(normalizeLeadingGlobalFlags(["--profile=local", "shell", "ls"])).toEqual([
+      "shell",
+      "ls",
+      "--profile=local",
+    ]);
+    expect(normalizeLeadingGlobalFlags([
+      "--gateway",
+      "http://localhost:4000",
+      "--platform=https://app.matrix-os.com",
+      "--token",
+      "token-1",
+      "--quiet",
+      "-v",
+      "status",
+    ])).toEqual([
+      "status",
+      "--gateway",
+      "http://localhost:4000",
+      "--platform=https://app.matrix-os.com",
+      "--token",
+      "token-1",
+      "--quiet",
+      "-v",
+    ]);
+  });
+
+  it("redirects published commands when documented global flags lead", () => {
+    expect(resolvePublishedCliRedirect(["--profile", "local", "status"])).toEqual([
+      "status",
+      "--profile",
+      "local",
+    ]);
+    expect(resolvePublishedCliRedirect(["--json", "profile", "ls"])).toEqual([
+      "profile",
+      "ls",
+      "--json",
+    ]);
+    expect(resolvePublishedCliRedirect(["--profile=local", "shell", "ls"])).toEqual([
+      "shell",
+      "ls",
+      "--profile=local",
+    ]);
+  });
+
+  it("does not normalize arbitrary leading flags or development commands", () => {
+    expect(normalizeLeadingGlobalFlags(["--unknown", "profile", "ls"])).toEqual([
+      "--unknown",
+      "profile",
+      "ls",
+    ]);
+    expect(resolvePublishedCliRedirect(["--json", "start", "--shell"])).toBeNull();
   });
 
   it("keeps development-only commands out of the published redirect set", () => {

--- a/tests/cli/unified-command-tree.test.ts
+++ b/tests/cli/unified-command-tree.test.ts
@@ -56,6 +56,11 @@ describe("unified CLI command tree", () => {
       "--quiet",
       "-v",
     ]);
+    expect(normalizeLeadingGlobalFlags(["--profile", "--json", "status"])).toEqual([
+      "status",
+      "--profile",
+      "--json",
+    ]);
   });
 
   it("redirects published commands when documented global flags lead", () => {


### PR DESCRIPTION
## Summary
- Normalize documented leading CLI global flags before published CLI command dispatch.
- Apply the same normalization to root `matrixos` published-command redirects.
- Add unit and process-level regressions for leading `--profile` and `--json` forms.

## Tests
- `pnpm exec vitest run tests/cli/unified-command-tree.test.ts`
- `pnpm exec vitest run tests/cli/global-flags.test.ts`
- `pnpm --filter @finnaai/matrix test`
- `pnpm --filter @finnaai/matrix exec tsc --noEmit`
- `./scripts/review/check-patterns.sh` (0 violations, existing warnings only; run before the final one-line cleanup)
- Not run: `bun run check:patterns` and `bun run typecheck` because `bun` is not installed in this environment.

## Review/Monitoring
- Branch pushed: `codex/cli-global-flags`
- GitHub checks: passing (`check`, Vercel, Vercel Preview Comments)
- Greptile: latest trusted review is 5/5 on `1c87381a63c36015a8e5caf5de42e1072cc7569d`
- Review request: GitHub rejected `Nima-Naderi` because that account is the PR author.

## Invariants
- Source of truth: raw CLI argv remains the source of truth; normalization only reorders a documented leading global-flag prefix so existing command handlers receive the same flags they already support.
- Lock/transaction scope: no database writes, file writes, or transactions are introduced.
- Acceptable orphan states: none; this change only affects in-process argument normalization before dispatch.
- Auth source of truth: unchanged. Existing profile/auth resolution still happens in each command handler after dispatch.
- Deferred scope: this does not add new global flags or normalize arbitrary command-specific flags; unknown leading flags remain in their original order. The monorepo-only `packages/cli` import from sync-client source remains intentionally deferred instead of exposing an internal argv helper as public package API.
