### PR TITLE
feat(086): add native model network terminal clients

### DIFF
--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: "MatrixModel", targets: ["MatrixModel"]),
         .library(name: "MatrixNet", targets: ["MatrixNet"]),
         .library(name: "MatrixTerminal", targets: ["MatrixTerminal"]),
+        .library(name: "MatrixBoard", targets: ["MatrixBoard"]),
     ],
     dependencies: [
         // SwiftTerm: battle-tested VT100/xterm emulator used by the Terminal panel.
@@ -45,9 +46,18 @@ let package = Package(
         ),
         .target(
             name: "MatrixTerminal",
-            // ShellWSClient (Phase 2) is pure URLSession — Foundation-only, independent.
-            // SwiftTerm view + Model wiring land in Phase 3 (T034).
+            dependencies: [
+                "DesignSystem",
+                // SwiftTerm-backed TerminalPanelView lands in US1 (T034).
+                .product(name: "SwiftTerm", package: "SwiftTerm"),
+            ],
             path: "Sources/Terminal",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .target(
+            name: "MatrixBoard",
+            dependencies: ["MatrixNet", "MatrixModel"],
+            path: "Sources/Board",
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
         .executableTarget(
@@ -57,7 +67,7 @@ let package = Package(
                 "MatrixModel",
                 "MatrixNet",
                 "MatrixTerminal",
-                // "SwiftTerm", // TODO(086): enable when Terminal panel view is implemented (T034).
+                "MatrixBoard",
             ],
             path: "Sources/App",
             swiftSettings: [
@@ -88,6 +98,12 @@ let package = Package(
             name: "TerminalTests",
             dependencies: ["MatrixTerminal"],
             path: "Tests/TerminalTests",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "BoardTests",
+            dependencies: ["MatrixBoard"],
+            path: "Tests/BoardTests",
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
     ]

--- a/macos/Sources/Board/_Module.swift
+++ b/macos/Sources/Board/_Module.swift
@@ -1,0 +1,3 @@
+// MatrixBoard — board state (fetch tasks → cards grouped by column) over MatrixNet.
+// US1: read-only BoardStore (T032). US2: mutations + live events (T042/T044).
+import Foundation

--- a/macos/Sources/Model/Card.swift
+++ b/macos/Sources/Model/Card.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Kanban column / lifecycle state of a task. Mirrors the gateway
+/// `task-manager` `CreateTaskSchema.status` enum exactly.
+public enum TaskStatus: String, Codable, Sendable, CaseIterable {
+    case todo
+    case running
+    case waiting
+    case blocked
+    case complete
+    case archived
+}
+
+/// Task priority. Mirrors the gateway `task-manager` `priority` enum.
+public enum TaskPriority: String, Codable, Sendable, CaseIterable {
+    case low
+    case normal
+    case high
+    case urgent
+}
+
+/// Client view model mapping a gateway task 1:1. Value type, never persisted —
+/// diff-updated in memory from workspace events. `column` is the kanban column
+/// (== `status`); `isLive` derives the live badge from a running session.
+public struct Card: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let projectSlug: String
+    public var title: String
+    public var description: String?
+    public var status: TaskStatus
+    public var priority: TaskPriority
+    public var order: Double
+    public var parentTaskId: String?
+    public var linkedSessionId: String?
+    public var linkedWorktreeId: String?
+    public var previewIds: [String]
+    public var tags: [String]
+    public var updatedAt: String
+    /// Optimistic-concurrency revision from the server, when present.
+    public var revision: Int?
+
+    public init(
+        id: String,
+        projectSlug: String,
+        title: String,
+        description: String? = nil,
+        status: TaskStatus,
+        priority: TaskPriority,
+        order: Double,
+        parentTaskId: String? = nil,
+        linkedSessionId: String? = nil,
+        linkedWorktreeId: String? = nil,
+        previewIds: [String] = [],
+        tags: [String] = [],
+        updatedAt: String,
+        revision: Int? = nil
+    ) {
+        self.id = id
+        self.projectSlug = projectSlug
+        self.title = title
+        self.description = description
+        self.status = status
+        self.priority = priority
+        self.order = order
+        self.parentTaskId = parentTaskId
+        self.linkedSessionId = linkedSessionId
+        self.linkedWorktreeId = linkedWorktreeId
+        self.previewIds = previewIds
+        self.tags = tags
+        self.updatedAt = updatedAt
+        self.revision = revision
+    }
+
+    /// Kanban column this card belongs to. Column == `status`.
+    public var column: TaskStatus { status }
+
+    /// Live badge: true only while the linked session is actively running.
+    /// Never stored as truth — derived from status (and session state upstream).
+    public var isLive: Bool { status == .running }
+}

--- a/macos/Sources/Model/ConnectionProfile.swift
+++ b/macos/Sources/Model/ConnectionProfile.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Describes how the app connects to a user's gateway runtime.
+///
+/// SECURITY: this struct holds only a Keychain *reference* (`credentialRef`),
+/// never the raw token. The token itself lives in the macOS Keychain and is
+/// resolved at request time. Only this reference is ever persisted.
+public struct ConnectionProfile: Codable, Sendable, Equatable {
+    public let handle: String
+    public let gatewayHost: String
+    public let runtimeSlot: String
+    /// Keychain key under which the auth token is stored — NOT the token itself.
+    public let credentialRef: String
+
+    public init(
+        handle: String,
+        gatewayHost: String,
+        runtimeSlot: String = "primary",
+        credentialRef: String
+    ) {
+        self.handle = handle
+        self.gatewayHost = gatewayHost
+        self.runtimeSlot = runtimeSlot
+        self.credentialRef = credentialRef
+    }
+}

--- a/macos/Sources/Model/Panel.swift
+++ b/macos/Sources/Model/Panel.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Client-only UI state for what a window pane is currently showing.
+public enum Panel: Sendable, Equatable {
+    case terminal
+    case shell
+    case app(slug: String)
+}

--- a/macos/Sources/Model/SessionRef.swift
+++ b/macos/Sources/Model/SessionRef.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Live state of a session as reported by the session orchestrator / zellij registry.
+public enum SessionStatus: String, Codable, Sendable, CaseIterable {
+    case active
+    case exited
+}
+
+/// Client reference to a server-side session. Value type, never persisted.
+public struct SessionRef: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public var status: SessionStatus
+    public var cwd: String?
+    public var layoutName: String?
+    public var tabs: [String]
+
+    public init(
+        id: String,
+        status: SessionStatus,
+        cwd: String? = nil,
+        layoutName: String? = nil,
+        tabs: [String] = []
+    ) {
+        self.id = id
+        self.status = status
+        self.cwd = cwd
+        self.layoutName = layoutName
+        self.tabs = tabs
+    }
+}

--- a/macos/Sources/Model/StoredConnectionProfile.swift
+++ b/macos/Sources/Model/StoredConnectionProfile.swift
@@ -5,7 +5,7 @@ import Foundation
 /// SECURITY: this struct holds only a Keychain *reference* (`credentialRef`),
 /// never the raw token. The token itself lives in the macOS Keychain and is
 /// resolved at request time. Only this reference is ever persisted.
-public struct ConnectionProfile: Codable, Sendable, Equatable {
+public struct StoredConnectionProfile: Codable, Sendable, Equatable {
     public let handle: String
     public let gatewayHost: String
     public let runtimeSlot: String

--- a/macos/Sources/Model/_Module.swift
+++ b/macos/Sources/Model/_Module.swift
@@ -1,3 +1,0 @@
-// MatrixModel — client view models (Card, SessionRef, Panel, ConnectionProfile).
-// Real implementations land in Phase 2 (T027). Value types, bounded, never persisted.
-import Foundation

--- a/macos/Sources/Net/DeviceAuthClient.swift
+++ b/macos/Sources/Net/DeviceAuthClient.swift
@@ -1,0 +1,132 @@
+// MatrixNet — platform device-authorization flow client.
+//
+// Mirrors the `matrix` CLI flow against the platform:
+//   POST /api/auth/device/code  -> { deviceCode, userCode, verificationUri, expiresIn, interval }
+//   POST /api/auth/device/token -> 200 { accessToken, expiresAt, userId, handle }
+//                                  428 authorization_pending / 429 slow_down
+//                                  410 expired_token / 5xx server_error
+//
+// Network calls sit behind the DeviceAuthorizing protocol so callers (and tests)
+// can inject a mock. Errors are mapped to generic GatewayError (no body leakage).
+import Foundation
+
+/// A started device-authorization request the user must approve in a browser.
+public struct DeviceAuthStart: Codable, Equatable, Sendable {
+    public let deviceCode: String
+    public let userCode: String
+    public let verificationUri: String
+    public let expiresIn: Int
+    public let interval: Int
+}
+
+/// A successfully issued principal token + identity metadata.
+public struct DeviceAuthToken: Codable, Equatable, Sendable {
+    public let accessToken: String
+    public let expiresAt: String?
+    public let userId: String?
+    public let handle: String?
+}
+
+/// One poll outcome of the device-token endpoint.
+public enum DevicePollResult: Equatable, Sendable {
+    case pending
+    case slowDown
+    case expired
+    case approved(DeviceAuthToken)
+}
+
+public protocol DeviceAuthorizing: Sendable {
+    func startDeviceAuth() async throws -> DeviceAuthStart
+    func pollForToken(deviceCode: String) async throws -> DevicePollResult
+}
+
+public struct DeviceAuthClient: DeviceAuthorizing {
+    private let platformURL: URL
+    private let session: URLSession
+    private let timeout: TimeInterval
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(
+        platformURL: URL,
+        sessionConfiguration: URLSessionConfiguration = .ephemeral,
+        timeout: TimeInterval = 10
+    ) {
+        self.platformURL = platformURL
+        self.session = URLSession(configuration: sessionConfiguration)
+        self.timeout = timeout
+    }
+
+    public func startDeviceAuth() async throws -> DeviceAuthStart {
+        let (data, http) = try await post(path: "/api/auth/device/code", body: EmptyBody())
+        guard GatewayError.from(statusCode: http.statusCode) == nil else {
+            throw GatewayError.from(statusCode: http.statusCode) ?? .server
+        }
+        do {
+            return try decoder.decode(DeviceAuthStart.self, from: data)
+        } catch {
+            throw GatewayError.decoding
+        }
+    }
+
+    private struct PollBody: Encodable { let deviceCode: String }
+
+    public func pollForToken(deviceCode: String) async throws -> DevicePollResult {
+        let (data, http) = try await post(
+            path: "/api/auth/device/token",
+            body: PollBody(deviceCode: deviceCode)
+        )
+        switch http.statusCode {
+        case 200..<300:
+            do {
+                return .approved(try decoder.decode(DeviceAuthToken.self, from: data))
+            } catch {
+                throw GatewayError.decoding
+            }
+        case 428:
+            return .pending
+        case 429:
+            return .slowDown
+        case 410:
+            return .expired
+        case 401:
+            throw GatewayError.unauthorized
+        case 404:
+            throw GatewayError.notFound
+        default:
+            throw GatewayError.server
+        }
+    }
+
+    // MARK: - Transport
+
+    private struct EmptyBody: Encodable {}
+
+    private func post<Body: Encodable>(path: String, body: Body) async throws -> (Data, HTTPURLResponse) {
+        guard var comps = URLComponents(url: platformURL, resolvingAgainstBaseURL: false) else {
+            throw GatewayError.misconfigured
+        }
+        comps.path = path
+        guard let url = comps.url else { throw GatewayError.misconfigured }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            request.httpBody = try encoder.encode(body)
+        } catch {
+            throw GatewayError.decoding
+        }
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { throw GatewayError.server }
+            return (data, http)
+        } catch let error as GatewayError {
+            throw error
+        } catch {
+            throw GatewayError.from(transport: error)
+        }
+    }
+}

--- a/macos/Sources/Net/DeviceAuthClient.swift
+++ b/macos/Sources/Net/DeviceAuthClient.swift
@@ -59,8 +59,8 @@ public struct DeviceAuthClient: DeviceAuthorizing {
 
     public func startDeviceAuth() async throws -> DeviceAuthStart {
         let (data, http) = try await post(path: "/api/auth/device/code", body: EmptyBody())
-        guard GatewayError.from(statusCode: http.statusCode) == nil else {
-            throw GatewayError.from(statusCode: http.statusCode) ?? .server
+        if let mapped = GatewayError.from(statusCode: http.statusCode) {
+            throw mapped
         }
         do {
             return try decoder.decode(DeviceAuthStart.self, from: data)

--- a/macos/Sources/Net/GatewayError.swift
+++ b/macos/Sources/Net/GatewayError.swift
@@ -1,0 +1,60 @@
+// MatrixNet — gateway/platform error model.
+//
+// Every networking failure is mapped to one of these GENERIC cases. Raw server
+// bodies, provider names, Postgres/Twilio/filesystem text, and transport detail
+// are NEVER surfaced (FR-023, CLAUDE.md "never expose provider names or raw
+// error messages to clients"). The real cause is logged at the call site; the
+// UI only ever sees `userMessage`.
+import Foundation
+
+public enum GatewayError: Error, Equatable, Sendable {
+    /// 401 — principal token is missing/invalid/expired. Caller should re-auth.
+    case unauthorized
+    /// 404 — the requested resource does not exist.
+    case notFound
+    /// 5xx or any unexpected non-2xx status. Generic server-side failure.
+    case server
+    /// Transport-level connectivity failure (host unreachable, offline, TLS, ...).
+    case network
+    /// Request exceeded its bounded timeout.
+    case timeout
+    /// Response body could not be decoded into the expected type.
+    case decoding
+    /// Local misconfiguration (e.g. no VPS resolved / empty host) — distinct from
+    /// not-found and from transient connectivity.
+    case misconfigured
+
+    /// Safe, generic, user-facing copy. Contains no server/provider/path detail.
+    public var userMessage: String {
+        switch self {
+        case .unauthorized: return "Your session has expired. Please sign in again."
+        case .notFound: return "That item could not be found."
+        case .server: return "Something went wrong. Please try again."
+        case .network: return "Can't reach Matrix OS. Check your connection."
+        case .timeout: return "The request timed out. Please try again."
+        case .decoding: return "Received an unexpected response. Please try again."
+        case .misconfigured: return "No computer is connected. Select a runtime to continue."
+        }
+    }
+
+    /// Maps an HTTP status code to a generic error. 2xx returns nil (success).
+    static func from(statusCode: Int) -> GatewayError? {
+        switch statusCode {
+        case 200..<300: return nil
+        case 401: return .unauthorized
+        case 404: return .notFound
+        default: return .server
+        }
+    }
+
+    /// Maps a transport error (typically URLError) to a generic case.
+    static func from(transport error: Error) -> GatewayError {
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut: return .timeout
+            default: return .network
+            }
+        }
+        return .network
+    }
+}

--- a/macos/Sources/Net/GatewayHTTPClient.swift
+++ b/macos/Sources/Net/GatewayHTTPClient.swift
@@ -145,7 +145,30 @@ public struct GatewayHTTPClient: Sendable {
         guard var comps = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
             return nil
         }
-        comps.path = path
+        let parts = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+        let relativePath = String(parts.first ?? "")
+        comps.path = appendPath(base: comps.path, relative: relativePath)
+        if parts.count == 2,
+           let relative = URLComponents(string: path),
+           let queryItems = relative.queryItems,
+           !queryItems.isEmpty {
+            comps.queryItems = (comps.queryItems ?? []) + queryItems
+        }
         return comps.url
+    }
+
+    private func appendPath(base: String, relative: String) -> String {
+        let cleanBase = base.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let cleanRelative = relative.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        switch (cleanBase.isEmpty, cleanRelative.isEmpty) {
+        case (true, true):
+            return ""
+        case (true, false):
+            return "/\(cleanRelative)"
+        case (false, true):
+            return "/\(cleanBase)"
+        case (false, false):
+            return "/\(cleanBase)/\(cleanRelative)"
+        }
     }
 }

--- a/macos/Sources/Net/GatewayHTTPClient.swift
+++ b/macos/Sources/Net/GatewayHTTPClient.swift
@@ -1,0 +1,151 @@
+// MatrixNet — gateway/platform HTTP client.
+//
+// Wraps URLSession with:
+//   * bounded per-request timeouts (default 10s, injectable),
+//   * an `Authorization: Bearer <token>` header pulled from an injected
+//     TokenProviding on every request,
+//   * generic GET/POST/PATCH/DELETE returning decoded Codable or throwing a
+//     GENERIC GatewayError that never leaks the server body / provider text.
+//
+// All calls go through the platform proxy at the app domain (research.md C4);
+// this client never addresses a VPS IP directly.
+import Foundation
+
+public struct GatewayHTTPClient: Sendable {
+    private let baseURL: URL
+    private let tokenProvider: any TokenProviding
+    private let session: URLSession
+    private let defaultTimeout: TimeInterval
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(
+        baseURL: URL,
+        tokenProvider: any TokenProviding,
+        sessionConfiguration: URLSessionConfiguration = .ephemeral,
+        defaultTimeout: TimeInterval = 10
+    ) {
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
+        self.session = URLSession(configuration: sessionConfiguration)
+        self.defaultTimeout = defaultTimeout
+        self.encoder = JSONEncoder()
+        self.decoder = JSONDecoder()
+    }
+
+    // MARK: - Public verbs
+
+    public func get<Response: Decodable>(
+        _ path: String,
+        as type: Response.Type = Response.self,
+        timeout: TimeInterval? = nil
+    ) async throws -> Response {
+        try await send(method: "GET", path: path, body: Optional<EmptyBody>.none, timeout: timeout)
+    }
+
+    public func post<Body: Encodable, Response: Decodable>(
+        _ path: String,
+        body: Body,
+        as type: Response.Type = Response.self,
+        timeout: TimeInterval? = nil
+    ) async throws -> Response {
+        try await send(method: "POST", path: path, body: body, timeout: timeout)
+    }
+
+    public func patch<Body: Encodable, Response: Decodable>(
+        _ path: String,
+        body: Body,
+        as type: Response.Type = Response.self,
+        timeout: TimeInterval? = nil
+    ) async throws -> Response {
+        try await send(method: "PATCH", path: path, body: body, timeout: timeout)
+    }
+
+    /// DELETE with no decoded response body.
+    public func delete(_ path: String, timeout: TimeInterval? = nil) async throws {
+        _ = try await sendRaw(method: "DELETE", path: path, body: Optional<EmptyBody>.none, timeout: timeout)
+    }
+
+    // MARK: - Core
+
+    private struct EmptyBody: Encodable {}
+
+    private func send<Body: Encodable, Response: Decodable>(
+        method: String,
+        path: String,
+        body: Body?,
+        timeout: TimeInterval?
+    ) async throws -> Response {
+        let data = try await sendRaw(method: method, path: path, body: body, timeout: timeout)
+        do {
+            return try decoder.decode(Response.self, from: data)
+        } catch {
+            // Do not surface the decoding error detail; it can echo response text.
+            throw GatewayError.decoding
+        }
+    }
+
+    private func sendRaw<Body: Encodable>(
+        method: String,
+        path: String,
+        body: Body?,
+        timeout: TimeInterval?
+    ) async throws -> Data {
+        let request = try await makeRequest(method: method, path: path, body: body, timeout: timeout)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            // Map transport failures; never rethrow the raw URLError to callers.
+            throw GatewayError.from(transport: error)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw GatewayError.server
+        }
+        if let mapped = GatewayError.from(statusCode: http.statusCode) {
+            throw mapped
+        }
+        return data
+    }
+
+    private func makeRequest<Body: Encodable>(
+        method: String,
+        path: String,
+        body: Body?,
+        timeout: TimeInterval?
+    ) async throws -> URLRequest {
+        guard let url = resolve(path: path) else {
+            throw GatewayError.misconfigured
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = timeout ?? defaultTimeout
+
+        if let token = await tokenProvider.token() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        if let body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            do {
+                request.httpBody = try encoder.encode(body)
+            } catch {
+                // Encoding our own request body should never leak server text.
+                throw GatewayError.decoding
+            }
+        }
+        return request
+    }
+
+    private func resolve(path: String) -> URL? {
+        // Preserve any base query (e.g. ?runtime=staging) while appending the path.
+        guard var comps = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        comps.path = path
+        return comps.url
+    }
+}

--- a/macos/Sources/Net/GatewayHTTPClient.swift
+++ b/macos/Sources/Net/GatewayHTTPClient.swift
@@ -152,7 +152,9 @@ public struct GatewayHTTPClient: Sendable {
            let relative = URLComponents(string: path),
            let queryItems = relative.queryItems,
            !queryItems.isEmpty {
-            comps.queryItems = (comps.queryItems ?? []) + queryItems
+            let overriddenNames = Set(queryItems.map(\.name))
+            let baseItems = (comps.queryItems ?? []).filter { !overriddenNames.contains($0.name) }
+            comps.queryItems = baseItems + queryItems
         }
         return comps.url
     }

--- a/macos/Sources/Net/KeychainStore.swift
+++ b/macos/Sources/Net/KeychainStore.swift
@@ -1,0 +1,90 @@
+// MatrixNet — Keychain-backed secure token storage.
+//
+// Stores/retrieves/deletes string secrets keyed by account, in the macOS
+// Keychain (kSecClassGenericPassword). The principal/device-auth token is the
+// only durable local credential the app keeps (Constitution P1: no other local
+// durable user data). Sendable-safe: holds only an immutable service string.
+import Foundation
+import Security
+
+/// Abstraction so PrincipalProvider can be unit-tested without the system Keychain.
+public protocol TokenStoring: Sendable {
+    func get(key: String) throws -> String?
+    func set(key: String, value: String) throws
+    func delete(key: String) throws
+}
+
+public enum KeychainError: Error, Equatable, Sendable {
+    case unexpectedStatus(OSStatus)
+    case encodingFailed
+}
+
+public struct KeychainStore: TokenStoring {
+    private let service: String
+
+    public init(service: String = "com.matrix-os.app") {
+        self.service = service
+    }
+
+    private func baseQuery(key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+
+    public func get(key: String) throws -> String? {
+        var query = baseQuery(key: key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data, let value = String(data: data, encoding: .utf8) else {
+                throw KeychainError.encodingFailed
+            }
+            return value
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    public func set(key: String, value: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.encodingFailed
+        }
+        // Upsert: try update first, fall back to add. Avoids check-then-insert races.
+        let query = baseQuery(key: key)
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw KeychainError.unexpectedStatus(addStatus)
+            }
+        default:
+            throw KeychainError.unexpectedStatus(updateStatus)
+        }
+    }
+
+    public func delete(key: String) throws {
+        let status = SecItemDelete(baseQuery(key: key) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}

--- a/macos/Sources/Net/PrincipalProvider.swift
+++ b/macos/Sources/Net/PrincipalProvider.swift
@@ -1,0 +1,40 @@
+// MatrixNet — current principal token holder.
+//
+// Loads the principal/device-auth token from a TokenStoring backend (Keychain in
+// production), caches it in memory, and exposes it to the GatewayHTTPClient via
+// TokenProviding. Supports clear-on-signout. Implemented as an actor so the
+// cached token is mutated under strict Swift 6 concurrency safely.
+import Foundation
+
+public actor PrincipalProvider: TokenProviding {
+    /// Keychain account key for the principal token.
+    public static let tokenKey = "principal-token"
+
+    private let store: any TokenStoring
+    private var cached: String?
+
+    /// Creates the provider and eagerly loads any persisted token.
+    public init(store: any TokenStoring) {
+        self.store = store
+        // Best-effort warm load; a Keychain failure leaves us signed-out rather
+        // than crashing. The error is intentionally swallowed here because a
+        // missing/locked Keychain is a valid "no token" state at startup.
+        self.cached = try? store.get(key: Self.tokenKey)
+    }
+
+    public func currentToken() -> String? { cached }
+
+    public func token() -> String? { cached }
+
+    /// Persists and caches a freshly issued token (after device auth).
+    public func setToken(_ token: String) throws {
+        try store.set(key: Self.tokenKey, value: token)
+        cached = token
+    }
+
+    /// Clears the token on sign-out, from both cache and durable store.
+    public func clear() throws {
+        try store.delete(key: Self.tokenKey)
+        cached = nil
+    }
+}

--- a/macos/Sources/Net/TokenProviding.swift
+++ b/macos/Sources/Net/TokenProviding.swift
@@ -1,0 +1,18 @@
+// MatrixNet — token provider abstraction for the HTTP client.
+//
+// The GatewayHTTPClient stays decoupled from where the principal token lives.
+// In production this is the Keychain-backed PrincipalProvider; in tests it is a
+// static provider. `token()` is async so a Keychain read / refresh can be awaited.
+import Foundation
+
+public protocol TokenProviding: Sendable {
+    /// The current principal bearer token, or nil if signed out.
+    func token() async -> String?
+}
+
+/// A fixed-token provider, primarily for tests and previews.
+public struct StaticTokenProvider: TokenProviding {
+    private let value: String?
+    public init(token: String?) { self.value = token }
+    public func token() async -> String? { value }
+}

--- a/macos/Sources/Net/VPSResolver.swift
+++ b/macos/Sources/Net/VPSResolver.swift
@@ -1,0 +1,91 @@
+// MatrixNet — gateway endpoint + WebSocket URL resolution.
+//
+// Per research.md C4, the macOS client never addresses a VPS IP directly. It
+// always talks to the platform app domain (e.g. app.matrix-os.com); the platform
+// reverse-proxies to the user's VPS, selecting the machine by Clerk identity +
+// `runtimeSlot`. Multi-VM selection is expressed as `?runtime=<slot>` on requests
+// (default slot is `primary`, expressed here as `nil` -> no query param).
+import Foundation
+
+public enum VPSResolver {
+    /// Builds the gateway base URL `https://<gatewayHost>[?runtime=<slot>]`.
+    /// `runtimeSlot == nil` (or "primary") omits the query param.
+    public static func gatewayBaseURL(gatewayHost: String, runtimeSlot: String?) throws -> URL {
+        let host = gatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty else { throw GatewayError.misconfigured }
+
+        var comps = URLComponents()
+        comps.scheme = "https"
+        comps.host = host
+        if let slot = normalizedSlot(runtimeSlot) {
+            comps.queryItems = [URLQueryItem(name: "runtime", value: slot)]
+        }
+        guard let url = comps.url else { throw GatewayError.misconfigured }
+        return url
+    }
+
+    /// Builds a shell/board WebSocket URL `wss://<host><path>?session=&fromSeq=&runtime=`.
+    /// `fromSeq` is omitted when nil (initial attach / live tail).
+    public static func webSocketURL(
+        gatewayHost: String,
+        runtimeSlot: String?,
+        path: String,
+        session: String,
+        fromSeq: Int?
+    ) throws -> URL {
+        let host = gatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty else { throw GatewayError.misconfigured }
+
+        var comps = URLComponents()
+        comps.scheme = "wss"
+        comps.host = host
+        comps.path = path
+        var items = [URLQueryItem(name: "session", value: session)]
+        if let fromSeq {
+            items.append(URLQueryItem(name: "fromSeq", value: String(fromSeq)))
+        }
+        if let slot = normalizedSlot(runtimeSlot) {
+            items.append(URLQueryItem(name: "runtime", value: slot))
+        }
+        comps.queryItems = items
+        guard let url = comps.url else { throw GatewayError.misconfigured }
+        return url
+    }
+
+    /// "primary" and empty/whitespace are treated as the default slot (no param).
+    private static func normalizedSlot(_ slot: String?) -> String? {
+        guard let raw = slot?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty, raw != "primary" else {
+            return nil
+        }
+        return raw
+    }
+}
+
+/// Client-only connection profile (Keychain-backed credentials elsewhere).
+/// Holds the primitives needed to resolve gateway/WS URLs for one selected VPS.
+public struct ConnectionProfile: Equatable, Sendable {
+    public let handle: String
+    public let gatewayHost: String
+    public let runtimeSlot: String?
+
+    public init(handle: String, gatewayHost: String, runtimeSlot: String? = nil) {
+        self.handle = handle
+        self.gatewayHost = gatewayHost
+        self.runtimeSlot = runtimeSlot
+    }
+
+    public func gatewayBaseURL() throws -> URL {
+        try VPSResolver.gatewayBaseURL(gatewayHost: gatewayHost, runtimeSlot: runtimeSlot)
+    }
+
+    public func webSocketURL(path: String, session: String, fromSeq: Int?) throws -> URL {
+        try VPSResolver.webSocketURL(
+            gatewayHost: gatewayHost,
+            runtimeSlot: runtimeSlot,
+            path: path,
+            session: session,
+            fromSeq: fromSeq
+        )
+    }
+}

--- a/macos/Sources/Net/_Module.swift
+++ b/macos/Sources/Net/_Module.swift
@@ -1,4 +1,0 @@
-// MatrixNet — gateway HTTP/WS networking, principal/auth, Keychain.
-// Real implementations land in Phase 2: GatewayHTTPClient (T021), KeychainStore +
-// PrincipalProvider (T023), ConnectionProfile/VPS resolver (T026).
-import Foundation

--- a/macos/Sources/Terminal/ScrollbackRing.swift
+++ b/macos/Sources/Terminal/ScrollbackRing.swift
@@ -9,26 +9,42 @@ public struct ScrollbackRing: Sendable {
     }
 
     public let capacity: Int
-    private var entries: [Entry] = []
+    private var entries: [Entry?]
+    private var startIndex = 0
+    private var entryCount = 0
 
     public init(capacity: Int) {
         precondition(capacity > 0, "ScrollbackRing capacity must be > 0")
         self.capacity = capacity
-        entries.reserveCapacity(capacity)
+        self.entries = Array(repeating: nil, count: capacity)
     }
 
-    public var count: Int { entries.count }
-    public var oldestSeq: Int? { entries.first?.seq }
-    public var newestSeq: Int? { entries.last?.seq }
+    public var count: Int { entryCount }
+    public var oldestSeq: Int? {
+        guard entryCount > 0 else { return nil }
+        return entries[startIndex]?.seq
+    }
+    public var newestSeq: Int? {
+        guard entryCount > 0 else { return nil }
+        let index = (startIndex + entryCount - 1) % capacity
+        return entries[index]?.seq
+    }
 
     public mutating func append(seq: Int, data: String) {
-        entries.append(Entry(seq: seq, data: data))
-        if entries.count > capacity {
-            entries.removeFirst(entries.count - capacity)
+        let entry = Entry(seq: seq, data: data)
+        if entryCount < capacity {
+            let index = (startIndex + entryCount) % capacity
+            entries[index] = entry
+            entryCount += 1
+        } else {
+            entries[startIndex] = entry
+            startIndex = (startIndex + 1) % capacity
         }
     }
 
     public mutating func clear() {
-        entries.removeAll(keepingCapacity: true)
+        entries = Array(repeating: nil, count: capacity)
+        startIndex = 0
+        entryCount = 0
     }
 }

--- a/macos/Sources/Terminal/ScrollbackRing.swift
+++ b/macos/Sources/Terminal/ScrollbackRing.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Bounded scrollback ring buffer for replay/resume bookkeeping (R1).
+/// Evicts oldest entries once `capacity` is exceeded.
+public struct ScrollbackRing: Sendable {
+    public struct Entry: Sendable, Equatable {
+        public let seq: Int
+        public let data: String
+    }
+
+    public let capacity: Int
+    private var entries: [Entry] = []
+
+    public init(capacity: Int) {
+        precondition(capacity > 0, "ScrollbackRing capacity must be > 0")
+        self.capacity = capacity
+        entries.reserveCapacity(capacity)
+    }
+
+    public var count: Int { entries.count }
+    public var oldestSeq: Int? { entries.first?.seq }
+    public var newestSeq: Int? { entries.last?.seq }
+
+    public mutating func append(seq: Int, data: String) {
+        entries.append(Entry(seq: seq, data: data))
+        if entries.count > capacity {
+            entries.removeFirst(entries.count - capacity)
+        }
+    }
+
+    public mutating func clear() {
+        entries.removeAll(keepingCapacity: true)
+    }
+}

--- a/macos/Sources/Terminal/ShellBackoff.swift
+++ b/macos/Sources/Terminal/ShellBackoff.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Bounded exponential backoff with optional jitter for reconnect (F1).
+public struct BackoffPolicy: Sendable {
+    public let base: Double
+    public let factor: Double
+    public let cap: Double
+    /// Fractional jitter in [0, 1]; applied as a random subtractive fraction of the delay.
+    public let jitter: Double
+
+    public init(base: Double = 0.5, factor: Double = 2, cap: Double = 30, jitter: Double = 0.5) {
+        self.base = base
+        self.factor = factor
+        self.cap = cap
+        self.jitter = max(0, min(1, jitter))
+    }
+
+    /// Default production policy.
+    public static let `default` = BackoffPolicy()
+
+    /// Deterministic, fast policy for tests (no jitter, small cap).
+    public static let test = BackoffPolicy(base: 0.01, factor: 2, cap: 0.04, jitter: 0)
+
+    /// Delay (seconds) for a zero-based reconnect attempt, never exceeding `cap`.
+    public func delay(forAttempt attempt: Int) -> Double {
+        let raw = base * pow(factor, Double(max(0, attempt)))
+        let capped = min(raw, cap)
+        guard jitter > 0 else { return capped }
+        let reduction = capped * jitter * Double.random(in: 0...1)
+        return max(0, capped - reduction)
+    }
+}

--- a/macos/Sources/Terminal/ShellMessages.swift
+++ b/macos/Sources/Terminal/ShellMessages.swift
@@ -1,0 +1,130 @@
+// Wire protocol for the shell terminal WebSocket.
+// Source of truth: packages/gateway/src/shell/ws.ts (+ @finnaai/matrix/shell-protocol).
+import Foundation
+
+/// Sentinel `fromSeq` requesting the live tail (recent replay + live output).
+/// Mirrors `SHELL_ATTACH_LIVE_TAIL_FROM_SEQ = Number.MAX_SAFE_INTEGER`.
+public let SHELL_ATTACH_LIVE_TAIL_FROM_SEQ: Int = 9_007_199_254_740_991
+
+/// Roughly how many recent events the server replays on a live-tail attach.
+public let SHELL_ATTACH_RECENT_REPLAY_EVENTS: Int = 50
+
+/// Client → server messages.
+public enum ClientMessage: Sendable, Equatable {
+    case input(data: String)
+    case resize(cols: Int, rows: Int)
+    case detach
+    case ping
+}
+
+extension ClientMessage: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type, data, cols, rows
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .input(data):
+            try container.encode("input", forKey: .type)
+            try container.encode(data, forKey: .data)
+        case let .resize(cols, rows):
+            try container.encode("resize", forKey: .type)
+            try container.encode(cols, forKey: .cols)
+            try container.encode(rows, forKey: .rows)
+        case .detach:
+            try container.encode("detach", forKey: .type)
+        case .ping:
+            try container.encode("ping", forKey: .type)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "input":
+            self = .input(data: try container.decode(String.self, forKey: .data))
+        case "resize":
+            self = .resize(
+                cols: try container.decode(Int.self, forKey: .cols),
+                rows: try container.decode(Int.self, forKey: .rows)
+            )
+        case "detach":
+            self = .detach
+        case "ping":
+            self = .ping
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown client message type: \(type)"
+            )
+        }
+    }
+}
+
+/// Server → client messages.
+public enum ServerMessage: Sendable, Equatable {
+    case attached(session: String, state: String, fromSeq: Int)
+    case output(seq: Int, data: String)
+    case exit(code: Int)
+    case error(code: String, message: String)
+    case pong
+    /// Requested seq was older than the buffer; client must clear and re-attach at live tail.
+    case replayEvicted(fromSeq: Int, nextSeq: Int)
+}
+
+extension ServerMessage: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case type, session, state, fromSeq, nextSeq, seq, data, code, message
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "attached":
+            self = .attached(
+                session: try container.decode(String.self, forKey: .session),
+                state: try container.decodeIfPresent(String.self, forKey: .state) ?? "running",
+                fromSeq: try container.decodeIfPresent(Int.self, forKey: .fromSeq) ?? 0
+            )
+        case "output":
+            self = .output(
+                seq: try container.decode(Int.self, forKey: .seq),
+                data: try container.decode(String.self, forKey: .data)
+            )
+        case "exit":
+            self = .exit(code: try container.decode(Int.self, forKey: .code))
+        case "error":
+            self = .error(
+                code: try container.decode(String.self, forKey: .code),
+                message: try container.decodeIfPresent(String.self, forKey: .message) ?? ""
+            )
+        case "pong":
+            self = .pong
+        case "replay-evicted":
+            self = .replayEvicted(
+                fromSeq: try container.decode(Int.self, forKey: .fromSeq),
+                nextSeq: try container.decode(Int.self, forKey: .nextSeq)
+            )
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown server message type: \(type)"
+            )
+        }
+    }
+}
+
+/// Decoded events surfaced to consumers of the client.
+public enum ServerEvent: Sendable, Equatable {
+    case attached(state: String, fromSeq: Int)
+    case output(seq: Int, data: String)
+    case exit(code: Int)
+    case error(code: String, message: String)
+    /// Emitted after the client has reset its buffer and re-attached at live tail.
+    case replayEvicted
+}

