### PR TITLE
fix(sync-client): scale daemon initial pull downloads

### DIFF
--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -38,9 +38,12 @@ import {
   fetchManifest,
   AuthRejectedError,
   VersionConflictError,
+  type GatewayClient,
+  type PresignedUrl,
 } from "./r2-client.js";
 import {
   RemoteManifestEnvelopeSchema,
+  type ManifestEntry,
   type LocalFileState,
   type RemoteManifestEnvelope,
   type SyncChangeEvent,
@@ -53,6 +56,9 @@ const socketPath = join(configDir, "daemon.sock");
 const pidFile = join(configDir, "daemon.pid");
 const SYNC_STATE_FILE_CAP = 50_000;
 const SYNC_STATE_CONFLICT_CAP = 500;
+const INITIAL_PULL_PRESIGN_BATCH_SIZE = 100;
+const INITIAL_PULL_CONCURRENCY = 4;
+const INITIAL_PULL_PROGRESS_EVERY = 100;
 
 interface PollLogger {
   info: (msg: string) => void;
@@ -876,6 +882,195 @@ export function parseRemoteManifestEnvelope(body: unknown): RemoteManifestEnvelo
   return parsed.data;
 }
 
+export interface InitialPullLogger {
+  info: (obj: unknown, msg?: string) => void;
+  warn: (obj: unknown, msg?: string) => void;
+  error: (obj: unknown, msg?: string) => void;
+}
+
+export interface InitialPullOptions {
+  gatewayClient: GatewayClient;
+  syncRoot: string;
+  syncState: SyncState;
+  remoteFiles: Record<string, ManifestEntry>;
+  toLocal: (remotePath: string) => string | null;
+  toRemote: (localRel: string) => string;
+  logger: InitialPullLogger;
+  requestPresignedUrls?: typeof requestPresignedUrls;
+  reconcileRemoteFileChange?: typeof reconcileRemoteFileChange;
+  downloadFile?: typeof downloadFile;
+  saveSyncState: () => Promise<void>;
+  refreshConflictCopyPathIndex: () => void;
+  concurrency?: number;
+  presignBatchSize?: number;
+  progressEvery?: number;
+}
+
+export interface InitialPullResult {
+  pulled: number;
+  skipped: number;
+  failed: number;
+}
+
+interface InitialPullFile {
+  remotePath: string;
+  localRel: string;
+  entry: ManifestEntry;
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  const limit = Math.max(1, Math.floor(concurrency));
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      for (;;) {
+        const index = nextIndex++;
+        const item = items[index];
+        if (!item) {
+          return;
+        }
+        await worker(item);
+      }
+    },
+  );
+  await Promise.all(workers);
+}
+
+function chunkInitialPullFiles(
+  files: InitialPullFile[],
+  chunkSize: number,
+): InitialPullFile[][] {
+  const size = Math.max(1, Math.floor(chunkSize));
+  const chunks: InitialPullFile[][] = [];
+  for (let start = 0; start < files.length; start += size) {
+    chunks.push(files.slice(start, start + size));
+  }
+  return chunks;
+}
+
+export async function runInitialPull(
+  options: InitialPullOptions,
+): Promise<InitialPullResult> {
+  const requestPresign = options.requestPresignedUrls ?? requestPresignedUrls;
+  const reconcileRemote = options.reconcileRemoteFileChange ?? reconcileRemoteFileChange;
+  const downloadRemoteFile = options.downloadFile ?? downloadFile;
+  const concurrency = options.concurrency ?? INITIAL_PULL_CONCURRENCY;
+  const presignBatchSize = options.presignBatchSize ?? INITIAL_PULL_PRESIGN_BATCH_SIZE;
+  const progressEvery = options.progressEvery ?? INITIAL_PULL_PROGRESS_EVERY;
+  const result: InitialPullResult = { pulled: 0, skipped: 0, failed: 0 };
+  let completed = 0;
+  const filesToPull: InitialPullFile[] = [];
+  const recordCompleted = () => {
+    completed++;
+    if (progressEvery > 0 && completed % progressEvery === 0) {
+      options.logger.info(
+        { completed, total: filesToPull.length, skipped: result.skipped, failed: result.failed },
+        "Initial pull progress",
+      );
+    }
+  };
+
+  for (const [remotePath, entry] of Object.entries(options.remoteFiles)) {
+    if (!entry?.hash) continue;
+    const localRel = options.toLocal(remotePath);
+    if (!localRel) continue;
+    const cached = options.syncState.files[remotePath];
+    if (cached?.lastSyncedHash === entry.hash) {
+      result.skipped++;
+      continue;
+    }
+    filesToPull.push({ remotePath, localRel, entry });
+  }
+
+  for (const batch of chunkInitialPullFiles(filesToPull, presignBatchSize)) {
+    let urls: PresignedUrl[];
+    try {
+      urls = await requestPresign(
+        options.gatewayClient,
+        batch.map(({ remotePath }) => ({ path: remotePath, action: "get" as const })),
+      );
+    } catch (err: unknown) {
+      if (err instanceof AuthRejectedError) {
+        throw err;
+      }
+      for (const { remotePath } of batch) {
+        result.failed++;
+        recordCompleted();
+        options.logger.error({ err, path: remotePath }, "Initial-pull failed");
+      }
+      continue;
+    }
+    const urlsByPath = new Map<string, PresignedUrl>(
+      urls.map((url) => [url.path, url]),
+    );
+
+    await runWithConcurrency(batch, concurrency, async ({ remotePath, localRel, entry }) => {
+      const url = urlsByPath.get(remotePath);
+      if (!url) {
+        result.failed++;
+        recordCompleted();
+        options.logger.error({ path: remotePath }, "Initial-pull presign missing");
+        return;
+      }
+
+      try {
+        const reconcileResult = await reconcileRemote(options.syncState, {
+          syncRoot: options.syncRoot,
+          localRel,
+          remotePath,
+          remoteHash: entry.hash,
+          remoteSize: entry.size,
+          remotePeerId: entry.peerId,
+          toRemotePath: options.toRemote,
+          onConflictCleanupError: (cleanupErr, conflictPath) => {
+            options.logger.warn(
+              { err: cleanupErr, path: conflictPath },
+              "Failed to clean up reserved conflict path after download error",
+            );
+          },
+          downloadRemote: (targetPath) => downloadRemoteFile(
+            url.url,
+            targetPath,
+            entry.hash,
+            {
+              expectedSize: entry.size,
+              maxBytes: entry.size,
+            },
+          ),
+        });
+        if (reconcileResult.status === "conflict-created") {
+          options.logger.warn(
+            { path: remotePath, conflictPath: reconcileResult.conflictPath },
+            "Initial pull conflicted with local edits; preserved both files",
+          );
+        }
+        options.refreshConflictCopyPathIndex();
+        result.pulled++;
+      } catch (err: unknown) {
+        if (err instanceof AuthRejectedError) {
+          throw err;
+        }
+        result.failed++;
+        options.logger.error({ err, path: remotePath }, "Initial-pull failed");
+      } finally {
+        recordCompleted();
+      }
+    });
+  }
+
+  if (result.pulled > 0 || result.skipped > 0) {
+    await options.saveSyncState();
+    options.logger.info(result, "Initial pull complete");
+  }
+
+  return result;
+}
+
 export interface DaemonAuthResolution {
   auth: AuthData | null;
   profileName: string;
@@ -1309,64 +1504,17 @@ export async function startDaemon(): Promise<void> {
     }
 
     const remoteFiles = remoteEnvelope.manifest.files;
-    let pulled = 0;
-    let skipped = 0;
-    for (const [remotePath, entry] of Object.entries(remoteFiles)) {
-      if (!entry?.hash) continue;
-      // Only pull files that belong to our prefix. A daemon for `~/audit`
-      // doesn't materialize `notes/...` from the same gateway.
-      const localRel = toLocal(remotePath);
-      if (!localRel) continue;
-
-      const cached = syncState.files[remotePath];
-      if (cached?.lastSyncedHash === entry.hash) {
-        skipped++;
-        continue;
-      }
-
-      try {
-        const urls = await requestPresignedUrls(gatewayClient, [
-          { path: remotePath, action: "get" },
-        ]);
-        if (!urls[0]) continue;
-
-        const result = await reconcileRemoteFileChange(syncState, {
-          syncRoot: config.syncPath,
-          localRel,
-          remotePath,
-          remoteHash: entry.hash,
-          remoteSize: entry.size,
-          remotePeerId: entry.peerId,
-          toRemotePath: toRemote,
-          onConflictCleanupError: (cleanupErr, conflictPath) => {
-            logger.warn(
-              { err: cleanupErr, path: conflictPath },
-              "Failed to clean up reserved conflict path after download error",
-            );
-          },
-          downloadRemote: (targetPath) => downloadFile(
-            urls[0]!.url,
-            targetPath,
-            entry.hash,
-          ),
-        });
-        if (result.status === "conflict-created") {
-          logger.warn(
-            { path: remotePath, conflictPath: result.conflictPath },
-            "Initial pull conflicted with local edits; preserved both files",
-          );
-        }
-        refreshConflictCopyPathIndex();
-        pulled++;
-      } catch (err) {
-        if (exitOnAuthFailure(err, logger)) return;
-        logger.error({ err, path: remotePath }, "Initial-pull failed");
-      }
-    }
-    if (pulled > 0 || skipped > 0) {
-      await saveSyncState(stateFile, syncState);
-      logger.info({ pulled, skipped }, "Initial pull complete");
-    }
+    await runInitialPull({
+      gatewayClient,
+      syncRoot: config.syncPath,
+      syncState,
+      remoteFiles,
+      toLocal,
+      toRemote,
+      logger,
+      saveSyncState: () => saveSyncState(stateFile, syncState),
+      refreshConflictCopyPathIndex,
+    });
   } catch (err) {
     if (exitOnAuthFailure(err, logger)) return;
     logger.warn(

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -930,11 +930,10 @@ async function runWithConcurrency<T>(
     async () => {
       for (;;) {
         const index = nextIndex++;
-        const item = items[index];
-        if (!item) {
+        if (index >= items.length) {
           return;
         }
-        await worker(item);
+        await worker(items[index]!);
       }
     },
   );

--- a/packages/sync-client/src/daemon/r2-client.ts
+++ b/packages/sync-client/src/daemon/r2-client.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
+import { createWriteStream } from "node:fs";
 import { lstat, readFile, writeFile, mkdir, stat, rename, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
+import { once } from "node:events";
 
 export interface PresignedUrl {
   path: string;
@@ -11,6 +13,11 @@ export interface PresignedUrl {
 export interface GatewayClient {
   gatewayUrl: string;
   token: string;
+}
+
+export interface DownloadFileOptions {
+  expectedSize?: number;
+  maxBytes?: number;
 }
 
 export class AuthRejectedError extends Error {
@@ -81,6 +88,7 @@ export async function downloadFile(
   presignedUrl: string,
   localPath: string,
   expectedHash?: string,
+  options: DownloadFileOptions = {},
 ): Promise<void> {
   const res = await fetch(presignedUrl, {
     signal: AbortSignal.timeout(30_000),
@@ -90,17 +98,24 @@ export async function downloadFile(
     throw new Error(`Download failed: ${res.status}`);
   }
 
-  const buffer = Buffer.from(await res.arrayBuffer());
-  if (expectedHash) {
-    const actualHash = `sha256:${createHash("sha256").update(buffer).digest("hex")}`;
-    if (actualHash !== expectedHash) {
-      throw new Error("Downloaded content hash did not match expected hash");
-    }
+  const contentLength = Number(res.headers.get("content-length") ?? "");
+  if (
+    options.maxBytes !== undefined &&
+    Number.isFinite(contentLength) &&
+    contentLength > options.maxBytes
+  ) {
+    throw new Error(`Downloaded content exceeded ${options.maxBytes} bytes`);
   }
   await mkdir(dirname(localPath), { recursive: true, mode: 0o700 });
   const tmpPath = `${localPath}.matrixos-${randomUUID()}.tmp`;
   try {
-    await writeFile(tmpPath, buffer, { flag: "wx", mode: 0o600 });
+    const { size, hash } = await writeResponseBodyToTempFile(res, tmpPath, options);
+    if (options.expectedSize !== undefined && size !== options.expectedSize) {
+      throw new Error("Downloaded content size did not match expected size");
+    }
+    if (expectedHash && hash !== expectedHash) {
+      throw new Error("Downloaded content hash did not match expected hash");
+    }
     try {
       const localStat = await lstat(localPath);
       if (localStat.isSymbolicLink()) {
@@ -130,6 +145,67 @@ export async function downloadFile(
     }
     throw err;
   }
+}
+
+async function writeResponseBodyToTempFile(
+  res: Response,
+  tmpPath: string,
+  options: DownloadFileOptions,
+): Promise<{ size: number; hash: string }> {
+  const hash = createHash("sha256");
+  let size = 0;
+  const writer = createWriteStream(tmpPath, {
+    flags: "wx",
+    mode: 0o600,
+  });
+  const writerError = new Promise<never>((_, reject) => {
+    writer.once("error", reject);
+  });
+  const writerClosed = once(writer, "close");
+
+  const writeChunk = async (chunk: Uint8Array): Promise<void> => {
+    size += chunk.byteLength;
+    if (options.maxBytes !== undefined && size > options.maxBytes) {
+      throw new Error(`Downloaded content exceeded ${options.maxBytes} bytes`);
+    }
+    hash.update(chunk);
+    if (!writer.write(chunk)) {
+      await Promise.race([once(writer, "drain"), writerError]);
+    }
+  };
+
+  try {
+    if (!res.body) {
+      const buffer = Buffer.from(await res.arrayBuffer());
+      await writeChunk(buffer);
+    } else {
+      const reader = res.body.getReader();
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          if (value) {
+            await writeChunk(value);
+          }
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    }
+    await Promise.race([
+      new Promise<void>((resolve) => writer.end(resolve)),
+      writerError,
+    ]);
+  } catch (err: unknown) {
+    writer.destroy();
+    await writerClosed;
+    throw err;
+  }
+
+  return {
+    size,
+    hash: `sha256:${hash.digest("hex")}`,
+  };
 }
 
 export async function commitFiles(

--- a/packages/sync-client/src/daemon/r2-client.ts
+++ b/packages/sync-client/src/daemon/r2-client.ts
@@ -2,7 +2,6 @@ import { createHash, randomUUID } from "node:crypto";
 import { createWriteStream } from "node:fs";
 import { lstat, readFile, writeFile, mkdir, stat, rename, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
-import { once } from "node:events";
 
 export interface PresignedUrl {
   path: string;
@@ -158,10 +157,36 @@ async function writeResponseBodyToTempFile(
     flags: "wx",
     mode: 0o600,
   });
-  const writerError = new Promise<never>((_, reject) => {
-    writer.once("error", reject);
+  let writerFailure: unknown;
+  const recordWriterError = (err: unknown): void => {
+    writerFailure = err;
+  };
+  writer.on("error", recordWriterError);
+  const writerClosed = new Promise<void>((resolve) => {
+    writer.once("close", resolve);
   });
-  const writerClosed = once(writer, "close");
+
+  const waitForWriterEvent = (event: "drain" | "finish"): Promise<void> => {
+    if (writerFailure) {
+      return Promise.reject(writerFailure);
+    }
+    return new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        writer.off(event, onEvent);
+        writer.off("error", onError);
+      };
+      const onEvent = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = (err: unknown) => {
+        cleanup();
+        reject(err);
+      };
+      writer.once(event, onEvent);
+      writer.once("error", onError);
+    });
+  };
 
   const writeChunk = async (chunk: Uint8Array): Promise<void> => {
     size += chunk.byteLength;
@@ -170,7 +195,7 @@ async function writeResponseBodyToTempFile(
     }
     hash.update(chunk);
     if (!writer.write(chunk)) {
-      await Promise.race([once(writer, "drain"), writerError]);
+      await waitForWriterEvent("drain");
     }
   };
 
@@ -192,14 +217,16 @@ async function writeResponseBodyToTempFile(
         reader.releaseLock();
       }
     }
-    await Promise.race([
-      new Promise<void>((resolve) => writer.end(resolve)),
-      writerError,
-    ]);
+    const finished = waitForWriterEvent("finish");
+    writer.end();
+    await finished;
+    await writerClosed;
   } catch (err: unknown) {
     writer.destroy();
     await writerClosed;
     throw err;
+  } finally {
+    writer.off("error", recordWriterError);
   }
 
   return {

--- a/packages/sync-client/src/daemon/r2-client.ts
+++ b/packages/sync-client/src/daemon/r2-client.ts
@@ -103,7 +103,9 @@ export async function downloadFile(
     Number.isFinite(contentLength) &&
     contentLength > options.maxBytes
   ) {
-    throw new Error(`Downloaded content exceeded ${options.maxBytes} bytes`);
+    const err = new Error(`Downloaded content exceeded ${options.maxBytes} bytes`);
+    await res.body?.cancel(err);
+    throw err;
   }
   await mkdir(dirname(localPath), { recursive: true, mode: 0o700 });
   const tmpPath = `${localPath}.matrixos-${randomUUID()}.tmp`;
@@ -205,14 +207,23 @@ async function writeResponseBodyToTempFile(
       await writeChunk(buffer);
     } else {
       const reader = res.body.getReader();
+      let streamFinished = false;
       try {
         for (;;) {
           const { value, done } = await reader.read();
-          if (done) break;
+          if (done) {
+            streamFinished = true;
+            break;
+          }
           if (value) {
             await writeChunk(value);
           }
         }
+      } catch (err: unknown) {
+        if (!streamFinished) {
+          await reader.cancel(err);
+        }
+        throw err;
       } finally {
         reader.releaseLock();
       }

--- a/packages/sync-client/tests/unit/r2-client.test.ts
+++ b/packages/sync-client/tests/unit/r2-client.test.ts
@@ -9,6 +9,8 @@ import {
   requestPresignedUrls,
 } from "../../src/daemon/r2-client.js";
 
+const HASH_A = `sha256:${"a".repeat(64)}`;
+
 describe("daemon/r2-client", () => {
   let tempDir: string;
 
@@ -140,6 +142,53 @@ describe("daemon/r2-client", () => {
       }),
     ).rejects.toThrow(/exceeded/i);
 
+    await expect(stat(finalPath)).rejects.toThrow(/ENOENT/);
+    expect(await readdir(join(tempDir, "notes")).catch(() => [])).toEqual([]);
+  });
+
+  it("cancels the response body before rejecting oversized content-length", async () => {
+    const finalPath = join(tempDir, "notes", "declared-too-large.md");
+    const cancel = vi.fn(async () => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": "100" }),
+      body: { cancel } as unknown as ReadableStream<Uint8Array>,
+    } as unknown as Response);
+
+    await expect(
+      downloadFile("https://example.test/get", finalPath, HASH_A, {
+        maxBytes: 10,
+      }),
+    ).rejects.toThrow(/exceeded 10 bytes/);
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    await expect(stat(finalPath)).rejects.toThrow(/ENOENT/);
+  });
+
+  it("cancels an unfinished response stream when it exceeds maxBytes mid-read", async () => {
+    const finalPath = join(tempDir, "notes", "stream-too-large.md");
+    const body = Buffer.from("too large");
+    const hash = `sha256:${createHash("sha256").update(body).digest("hex")}`;
+    const cancel = vi.fn(async () => {});
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(body.subarray(0, 3));
+        controller.enqueue(body.subarray(3));
+      },
+      cancel,
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(stream, { status: 200 }),
+    );
+
+    await expect(
+      downloadFile("https://example.test/get", finalPath, hash, {
+        maxBytes: body.length - 1,
+      }),
+    ).rejects.toThrow(/exceeded/i);
+
+    expect(cancel).toHaveBeenCalledTimes(1);
     await expect(stat(finalPath)).rejects.toThrow(/ENOENT/);
     expect(await readdir(join(tempDir, "notes")).catch(() => [])).toEqual([]);
   });

--- a/packages/sync-client/tests/unit/r2-client.test.ts
+++ b/packages/sync-client/tests/unit/r2-client.test.ts
@@ -97,6 +97,53 @@ describe("daemon/r2-client", () => {
     ).toEqual([]);
   });
 
+  it("streams downloads without requiring arrayBuffer", async () => {
+    const finalPath = join(tempDir, "notes", "streamed.md");
+    const body = Buffer.from("hello streamed world");
+    const hash = `sha256:${createHash("sha256").update(body).digest("hex")}`;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(body.subarray(0, 5));
+        controller.enqueue(body.subarray(5));
+        controller.close();
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": String(body.length) }),
+      body: stream,
+      arrayBuffer: vi.fn(async () => {
+        throw new Error("arrayBuffer should not be used");
+      }),
+    } as unknown as Response);
+
+    await downloadFile("https://example.test/get", finalPath, hash, {
+      expectedSize: body.length,
+      maxBytes: body.length,
+    });
+
+    expect(await readFile(finalPath, "utf8")).toBe("hello streamed world");
+  });
+
+  it("rejects oversized streamed downloads before final rename", async () => {
+    const finalPath = join(tempDir, "notes", "too-large.md");
+    const body = Buffer.from("too large");
+    const hash = `sha256:${createHash("sha256").update(body).digest("hex")}`;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(body, { status: 200 }),
+    );
+
+    await expect(
+      downloadFile("https://example.test/get", finalPath, hash, {
+        maxBytes: body.length - 1,
+      }),
+    ).rejects.toThrow(/exceeded/i);
+
+    await expect(stat(finalPath)).rejects.toThrow(/ENOENT/);
+    expect(await readdir(join(tempDir, "notes")).catch(() => [])).toEqual([]);
+  });
+
   it("does not clobber stale PID-based temp files from an earlier crash", async () => {
     const finalPath = join(tempDir, "notes", "today.md");
     const legacyTmpPath = `${finalPath}.${process.pid}.tmp`;

--- a/packages/sync-client/tests/unit/second-initial-pull.test.ts
+++ b/packages/sync-client/tests/unit/second-initial-pull.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  runInitialPull,
+  type InitialPullLogger,
+} from "../../src/daemon/index.js";
+import type { SyncState, ManifestEntry } from "../../src/daemon/types.js";
+
+const HASH_A = `sha256:${"a".repeat(64)}`;
+const HASH_B = `sha256:${"b".repeat(64)}`;
+const HASH_C = `sha256:${"c".repeat(64)}`;
+
+function entry(hash: string, size = 10): ManifestEntry {
+  return {
+    hash,
+    size,
+    mtime: Date.now(),
+    peerId: "remote-peer",
+    version: 1,
+  };
+}
+
+function logger(): InitialPullLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe("runInitialPull", () => {
+  it("batches presign requests and downloads with bounded concurrency", async () => {
+    const remoteFiles = Object.fromEntries(
+      Array.from({ length: 105 }, (_, i) => [`file-${i}.txt`, entry(HASH_A, i + 1)]),
+    );
+    const syncState: SyncState = { manifestVersion: 1, lastSyncAt: 0, files: {} };
+    let activeDownloads = 0;
+    let maxActiveDownloads = 0;
+
+    const requestPresignedUrls = vi.fn(async (_client, files) =>
+      files.map((file) => ({
+        path: file.path,
+        url: `https://r2.example.test/${file.path}`,
+        expiresIn: 900,
+      })),
+    );
+    const reconcileRemoteFileChange = vi.fn(async (_state, input) => {
+      await input.downloadRemote(`/sync/${input.localRel}`);
+      return { status: "downloaded" as const };
+    });
+    const downloadFile = vi.fn(async () => {
+      activeDownloads++;
+      maxActiveDownloads = Math.max(maxActiveDownloads, activeDownloads);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      activeDownloads--;
+    });
+
+    const result = await runInitialPull({
+      gatewayClient: { gatewayUrl: "https://app.matrix-os.com", token: "token" },
+      syncRoot: "/sync",
+      syncState,
+      remoteFiles,
+      toLocal: (remotePath) => remotePath,
+      toRemote: (localPath) => localPath,
+      logger: logger(),
+      concurrency: 4,
+      requestPresignedUrls,
+      reconcileRemoteFileChange,
+      downloadFile,
+      saveSyncState: vi.fn(),
+      refreshConflictCopyPathIndex: vi.fn(),
+    });
+
+    expect(result).toMatchObject({ pulled: 105, skipped: 0, failed: 0 });
+    expect(requestPresignedUrls).toHaveBeenCalledTimes(2);
+    expect(requestPresignedUrls.mock.calls[0]![1]).toHaveLength(100);
+    expect(requestPresignedUrls.mock.calls[1]![1]).toHaveLength(5);
+    expect(maxActiveDownloads).toBeGreaterThan(1);
+    expect(maxActiveDownloads).toBeLessThanOrEqual(4);
+    expect(downloadFile).toHaveBeenCalledTimes(105);
+  });
+
+  it("skips cached files and keeps going when one download fails", async () => {
+    const syncState: SyncState = {
+      manifestVersion: 1,
+      lastSyncAt: 0,
+      files: {
+        "cached.txt": {
+          hash: HASH_A,
+          mtime: Date.now(),
+          size: 10,
+          lastSyncedHash: HASH_A,
+        },
+      },
+    };
+    const testLogger = logger();
+    const saveSyncState = vi.fn();
+    const refreshConflictCopyPathIndex = vi.fn();
+    const requestPresignedUrls = vi.fn(async (_client, files) =>
+      files.map((file) => ({
+        path: file.path,
+        url: `https://r2.example.test/${file.path}`,
+        expiresIn: 900,
+      })),
+    );
+    const reconcileRemoteFileChange = vi.fn(async (_state, input) => {
+      await input.downloadRemote(`/sync/${input.localRel}`);
+      return { status: "downloaded" as const };
+    });
+    const downloadFile = vi.fn(async (url: string) => {
+      if (url.endsWith("/bad.txt")) {
+        throw new Error("download unavailable");
+      }
+    });
+
+    const result = await runInitialPull({
+      gatewayClient: { gatewayUrl: "https://app.matrix-os.com", token: "token" },
+      syncRoot: "/sync",
+      syncState,
+      remoteFiles: {
+        "cached.txt": entry(HASH_A),
+        "ok.txt": entry(HASH_B),
+        "bad.txt": entry(HASH_C),
+        "outside.txt": entry(HASH_B),
+      },
+      toLocal: (remotePath) => remotePath === "outside.txt" ? null : remotePath,
+      toRemote: (localPath) => localPath,
+      logger: testLogger,
+      concurrency: 2,
+      requestPresignedUrls,
+      reconcileRemoteFileChange,
+      downloadFile,
+      saveSyncState,
+      refreshConflictCopyPathIndex,
+    });
+
+    expect(result).toMatchObject({ pulled: 1, skipped: 1, failed: 1 });
+    expect(downloadFile).toHaveBeenCalledTimes(2);
+    expect(saveSyncState).toHaveBeenCalledTimes(1);
+    expect(refreshConflictCopyPathIndex).toHaveBeenCalledTimes(1);
+    expect(testLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "bad.txt" }),
+      "Initial-pull failed",
+    );
+  });
+});


### PR DESCRIPTION
Summary
- Extracts daemon initial pull into a testable helper with batched GET presign requests.
- Adds bounded concurrent initial downloads and streams presigned responses to temp files with incremental hash/size checks.
- Adds unit coverage for batching, concurrency, failure isolation, and streamed download cleanup.

Tests
- pnpm --dir packages/sync-client exec vitest run tests/unit/second-initial-pull.test.ts tests/unit/r2-client.test.ts tests/unit/daemon-runtime-guards.test.ts
- pnpm --dir packages/sync-client exec tsc --noEmit
- ./scripts/review/check-patterns.sh --diff origin/main

Review
- Problem statement, plan, and final verification comments will be posted separately.

Invariants
- Source of truth: gateway manifest remains canonical for remote files; local sync-state caches last synced hashes.
- Lock/transaction scope: no DB writes; file materialization remains temp-file plus atomic rename.
- Acceptable orphan states: failed files are logged and counted while other files can continue; partial temp downloads are cleaned up.
- Auth source of truth: existing daemon gateway JWT handling is unchanged; auth rejection still aborts startup sync.
- Deferred scope: gateway home-mirror streaming and shared-folder data-plane are not in this slice.