### PR TITLE
feat(086): add native macOS package foundation

### DIFF
--- a/.github/workflows/macos-086.yml
+++ b/.github/workflows/macos-086.yml
@@ -1,0 +1,50 @@
+name: macOS app (086)
+
+# Native macOS shell build+test. Intentionally separate from the pnpm/turbo
+# pipeline — this target is a Swift package, not part of the TS monorepo build.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "macos/**"
+      - ".github/workflows/macos-086.yml"
+  pull_request:
+    paths:
+      - "macos/**"
+      - ".github/workflows/macos-086.yml"
+
+concurrency:
+  group: macos-086-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: swift build + test
+    runs-on: macos-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: macos
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.app || xcode-select -p
+
+      - name: Swift version
+        run: swift --version
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: macos/.build
+          key: spm-${{ runner.os }}-${{ hashFiles('macos/Package.swift', 'macos/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Build
+        run: swift build -v
+
+      - name: Test
+        run: swift test -v

--- a/.github/workflows/macos-086.yml
+++ b/.github/workflows/macos-086.yml
@@ -30,7 +30,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode_26.4.app || xcode-select -p
+        run: |
+          XCODE_PATH="${XCODE_PATH:-/Applications/Xcode_26.4.app}"
+          if [[ ! -d "$XCODE_PATH" ]]; then
+            echo "::error::Required Xcode path not found: $XCODE_PATH"
+            ls -1 /Applications | grep -E '^Xcode' || true
+            exit 1
+          fi
+          sudo xcode-select -switch "$XCODE_PATH"
 
       - name: Swift version
         run: swift --version

--- a/.github/workflows/macos-086.yml
+++ b/.github/workflows/macos-086.yml
@@ -31,12 +31,31 @@ jobs:
 
       - name: Select Xcode
         run: |
-          XCODE_PATH="${XCODE_PATH:-/Applications/Xcode_26.4.app}"
+          if [[ -n "${XCODE_PATH:-}" ]]; then
+            candidates=("$XCODE_PATH")
+          else
+            candidates=(
+              /Applications/Xcode_26.4.app
+              /Applications/Xcode_26.3.app
+              /Applications/Xcode_26.2.app
+              /Applications/Xcode_26.1.app
+              /Applications/Xcode_26.0.app
+              /Applications/Xcode.app
+            )
+          fi
+          XCODE_PATH=""
+          for candidate in "${candidates[@]}"; do
+            if [[ -d "$candidate" ]]; then
+              XCODE_PATH="$candidate"
+              break
+            fi
+          done
           if [[ ! -d "$XCODE_PATH" ]]; then
-            echo "::error::Required Xcode path not found: $XCODE_PATH"
+            echo "::error::No supported Xcode path found"
             ls -1 /Applications | grep -E '^Xcode' || true
             exit 1
           fi
+          echo "Using Xcode at $XCODE_PATH"
           sudo xcode-select -switch "$XCODE_PATH"
 
       - name: Swift version

--- a/macos/.gitignore
+++ b/macos/.gitignore
@@ -1,7 +1,6 @@
 ## Swift / SwiftPM
 .build/
 .swiftpm/
-Package.resolved
 *.xcodeproj/project.xcworkspace/xcuserdata/
 *.xcodeproj/xcuserdata/
 xcuserdata/

--- a/macos/.gitignore
+++ b/macos/.gitignore
@@ -1,0 +1,11 @@
+## Swift / SwiftPM
+.build/
+.swiftpm/
+Package.resolved
+*.xcodeproj/project.xcworkspace/xcuserdata/
+*.xcodeproj/xcuserdata/
+xcuserdata/
+DerivedData/
+
+## macOS
+.DS_Store

--- a/macos/.swift-format
+++ b/macos/.swift-format
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "lineLength": 100,
+  "indentation": {
+    "spaces": 4
+  },
+  "tabWidth": 4,
+  "maximumBlankLines": 1,
+  "respectsExistingLineBreaks": true,
+  "lineBreakBeforeControlFlowKeywords": false,
+  "lineBreakBeforeEachArgument": false,
+  "prioritizeKeepingFunctionOutputTogether": true,
+  "indentConditionalCompilationBlocks": false,
+  "rules": {
+    "AllPublicDeclarationsHaveDocumentation": false,
+    "AlwaysUseLowerCamelCase": true,
+    "NoEmptyTrailingClosureParentheses": true,
+    "OrderedImports": true,
+    "UseLetInEveryBoundCaseVariable": true,
+    "UseShorthandTypeNames": true
+  }
+}

--- a/macos/.swiftlint.yml
+++ b/macos/.swiftlint.yml
@@ -1,0 +1,33 @@
+# SwiftLint config for the Matrix OS macOS app (086).
+# Optional: CI uses `swift-format` (see .swift-format); SwiftLint is for local use if installed.
+
+included:
+  - Sources
+  - Tests
+
+excluded:
+  - .build
+
+line_length:
+  warning: 100
+  error: 140
+  ignores_comments: true
+  ignores_urls: true
+
+identifier_name:
+  min_length: 1
+  excluded:
+    - id
+    - x
+    - r
+    - g
+    - b
+    - a
+
+disabled_rules:
+  - todo # TODOs are intentional placeholders for later phases (fonts, SwiftTerm).
+
+opt_in_rules:
+  - empty_count
+  - closure_spacing
+  - explicit_init

--- a/macos/Package.resolved
+++ b/macos/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "76df76a2d249c98749db73d482ec32c708d4b71e92c369aa06edf4ebff59ff47",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm",
+      "state" : {
+        "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
+        "version" : "1.13.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -38,14 +38,15 @@ let package = Package(
         ),
         .target(
             name: "MatrixNet",
-            dependencies: ["MatrixModel"],
+            // Independent in Phase 2 (Foundation-only) so swarm agents build in isolation
+            // via `swift build --target MatrixNet`. Integrated in the App/Board layer later.
             path: "Sources/Net",
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .target(
             name: "MatrixTerminal",
-            dependencies: ["MatrixNet", "MatrixModel"],
-            // SwiftTerm view lands in Phase 3 (T034); ShellWSClient (Phase 2) is pure URLSession.
+            // ShellWSClient (Phase 2) is pure URLSession — Foundation-only, independent.
+            // SwiftTerm view + Model wiring land in Phase 3 (T034).
             path: "Sources/Terminal",
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
     products: [
         .executable(name: "MatrixOS", targets: ["MatrixOS"]),
         .library(name: "DesignSystem", targets: ["DesignSystem"]),
+        .library(name: "MatrixModel", targets: ["MatrixModel"]),
+        .library(name: "MatrixNet", targets: ["MatrixNet"]),
+        .library(name: "MatrixTerminal", targets: ["MatrixTerminal"]),
     ],
     dependencies: [
         // SwiftTerm: battle-tested VT100/xterm emulator used by the Terminal panel.
@@ -26,11 +29,34 @@ let package = Package(
                 .swiftLanguageMode(.v6),
             ]
         ),
+        // Foundational modules (Phase 2). Agents add files into these dirs WITHOUT
+        // editing Package.swift, to avoid manifest contention in the swarm.
+        .target(
+            name: "MatrixModel",
+            path: "Sources/Model",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .target(
+            name: "MatrixNet",
+            dependencies: ["MatrixModel"],
+            path: "Sources/Net",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .target(
+            name: "MatrixTerminal",
+            dependencies: ["MatrixNet", "MatrixModel"],
+            // SwiftTerm view lands in Phase 3 (T034); ShellWSClient (Phase 2) is pure URLSession.
+            path: "Sources/Terminal",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
         .executableTarget(
             name: "MatrixOS",
             dependencies: [
                 "DesignSystem",
-                // "SwiftTerm", // TODO(086): enable when Terminal panel is implemented.
+                "MatrixModel",
+                "MatrixNet",
+                "MatrixTerminal",
+                // "SwiftTerm", // TODO(086): enable when Terminal panel view is implemented (T034).
             ],
             path: "Sources/App",
             swiftSettings: [
@@ -44,6 +70,24 @@ let package = Package(
             swiftSettings: [
                 .swiftLanguageMode(.v6),
             ]
+        ),
+        .testTarget(
+            name: "ModelTests",
+            dependencies: ["MatrixModel"],
+            path: "Tests/ModelTests",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "NetTests",
+            dependencies: ["MatrixNet"],
+            path: "Tests/NetTests",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "TerminalTests",
+            dependencies: ["MatrixTerminal"],
+            path: "Tests/TerminalTests",
+            swiftSettings: [.swiftLanguageMode(.v6)]
         ),
     ]
 )

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -1,0 +1,49 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MatrixOS",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .executable(name: "MatrixOS", targets: ["MatrixOS"]),
+        .library(name: "DesignSystem", targets: ["DesignSystem"]),
+    ],
+    dependencies: [
+        // SwiftTerm: battle-tested VT100/xterm emulator used by the Terminal panel.
+        // TODO(086): wire SwiftTerm into Sources/Terminal once the shell-WS client lands
+        // (Phase 2/3). Resolution requires network access; if `swift build` is run fully
+        // offline and this fails to resolve, temporarily comment this dependency and the
+        // matching target dependency below — the rest of the package builds without it.
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.0"),
+    ],
+    targets: [
+        .target(
+            name: "DesignSystem",
+            path: "Sources/DesignSystem",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .executableTarget(
+            name: "MatrixOS",
+            dependencies: [
+                "DesignSystem",
+                // "SwiftTerm", // TODO(086): enable when Terminal panel is implemented.
+            ],
+            path: "Sources/App",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .testTarget(
+            name: "DesignSystemTests",
+            dependencies: ["DesignSystem"],
+            path: "Tests/DesignSystemTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+    ]
+)

--- a/macos/Resources/Fonts/README.md
+++ b/macos/Resources/Fonts/README.md
@@ -1,0 +1,78 @@
+# Bundled fonts — IBM Plex Sans + IBM Plex Mono
+
+The OPERATOR design system (see `specs/086-macos-native-shell/design.md` §3) uses
+two licensable families:
+
+- **IBM Plex Sans** — display / chrome / titles (weights 400/500/600)
+- **IBM Plex Mono** — terminal / data / badges (weights 400/600)
+
+Both are open-source under the **SIL Open Font License 1.1**, so they can be
+redistributed inside the app bundle.
+
+## What to drop in
+
+Place the `.otf` (or `.ttf`) files in this directory. Recommended minimal set:
+
+```
+macos/Resources/Fonts/
+├── IBMPlexSans-Regular.otf
+├── IBMPlexSans-Medium.otf
+├── IBMPlexSans-SemiBold.otf
+├── IBMPlexMono-Regular.otf
+└── IBMPlexMono-SemiBold.otf
+```
+
+Download from:
+- https://github.com/IBM/plex/releases (official IBM Plex release tarballs)
+- or https://www.fontsquirrel.com/fonts/ibm-plex-sans
+
+## Wiring into the app bundle
+
+This is a SwiftPM executable today (`swift build`). Font registration depends on
+how the app is finally packaged:
+
+### A) When packaged as an `.app` with an `Info.plist`
+
+Add the fonts to `Resources/Fonts/` in the bundle and declare the directory in
+`Info.plist`:
+
+```xml
+<key>ATSApplicationFontsPath</key>
+<string>Fonts</string>
+```
+
+`ATSApplicationFontsPath` is relative to the bundle's `Resources/` directory, so
+a value of `Fonts` registers everything under `Contents/Resources/Fonts/`
+automatically at launch — no manual `CTFontManagerRegister...` call needed.
+
+### B) When loaded from a SwiftPM resource bundle (no Info.plist control)
+
+If the executable is run outside a full `.app` (e.g. during `swift run` / tests),
+register the fonts at startup with Core Text:
+
+```swift
+import CoreText
+
+func registerBundledFonts() {
+    for url in Bundle.module.urls(forResourcesWithExtension: "otf", subdirectory: "Fonts") ?? [] {
+        var error: Unmanaged<CFError>?
+        CTFontManagerRegisterFontsForURL(url as CFURL, .process, &error)
+    }
+}
+```
+
+To make `Bundle.module` see these files, add a `.copy("../Resources/Fonts")`
+(or `.process`) resource entry to the relevant target in `Package.swift`.
+
+## Current fallback (no binaries shipped yet)
+
+`Font.plexSans(_:weight:)` / `Font.plexMono(_:weight:)` in
+`Sources/DesignSystem/DesignTokens.swift` check whether the family
+(`IBMPlexSans` / `IBMPlexMono`) is registered. Until the binaries above are
+dropped in and wired up, they **fall back to the system sans / monospaced font**
+so the build never blocks on missing font files.
+
+After adding the fonts, no code change is required — the helpers pick up the real
+family automatically once it is registered. Verify the PostScript family name
+matches `IBMPlexSans` / `IBMPlexMono`; if IBM ships them under a different
+internal name, update `Font.PlexFamily` in `DesignTokens.swift`.

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -1,0 +1,99 @@
+// Matrix OS — native macOS app entrypoint (Phase 1 scaffold).
+//
+// Minimal SwiftUI `App` hosting a placeholder board-shell view. Real board/terminal/panel
+// implementation lands in later phases (see specs/086-macos-native-shell/tasks.md). This
+// file exists so the package builds headlessly via `swift build` and the OPERATOR design
+// tokens render in a window.
+
+import SwiftUI
+import DesignSystem
+
+@main
+struct MatrixOSApp: App {
+    var body: some Scene {
+        WindowGroup("Matrix OS") {
+            BoardShellScaffold()
+                .frame(minWidth: 960, minHeight: 600)
+        }
+        .windowStyle(.titleBar)
+    }
+}
+
+/// Placeholder board-shell: a row of lifecycle columns rendered with OPERATOR tokens so the
+/// design system is exercised end-to-end. Replaced by the real `BoardView` in Phase 3 (US1).
+struct BoardShellScaffold: View {
+    private let columns = ["TODO", "RUNNING", "WAITING", "BLOCKED", "COMPLETE"]
+
+    var body: some View {
+        ZStack {
+            Color.canvasVoid.ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: Spacing.x5) {
+                header
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .top, spacing: Spacing.x4) {
+                        ForEach(columns, id: \.self) { column in
+                            ColumnScaffold(title: column)
+                        }
+                    }
+                    .padding(.horizontal, Spacing.x5)
+                }
+            }
+            .padding(.vertical, Spacing.x5)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: Spacing.x3) {
+            Circle()
+                .fill(Color.signalLive)
+                .frame(width: 8, height: 8)
+            Text("MATRIX OS — OPERATOR")
+                .font(.plexMono(11, weight: .semibold))
+                .tracking(1.2)
+                .foregroundStyle(Color.inkSecondary)
+            Spacer()
+        }
+        .padding(.horizontal, Spacing.x5)
+    }
+}
+
+/// A single empty lifecycle column rendered with OPERATOR surfaces, hairlines, and spacing.
+private struct ColumnScaffold: View {
+    let title: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.x3) {
+            Text(title)
+                .font(.plexMono(11, weight: .semibold))
+                .tracking(1.4)
+                .foregroundStyle(Color.inkTertiary)
+                .padding(.bottom, Spacing.x1)
+
+            EmptyColumnPlaceholder()
+        }
+        .padding(Spacing.x3)
+        .frame(width: 240, alignment: .leading)
+        .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: Radius.card))
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.card)
+                .strokeBorder(Color.hairlineHighlight, lineWidth: 1)
+        )
+    }
+}
+
+private struct EmptyColumnPlaceholder: View {
+    var body: some View {
+        RoundedRectangle(cornerRadius: Radius.control)
+            .strokeBorder(
+                Color.inkDisabled,
+                style: StrokeStyle(lineWidth: 1, dash: [4, 4])
+            )
+            .frame(height: 64)
+            .overlay(
+                Text("Drop a task here or ⌘N")
+                    .font(.plexSans(13))
+                    .foregroundStyle(Color.inkTertiary)
+            )
+    }
+}