--- a/macos/Sources/Terminal/ShellTransport.swift
+++ b/macos/Sources/Terminal/ShellTransport.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Abstraction over the WebSocket transport so the client state machine can be
+/// driven deterministically in tests. Production impl wraps `URLSessionWebSocketTask`.
+public protocol ShellTransport: Sendable {
+    /// Opens a connection for `request` and returns a stream of received text frames.
+    /// The stream finishes (optionally throwing) when the socket closes/errors.
+    func open(_ request: URLRequest) async -> AsyncThrowingStream<String, Error>
+    /// Sends a text frame to the server.
+    func send(_ text: String) async throws
+    /// Closes the active connection.
+    func close() async
+}
+
+/// Abstraction over time so reconnect backoff is deterministic in tests.
+public protocol ShellClock: Sendable {
+    func sleep(seconds: Double) async
+}
+
+/// Production clock backed by `Task.sleep`.
+public struct SystemClock: ShellClock {
+    public init() {}
+    public func sleep(seconds: Double) async {
+        let nanos = UInt64((max(0, seconds) * 1_000_000_000).rounded())
+        try? await Task.sleep(nanoseconds: nanos)
+    }
+}
+
+/// Production transport over `URLSessionWebSocketTask`.
+/// Auth travels in the `Authorization` header on the upgrade request (FR-015a / S1).
+public actor URLSessionShellTransport: ShellTransport {
+    private let session: URLSession
+    private var task: URLSessionWebSocketTask?
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func open(_ request: URLRequest) async -> AsyncThrowingStream<String, Error> {
+        let task = session.webSocketTask(with: request)
+        self.task = task
+        task.resume()
+        return AsyncThrowingStream { continuation in
+            let receiver = Task {
+                while !Task.isCancelled {
+                    do {
+                        let message = try await task.receive()
+                        switch message {
+                        case let .string(text):
+                            continuation.yield(text)
+                        case let .data(data):
+                            if let text = String(data: data, encoding: .utf8) {
+                                continuation.yield(text)
+                            }
+                        @unknown default:
+                            break
+                        }
+                    } catch {
+                        continuation.finish(throwing: error)
+                        return
+                    }
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                receiver.cancel()
+            }
+        }
+    }
+
+    public func send(_ text: String) async throws {
+        guard let task else { throw URLError(.badServerResponse) }
+        try await task.send(.string(text))
+    }
+
+    public func close() async {
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+    }
+}

--- a/macos/Sources/Terminal/ShellWSClient.swift
+++ b/macos/Sources/Terminal/ShellWSClient.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Shell terminal WebSocket client (T024/T025).
+///
+/// Implements `contracts/shell-ws-protocol.md`:
+/// - Connects to the gateway shell-WS route with `Authorization: Bearer <token>`
+///   on the upgrade (FR-015a / S1 — header auth, never a query token).
+/// - Tracks `lastSeq` from `output` frames; on reconnect resumes at `lastSeq + 1`.
+/// - On a fresh connect attaches at the live-tail sentinel.
+/// - On `replay-evicted` clears its buffer and re-attaches at live tail (accepts
+///   the unrecoverable gap; never duplicates or silently re-requests evicted seqs).
+/// - Bounded exponential reconnect backoff with jitter (F1) and a bounded
+///   scrollback ring buffer with eviction (R1).
+public actor ShellWSClient {
+    private let baseURL: URL
+    private let token: String
+    private let session: String
+    private let transport: ShellTransport
+    private let backoff: BackoffPolicy
+    private let clock: ShellClock
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private var ring: ScrollbackRing
+    private var lastSeqValue: Int = 0
+    private var pendingSize: (cols: Int, rows: Int)?
+    private var runLoop: Task<Void, Never>?
+    private var stopped = false
+
+    private let eventStream: AsyncStream<ServerEvent>
+    private let eventContinuation: AsyncStream<ServerEvent>.Continuation
+
+    public init(
+        url: URL,
+        token: String,
+        session: String,
+        transport: ShellTransport,
+        backoff: BackoffPolicy = .default,
+        clock: ShellClock = SystemClock(),
+        scrollbackCapacity: Int = 5_000
+    ) {
+        self.baseURL = url
+        self.token = token
+        self.session = session
+        self.transport = transport
+        self.backoff = backoff
+        self.clock = clock
+        self.ring = ScrollbackRing(capacity: scrollbackCapacity)
+        var continuation: AsyncStream<ServerEvent>.Continuation!
+        self.eventStream = AsyncStream { continuation = $0 }
+        self.eventContinuation = continuation
+    }
+
+    /// Stream of decoded server events for consumers (the terminal view).
+    public var events: AsyncStream<ServerEvent> { eventStream }
+
+    /// Last applied output sequence number (0 before any output / after reset).
+    public var lastSeq: Int { lastSeqValue }
+
+    /// Starts the connect+reconnect run loop.
+    public func connect() {
+        guard runLoop == nil, !stopped else { return }
+        runLoop = Task { [weak self] in
+            await self?.runUntilStopped()
+        }
+    }
+
+    /// Sends a keystroke/byte payload to the PTY.
+    public func sendInput(_ data: String) async {
+        await sendClient(.input(data: data))
+    }
+
+    /// Records a resize; sent immediately if connected and once after each attach.
+    public func resize(cols: Int, rows: Int) async {
+        pendingSize = (cols, rows)
+        await sendClient(.resize(cols: cols, rows: rows))
+    }
+
+    /// Detaches (leave session running) and stops reconnecting.
+    public func detach() async {
+        await sendClient(.detach)
+        await shutdown()
+    }
+
+    /// Stops the run loop and tears down the connection.
+    public func shutdown() async {
+        stopped = true
+        runLoop?.cancel()
+        runLoop = nil
+        await transport.close()
+        eventContinuation.finish()
+    }
+
+    // MARK: - Run loop
+
+    private func runUntilStopped() async {
+        var attempt = 0
+        while !stopped && !Task.isCancelled {
+            // Fresh connect → live tail; reconnect → resume at lastSeq + 1.
+            let fromSeq = lastSeqValue > 0 ? lastSeqValue + 1 : SHELL_ATTACH_LIVE_TAIL_FROM_SEQ
+            let request = makeRequest(fromSeq: fromSeq)
+            let frames = await transport.open(request)
+            let cleanly = await consume(frames)
+            if stopped || Task.isCancelled { break }
+            attempt = cleanly ? 0 : attempt + 1
+            await clock.sleep(seconds: backoff.delay(forAttempt: attempt))
+        }
+    }
+
+    /// Drains one connection's frame stream. Returns `true` if it closed cleanly.
+    private func consume(_ frames: AsyncThrowingStream<String, Error>) async -> Bool {
+        do {
+            for try await raw in frames {
+                if stopped { return true }
+                await handle(raw)
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func handle(_ raw: String) async {
+        guard let data = raw.data(using: .utf8),
+              let message = try? decoder.decode(ServerMessage.self, from: data) else {
+            return // ignore malformed/unknown frames
+        }
+        switch message {
+        case let .attached(_, state, fromSeq):
+            eventContinuation.yield(.attached(state: state, fromSeq: fromSeq))
+            // Resize once immediately after attach.
+            if let size = pendingSize {
+                await sendClient(.resize(cols: size.cols, rows: size.rows))
+            }
+        case let .output(seq, payload):
+            lastSeqValue = max(lastSeqValue, seq)
+            ring.append(seq: seq, data: payload)
+            eventContinuation.yield(.output(seq: seq, data: payload))
+        case let .exit(code):
+            eventContinuation.yield(.exit(code: code))
+        case let .error(code, text):
+            eventContinuation.yield(.error(code: code, message: text))
+        case .pong:
+            break
+        case .replayEvicted:
+            // Unrecoverable gap: clear buffer + seq, re-attach at live tail.
+            ring.clear()
+            lastSeqValue = 0
+            eventContinuation.yield(.replayEvicted)
+            await transport.close() // drop current connection; run loop re-attaches at live tail
+        }
+    }
+
+    // MARK: - Sending
+
+    private func sendClient(_ message: ClientMessage) async {
+        guard !stopped, let encoded = try? encoder.encode(message),
+              let text = String(data: encoded, encoding: .utf8) else { return }
+        try? await transport.send(text)
+    }
+
+    // MARK: - Request building
+
+    private func makeRequest(fromSeq: Int) -> URLRequest {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        var items = components?.queryItems ?? []
+        items.removeAll { $0.name == "session" || $0.name == "fromSeq" || $0.name == "token" }
+        items.append(URLQueryItem(name: "session", value: session))
+        items.append(URLQueryItem(name: "fromSeq", value: String(fromSeq)))
+        components?.queryItems = items
+        let url = components?.url ?? baseURL
+        var request = URLRequest(url: url)
+        // FR-015a / S1: principal token in the Authorization header, never the query string.
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+}

--- a/macos/Sources/Terminal/ShellWSClient.swift
+++ b/macos/Sources/Terminal/ShellWSClient.swift
@@ -13,7 +13,7 @@ import Foundation
 ///   scrollback ring buffer with eviction (R1).
 public actor ShellWSClient {
     private let baseURL: URL
-    private let token: String
+    private let tokenProvider: @Sendable () async -> String
     private let session: String
     private let transport: ShellTransport
     private let backoff: BackoffPolicy
@@ -39,8 +39,28 @@ public actor ShellWSClient {
         clock: ShellClock = SystemClock(),
         scrollbackCapacity: Int = 5_000
     ) {
+        self.init(
+            url: url,
+            tokenProvider: { token },
+            session: session,
+            transport: transport,
+            backoff: backoff,
+            clock: clock,
+            scrollbackCapacity: scrollbackCapacity
+        )
+    }
+
+    public init(
+        url: URL,
+        tokenProvider: @escaping @Sendable () async -> String,
+        session: String,
+        transport: ShellTransport,
+        backoff: BackoffPolicy = .default,
+        clock: ShellClock = SystemClock(),
+        scrollbackCapacity: Int = 5_000
+    ) {
         self.baseURL = url
-        self.token = token
+        self.tokenProvider = tokenProvider
         self.session = session
         self.transport = transport
         self.backoff = backoff
@@ -98,7 +118,7 @@ public actor ShellWSClient {
         while !stopped && !Task.isCancelled {
             // Fresh connect → live tail; reconnect → resume at lastSeq + 1.
             let fromSeq = lastSeqValue > 0 ? lastSeqValue + 1 : SHELL_ATTACH_LIVE_TAIL_FROM_SEQ
-            let request = makeRequest(fromSeq: fromSeq)
+            let request = await makeRequest(fromSeq: fromSeq)
             let frames = await transport.open(request)
             let cleanly = await consume(frames)
             if stopped || Task.isCancelled { break }
@@ -161,7 +181,7 @@ public actor ShellWSClient {
 
     // MARK: - Request building
 
-    private func makeRequest(fromSeq: Int) -> URLRequest {
+    private func makeRequest(fromSeq: Int) async -> URLRequest {
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
         var items = components?.queryItems ?? []
         items.removeAll { $0.name == "session" || $0.name == "fromSeq" || $0.name == "token" }
@@ -171,6 +191,7 @@ public actor ShellWSClient {
         let url = components?.url ?? baseURL
         var request = URLRequest(url: url)
         // FR-015a / S1: principal token in the Authorization header, never the query string.
+        let token = await tokenProvider()
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         return request
     }

--- a/macos/Tests/BoardTests/_Placeholder.swift
+++ b/macos/Tests/BoardTests/_Placeholder.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import MatrixBoard
+
+// Placeholder so MatrixBoard test target builds before US1 tests land (T032).
+final class BoardModulePlaceholderTests: XCTestCase {
+    func testModuleLoads() { XCTAssertTrue(true) }
+}

--- a/macos/Tests/ModelTests/CardTests.swift
+++ b/macos/Tests/ModelTests/CardTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import MatrixModel
+
+final class CardTests: XCTestCase {
+    // A representative task payload as emitted by the gateway task-manager.
+    private let sampleTaskJSON = """
+    {
+        "id": "task_abc123",
+        "projectSlug": "matrix-os",
+        "title": "Wire the board",
+        "description": "Hook up kanban columns",
+        "status": "running",
+        "priority": "high",
+        "order": 12.5,
+        "parentTaskId": "task_parent1",
+        "linkedSessionId": "sess_live1",
+        "linkedWorktreeId": "wt_branch1",
+        "previewIds": ["prev_one", "prev_two"],
+        "tags": ["backend", "urgent-fix"],
+        "updatedAt": "2026-06-05T10:00:00.000Z",
+        "revision": 7
+    }
+    """
+
+    func testCardDecodesGatewayTaskJSON() throws {
+        let data = Data(sampleTaskJSON.utf8)
+        let card = try JSONDecoder().decode(Card.self, from: data)
+
+        XCTAssertEqual(card.id, "task_abc123")
+        XCTAssertEqual(card.projectSlug, "matrix-os")
+        XCTAssertEqual(card.title, "Wire the board")
+        XCTAssertEqual(card.description, "Hook up kanban columns")
+        XCTAssertEqual(card.status, .running)
+        XCTAssertEqual(card.priority, .high)
+        XCTAssertEqual(card.order, 12.5, accuracy: 0.0001)
+        XCTAssertEqual(card.parentTaskId, "task_parent1")
+        XCTAssertEqual(card.linkedSessionId, "sess_live1")
+        XCTAssertEqual(card.linkedWorktreeId, "wt_branch1")
+        XCTAssertEqual(card.previewIds, ["prev_one", "prev_two"])
+        XCTAssertEqual(card.tags, ["backend", "urgent-fix"])
+        XCTAssertEqual(card.updatedAt, "2026-06-05T10:00:00.000Z")
+        XCTAssertEqual(card.revision, 7)
+    }
+
+    func testCardRoundTripsThroughCodable() throws {
+        let data = Data(sampleTaskJSON.utf8)
+        let decoded = try JSONDecoder().decode(Card.self, from: data)
+        let reencoded = try JSONEncoder().encode(decoded)
+        let roundTripped = try JSONDecoder().decode(Card.self, from: reencoded)
+        XCTAssertEqual(decoded, roundTripped)
+    }
+
+    func testCardDecodesWithMinimalFields() throws {
+        let json = """
+        {
+            "id": "task_min",
+            "projectSlug": "p",
+            "title": "Bare",
+            "status": "todo",
+            "priority": "normal",
+            "order": 0,
+            "previewIds": [],
+            "tags": [],
+            "updatedAt": "2026-06-05T10:00:00.000Z"
+        }
+        """
+        let card = try JSONDecoder().decode(Card.self, from: Data(json.utf8))
+        XCTAssertNil(card.description)
+        XCTAssertNil(card.parentTaskId)
+        XCTAssertNil(card.linkedSessionId)
+        XCTAssertNil(card.linkedWorktreeId)
+        XCTAssertNil(card.revision)
+        XCTAssertTrue(card.previewIds.isEmpty)
+        XCTAssertTrue(card.tags.isEmpty)
+    }
+
+    func testIsLiveReflectsRunningStatus() {
+        XCTAssertTrue(makeCard(status: .running).isLive)
+        for status: TaskStatus in [.todo, .waiting, .blocked, .complete, .archived] {
+            XCTAssertFalse(makeCard(status: status).isLive)
+        }
+    }
+
+    func testColumnEqualsStatus() {
+        for status: TaskStatus in TaskStatus.allCases {
+            XCTAssertEqual(makeCard(status: status).column, status)
+        }
+    }
+
+    private func makeCard(status: TaskStatus) -> Card {
+        Card(
+            id: "task_x",
+            projectSlug: "p",
+            title: "t",
+            status: status,
+            priority: .normal,
+            order: 0,
+            previewIds: [],
+            tags: [],
+            updatedAt: "2026-06-05T10:00:00.000Z"
+        )
+    }
+}
+
+final class TaskStatusTests: XCTestCase {
+    func testStatusDecodesAllKanbanColumns() throws {
+        let mapping: [(String, TaskStatus)] = [
+            ("todo", .todo),
+            ("running", .running),
+            ("waiting", .waiting),
+            ("blocked", .blocked),
+            ("complete", .complete),
+            ("archived", .archived),
+        ]
+        for (raw, expected) in mapping {
+            let decoded = try JSONDecoder().decode(TaskStatus.self, from: Data("\"\(raw)\"".utf8))
+            XCTAssertEqual(decoded, expected)
+            let encoded = try JSONEncoder().encode(expected)
+            XCTAssertEqual(String(decoding: encoded, as: UTF8.self), "\"\(raw)\"")
+        }
+    }
+
+    func testAllCasesCoversSixColumns() {
+        XCTAssertEqual(TaskStatus.allCases.count, 6)
+    }
+}
+
+final class TaskPriorityTests: XCTestCase {
+    func testPriorityDecodesAllLevels() throws {
+        let mapping: [(String, TaskPriority)] = [
+            ("low", .low),
+            ("normal", .normal),
+            ("high", .high),
+            ("urgent", .urgent),
+        ]
+        for (raw, expected) in mapping {
+            let decoded = try JSONDecoder().decode(TaskPriority.self, from: Data("\"\(raw)\"".utf8))
+            XCTAssertEqual(decoded, expected)
+        }
+    }
+}

--- a/macos/Tests/ModelTests/ConnectionProfileTests.swift
+++ b/macos/Tests/ModelTests/ConnectionProfileTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import MatrixModel
+
+final class ConnectionProfileTests: XCTestCase {
+    func testRuntimeSlotDefaultsToPrimary() {
+        let profile = ConnectionProfile(
+            handle: "hamed",
+            gatewayHost: "app.matrix-os.com",
+            credentialRef: "matrixos.token.hamed"
+        )
+        XCTAssertEqual(profile.runtimeSlot, "primary")
+    }
+
+    func testProfileStoresOnlyCredentialReference() {
+        // The struct must never carry a raw token — only a Keychain key reference.
+        let profile = ConnectionProfile(
+            handle: "hamed",
+            gatewayHost: "app.matrix-os.com",
+            runtimeSlot: "secondary",
+            credentialRef: "matrixos.token.hamed"
+        )
+        XCTAssertEqual(profile.handle, "hamed")
+        XCTAssertEqual(profile.gatewayHost, "app.matrix-os.com")
+        XCTAssertEqual(profile.runtimeSlot, "secondary")
+        XCTAssertEqual(profile.credentialRef, "matrixos.token.hamed")
+    }
+
+    func testProfileRoundTrips() throws {
+        let profile = ConnectionProfile(
+            handle: "hamed",
+            gatewayHost: "app.matrix-os.com",
+            credentialRef: "matrixos.token.hamed"
+        )
+        let data = try JSONEncoder().encode(profile)
+        XCTAssertEqual(try JSONDecoder().decode(ConnectionProfile.self, from: data), profile)
+    }
+}

--- a/macos/Tests/ModelTests/SessionRefTests.swift
+++ b/macos/Tests/ModelTests/SessionRefTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import MatrixModel
+
+final class SessionRefTests: XCTestCase {
+    func testSessionRefDecodes() throws {
+        let json = """
+        {
+            "id": "sess_live1",
+            "status": "active",
+            "cwd": "/home/matrix/projects/x",
+            "layoutName": "dev",
+            "tabs": ["editor", "logs"]
+        }
+        """
+        let ref = try JSONDecoder().decode(SessionRef.self, from: Data(json.utf8))
+        XCTAssertEqual(ref.id, "sess_live1")
+        XCTAssertEqual(ref.status, .active)
+        XCTAssertEqual(ref.cwd, "/home/matrix/projects/x")
+        XCTAssertEqual(ref.layoutName, "dev")
+        XCTAssertEqual(ref.tabs, ["editor", "logs"])
+    }
+
+    func testSessionStatusDecodesActiveAndExited() throws {
+        XCTAssertEqual(
+            try JSONDecoder().decode(SessionStatus.self, from: Data("\"active\"".utf8)),
+            .active
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode(SessionStatus.self, from: Data("\"exited\"".utf8)),
+            .exited
+        )
+    }
+
+    func testSessionRefRoundTrips() throws {
+        let ref = SessionRef(id: "sess_a", status: .exited, cwd: nil, layoutName: nil, tabs: [])
+        let data = try JSONEncoder().encode(ref)
+        XCTAssertEqual(try JSONDecoder().decode(SessionRef.self, from: data), ref)
+    }
+}
+
+final class PanelTests: XCTestCase {
+    func testPanelEquality() {
+        XCTAssertEqual(Panel.terminal, Panel.terminal)
+        XCTAssertEqual(Panel.shell, Panel.shell)
+        XCTAssertEqual(Panel.app(slug: "notes"), Panel.app(slug: "notes"))
+        XCTAssertNotEqual(Panel.app(slug: "notes"), Panel.app(slug: "mail"))
+        XCTAssertNotEqual(Panel.terminal, Panel.shell)
+    }
+}

--- a/macos/Tests/ModelTests/StoredConnectionProfileTests.swift
+++ b/macos/Tests/ModelTests/StoredConnectionProfileTests.swift
@@ -1,9 +1,9 @@
 import XCTest
 @testable import MatrixModel
 
-final class ConnectionProfileTests: XCTestCase {
+final class StoredConnectionProfileTests: XCTestCase {
     func testRuntimeSlotDefaultsToPrimary() {
-        let profile = ConnectionProfile(
+        let profile = StoredConnectionProfile(
             handle: "hamed",
             gatewayHost: "app.matrix-os.com",
             credentialRef: "matrixos.token.hamed"
@@ -13,7 +13,7 @@ final class ConnectionProfileTests: XCTestCase {
 
     func testProfileStoresOnlyCredentialReference() {
         // The struct must never carry a raw token — only a Keychain key reference.
-        let profile = ConnectionProfile(
+        let profile = StoredConnectionProfile(
             handle: "hamed",
             gatewayHost: "app.matrix-os.com",
             runtimeSlot: "secondary",
@@ -26,12 +26,12 @@ final class ConnectionProfileTests: XCTestCase {
     }
 
     func testProfileRoundTrips() throws {
-        let profile = ConnectionProfile(
+        let profile = StoredConnectionProfile(
             handle: "hamed",
             gatewayHost: "app.matrix-os.com",
             credentialRef: "matrixos.token.hamed"
         )
         let data = try JSONEncoder().encode(profile)
-        XCTAssertEqual(try JSONDecoder().decode(ConnectionProfile.self, from: data), profile)
+        XCTAssertEqual(try JSONDecoder().decode(StoredConnectionProfile.self, from: data), profile)
     }
 }

--- a/macos/Tests/ModelTests/_Placeholder.swift
+++ b/macos/Tests/ModelTests/_Placeholder.swift
@@ -1,7 +1,0 @@
-import XCTest
-@testable import MatrixModel
-
-// Placeholder so the MatrixModel test target builds before Phase 2 tests land (T027).
-final class ModelModulePlaceholderTests: XCTestCase {
-    func testModuleLoads() { XCTAssertTrue(true) }
-}

--- a/macos/Tests/NetTests/DeviceAuthClientTests.swift
+++ b/macos/Tests/NetTests/DeviceAuthClientTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import MatrixNet
+
+final class DeviceAuthClientTests: XCTestCase {
+    private let platformURL = URL(string: "https://app.matrix-os.com")!
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private func makeClient() -> DeviceAuthClient {
+        DeviceAuthClient(platformURL: platformURL, sessionConfiguration: .mocked())
+    }
+
+    func testStartDeviceAuthParsesResponse() async throws {
+        MockURLProtocol.setHandler { req in
+            XCTAssertEqual(req.url?.path, "/api/auth/device/code")
+            XCTAssertEqual(req.httpMethod, "POST")
+            let json = """
+            {"deviceCode":"DC","userCode":"ABCD-EFGH","verificationUri":"https://app.matrix-os.com/auth/device?user_code=ABCD-EFGH","expiresIn":900,"interval":5}
+            """
+            return (httpResponse(req.url!, 200), Data(json.utf8))
+        }
+        let client = makeClient()
+        let start = try await client.startDeviceAuth()
+        XCTAssertEqual(start.deviceCode, "DC")
+        XCTAssertEqual(start.userCode, "ABCD-EFGH")
+        XCTAssertEqual(start.interval, 5)
+        XCTAssertEqual(start.expiresIn, 900)
+    }
+
+    func testPollPendingReturnsPending() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 428), Data("{\"error\":\"authorization_pending\"}".utf8))
+        }
+        let client = makeClient()
+        let result = try await client.pollForToken(deviceCode: "DC")
+        guard case .pending = result else { return XCTFail("expected pending, got \(result)") }
+    }
+
+    func testPollSlowDownReturnsSlowDown() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 429), Data("{\"error\":\"slow_down\"}".utf8))
+        }
+        let client = makeClient()
+        let result = try await client.pollForToken(deviceCode: "DC")
+        guard case .slowDown = result else { return XCTFail("expected slowDown, got \(result)") }
+    }
+
+    func testPollExpiredReturnsExpired() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 410), Data("{\"error\":\"expired_token\"}".utf8))
+        }
+        let client = makeClient()
+        let result = try await client.pollForToken(deviceCode: "DC")
+        guard case .expired = result else { return XCTFail("expected expired, got \(result)") }
+    }
+
+    func testPollApprovedReturnsToken() async throws {
+        MockURLProtocol.setHandler { req in
+            let json = """
+            {"accessToken":"JWT","expiresAt":"2026-01-01T00:00:00Z","userId":"user_1","handle":"hamed"}
+            """
+            return (httpResponse(req.url!, 200), Data(json.utf8))
+        }
+        let client = makeClient()
+        let result = try await client.pollForToken(deviceCode: "DC")
+        guard case let .approved(token) = result else { return XCTFail("expected approved, got \(result)") }
+        XCTAssertEqual(token.accessToken, "JWT")
+        XCTAssertEqual(token.handle, "hamed")
+    }
+
+    func testPollServerErrorThrowsGenericError() async {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 500), Data("internal postgres meltdown".utf8))
+        }
+        let client = makeClient()
+        do {
+            _ = try await client.pollForToken(deviceCode: "DC")
+            XCTFail("expected throw")
+        } catch let error as GatewayError {
+            XCTAssertEqual(error, .server)
+            XCTAssertFalse(error.userMessage.lowercased().contains("postgres"))
+        } catch {
+            XCTFail("expected GatewayError, got \(error)")
+        }
+    }
+}

--- a/macos/Tests/NetTests/GatewayHTTPClientTests.swift
+++ b/macos/Tests/NetTests/GatewayHTTPClientTests.swift
@@ -36,6 +36,42 @@ final class GatewayHTTPClientTests: XCTestCase {
         XCTAssertEqual(req.url?.path, "/api/workspace/projects")
     }
 
+    func testGetPreservesBaseRuntimeAndRelativeQuery() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 200), Data("{\"id\":\"abc\",\"count\":3}".utf8))
+        }
+        let client = GatewayHTTPClient(
+            baseURL: URL(string: "https://app.matrix-os.com?runtime=staging")!,
+            tokenProvider: StaticTokenProvider(token: "principal-token"),
+            sessionConfiguration: .mocked()
+        )
+        let _: Sample = try await client.get("/api/files/list?path=projects/matrix-os", as: Sample.self)
+
+        let req = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertEqual(req.url?.path, "/api/files/list")
+        let query = req.url?.query ?? ""
+        XCTAssertTrue(query.contains("runtime=staging"), query)
+        XCTAssertTrue(query.contains("path=projects/matrix-os"), query)
+    }
+
+    func testGetAppendsPathBelowBasePathAndPreservesRepeatedQueryItems() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 200), Data("{\"id\":\"abc\",\"count\":3}".utf8))
+        }
+        let client = GatewayHTTPClient(
+            baseURL: URL(string: "https://app.matrix-os.com/vm/alice?runtime=staging")!,
+            tokenProvider: StaticTokenProvider(token: "principal-token"),
+            sessionConfiguration: .mocked()
+        )
+        let _: Sample = try await client.get("/api/search?tag=one&tag=two", as: Sample.self)
+
+        let req = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertEqual(req.url?.path, "/vm/alice/api/search")
+        let items = URLComponents(url: try XCTUnwrap(req.url), resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.filter { $0.name == "runtime" }.map(\.value), ["staging"])
+        XCTAssertEqual(items.filter { $0.name == "tag" }.map(\.value), ["one", "two"])
+    }
+
     func testTimeoutIsConfiguredOnRequest() async throws {
         MockURLProtocol.setHandler { req in
             (httpResponse(req.url!, 200), Data("{\"id\":\"x\",\"count\":1}".utf8))

--- a/macos/Tests/NetTests/GatewayHTTPClientTests.swift
+++ b/macos/Tests/NetTests/GatewayHTTPClientTests.swift
@@ -72,6 +72,23 @@ final class GatewayHTTPClientTests: XCTestCase {
         XCTAssertEqual(items.filter { $0.name == "tag" }.map(\.value), ["one", "two"])
     }
 
+    func testRelativeQueryOverridesMatchingBaseQueryKeys() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 200), Data("{\"id\":\"abc\",\"count\":3}".utf8))
+        }
+        let client = GatewayHTTPClient(
+            baseURL: URL(string: "https://app.matrix-os.com/vm/alice?runtime=staging&flag=1")!,
+            tokenProvider: StaticTokenProvider(token: "principal-token"),
+            sessionConfiguration: .mocked()
+        )
+        let _: Sample = try await client.get("/api/search?runtime=production&runtime=canary", as: Sample.self)
+
+        let req = try XCTUnwrap(MockURLProtocol.lastRequest)
+        let items = URLComponents(url: try XCTUnwrap(req.url), resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.filter { $0.name == "flag" }.map(\.value), ["1"])
+        XCTAssertEqual(items.filter { $0.name == "runtime" }.map(\.value), ["production", "canary"])
+    }
+
     func testTimeoutIsConfiguredOnRequest() async throws {
         MockURLProtocol.setHandler { req in
             (httpResponse(req.url!, 200), Data("{\"id\":\"x\",\"count\":1}".utf8))

--- a/macos/Tests/NetTests/GatewayHTTPClientTests.swift
+++ b/macos/Tests/NetTests/GatewayHTTPClientTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import MatrixNet
+
+final class GatewayHTTPClientTests: XCTestCase {
+    private struct Sample: Codable, Equatable { let id: String; let count: Int }
+    private struct Payload: Codable, Equatable { let title: String }
+
+    private let baseURL = URL(string: "https://app.matrix-os.com")!
+
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private func makeClient(token: String? = "principal-token", timeout: TimeInterval = 10) -> GatewayHTTPClient {
+        GatewayHTTPClient(
+            baseURL: baseURL,
+            tokenProvider: StaticTokenProvider(token: token),
+            sessionConfiguration: .mocked(),
+            defaultTimeout: timeout
+        )
+    }
+
+    func testGetDecodesAndSetsAuthorizationHeader() async throws {
+        MockURLProtocol.setHandler { req in
+            let body = try JSONEncoder().encode(Sample(id: "abc", count: 3))
+            return (httpResponse(req.url!, 200), body)
+        }
+        let client = makeClient()
+        let result: Sample = try await client.get("/api/workspace/projects", as: Sample.self)
+        XCTAssertEqual(result, Sample(id: "abc", count: 3))
+
+        let req = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Authorization"), "Bearer principal-token")
+        XCTAssertEqual(req.httpMethod, "GET")
+        XCTAssertEqual(req.url?.path, "/api/workspace/projects")
+    }
+
+    func testTimeoutIsConfiguredOnRequest() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 200), Data("{\"id\":\"x\",\"count\":1}".utf8))
+        }
+        let client = makeClient(timeout: 7)
+        _ = try await client.get("/api/workspace/projects", as: Sample.self)
+        let req = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertEqual(req.timeoutInterval, 7, accuracy: 0.001)
+    }
+
+    func testNoAuthorizationHeaderWhenTokenMissing() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 200), Data("{\"id\":\"x\",\"count\":1}".utf8))
+        }
+        let client = makeClient(token: nil)
+        _ = try await client.get("/api/workspace/projects", as: Sample.self)
+        let req = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertNil(req.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    func testPostSendsBodyAndDecodes() async throws {
+        MockURLProtocol.setHandler { req in
+            // body is delivered via httpBodyStream under URLProtocol; assert method/path here.
+            let body = try JSONEncoder().encode(Sample(id: "new", count: 9))
+            return (httpResponse(req.url!, 201), body)
+        }
+        let client = makeClient()
+        let result: Sample = try await client.post("/api/projects/foo/tasks", body: Payload(title: "hi"), as: Sample.self)
+        XCTAssertEqual(result, Sample(id: "new", count: 9))
+        let req = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func testPatchUsesPatchMethod() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 200), try JSONEncoder().encode(Sample(id: "p", count: 1)))
+        }
+        let client = makeClient()
+        let _: Sample = try await client.patch("/api/projects/foo/tasks/1", body: Payload(title: "x"), as: Sample.self)
+        XCTAssertEqual(MockURLProtocol.lastRequest?.httpMethod, "PATCH")
+    }
+
+    func testDeleteUsesDeleteMethod() async throws {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 200), Data("{}".utf8))
+        }
+        let client = makeClient()
+        try await client.delete("/api/projects/foo/tasks/1")
+        XCTAssertEqual(MockURLProtocol.lastRequest?.httpMethod, "DELETE")
+    }
+
+    // MARK: - Error mapping (generic, no leakage)
+
+    func testUnauthorizedMapsTo401() async {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 401), Data("Postgres connection string leaked: postgres://secret".utf8))
+        }
+        let client = makeClient()
+        await assertThrows(client) { try await $0.get("/x", as: Sample.self) } expecting: { error in
+            XCTAssertEqual(error, .unauthorized)
+        }
+    }
+
+    func testNotFoundMapsTo404() async {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 404), Data("/home/matrix/secret/path not found".utf8))
+        }
+        let client = makeClient()
+        await assertThrows(client) { try await $0.get("/x", as: Sample.self) } expecting: { error in
+            XCTAssertEqual(error, .notFound)
+        }
+    }
+
+    func testServerErrorMapsToServerForAll5xx() async {
+        for status in [500, 502, 503] {
+            MockURLProtocol.setHandler { req in
+                (httpResponse(req.url!, status), Data("Twilio upstream exploded: account SID AC123".utf8))
+            }
+            let client = makeClient()
+            await assertThrows(client) { try await $0.get("/x", as: Sample.self) } expecting: { error in
+                XCTAssertEqual(error, .server)
+            }
+        }
+    }
+
+    func testUnexpectedClientStatusMapsToServer() async {
+        // A non-401/404 4xx still must not leak; map to a generic bucket.
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 418), Data("teapot internals".utf8))
+        }
+        let client = makeClient()
+        await assertThrows(client) { try await $0.get("/x", as: Sample.self) } expecting: { error in
+            XCTAssertEqual(error, .server)
+        }
+    }
+
+    func testMalformedJSONMapsToDecoding() async {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 200), Data("not json at all".utf8))
+        }
+        let client = makeClient()
+        await assertThrows(client) { try await $0.get("/x", as: Sample.self) } expecting: { error in
+            XCTAssertEqual(error, .decoding)
+        }
+    }
+
+    func testTransportTimeoutMapsToTimeout() async {
+        MockURLProtocol.setHandler { _ in throw URLError(.timedOut) }
+        let client = makeClient()
+        await assertThrows(client) { try await $0.get("/x", as: Sample.self) } expecting: { error in
+            XCTAssertEqual(error, .timeout)
+        }
+    }
+
+    func testTransportFailureMapsToNetwork() async {
+        MockURLProtocol.setHandler { _ in throw URLError(.cannotConnectToHost) }
+        let client = makeClient()
+        await assertThrows(client) { try await $0.get("/x", as: Sample.self) } expecting: { error in
+            XCTAssertEqual(error, .network)
+        }
+    }
+
+    func testErrorDescriptionNeverLeaksServerBody() async {
+        MockURLProtocol.setHandler { req in
+            (httpResponse(req.url!, 500), Data("postgres://user:pass@db internal stack trace".utf8))
+        }
+        let client = makeClient()
+        await assertThrows(client) { try await $0.get("/x", as: Sample.self) } expecting: { error in
+            let text = error.userMessage + " " + String(describing: error)
+            XCTAssertFalse(text.lowercased().contains("postgres"))
+            XCTAssertFalse(text.contains("stack trace"))
+        }
+    }
+
+    // MARK: - helper
+
+    private func assertThrows(
+        _ client: GatewayHTTPClient,
+        _ block: (GatewayHTTPClient) async throws -> Void,
+        expecting: (GatewayError) -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            try await block(client)
+            XCTFail("expected GatewayError to be thrown", file: file, line: line)
+        } catch let error as GatewayError {
+            expecting(error)
+        } catch {
+            XCTFail("expected GatewayError, got \(error)", file: file, line: line)
+        }
+    }
+}

