### PR TITLE
fix(platform): fail closed on host bundle signer storage

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -206,8 +206,22 @@ jobs:
             echo "Candidate host bundle channel smoke did not return a signed bundle URL." >&2
             exit 1
           fi
-          if printf '%s\n' "$bundle_url" | grep -q 'matrixos-sync'; then
-            echo "Candidate host bundle signer returned the sync bucket; refusing to promote." >&2
+          sync_bucket="$(gcloud secrets versions access latest --secret=r2-bucket)"
+          bundle_bucket="$(gcloud secrets versions access latest --secret=r2-bundles-bucket)"
+          if [ -z "$sync_bucket" ] || [ -z "$bundle_bucket" ]; then
+            echo "Candidate host bundle smoke could not read required bucket secret names." >&2
+            exit 1
+          fi
+          if [ "$bundle_bucket" = "$sync_bucket" ]; then
+            echo "Dedicated host bundle bucket secret matches the sync bucket secret; refusing to promote." >&2
+            exit 1
+          fi
+          if printf '%s\n' "$bundle_url" | grep -Fq -- "$sync_bucket"; then
+            echo "Candidate host bundle signer returned the configured sync bucket; refusing to promote." >&2
+            exit 1
+          fi
+          if printf '%s\n' "$bundle_url" | grep -Fq 'r2.cloudflarestorage.com' && ! printf '%s\n' "$bundle_url" | grep -Fq -- "$bundle_bucket"; then
+            echo "Candidate host bundle signer returned a native R2 URL outside the bundle bucket; refusing to promote." >&2
             exit 1
           fi
           curl --fail --silent --show-error --max-time 20 --range 0-0 "$bundle_url" >/dev/null

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -191,11 +191,26 @@ jobs:
       - name: Smoke candidate revision
         run: |
           set -euo pipefail
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq is required to parse host bundle smoke JSON output." >&2
+            exit 1
+          fi
           if [ -z "${CANDIDATE_URL:-}" ]; then
             echo "No tagged candidate Cloud Run URL found; refusing to smoke the live service URL." >&2
             exit 1
           fi
           curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/health" >/dev/null
+          manifest="$(curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/system-bundles/channels/dev.json")"
+          bundle_url="$(printf '%s\n' "$manifest" | jq -r '.url // empty')"
+          if [ -z "$bundle_url" ]; then
+            echo "Candidate host bundle channel smoke did not return a signed bundle URL." >&2
+            exit 1
+          fi
+          if printf '%s\n' "$bundle_url" | grep -q 'matrixos-sync'; then
+            echo "Candidate host bundle signer returned the sync bucket; refusing to promote." >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error --max-time 20 --range 0-0 "$bundle_url" >/dev/null
 
       - name: Promote revision
         if: ${{ inputs.promote }}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1366,6 +1366,38 @@ export function checkUnsafeDefaultSecrets(
   return problems;
 }
 
