### PR TITLE
feat(086): add native board and terminal MVP

### DIFF
--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -127,7 +127,9 @@ public final class AppModel: ObservableObject {
             GatewayHTTPClient(baseURL: url, tokenProvider: provider)
         },
         makeLoader: @escaping @Sendable (GatewayHTTPClient) -> any BoardLoading = { client in
-            GatewayBoardLoader(client: client)
+            // Render the user's live zellij sessions as cards (their original intent;
+            // a fresh VPS has sessions but no tasks). Task-backed boards land in US2.
+            SessionsBoardLoader(client: client)
         },
         makeTerminal: @escaping @MainActor (URL, String, String, String) -> TerminalSession = { url, token, session, name in
             let client = ShellWSClient(
@@ -153,13 +155,20 @@ public final class AppModel: ObservableObject {
         self.deviceAuth = deviceAuth
         self.signInGatewayHost = signInGatewayHost
         self.openExternalURL = openExternalURL
-        // A placeholder loader so `board` is non-nil before a profile is selected.
-        // Replaced on `selectProfile`. The placeholder never fetches (no profile).
-        self.board = BoardStore(loader: UnconfiguredBoardLoader())
-        self.phase = profile == nil ? .needsProfile : .connecting
+        // If a profile is already known (persisted sign-in), wire the real board
+        // loader immediately so the first `refresh()` fetches. Otherwise a
+        // placeholder keeps `board` non-nil until `selectProfile`.
+        if let profile, let baseURL = try? profile.gatewayBaseURL() {
+            self.board = BoardStore(loader: makeLoader(makeClient(baseURL, principal)))
+            self.phase = .connecting
+        } else {
+            self.board = BoardStore(loader: UnconfiguredBoardLoader())
+            self.phase = .needsProfile
+        }
     }
 
     /// Convenience production initializer: Keychain principal, default app domain.
+    /// Falls back to a persisted profile so a signed-in user stays signed in.
     public static func live(
         projectSlug: String,
         profile: ConnectionProfile? = nil
@@ -167,8 +176,30 @@ public final class AppModel: ObservableObject {
         AppModel(
             principal: PrincipalProvider(store: KeychainStore()),
             projectSlug: projectSlug,
-            profile: profile
+            profile: profile ?? loadPersistedProfile()
         )
+    }
+
+    // MARK: - Profile persistence (handle/host/slot only — token stays in Keychain)
+
+    private static let handleKey = "matrix.profile.handle"
+    private static let hostKey = "matrix.profile.host"
+    private static let slotKey = "matrix.profile.slot"
+
+    /// Loads a previously signed-in profile (non-secret) from UserDefaults.
+    public static func loadPersistedProfile() -> ConnectionProfile? {
+        let d = UserDefaults.standard
+        guard let handle = d.string(forKey: handleKey), !handle.isEmpty else { return nil }
+        let host = d.string(forKey: hostKey) ?? "app.matrix-os.com"
+        let slot = d.string(forKey: slotKey)
+        return ConnectionProfile(handle: handle, gatewayHost: host, runtimeSlot: slot)
+    }
+
+    private func persistProfile(_ profile: ConnectionProfile) {
+        let d = UserDefaults.standard
+        d.set(profile.handle, forKey: Self.handleKey)
+        d.set(profile.gatewayHost, forKey: Self.hostKey)
+        d.set(profile.runtimeSlot, forKey: Self.slotKey)
     }
 
     // MARK: - Sign in (device authorization)
@@ -223,7 +254,9 @@ public final class AppModel: ObservableObject {
                     try await principal.setToken(token.accessToken)
                     signIn = .idle
                     let handle = (token.handle?.isEmpty == false ? token.handle : nil) ?? "me"
-                    selectProfile(ConnectionProfile(handle: handle, gatewayHost: signInGatewayHost, runtimeSlot: nil))
+                    let newProfile = ConnectionProfile(handle: handle, gatewayHost: signInGatewayHost, runtimeSlot: nil)
+                    persistProfile(newProfile)
+                    selectProfile(newProfile)
                     await refresh()
                     return
                 }
@@ -335,7 +368,7 @@ public final class AppModel: ObservableObject {
         let wsURL: URL
         do {
             wsURL = try profile.webSocketURL(
-                path: "/shell",
+                path: "/ws/terminal/session",
                 session: sessionId,
                 fromSeq: Int?.none
             )

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1,0 +1,290 @@
+// Matrix OS — top-level app coordinator (US1 / T033 + T035 + T037).
+//
+// `AppModel` is the @MainActor ObservableObject the SwiftUI scene binds to. It owns:
+//   * the selected `ConnectionProfile` (MatrixNet — carries gateway/WS URL resolution),
+//   * a `PrincipalProvider` (Keychain-backed bearer token, async),
+//   * a `GatewayHTTPClient` built from the resolved gateway base URL,
+//   * a `BoardStore` (read-only board snapshot for US1),
+//   * the active `projectSlug` and currently selected `Card`,
+//   * a top-level `AppPhase` driving which root view renders.
+//
+// Phase logic is kept free of SwiftUI so it stays unit-testable. Opening a card
+// builds a `ShellWSClient` for the card's `linkedSessionId` (header-auth bearer
+// token, never a query token) and wraps it in a `TerminalSession`. All surfaced
+// errors are GENERIC — raw gateway/provider/path text never reaches the UI (FR-023).
+import Foundation
+import MatrixBoard
+import MatrixModel
+import MatrixNet
+import MatrixTerminal
+
+/// Within the App module, `ConnectionProfile` means the MatrixNet one (carries
+/// gateway/WS URL resolution). MatrixModel also defines a Keychain-ref profile;
+/// this alias resolves the ambiguity at every call site.
+public typealias ConnectionProfile = MatrixNet.ConnectionProfile
+
+/// Top-level lifecycle of the app's root view. Drives onboarding vs board vs
+/// disconnected chrome (design.md §6.6). Pure value type — no SwiftUI dependency.
+public enum AppPhase: Equatable, Sendable {
+    /// No VPS/runtime selected yet → onboarding empty state ("No Matrix computer yet").
+    case needsProfile
+    /// A profile is selected and the first board load is in flight.
+    case connecting
+    /// Board loaded; the operator is working.
+    case ready
+    /// Lost the live connection; board goes read-only with a reconnecting bar.
+    case disconnected
+}
+
+/// Generic, user-safe reason a card couldn't be opened. No raw text (FR-023).
+public enum OpenCardError: Error, Equatable, Sendable {
+    /// The card has no linked session to attach to.
+    case noSession
+    /// The profile/runtime is missing or its URL could not be resolved.
+    case misconfigured
+    /// No principal token — the user must sign in again.
+    case unauthorized
+
+    public var message: String {
+        switch self {
+        case .noSession: return "This card has no live session to open."
+        case .misconfigured: return "No computer is connected. Select a runtime to continue."
+        case .unauthorized: return "Your session has expired. Please sign in again."
+        }
+    }
+}
+
+@MainActor
+public final class AppModel: ObservableObject {
+    // MARK: - Published state (SwiftUI binds to these)
+
+    /// The currently selected connection profile (nil → onboarding).
+    @Published public private(set) var profile: ConnectionProfile?
+    /// Top-level phase driving the root view.
+    @Published public private(set) var phase: AppPhase = .needsProfile
+    /// The board the operator is working in (read-only in US1).
+    @Published public private(set) var board: BoardStore
+    /// The currently selected/open card (detail pane + terminal).
+    @Published public private(set) var selectedCard: Card?
+    /// The live terminal session for the open card, if one is attached.
+    @Published public private(set) var terminal: TerminalSession?
+    /// Which pane the detail view is showing (US1 ships Terminal only).
+    @Published public var activePanel: Panel = .terminal
+    /// A generic, user-safe error to surface in chrome (nil when clear).
+    @Published public private(set) var openError: OpenCardError?
+
+    // MARK: - Dependencies
+
+    private let principal: PrincipalProvider
+    /// The project whose tasks the board renders.
+    public private(set) var projectSlug: String
+
+    /// Factory for the gateway client given a resolved base URL + token provider.
+    /// Injected so tests can stub it without real networking.
+    private let makeClient: @Sendable (URL, PrincipalProvider) -> GatewayHTTPClient
+
+    /// Factory for a board loader given a gateway client. Injected for tests.
+    private let makeLoader: @Sendable (GatewayHTTPClient) -> any BoardLoading
+
+    /// Factory for a terminal session given a resolved WS URL, token, and session id.
+    /// Injected so tests can supply a mock event source instead of a real socket.
+    private let makeTerminal: @MainActor (URL, String, String, String) -> TerminalSession
+
+    // MARK: - Init
+
+    /// Designated initializer. All collaborators are injectable for testability;
+    /// the production app calls `AppModel()` which supplies real factories.
+    public init(
+        principal: PrincipalProvider,
+        projectSlug: String,
+        profile: ConnectionProfile? = nil,
+        makeClient: @escaping @Sendable (URL, PrincipalProvider) -> GatewayHTTPClient = { url, provider in
+            GatewayHTTPClient(baseURL: url, tokenProvider: provider)
+        },
+        makeLoader: @escaping @Sendable (GatewayHTTPClient) -> any BoardLoading = { client in
+            GatewayBoardLoader(client: client)
+        },
+        makeTerminal: @escaping @MainActor (URL, String, String, String) -> TerminalSession = { url, token, session, name in
+            let client = ShellWSClient(
+                url: url,
+                token: token,
+                session: session,
+                transport: URLSessionShellTransport()
+            )
+            return TerminalSession(displayName: name, client: client)
+        }
+    ) {
+        self.principal = principal
+        self.projectSlug = projectSlug
+        self.profile = profile
+        self.makeClient = makeClient
+        self.makeLoader = makeLoader
+        self.makeTerminal = makeTerminal
+        // A placeholder loader so `board` is non-nil before a profile is selected.
+        // Replaced on `selectProfile`. The placeholder never fetches (no profile).
+        self.board = BoardStore(loader: UnconfiguredBoardLoader())
+        self.phase = profile == nil ? .needsProfile : .connecting
+    }
+
+    /// Convenience production initializer: Keychain principal, default app domain.
+    public static func live(
+        projectSlug: String,
+        profile: ConnectionProfile? = nil
+    ) -> AppModel {
+        AppModel(
+            principal: PrincipalProvider(store: KeychainStore()),
+            projectSlug: projectSlug,
+            profile: profile
+        )
+    }
+
+    // MARK: - Profile selection
+
+    /// Selects a connection profile, rebuilds the gateway client + board store,
+    /// and transitions to `.connecting`. The next `refresh()` loads the board.
+    public func selectProfile(_ profile: ConnectionProfile) {
+        self.profile = profile
+        self.phase = .connecting
+        self.openError = nil
+        do {
+            let baseURL = try profile.gatewayBaseURL()
+            let client = makeClient(baseURL, principal)
+            self.board = BoardStore(loader: makeLoader(client))
+        } catch {
+            // URL resolution failed → treat as misconfiguration, not "no data".
+            self.board = BoardStore(loader: UnconfiguredBoardLoader())
+            self.phase = .needsProfile
+        }
+    }
+
+    // MARK: - Board lifecycle
+
+    /// Loads the read-only board snapshot and reconciles the top-level phase.
+    /// `.connecting → .ready` on success; `.disconnected` on a transient/offline
+    /// failure (board stays read-only with last-known cards). Auth/config failures
+    /// route back to onboarding.
+    public func refresh() async {
+        guard profile != nil else {
+            phase = .needsProfile
+            return
+        }
+        if phase == .ready {
+            // Keep showing the board while refreshing; only drop to disconnected on failure.
+        } else {
+            phase = .connecting
+        }
+        await board.load(projectSlug: projectSlug)
+        switch board.state {
+        case .loaded:
+            phase = .ready
+        case let .failed(error):
+            phase = reconcilePhase(for: error)
+        case .idle, .loading:
+            phase = .connecting
+        }
+    }
+
+    /// Maps a board error to the appropriate top-level phase. Transient/offline
+    /// errors keep the read-only board (`.disconnected`); auth/config send the
+    /// user back to onboarding so they can reconnect.
+    private func reconcilePhase(for error: BoardError) -> AppPhase {
+        switch error {
+        case .offline, .timeout, .generic:
+            return .disconnected
+        case .unauthorized, .misconfigured:
+            return .needsProfile
+        }
+    }
+
+    /// Marks the live connection as dropped: board goes read-only (design.md §6.6).
+    /// Driven by an observed socket drop on the open terminal.
+    public func markReconnecting() {
+        if phase == .ready {
+            phase = .disconnected
+        }
+        terminal?.markReconnecting()
+    }
+
+    // MARK: - Card → terminal wiring (T035)
+
+    /// Opens a card: selects it and, if it has a linked session, builds a
+    /// `ShellWSClient` for that session over the profile's WS URL (header bearer
+    /// token) and wraps it in a `TerminalSession`. Returns the session, or throws
+    /// a GENERIC `OpenCardError` (no raw text).
+    @discardableResult
+    public func openCard(_ card: Card) async throws -> TerminalSession {
+        openError = nil
+        selectedCard = card
+        activePanel = .terminal
+
+        guard let profile else {
+            let err = OpenCardError.misconfigured
+            openError = err
+            throw err
+        }
+        guard let sessionId = card.linkedSessionId, !sessionId.isEmpty else {
+            let err = OpenCardError.noSession
+            openError = err
+            throw err
+        }
+        guard let token = await principal.token() else {
+            let err = OpenCardError.unauthorized
+            openError = err
+            throw err
+        }
+
+        let wsURL: URL
+        do {
+            wsURL = try profile.webSocketURL(
+                path: "/shell",
+                session: sessionId,
+                fromSeq: Int?.none
+            )
+        } catch {
+            let err = OpenCardError.misconfigured
+            openError = err
+            throw err
+        }
+
+        // Tear down any previously open session before swapping in the new one.
+        terminal?.shutdown()
+        let session = makeTerminal(wsURL, token, sessionId, displayName(for: card))
+        terminal = session
+        session.start()
+        return session
+    }
+
+    /// Closes the open card's terminal and detail pane (Esc / light-dismiss).
+    public func closeCard() {
+        terminal?.shutdown()
+        terminal = nil
+        selectedCard = nil
+        openError = nil
+    }
+
+    /// Switches the active detail panel (⌘1/2/3). US1 only renders Terminal.
+    public func switchPanel(_ panel: Panel) {
+        activePanel = panel
+    }
+
+    /// Placeholder ⌘N action — card creation lands in US2 (mutations).
+    public func newCardPlaceholder() {
+        // Intentionally a no-op in US1; wired in US2.
+    }
+
+    private func displayName(for card: Card) -> String {
+        if let session = card.linkedSessionId, !session.isEmpty {
+            return session
+        }
+        return card.title
+    }
+}
+
+/// A `BoardLoading` that never fetches — used before a profile is selected or when
+/// URL resolution fails. Always reports a generic misconfiguration so the UI shows
+/// "no computer connected" rather than implying the board is simply empty.
+private struct UnconfiguredBoardLoader: BoardLoading {
+    func fetchTasks(projectSlug: String) async throws -> [Card] {
+        throw GatewayError.misconfigured
+    }
+}

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -99,6 +99,8 @@ public final class AppModel: ObservableObject {
     private let openExternalURL: @Sendable (URL) -> Void
     /// Gateway host for the profile created after a successful sign-in.
     private let signInGatewayHost: String
+    /// Monotonic token used to ignore stale `openCard` calls that resume after a newer tap.
+    private var openCardGeneration = 0
     /// In-flight sign-in task, so a re-tap cancels the previous attempt.
     private var signInTask: Task<Void, Never>?
     /// The project whose tasks the board renders.
@@ -349,6 +351,8 @@ public final class AppModel: ObservableObject {
         openError = nil
         selectedCard = card
         activePanel = .terminal
+        openCardGeneration += 1
+        let generation = openCardGeneration
 
         guard let profile else {
             let err = OpenCardError.misconfigured
@@ -364,6 +368,9 @@ public final class AppModel: ObservableObject {
             let err = OpenCardError.unauthorized
             openError = err
             throw err
+        }
+        guard generation == openCardGeneration, selectedCard?.id == card.id else {
+            throw OpenCardError.noSession
         }
 
         let wsURL: URL

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -111,9 +111,9 @@ public final class AppModel: ObservableObject {
     /// Factory for a board loader given a gateway client. Injected for tests.
     private let makeLoader: @Sendable (GatewayHTTPClient) -> any BoardLoading
 
-    /// Factory for a terminal session given a resolved WS URL, token, and session id.
+    /// Factory for a terminal session given a resolved WS URL, principal provider, and session id.
     /// Injected so tests can supply a mock event source instead of a real socket.
-    private let makeTerminal: @MainActor (URL, String, String, String) -> TerminalSession
+    private let makeTerminal: @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession
 
     // MARK: - Init
 
@@ -131,10 +131,11 @@ public final class AppModel: ObservableObject {
             // a fresh VPS has sessions but no tasks). Task-backed boards land in US2.
             SessionsBoardLoader(client: client)
         },
-        makeTerminal: @escaping @MainActor (URL, String, String, String) -> TerminalSession = { url, token, session, name in
+        makeTerminal: @escaping @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession = { url, provider, session, name in
+            let tokenProvider = provider as any TokenProviding
             let client = ShellWSClient(
                 url: url,
-                token: token,
+                tokenProvider: { await tokenProvider.token() ?? "" },
                 session: session,
                 transport: URLSessionShellTransport()
             )
@@ -359,7 +360,7 @@ public final class AppModel: ObservableObject {
             openError = err
             throw err
         }
-        guard let token = await principal.token() else {
+        guard await principal.token() != nil else {
             let err = OpenCardError.unauthorized
             openError = err
             throw err
@@ -380,9 +381,8 @@ public final class AppModel: ObservableObject {
 
         // Tear down any previously open session before swapping in the new one.
         terminal?.shutdown()
-        let session = makeTerminal(wsURL, token, sessionId, displayName(for: card))
+        let session = makeTerminal(wsURL, principal, sessionId, displayName(for: card))
         terminal = session
-        session.start()
         return session
     }
 

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -17,6 +17,9 @@ import MatrixBoard
 import MatrixModel
 import MatrixNet
 import MatrixTerminal
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// Within the App module, `ConnectionProfile` means the MatrixNet one (carries
 /// gateway/WS URL resolution). MatrixModel also defines a Keychain-ref profile;
@@ -54,6 +57,18 @@ public enum OpenCardError: Error, Equatable, Sendable {
     }
 }
 
+/// Device-authorization sign-in progress (drives the onboarding UI).
+public enum SignInState: Equatable, Sendable {
+    /// Not signing in.
+    case idle
+    /// Requesting a device code from the platform.
+    case starting
+    /// Waiting for the user to approve in the browser. Shows the user code.
+    case awaitingApproval(userCode: String, verificationUri: String)
+    /// Sign-in failed; generic, user-safe message (no internal leakage).
+    case failed(String)
+}
+
 @MainActor
 public final class AppModel: ObservableObject {
     // MARK: - Published state (SwiftUI binds to these)
@@ -72,10 +87,20 @@ public final class AppModel: ObservableObject {
     @Published public var activePanel: Panel = .terminal
     /// A generic, user-safe error to surface in chrome (nil when clear).
     @Published public private(set) var openError: OpenCardError?
+    /// Device-auth sign-in progress (drives the onboarding sign-in UI).
+    @Published public private(set) var signIn: SignInState = .idle
 
     // MARK: - Dependencies
 
     private let principal: PrincipalProvider
+    /// Device-authorization client for in-app sign-in (same flow as the `matrix` CLI).
+    private let deviceAuth: any DeviceAuthorizing
+    /// Opens an external URL (browser) for device approval. Injected for tests.
+    private let openExternalURL: @Sendable (URL) -> Void
+    /// Gateway host for the profile created after a successful sign-in.
+    private let signInGatewayHost: String
+    /// In-flight sign-in task, so a re-tap cancels the previous attempt.
+    private var signInTask: Task<Void, Never>?
     /// The project whose tasks the board renders.
     public private(set) var projectSlug: String
 
@@ -112,7 +137,12 @@ public final class AppModel: ObservableObject {
                 transport: URLSessionShellTransport()
             )
             return TerminalSession(displayName: name, client: client)
-        }
+        },
+        deviceAuth: any DeviceAuthorizing = DeviceAuthClient(
+            platformURL: URL(string: "https://app.matrix-os.com")!
+        ),
+        signInGatewayHost: String = "app.matrix-os.com",
+        openExternalURL: @escaping @Sendable (URL) -> Void = AppModel.defaultOpenExternalURL
     ) {
         self.principal = principal
         self.projectSlug = projectSlug
@@ -120,6 +150,9 @@ public final class AppModel: ObservableObject {
         self.makeClient = makeClient
         self.makeLoader = makeLoader
         self.makeTerminal = makeTerminal
+        self.deviceAuth = deviceAuth
+        self.signInGatewayHost = signInGatewayHost
+        self.openExternalURL = openExternalURL
         // A placeholder loader so `board` is non-nil before a profile is selected.
         // Replaced on `selectProfile`. The placeholder never fetches (no profile).
         self.board = BoardStore(loader: UnconfiguredBoardLoader())
@@ -136,6 +169,72 @@ public final class AppModel: ObservableObject {
             projectSlug: projectSlug,
             profile: profile
         )
+    }
+
+    // MARK: - Sign in (device authorization)
+
+    /// Default browser opener used outside tests.
+    public static let defaultOpenExternalURL: @Sendable (URL) -> Void = { url in
+        #if canImport(AppKit)
+        NSWorkspace.shared.open(url)
+        #endif
+    }
+
+    /// Starts the device-authorization sign-in: requests a device code, opens the
+    /// verification page in the browser, and polls until approved. On success it
+    /// stores the principal token, builds a profile, and loads the board.
+    public func beginSignIn() {
+        signInTask?.cancel()
+        signIn = .starting
+        signInTask = Task { [weak self] in await self?.runSignIn() }
+    }
+
+    /// Cancels an in-flight sign-in and returns to the idle onboarding state.
+    public func cancelSignIn() {
+        signInTask?.cancel()
+        signInTask = nil
+        signIn = .idle
+    }
+
+    private func runSignIn() async {
+        do {
+            let start = try await deviceAuth.startDeviceAuth()
+            if Task.isCancelled { return }
+            signIn = .awaitingApproval(userCode: start.userCode, verificationUri: start.verificationUri)
+            if let url = URL(string: start.verificationUri) {
+                openExternalURL(url)
+            }
+
+            let deadline = Date().addingTimeInterval(TimeInterval(max(1, start.expiresIn)))
+            var interval = max(1, start.interval)
+            while Date() < deadline {
+                try await Task.sleep(nanoseconds: UInt64(interval) * 1_000_000_000)
+                if Task.isCancelled { return }
+                let result = try await deviceAuth.pollForToken(deviceCode: start.deviceCode)
+                switch result {
+                case .pending:
+                    continue
+                case .slowDown:
+                    interval += 5
+                case .expired:
+                    signIn = .failed("Sign-in expired. Try again.")
+                    return
+                case let .approved(token):
+                    try await principal.setToken(token.accessToken)
+                    signIn = .idle
+                    let handle = (token.handle?.isEmpty == false ? token.handle : nil) ?? "me"
+                    selectProfile(ConnectionProfile(handle: handle, gatewayHost: signInGatewayHost, runtimeSlot: nil))
+                    await refresh()
+                    return
+                }
+            }
+            signIn = .failed("Sign-in timed out. Try again.")
+        } catch is CancellationError {
+            // Cancelled by a re-tap or sign-out; leave state as set by the canceller.
+        } catch {
+            // Generic, user-safe — never surface raw gateway/provider text.
+            signIn = .failed("Sign-in failed. Check your connection and try again.")
+        }
     }
 
     // MARK: - Profile selection

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -1,0 +1,214 @@
+// Matrix OS — board surface + detail pane (US1 / T033).
+//
+// Renders the BoardStore's 5 OPERATOR lifecycle columns in a horizontal scroll.
+// Selecting a card opens a detail pane that shows the attached TerminalPanelView
+// (T035 wiring). Disconnected → an amber reconnecting bar over a read-only board.
+// All errors are generic (FR-023). Tokens only — no inline hex/sizes.
+#if os(macOS)
+import SwiftUI
+import DesignSystem
+import MatrixBoard
+import MatrixModel
+import MatrixTerminal
+
+struct BoardView: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        ZStack {
+            Color.canvasVoid.ignoresSafeArea()
+            content
+        }
+        .toolbar { toolbarContent }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .needsProfile:
+            NoProfileView(onCreate: openCreateFlow)
+        case .connecting:
+            BoardSkeletonView()
+        case .ready, .disconnected:
+            boardWithDetail
+        }
+    }
+
+    // MARK: - Board + detail split
+
+    private var boardWithDetail: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                if model.phase == .disconnected {
+                    ReconnectingBar(handle: model.profile?.handle ?? "your computer")
+                }
+                if let error = model.openError {
+                    GenericErrorBanner(message: error.message, onRetry: nil)
+                }
+                columns
+                    .opacity(model.phase == .disconnected ? 0.7 : 1)
+                    .saturation(model.phase == .disconnected ? 0.6 : 1)
+                    .allowsHitTesting(model.phase != .disconnected)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            if model.selectedCard != nil {
+                detailPane
+                    .frame(width: 520)
+                    .transition(.move(edge: .trailing))
+            }
+        }
+        .animation(Motion.panelSwitch, value: model.selectedCard?.id)
+    }
+
+    private var columns: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .top, spacing: 0) {
+                ForEach(model.board.columns) { column in
+                    ColumnView(
+                        column: column,
+                        selectedCardID: model.selectedCard?.id,
+                        onOpenCard: openCard
+                    )
+                    .frame(maxHeight: .infinity, alignment: .top)
+                }
+            }
+        }
+    }
+
+    // MARK: - Detail pane (panel switcher + terminal)
+
+    private var detailPane: some View {
+        VStack(spacing: 0) {
+            detailHeader
+            Divider().overlay(Color.hairlineDark)
+            panelBody
+        }
+        .background(Color.surfaceRail)
+        .overlay(alignment: .leading) {
+            Rectangle().fill(Color.hairlineDark).frame(width: 1)
+        }
+    }
+
+    private var detailHeader: some View {
+        HStack(spacing: Spacing.x3) {
+            Text(model.selectedCard?.title ?? "")
+                .font(.plexSans(14, weight: .medium))
+                .foregroundStyle(Color.inkPrimary)
+                .lineLimit(1)
+            Spacer()
+            PanelSwitcher(active: model.activePanel) { model.switchPanel($0) }
+            Button(action: model.closeCard) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color.inkTertiary)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, Spacing.x4)
+        .padding(.vertical, Spacing.x3)
+    }
+
+    @ViewBuilder
+    private var panelBody: some View {
+        switch model.activePanel {
+        case .terminal:
+            if let terminal = model.terminal {
+                TerminalPanelView(session: terminal)
+                    .padding(Spacing.x3)
+            } else {
+                placeholderPane("No live session for this card.")
+            }
+        case .shell:
+            placeholderPane("Shell view — coming soon.")
+        case .app:
+            placeholderPane("App view — coming soon.")
+        }
+    }
+
+    private func placeholderPane(_ text: String) -> some View {
+        VStack {
+            Spacer()
+            Text(text)
+                .font(.plexSans(13))
+                .foregroundStyle(Color.inkTertiary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.surfaceTerminal)
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .navigation) {
+            HStack(spacing: Spacing.x2) {
+                Circle().fill(Color.signalLive).frame(width: 7, height: 7)
+                Text("OPERATOR")
+                    .font(.plexMono(11, weight: .semibold))
+                    .tracking(1.2)
+                    .foregroundStyle(Color.inkSecondary)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func openCard(_ card: Card) {
+        Task { try? await model.openCard(card) }
+    }
+
+    private func openCreateFlow() {
+        // Hand off to the platform onboarding flow. In US1 this opens the web flow.
+        if let url = URL(string: "https://app.matrix-os.com/runtime") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+/// Segmented Terminal · Shell · App switcher (design.md §6.5). Active segment
+/// carries a thin signal underline + ink.primary; inactive is ink.tertiary.
+struct PanelSwitcher: View {
+    let active: Panel
+    let onSelect: (Panel) -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            segment("Terminal", panel: .terminal, isActive: active == .terminal)
+            segment("Shell", panel: .shell, isActive: active == .shell)
+            segment("App", panel: .app(slug: ""), isActive: isApp)
+        }
+        .padding(2)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .strokeBorder(Color.hairlineHighlight, lineWidth: 1)
+        )
+    }
+
+    private var isApp: Bool {
+        if case .app = active { return true }
+        return false
+    }
+
+    private func segment(_ label: String, panel: Panel, isActive: Bool) -> some View {
+        Button {
+            onSelect(panel)
+        } label: {
+            VStack(spacing: 2) {
+                Text(label)
+                    .font(.plexMono(10, weight: isActive ? .semibold : .regular))
+                    .foregroundStyle(isActive ? Color.inkPrimary : Color.inkTertiary)
+                Rectangle()
+                    .fill(isActive ? Color.signalLive : Color.clear)
+                    .frame(height: 1.5)
+            }
+            .padding(.horizontal, Spacing.x2)
+            .padding(.vertical, 3)
+        }
+        .buttonStyle(.plain)
+    }
+}
+#endif

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -13,6 +13,13 @@ import MatrixTerminal
 
 struct BoardView: View {
     @ObservedObject var model: AppModel
+    /// Board zoom (Conductor-style). ⌘+/⌘-/⌘0 and pinch.
+    @State private var zoom: CGFloat = 1
+    @GestureState private var pinch: CGFloat = 1
+
+    private static let minZoom: CGFloat = 0.5
+    private static let maxZoom: CGFloat = 1.6
+    private func clampZoom(_ z: CGFloat) -> CGFloat { min(max(z, Self.minZoom), Self.maxZoom) }
 
     var body: some View {
         ZStack {
@@ -67,18 +74,41 @@ struct BoardView: View {
     }
 
     private var columns: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(alignment: .top, spacing: 0) {
-                ForEach(model.board.columns) { column in
-                    ColumnView(
-                        column: column,
-                        selectedCardID: model.selectedCard?.id,
-                        onOpenCard: openCard
-                    )
-                    .frame(maxHeight: .infinity, alignment: .top)
-                }
+        // Five lifecycle lanes fill the available width evenly (no dead space).
+        // Pinch / ⌘+/⌘-/⌘0 scale the lanes (Conductor-style zoom).
+        let effectiveZoom = clampZoom(zoom * pinch)
+        return HStack(alignment: .top, spacing: 0) {
+            ForEach(model.board.columns) { column in
+                ColumnView(
+                    column: column,
+                    selectedCardID: model.selectedCard?.id,
+                    onOpenCard: openCard
+                )
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .scaleEffect(effectiveZoom, anchor: .topLeading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .gesture(
+            MagnificationGesture()
+                .updating($pinch) { value, state, _ in state = value }
+                .onEnded { value in zoom = clampZoom(zoom * value) }
+        )
+        .background(zoomShortcuts)
+    }
+
+    /// Hidden buttons providing ⌘+/⌘-/⌘0 zoom shortcuts.
+    private var zoomShortcuts: some View {
+        ZStack {
+            Button("") { zoom = clampZoom(zoom + 0.1) }
+                .keyboardShortcut("=", modifiers: .command)
+            Button("") { zoom = clampZoom(zoom - 0.1) }
+                .keyboardShortcut("-", modifiers: .command)
+            Button("") { zoom = 1 }
+                .keyboardShortcut("0", modifiers: .command)
+        }
+        .opacity(0)
+        .allowsHitTesting(false)
     }
 
     // MARK: - Detail pane (panel switcher + terminal)

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -26,7 +26,12 @@ struct BoardView: View {
     private var content: some View {
         switch model.phase {
         case .needsProfile:
-            NoProfileView(onCreate: openCreateFlow)
+            NoProfileView(
+                onCreate: openCreateFlow,
+                onSignIn: { model.beginSignIn() },
+                onCancelSignIn: { model.cancelSignIn() },
+                signIn: model.signIn
+            )
         case .connecting:
             BoardSkeletonView()
         case .ready, .disconnected:

--- a/macos/Sources/App/CardView.swift
+++ b/macos/Sources/App/CardView.swift
@@ -1,0 +1,163 @@
+// Matrix OS — board card (design.md §6.2).
+//
+// Layout: left signal edge bar (3pt, color = status; glows/breathes when live) ·
+// Plex Sans 14 title · mono meta row (session name, worktree/branch, relative time)
+// · status badge. Selected card carries a persistent ink hairline + faint signal
+// tint (spatial memory, §6.2). Hover raises to surface.cardRaised with no layout
+// shift. A value-type SwiftUI view — never rebuilds the whole list.
+#if os(macOS)
+import SwiftUI
+import DesignSystem
+import MatrixModel
+
+struct CardView: View {
+    let card: Card
+    let isSelected: Bool
+    let onOpen: () -> Void
+
+    @State private var isHovered = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Button(action: onOpen) {
+            HStack(spacing: 0) {
+                signalEdge
+                content
+            }
+            .background(surface, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
+            .overlay(border)
+            .overlay(alignment: .leading) { liveGlow }
+            .shadow(color: isHovered ? Color.black.opacity(0.35) : .clear, radius: isHovered ? 10 : 0, y: isHovered ? 2 : 0)
+            .clipShape(RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(reduceMotion ? nil : Motion.hover) { isHovered = hovering }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(card.title), \(card.status.rawValue)")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Signal edge
+
+    private var signalEdge: some View {
+        Rectangle()
+            .fill(edgeColor)
+            .frame(width: 3)
+            .opacity(card.isLive ? 1 : 0.7)
+    }
+
+    /// Left-edge phosphor bloom on live cards (signal.glow.live). Breathes on a
+    /// 2.4s loop; Reduce Motion shows a steady glow.
+    @ViewBuilder
+    private var liveGlow: some View {
+        if card.isLive {
+            LiveEdgeGlow(reduceMotion: reduceMotion)
+                .allowsHitTesting(false)
+        }
+    }
+
+    private var edgeColor: Color {
+        switch card.status {
+        case .todo: return .signalIdle
+        case .running: return .signalLive
+        case .waiting: return .signalWaiting
+        case .blocked: return .signalBlocked
+        case .complete: return .signalDone
+        case .archived: return .signalIdle
+        }
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: Spacing.x2) {
+            HStack(alignment: .top, spacing: Spacing.x2) {
+                Text(card.title)
+                    .font(.plexSans(14, weight: .medium))
+                    .tracking(-0.14)
+                    .foregroundStyle(Color.inkPrimary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                StatusBadge(status: card.status)
+            }
+            metaRow
+        }
+        .padding(.horizontal, Spacing.x3)
+        .padding(.vertical, Spacing.x3)
+    }
+
+    private var metaRow: some View {
+        HStack(spacing: Spacing.x2) {
+            if let session = card.linkedSessionId, !session.isEmpty {
+                metaItem(text: session)
+            }
+            if let worktree = card.linkedWorktreeId, !worktree.isEmpty {
+                metaItem(text: worktree, separator: true)
+            }
+            Spacer(minLength: Spacing.x1)
+            Text(RelativeTime.compact(card.updatedAt))
+                .font(.plexMono(11))
+                .tracking(0.22)
+                .foregroundStyle(Color.inkTertiary)
+        }
+    }
+
+    private func metaItem(text: String, separator: Bool = false) -> some View {
+        HStack(spacing: Spacing.x1) {
+            if separator {
+                Text("·")
+                    .font(.plexMono(11))
+                    .foregroundStyle(Color.inkDisabled)
+            }
+            Text(text)
+                .font(.plexMono(11))
+                .tracking(0.22)
+                .foregroundStyle(Color.inkSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    // MARK: - Surface / border
+
+    private var surface: Color {
+        isHovered ? .surfaceCardRaised : .surfaceCard
+    }
+
+    @ViewBuilder
+    private var border: some View {
+        if isSelected {
+            RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+                .strokeBorder(Color.inkPrimary.opacity(0.5), lineWidth: 1)
+                .background(
+                    RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+                        .fill(edgeColor.opacity(0.06))
+                )
+        } else {
+            RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+                .strokeBorder(Color.hairlineHighlight, lineWidth: 1)
+        }
+    }
+}
+
+/// Left-edge radial phosphor bloom that breathes (opacity 0.12↔0.26, 2.4s loop).
+private struct LiveEdgeGlow: View {
+    let reduceMotion: Bool
+    @State private var bright = false
+
+    var body: some View {
+        LinearGradient(
+            colors: [Color.signalLive.opacity(0.5), .clear],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        .frame(width: 36)
+        .blur(radius: 8)
+        .opacity(reduceMotion ? 0.20 : (bright ? 0.26 : 0.12))
+        .animation(reduceMotion ? nil : Motion.liveBreathe, value: bright)
+        .onAppear { if !reduceMotion { bright = true } }
+    }
+}
+#endif

--- a/macos/Sources/App/ColumnView.swift
+++ b/macos/Sources/App/ColumnView.swift
@@ -37,7 +37,7 @@ struct ColumnView: View {
                 .padding(.bottom, Spacing.x4)
             }
         }
-        .frame(width: 264)
+        .frame(minWidth: 240, maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color.surfaceRail)
         .overlay(alignment: .trailing) {
             // Subtle vertical hairline between columns.

--- a/macos/Sources/App/ColumnView.swift
+++ b/macos/Sources/App/ColumnView.swift
@@ -1,0 +1,114 @@
+// Matrix OS — board column / lifecycle lane (design.md §6.1).
+//
+// Sticky header: uppercase Plex Mono label + count chip + a live signal dot when
+// any card in the column is live. Body is a LazyVStack (view recycling for 200+
+// cards) over the column's cards. Empty columns show the ghosted insertion zone
+// (§6.6). Column background is surface.rail, a hair lighter than the void.
+#if os(macOS)
+import SwiftUI
+import DesignSystem
+import MatrixBoard
+import MatrixModel
+
+struct ColumnView: View {
+    let column: BoardColumn
+    let selectedCardID: Card.ID?
+    let onOpenCard: (Card) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(alignment: .leading, spacing: Spacing.x3) {
+                    if column.cards.isEmpty {
+                        EmptyColumnZone()
+                    } else {
+                        ForEach(column.cards) { card in
+                            CardView(
+                                card: card,
+                                isSelected: card.id == selectedCardID,
+                                onOpen: { onOpenCard(card) }
+                            )
+                        }
+                    }
+                }
+                .padding(.horizontal, Spacing.x2)
+                .padding(.top, Spacing.x2)
+                .padding(.bottom, Spacing.x4)
+            }
+        }
+        .frame(width: 264)
+        .background(Color.surfaceRail)
+        .overlay(alignment: .trailing) {
+            // Subtle vertical hairline between columns.
+            Rectangle().fill(Color.hairlineDark).frame(width: 1)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: Spacing.x2) {
+            Text(title)
+                .font(.plexMono(11, weight: .semibold))
+                .tracking(1.32)
+                .foregroundStyle(Color.inkSecondary)
+
+            if hasLive {
+                Circle()
+                    .fill(Color.signalLive)
+                    .frame(width: 6, height: 6)
+            }
+
+            Spacer(minLength: Spacing.x2)
+
+            Text("\(column.cards.count)")
+                .font(.plexMono(11, weight: .medium))
+                .foregroundStyle(Color.inkTertiary)
+                .padding(.horizontal, Spacing.x2)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: Radius.badge, style: .continuous)
+                        .fill(Color.surfaceCard)
+                )
+        }
+        .padding(.horizontal, Spacing.x3)
+        .padding(.vertical, Spacing.x3)
+        .background(Color.surfaceRail)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.hairlineDark).frame(height: 1)
+        }
+    }
+
+    private var hasLive: Bool {
+        column.cards.contains { $0.isLive }
+    }
+
+    private var title: String {
+        switch column.status {
+        case .todo: return "TODO"
+        case .running: return "RUNNING"
+        case .waiting: return "WAITING"
+        case .blocked: return "BLOCKED"
+        case .complete: return "COMPLETE"
+        case .archived: return "ARCHIVED"
+        }
+    }
+}
+
+/// Ghosted dashed insertion zone for an empty column (design.md §6.6).
+private struct EmptyColumnZone: View {
+    var body: some View {
+        RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+            .strokeBorder(
+                Color.inkDisabled,
+                style: StrokeStyle(lineWidth: 1, dash: [4, 4])
+            )
+            .frame(height: 72)
+            .overlay(
+                Text("Drop a task here or ⌘N")
+                    .font(.plexSans(13))
+                    .foregroundStyle(Color.inkTertiary)
+            )
+            .padding(.top, Spacing.x1)
+    }
+}
+#endif

--- a/macos/Sources/App/EmptyStates.swift
+++ b/macos/Sources/App/EmptyStates.swift
@@ -13,6 +13,9 @@ import DesignSystem
 /// platform flow (wired by the host scene).
 struct NoProfileView: View {
     let onCreate: () -> Void
+    var onSignIn: () -> Void = {}
+    var onCancelSignIn: () -> Void = {}
+    var signIn: SignInState = .idle
 
     var body: some View {
         ZStack {
@@ -23,26 +26,95 @@ struct NoProfileView: View {
                     .font(.plexSans(20, weight: .semibold))
                     .tracking(-0.4)
                     .foregroundStyle(Color.inkPrimary)
-                Text("Create your Matrix OS to see your sessions as a live board\nand work in a terminal — no local setup required.")
+                Text("Sign in to see your sessions as a live board and work in a\nterminal — or create your Matrix OS if you don't have one.")
                     .font(.plexSans(13))
                     .multilineTextAlignment(.center)
                     .foregroundStyle(Color.inkSecondary)
-                Button(action: onCreate) {
-                    Text("Create your Matrix OS")
-                        .font(.plexSans(13, weight: .semibold))
-                        .foregroundStyle(Color.canvasVoid)
-                        .padding(.horizontal, Spacing.x4)
-                        .padding(.vertical, Spacing.x2)
-                        .background(
-                            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                                .fill(Color.signalLive)
-                        )
+
+                switch signIn {
+                case .awaitingApproval(let code, let uri):
+                    approvalCard(code: code, uri: uri)
+                default:
+                    actions
                 }
-                .buttonStyle(.plain)
-                .padding(.top, Spacing.x2)
+
+                if case .failed(let message) = signIn {
+                    Text(message)
+                        .font(.plexMono(11))
+                        .foregroundStyle(Color.signalWaiting)
+                        .padding(.top, Spacing.x1)
+                }
             }
             .padding(Spacing.x7)
         }
+    }
+
+    private var actions: some View {
+        VStack(spacing: Spacing.x3) {
+            Button(action: onSignIn) {
+                HStack(spacing: Spacing.x2) {
+                    if case .starting = signIn { ProgressView().controlSize(.small) }
+                    Text(isStarting ? "Starting sign-in…" : "Sign in")
+                        .font(.plexSans(13, weight: .semibold))
+                        .foregroundStyle(Color.canvasVoid)
+                }
+                .padding(.horizontal, Spacing.x4)
+                .padding(.vertical, Spacing.x2)
+                .background(
+                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                        .fill(Color.signalLive)
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(isStarting)
+
+            Button(action: onCreate) {
+                Text("Create your Matrix OS")
+                    .font(.plexSans(12, weight: .medium))
+                    .foregroundStyle(Color.inkSecondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.top, Spacing.x2)
+    }
+
+    private var isStarting: Bool { if case .starting = signIn { return true }; return false }
+
+    /// Device-approval card: shows the user code + a hint that the browser is open.
+    private func approvalCard(code: String, uri: String) -> some View {
+        VStack(spacing: Spacing.x3) {
+            Text("Approve in your browser")
+                .font(.plexSans(13, weight: .semibold))
+                .foregroundStyle(Color.inkPrimary)
+            Text("Enter this code if prompted:")
+                .font(.plexSans(11))
+                .foregroundStyle(Color.inkSecondary)
+            Text(code)
+                .font(.plexMono(22, weight: .semibold))
+                .tracking(4)
+                .foregroundStyle(Color.signalLive)
+                .padding(.horizontal, Spacing.x4)
+                .padding(.vertical, Spacing.x2)
+                .background(
+                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                        .fill(Color.surfaceCard)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                                .strokeBorder(Color.hairlineHighlight, lineWidth: 1)
+                        )
+                )
+            HStack(spacing: Spacing.x2) {
+                ProgressView().controlSize(.small)
+                Text("Waiting for approval…")
+                    .font(.plexMono(11))
+                    .foregroundStyle(Color.inkSecondary)
+            }
+            Button("Cancel", action: onCancelSignIn)
+                .buttonStyle(.plain)
+                .font(.plexSans(11))
+                .foregroundStyle(Color.inkTertiary)
+        }
+        .padding(.top, Spacing.x2)
     }
 
     /// Engraved Matrix glyph: a recessed rounded square with a phosphor signal dot.

--- a/macos/Sources/App/EmptyStates.swift
+++ b/macos/Sources/App/EmptyStates.swift
@@ -1,0 +1,190 @@
+// Matrix OS — onboarding / loading / disconnected chrome (design.md §6.6).
+//
+// Onboarding-as-empty-state: calm, never an error. The "no VPS" state centers an
+// engraved Matrix glyph + headline + one line of copy + a primary CTA. The board
+// loading state is one orchestrated skeleton with a single sweeping shimmer (not
+// per-card spinners). The disconnected state is a top amber inset bar; the board
+// behind it goes read-only with a faint desaturation.
+#if os(macOS)
+import SwiftUI
+import DesignSystem
+
+/// "No Matrix computer yet" onboarding empty state. The CTA hands off to the
+/// platform flow (wired by the host scene).
+struct NoProfileView: View {
+    let onCreate: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.canvasVoid.ignoresSafeArea()
+            VStack(spacing: Spacing.x4) {
+                glyph
+                Text("No Matrix computer yet")
+                    .font(.plexSans(20, weight: .semibold))
+                    .tracking(-0.4)
+                    .foregroundStyle(Color.inkPrimary)
+                Text("Create your Matrix OS to see your sessions as a live board\nand work in a terminal — no local setup required.")
+                    .font(.plexSans(13))
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(Color.inkSecondary)
+                Button(action: onCreate) {
+                    Text("Create your Matrix OS")
+                        .font(.plexSans(13, weight: .semibold))
+                        .foregroundStyle(Color.canvasVoid)
+                        .padding(.horizontal, Spacing.x4)
+                        .padding(.vertical, Spacing.x2)
+                        .background(
+                            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                                .fill(Color.signalLive)
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(.top, Spacing.x2)
+            }
+            .padding(Spacing.x7)
+        }
+    }
+
+    /// Engraved Matrix glyph: a recessed rounded square with a phosphor signal dot.
+    private var glyph: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                .fill(Color.surfaceCard)
+                .frame(width: 72, height: 72)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                        .strokeBorder(Color.hairlineHighlight, lineWidth: 1)
+                )
+            Circle()
+                .fill(Color.signalLive)
+                .frame(width: 12, height: 12)
+                .shadow(color: Color.signalGlowLive, radius: 8)
+        }
+    }
+}
+
+/// Board loading skeleton: a few ghost cards under one orchestrated sweeping
+/// shimmer (design.md §6.6) — not per-card spinners. Reduce Motion → static cards.
+struct BoardSkeletonView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var sweep = false
+
+    private let columns = ["TODO", "RUNNING", "WAITING", "BLOCKED", "COMPLETE"]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .top, spacing: 0) {
+                ForEach(Array(columns.enumerated()), id: \.offset) { _, label in
+                    VStack(alignment: .leading, spacing: Spacing.x3) {
+                        Text(label)
+                            .font(.plexMono(11, weight: .semibold))
+                            .tracking(1.32)
+                            .foregroundStyle(Color.inkTertiary)
+                            .padding(.horizontal, Spacing.x3)
+                            .padding(.top, Spacing.x3)
+                        ForEach(0..<3, id: \.self) { _ in
+                            skeletonCard
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .frame(width: 264)
+                    .frame(maxHeight: .infinity, alignment: .top)
+                    .background(Color.surfaceRail)
+                    .overlay(alignment: .trailing) {
+                        Rectangle().fill(Color.hairlineDark).frame(width: 1)
+                    }
+                }
+            }
+        }
+        .background(Color.canvasVoid)
+        .overlay { shimmer.allowsHitTesting(false) }
+        .onAppear { if !reduceMotion { sweep = true } }
+    }
+
+    private var skeletonCard: some View {
+        RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+            .fill(Color.surfaceCard)
+            .frame(height: 64)
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+                    .strokeBorder(Color.hairlineHighlight, lineWidth: 1)
+            )
+            .padding(.horizontal, Spacing.x2)
+    }
+
+    @ViewBuilder
+    private var shimmer: some View {
+        if reduceMotion {
+            EmptyView()
+        } else {
+            GeometryReader { geo in
+                LinearGradient(
+                    colors: [.clear, Color.signalIdle.opacity(0.12), .clear],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: geo.size.width * 0.5)
+                .offset(x: sweep ? geo.size.width : -geo.size.width * 0.5)
+                .animation(
+                    .easeInOut(duration: 1.4).repeatForever(autoreverses: false),
+                    value: sweep
+                )
+            }
+        }
+    }
+}
+
+/// Top amber inset bar shown while the live connection is dropped (design.md §6.6).
+/// The board behind it stays visible but read-only (view-only, never persisted).
+struct ReconnectingBar: View {
+    let handle: String
+
+    var body: some View {
+        HStack(spacing: Spacing.x2) {
+            Circle().fill(Color.signalWaiting).frame(width: 6, height: 6)
+            Text("reconnecting to \(handle)…")
+                .font(.plexMono(11, weight: .medium))
+                .foregroundStyle(Color.signalWaiting)
+            Spacer()
+        }
+        .padding(.horizontal, Spacing.x4)
+        .padding(.vertical, Spacing.x2)
+        .background(.ultraThinMaterial)
+        .background(Color.signalWaiting.opacity(0.10))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.signalWaiting.opacity(0.30)).frame(height: 1)
+        }
+    }
+}
+
+/// Generic, user-safe error banner (FR-023). Never shows raw text.
+struct GenericErrorBanner: View {
+    let message: String
+    let onRetry: (() -> Void)?
+
+    var body: some View {
+        HStack(spacing: Spacing.x2) {
+            Circle().fill(Color.signalBlocked).frame(width: 6, height: 6)
+            Text(message)
+                .font(.plexMono(11, weight: .medium))
+                .foregroundStyle(Color.inkSecondary)
+                .lineLimit(2)
+            Spacer()
+            if let onRetry {
+                Button(action: onRetry) {
+                    Text("Retry")
+                        .font(.plexMono(11, weight: .semibold))
+                        .foregroundStyle(Color.inkPrimary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, Spacing.x4)
+        .padding(.vertical, Spacing.x2)
+        .background(.ultraThinMaterial)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.hairlineDark).frame(height: 1)
+        }
+    }
+}
+#endif

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -1,99 +1,99 @@
-// Matrix OS — native macOS app entrypoint (Phase 1 scaffold).
+// Matrix OS — native macOS app entrypoint (US1 / T033).
 //
-// Minimal SwiftUI `App` hosting a placeholder board-shell view. Real board/terminal/panel
-// implementation lands in later phases (see specs/086-macos-native-shell/tasks.md). This
-// file exists so the package builds headlessly via `swift build` and the OPERATOR design
-// tokens render in a window.
-
+// SwiftUI `App` hosting the real OPERATOR board. `AppModel` coordinates the
+// connection profile, principal token, gateway client, board store, and the
+// open-card → terminal wiring. The root view renders onboarding, the loading
+// skeleton, the live board, or the read-only disconnected board depending on
+// `AppModel.phase`. Window chrome is titlebar-transparent with a unified toolbar
+// so the machined void/grain shows through floating chrome (design.md §7).
+//
+// US1 boots into the onboarding empty state (no profile selected). Selecting a
+// runtime and signing in lands with US2/auth wiring; the device-auth client and
+// VPS resolver already exist in MatrixNet and are composed here when a profile
+// is supplied. Set MATRIX_DEV_GATEWAY_HOST + MATRIX_DEV_HANDLE in the environment
+// to auto-select a dev profile for local source dev.
 import SwiftUI
 import DesignSystem
+import MatrixNet
 
 @main
 struct MatrixOSApp: App {
+    @StateObject private var model: AppModel
+
+    init() {
+        let model = AppModel.live(
+            projectSlug: ProcessInfo.processInfo.environment["MATRIX_PROJECT_SLUG"] ?? "default",
+            profile: Self.devProfile()
+        )
+        _model = StateObject(wrappedValue: model)
+    }
+
     var body: some Scene {
         WindowGroup("Matrix OS") {
-            BoardShellScaffold()
-                .frame(minWidth: 960, minHeight: 600)
+            RootView(model: model)
+                .frame(minWidth: 1024, minHeight: 640)
+                .task { await model.refresh() }
         }
         .windowStyle(.titleBar)
+        .windowToolbarStyle(.unified(showsTitle: false))
+        .commands { OperatorCommands(model: model) }
+    }
+
+    /// Optional dev profile from environment for local source dev only. Production
+    /// boots into onboarding until the user selects a runtime + signs in.
+    private static func devProfile() -> ConnectionProfile? {
+        let env = ProcessInfo.processInfo.environment
+        let host = env["MATRIX_DEV_GATEWAY_HOST"] ?? "app.matrix-os.com"
+        guard let handle = env["MATRIX_DEV_HANDLE"], !handle.isEmpty else { return nil }
+        let slot = env["MATRIX_DEV_RUNTIME_SLOT"]
+        return ConnectionProfile(handle: handle, gatewayHost: host, runtimeSlot: slot)
     }
 }
 
-/// Placeholder board-shell: a row of lifecycle columns rendered with OPERATOR tokens so the
-/// design system is exercised end-to-end. Replaced by the real `BoardView` in Phase 3 (US1).
-struct BoardShellScaffold: View {
-    private let columns = ["TODO", "RUNNING", "WAITING", "BLOCKED", "COMPLETE"]
+/// Root view: binds the OPERATOR look to the window and renders the board.
+private struct RootView: View {
+    @ObservedObject var model: AppModel
 
     var body: some View {
-        ZStack {
-            Color.canvasVoid.ignoresSafeArea()
-
-            VStack(alignment: .leading, spacing: Spacing.x5) {
-                header
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(alignment: .top, spacing: Spacing.x4) {
-                        ForEach(columns, id: \.self) { column in
-                            ColumnScaffold(title: column)
-                        }
-                    }
-                    .padding(.horizontal, Spacing.x5)
-                }
-            }
-            .padding(.vertical, Spacing.x5)
-        }
-    }
-
-    private var header: some View {
-        HStack(spacing: Spacing.x3) {
-            Circle()
-                .fill(Color.signalLive)
-                .frame(width: 8, height: 8)
-            Text("MATRIX OS — OPERATOR")
-                .font(.plexMono(11, weight: .semibold))
-                .tracking(1.2)
-                .foregroundStyle(Color.inkSecondary)
-            Spacer()
-        }
-        .padding(.horizontal, Spacing.x5)
+        BoardView(model: model)
+            .background(WindowVibrancy())
+            .preferredColorScheme(.dark)
     }
 }
 
-/// A single empty lifecycle column rendered with OPERATOR surfaces, hairlines, and spacing.
-private struct ColumnScaffold: View {
-    let title: String
+/// Operator-grade keyboard model (design.md §7). US1 wires panel switching and
+/// dismiss; ⌘N is a placeholder until US2 mutations land.
+private struct OperatorCommands: Commands {
+    let model: AppModel
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.x3) {
-            Text(title)
-                .font(.plexMono(11, weight: .semibold))
-                .tracking(1.4)
-                .foregroundStyle(Color.inkTertiary)
-                .padding(.bottom, Spacing.x1)
-
-            EmptyColumnPlaceholder()
+    var body: some Commands {
+        CommandMenu("Operator") {
+            Button("New Card") { model.newCardPlaceholder() }
+                .keyboardShortcut("n", modifiers: .command)
+            Divider()
+            Button("Terminal Panel") { model.switchPanel(.terminal) }
+                .keyboardShortcut("1", modifiers: .command)
+            Button("Shell Panel") { model.switchPanel(.shell) }
+                .keyboardShortcut("2", modifiers: .command)
+            Button("App Panel") { model.switchPanel(.app(slug: "")) }
+                .keyboardShortcut("3", modifiers: .command)
+            Divider()
+            Button("Close Card") { model.closeCard() }
+                .keyboardShortcut(.escape, modifiers: [])
         }
-        .padding(Spacing.x3)
-        .frame(width: 240, alignment: .leading)
-        .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: Radius.card))
-        .overlay(
-            RoundedRectangle(cornerRadius: Radius.card)
-                .strokeBorder(Color.hairlineHighlight, lineWidth: 1)
-        )
     }
 }
 
-private struct EmptyColumnPlaceholder: View {
-    var body: some View {
-        RoundedRectangle(cornerRadius: Radius.control)
-            .strokeBorder(
-                Color.inkDisabled,
-                style: StrokeStyle(lineWidth: 1, dash: [4, 4])
-            )
-            .frame(height: 64)
-            .overlay(
-                Text("Drop a task here or ⌘N")
-                    .font(.plexSans(13))
-                    .foregroundStyle(Color.inkTertiary)
-            )
+/// True window vibrancy: the machined void/grain shows faintly through floating
+/// chrome (design.md §7). Honors Reduce Transparency automatically (NSVisualEffectView).
+private struct WindowVibrancy: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = .underWindowBackground
+        view.blendingMode = .behindWindow
+        view.state = .active
+        return view
     }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
 }

--- a/macos/Sources/App/RelativeTime.swift
+++ b/macos/Sources/App/RelativeTime.swift
@@ -1,0 +1,40 @@
+// Matrix OS — compact relative-time formatting for card meta rows.
+//
+// Cards carry an ISO-8601 `updatedAt` string. The meta row renders a compact
+// relative stamp ("3m", "2h", "5d") in mono ink.tertiary (design.md §6.2).
+import Foundation
+
+enum RelativeTime {
+    /// Parses an ISO-8601 timestamp (with or without fractional seconds).
+    ///
+    /// Formatters are created per call rather than cached in a static: under
+    /// strict Swift 6 concurrency `ISO8601DateFormatter` is non-Sendable, so a
+    /// shared static would be unsafe. Card-meta formatting is infrequent enough
+    /// that per-call construction is fine.
+    static func parse(_ string: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: string) { return date }
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: string)
+    }
+
+    /// Compact relative label for `updatedAt` vs `now`. Returns "—" when unparseable.
+    static func compact(_ updatedAt: String, now: Date = Date()) -> String {
+        guard let date = parse(updatedAt) else { return "—" }
+        let seconds = max(0, now.timeIntervalSince(date))
+        switch seconds {
+        case ..<60:
+            return "now"
+        case ..<3600:
+            return "\(Int(seconds / 60))m"
+        case ..<86_400:
+            return "\(Int(seconds / 3600))h"
+        case ..<604_800:
+            return "\(Int(seconds / 86_400))d"
+        default:
+            return "\(Int(seconds / 604_800))w"
+        }
+    }
+}

--- a/macos/Sources/App/StatusBadge.swift
+++ b/macos/Sources/App/StatusBadge.swift
@@ -1,0 +1,84 @@
+// Matrix OS — card status badge (design.md §6.3).
+//
+// Mono 10pt uppercase on a 10%-tint of its signal color with a solid signal dot.
+// The RUNNING dot breathes (signal.live); other states are static. Reduce Motion
+// collapses the breathe to a steady glow. State always pairs color with shape so
+// it never relies on color alone (accessibility, §8).
+#if os(macOS)
+import SwiftUI
+import DesignSystem
+import MatrixModel
+
+struct StatusBadge: View {
+    let status: TaskStatus
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        HStack(spacing: Spacing.x1) {
+            dot
+            Text(label)
+                .font(.plexMono(10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, Spacing.x2)
+        .padding(.vertical, 2)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.badge, style: .continuous)
+                .fill(color.opacity(0.12))
+        )
+        .accessibilityElement()
+        .accessibilityLabel(label)
+    }
+
+    @ViewBuilder
+    private var dot: some View {
+        if status == .running {
+            BreathingDot(color: color, reduceMotion: reduceMotion)
+        } else {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+        }
+    }
+
+    private var label: String {
+        switch status {
+        case .todo: return "IDLE"
+        case .running: return "RUNNING"
+        case .waiting: return "WAITING"
+        case .blocked: return "BLOCKED"
+        case .complete: return "COMPLETE"
+        case .archived: return "EXITED"
+        }
+    }
+
+    private var color: Color {
+        switch status {
+        case .todo: return .signalIdle
+        case .running: return .signalLive
+        case .waiting: return .signalWaiting
+        case .blocked: return .signalBlocked
+        case .complete: return .signalDone
+        case .archived: return .signalIdle
+        }
+    }
+}
+
+/// A signal dot that breathes (opacity 0.55↔1.0 over 2.4s). The board's heartbeat
+/// (design.md §6.3). Reduce Motion → steady full-opacity dot.
+struct BreathingDot: View {
+    let color: Color
+    let reduceMotion: Bool
+    @State private var breathing = false
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 6, height: 6)
+            .opacity(reduceMotion ? 1 : (breathing ? 1 : 0.55))
+            .animation(reduceMotion ? nil : Motion.liveBreathe, value: breathing)
+            .onAppear { if !reduceMotion { breathing = true } }
+    }
+}
+#endif

--- a/macos/Sources/Board/BoardLoading.swift
+++ b/macos/Sources/Board/BoardLoading.swift
@@ -1,0 +1,39 @@
+// MatrixBoard — board data source abstraction.
+//
+// `BoardLoading` decouples `BoardStore` from the concrete HTTP client so tests
+// can inject a mock. The production adapter `GatewayBoardLoader` GETs
+// `/api/projects/:slug/tasks` (contracts/gateway-endpoints.md), decodes the
+// `{ tasks, nextCursor }` envelope into `[GatewayTaskDTO]`, and maps to `[Card]`.
+import Foundation
+import MatrixModel
+import MatrixNet
+
+/// Loads the read-only board snapshot for a project. US1 is REST-only
+/// (research.md C2: poll `GET /api/projects/:slug/tasks`; no events WS yet).
+public protocol BoardLoading: Sendable {
+    func fetchTasks(projectSlug: String) async throws -> [Card]
+}
+
+/// Gateway list-tasks response envelope: `{ tasks, nextCursor }`. We only need
+/// the first page for the read-only board; pagination lands with mutations (US2).
+private struct TaskListEnvelope: Decodable {
+    let tasks: [GatewayTaskDTO]
+}
+
+/// Production `BoardLoading` backed by the shared `GatewayHTTPClient`.
+public struct GatewayBoardLoader: BoardLoading {
+    private let client: GatewayHTTPClient
+
+    public init(client: GatewayHTTPClient) {
+        self.client = client
+    }
+
+    public func fetchTasks(projectSlug: String) async throws -> [Card] {
+        // `projectSlug` is owner-controlled and constrained server-side; it is
+        // only ever a path segment of a fixed route here.
+        let envelope: TaskListEnvelope = try await client.get(
+            "/api/projects/\(projectSlug)/tasks"
+        )
+        return envelope.tasks.map { $0.toCard() }
+    }
+}

--- a/macos/Sources/Board/BoardStore.swift
+++ b/macos/Sources/Board/BoardStore.swift
@@ -1,0 +1,108 @@
+// MatrixBoard — read-only board state for US1 (T032).
+//
+// `BoardStore` is an @MainActor ObservableObject that SwiftUI binds to. It holds
+// the bounded board snapshot (`cards`), derives kanban `columns`, and exposes a
+// `load(projectSlug:)` that drives an idle → loading → loaded/failed lifecycle.
+// All errors collapse to a generic `BoardError`; raw server/provider/path text
+// never reaches the UI (FR-023, CLAUDE.md error policy).
+import Foundation
+import MatrixModel
+import MatrixNet
+
+/// A kanban column: a status and the cards in it (ordered by `Card.order`).
+public struct BoardColumn: Sendable, Equatable, Identifiable {
+    public let status: TaskStatus
+    public let cards: [Card]
+    public var id: TaskStatus { status }
+
+    public init(status: TaskStatus, cards: [Card]) {
+        self.status = status
+        self.cards = cards
+    }
+}
+
+/// Generic, user-safe board error. Carries no raw server/DB/provider/path text.
+public enum BoardError: Error, Equatable, Sendable {
+    case unauthorized
+    case offline
+    case timeout
+    case misconfigured
+    case generic
+
+    /// Safe copy for the UI.
+    public var message: String {
+        switch self {
+        case .unauthorized: return "Your session has expired. Please sign in again."
+        case .offline: return "Can't reach Matrix OS. Check your connection."
+        case .timeout: return "The board took too long to load. Please try again."
+        case .misconfigured: return "No computer is connected. Select a runtime to continue."
+        case .generic: return "Couldn't load the board. Please try again."
+        }
+    }
+
+    /// Map any thrown error to a generic case. Unknown errors collapse to
+    /// `.generic` so leaky messages can never surface.
+    static func from(_ error: Error) -> BoardError {
+        guard let gateway = error as? GatewayError else { return .generic }
+        switch gateway {
+        case .unauthorized: return .unauthorized
+        case .network: return .offline
+        case .timeout: return .timeout
+        case .misconfigured: return .misconfigured
+        case .notFound, .server, .decoding: return .generic
+        }
+    }
+}
+
+/// Lifecycle of a board load.
+public enum BoardLoadState: Equatable, Sendable {
+    case idle
+    case loading
+    case loaded
+    case failed(BoardError)
+}
+
+/// Columns the board renders, in canonical left-to-right order. `archived` is
+/// intentionally excluded — archived cards are hidden from the board.
+private let boardColumnOrder: [TaskStatus] = [.todo, .running, .waiting, .blocked, .complete]
+
+@MainActor
+public final class BoardStore: ObservableObject {
+    @Published public private(set) var cards: [Card] = []
+    @Published public private(set) var state: BoardLoadState = .idle
+
+    private let loader: any BoardLoading
+
+    public init(loader: any BoardLoading) {
+        self.loader = loader
+    }
+
+    /// Kanban columns grouped by status, each sorted by `Card.order` then `id`
+    /// for a stable tie-break. Archived cards are excluded.
+    public var columns: [BoardColumn] {
+        var byStatus: [TaskStatus: [Card]] = [:]
+        for card in cards where card.status != .archived {
+            byStatus[card.status, default: []].append(card)
+        }
+        return boardColumnOrder.map { status in
+            let sorted = (byStatus[status] ?? []).sorted {
+                $0.order != $1.order ? $0.order < $1.order : $0.id < $1.id
+            }
+            return BoardColumn(status: status, cards: sorted)
+        }
+    }
+
+    /// Fetch the read-only board snapshot for a project. Sets `state` to
+    /// `.loaded` on success or `.failed(.generic-ish)` on any error.
+    public func load(projectSlug: String) async {
+        state = .loading
+        do {
+            let fetched = try await loader.fetchTasks(projectSlug: projectSlug)
+            cards = fetched
+            state = .loaded
+        } catch {
+            // Never surface the raw error; collapse to a generic BoardError.
+            state = .failed(BoardError.from(error))
+        }
+    }
+}

--- a/macos/Sources/Board/GatewayTaskDTO.swift
+++ b/macos/Sources/Board/GatewayTaskDTO.swift
@@ -1,0 +1,50 @@
+// MatrixBoard — gateway task wire shape → Card mapping.
+//
+// The gateway `TaskRecord` (packages/gateway/src/task-manager.ts) does NOT carry
+// `tags` or `revision` until a server delta ships them (data-model.md "Server
+// delta"). `Card` requires `tags`, so decoding the raw gateway JSON directly
+// would fail. This DTO models the wire shape with `tags`/`revision` OPTIONAL and
+// maps to `Card` with `tags` defaulting to [] and `revision` to nil. When the
+// server delta lands, present values pass straight through.
+import Foundation
+import MatrixModel
+
+/// Decodable mirror of the gateway task JSON. Tolerates absent `tags`,
+/// `revision`, and `previewIds` (gateway omits the first two today).
+public struct GatewayTaskDTO: Decodable, Sendable {
+    public let id: String
+    public let projectSlug: String
+    public let title: String
+    public let description: String?
+    public let status: TaskStatus
+    public let priority: TaskPriority
+    public let order: Double
+    public let parentTaskId: String?
+    public let linkedSessionId: String?
+    public let linkedWorktreeId: String?
+    public let previewIds: [String]?
+    public let tags: [String]?
+    public let updatedAt: String
+    public let revision: Int?
+
+    /// Map the wire shape to the in-memory `Card`, supplying defaults for fields
+    /// the gateway omits today (`tags` → [], `revision` → nil).
+    public func toCard() -> Card {
+        Card(
+            id: id,
+            projectSlug: projectSlug,
+            title: title,
+            description: description,
+            status: status,
+            priority: priority,
+            order: order,
+            parentTaskId: parentTaskId,
+            linkedSessionId: linkedSessionId,
+            linkedWorktreeId: linkedWorktreeId,
+            previewIds: previewIds ?? [],
+            tags: tags ?? [],
+            updatedAt: updatedAt,
+            revision: revision
+        )
+    }
+}

--- a/macos/Sources/Board/SessionsBoardLoader.swift
+++ b/macos/Sources/Board/SessionsBoardLoader.swift
@@ -20,10 +20,10 @@ private struct SessionDTO: Decodable {
     let status: String
     let updatedAt: String?
 
-    func toCard(order: Double) -> Card {
+    func toCard(id: String, order: Double) -> Card {
         let active = status == "active"
         return Card(
-            id: name,
+            id: id,
             projectSlug: "",
             title: name,
             status: active ? .running : .complete,
@@ -47,8 +47,13 @@ public struct SessionsBoardLoader: BoardLoading {
 
     public func fetchTasks(projectSlug: String) async throws -> [Card] {
         let envelope: SessionListEnvelope = try await client.get("/api/sessions")
+        var seenIDs: [String: Int] = [:]
         return envelope.sessions.enumerated().map { index, session in
-            session.toCard(order: Double(index))
+            let baseID = "session:\(session.name)"
+            let count = seenIDs[baseID, default: 0]
+            seenIDs[baseID] = count + 1
+            let cardID = count == 0 ? baseID : "\(baseID):\(count + 1)"
+            return session.toCard(id: cardID, order: Double(index))
         }
     }
 }

--- a/macos/Sources/Board/SessionsBoardLoader.swift
+++ b/macos/Sources/Board/SessionsBoardLoader.swift
@@ -1,0 +1,54 @@
+// MatrixBoard — zellij sessions as board cards.
+//
+// The user's original intent ("use the zellij sessions we have for the kanban
+// tasks") + the common reality that a fresh VPS has live sessions but no tasks.
+// This loader GETs `/api/sessions` (contracts/gateway-endpoints.md) and renders
+// each live zellij session as a card whose `linkedSessionId` opens its terminal.
+// `projectSlug` is ignored — sessions are not project-scoped.
+import Foundation
+import MatrixModel
+import MatrixNet
+
+/// Gateway sessions list response: `{ sessions: [...] }`.
+private struct SessionListEnvelope: Decodable {
+    let sessions: [SessionDTO]
+}
+
+/// One zellij session as returned by `GET /api/sessions`.
+private struct SessionDTO: Decodable {
+    let name: String
+    let status: String
+    let updatedAt: String?
+
+    func toCard(order: Double) -> Card {
+        let active = status == "active"
+        return Card(
+            id: name,
+            projectSlug: "",
+            title: name,
+            status: active ? .running : .complete,
+            priority: .normal,
+            order: order,
+            linkedSessionId: name,
+            updatedAt: updatedAt ?? "",
+            revision: nil
+        )
+    }
+}
+
+/// A `BoardLoading` that renders live zellij sessions as cards. Active sessions
+/// land in RUNNING; exited ones in COMPLETE. Opening a card attaches its terminal.
+public struct SessionsBoardLoader: BoardLoading {
+    private let client: GatewayHTTPClient
+
+    public init(client: GatewayHTTPClient) {
+        self.client = client
+    }
+
+    public func fetchTasks(projectSlug: String) async throws -> [Card] {
+        let envelope: SessionListEnvelope = try await client.get("/api/sessions")
+        return envelope.sessions.enumerated().map { index, session in
+            session.toCard(order: Double(index))
+        }
+    }
+}

--- a/macos/Sources/Board/_Module.swift
+++ b/macos/Sources/Board/_Module.swift
@@ -1,3 +1,0 @@
-// MatrixBoard — board state (fetch tasks → cards grouped by column) over MatrixNet.
-// US1: read-only BoardStore (T032). US2: mutations + live events (T042/T044).
-import Foundation

--- a/macos/Sources/Net/DeviceAuthClient.swift
+++ b/macos/Sources/Net/DeviceAuthClient.swift
@@ -44,21 +44,27 @@ public struct DeviceAuthClient: DeviceAuthorizing {
     private let platformURL: URL
     private let session: URLSession
     private let timeout: TimeInterval
+    private let clientId: String
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
     public init(
         platformURL: URL,
+        clientId: String = "matrix-os-macos",
         sessionConfiguration: URLSessionConfiguration = .ephemeral,
         timeout: TimeInterval = 10
     ) {
         self.platformURL = platformURL
+        self.clientId = clientId
         self.session = URLSession(configuration: sessionConfiguration)
         self.timeout = timeout
     }
 
+    private struct CodeBody: Encodable { let clientId: String }
+
     public func startDeviceAuth() async throws -> DeviceAuthStart {
-        let (data, http) = try await post(path: "/api/auth/device/code", body: EmptyBody())
+        // RFC 8628 device-code request. The platform requires a clientId.
+        let (data, http) = try await post(path: "/api/auth/device/code", body: CodeBody(clientId: clientId))
         if let mapped = GatewayError.from(statusCode: http.statusCode) {
             throw mapped
         }

--- a/macos/Sources/Net/DeviceAuthClient.swift
+++ b/macos/Sources/Net/DeviceAuthClient.swift
@@ -22,7 +22,8 @@ public struct DeviceAuthStart: Codable, Equatable, Sendable {
 /// A successfully issued principal token + identity metadata.
 public struct DeviceAuthToken: Codable, Equatable, Sendable {
     public let accessToken: String
-    public let expiresAt: String?
+    /// Epoch milliseconds when the token expires (the platform sends a JSON number).
+    public let expiresAt: Double?
     public let userId: String?
     public let handle: String?
 }

--- a/macos/Sources/Terminal/ShellEventSource.swift
+++ b/macos/Sources/Terminal/ShellEventSource.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A minimal seam over the live shell connection so `TerminalSession` can be driven
+/// deterministically in tests without a real socket. The production `ShellWSClient`
+/// already exposes exactly this surface (an `events` `AsyncStream`, `connect`, input,
+/// resize, detach, shutdown), so it conforms via the extension below — no behavioral
+/// change to the client itself.
+///
+/// Tests inject a `MockShellEventSource` that yields `ServerEvent`s on demand.
+public protocol ShellEventSource: Sendable {
+    /// Stream of decoded server events for the terminal view-model to consume.
+    var events: AsyncStream<ServerEvent> { get async }
+
+    /// Starts the connect+reconnect run loop.
+    func connect() async
+
+    /// Sends a keystroke/byte payload to the PTY.
+    func sendInput(_ data: String) async
+
+    /// Records a resize; sent immediately if connected and once after each attach.
+    func resize(cols: Int, rows: Int) async
+
+    /// Detaches (leave session running) and stops reconnecting.
+    func detach() async
+
+    /// Stops the run loop and tears down the connection.
+    func shutdown() async
+}
+
+extension ShellWSClient: ShellEventSource {}

--- a/macos/Sources/Terminal/TerminalPanelView.swift
+++ b/macos/Sources/Terminal/TerminalPanelView.swift
@@ -1,0 +1,250 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+import SwiftTerm
+import DesignSystem
+
+// SwiftTerm also exports a `Color` type; disambiguate to SwiftUI's within this file.
+private typealias Color = SwiftUI.Color
+
+/// SwiftTerm-backed terminal panel (T034 / US1).
+///
+/// OPERATOR treatment (design.md §6.4):
+/// - `surface.terminal` background, `radius.panel`, engraved hairline.
+/// - IBM Plex Mono 12.5 / 1.45 line height, phosphor selection tint, block cursor.
+/// - Top strip: session name + status badge + "● LIVE" / "↓ N new" affordance.
+/// - Calm inline states: `reconnecting…` (amber), `session exited` (grey) — never raw errors.
+public struct TerminalPanelView: View {
+    @ObservedObject private var session: TerminalSession
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    public init(session: TerminalSession) {
+        self.session = session
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            topStrip
+            terminalSurface
+        }
+        .background(Color.surfaceTerminal)
+        .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                .strokeBorder(Color.hairlineDark, lineWidth: 1)
+        )
+    }
+
+    // MARK: - Top strip
+
+    private var topStrip: some View {
+        HStack(spacing: Spacing.x3) {
+            Text(session.displayName)
+                .font(.plexMono(12, weight: .medium))
+                .foregroundStyle(Color.inkPrimary)
+                .lineLimit(1)
+
+            statusBadge
+
+            Spacer(minLength: Spacing.x2)
+
+            liveAffordance
+        }
+        .padding(.horizontal, Spacing.x4)
+        .padding(.vertical, Spacing.x2)
+        .background(Color.surfaceRail)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.hairlineDark)
+                .frame(height: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var statusBadge: some View {
+        switch session.connectionState {
+        case .connecting:
+            badge(text: "connecting", color: .inkSecondary)
+        case .attached:
+            badge(text: "attached", color: .signalLive)
+        case .reconnecting:
+            // Amber, animated ellipsis (calm, Reduce-Motion-aware).
+            badge(text: "reconnecting", color: .signalWaiting, animatedEllipsis: true)
+        case .exited:
+            badge(text: "session exited", color: .signalIdle)
+        case .error:
+            // Generic copy only — the internal code is never surfaced.
+            badge(text: "connection lost", color: .signalBlocked)
+        }
+    }
+
+    private func badge(
+        text: String,
+        color: Color,
+        animatedEllipsis: Bool = false
+    ) -> some View {
+        HStack(spacing: Spacing.x1) {
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+            Text(text)
+                .font(.plexMono(10, weight: .medium))
+                .foregroundStyle(color)
+            if animatedEllipsis {
+                AnimatedEllipsis(color: color, reduceMotion: reduceMotion)
+            }
+        }
+        .padding(.horizontal, Spacing.x2)
+        .padding(.vertical, Spacing.x1)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.badge, style: .continuous)
+                .fill(color.opacity(0.12))
+        )
+    }
+
+    @ViewBuilder
+    private var liveAffordance: some View {
+        if session.isPinnedToBottom {
+            HStack(spacing: Spacing.x1) {
+                Circle().fill(Color.signalLive).frame(width: 6, height: 6)
+                Text("LIVE")
+                    .font(.plexMono(10, weight: .semibold))
+                    .foregroundStyle(Color.signalLive)
+            }
+        } else {
+            Button {
+                session.setPinnedToBottom(true)
+            } label: {
+                Text("↓ \(session.unseenLines) new")
+                    .font(.plexMono(10, weight: .medium))
+                    .foregroundStyle(Color.inkSecondary)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Terminal surface
+
+    private var terminalSurface: some View {
+        SwiftTermView(session: session)
+            .background(Color.surfaceTerminal)
+    }
+}
+
+// MARK: - Animated ellipsis (Reduce-Motion aware)
+
+private struct AnimatedEllipsis: View {
+    let color: Color
+    let reduceMotion: Bool
+    @State private var phase = 0
+    @State private var ticker: Task<Void, Never>?
+
+    var body: some View {
+        Text(reduceMotion ? "…" : dots)
+            .font(.plexMono(10, weight: .medium))
+            .foregroundStyle(color)
+            .onAppear {
+                guard !reduceMotion else { return }
+                ticker = Task { @MainActor in
+                    // Calm ellipsis: never a harsh blink. Stops when the view goes away.
+                    while !Task.isCancelled {
+                        try? await Task.sleep(nanoseconds: 450_000_000)
+                        phase = (phase + 1) % 4
+                    }
+                }
+            }
+            .onDisappear { ticker?.cancel() }
+    }
+
+    private var dots: String {
+        String(repeating: ".", count: phase)
+    }
+}
+
+// MARK: - SwiftTerm NSViewRepresentable
+
+/// Wraps SwiftTerm's macOS `TerminalView`, binding it to a `TerminalSession`:
+/// - feeds decoded output bytes in (via the session's output sink),
+/// - forwards keystrokes out (`TerminalViewDelegate.send`),
+/// - reports size changes back to the session (`resize`).
+private struct SwiftTermView: NSViewRepresentable {
+    let session: TerminalSession
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(session: session)
+    }
+
+    func makeNSView(context: Context) -> TerminalView {
+        let view = TerminalView(frame: .zero)
+        view.terminalDelegate = context.coordinator
+        context.coordinator.terminalView = view
+
+        // OPERATOR look: deep terminal surface + phosphor ink, Plex Mono 12.5.
+        view.nativeBackgroundColor = NSColor(Color.surfaceTerminal)
+        view.nativeForegroundColor = NSColor(Color.inkPrimary)
+        if let mono = NSFont(name: "IBMPlexMono", size: 12.5) {
+            view.font = mono
+        } else {
+            view.font = NSFont.monospacedSystemFont(ofSize: 12.5, weight: .regular)
+        }
+
+        // Install the output sink so future server `output` events feed SwiftTerm.
+        session.setOutputSink { [weak view] text in
+            view?.feed(text: text)
+        }
+
+        // Report the initial size once the view has a backing dimension, and start.
+        let dims = view.getTerminal().getDims()
+        session.resize(cols: dims.cols, rows: dims.rows)
+        session.start()
+        return view
+    }
+
+    func updateNSView(_ nsView: TerminalView, context: Context) {
+        // Keep the coordinator's reference fresh; sizing is reported via the delegate.
+        context.coordinator.terminalView = nsView
+    }
+
+    /// Bridges SwiftTerm's `TerminalViewDelegate` to the `TerminalSession`.
+    ///
+    /// `TerminalViewDelegate` is a `nonisolated` protocol, but SwiftTerm's macOS
+    /// `TerminalView` only invokes its delegate on the main thread (it is an NSView).
+    /// We therefore use `MainActor.assumeIsolated` to reach the main-actor-isolated
+    /// `TerminalSession` without an extra async hop.
+    final class Coordinator: NSObject, TerminalViewDelegate {
+        private let session: TerminalSession
+        weak var terminalView: TerminalView?
+
+        init(session: TerminalSession) {
+            self.session = session
+        }
+
+        // User keystrokes → PTY.
+        func send(source: TerminalView, data: ArraySlice<UInt8>) {
+            let text = String(decoding: data, as: UTF8.self)
+            let session = self.session // capture the Sendable @MainActor view-model only
+            MainActor.assumeIsolated { session.send(text) }
+        }
+
+        // Terminal grid resized (font/frame change) → tell the server.
+        func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {
+            let session = self.session
+            MainActor.assumeIsolated { session.resize(cols: newCols, rows: newRows) }
+        }
+
+        // Scroll position → drive the LIVE / "↓ N new" affordance. 1.0 == bottom.
+        func scrolled(source: TerminalView, position: Double) {
+            let session = self.session
+            MainActor.assumeIsolated { session.setPinnedToBottom(position >= 0.999) }
+        }
+
+        func setTerminalTitle(source: TerminalView, title: String) {}
+        func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+        func requestOpenLink(source: TerminalView, link: String, params: [String: String]) {}
+        func bell(source: TerminalView) {}
+        func clipboardCopy(source: TerminalView, content: Data) {}
+        func iTermContent(source: TerminalView, content: ArraySlice<UInt8>) {}
+        func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
+    }
+}
+#endif

--- a/macos/Sources/Terminal/TerminalPanelView.swift
+++ b/macos/Sources/Terminal/TerminalPanelView.swift
@@ -144,25 +144,36 @@ private struct AnimatedEllipsis: View {
             .font(.plexMono(10, weight: .medium))
             .foregroundStyle(color)
             .onAppear {
-                ticker?.cancel()
-                ticker = nil
-                guard !reduceMotion else { return }
-                ticker = Task { @MainActor in
-                    // Calm ellipsis: never a harsh blink. Stops when the view goes away.
-                    while !Task.isCancelled {
-                        try? await Task.sleep(nanoseconds: 450_000_000)
-                        phase = (phase + 1) % 4
-                    }
-                }
+                syncTickerForMotionPreference()
             }
+            .onChange(of: reduceMotion) { _, _ in syncTickerForMotionPreference() }
             .onDisappear {
-                ticker?.cancel()
-                ticker = nil
+                stopTicker()
             }
     }
 
     private var dots: String {
         String(repeating: ".", count: phase)
+    }
+
+    private func syncTickerForMotionPreference() {
+        stopTicker()
+        guard !reduceMotion else {
+            phase = 0
+            return
+        }
+        ticker = Task { @MainActor in
+            // Calm ellipsis: never a harsh blink. Stops when the view goes away.
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 450_000_000)
+                phase = (phase + 1) % 4
+            }
+        }
+    }
+
+    private func stopTicker() {
+        ticker?.cancel()
+        ticker = nil
     }
 }
 

--- a/macos/Sources/Terminal/TerminalPanelView.swift
+++ b/macos/Sources/Terminal/TerminalPanelView.swift
@@ -144,6 +144,8 @@ private struct AnimatedEllipsis: View {
             .font(.plexMono(10, weight: .medium))
             .foregroundStyle(color)
             .onAppear {
+                ticker?.cancel()
+                ticker = nil
                 guard !reduceMotion else { return }
                 ticker = Task { @MainActor in
                     // Calm ellipsis: never a harsh blink. Stops when the view goes away.
@@ -153,7 +155,10 @@ private struct AnimatedEllipsis: View {
                     }
                 }
             }
-            .onDisappear { ticker?.cancel() }
+            .onDisappear {
+                ticker?.cancel()
+                ticker = nil
+            }
     }
 
     private var dots: String {

--- a/macos/Sources/Terminal/TerminalSession.swift
+++ b/macos/Sources/Terminal/TerminalSession.swift
@@ -1,0 +1,174 @@
+import Foundation
+import SwiftUI
+
+/// Connection/UI state for a terminal panel, derived from the shell-WS event stream.
+///
+/// These are calm, generic states surfaced to the user (design.md §6.4) — never a raw
+/// error string. `error` carries an internal `code` for diagnostics/telemetry only; the
+/// view renders a fixed generic message for it.
+public enum TerminalConnectionState: Equatable, Sendable {
+    /// Socket opening / waiting for the first `attached` ack.
+    case connecting
+    /// Attached and streaming live output.
+    case attached
+    /// Lost the connection; the client is backing off and retrying.
+    case reconnecting
+    /// The session/process exited (`exit`). Carries the exit code for the UI.
+    case exited(code: Int)
+    /// A generic, non-recoverable error. `code` is internal-only (not shown raw).
+    case error(code: String)
+}
+
+/// `@MainActor` view-model that owns a `ShellEventSource` (the shell-WS client),
+/// consumes its `AsyncStream<ServerEvent>`, and publishes UI-facing state for the
+/// SwiftTerm-backed `TerminalPanelView`.
+///
+/// Responsibilities (T034 / US1):
+/// - Drive connection state: `connecting → attached`, drop → `reconnecting`,
+///   `exit → exited`, `error → error` (generic), `replay-evicted → connecting`
+///   (buffer cleared; the client re-attaches at live tail).
+/// - Feed `output` bytes to a sink (the SwiftTerm view) and track the last applied seq.
+/// - Forward user keystrokes (`sendInput`) and `resize` to the client.
+/// - Track scroll-pin ("● LIVE" vs "↓ N new") so the view can render the affordance.
+@MainActor
+public final class TerminalSession: ObservableObject {
+    /// Human-readable session label shown in the top strip.
+    public let displayName: String
+
+    /// Current connection state (drives inline status UI).
+    @Published public private(set) var connectionState: TerminalConnectionState = .connecting
+
+    /// Last output `seq` applied to the terminal (0 before any output / after a reset).
+    @Published public private(set) var lastSeq: Int = 0
+
+    /// Whether the view is pinned to the live tail ("● LIVE"). When false the user has
+    /// scrolled up and `unseenLines` accumulates ("↓ N new").
+    @Published public private(set) var isPinnedToBottom: Bool = true
+
+    /// Count of output flushes received while scrolled up (for the "↓ N new" badge).
+    @Published public private(set) var unseenLines: Int = 0
+
+    private let client: ShellEventSource
+    /// Sink for decoded PTY output text. The view installs this to feed SwiftTerm.
+    /// Called on the main actor.
+    private var outputSink: (@MainActor (String) -> Void)?
+    private var consumeTask: Task<Void, Never>?
+    private var started = false
+    /// Latest requested terminal size, re-sent once after each successful attach.
+    private var lastSize: (cols: Int, rows: Int)?
+
+    public init(displayName: String, client: ShellEventSource) {
+        self.displayName = displayName
+        self.client = client
+    }
+
+    deinit {
+        consumeTask?.cancel()
+    }
+
+    /// Installs the output sink (the SwiftTerm feed) before/while starting.
+    public func setOutputSink(_ sink: @escaping @MainActor (String) -> Void) {
+        outputSink = sink
+    }
+
+    /// Connects the client and begins consuming its event stream. Idempotent.
+    public func start() {
+        guard !started else { return }
+        started = true
+        let client = self.client
+        consumeTask = Task { [weak self] in
+            await client.connect()
+            let stream = await client.events
+            for await event in stream {
+                if Task.isCancelled { break }
+                self?.apply(event)
+            }
+        }
+    }
+
+    /// Forwards a keystroke/byte payload to the PTY.
+    public func send(_ data: String) {
+        let client = self.client
+        Task { await client.sendInput(data) }
+    }
+
+    /// Forwards a resize to the client and remembers it for re-send after attach.
+    public func resize(cols: Int, rows: Int) {
+        guard cols > 0, rows > 0 else { return }
+        lastSize = (cols, rows)
+        let client = self.client
+        Task { await client.resize(cols: cols, rows: rows) }
+    }
+
+    /// Detaches (leaves the session running) and stops consuming.
+    public func detach() {
+        consumeTask?.cancel()
+        let client = self.client
+        Task { await client.detach() }
+    }
+
+    /// Tears down the connection and stops consuming.
+    public func shutdown() {
+        consumeTask?.cancel()
+        consumeTask = nil
+        let client = self.client
+        Task { await client.shutdown() }
+    }
+
+    /// Marks the session as reconnecting. The shell-WS client reconnects internally
+    /// (it does not emit a disconnect event), so the transport-aware layer drives this
+    /// when it observes a socket drop; the next `attached`/`output` clears it.
+    public func markReconnecting() {
+        switch connectionState {
+        case .exited, .error:
+            return // terminal states are not overridden by a transient drop
+        default:
+            connectionState = .reconnecting
+        }
+    }
+
+    // MARK: - Scroll pin (driven by the SwiftTerm view's scroll delegate)
+
+    /// Updates the pinned-to-bottom affordance. Pinning back to the bottom clears the
+    /// unseen counter ("↓ N new" → "● LIVE").
+    public func setPinnedToBottom(_ pinned: Bool) {
+        if pinned {
+            unseenLines = 0
+        }
+        isPinnedToBottom = pinned
+    }
+
+    // MARK: - Event application
+
+    private func apply(_ event: ServerEvent) {
+        switch event {
+        case .attached:
+            connectionState = .attached
+            // Re-send the last known size once after attach (protocol requirement).
+            if let size = lastSize {
+                let client = self.client
+                Task { await client.resize(cols: size.cols, rows: size.rows) }
+            }
+        case let .output(seq, data):
+            lastSeq = max(lastSeq, seq)
+            // A late output frame while still "connecting" implies we're attached.
+            if case .connecting = connectionState { connectionState = .attached }
+            if case .reconnecting = connectionState { connectionState = .attached }
+            outputSink?(data)
+            if !isPinnedToBottom {
+                unseenLines += 1
+            }
+        case let .exit(code):
+            connectionState = .exited(code: code)
+        case let .error(code, _):
+            // Never surface raw `message`; keep only the internal code.
+            connectionState = .error(code: code)
+        case .replayEvicted:
+            // Client cleared its buffer and re-attaches at live tail. Reset local seq
+            // and show the connecting state until the next `attached`/`output`.
+            lastSeq = 0
+            unseenLines = 0
+            connectionState = .connecting
+        }
+    }
+}

--- a/macos/Sources/Terminal/TerminalSession.swift
+++ b/macos/Sources/Terminal/TerminalSession.swift
@@ -93,8 +93,11 @@ public final class TerminalSession: ObservableObject {
     }
 
     /// Forwards a resize to the client and remembers it for re-send after attach.
+    /// De-duplicates identical sizes so layout passes that report the same grid do
+    /// not spam the server (which made zellij thrash/rearrange panes).
     public func resize(cols: Int, rows: Int) {
         guard cols > 0, rows > 0 else { return }
+        if let last = lastSize, last.cols == cols, last.rows == rows { return }
         lastSize = (cols, rows)
         let client = self.client
         Task { await client.resize(cols: cols, rows: rows) }

--- a/macos/Tests/BoardTests/BoardStoreTests.swift
+++ b/macos/Tests/BoardTests/BoardStoreTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import MatrixBoard
+import MatrixModel
+import MatrixNet
+
+/// Mock loader so the store can be exercised without a live gateway.
+private actor MockBoardLoader: BoardLoading {
+    enum Mode: Sendable {
+        case success([Card])
+        case failure(Error)
+    }
+    private let mode: Mode
+    private(set) var requestedSlugs: [String] = []
+
+    init(_ mode: Mode) { self.mode = mode }
+
+    func fetchTasks(projectSlug: String) async throws -> [Card] {
+        requestedSlugs.append(projectSlug)
+        switch mode {
+        case .success(let cards): return cards
+        case .failure(let error): throw error
+        }
+    }
+
+    func slugs() -> [String] { requestedSlugs }
+}
+
+private func card(
+    _ id: String,
+    status: TaskStatus,
+    order: Double,
+    title: String = "t"
+) -> Card {
+    Card(
+        id: id,
+        projectSlug: "demo",
+        title: title,
+        status: status,
+        priority: .normal,
+        order: order,
+        updatedAt: "2026-06-01T00:00:00.000Z"
+    )
+}
+
+@MainActor
+final class BoardStoreTests: XCTestCase {
+    func testInitialStateIsIdle() {
+        let store = BoardStore(loader: MockBoardLoader(.success([])))
+        XCTAssertEqual(store.state, .idle)
+        XCTAssertTrue(store.cards.isEmpty)
+        // Columns always render the canonical 5 statuses; each is empty initially.
+        XCTAssertEqual(store.columns.map(\.status), [.todo, .running, .waiting, .blocked, .complete])
+        XCTAssertTrue(store.columns.allSatisfy { $0.cards.isEmpty })
+    }
+
+    func testLoadSuccessPopulatesCardsAndState() async {
+        let loader = MockBoardLoader(.success([
+            card("task_1", status: .todo, order: 0)
+        ]))
+        let store = BoardStore(loader: loader)
+        await store.load(projectSlug: "demo")
+        XCTAssertEqual(store.state, .loaded)
+        XCTAssertEqual(store.cards.count, 1)
+        let requested = await loader.slugs()
+        XCTAssertEqual(requested, ["demo"])
+    }
+
+    func testColumnsGroupByStatusOrderedByCardOrder() async {
+        let loader = MockBoardLoader(.success([
+            card("a", status: .todo, order: 2),
+            card("b", status: .todo, order: 1),
+            card("c", status: .running, order: 5),
+            card("d", status: .complete, order: 0),
+        ]))
+        let store = BoardStore(loader: loader)
+        await store.load(projectSlug: "demo")
+
+        // Columns are in canonical order: todo, running, waiting, blocked, complete.
+        let statuses = store.columns.map(\.status)
+        XCTAssertEqual(statuses, [.todo, .running, .waiting, .blocked, .complete])
+
+        let todo = store.columns.first { $0.status == .todo }
+        XCTAssertEqual(todo?.cards.map(\.id), ["b", "a"]) // order 1 before order 2
+
+        let running = store.columns.first { $0.status == .running }
+        XCTAssertEqual(running?.cards.map(\.id), ["c"])
+    }
+
+    func testArchivedCardsAreHidden() async {
+        let loader = MockBoardLoader(.success([
+            card("a", status: .todo, order: 0),
+            card("z", status: .archived, order: 0),
+        ]))
+        let store = BoardStore(loader: loader)
+        await store.load(projectSlug: "demo")
+
+        XCTAssertEqual(store.columns.map(\.status), [.todo, .running, .waiting, .blocked, .complete])
+        let allCardIds = store.columns.flatMap { $0.cards.map(\.id) }
+        XCTAssertEqual(allCardIds, ["a"])
+        XCTAssertFalse(allCardIds.contains("z"))
+    }
+
+    func testLoadFailureSetsGenericErrorAndDoesNotLeak() async {
+        // A raw, leaky error must never surface to the UI.
+        struct LeakyError: Error { let message = "postgres: relation tasks does not exist at /var/lib" }
+        let loader = MockBoardLoader(.failure(LeakyError()))
+        let store = BoardStore(loader: loader)
+        await store.load(projectSlug: "demo")
+
+        guard case .failed(let boardError) = store.state else {
+            return XCTFail("expected failed state, got \(store.state)")
+        }
+        // Generic, user-safe copy only.
+        XCTAssertFalse(boardError.message.contains("postgres"))
+        XCTAssertFalse(boardError.message.contains("/var/lib"))
+        XCTAssertFalse(boardError.message.isEmpty)
+    }
+
+    func testGatewayErrorMapsToGenericBoardError() async {
+        let loader = MockBoardLoader(.failure(GatewayError.unauthorized))
+        let store = BoardStore(loader: loader)
+        await store.load(projectSlug: "demo")
+
+        guard case .failed(let boardError) = store.state else {
+            return XCTFail("expected failed state")
+        }
+        XCTAssertEqual(boardError, BoardError.unauthorized)
+    }
+
+    func testReloadAfterFailureCanSucceed() async {
+        let loader = MockBoardLoader(.success([card("a", status: .todo, order: 0)]))
+        let store = BoardStore(loader: loader)
+        await store.load(projectSlug: "demo")
+        XCTAssertEqual(store.state, .loaded)
+        XCTAssertEqual(store.cards.count, 1)
+    }
+}

--- a/macos/Tests/BoardTests/GatewayTaskDTOTests.swift
+++ b/macos/Tests/BoardTests/GatewayTaskDTOTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import MatrixBoard
+import MatrixModel
+
+final class GatewayTaskDTOTests: XCTestCase {
+    private func decode(_ json: String) throws -> GatewayTaskDTO {
+        try JSONDecoder().decode(GatewayTaskDTO.self, from: Data(json.utf8))
+    }
+
+    /// The gateway omits `tags` and `revision` until a server delta ships them.
+    /// Decoding must succeed and the mapped Card must default tags == [] / revision == nil.
+    func testDecodesTaskWithoutTagsOrRevision() throws {
+        let json = """
+        {
+          "id": "task_abc",
+          "projectSlug": "demo",
+          "title": "Wire the board",
+          "status": "todo",
+          "priority": "normal",
+          "order": 1.5,
+          "previewIds": [],
+          "createdAt": "2026-06-01T00:00:00.000Z",
+          "updatedAt": "2026-06-01T00:00:00.000Z"
+        }
+        """
+        let dto = try decode(json)
+        let card = dto.toCard()
+        XCTAssertEqual(card.id, "task_abc")
+        XCTAssertEqual(card.projectSlug, "demo")
+        XCTAssertEqual(card.title, "Wire the board")
+        XCTAssertEqual(card.status, .todo)
+        XCTAssertEqual(card.priority, .normal)
+        XCTAssertEqual(card.order, 1.5)
+        XCTAssertEqual(card.tags, [])
+        XCTAssertNil(card.revision)
+        XCTAssertEqual(card.updatedAt, "2026-06-01T00:00:00.000Z")
+    }
+
+    /// Optional fields present should still map through cleanly.
+    func testDecodesTaskWithOptionalFields() throws {
+        let json = """
+        {
+          "id": "task_def",
+          "projectSlug": "demo",
+          "title": "Run it",
+          "description": "long body",
+          "status": "running",
+          "priority": "high",
+          "order": 3,
+          "parentTaskId": "task_root",
+          "linkedSessionId": "sess_1",
+          "linkedWorktreeId": "wt_1",
+          "previewIds": ["prev_1", "prev_2"],
+          "createdAt": "2026-06-01T00:00:00.000Z",
+          "updatedAt": "2026-06-02T00:00:00.000Z"
+        }
+        """
+        let card = try decode(json).toCard()
+        XCTAssertEqual(card.description, "long body")
+        XCTAssertEqual(card.status, .running)
+        XCTAssertEqual(card.priority, .high)
+        XCTAssertEqual(card.parentTaskId, "task_root")
+        XCTAssertEqual(card.linkedSessionId, "sess_1")
+        XCTAssertEqual(card.linkedWorktreeId, "wt_1")
+        XCTAssertEqual(card.previewIds, ["prev_1", "prev_2"])
+        XCTAssertTrue(card.isLive)
+    }
+
+    /// When the server delta eventually adds tags/revision, decode should honor them.
+    func testDecodesTagsAndRevisionWhenPresent() throws {
+        let json = """
+        {
+          "id": "task_ghi",
+          "projectSlug": "demo",
+          "title": "Future",
+          "status": "todo",
+          "priority": "normal",
+          "order": 0,
+          "previewIds": [],
+          "tags": ["bug", "ui"],
+          "revision": 7,
+          "createdAt": "2026-06-01T00:00:00.000Z",
+          "updatedAt": "2026-06-01T00:00:00.000Z"
+        }
+        """
+        let card = try decode(json).toCard()
+        XCTAssertEqual(card.tags, ["bug", "ui"])
+        XCTAssertEqual(card.revision, 7)
+    }
+
+    /// previewIds omitted should default to [].
+    func testDecodesTaskWithoutPreviewIds() throws {
+        let json = """
+        {
+          "id": "task_jkl",
+          "projectSlug": "demo",
+          "title": "No previews",
+          "status": "todo",
+          "priority": "normal",
+          "order": 0,
+          "createdAt": "2026-06-01T00:00:00.000Z",
+          "updatedAt": "2026-06-01T00:00:00.000Z"
+        }
+        """
+        let card = try decode(json).toCard()
+        XCTAssertEqual(card.previewIds, [])
+    }
+}

--- a/macos/Tests/BoardTests/_Placeholder.swift
+++ b/macos/Tests/BoardTests/_Placeholder.swift
@@ -1,7 +1,0 @@
-import XCTest
-@testable import MatrixBoard
-
-// Placeholder so MatrixBoard test target builds before US1 tests land (T032).
-final class BoardModulePlaceholderTests: XCTestCase {
-    func testModuleLoads() { XCTAssertTrue(true) }
-}

--- a/macos/Tests/NetTests/DeviceAuthClientTests.swift
+++ b/macos/Tests/NetTests/DeviceAuthClientTests.swift
@@ -59,8 +59,9 @@ final class DeviceAuthClientTests: XCTestCase {
 
     func testPollApprovedReturnsToken() async throws {
         MockURLProtocol.setHandler { req in
+            // Platform sends expiresAt as a JSON number (epoch ms), not a string.
             let json = """
-            {"accessToken":"JWT","expiresAt":"2026-01-01T00:00:00Z","userId":"user_1","handle":"hamed"}
+            {"accessToken":"JWT","expiresAt":1893456000000,"userId":"user_1","handle":"hamed"}
             """
             return (httpResponse(req.url!, 200), Data(json.utf8))
         }

--- a/macos/Tests/TerminalTests/MockShellEventSource.swift
+++ b/macos/Tests/TerminalTests/MockShellEventSource.swift
@@ -1,0 +1,48 @@
+import Foundation
+@testable import MatrixTerminal
+
+/// Deterministic in-memory `ShellEventSource` for `TerminalSession` state-machine tests.
+/// Tests `emit(_:)` `ServerEvent`s and the session applies them on the main actor.
+/// Sent input/resize/detach/shutdown calls are recorded for assertions.
+actor MockShellEventSource: ShellEventSource {
+    private let stream: AsyncStream<ServerEvent>
+    private let continuation: AsyncStream<ServerEvent>.Continuation
+
+    private(set) var didConnect = false
+    private(set) var sentInputs: [String] = []
+    private(set) var resizes: [(cols: Int, rows: Int)] = []
+    private(set) var didDetach = false
+    private(set) var didShutdown = false
+
+    init() {
+        var cont: AsyncStream<ServerEvent>.Continuation!
+        self.stream = AsyncStream { cont = $0 }
+        self.continuation = cont
+    }
+
+    var events: AsyncStream<ServerEvent> { stream }
+
+    func connect() { didConnect = true }
+
+    func sendInput(_ data: String) { sentInputs.append(data) }
+
+    func resize(cols: Int, rows: Int) { resizes.append((cols, rows)) }
+
+    func detach() { didDetach = true }
+
+    func shutdown() {
+        didShutdown = true
+        continuation.finish()
+    }
+
+    // MARK: test driver
+
+    /// Pushes a server event into the stream consumed by the session.
+    func emit(_ event: ServerEvent) {
+        continuation.yield(event)
+    }
+
+    func finish() {
+        continuation.finish()
+    }
+}

--- a/macos/Tests/TerminalTests/TerminalSessionTests.swift
+++ b/macos/Tests/TerminalTests/TerminalSessionTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+@testable import MatrixTerminal
+
+/// T034 — state-transition tests for `TerminalSession` against a mock event stream.
+/// SwiftTerm view rendering is not unit-testable headlessly, so these assert the
+/// view-model's published state, output sink wiring, and input/resize forwarding.
+@MainActor
+final class TerminalSessionTests: XCTestCase {
+    private func makeSession(
+        name: String = "zsh"
+    ) -> (TerminalSession, MockShellEventSource) {
+        let source = MockShellEventSource()
+        let session = TerminalSession(displayName: name, client: source)
+        return (session, source)
+    }
+
+    /// Awaits until `predicate` holds or a short timeout elapses (event delivery is async).
+    private func eventually(
+        _ predicate: @escaping @MainActor () -> Bool,
+        timeout: TimeInterval = 2.0,
+        _ message: String = "condition not met"
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try? await Task.sleep(nanoseconds: 5_000_000) // 5ms
+        }
+        XCTFail(message)
+    }
+
+    /// Async-predicate variant of `eventually` for reading actor-isolated mock state.
+    private func eventuallyAsync(
+        _ predicate: @escaping () async -> Bool,
+        timeout: TimeInterval = 2.0,
+        _ message: String = "condition not met"
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await predicate() { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail(message)
+    }
+
+    func testInitialStateIsConnecting() {
+        let (session, _) = makeSession()
+        XCTAssertEqual(session.connectionState, .connecting)
+        XCTAssertEqual(session.lastSeq, 0)
+        XCTAssertTrue(session.isPinnedToBottom)
+    }
+
+    func testStartConnectsTheClient() async {
+        let (session, source) = makeSession()
+        session.start()
+        await eventuallyAsync({ await source.didConnect })
+    }
+
+    func testAttachedEventMovesToAttached() async {
+        let (session, source) = makeSession()
+        session.start()
+        await source.emit(.attached(state: "running", fromSeq: 0))
+        await eventually({ session.connectionState == .attached })
+    }
+
+    func testOutputAdvancesSeqAndFeedsSink() async {
+        let (session, source) = makeSession()
+        var fed: [String] = []
+        session.setOutputSink { fed.append($0) }
+        session.start()
+
+        await source.emit(.output(seq: 1, data: "hello "))
+        await source.emit(.output(seq: 2, data: "world"))
+
+        await eventually({ session.lastSeq == 2 })
+        XCTAssertEqual(fed, ["hello ", "world"])
+        // A bare output (before an explicit attached) implies attachment.
+        XCTAssertEqual(session.connectionState, .attached)
+    }
+
+    func testOutWhileScrolledUpAccumulatesUnseen() async {
+        let (session, source) = makeSession()
+        session.start()
+        session.setPinnedToBottom(false)
+
+        await source.emit(.output(seq: 1, data: "a"))
+        await source.emit(.output(seq: 2, data: "b"))
+
+        await eventually({ session.unseenLines == 2 })
+        XCTAssertFalse(session.isPinnedToBottom)
+
+        // Re-pinning clears the unseen counter.
+        session.setPinnedToBottom(true)
+        XCTAssertEqual(session.unseenLines, 0)
+        XCTAssertTrue(session.isPinnedToBottom)
+    }
+
+    func testErrorEventMovesToGenericError() async {
+        let (session, source) = makeSession()
+        session.start()
+        await source.emit(.error(code: "internal", message: "raw secret detail"))
+        await eventually({
+            if case .error(let code) = session.connectionState { return code == "internal" }
+            return false
+        })
+        // The raw message must not be retained anywhere on the published state.
+        if case .error(let code) = session.connectionState {
+            XCTAssertFalse(code.contains("raw secret detail"))
+        }
+    }
+
+    func testExitEventMovesToExitedWithCode() async {
+        let (session, source) = makeSession()
+        session.start()
+        await source.emit(.exit(code: 137))
+        await eventually({ session.connectionState == .exited(code: 137) })
+    }
+
+    func testReplayEvictedResetsAndReturnsToConnecting() async {
+        let (session, source) = makeSession()
+        session.start()
+        await source.emit(.attached(state: "running", fromSeq: 0))
+        await source.emit(.output(seq: 5, data: "x"))
+        await eventually({ session.lastSeq == 5 })
+
+        await source.emit(.replayEvicted)
+        await eventually({ session.connectionState == .connecting && session.lastSeq == 0 })
+        XCTAssertEqual(session.unseenLines, 0)
+    }
+
+    func testReconnectingThenAttachedClears() async {
+        let (session, source) = makeSession()
+        session.start()
+        session.markReconnecting()
+        XCTAssertEqual(session.connectionState, .reconnecting)
+
+        await source.emit(.output(seq: 1, data: "back"))
+        await eventually({ session.connectionState == .attached })
+    }
+
+    func testMarkReconnectingDoesNotOverrideTerminalStates() async {
+        let (session, source) = makeSession()
+        session.start()
+        await source.emit(.exit(code: 0))
+        await eventually({ session.connectionState == .exited(code: 0) })
+
+        session.markReconnecting()
+        XCTAssertEqual(session.connectionState, .exited(code: 0))
+    }
+
+    func testSendForwardsInput() async {
+        let (session, source) = makeSession()
+        session.send("ls\n")
+        await eventuallyAsync({ await source.sentInputs == ["ls\n"] })
+    }
+
+    func testResizeForwardsAndRemembersSize() async {
+        let (session, source) = makeSession()
+        session.resize(cols: 120, rows: 40)
+        await eventuallyAsync({ await source.resizes.first?.cols == 120 })
+        let resizes = await source.resizes
+        XCTAssertEqual(resizes.first?.cols, 120)
+        XCTAssertEqual(resizes.first?.rows, 40)
+    }
+
+    func testResizeIgnoresNonPositiveDimensions() async {
+        let (session, source) = makeSession()
+        session.resize(cols: 0, rows: 0)
+        // Give any (incorrect) forwarding a chance to land, then assert none did.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let resizes = await source.resizes
+        XCTAssertTrue(resizes.isEmpty)
+    }
+
+    func testAttachReSendsLastSize() async {
+        let (session, source) = makeSession()
+        session.start()
+        session.resize(cols: 100, rows: 30)
+        await eventuallyAsync({ await source.resizes.count >= 1 })
+
+        await source.emit(.attached(state: "running", fromSeq: 0))
+        // After attach there should be a second resize echoing the remembered size.
+        await eventuallyAsync({ await source.resizes.count >= 2 })
+        let resizes = await source.resizes
+        XCTAssertGreaterThanOrEqual(resizes.count, 2)
+        XCTAssertEqual(resizes.last?.cols, 100)
+        XCTAssertEqual(resizes.last?.rows, 30)
+    }
+
+    func testDetachAndShutdownForward() async {
+        let (session, source) = makeSession()
+        session.start()
+        session.detach()
+        await eventuallyAsync({ await source.didDetach })
+
+        session.shutdown()
+        await eventuallyAsync({ await source.didShutdown })
+    }
+}


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 4/11.

## Summary

Adds the first native board MVP: task columns, card opening, terminal panel/session handling, device sign-in wiring, and zellij session cards.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

No backend route, database, or auth behavior changes in this layer.