--- a/macos/Sources/DesignSystem/DesignTokens.swift
+++ b/macos/Sources/DesignSystem/DesignTokens.swift
@@ -1,0 +1,167 @@
+// OPERATOR design system tokens for the Matrix OS macOS app.
+//
+// These tokens are the single source of truth for the "OPERATOR" look defined in
+// specs/086-macos-native-shell/design.md (§2 color, §3 typography, §4 spacing/radius,
+// §5 motion). Component code MUST reference these tokens only — never inline hex,
+// sizes, or animation timings — so the look stays cohesive and themeable for the
+// later light mode.
+
+import SwiftUI
+
+// MARK: - Hex helper
+
+extension Color {
+    /// Creates a `Color` from a 24-bit RGB hex value (e.g. `0x9EF01A`) with optional opacity.
+    /// Tokens are P3-friendly; SwiftUI resolves them in the display's working color space.
+    init(hex: UInt32, opacity: Double = 1.0) {
+        let red = Double((hex >> 16) & 0xFF) / 255.0
+        let green = Double((hex >> 8) & 0xFF) / 255.0
+        let blue = Double(hex & 0xFF) / 255.0
+        self.init(.sRGB, red: red, green: green, blue: blue, opacity: opacity)
+    }
+}
+
+// MARK: - §2 Color system (dark-first)
+
+extension Color {
+    // Canvas & surfaces
+    /// `canvas.void` — window background (machined near-black). `#0A0B0D`
+    public static let canvasVoid = Color(hex: 0x0A0B0D)
+    /// `surface.rail` — column rails / sidebar. `#101216`
+    public static let surfaceRail = Color(hex: 0x101216)
+    /// `surface.card` — card body. `#15171C`
+    public static let surfaceCard = Color(hex: 0x15171C)
+    /// `surface.cardRaised` — hovered/dragging card. `#1B1E24`
+    public static let surfaceCardRaised = Color(hex: 0x1B1E24)
+    /// `surface.terminal` — terminal panel (deeper than cards). `#0C0D10`
+    public static let surfaceTerminal = Color(hex: 0x0C0D10)
+
+    // Hairline (dual-tone engraved 1px borders, §2)
+    /// Dark line of the engraved hairline: `#000000 @ 60%`.
+    public static let hairlineDark = Color(hex: 0x000000, opacity: 0.60)
+    /// Top highlight of the engraved hairline: `#FFFFFF @ 6%`.
+    public static let hairlineHighlight = Color(hex: 0xFFFFFF, opacity: 0.06)
+
+    // Ink (text)
+    /// `ink.primary` — titles, terminal text. `#E8EAED`
+    public static let inkPrimary = Color(hex: 0xE8EAED)
+    /// `ink.secondary` — metadata. `#9BA1AC`
+    public static let inkSecondary = Color(hex: 0x9BA1AC)
+    /// `ink.tertiary` — timestamps, hints. `#5C636E`
+    public static let inkTertiary = Color(hex: 0x5C636E)
+    /// `ink.disabled`. `#3A3F47`
+    public static let inkDisabled = Color(hex: 0x3A3F47)
+
+    // Signal (the only saturated colors — reserved for state, §2)
+    /// `signal.live` — phosphor lime, running/streaming (the breathing glow). `#9EF01A`
+    public static let signalLive = Color(hex: 0x9EF01A)
+    /// `signal.waiting` — amber, waiting on input/approval. `#FFB020`
+    public static let signalWaiting = Color(hex: 0xFFB020)
+    /// `signal.blocked` — coral, blocked/error. `#FF5C5C`
+    public static let signalBlocked = Color(hex: 0xFF5C5C)
+    /// `signal.done` — teal, complete. `#43C59E`
+    public static let signalDone = Color(hex: 0x43C59E)
+    /// `signal.idle` — grey, todo/exited (no color = no life). `#5C636E`
+    public static let signalIdle = Color(hex: 0x5C636E)
+    /// `signal.glow.live` — edge bloom on active cards: `signal.live @ 22%`.
+    public static let signalGlowLive = Color(hex: 0x9EF01A, opacity: 0.22)
+}
+
+// MARK: - §4 Spacing (8pt base with 4pt sub-step)
+
+/// Spacing scale. `space.1=4 … space.7=48` (design.md §4).
+public enum Spacing {
+    /// 4 pt
+    public static let x1: CGFloat = 4
+    /// 8 pt
+    public static let x2: CGFloat = 8
+    /// 12 pt
+    public static let x3: CGFloat = 12
+    /// 16 pt
+    public static let x4: CGFloat = 16
+    /// 24 pt
+    public static let x5: CGFloat = 24
+    /// 32 pt
+    public static let x6: CGFloat = 32
+    /// 48 pt
+    public static let x7: CGFloat = 48
+}
+
+// MARK: - §4 Radius (engraved, not pill-soft)
+
+/// Corner radius scale (design.md §4).
+public enum Radius {
+    /// Card corner radius. `radius.card=10`
+    public static let card: CGFloat = 10
+    /// Badge corner radius. `radius.badge=5`
+    public static let badge: CGFloat = 5
+    /// Panel corner radius. `radius.panel=14`
+    public static let panel: CGFloat = 14
+    /// Control corner radius. `radius.control=8`
+    public static let control: CGFloat = 8
+}
+
+// MARK: - §5 Motion (instrument-crisp, never bouncy-toy)
+
+/// Animation timings (design.md §5). Component code references these — never inline
+/// `.spring`/`.easeOut` literals — so motion stays consistent and Reduce-Motion-aware.
+public enum Motion {
+    /// Hover/tint: `.easeOut`, 120 ms.
+    public static let hover = Animation.easeOut(duration: 0.12)
+    /// Panel toggle (term↔shell↔app): `.spring(response: 0.34, damping: 0.86)`.
+    public static let panelSwitch = Animation.spring(response: 0.34, dampingFraction: 0.86)
+    /// Card drag pickup/drop: `.spring(response: 0.30, damping: 0.80)`.
+    public static let cardDrag = Animation.spring(response: 0.30, dampingFraction: 0.80)
+    /// Column reflow on drop: `.spring(response: 0.40, damping: 0.90)`.
+    public static let columnReflow = Animation.spring(response: 0.40, dampingFraction: 0.90)
+    /// Card enter (new): fade+rise, `.easeOut`, 180 ms (stagger 24 ms applied per-card).
+    public static let cardEnter = Animation.easeOut(duration: 0.18)
+    /// Per-card stagger for orchestrated enters/loads (24 ms).
+    public static let cardEnterStagger: Double = 0.024
+    /// Live edge-glow breathe: `.easeInOut` autoreverse, 2.4 s loop.
+    public static let liveBreathe = Animation.easeInOut(duration: 2.4).repeatForever(autoreverses: true)
+    /// Status change flash: `.easeOut`, 200 ms one-shot.
+    public static let statusFlash = Animation.easeOut(duration: 0.20)
+}
+
+// MARK: - §3 Typography helpers
+
+extension Font {
+    /// Internal font-family names for IBM Plex once the bundled binaries are present.
+    /// Until the fonts ship (see Resources/Fonts/README.md), the helpers fall back to a
+    /// monospaced system font so the build never blocks on missing binaries.
+    enum PlexFamily {
+        static let sans = "IBMPlexSans"
+        static let mono = "IBMPlexMono"
+    }
+
+    /// Returns whether a custom font family is registered/available by name.
+    private static func isAvailable(_ familyName: String) -> Bool {
+        #if canImport(AppKit)
+        return NSFontManager.shared.availableFontFamilies.contains(familyName)
+            || NSFont(name: familyName, size: 12) != nil
+        #else
+        return false
+        #endif
+    }
+
+    /// IBM Plex Sans — display/chrome/titles (design.md §3).
+    /// TODO(086): ships the IBM Plex Sans binaries per Resources/Fonts/README.md.
+    /// Falls back to a humanist-leaning system font until then.
+    public static func plexSans(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
+        if isAvailable(PlexFamily.sans) {
+            return .custom(PlexFamily.sans, size: size).weight(weight)
+        }
+        return .system(size: size, weight: weight, design: .default)
+    }
+
+    /// IBM Plex Mono — mono/data/terminal/badges, "the voice of the machine" (design.md §3).
+    /// TODO(086): ships the IBM Plex Mono binaries per Resources/Fonts/README.md.
+    /// Falls back to a monospaced system font until then.
+    public static func plexMono(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
+        if isAvailable(PlexFamily.mono) {
+            return .custom(PlexFamily.mono, size: size).weight(weight)
+        }
+        return .system(size: size, weight: weight, design: .monospaced)
+    }
+}

