### PR TITLE
fix(cloud-run): bootstrap edge router secret

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -43,7 +43,6 @@ jobs:
       CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}
       POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
       POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || 'https://neo.matrix-os.com' }}
-      EDGE_ROUTER_SECRET_VALUE: ${{ secrets.EDGE_ROUTER_SECRET }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -85,23 +84,20 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
 
       - name: Ensure edge router secret access
+        env:
+          EDGE_ROUTER_SECRET_VALUE: ${{ secrets.EDGE_ROUTER_SECRET }}
         run: |
           set -euo pipefail
-          if [ -n "${EDGE_ROUTER_SECRET_VALUE:-}" ]; then
-            if gcloud secrets describe edge-router-secret \
-              --project "$GCP_PROJECT_ID" >/dev/null 2>&1; then
-              printf '%s' "$EDGE_ROUTER_SECRET_VALUE" | gcloud secrets versions add edge-router-secret \
-                --project "$GCP_PROJECT_ID" \
-                --data-file=-
-            else
-              printf '%s' "$EDGE_ROUTER_SECRET_VALUE" | gcloud secrets create edge-router-secret \
-                --project "$GCP_PROJECT_ID" \
-                --replication-policy=automatic \
-                --data-file=-
+          if ! gcloud secrets describe edge-router-secret \
+            --project "$GCP_PROJECT_ID" >/dev/null 2>&1; then
+            if [ -z "${EDGE_ROUTER_SECRET_VALUE:-}" ]; then
+              echo "edge-router-secret is missing and EDGE_ROUTER_SECRET is not configured in the GitHub environment." >&2
+              exit 1
             fi
-          else
-            gcloud secrets describe edge-router-secret \
-              --project "$GCP_PROJECT_ID" >/dev/null
+            printf '%s' "$EDGE_ROUTER_SECRET_VALUE" | gcloud secrets create edge-router-secret \
+              --project "$GCP_PROJECT_ID" \
+              --replication-policy=automatic \
+              --data-file=-
           fi
           gcloud secrets add-iam-policy-binding edge-router-secret \
             --project "$GCP_PROJECT_ID" \

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -43,6 +43,7 @@ jobs:
       CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}
       POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
       POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || 'https://neo.matrix-os.com' }}
+      EDGE_ROUTER_SECRET_VALUE: ${{ secrets.EDGE_ROUTER_SECRET }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -86,8 +87,22 @@ jobs:
       - name: Ensure edge router secret access
         run: |
           set -euo pipefail
-          gcloud secrets describe edge-router-secret \
-            --project "$GCP_PROJECT_ID" >/dev/null
+          if [ -n "${EDGE_ROUTER_SECRET_VALUE:-}" ]; then
+            if gcloud secrets describe edge-router-secret \
+              --project "$GCP_PROJECT_ID" >/dev/null 2>&1; then
+              printf '%s' "$EDGE_ROUTER_SECRET_VALUE" | gcloud secrets versions add edge-router-secret \
+                --project "$GCP_PROJECT_ID" \
+                --data-file=-
+            else
+              printf '%s' "$EDGE_ROUTER_SECRET_VALUE" | gcloud secrets create edge-router-secret \
+                --project "$GCP_PROJECT_ID" \
+                --replication-policy=automatic \
+                --data-file=-
+            fi
+          else
+            gcloud secrets describe edge-router-secret \
+              --project "$GCP_PROJECT_ID" >/dev/null
+          fi
           gcloud secrets add-iam-policy-binding edge-router-secret \
             --project "$GCP_PROJECT_ID" \
             --member "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \


### PR DESCRIPTION
## Summary
- Allow the Platform Cloud Run workflow to create GCP Secret Manager `edge-router-secret` from the masked GitHub environment secret `EDGE_ROUTER_SECRET` only when the GCP secret is missing.
- Scope the GitHub bootstrap secret to the single Secret Manager bootstrap step.
- Preserve fail-fast behavior when neither the GCP secret nor bootstrap secret exists, and preserve the idempotent Secret Manager accessor binding for the Cloud Run runtime service account.

## Invariants
- Source of truth: Cloud Run reads `EDGE_ROUTER_SECRET` from GCP Secret Manager; the GitHub environment secret is only a masked first-time bootstrap input when the GCP secret is absent.
- Lock/transaction scope: no database writes; the workflow either creates one Secret Manager secret and grants one IAM binding before build/deploy, or fails before deployment.
- Acceptable orphan states: if the bootstrap secret is absent and the GCP secret is absent, the workflow fails before building or deploying; if IAM cannot be granted, it fails before deployment.
- Auth source of truth: platform runtime validation still compares `X-Matrix-Edge-Secret` against the Cloud Run env var sourced from Secret Manager.
- Deferred scope: this does not perform routine secret rotation; rotation should add a new GCP Secret Manager version deliberately and update the Worker secret to match.

## Tests
- `git diff --check`