### PR TITLE
feat(edge): route matrix hosts through Cloud Run

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:coverage": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run --coverage \"$@\"' --",
     "test:e2e": "sh -c 'pnpm --filter @matrix-os/observability build && pnpm --filter @matrix-os/kernel build && vitest run --config vitest.e2e.config.ts \"$@\"' --",
     "typecheck:build-kernel": "pnpm --filter '@matrix-os/observability' build && pnpm --filter '@matrix-os/kernel' build",
-    "typecheck": "bun run typecheck:build-kernel && pnpm --filter '@matrix-os/observability' exec tsc --noEmit && pnpm --filter '@matrix-os/gateway' exec tsc --noEmit && pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json && pnpm --filter '@matrix-os/proxy' exec tsc --noEmit",
+    "typecheck": "bun run typecheck:build-kernel && pnpm --filter '@matrix-os/observability' exec tsc --noEmit && pnpm --filter '@matrix-os/gateway' exec tsc --noEmit && pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json && pnpm --filter '@matrix-os/proxy' exec tsc --noEmit && pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit",
     "check:patterns": "./scripts/review/check-patterns.sh",
     "check:patterns:diff": "./scripts/review/check-patterns.sh --diff main",
     "lint": "bun run --filter './shell' lint"

--- a/packages/edge-router/package.json
+++ b/packages/edge-router/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@matrix-os/edge-router",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run --root ../.. tests/edge-router",
+    "typecheck": "tsc --noEmit",
+    "deploy:dry-run": "wrangler deploy --dry-run",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260526.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18",
+    "wrangler": "^4.49.1"
+  }
+}

--- a/packages/edge-router/src/index.ts
+++ b/packages/edge-router/src/index.ts
@@ -1,0 +1,142 @@
+const DEFAULT_PLATFORM_ORIGIN = "https://matrix-platform-jqxkjdhtkq-ey.a.run.app";
+const UPSTREAM_TIMEOUT_MS = 10_000;
+
+export type EdgeRouteClass = "platform" | "app" | "code" | "unknown";
+
+export interface EdgeRouterEnv {
+  PLATFORM_ORIGIN?: string;
+}
+
+export function classifyEdgeRoute(host: string): EdgeRouteClass {
+  const normalized = normalizeHost(host);
+  if (normalized === "api.matrix-os.com") return "platform";
+  if (normalized === "app.matrix-os.com") return "app";
+  if (normalized === "code.matrix-os.com") return "code";
+  return "unknown";
+}
+
+export async function handleEdgeRouterRequest(
+  request: Request,
+  env: EdgeRouterEnv,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const routeClass = classifyEdgeRoute(url.host);
+  if (routeClass === "unknown") {
+    return new Response("not found", {
+      status: 404,
+      headers: noStoreTextHeaders(),
+    });
+  }
+
+  const platformOrigin = normalizePlatformOrigin(env.PLATFORM_ORIGIN ?? DEFAULT_PLATFORM_ORIGIN);
+  if (!platformOrigin) {
+    console.error("[edge-router] invalid_platform_origin");
+    return new Response("upstream unavailable", {
+      status: 503,
+      headers: noStoreTextHeaders(),
+    });
+  }
+
+  const upstreamUrl = `${platformOrigin}${url.pathname}${url.search}`;
+  const upstreamRequest = await buildPlatformRequest(request, upstreamUrl, url.host);
+
+  let response: Response;
+  try {
+    response = await fetch(upstreamRequest, {
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+  } catch (err: unknown) {
+    const status = isTimeoutError(err) ? 504 : 502;
+    console.error(`[edge-router] upstream_${status === 504 ? "timeout" : "failure"}`);
+    return new Response("upstream unavailable", {
+      status,
+      headers: noStoreTextHeaders(),
+    });
+  }
+
+  return withEdgeHeaders(response, routeClass);
+}
+
+async function buildPlatformRequest(
+  request: Request,
+  upstreamUrl: string,
+  externalHost: string,
+): Promise<Request> {
+  const headers = new Headers(request.headers);
+  const forwardedFor = sanitizeForwardedFor(headers.get("CF-Connecting-IP"));
+
+  headers.delete("host");
+  headers.delete("Host");
+  headers.set("X-Forwarded-Host", externalHost);
+  headers.set("X-Forwarded-Proto", "https");
+
+  if (forwardedFor) {
+    headers.set("X-Forwarded-For", forwardedFor);
+  } else {
+    headers.delete("X-Forwarded-For");
+  }
+
+  return new Request(upstreamUrl, {
+    method: request.method,
+    headers,
+    body: request.method === "GET" || request.method === "HEAD" ? null : await request.arrayBuffer(),
+    redirect: "manual",
+  });
+}
+
+function withEdgeHeaders(response: Response, routeClass: EdgeRouteClass): Response {
+  const headers = new Headers(response.headers);
+  if (routeClass === "app" || routeClass === "code") {
+    headers.set("cache-control", "no-store");
+    headers.set("cdn-cache-control", "no-store");
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase().replace(/:\d+$/, "");
+}
+
+function normalizePlatformOrigin(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") return null;
+    url.pathname = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch (err: unknown) {
+    const kind = err instanceof Error ? err.name : typeof err;
+    console.warn(`[edge-router] invalid platform origin: ${kind}`);
+    return null;
+  }
+}
+
+function sanitizeForwardedFor(value: string | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > 64) return null;
+  return /^[0-9A-Fa-f:.]+$/.test(trimmed) ? trimmed : null;
+}
+
+function isTimeoutError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "TimeoutError";
+}
+
+function noStoreTextHeaders(): Headers {
+  return new Headers({
+    "content-type": "text/plain; charset=utf-8",
+    "cache-control": "no-store",
+    "cdn-cache-control": "no-store",
+  });
+}
+
+const worker = {
+  fetch: handleEdgeRouterRequest,
+};
+
+export default worker;

--- a/packages/edge-router/src/index.ts
+++ b/packages/edge-router/src/index.ts
@@ -1,4 +1,4 @@
-const UPSTREAM_TIMEOUT_MS = 10_000;
+export const UPSTREAM_TIMEOUT_MS = 30_000;
 const WORKER_BODY_LIMIT = 10 * 1024 * 1024;
 const EDGE_SECRET_HEADER = "X-Matrix-Edge-Secret";
 

--- a/packages/edge-router/src/index.ts
+++ b/packages/edge-router/src/index.ts
@@ -1,5 +1,5 @@
-const DEFAULT_PLATFORM_ORIGIN = "https://matrix-platform-jqxkjdhtkq-ey.a.run.app";
 const UPSTREAM_TIMEOUT_MS = 10_000;
+const WORKER_BODY_LIMIT = 10 * 1024 * 1024;
 
 export type EdgeRouteClass = "platform" | "app" | "code" | "unknown";
 
@@ -28,7 +28,7 @@ export async function handleEdgeRouterRequest(
     });
   }
 
