### PR TITLE
docs(sync): clarify shared-folder data-plane status

### DIFF
--- a/specs/066-file-sync/contracts/sync-api.md
+++ b/specs/066-file-sync/contracts/sync-api.md
@@ -39,6 +39,8 @@ Fetch the current sync manifest for the authenticated user.
 
 **Response 401**: Invalid or missing JWT.
 
+**Status caveat**: Shared-folder manifest filtering is target behavior tracked by F19 in `../follow-ups.md`. Current `/api/sync/manifest` responses are caller-namespace only.
+
 **Headers**:
 - `ETag`: Current manifest ETag for client caching
 
@@ -96,7 +98,7 @@ const PresignRequestSchema = z.object({
 
 **Security**:
 - Every `path` is validated with `resolveWithinPrefix(userId, path)`
-- For shared folders: checks `sync_shares` table for grantee permissions
+- For shared folders *(target behavior — not yet wired; see F19 status caveat above)*: checks `sync_shares` table for grantee permissions
 - `action: "put"` requires editor or admin role on shared paths
 - `action: "get"` requires viewer or higher role on shared paths
 

--- a/specs/066-file-sync/contracts/sync-api.md
+++ b/specs/066-file-sync/contracts/sync-api.md
@@ -92,6 +92,8 @@ const PresignRequestSchema = z.object({
 **Response 403**: Path outside user's prefix or insufficient share permissions.
 **Response 429**: Rate limit exceeded (100 req/min per user).
 
+**Status caveat**: Shared-folder permission checks in this contract are target behavior tracked by F19 in `../follow-ups.md`. Current `/api/sync/presign` and `/api/sync/commit` data-plane routes are caller-namespace only.
+
 **Security**:
 - Every `path` is validated with `resolveWithinPrefix(userId, path)`
 - For shared folders: checks `sync_shares` table for grantee permissions
@@ -150,6 +152,8 @@ const CommitRequestSchema = z.object({
 **Response 400**: Validation error.
 **Response 401**: Invalid JWT.
 **Response 403**: Insufficient permissions.
+
+**Status caveat**: Shared-folder commit authorization is target behavior tracked by F19 in `../follow-ups.md`; the current commit route is caller-namespace only.
 
 **Server-side behavior**:
 1. Acquire Postgres advisory lock for user: `pg_advisory_xact_lock(hashtext(user_id))`

--- a/specs/066-file-sync/follow-ups.md
+++ b/specs/066-file-sync/follow-ups.md
@@ -47,13 +47,22 @@ macOS requires the user to turn on the Finder extension manually in System Setti
 
 ### F19. Shared-folder data plane still fail-closed
 
-Share CRUD/listing landed, but the actual presign/commit path for a grantee syncing an owner's folder is not wired yet. The current routes still operate on the caller's own namespace only; `checkSharePermission()` exists, but owner-scoped JWTs and daemon-side shared-folder plumbing have not shipped.
+Share CRUD/listing landed, but shared-folder sync is **not end-to-end** yet. The actual data plane for a grantee syncing an owner's folder is still intentionally fail-closed:
 
-Before enabling shared-folder sync:
+- `/api/sync/manifest`, `/api/sync/presign`, and `/api/sync/commit` operate on the authenticated caller's own namespace only.
+- `checkSharePermission()` exists and is unit-tested, but the data-plane routes do not call it.
+- Sync JWTs identify the caller; they do not carry a target owner/share scope.
+- The daemon parses/handles file change events only; `sync:share-invite` and `sync:access-revoked` are not mounted into a shared local tree.
+- Change broadcasts fan out to peers in one owner namespace; they do not notify authorized grantee peers for shared prefixes.
 
-- Add owner-scoped sync auth so the gateway can distinguish "caller" from "target owner" on presign/commit.
-- Wire `checkSharePermission()` into those presign/commit paths using the owner scope from the auth context.
-- Finish daemon shared-folder handling (`sync:share-invite` / `sync:access-revoked`) so accepted shares mount under `~/matrixos/shared/{owner}/...`.
+Do not implement this as one large PR. Split it into safe, reviewable slices:
+
+1. **Gateway owner-scope contract PR**: add a validated target-owner/share-scope contract for sync data-plane requests. Keep it fail-closed and covered by route tests; do not grant R2 access yet.
+2. **Gateway shared read PR**: filter owner manifests and presign GETs through accepted, unexpired shares. Grantees must only see entries under their shared prefixes.
+3. **Gateway shared write PR**: wire PUT/delete commit paths through `checkSharePermission()`, owner-scoped manifest locks, owner R2 keys, and role checks. Viewer cannot write; editor cannot delete.
+4. **WebSocket fanout PR**: deliver owner shared-prefix changes to authorized grantee peers, and stop delivery after revoke.
+5. **Daemon event/mount PR**: parse `sync:share-invite` and `sync:access-revoked`, accept/mount shared folders under `~/matrixos/shared/{owner}/...`, stop syncing on revoke, and keep local copies.
+6. **End-to-end PR**: add a full owner-share-accept-sync-edit-revoke regression covering gateway + daemon behavior.
 
 Until then, shared-folder access remains intentionally fail-closed instead of silently granting the wrong namespace.
 

--- a/specs/066-file-sync/plan.md
+++ b/specs/066-file-sync/plan.md
@@ -148,7 +148,7 @@ No constitution violations to justify.
 
 1. **Gateway auth**: Existing `authMiddleware` validates Bearer JWT on all `/api/sync/*` routes
 2. **Path validation**: `resolveWithinPrefix(userId, path)` on every file path in presign/commit requests — prevents path traversal
-3. **Scoped R2 tokens**: Per-user R2 API tokens scoped to `matrixos-sync/{userId}/*`. Share tokens scoped to shared prefix only.
+3. **Scoped R2 tokens**: Per-user R2 API tokens scoped to `matrixos-sync/{userId}/*`. Per-share scoped R2 tokens and shared-prefix data-plane access are deferred to F19 follow-up slices.
 4. **Body limits**: `bodyLimit({ maxSize: 65536 })` on all mutating sync endpoints (metadata only, no file content)
 5. **Timeouts**: `AbortSignal.timeout(10_000)` on all R2 API calls, `AbortSignal.timeout(30_000)` on presigned URL generation for large batches
 6. **Rate limiting**: Per-user rate limits on presign requests (100 req/min) to prevent URL farming
@@ -160,7 +160,7 @@ No constitution violations to justify.
 |-------|---------|-------|--------|------------|
 | **1** | `packages/gateway` | Sync engine core: R2 presigned URL generation, manifest management (Postgres-backed versioning), sync routes (`/api/sync/*`), WebSocket events (`sync:*`), conflict detection | DONE | — |
 | **2** | `packages/sync-client` | CLI + daemon: `matrixos` CLI (citty), background daemon (chokidar + WS client + R2 presigned upload/download), launchd/systemd service management, Unix socket IPC | DONE (login broken pending Phase 6) | Phase 1 |
-| **3** | `packages/gateway` + `packages/sync-client` | Sharing: Postgres permissions table, scoped R2 tokens, invite notifications | GATEWAY DONE; CLI commands + daemon event handling pending (T052-T054) | Phase 1, 2 |
+| **3** | `packages/gateway` + `packages/sync-client` | Sharing: Postgres permissions table, scoped R2 tokens, invite notifications | GATEWAY DONE for control-plane; per-share scoped tokens and shared-prefix data-plane access deferred to F19; CLI commands + daemon event handling pending (T052-T054) | Phase 1, 2 |
 | **4** | `packages/gateway` + `packages/sync-client` | Shell access: zellij-backed `matrixos shell` over the gateway terminal WebSocket | DONE | Phase 2 (auth) |
 | **5** | `packages/sync-client/macos` | Mac menu bar app: Swift/SwiftUI, daemon communication via Unix socket | DONE (notifications pending T063) | Phase 2 |
 | **6 (NEW)** | `packages/platform` + gateway + sync-client | OAuth 2.0 Device Flow on platform service: device code endpoints, JWT issuance, gateway JWT validation, replace stub auth with real Clerk-backed login | NOT STARTED -- see Phase 9 in tasks.md (T071-T092) | Phase 2 |

--- a/specs/066-file-sync/spec.md
+++ b/specs/066-file-sync/spec.md
@@ -255,6 +255,8 @@ R2 Token: share-xyz        -> scoped to matrixos-sync/hamed/files/projects/start
 
 ## 4. Sharing & Collaboration
 
+**Status caveat**: This section describes the target shared-folder data-plane behavior tracked by F19 in `follow-ups.md`. Current shipped behavior is share CRUD/list/accept/revoke only; `/manifest`, `/presign`, `/commit`, daemon shared mounts, and revoke handling are not end-to-end yet.
+
 ### Sharing Model
 
 Sharing is an access grant on an existing path within the owner's R2 prefix. No file duplication.

--- a/specs/066-file-sync/spec.md
+++ b/specs/066-file-sync/spec.md
@@ -264,7 +264,7 @@ Sharing is an access grant on an existing path within the owner's R2 prefix. No 
 ### Sharing Flow
 
 1. Owner runs `matrixos share projects/startup/ @colleague:matrix-os.com --role editor`
-2. Gateway inserts row in sharing permissions table (Postgres), generates scoped R2 token
+2. Gateway inserts row in sharing permissions table (Postgres) *(scoped R2 token generation deferred to F19 slice 3)*
 3. Colleague gets a notification (WebSocket `sync:share-invite` + shell notification)
 4. Colleague accepts; their daemon adds the shared folder to their local tree at `~/matrixos/shared/hamed/projects/startup/`
 5. Both peers' daemons sync that subtree bidirectionally

--- a/specs/066-file-sync/tasks.md
+++ b/specs/066-file-sync/tasks.md
@@ -133,18 +133,25 @@
 
 ### Tests for US3
 
-- [x] T048 [P] [US3] Unit tests for sharing CRUD in `tests/gateway/sync/sharing.test.ts` (create share, accept share, revoke share, list shares, reject self-share, enforce UNIQUE constraint, check expiry, role enforcement for presign/commit)
-- [x] T049 [P] [US3] Contract tests for sharing endpoints in `tests/gateway/sync/routes.test.ts` (POST /share returns 201, POST /share/accept returns 200, DELETE /share revokes + sends WS event, GET /shares lists owned and received, 403 on insufficient role, 404 on unknown grantee, 409 on duplicate share)
+- [x] T048 [P] [US3] Unit tests for sharing CRUD in `tests/gateway/sync/sharing.test.ts` (create share, accept share, revoke share, list shares, reject self-share, enforce UNIQUE constraint, check expiry, and validate `checkSharePermission()` role decisions in isolation)
+- [x] T049 [P] [US3] Contract tests for sharing control-plane endpoints in `tests/gateway/sync/routes.test.ts` (POST /share returns 201, POST /share/accept returns 200, DELETE /share revokes, GET /shares lists owned and received, and authz/not-found/validation paths return safe errors)
 
 ### Implementation for US3
 
-- [x] T050 [US3] Implement sharing service in `packages/gateway/src/sync/sharing.ts` (createShare: insert into sync_shares + generate scoped R2 token + broadcast sync:share-invite WS event, acceptShare: update accepted=true, revokeShare: delete row + invalidate token + broadcast sync:access-revoked, listShares: query owned + received, checkSharePermission: validate grantee has required role for path)
-- [x] T051 [US3] Implement sharing REST routes in `packages/gateway/src/sync/routes.ts` (add POST /share, DELETE /share, POST /share/accept, GET /shares routes -- all per contracts/sync-api.md, integrate checkSharePermission into presign/commit routes for shared path access)
+- [x] T050 [US3] Implement sharing service in `packages/gateway/src/sync/sharing.ts` (createShare: insert into sync_shares + broadcast sync:share-invite WS event, acceptShare: update accepted=true, revokeShare: delete row + broadcast sync:access-revoked, listShares: query owned + received, checkSharePermission: validate grantee has required role for path)
+- [x] T051 [US3] Implement sharing control-plane REST routes in `packages/gateway/src/sync/routes.ts` (add POST /share, DELETE /share, POST /share/accept, GET /shares routes). **Data-plane integration is not done**: `/manifest`, `/presign`, and `/commit` remain caller-namespace only; see F19 in `specs/066-file-sync/follow-ups.md`.
 - [ ] T052 [US3] Implement `matrixos share` command in `packages/sync-client/src/cli/commands/share.ts` (positional path + handle args, --role flag default editor, call POST /api/sync/share) -- **NOT STARTED**: file does not exist
 - [ ] T053 [US3] Implement `matrixos unshare` command in `packages/sync-client/src/cli/commands/share.ts` (positional path + handle args, call DELETE /api/sync/share) -- **NOT STARTED**
 - [ ] T054 [US3] Handle share events in daemon in `packages/sync-client/src/daemon/sync-engine.ts` (on sync:share-invite: prompt user or auto-accept per config, add shared folder to sync tree at ~/matrixos/shared/{owner}/{path}/, on sync:access-revoked: stop syncing shared folder, keep local copy) -- **NOT STARTED**: daemon doesn't handle share WS events yet
 
-**Checkpoint**: Sharing works end-to-end. Share a folder, colleague syncs it, edits propagate bidirectionally, revocation stops sync.
+**Shared data-plane follow-up slices** (unnumbered; see F19 in `specs/066-file-sync/follow-ups.md`):
+- [ ] Define owner-scoped shared sync data-plane contract (caller principal + target owner/share scope) with fail-closed route tests before granting access.
+- [ ] Wire shared manifest and presign GET access through accepted, unexpired shares and filtered owner manifests.
+- [ ] Wire shared PUT/delete commits through `checkSharePermission()`, owner-scoped manifest locks, owner R2 keys, and role-specific write/delete checks.
+- [ ] Broadcast owner shared-prefix changes to authorized grantee peers and stop fanout after revoke.
+- [ ] Add an end-to-end shared-folder regression covering owner share, grantee accept, download, edit propagation, and revoke.
+
+**Checkpoint**: Sharing works end-to-end only after T052-T054 and the F19 shared data-plane follow-up slices. Share a folder, colleague syncs it, edits propagate bidirectionally, revocation stops sync. Current status is control-plane only; the shared-folder data plane remains intentionally fail-closed.
 
 ---
 
@@ -493,8 +500,9 @@ With multiple agents:
 4. **T112 tail** -- home-mirror tests landed; still owe `packages/sync-client/tests/unit/initial-pull.test.ts` for the daemon's initial-pull path.
 5. **T052/T053 (share CLI)** -- gateway endpoints work; CLI commands missing.
 6. **T054 (share events in daemon)** -- daemon ignores `sync:share-invite` and `sync:access-revoked` WS events.
-7. **T064 (tombstone GC scheduler)** -- function exists but never called periodically.
-8. **T063 (Mac app notifications)** -- menu bar app shows status but doesn't post Notification Center alerts.
+7. **Shared-folder data plane (F19)** -- gateway manifest/presign/commit and WS fanout are still caller-namespace only; split according to F19 before enabling shared-folder sync.
+8. **T064 (tombstone GC scheduler)** -- function exists but never called periodically.
+9. **T063 (Mac app notifications)** -- menu bar app shows status but doesn't post Notification Center alerts.
 
 ## Notes
 

--- a/specs/066-file-sync/tasks.md
+++ b/specs/066-file-sync/tasks.md
@@ -138,7 +138,7 @@
 
 ### Implementation for US3
 
-- [x] T050 [US3] Implement sharing service in `packages/gateway/src/sync/sharing.ts` (createShare: insert into sync_shares + broadcast sync:share-invite WS event, acceptShare: update accepted=true, revokeShare: delete row + broadcast sync:access-revoked, listShares: query owned + received, checkSharePermission: validate grantee has required role for path)
+- [x] T050 [US3] Implement sharing service in `packages/gateway/src/sync/sharing.ts` (createShare: insert into sync_shares + broadcast sync:share-invite WS event, acceptShare: update accepted=true, revokeShare: delete row + broadcast sync:access-revoked, listShares: query owned + received, checkSharePermission: validate grantee has required role for path). Scoped-per-share R2 token generation is deferred to F19 slice 3.
 - [x] T051 [US3] Implement sharing control-plane REST routes in `packages/gateway/src/sync/routes.ts` (add POST /share, DELETE /share, POST /share/accept, GET /shares routes). **Data-plane integration is not done**: `/manifest`, `/presign`, and `/commit` remain caller-namespace only; see F19 in `specs/066-file-sync/follow-ups.md`.
 - [ ] T052 [US3] Implement `matrixos share` command in `packages/sync-client/src/cli/commands/share.ts` (positional path + handle args, --role flag default editor, call POST /api/sync/share) -- **NOT STARTED**: file does not exist
 - [ ] T053 [US3] Implement `matrixos unshare` command in `packages/sync-client/src/cli/commands/share.ts` (positional path + handle args, call DELETE /api/sync/share) -- **NOT STARTED**
@@ -149,6 +149,7 @@
 - [ ] Wire shared manifest and presign GET access through accepted, unexpired shares and filtered owner manifests.
 - [ ] Wire shared PUT/delete commits through `checkSharePermission()`, owner-scoped manifest locks, owner R2 keys, and role-specific write/delete checks.
 - [ ] Broadcast owner shared-prefix changes to authorized grantee peers and stop fanout after revoke.
+- [ ] Parse `sync:share-invite` and `sync:access-revoked` in the daemon, mount accepted shares under `~/matrixos/shared/{owner}/...`, stop syncing on revoke, and keep local copies.
 - [ ] Add an end-to-end shared-folder regression covering owner share, grantee accept, download, edit propagation, and revoke.
 
 **Checkpoint**: Sharing works end-to-end only after T052-T054 and the F19 shared data-plane follow-up slices. Share a folder, colleague syncs it, edits propagate bidirectionally, revocation stops sync. Current status is control-plane only; the shared-folder data plane remains intentionally fail-closed.


### PR DESCRIPTION
Summary
- Documents that shared-folder sync currently has only the share control plane and intentionally fail-closed data-plane behavior.
- Adds unnumbered follow-up slices for owner-scoped contract, shared reads/writes/deletes, grantee fanout, revoke behavior, and E2E coverage.

Tests
- git diff --check

Review
- Problem statement, plan, and final verification comments are prepared but could not be posted if GitHub auth blocks this command.

Invariants
- Source of truth: docs/spec tasks only; no runtime behavior changed.
- Lock/transaction scope: not applicable.
- Acceptable orphan states: not applicable.
- Auth source of truth: documents existing caller-namespace JWT behavior as current limitation.
- Deferred scope: actual shared data-plane implementation remains follow-up work.