### PR TITLE
fix(vps): bound matrixctl r2 aws operations

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -644,10 +644,12 @@ write_files:
       check_r2_exists_or_skip_restore() {
         local key="$1"
         local label="$2"
+        local status
         if /opt/matrix/bin/matrixctl r2 exists "$key"; then
           return 0
+        else
+          status="$?"
         fi
-        local status="$?"
         if [ "$status" -eq 1 ]; then
           touch "$restore_flag"
           exit 0

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -349,6 +349,9 @@ write_files:
       R2_ACCOUNT_ID="${R2_ACCOUNT_ID:-}"
       MATRIX_PLATFORM_URL="${MATRIX_PLATFORM_URL:-${PLATFORM_URL:-}}"
       MATRIX_PLATFORM_TOKEN="${MATRIX_PLATFORM_TOKEN:-${PLATFORM_TOKEN:-}}"
+      MATRIX_R2_OPERATION_TIMEOUT_SECONDS="${MATRIX_R2_OPERATION_TIMEOUT_SECONDS:-300}"
+      MATRIX_R2_CONNECT_TIMEOUT_SECONDS="${MATRIX_R2_CONNECT_TIMEOUT_SECONDS:-10}"
+      MATRIX_R2_READ_TIMEOUT_SECONDS="${MATRIX_R2_READ_TIMEOUT_SECONDS:-60}"
 
       usage() {
         echo "usage: matrixctl r2 <put|get|exists|put-latest|prune> ..." >&2
@@ -393,11 +396,11 @@ write_files:
       aws_s3() {
         local endpoint
         endpoint="$(r2_endpoint_arg)"
+        local args=(--cli-connect-timeout "$MATRIX_R2_CONNECT_TIMEOUT_SECONDS" --cli-read-timeout "$MATRIX_R2_READ_TIMEOUT_SECONDS")
         if [ -n "$endpoint" ]; then
-          aws --endpoint-url "$endpoint" "$@"
-        else
-          aws "$@"
+          args=(--endpoint-url "$endpoint" "${args[@]}")
         fi
+        timeout --preserve-status "$MATRIX_R2_OPERATION_TIMEOUT_SECONDS" aws "${args[@]}" "$@"
       }
 
       r2_put() {

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -423,12 +423,29 @@ write_files:
       }
 
       r2_exists() {
-        local key
+        local key output status
         key="$(full_key "$1")"
-        if aws_s3 s3api head-object --bucket "$R2_BUCKET" --key "$key" >/dev/null 2>&1; then
+        if output="$(aws_s3 s3api head-object --bucket "$R2_BUCKET" --key "$key" 2>&1 >/dev/null)"; then
           return 0
+        else
+          status="$?"
         fi
-        return 1
+        case "$status" in
+          124|143)
+            echo "matrixctl: r2 exists timed out" >&2
+            return "$status"
+            ;;
+        esac
+        case "$output" in
+          *"(404)"*|*"Not Found"*|*"NotFound"*|*"NoSuchKey"*)
+            return 1
+            ;;
+        esac
+        echo "matrixctl: r2 exists failed" >&2
+        if [ "$status" -eq 1 ]; then
+          return 2
+        fi
+        return "$status"
       }
 
       r2_put_latest() {
@@ -624,15 +641,23 @@ write_files:
       mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
       rm -f "$restore_flag"
 
-      if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then
-        touch "$restore_flag"
-        exit 0
-      fi
+      check_r2_exists_or_skip_restore() {
+        local key="$1"
+        local label="$2"
+        if /opt/matrix/bin/matrixctl r2 exists "$key"; then
+          return 0
+        fi
+        local status="$?"
+        if [ "$status" -eq 1 ]; then
+          touch "$restore_flag"
+          exit 0
+        fi
+        echo "matrix-restore: failed to check ${label}" >&2
+        exit 1
+      }
 
-      if ! /opt/matrix/bin/matrixctl r2 exists "$latest_pointer_key"; then
-        touch "$restore_flag"
-        exit 0
-      fi
+      check_r2_exists_or_skip_restore system/vps-meta.json "VPS metadata"
+      check_r2_exists_or_skip_restore "$latest_pointer_key" "latest snapshot pointer"
 
       if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then
         echo "matrix-restore: failed to fetch latest pointer" >&2

--- a/distro/customer-vps/matrix-restore.sh
+++ b/distro/customer-vps/matrix-restore.sh
@@ -24,15 +24,23 @@ fi
 mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db
 rm -f "$restore_flag"
 
-if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then
-  touch "$restore_flag"
-  exit 0
-fi
+check_r2_exists_or_skip_restore() {
+  local key="$1"
+  local label="$2"
+  if /opt/matrix/bin/matrixctl r2 exists "$key"; then
+    return 0
+  fi
+  local status="$?"
+  if [ "$status" -eq 1 ]; then
+    touch "$restore_flag"
+    exit 0
+  fi
+  echo "matrix-restore: failed to check ${label}" >&2
+  exit 1
+}
 
-if ! /opt/matrix/bin/matrixctl r2 exists "$latest_pointer_key"; then
-  touch "$restore_flag"
-  exit 0
-fi
+check_r2_exists_or_skip_restore system/vps-meta.json "VPS metadata"
+check_r2_exists_or_skip_restore "$latest_pointer_key" "latest snapshot pointer"
 
 if ! /opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"; then
   echo "matrix-restore: failed to fetch latest pointer" >&2

--- a/distro/customer-vps/matrix-restore.sh
+++ b/distro/customer-vps/matrix-restore.sh
@@ -27,10 +27,12 @@ rm -f "$restore_flag"
 check_r2_exists_or_skip_restore() {
   local key="$1"
   local label="$2"
+  local status
   if /opt/matrix/bin/matrixctl r2 exists "$key"; then
     return 0
+  else
+    status="$?"
   fi
-  local status="$?"
   if [ "$status" -eq 1 ]; then
     touch "$restore_flag"
     exit 0

--- a/distro/customer-vps/matrixctl
+++ b/distro/customer-vps/matrixctl
@@ -99,12 +99,29 @@ r2_get() {
 }
 
 r2_exists() {
-  local key
+  local key output status
   key="$(full_key "$1")"
-  if aws_s3 s3api head-object --bucket "$R2_BUCKET" --key "$key" >/dev/null 2>&1; then
+  if output="$(aws_s3 s3api head-object --bucket "$R2_BUCKET" --key "$key" 2>&1 >/dev/null)"; then
     return 0
+  else
+    status="$?"
   fi
-  return 1
+  case "$status" in
+    124|143)
+      echo "matrixctl: r2 exists timed out" >&2
+      return "$status"
+      ;;
+  esac
+  case "$output" in
+    *"(404)"*|*"Not Found"*|*"NotFound"*|*"NoSuchKey"*)
+      return 1
+      ;;
+  esac
+  echo "matrixctl: r2 exists failed" >&2
+  if [ "$status" -eq 1 ]; then
+    return 2
+  fi
+  return "$status"
 }
 
 r2_put_latest() {

--- a/distro/customer-vps/matrixctl
+++ b/distro/customer-vps/matrixctl
@@ -24,6 +24,9 @@ R2_ENDPOINT="${R2_ENDPOINT:-}"
 R2_ACCOUNT_ID="${R2_ACCOUNT_ID:-}"
 MATRIX_PLATFORM_URL="${MATRIX_PLATFORM_URL:-${PLATFORM_URL:-}}"
 MATRIX_PLATFORM_TOKEN="${MATRIX_PLATFORM_TOKEN:-${PLATFORM_TOKEN:-}}"
+MATRIX_R2_OPERATION_TIMEOUT_SECONDS="${MATRIX_R2_OPERATION_TIMEOUT_SECONDS:-300}"
+MATRIX_R2_CONNECT_TIMEOUT_SECONDS="${MATRIX_R2_CONNECT_TIMEOUT_SECONDS:-10}"
+MATRIX_R2_READ_TIMEOUT_SECONDS="${MATRIX_R2_READ_TIMEOUT_SECONDS:-60}"
 
 usage() {
   echo "usage: matrixctl r2 <put|get|exists|put-latest|prune> ..." >&2
@@ -69,11 +72,11 @@ full_key() {
 aws_s3() {
   local endpoint
   endpoint="$(r2_endpoint_arg)"
+  local args=(--cli-connect-timeout "$MATRIX_R2_CONNECT_TIMEOUT_SECONDS" --cli-read-timeout "$MATRIX_R2_READ_TIMEOUT_SECONDS")
   if [ -n "$endpoint" ]; then
-    aws --endpoint-url "$endpoint" "$@"
-  else
-    aws "$@"
+    args=(--endpoint-url "$endpoint" "${args[@]}")
   fi
+  timeout --preserve-status "$MATRIX_R2_OPERATION_TIMEOUT_SECONDS" aws "${args[@]}" "$@"
 }
 
 r2_put() {

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -59,6 +59,56 @@ describe('platform/customer-vps-cloud-init', () => {
           R2_ENDPOINT: 'https://r2.example',
         },
       });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  function runRestoreWithFakeMatrixctl(existsStatus: number) {
+    const root = process.cwd();
+    const tempDir = mkdtempSync(join(tmpdir(), 'second-restore-r2-'));
+    const fakeMatrixctlPath = join(tempDir, 'matrixctl');
+    const restorePath = join(tempDir, 'matrix-restore.sh');
+    const restoreFlag = join(tempDir, 'restore-complete');
+
+    writeFileSync(
+      fakeMatrixctlPath,
+      `#!/usr/bin/env bash
+if [ "$1" = "r2" ] && [ "$2" = "exists" ]; then
+  exit ${existsStatus}
+fi
+echo "unexpected matrixctl call: $*" >&2
+exit 99
+`,
+    );
+    chmodSync(fakeMatrixctlPath, 0o755);
+
+    const restoreScript = readFileSync(join(root, 'distro/customer-vps/matrix-restore.sh'), 'utf8')
+      .split('/opt/matrix/bin/matrixctl')
+      .join(fakeMatrixctlPath)
+      .replace('restore_flag="/opt/matrix/restore-complete"', `restore_flag=${JSON.stringify(restoreFlag)}`)
+      .replace('latest_file="/var/lib/matrix/db/latest"', `latest_file=${JSON.stringify(join(tempDir, 'latest'))}`)
+      .replace('snapshot_path="/var/lib/matrix/db/latest.dump"', `snapshot_path=${JSON.stringify(join(tempDir, 'latest.dump'))}`)
+      .replace(
+        'mkdir -p /home/matrix/home /home/matrix/projects /var/lib/matrix/db',
+        'mkdir -p "$SECOND_RESTORE_TEST_ROOT/home" "$SECOND_RESTORE_TEST_ROOT/projects" "$SECOND_RESTORE_TEST_ROOT/db"',
+      );
+    writeFileSync(restorePath, restoreScript);
+    chmodSync(restorePath, 0o755);
+
+    try {
+      const result = spawnSync('bash', [restorePath], {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          SECOND_RESTORE_TEST_ROOT: tempDir,
+        },
+      });
+      return {
+        result,
+        restoreFlagExists: existsSync(restoreFlag),
+      };
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -424,13 +474,30 @@ describe('platform/customer-vps-cloud-init', () => {
 
     for (const script of [restore, cloudInit]) {
       expect(script).toContain('check_r2_exists_or_skip_restore()');
-      expect(script).toContain('local status="$?"');
+      expect(script).toContain('local status');
+      expect(script).toMatch(/else\n\s+status="\$[?]"/);
       expect(script).toContain('if [ "$status" -eq 1 ]; then');
       expect(script).toContain('touch "$restore_flag"');
       expect(script).toContain('matrix-restore: failed to check');
       expect(script).not.toContain('if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then');
       expect(script).not.toContain('if ! /opt/matrix/bin/matrixctl r2 exists "$latest_pointer_key"; then');
     }
+  });
+
+  it('executes restore skip only for not-found R2 exists status', () => {
+    const notFound = runRestoreWithFakeMatrixctl(1);
+    expect(notFound.result.status, notFound.result.stderr).toBe(0);
+    expect(notFound.restoreFlagExists).toBe(true);
+
+    const timeout = runRestoreWithFakeMatrixctl(124);
+    expect(timeout.result.status).toBe(1);
+    expect(timeout.restoreFlagExists).toBe(false);
+    expect(timeout.result.stderr).toContain('matrix-restore: failed to check VPS metadata');
+
+    const operationalError = runRestoreWithFakeMatrixctl(2);
+    expect(operationalError.result.status).toBe(1);
+    expect(operationalError.restoreFlagExists).toBe(false);
+    expect(operationalError.result.stderr).toContain('matrix-restore: failed to check VPS metadata');
   });
 
   it('runs DB backup on an hourly systemd timer', () => {

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { parseDocument } from 'yaml';
 import {
   loadCustomerVpsCloudInitTemplate,
@@ -34,6 +36,33 @@ describe('platform/customer-vps-cloud-init', () => {
     posthogHost: 'https://eu.i.posthog.com',
     posthogApiHost: '/ingest',
   };
+
+  function runMatrixctlExistsWithFakeAws(exitCode: number, stderr: string) {
+    const root = process.cwd();
+    const tempDir = mkdtempSync(join(tmpdir(), 'second-matrixctl-r2-'));
+    const fakeAwsPath = join(tempDir, 'aws');
+    writeFileSync(
+      fakeAwsPath,
+      `#!/usr/bin/env bash\nprintf '%s\\n' ${JSON.stringify(stderr)} >&2\nexit ${exitCode}\n`,
+    );
+    chmodSync(fakeAwsPath, 0o755);
+
+    try {
+      return spawnSync('bash', [join(root, 'distro/customer-vps/matrixctl'), 'r2', 'exists', 'system/db/latest'], {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${tempDir}:${process.env.PATH ?? ''}`,
+          R2_BUCKET: 'matrixos-sync',
+          R2_PREFIX: 'matrixos-sync/user_123/',
+          R2_ENDPOINT: 'https://r2.example',
+        },
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
 
   it('renders required host variables into the cloud-init template', () => {
     const rendered = renderCloudInitTemplate(
@@ -388,6 +417,22 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(gateway).toContain('ConditionPathExists=/opt/matrix/restore-complete');
   });
 
+  it('only skips restore on confirmed missing R2 backup markers', () => {
+    const root = process.cwd();
+    const restore = readFileSync(join(root, 'distro/customer-vps/matrix-restore.sh'), 'utf8');
+    const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
+
+    for (const script of [restore, cloudInit]) {
+      expect(script).toContain('check_r2_exists_or_skip_restore()');
+      expect(script).toContain('local status="$?"');
+      expect(script).toContain('if [ "$status" -eq 1 ]; then');
+      expect(script).toContain('touch "$restore_flag"');
+      expect(script).toContain('matrix-restore: failed to check');
+      expect(script).not.toContain('if ! /opt/matrix/bin/matrixctl r2 exists system/vps-meta.json; then');
+      expect(script).not.toContain('if ! /opt/matrix/bin/matrixctl r2 exists "$latest_pointer_key"; then');
+    }
+  });
+
   it('runs DB backup on an hourly systemd timer', () => {
     const root = process.cwd();
     const service = readFileSync(join(root, 'distro/customer-vps/systemd/matrix-db-backup.service'), 'utf8');
@@ -451,5 +496,21 @@ describe('platform/customer-vps-cloud-init', () => {
       expect(script).toContain('aws_s3 s3 cp "s3://${R2_BUCKET}/${key}" "$dest"');
       expect(script).toContain('aws_s3 s3api head-object --bucket "$R2_BUCKET" --key "$key"');
     }
+  });
+
+  it('keeps matrixctl R2 exists timeouts distinct from not-found', () => {
+    const timeoutResult = runMatrixctlExistsWithFakeAws(124, 'timed out');
+    expect(timeoutResult.status).toBe(124);
+    expect(timeoutResult.stderr).toContain('matrixctl: r2 exists timed out');
+
+    const terminatedResult = runMatrixctlExistsWithFakeAws(143, 'terminated');
+    expect(terminatedResult.status).toBe(143);
+    expect(terminatedResult.stderr).toContain('matrixctl: r2 exists timed out');
+
+    const notFoundResult = runMatrixctlExistsWithFakeAws(
+      255,
+      'An error occurred (404) when calling the HeadObject operation: Not Found',
+    );
+    expect(notFoundResult.status).toBe(1);
   });
 });

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -434,4 +434,22 @@ describe('platform/customer-vps-cloud-init', () => {
     expect(cloudInit).toContain('""|[!a-z0-9]*|*[^a-z0-9-]*|*-) fail "invalid runtime slot"');
     expect(cloudInit).toContain('{"clerkUserId":"%s","runtimeSlot":"%s","allowEmpty":%s}');
   });
+
+  it('bounds matrixctl R2 aws operations in host scripts and cloud-init', () => {
+    const root = process.cwd();
+    const matrixctl = readFileSync(join(root, 'distro/customer-vps/matrixctl'), 'utf8');
+    const cloudInit = readFileSync(join(root, 'distro/customer-vps/cloud-init.yaml'), 'utf8');
+
+    for (const script of [matrixctl, cloudInit]) {
+      expect(script).toContain('MATRIX_R2_OPERATION_TIMEOUT_SECONDS="${MATRIX_R2_OPERATION_TIMEOUT_SECONDS:-300}"');
+      expect(script).toContain('MATRIX_R2_CONNECT_TIMEOUT_SECONDS="${MATRIX_R2_CONNECT_TIMEOUT_SECONDS:-10}"');
+      expect(script).toContain('MATRIX_R2_READ_TIMEOUT_SECONDS="${MATRIX_R2_READ_TIMEOUT_SECONDS:-60}"');
+      expect(script).toContain('timeout --preserve-status "$MATRIX_R2_OPERATION_TIMEOUT_SECONDS"');
+      expect(script).toContain('--cli-connect-timeout "$MATRIX_R2_CONNECT_TIMEOUT_SECONDS"');
+      expect(script).toContain('--cli-read-timeout "$MATRIX_R2_READ_TIMEOUT_SECONDS"');
+      expect(script).toContain('aws_s3 s3 cp "$src" "s3://${R2_BUCKET}/${key}"');
+      expect(script).toContain('aws_s3 s3 cp "s3://${R2_BUCKET}/${key}" "$dest"');
+      expect(script).toContain('aws_s3 s3api head-object --bucket "$R2_BUCKET" --key "$key"');
+    }
+  });
 });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -444,7 +444,8 @@ describe('customer VPS host bundle', () => {
     const root = process.cwd();
     const restore = readFileSync(join(root, 'distro/customer-vps/matrix-restore.sh'), 'utf8');
 
-    expect(restore).toContain('/opt/matrix/bin/matrixctl r2 exists system/vps-meta.json');
+    expect(restore).toContain('if /opt/matrix/bin/matrixctl r2 exists "$key"; then');
+    expect(restore).toContain('check_r2_exists_or_skip_restore system/vps-meta.json "VPS metadata"');
     expect(restore).toContain('latest_pointer_key="system/db/latest"');
     expect(restore).toContain('/opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"');
   });


### PR DESCRIPTION
Summary
- Adds total operation, connect, and read deadlines to matrixctl R2 aws s3api operations.
- Routes matrixctl put/get/exists through the bounded aws_s3 wrapper in both matrixctl and cloud-init template.
- Adds tests to keep customer VPS R2 operations from regressing to unbounded AWS CLI calls.

Tests
- pnpm exec vitest run tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts
- bash -n distro/customer-vps/matrixctl distro/customer-vps/matrix-db-backup.sh distro/customer-vps/matrix-restore.sh
- pnpm run check:patterns

Review
- Problem statement, plan, and final verification comments will be posted separately.

Invariants
- Source of truth: R2 remains the remote backup object store; local backup files remain temporary staging artifacts.
- Lock/transaction scope: no DB transaction changes; this only bounds external AWS CLI calls.
- Acceptable orphan states: a timed-out upload/download may leave the same partial failure modes AWS CLI already had, but backup scripts fail instead of hanging indefinitely.
- Auth source of truth: existing R2 credentials and endpoint configuration are unchanged.
- Deferred scope: no retry/backoff or multipart backup upload redesign in this slice.