### PR TITLE
docs(086): specify native macOS shell

### DIFF
--- a/specs/086-macos-native-shell/checklists/requirements.md
+++ b/specs/086-macos-native-shell/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Matrix OS Native macOS App (Kanban-with-Terminals Shell)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — *user-facing sections are clean; technical detail is intentionally confined to the Security/Integration/Failure-Mode sections that Matrix OS Spec Quality Gates require for any spec touching WebSockets/DB/IPC. This is a deliberate Matrix-specific override of the generic speckit rule.*
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders (user stories, success criteria)
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain (informed guesses documented in Integration Wiring / Constitution Alignment / Out of Scope)
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (SC-006 names Keychain as the user-meaningful "secure store"; otherwise outcome-focused)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (Out of Scope section)
+- [x] Dependencies and assumptions identified (Integration Wiring; gateway dependencies flagged for plan confirmation)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria (mapped to prioritized user stories)
+- [x] User scenarios cover primary flows (P1 terminal → P2 board → P3 shell → P4 app → P5 symphony → P6 cli/mcp)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification beyond the mandated Matrix gate sections
+
+## Notes
+
+- Gateway dependencies (shell WS attach, zellij list/create/tabs, request-principal, query-token WS allowlist, Symphony status) are asserted from existing code (`packages/gateway/src/shell/*`, `zellij-runtime.ts`) and MUST be confirmed exactly during `/speckit.plan`. New board-metadata CRUD routes + Postgres table are net-new and called out.
+- The "no implementation details" item is intentionally satisfied at the user-story/SC level; Matrix Spec Quality Gates mandate the technical security/wiring/failure sections, so their presence is correct, not a violation.

--- a/specs/086-macos-native-shell/data-model.md
+++ b/specs/086-macos-native-shell/data-model.md
@@ -1,0 +1,31 @@
+# Data Model: Matrix OS macOS App
+
+**Feature**: [086-macos-native-shell](./spec.md) · **Source of truth**: user's Postgres via gateway. No local durable store.
+
+## Server (existing — reused, not redefined)
+
+- **Task** (`task-manager`): `id, projectSlug, title, description?, status(todo|running|waiting|blocked|complete|archived), priority(low|normal|high|urgent), order, parentTaskId?, linkedSessionId?, linkedWorktreeId?, previewIds[], createdAt, updatedAt, revision`.
+- **Session** (session orchestrator + zellij registry): `id/name, status(active|exited), cwd, layoutName?, tabs[]`.
+- **WorkspaceEvent**: `type(task.created|task.updated|…), scope{projectSlug,taskId}, payload, seq/ts`.
+
+## Server delta (net-new, only if in v1 scope)
+
+- **Task.tags**: `tags: string[]?` (≤ N tags, each `SAFE_SLUG`, validated at route boundary; Kysely migration on owner Postgres). If deferred, labels are out of v1.
+
+## Client view models (in-memory, bounded — never persisted)
+
+| Model | Fields | Notes |
+|---|---|---|
+| `Card` | maps Task 1:1 + derived `liveBadge`, `lastOutputLine?` | value type; diff-updated from events |
+| `SessionRef` | `id, status, tabs[], cwd` | from session/zellij |
+| `Panel` | `.terminal \| .shell \| .app(slug)` | client-only UI state |
+| `ConnectionProfile` | `handle, gatewayEndpoint, selectedVpsId, credentialRef(Keychain)` | only Keychain ref persists |
+| `TerminalBuffer` | `lastSeq, ringBuffer(cap)` | capped + evicted (R1) |
+
+## Invariants
+
+- One Card ↔ at most one `linkedSessionId`. Creating a card may create a session; archiving defaults to **detach** (session survives) — terminate requires explicit confirm.
+- Board writes are **revision-guarded** in the UPDATE (optimistic concurrency); stale writers refresh.
+- Column = Task.status; intra-column position = Task.order. Moving a card = status/order PATCH (atomic).
+- Live badge derives from Session.status + workspace events; never stored client-side as truth.
+- Tags (if shipped) validated server-side; client never trusts its own cache as authority.