--- a/macos/Tests/NetTests/KeychainStoreTests.swift
+++ b/macos/Tests/NetTests/KeychainStoreTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import MatrixNet
+
+final class KeychainStoreTests: XCTestCase {
+    private let service = "com.matrixos.tests.keychain"
+    private var store: KeychainStore!
+    private let key = "principal-token"
+
+    override func setUp() {
+        super.setUp()
+        store = KeychainStore(service: service)
+        try? store.delete(key: key)
+    }
+
+    override func tearDown() {
+        try? store.delete(key: key)
+        super.tearDown()
+    }
+
+    func testStoreAndRetrieveRoundTrips() throws {
+        try store.set(key: key, value: "abc123")
+        XCTAssertEqual(try store.get(key: key), "abc123")
+    }
+
+    func testOverwriteReplacesValue() throws {
+        try store.set(key: key, value: "first")
+        try store.set(key: key, value: "second")
+        XCTAssertEqual(try store.get(key: key), "second")
+    }
+
+    func testGetMissingReturnsNil() throws {
+        XCTAssertNil(try store.get(key: key))
+    }
+
+    func testDeleteRemovesValue() throws {
+        try store.set(key: key, value: "to-delete")
+        try store.delete(key: key)
+        XCTAssertNil(try store.get(key: key))
+    }
+
+    func testDeleteMissingDoesNotThrow() throws {
+        XCTAssertNoThrow(try store.delete(key: "never-stored"))
+    }
+}

