### PR TITLE
chore(platform): add managed postgres migration workflow

### DIFF
--- a/.github/workflows/platform-db-migration.yml
+++ b/.github/workflows/platform-db-migration.yml
@@ -81,6 +81,18 @@ jobs:
             printf 'Missing required value(s): %s\n' "${missing[*]}" >&2
             exit 1
           fi
+          safe_identifier_re='^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$'
+          safe_secret_re='^[A-Za-z0-9_][A-Za-z0-9_-]{0,127}$'
+          for name in SOURCE_CONTAINER SOURCE_DATABASE SOURCE_USER; do
+            if ! printf '%s\n' "${!name}" | grep -Eq "$safe_identifier_re"; then
+              printf 'Invalid %s: only letters, numbers, underscore, and hyphen are allowed.\n' "$name" >&2
+              exit 1
+            fi
+          done
+          if ! printf '%s\n' "$TARGET_SECRET" | grep -Eq "$safe_secret_re"; then
+            echo "Invalid TARGET_SECRET: only letters, numbers, underscore, and hyphen are allowed." >&2
+            exit 1
+          fi
           if [ "$MODE" = "migrate" ] && [ "$CONFIRMATION" != "MIGRATE PLATFORM DB TO MANAGED POSTGRES" ]; then
             echo "Refusing destructive migration without the exact confirmation phrase." >&2
             exit 1
@@ -137,6 +149,12 @@ jobs:
           ssh -i ~/.ssh/matrix-platform-migration "root@$VPS_HOST" \
             "set -euo pipefail; install -d -m 0700 /home/deploy/backups/platform-migration; docker exec '$SOURCE_CONTAINER' pg_dump --format=custom --no-owner --no-acl -U '$SOURCE_USER' -d '$SOURCE_DATABASE' > '$remote_backup'; chmod 0600 '$remote_backup'; stat -c '%s bytes' '$remote_backup'"
 
+      - name: Prune old VPS migration snapshots
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/matrix-platform-migration "root@$VPS_HOST" \
+            "set -euo pipefail; find /home/deploy/backups/platform-migration -maxdepth 1 -type f -name 'platform-*.dump' -mtime +7 -delete"
+
       - name: Download source snapshot to runner
         run: |
           set -euo pipefail
@@ -154,6 +172,7 @@ jobs:
           echo "Source counts:"
           printf '%s\n' "$source_counts"
           echo "Target counts before migration:"
+          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "SELECT 1" > /dev/null
           psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select 'users=' || count(*) from users union all select 'user_machines=' || count(*) from user_machines union all select 'host_bundle_releases=' || count(*) from host_bundle_releases;" || true
 
       - name: Restore into managed database