--- a/macos/Sources/Model/_Module.swift
+++ b/macos/Sources/Model/_Module.swift
@@ -1,0 +1,3 @@
+// MatrixModel — client view models (Card, SessionRef, Panel, ConnectionProfile).
+// Real implementations land in Phase 2 (T027). Value types, bounded, never persisted.
+import Foundation

--- a/macos/Sources/Net/_Module.swift
+++ b/macos/Sources/Net/_Module.swift
@@ -1,0 +1,4 @@
+// MatrixNet — gateway HTTP/WS networking, principal/auth, Keychain.
+// Real implementations land in Phase 2: GatewayHTTPClient (T021), KeychainStore +
+// PrincipalProvider (T023), ConnectionProfile/VPS resolver (T026).
+import Foundation

--- a/macos/Sources/Terminal/_Module.swift
+++ b/macos/Sources/Terminal/_Module.swift
@@ -1,0 +1,3 @@
+// MatrixTerminal — shell WebSocket client (resume-from-seq) + terminal panel.
+// Phase 2: ShellWSClient (T025). Phase 3: SwiftTerm-backed view (T034).
+import Foundation

--- a/macos/Tests/DesignSystemTests/DesignTokensTests.swift
+++ b/macos/Tests/DesignSystemTests/DesignTokensTests.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import XCTest
+
+@testable import DesignSystem
+
+/// Proves the OPERATOR token values from design.md §2–§5/§9 resolve exactly, and that the
+/// DesignSystem target compiles and tests run (Phase 1 gate). Color components are compared
+/// in sRGB with a small tolerance for floating-point division.
+final class DesignTokensTests: XCTestCase {
+
+    private let tolerance: CGFloat = 0.5 / 255.0
+
+    /// Resolve a SwiftUI `Color` to sRGB 0–255 components via AppKit.
+    private func rgba(_ color: Color) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        let ns = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
+        return (ns.redComponent, ns.greenComponent, ns.blueComponent, ns.alphaComponent)
+    }
+
+    private func assertColor(
+        _ color: Color,
+        hex: UInt32,
+        opacity: CGFloat = 1.0,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let expectedR = CGFloat((hex >> 16) & 0xFF) / 255.0
+        let expectedG = CGFloat((hex >> 8) & 0xFF) / 255.0
+        let expectedB = CGFloat(hex & 0xFF) / 255.0
+        let actual = rgba(color)
+        XCTAssertEqual(actual.r, expectedR, accuracy: tolerance, "\(message) red", file: file, line: line)
+        XCTAssertEqual(actual.g, expectedG, accuracy: tolerance, "\(message) green", file: file, line: line)
+        XCTAssertEqual(actual.b, expectedB, accuracy: tolerance, "\(message) blue", file: file, line: line)
+        XCTAssertEqual(actual.a, opacity, accuracy: tolerance, "\(message) alpha", file: file, line: line)
+    }
+
+    // MARK: §2 Signal colors (the load-bearing semantic tokens)
+
+    func testSignalLiveIsPhosphorLime() {
+        assertColor(.signalLive, hex: 0x9EF01A, "signal.live")
+    }
+
+    func testSignalWaitingIsAmber() {
+        assertColor(.signalWaiting, hex: 0xFFB020, "signal.waiting")
+    }
+
+    func testSignalBlockedIsCoral() {
+        assertColor(.signalBlocked, hex: 0xFF5C5C, "signal.blocked")
+    }
+
+    func testSignalDoneIsTeal() {
+        assertColor(.signalDone, hex: 0x43C59E, "signal.done")
+    }
+
+    func testSignalIdleIsGrey() {
+        assertColor(.signalIdle, hex: 0x5C636E, "signal.idle")
+    }
+
+    func testSignalGlowLiveIsLimeAt22Percent() {
+        assertColor(.signalGlowLive, hex: 0x9EF01A, opacity: 0.22, "signal.glow.live")
+    }
+
+    // MARK: §2 Canvas & surfaces
+
+    func testCanvasAndSurfaceTokens() {
+        assertColor(.canvasVoid, hex: 0x0A0B0D, "canvas.void")
+        assertColor(.surfaceRail, hex: 0x101216, "surface.rail")
+        assertColor(.surfaceCard, hex: 0x15171C, "surface.card")
+        assertColor(.surfaceCardRaised, hex: 0x1B1E24, "surface.cardRaised")
+        assertColor(.surfaceTerminal, hex: 0x0C0D10, "surface.terminal")
+    }
+
+    // MARK: §2 Ink
+
+    func testInkTokens() {
+        assertColor(.inkPrimary, hex: 0xE8EAED, "ink.primary")
+        assertColor(.inkSecondary, hex: 0x9BA1AC, "ink.secondary")
+        assertColor(.inkTertiary, hex: 0x5C636E, "ink.tertiary")
+        assertColor(.inkDisabled, hex: 0x3A3F47, "ink.disabled")
+    }
+
+    // MARK: §2 Hairline (dual-tone)
+
+    func testHairlineTokens() {
+        assertColor(.hairlineDark, hex: 0x000000, opacity: 0.60, "hairline.dark")
+        assertColor(.hairlineHighlight, hex: 0xFFFFFF, opacity: 0.06, "hairline.highlight")
+    }
+
+    // MARK: §4 Spacing scale (4/8/12/16/24/32/48)
+
+    func testSpacingScale() {
+        XCTAssertEqual(Spacing.x1, 4)
+        XCTAssertEqual(Spacing.x2, 8)
+        XCTAssertEqual(Spacing.x3, 12)
+        XCTAssertEqual(Spacing.x4, 16)
+        XCTAssertEqual(Spacing.x5, 24)
+        XCTAssertEqual(Spacing.x6, 32)
+        XCTAssertEqual(Spacing.x7, 48)
+    }
+
+    // MARK: §4 Radius scale
+
+    func testRadiusScale() {
+        XCTAssertEqual(Radius.card, 10)
+        XCTAssertEqual(Radius.badge, 5)
+        XCTAssertEqual(Radius.panel, 14)
+        XCTAssertEqual(Radius.control, 8)
+    }
+
+    // MARK: §5 Motion tokens exist (timings are opaque to runtime introspection;
+    // we assert the derived stagger constant which is comparable).
+
+    func testMotionStaggerConstant() {
+        XCTAssertEqual(Motion.cardEnterStagger, 0.024, accuracy: 0.0001)
+    }
+
+    // MARK: §3 Typography helpers never crash and return a usable font.
+
+    func testTypographyHelpersResolve() {
+        // Until IBM Plex binaries ship, these fall back to system fonts; the call must
+        // not crash and must return a non-nil Font (compile + runtime smoke).
+        _ = Font.plexSans(14, weight: .medium)
+        _ = Font.plexMono(12.5, weight: .regular)
+    }
+}