--- a/macos/Tests/NetTests/MockURLProtocol.swift
+++ b/macos/Tests/NetTests/MockURLProtocol.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Test double that intercepts URLSession traffic so networking code can be
+/// asserted without a live server. Handlers are stored per-thread-safe box and
+/// produce a (response, body) or an error.
+final class MockURLProtocol: URLProtocol {
+    struct Stub: @unchecked Sendable {
+        let handler: (URLRequest) throws -> (HTTPURLResponse, Data)
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var _stub: Stub?
+    nonisolated(unsafe) private static var _capturedRequests: [URLRequest] = []
+
+    static func setHandler(_ handler: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)) {
+        lock.lock(); defer { lock.unlock() }
+        _stub = Stub(handler: handler)
+        _capturedRequests = []
+    }
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        _stub = nil
+        _capturedRequests = []
+    }
+
+    static var capturedRequests: [URLRequest] {
+        lock.lock(); defer { lock.unlock() }
+        return _capturedRequests
+    }
+
+    static var lastRequest: URLRequest? {
+        capturedRequests.last
+    }
+
+    private static func record(_ request: URLRequest) {
+        lock.lock(); defer { lock.unlock() }
+        _capturedRequests.append(request)
+    }
+
+    private static func currentStub() -> Stub? {
+        lock.lock(); defer { lock.unlock() }
+        return _stub
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        MockURLProtocol.record(request)
+        guard let stub = MockURLProtocol.currentStub() else {
+            client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+            return
+        }
+        do {
+            let (response, data) = try stub.handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+extension URLSessionConfiguration {
+    /// An ephemeral configuration wired to the mock protocol for tests.
+    static func mocked() -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        return config
+    }
+}
+
+/// Convenience to build an HTTPURLResponse for a given URL + status.
+func httpResponse(_ url: URL, _ status: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: nil)!
+}