--- a/.github/workflows/platform-db-migration.yml
+++ b/.github/workflows/platform-db-migration.yml
@@ -1,0 +1,185 @@
+name: Platform DB Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment with GCP OIDC access
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+      mode:
+        description: Verify counts or restore Docker platform DB into the managed target
+        required: true
+        default: verify
+        type: choice
+        options:
+          - verify
+          - migrate
+      confirmation:
+        description: Type MIGRATE PLATFORM DB TO MANAGED POSTGRES when mode=migrate
+        required: false
+        default: ""
+        type: string
+      source_container:
+        description: Docker Postgres container on the current platform VPS
+        required: true
+        default: distro-postgres-1
+        type: string
+      source_database:
+        description: Source platform database name
+        required: true
+        default: matrixos_platform
+        type: string
+      source_user:
+        description: Source Postgres user inside the Docker Postgres container
+        required: true
+        default: matrixos
+        type: string
+      target_secret:
+        description: GCP Secret Manager secret containing the managed Postgres URL
+        required: true
+        default: platform-database-url
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: platform-db-migration-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Migrate platform Postgres
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      VPS_HOST: ${{ secrets.VPS_HOST }}
+      SOURCE_CONTAINER: ${{ inputs.source_container }}
+      SOURCE_DATABASE: ${{ inputs.source_database }}
+      SOURCE_USER: ${{ inputs.source_user }}
+      TARGET_SECRET: ${{ inputs.target_secret }}
+      MODE: ${{ inputs.mode }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+    steps:
+      - name: Validate migration inputs
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in GCP_PROJECT_ID VPS_HOST SOURCE_CONTAINER SOURCE_DATABASE SOURCE_USER TARGET_SECRET MODE; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing required value(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+          if [ "$MODE" = "migrate" ] && [ "$CONFIRMATION" != "MIGRATE PLATFORM DB TO MANAGED POSTGRES" ]; then
+            echo "Refusing destructive migration without the exact confirmation phrase." >&2
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Install Postgres client
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Configure SSH
+        run: |
+          set -euo pipefail
+          install -m 0700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/matrix-platform-migration
+          chmod 0600 ~/.ssh/matrix-platform-migration
+          ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts
+
+      - name: Read managed database URL
+        run: |
+          set -euo pipefail
+          target_url="$(gcloud secrets versions access latest \
+            --project "$GCP_PROJECT_ID" \
+            --secret "$TARGET_SECRET")"
+          if [ -z "$target_url" ]; then
+            echo "Managed database URL secret is empty." >&2
+            exit 1
+          fi
+          echo "::add-mask::$target_url"
+          case "$target_url" in
+            postgresql://*|postgres://*) ;;
+            *)
+              echo "Managed database URL secret is not a Postgres URL." >&2
+              exit 1
+              ;;
+          esac
+          echo "TARGET_DATABASE_URL=$target_url" >> "$GITHUB_ENV"
+
+      - name: Snapshot source database on VPS
+        run: |
+          set -euo pipefail
+          remote_backup="/home/deploy/backups/platform-migration/platform-${GITHUB_RUN_ID}.dump"
+          echo "REMOTE_BACKUP=$remote_backup" >> "$GITHUB_ENV"
+          ssh -i ~/.ssh/matrix-platform-migration "root@$VPS_HOST" \
+            "set -euo pipefail; install -d -m 0700 /home/deploy/backups/platform-migration; docker exec '$SOURCE_CONTAINER' pg_dump --format=custom --no-owner --no-acl -U '$SOURCE_USER' -d '$SOURCE_DATABASE' > '$remote_backup'; chmod 0600 '$remote_backup'; stat -c '%s bytes' '$remote_backup'"
+
+      - name: Download source snapshot to runner
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/matrix-platform-migration "root@$VPS_HOST" \
+            "cat '$REMOTE_BACKUP'" > platform-source.dump
+          test -s platform-source.dump
+          pg_restore --list platform-source.dump | grep -q 'TABLE DATA public user_machines'
+          pg_restore --list platform-source.dump | grep -q 'TABLE DATA public host_bundle_releases'
+
+      - name: Compare source and target counts
+        run: |
+          set -euo pipefail
+          source_counts="$(ssh -i ~/.ssh/matrix-platform-migration "root@$VPS_HOST" \
+            "docker exec '$SOURCE_CONTAINER' psql -U '$SOURCE_USER' -d '$SOURCE_DATABASE' -At -c \"select 'users=' || count(*) from users union all select 'user_machines=' || count(*) from user_machines union all select 'host_bundle_releases=' || count(*) from host_bundle_releases;\"")"
+          echo "Source counts:"
+          printf '%s\n' "$source_counts"
+          echo "Target counts before migration:"
+          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select 'users=' || count(*) from users union all select 'user_machines=' || count(*) from user_machines union all select 'host_bundle_releases=' || count(*) from host_bundle_releases;" || true
+
+      - name: Restore into managed database
+        if: ${{ inputs.mode == 'migrate' }}
+        run: |
+          set -euo pipefail
+          pg_restore \
+            --clean \
+            --if-exists \
+            --no-owner \
+            --no-privileges \
+            --single-transaction \
+            --dbname "$TARGET_DATABASE_URL" \
+            platform-source.dump
+
+      - name: Verify managed database after migration
+        run: |
+          set -euo pipefail
+          if [ "$MODE" = "verify" ]; then
+            echo "Verify mode completed without restoring into the managed database."
+            exit 0
+          fi
+          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select 'users=' || count(*) from users union all select 'user_machines=' || count(*) from user_machines union all select 'host_bundle_releases=' || count(*) from host_bundle_releases;"
+          machine_count="$(psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select count(*) from user_machines;")"
+          release_count="$(psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select count(*) from host_bundle_releases;")"
+          if [ "$machine_count" -lt 1 ] || [ "$release_count" -lt 1 ]; then
+            echo "Managed database validation failed: expected machine and release rows after restore." >&2
+            exit 1
+          fi

