### PR TITLE
fix(cloud-run): preflight edge router secret

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -83,27 +83,11 @@ jobs:
         # Keep this aligned with auth@v3 until google-github-actions publishes v4.
         uses: google-github-actions/setup-gcloud@v3
 
-      - name: Ensure edge router secret access
-        env:
-          EDGE_ROUTER_SECRET_VALUE: ${{ secrets.EDGE_ROUTER_SECRET }}
+      - name: Verify edge router secret
         run: |
           set -euo pipefail
-          if ! gcloud secrets describe edge-router-secret \
-            --project "$GCP_PROJECT_ID" >/dev/null 2>&1; then
-            if [ -z "${EDGE_ROUTER_SECRET_VALUE:-}" ]; then
-              echo "edge-router-secret is missing and EDGE_ROUTER_SECRET is not configured in the GitHub environment." >&2
-              exit 1
-            fi
-            printf '%s' "$EDGE_ROUTER_SECRET_VALUE" | gcloud secrets create edge-router-secret \
-              --project "$GCP_PROJECT_ID" \
-              --replication-policy=automatic \
-              --data-file=-
-          fi
-          gcloud secrets add-iam-policy-binding edge-router-secret \
-            --project "$GCP_PROJECT_ID" \
-            --member "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \
-            --role roles/secretmanager.secretAccessor \
-            --quiet >/dev/null
+          gcloud secrets describe edge-router-secret \
+            --project "$GCP_PROJECT_ID" >/dev/null
 
       - name: Build platform image
         run: |

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -88,6 +88,18 @@ jobs:
           set -euo pipefail
           gcloud secrets describe edge-router-secret \
             --project "$GCP_PROJECT_ID" >/dev/null
+          accessor_member="$(
+            gcloud secrets get-iam-policy edge-router-secret \
+              --project "$GCP_PROJECT_ID" \
+              --flatten='bindings[].members' \
+              --filter="bindings.role:roles/secretmanager.secretAccessor AND bindings.members:serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \
+              --format='value(bindings.members)' \
+              | head -1
+          )"
+          if [ "$accessor_member" != "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" ]; then
+            echo "edge-router-secret must grant roles/secretmanager.secretAccessor to ${CLOUD_RUN_SERVICE_ACCOUNT}" >&2
+            exit 1
+          fi
 
       - name: Build platform image
         run: |


### PR DESCRIPTION
## Summary
- Replace the Cloud Run workflow edge-secret bootstrap/IAM mutation with read-only preflight checks.
- Verify `edge-router-secret` exists before build.
- Verify `edge-router-secret` grants `roles/secretmanager.secretAccessor` to the Cloud Run runtime service account before build.
- Keep `EDGE_ROUTER_SECRET=edge-router-secret:latest` wired into the Cloud Run revision.

## Invariants
- Source of truth: GCP Secret Manager owns `edge-router-secret`; Cloud Run reads it as `EDGE_ROUTER_SECRET`.
- Lock/transaction scope: no database writes; workflow only verifies the secret and runtime IAM binding before building/deploying.
- Acceptable orphan states: if the secret or runtime accessor binding is missing, the workflow fails before build/deploy.
- Auth source of truth: platform validates `X-Matrix-Edge-Secret` against the Cloud Run env var sourced from Secret Manager.
- Deferred scope: secret creation, IAM binding, and rotation remain explicit owner/provisioning operations, not GitHub deploy workflow side effects.

## Tests
- `git diff --check`
- Verified locally: `edge-router-secret` grants `roles/secretmanager.secretAccessor` to `matrix-platform-runner@matrix-os-1144.iam.gserviceaccount.com`