-  const platformOrigin = normalizePlatformOrigin(env.PLATFORM_ORIGIN ?? DEFAULT_PLATFORM_ORIGIN);
+  const platformOrigin = env.PLATFORM_ORIGIN ? normalizePlatformOrigin(env.PLATFORM_ORIGIN) : null;
   if (!platformOrigin) {
     console.error("[edge-router] invalid_platform_origin");
     return new Response("upstream unavailable", {
@@ -38,7 +38,9 @@ export async function handleEdgeRouterRequest(
   }
 
   const upstreamUrl = `${platformOrigin}${url.pathname}${url.search}`;
-  const upstreamRequest = await buildPlatformRequest(request, upstreamUrl, url.host);
+  const body = await readRequestBody(request);
+  if (body instanceof Response) return body;
+  const upstreamRequest = buildPlatformRequest(request, upstreamUrl, url.host, body);
 
   let response: Response;
   try {
@@ -54,14 +56,15 @@ export async function handleEdgeRouterRequest(
     });
   }
 
-  return withEdgeHeaders(response, routeClass);
+  return withEdgeHeaders(response);
 }
 
-async function buildPlatformRequest(
+function buildPlatformRequest(
   request: Request,
   upstreamUrl: string,
   externalHost: string,
-): Promise<Request> {
+  body: ArrayBuffer | null,
+): Request {
   const headers = new Headers(request.headers);
   const forwardedFor = sanitizeForwardedFor(headers.get("CF-Connecting-IP"));
 
@@ -79,22 +82,42 @@ async function buildPlatformRequest(
   return new Request(upstreamUrl, {
     method: request.method,
     headers,
-    body: request.method === "GET" || request.method === "HEAD" ? null : await request.arrayBuffer(),
+    body,
     redirect: "manual",
   });
 }
 
-function withEdgeHeaders(response: Response, routeClass: EdgeRouteClass): Response {
-  const headers = new Headers(response.headers);
-  if (routeClass === "app" || routeClass === "code") {
-    headers.set("cache-control", "no-store");
-    headers.set("cdn-cache-control", "no-store");
+async function readRequestBody(request: Request): Promise<ArrayBuffer | null | Response> {
+  if (request.method === "GET" || request.method === "HEAD") return null;
+
+  const contentLength = Number(request.headers.get("content-length") ?? NaN);
+  if (!Number.isNaN(contentLength) && contentLength > WORKER_BODY_LIMIT) {
+    return payloadTooLargeResponse();
   }
+
+  const body = await request.arrayBuffer();
+  if (body.byteLength > WORKER_BODY_LIMIT) {
+    return payloadTooLargeResponse();
+  }
+  return body;
+}
+
+function withEdgeHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set("cache-control", "no-store");
+  headers.set("cdn-cache-control", "no-store");
 
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers,
+  });
+}
+
+function payloadTooLargeResponse(): Response {
+  return new Response("payload too large", {
+    status: 413,
+    headers: noStoreTextHeaders(),
   });
 }
 

--- a/packages/edge-router/src/index.ts
+++ b/packages/edge-router/src/index.ts
@@ -1,9 +1,11 @@
 const UPSTREAM_TIMEOUT_MS = 10_000;
 const WORKER_BODY_LIMIT = 10 * 1024 * 1024;
+const EDGE_SECRET_HEADER = "X-Matrix-Edge-Secret";
 
 export type EdgeRouteClass = "platform" | "app" | "code" | "unknown";
 
 export interface EdgeRouterEnv {
+  EDGE_ROUTER_SECRET?: string;
   PLATFORM_ORIGIN?: string;
 }
 
@@ -40,11 +42,19 @@ export async function handleEdgeRouterRequest(
       headers: noStoreTextHeaders(),
     });
   }
+  const edgeSecret = normalizeEdgeSecret(env.EDGE_ROUTER_SECRET);
+  if (!edgeSecret) {
+    console.error("[edge-router] missing_edge_secret");
+    return new Response("upstream unavailable", {
+      status: 503,
+      headers: noStoreTextHeaders(),
+    });
+  }
 
   const upstreamUrl = `${platformOrigin}${url.pathname}${url.search}`;
   const body = await readRequestBody(request);
   if (body instanceof Response) return body;
