### PR TITLE
fix(platform): harden db migration restore validation

### DIFF
--- a/.github/workflows/platform-db-migration.yml
+++ b/.github/workflows/platform-db-migration.yml
@@ -161,25 +161,32 @@ jobs:
           ssh -i ~/.ssh/matrix-platform-migration "root@$VPS_HOST" \
             "cat '$REMOTE_BACKUP'" > platform-source.dump
           test -s platform-source.dump
-          pg_restore --list platform-source.dump | grep -q 'TABLE DATA public user_machines'
-          pg_restore --list platform-source.dump | grep -q 'TABLE DATA public host_bundle_releases'
+          pg_restore --list platform-source.dump | grep -q 'TABLE public users '
+          pg_restore --list platform-source.dump | grep -q 'TABLE public user_machines '
+          pg_restore --list platform-source.dump | grep -q 'TABLE public host_bundle_releases '
+          pg_restore --list platform-source.dump | grep -q 'TABLE DATA public user_machines '
+          pg_restore --list platform-source.dump | grep -q 'TABLE DATA public host_bundle_releases '
 
       - name: Compare source and target counts
         run: |
           set -euo pipefail
           source_counts="$(ssh -i ~/.ssh/matrix-platform-migration "root@$VPS_HOST" \
-            "docker exec '$SOURCE_CONTAINER' psql -U '$SOURCE_USER' -d '$SOURCE_DATABASE' -At -c \"select 'users=' || count(*) from users union all select 'user_machines=' || count(*) from user_machines union all select 'host_bundle_releases=' || count(*) from host_bundle_releases;\"")"
+            "docker exec '$SOURCE_CONTAINER' psql -U '$SOURCE_USER' -d '$SOURCE_DATABASE' -At -c \"select 'users=' || count(*) from public.users union all select 'user_machines=' || count(*) from public.user_machines union all select 'host_bundle_releases=' || count(*) from public.host_bundle_releases;\"")"
           echo "Source counts:"
           printf '%s\n' "$source_counts"
+          echo "Managed database visible platform tables:"
+          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select table_schema || '.' || table_name from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema') and table_name in ('users', 'user_machines', 'host_bundle_releases') order by table_schema, table_name;" || true
           echo "Target counts before migration:"
           psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "SELECT 1" > /dev/null
-          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select 'users=' || count(*) from users union all select 'user_machines=' || count(*) from user_machines union all select 'host_bundle_releases=' || count(*) from host_bundle_releases;" || true
+          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select 'users=' || count(*) from public.users union all select 'user_machines=' || count(*) from public.user_machines union all select 'host_bundle_releases=' || count(*) from public.host_bundle_releases;" || true
 
       - name: Restore into managed database
         if: ${{ inputs.mode == 'migrate' }}
         run: |
           set -euo pipefail
           pg_restore \
+            --exit-on-error \
+            --verbose \
             --clean \
             --if-exists \
             --no-owner \
@@ -195,9 +202,12 @@ jobs:
             echo "Verify mode completed without restoring into the managed database."
             exit 0
           fi
-          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select 'users=' || count(*) from users union all select 'user_machines=' || count(*) from user_machines union all select 'host_bundle_releases=' || count(*) from host_bundle_releases;"
-          machine_count="$(psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select count(*) from user_machines;")"
-          release_count="$(psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select count(*) from host_bundle_releases;")"
+          echo "Managed database tables after restore:"
+          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select table_schema || '.' || table_name from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema') and table_name in ('users', 'user_machines', 'host_bundle_releases') order by table_schema, table_name;"
+          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select to_regclass('public.users'), to_regclass('public.user_machines'), to_regclass('public.host_bundle_releases');"
+          psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select 'users=' || count(*) from public.users union all select 'user_machines=' || count(*) from public.user_machines union all select 'host_bundle_releases=' || count(*) from public.host_bundle_releases;"
+          machine_count="$(psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select count(*) from public.user_machines;")"
+          release_count="$(psql "$TARGET_DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "select count(*) from public.host_bundle_releases;")"
           if [ "$machine_count" -lt 1 ] || [ "$release_count" -lt 1 ]; then
             echo "Managed database validation failed: expected machine and release rows after restore." >&2
             exit 1

