### PR TITLE
fix(edge): use worker routes for managed hosts

### DIFF
--- a/packages/edge-router/wrangler.toml
+++ b/packages/edge-router/wrangler.toml
@@ -3,9 +3,9 @@ main = "src/index.ts"
 compatibility_date = "2026-06-06"
 
 routes = [
-  { pattern = "api.matrix-os.com", custom_domain = true },
-  { pattern = "app.matrix-os.com", custom_domain = true },
-  { pattern = "code.matrix-os.com", custom_domain = true }
+  { pattern = "api.matrix-os.com/*", zone_name = "matrix-os.com" },
+  { pattern = "app.matrix-os.com/*", zone_name = "matrix-os.com" },
+  { pattern = "code.matrix-os.com/*", zone_name = "matrix-os.com" }
 ]
 
 [vars]

--- a/packages/edge-router/wrangler.toml
+++ b/packages/edge-router/wrangler.toml
@@ -2,6 +2,8 @@ name = "matrix-edge-router"
 main = "src/index.ts"
 compatibility_date = "2026-06-06"
 
+# These routes require the api/app/code DNS records to stay Cloudflare-proxied
+# (orange-cloud); DNS-only records bypass the Worker and its edge secret header.
 routes = [
   { pattern = "api.matrix-os.com/*", zone_name = "matrix-os.com" },
   { pattern = "app.matrix-os.com/*", zone_name = "matrix-os.com" },


### PR DESCRIPTION
## Summary
- Replace Worker custom-domain bindings with route patterns for `api`, `app`, and `code.matrix-os.com`.
- Matches the live successful deployment path: existing DNS records remain in place and Worker routes attach to `matrix-os.com`.

## Invariants
- Source of truth: Cloudflare DNS remains externally managed; Worker routing is attached via zone routes.
- Lock/transaction scope: no app/database changes; this only changes Worker deployment config.
- Acceptable orphan states: if route creation permissions are missing, Wrangler deploy fails rather than changing DNS.
- Auth source of truth: the Worker still forwards with `X-Matrix-Edge-Secret`; platform still validates against `EDGE_ROUTER_SECRET`.
- Deferred scope: no DNS record deletion or custom-domain migration.

## Tests
- `git diff --check`
- `pnpm --filter @matrix-os/edge-router exec wrangler deploy --dry-run --config /home/deploy/matrix-os.worktrees/edge-router-route-patterns/packages/edge-router/wrangler.toml`
- Live route deploy already succeeded for `api.matrix-os.com/*`, `app.matrix-os.com/*`, `code.matrix-os.com/*`.