--- a/docs/dev/vps-deployment.md
+++ b/docs/dev/vps-deployment.md
@@ -1151,6 +1151,60 @@ Add to cron:
 echo "0 3 * * * /root/matrix-os/scripts/backup.sh" | crontab -
 ```
 
+## Migrating Platform Postgres To Managed Postgres
+
+The current Docker platform stack owns the canonical `matrixos_platform` database
+until Cloud Run proves it can see the same users, machines, and host-bundle
+release metadata. Do not promote Cloud Run or stop `distro-platform-1` while the
+candidate `/vps/fleet` is empty or `/system-bundles/releases` has no rows.
+
+Use the guarded manual workflow:
+
+```bash
+gh workflow run "Platform DB Migration" \
+  --repo HamedMP/matrix-os \
+  --ref main \
+  -f environment=staging \
+  -f mode=verify
+```
+
+If the verify run can read the Docker source and the managed target, run the
+restore with the exact confirmation phrase:
+
+```bash
+gh workflow run "Platform DB Migration" \
+  --repo HamedMP/matrix-os \
+  --ref main \
+  -f environment=staging \
+  -f mode=migrate \
+  -f confirmation="MIGRATE PLATFORM DB TO MANAGED POSTGRES"
+```
+
+The workflow keeps a VPS-local custom-format dump under
+`/home/deploy/backups/platform-migration/`, reads the managed target from the
+GCP `platform-database-url` secret, restores with `pg_restore --clean
+--if-exists --single-transaction`, and verifies non-zero `users`,
+`user_machines`, and `host_bundle_releases` counts.
+
+After migration:
+
+```bash
+gh workflow run "Platform Cloud Run" \
+  --repo HamedMP/matrix-os \
+  --ref main \
+  -f environment=staging \
+  -f promote=true
+
+curl -fsS https://api.matrix-os.com/health
+curl -fsS https://api.matrix-os.com/system-bundles/channels/dev.json
+curl -fsS -H "Authorization: Bearer $PLATFORM_SECRET" https://api.matrix-os.com/vps/fleet
+```
+
+Docker platform can be stopped only after Cloud Run is serving 100% traffic and
+the Cloud Run `/vps/fleet` output matches the Docker platform fleet. Customer VPS
+Postgres databases are not part of this migration; they stay owner-local on each
+VPS.
+
 ### Hetzner Snapshots
 
 For full-server backups, use Hetzner server snapshots:

--- a/tests/platform/platform-db-migration-workflow.test.ts
+++ b/tests/platform/platform-db-migration-workflow.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('platform DB migration workflow', () => {
+  it('requires explicit confirmation before restoring into managed Postgres', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-db-migration.yml'), 'utf8');
+
+    expect(workflow).toContain('default: verify');
+    expect(workflow).toContain('MIGRATE PLATFORM DB TO MANAGED POSTGRES');
+    expect(workflow).toContain('Refusing destructive migration without the exact confirmation phrase.');
+    expect(workflow).toContain("if: ${{ inputs.mode == 'migrate' }}");
+  });
+
+  it('moves data through a VPS-local snapshot without uploading database dumps as artifacts', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-db-migration.yml'), 'utf8');
+
+    expect(workflow).toContain('docker exec \'$SOURCE_CONTAINER\' pg_dump --format=custom --no-owner --no-acl');
+    expect(workflow).toContain('/home/deploy/backups/platform-migration/platform-${GITHUB_RUN_ID}.dump');
+    expect(workflow).toContain('cat \'$REMOTE_BACKUP\'');
+    expect(workflow).toContain('pg_restore --list platform-source.dump');
+    expect(workflow).not.toContain('actions/upload-artifact');
+  });
+
+  it('reads the managed target from GCP Secret Manager and masks the URL', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-db-migration.yml'), 'utf8');
+
+    expect(workflow).toContain('google-github-actions/auth@v3');
+    expect(workflow).toContain('gcloud secrets versions access latest');
+    expect(workflow).toContain('--secret "$TARGET_SECRET"');
+    expect(workflow).toContain('echo "::add-mask::$target_url"');
+    expect(workflow).toContain('TARGET_DATABASE_URL=$target_url');
+  });
+
+  it('verifies key platform row counts after restore', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-db-migration.yml'), 'utf8');
+
+    expect(workflow).toContain("select 'users=' || count(*) from users");
+    expect(workflow).toContain("select 'user_machines=' || count(*) from user_machines");
+    expect(workflow).toContain("select 'host_bundle_releases=' || count(*) from host_bundle_releases");
+    expect(workflow).toContain('expected machine and release rows after restore');
+  });
+});

--- a/tests/platform/platform-db-migration-workflow.test.ts
+++ b/tests/platform/platform-db-migration-workflow.test.ts
@@ -11,6 +11,8 @@ describe('platform DB migration workflow', () => {
     expect(workflow).toContain('MIGRATE PLATFORM DB TO MANAGED POSTGRES');
     expect(workflow).toContain('Refusing destructive migration without the exact confirmation phrase.');
     expect(workflow).toContain("if: ${{ inputs.mode == 'migrate' }}");
+    expect(workflow).toContain("safe_identifier_re='^[A-Za-z0-9_][A-Za-z0-9_-]{0,63}$'");
+    expect(workflow).toContain('Invalid %s: only letters, numbers, underscore, and hyphen are allowed.');
   });
 
   it('moves data through a VPS-local snapshot without uploading database dumps as artifacts', () => {
@@ -21,6 +23,7 @@ describe('platform DB migration workflow', () => {
     expect(workflow).toContain('/home/deploy/backups/platform-migration/platform-${GITHUB_RUN_ID}.dump');
     expect(workflow).toContain('cat \'$REMOTE_BACKUP\'');
     expect(workflow).toContain('pg_restore --list platform-source.dump');
+    expect(workflow).toContain("find /home/deploy/backups/platform-migration -maxdepth 1 -type f -name 'platform-*.dump' -mtime +7 -delete");
     expect(workflow).not.toContain('actions/upload-artifact');
   });
 
@@ -33,6 +36,7 @@ describe('platform DB migration workflow', () => {
     expect(workflow).toContain('--secret "$TARGET_SECRET"');
     expect(workflow).toContain('echo "::add-mask::$target_url"');
     expect(workflow).toContain('TARGET_DATABASE_URL=$target_url');
+    expect(workflow).toContain('psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "SELECT 1" > /dev/null');
   });
 
   it('verifies key platform row counts after restore', () => {


### PR DESCRIPTION
## Summary
- add a guarded manual Platform DB Migration workflow for moving the Docker `matrixos_platform` DB into the managed Postgres URL stored in GCP Secret Manager
- keep the source dump on the VPS and ephemeral runner only; no database artifact upload
- document the migration/Cloud Run promotion gate before the Docker platform can be stopped

## Verification
- `bun run test tests/platform/platform-db-migration-workflow.test.ts`
- `python3` YAML parse for `.github/workflows/platform-db-migration.yml`
- `bun run check:patterns`
- `git diff --check`

## Invariants
- **Source of truth**: before migration, Docker Postgres `matrixos_platform` remains canonical; after a successful restore and Cloud Run verification, the GCP `platform-database-url` managed Postgres target becomes canonical for the platform control plane.
- **Lock/transaction scope**: restore mode uses `pg_restore --clean --if-exists --single-transaction` against the managed target so the target is not left partially restored on restore failure.
- **Acceptable orphan states**: verify mode only creates a VPS-local dump under `/home/deploy/backups/platform-migration/`; failed migrate runs may leave that backup file but do not promote Cloud Run or stop Docker.
- **Auth source of truth**: GitHub environment OIDC reads the GCP secret; repo `VPS_HOST`/`VPS_SSH_KEY` access the current Docker platform host as root, matching the existing Docker deploy workflow.
- **Deferred scope**: this does not migrate owner-local customer VPS Postgres databases; those remain per-owner data stores by design. It also does not automatically stop Docker after migration.
