### PR TITLE
fix(platform): accept native app sessions

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -3581,7 +3581,7 @@ export function createApp(deps: {
   });
 
   app.post('/api/auth/app-session', bodyLimit({ maxSize: 1024 }), async (c) => {
-    if (!platformJwtSecret || !clerkAuth) {
+    if (!platformJwtSecret) {
       applyNoStoreHeaders(c);
       return c.json({ error: 'Session unavailable' }, 503);
     }
@@ -3602,8 +3602,37 @@ export function createApp(deps: {
       return c.json({ error: 'Validation error' }, 400);
     }
     const redirectTo = normalizePostAuthRedirectPath(parsed.data.redirectTo);
+    const requestedRuntimeSlot =
+      parsed.data.runtime ?? readRuntimeSlotSelection(new URL(redirectTo, 'https://app.matrix-os.com').toString()).slot;
+    const authHeader = c.req.header('authorization');
 
-    const token = clerkAuth.extractToken(c.req.header('authorization'), c.req.header('cookie'));
+    if (authHeader?.startsWith('Bearer ')) {
+      try {
+        const nativeIdentity = await resolveAppDomainIdentity({
+          authHeader,
+          cookieHeader: undefined,
+          db,
+          platformJwtSecret,
+          runtimeSlot: requestedRuntimeSlot,
+        });
+        if (nativeIdentity) {
+          applyNoStoreHeaders(c);
+          c.header('Set-Cookie', buildAppSessionCookie(authHeader.slice(7)));
+          return c.json({ redirectTo });
+        }
+      } catch (err: unknown) {
+        logPlatformRouteError('/api/auth/app-session native exchange', err);
+        applyNoStoreHeaders(c);
+        return c.json({ error: 'Session unavailable' }, 503);
+      }
+    }
+
+    if (!clerkAuth) {
+      applyNoStoreHeaders(c);
+      return c.json({ error: 'Session unavailable' }, 503);
+    }
+
+    const token = clerkAuth.extractToken(authHeader, c.req.header('cookie'));
     if (!token) {
       applyNoStoreHeaders(c);
       return c.json({ error: 'Unauthorized' }, 401);
@@ -3616,8 +3645,6 @@ export function createApp(deps: {
     }
 
     const record = await getContainerByClerkId(db, result.userId);
-    const requestedRuntimeSlot =
-      parsed.data.runtime ?? readRuntimeSlotSelection(new URL(redirectTo, 'https://app.matrix-os.com').toString()).slot;
     const machine = record ? undefined : await getActiveUserMachineByClerkId(db, result.userId, requestedRuntimeSlot);
     const handle = record?.handle ?? machine?.handle;
     if (!handle) {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1377,6 +1377,54 @@ describe("platform proxy routing", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.35:443/");
   });
 
+  it("exchanges a native sync JWT for an app session cookie before continuing", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://alice.matrix-os.com",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("shell", { status: 200 }),
+    );
+    const verifyToken = vi.fn().mockResolvedValue(null);
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({ verifyToken }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const exchange = await app.request("/api/auth/app-session", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: `Bearer ${issued.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ redirectTo: "/" }),
+    });
+
+    expect(exchange.status).toBe(200);
+    await expect(exchange.json()).resolves.toEqual({ redirectTo: "/" });
+    const setCookie = exchange.headers.get("set-cookie");
+    expect(setCookie).toContain("matrix_app_session=");
+    expect(setCookie).toContain(encodeURIComponent(issued.token));
+    expect(verifyToken).not.toHaveBeenCalled();
+
+    const appSession = setCookie?.split(";", 1)[0] ?? "";
+    const shell = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: appSession,
+      },
+    });
+
+    expect(shell.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://matrixos-alice:3000/");
+  });
+
   it("reports no runtime when a signed-in Clerk user has no Matrix computer", async () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     await deleteContainer(db, "alice");


### PR DESCRIPTION
Summary
- Let /api/auth/app-session accept a valid Matrix sync JWT from the native macOS shell.
- Set the existing Matrix app-session cookie from that token so app.matrix-os.com can route back into the user runtime without Clerk running inside the WebView.
- Keep Clerk token exchange as the browser path fallback.

Tests
- flox activate -- bun run test tests/platform/proxy-routing.test.ts

Invariants
- Source of truth: the Matrix sync JWT remains the runtime identity token; the platform DB is used only to verify that the JWT handle belongs to the token subject before setting the app-session cookie.
- Lock/transaction scope: no new writes or transactions; this is a request-scoped validation and cookie issuance path.
- Acceptable orphan states: if native JWT verification or runtime lookup fails, no cookie is set and the client receives a generic session-unavailable response; the Clerk browser exchange path still handles normal web auth.
- Auth source of truth: native requests authenticate via signed Matrix sync JWT; browser requests authenticate via Clerk and then mint a sync JWT as before.
- Deferred scope: no native UI changes, no provisioning changes, and no host-bundle deployment are included in this platform PR.