--- a/macos/Tests/ModelTests/_Placeholder.swift
+++ b/macos/Tests/ModelTests/_Placeholder.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import MatrixModel
+
+// Placeholder so the MatrixModel test target builds before Phase 2 tests land (T027).
+final class ModelModulePlaceholderTests: XCTestCase {
+    func testModuleLoads() { XCTAssertTrue(true) }
+}

--- a/macos/Tests/NetTests/_Placeholder.swift
+++ b/macos/Tests/NetTests/_Placeholder.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import MatrixNet
+
+// Placeholder so the MatrixNet test target builds before Phase 2 tests land (T020/T022/T024).
+final class NetModulePlaceholderTests: XCTestCase {
+    func testModuleLoads() { XCTAssertTrue(true) }
+}

--- a/macos/Tests/TerminalTests/_Placeholder.swift
+++ b/macos/Tests/TerminalTests/_Placeholder.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import MatrixTerminal
+
+// Placeholder so the MatrixTerminal test target builds before Phase 2 tests land (T024).
+final class TerminalModulePlaceholderTests: XCTestCase {
+    func testModuleLoads() { XCTAssertTrue(true) }
+}

--- a/specs/086-macos-native-shell/contracts/gateway-endpoints.md
+++ b/specs/086-macos-native-shell/contracts/gateway-endpoints.md
@@ -1,0 +1,34 @@
+# Contract: Gateway Endpoints Consumed by the macOS App
+
+These already exist in `packages/gateway/src/workspace-routes.ts` (+ session orchestrator, symphony proxy). The app is a client; confirm exact shapes against source during implementation. All carry the principal (`Authorization` header) and are scoped via `ownerScopeFromPrincipal`. All responses use generic error bodies (no raw internals).
+
+## Tasks (= kanban cards)
+- `GET  /api/workspace/projects` — list projects.
+- `GET  /api/projects/:slug/tasks` — list tasks (cards) for a project.
+- `POST /api/projects/:slug/tasks` — create. Body (`CreateTaskSchema`): `{ title(1..200), description?(<=10000), status?(todo|running|waiting|blocked|complete|archived), priority?(low|normal|high|urgent), order?, parentTaskId?, dueAt?, linkedSessionId?, linkedWorktreeId?, previewIds?[<=20] }`. (`tags?` only if T040 ships it.)
+- `PATCH /api/projects/:slug/tasks/:taskId` — partial update (`UpdateTaskSchema` = CreateTaskSchema.partial()). Used for move (status), reorder (order), rename (title), tag. MUST be revision/`updatedAt`-guarded server-side (optimistic concurrency).
+- `DELETE /api/projects/:slug/tasks/:taskId` — archive/delete (filter already-deleted).
+
+**Mapping**: column = `status`; intra-column position = `order`; card↔session = `linkedSessionId`; worktree chip = `linkedWorktreeId`; preview chips = `previewIds`.
+
+## Sessions (zellij-backed)
+- `POST /api/sessions` — start a session (links to a task via request). Returns `{ session }`.
+- `GET  /api/sessions?projectSlug=&taskId=&status=&limit=&cursor=` — list (filter by `taskId` to find a card's session). Returns `{ sessions, nextCursor }`.
+- `GET  /api/sessions/:sessionId` — get one.
+- `POST /api/sessions/:sessionId/send` — send input (non-WS path).
+- `POST /api/sessions/:sessionId/observe` — attach read-only.
+- `POST /api/sessions/:sessionId/takeover` — attach as owner.
+
+Terminal I/O for the UI uses the **shell WS** (see `shell-ws-protocol.md`), not `/send`.
+
+## Workspace events (live board updates)
+- Publisher: `workspace-event-publisher.ts` emits `task.created`, `task.updated` (scope `{projectSlug, taskId}`). Phase 0/T002 confirms the client-facing delivery (existing WS vs new subscription). Client diff-applies to `BoardStore`.
+
+## Symphony
+- Via `packages/gateway/src/symphony/proxy.ts` — run status + agent activity read-model; start/observe actions. Exact routes confirmed in T070.
+
+## Auth / endpoint resolution
+- Device-auth + VPS endpoint resolution via platform (`packages/platform/src/customer-vps-routes.ts`, `/runtime`); see `auth.md` matrix in plan.md. Confirmed in T004.
+
+## Error policy
+- Every client-facing error is generic; the app shows safe copy and never echoes gateway/DB/provider/path text (FR-023). Misconfiguration (no VPS) is distinguished from not-found and transient connectivity.

--- a/specs/086-macos-native-shell/contracts/shell-ws-protocol.md
+++ b/specs/086-macos-native-shell/contracts/shell-ws-protocol.md
@@ -1,0 +1,36 @@
+# Contract: Shell Terminal WebSocket Protocol
+
+Source of truth: `packages/gateway/src/shell/ws.ts` (+ `@finnaai/matrix/shell-protocol`). The native `ShellWSClient` (T024/T025) implements this exactly.
+
+## Connection
+- Upgrade to the gateway shell WS route (path confirmed in Phase 0 / T001).
+- **Auth (S1)**: send the principal token in the `Authorization` header (or token-bearing subprotocol) on the upgrade — NOT in the query string. The gateway resolves the principal via `requireRequestPrincipal(c)` (same pattern as the canvas WS).
+- Attach targets a zellij session by name (the task's `linkedSessionId`); the gateway validates the session name (safe-name rules).
+
+## Client → server messages
+| `type` | fields | meaning |
+|---|---|---|
+| `input` | `data: string` | keystrokes/bytes to the PTY |
+| `resize` | `cols: number, rows: number` | terminal dimensions |
+| `detach` | — | leave the session running, close the socket |
+| `ping` | — | keepalive |
+
+## Server → client messages
+| `type` | fields | meaning |
+|---|---|---|
+| `attached` | (attach ack) | session attached; replay begins |
+| `output` | `seq: number, data: string` | ordered PTY output; **track the last `seq`** |
+| `exit` | `code: number` | session/process exited |
+| `error` | `code: string, message: string` | generic error (never surface raw text to the user beyond the provided message) |
+| `pong` | — | keepalive ack |
+
+## Scrollback & resume (F1)
+- Constants: `SHELL_ATTACH_RECENT_REPLAY_EVENTS = 50`; sentinel `SHELL_ATTACH_LIVE_TAIL_FROM_SEQ`.
+- On a fresh attach for live tail, pass `fromSeq = SHELL_ATTACH_LIVE_TAIL_FROM_SEQ` → server replays roughly the last 50 events then live output (`ShellReplayBuffer.replayFromSeq`).
+- On reconnect, pass `fromSeq = lastSeq + 1` to resume exactly where the client left off.
+- If the requested seq is older than the buffer, the server emits a `replay-evicted` event → client MUST clear its buffer and re-attach at `SHELL_ATTACH_LIVE_TAIL_FROM_SEQ` (accept the gap is unrecoverable; never duplicate).
+
+## Client requirements
+- Bounded reconnect backoff (cap). Bounded scrollback ring buffer with eviction (R1).
+- Coalesce `output` application to the UI (batch flushes) to keep 60fps under fast output.
+- Resize is sent on window/pane size change and once immediately after `attached`.

--- a/specs/086-macos-native-shell/tasks.md
+++ b/specs/086-macos-native-shell/tasks.md
@@ -55,7 +55,7 @@ description: "Task list for 086 Matrix OS native macOS app"
 **Goal**: sign in → board of sessions → open card → terminal attaches with scrollback + live I/O.
 **Independent Test**: attach to a real test zellij session, round-trip a command.
 
-- [ ] T030 [P] [US1] Failing integration test: device-auth → resolve VPS → `GET /api/projects/:slug/tasks` renders cards (mock gateway) in `macos/Tests/Integration/BoardLoadTests.swift`.
+- [ ] T030 [P] [US1] Failing integration test: device-auth → resolve VPS (`app.matrix-os.com`, optional `?runtime=<slot>`) → `GET /api/projects/:slug/tasks` renders cards (mock gateway) in `macos/Tests/Integration/BoardLoadTests.swift`. (Phase-0 confirmed: no per-VPS IP addressing; bearer header on all calls.)
 - [ ] T031 [P] [US1] Failing integration test: open card → `ShellWSClient` attaches to `linkedSessionId`, scrollback replays, input echoes (test gateway + zellij) in `macos/Tests/Integration/TerminalAttachTests.swift`.
 - [ ] T032 [US1] Implement read-only `BoardStore` (fetch tasks→cards, map status→columns, order) in `macos/Sources/Board/`.
 - [ ] T033 [US1] Implement `BoardView`/`ColumnView`/`CardView` (LazyVStack recycling, OPERATOR design tokens, status badges, live edge-glow) in `macos/Sources/Board/`.


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 2/11.

## Summary

Adds the SwiftPM macOS package scaffold, design tokens, macOS CI workflow, and shell/gateway protocol contracts.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

No backend route, database, or auth behavior changes in this layer.