--- a/macos/Tests/NetTests/PrincipalProviderTests.swift
+++ b/macos/Tests/NetTests/PrincipalProviderTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import MatrixNet
+
+/// In-memory token store so PrincipalProvider can be tested without the system Keychain.
+final class InMemoryTokenStore: TokenStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: String] = [:]
+
+    func get(key: String) throws -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return storage[key]
+    }
+
+    func set(key: String, value: String) throws {
+        lock.lock(); defer { lock.unlock() }
+        storage[key] = value
+    }
+
+    func delete(key: String) throws {
+        lock.lock(); defer { lock.unlock() }
+        storage.removeValue(forKey: key)
+    }
+}
+
+final class PrincipalProviderTests: XCTestCase {
+    func testLoadsTokenFromStoreOnInit() async throws {
+        let backing = InMemoryTokenStore()
+        try backing.set(key: PrincipalProvider.tokenKey, value: "stored-token")
+        let provider = PrincipalProvider(store: backing)
+        let token = await provider.currentToken()
+        XCTAssertEqual(token, "stored-token")
+    }
+
+    func testStartsNilWhenNothingStored() async {
+        let provider = PrincipalProvider(store: InMemoryTokenStore())
+        let token = await provider.currentToken()
+        XCTAssertNil(token)
+    }
+
+    func testSetPersistsAndUpdatesCurrent() async throws {
+        let backing = InMemoryTokenStore()
+        let provider = PrincipalProvider(store: backing)
+        try await provider.setToken("new-token")
+        let token = await provider.currentToken()
+        XCTAssertEqual(token, "new-token")
+        XCTAssertEqual(try backing.get(key: PrincipalProvider.tokenKey), "new-token")
+    }
+
+    func testClearOnSignoutRemovesToken() async throws {
+        let backing = InMemoryTokenStore()
+        let provider = PrincipalProvider(store: backing)
+        try await provider.setToken("token")
+        try await provider.clear()
+        let token = await provider.currentToken()
+        XCTAssertNil(token)
+        XCTAssertNil(try backing.get(key: PrincipalProvider.tokenKey))
+    }
+
+    func testConformsToTokenProvidingForHTTPClient() async throws {
+        let backing = InMemoryTokenStore()
+        let provider = PrincipalProvider(store: backing)
+        try await provider.setToken("bearer-x")
+        // TokenProviding is async; HTTP client awaits it per request.
+        let token = await (provider as TokenProviding).token()
+        XCTAssertEqual(token, "bearer-x")
+    }
+}