--- a/packages/platform/src/r2-client.ts
+++ b/packages/platform/src/r2-client.ts
@@ -40,11 +40,25 @@ export interface R2Client {
   destroy(): void;
 }
 
+function normalizeConfigValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 export async function createR2Client(config: R2ClientConfig): Promise<R2Client> {
-  const { accountId, accessKeyId, secretAccessKey, bucket } = config;
-  const endpoint = config.endpoint ?? (accountId ? `https://${accountId}.r2.cloudflarestorage.com` : null);
+  const accountId = normalizeConfigValue(config.accountId);
+  const accessKeyId = normalizeConfigValue(config.accessKeyId);
+  const secretAccessKey = normalizeConfigValue(config.secretAccessKey);
+  const bucket = normalizeConfigValue(config.bucket);
+  const endpoint =
+    normalizeConfigValue(config.endpoint) ??
+    (accountId ? `https://${accountId}.r2.cloudflarestorage.com` : null);
+  const publicEndpoint = normalizeConfigValue(config.publicEndpoint);
   if (!endpoint) {
     throw new Error("R2 client requires either accountId or endpoint");
+  }
+  if (!accessKeyId || !secretAccessKey || !bucket) {
+    throw new Error("R2 client requires access key, secret key, and bucket");
   }
 
   const {
@@ -64,9 +78,9 @@ export async function createR2Client(config: R2ClientConfig): Promise<R2Client> 
   });
 
   function rewritePublicEndpoint(url: string): string {
-    if (!config.publicEndpoint) return url;
+    if (!publicEndpoint) return url;
     const signed = new URL(url);
-    const publicUrl = new URL(config.publicEndpoint);
+    const publicUrl = new URL(publicEndpoint);
     signed.protocol = publicUrl.protocol;
     signed.host = publicUrl.host;
     return signed.toString();

--- a/tests/platform/platform-db-migration-workflow.test.ts
+++ b/tests/platform/platform-db-migration-workflow.test.ts
@@ -23,6 +23,11 @@ describe('platform DB migration workflow', () => {
     expect(workflow).toContain('/home/deploy/backups/platform-migration/platform-${GITHUB_RUN_ID}.dump');
     expect(workflow).toContain('cat \'$REMOTE_BACKUP\'');
     expect(workflow).toContain('pg_restore --list platform-source.dump');
+    expect(workflow).toContain("pg_restore --list platform-source.dump | grep -q 'TABLE public users '");
+    expect(workflow).toContain("pg_restore --list platform-source.dump | grep -q 'TABLE public user_machines '");
+    expect(workflow).toContain("pg_restore --list platform-source.dump | grep -q 'TABLE public host_bundle_releases '");
+    expect(workflow).toContain("pg_restore --list platform-source.dump | grep -q 'TABLE DATA public user_machines '");
+    expect(workflow).toContain("pg_restore --list platform-source.dump | grep -q 'TABLE DATA public host_bundle_releases '");
     expect(workflow).toContain("find /home/deploy/backups/platform-migration -maxdepth 1 -type f -name 'platform-*.dump' -mtime +7 -delete");
     expect(workflow).not.toContain('actions/upload-artifact');
   });
@@ -43,9 +48,20 @@ describe('platform DB migration workflow', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-db-migration.yml'), 'utf8');
 
-    expect(workflow).toContain("select 'users=' || count(*) from users");
-    expect(workflow).toContain("select 'user_machines=' || count(*) from user_machines");
-    expect(workflow).toContain("select 'host_bundle_releases=' || count(*) from host_bundle_releases");
+    expect(workflow).toContain("select 'users=' || count(*) from public.users");
+    expect(workflow).toContain("select 'user_machines=' || count(*) from public.user_machines");
+    expect(workflow).toContain("select 'host_bundle_releases=' || count(*) from public.host_bundle_releases");
+    expect(workflow).toContain("to_regclass('public.users')");
     expect(workflow).toContain('expected machine and release rows after restore');
+  });
+
+  it('fails loudly if pg_restore hits target-side SQL errors', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-db-migration.yml'), 'utf8');
+
+    expect(workflow).toContain('pg_restore \\');
+    expect(workflow).toContain('--exit-on-error \\');
+    expect(workflow).toContain('--verbose \\');
+    expect(workflow).toContain('Managed database tables after restore:');
   });
 });

