### PR TITLE
feat(086): add native workspace shell sections

### DIFF
--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -69,9 +69,43 @@ public enum SignInState: Equatable, Sendable {
     case failed(String)
 }
 
+/// Top-level workspace sections (left rail). Board = task kanban; Terminals =
+/// the live zellij session list opened in a full/side terminal.
+public enum AppSection: String, CaseIterable, Sendable {
+    case board
+    case terminals
+
+    public var title: String {
+        switch self {
+        case .board: return "Board"
+        case .terminals: return "Terminals"
+        }
+    }
+
+    public var symbol: String {
+        switch self {
+        case .board: return "rectangle.split.3x1"
+        case .terminals: return "terminal"
+        }
+    }
+}
+
+/// A live zellij session entry for the Terminals section.
+public struct WorkspaceSession: Identifiable, Equatable, Sendable {
+    public let name: String
+    public let status: String
+    public var id: String { name }
+    public var isActive: Bool { status == "active" }
+}
+
 @MainActor
 public final class AppModel: ObservableObject {
     // MARK: - Published state (SwiftUI binds to these)
+
+    /// The active top-level section (left rail selection).
+    @Published public var section: AppSection = .board
+    /// Live zellij sessions for the Terminals section.
+    @Published public private(set) var sessions: [WorkspaceSession] = []
 
     /// The currently selected connection profile (nil → onboarding).
     @Published public private(set) var profile: ConnectionProfile?
@@ -129,9 +163,10 @@ public final class AppModel: ObservableObject {
             GatewayHTTPClient(baseURL: url, tokenProvider: provider)
         },
         makeLoader: @escaping @Sendable (GatewayHTTPClient) -> any BoardLoading = { client in
-            // Render the user's live zellij sessions as cards (their original intent;
-            // a fresh VPS has sessions but no tasks). Task-backed boards land in US2.
-            SessionsBoardLoader(client: client)
+            // The board is the task kanban (Linear/SlayZone-style). Opening a task
+            // attaches/creates its zellij session. The raw session list lives in the
+            // separate Terminals section, not as board cards.
+            GatewayBoardLoader(client: client)
         },
         makeTerminal: @escaping @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession = { url, provider, session, name in
             let tokenProvider = provider as any TokenProviding
@@ -308,6 +343,8 @@ public final class AppModel: ObservableObject {
         } else {
             phase = .connecting
         }
+        await resolveProjectIfNeeded()
+        await loadSessions()
         await board.load(projectSlug: projectSlug)
         switch board.state {
         case .loaded:
@@ -316,6 +353,71 @@ public final class AppModel: ObservableObject {
             phase = reconcilePhase(for: error)
         case .idle, .loading:
             phase = .connecting
+        }
+    }
+
+    // MARK: - Project + sessions
+
+    private func gatewayClient() -> GatewayHTTPClient? {
+        guard let profile, let baseURL = try? profile.gatewayBaseURL() else { return nil }
+        return makeClient(baseURL, principal)
+    }
+
+    /// Resolves the active project slug from the user's projects when unset, so the
+    /// board targets a real project instead of a hardcoded "default" (which 404s).
+    private func resolveProjectIfNeeded() async {
+        guard projectSlug == "default" || projectSlug.isEmpty, let client = gatewayClient() else { return }
+        struct ProjectsResponse: Decodable { struct Project: Decodable { let slug: String }; let projects: [Project] }
+        if let response: ProjectsResponse = try? await client.get("/api/workspace/projects"),
+           let first = response.projects.first {
+            projectSlug = first.slug
+            // Rebuild the board store against the resolved project.
+            self.board = BoardStore(loader: makeLoader(client))
+        }
+    }
+
+    /// Loads the live zellij session list for the Terminals section.
+    public func loadSessions() async {
+        guard let client = gatewayClient() else { return }
+        struct SessionsResponse: Decodable {
+            struct Session: Decodable { let name: String; let status: String }
+            let sessions: [Session]
+        }
+        if let response: SessionsResponse = try? await client.get("/api/sessions") {
+            sessions = response.sessions.map { WorkspaceSession(name: $0.name, status: $0.status) }
+        }
+    }
+
+    /// Opens a raw zellij session (Terminals section) in the side terminal view.
+    public func openSession(named name: String) {
+        let card = Card(
+            id: name, projectSlug: projectSlug, title: name,
+            status: .running, priority: .normal, order: 0,
+            linkedSessionId: name, updatedAt: ""
+        )
+        Task { try? await openCard(card) }
+    }
+
+    /// Creates a new task in the given column and refreshes the board (TE01/US7).
+    public func createTask(status: TaskStatus = .todo) {
+        guard !isCreatingSession else { return }
+        isCreatingSession = true
+        Task { [weak self] in
+            defer { Task { @MainActor in self?.isCreatingSession = false } }
+            guard let self, let client = await self.gatewayClient() else { return }
+            await self.resolveProjectIfNeeded()
+            let slug = await self.projectSlug
+            struct CreateTaskRequest: Encodable { let title: String; let status: String }
+            struct CreateTaskResponse: Decodable {}
+            do {
+                let _: CreateTaskResponse = try await client.post(
+                    "/api/projects/\(slug)/tasks",
+                    body: CreateTaskRequest(title: "New task", status: status.rawValue)
+                )
+                await self.refresh()
+            } catch {
+                // Silent-safe: never leak raw error; board simply does not gain a card.
+            }
         }
     }
 
@@ -406,18 +508,16 @@ public final class AppModel: ObservableObject {
         activePanel = panel
     }
 
-    /// ⌘N / column "+": create a new zellij session on the VPS and refresh the
-    /// board so it appears as a card (TE01). Best-effort; failures are silent-safe
-    /// (no raw text), the board simply does not gain a card.
-    public func newCardPlaceholder() { createSession() }
+    /// ⌘N / column "+": create a new task card on the board.
+    public func newCardPlaceholder() { createTask(status: .todo) }
 
-    /// Whether a session create is in flight (disables the action, shows progress).
+    /// Whether a create (task or session) is in flight.
     @Published public private(set) var isCreatingSession = false
 
+    /// Creates a new zellij session (Terminals section "+") and reloads the list.
     public func createSession() {
-        guard !isCreatingSession, let profile, let baseURL = try? profile.gatewayBaseURL() else { return }
+        guard !isCreatingSession, let client = gatewayClient() else { return }
         isCreatingSession = true
-        let client = makeClient(baseURL, principal)
         Task { [weak self] in
             defer { Task { @MainActor in self?.isCreatingSession = false } }
             struct CreateSessionRequest: Encodable {
@@ -430,10 +530,9 @@ public final class AppModel: ObservableObject {
                     "/api/sessions",
                     body: CreateSessionRequest()
                 )
-                await self?.refresh()
+                await self?.loadSessions()
             } catch {
-                // Generic, user-safe: surface a board-level disconnected hint only
-                // if we are otherwise idle. Never leak the underlying error.
+                // Silent-safe: never leak the underlying error.
             }
         }
     }

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -163,10 +163,7 @@ public final class AppModel: ObservableObject {
             GatewayHTTPClient(baseURL: url, tokenProvider: provider)
         },
         makeLoader: @escaping @Sendable (GatewayHTTPClient) -> any BoardLoading = { client in
-            // The board is the task kanban (Linear/SlayZone-style). Opening a task
-            // attaches/creates its zellij session. The raw session list lives in the
-            // separate Terminals section, not as board cards.
-            GatewayBoardLoader(client: client)
+            CompositeBoardLoader(client: client)
         },
         makeTerminal: @escaping @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession = { url, provider, session, name in
             let tokenProvider = provider as any TokenProviding
@@ -343,7 +340,7 @@ public final class AppModel: ObservableObject {
         } else {
             phase = .connecting
         }
-        await resolveProjectIfNeeded()
+        guard await resolveProjectIfNeeded() else { return }
         await loadSessions()
         await board.load(projectSlug: projectSlug)
         switch board.state {
@@ -365,14 +362,23 @@ public final class AppModel: ObservableObject {
 
     /// Resolves the active project slug from the user's projects when unset, so the
     /// board targets a real project instead of a hardcoded "default" (which 404s).
-    private func resolveProjectIfNeeded() async {
-        guard projectSlug == "default" || projectSlug.isEmpty, let client = gatewayClient() else { return }
+    private func resolveProjectIfNeeded() async -> Bool {
+        guard projectSlug == "default" || projectSlug.isEmpty else { return true }
+        guard let client = gatewayClient() else {
+            phase = .needsProfile
+            return false
+        }
         struct ProjectsResponse: Decodable { struct Project: Decodable { let slug: String }; let projects: [Project] }
-        if let response: ProjectsResponse = try? await client.get("/api/workspace/projects"),
-           let first = response.projects.first {
+        do {
+            let response: ProjectsResponse = try await client.get("/api/workspace/projects")
+            guard let first = response.projects.first else { return true }
             projectSlug = first.slug
             // Rebuild the board store against the resolved project.
             self.board = BoardStore(loader: makeLoader(client))
+            return true
+        } catch {
+            phase = .disconnected
+            return false
         }
     }
 
@@ -400,12 +406,12 @@ public final class AppModel: ObservableObject {
 
     /// Creates a new task in the given column and refreshes the board (TE01/US7).
     public func createTask(status: TaskStatus = .todo) {
-        guard !isCreatingSession else { return }
-        isCreatingSession = true
+        guard !isCreatingWorkItem else { return }
+        isCreatingWorkItem = true
         Task { [weak self] in
-            defer { Task { @MainActor in self?.isCreatingSession = false } }
+            defer { Task { @MainActor in self?.isCreatingWorkItem = false } }
             guard let self, let client = await self.gatewayClient() else { return }
-            await self.resolveProjectIfNeeded()
+            guard await self.resolveProjectIfNeeded() else { return }
             let slug = await self.projectSlug
             struct CreateTaskRequest: Encodable { let title: String; let status: String }
             struct CreateTaskResponse: Decodable {}
@@ -511,15 +517,15 @@ public final class AppModel: ObservableObject {
     /// ⌘N / column "+": create a new task card on the board.
     public func newCardPlaceholder() { createTask(status: .todo) }
 
-    /// Whether a create (task or session) is in flight.
-    @Published public private(set) var isCreatingSession = false
+    /// Whether a task or terminal-session create request is in flight.
+    @Published public private(set) var isCreatingWorkItem = false
 
     /// Creates a new zellij session (Terminals section "+") and reloads the list.
     public func createSession() {
-        guard !isCreatingSession, let client = gatewayClient() else { return }
-        isCreatingSession = true
+        guard !isCreatingWorkItem, let client = gatewayClient() else { return }
+        isCreatingWorkItem = true
         Task { [weak self] in
-            defer { Task { @MainActor in self?.isCreatingSession = false } }
+            defer { Task { @MainActor in self?.isCreatingWorkItem = false } }
             struct CreateSessionRequest: Encodable {
                 let kind = "shell"
                 let runtimePreference = "zellij"

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -406,9 +406,36 @@ public final class AppModel: ObservableObject {
         activePanel = panel
     }
 
-    /// Placeholder ⌘N action — card creation lands in US2 (mutations).
-    public func newCardPlaceholder() {
-        // Intentionally a no-op in US1; wired in US2.
+    /// ⌘N / column "+": create a new zellij session on the VPS and refresh the
+    /// board so it appears as a card (TE01). Best-effort; failures are silent-safe
+    /// (no raw text), the board simply does not gain a card.
+    public func newCardPlaceholder() { createSession() }
+
+    /// Whether a session create is in flight (disables the action, shows progress).
+    @Published public private(set) var isCreatingSession = false
+
+    public func createSession() {
+        guard !isCreatingSession, let profile, let baseURL = try? profile.gatewayBaseURL() else { return }
+        isCreatingSession = true
+        let client = makeClient(baseURL, principal)
+        Task { [weak self] in
+            defer { Task { @MainActor in self?.isCreatingSession = false } }
+            struct CreateSessionRequest: Encodable {
+                let kind = "shell"
+                let runtimePreference = "zellij"
+            }
+            struct CreateSessionResponse: Decodable {}
+            do {
+                let _: CreateSessionResponse = try await client.post(
+                    "/api/sessions",
+                    body: CreateSessionRequest()
+                )
+                await self?.refresh()
+            } catch {
+                // Generic, user-safe: surface a board-level disconnected hint only
+                // if we are otherwise idle. Never leak the underlying error.
+            }
+        }
     }
 
     private func displayName(for card: Card) -> String {

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -49,7 +49,9 @@ struct BoardView: View {
     // MARK: - Board + detail split
 
     private var boardWithDetail: some View {
-        HStack(spacing: 0) {
+        // Native draggable divider: drag to choose how wide the board vs the
+        // detail/terminal are. Each side has a min width so neither collapses.
+        HSplitView {
             VStack(spacing: 0) {
                 if model.phase == .disconnected {
                     ReconnectingBar(handle: model.profile?.handle ?? "your computer")
@@ -62,15 +64,13 @@ struct BoardView: View {
                     .saturation(model.phase == .disconnected ? 0.6 : 1)
                     .allowsHitTesting(model.phase != .disconnected)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .frame(minWidth: 360, maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
             if model.selectedCard != nil {
                 detailPane
-                    .frame(width: 520)
-                    .transition(.move(edge: .trailing))
+                    .frame(minWidth: 380, idealWidth: 560, maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .animation(Motion.panelSwitch, value: model.selectedCard?.id)
     }
 
     private var columns: some View {
@@ -82,7 +82,8 @@ struct BoardView: View {
                 ColumnView(
                     column: column,
                     selectedCardID: model.selectedCard?.id,
-                    onOpenCard: openCard
+                    onOpenCard: openCard,
+                    onAddCard: { model.createTask(status: $0) }
                 )
             }
         }

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -56,7 +56,7 @@ struct BoardView: View {
             if let error = model.openError {
                 GenericErrorBanner(message: error.message, onRetry: nil)
             }
-            if model.selectedCard != nil {
+            if selectedBoardCard != nil {
                 detailPane
             } else {
                 columns
@@ -76,7 +76,7 @@ struct BoardView: View {
             ForEach(model.board.columns) { column in
                 ColumnView(
                     column: column,
-                    selectedCardID: model.selectedCard?.id,
+                    selectedCardID: selectedBoardCard?.id,
                     onOpenCard: openCard,
                     onAddCard: { model.createTask(status: $0) }
                 )
@@ -109,6 +109,13 @@ struct BoardView: View {
 
     // MARK: - Detail pane (panel switcher + terminal)
 
+    private var selectedBoardCard: Card? {
+        guard let selected = model.selectedCard else { return nil }
+        return model.board.columns
+            .flatMap(\.cards)
+            .first { $0.id == selected.id }
+    }
+
     private var detailPane: some View {
         VStack(spacing: 0) {
             detailHeader
@@ -123,7 +130,7 @@ struct BoardView: View {
 
     private var detailHeader: some View {
         HStack(spacing: Spacing.x3) {
-            Text(model.selectedCard?.title ?? "")
+            Text(selectedBoardCard?.title ?? "")
                 .font(.plexSans(14, weight: .medium))
                 .foregroundStyle(Color.inkPrimary)
                 .lineLimit(1)

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -49,28 +49,23 @@ struct BoardView: View {
     // MARK: - Board + detail split
 
     private var boardWithDetail: some View {
-        // Native draggable divider: drag to choose how wide the board vs the
-        // detail/terminal are. Each side has a min width so neither collapses.
-        HSplitView {
-            VStack(spacing: 0) {
-                if model.phase == .disconnected {
-                    ReconnectingBar(handle: model.profile?.handle ?? "your computer")
-                }
-                if let error = model.openError {
-                    GenericErrorBanner(message: error.message, onRetry: nil)
-                }
+        VStack(spacing: 0) {
+            if model.phase == .disconnected {
+                ReconnectingBar(handle: model.profile?.handle ?? "your computer")
+            }
+            if let error = model.openError {
+                GenericErrorBanner(message: error.message, onRetry: nil)
+            }
+            if model.selectedCard != nil {
+                detailPane
+            } else {
                 columns
                     .opacity(model.phase == .disconnected ? 0.7 : 1)
                     .saturation(model.phase == .disconnected ? 0.6 : 1)
                     .allowsHitTesting(model.phase != .disconnected)
             }
-            .frame(minWidth: 360, maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-            if model.selectedCard != nil {
-                detailPane
-                    .frame(minWidth: 380, idealWidth: 560, maxWidth: .infinity, maxHeight: .infinity)
-            }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private var columns: some View {

--- a/macos/Sources/App/ColumnView.swift
+++ b/macos/Sources/App/ColumnView.swift
@@ -14,6 +14,7 @@ struct ColumnView: View {
     let column: BoardColumn
     let selectedCardID: Card.ID?
     let onOpenCard: (Card) -> Void
+    var onAddCard: (TaskStatus) -> Void = { _ in }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -69,6 +70,14 @@ struct ColumnView: View {
                     RoundedRectangle(cornerRadius: Radius.badge, style: .continuous)
                         .fill(Color.surfaceCard)
                 )
+
+            Button { onAddCard(column.status) } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(Color.inkTertiary)
+            }
+            .buttonStyle(.plain)
+            .help("New task in \(title)")
         }
         .padding(.horizontal, Spacing.x3)
         .padding(.vertical, Spacing.x3)

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -55,7 +55,7 @@ private struct RootView: View {
     @ObservedObject var model: AppModel
 
     var body: some View {
-        BoardView(model: model)
+        RootShellView(model: model)
             .background(WindowVibrancy())
             .preferredColorScheme(.dark)
     }

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -91,7 +91,7 @@ private struct Sidebar: View {
                 .background(Circle().fill(Color.signalLive))
         }
         .buttonStyle(.plain)
-        .disabled(model.isCreatingSession)
+        .disabled(model.isCreatingWorkItem)
         .help(model.section == .terminals ? "New session" : "New task (⌘N)")
     }
 
@@ -137,7 +137,7 @@ private struct TerminalsView: View {
                     Image(systemName: "plus").font(.system(size: 11, weight: .bold))
                         .foregroundStyle(Color.inkSecondary)
                 }
-                .buttonStyle(.plain).disabled(model.isCreatingSession)
+                .buttonStyle(.plain).disabled(model.isCreatingWorkItem)
             }
             .padding(.horizontal, Spacing.x3).padding(.vertical, Spacing.x3)
 

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -1,0 +1,204 @@
+// Matrix OS — workspace shell: left rail (Board / Terminals) + section content.
+//
+// Board = task kanban (cards open a zellij session). Terminals = the live zellij
+// session list, opened in a side terminal (full terminal experience). This keeps
+// raw sessions OUT of the kanban (per product direction) while still one click away.
+#if os(macOS)
+import SwiftUI
+import DesignSystem
+import MatrixTerminal
+
+struct RootShellView: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        Group {
+            if model.phase == .needsProfile {
+                // Onboarding/sign-in takes the whole window (no rail yet).
+                BoardView(model: model)
+            } else {
+                HStack(spacing: 0) {
+                    Sidebar(model: model)
+                    Rectangle().fill(Color.hairlineDark).frame(width: 1)
+                    sectionContent
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+        }
+        .background(Color.canvasVoid)
+    }
+
+    @ViewBuilder
+    private var sectionContent: some View {
+        switch model.section {
+        case .board:
+            BoardView(model: model)
+        case .terminals:
+            TerminalsView(model: model)
+        }
+    }
+}
+
+/// Narrow left rail with section icons + a context "+" (new task / new session).
+private struct Sidebar: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        VStack(spacing: Spacing.x2) {
+            ForEach(AppSection.allCases, id: \.self) { section in
+                railButton(section)
+            }
+            Divider().overlay(Color.hairlineDark).padding(.vertical, Spacing.x1)
+            addButton
+            Spacer()
+            handleBadge
+        }
+        .padding(.vertical, Spacing.x3)
+        .frame(width: 60)
+        .frame(maxHeight: .infinity)
+        .background(Color.surfaceRail)
+    }
+
+    private func railButton(_ section: AppSection) -> some View {
+        let active = model.section == section
+        return Button { model.section = section } label: {
+            VStack(spacing: 3) {
+                Image(systemName: section.symbol)
+                    .font(.system(size: 16, weight: .medium))
+                Text(section.title)
+                    .font(.plexMono(8, weight: .medium))
+                    .tracking(0.3)
+            }
+            .foregroundStyle(active ? Color.signalLive : Color.inkTertiary)
+            .frame(width: 48, height: 44)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(active ? Color.surfaceCardRaised : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .help(section.title)
+    }
+
+    private var addButton: some View {
+        Button {
+            if model.section == .terminals { model.createSession() } else { model.createTask(status: .todo) }
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(Color.canvasVoid)
+                .frame(width: 30, height: 30)
+                .background(Circle().fill(Color.signalLive))
+        }
+        .buttonStyle(.plain)
+        .disabled(model.isCreatingSession)
+        .help(model.section == .terminals ? "New session" : "New task (⌘N)")
+    }
+
+    private var handleBadge: some View {
+        Text(String((model.profile?.handle ?? "?").prefix(2)).uppercased())
+            .font(.plexMono(10, weight: .semibold))
+            .foregroundStyle(Color.inkSecondary)
+            .frame(width: 30, height: 30)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(Color.surfaceCard)
+                    .overlay(RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                        .strokeBorder(Color.hairlineHighlight, lineWidth: 1))
+            )
+            .help(model.profile?.handle ?? "")
+    }
+}
+
+/// Terminals section: list of live zellij sessions on the left, full terminal on
+/// the right (resizable). One click opens the session over the gateway shell WS.
+private struct TerminalsView: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        HSplitView {
+            sessionList
+                .frame(minWidth: 220, idealWidth: 300, maxWidth: 420, maxHeight: .infinity)
+            terminalPane
+                .frame(minWidth: 380, maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var sessionList: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("TERMINALS")
+                    .font(.plexMono(11, weight: .semibold)).tracking(1.32)
+                    .foregroundStyle(Color.inkTertiary)
+                Spacer()
+                Text("\(model.sessions.count)")
+                    .font(.plexMono(11)).foregroundStyle(Color.inkTertiary)
+                Button { model.createSession() } label: {
+                    Image(systemName: "plus").font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(Color.inkSecondary)
+                }
+                .buttonStyle(.plain).disabled(model.isCreatingSession)
+            }
+            .padding(.horizontal, Spacing.x3).padding(.vertical, Spacing.x3)
+
+            ScrollView {
+                LazyVStack(spacing: Spacing.x1) {
+                    ForEach(model.sessions) { session in
+                        sessionRow(session)
+                    }
+                }
+                .padding(.horizontal, Spacing.x2)
+            }
+            if model.sessions.isEmpty {
+                Spacer()
+                Text("No sessions yet — press + to start one.")
+                    .font(.plexSans(12)).foregroundStyle(Color.inkTertiary)
+                    .padding(Spacing.x4)
+                Spacer()
+            }
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(Color.surfaceRail)
+    }
+
+    private func sessionRow(_ session: WorkspaceSession) -> some View {
+        let selected = model.selectedCard?.id == session.name
+        return Button { model.openSession(named: session.name) } label: {
+            HStack(spacing: Spacing.x2) {
+                Circle()
+                    .fill(session.isActive ? Color.signalLive : Color.inkTertiary)
+                    .frame(width: 7, height: 7)
+                Text(session.name)
+                    .font(.plexMono(12)).foregroundStyle(Color.inkPrimary)
+                    .lineLimit(1).truncationMode(.middle)
+                Spacer()
+            }
+            .padding(.horizontal, Spacing.x3).padding(.vertical, Spacing.x2)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.badge, style: .continuous)
+                    .fill(selected ? Color.surfaceCardRaised : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var terminalPane: some View {
+        if let terminal = model.terminal {
+            TerminalPanelView(session: terminal)
+                .background(Color.surfaceTerminal)
+        } else {
+            ZStack {
+                Color.surfaceTerminal
+                VStack(spacing: Spacing.x2) {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 28, weight: .light))
+                        .foregroundStyle(Color.inkTertiary)
+                    Text("Select a session to open its terminal")
+                        .font(.plexSans(13)).foregroundStyle(Color.inkSecondary)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/macos/Sources/Board/CompositeBoardLoader.swift
+++ b/macos/Sources/Board/CompositeBoardLoader.swift
@@ -1,0 +1,32 @@
+// MatrixBoard — project tasks + live sessions, merged into one board.
+//
+// Linear/SlayZone-style: the board is task-first (addable cards in lifecycle
+// columns). Live zellij sessions that are not already linked to a task are also
+// surfaced so in-flight work is visible. Tasks come from the resolved project;
+// sessions from `/api/sessions`. Auth/transport failures propagate (via the
+// sessions fetch); a missing/empty project (404) is tolerated as "no tasks yet".
+import Foundation
+import MatrixModel
+import MatrixNet
+
+public struct CompositeBoardLoader: BoardLoading {
+    private let tasks: GatewayBoardLoader
+    private let sessions: SessionsBoardLoader
+
+    public init(client: GatewayHTTPClient) {
+        self.tasks = GatewayBoardLoader(client: client)
+        self.sessions = SessionsBoardLoader(client: client)
+    }
+
+    public func fetchTasks(projectSlug: String) async throws -> [Card] {
+        // Sessions fetch is authoritative for connectivity (it always exists);
+        // let its errors surface so the app can show reconnecting/auth states.
+        let sessionCards = try await sessions.fetchTasks(projectSlug: projectSlug)
+        // Tasks are tolerant: a project with no tasks (or a 404 slug) yields none.
+        let taskCards = (try? await tasks.fetchTasks(projectSlug: projectSlug)) ?? []
+
+        let linkedSessionIds = Set(taskCards.compactMap { $0.linkedSessionId })
+        let unlinkedSessions = sessionCards.filter { !linkedSessionIds.contains($0.id) }
+        return taskCards + unlinkedSessions
+    }
+}

--- a/specs/086-macos-native-shell/phase2-expansion.md
+++ b/specs/086-macos-native-shell/phase2-expansion.md
@@ -1,0 +1,59 @@
+# Phase 2 Expansion: Project + Task Management, Integrations, Symphony
+
+**Feature**: [086-macos-native-shell](./spec.md) · **Status**: planned (requested during live MVP testing 2026-06-05)
+**Context**: MVP works end-to-end (sign-in → sessions-as-cards → live zellij terminal on the VPS). These stories turn the board from a read-only session viewer into a full operator workspace.
+
+## Reuse audit (what already exists on the gateway)
+
+| Need | Existing surface | Net-new |
+|---|---|---|
+| Create a session | `POST /api/sessions` (orchestrator `startSession`); zellij `createSession`/`createTab` | wire to ⌘N + card-create |
+| Create/list projects | `POST /api/projects`, `GET /api/workspace/projects`, `GET /api/projects/:slug` | clone-from-remote flow + UI |
+| Tasks CRUD (move/rename/order) | `POST/PATCH/DELETE /api/projects/:slug/tasks` (status, order, priority, linkedSessionId) | client mutations (US2) |
+| GitHub status / PRs | `GET /api/github/status`, `/api/projects/:slug/prs`, `/branches` | issue import mapping |
+| `gh auth login` | runs in any card terminal (already attachable) | a guided "connect GitHub" affordance |
+| Symphony | `packages/gateway/src/symphony/*` proxy | assign-to-symphony action |
+| Labels / assignees | **not in task schema** (`CreateTaskSchema` has no tags/assignee) | **server delta**: add `tags`/`assignee` columns + validation |
+| Linear import | **no Linear integration on VPS gateway** | platform-owned Pipedream/Linear proxy (PIPEDREAM_* stays platform-side per CLAUDE.md) |
+
+## User Stories
+
+### US7 — A card is backed by a fresh zellij session (P1 for this phase)
+Creating a card (⌘N or the column "+") provisions a **new** zellij session on the VPS and links it (`linkedSessionId`); opening the card attaches its terminal. Opening an existing session-card attaches; "new terminal" adds a zellij **tab** (`createTab`).
+- **FR-E1**: ⌘N / column-"+" creates a card → `POST /api/sessions` (idempotent) → links the new session id; the board shows it immediately and optimistically.
+- **FR-E2**: A card titled by the user; the session name is derived safely (SAFE_SLUG) server-side.
+- **FR-E3**: "New terminal" on a card opens a new zellij tab in that session.
+
+### US8 — Projects: clone remote, new project, GitHub auth (P1)
+The operator can create a project, **clone a remote git repo onto the VPS**, and authenticate git via `gh auth login` from a terminal.
+- **FR-E4**: "New project" → `POST /api/projects` (name, optional git remote). Unique-slug create is idempotent server-side.
+- **FR-E5**: "Clone repo" → provisions a session whose terminal runs the clone (or a gateway clone route if one exists) into `~/projects/<slug>`; progress visible in the card terminal.
+- **FR-E6**: "Connect GitHub" → opens a card terminal pre-running `gh auth login` (device flow in-terminal); status reflected from `GET /api/github/status`.
+- **FR-E7**: A project picker in the board chrome switches the active project/board (replaces the hardcoded slug).
+
+### US9 — Import tickets from GitHub / Linear (P2)
+Import issues into the board as cards.
+- **FR-E8**: GitHub issues import for the project's repo → create tasks (title, body→description, labels→tags, state→column). Uses GitHub via the existing project GitHub auth.
+- **FR-E9**: Linear import via a **platform-owned** integration (Pipedream/Linear proxy; `PIPEDREAM_*` never on the VPS — proxy through `PLATFORM_INTERNAL_URL` per CLAUDE.md). Maps Linear issues → tasks.
+- **FR-E10**: Import is idempotent (re-import updates, does not duplicate; key on external id).
+
+### US10 — Labels and assignment (incl. Symphony) (P2)
+- **FR-E11**: Add/remove **labels** on a card (server delta: `tags: string[]` on task, validated `SAFE_SLUG`, capped).
+- **FR-E12**: **Assign** a card to a person or an **agent** (server delta: `assignee` — a principal/agent ref). Assignment is visible on the card.
+- **FR-E13**: **Assign to Symphony** → hands the task to the Symphony orchestrator (start a run scoped to the task/session); card shows run status + agent activity (ties to US5).
+
+## Security / failure / resource notes
+- All new routes principal-scoped (`requireRequestPrincipal`, owner scope); `bodyLimit` on every mutation; generic errors only.
+- Session/project create idempotent (`ON CONFLICT` / unique-slug select-existing) — no duplicate sessions on double-tap.
+- Import jobs bounded + paginated; external fetches (GitHub/Linear) time-bounded and SSRF-safe; Linear stays platform-side.
+- Label/assignee server delta is a Kysely migration on owner Postgres (no new embedded DB).
+- Symphony assignment must reflect terminal run state honestly (no silent success).
+
+## Server deltas required (call out for review-spec)
+1. `tasks.tags string[]` + `tasks.assignee` columns (+ validation, + PATCH support, revision-guarded).
+2. (Maybe) a gateway clone route, or do clone purely in-terminal (no new route).
+3. GitHub issue import endpoint (or client-side via gh in terminal + task POST).
+4. Platform Linear proxy route (platform-owned).
+
+## Task additions (appended to tasks.md Phase 4+)
+See tasks.md "Phase 4b — Expansion (US7–US10)".

--- a/specs/086-macos-native-shell/tasks.md
+++ b/specs/086-macos-native-shell/tasks.md
@@ -124,6 +124,31 @@ description: "Task list for 086 Matrix OS native macOS app"
 
 ---
 
+## Phase 4b — Expansion (US7–US10) — see phase2-expansion.md
+
+**US7 — fresh session per card**
+- [ ] TE01 [US7] ⌘N + column "+" create a card → `POST /api/sessions` (idempotent), link new `linkedSessionId`, optimistic add; open attaches terminal.
+- [ ] TE02 [US7] "New terminal" on a card → zellij `createTab`; tabs strip switches tabs.
+
+**US8 — projects: clone / new / GitHub auth**
+- [ ] TE03 [US8] Project picker in board chrome (replace hardcoded slug); `GET /api/workspace/projects`; persist last project.
+- [ ] TE04 [US8] "New project" → `POST /api/projects` (name + optional remote); idempotent unique-slug.
+- [ ] TE05 [US8] "Clone repo" → session terminal runs the clone into `~/projects/<slug>` (or gateway clone route if present); progress in the card terminal.
+- [ ] TE06 [US8] "Connect GitHub" → card terminal pre-runs `gh auth login`; reflect `GET /api/github/status`.
+
+**US9 — ticket import**
+- [ ] TE07 [US9] GitHub issues import → tasks (title/body/labels/state→column); idempotent on issue id.
+- [ ] TE08 [US9] Linear import via **platform-owned** proxy (`PLATFORM_INTERNAL_URL`; no `PIPEDREAM_*` on VPS); idempotent on Linear id.
+
+**US10 — labels & assignment (incl. Symphony)**
+- [ ] TE09 [US10] Server delta (TDD-first, Kysely migration): `tasks.tags string[]` + `tasks.assignee`; PATCH support; revision-guarded; `bodyLimit`; generic errors. Tests in `tests/gateway/`.
+- [ ] TE10 [US10] Label add/remove + assignee UI on cards; validated `SAFE_SLUG`, capped.
+- [ ] TE11 [US10] "Assign to Symphony" → start a Symphony run scoped to the task/session; card shows run status + agent activity (ties US5).
+
+**Notes**: TE09 is the only hard server delta; clone/gh/import can run largely in-terminal + existing task POSTs first, then graduate to dedicated routes. Each sub-group is its own stacked PR; Greptile 5/5.
+
+---
+
 ## Dependencies & Execution Order
 
 - **Phase 0** (spikes) → unblocks risky areas; do first.


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 5/11.

## Summary

Separates the native workspace into project board and standalone terminals sections, including CMD-N session creation and composite board loading.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

No backend route, database, or auth behavior changes in this layer.