+export function checkHostBundleStorageEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  log: (msg: string) => void = console.warn,
+): string[] {
+  if (env.CUSTOMER_VPS_ENABLED !== 'true') return [];
+  const problems: string[] = [];
+  if (!(env.S3_BUNDLES_ENDPOINT || env.R2_BUNDLES_ENDPOINT || env.S3_BUNDLES_ACCOUNT_ID || env.R2_BUNDLES_ACCOUNT_ID)) {
+    problems.push('S3_BUNDLES_ENDPOINT/R2_BUNDLES_ENDPOINT or S3_BUNDLES_ACCOUNT_ID/R2_BUNDLES_ACCOUNT_ID');
+  }
+  if (!(env.S3_BUNDLES_ACCESS_KEY_ID || env.R2_BUNDLES_ACCESS_KEY_ID)) {
+    problems.push('S3_BUNDLES_ACCESS_KEY_ID/R2_BUNDLES_ACCESS_KEY_ID');
+  }
+  if (!(env.S3_BUNDLES_SECRET_ACCESS_KEY || env.R2_BUNDLES_SECRET_ACCESS_KEY)) {
+    problems.push('S3_BUNDLES_SECRET_ACCESS_KEY/R2_BUNDLES_SECRET_ACCESS_KEY');
+  }
+  const bundleBucket = env.S3_BUNDLES_BUCKET ?? env.R2_BUNDLES_BUCKET;
+  if (!bundleBucket) {
+    problems.push('S3_BUNDLES_BUCKET/R2_BUNDLES_BUCKET');
+  } else {
+    const syncBucket = env.S3_BUCKET ?? env.R2_BUCKET ?? 'matrixos-sync';
+    if (bundleBucket === syncBucket) {
+      problems.push('S3_BUNDLES_BUCKET/R2_BUNDLES_BUCKET must not equal S3_BUCKET/R2_BUCKET');
+    }
+  }
+  if (problems.length > 0) {
+    log(
+      `[platform] CUSTOMER_VPS_ENABLED=true but dedicated host bundle storage is incomplete; refusing to fall back to the sync bucket for signed host bundle URLs. Problems: ${problems.join(', ')}.`,
+    );
+  }
+  return problems;
+}
+
 interface AppDomainIdentity {
   handle: string;
   userId: string;
@@ -2892,6 +2924,7 @@ export function createApp(deps: {
   const legacyContainerRoutingEnabled =
     appEnv.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED === 'true' && !deps.customerVpsService;
   const platformSecret = deps.platformSecret ?? appEnv.PLATFORM_SECRET ?? '';
+  const allowHostBundleSyncStoreFallback = appEnv.CUSTOMER_VPS_ENABLED !== 'true';
   type CachedVpsRuntimeMetrics = {
     machineKey: string;
     expiresAt: number;
@@ -3137,8 +3170,12 @@ export function createApp(deps: {
     });
   });
 
+  function getHostBundleObjectStore(): CustomerVpsObjectStore | undefined {
+    return deps.hostBundleObjectStore ?? (allowHostBundleSyncStoreFallback ? deps.customerVpsObjectStore : undefined);
+  }
+
   async function getSignedBundleUrl(release: HostBundleReleaseRecord): Promise<string> {
-    const hostBundleObjectStore = deps.hostBundleObjectStore ?? deps.customerVpsObjectStore;
+    const hostBundleObjectStore = getHostBundleObjectStore();
     if (!hostBundleObjectStore) {
       throw new Error('Host bundle storage unavailable');
     }
@@ -3277,7 +3314,7 @@ export function createApp(deps: {
   // Public, immutable host-service bundles used by customer VPS cloud-init.
   // Metadata comes from Postgres; R2 only stores the bytes.
   app.get('/system-bundles/:imageVersion/:file', async (c) => {
-    const hostBundleObjectStore = deps.hostBundleObjectStore ?? deps.customerVpsObjectStore;
+    const hostBundleObjectStore = getHostBundleObjectStore();
     if (!hostBundleObjectStore) {
       return c.json({ error: 'Host bundle storage unavailable' }, 503);
     }
@@ -3398,7 +3435,7 @@ export function createApp(deps: {
   });
 
   app.get('/system-bundles/channels/:channel', async (c) => {
-    const hostBundleObjectStore = deps.hostBundleObjectStore ?? deps.customerVpsObjectStore;
+    const hostBundleObjectStore = getHostBundleObjectStore();
     if (!hostBundleObjectStore) {
       return c.json({ error: 'Host bundle storage unavailable' }, 503);
     }
@@ -4864,10 +4901,14 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
     }
     throw err;
   }
+  checkHomeMirrorS3Env();
+  const hostBundleStorageProblems = checkHostBundleStorageEnv();
+  if (hostBundleStorageProblems.length > 0) {
+    process.exit(1);
+  }
+
   const db = createPlatformDb(runtimeConfig.platformDatabaseUrl);
   await db.ready;
-
-  checkHomeMirrorS3Env();
 
   let docker: Dockerode | undefined;
   let orchestrator: Orchestrator;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -98,6 +98,7 @@ const PLATFORM_SECRET = process.env.PLATFORM_SECRET ?? '';
 const PLATFORM_JWT_SECRET = process.env.PLATFORM_JWT_SECRET ?? '';
 const DEV_PLATFORM_SECRET = 'dev-secret';
 const DEV_PLATFORM_JWT_SECRET = 'dev-platform-jwt-secret-please-change-32';
+const DEFAULT_SYNC_BUCKET = 'matrixos-sync';
 const HANDLE_PATTERN = /^[a-z][a-z0-9-]{2,30}$/;
 const ADMIN_BODY_LIMIT = 64 * 1024;
 const PROXY_BODY_LIMIT = 10 * 1024 * 1024;
@@ -1385,7 +1386,7 @@ export function checkHostBundleStorageEnv(
   if (!bundleBucket) {
     problems.push('S3_BUNDLES_BUCKET/R2_BUNDLES_BUCKET');
   } else {
-    const syncBucket = env.S3_BUCKET ?? env.R2_BUCKET ?? 'matrixos-sync';
+    const syncBucket = env.S3_BUCKET ?? env.R2_BUCKET ?? DEFAULT_SYNC_BUCKET;
     if (bundleBucket === syncBucket) {
       problems.push('S3_BUNDLES_BUCKET/R2_BUNDLES_BUCKET must not equal S3_BUCKET/R2_BUCKET');
     }

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -448,4 +448,16 @@ describe('customer VPS host bundle', () => {
     expect(restore).toContain('latest_pointer_key="system/db/latest"');
     expect(restore).toContain('/opt/matrix/bin/matrixctl r2 get "$latest_pointer_key" "$latest_file"');
   });
+
+  it('platform Cloud Run workflow smokes signed host bundle URLs before promotion', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/health"');
+    expect(workflow).toContain('$CANDIDATE_URL/system-bundles/channels/dev.json');
+    expect(workflow).toContain("jq -r '.url // empty'");
+    expect(workflow).toContain("grep -q 'matrixos-sync'");
+    expect(workflow).toContain('Candidate host bundle signer returned the sync bucket; refusing to promote.');
+    expect(workflow).toContain('curl --fail --silent --show-error --max-time 20 --range 0-0 "$bundle_url"');
+  });
 });

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -456,8 +456,13 @@ describe('customer VPS host bundle', () => {
     expect(workflow).toContain('curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/health"');
     expect(workflow).toContain('$CANDIDATE_URL/system-bundles/channels/dev.json');
     expect(workflow).toContain("jq -r '.url // empty'");
-    expect(workflow).toContain("grep -q 'matrixos-sync'");
-    expect(workflow).toContain('Candidate host bundle signer returned the sync bucket; refusing to promote.');
+    expect(workflow).toContain('sync_bucket="$(gcloud secrets versions access latest --secret=r2-bucket)"');
+    expect(workflow).toContain('bundle_bucket="$(gcloud secrets versions access latest --secret=r2-bundles-bucket)"');
+    expect(workflow).toContain('Dedicated host bundle bucket secret matches the sync bucket secret; refusing to promote.');
+    expect(workflow).toContain('grep -Fq -- "$sync_bucket"');
+    expect(workflow).toContain('Candidate host bundle signer returned the configured sync bucket; refusing to promote.');
+    expect(workflow).toContain("grep -Fq 'r2.cloudflarestorage.com'");
+    expect(workflow).toContain('Candidate host bundle signer returned a native R2 URL outside the bundle bucket; refusing to promote.');
     expect(workflow).toContain('curl --fail --silent --show-error --max-time 20 --range 0-0 "$bundle_url"');
   });
 });

--- a/tests/platform/home-mirror-env-check.test.ts
+++ b/tests/platform/home-mirror-env-check.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  checkHostBundleStorageEnv,
   checkHomeMirrorS3Env,
   checkUnsafeDefaultSecrets,
 } from "../../packages/platform/src/main.js";
@@ -99,6 +100,80 @@ describe("checkHomeMirrorS3Env (startup assertion for silent-failure #6)", () =>
     expect(() =>
       checkHomeMirrorS3Env({ MATRIX_HOME_MIRROR: "true" }, log),
     ).not.toThrow();
+  });
+});
+
+describe("checkHostBundleStorageEnv", () => {
+  it("returns [] and does not log when customer VPSes are disabled", () => {
+    const log = vi.fn();
+    const missing = checkHostBundleStorageEnv({}, log);
+    expect(missing).toEqual([]);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("returns [] and does not log when dedicated bundle storage is configured", () => {
+    const log = vi.fn();
+    const missing = checkHostBundleStorageEnv(
+      {
+        CUSTOMER_VPS_ENABLED: "true",
+        R2_BUNDLES_ACCOUNT_ID: "acc_123",
+        R2_BUNDLES_ACCESS_KEY_ID: "bundle-key",
+        R2_BUNDLES_SECRET_ACCESS_KEY: "bundle-secret",
+        R2_BUNDLES_BUCKET: "matrixos-bundles",
+      },
+      log,
+    );
+    expect(missing).toEqual([]);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("warns when customer VPSes are enabled without dedicated bundle storage", () => {
+    const log = vi.fn();
+    const missing = checkHostBundleStorageEnv(
+      {
+        CUSTOMER_VPS_ENABLED: "true",
+        R2_ACCOUNT_ID: "sync-account",
+        R2_ACCESS_KEY_ID: "sync-key",
+        R2_SECRET_ACCESS_KEY: "sync-secret",
+        R2_BUCKET: "matrixos-sync",
+      },
+      log,
+    );
+    expect(missing).toEqual([
+      "S3_BUNDLES_ENDPOINT/R2_BUNDLES_ENDPOINT or S3_BUNDLES_ACCOUNT_ID/R2_BUNDLES_ACCOUNT_ID",
+      "S3_BUNDLES_ACCESS_KEY_ID/R2_BUNDLES_ACCESS_KEY_ID",
+      "S3_BUNDLES_SECRET_ACCESS_KEY/R2_BUNDLES_SECRET_ACCESS_KEY",
+      "S3_BUNDLES_BUCKET/R2_BUNDLES_BUCKET",
+    ]);
+    expect(log).toHaveBeenCalledOnce();
+    const msg = log.mock.calls[0][0];
+    expect(msg).toContain("CUSTOMER_VPS_ENABLED=true");
+    expect(msg).toContain("dedicated host bundle storage is incomplete");
+    expect(msg).toContain("refusing to fall back to the sync bucket");
+    expect(msg).toContain("S3_BUNDLES_BUCKET/R2_BUNDLES_BUCKET");
+  });
+
+  it("warns when dedicated bundle storage points at the sync bucket", () => {
+    const log = vi.fn();
+    const missing = checkHostBundleStorageEnv(
+      {
+        CUSTOMER_VPS_ENABLED: "true",
+        R2_ACCOUNT_ID: "sync-account",
+        R2_BUCKET: "matrixos-sync",
+        R2_BUNDLES_ACCOUNT_ID: "bundle-account",
+        R2_BUNDLES_ACCESS_KEY_ID: "bundle-key",
+        R2_BUNDLES_SECRET_ACCESS_KEY: "bundle-secret",
+        R2_BUNDLES_BUCKET: "matrixos-sync",
+      },
+      log,
+    );
+    expect(missing).toEqual([
+      "S3_BUNDLES_BUCKET/R2_BUNDLES_BUCKET must not equal S3_BUCKET/R2_BUCKET",
+    ]);
+    expect(log).toHaveBeenCalledOnce();
+    const msg = log.mock.calls[0][0];
+    expect(msg).toContain("Problems:");
+    expect(msg).toContain("must not equal S3_BUCKET/R2_BUCKET");
   });
 });
 

--- a/tests/platform/host-bundle-route.test.ts
+++ b/tests/platform/host-bundle-route.test.ts
@@ -255,6 +255,44 @@ describe('platform host bundle route', () => {
     expect(syncGetPresignedGetUrl).not.toHaveBeenCalled();
   });
 
+  it('uses dedicated host bundle object storage for dev channel manifests in customer VPS mode', async () => {
+    await seedRelease();
+    await promoteHostBundleChannel(db, 'dev', 'v2026.05.12-1');
+    const syncGetPresignedGetUrl = vi.fn().mockResolvedValue('https://sync.example/wrong-bucket');
+    const bundleGetPresignedGetUrl = vi.fn().mockResolvedValue('https://bundles.example/dev-host-bundle');
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: syncGetPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+      hostBundleObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: bundleGetPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+      env: {
+        CUSTOMER_VPS_ENABLED: 'true',
+      },
+    });
+
+    const res = await app.request('/system-bundles/channels/dev.json');
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      version: 'v2026.05.12-1',
+      channel: 'dev',
+      url: 'https://bundles.example/dev-host-bundle',
+    });
+    expect(bundleGetPresignedGetUrl).toHaveBeenCalledWith(
+      'system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz',
+      3600,
+    );
+    expect(syncGetPresignedGetUrl).not.toHaveBeenCalled();
+  });
+
   it('serializes the requested channel for promoted channel aliases', async () => {
     await upsertHostBundleRelease(db, {
       version: 'v2026.05.12-7',

--- a/tests/platform/host-bundle-route.test.ts
+++ b/tests/platform/host-bundle-route.test.ts
@@ -124,6 +124,29 @@ describe('platform host bundle route', () => {
     expect(syncGetPresignedGetUrl).not.toHaveBeenCalled();
   });
 
+  it('does not fall back to sync storage for customer VPS host bundle archives', async () => {
+    await seedRelease();
+    const syncGetPresignedGetUrl = vi.fn().mockResolvedValue('https://sync.example/wrong-bucket');
+    const app = createApp({
+      db,
+      orchestrator,
+      customerVpsObjectStore: {
+        getObject: vi.fn(),
+        getPresignedGetUrl: syncGetPresignedGetUrl,
+        putObject: vi.fn(),
+      } as unknown as CustomerVpsObjectStore,
+      env: {
+        CUSTOMER_VPS_ENABLED: 'true',
+      },
+    });
+
+    const res = await app.request('/system-bundles/v2026.05.12-1/matrix-host-bundle.tar.gz');
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ error: 'Host bundle storage unavailable' });
+    expect(syncGetPresignedGetUrl).not.toHaveBeenCalled();
+  });
+
   it('returns JSON 502 when release metadata cannot mint a signed URL', async () => {
     await seedRelease();
     const getPresignedGetUrl = vi.fn().mockRejectedValue(new Error('r2 unavailable'));


### PR DESCRIPTION
## Summary
- fail closed when customer VPS mode lacks a dedicated host-bundle R2 store instead of falling back to the sync bucket
- reject bundle storage config that points at the same bucket as sync storage
- extend Platform Cloud Run candidate smoke to verify a signed dev host-bundle manifest and one-byte bundle read before promotion

## Invariants
- Source of truth: platform Postgres remains the release metadata and channel source of truth; R2 only stores immutable bundle bytes.
- Lock/transaction scope: no database writes are added; startup config validation runs before opening the platform DB, and route reads continue through existing release lookup helpers.
- Acceptable orphan states: a misconfigured platform revision may fail startup or return host-bundle storage unavailable; it must not sign bundle URLs from the sync bucket.
- Auth source of truth: public host-bundle metadata/download routes remain public; release registration and channel promotion still require the platform admin bearer token.
- Deferred scope: Neon database migration and production domain cutover are not included in this PR.

## Verification
- bun run test tests/platform/home-mirror-env-check.test.ts tests/platform/host-bundle-route.test.ts tests/platform/customer-vps-host-bundle.test.ts
- bun run check:patterns
- bun run typecheck