-  const upstreamRequest = buildPlatformRequest(request, upstreamUrl, url.host, body);
+  const upstreamRequest = buildPlatformRequest(request, upstreamUrl, url.host, edgeSecret, body);
 
   let response: Response;
   try {
@@ -67,6 +77,7 @@ function buildPlatformRequest(
   request: Request,
   upstreamUrl: string,
   externalHost: string,
+  edgeSecret: string,
   body: ArrayBuffer | null,
 ): Request {
   const headers = new Headers(request.headers);
@@ -76,6 +87,7 @@ function buildPlatformRequest(
   headers.delete("Host");
   headers.set("X-Forwarded-Host", externalHost);
   headers.set("X-Forwarded-Proto", "https");
+  headers.set(EDGE_SECRET_HEADER, edgeSecret);
 
   if (forwardedFor) {
     headers.set("X-Forwarded-For", forwardedFor);
@@ -151,6 +163,11 @@ function normalizePlatformOrigin(value: string): string | null {
     console.warn(`[edge-router] invalid platform origin: ${kind}`);
     return null;
   }
+}
+
+function normalizeEdgeSecret(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
 }
 
 function sanitizeForwardedFor(value: string | null): string | null {

--- a/packages/edge-router/src/index.ts
+++ b/packages/edge-router/src/index.ts
@@ -7,6 +7,10 @@ export interface EdgeRouterEnv {
   PLATFORM_ORIGIN?: string;
 }
 
+export type EdgeResponseInit = ResponseInit & {
+  webSocket?: WebSocket | null;
+};
+
 export function classifyEdgeRoute(host: string): EdgeRouteClass {
   const normalized = normalizeHost(host);
   if (normalized === "api.matrix-os.com") return "platform";
@@ -106,12 +110,21 @@ function withEdgeHeaders(response: Response): Response {
   const headers = new Headers(response.headers);
   headers.set("cache-control", "no-store");
   headers.set("cdn-cache-control", "no-store");
+  const isWebSocketUpgrade = response.status === 101;
 
-  return new Response(response.body, {
+  return new Response(isWebSocketUpgrade ? null : response.body, buildEdgeResponseInit(response, headers));
+}
+
+export function buildEdgeResponseInit(response: Response, headers: Headers): EdgeResponseInit {
+  const init: EdgeResponseInit = {
     status: response.status,
     statusText: response.statusText,
     headers,
-  });
+  };
+  if (response.status === 101) {
+    init.webSocket = (response as Response & { webSocket?: WebSocket | null }).webSocket ?? null;
+  }
+  return init;
 }
 
 function payloadTooLargeResponse(): Response {

--- a/packages/edge-router/tsconfig.json
+++ b/packages/edge-router/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/edge-router/wrangler.toml
+++ b/packages/edge-router/wrangler.toml
@@ -1,0 +1,12 @@
+name = "matrix-edge-router"
+main = "src/index.ts"
+compatibility_date = "2026-06-06"
+
+routes = [
+  { pattern = "api.matrix-os.com", custom_domain = true },
+  { pattern = "app.matrix-os.com", custom_domain = true },
+  { pattern = "code.matrix-os.com", custom_domain = true }
+]
+
+[vars]
+PLATFORM_ORIGIN = "https://matrix-platform-jqxkjdhtkq-ey.a.run.app"

--- a/packages/edge-router/wrangler.toml
+++ b/packages/edge-router/wrangler.toml
@@ -10,3 +10,6 @@ routes = [
 
 [vars]
 PLATFORM_ORIGIN = "https://matrix-platform-jqxkjdhtkq-ey.a.run.app"
+# EDGE_ROUTER_SECRET must be provisioned as a Wrangler secret before deployment:
+#   wrangler secret put EDGE_ROUTER_SECRET
+# The Worker returns 503 for all requests until this secret is set.

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -133,6 +133,7 @@ const HOST_BUNDLE_FILES = new Set([
 ]);
 const HOST_BUNDLE_CHANNEL_PATTERN = /^(stable|canary|dev|beta)$/;
 const HOST_BUNDLE_CHANNEL_FILE_PATTERN = /^(stable|canary|dev|beta)\.json$/;
+type HeaderValue = string | string[] | undefined;
 const TENANT_PUBLIC_TELEMETRY_ENV_KEYS = [
   'POSTHOG_TOKEN',
   'POSTHOG_PROJECT_TOKEN',
@@ -1250,21 +1251,39 @@ function buildCodeDomainProxyHeaders(
   return headers;
 }
 
-function getTrustedSessionRouteHost(
-  host: string | undefined,
-  forwardedHost: string | undefined,
-  edgeSecretHeader: string | undefined,
+function firstHeaderValue(value: HeaderValue): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+export function getTrustedSessionRouteHost(
+  host: HeaderValue,
+  forwardedHost: HeaderValue,
+  edgeSecretHeader: HeaderValue,
   edgeRouterSecret: string | undefined,
 ): string {
-  const rawHost = host ?? '';
-  const normalizedForwardedHost = forwardedHost?.trim();
+  const rawHost = getWebSocketUpgradeHost(host, undefined);
+  const normalizedForwardedHost = getWebSocketUpgradeHost(undefined, forwardedHost);
   if (!normalizedForwardedHost) return rawHost;
 
   const normalizedSecret = edgeRouterSecret?.trim();
   if (!normalizedSecret) return rawHost;
-  if (!timingSafeTokenEquals(edgeSecretHeader, normalizedSecret)) return rawHost;
+  if (!timingSafeTokenEquals(firstHeaderValue(edgeSecretHeader), normalizedSecret)) return rawHost;
 
-  return getWebSocketUpgradeHost(rawHost, normalizedForwardedHost);
+  return normalizedForwardedHost;
+}
+
+export function getTrustedSessionRoutedWebSocketHost(
+  host: HeaderValue,
+  forwardedHost: HeaderValue,
+  edgeSecretHeader: HeaderValue,
+  edgeRouterSecret: string | undefined,
+  path: string,
+): string {
+  const trustedHost = getTrustedSessionRouteHost(host, forwardedHost, edgeSecretHeader, edgeRouterSecret);
+  return getSessionRoutedWebSocketHost(trustedHost, undefined, path);
 }
 
 function buildPlatformUserProof(handle: string, userId: string, platformSecret: string): string {
@@ -5329,7 +5348,13 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
 
     const path = req.url ?? '/';
     const pathClass = classifyWebSocketPath(path);
-    const host = getSessionRoutedWebSocketHost(req.headers.host, req.headers['x-forwarded-host'], path);
+    const host = getTrustedSessionRoutedWebSocketHost(
+      req.headers.host,
+      req.headers['x-forwarded-host'],
+      req.headers[EDGE_SECRET_HEADER],
+      appEnv.EDGE_ROUTER_SECRET,
+      path,
+    );
     if (!isSessionRoutedHost(host)) {
       socket.destroy();
       return;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -44,6 +44,7 @@ import { createAuthRoutes } from './auth-routes.js';
 import { issueSyncJwt, verifySyncJwt } from './sync-jwt.js';
 import {
   getSessionRoutedWebSocketHost,
+  getWebSocketUpgradeHost,
   getWebSocketUpgradeToken,
   isAppDomainHost,
   isCodeDomainHost,
@@ -3685,7 +3686,7 @@ export function createApp(deps: {
   // - app.matrix-os.com -> Clerk session -> Matrix OS shell/gateway
   // - code.matrix-os.com -> Clerk session -> code-server on the user's VPS
   app.use('*', bodyLimit({ maxSize: PROXY_BODY_LIMIT }), async (c, next) => {
-    const host = c.req.header('host') ?? '';
+    const host = getWebSocketUpgradeHost(c.req.header('host'), c.req.header('x-forwarded-host'));
     const isAppDomain = isAppDomainHost(host);
     const isCodeDomain = isCodeDomainHost(host);
     if (!isAppDomain && !isCodeDomain) return next();

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -105,6 +105,7 @@ const ADMIN_BODY_LIMIT = 64 * 1024;
 const PROXY_BODY_LIMIT = 10 * 1024 * 1024;
 const CLERK_SCRIPT_ORIGIN = 'https://clerk.matrix-os.com';
 const PROXY_TIMEOUT_MS = 30_000;
+const EDGE_SECRET_HEADER = 'x-matrix-edge-secret';
 const VPS_RELEASE_PROBE_TIMEOUT_MS = 10_000;
 const CLERK_USER_LOOKUP_TIMEOUT_MS = 10_000;
 const RUNTIME_PICKER_PROBE_TIMEOUT_MS = 2_500;
@@ -1247,6 +1248,23 @@ function buildCodeDomainProxyHeaders(
   headers.set('x-forwarded-proto', 'https');
   headers.set('connection', 'close');
   return headers;
+}
+
+function getTrustedSessionRouteHost(
+  host: string | undefined,
+  forwardedHost: string | undefined,
+  edgeSecretHeader: string | undefined,
+  edgeRouterSecret: string | undefined,
+): string {
+  const rawHost = host ?? '';
+  const normalizedForwardedHost = forwardedHost?.trim();
+  if (!normalizedForwardedHost) return rawHost;
+
+  const normalizedSecret = edgeRouterSecret?.trim();
+  if (!normalizedSecret) return rawHost;
+  if (!timingSafeTokenEquals(edgeSecretHeader, normalizedSecret)) return rawHost;
+
+  return getWebSocketUpgradeHost(rawHost, normalizedForwardedHost);
 }
 
 function buildPlatformUserProof(handle: string, userId: string, platformSecret: string): string {
@@ -3686,7 +3704,12 @@ export function createApp(deps: {
   // - app.matrix-os.com -> Clerk session -> Matrix OS shell/gateway
   // - code.matrix-os.com -> Clerk session -> code-server on the user's VPS
   app.use('*', bodyLimit({ maxSize: PROXY_BODY_LIMIT }), async (c, next) => {
-    const host = getWebSocketUpgradeHost(c.req.header('host'), c.req.header('x-forwarded-host'));
+    const host = getTrustedSessionRouteHost(
+      c.req.header('host'),
+      c.req.header('x-forwarded-host'),
+      c.req.header(EDGE_SECRET_HEADER),
+      appEnv.EDGE_ROUTER_SECRET,
+    );
     const isAppDomain = isAppDomainHost(host);
     const isCodeDomain = isCodeDomainHost(host);
     if (!isAppDomain && !isCodeDomain) return next();

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -163,7 +163,12 @@ const customerVpsProxyDispatcher = new Agent({
   },
 });
 const WS_TOKEN_EXPIRES_IN_SEC = 5 * 60;
-const SENSITIVE_PROXY_HEADERS = new Set(['authorization', 'cookie']);
+const SENSITIVE_PROXY_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  EDGE_SECRET_HEADER,
+  'x-matrix-code-proxy-token',
+]);
 const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
   'connection',
   'keep-alive',
@@ -1237,7 +1242,7 @@ function buildCodeDomainProxyHeaders(
 ): Headers {
   const headers = new Headers();
   for (const [key, value] of Object.entries(requestHeaders)) {
-    if (key !== 'host' && key !== 'cookie' && key !== 'authorization' && key !== 'x-matrix-code-proxy-token' && value) {
+    if (shouldForwardProxyHeader(key, value)) {
       headers.set(key, value);
     }
   }
@@ -1249,6 +1254,11 @@ function buildCodeDomainProxyHeaders(
   headers.set('x-forwarded-proto', 'https');
   headers.set('connection', 'close');
   return headers;
+}
+
+function shouldForwardProxyHeader(key: string, value: string | undefined): value is string {
+  const lowerKey = key.toLowerCase();
+  return lowerKey !== 'host' && !SENSITIVE_PROXY_HEADERS.has(lowerKey) && Boolean(value);
 }
 
 function firstHeaderValue(value: HeaderValue): string | undefined {
@@ -3784,8 +3794,7 @@ export function createApp(deps: {
 
       const headers = new Headers();
       for (const [key, value] of Object.entries(c.req.header())) {
-        const lowerKey = key.toLowerCase();
-        if (lowerKey !== 'host' && !SENSITIVE_PROXY_HEADERS.has(lowerKey) && value) {
+        if (shouldForwardProxyHeader(key, value)) {
           headers.set(key, value);
         }
       }
@@ -3975,7 +3984,7 @@ export function createApp(deps: {
       }
       const headers = new Headers();
       for (const [key, value] of Object.entries(c.req.header())) {
-        if (key !== 'host' && key !== 'cookie' && key !== 'authorization' && value) {
+        if (shouldForwardProxyHeader(key, value)) {
           headers.set(key, value);
         }
       }
@@ -4124,7 +4133,7 @@ export function createApp(deps: {
         : new Headers();
       if (!isCodeDomain) {
         for (const [key, value] of Object.entries(c.req.header())) {
-          if (key !== 'host' && key !== 'cookie' && key !== 'authorization' && value) {
+          if (shouldForwardProxyHeader(key, value)) {
             headers.set(key, value);
           }
         }
@@ -4284,7 +4293,7 @@ export function createApp(deps: {
       : new Headers();
     if (!isCodeDomain) {
       for (const [key, value] of Object.entries(c.req.header())) {
-        if (key !== 'host' && key !== 'cookie' && key !== 'authorization' && value) {
+        if (shouldForwardProxyHeader(key, value)) {
           headers.set(key, value);
         }
       }
@@ -4880,8 +4889,7 @@ export function createApp(deps: {
         const headers = new Headers();
         const originalHost = c.req.header('host') ?? `${handle}.matrix-os.com`;
         for (const [key, value] of Object.entries(c.req.header())) {
-          const lowerKey = key.toLowerCase();
-          if (lowerKey !== 'host' && !SENSITIVE_PROXY_HEADERS.has(lowerKey) && value) headers.set(key, value);
+          if (shouldForwardProxyHeader(key, value)) headers.set(key, value);
         }
         headers.set('host', `${handle}.matrix-os.com`);
         headers.set('x-forwarded-host', originalHost);
@@ -4931,8 +4939,7 @@ export function createApp(deps: {
       const headers = new Headers();
       const originalHost = c.req.header('host') ?? '';
       for (const [key, value] of Object.entries(c.req.header())) {
-        const lowerKey = key.toLowerCase();
-        if (lowerKey !== 'host' && !SENSITIVE_PROXY_HEADERS.has(lowerKey) && value) headers.set(key, value);
+        if (shouldForwardProxyHeader(key, value)) headers.set(key, value);
       }
       headers.set('x-forwarded-host', originalHost);
       headers.set('x-forwarded-proto', 'https');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 12.10.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.28.14)(pg@8.21.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260530.1)(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.28.14)(pg@8.21.0)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.6)
@@ -220,6 +220,21 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  packages/edge-router:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260526.1
+        version: 4.20260530.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(sass@1.51.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+      wrangler:
+        specifier: ^4.49.1
+        version: 4.95.0(@cloudflare/workers-types@4.20260530.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
   packages/gateway:
     dependencies:
       '@aws-sdk/client-s3':
@@ -345,7 +360,7 @@ importers:
         version: 5.0.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.28.14)(pg@8.21.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260530.1)(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.28.14)(pg@8.21.0)
       linkedom:
         specifier: ^0.18.12
         version: 0.18.12
@@ -408,7 +423,7 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(sass@1.51.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.49.1
-        version: 4.95.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+        version: 4.95.0(@cloudflare/workers-types@4.20260530.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   packages/observability:
     dependencies:
@@ -1866,6 +1881,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-types@4.20260530.1':
+    resolution: {integrity: sha512-H0BcFCJqqDwoDUY88mv3qJuA3DUdnMmtUdsHRrEZY+SRhXOK8TyFqFb+iS7A/84+qzpTFmFzWo6JN9tVALO2nw==}
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -14532,7 +14550,7 @@ snapshots:
       ansis: 4.2.0
       fzf: 0.5.2
       package-manager-detector: 1.6.0
-      tinyexec: 1.0.4
+      tinyexec: 1.1.2
 
   '@anthropic-ai/claude-agent-sdk@0.2.79(zod@4.4.3)':
     dependencies:
@@ -15983,6 +16001,8 @@ snapshots:
 
   '@cloudflare/workerd-windows-64@1.20260526.1':
     optional: true
+
+  '@cloudflare/workers-types@4.20260530.1': {}
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -17957,7 +17977,7 @@ snapshots:
       semver: 7.7.4
       string-width: 4.2.3
       supports-color: 8.1.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -21904,7 +21924,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.8': {}
 
@@ -23857,8 +23877,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.28.14)(pg@8.21.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260530.1)(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.10.0)(kysely@0.28.14)(pg@8.21.0):
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260530.1
       '@electric-sql/pglite': 0.4.1
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.13
@@ -24260,7 +24281,7 @@ snapshots:
       get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
@@ -24431,7 +24452,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -24444,7 +24465,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -27886,7 +27907,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -27897,7 +27918,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -27914,7 +27935,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -27950,7 +27971,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -28014,7 +28035,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -28346,7 +28367,7 @@ snapshots:
       proc-log: 6.1.0
       semver: 7.7.4
       tar: 7.5.15
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       undici: 6.25.0
       which: 6.0.1
 
@@ -29714,7 +29735,7 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -29729,14 +29750,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -29831,7 +29852,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -31695,7 +31716,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260526.1
       '@cloudflare/workerd-windows-64': 1.20260526.1
 
-  wrangler@4.95.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  wrangler@4.95.0(@cloudflare/workers-types@4.20260530.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)
@@ -31707,6 +31728,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260526.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260530.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -9,6 +9,11 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+const EDGE_ENV = {
+  EDGE_ROUTER_SECRET: "edge-secret",
+  PLATFORM_ORIGIN: "https://matrix-platform.example.run.app",
+};
+
 describe("edge router worker", () => {
   it("classifies managed Matrix OS hosts", () => {
     expect(classifyEdgeRoute("api.matrix-os.com")).toBe("platform");
@@ -35,7 +40,7 @@ describe("edge router worker", () => {
         },
         body: "{}",
       }),
-      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
+      EDGE_ENV,
     );
 
     expect(response.status).toBe(200);
@@ -48,6 +53,7 @@ describe("edge router worker", () => {
     expect(upstream.headers.get("x-forwarded-host")).toBe("app.matrix-os.com");
     expect(upstream.headers.get("x-forwarded-proto")).toBe("https");
     expect(upstream.headers.get("x-forwarded-for")).toBe("203.0.113.7");
+    expect(upstream.headers.get("x-matrix-edge-secret")).toBe("edge-secret");
   });
 
   it("forwards code-domain requests with the code external host", async () => {
@@ -55,7 +61,7 @@ describe("edge router worker", () => {
 
     await handleEdgeRouterRequest(
       new Request("https://code.matrix-os.com/?folder=/home/matrix/home"),
-      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app/" },
+      { ...EDGE_ENV, PLATFORM_ORIGIN: "https://matrix-platform.example.run.app/" },
     );
 
     const [request] = fetchMock.mock.calls[0]!;
@@ -75,7 +81,7 @@ describe("edge router worker", () => {
 
     const response = await handleEdgeRouterRequest(
       new Request("https://api.matrix-os.com/health"),
-      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
+      EDGE_ENV,
     );
 
     expect(response.status).toBe(200);
@@ -94,7 +100,7 @@ describe("edge router worker", () => {
         },
         body: "too large",
       }),
-      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
+      EDGE_ENV,
     );
 
     expect(response.status).toBe(413);
@@ -124,7 +130,7 @@ describe("edge router worker", () => {
 
     const response = await handleEdgeRouterRequest(
       new Request("https://alice.matrix-os.com/"),
-      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
+      EDGE_ENV,
     );
 
     expect(response.status).toBe(404);
@@ -136,7 +142,7 @@ describe("edge router worker", () => {
 
     const response = await handleEdgeRouterRequest(
       new Request("https://api.matrix-os.com/health"),
-      { PLATFORM_ORIGIN: "http://127.0.0.1:9000" },
+      { ...EDGE_ENV, PLATFORM_ORIGIN: "http://127.0.0.1:9000" },
     );
 
     expect(response.status).toBe(503);
@@ -149,6 +155,18 @@ describe("edge router worker", () => {
     const response = await handleEdgeRouterRequest(
       new Request("https://api.matrix-os.com/health"),
       {},
+    );
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the edge secret is missing", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope"));
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://api.matrix-os.com/health"),
+      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
     );
 
     expect(response.status).toBe(503);

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildEdgeResponseInit,
   classifyEdgeRoute,
   handleEdgeRouterRequest,
 } from "../../packages/edge-router/src/index.js";
@@ -99,6 +100,23 @@ describe("edge router worker", () => {
     expect(response.status).toBe(413);
     expect(await response.text()).toBe("payload too large");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves Cloudflare WebSocket tunnel handles on upgrade responses", () => {
+    const webSocket = {} as WebSocket;
+    const response = {
+      status: 101,
+      statusText: "Switching Protocols",
+      headers: new Headers({
+        upgrade: "websocket",
+      }),
+      webSocket,
+    } as Response & { webSocket: WebSocket };
+
+    const init = buildEdgeResponseInit(response, new Headers(response.headers));
+
+    expect(init.status).toBe(101);
+    expect(init.webSocket).toBe(webSocket);
   });
 
   it("returns 404 for unmanaged hosts", async () => {

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  classifyEdgeRoute,
+  handleEdgeRouterRequest,
+} from "../../packages/edge-router/src/index.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("edge router worker", () => {
+  it("classifies managed Matrix OS hosts", () => {
+    expect(classifyEdgeRoute("api.matrix-os.com")).toBe("platform");
+    expect(classifyEdgeRoute("app.matrix-os.com")).toBe("app");
+    expect(classifyEdgeRoute("code.matrix-os.com")).toBe("code");
+    expect(classifyEdgeRoute("alice.matrix-os.com")).toBe("unknown");
+  });
+
+  it("forwards app-domain requests to Cloud Run with external host preserved", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("ok", {
+        headers: {
+          "cache-control": "private, max-age=60",
+        },
+      }),
+    );
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://app.matrix-os.com/api/auth/app-session", {
+        method: "POST",
+        headers: {
+          "CF-Connecting-IP": "203.0.113.7",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      }),
+      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+    const [request] = fetchMock.mock.calls[0]!;
+    expect(request).toBeInstanceOf(Request);
+    const upstream = request as Request;
+    expect(upstream.url).toBe("https://matrix-platform.example.run.app/api/auth/app-session");
+    expect(upstream.headers.get("x-forwarded-host")).toBe("app.matrix-os.com");
+    expect(upstream.headers.get("x-forwarded-proto")).toBe("https");
+    expect(upstream.headers.get("x-forwarded-for")).toBe("203.0.113.7");
+  });
+
+  it("forwards code-domain requests with the code external host", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("editor"));
+
+    await handleEdgeRouterRequest(
+      new Request("https://code.matrix-os.com/?folder=/home/matrix/home"),
+      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app/" },
+    );
+
+    const [request] = fetchMock.mock.calls[0]!;
+    const upstream = request as Request;
+    expect(upstream.url).toBe("https://matrix-platform.example.run.app/?folder=/home/matrix/home");
+    expect(upstream.headers.get("x-forwarded-host")).toBe("code.matrix-os.com");
+  });
+
+  it("returns 404 for unmanaged hosts", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope"));
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://alice.matrix-os.com/"),
+      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
+    );
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the platform origin is not https", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope"));
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://api.matrix-os.com/health"),
+      { PLATFORM_ORIGIN: "http://127.0.0.1:9000" },
+    );
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -63,6 +63,44 @@ describe("edge router worker", () => {
     expect(upstream.headers.get("x-forwarded-host")).toBe("code.matrix-os.com");
   });
 
+  it("marks platform API responses as no-store", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("ok", {
+        headers: {
+          "cache-control": "public, max-age=3600",
+        },
+      }),
+    );
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://api.matrix-os.com/health"),
+      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+  });
+
+  it("rejects oversized bodies before forwarding", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope"));
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://app.matrix-os.com/api/upload", {
+        method: "POST",
+        headers: {
+          "content-length": String(10 * 1024 * 1024 + 1),
+        },
+        body: "too large",
+      }),
+      { PLATFORM_ORIGIN: "https://matrix-platform.example.run.app" },
+    );
+
+    expect(response.status).toBe(413);
+    expect(await response.text()).toBe("payload too large");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("returns 404 for unmanaged hosts", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope"));
 
@@ -81,6 +119,18 @@ describe("edge router worker", () => {
     const response = await handleEdgeRouterRequest(
       new Request("https://api.matrix-os.com/health"),
       { PLATFORM_ORIGIN: "http://127.0.0.1:9000" },
+    );
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the platform origin is missing", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope"));
+
+    const response = await handleEdgeRouterRequest(
+      new Request("https://api.matrix-os.com/health"),
+      {},
     );
 
     expect(response.status).toBe(503);

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -3,6 +3,7 @@ import {
   buildEdgeResponseInit,
   classifyEdgeRoute,
   handleEdgeRouterRequest,
+  UPSTREAM_TIMEOUT_MS,
 } from "../../packages/edge-router/src/index.js";
 
 afterEach(() => {
@@ -20,6 +21,10 @@ describe("edge router worker", () => {
     expect(classifyEdgeRoute("app.matrix-os.com")).toBe("app");
     expect(classifyEdgeRoute("code.matrix-os.com")).toBe("code");
     expect(classifyEdgeRoute("alice.matrix-os.com")).toBe("unknown");
+  });
+
+  it("matches the platform proxy timeout budget", () => {
+    expect(UPSTREAM_TIMEOUT_MS).toBe(30_000);
   });
 
   it("forwards app-domain requests to Cloud Run with external host preserved", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1431,6 +1431,7 @@ describe("platform proxy routing", () => {
     );
     const app = createApp({
       db,
+      env: { ...process.env, EDGE_ROUTER_SECRET: "edge-secret" },
       orchestrator: stubOrchestrator(),
       clerkAuth: createClerkAuth({
         verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
@@ -1442,6 +1443,7 @@ describe("platform proxy routing", () => {
       headers: {
         host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
         "x-forwarded-host": "app.matrix-os.com",
+        "x-matrix-edge-secret": "edge-secret",
         authorization: "Bearer clerk-session",
       },
     });
@@ -1471,6 +1473,7 @@ describe("platform proxy routing", () => {
     );
     const app = createApp({
       db,
+      env: { ...process.env, EDGE_ROUTER_SECRET: "edge-secret" },
       orchestrator: stubOrchestrator(),
       clerkAuth: createClerkAuth({
         verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
@@ -1482,6 +1485,7 @@ describe("platform proxy routing", () => {
       headers: {
         host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
         "x-forwarded-host": "code.matrix-os.com",
+        "x-matrix-edge-secret": "edge-secret",
         authorization: "Bearer clerk-session",
       },
     });
@@ -1493,6 +1497,32 @@ describe("platform proxy routing", () => {
     const headers = init?.headers as Headers;
     expect(headers.get("host")).toBe("code.matrix-os.com");
     expect(headers.get("x-forwarded-host")).toBe("code.matrix-os.com");
+  });
+
+  it("does not trust x-forwarded-host for app-domain routing without the edge secret", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("shell", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      env: { ...process.env, EDGE_ROUTER_SECRET: "edge-secret" },
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
+        "x-forwarded-host": "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(200);
   });
 
   it("reports no runtime when a signed-in Clerk user has no Matrix computer", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1499,6 +1499,7 @@ describe("platform proxy routing", () => {
     expect(url).toBe("http://matrixos-alice:3000/");
     const headers = init?.headers as Headers;
     expect(headers.get("x-forwarded-host")).toBe("app.matrix-os.com");
+    expect(headers.get("x-matrix-edge-secret")).toBeNull();
   });
 
   it("uses x-forwarded-host for code-domain routing behind Cloud Run", async () => {
@@ -1542,6 +1543,7 @@ describe("platform proxy routing", () => {
     const headers = init?.headers as Headers;
     expect(headers.get("host")).toBe("code.matrix-os.com");
     expect(headers.get("x-forwarded-host")).toBe("code.matrix-os.com");
+    expect(headers.get("x-matrix-edge-secret")).toBeNull();
   });
 
   it("does not trust x-forwarded-host for app-domain routing without the edge secret", async () => {
@@ -3254,12 +3256,15 @@ describe("platform proxy routing", () => {
       headers: {
         host: "app.matrix-os.com",
         authorization: "Bearer clerk-session",
+        "x-matrix-edge-secret": "edge-secret",
       },
     });
 
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("explicit shell");
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.28:443/");
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(headers.get("x-matrix-edge-secret")).toBeNull();
     expect(res.headers.get("set-cookie")).toContain("matrix_shell_route=alice");
   });
 

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -17,6 +17,7 @@ import {
   classifyWebSocketPath,
   createApp,
   escapeInlineScriptJson,
+  getTrustedSessionRoutedWebSocketHost,
 } from "../../packages/platform/src/main.js";
 import type { Orchestrator } from "../../packages/platform/src/orchestrator.js";
 import { createClerkAuth } from "../../packages/platform/src/clerk-auth.js";
@@ -437,6 +438,50 @@ describe("platform proxy routing", () => {
     expect(classifySessionRoutedHost("app.matrix-os.com")).toBe("app");
     expect(classifySessionRoutedHost("code.matrix-os.com")).toBe("code");
     expect(classifySessionRoutedHost("alice.matrix-os.com")).toBe("other");
+  });
+
+  it("requires the edge secret before websocket routing trusts x-forwarded-host", () => {
+    const cloudRunHost = "matrix-platform-jqxkjdhtkq-ey.a.run.app";
+
+    expect(
+      getTrustedSessionRoutedWebSocketHost(
+        cloudRunHost,
+        "code.matrix-os.com",
+        undefined,
+        "edge-secret",
+        "/ws?token=secret",
+      ),
+    ).toBe(cloudRunHost);
+    expect(
+      getTrustedSessionRoutedWebSocketHost(
+        cloudRunHost,
+        "code.matrix-os.com",
+        "wrong-secret",
+        "edge-secret",
+        "/ws?token=secret",
+      ),
+    ).toBe(cloudRunHost);
+    expect(
+      getTrustedSessionRoutedWebSocketHost(
+        cloudRunHost,
+        "code.matrix-os.com",
+        "edge-secret",
+        "edge-secret",
+        "/ws?token=secret",
+      ),
+    ).toBe("code.matrix-os.com");
+  });
+
+  it("keeps token-authenticated websocket fallback for internal platform hosts", () => {
+    expect(
+      getTrustedSessionRoutedWebSocketHost(
+        "platform:9000",
+        undefined,
+        undefined,
+        "edge-secret",
+        "/ws?token=secret",
+      ),
+    ).toBe("app.matrix-os.com");
   });
 
   it("shows a boot page for Clerk-authenticated users while their first VPS is provisioning", async () => {

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1425,6 +1425,76 @@ describe("platform proxy routing", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("http://matrixos-alice:3000/");
   });
 
+  it("uses x-forwarded-host for app-domain routing behind Cloud Run", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("shell", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
+        "x-forwarded-host": "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("shell");
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://matrixos-alice:3000/");
+    const headers = init?.headers as Headers;
+    expect(headers.get("x-forwarded-host")).toBe("app.matrix-os.com");
+  });
+
+  it("uses x-forwarded-host for code-domain routing behind Cloud Run", async () => {
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff151",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123491,
+      publicIPv4: "203.0.113.91",
+      imageVersion: "matrix-os-host-2026.06.06-1",
+      provisionedAt: "2026-06-06T12:00:00.000Z",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("editor", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_alice" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?folder=/home/matrix/home", {
+      headers: {
+        host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
+        "x-forwarded-host": "code.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("editor");
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://203.0.113.91:443/?folder=/home/matrix/home");
+    const headers = init?.headers as Headers;
+    expect(headers.get("host")).toBe("code.matrix-os.com");
+    expect(headers.get("x-forwarded-host")).toBe("code.matrix-os.com");
+  });
+
   it("reports no runtime when a signed-in Clerk user has no Matrix computer", async () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     await deleteContainer(db, "alice");


### PR DESCRIPTION
## Summary

- add a stateless Cloudflare Worker edge router for `api.matrix-os.com`, `app.matrix-os.com`, and `code.matrix-os.com`
- preserve the external hostname with `X-Forwarded-Host` when forwarding to the Cloud Run platform origin
- teach platform app/code session routing to honor the forwarded external host, matching the existing WebSocket upgrade path
- cover Worker forwarding and Cloud Run forwarded-host app/code routing with regression tests

## Invariants

- **Source of truth**: platform routing, auth, VPS inventory, and release state remain canonical in the platform service and platform Postgres. The Worker is a stateless edge transport shim only.
- **Lock/transaction scope**: no database writes or multi-step mutations are added. There is no new transaction scope; requests are forwarded to the existing platform routing path.
- **Acceptable orphan states**: deploying the platform change before the Worker is safe because direct host routing still works. Deploying the Worker before the platform change keeps `api.matrix-os.com` viable, but `app.matrix-os.com`/`code.matrix-os.com` host-based routing depends on this forwarded-host platform change.
- **Auth source of truth**: Clerk sessions, Matrix sync JWTs, platform secrets, and app/code session cookies are still validated by the platform and customer VPS paths. The Worker does not authenticate users and does not grant access by itself; it only proves trusted edge transit with `X-Matrix-Edge-Secret`, and platform ignores `X-Forwarded-Host` without the matching `EDGE_ROUTER_SECRET`.
- **Deferred scope**: this does not implement direct Worker-to-VPS routing, wildcard customer subdomain routing, Cloud Run ingress restriction, or Docker retirement automation. It only moves the managed Matrix hosts onto Cloud Run through Cloudflare Worker forwarding with a shared edge secret.

## Validation

- `bun run test tests/edge-router/edge-router.test.ts tests/platform/proxy-routing.test.ts -- -t "edge router|x-forwarded-host for app-domain|x-forwarded-host for code-domain"`
- `pnpm --filter '@matrix-os/edge-router' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit`
- `bun run typecheck`
- `bun run check:patterns` (warnings only; no violations)
- `git diff --check`
- `pnpm --filter '@matrix-os/edge-router' exec wrangler deploy --dry-run`