--- a/tests/platform/r2-client.test.ts
+++ b/tests/platform/r2-client.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSend = vi.fn();
+const mockGetSignedUrl = vi.fn();
+const createdClientConfigs: unknown[] = [];
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class MockS3Client {
+    constructor(config: unknown) {
+      createdClientConfigs.push(config);
+    }
+
+    send = mockSend;
+    destroy = vi.fn();
+  }
+
+  return {
+    S3Client: MockS3Client,
+    GetObjectCommand: class {
+      constructor(public params: unknown) {}
+    },
+    PutObjectCommand: class {
+      constructor(public params: unknown) {}
+    },
+    DeleteObjectCommand: class {
+      constructor(public params: unknown) {}
+    },
+    CreateMultipartUploadCommand: class {
+      constructor(public params: unknown) {}
+    },
+    UploadPartCommand: class {
+      constructor(public params: unknown) {}
+    },
+  };
+});
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
+}));
+
+import { createR2Client } from "../../packages/platform/src/r2-client.js";
+
+describe("platform R2 client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createdClientConfigs.length = 0;
+  });
+
+  it("trims object-store secrets and endpoints before creating the S3 client", async () => {
+    mockGetSignedUrl.mockResolvedValue("https://internal.example.com/bundle.tar.gz?sig=1");
+    const client = await createR2Client({
+      accountId: " account-id\n",
+      accessKeyId: "bundle-key\n",
+      secretAccessKey: " bundle-secret ",
+      bucket: " matrixos-bundles\n",
+      publicEndpoint: " https://bundles.example.com\n",
+    });
+
+    expect(createdClientConfigs.at(-1)).toMatchObject({
+      endpoint: "https://account-id.r2.cloudflarestorage.com",
+      credentials: {
+        accessKeyId: "bundle-key",
+        secretAccessKey: "bundle-secret",
+      },
+    });
+
+    await expect(client.getPresignedGetUrl("system-bundles/dev.tar.gz")).resolves.toBe(
+      "https://bundles.example.com/bundle.tar.gz?sig=1",
+    );
+    client.destroy();
+  });
+
+  it("rejects blank credentials after trimming", async () => {
+    await expect(
+      createR2Client({
+        endpoint: "https://r2.example.com",
+        accessKeyId: "\n",
+        secretAccessKey: "secret",
+        bucket: "matrixos-bundles",
+      }),
+    ).rejects.toThrow(/access key, secret key, and bucket/i);
+  });
+});


### PR DESCRIPTION
## Summary
- make platform DB restore fail loudly with `pg_restore --exit-on-error --verbose`
- validate the source dump includes public platform table definitions before restore
- verify managed target counts with schema-qualified `public.*` queries and print the relevant target table list for diagnosis
- trim platform R2/S3 client config values so copied secrets with trailing newlines cannot poison signed bundle URLs

## Validation
- `bun run test tests/platform/platform-db-migration-workflow.test.ts tests/platform/r2-client.test.ts`
- `bun run typecheck`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `bun run check:patterns` (0 violations, existing warnings only)
- `git diff --check`
- Branch `Platform DB Migration` verify run `27060713394` confirmed managed target counts match source: `users=4`, `user_machines=33`, `host_bundle_releases=142`

## Invariants
- **Source of truth**: Docker platform Postgres remains the migration source until the managed target is validated and Cloud Run is promoted.
- **Lock/transaction scope**: `pg_restore --single-transaction --exit-on-error` keeps restore application all-or-nothing on the managed target.
- **Acceptable orphan states**: the VPS-local dump may remain for up to 7 days for rollback/debug; failed restores must leave the managed database unchanged or fail before promotion.
- **Auth source of truth**: GitHub environment secrets plus GCP OIDC read the managed database URL; the URL is masked and never uploaded as an artifact. R2 credentials are normalized at the object-store client boundary before signing.
- **Deferred scope**: this does not promote Cloud Run or stop the Docker platform; those remain gated on a successful Cloud Run rerun and live service verification.