--- a/macos/Tests/NetTests/VPSResolverTests.swift
+++ b/macos/Tests/NetTests/VPSResolverTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import MatrixNet
+
+final class VPSResolverTests: XCTestCase {
+    func testGatewayURLDefaultsToHostHTTPS() throws {
+        let url = try VPSResolver.gatewayBaseURL(gatewayHost: "app.matrix-os.com", runtimeSlot: nil)
+        XCTAssertEqual(url.absoluteString, "https://app.matrix-os.com")
+    }
+
+    func testGatewayURLAddsRuntimeQueryWhenSlotProvided() throws {
+        let url = try VPSResolver.gatewayBaseURL(gatewayHost: "app.matrix-os.com", runtimeSlot: "staging")
+        XCTAssertEqual(url.absoluteString, "https://app.matrix-os.com?runtime=staging")
+    }
+
+    func testPrimarySlotStillOmitsQueryWhenNil() throws {
+        let url = try VPSResolver.gatewayBaseURL(gatewayHost: "app.localhost", runtimeSlot: nil)
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertNil(url.query)
+    }
+
+    func testEmptyHostThrows() {
+        XCTAssertThrowsError(try VPSResolver.gatewayBaseURL(gatewayHost: "", runtimeSlot: nil)) { error in
+            XCTAssertEqual(error as? GatewayError, .misconfigured)
+        }
+    }
+
+    func testWebSocketURLBuildsWSSWithSessionAndSeq() throws {
+        let url = try VPSResolver.webSocketURL(
+            gatewayHost: "app.matrix-os.com",
+            runtimeSlot: nil,
+            path: "/ws/terminal/session",
+            session: "card-42",
+            fromSeq: 100
+        )
+        let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        XCTAssertEqual(comps.scheme, "wss")
+        XCTAssertEqual(comps.host, "app.matrix-os.com")
+        XCTAssertEqual(comps.path, "/ws/terminal/session")
+        let items = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(items["session"], "card-42")
+        XCTAssertEqual(items["fromSeq"], "100")
+    }
+
+    func testWebSocketURLOmitsSeqWhenNil() throws {
+        let url = try VPSResolver.webSocketURL(
+            gatewayHost: "app.matrix-os.com",
+            runtimeSlot: nil,
+            path: "/ws/terminal/session",
+            session: "card-42",
+            fromSeq: nil
+        )
+        let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let names = (comps.queryItems ?? []).map(\.name)
+        XCTAssertFalse(names.contains("fromSeq"))
+        XCTAssertTrue(names.contains("session"))
+    }
+
+    func testWebSocketURLIncludesRuntimeSlot() throws {
+        let url = try VPSResolver.webSocketURL(
+            gatewayHost: "app.matrix-os.com",
+            runtimeSlot: "staging",
+            path: "/ws/terminal/session",
+            session: "s",
+            fromSeq: nil
+        )
+        let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let items = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(items["runtime"], "staging")
+    }
+
+    func testConnectionProfileResolvesGatewayURL() throws {
+        let profile = ConnectionProfile(handle: "hamed", gatewayHost: "app.matrix-os.com", runtimeSlot: "staging")
+        let url = try profile.gatewayBaseURL()
+        XCTAssertEqual(url.absoluteString, "https://app.matrix-os.com?runtime=staging")
+    }
+}

