### PR TITLE
fix(sync): complete multipart uploads from daemon

### DIFF
--- a/packages/gateway/src/sync/platform-r2-client.ts
+++ b/packages/gateway/src/sync/platform-r2-client.ts
@@ -81,6 +81,29 @@ export function createPlatformR2Client(config: {
       return (await expectJson<{ url: string }>(res)).url;
     },
 
+    async completeMultipartUpload(
+      key: string,
+      uploadId: string,
+      parts: Array<{ partNumber: number; etag: string }>,
+    ): Promise<{ etag?: string }> {
+      const res = await request("/multipart/complete", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ key, uploadId, parts }),
+      }, INTERNAL_SYNC_WRITE_TIMEOUT_MS);
+      const data = await expectJson<{ etag: string | null }>(res);
+      return { etag: data.etag ?? undefined };
+    },
+
+    async abortMultipartUpload(key: string, uploadId: string): Promise<void> {
+      const res = await request("/multipart/abort", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ key, uploadId }),
+      }, INTERNAL_SYNC_WRITE_TIMEOUT_MS);
+      await expectJson<{ ok: true }>(res);
+    },
+
     async getObject(
       key: string,
       options?: { signal?: AbortSignal },

--- a/packages/gateway/src/sync/r2-client.ts
+++ b/packages/gateway/src/sync/r2-client.ts
@@ -2,6 +2,11 @@ import { buildFileKey, buildManifestKey } from "./r2-keys.js";
 
 type S3ClientType = import("@aws-sdk/client-s3").S3Client;
 
+export interface MultipartUploadedPart {
+  partNumber: number;
+  etag: string;
+}
+
 async function loadS3() {
   const [s3, presigner] = await Promise.all([
     import("@aws-sdk/client-s3"),
@@ -28,6 +33,12 @@ export interface R2Client {
   getPresignedPutUrl(key: string, size: number, expiresIn?: number): Promise<string>;
   createMultipartUpload(key: string): Promise<string>;
   getPresignedPartUrl(key: string, uploadId: string, partNumber: number, expiresIn?: number): Promise<string>;
+  completeMultipartUpload(
+    key: string,
+    uploadId: string,
+    parts: MultipartUploadedPart[],
+  ): Promise<{ etag?: string }>;
+  abortMultipartUpload(key: string, uploadId: string): Promise<void>;
   getObject(
     key: string,
     options?: { signal?: AbortSignal },
@@ -48,7 +59,17 @@ export async function createR2Client(config: R2ClientConfig): Promise<R2Client> 
     throw new Error("R2 client requires either accountId or endpoint");
   }
 
-  const { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand, CreateMultipartUploadCommand, UploadPartCommand, getSignedUrl } = await loadS3();
+  const {
+    S3Client,
+    GetObjectCommand,
+    PutObjectCommand,
+    DeleteObjectCommand,
+    CreateMultipartUploadCommand,
+    UploadPartCommand,
+    CompleteMultipartUploadCommand,
+    AbortMultipartUploadCommand,
+    getSignedUrl,
+  } = await loadS3();
   const s3 = new S3Client({
     region: "auto",
     endpoint,
@@ -127,6 +148,40 @@ export async function createR2Client(config: R2ClientConfig): Promise<R2Client> 
         expiresIn,
         signingDate: new Date(),
       }));
+    },
+
+    async completeMultipartUpload(
+      key: string,
+      uploadId: string,
+      parts: MultipartUploadedPart[],
+    ): Promise<{ etag?: string }> {
+      const orderedParts = [...parts]
+        .sort((left, right) => left.partNumber - right.partNumber)
+        .map((part) => ({
+          PartNumber: part.partNumber,
+          ETag: part.etag,
+        }));
+      const command = new CompleteMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId,
+        MultipartUpload: { Parts: orderedParts },
+      });
+      const response = await s3.send(command, {
+        abortSignal: AbortSignal.timeout(R2_WRITE_TIMEOUT_MS),
+      });
+      return { etag: response.ETag ?? undefined };
+    },
+
+    async abortMultipartUpload(key: string, uploadId: string): Promise<void> {
+      const command = new AbortMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId,
+      });
+      await s3.send(command, {
+        abortSignal: AbortSignal.timeout(R2_WRITE_TIMEOUT_MS),
+      });
     },
 
     async getObject(

--- a/packages/gateway/src/sync/routes.ts
+++ b/packages/gateway/src/sync/routes.ts
@@ -49,6 +49,7 @@ import { MissingSyncUserIdentityError } from "../auth.js";
 import { RequestPrincipalMisconfiguredError, isRequestPrincipalError } from "../request-principal.js";
 
 const SYNC_BODY_LIMIT = 65536;
+const MULTIPART_COMPLETE_BODY_LIMIT = 1024 * 1024;
 
 export interface SyncRouteDeps {
   r2: R2Client;
@@ -62,6 +63,7 @@ export interface SyncRouteDeps {
 export function createSyncRoutes(deps: SyncRouteDeps): Hono {
   const app = new Hono();
   const mutatingBodyLimit = bodyLimit({ maxSize: SYNC_BODY_LIMIT });
+  const multipartCompleteBodyLimit = bodyLimit({ maxSize: MULTIPART_COMPLETE_BODY_LIMIT });
   const store: ManifestStore = { r2: deps.r2, db: deps.db };
   const presignLimiter = createSyncRateLimiter({ maxRequests: 100, windowMs: 60_000 });
   const commitLimiter = createSyncRateLimiter({ maxRequests: 100, windowMs: 60_000 });
@@ -159,7 +161,7 @@ export function createSyncRoutes(deps: SyncRouteDeps): Hono {
   });
 
   // POST /multipart/complete
-  app.post("/multipart/complete", mutatingBodyLimit, async (c) => {
+  app.post("/multipart/complete", multipartCompleteBodyLimit, async (c) => {
     const userId = getUserId(c);
     if (!commitLimiter.check(userId)) {
       return c.json({ error: "Rate limit exceeded" }, 429);

--- a/packages/gateway/src/sync/routes.ts
+++ b/packages/gateway/src/sync/routes.ts
@@ -4,6 +4,8 @@ import { HTTPException } from "hono/http-exception";
 import {
   PresignRequestSchema,
   CommitRequestSchema,
+  CompleteMultipartRequestSchema,
+  AbortMultipartRequestSchema,
   ResolveConflictSchema,
   CreateShareSchema,
   AcceptShareSchema,
@@ -153,6 +155,70 @@ export function createSyncRoutes(deps: SyncRouteDeps): Hono {
         { error: isValidationErr ? "Invalid request" : "Presign generation failed" },
         isValidationErr ? 400 : 500,
       );
+    }
+  });
+
+  // POST /multipart/complete
+  app.post("/multipart/complete", mutatingBodyLimit, async (c) => {
+    const userId = getUserId(c);
+    if (!commitLimiter.check(userId)) {
+      return c.json({ error: "Rate limit exceeded" }, 429);
+    }
+    const json = await parseJsonBody(c);
+    if (!json.ok) {
+      return c.json({ error: "Invalid JSON" }, 400);
+    }
+    const parsed = CompleteMultipartRequestSchema.safeParse(json.body);
+    if (!parsed.success) {
+      return validationError(c);
+    }
+    const pathCheck = resolveWithinPrefix(userId, parsed.data.path);
+    if (!pathCheck.valid) {
+      return c.json({ error: "Invalid request" }, 400);
+    }
+    try {
+      const result = await deps.r2.completeMultipartUpload(
+        pathCheck.key,
+        parsed.data.uploadId,
+        parsed.data.parts,
+      );
+      return c.json({ etag: result.etag ?? null });
+    } catch (err: unknown) {
+      console.error(
+        "[sync/multipart] Complete failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return c.json({ error: "Multipart completion failed" }, 500);
+    }
+  });
+
+  // POST /multipart/abort
+  app.post("/multipart/abort", mutatingBodyLimit, async (c) => {
+    const userId = getUserId(c);
+    if (!commitLimiter.check(userId)) {
+      return c.json({ error: "Rate limit exceeded" }, 429);
+    }
+    const json = await parseJsonBody(c);
+    if (!json.ok) {
+      return c.json({ error: "Invalid JSON" }, 400);
+    }
+    const parsed = AbortMultipartRequestSchema.safeParse(json.body);
+    if (!parsed.success) {
+      return validationError(c);
+    }
+    const pathCheck = resolveWithinPrefix(userId, parsed.data.path);
+    if (!pathCheck.valid) {
+      return c.json({ error: "Invalid request" }, 400);
+    }
+    try {
+      await deps.r2.abortMultipartUpload(pathCheck.key, parsed.data.uploadId);
+      return c.json({ ok: true });
+    } catch (err: unknown) {
+      console.error(
+        "[sync/multipart] Abort failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return c.json({ error: "Multipart abort failed" }, 500);
     }
   });
 
@@ -447,6 +513,8 @@ export function createSyncRoutes(deps: SyncRouteDeps): Hono {
 const syncApp = new Hono();
 syncApp.get("/manifest", (c) => c.json({ error: "Not configured" }, 503));
 syncApp.post("/presign", (c) => c.json({ error: "Not configured" }, 503));
+syncApp.post("/multipart/complete", (c) => c.json({ error: "Not configured" }, 503));
+syncApp.post("/multipart/abort", (c) => c.json({ error: "Not configured" }, 503));
 syncApp.post("/commit", (c) => c.json({ error: "Not configured" }, 503));
 syncApp.get("/status", (c) => c.json({ error: "Not configured" }, 503));
 syncApp.post("/resolve-conflict", (c) => c.json({ error: "Not configured" }, 503));

--- a/packages/gateway/src/sync/routes.ts
+++ b/packages/gateway/src/sync/routes.ts
@@ -66,6 +66,8 @@ export function createSyncRoutes(deps: SyncRouteDeps): Hono {
   const multipartCompleteBodyLimit = bodyLimit({ maxSize: MULTIPART_COMPLETE_BODY_LIMIT });
   const store: ManifestStore = { r2: deps.r2, db: deps.db };
   const presignLimiter = createSyncRateLimiter({ maxRequests: 100, windowMs: 60_000 });
+  const multipartCompleteLimiter = createSyncRateLimiter({ maxRequests: 100, windowMs: 60_000 });
+  const multipartAbortLimiter = createSyncRateLimiter({ maxRequests: 300, windowMs: 60_000 });
   const commitLimiter = createSyncRateLimiter({ maxRequests: 100, windowMs: 60_000 });
   const shareLimiter = createSyncRateLimiter({ maxRequests: 60, windowMs: 60_000 });
   // Shared-folder data-plane access remains intentionally fail-closed in this
@@ -163,7 +165,7 @@ export function createSyncRoutes(deps: SyncRouteDeps): Hono {
   // POST /multipart/complete
   app.post("/multipart/complete", multipartCompleteBodyLimit, async (c) => {
     const userId = getUserId(c);
-    if (!commitLimiter.check(userId)) {
+    if (!multipartCompleteLimiter.check(userId)) {
       return c.json({ error: "Rate limit exceeded" }, 429);
     }
     const json = await parseJsonBody(c);
@@ -197,7 +199,7 @@ export function createSyncRoutes(deps: SyncRouteDeps): Hono {
   // POST /multipart/abort
   app.post("/multipart/abort", mutatingBodyLimit, async (c) => {
     const userId = getUserId(c);
-    if (!commitLimiter.check(userId)) {
+    if (!multipartAbortLimiter.check(userId)) {
       return c.json({ error: "Rate limit exceeded" }, 429);
     }
     const json = await parseJsonBody(c);

--- a/packages/gateway/src/sync/types.ts
+++ b/packages/gateway/src/sync/types.ts
@@ -111,6 +111,25 @@ export const PresignRequestSchema = z.object({
 });
 export type PresignRequest = z.infer<typeof PresignRequestSchema>;
 
+export const MultipartUploadedPartSchema = z.object({
+  partNumber: z.int().positive().max(10_000),
+  etag: z.string().min(1).max(512),
+});
+export type MultipartUploadedPart = z.infer<typeof MultipartUploadedPartSchema>;
+
+export const CompleteMultipartRequestSchema = z.object({
+  path: z.string().min(1).max(1024),
+  uploadId: z.string().min(1).max(1024),
+  parts: z.array(MultipartUploadedPartSchema).min(1).max(10_000),
+});
+export type CompleteMultipartRequest = z.infer<typeof CompleteMultipartRequestSchema>;
+
+export const AbortMultipartRequestSchema = z.object({
+  path: z.string().min(1).max(1024),
+  uploadId: z.string().min(1).max(1024),
+});
+export type AbortMultipartRequest = z.infer<typeof AbortMultipartRequestSchema>;
+
 // ---------------------------------------------------------------------------
 // Commit request / response
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/sync/types.ts
+++ b/packages/gateway/src/sync/types.ts
@@ -121,6 +121,12 @@ export const CompleteMultipartRequestSchema = z.object({
   path: z.string().min(1).max(1024),
   uploadId: z.string().min(1).max(1024),
   parts: z.array(MultipartUploadedPartSchema).min(1).max(10_000),
+}).refine((request) => {
+  const partNumbers = new Set(request.parts.map((part) => part.partNumber));
+  return partNumbers.size === request.parts.length;
+}, {
+  message: "Duplicate multipart part numbers",
+  path: ["parts"],
 });
 export type CompleteMultipartRequest = z.infer<typeof CompleteMultipartRequestSchema>;
 

--- a/packages/platform/src/internal-sync-routes.ts
+++ b/packages/platform/src/internal-sync-routes.ts
@@ -165,6 +165,7 @@ function parseMultipartCompleteInput(input: unknown): MultipartCompleteInput | n
     return null;
   }
   const parts: Array<{ partNumber: number; etag: string }> = [];
+  const partNumbers = new Set<number>();
   for (const part of record.parts) {
     const partRecord = asRecord(part);
     if (!partRecord) return null;
@@ -180,6 +181,10 @@ function parseMultipartCompleteInput(input: unknown): MultipartCompleteInput | n
     ) {
       return null;
     }
+    if (partNumbers.has(partNumber)) {
+      return null;
+    }
+    partNumbers.add(partNumber);
     parts.push({ partNumber, etag });
   }
   return { ...parsed, parts };

--- a/packages/platform/src/internal-sync-routes.ts
+++ b/packages/platform/src/internal-sync-routes.ts
@@ -7,6 +7,7 @@ import {
 } from "./platform-token.js";
 
 const INTERNAL_SYNC_BODY_LIMIT = 64 * 1024;
+const INTERNAL_SYNC_MULTIPART_COMPLETE_LIMIT = 1024 * 1024;
 const INTERNAL_SYNC_OBJECT_BODY_LIMIT = 100 * 1024 * 1024;
 const SAFE_USER_ID = /^[A-Za-z0-9_-]{1,256}$/;
 
@@ -294,20 +295,32 @@ export function createInternalSyncRoutes(opts: {
     return c.json({ url });
   });
 
-  app.post("/multipart/complete", bodyLimit({ maxSize: INTERNAL_SYNC_BODY_LIMIT }), async (c) => {
-    const parsed = parseMultipartCompleteInput(await parseJsonBody(c));
-    if (!parsed) {
-      return c.json({ error: "Validation error" }, 400);
-    }
-    const allowed = requireAllowedKey(c, parsed.key);
-    if (allowed instanceof Response) return allowed;
-    const result = await opts.r2.completeMultipartUpload(
-      parsed.key,
-      parsed.uploadId,
-      parsed.parts,
-    );
-    return c.json({ etag: result.etag ?? null });
-  });
+  app.post(
+    "/multipart/complete",
+    bodyLimit({ maxSize: INTERNAL_SYNC_MULTIPART_COMPLETE_LIMIT }),
+    async (c) => {
+      const parsed = parseMultipartCompleteInput(await parseJsonBody(c));
+      if (!parsed) {
+        return c.json({ error: "Validation error" }, 400);
+      }
+      const allowed = requireAllowedKey(c, parsed.key);
+      if (allowed instanceof Response) return allowed;
+      try {
+        const result = await opts.r2.completeMultipartUpload(
+          parsed.key,
+          parsed.uploadId,
+          parsed.parts,
+        );
+        return c.json({ etag: result.etag ?? null });
+      } catch (err: unknown) {
+        console.error(
+          "[internal-sync] Multipart completion failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+        return c.json({ error: "Multipart completion failed" }, 500);
+      }
+    },
+  );
 
   app.post("/multipart/abort", bodyLimit({ maxSize: INTERNAL_SYNC_BODY_LIMIT }), async (c) => {
     const parsed = parseMultipartUploadIdInput(await parseJsonBody(c));
@@ -316,8 +329,16 @@ export function createInternalSyncRoutes(opts: {
     }
     const allowed = requireAllowedKey(c, parsed.key);
     if (allowed instanceof Response) return allowed;
-    await opts.r2.abortMultipartUpload(parsed.key, parsed.uploadId);
-    return c.json({ ok: true });
+    try {
+      await opts.r2.abortMultipartUpload(parsed.key, parsed.uploadId);
+      return c.json({ ok: true });
+    } catch (err: unknown) {
+      console.error(
+        "[internal-sync] Multipart abort failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return c.json({ error: "Multipart abort failed" }, 500);
+    }
   });
 
   app.get("/object", async (c) => {

--- a/packages/platform/src/internal-sync-routes.ts
+++ b/packages/platform/src/internal-sync-routes.ts
@@ -171,6 +171,7 @@ function parseMultipartCompleteInput(input: unknown): MultipartCompleteInput | n
     const etag = parseNonEmptyString(partRecord.etag);
     if (
       !etag ||
+      etag.length > 512 ||
       !Number.isInteger(partNumber) ||
       typeof partNumber !== "number" ||
       partNumber <= 0 ||

--- a/packages/platform/src/internal-sync-routes.ts
+++ b/packages/platform/src/internal-sync-routes.ts
@@ -20,6 +20,12 @@ interface R2Client {
     partNumber: number,
     expiresIn?: number,
   ): Promise<string>;
+  completeMultipartUpload(
+    key: string,
+    uploadId: string,
+    parts: Array<{ partNumber: number; etag: string }>,
+  ): Promise<{ etag?: string }>;
+  abortMultipartUpload(key: string, uploadId: string): Promise<void>;
   getObject(key: string): Promise<{ body: ReadableStream | null; etag?: string }>;
   putObject(
     key: string,
@@ -45,6 +51,15 @@ interface MultipartPartInput extends MultipartCreateInput {
   uploadId: string;
   partNumber: number;
   expiresIn?: number;
+}
+
+interface MultipartCompleteInput extends MultipartCreateInput {
+  uploadId: string;
+  parts: Array<{ partNumber: number; etag: string }>;
+}
+
+interface MultipartAbortInput extends MultipartCreateInput {
+  uploadId: string;
 }
 
 async function getAuthorizedUserId(db: PlatformDB, handle: string): Promise<string | null> {
@@ -132,6 +147,40 @@ function parseMultipartPartInput(input: unknown): MultipartPartInput | null {
   return expiresIn === undefined
     ? { ...parsed, uploadId, partNumber }
     : { ...parsed, uploadId, partNumber, expiresIn };
+}
+
+function parseMultipartUploadIdInput(input: unknown): MultipartAbortInput | null {
+  const parsed = parseMultipartCreateInput(input);
+  const record = asRecord(input);
+  if (!parsed || !record) return null;
+  const uploadId = parseNonEmptyString(record.uploadId);
+  return uploadId ? { ...parsed, uploadId } : null;
+}
+
+function parseMultipartCompleteInput(input: unknown): MultipartCompleteInput | null {
+  const parsed = parseMultipartUploadIdInput(input);
+  const record = asRecord(input);
+  if (!parsed || !record || !Array.isArray(record.parts) || record.parts.length === 0 || record.parts.length > 10_000) {
+    return null;
+  }
+  const parts: Array<{ partNumber: number; etag: string }> = [];
+  for (const part of record.parts) {
+    const partRecord = asRecord(part);
+    if (!partRecord) return null;
+    const partNumber = partRecord.partNumber;
+    const etag = parseNonEmptyString(partRecord.etag);
+    if (
+      !etag ||
+      !Number.isInteger(partNumber) ||
+      typeof partNumber !== "number" ||
+      partNumber <= 0 ||
+      partNumber > 10_000
+    ) {
+      return null;
+    }
+    parts.push({ partNumber, etag });
+  }
+  return { ...parsed, parts };
 }
 
 async function parseJsonBody(c: { req: { json: () => Promise<unknown> } }): Promise<unknown | null> {
@@ -242,6 +291,32 @@ export function createInternalSyncRoutes(opts: {
       parsed.expiresIn,
     );
     return c.json({ url });
+  });
+
+  app.post("/multipart/complete", bodyLimit({ maxSize: INTERNAL_SYNC_BODY_LIMIT }), async (c) => {
+    const parsed = parseMultipartCompleteInput(await parseJsonBody(c));
+    if (!parsed) {
+      return c.json({ error: "Validation error" }, 400);
+    }
+    const allowed = requireAllowedKey(c, parsed.key);
+    if (allowed instanceof Response) return allowed;
+    const result = await opts.r2.completeMultipartUpload(
+      parsed.key,
+      parsed.uploadId,
+      parsed.parts,
+    );
+    return c.json({ etag: result.etag ?? null });
+  });
+
+  app.post("/multipart/abort", bodyLimit({ maxSize: INTERNAL_SYNC_BODY_LIMIT }), async (c) => {
+    const parsed = parseMultipartUploadIdInput(await parseJsonBody(c));
+    if (!parsed) {
+      return c.json({ error: "Validation error" }, 400);
+    }
+    const allowed = requireAllowedKey(c, parsed.key);
+    if (allowed instanceof Response) return allowed;
+    await opts.r2.abortMultipartUpload(parsed.key, parsed.uploadId);
+    return c.json({ ok: true });
   });
 
   app.get("/object", async (c) => {

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -308,6 +308,12 @@ interface GatewayR2Client {
     partNumber: number,
     expiresIn?: number,
   ): Promise<string>;
+  completeMultipartUpload(
+    key: string,
+    uploadId: string,
+    parts: Array<{ partNumber: number; etag: string }>,
+  ): Promise<{ etag?: string }>;
+  abortMultipartUpload(key: string, uploadId: string): Promise<void>;
   getObject(
     key: string,
     options?: { signal?: AbortSignal },

--- a/packages/sync-client/src/daemon/index.ts
+++ b/packages/sync-client/src/daemon/index.ts
@@ -1078,8 +1078,9 @@ export async function startDaemon(): Promise<void> {
           ]);
           if (urls[0]) {
             await uploadFile(
-              urls[0].url,
+              urls[0],
               join(config.syncPath, event.path),
+              gatewayClient,
             );
             const result = await commitFiles(gatewayClient, [
               { path: remotePath, hash: event.hash, size: event.size },

--- a/packages/sync-client/src/daemon/r2-client.ts
+++ b/packages/sync-client/src/daemon/r2-client.ts
@@ -1,11 +1,19 @@
 import { createHash, randomUUID } from "node:crypto";
+import { createReadStream } from "node:fs";
 import { lstat, readFile, writeFile, mkdir, stat, rename, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
+
+export interface MultipartInfo {
+  uploadId: string;
+  partUrls: string[];
+  partSize: number;
+}
 
 export interface PresignedUrl {
   path: string;
   url: string;
   expiresIn: number;
+  multipart?: MultipartInfo;
 }
 
 export interface GatewayClient {
@@ -28,6 +36,11 @@ export class VersionConflictError extends Error {
     this.name = "VersionConflictError";
     this.currentVersion = currentVersion;
   }
+}
+
+export interface MultipartUploadedPart {
+  partNumber: number;
+  etag: string;
 }
 
 export async function requestPresignedUrls(
@@ -56,14 +69,142 @@ export async function requestPresignedUrls(
   return data.urls;
 }
 
-export async function uploadFile(
-  presignedUrl: string,
+export async function completeMultipartUpload(
+  client: GatewayClient,
+  path: string,
+  uploadId: string,
+  parts: MultipartUploadedPart[],
+): Promise<void> {
+  const res = await fetch(`${client.gatewayUrl}/api/sync/multipart/complete`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: `Bearer ${client.token}`,
+    },
+    body: JSON.stringify({ path, uploadId, parts }),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new AuthRejectedError();
+  }
+
+  if (!res.ok) {
+    throw new Error(`Multipart completion failed: ${res.status}`);
+  }
+}
+
+export async function abortMultipartUpload(
+  client: GatewayClient,
+  path: string,
+  uploadId: string,
+): Promise<void> {
+  const res = await fetch(`${client.gatewayUrl}/api/sync/multipart/abort`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: `Bearer ${client.token}`,
+    },
+    body: JSON.stringify({ path, uploadId }),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new AuthRejectedError();
+  }
+
+  if (!res.ok) {
+    throw new Error(`Multipart abort failed: ${res.status}`);
+  }
+}
+
+async function uploadMultipartFile(
+  client: GatewayClient,
+  presigned: PresignedUrl & { multipart: MultipartInfo },
   localPath: string,
 ): Promise<void> {
+  const fileStat = await stat(localPath);
+  const { multipart } = presigned;
+  if (multipart.partSize <= 0) {
+    throw new Error("Multipart upload returned an invalid part size");
+  }
+  const expectedPartCount = Math.ceil(fileStat.size / multipart.partSize);
+  if (multipart.partUrls.length !== expectedPartCount) {
+    throw new Error("Multipart upload returned the wrong number of part URLs");
+  }
+
+  const parts: MultipartUploadedPart[] = [];
+  try {
+    for (const [index, partUrl] of multipart.partUrls.entries()) {
+      const partNumber = index + 1;
+      const start = index * multipart.partSize;
+      const endExclusive = Math.min(fileStat.size, start + multipart.partSize);
+      const contentLength = endExclusive - start;
+      const res = await fetch(partUrl, {
+        method: "PUT",
+        body: createReadStream(localPath, {
+          start,
+          end: endExclusive - 1,
+        }) as unknown as BodyInit,
+        headers: {
+          "Content-Length": String(contentLength),
+        },
+        signal: AbortSignal.timeout(30_000),
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+      if (!res.ok) {
+        throw new Error(`Upload failed: ${res.status}`);
+      }
+      const etag = res.headers.get("etag");
+      if (!etag) {
+        throw new Error("Multipart upload part did not return an ETag");
+      }
+      parts.push({ partNumber, etag });
+    }
+
+    await completeMultipartUpload(
+      client,
+      presigned.path,
+      multipart.uploadId,
+      parts,
+    );
+  } catch (err: unknown) {
+    try {
+      await abortMultipartUpload(client, presigned.path, multipart.uploadId);
+    } catch (abortErr: unknown) {
+      console.warn(
+        "[sync-client] Failed to abort multipart upload after upload failure:",
+        abortErr instanceof Error ? abortErr.message : String(abortErr),
+      );
+    }
+    throw err;
+  }
+}
+
+export async function uploadFile(
+  presignedUrl: string | PresignedUrl,
+  localPath: string,
+  client?: GatewayClient,
+): Promise<void> {
+  if (typeof presignedUrl !== "string" && presignedUrl.multipart) {
+    if (!client) {
+      throw new Error("Gateway client is required for multipart uploads");
+    }
+    await uploadMultipartFile(
+      client,
+      presignedUrl as PresignedUrl & { multipart: MultipartInfo },
+      localPath,
+    );
+    return;
+  }
+  const uploadUrl = typeof presignedUrl === "string" ? presignedUrl : presignedUrl.url;
+  if (!uploadUrl) {
+    throw new Error("Presigned upload URL is empty");
+  }
   const fileContent = await readFile(localPath);
   const fileStat = await stat(localPath);
 
-  const res = await fetch(presignedUrl, {
+  const res = await fetch(uploadUrl, {
     method: "PUT",
     body: fileContent,
     headers: {

--- a/packages/sync-client/src/daemon/r2-client.ts
+++ b/packages/sync-client/src/daemon/r2-client.ts
@@ -3,6 +3,8 @@ import { createReadStream } from "node:fs";
 import { lstat, readFile, writeFile, mkdir, stat, rename, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 
+const MULTIPART_COMPLETE_TIMEOUT_MS = 60_000;
+
 export interface MultipartInfo {
   uploadId: string;
   partUrls: string[];
@@ -82,7 +84,7 @@ export async function completeMultipartUpload(
       authorization: `Bearer ${client.token}`,
     },
     body: JSON.stringify({ path, uploadId, parts }),
-    signal: AbortSignal.timeout(10_000),
+    signal: AbortSignal.timeout(MULTIPART_COMPLETE_TIMEOUT_MS),
   });
 
   if (res.status === 401 || res.status === 403) {

--- a/packages/sync-client/tests/unit/r2-client.test.ts
+++ b/packages/sync-client/tests/unit/r2-client.test.ts
@@ -50,7 +50,7 @@ describe("daemon/r2-client", () => {
     });
   });
 
-    it("throws AuthRejectedError for 401/403 presign responses", async () => {
+  it("throws AuthRejectedError for 401/403 presign responses", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("nope", { status: 401 }),
     );
@@ -61,48 +61,93 @@ describe("daemon/r2-client", () => {
         [{ path: "notes/today.md", action: "get" }],
       ),
     ).rejects.toBeInstanceOf(AuthRejectedError);
+  });
+
+  it("uploads multipart presigned files and completes them through the gateway", async () => {
+    const localPath = join(tempDir, "large.bin");
+    await writeFile(localPath, "hello world");
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+      const href = String(url);
+      if (href === "https://r2.example.test/part-1") {
+        expect(init?.method).toBe("PUT");
+        expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("5");
+        return new Response(null, { status: 200, headers: { ETag: '"etag-1"' } });
+      }
+      if (href === "https://r2.example.test/part-2") {
+        expect(init?.method).toBe("PUT");
+        expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("5");
+        return new Response(null, { status: 200, headers: { ETag: '"etag-2"' } });
+      }
+      if (href === "https://r2.example.test/part-3") {
+        expect(init?.method).toBe("PUT");
+        expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("1");
+        return new Response(null, { status: 200, headers: { ETag: '"etag-3"' } });
+      }
+      if (href === "https://app.matrix-os.com/api/sync/multipart/complete") {
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          path: "large.bin",
+          uploadId: "upload-123",
+          parts: [
+            { partNumber: 1, etag: '"etag-1"' },
+            { partNumber: 2, etag: '"etag-2"' },
+            { partNumber: 3, etag: '"etag-3"' },
+          ],
+        });
+        return new Response(JSON.stringify({ etag: '"complete-etag"' }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch ${href}`);
     });
 
-    it("uploads multipart presigned files and completes them through the gateway", async () => {
-      const localPath = join(tempDir, "large.bin");
-      await writeFile(localPath, "hello world");
-      const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
-        const href = String(url);
-        if (href === "https://r2.example.test/part-1") {
-          expect(init?.method).toBe("PUT");
-          expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("5");
-          return new Response(null, { status: 200, headers: { ETag: '"etag-1"' } });
-        }
-        if (href === "https://r2.example.test/part-2") {
-          expect(init?.method).toBe("PUT");
-          expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("5");
-          return new Response(null, { status: 200, headers: { ETag: '"etag-2"' } });
-        }
-        if (href === "https://r2.example.test/part-3") {
-          expect(init?.method).toBe("PUT");
-          expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("1");
-          return new Response(null, { status: 200, headers: { ETag: '"etag-3"' } });
-        }
-        if (href === "https://app.matrix-os.com/api/sync/multipart/complete") {
-          expect(init?.method).toBe("POST");
-          expect(JSON.parse(String(init?.body))).toEqual({
-            path: "large.bin",
-            uploadId: "upload-123",
-            parts: [
-              { partNumber: 1, etag: '"etag-1"' },
-              { partNumber: 2, etag: '"etag-2"' },
-              { partNumber: 3, etag: '"etag-3"' },
-            ],
-          });
-          return new Response(JSON.stringify({ etag: '"complete-etag"' }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          });
-        }
-        throw new Error(`unexpected fetch ${href}`);
-      });
+    await uploadFile(
+      {
+        path: "large.bin",
+        url: "",
+        expiresIn: 900,
+        multipart: {
+          uploadId: "upload-123",
+          partSize: 5,
+          partUrls: [
+            "https://r2.example.test/part-1",
+            "https://r2.example.test/part-2",
+            "https://r2.example.test/part-3",
+          ],
+        },
+      },
+      localPath,
+      { gatewayUrl: "https://app.matrix-os.com", token: "token" },
+    );
 
-      await uploadFile(
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(timeoutSpy).toHaveBeenCalledWith(60_000);
+  });
+
+  it("aborts multipart uploads when a part upload fails", async () => {
+    const localPath = join(tempDir, "large.bin");
+    await writeFile(localPath, "helloworld");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      const href = String(url);
+      if (href === "https://r2.example.test/part-1") {
+        return new Response(null, { status: 200, headers: { ETag: '"etag-1"' } });
+      }
+      if (href === "https://r2.example.test/part-2") {
+        return new Response("failed", { status: 503 });
+      }
+      if (href === "https://app.matrix-os.com/api/sync/multipart/abort") {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch ${href}`);
+    });
+
+    await expect(
+      uploadFile(
         {
           path: "large.bin",
           url: "",
@@ -113,67 +158,24 @@ describe("daemon/r2-client", () => {
             partUrls: [
               "https://r2.example.test/part-1",
               "https://r2.example.test/part-2",
-              "https://r2.example.test/part-3",
             ],
           },
         },
         localPath,
         { gatewayUrl: "https://app.matrix-os.com", token: "token" },
-      );
+      ),
+    ).rejects.toThrow(/upload failed/i);
 
-      expect(fetchMock).toHaveBeenCalledTimes(4);
-    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://app.matrix-os.com/api/sync/multipart/abort",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ path: "large.bin", uploadId: "upload-123" }),
+      }),
+    );
+  });
 
-    it("aborts multipart uploads when a part upload fails", async () => {
-      const localPath = join(tempDir, "large.bin");
-      await writeFile(localPath, "helloworld");
-      const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
-        const href = String(url);
-        if (href === "https://r2.example.test/part-1") {
-          return new Response(null, { status: 200, headers: { ETag: '"etag-1"' } });
-        }
-        if (href === "https://r2.example.test/part-2") {
-          return new Response("failed", { status: 503 });
-        }
-        if (href === "https://app.matrix-os.com/api/sync/multipart/abort") {
-          return new Response(JSON.stringify({ ok: true }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          });
-        }
-        throw new Error(`unexpected fetch ${href}`);
-      });
-
-      await expect(
-        uploadFile(
-          {
-            path: "large.bin",
-            url: "",
-            expiresIn: 900,
-            multipart: {
-              uploadId: "upload-123",
-              partSize: 5,
-              partUrls: [
-                "https://r2.example.test/part-1",
-                "https://r2.example.test/part-2",
-              ],
-            },
-          },
-          localPath,
-          { gatewayUrl: "https://app.matrix-os.com", token: "token" },
-        ),
-      ).rejects.toThrow(/upload failed/i);
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        "https://app.matrix-os.com/api/sync/multipart/abort",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({ path: "large.bin", uploadId: "upload-123" }),
-        }),
-      );
-    });
-
-    it("verifies download hashes before replacing the destination file", async () => {
+  it("verifies download hashes before replacing the destination file", async () => {
     const finalPath = join(tempDir, "notes", "today.md");
     const body = Buffer.from("tampered");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/packages/sync-client/tests/unit/r2-client.test.ts
+++ b/packages/sync-client/tests/unit/r2-client.test.ts
@@ -4,10 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import {
-  AuthRejectedError,
-  downloadFile,
-  requestPresignedUrls,
-} from "../../src/daemon/r2-client.js";
+    AuthRejectedError,
+    downloadFile,
+    requestPresignedUrls,
+    uploadFile,
+  } from "../../src/daemon/r2-client.js";
 
 describe("daemon/r2-client", () => {
   let tempDir: string;
@@ -49,7 +50,7 @@ describe("daemon/r2-client", () => {
     });
   });
 
-  it("throws AuthRejectedError for 401/403 presign responses", async () => {
+    it("throws AuthRejectedError for 401/403 presign responses", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("nope", { status: 401 }),
     );
@@ -60,9 +61,119 @@ describe("daemon/r2-client", () => {
         [{ path: "notes/today.md", action: "get" }],
       ),
     ).rejects.toBeInstanceOf(AuthRejectedError);
-  });
+    });
 
-  it("verifies download hashes before replacing the destination file", async () => {
+    it("uploads multipart presigned files and completes them through the gateway", async () => {
+      const localPath = join(tempDir, "large.bin");
+      await writeFile(localPath, "hello world");
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+        const href = String(url);
+        if (href === "https://r2.example.test/part-1") {
+          expect(init?.method).toBe("PUT");
+          expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("5");
+          return new Response(null, { status: 200, headers: { ETag: '"etag-1"' } });
+        }
+        if (href === "https://r2.example.test/part-2") {
+          expect(init?.method).toBe("PUT");
+          expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("5");
+          return new Response(null, { status: 200, headers: { ETag: '"etag-2"' } });
+        }
+        if (href === "https://r2.example.test/part-3") {
+          expect(init?.method).toBe("PUT");
+          expect((init?.headers as Record<string, string>)["Content-Length"]).toBe("1");
+          return new Response(null, { status: 200, headers: { ETag: '"etag-3"' } });
+        }
+        if (href === "https://app.matrix-os.com/api/sync/multipart/complete") {
+          expect(init?.method).toBe("POST");
+          expect(JSON.parse(String(init?.body))).toEqual({
+            path: "large.bin",
+            uploadId: "upload-123",
+            parts: [
+              { partNumber: 1, etag: '"etag-1"' },
+              { partNumber: 2, etag: '"etag-2"' },
+              { partNumber: 3, etag: '"etag-3"' },
+            ],
+          });
+          return new Response(JSON.stringify({ etag: '"complete-etag"' }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        throw new Error(`unexpected fetch ${href}`);
+      });
+
+      await uploadFile(
+        {
+          path: "large.bin",
+          url: "",
+          expiresIn: 900,
+          multipart: {
+            uploadId: "upload-123",
+            partSize: 5,
+            partUrls: [
+              "https://r2.example.test/part-1",
+              "https://r2.example.test/part-2",
+              "https://r2.example.test/part-3",
+            ],
+          },
+        },
+        localPath,
+        { gatewayUrl: "https://app.matrix-os.com", token: "token" },
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it("aborts multipart uploads when a part upload fails", async () => {
+      const localPath = join(tempDir, "large.bin");
+      await writeFile(localPath, "helloworld");
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+        const href = String(url);
+        if (href === "https://r2.example.test/part-1") {
+          return new Response(null, { status: 200, headers: { ETag: '"etag-1"' } });
+        }
+        if (href === "https://r2.example.test/part-2") {
+          return new Response("failed", { status: 503 });
+        }
+        if (href === "https://app.matrix-os.com/api/sync/multipart/abort") {
+          return new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        throw new Error(`unexpected fetch ${href}`);
+      });
+
+      await expect(
+        uploadFile(
+          {
+            path: "large.bin",
+            url: "",
+            expiresIn: 900,
+            multipart: {
+              uploadId: "upload-123",
+              partSize: 5,
+              partUrls: [
+                "https://r2.example.test/part-1",
+                "https://r2.example.test/part-2",
+              ],
+            },
+          },
+          localPath,
+          { gatewayUrl: "https://app.matrix-os.com", token: "token" },
+        ),
+      ).rejects.toThrow(/upload failed/i);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://app.matrix-os.com/api/sync/multipart/abort",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ path: "large.bin", uploadId: "upload-123" }),
+        }),
+      );
+    });
+
+    it("verifies download hashes before replacing the destination file", async () => {
     const finalPath = join(tempDir, "notes", "today.md");
     const body = Buffer.from("tampered");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/specs/066-file-sync/contracts/sync-api.md
+++ b/specs/066-file-sync/contracts/sync-api.md
@@ -81,8 +81,13 @@ const PresignRequestSchema = z.object({
 {
   urls: Array<{
     path: string,
-    url: string,          // Presigned R2 URL (valid 15 min)
+    url: string,          // Presigned R2 URL (valid 15 min); empty for multipart PUT
     expiresIn: number,    // Seconds until expiry (900)
+    multipart?: {         // Present for PUT files >100MB
+      uploadId: string,
+      partUrls: string[],
+      partSize: number,
+    },
   }>
 }
 ```
@@ -97,6 +102,56 @@ const PresignRequestSchema = z.object({
 - For shared folders: checks `sync_shares` table for grantee permissions
 - `action: "put"` requires editor or admin role on shared paths
 - `action: "get"` requires viewer or higher role on shared paths
+
+---
+
+## POST /api/sync/multipart/complete
+
+Called after the client uploads every multipart part directly to R2. Finalizes the R2 object before the client calls `/api/sync/commit`.
+
+**Request Body**:
+```typescript
+{
+  path: string,
+  uploadId: string,
+  parts: Array<{
+    partNumber: number,
+    etag: string,
+  }>,
+}
+```
+
+**Response 200**:
+```typescript
+{ etag: string | null }
+```
+
+**Response 400**: Validation error or invalid path.
+**Response 401**: Invalid JWT.
+**Response 429**: Rate limit exceeded.
+
+---
+
+## POST /api/sync/multipart/abort
+
+Best-effort cleanup call used when multipart upload fails before completion.
+
+**Request Body**:
+```typescript
+{
+  path: string,
+  uploadId: string,
+}
+```
+
+**Response 200**:
+```typescript
+{ ok: true }
+```
+
+**Response 400**: Validation error or invalid path.
+**Response 401**: Invalid JWT.
+**Response 429**: Rate limit exceeded.
 
 ---
 

--- a/tests/gateway/sync/r2-client.test.ts
+++ b/tests/gateway/sync/r2-client.test.ts
@@ -241,7 +241,7 @@ describe("R2 client", () => {
     });
   });
 
-    describe("deleteObject", () => {
+  describe("deleteObject", () => {
     it("sends DeleteObjectCommand with AbortSignal timeout", async () => {
       mockSend.mockResolvedValue({});
 
@@ -252,52 +252,52 @@ describe("R2 client", () => {
       expect(command.Key).toBe("matrixos-sync/user1/files/old.txt");
       expect(options.abortSignal).toBeDefined();
     });
+  });
 
-    describe("multipart completion", () => {
-      it("sends CompleteMultipartUploadCommand with ordered parts and timeout", async () => {
-        const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
-        mockSend.mockResolvedValue({ ETag: '"complete-etag"' });
+  describe("multipart completion", () => {
+    it("sends CompleteMultipartUploadCommand with ordered parts and timeout", async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+      mockSend.mockResolvedValue({ ETag: '"complete-etag"' });
 
-        const result = await client.completeMultipartUpload(
-          "matrixos-sync/user1/files/large.bin",
-          "upload-123",
-          [
-            { partNumber: 2, etag: '"etag-2"' },
-            { partNumber: 1, etag: '"etag-1"' },
-          ],
-        );
+      const result = await client.completeMultipartUpload(
+        "matrixos-sync/user1/files/large.bin",
+        "upload-123",
+        [
+          { partNumber: 2, etag: '"etag-2"' },
+          { partNumber: 1, etag: '"etag-1"' },
+        ],
+      );
 
-        expect(mockSend).toHaveBeenCalledOnce();
-        const [command, options] = mockSend.mock.calls[0]!;
-        expect(command.Key).toBe("matrixos-sync/user1/files/large.bin");
-        expect(command.UploadId).toBe("upload-123");
-        expect(command.MultipartUpload).toEqual({
-          Parts: [
-            { PartNumber: 1, ETag: '"etag-1"' },
-            { PartNumber: 2, ETag: '"etag-2"' },
-          ],
-        });
-        expect(options.abortSignal).toBeDefined();
-        expect(timeoutSpy).toHaveBeenLastCalledWith(30_000);
-        expect(result.etag).toBe('"complete-etag"');
+      expect(mockSend).toHaveBeenCalledOnce();
+      const [command, options] = mockSend.mock.calls[0]!;
+      expect(command.Key).toBe("matrixos-sync/user1/files/large.bin");
+      expect(command.UploadId).toBe("upload-123");
+      expect(command.MultipartUpload).toEqual({
+        Parts: [
+          { PartNumber: 1, ETag: '"etag-1"' },
+          { PartNumber: 2, ETag: '"etag-2"' },
+        ],
       });
+      expect(options.abortSignal).toBeDefined();
+      expect(timeoutSpy).toHaveBeenLastCalledWith(30_000);
+      expect(result.etag).toBe('"complete-etag"');
+    });
 
-      it("sends AbortMultipartUploadCommand with timeout", async () => {
-        const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
-        mockSend.mockResolvedValue({});
+    it("sends AbortMultipartUploadCommand with timeout", async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+      mockSend.mockResolvedValue({});
 
-        await client.abortMultipartUpload(
-          "matrixos-sync/user1/files/large.bin",
-          "upload-123",
-        );
+      await client.abortMultipartUpload(
+        "matrixos-sync/user1/files/large.bin",
+        "upload-123",
+      );
 
-        expect(mockSend).toHaveBeenCalledOnce();
-        const [command, options] = mockSend.mock.calls[0]!;
-        expect(command.Key).toBe("matrixos-sync/user1/files/large.bin");
-        expect(command.UploadId).toBe("upload-123");
-        expect(options.abortSignal).toBeDefined();
-        expect(timeoutSpy).toHaveBeenLastCalledWith(30_000);
-      });
+      expect(mockSend).toHaveBeenCalledOnce();
+      const [command, options] = mockSend.mock.calls[0]!;
+      expect(command.Key).toBe("matrixos-sync/user1/files/large.bin");
+      expect(command.UploadId).toBe("upload-123");
+      expect(options.abortSignal).toBeDefined();
+      expect(timeoutSpy).toHaveBeenLastCalledWith(30_000);
     });
   });
 });

--- a/tests/gateway/sync/r2-client.test.ts
+++ b/tests/gateway/sync/r2-client.test.ts
@@ -34,16 +34,63 @@ vi.mock("@aws-sdk/client-s3", () => {
         this.ContentLength = params.ContentLength;
       }
     },
-    DeleteObjectCommand: class {
-      Bucket: string;
-      Key: string;
-      constructor(params: { Bucket: string; Key: string }) {
-        this.Bucket = params.Bucket;
-        this.Key = params.Key;
-      }
-    },
-  };
-});
+      DeleteObjectCommand: class {
+        Bucket: string;
+        Key: string;
+        constructor(params: { Bucket: string; Key: string }) {
+          this.Bucket = params.Bucket;
+          this.Key = params.Key;
+        }
+      },
+      CreateMultipartUploadCommand: class {
+        Bucket: string;
+        Key: string;
+        constructor(params: { Bucket: string; Key: string }) {
+          this.Bucket = params.Bucket;
+          this.Key = params.Key;
+        }
+      },
+      UploadPartCommand: class {
+        Bucket: string;
+        Key: string;
+        UploadId: string;
+        PartNumber: number;
+        constructor(params: { Bucket: string; Key: string; UploadId: string; PartNumber: number }) {
+          this.Bucket = params.Bucket;
+          this.Key = params.Key;
+          this.UploadId = params.UploadId;
+          this.PartNumber = params.PartNumber;
+        }
+      },
+      CompleteMultipartUploadCommand: class {
+        Bucket: string;
+        Key: string;
+        UploadId: string;
+        MultipartUpload?: { Parts?: Array<{ PartNumber: number; ETag: string }> };
+        constructor(params: {
+          Bucket: string;
+          Key: string;
+          UploadId: string;
+          MultipartUpload?: { Parts?: Array<{ PartNumber: number; ETag: string }> };
+        }) {
+          this.Bucket = params.Bucket;
+          this.Key = params.Key;
+          this.UploadId = params.UploadId;
+          this.MultipartUpload = params.MultipartUpload;
+        }
+      },
+      AbortMultipartUploadCommand: class {
+        Bucket: string;
+        Key: string;
+        UploadId: string;
+        constructor(params: { Bucket: string; Key: string; UploadId: string }) {
+          this.Bucket = params.Bucket;
+          this.Key = params.Key;
+          this.UploadId = params.UploadId;
+        }
+      },
+    };
+  });
 
 vi.mock("@aws-sdk/s3-request-presigner", () => {
   return {
@@ -194,7 +241,7 @@ describe("R2 client", () => {
     });
   });
 
-  describe("deleteObject", () => {
+    describe("deleteObject", () => {
     it("sends DeleteObjectCommand with AbortSignal timeout", async () => {
       mockSend.mockResolvedValue({});
 
@@ -204,6 +251,53 @@ describe("R2 client", () => {
       const [command, options] = mockSend.mock.calls[0]!;
       expect(command.Key).toBe("matrixos-sync/user1/files/old.txt");
       expect(options.abortSignal).toBeDefined();
+    });
+
+    describe("multipart completion", () => {
+      it("sends CompleteMultipartUploadCommand with ordered parts and timeout", async () => {
+        const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+        mockSend.mockResolvedValue({ ETag: '"complete-etag"' });
+
+        const result = await client.completeMultipartUpload(
+          "matrixos-sync/user1/files/large.bin",
+          "upload-123",
+          [
+            { partNumber: 2, etag: '"etag-2"' },
+            { partNumber: 1, etag: '"etag-1"' },
+          ],
+        );
+
+        expect(mockSend).toHaveBeenCalledOnce();
+        const [command, options] = mockSend.mock.calls[0]!;
+        expect(command.Key).toBe("matrixos-sync/user1/files/large.bin");
+        expect(command.UploadId).toBe("upload-123");
+        expect(command.MultipartUpload).toEqual({
+          Parts: [
+            { PartNumber: 1, ETag: '"etag-1"' },
+            { PartNumber: 2, ETag: '"etag-2"' },
+          ],
+        });
+        expect(options.abortSignal).toBeDefined();
+        expect(timeoutSpy).toHaveBeenLastCalledWith(30_000);
+        expect(result.etag).toBe('"complete-etag"');
+      });
+
+      it("sends AbortMultipartUploadCommand with timeout", async () => {
+        const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+        mockSend.mockResolvedValue({});
+
+        await client.abortMultipartUpload(
+          "matrixos-sync/user1/files/large.bin",
+          "upload-123",
+        );
+
+        expect(mockSend).toHaveBeenCalledOnce();
+        const [command, options] = mockSend.mock.calls[0]!;
+        expect(command.Key).toBe("matrixos-sync/user1/files/large.bin");
+        expect(command.UploadId).toBe("upload-123");
+        expect(options.abortSignal).toBeDefined();
+        expect(timeoutSpy).toHaveBeenLastCalledWith(30_000);
+      });
     });
   });
 });

--- a/tests/gateway/sync/routes.test.ts
+++ b/tests/gateway/sync/routes.test.ts
@@ -327,6 +327,28 @@ describe("POST /api/sync/multipart/complete", () => {
       parts,
     );
   });
+
+  it("does not consume the commit rate-limit bucket", async () => {
+    const app = createTestApp();
+
+    for (let index = 0; index < 100; index += 1) {
+      const res = await app.request(jsonRequest("/api/sync/multipart/complete", {
+        path: `videos/large-${index}.mov`,
+        uploadId: `upload-${index}`,
+        parts: [{ partNumber: 1, etag: `"etag-${index}"` }],
+      }));
+      expect(res.status).toBe(200);
+    }
+
+    const res = await app.request("/api/sync/commit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON" });
+  });
 });
 
 describe("POST /api/sync/multipart/abort", () => {
@@ -337,6 +359,31 @@ describe("POST /api/sync/multipart/abort", () => {
 
   it("aborts a multipart upload inside the authenticated user prefix", async () => {
     const app = createTestApp();
+
+    const res = await app.request(jsonRequest("/api/sync/multipart/abort", {
+      path: "videos/large.mov",
+      uploadId: "upload-123",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockR2.abortMultipartUpload).toHaveBeenCalledWith(
+      "matrixos-sync/test-user/files/videos/large.mov",
+      "upload-123",
+    );
+  });
+
+  it("does not block cleanup after the commit bucket is exhausted", async () => {
+    const app = createTestApp();
+
+    for (let index = 0; index < 100; index += 1) {
+      const res = await app.request("/api/sync/commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{",
+      });
+      expect(res.status).toBe(400);
+    }
 
     const res = await app.request(jsonRequest("/api/sync/multipart/abort", {
       path: "videos/large.mov",

--- a/tests/gateway/sync/routes.test.ts
+++ b/tests/gateway/sync/routes.test.ts
@@ -17,10 +17,14 @@ const mockR2 = {
   getObject: vi.fn(),
   putObject: vi.fn(),
   deleteObject: vi.fn(),
-  getPresignedGetUrl: vi.fn(),
-  getPresignedPutUrl: vi.fn(),
-  destroy: vi.fn(),
-};
+    getPresignedGetUrl: vi.fn(),
+    getPresignedPutUrl: vi.fn(),
+    createMultipartUpload: vi.fn(),
+    getPresignedPartUrl: vi.fn(),
+    completeMultipartUpload: vi.fn(),
+    abortMultipartUpload: vi.fn(),
+    destroy: vi.fn(),
+  };
 
 const mockDb = {
   getManifestMeta: vi.fn(),
@@ -231,6 +235,73 @@ describe("POST /api/sync/presign", () => {
 
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toMatchObject({ error: "Invalid JSON" });
+  });
+});
+
+describe("POST /api/sync/multipart/complete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockR2.completeMultipartUpload.mockResolvedValue({ etag: '"complete-etag"' });
+  });
+
+  it("completes a multipart upload inside the authenticated user prefix", async () => {
+    const app = createTestApp();
+
+    const res = await app.request(jsonRequest("/api/sync/multipart/complete", {
+      path: "videos/large.mov",
+      uploadId: "upload-123",
+      parts: [
+        { partNumber: 1, etag: '"etag-1"' },
+        { partNumber: 2, etag: '"etag-2"' },
+      ],
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ etag: '"complete-etag"' });
+    expect(mockR2.completeMultipartUpload).toHaveBeenCalledWith(
+      "matrixos-sync/test-user/files/videos/large.mov",
+      "upload-123",
+      [
+        { partNumber: 1, etag: '"etag-1"' },
+        { partNumber: 2, etag: '"etag-2"' },
+      ],
+    );
+  });
+
+  it("rejects invalid complete payloads before calling storage", async () => {
+    const app = createTestApp();
+
+    const res = await app.request(jsonRequest("/api/sync/multipart/complete", {
+      path: "../large.mov",
+      uploadId: "upload-123",
+      parts: [{ partNumber: 1, etag: '"etag-1"' }],
+    }));
+
+    expect(res.status).toBe(400);
+    expect(mockR2.completeMultipartUpload).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/sync/multipart/abort", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockR2.abortMultipartUpload.mockResolvedValue(undefined);
+  });
+
+  it("aborts a multipart upload inside the authenticated user prefix", async () => {
+    const app = createTestApp();
+
+    const res = await app.request(jsonRequest("/api/sync/multipart/abort", {
+      path: "videos/large.mov",
+      uploadId: "upload-123",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockR2.abortMultipartUpload).toHaveBeenCalledWith(
+      "matrixos-sync/test-user/files/videos/large.mov",
+      "upload-123",
+    );
   });
 });
 

--- a/tests/gateway/sync/routes.test.ts
+++ b/tests/gateway/sync/routes.test.ts
@@ -17,14 +17,14 @@ const mockR2 = {
   getObject: vi.fn(),
   putObject: vi.fn(),
   deleteObject: vi.fn(),
-    getPresignedGetUrl: vi.fn(),
-    getPresignedPutUrl: vi.fn(),
-    createMultipartUpload: vi.fn(),
-    getPresignedPartUrl: vi.fn(),
-    completeMultipartUpload: vi.fn(),
-    abortMultipartUpload: vi.fn(),
-    destroy: vi.fn(),
-  };
+  getPresignedGetUrl: vi.fn(),
+  getPresignedPutUrl: vi.fn(),
+  createMultipartUpload: vi.fn(),
+  getPresignedPartUrl: vi.fn(),
+  completeMultipartUpload: vi.fn(),
+  abortMultipartUpload: vi.fn(),
+  destroy: vi.fn(),
+};
 
 const mockDb = {
   getManifestMeta: vi.fn(),
@@ -279,6 +279,53 @@ describe("POST /api/sync/multipart/complete", () => {
 
     expect(res.status).toBe(400);
     expect(mockR2.completeMultipartUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects duplicate multipart part numbers before calling storage", async () => {
+    const app = createTestApp();
+
+    const res = await app.request(jsonRequest("/api/sync/multipart/complete", {
+      path: "videos/large.mov",
+      uploadId: "upload-123",
+      parts: [
+        { partNumber: 1, etag: '"etag-1a"' },
+        { partNumber: 1, etag: '"etag-1b"' },
+      ],
+    }));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "Validation error" });
+    expect(mockR2.completeMultipartUpload).not.toHaveBeenCalled();
+  });
+
+  it("accepts complete bodies over the shared mutating limit within the multipart cap", async () => {
+    const app = createTestApp();
+    const parts = Array.from({ length: 140 }, (_, index) => ({
+      partNumber: index + 1,
+      etag: `"${String(index + 1).padStart(5, "0")}-${"e".repeat(490)}"`,
+    }));
+    const body = JSON.stringify({
+      path: "videos/large.mov",
+      uploadId: "upload-123",
+      parts,
+    });
+
+    expect(Buffer.byteLength(body)).toBeGreaterThan(65_536);
+    expect(Buffer.byteLength(body)).toBeLessThan(1024 * 1024);
+
+    const res = await app.request("/api/sync/multipart/complete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ etag: '"complete-etag"' });
+    expect(mockR2.completeMultipartUpload).toHaveBeenCalledWith(
+      "matrixos-sync/test-user/files/videos/large.mov",
+      "upload-123",
+      parts,
+    );
   });
 });
 

--- a/tests/platform/internal-sync-routes.test.ts
+++ b/tests/platform/internal-sync-routes.test.ts
@@ -189,6 +189,26 @@ describe("platform/internal-sync-routes", () => {
     );
   });
 
+  it("rejects multipart complete requests with oversized ETags", async () => {
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/alice/sync/multipart/complete", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "platform-secret-123")}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        key: "matrixos-sync/user_alice/files/videos/large.mov",
+        uploadId: "upload-123",
+        parts: [{ partNumber: 1, etag: "x".repeat(513) }],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(r2.completeMultipartUpload).not.toHaveBeenCalled();
+  });
+
   it("aborts multipart uploads only for keys in the container user's prefix", async () => {
     r2.abortMultipartUpload.mockResolvedValue(undefined);
     const app = createTestApp();

--- a/tests/platform/internal-sync-routes.test.ts
+++ b/tests/platform/internal-sync-routes.test.ts
@@ -18,13 +18,13 @@ describe("platform/internal-sync-routes", () => {
     getPresignedPutUrl: vi.fn(),
     createMultipartUpload: vi.fn(),
     getPresignedPartUrl: vi.fn(),
-      getObject: vi.fn(),
-      putObject: vi.fn(),
-      deleteObject: vi.fn(),
-      completeMultipartUpload: vi.fn(),
-      abortMultipartUpload: vi.fn(),
-      destroy: vi.fn(),
-    };
+    getObject: vi.fn(),
+    putObject: vi.fn(),
+    deleteObject: vi.fn(),
+    completeMultipartUpload: vi.fn(),
+    abortMultipartUpload: vi.fn(),
+    destroy: vi.fn(),
+  };
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -40,6 +40,7 @@ describe("platform/internal-sync-routes", () => {
 
   afterEach(async () => {
     await destroyTestPlatformDb(db);
+    vi.restoreAllMocks();
   });
 
   function stubOrchestrator(): Orchestrator {
@@ -209,6 +210,66 @@ describe("platform/internal-sync-routes", () => {
     expect(r2.completeMultipartUpload).not.toHaveBeenCalled();
   });
 
+  it("accepts multipart complete bodies over 64KB within the internal complete cap", async () => {
+    r2.completeMultipartUpload.mockResolvedValue({ etag: '"complete-etag"' });
+    const app = createTestApp();
+    const parts = Array.from({ length: 140 }, (_, index) => ({
+      partNumber: index + 1,
+      etag: `"${String(index + 1).padStart(5, "0")}-${"e".repeat(490)}"`,
+    }));
+    const body = JSON.stringify({
+      key: "matrixos-sync/user_alice/files/videos/large.mov",
+      uploadId: "upload-123",
+      parts,
+    });
+
+    expect(Buffer.byteLength(body)).toBeGreaterThan(64 * 1024);
+    expect(Buffer.byteLength(body)).toBeLessThan(1024 * 1024);
+
+    const res = await app.request("/internal/containers/alice/sync/multipart/complete", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "platform-secret-123")}`,
+        "content-type": "application/json",
+      },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ etag: '"complete-etag"' });
+    expect(r2.completeMultipartUpload).toHaveBeenCalledWith(
+      "matrixos-sync/user_alice/files/videos/large.mov",
+      "upload-123",
+      parts,
+    );
+  });
+
+  it("returns a generic JSON 500 when multipart completion fails in storage", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    r2.completeMultipartUpload.mockRejectedValue(new Error("r2 complete exploded"));
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/alice/sync/multipart/complete", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "platform-secret-123")}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        key: "matrixos-sync/user_alice/files/videos/large.mov",
+        uploadId: "upload-123",
+        parts: [{ partNumber: 1, etag: '"etag-1"' }],
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Multipart completion failed" });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[internal-sync] Multipart completion failed:",
+      expect.any(String),
+    );
+  });
+
   it("aborts multipart uploads only for keys in the container user's prefix", async () => {
     r2.abortMultipartUpload.mockResolvedValue(undefined);
     const app = createTestApp();
@@ -230,6 +291,31 @@ describe("platform/internal-sync-routes", () => {
     expect(r2.abortMultipartUpload).toHaveBeenCalledWith(
       "matrixos-sync/user_alice/files/videos/large.mov",
       "upload-123",
+    );
+  });
+
+  it("returns a generic JSON 500 when multipart abort fails in storage", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    r2.abortMultipartUpload.mockRejectedValue(new Error("r2 abort exploded"));
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/alice/sync/multipart/abort", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "platform-secret-123")}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        key: "matrixos-sync/user_alice/files/videos/large.mov",
+        uploadId: "upload-123",
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Multipart abort failed" });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[internal-sync] Multipart abort failed:",
+      expect.any(String),
     );
   });
 

--- a/tests/platform/internal-sync-routes.test.ts
+++ b/tests/platform/internal-sync-routes.test.ts
@@ -210,6 +210,29 @@ describe("platform/internal-sync-routes", () => {
     expect(r2.completeMultipartUpload).not.toHaveBeenCalled();
   });
 
+  it("rejects multipart complete requests with duplicate part numbers", async () => {
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/alice/sync/multipart/complete", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "platform-secret-123")}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        key: "matrixos-sync/user_alice/files/videos/large.mov",
+        uploadId: "upload-123",
+        parts: [
+          { partNumber: 1, etag: '"etag-1a"' },
+          { partNumber: 1, etag: '"etag-1b"' },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(r2.completeMultipartUpload).not.toHaveBeenCalled();
+  });
+
   it("accepts multipart complete bodies over 64KB within the internal complete cap", async () => {
     r2.completeMultipartUpload.mockResolvedValue({ etag: '"complete-etag"' });
     const app = createTestApp();

--- a/tests/platform/internal-sync-routes.test.ts
+++ b/tests/platform/internal-sync-routes.test.ts
@@ -18,11 +18,13 @@ describe("platform/internal-sync-routes", () => {
     getPresignedPutUrl: vi.fn(),
     createMultipartUpload: vi.fn(),
     getPresignedPartUrl: vi.fn(),
-    getObject: vi.fn(),
-    putObject: vi.fn(),
-    deleteObject: vi.fn(),
-    destroy: vi.fn(),
-  };
+      getObject: vi.fn(),
+      putObject: vi.fn(),
+      deleteObject: vi.fn(),
+      completeMultipartUpload: vi.fn(),
+      abortMultipartUpload: vi.fn(),
+      destroy: vi.fn(),
+    };
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -153,6 +155,62 @@ describe("platform/internal-sync-routes", () => {
 
     expect(res.status).toBe(403);
     expect(r2.getPresignedGetUrl).not.toHaveBeenCalled();
+  });
+
+  it("completes multipart uploads only for keys in the container user's prefix", async () => {
+    r2.completeMultipartUpload.mockResolvedValue({ etag: '"complete-etag"' });
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/alice/sync/multipart/complete", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "platform-secret-123")}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        key: "matrixos-sync/user_alice/files/videos/large.mov",
+        uploadId: "upload-123",
+        parts: [
+          { partNumber: 1, etag: '"etag-1"' },
+          { partNumber: 2, etag: '"etag-2"' },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ etag: '"complete-etag"' });
+    expect(r2.completeMultipartUpload).toHaveBeenCalledWith(
+      "matrixos-sync/user_alice/files/videos/large.mov",
+      "upload-123",
+      [
+        { partNumber: 1, etag: '"etag-1"' },
+        { partNumber: 2, etag: '"etag-2"' },
+      ],
+    );
+  });
+
+  it("aborts multipart uploads only for keys in the container user's prefix", async () => {
+    r2.abortMultipartUpload.mockResolvedValue(undefined);
+    const app = createTestApp();
+
+    const res = await app.request("/internal/containers/alice/sync/multipart/abort", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${bearerFor("alice", "platform-secret-123")}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        key: "matrixos-sync/user_alice/files/videos/large.mov",
+        uploadId: "upload-123",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(r2.abortMultipartUpload).toHaveBeenCalledWith(
+      "matrixos-sync/user_alice/files/videos/large.mov",
+      "upload-123",
+    );
   });
 
   it("maps NoSuchKey from storage reads to a 404", async () => {


### PR DESCRIPTION
## Summary
- Add gateway and platform internal complete/abort paths for sync multipart uploads.
- Extend R2 clients and sync daemon upload flow so >100MB files upload parts, complete with ETags, and abort on failure.
- Keep multipart complete/abort on their own bounded rate-limit buckets so large-file finalization and cleanup do not consume commit capacity.
- Match internal platform multipart validation to the public gateway contract, including duplicate part-number rejection.
- Document the multipart sync API contract.

## Tests
- flox activate -- pnpm exec vitest run tests/gateway/sync/routes.test.ts tests/platform/internal-sync-routes.test.ts
- flox activate -- pnpm --filter @matrix-os/gateway exec tsc --noEmit
- flox activate -- pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json
- ./scripts/review/check-patterns.sh --diff 28bdff856deeb347f51050371b75322c052ce2c8
- git diff --check
- pnpm exec tsc --noEmit -p packages/gateway/tsconfig.json
- pnpm exec tsc --noEmit -p packages/platform/tsconfig.json
- pnpm exec tsc --noEmit -p packages/sync-client/tsconfig.json
- pnpm run check:patterns
- pnpm exec vitest run tests/gateway/sync/r2-client.test.ts tests/gateway/sync/routes.test.ts tests/platform/internal-sync-routes.test.ts
- cd packages/sync-client && pnpm exec vitest run tests/unit/r2-client.test.ts

## Invariants
- Source of truth: R2 object bytes are finalized before manifest commit; manifest remains canonical for peer-visible sync state.
- Lock/transaction scope: multipart complete/abort are storage operations outside manifest locks; /commit retains existing manifest concurrency behavior.
- Acceptable orphan states: failed/crashed multipart uploads may leave R2 multipart state until abort or bucket lifecycle cleanup; no manifest entry is committed before completion.
- Auth source of truth: existing sync bearer identity chooses the user prefix; internal platform routes continue to use per-container platform bearer tokens and key-prefix checks.
- Deferred scope: resumable multipart uploads, parallel part concurrency tuning, and large-file download streaming are not included.