--- a/specs/086-macos-native-shell/design.md
+++ b/specs/086-macos-native-shell/design.md
@@ -1,0 +1,147 @@
+# Design System: Matrix OS macOS App — "OPERATOR"
+
+**Artifact type**: UI design spec (not code). SwiftUI-translatable tokens + per-component guidance.
+**Feature**: [086-macos-native-shell](./spec.md) · **Companion**: [plan.md](./plan.md)
+
+## 1. Concept & Point of View
+
+**OPERATOR** is a precision control surface for someone running many AI agents in parallel — a flight-deck for zellij sessions. The aesthetic fuses **terminal/CRT-phosphor heritage** with **aerospace instrument-panel restraint**: a near-black machined canvas where information is dense but calm, and the only saturated color in the room is *living signal* — a phosphor pulse that means "an agent is doing something right now."
+
+This is deliberately **not** the generic SaaS kanban look (no white cards on grey, no purple gradients, no Inter). It is dark-first to sit beside the Matrix shell, monospace-led to honor the terminal, and quiet until something is alive.
+
+**The one unforgettable thing**: live cards *breathe*. A running session emits a slow phosphor glow at the card's left edge — the board reads at a glance like a rack of blinking machines.
+
+## 2. Color System (dark-first)
+
+Semantic tokens (asset-catalog colors; values are P3-friendly hex). Light theme is a later phase; tokens are named, not hard-coded.
+
+### Canvas & surfaces
+| Token | Hex | Use |
+|---|---|---|
+| `canvas.void` | `#0A0B0D` | window background (machined near-black) |
+| `canvas.grain` | overlay | 4% monochrome noise + faint 1px grid at 8% on void |
+| `surface.rail` | `#101216` | column rails / sidebar |
+| `surface.card` | `#15171C` | card body |
+| `surface.cardRaised` | `#1B1E24` | hovered/dragging card |
+| `surface.terminal` | `#0C0D10` | terminal panel (deeper than cards for "into the machine" depth) |
+| `hairline` | `#000000 @ 60%` + `#FFFFFF @ 6%` | dual-tone 1px borders (dark line + top highlight = engraved edge) |
+
+### Ink (text)
+| Token | Hex | Use |
+|---|---|---|
+| `ink.primary` | `#E8EAED` | titles, terminal text |
+| `ink.secondary` | `#9BA1AC` | metadata |
+| `ink.tertiary` | `#5C636E` | timestamps, hints |
+| `ink.disabled` | `#3A3F47` | — |
+
+### Signal (the only saturated colors — reserved for state)
+| Token | Hex | Meaning |
+|---|---|---|
+| `signal.live` | `#9EF01A` | **phosphor lime** — running / streaming (the breathing glow) |
+| `signal.waiting` | `#FFB020` | amber — waiting on input/approval |
+| `signal.blocked` | `#FF5C5C` | coral — blocked/error |
+| `signal.done` | `#43C59E` | teal — complete |
+| `signal.idle` | `#5C636E` | grey — todo/exited (no color = no life) |
+| `signal.glow.live` | `signal.live @ 22%` radial | the edge bloom on active cards |
+
+**Rule**: saturated signal color appears ONLY on status badges, the live edge-glow, and the active panel-switcher segment. Chrome, text, and structure stay monochrome. This keeps a 200-card board readable and makes one running agent pop instantly.
+
+## 3. Typography
+
+Bundle two characterful, licensable families (avoid SF/Inter/Roboto/Arial):
+
+- **Display / chrome / titles** → **IBM Plex Sans** (humanist, engineered character; weights 400/500/600). Used for column headers, card titles, buttons.
+- **Mono / data / terminal / badges** → **IBM Plex Mono** (or Berkeley Mono if licensed) for terminal, session names, status labels, counts, timestamps. The mono is the "voice of the machine."
+
+Cohesive single-family option keeps the OS feel tight (Plex Sans + Plex Mono are designed to pair).
+
+### Scale (pt; SwiftUI `Font.custom(...).weight`)
+| Role | Family | Size / Weight / Tracking |
+|---|---|---|
+| Column header | Plex Mono 600 | 11 / uppercase / +0.12em |
+| Card title | Plex Sans 500 | 14 / -0.01em |
+| Card meta | Plex Mono 400 | 11 / +0.02em |
+| Status badge | Plex Mono 600 | 10 / uppercase / +0.08em |
+| Terminal | Plex Mono 400 | 12.5 / line-height 1.45 |
+| Section/empty headline | Plex Sans 600 | 20 / -0.02em |
+| Body/empty copy | Plex Sans 400 | 13 |
+
+## 4. Spacing, Radius, Elevation
+
+- **Grid**: 8pt base with 4pt sub-step. Tokens: `space.1=4, .2=8, .3=12, .4=16, .5=24, .6=32, .7=48`.
+- **Radius**: `radius.card=10`, `radius.badge=5`, `radius.panel=14`, `radius.control=8`. Engraved, not pill-soft.
+- **Elevation** = macOS material + shadow, not flat fills:
+  - Resting card: `surface.card` + 1px engraved hairline, no shadow.
+  - Hover card: lift to `surface.cardRaised`, `shadow(y:2, blur:10, #000@35%)`.
+  - Dragging card: `.regularMaterial` ghost + `shadow(y:8, blur:28, #000@50%)`, scale 1.03.
+  - Floating chrome (panel switcher, popovers, command bar): SwiftUI **`.ultraThinMaterial`** with vibrancy so the void/grain shows through — this is where the macOS-native feel lives.
+  - Terminal panel: inset/recessed (inner top shadow) to read as "below" the card surface.
+
+## 5. Motion (instrument-crisp, never bouncy-toy)
+
+Timings (SwiftUI `Animation`):
+| Interaction | Curve | Duration |
+|---|---|---|
+| Hover/tint | `.easeOut` | 120 ms |
+| Panel toggle (term↔shell↔app) | `.spring(response:0.34, damping:0.86)` | ~340 ms |
+| Card drag pickup/drop | `.spring(response:0.30, damping:0.80)` | — |
+| Column reflow on drop | `.spring(response:0.40, damping:0.90)` | — |
+| Card enter (new) | fade+rise 8pt, `.easeOut` | 180 ms, staggered 24 ms |
+| Live edge-glow breathe | `.easeInOut` autoreverse | 2.4 s loop |
+| Status change flash | `.easeOut` | 200 ms one-shot |
+
+**Live breathe**: `signal.glow.live` opacity 0.12↔0.26 on a 2.4s autoreversing loop, applied as a left-edge radial; pauses when the card is offscreen (ties to the suspension/perf model — no animation cost for unsuspended-but-hidden cards).
+
+**Panel switch uses `matchedGeometryEffect`** so the card frame morphs between Terminal/Shell/App with **no layout shift** (ux-guide rule): the panel content cross-fades inside a stable frame.
+
+## 6. Per-Component Specs
+
+### 6.1 Column (lifecycle lane)
+- Header row: uppercase mono label + live count chip (`signal` dot if any card in column is live) + `+` add. Sticky on scroll.
+- Body: `LazyVStack` for view recycling (perf: 200+ cards). 8pt gutters, `space.3` between cards.
+- Subtle vertical hairline between columns; column background `surface.rail` a hair lighter than void.
+- Drop target: when dragging, the target column's rail brightens 4% and shows an `signal.idle` insertion bar at the drop index (animated).
+- Columns: `TODO · RUNNING · WAITING · BLOCKED · COMPLETE` (maps to task `status`). Order/priority within column via `order`.
+
+### 6.2 Card
+- Layout: left **signal edge** (3pt bar, color = status; glows if live) · title (Plex Sans 14) · meta row (mono: session name, tab count, worktree/branch if `linkedWorktreeId`, relative time).
+- A card is a value-type SwiftUI view; mutations come diffable from workspace events — never rebuild the whole list.
+- Footers (contextual, Conductor-style): live agent activity ticker (last line of session output, dimmed mono, truncated), PR/preview chips from `previewIds`.
+- Hover: raise + reveal quick actions (open, new tab, archive) as a vibrancy overlay — **no layout shift** (actions overlay, don't push).
+- Selected/open card: persistent `ink.primary` hairline + faint signal tint; remembered across reloads (spatial memory).
+
+### 6.3 Status / live-session badges
+- Badge = mono 10pt uppercase, `radius.badge`, on a 10%-tint of its signal color with a solid signal dot.
+- States: `IDLE`(grey) · `RUNNING`(lime, dot pulses) · `WAITING`(amber) · `BLOCKED`(coral) · `COMPLETE`(teal) · `EXITED`(grey, hollow dot).
+- **Live dot** = breathing `signal.live`; **exited** = hollow ring (the machine is off). This dot is the board's heartbeat.
+
+### 6.4 Terminal panel
+- `surface.terminal` (deeper than card), recessed inner shadow, `radius.panel`.
+- SwiftTerm view; Plex Mono 12.5 / 1.45; phosphor selection tint (`signal.live @ 18%`); cursor is a solid block that dims (not blinks harshly) when unfocused.
+- Top strip: zellij **tabs** (mono, underline-active in signal color), session name, status badge, detach/terminate. New-tab `+` → `createTab`.
+- Scroll: momentum; a faint top fade where scrollback meets the live tail; a "● LIVE" affixed marker (lime) when pinned to bottom, turns grey + "↓ N new" when scrolled up.
+- Connection states inline & calm: `reconnecting…` (amber, animated ellipsis), `session exited` (grey, with re-create/archive), never a raw error string.
+
+### 6.5 Panel switcher (Terminal · Shell · App)
+- Segmented control in `.ultraThinMaterial`, lives in the card/detail header. Active segment carries a thin signal underline + `ink.primary`; inactive `ink.tertiary`.
+- **Toggle consistency**: clicking the active segment is a no-op highlight; switching morphs via `matchedGeometryEffect` (no resize). App mode adds a small app-icon affordance to pick which Matrix app.
+- Light-dismiss for any popover it spawns; `Esc` closes; same gesture re-closes what it opened.
+
+### 6.6 Empty states (onboarding-as-empty-state)
+- **No VPS**: centered — engraved Matrix glyph, headline "No Matrix computer yet" (Plex Sans 20), one line of copy, primary CTA "Create your Matrix OS" → platform flow. Calm, not an error.
+- **Empty column**: ghosted dashed insertion zone + "Drop a task here or ⌘N".
+- **Board loading**: skeleton cards in `surface.card` with a single sweeping `signal.idle` shimmer (one orchestrated load, staggered 24ms), not per-card spinners.
+- **Disconnected**: top inset bar `reconnecting to <handle>…` in amber vibrancy; board goes read-only with a faint desaturation, last-known cards still visible (view-only, never persisted).
+
+## 7. macOS-native details that sell it
+- True window vibrancy: titlebar-transparent, content under a unified toolbar; the grain/grid void shows faintly through floating chrome.
+- `NSVisualEffectView`/SwiftUI `Material` for all transient surfaces; respect Reduce Transparency & Reduce Motion (breathe → static glow; springs → cross-fade).
+- Full keyboard model: `⌘N` new card, `⌘[`/`⌘]` move card across columns, `⌘T` new terminal tab, `⌘1/2/3` panel switch, `Esc` light-dismiss, arrow nav between cards. Operator-grade.
+- Custom I-beam stays in terminal; elsewhere a crisp arrow; drag uses a grabbing cursor.
+
+## 8. Accessibility & honoring ux-guide
+- Contrast: ink.primary on surfaces ≥ 7:1; signal colors paired with shape (dot fill vs ring) so state never relies on color alone.
+- ux-guide compliance: **toggle consistency** (§6.5), **no layout shift** (overlays + matchedGeometry), **spatial memory** (selected/positions persist across reload), **progressive disclosure** (quick actions on hover), **empty-states-as-onboarding** (§6.6), **light dismiss + Esc** everywhere.
+
+## 9. Token quick-reference (for implementation)
+Define as an asset catalog + a `DesignTokens.swift` enum: `Color.canvasVoid`, `…surfaceCard`, `…signalLive`, etc.; `Font.plexSans(_:weight:)`, `Font.plexMono(_:weight:)`; `Spacing.x`, `Radius.x`, `Motion.panelSwitch`. All component code references tokens only — no inline hex/sizes — so the OPERATOR look stays cohesive and themeable for the later light mode.

--- a/specs/086-macos-native-shell/plan.md
+++ b/specs/086-macos-native-shell/plan.md
@@ -59,7 +59,7 @@ Native app authenticates to the **platform** (device-authorization flow, same as
 | Platform device auth / VPS resolution | HTTPS | Device-authorization → JWT | user account |
 | `GET/POST/PATCH/DELETE /api/projects[...]/tasks` | HTTPS | `requireRequestPrincipal` (Authorization header) | `ownerScopeFromPrincipal` |
 | `/api/sessions*` | HTTPS | `requireRequestPrincipal` | owner scope |
-| Shell terminal WS (`createShellWsHandler` route) | WSS upgrade | **Authorization header / WS subprotocol** (S1 — NOT query token) → `requireRequestPrincipal(c)` (same pattern as canvas WS) | owner scope, session-name validated |
+| Shell terminal WS (`createShellWsHandler` route) | WSS upgrade | Global `authMiddleware` accepts `Authorization: Bearer` (native) or allowlisted query token (browser fallback); handlers do not call `requireRequestPrincipal(c)` | single-VPS owner scope via platform routing; session-name validated |
 | Board-update subscription WS | WSS upgrade | Authorization header → principal | owner scope; bounded subscriber registry, TTL eviction, per-send isolation, dead-sender eviction |
 | Symphony proxy routes | HTTPS/WSS | `requireRequestPrincipal` | owner scope |
 | CLI/MCP board ops | HTTPS | same principal token (Keychain/CLI creds) | owner scope |

--- a/specs/086-macos-native-shell/plan.md
+++ b/specs/086-macos-native-shell/plan.md
@@ -98,6 +98,8 @@ specs/086-macos-native-shell/
 ├── research.md        # gateway-reuse findings, SwiftTerm/WS decisions
 ├── data-model.md      # task/session/panel view models + tags delta
 ├── design.md          # frontend-design output: macOS UI system
+├── checklists/
+│   └── requirements.md # spec quality checklist
 └── tasks.md           # /speckit.tasks output
 ```
 

--- a/specs/086-macos-native-shell/plan.md
+++ b/specs/086-macos-native-shell/plan.md
@@ -98,7 +98,6 @@ specs/086-macos-native-shell/
 ├── research.md        # gateway-reuse findings, SwiftTerm/WS decisions
 ├── data-model.md      # task/session/panel view models + tags delta
 ├── design.md          # frontend-design output: macOS UI system
-├── contracts/         # auth-matrix.md, gateway endpoints used, WS protocols
 └── tasks.md           # /speckit.tasks output
 ```
 

--- a/specs/086-macos-native-shell/plan.md
+++ b/specs/086-macos-native-shell/plan.md
@@ -1,0 +1,166 @@
+# Implementation Plan: Matrix OS Native macOS App (Kanban-with-Terminals Shell)
+
+**Branch**: `086-macos-native-shell` | **Date**: 2026-06-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/086-macos-native-shell/spec.md`
+
+## Summary
+
+Build a **native macOS (Swift 6 / SwiftUI) app** that renders the user's Matrix computer as a **Conductor-style, high-performance kanban board of terminals**. Each card is a Matrix **task** whose `linkedSessionId` binds it to a **zellij session** on the user's VPS. The card's Terminal panel attaches to that session over the existing gateway **shell WebSocket** (resume-from-seq capable); Shell and App panels embed the user's Canvas/Desktop and Matrix Apps via `WKWebView`.
+
+**Critical finding from research**: the backend already exists. The gateway's `/api/projects/:slug/tasks` model is a full kanban (`status` = columns `todo|running|waiting|blocked|complete|archived`, plus `order`, `priority`, `parentTaskId`, `linkedSessionId`, `linkedWorktreeId`, `previewIds`), `/api/sessions*` manages session lifecycle (`startSession`, `observe`, `takeover`, `send`, `listSessions({taskId})`), `workspace-event-publisher.ts` already broadcasts `task.created/updated`, the shell WS supports scrollback + resume, Symphony is reachable via `symphony/proxy.ts`, and platform `customer-vps-routes` resolves per-VPS endpoints. **This feature is therefore backend-light and client-heavy** — the bulk of the work is the native Swift app plus a thin gateway delta (tags, terminal-tab plumbing, native WS header-auth, board-update subprotocol if not already covered) and the CLI/MCP surface.
+
+## Technical Context
+
+**Language/Version**: Swift 6.3 (strict concurrency), SwiftUI; gateway delta in TypeScript 5.5+ strict / Node 24 (existing stack).
+**Primary Dependencies**: SwiftUI, `WKWebView`, `URLSessionWebSocketTask` (native WS), Swift Concurrency (`async`/`await`, actors), `SwiftTerm` (battle-tested VT100/xterm emulator for Swift) for terminal rendering, Keychain Services. No third-party kanban/DB libraries.
+**Storage**: **None local-durable.** Board = user's Postgres via gateway. Credentials = macOS Keychain only. In-memory only: bounded board view + bounded scrollback buffers.
+**Testing**: XCTest (unit + UI), Swift integration tests against a disposable test gateway/zellij; Vitest contract tests for any gateway delta (TDD, existing convention).
+**Target Platform**: macOS 14+ (built with Xcode 26 / Swift 6.3); Apple Silicon primary.
+**Project Type**: Native desktop client + thin server delta (the macOS app is a new top-level target; gateway changes live in `packages/gateway`).
+**Performance Goals**: 60 fps board scroll/drag with 200+ cards; terminal keystroke-to-echo p95 ≤150 ms on broadband; board first-paint ≤5 s; smooth output rendering under high-throughput PTY streams via backpressure.
+**Constraints**: Zero local durable user data (Constitution P1); thin client (no local PTY, no local DB); native WS auth via header (no token-in-URL); bounded memory across many open cards.
+**Scale/Scope**: One user, one selected VPS at a time; boards up to a few hundred cards; up to a bounded number of simultaneously-live terminals/web views (offscreen cards suspended).
+
+## Constitution Check
+
+*GATE: passes.*
+
+- **P1 Data Belongs to Its Owner**: PASS — no local durable user data; board in user's Postgres; sessions on VPS; only Keychain creds locally.
+- **P3 Headless Core, Multi-Shell**: PASS — app is a renderer over existing gateway routes; adds no core logic the web shell lacks. (Elevates desktop to first-class shell per Principle III; offline support is a documented phased deferral, not a violation.)
+- **P4 / VIII Defense in Depth (NON-NEGOTIABLE)**: PASS by design — principal-scoped authz on every call, input validation at route boundary, bounded resources/timeouts, sandbox preservation for embedded apps, no raw error leakage.
+- **P5 / IX TDD (NON-NEGOTIABLE)**: PASS — every gateway delta and client networking/state component is specified test-first; integration checkpoints per story (T1).
+- **P10 / X Worktree + PR + Greptile 5/5 (NON-NEGOTIABLE)**: in progress — work is on manual worktree `086-macos-native-shell`; ships via PR(s) with Greptile 5/5.
+
+No violations → Complexity Tracking empty.
+
+## Architecture: reuse map (spec → existing gateway)
+
+| Spec capability | Existing gateway surface (reuse) | Net-new |
+|---|---|---|
+| Board columns + cards (FR-005/6/7/8) | `GET/POST/PATCH/DELETE /api/projects/:slug/tasks`; `status` enum = columns; `order`, `priority`, `parentTaskId` | **Tags** (not in `CreateTaskSchema`) — add optional `tags: string[]` to task schema + migration, or model as labels; confirm in data-model |
+| Card ⇄ session link (FR-005/6) | task `linkedSessionId`; `/api/sessions` (`startSession`), `listSessions({taskId})`, `getSession` | none (already present) |
+| Session lifecycle (FR-009) | `/api/sessions/:id/observe|takeover|send`; session orchestrator detach vs terminate | confirm "detach not destroy" semantics on archive |
+| Terminal attach + scrollback + resume (FR-011/12/14) | shell WS via `createShellWsHandler` (`fromSeq`, `SHELL_ATTACH_LIVE_TAIL_FROM_SEQ`, `SHELL_ATTACH_RECENT_REPLAY_EVENTS=50`, `ShellReplayBuffer.replayFromSeq`, `replay-evicted`) | **Native WS header auth** path (S1) + per-card **zellij tabs** (`listTabs`/`createTab`) UI |
+| Live board updates (FR-008a) | `workspace-event-publisher.ts` (`task.created`, `task.updated`) + workspace events store; canvas WS shows the subscriber-hub pattern | **board-update subscription** for the native client if a task-events WS isn't already exposed; reuse bounded subscriber-hub pattern |
+| Matrix Shell panel (FR-017) | user's Canvas/Desktop origin (`SHELL_ORIGIN`); existing Clerk/principal session | `WKWebView` host loading ONLY the user's own shell origin; auth handoff via a scoped session cookie for that origin — the principal **bearer token is never injected into web content** or exposed to any non-Matrix origin. Re-auth prompt on expiry. |
+| Matrix App panel (FR-018) | `AppViewer` bridge contract (`window.MatrixOS`: `db.*`, `readData/writeData`, `proxyFetch`), sandboxed `srcdoc` | `WKWebView` that **loads the app through the user's shell-origin `AppViewer` URL** so the existing server-side bridge + sandbox serve it — do NOT re-implement `window.MatrixOS` or the sandbox in Swift (that would duplicate scope and risk a sandbox escape). Native side only hosts the web view and the panel chrome. |
+| Symphony (FR-019/20) | `symphony/proxy.ts` gateway routes | read-model client + start/observe action wiring |
+| CLI/MCP (FR-021/22) | existing `matrix` CLI + gateway routes above | `matrix board` command group + MCP server exposing board read/write under same principal |
+| Endpoint resolution (W2) | platform `customer-vps-routes.ts`, `ws-upgrade.ts`, `/runtime` routing | native profile/endpoint resolver + multi-VM picker |
+
+**Net-new backend is small.** Most server capability already exists; confirm each row during implementation before adding anything.
+
+## Auth Matrix (resolves S2)
+
+Native app authenticates to the **platform** (device-authorization flow, same as CLI) → obtains principal token → resolves the selected VPS gateway → all calls carry the principal.
+
+| Surface | Method | Auth | Scope |
+|---|---|---|---|
+| Platform device auth / VPS resolution | HTTPS | Device-authorization → JWT | user account |
+| `GET/POST/PATCH/DELETE /api/projects[...]/tasks` | HTTPS | `requireRequestPrincipal` (Authorization header) | `ownerScopeFromPrincipal` |
+| `/api/sessions*` | HTTPS | `requireRequestPrincipal` | owner scope |
+| Shell terminal WS (`createShellWsHandler` route) | WSS upgrade | **Authorization header / WS subprotocol** (S1 — NOT query token) → `requireRequestPrincipal(c)` (same pattern as canvas WS) | owner scope, session-name validated |
+| Board-update subscription WS | WSS upgrade | Authorization header → principal | owner scope; bounded subscriber registry, TTL eviction, per-send isolation, dead-sender eviction |
+| Symphony proxy routes | HTTPS/WSS | `requireRequestPrincipal` | owner scope |
+| CLI/MCP board ops | HTTPS | same principal token (Keychain/CLI creds) | owner scope |
+
+Every client-facing error returns a generic message; raw gateway/DB/provider/path text is never surfaced (FR-023).
+
+## Data Model (delta only)
+
+Source of truth = user's Postgres (existing `task-manager` tables). Card view model (client-side, in-memory, bounded):
+
+- **Card** ← Task: `id, projectSlug, title, description?, status (column), priority, order, parentTaskId?, linkedSessionId?, linkedWorktreeId?, previewIds[], tags[]?, revision, updatedAt`.
+- **Session** ← zellij/session orchestrator: `name/id, status (active|exited), cwd, layout, tabs[]`.
+- **Panel** (client-only): `.terminal | .shell | .app(appSlug)`.
+- **ConnectionProfile** (client-only, Keychain-backed): `handle, gatewayEndpoint, selectedVpsId, credentialRef`.
+
+Net-new persistence: at most an optional `tags` column on tasks (migration via Kysely, owner Postgres) if labels are in scope for v1; otherwise deferred. **No new embedded DB.** Optimistic concurrency uses the task `revision`/`updatedAt` already present; writes enforce concurrency in the UPDATE (per CLAUDE.md atomicity rules).
+
+## UI/UX & Performance Design (Conductor-style, zellij-native)
+
+The board is the product. Targets a **Conductor AI** feel — parallel agent lanes, each card a live worktree/agent — fused with Matrix's zellij sessions.
+
+- **Native performance**: SwiftUI `LazyVGrid`/`LazyHStack` columns with view recycling; cards are lightweight value-type view models; drag-and-drop via native `Transferable`/drop delegates (no web DnD jank); diffable updates from workspace events; off-main-thread decoding of terminal output with coalesced UI flushes (target 60 fps with 200+ cards).
+- **Zellij integration depth**: card surfaces session status (active/exited), tabs map to zellij tabs (`listTabs`/`createTab`), layout awareness; "new terminal" on a card = new zellij tab; detach vs terminate is explicit; live session badges driven by workspace events.
+- **Conductor-like flows**: columns reflect agent lifecycle (`todo → running → waiting → blocked → complete`), per-card live activity/diff/PR affordances (reuse `linkedWorktreeId`, `previewIds`), quick "start agent in worktree" from a card.
+- **Suspension model (R1)**: only focused/visible cards hold a live WS + web view; offscreen cards render a static last-frame snapshot and reattach on focus — bounded aggregate sockets/memory.
+- **Design language**: produced via the **frontend-design skill** (see `design.md`): distinctive, non-generic macOS aesthetic — depth, materials/vibrancy, typography, motion, dark-first to match the shell. Honors `specs/ux-guide.md` (toggle consistency, no layout shift, spatial memory across reloads, empty-states-as-onboarding).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/086-macos-native-shell/
+├── plan.md            # this file
+├── spec.md
+├── research.md        # gateway-reuse findings, SwiftTerm/WS decisions
+├── data-model.md      # task/session/panel view models + tags delta
+├── design.md          # frontend-design output: macOS UI system
+├── contracts/         # auth-matrix.md, gateway endpoints used, WS protocols
+└── tasks.md           # /speckit.tasks output
+```
+
+### Source Code (repository root)
+
+```text
+macos/                         # new top-level native app target
+├── MatrixOS.xcodeproj / Package.swift
+├── Sources/
+│   ├── App/                   # @main, window/scene, profile/onboarding
+│   ├── Board/                 # kanban: columns, cards, DnD, virtualization
+│   ├── Terminal/              # SwiftTerm view + shell WS client (resume-from-seq)
+│   ├── Panels/                # Shell (WKWebView) + App (bridge) hosts
+│   ├── Symphony/              # run read-model + controls
+│   ├── Net/                   # gateway HTTP client, WS client, principal/Keychain
+│   └── Model/                 # Card/Session/Panel/Profile view models
+└── Tests/                     # XCTest unit + UI + integration
+
+packages/gateway/              # thin delta only (TDD-first)
+├── src/...                    # tags on task schema (if in scope), native WS header-auth confirm, board-update sub if needed
+└── (tests under repo-root tests/gateway per convention)
+
+packages/cli (or existing matrix CLI) + MCP server   # `matrix board` commands + MCP board tools
+```
+
+**Structure Decision**: New top-level `macos/` Swift package/Xcode target (keeps GPL/native concerns isolated from the TS monorepo build; not part of pnpm/turbo). Gateway delta stays in `packages/gateway`. CLI/MCP extends the existing `matrix` surface.
+
+## Phasing (mapped to prioritized user stories)
+
+- **Phase 0 — Research** (`research.md`): confirm shell WS route path + header-auth acceptance; confirm session detach-vs-terminate; confirm task-events WS exposure; SwiftTerm vs hand-rolled VT decision; platform endpoint-resolution contract. *(De-risks F1/W1/W2/W3/S1.)*
+- **Phase 1 — P1 MVP (terminal)**: profile/device-auth + Keychain; VPS resolve; board renders from `/api/projects/:slug/tasks` (read); open card → SwiftTerm attaches to `linkedSessionId` via shell WS with scrollback + resume; input/resize. Integration test: attach to a real test zellij session, round-trip I/O.
+- **Phase 2 — P2 board CRUD + live**: create/move/reorder/rename/tag/archive via task routes (write, revision-guarded); subscribe to workspace events for <2 s propagation; session create on new card; detach-on-archive. Integration test: two clients converge.
+- **Phase 3 — P3 Shell panel**: `WKWebView` host loading the user's Canvas authenticated (cookie/token handoff), re-auth on expiry.
+- **Phase 4 — P4 App panel**: bridge-injecting `WKWebView` reproducing `window.MatrixOS` + sandbox; block un-bridged fetch.
+- **Phase 5 — P5 Symphony**: run read-model on cards + start/observe via symphony proxy.
+- **Phase 6 — P6 CLI/MCP**: `matrix board` commands + MCP board tools under the same principal.
+
+Each phase = its own PR (size-limited per CLAUDE.md), each with an integration-test checkpoint (T1), each gated on Greptile 5/5.
+
+## Failure Modes & Resource Management (design)
+
+- **Timeouts**: every gateway HTTP call uses a bounded `URLSession` timeout; WS connect/reconnect uses capped exponential backoff.
+- **Reconnect (F1)**: terminal tracks last applied `seq`; on reconnect attaches with `fromSeq = lastSeq + 1`; on `replay-evicted` it clears and refetches a live tail (no silent gap/dup).
+- **Concurrency**: task writes are revision/`updatedAt`-guarded in the UPDATE; session create idempotent; losing client refreshes.
+- **Subscriber registry (W1/C1)**: bounded, TTL/stale eviction, per-subscriber send isolation, dead-sender eviction (mirror canvas hub).
+- **Resource caps (R1)**: scrollback buffers capped + evicted; aggregate live-attach/web-view cap with offscreen suspension; web views released on panel close; all timers cleared on teardown.
+- **Error policy**: no silent catches; failed create/attach/load sets a visible generic error + recovery; misconfiguration (no VPS) distinguished from not-found and from transient connectivity.
+
+## Plan obligations from review-spec (status)
+
+| ID | Obligation | Resolution in plan |
+|---|---|---|
+| S1 | Native WS header auth | Auth matrix mandates Authorization header/subprotocol on WS; canvas WS confirms pattern. |
+| S2 | Explicit auth matrix | Provided above. |
+| W1/C1 | Board-update channel + bounded subscriber registry | Reuse workspace events + subscriber-hub pattern; add native sub only if not exposed. |
+| W2 | VPS endpoint resolution | Platform `customer-vps-routes`/`/runtime`; native resolver + multi-VM picker. |
+| W3 | Symphony source | `symphony/proxy.ts` gateway routes. |
+| F1 | Reconnect resume semantics | Confirmed shell WS `fromSeq` support; client tracks last seq, handles `replay-evicted`. |
+| T1 | Integration-test checkpoints | One per phase exercising client↔gateway↔zellij. |
+| R1 | Aggregate resource cap | Offscreen suspension + bounded live attaches/web views. |
+| A1 | Offline deferral vs Principle III | Documented phased deferral; v1 keeps thin-client invariant. |
+
+## Complexity Tracking
+
+*No constitution violations; section intentionally empty.*

--- a/specs/086-macos-native-shell/research.md
+++ b/specs/086-macos-native-shell/research.md
@@ -1,0 +1,39 @@
+# Research: Matrix OS macOS App (Phase 0)
+
+**Feature**: [086-macos-native-shell](./spec.md)
+
+## Headline finding: the backend already exists
+
+A grep-level audit of `packages/gateway/src` shows the "card ⇄ session ⇄ task" model is already implemented. The macOS app is a **native client over existing routes**, not a new backend.
+
+### Evidence
+
+| Concern | Existing surface | File |
+|---|---|---|
+| Kanban tasks | `CreateTaskSchema { title, description, status: todo\|running\|waiting\|blocked\|complete\|archived, priority, order, parentTaskId, linkedSessionId, linkedWorktreeId, previewIds }`; routes `GET/POST/PATCH/DELETE /api/projects/:slug/tasks[/:taskId]` | `workspace-routes.ts`, `task-manager.ts` |
+| Card↔session link | task `linkedSessionId`; `listSessions({ taskId })` | `workspace-routes.ts` |
+| Session lifecycle | `/api/sessions` (start), `/:id` (get), `/:id/send`, `/:id/observe`, `/:id/takeover`; session orchestrator | `workspace-routes.ts`, `workspace-session-orchestrator.ts` |
+| Terminal attach | `createShellWsHandler` with `fromSeq`, `SHELL_ATTACH_LIVE_TAIL_FROM_SEQ`, `SHELL_ATTACH_RECENT_REPLAY_EVENTS=50`, `ShellReplayBuffer.replayFromSeq`, `replay-evicted`; messages `input/resize/detach/ping` ↔ `attached/output(seq)/exit/error/pong` | `shell/ws.ts` |
+| zellij ops | `listSessions / createSession({name,cwd,layout,cmd}) / attachSession / listTabs / createTab` | `shell/zellij.ts` |
+| Live board updates | `workspace-event-publisher.ts` → `task.created`, `task.updated` with scope `{projectSlug, taskId}`; events store | `workspace-event-publisher.ts`, `workspace-events.ts` |
+| WS principal auth (header) | canvas WS does `requireRequestPrincipal(c).userId` inside `upgradeWebSocket((c)=>…)` — proves header-based principal on WS upgrades | `server.ts` (`/api/canvases/:id/ws`) |
+| Subscriber hub pattern | `canvasSubscriptionHub.subscribe({connectionId,userId,send})` with per-send try/catch | `server.ts` |
+| Symphony | `symphony/proxy.ts`, `symphony-runner.ts` | gateway |
+| VPS endpoint resolution | platform `customer-vps-routes.ts`, `ws-upgrade.ts`, `/runtime` | `packages/platform` |
+
+## Decisions
+
+1. **D1 — Reuse, don't rebuild.** Board CRUD = task routes; sessions = session routes; terminals = shell WS. Net-new backend limited to: optional task `tags`, native-WS header-auth confirmation, and a native board-events subscription only if `task.*` events aren't already exposed over a client WS.
+2. **D2 — Terminal emulator = SwiftTerm.** Mature Swift VT100/xterm emulator; avoids hand-rolling ANSI parsing. The WS client maps `output/seq` → feed, `input` → send, `resize` → resize; tracks `lastSeq` for resume.
+3. **D3 — Reconnect (F1).** Reattach with `fromSeq = lastSeq + 1`; on `replay-evicted` clear buffer and re-attach at `SHELL_ATTACH_LIVE_TAIL_FROM_SEQ`. No duplication/gap.
+4. **D4 — Native networking.** `URLSession` (HTTP, bounded timeouts) + `URLSessionWebSocketTask` (sets `Authorization` header on the upgrade — S1). No third-party networking deps.
+5. **D5 — App target placement.** New top-level `macos/` Swift package/Xcode target, outside pnpm/turbo, to isolate native build + any GPL-adjacent UX inspiration from the TS monorepo.
+6. **D6 — Auth = platform device flow** (same as `matrix` CLI), principal token in Keychain; VPS resolved via platform.
+
+## Open confirmations for implementation (cheap, do first)
+- C1: exact shell-WS route path + that it reads principal from the `Authorization` header (extend if it currently only accepts query token).
+- C2: whether `task.*` workspace events are already delivered over a client-facing WS (if yes, no new subscription needed).
+- C3: session-archive semantics — detach vs terminate in the orchestrator.
+- C4: platform endpoint-resolution contract for multi-VM selection.
+
+These are confirmations, not unknowns that block design; each maps to a Phase-0 task.

--- a/specs/086-macos-native-shell/research.md
+++ b/specs/086-macos-native-shell/research.md
@@ -2,9 +2,9 @@
 
 **Feature**: [086-macos-native-shell](./spec.md)
 
-## Headline finding: the backend already exists
+## Headline finding: the backend is mostly reusable
 
-A grep-level audit of `packages/gateway/src` shows the "card ⇄ session ⇄ task" model is already implemented. The macOS app is a **native client over existing routes**, not a new backend.
+A grep-level audit of `packages/gateway/src` shows the "card ⇄ session ⇄ task" model is already implemented. The macOS app is a **native client over existing routes** with a thin gateway delta for board-event push and optional task metadata.
 
 ### Evidence
 
@@ -40,7 +40,7 @@ These are confirmations, not unknowns that block design; each maps to a Phase-0 
 
 ## Phase 0 confirmation results (T001-T004)
 
-Verified against `packages/gateway/src` and `packages/platform/src` at branch `086-macos-native-shell`. All four confirmations resolved; **no gateway delta is required** (no failing tests added).
+Verified against `packages/gateway/src` and `packages/platform/src` at branch `086-macos-native-shell`. All four confirmations resolved; most surfaces already exist, and the remaining gateway delta is the board-events subscription described in C2.
 
 ### C1 / S1 — Shell-WS route + Authorization-header auth ✅ CONFIRMED (header auth already accepted)
 

--- a/specs/086-macos-native-shell/research.md
+++ b/specs/086-macos-native-shell/research.md
@@ -37,3 +37,66 @@ A grep-level audit of `packages/gateway/src` shows the "card ⇄ session ⇄ tas
 - C4: platform endpoint-resolution contract for multi-VM selection.
 
 These are confirmations, not unknowns that block design; each maps to a Phase-0 task.
+
+## Phase 0 confirmation results (T001-T004)
+
+Verified against `packages/gateway/src` and `packages/platform/src` at branch `086-macos-native-shell`. All four confirmations resolved; **no gateway delta is required** (no failing tests added).
+
+### C1 / S1 — Shell-WS route + Authorization-header auth ✅ CONFIRMED (header auth already accepted)
+
+**Routes.** There are two zellij shell-WS routes, both `app.get(...)` + `upgradeWebSocket(...)` in `packages/gateway/src/server.ts`:
+- `/ws/terminal/session` — `server.ts:2274` (attach an existing named session; requires `?session=`, optional `?fromSeq=`).
+- `/ws/terminal` — `server.ts:2358` (named attach via `?session=` OR auto-create via `?cwd=`; optional `?fromSeq=`).
+
+Both delegate to `zellijShellWs.open({ ws, session, fromSeq })`, where `zellijShellWs = createShellWsHandler(...)` (`server.ts:511`, handler in `packages/gateway/src/shell/ws.ts:108`). The handler validates the session name (`validateSessionName`), attaches, replays from `effectiveFromSeq`, and pumps `output(seq)/exit/error/pong` ↔ `input/resize/detach/ping` (matches D2/D3).
+
+**Auth mechanism.** Auth is enforced by the global `authMiddleware(process.env.MATRIX_AUTH_TOKEN)` (`server.ts:1632`, impl `packages/gateway/src/auth.ts:142`), not by the route handlers. The handlers themselves do **not** call `requireRequestPrincipal(c)` (unlike the canvas WS at `server.ts:4124`).
+
+Both shell-WS paths are listed in `WS_QUERY_TOKEN_PATHS` (`auth.ts:89`): `["/ws", "/ws/voice", "/ws/terminal", "/ws/terminal/session", "/ws/onboarding", "/ws/vocal"]`. For these paths the middleware computes `presentedToken` from **either** an `Authorization: Bearer <token>` header **or** the `?token=` query param (`auth.ts:233-237`). The query-param fallback exists only because browsers cannot set headers on a WS upgrade; native clients can. Both legacy shared-secret (`timingSafeCompare`, `auth.ts:270-277`) and platform JWT (`looksLikeJwt` → `validateSyncJwt`, `auth.ts:243-268`) accept the token from header or query.
+
+**Conclusion:** the shell WS **already accepts header-based auth**. `URLSessionWebSocketTask` can set `Authorization` on the upgrade (D4/S1), so the macOS client needs no gateway change. This is already locked by existing tests:
+- `tests/gateway/terminal-zellij-ws.test.ts:254` "accepts terminal query token and bearer auth..." asserts `/ws/terminal` succeeds with `Authorization: Bearer secret-token` (`next` called twice, line 276).
+- `tests/gateway/auth.test.ts:201,211` cover `/ws/terminal[/session]` query-token success; `tests/gateway/auth-jwt.test.ts:206` covers JWT query-token success.
+
+Because the "header auth missing" branch is **false**, no `tests/gateway/shell-ws-header-auth.test.ts` failing test was written (it would duplicate green coverage). One caveat for the client design (not a gateway blocker): the shell-WS handlers do not derive a per-user principal — the gateway is single-user/single-VPS and the principal is implicit. The macOS client resolves the correct VPS via the platform (see C4) and presents that VPS's principal token; cross-user isolation is enforced by the platform proxy, not by per-handler scoping on these routes.
+
+### C2 / W1 — Are `task.*` events delivered over a client WS? ❌ NO. A new board-events subscription is needed.
+
+`task.created` / `task.updated` / `task.deleted` are produced by `createWorkspaceEventPublisher` (`packages/gateway/src/workspace-event-publisher.ts:48-70`) and **persisted only** to the JSON file `system/workspace-events.json` via `createWorkspaceEventStore.publishEvent` (`packages/gateway/src/workspace-events.ts:127-142`, max 5000 events). They are exposed to clients **only by polling** `GET /api/workspace/events` (`packages/gateway/src/workspace-routes.ts:484`, → `eventStore.listEvents`, query-filterable by `projectSlug/taskId/...` with cursor+limit).
+
+There is **no client-facing WebSocket that pushes `task.*` events**. The only WS subscription hubs in the gateway are:
+- `CanvasSubscriptionHub` (`server.ts:756`, `packages/gateway/src/canvas/subscriptions.ts`) — canvas documents only.
+- The sync peer registry (`sync/ws-events.ts`, `server.ts:2133` `sync:subscribe`) — file-sync `sync:change` between device peers, not workspace task events.
+
+Neither carries board events.
+
+**Decision (W1) — a new board-events subscription endpoint IS required** for the "<2s cross-client" board-sync goal (US2 / T040, T044). Until it exists, US1 can ship by polling `GET /api/workspace/events`. Design for the new endpoint (do **not** implement in Phase 0):
+- **Route:** `GET /api/workspace/events/ws` (or `/ws/workspace-events`) as a Hono `upgradeWebSocket` route. Add its path to `WS_QUERY_TOKEN_PATHS` / `WS_QUERY_TOKEN_PATH_PATTERNS` in `auth.ts` so browser query-token upgrades pass (native clients use the header). Derive the principal with `requireRequestPrincipal(c)` inside the upgrade callback (mirror canvas WS at `server.ts:4124`).
+- **Subscriber registry:** a bounded hub modeled on `CanvasSubscriptionHub` — `subscribe({ connectionId, userId, projectSlug?, send })`, per-send `try/catch` that logs and **evicts dead senders** after the broadcast loop, an explicit **size cap + LRU/stale eviction** (network partitions can skip `onClose`), a periodic stale-`lastTouched` sweep, and a **shutdown drain** added to the gateway close path. Filter delivery by `event.scope.projectSlug` (and optionally `taskId`) so a subscriber only receives its project's events.
+- **Publish hook:** have `createWorkspaceEventPublisher` (or the routes that call it) notify the hub after `publishEvent` succeeds, emitting the generic stored `ActivityEvent` (id, type, scope, payload, createdAt). Persisted store remains the source of truth; the WS is a best-effort fast path with REST polling as the backstop/reconciliation read.
+
+### C3 — Session archive = detach, NOT terminate ✅ CONFIRMED
+
+Archiving a task is a **pure metadata mutation** on the task record. `taskManager.updateTask` (`packages/gateway/src/task-manager.ts:206-228`) sets `status: "archived"` and stamps `archivedAt` (`task-manager.ts:225`); it never touches `linkedSessionId`'s runtime. There is **no** call to `killSession` / `stopSession` / `registry.destroy` anywhere in the archive path. Archived tasks are simply filtered out of normal `listTasks` reads unless `includeArchived` is set (`task-manager.ts:198`).
+
+Session lifecycle is fully decoupled and has two distinct operations:
+- **detach** — `SessionRegistry` handle `detach()` (`packages/gateway/src/session-registry.ts:474-487`): removes the subscriber, decrements `attachedClients`. The PTY/zellij session keeps running; nothing is killed. (Shell-WS `detach` message → `closeSession` aborts only that attach process; the underlying zellij session persists — `shell/ws.ts:228-232`.)
+- **terminate** — `SessionRegistry.destroy(sessionId)` (`session-registry.ts:493-515`): `session.kill()`, clears subscribers + replay buffer, deletes the registry entry. The workspace-level equivalent is `orchestrator.stopSession` → `agentSessionManager.killSession` (`workspace-session-orchestrator.ts:177-182`, `agent-session-manager.ts:405`), which also publishes `session.stopped`.
+
+**Semantics for the app (validates T045):** archive defaults to **detach** (close the terminal panel, leave the zellij session alive and reattachable via `fromSeq`); **terminate** (`stopSession`/`destroy`) is a separate, explicit, confirm-gated action. No backend change required; the app drives both via existing routes.
+
+### C4 / W2 — Platform VPS endpoint resolution + multi-VM selection ✅ CONFIRMED
+
+The macOS app does **not** address a VPS directly. The platform (`packages/platform/src/main.ts`) is a **reverse proxy**: the client always talks to the app domain (`app.matrix-os.com` / `app.localhost`, `customer-vps` for code domain), and the platform resolves and forwards to the user's VPS over `https://${machine.publicIPv4}:443/...` (e.g. `main.ts:1579`, `:3607`, `:3810`, `:3964`, `:4140`; health probe `main.ts:4278`).
+
+**Resolution key = Clerk identity + `runtimeSlot`.** Requests are authenticated to a Clerk `userId`/`handle` (app-session cookie / JWT). The platform selects the machine with `getRunningUserMachineByClerkId(db, userId, runtimeSlot)` then `getActiveUserMachineByClerkId(...)` (`main.ts:3885-3896`, also `:1532-1536`, `:4018`), falling back to handle lookup. `runtimeSlot` (`RuntimeSlotSchema`, `customer-vps-schema.ts`) defaults to `'primary'`; other slots (e.g. `staging`) are the multi-VM mechanism.
+
+**Multi-VM selection / `/runtime`.** The slot is chosen by the `?runtime=<slot>` query param (`main.ts:481-488`, `:522-524`); it is a platform-only selector that is stripped before forwarding upstream (`ws-upgrade.ts:116` `stripWebSocketUpgradeToken` deletes `runtime`; query-forwarding allowlist omits it, `main.ts:508-524`). The `/runtime` path renders a **runtime picker** page when the user has machines (and auto-redirects when 0/1) — `main.ts:3860-3881` (`getRuntimePickerPage`, `buildRuntimePickerMachines`, `listActiveUserMachinesByClerkId`). Explicit addressing of a specific machine uses `/vm/{handle}/...` routes (`main.ts:1089`, `:951`).
+
+**WS upgrades** through the platform use `getSessionRoutedWebSocketHost` / `getWebSocketUpgradeHost` (`ws-upgrade.ts:12-64`), reading `x-forwarded-host`, validating the host against the app/code allowlists, and treating internal-origin upgrades that carry a `?token=` as `app.matrix-os.com`.
+
+**Client-facing flow for the macOS app (validates D6, T026):**
+1. Device-auth via the platform device flow (same as the `matrix` CLI; `packages/platform/src/device-flow.ts`), store the principal/JWT in Keychain.
+2. Connect to the app domain (`https://app.matrix-os.com`), not the VPS IP. The platform resolves `userId → primary` machine and proxies.
+3. For multi-VM, fetch the user's machines (runtime picker / fleet) and let the user select a slot; pass `?runtime=<slot>` on subsequent requests. Default is `primary`.
+4. All HTTP and the shell WS go through the platform proxy; the macOS client never needs (and must not assume) a direct `publicIPv4`. Auth token travels in the `Authorization` header (HTTP + WS), which both the platform proxy and the gateway accept (C1).

--- a/specs/086-macos-native-shell/spec.md
+++ b/specs/086-macos-native-shell/spec.md
@@ -67,7 +67,7 @@ From any card the user can switch the panel from Terminal to **Matrix Shell**, e
 
 ---
 
-### User Story 4 - Run a Matrix App inside a card (Priority: P3)
+### User Story 4 - Run a Matrix App inside a card (Priority: P4)
 
 The user pins a specific Matrix App (e.g. a kanban app, a notes app, a game) as a card's panel. The app runs through the MatrixOS app bridge with the same data access it has in the web shell (owner Postgres, KV, allowlisted external fetch).
 
@@ -83,7 +83,7 @@ The user pins a specific Matrix App (e.g. a kanban app, a notes app, a game) as 
 
 ---
 
-### User Story 5 - See and steer Symphony runs from the board (Priority: P4)
+### User Story 5 - See and steer Symphony runs from the board (Priority: P5)
 
 When the user runs the Symphony orchestrator on the VPS, related cards show run status and agent activity, and the user can start/observe an orchestrated run from the board.
 
@@ -99,7 +99,7 @@ When the user runs the Symphony orchestrator on the VPS, related cards show run 
 
 ---
 
-### User Story 6 - Control the board from any terminal (CLI/MCP) (Priority: P4)
+### User Story 6 - Control the board from any terminal (CLI/MCP) (Priority: P6)
 
 A Matrix-targeted CLI command set and MCP server let agents and power users read board context and create/update/move cards from inside any terminal session — the native analogue of SlayZone's `slay`.
 

--- a/specs/086-macos-native-shell/spec.md
+++ b/specs/086-macos-native-shell/spec.md
@@ -1,0 +1,248 @@
+# Feature Specification: Matrix OS Native macOS App (Kanban-with-Terminals Shell)
+
+**Feature Branch**: `086-macos-native-shell`
+**Created**: 2026-06-05
+**Status**: Draft
+**Input**: Native macOS (Swift/SwiftUI) desktop app for Matrix OS in the SlayZone "kanban-with-terminals" UX. Each kanban card maps to a Matrix zellij session on the user's VPS (card ⇄ session ⇄ task). Card panels: Terminal (attach to the card's zellij session over the gateway shell WebSocket), Matrix Shell (embedded Canvas/Desktop), Matrix App (MatrixOS bridge). Thin remote client — no local persistence DB and no local PTY. Connects to the user's Matrix shell and Symphony orchestrator. Keep a Matrix-targeted CLI/MCP control surface.
+
+## Overview
+
+Matrix OS is headless-core, multi-shell (Constitution Principle 3). Today the primary renderer is the web Canvas/Desktop shell served from the user's VPS. This feature adds a **native macOS desktop app** as a first-class additional shell, presenting the user's Matrix computer as a **kanban board of terminals** (inspired by SlayZone's "Card → Terminal → Agent" UX).
+
+The app is a **thin remote client**: it owns no durable data and spawns no local terminal processes. Every card is backed by a **zellij session on the user's VPS**, every terminal is a live attach to that session over the existing gateway shell WebSocket, and all board metadata lives in the **user's own Postgres** via gateway routes. The app is therefore fully aligned with Constitution Principle 1 (Data Belongs to Its Owner): deleting the app leaves zero user data on the local machine.
+
+A card exposes three interchangeable panels onto the same Matrix computer: a **Terminal** (the card's zellij session), the **Matrix Shell** (the user's Canvas/Desktop, embedded), and a **Matrix App** (loaded through the MatrixOS app bridge). The board also surfaces the **Symphony** orchestrator so multi-agent runs are visible and controllable where the work happens.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Connect to my Matrix computer and work in a terminal (Priority: P1)
+
+A Matrix OS user installs the macOS app, signs in with their existing Matrix identity, and immediately sees their VPS's live zellij sessions rendered as cards on a board. Opening a card attaches a terminal to that session: prior output replays as scrollback, and keystrokes drive the real session on the VPS (where Claude Code / Codex / shells already run).
+
+**Why this priority**: This is the irreducible MVP. It proves the entire thin-client thesis — native UI, remote zellij, no local PTY, no local DB — in a single working card. Without it nothing else matters; with it the user already has a usable native terminal client for their Matrix computer.
+
+**Independent Test**: Sign in, confirm the board lists the same sessions as `matrix` shell session list on the VPS, open one card, observe scrollback replay, type a command, and verify it executes in the real VPS session (visible from another attach).
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in user whose VPS has ≥1 active zellij session, **When** the board loads, **Then** each active session appears as exactly one card with its session name and status.
+2. **Given** a card backed by an active session, **When** the user opens it, **Then** recent session output replays as scrollback and the terminal reaches an interactive prompt without the user spawning anything locally.
+3. **Given** an attached terminal, **When** the user types a command and presses return, **Then** the command executes in the VPS session and output streams back in order.
+4. **Given** an attached terminal, **When** the user resizes the window, **Then** the remote session's dimensions update so output wraps correctly.
+5. **Given** no VPS is provisioned for the account yet, **When** the user signs in, **Then** the app shows an onboarding empty state (not an error) explaining how to create a Matrix computer.
+
+---
+
+### User Story 2 - Organize work as a board that persists across my devices (Priority: P2)
+
+The user creates, renames, moves between columns, tags, and archives cards. Each new card provisions a backing zellij session; board layout (column, order, title, tags) is stored in the user's Postgres through the gateway, so the same board appears identically on the web shell and on another Mac, and survives app restarts.
+
+**Why this priority**: Turns a flat session list into an actual task board — the core SlayZone value. Depends on P1's connection but is independently demonstrable and is what makes the app a workspace rather than a terminal multiplexer.
+
+**Independent Test**: Create a card in column "Doing", reload the app, confirm it persists in the same column; open the web shell or a second device and confirm the same card/column/order is present; archive it and confirm it disappears from the active board on both.
+
+**Acceptance Scenarios**:
+
+1. **Given** the board, **When** the user creates a card with a title, **Then** a backing zellij session is created and the card is stored with its column, order, title, and timestamp.
+2. **Given** an existing card, **When** the user moves it to another column or reorders it, **Then** the new position persists and is reflected on other connected clients within a short interval.
+3. **Given** a card, **When** the user renames or tags it, **Then** the metadata persists without affecting the backing session's identity.
+4. **Given** a card, **When** the user archives it, **Then** it leaves the active board, its backing session is detached (not destroyed) unless the user explicitly chooses to terminate it, and the choice is recorded.
+5. **Given** two devices editing the same card concurrently, **When** both submit changes, **Then** the system resolves with revision-based concurrency without corrupting the board, and the losing client is refreshed rather than silently overwritten.
+
+---
+
+### User Story 3 - Open my Matrix Shell inside a card (Priority: P3)
+
+From any card the user can switch the panel from Terminal to **Matrix Shell**, embedding their own Canvas/Desktop experience (file browser, apps, chat) authenticated as themselves, without leaving the native board.
+
+**Why this priority**: Gives the native app full Matrix reach (not just terminals) by reusing the existing web shell, with minimal new surface. Valuable but layered on top of the P1/P2 core.
+
+**Independent Test**: Open a card, switch to the Shell panel, confirm the user's real Canvas shell loads already-authenticated and that opening a file or app there works the same as in a browser.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in user, **When** they select the Shell panel on a card, **Then** their Canvas/Desktop shell loads authenticated as them (no second login).
+2. **Given** the Shell panel is open, **When** the user interacts with it (open file, switch app), **Then** it behaves identically to the web shell.
+3. **Given** an unauthenticated or expired session, **When** the Shell panel attempts to load, **Then** the user is prompted to re-authenticate rather than shown a broken page.
+
+---
+
+### User Story 4 - Run a Matrix App inside a card (Priority: P3)
+
+The user pins a specific Matrix App (e.g. a kanban app, a notes app, a game) as a card's panel. The app runs through the MatrixOS app bridge with the same data access it has in the web shell (owner Postgres, KV, allowlisted external fetch).
+
+**Why this priority**: Lets a card *be* an app, not just a terminal or whole shell — closing the loop on "open apps in the native app." Depends on the shell-embedding plumbing from P3.
+
+**Independent Test**: Pin a known Matrix App to a card, confirm it loads through the bridge and can read/write its owner data exactly as in the browser, and that it cannot make un-bridged network calls.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user selects an installed Matrix App for a card, **When** the App panel loads, **Then** the app renders through the bridge and can use its normal data APIs.
+2. **Given** an App panel, **When** the app attempts a direct (un-bridged) network call, **Then** it is blocked exactly as in the sandboxed web shell.
+3. **Given** an App panel, **When** the user switches back to Terminal, **Then** the app state is suspended/closed cleanly and the terminal reattaches.
+
+---
+
+### User Story 5 - See and steer Symphony runs from the board (Priority: P4)
+
+When the user runs the Symphony orchestrator on the VPS, related cards show run status and agent activity, and the user can start/observe an orchestrated run from the board.
+
+**Why this priority**: Connects the native app to the multi-agent control plane, making the board the cockpit for agent work. Highest-value once terminals + board exist, but explicitly after them.
+
+**Independent Test**: Trigger a Symphony run on the VPS, confirm the corresponding card(s) reflect run state and agent turns, and that starting a run from the board produces the same result as starting it from the VPS.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active Symphony run, **When** the user views the board, **Then** affected cards display current run status and recent agent activity.
+2. **Given** the board, **When** the user starts an orchestrated run from a card, **Then** the run begins on the VPS and the card reflects progress.
+3. **Given** a Symphony run finishes or fails, **When** the user views the card, **Then** the terminal/status accurately reflects the terminal state.
+
+---
+
+### User Story 6 - Control the board from any terminal (CLI/MCP) (Priority: P4)
+
+A Matrix-targeted CLI command set and MCP server let agents and power users read board context and create/update/move cards from inside any terminal session — the native analogue of SlayZone's `slay`.
+
+**Why this priority**: Lets agents running in the cards manage the board itself (self-organizing work), and gives scriptable parity. Useful but strictly additive on top of the board's existence.
+
+**Independent Test**: From a terminal, list the board, create a card, move it, and confirm the native app reflects each change live; from an agent via MCP, update a card's status and confirm propagation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in CLI, **When** the user lists/creates/moves cards, **Then** the same gateway/Postgres state changes and the native app updates live.
+2. **Given** an MCP-connected agent, **When** it reads board context, **Then** it receives the current cards/columns/tags for the authorized board only.
+3. **Given** an MCP write, **When** an agent moves or updates a card, **Then** the change is authorized against the same principal rules as the UI and is reflected everywhere.
+
+---
+
+### Edge Cases
+
+- **Gateway unreachable / VPS asleep**: board shows a clear reconnecting state; no crash; auto-retry with backoff; last-known board view shown read-only with a staleness indicator (view only — never written locally as durable data).
+- **WebSocket drop mid-session**: terminal auto-reconnects, re-attaches, and replays scrollback from the last acknowledged sequence; no duplicated or lost output beyond the documented replay window.
+- **Backing zellij session exited/killed externally**: card marks the session as exited, offers re-create or archive; terminal shows the exit cleanly rather than hanging.
+- **Token expired / revoked**: any in-flight request or WS surfaces a re-auth prompt; no silent failure; no leaking of raw gateway errors.
+- **Concurrent board edits from web shell + native app + CLI**: resolved by revision-based concurrency; the losing client refreshes rather than overwriting.
+- **No VPS provisioned**: onboarding empty state, not a 404/error.
+- **Very large scrollback / fast output**: terminal buffer is capped; rendering stays responsive; backpressure prevents unbounded memory growth.
+- **Multiple Matrix computers (VMs) on one account**: user can select which VPS/board the app targets; switching is explicit and does not mix sessions.
+- **Offline launch**: app opens to a clear disconnected state; no destructive assumptions; reconnects when network returns.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Connection & Identity**
+
+- **FR-001**: The app MUST authenticate the user with their existing Matrix identity using the same device-authorization/token flow as the Matrix CLI, with no app-specific account.
+- **FR-002**: The app MUST let the user select which of their Matrix computers (VPS endpoints) to connect to when more than one exists, and remember the last selection.
+- **FR-003**: The app MUST store credentials only in the macOS secure credential store (Keychain) and MUST NOT persist any board, terminal, or app data to local durable storage.
+- **FR-004**: The app MUST function against any user's VPS purely by resolving the user's handle/endpoint — no hardcoded environment assumptions.
+
+**Board ⇄ Sessions**
+
+- **FR-005**: The app MUST render the user's VPS zellij sessions as cards, one card per session, showing name and live status (active/exited).
+- **FR-006**: The app MUST let the user create a card, which MUST provision a backing zellij session on the VPS.
+- **FR-007**: The app MUST persist board metadata (column, order, title, tags, archived state, session reference) in the user's Postgres via gateway routes, and MUST NOT store it locally as the source of truth.
+- **FR-008**: The app MUST let the user move, reorder, rename, tag, and archive cards, with changes persisted and propagated to other connected clients.
+- **FR-008a**: Board changes MUST be propagated to other connected clients via a server-pushed update channel (not client polling) so SC-005's propagation target is met. The server-side subscriber registry MUST be bounded with TTL/stale-connection eviction, isolate per-subscriber send failures, and evict dead senders — per the Matrix realtime-subscriber rules. *(Plan obligation W1/C1: define this channel; it is net-new alongside the board-metadata routes.)*
+- **FR-009**: Archiving a card MUST default to detaching (not destroying) its backing session, and MUST require explicit confirmation to terminate a session.
+- **FR-010**: Concurrent edits to the same card MUST be resolved with revision-based optimistic concurrency; a client whose write is stale MUST be refreshed rather than overwrite newer state.
+
+**Terminal Panel**
+
+- **FR-011**: A card's Terminal panel MUST attach to that card's zellij session over the gateway shell WebSocket using the existing input/resize/output/scrollback protocol.
+- **FR-012**: On attach, the terminal MUST replay available recent scrollback before live output.
+- **FR-013**: The terminal MUST forward keystrokes as input and window size changes as resize events to the remote session.
+- **FR-014**: On WebSocket disconnect, the terminal MUST automatically reconnect with bounded backoff and restore continuity of output. If the gateway supports resuming from a client-supplied sequence number, reconnect MUST resume from the last acknowledged sequence; if it does not, the client MUST de-duplicate the fixed replay window so no committed output is duplicated or dropped. *(Plan obligation F1: confirm exact resume semantics of the gateway shell WS — `SHELL_ATTACH_LIVE_TAIL_FROM_SEQ` and the recent-replay window — before relying on resume-from-seq.)*
+- **FR-015**: The terminal MUST NOT spawn any local PTY/process.
+- **FR-015a**: WebSocket authentication MUST use an `Authorization` header or a token-bearing WebSocket subprotocol — NOT a token in the URL/query string — so credentials are never written to gateway/proxy access logs. *(Native clients can set upgrade headers; the browser-only query-token path MUST NOT be reused here.)*
+
+**Shell & App Panels**
+
+- **FR-016**: A card MUST be switchable between Terminal, Matrix Shell, and Matrix App panels.
+- **FR-017**: The Matrix Shell panel MUST embed the user's Canvas/Desktop shell authenticated as the same user (no second sign-in).
+- **FR-018**: The Matrix App panel MUST load a selected Matrix App through the MatrixOS app bridge with the same data-access and sandbox guarantees as the web shell, and MUST block un-bridged network calls.
+
+**Symphony**
+
+- **FR-019**: The app MUST surface Symphony run status and recent agent activity on related cards.
+- **FR-020**: The app MUST let the user start/observe a Symphony orchestrated run from the board, reflecting progress and terminal state.
+
+**CLI / MCP Control Surface**
+
+- **FR-021**: The system MUST provide a Matrix-targeted command set and MCP server to list/create/update/move cards against the same gateway/Postgres state and authorization rules as the app.
+- **FR-022**: Board changes made via CLI/MCP MUST propagate live to the native app and web shell.
+
+**Cross-cutting**
+
+- **FR-023**: All client-facing errors MUST be generic and safe; the app MUST NOT display raw gateway, database, provider, or filesystem error text.
+- **FR-024**: The app MUST present clear connection/empty/error states (reconnecting, no VPS, session exited, re-auth) rather than blank or broken screens.
+- **FR-025**: The app MUST request only the authorized user's board/sessions; it MUST NOT be able to access another principal's data.
+
+### Key Entities *(include if feature involves data)*
+
+- **Connection Profile**: A target Matrix computer — user handle, resolved gateway endpoint, selected VPS, and a reference to credentials in the Keychain. No durable board data.
+- **Board**: The set of cards for a given VPS/project, owned by the user. Source of truth in the user's Postgres.
+- **Card**: A unit of work that references exactly one backing zellij **Session**, plus kanban metadata: title, column, order, tags, archived state, revision, timestamps.
+- **Session (zellij)**: A live remote terminal session on the VPS — name, status (active/exited), working directory, layout, and tabs. Runtime truth lives on the VPS; the card holds only a reference.
+- **Panel**: The current view of a card — Terminal, Matrix Shell, or Matrix App — including which app is pinned when in App mode.
+- **Symphony Run (read model)**: Orchestrator run status and agent activity associated with a card, sourced from the VPS.
+
+## Security & Privacy Architecture *(mandatory per Spec Quality Gates)*
+
+- **Auth source of truth**: Gateway-issued principal (JWT/device token), identical to CLI and request-principal model. The app holds no independent identity.
+- **WebSocket auth transport (S1)**: WebSocket attaches authenticate via an `Authorization` header or token-bearing subprotocol on the upgrade request — the native app is NOT a browser and MUST NOT use the query-token path (which leaks tokens into access logs). Existing principal validation is reused; only the token-carrying channel differs. The gateway's query-token allowlist is browser-only and out of scope for this client.
+- **Auth matrix (S2 — plan obligation)**: `/speckit.plan` MUST emit an explicit table listing every new/used HTTP route and WS endpoint (board CRUD, session list/create, terminal attach, board-update subscription, Symphony status) with its method, principal requirement, and scope. Prose here is not a substitute for that table.
+- **Authorization matrix**: Every board read/write, session list/create/attach, shell embed, app load, and Symphony action is authorized against the request principal and scoped to the user's own VPS. No cross-principal access. CLI/MCP writes pass the same authorization as UI writes.
+- **Input validation**: All board mutations validate IDs, column names, tags, ordering, and session names at the route boundary with bounded schemas before touching Postgres. Session names are validated against the safe-name rules already enforced by the shell registry. WebSocket frames are schema-validated after parse.
+- **Secret handling**: Tokens live only in Keychain; never written to logs, board metadata, or local files. No provider names or raw upstream errors are surfaced to the UI.
+- **Sandbox guarantees**: The App panel preserves the web shell's sandbox contract (bridge-only data access, blocked direct fetch). The Shell panel runs the user's own origin authenticated as the user; it does not bypass shell-side authorization.
+- **Data ownership**: Zero durable local persistence of user content. Uninstalling the app removes no board/terminal/app data because none is stored locally.
+
+## Integration Wiring *(mandatory per Spec Quality Gates)*
+
+- **Startup sequence**: Resolve stored profile → load token from Keychain → resolve gateway endpoint for the selected VPS → fetch board (cards + sessions) → render → lazily attach terminal WS only when a card's Terminal panel is opened.
+- **Cross-surface communication**: Native app ⇄ gateway over HTTPS (board CRUD, session list/create) and WSS (terminal attach, live board updates / Symphony status). The web Shell/App panels load the user's existing shell origin. The CLI/MCP surface targets the same gateway routes.
+- **Gateway dependencies (existing, to be confirmed/extended in plan)**: shell WebSocket attach protocol, zellij session list/create/tabs, request-principal auth, Symphony status. New gateway routes are required for board metadata CRUD (cards/columns/tags) backed by the user's Postgres, plus a board-update subscription channel (FR-008a).
+- **VPS endpoint resolution (W2 — plan obligation)**: The plan MUST specify how the app discovers a user's per-VPS gateway URL (via the platform/`app.matrix-os.com` runtime routing) and how multi-VM selection/switching works, including the pre-VPS (no computer yet) onboarding path.
+- **Symphony source (W3 — plan obligation)**: The plan MUST pin the concrete Symphony run/agent-activity read-model source (gateway route vs. Symphony service) and its authorization.
+- **No new shared global state**: board state is server-authoritative; the app is a renderer.
+- **Integration test checkpoint (T1)**: Each implemented user story MUST ship with an end-to-end check exercising the client↔gateway chain — gateway contract tests for the new board routes/subscription, and a native integration test that attaches a terminal to a real test zellij session and round-trips input/output. Unit tests alone do not satisfy a phase checkpoint.
+
+## Failure Modes & Resource Management *(mandatory per Spec Quality Gates)*
+
+- **Timeouts**: All HTTP calls to the gateway use bounded timeouts; no request hangs indefinitely. WS attach and reconnect use bounded backoff with a cap.
+- **Concurrent access**: Revision-based optimistic concurrency for board edits; losing writers refresh. Session create is idempotent server-side so double-taps do not create duplicate sessions.
+- **Crash/disconnect recovery**: Terminal reconnects and replays from last acknowledged sequence. Board refetches on reconnect. Stale live-session references are reconciled on the main read path (mark exited sessions recoverable), not only via explicit recovery.
+- **Resource limits**: Terminal scrollback buffers are capped with eviction; rendering applies backpressure under fast output. Any in-memory caches (board view, session map) are bounded. Embedded web views are released when panels close. **(R1)** There is also an *aggregate* cap across the whole board: the number of simultaneously live terminal attaches and embedded web views is bounded, and offscreen/background cards are suspended (WS detached, web view released) and reattached on focus, so a large board cannot exhaust sockets or memory.
+- **Error policy**: No silent failures; every failed create/attach/load sets a visible, generic error state and offers a recovery action. Misconfiguration (no VPS, missing endpoint) is distinguished from "not found" and from transient connectivity.
+
+## Constitution Alignment
+
+- **P1 Data Belongs to Its Owner**: No local durable user data; board in user's Postgres; sessions on user's VPS.
+- **P3 Headless Core, Multi-Shell**: The macOS app is one more renderer over the same gateway; it adds no core logic the web shell lacks.
+- **P4 Defense in Depth**: Principal-scoped authz, input validation, bounded resources/timeouts, sandbox preservation.
+- **P5 TDD**: All new gateway routes and client logic are specified test-first (see plan/tasks).
+
+## Out of Scope (Deferred)
+
+- Windows/Linux native clients (the web shell and/or an Electron SlayZone fork cover those).
+- Offline-first/local-first mode or any local database. *(Note A1: Constitution Principle III lists offline support as a goal for first-class desktop shells. This spec deliberately defers it to a later phase to keep the thin-client/no-local-data invariant clean for v1; a future read-only offline cache may be revisited without violating data-ownership. This is a phased deferral, not a permanent exclusion.)*
+- Replacing or re-implementing the web Canvas/Desktop shell or Matrix Apps natively (they are embedded, not rewritten).
+- Mobile clients (covered by spec 075-mobile-shell).
+- Running terminals/PTY locally on the Mac.
+- App Store distribution mechanics (addressed in plan only if/when packaging is in scope).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After signing in, a user with an active VPS sees their session board within 5 seconds on a typical broadband connection.
+- **SC-002**: Opening a card's terminal reaches an interactive, scrollback-populated prompt within 3 seconds, with no local process spawned.
+- **SC-003**: Terminal input feels native: 95th-percentile keystroke-to-echo round trip stays under typical interactive thresholds (≤150 ms on broadband) and the UI never blocks during fast output.
+- **SC-004**: After a network drop, the terminal reconnects and restores scrollback within 5 seconds without losing committed output.
+- **SC-005**: A board edit made on one device (or via CLI) appears on another connected client within 2 seconds.
+- **SC-006**: 100% of user content is server-side: an audit of the uninstalled app's local footprint finds zero board, terminal, or app data (only Keychain credentials, which clear on sign-out).
+- **SC-007**: 90% of first-time users can connect and open a working terminal on their Matrix computer without external help.
+- **SC-008**: The same board (cards, columns, order, tags) is identical across the native app, the web shell, and the CLI for the same user.
+- **SC-009**: No client-visible error message exposes raw gateway, database, provider, or filesystem internals (verified by error-path review).

--- a/specs/086-macos-native-shell/tasks.md
+++ b/specs/086-macos-native-shell/tasks.md
@@ -1,0 +1,146 @@
+---
+description: "Task list for 086 Matrix OS native macOS app"
+---
+
+# Tasks: Matrix OS Native macOS App (Kanban-with-Terminals Shell)
+
+**Input**: `/specs/086-macos-native-shell/` (spec.md, plan.md, research.md, data-model.md, design.md)
+**Tests**: REQUIRED (Constitution IX TDD — tests first, red→green→refactor).
+**App root**: `macos/` (Swift 6 / SwiftUI, new top-level target). **Gateway delta**: `packages/gateway/`. **Gateway tests**: repo-root `tests/gateway/`.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]** = parallelizable (different files, no dependency). **[Story]** = US1..US6.
+
+---
+
+## Phase 0: Spike Confirmations (de-risk; do first, cheap)
+
+- [ ] T001 [P] Confirm shell-WS route path and that it authenticates via `Authorization` header (not only query token); document in `research.md`. If header-auth is missing on the shell WS, add it in `packages/gateway/src/shell/` + `server.ts` (mirror canvas WS `requireRequestPrincipal(c)`), test-first in `tests/gateway/shell-ws-auth.test.ts`. (C1, S1)
+- [ ] T002 [P] Confirm whether `task.*` workspace events are delivered over a client-facing WS; if not, design the board-events subscription endpoint (bounded subscriber registry) — note decision in `research.md`. (C2, W1)
+- [ ] T003 [P] Confirm session archive = detach (not terminate) in `workspace-session-orchestrator.ts`; document semantics. (C3)
+- [ ] T004 [P] Confirm platform VPS endpoint-resolution + multi-VM selection contract (`packages/platform/src/customer-vps-routes.ts`, `/runtime`); document client flow. (C4, W2)
+
+**Checkpoint**: all four confirmations resolved; any required gateway deltas have failing tests written.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T010 Create `macos/` Swift package + Xcode project (`MatrixOS.xcodeproj`/`Package.swift`), macOS 14+ target, Swift 6 strict concurrency, app entrypoint window/scene.
+- [ ] T011 [P] Add `SwiftTerm` dependency (terminal emulator) and `swift-format`/SwiftLint config.
+- [ ] T012 [P] Bundle fonts (IBM Plex Sans + IBM Plex Mono) and add to the app bundle + Info.plist.
+- [ ] T013 [P] Implement `DesignTokens.swift` (colors asset catalog, `Spacing`, `Radius`, `Motion`, `Font.plexSans/plexMono`) exactly per `design.md` §9; snapshot test the token values.
+- [ ] T014 [P] CI: add a macOS build+test job (xcodebuild) for the `macos/` target; keep it separate from the pnpm/turbo pipeline.
+
+---
+
+## Phase 2: Foundational (BLOCKS all stories)
+
+- [ ] T020 [US-all] Write failing unit tests for `GatewayHTTPClient` (bounded timeouts, principal header, generic-error mapping) in `macos/Tests/Net/GatewayHTTPClientTests.swift`.
+- [ ] T021 [US-all] Implement `GatewayHTTPClient` (`URLSession`, `AbortSignal`-equivalent timeouts, `Authorization` header, no raw error leakage) in `macos/Sources/Net/`.
+- [ ] T022 [US-all] [P] Write failing tests for `KeychainStore` + `PrincipalProvider` (device-auth token storage/retrieval/clear) in `macos/Tests/Net/`.
+- [ ] T023 [US-all] Implement `KeychainStore` + `PrincipalProvider` + platform device-auth flow in `macos/Sources/Net/`.
+- [ ] T024 [US-all] [P] Write failing tests for `ShellWSClient` resume logic (track `lastSeq`, reconnect with `fromSeq=lastSeq+1`, handle `replay-evicted`, bounded backoff) in `macos/Tests/Terminal/ShellWSClientTests.swift`.
+- [ ] T025 [US-all] Implement `ShellWSClient` (`URLSessionWebSocketTask`, header auth, input/resize/detach/ping ↔ attached/output/exit/error/pong) in `macos/Sources/Terminal/`.
+- [ ] T026 [US-all] [P] Implement `ConnectionProfile` + VPS resolver (platform endpoint resolution, multi-VM picker) in `macos/Sources/App/` with tests.
+- [ ] T027 [US-all] [P] Implement core view models (`Card`, `SessionRef`, `Panel`) per `data-model.md` in `macos/Sources/Model/` with tests (bounded, value types).
+- [ ] T028 [US-all] App shell: window, profile/onboarding gate, global keyboard map (`⌘N/⌘[/⌘]/⌘T/⌘1-3/Esc`), Reduce Motion/Transparency handling.
+
+**Checkpoint**: networking + auth + WS client + tokens + design system ready; user stories can start in parallel.
+
+---
+
+## Phase 3: User Story 1 — Connect + work in a terminal (P1) 🎯 MVP
+
+**Goal**: sign in → board of sessions → open card → terminal attaches with scrollback + live I/O.
+**Independent Test**: attach to a real test zellij session, round-trip a command.
+
+- [ ] T030 [P] [US1] Failing integration test: device-auth → resolve VPS → `GET /api/projects/:slug/tasks` renders cards (mock gateway) in `macos/Tests/Integration/BoardLoadTests.swift`.
+- [ ] T031 [P] [US1] Failing integration test: open card → `ShellWSClient` attaches to `linkedSessionId`, scrollback replays, input echoes (test gateway + zellij) in `macos/Tests/Integration/TerminalAttachTests.swift`.
+- [ ] T032 [US1] Implement read-only `BoardStore` (fetch tasks→cards, map status→columns, order) in `macos/Sources/Board/`.
+- [ ] T033 [US1] Implement `BoardView`/`ColumnView`/`CardView` (LazyVStack recycling, OPERATOR design tokens, status badges, live edge-glow) in `macos/Sources/Board/`.
+- [ ] T034 [US1] Implement `TerminalPanel` (SwiftTerm view bound to `ShellWSClient`, resume, resize-on-window-change, scrollback fade + LIVE marker) in `macos/Sources/Terminal/`.
+- [ ] T035 [US1] Card → terminal open/close wiring; lazy attach only on open; detach on close (R1).
+- [ ] T036 [US1] Empty/onboarding states: no-VPS, board loading skeleton, disconnected bar (per `design.md` §6.6).
+- [ ] T037 [US1] Generic error surfacing for attach/list failures (no raw gateway text).
+
+**Checkpoint**: MVP — native terminal client over remote zellij, no local PTY/DB. STOP & validate.
+
+---
+
+## Phase 4: User Story 2 — Board CRUD + live sync (P2)
+
+**Goal**: create/move/reorder/rename/tag/archive cards; persisted to Postgres; <2s cross-client.
+**Independent Test**: two clients converge; reload persists.
+
+- [ ] T040 [P] [US2] (If T002 requires it) gateway: tags on task + board-events delivery — failing tests in `tests/gateway/` first, then implement (Kysely migration, route validation, atomic revision-guarded updates).
+- [ ] T041 [P] [US2] Failing integration test: create card → session provisioned + task stored; move card → status/order PATCH; second client sees update via events.
+- [ ] T042 [US2] Extend `BoardStore` with mutations (create/move/reorder/rename/tag/archive) using revision-guarded PATCH; optimistic UI with refresh-on-conflict.
+- [ ] T043 [US2] Native drag-and-drop (Transferable/drop delegates) with insertion bar, column reflow springs, no layout shift; `⌘[`/`⌘]` move.
+- [ ] T044 [US2] Subscribe to workspace/board events; diff-apply to `BoardStore`; bounded in-memory state.
+- [ ] T045 [US2] Archive flow: default detach session, explicit-confirm terminate (C3).
+
+**Checkpoint**: real task board, multi-device live.
+
+---
+
+## Phase 5: User Story 3 — Matrix Shell panel (P3)
+
+- [ ] T050 [P] [US3] Failing test: Shell panel loads user's own shell origin authenticated; bearer never injected into web content.
+- [ ] T051 [US3] `ShellPanel` (`WKWebView` to `SHELL_ORIGIN`, scoped-cookie auth handoff, re-auth on expiry, release on close) in `macos/Sources/Panels/`.
+- [ ] T052 [US3] Panel switcher (Terminal·Shell·App) with `matchedGeometryEffect` (no layout shift), toggle consistency, light-dismiss, `⌘1/2/3`.
+
+---
+
+## Phase 6: User Story 4 — Matrix App panel (P3)
+
+- [ ] T060 [P] [US4] Failing test: App panel loads via shell-origin `AppViewer` URL (server-side bridge serves it); un-bridged fetch blocked; no native bridge re-impl.
+- [ ] T061 [US4] `AppPanel` (`WKWebView` to shell-origin AppViewer for selected app slug; app picker; suspend/release on switch) in `macos/Sources/Panels/`.
+
+---
+
+## Phase 7: User Story 5 — Symphony on the board (P4)
+
+- [ ] T070 [P] [US5] Failing test: Symphony run read-model surfaces on related cards; start/observe via `symphony/proxy.ts`.
+- [ ] T071 [US5] `SymphonyClient` + card run-status/agent-activity overlays + start/observe controls in `macos/Sources/Symphony/`.
+
+---
+
+## Phase 8: User Story 6 — CLI/MCP board control (P4)
+
+- [ ] T080 [P] [US6] Failing tests for `matrix board` commands (list/create/move/update) against gateway under principal, in `tests/` (existing convention).
+- [ ] T081 [US6] Implement `matrix board` command group (extend existing CLI) + MCP server exposing board read/write tools under the same principal; live-propagation to the app.
+
+---
+
+## Phase 9: Polish & Cross-Cutting
+
+- [ ] T090 [P] Performance pass: verify 60fps board with 200+ cards (Instruments), coalesced terminal flushes, offscreen card suspension (R1).
+- [ ] T091 [P] Accessibility: contrast, Reduce Motion/Transparency, color+shape state encoding, full keyboard nav.
+- [ ] T092 [P] Aggregate resource caps verified (live attaches/web views bounded; scrollback eviction; timer teardown).
+- [ ] T093 [P] Docs: `macos/README.md`, update repo docs; run `/update-docs`.
+- [ ] T094 Security sweep: auth matrix honored on every call; no bearer in web content; generic errors only; `bun run check:patterns` for gateway delta.
+- [ ] T095 react-doctor N/A (no React); ensure gateway delta passes `bun run typecheck` + `bun run test`.
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 0** (spikes) → unblocks risky areas; do first.
+- **Phase 1 Setup** → **Phase 2 Foundational** (BLOCKS all stories).
+- **US1 (P1)** after Foundational = MVP. **US2..US6** after Foundational; can parallelize across agents but US4 depends on US3's panel switcher; US2's drag depends on US1's board.
+- **Phase 9** after desired stories.
+
+### Graphite Stack Plan
+- **Stack 1**: Phase 0 spikes + Phase 1 setup + design tokens + docs.
+- **Stack 2**: Phase 2 foundational (net/auth/WS/models) + any gateway delta.
+- **Stack 3**: US1 MVP.  **Stack 4**: US2.  **Stack 5**: US3+US4 (panels).  **Stack 6**: US5.  **Stack 7**: US6.  **Final**: Phase 9.
+- One PR per stack layer; respect PR size limits; Greptile 5/5 per layer; do not flatten.
+
+### Parallel opportunities
+- All Phase 0 tasks [P]. Phase 1 T011–T014 [P]. Phase 2 [P]-marked net/model tasks. Within each story, the failing tests [P] run together; models before views before wiring.
+
+## Notes
+- Tests fail first, then implement (TDD). Commit after each task or logical group.
+- No local durable user data; no local PTY. Every external call has a bounded timeout.
+- Validate each story independently at its checkpoint before moving on.

--- a/specs/086-macos-native-shell/tasks.md
+++ b/specs/086-macos-native-shell/tasks.md
@@ -15,10 +15,10 @@ description: "Task list for 086 Matrix OS native macOS app"
 
 ## Phase 0: Spike Confirmations (de-risk; do first, cheap)
 
-- [ ] T001 [P] Confirm shell-WS route path and that it authenticates via `Authorization` header (not only query token); document in `research.md`. If header-auth is missing on the shell WS, add it in `packages/gateway/src/shell/` + `server.ts` (mirror canvas WS `requireRequestPrincipal(c)`), test-first in `tests/gateway/shell-ws-auth.test.ts`. (C1, S1)
-- [ ] T002 [P] Confirm whether `task.*` workspace events are delivered over a client-facing WS; if not, design the board-events subscription endpoint (bounded subscriber registry) — note decision in `research.md`. (C2, W1)
-- [ ] T003 [P] Confirm session archive = detach (not terminate) in `workspace-session-orchestrator.ts`; document semantics. (C3)
-- [ ] T004 [P] Confirm platform VPS endpoint-resolution + multi-VM selection contract (`packages/platform/src/customer-vps-routes.ts`, `/runtime`); document client flow. (C4, W2)
+- [x] T001 [P] Confirm shell-WS route path and that it authenticates via `Authorization` header (not only query token); document in `research.md`. If header-auth is missing on the shell WS, add it in `packages/gateway/src/shell/` + `server.ts` (mirror canvas WS `requireRequestPrincipal(c)`), test-first in `tests/gateway/shell-ws-auth.test.ts`. (C1, S1)
+- [x] T002 [P] Confirm whether `task.*` workspace events are delivered over a client-facing WS; if not, design the board-events subscription endpoint (bounded subscriber registry) — note decision in `research.md`. (C2, W1)
+- [x] T003 [P] Confirm session archive = detach (not terminate) in `workspace-session-orchestrator.ts`; document semantics. (C3)
+- [x] T004 [P] Confirm platform VPS endpoint-resolution + multi-VM selection contract (`packages/platform/src/customer-vps-routes.ts`, `/runtime`); document client flow. (C4, W2)
 
 **Checkpoint**: all four confirmations resolved; any required gateway deltas have failing tests written.
 

--- a/specs/086-macos-native-shell/tasks.md
+++ b/specs/086-macos-native-shell/tasks.md
@@ -92,21 +92,21 @@ description: "Task list for 086 Matrix OS native macOS app"
 
 ---
 
-## Phase 6: User Story 4 — Matrix App panel (P3)
+## Phase 6: User Story 4 — Matrix App panel (P4)
 
 - [ ] T060 [P] [US4] Failing test: App panel loads via shell-origin `AppViewer` URL (server-side bridge serves it); un-bridged fetch blocked; no native bridge re-impl.
 - [ ] T061 [US4] `AppPanel` (`WKWebView` to shell-origin AppViewer for selected app slug; app picker; suspend/release on switch) in `macos/Sources/Panels/`.
 
 ---
 
-## Phase 7: User Story 5 — Symphony on the board (P4)
+## Phase 7: User Story 5 — Symphony on the board (P5)
 
 - [ ] T070 [P] [US5] Failing test: Symphony run read-model surfaces on related cards; start/observe via `symphony/proxy.ts`.
 - [ ] T071 [US5] `SymphonyClient` + card run-status/agent-activity overlays + start/observe controls in `macos/Sources/Symphony/`.
 
 ---
 
-## Phase 8: User Story 6 — CLI/MCP board control (P4)
+## Phase 8: User Story 6 — CLI/MCP board control (P6)
 
 - [ ] T080 [P] [US6] Failing tests for `matrix board` commands (list/create/move/update) against gateway under principal, in `tests/` (existing convention).
 - [ ] T081 [US6] Implement `matrix board` command group (extend existing CLI) + MCP server exposing board read/write tools under the same principal; live-propagation to the app.


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 1/11.

## Summary

Adds the 086 native macOS shell spec, research, data model, requirements checklist, and task breakdown so the implementation layers have reviewable acceptance criteria.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

No backend route, database, or auth behavior changes in this layer.