--- a/macos/Tests/NetTests/_Placeholder.swift
+++ b/macos/Tests/NetTests/_Placeholder.swift
@@ -1,7 +1,0 @@
-import XCTest
-@testable import MatrixNet
-
-// Placeholder so the MatrixNet test target builds before Phase 2 tests land (T020/T022/T024).
-final class NetModulePlaceholderTests: XCTestCase {
-    func testModuleLoads() { XCTAssertTrue(true) }
-}

--- a/macos/Tests/TerminalTests/MockShellTransport.swift
+++ b/macos/Tests/TerminalTests/MockShellTransport.swift
@@ -1,0 +1,102 @@
+import Foundation
+@testable import MatrixTerminal
+
+// Deterministic in-memory transport + clock so ShellWSClient state-machine tests
+// run with no real socket or wall-clock sleeps. All waiting is signal-based
+// (no polling) so there are no missed-wakeup races against the actor run loop.
+
+actor MockShellTransport: ShellTransport {
+    private(set) var connectCount = 0
+    private(set) var lastConnectRequest: URLRequest?
+    private var continuation: AsyncThrowingStream<String, Error>.Continuation?
+    private var connectWaiters: [(target: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    func open(_ request: URLRequest) -> AsyncThrowingStream<String, Error> {
+        connectCount += 1
+        lastConnectRequest = request
+        resolveConnectWaiters()
+        return AsyncThrowingStream { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func send(_ text: String) async throws {
+        // No-op for state-machine tests; client→server payloads are asserted via codec tests.
+    }
+
+    func close() {
+        continuation?.finish()
+        continuation = nil
+    }
+
+    // MARK: test drivers
+
+    func emit(_ json: String) {
+        continuation?.yield(json)
+    }
+
+    func failCurrent() {
+        continuation?.finish(throwing: ShellTransportError.disconnected)
+        continuation = nil
+    }
+
+    /// Suspends until at least `count` connections have been opened.
+    func waitForConnect(count: Int) async {
+        if connectCount >= count { return }
+        await withCheckedContinuation { continuation in
+            connectWaiters.append((count, continuation))
+        }
+    }
+
+    private func resolveConnectWaiters() {
+        let ready = connectWaiters.filter { connectCount >= $0.target }
+        connectWaiters.removeAll { connectCount >= $0.target }
+        for waiter in ready { waiter.continuation.resume() }
+    }
+}
+
+enum ShellTransportError: Error {
+    case disconnected
+}
+
+/// A clock whose sleeps complete only when the test advances them. Uses a latch
+/// so an `advanceAll()` that arrives before the run loop parks is not lost — the
+/// next `sleep` returns immediately. Also exposes `waitForSleeper()` so tests can
+/// await the run loop reaching its backoff park deterministically.
+actor MockClock: ShellClock {
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var pendingAdvances = 0
+    private var sleeperWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func sleep(seconds: Double) async {
+        if pendingAdvances > 0 {
+            pendingAdvances -= 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+            let parked = sleeperWaiters
+            sleeperWaiters.removeAll()
+            for waiter in parked { waiter.resume() }
+        }
+    }
+
+    /// Releases all parked sleepers; if none are parked, latches one advance for the next sleep.
+    func advanceAll() {
+        if waiters.isEmpty {
+            pendingAdvances += 1
+            return
+        }
+        let parked = waiters
+        waiters.removeAll()
+        for waiter in parked { waiter.resume() }
+    }
+
+    /// Suspends until the run loop is parked in `sleep` (a backoff wait).
+    func waitForSleeper() async {
+        if !waiters.isEmpty { return }
+        await withCheckedContinuation { continuation in
+            sleeperWaiters.append(continuation)
+        }
+    }
+}

--- a/macos/Tests/TerminalTests/ShellWSClientTests.swift
+++ b/macos/Tests/TerminalTests/ShellWSClientTests.swift
@@ -1,0 +1,286 @@
+import XCTest
+@testable import MatrixTerminal
+
+// T024 — failing-first state-machine + codec tests for ShellWSClient.
+// No real socket/network: a MockShellTransport + manual clock drive the actor
+// deterministically. Wire shapes mirror packages/gateway/src/shell/ws.ts.
+
+final class ShellMessageCodecTests: XCTestCase {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    // MARK: ClientMessage encoding
+
+    func testClientInputEncodesWireShape() throws {
+        let data = try encoder.encode(ClientMessage.input(data: "ls -la\n"))
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["type"] as? String, "input")
+        XCTAssertEqual(obj?["data"] as? String, "ls -la\n")
+        XCTAssertEqual(obj?.count, 2)
+    }
+
+    func testClientResizeEncodesWireShape() throws {
+        let data = try encoder.encode(ClientMessage.resize(cols: 120, rows: 40))
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["type"] as? String, "resize")
+        XCTAssertEqual(obj?["cols"] as? Int, 120)
+        XCTAssertEqual(obj?["rows"] as? Int, 40)
+    }
+
+    func testClientDetachEncodesWireShape() throws {
+        let data = try encoder.encode(ClientMessage.detach)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["type"] as? String, "detach")
+        XCTAssertEqual(obj?.count, 1)
+    }
+
+    func testClientPingEncodesWireShape() throws {
+        let data = try encoder.encode(ClientMessage.ping)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["type"] as? String, "ping")
+        XCTAssertEqual(obj?.count, 1)
+    }
+
+    func testClientMessageRoundTrips() throws {
+        let cases: [ClientMessage] = [
+            .input(data: "x"),
+            .resize(cols: 80, rows: 24),
+            .detach,
+            .ping,
+        ]
+        for message in cases {
+            let encoded = try encoder.encode(message)
+            let decoded = try decoder.decode(ClientMessage.self, from: encoded)
+            XCTAssertEqual(decoded, message)
+        }
+    }
+
+    // MARK: ServerMessage decoding
+
+    func testServerAttachedDecodes() throws {
+        let json = #"{"type":"attached","session":"main","state":"running","fromSeq":12}"#
+        let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
+        guard case let .attached(session, state, fromSeq) = message else {
+            return XCTFail("expected attached, got \(message)")
+        }
+        XCTAssertEqual(session, "main")
+        XCTAssertEqual(state, "running")
+        XCTAssertEqual(fromSeq, 12)
+    }
+
+    func testServerOutputDecodes() throws {
+        let json = #"{"type":"output","seq":7,"data":"hello"}"#
+        let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
+        guard case let .output(seq, data) = message else {
+            return XCTFail("expected output, got \(message)")
+        }
+        XCTAssertEqual(seq, 7)
+        XCTAssertEqual(data, "hello")
+    }
+
+    func testServerExitDecodes() throws {
+        let json = #"{"type":"exit","code":0}"#
+        let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
+        guard case let .exit(code) = message else {
+            return XCTFail("expected exit, got \(message)")
+        }
+        XCTAssertEqual(code, 0)
+    }
+
+    func testServerErrorDecodes() throws {
+        let json = #"{"type":"error","code":"session_not_found","message":"Session not found"}"#
+        let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
+        guard case let .error(code, text) = message else {
+            return XCTFail("expected error, got \(message)")
+        }
+        XCTAssertEqual(code, "session_not_found")
+        XCTAssertEqual(text, "Session not found")
+    }
+
+    func testServerPongDecodes() throws {
+        let json = #"{"type":"pong"}"#
+        let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
+        guard case .pong = message else {
+            return XCTFail("expected pong, got \(message)")
+        }
+    }
+
+    func testServerReplayEvictedDecodes() throws {
+        let json = #"{"type":"replay-evicted","fromSeq":3,"nextSeq":50}"#
+        let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
+        guard case let .replayEvicted(fromSeq, nextSeq) = message else {
+            return XCTFail("expected replayEvicted, got \(message)")
+        }
+        XCTAssertEqual(fromSeq, 3)
+        XCTAssertEqual(nextSeq, 50)
+    }
+
+    func testUnknownServerTypeThrows() {
+        let json = #"{"type":"nope"}"#
+        XCTAssertThrowsError(try decoder.decode(ServerMessage.self, from: Data(json.utf8)))
+    }
+}
+
+final class ShellWSClientStateMachineTests: XCTestCase {
+    func testLiveTailSentinelIsMaxSafeInteger() {
+        // Mirrors packages/sync-client/src/protocol/shell.js (Number.MAX_SAFE_INTEGER).
+        XCTAssertEqual(SHELL_ATTACH_LIVE_TAIL_FROM_SEQ, 9_007_199_254_740_991)
+        XCTAssertEqual(SHELL_ATTACH_RECENT_REPLAY_EVENTS, 50)
+    }
+
+    func testFirstConnectAttachesAtLiveTail() async throws {
+        let transport = MockShellTransport()
+        let client = ShellWSClient(
+            url: URL(string: "wss://vps.example/ws/terminal/session")!,
+            token: "secret-token",
+            session: "main",
+            transport: transport,
+            backoff: .test,
+            clock: MockClock()
+        )
+        await client.connect()
+        await transport.waitForConnect(count: 1)
+        let first = await transport.lastConnectRequest
+        // Auth must be a header, never a query token (FR-015a / S1).
+        XCTAssertEqual(first?.value(forHTTPHeaderField: "Authorization"), "Bearer secret-token")
+        let query = first?.url?.query ?? ""
+        XCTAssertFalse(query.contains("token="), "token must not be in query: \(query)")
+        XCTAssertTrue(query.contains("session=main"))
+        XCTAssertTrue(query.contains("fromSeq=\(SHELL_ATTACH_LIVE_TAIL_FROM_SEQ)"))
+        await client.shutdown()
+    }
+
+    func testLastSeqAdvancesOnOutput() async throws {
+        let transport = MockShellTransport()
+        let client = makeClient(transport: transport)
+        await client.connect()
+        await transport.waitForConnect(count: 1)
+        await transport.emit(#"{"type":"attached","session":"main","state":"running","fromSeq":0}"#)
+        await transport.emit(#"{"type":"output","seq":1,"data":"a"}"#)
+        await transport.emit(#"{"type":"output","seq":2,"data":"b"}"#)
+        // drain the three events (attached + 2 output)
+        var seen: [ServerEvent] = []
+        let stream = await client.events
+        for await event in stream {
+            seen.append(event)
+            if seen.count == 3 { break }
+        }
+        let lastSeq = await client.lastSeq
+        XCTAssertEqual(lastSeq, 2)
+        await client.shutdown()
+    }
+
+    func testReconnectResumesFromLastSeqPlusOne() async throws {
+        let transport = MockShellTransport()
+        let clock = MockClock()
+        let client = makeClient(transport: transport, clock: clock)
+        await client.connect()
+        await transport.waitForConnect(count: 1)
+        await transport.emit(#"{"type":"output","seq":5,"data":"x"}"#)
+        _ = await drain(client, count: 1)
+        // simulate server-side disconnect → run loop parks in backoff sleep
+        await transport.failCurrent()
+        await clock.waitForSleeper()
+        await clock.advanceAll()
+        await transport.waitForConnect(count: 2)
+        let reconnect = await transport.lastConnectRequest
+        let query = reconnect?.url?.query ?? ""
+        XCTAssertTrue(query.contains("fromSeq=6"), "expected resume fromSeq=6, got \(query)")
+        await client.shutdown()
+    }
+
+    func testReplayEvictedResetsToLiveTail() async throws {
+        let transport = MockShellTransport()
+        let clock = MockClock()
+        let client = makeClient(transport: transport, clock: clock)
+        await client.connect()
+        await transport.waitForConnect(count: 1)
+        await transport.emit(#"{"type":"output","seq":9,"data":"y"}"#)
+        _ = await drain(client, count: 1)
+        let seqAfterOutput = await client.lastSeq
+        XCTAssertEqual(seqAfterOutput, 9)
+
+        // replay-evicted: client clears buffer + seq, drops the socket, re-attaches at live tail.
+        await transport.emit(#"{"type":"replay-evicted","fromSeq":6,"nextSeq":40}"#)
+        _ = await drain(client, count: 1) // the .replayEvicted event
+        await clock.waitForSleeper()
+        await clock.advanceAll()
+        await transport.waitForConnect(count: 2)
+
+        let lastSeq = await client.lastSeq
+        XCTAssertEqual(lastSeq, 0, "buffer/seq must reset after replay-evicted")
+        let reattach = await transport.lastConnectRequest
+        let query = reattach?.url?.query ?? ""
+        XCTAssertTrue(query.contains("fromSeq=\(SHELL_ATTACH_LIVE_TAIL_FROM_SEQ)"), "got \(query)")
+        await client.shutdown()
+    }
+
+    func testBackoffIsBoundedAndCapped() {
+        let policy = BackoffPolicy(base: 0.5, factor: 2, cap: 8, jitter: 0)
+        let delays = (0..<8).map { policy.delay(forAttempt: $0) }
+        // 0.5, 1, 2, 4, 8, 8, 8, 8 — never exceeds cap.
+        XCTAssertEqual(delays[0], 0.5, accuracy: 0.0001)
+        XCTAssertEqual(delays[1], 1.0, accuracy: 0.0001)
+        XCTAssertEqual(delays[2], 2.0, accuracy: 0.0001)
+        XCTAssertEqual(delays[3], 4.0, accuracy: 0.0001)
+        XCTAssertEqual(delays[4], 8.0, accuracy: 0.0001)
+        for delay in delays {
+            XCTAssertLessThanOrEqual(delay, policy.cap)
+            XCTAssertGreaterThanOrEqual(delay, 0)
+        }
+    }
+
+    func testBackoffJitterStaysWithinBounds() {
+        let policy = BackoffPolicy(base: 1, factor: 2, cap: 30, jitter: 0.5)
+        for attempt in 0..<10 {
+            let delay = policy.delay(forAttempt: attempt)
+            XCTAssertGreaterThanOrEqual(delay, 0)
+            XCTAssertLessThanOrEqual(delay, policy.cap)
+        }
+    }
+
+    // MARK: Ring buffer
+
+    func testRingBufferEvictsAtCap() {
+        var ring = ScrollbackRing(capacity: 3)
+        ring.append(seq: 1, data: "a")
+        ring.append(seq: 2, data: "b")
+        ring.append(seq: 3, data: "c")
+        ring.append(seq: 4, data: "d")
+        XCTAssertEqual(ring.count, 3)
+        XCTAssertEqual(ring.oldestSeq, 2)
+        XCTAssertEqual(ring.newestSeq, 4)
+    }
+
+    func testRingBufferClearResets() {
+        var ring = ScrollbackRing(capacity: 4)
+        ring.append(seq: 1, data: "a")
+        ring.append(seq: 2, data: "b")
+        ring.clear()
+        XCTAssertEqual(ring.count, 0)
+        XCTAssertNil(ring.newestSeq)
+    }
+
+    // MARK: helpers
+
+    private func makeClient(transport: MockShellTransport, clock: MockClock = MockClock()) -> ShellWSClient {
+        ShellWSClient(
+            url: URL(string: "wss://vps.example/ws/terminal/session")!,
+            token: "secret-token",
+            session: "main",
+            transport: transport,
+            backoff: .test,
+            clock: clock
+        )
+    }
+
+    private func drain(_ client: ShellWSClient, count: Int) async -> [ServerEvent] {
+        var seen: [ServerEvent] = []
+        let stream = await client.events
+        for await event in stream {
+            seen.append(event)
+            if seen.count == count { break }
+        }
+        return seen
+    }
+}

--- a/macos/Tests/TerminalTests/ShellWSClientTests.swift
+++ b/macos/Tests/TerminalTests/ShellWSClientTests.swift
@@ -189,6 +189,35 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         await client.shutdown()
     }
 
+    func testReconnectUsesFreshTokenFromProvider() async throws {
+        let transport = MockShellTransport()
+        let clock = MockClock()
+        let tokenSource = SequenceTokenSource(["initial-token", "refreshed-token"])
+        let client = ShellWSClient(
+            url: URL(string: "wss://vps.example/ws/terminal/session")!,
+            tokenProvider: {
+                await tokenSource.next()
+            },
+            session: "main",
+            transport: transport,
+            backoff: .test,
+            clock: clock
+        )
+        await client.connect()
+        await transport.waitForConnect(count: 1)
+        let first = await transport.lastConnectRequest
+        XCTAssertEqual(first?.value(forHTTPHeaderField: "Authorization"), "Bearer initial-token")
+
+        await transport.failCurrent()
+        await clock.waitForSleeper()
+        await clock.advanceAll()
+        await transport.waitForConnect(count: 2)
+
+        let reconnect = await transport.lastConnectRequest
+        XCTAssertEqual(reconnect?.value(forHTTPHeaderField: "Authorization"), "Bearer refreshed-token")
+        await client.shutdown()
+    }
+
     func testReplayEvictedResetsToLiveTail() async throws {
         let transport = MockShellTransport()
         let clock = MockClock()
@@ -282,5 +311,17 @@ final class ShellWSClientStateMachineTests: XCTestCase {
             if seen.count == count { break }
         }
         return seen
+    }
+}
+
+private actor SequenceTokenSource {
+    private var tokens: [String]
+
+    init(_ tokens: [String]) {
+        self.tokens = tokens
+    }
+
+    func next() -> String {
+        tokens.isEmpty ? "fallback-token" : tokens.removeFirst()
     }
 }


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 3/11.

## Summary

Adds native model, gateway HTTP, keychain/principal, VPS resolver, and terminal WebSocket client modules with focused Swift tests.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

No backend route, database, or auth behavior changes in this layer.