### PR TITLE
feat(086): refine native workspace core

### DIFF
--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -926,7 +926,7 @@ public final class AppModel: ObservableObject {
             throw err
         }
         guard generation == openCardGeneration, selectedCard?.id == card.id else {
-            throw OpenCardError.noSession
+            throw OperatorError.noSession
         }
 
         // Existing session → attach by name. No session yet → connect to

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -577,13 +577,14 @@ public final class AppModel: ObservableObject {
 
     public func ensureHomeTab(select: Bool = false) {
         guard profile != nil else { return }
+        let existingPanel = openTabs.first(where: { $0.id == "home" })?.panel
         let home = WorkspaceTab(
             id: "home",
             title: homeTitle(),
             projectSlug: projectSlug,
             projectName: activeProjectName,
             kind: .home,
-            panel: .shell
+            panel: existingPanel ?? .shell
         )
         if let index = openTabs.firstIndex(where: { $0.id == home.id }) {
             openTabs[index] = home
@@ -676,16 +677,16 @@ public final class AppModel: ObservableObject {
             let sessions: [SessionDTO]
         }
         var byName: [String: WorkspaceSession] = [:]
+        var nextAttachNames: [String: String] = [:]
         func merge(_ dtos: [SessionDTO]) {
             for dto in dtos where !dto.name.isEmpty {
                 byName[dto.name] = WorkspaceSession(name: dto.name, attachName: dto.attachName, status: dto.status)
                 for alias in dto.aliases {
-                    sessionAttachNames[alias] = dto.attachName
+                    nextAttachNames[alias] = dto.attachName
                 }
-                sessionAttachNames[dto.name] = dto.attachName
+                nextAttachNames[dto.name] = dto.attachName
             }
         }
-        sessionAttachNames.removeAll(keepingCapacity: true)
         if let response: SessionsResponse = try? await client.get("/api/terminal/sessions") {
             merge(response.sessions)
         }
@@ -699,6 +700,7 @@ public final class AppModel: ObservableObject {
             if lhs.isActive != rhs.isActive { return lhs.isActive && !rhs.isActive }
             return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
         }
+        sessionAttachNames = nextAttachNames
         sessions = loaded
         if !loaded.isEmpty {
             if section == .shell, terminal == nil, let first = sessions.first(where: \.isActive) ?? sessions.first {
@@ -1449,16 +1451,10 @@ public final class AppModel: ObservableObject {
     private func upsertTab(for card: Card) -> String {
         let kind: WorkspaceTab.Kind = card.id.hasPrefix("task_") ? .task : .session
         let title = displayName(for: card)
-        let candidate = WorkspaceTab(
-            title: title,
-            projectSlug: projectSlug,
-            projectName: activeProjectName,
-            kind: kind,
-            card: card,
-            panel: .terminal
-        )
-        let existingPanel = openTabs.first(where: { $0.id == candidate.id })?.panel
+        let tabID = "\(kind.rawValue):\(projectSlug):\(card.id)"
+        let existingPanel = openTabs.first(where: { $0.id == tabID })?.panel
         let tab = WorkspaceTab(
+            id: tabID,
             title: title,
             projectSlug: projectSlug,
             projectName: activeProjectName,

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1449,13 +1449,22 @@ public final class AppModel: ObservableObject {
     private func upsertTab(for card: Card) -> String {
         let kind: WorkspaceTab.Kind = card.id.hasPrefix("task_") ? .task : .session
         let title = displayName(for: card)
-        let tab = WorkspaceTab(
+        let candidate = WorkspaceTab(
             title: title,
             projectSlug: projectSlug,
             projectName: activeProjectName,
             kind: kind,
             card: card,
             panel: .terminal
+        )
+        let existingPanel = openTabs.first(where: { $0.id == candidate.id })?.panel
+        let tab = WorkspaceTab(
+            title: title,
+            projectSlug: projectSlug,
+            projectName: activeProjectName,
+            kind: kind,
+            card: card,
+            panel: existingPanel ?? .terminal
         )
         if let index = openTabs.firstIndex(where: { $0.id == tab.id }) {
             openTabs[index] = tab

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -42,8 +42,8 @@ public enum AppPhase: Equatable, Sendable {
     case disconnected
 }
 
-/// Generic, user-safe reason a card couldn't be opened. No raw text (FR-023).
-public enum OpenCardError: Error, Equatable, Sendable {
+/// Generic, user-safe operation errors shown in the board chrome. No raw text (FR-023).
+public enum OperatorError: Error, Equatable, Sendable {
     /// The card has no linked session to attach to.
     case noSession
     /// The profile/runtime is missing or its URL could not be resolved.
@@ -84,20 +84,23 @@ public enum SignInState: Equatable, Sendable {
 /// Top-level workspace sections (left rail). Board = task kanban; Terminals =
 /// the live zellij session list opened in a full/side terminal.
 public enum AppSection: String, CaseIterable, Sendable {
+    case home
     case board
-    case terminals
+    case shell
 
     public var title: String {
         switch self {
+        case .home: return "Home"
         case .board: return "Board"
-        case .terminals: return "Terminals"
+        case .shell: return "Shell"
         }
     }
 
     public var symbol: String {
         switch self {
+        case .home: return "house"
         case .board: return "rectangle.split.3x1"
-        case .terminals: return "terminal"
+        case .shell: return "terminal"
         }
     }
 }
@@ -105,9 +108,55 @@ public enum AppSection: String, CaseIterable, Sendable {
 /// A live zellij session entry for the Terminals section.
 public struct WorkspaceSession: Identifiable, Equatable, Sendable {
     public let name: String
+    public let attachName: String
     public let status: String
     public var id: String { name }
-    public var isActive: Bool { status == "active" }
+    public var isActive: Bool {
+        ["active", "running", "attached", "ready"].contains(status.lowercased())
+    }
+
+    public init(name: String, attachName: String? = nil, status: String) {
+        self.name = name
+        self.attachName = attachName ?? name
+        self.status = status
+    }
+}
+
+/// Open workspace tab for a task card or raw zellij session. The tab is the
+/// stable unit of work shown in the native chrome.
+public struct WorkspaceTab: Identifiable, Equatable, Sendable {
+    public enum Kind: String, Sendable {
+        case home
+        case task
+        case session
+        case app
+    }
+
+    public let id: String
+    public let title: String
+    public let projectSlug: String
+    public let projectName: String
+    public let kind: Kind
+    public let card: Card?
+    public var panel: Panel
+
+    public init(
+        id: String? = nil,
+        title: String,
+        projectSlug: String,
+        projectName: String,
+        kind: Kind,
+        card: Card? = nil,
+        panel: Panel
+    ) {
+        self.id = id ?? "\(kind.rawValue):\(projectSlug):\(card?.id ?? title)"
+        self.title = title
+        self.projectSlug = projectSlug
+        self.projectName = projectName
+        self.kind = kind
+        self.card = card
+        self.panel = panel
+    }
 }
 
 /// A project the user can open/clone (project picker + Projects UI).
@@ -121,16 +170,96 @@ public struct ProjectSummary: Identifiable, Equatable, Sendable {
     }
 }
 
+public struct WorkspaceFileEntry: Identifiable, Equatable, Sendable {
+    public let name: String
+    public let type: String
+    public let size: Int?
+    public let gitStatus: String?
+    public let changedCount: Int?
+    public var id: String { "\(type):\(name)" }
+}
+
+public struct WorkspaceFileTreeNode: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let type: String
+    public let path: String
+    public let size: Int?
+    public let gitStatus: String?
+    public let changedCount: Int?
+    public var children: [WorkspaceFileTreeNode]?
+    public var expanded: Bool
+
+    public var isDirectory: Bool { type == "directory" }
+}
+
+public struct GitBranchSummary: Identifiable, Equatable, Sendable {
+    public let name: String
+    public var id: String { name }
+}
+
+public struct GitPullRequestSummary: Identifiable, Equatable, Sendable {
+    public let number: Int
+    public let title: String
+    public let headRefName: String?
+    public let baseRefName: String?
+    public var id: Int { number }
+}
+
+public struct GitWorktreeSummary: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let path: String
+    public let currentBranch: String
+    public let dirtyState: String
+    public let dirtyCount: Int?
+}
+
+public struct PreviewSummary: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let label: String
+    public let url: String
+    public let lastStatus: String
+}
+
 @MainActor
 public final class AppModel: ObservableObject {
     // MARK: - Published state (SwiftUI binds to these)
 
     /// The active top-level section (left rail selection).
-    @Published public var section: AppSection = .board
+    @Published public var section: AppSection = .home
     /// Live zellij sessions for the Terminals section.
     @Published public private(set) var sessions: [WorkspaceSession] = []
+    /// Open task/session tabs in the workspace. Tabs are project-marked so work
+    /// from multiple Matrix projects stays legible.
+    @Published public private(set) var openTabs: [WorkspaceTab] = []
+    /// The currently active workspace tab, if any.
+    @Published public private(set) var activeTabID: String?
+    /// Terminal sessions are retained per terminal tab so tab switching does not
+    /// tear down sockets or drop zellij output.
+    @Published public private(set) var terminalSessions: [String: TerminalSession] = [:]
     /// The user's projects (for the project picker / Projects UI).
     @Published public private(set) var projects: [ProjectSummary] = []
+    /// Files for the active project/editor panel.
+    @Published public private(set) var fileEntries: [WorkspaceFileEntry] = []
+    /// Expandable file tree for the active project/editor panel.
+    @Published public private(set) var fileTree: [WorkspaceFileTreeNode] = []
+    /// Current directory path shown by the native editor panel.
+    @Published public private(set) var filePanelPath: String = ""
+    /// Selected file path and contents for lightweight native editing.
+    @Published public private(set) var selectedFilePath: String?
+    @Published public private(set) var selectedFileData: Data?
+    @Published public var selectedFileContent: String = ""
+    @Published public private(set) var fileSaveState: String?
+    /// Git branches for the active project.
+    @Published public private(set) var gitBranches: [GitBranchSummary] = []
+    /// Pull requests for the active project, when GitHub is linked.
+    @Published public private(set) var gitPullRequests: [GitPullRequestSummary] = []
+    /// Managed worktrees for the active project.
+    @Published public private(set) var gitWorktrees: [GitWorktreeSummary] = []
+    /// Preview/artifact records for the active project/task/session.
+    @Published public private(set) var previews: [PreviewSummary] = []
+    /// Shared loading flag for secondary panels.
+    @Published public private(set) var isLoadingPanelData = false
     /// Command palette (⌘K) visibility.
     @Published public var showCommandPalette = false
 
@@ -138,16 +267,21 @@ public final class AppModel: ObservableObject {
     @Published public private(set) var profile: ConnectionProfile?
     /// Top-level phase driving the root view.
     @Published public private(set) var phase: AppPhase = .needsProfile
+    /// Whether the user has explicitly opened a project in this session. Until
+    /// then the ready state shows the Matrix home/onboarding surface instead of
+    /// auto-opening a kanban board.
+    @Published public private(set) var hasSelectedProject: Bool
     /// The board the operator is working in (read-only in US1).
     @Published public private(set) var board: BoardStore
     /// The currently selected/open card (detail pane + terminal).
     @Published public private(set) var selectedCard: Card?
     /// The live terminal session for the open card, if one is attached.
     @Published public private(set) var terminal: TerminalSession?
-    /// Which pane the detail view is showing (US1 ships Terminal only).
-    @Published public var activePanel: Panel = .terminal
+    /// Which pane the detail view is showing. The agent terminal is always the
+    /// left split; the right pane defaults to the editor.
+    @Published public var activePanel: Panel = .app(slug: "editor")
     /// A generic, user-safe error to surface in chrome (nil when clear).
-    @Published public private(set) var openError: OpenCardError?
+    @Published public private(set) var openError: OperatorError?
     /// Device-auth sign-in progress (drives the onboarding sign-in UI).
     @Published public private(set) var signIn: SignInState = .idle
 
@@ -166,6 +300,11 @@ public final class AppModel: ObservableObject {
     private var signInTask: Task<Void, Never>?
     /// The project whose tasks the board renders.
     public private(set) var projectSlug: String
+    /// Maps workspace session ids / terminal ids to the zellij shell session name
+    /// required by `/ws/terminal/session`.
+    private var sessionAttachNames: [String: String] = [:]
+    private let maxCachedTerminalSessions = 8
+    private var terminalSessionAccessOrder: [String] = []
 
     /// Factory for the gateway client given a resolved base URL + token provider.
     /// Injected so tests can stub it without real networking.
@@ -190,6 +329,8 @@ public final class AppModel: ObservableObject {
             GatewayHTTPClient(baseURL: url, tokenProvider: provider)
         },
         makeLoader: @escaping @Sendable (GatewayHTTPClient) -> any BoardLoading = { client in
+            // The board is project/task-first, but unlinked live zellij sessions are
+            // also surfaced so a fresh VPS never opens to an empty board.
             CompositeBoardLoader(client: client)
         },
         makeTerminal: @escaping @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession = { url, provider, session, name in
@@ -217,6 +358,7 @@ public final class AppModel: ObservableObject {
         self.deviceAuth = deviceAuth
         self.signInGatewayHost = signInGatewayHost
         self.openExternalURL = openExternalURL
+        self.hasSelectedProject = false
         // If a profile is already known (persisted sign-in), wire the real board
         // loader immediately so the first `refresh()` fetches. Otherwise a
         // placeholder keeps `board` non-nil until `selectProfile`.
@@ -289,6 +431,26 @@ public final class AppModel: ObservableObject {
         signIn = .idle
     }
 
+    public func handleOpenURL(_ url: URL) {
+        guard url.scheme == "matrixos", url.host == "auth" else { return }
+        let status = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "status" })?
+            .value
+        switch status {
+        case "approved":
+            if case let .awaitingApproval(code, uri) = signIn {
+                signIn = .awaitingApproval(userCode: code, verificationUri: uri)
+            }
+        case "expired":
+            signIn = .failed("Sign-in expired. Try again.")
+        case "error":
+            signIn = .failed("Sign-in failed. Check your connection and try again.")
+        default:
+            break
+        }
+    }
+
     private func runSignIn() async {
         do {
             let start = try await deviceAuth.startDeviceAuth()
@@ -349,6 +511,7 @@ public final class AppModel: ObservableObject {
             self.board = BoardStore(loader: UnconfiguredBoardLoader())
             self.phase = .needsProfile
         }
+        ensureHomeTab(select: activeTabID == nil)
     }
 
     // MARK: - Board lifecycle
@@ -362,12 +525,17 @@ public final class AppModel: ObservableObject {
             phase = .needsProfile
             return
         }
+        ensureHomeTab(select: activeTabID == nil)
         if phase == .ready {
             // Keep showing the board while refreshing; only drop to disconnected on failure.
         } else {
             phase = .connecting
         }
         await loadProjects()
+        guard hasSelectedProject else {
+            phase = .ready
+            return
+        }
         guard await resolveProjectIfNeeded() else { return }
         await loadSessions()
         await board.load(projectSlug: projectSlug)
@@ -386,6 +554,49 @@ public final class AppModel: ObservableObject {
     private func gatewayClient() -> GatewayHTTPClient? {
         guard let profile, let baseURL = try? profile.gatewayBaseURL() else { return nil }
         return makeClient(baseURL, principal)
+    }
+
+    public func currentBearerToken() async -> String? {
+        await principal.token()
+    }
+
+    public func shellURL() -> URL? {
+        try? profile?.gatewayBaseURL()
+    }
+
+    public func homeTitle() -> String {
+        "Home"
+    }
+
+    public func appURL(slug: String) -> URL? {
+        guard let base = try? profile?.gatewayBaseURL(),
+              var comps = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return nil }
+        comps.path = "/files/apps/\(slug)/index.html"
+        return comps.url
+    }
+
+    public func ensureHomeTab(select: Bool = false) {
+        guard profile != nil else { return }
+        let home = WorkspaceTab(
+            id: "home",
+            title: homeTitle(),
+            projectSlug: projectSlug,
+            projectName: activeProjectName,
+            kind: .home,
+            panel: .shell
+        )
+        if let index = openTabs.firstIndex(where: { $0.id == home.id }) {
+            openTabs[index] = home
+        } else {
+            openTabs.insert(home, at: 0)
+        }
+        if select || activeTabID == nil {
+            focusTab(id: home.id)
+        }
+    }
+
+    public func openAppTab(slug: String, title: String) {
+        switchPanel(.app(slug: slug))
     }
 
     /// Resolves the active project slug from the user's projects when unset, so the
@@ -418,12 +629,81 @@ public final class AppModel: ObservableObject {
     /// Loads the live zellij session list for the Terminals section.
     public func loadSessions() async {
         guard let client = gatewayClient() else { return }
-        struct SessionsResponse: Decodable {
-            struct Session: Decodable { let name: String; let status: String }
-            let sessions: [Session]
+        struct SessionDTO: Decodable {
+            let name: String
+            let attachName: String
+            let status: String
+            let aliases: [String]
+
+            private enum CodingKeys: String, CodingKey {
+                case name, id, sessionId, terminalSessionId, status, state, runtime
+            }
+
+            private enum RuntimeKeys: String, CodingKey {
+                case status, zellijSession
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let runtime = try? container.nestedContainer(keyedBy: RuntimeKeys.self, forKey: .runtime)
+                let directName = try container.decodeIfPresent(String.self, forKey: .name)
+                let zellijName = try runtime?.decodeIfPresent(String.self, forKey: .zellijSession)
+                let id = try container.decodeIfPresent(String.self, forKey: .id)
+                let terminalId = try container.decodeIfPresent(String.self, forKey: .terminalSessionId)
+                let sessionId = try container.decodeIfPresent(String.self, forKey: .sessionId)
+                name = directName
+                    ?? zellijName
+                    ?? terminalId
+                    ?? sessionId
+                    ?? id
+                    ?? ""
+                attachName = zellijName
+                    ?? directName
+                    ?? terminalId
+                    ?? sessionId
+                    ?? id
+                    ?? ""
+                aliases = [directName, zellijName, id, terminalId, sessionId]
+                    .compactMap { $0 }
+                    .filter { !$0.isEmpty }
+                status = try container.decodeIfPresent(String.self, forKey: .status)
+                    ?? container.decodeIfPresent(String.self, forKey: .state)
+                    ?? runtime?.decodeIfPresent(String.self, forKey: .status)
+                    ?? "active"
+            }
         }
-        if let response: SessionsResponse = try? await client.get("/api/sessions") {
-            sessions = response.sessions.map { WorkspaceSession(name: $0.name, status: $0.status) }
+        struct SessionsResponse: Decodable {
+            let sessions: [SessionDTO]
+        }
+        var byName: [String: WorkspaceSession] = [:]
+        func merge(_ dtos: [SessionDTO]) {
+            for dto in dtos where !dto.name.isEmpty {
+                byName[dto.name] = WorkspaceSession(name: dto.name, attachName: dto.attachName, status: dto.status)
+                for alias in dto.aliases {
+                    sessionAttachNames[alias] = dto.attachName
+                }
+                sessionAttachNames[dto.name] = dto.attachName
+            }
+        }
+        sessionAttachNames.removeAll(keepingCapacity: true)
+        if let response: SessionsResponse = try? await client.get("/api/terminal/sessions") {
+            merge(response.sessions)
+        }
+        if let response: SessionsResponse = try? await client.get("/api/sessions?limit=100") {
+            merge(response.sessions)
+        }
+        if let response: [SessionDTO] = try? await client.get("/api/terminal/pty-sessions") {
+            merge(response)
+        }
+        let loaded = Array(byName.values).sorted { lhs, rhs in
+            if lhs.isActive != rhs.isActive { return lhs.isActive && !rhs.isActive }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        sessions = loaded
+        if !loaded.isEmpty {
+            if section == .shell, terminal == nil, let first = sessions.first(where: \.isActive) ?? sessions.first {
+                openSession(named: first.name)
+            }
         }
     }
 
@@ -442,10 +722,39 @@ public final class AppModel: ObservableObject {
     /// Switches the active project and reloads its board.
     public func openProject(slug: String) {
         guard slug != projectSlug, let client = gatewayClient() else { return }
+        openError = nil
         projectSlug = slug
+        hasSelectedProject = true
+        filePanelPath = "projects/\(slug)"
+        selectedFilePath = nil
+        selectedFileData = nil
+        selectedFileContent = ""
         board = BoardStore(loader: makeLoader(client))
         section = .board
         Task { await refresh() }
+    }
+
+    public func openHome() {
+        hasSelectedProject = false
+        selectedCard = nil
+        terminal = nil
+        activeTabID = "home"
+        section = .home
+        activePanel = .shell
+    }
+
+    public var activeProjectName: String {
+        projects.first { $0.slug == projectSlug }?.name ?? projectSlug
+    }
+
+    public var activeTabTitle: String {
+        openTabs.first { $0.id == activeTabID }?.title
+            ?? selectedCard?.title
+            ?? homeTitle()
+    }
+
+    public var activeTerminalSessionName: String? {
+        selectedCard?.linkedSessionId ?? selectedCard?.id
     }
 
     /// Creates a project (optionally from a git remote) and opens it.
@@ -453,11 +762,23 @@ public final class AppModel: ObservableObject {
         guard let client = gatewayClient() else { return }
         openError = nil
         Task { [weak self] in
-            struct CreateProjectRequest: Encodable { let name: String; let remote: String? }
+            let source = (remote?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                ? remote?.trimmingCharacters(in: .whitespacesAndNewlines)
+                : name.trimmingCharacters(in: .whitespacesAndNewlines)) ?? ""
+            guard !source.isEmpty else {
+                await MainActor.run { self?.openError = .createProjectFailed }
+                return
+            }
+            let slug = name
+                .lowercased()
+                .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                .filter { !$0.isEmpty }
+                .joined(separator: "-")
+            struct CreateProjectRequest: Encodable { let url: String; let slug: String? }
             struct CreateProjectResponse: Decodable { let project: Project?; struct Project: Decodable { let slug: String } }
             do {
                 let response: CreateProjectResponse = try await client.post(
-                    "/api/projects", body: CreateProjectRequest(name: name, remote: remote)
+                    "/api/projects", body: CreateProjectRequest(url: source, slug: slug.isEmpty ? nil : slug)
                 )
                 await self?.loadProjects()
                 if let slug = response.project?.slug {
@@ -509,7 +830,7 @@ public final class AppModel: ObservableObject {
         Task {
             do {
                 try await openCard(card)
-            } catch let error as OpenCardError {
+            } catch let error as OperatorError {
                 await MainActor.run { self.openError = error }
             } catch {
                 await MainActor.run { self.openError = .misconfigured }
@@ -528,12 +849,23 @@ public final class AppModel: ObservableObject {
             guard await self.resolveProjectIfNeeded() else { return }
             let slug = self.projectSlug
             struct CreateTaskRequest: Encodable { let title: String; let status: String }
-            struct CreateTaskResponse: Decodable {}
+            struct CreateTaskResponse: Decodable {
+                let task: GatewayTaskDTO?
+            }
             do {
-                let _: CreateTaskResponse = try await client.post(
+                let response: CreateTaskResponse = try await client.post(
                     "/api/projects/\(slug)/tasks",
                     body: CreateTaskRequest(title: "New task", status: status.rawValue)
                 )
+                if let task = response.task {
+                    let card = task.toCard()
+                    await MainActor.run {
+                        self.selectedCard = card
+                        self.activePanel = .terminal
+                        _ = self.upsertTab(for: card)
+                    }
+                    Task { try? await self.openCard(card) }
+                }
                 await self.refresh()
             } catch {
                 await MainActor.run { self.openError = .taskMutationFailed }
@@ -567,22 +899,29 @@ public final class AppModel: ObservableObject {
     /// Opens a card: selects it and, if it has a linked session, builds a
     /// `ShellWSClient` for that session over the profile's WS URL (header bearer
     /// token) and wraps it in a `TerminalSession`. Returns the session, or throws
-    /// a GENERIC `OpenCardError` (no raw text).
+    /// a GENERIC `OperatorError` (no raw text).
     @discardableResult
     public func openCard(_ card: Card) async throws -> TerminalSession {
         openError = nil
         selectedCard = card
+        let tabID = upsertTab(for: card)
         activePanel = .terminal
         openCardGeneration += 1
         let generation = openCardGeneration
 
+        if let existing = terminalSessions[tabID] {
+            markTerminalSessionUsed(tabID)
+            terminal = existing
+            return existing
+        }
+
         guard let profile else {
-            let err = OpenCardError.misconfigured
+            let err = OperatorError.misconfigured
             openError = err
             throw err
         }
         guard await principal.token() != nil else {
-            let err = OpenCardError.unauthorized
+            let err = OperatorError.unauthorized
             openError = err
             throw err
         }
@@ -592,49 +931,411 @@ public final class AppModel: ObservableObject {
 
         // Existing session → attach by name. No session yet → connect to
         // `/ws/terminal?cwd=` which auto-creates one (matrix shell connect -c).
-        let hasSession = !(card.linkedSessionId ?? "").isEmpty
+        let requestedSession = card.linkedSessionId ?? ""
+        let attachSession = sessionAttachName(for: requestedSession)
+        let hasSession = !attachSession.isEmpty
         let wsURL: URL
         do {
             if hasSession {
                 wsURL = try profile.webSocketURL(
                     path: "/ws/terminal/session",
-                    session: card.linkedSessionId!,
+                    session: attachSession,
                     fromSeq: Int?.none
                 )
             } else {
                 wsURL = try profile.autoCreateTerminalURL(cwd: nil)
             }
         } catch {
-            let err = OpenCardError.misconfigured
+            let err = OperatorError.misconfigured
             openError = err
             throw err
         }
 
-        // Tear down any previously open session before swapping in the new one.
-        terminal?.shutdown()
-        let label = hasSession ? card.linkedSessionId! : card.title
-        let session = makeTerminal(wsURL, principal, card.linkedSessionId ?? "", label)
+        let label = hasSession ? attachSession : card.title
+        let session = makeTerminal(wsURL, principal, attachSession, label)
+        cacheTerminalSession(session, for: tabID)
         terminal = session
         if !hasSession {
             session.onNextAttach { [weak self] in
                 Task { await self?.loadSessions() }
             }
         }
-        session.start()
         return session
+    }
+
+    /// Opens a workspace tab by reattaching its card/session terminal.
+    public func focusTab(id: String) {
+        guard let tab = openTabs.first(where: { $0.id == id }) else { return }
+        activeTabID = id
+        activePanel = tab.panel
+        selectedCard = tab.card
+        if let cachedTerminal = terminalSessions[id] {
+            markTerminalSessionUsed(id)
+            terminal = cachedTerminal
+            return
+        }
+        if let card = tab.card {
+            Task {
+                do {
+                    try await openCard(card)
+                } catch let error as OperatorError {
+                    await MainActor.run { self.openError = error }
+                } catch {
+                    await MainActor.run { self.openError = .misconfigured }
+                }
+            }
+        } else {
+            terminal = nil
+        }
+    }
+
+    /// Closes a workspace tab. If the active tab closes, focus the nearest
+    /// remaining tab; otherwise detach the current terminal.
+    public func closeTab(id: String) {
+        guard id != "home" else {
+            focusTab(id: id)
+            return
+        }
+        guard let index = openTabs.firstIndex(where: { $0.id == id }) else { return }
+        let wasActive = activeTabID == id
+        openTabs.remove(at: index)
+        removeCachedTerminalSession(for: id)
+        if !wasActive { return }
+        terminal = nil
+        selectedCard = nil
+        openError = nil
+        let nextIndex = min(index, openTabs.count - 1)
+        guard nextIndex >= 0, openTabs.indices.contains(nextIndex) else {
+            activeTabID = nil
+            return
+        }
+        let next = openTabs[nextIndex]
+        activeTabID = next.id
+        focusTab(id: next.id)
     }
 
     /// Closes the open card's terminal and detail pane (Esc / light-dismiss).
     public func closeCard() {
+        if let activeTabID {
+            closeTab(id: activeTabID)
+            return
+        }
         terminal?.shutdown()
         terminal = nil
         selectedCard = nil
         openError = nil
     }
 
+    public func closeSession(named name: String) {
+        if let tab = openTabs.first(where: { tab in
+            tab.card?.linkedSessionId == name || tab.card?.id == name
+        }) {
+            closeTab(id: tab.id)
+            return
+        }
+        if selectedCard?.linkedSessionId == name || selectedCard?.id == name {
+            closeCard()
+        }
+    }
+
     /// Switches the active detail panel (⌘1/2/3). US1 only renders Terminal.
     public func switchPanel(_ panel: Panel) {
         activePanel = panel
+        if let activeTabID,
+           let index = openTabs.firstIndex(where: { $0.id == activeTabID }) {
+            openTabs[index].panel = panel
+        }
+        Task { await loadPanelData(for: panel) }
+    }
+
+    public func loadSelectedTabPanel() {
+        Task { await loadPanelData(for: activePanel) }
+    }
+
+    public func loadPanelData(for panel: Panel? = nil) async {
+        let panel = panel ?? activePanel
+        guard let client = gatewayClient() else { return }
+        isLoadingPanelData = true
+        defer { isLoadingPanelData = false }
+        switch panel {
+        case .terminal, .shell:
+            return
+        case .app(let slug):
+            switch slug {
+            case "editor":
+                await loadFiles(client: client)
+            case "git":
+                await loadGit(client: client)
+            case "artifacts":
+                await loadPreviews(client: client)
+            case "processes":
+                await loadSessions()
+            default:
+                return
+            }
+        }
+    }
+
+    private func loadFiles(client: GatewayHTTPClient) async {
+        struct FilesResponse: Decodable {
+            struct Entry: Decodable {
+                let name: String
+                let type: String
+                let size: Int?
+                let gitStatus: String?
+                let changedCount: Int?
+            }
+            let entries: [Entry]
+        }
+        if filePanelPath.isEmpty {
+            filePanelPath = "projects/\(projectSlug)"
+        }
+        await loadFileTree(path: filePanelPath, replaceRoot: true, client: client)
+        if let response: FilesResponse = try? await client.get("/api/files/list?path=\(queryValue(filePanelPath))") {
+            fileEntries = response.entries.map {
+                WorkspaceFileEntry(
+                    name: $0.name,
+                    type: $0.type,
+                    size: $0.size,
+                    gitStatus: $0.gitStatus,
+                    changedCount: $0.changedCount
+                )
+            }
+        }
+    }
+
+    private struct FileTreeDTO: Decodable {
+        let name: String
+        let type: String
+        let size: Int?
+        let gitStatus: String?
+        let changedCount: Int?
+    }
+
+    private func loadFileTree(path: String, replaceRoot: Bool, client: GatewayHTTPClient) async {
+        let entries: [FileTreeDTO]
+        do {
+            entries = try await client.get("/api/files/tree?path=\(queryValue(path))")
+        } catch {
+            return
+        }
+        let nodes = entries.map { dto in
+            let childPath = path.isEmpty ? dto.name : "\(path)/\(dto.name)"
+            return WorkspaceFileTreeNode(
+                id: childPath,
+                name: dto.name,
+                type: dto.type,
+                path: childPath,
+                size: dto.size,
+                gitStatus: dto.gitStatus,
+                changedCount: dto.changedCount,
+                children: nil,
+                expanded: false
+            )
+        }
+        if replaceRoot {
+            fileTree = nodes
+        } else {
+            fileTree = updateTree(fileTree, path: path) { node in
+                var next = node
+                next.children = nodes
+                next.expanded = true
+                return next
+            }
+        }
+    }
+
+    public func openFileEntry(_ entry: WorkspaceFileEntry) {
+        guard let client = gatewayClient() else { return }
+        let path = "\(filePanelPath.isEmpty ? "projects/\(projectSlug)" : filePanelPath)/\(entry.name)"
+        fileSaveState = nil
+        if entry.type == "directory" {
+            filePanelPath = path
+            selectedFilePath = nil
+            selectedFileData = nil
+            selectedFileContent = ""
+            Task { await loadFiles(client: client) }
+            return
+        }
+        openFile(path: path, client: client)
+    }
+
+    public func toggleFileTreeNode(_ node: WorkspaceFileTreeNode) {
+        guard node.isDirectory, let client = gatewayClient() else { return }
+        if node.expanded {
+            fileTree = updateTree(fileTree, path: node.path) { current in
+                var next = current
+                next.expanded = false
+                return next
+            }
+            return
+        }
+        Task { await loadFileTree(path: node.path, replaceRoot: false, client: client) }
+    }
+
+    public func openFileTreeNode(_ node: WorkspaceFileTreeNode) {
+        if node.isDirectory {
+            toggleFileTreeNode(node)
+            return
+        }
+        guard let client = gatewayClient() else { return }
+        openFile(path: node.path, client: client)
+    }
+
+    private func openFile(path: String, client: GatewayHTTPClient) {
+        selectedFilePath = path
+        selectedFileData = nil
+        selectedFileContent = ""
+        fileSaveState = nil
+        let route = fileRoute(path)
+        Task { [weak self] in
+            do {
+                let data = try await client.getData(route)
+                let text = String(data: data, encoding: .utf8) ?? ""
+                await MainActor.run {
+                    self?.selectedFileData = data
+                    self?.selectedFileContent = text
+                    self?.fileSaveState = nil
+                }
+            } catch {
+                await MainActor.run {
+                    self?.selectedFileData = nil
+                    self?.selectedFileContent = ""
+                    self?.fileSaveState = "Couldn't open this file."
+                }
+            }
+        }
+    }
+
+    private func updateTree(
+        _ nodes: [WorkspaceFileTreeNode],
+        path: String,
+        transform: (WorkspaceFileTreeNode) -> WorkspaceFileTreeNode
+    ) -> [WorkspaceFileTreeNode] {
+        nodes.map { node in
+            if node.path == path {
+                return transform(node)
+            }
+            var next = node
+            if let children = node.children {
+                next.children = updateTree(children, path: path, transform: transform)
+            }
+            return next
+        }
+    }
+
+    public func goUpInFiles() {
+        guard !filePanelPath.isEmpty else { return }
+        let parts = filePanelPath.split(separator: "/").map(String.init)
+        guard parts.count > 2 else { return }
+        filePanelPath = parts.dropLast().joined(separator: "/")
+        selectedFilePath = nil
+        selectedFileData = nil
+        selectedFileContent = ""
+        Task { await loadPanelData(for: .app(slug: "editor")) }
+    }
+
+    public func saveSelectedFile() {
+        guard let client = gatewayClient(), let path = selectedFilePath else { return }
+        fileSaveState = "Saving..."
+        let content = selectedFileContent
+        let route = fileRoute(path)
+        Task { [weak self] in
+            do {
+                try await client.putData(route, data: Data(content.utf8))
+                await MainActor.run { self?.fileSaveState = "Saved" }
+                await self?.loadPanelData(for: .app(slug: "editor"))
+            } catch {
+                await MainActor.run { self?.fileSaveState = "Couldn't save this file." }
+            }
+        }
+    }
+
+    private func loadGit(client: GatewayHTTPClient) async {
+        struct BranchesResponse: Decodable {
+            struct Branch: Decodable { let name: String }
+            let branches: [Branch]
+        }
+        struct PRsResponse: Decodable {
+            struct PR: Decodable {
+                let number: Int
+                let title: String
+                let headRefName: String?
+                let baseRefName: String?
+            }
+            let prs: [PR]
+        }
+        struct WorktreesResponse: Decodable {
+            struct Worktree: Decodable {
+                let id: String
+                let path: String
+                let currentBranch: String
+                let dirtyState: String
+                let dirtyCount: Int?
+            }
+            let worktrees: [Worktree]
+        }
+        async let branchesResponse: BranchesResponse? = try? client.get("/api/projects/\(projectSlug)/branches")
+        async let prsResponse: PRsResponse? = try? client.get("/api/projects/\(projectSlug)/prs")
+        async let worktreesResponse: WorktreesResponse? = try? client.get("/api/projects/\(projectSlug)/worktrees")
+        let branches = await branchesResponse?.branches ?? []
+        let prs = await prsResponse?.prs ?? []
+        let worktrees = await worktreesResponse?.worktrees ?? []
+        gitBranches = branches.map { GitBranchSummary(name: $0.name) }
+        gitPullRequests = prs.map {
+            GitPullRequestSummary(
+                number: $0.number,
+                title: $0.title,
+                headRefName: $0.headRefName,
+                baseRefName: $0.baseRefName
+            )
+        }
+        gitWorktrees = worktrees.map {
+            GitWorktreeSummary(
+                id: $0.id,
+                path: $0.path,
+                currentBranch: $0.currentBranch,
+                dirtyState: $0.dirtyState,
+                dirtyCount: $0.dirtyCount
+            )
+        }
+    }
+
+    private func loadPreviews(client: GatewayHTTPClient) async {
+        struct PreviewsResponse: Decodable {
+            struct Preview: Decodable {
+                let id: String
+                let label: String
+                let url: String
+                let lastStatus: String
+            }
+            let previews: [Preview]
+        }
+        var path = "/api/projects/\(projectSlug)/previews?limit=50"
+        if let taskId = selectedCard?.id, taskId.hasPrefix("task_") {
+            path += "&taskId=\(queryValue(taskId))"
+        } else if let sessionId = selectedCard?.linkedSessionId ?? selectedCard?.id, !sessionId.isEmpty {
+            path += "&sessionId=\(queryValue(sessionId))"
+        }
+        if let response: PreviewsResponse = try? await client.get(path) {
+            previews = response.previews.map {
+                PreviewSummary(id: $0.id, label: $0.label, url: $0.url, lastStatus: $0.lastStatus)
+            }
+        }
+    }
+
+    public func sendCommandToActiveTerminal(_ command: String) {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if terminal == nil, let first = sessions.first(where: \.isActive) ?? sessions.first {
+            openSession(named: first.name)
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                await MainActor.run { self?.terminal?.send(trimmed + "\n") }
+            }
+            return
+        }
+        terminal?.send(trimmed + "\n")
     }
 
     /// ⌘N / column "+": create a new task card on the board.
@@ -648,19 +1349,40 @@ public final class AppModel: ObservableObject {
         guard !isCreatingWorkItem, let client = gatewayClient() else { return }
         openError = nil
         isCreatingWorkItem = true
+        let existingSessionNames = Set(sessions.map(\.name))
         Task { [weak self] in
             defer { Task { @MainActor in self?.isCreatingWorkItem = false } }
             struct CreateSessionRequest: Encodable {
                 let kind = "shell"
                 let runtimePreference = "zellij"
+                let projectSlug: String
             }
-            struct CreateSessionResponse: Decodable {}
+            struct CreateSessionResponse: Decodable {
+                struct Session: Decodable {
+                    let name: String
+
+                    private enum CodingKeys: String, CodingKey { case name, id, sessionId }
+
+                    init(from decoder: Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        name = try container.decodeIfPresent(String.self, forKey: .name)
+                            ?? container.decodeIfPresent(String.self, forKey: .id)
+                            ?? container.decode(String.self, forKey: .sessionId)
+                    }
+                }
+                let session: Session?
+            }
             do {
-                let _: CreateSessionResponse = try await client.post(
+                let response: CreateSessionResponse = try await client.post(
                     "/api/sessions",
-                    body: CreateSessionRequest()
+                    body: CreateSessionRequest(projectSlug: self?.projectSlug ?? "default")
                 )
                 await self?.loadSessions()
+                if let name = response.session?.name {
+                    await MainActor.run { self?.openSession(named: name) }
+                } else if let created = self?.sessions.first(where: { !existingSessionNames.contains($0.name) }) {
+                    await MainActor.run { self?.openSession(named: created.name) }
+                }
             } catch {
                 await MainActor.run { self?.openError = .createSessionFailed }
             }
@@ -669,9 +1391,88 @@ public final class AppModel: ObservableObject {
 
     private func displayName(for card: Card) -> String {
         if let session = card.linkedSessionId, !session.isEmpty {
-            return session
+            return sessionAttachName(for: session)
         }
         return card.title
+    }
+
+    private func sessionAttachName(for session: String) -> String {
+        sessionAttachNames[session] ?? session
+    }
+
+    private func cacheTerminalSession(_ session: TerminalSession, for tabID: String) {
+        terminalSessions[tabID] = session
+        markTerminalSessionUsed(tabID)
+        evictCachedTerminalSessionsIfNeeded()
+    }
+
+    private func markTerminalSessionUsed(_ tabID: String) {
+        terminalSessionAccessOrder.removeAll { $0 == tabID }
+        terminalSessionAccessOrder.append(tabID)
+    }
+
+    private func evictCachedTerminalSessionsIfNeeded() {
+        while terminalSessions.count > maxCachedTerminalSessions {
+            guard let evictID = terminalSessionAccessOrder.first(where: { $0 != activeTabID })
+                ?? terminalSessions.keys.first(where: { $0 != activeTabID }) else {
+                return
+            }
+            removeCachedTerminalSession(for: evictID)
+        }
+    }
+
+    private func removeCachedTerminalSession(for tabID: String) {
+        terminalSessionAccessOrder.removeAll { $0 == tabID }
+        terminalSessions.removeValue(forKey: tabID)?.shutdown()
+    }
+
+    private func queryValue(_ value: String) -> String {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&=+?")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+
+    private func fileRoute(_ path: String) -> String {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/")
+        let encoded = path
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .map { component in
+                String(component).addingPercentEncoding(withAllowedCharacters: allowed) ?? String(component)
+            }
+            .joined(separator: "/")
+        return "/files/\(encoded)"
+    }
+
+    @discardableResult
+    private func upsertTab(for card: Card) -> String {
+        let kind: WorkspaceTab.Kind = card.id.hasPrefix("task_") ? .task : .session
+        let title = displayName(for: card)
+        let tab = WorkspaceTab(
+            title: title,
+            projectSlug: projectSlug,
+            projectName: activeProjectName,
+            kind: kind,
+            card: card,
+            panel: .terminal
+        )
+        if let index = openTabs.firstIndex(where: { $0.id == tab.id }) {
+            openTabs[index] = tab
+        } else {
+            openTabs.append(tab)
+            if openTabs.count > 16 {
+                let evictedTabs = Array(openTabs.prefix(openTabs.count - 16))
+                openTabs.removeFirst(evictedTabs.count)
+                for evicted in evictedTabs {
+                    removeCachedTerminalSession(for: evicted.id)
+                    if activeTabID == evicted.id {
+                        terminal = nil
+                    }
+                }
+            }
+        }
+        activeTabID = tab.id
+        return tab.id
     }
 }
 

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -960,6 +960,7 @@ public final class AppModel: ObservableObject {
                 Task { await self?.loadSessions() }
             }
         }
+        session.start()
         return session
     }
 

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1461,19 +1461,25 @@ public final class AppModel: ObservableObject {
             openTabs[index] = tab
         } else {
             openTabs.append(tab)
-            if openTabs.count > 16 {
-                let evictedTabs = Array(openTabs.prefix(openTabs.count - 16))
-                openTabs.removeFirst(evictedTabs.count)
-                for evicted in evictedTabs {
-                    removeCachedTerminalSession(for: evicted.id)
-                    if activeTabID == evicted.id {
-                        terminal = nil
-                    }
-                }
-            }
+            trimOpenTabsToLimit(protecting: tab.id)
         }
         activeTabID = tab.id
         return tab.id
+    }
+
+    private func trimOpenTabsToLimit(protecting protectedID: String) {
+        while openTabs.count > 16 {
+            guard let evictIndex = openTabs.firstIndex(where: { tab in
+                tab.id != "home" && tab.id != protectedID
+            }) else {
+                return
+            }
+            let evicted = openTabs.remove(at: evictIndex)
+            removeCachedTerminalSession(for: evicted.id)
+            if activeTabID == evicted.id {
+                terminal = nil
+            }
+        }
     }
 }
 

--- a/macos/Sources/App/CommandPalette.swift
+++ b/macos/Sources/App/CommandPalette.swift
@@ -41,8 +41,8 @@ struct CommandPalette: View {
             PaletteAction(id: "go-board", title: "Switch to Board", symbol: "rectangle.split.3x1") {
                 model.section = .board
             },
-            PaletteAction(id: "go-terminals", title: "Switch to Terminals", symbol: "terminal.fill") {
-                model.section = .terminals
+            PaletteAction(id: "go-shell", title: "Switch to Shell", symbol: "terminal.fill") {
+                model.section = .shell
             },
         ] + projectActions
     }

--- a/macos/Sources/App/EmptyStates.swift
+++ b/macos/Sources/App/EmptyStates.swift
@@ -259,4 +259,83 @@ struct GenericErrorBanner: View {
         }
     }
 }
+
+struct MatrixComputerHomeView: View {
+    @ObservedObject var model: AppModel
+    let onOpenShell: () -> Void
+
+    var body: some View {
+        VStack(spacing: Spacing.x6) {
+            Spacer(minLength: 0)
+            VStack(spacing: Spacing.x2) {
+                Image(systemName: "server.rack")
+                    .font(.system(size: 44, weight: .light))
+                    .foregroundStyle(Color.signalLive)
+                Text("Start coding on your Matrix computer")
+                    .font(.plexSans(24, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                Text("Open a project board or start a shell session on your private runtime.")
+                    .font(.plexSans(14))
+                    .foregroundStyle(Color.inkSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            HStack(spacing: Spacing.x3) {
+                homeAction("Create project", icon: "folder.badge.plus") {
+                    model.createProject(name: "New project", remote: nil)
+                }
+                homeAction("Open shell", icon: "terminal") {
+                    onOpenShell()
+                }
+                homeAction("New task", icon: "plus.rectangle") {
+                    model.createTask(status: .todo)
+                }
+            }
+            .frame(maxWidth: 760)
+            Spacer(minLength: 0)
+        }
+        .padding(Spacing.x6)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.canvasVoid)
+    }
+
+    private func homeAction(_ title: String, icon: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: Spacing.x3) {
+                Image(systemName: icon)
+                    .font(.system(size: 24, weight: .light))
+                    .foregroundStyle(Color.signalLive)
+                Text(title)
+                    .font(.plexSans(14, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+            }
+            .frame(maxWidth: .infinity, minHeight: 112, alignment: .leading)
+            .padding(Spacing.x4)
+            .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+                    .strokeBorder(Color.hairlineDark, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct ProjectSelectionRequiredView: View {
+    var body: some View {
+        VStack(spacing: Spacing.x3) {
+            Image(systemName: "rectangle.split.3x1")
+                .font(.system(size: 38, weight: .light))
+                .foregroundStyle(Color.signalLive)
+            Text("Select a project")
+                .font(.plexSans(20, weight: .semibold))
+                .foregroundStyle(Color.inkPrimary)
+            Text("Choose a project in the sidebar to open its kanban board.")
+                .font(.plexSans(13))
+                .foregroundStyle(Color.inkSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.canvasVoid)
+    }
+}
 #endif

--- a/macos/Sources/App/HitTarget.swift
+++ b/macos/Sources/App/HitTarget.swift
@@ -1,0 +1,10 @@
+#if os(macOS)
+import SwiftUI
+
+extension View {
+    func iconHitTarget(_ size: CGFloat = 32) -> some View {
+        frame(width: size, height: size)
+            .contentShape(Rectangle())
+    }
+}
+#endif

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -78,7 +78,7 @@ private struct OperatorCommands: Commands {
             Divider()
             Button("Board") { model.section = .board }
                 .keyboardShortcut("1", modifiers: .control)
-            Button("Terminals") { model.section = .terminals }
+            Button("Shell") { model.section = .shell }
                 .keyboardShortcut("2", modifiers: .control)
             Divider()
             Button("Terminal Panel") { model.switchPanel(.terminal) }

--- a/macos/Sources/App/ProjectPicker.swift
+++ b/macos/Sources/App/ProjectPicker.swift
@@ -27,6 +27,7 @@ enum ProjectSheetMode: Identifiable {
 /// native and keyboard-reachable; the trigger shows the active project initial.
 struct ProjectPickerRail: View {
     @ObservedObject var model: AppModel
+    var collapsed = false
     @State private var sheet: ProjectSheetMode?
 
     private var activeName: String {
@@ -70,6 +71,27 @@ struct ProjectPickerRail: View {
         .menuIndicator(.hidden)
         .fixedSize()
         .help("Project: \(activeName)")
+        .sheet(item: $sheet) { mode in
+            ProjectCreateSheet(mode: mode) { name, remote in
+                model.createProject(name: name, remote: remote)
+            }
+        }
+    }
+}
+
+struct NewProjectButton: View {
+    @ObservedObject var model: AppModel
+    @State private var sheet: ProjectSheetMode?
+
+    var body: some View {
+        Button { sheet = .create } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.inkSecondary)
+                .iconHitTarget(28)
+        }
+        .buttonStyle(.plain)
+        .help("New project")
         .sheet(item: $sheet) { mode in
             ProjectCreateSheet(mode: mode) { name, remote in
                 model.createProject(name: name, remote: remote)

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -152,14 +152,55 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
     private static func highlighted(_ text: String, filePath: String?, theme: CodeEditorTheme) -> NSAttributedString {
         let nsText = text as NSString
         let fullRange = NSRange(location: 0, length: nsText.length)
+        let language = syntaxLanguage(for: filePath)
         let output = NSMutableAttributedString(
             string: text,
             attributes: [.font: editorFont(size: 13), .foregroundColor: theme.foreground]
         )
         apply(pattern: #""(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`"#, color: theme.string, to: output, range: fullRange)
-        apply(pattern: #"(?m)(//.*$|#.*$)"#, color: theme.comment, to: output, range: fullRange)
-        apply(pattern: #"\b(import|export|from|func|function|let|const|var|struct|class|enum|protocol|extension|public|private|return|if|else|switch|case|for|while|guard|try|await|async|throws|type|interface|extends|implements|new|in|of)\b"#, color: theme.keyword, to: output, range: fullRange)
+        if language.supportsLineComments {
+            apply(pattern: language.commentPattern, color: theme.comment, to: output, range: fullRange)
+        }
+        if language.supportsKeywords {
+            apply(pattern: language.keywordPattern, color: theme.keyword, to: output, range: fullRange)
+        }
         return output
+    }
+
+    private struct SyntaxLanguage {
+        var supportsLineComments: Bool
+        var supportsKeywords: Bool
+        var commentPattern: String
+        var keywordPattern: String
+    }
+
+    private static func syntaxLanguage(for filePath: String?) -> SyntaxLanguage {
+        let fallback = SyntaxLanguage(
+            supportsLineComments: true,
+            supportsKeywords: true,
+            commentPattern: #"(?m)(//.*$|#.*$)"#,
+            keywordPattern: #"\b(import|export|from|func|function|let|const|var|struct|class|enum|protocol|extension|public|private|return|if|else|switch|case|for|while|guard|try|await|async|throws|type|interface|extends|implements|new|in|of)\b"#
+        )
+        guard let filePath, !filePath.isEmpty else { return fallback }
+        let ext = URL(fileURLWithPath: filePath).pathExtension.lowercased()
+        switch ext {
+        case "json", "jsonc", "yaml", "yml", "toml", "xml", "html", "htm", "md", "markdown", "txt", "log", "csv":
+            return SyntaxLanguage(
+                supportsLineComments: false,
+                supportsKeywords: false,
+                commentPattern: fallback.commentPattern,
+                keywordPattern: fallback.keywordPattern
+            )
+        case "py", "rb", "sh", "bash", "zsh":
+            return SyntaxLanguage(
+                supportsLineComments: true,
+                supportsKeywords: true,
+                commentPattern: #"(?m)#.*$"#,
+                keywordPattern: fallback.keywordPattern
+            )
+        default:
+            return fallback
+        }
     }
 
     private static func apply(pattern: String, color: NSColor, to output: NSMutableAttributedString, range: NSRange) {

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -261,17 +261,15 @@ private final class LineNumberRulerView: NSRulerView {
         let visible = textView.visibleRect
         let glyphRange = layoutManager.glyphRange(forBoundingRect: visible, in: textContainer)
         let text = textView.string as NSString
-        var line = 1
-        var index = 0
-        while index < glyphRange.location, index < text.length {
-            if text.character(at: index) == 10 { line += 1 }
-            index += 1
-        }
         var glyphIndex = glyphRange.location
+        var scanIndex = 0
+        var line = 1
         while glyphIndex < NSMaxRange(glyphRange) {
             var effective = NSRange()
             let rect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: &effective)
             let y = rect.minY + textView.textContainerOrigin.y - visible.minY + 1
+            let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+            advanceLineNumber(upTo: characterIndex, in: text, scanIndex: &scanIndex, line: &line)
             let label = "\(line)" as NSString
             label.draw(
                 at: NSPoint(x: 8, y: y),
@@ -281,7 +279,13 @@ private final class LineNumberRulerView: NSRulerView {
                 ]
             )
             glyphIndex = NSMaxRange(effective)
-            line += 1
+        }
+    }
+
+    private func advanceLineNumber(upTo characterIndex: Int, in text: NSString, scanIndex: inout Int, line: inout Int) {
+        while scanIndex < characterIndex, scanIndex < text.length {
+            if text.character(at: scanIndex) == 10 { line += 1 }
+            scanIndex += 1
         }
     }
 }

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -108,7 +108,9 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
         context.coordinator.textView = textView
         context.coordinator.theme = theme
         context.coordinator.filePath = filePath
-        apply(text: text, to: textView, theme: theme, filePath: filePath)
+        context.coordinator.applyHighlight {
+            apply(text: text, to: textView, theme: theme, filePath: filePath)
+        }
         return scrollView
     }
 
@@ -118,10 +120,13 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
             ruler.theme = theme
             ruler.needsDisplay = true
         }
-        if textView.string != text || context.coordinator.theme != theme || context.coordinator.filePath != filePath {
+        if textView.string != text || context.coordinator.needsHighlight || context.coordinator.theme != theme || context.coordinator.filePath != filePath {
             context.coordinator.theme = theme
             context.coordinator.filePath = filePath
-            apply(text: text, to: textView, theme: theme, filePath: filePath)
+            context.coordinator.needsHighlight = false
+            context.coordinator.applyHighlight {
+                apply(text: text, to: textView, theme: theme, filePath: filePath)
+            }
         }
     }
 
@@ -170,13 +175,23 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
         weak var textView: NSTextView?
         var theme: CodeEditorTheme?
         var filePath: String?
+        var needsHighlight = false
+        private var isApplyingHighlight = false
 
         init(text: Binding<String>) {
             _text = text
         }
 
+        func applyHighlight(_ body: () -> Void) {
+            isApplyingHighlight = true
+            defer { isApplyingHighlight = false }
+            body()
+        }
+
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+            guard !isApplyingHighlight else { return }
+            needsHighlight = true
             text = textView.string
         }
     }

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -1,0 +1,232 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+import DesignSystem
+
+enum CodeEditorTheme: String, CaseIterable, Identifiable {
+    case matrixLight = "Matrix Light"
+    case xcodeLight = "Xcode"
+    case terminalDark = "Terminal"
+
+    var id: String { rawValue }
+
+    var background: NSColor {
+        switch self {
+        case .matrixLight: return NSColor.matrixHex(0xFFFFFF)
+        case .xcodeLight: return NSColor(calibratedWhite: 0.99, alpha: 1)
+        case .terminalDark: return NSColor.matrixHex(0x0C0D10)
+        }
+    }
+
+    var foreground: NSColor {
+        switch self {
+        case .matrixLight, .xcodeLight: return NSColor.matrixHex(0x32352E)
+        case .terminalDark: return NSColor.matrixHex(0xE8EAED)
+        }
+    }
+
+    var keyword: NSColor {
+        switch self {
+        case .matrixLight: return NSColor(Color.signalLive)
+        case .xcodeLight: return NSColor(calibratedRed: 0.58, green: 0.16, blue: 0.66, alpha: 1)
+        case .terminalDark: return NSColor(calibratedRed: 0.67, green: 0.82, blue: 1.0, alpha: 1)
+        }
+    }
+
+    var string: NSColor {
+        switch self {
+        case .matrixLight: return NSColor(calibratedRed: 0.62, green: 0.31, blue: 0.12, alpha: 1)
+        case .xcodeLight: return NSColor(calibratedRed: 0.74, green: 0.25, blue: 0.12, alpha: 1)
+        case .terminalDark: return NSColor(calibratedRed: 0.84, green: 0.70, blue: 0.45, alpha: 1)
+        }
+    }
+
+    var comment: NSColor {
+        switch self {
+        case .matrixLight, .xcodeLight: return NSColor.matrixHex(0x7A7768)
+        case .terminalDark: return NSColor.matrixHex(0x9BA1AC)
+        }
+    }
+
+    var gutterBackground: NSColor {
+        switch self {
+        case .matrixLight: return NSColor.matrixHex(0xF0EDE4)
+        case .xcodeLight: return NSColor(calibratedWhite: 0.95, alpha: 1)
+        case .terminalDark: return NSColor(calibratedWhite: 0.08, alpha: 1)
+        }
+    }
+}
+
+private extension NSColor {
+    static func matrixHex(_ hex: UInt32, alpha: CGFloat = 1) -> NSColor {
+        NSColor(
+            srgbRed: CGFloat((hex >> 16) & 0xff) / 255.0,
+            green: CGFloat((hex >> 8) & 0xff) / 255.0,
+            blue: CGFloat(hex & 0xff) / 255.0,
+            alpha: alpha
+        )
+    }
+}
+
+struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
+    @Binding var text: String
+    let filePath: String?
+    let theme: CodeEditorTheme
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = true
+
+        let textView = NSTextView()
+        textView.isRichText = false
+        textView.drawsBackground = true
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.allowsUndo = true
+        textView.delegate = context.coordinator
+        textView.textContainerInset = NSSize(width: 14, height: 14)
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(width: scrollView.contentSize.width, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = true
+
+        scrollView.documentView = textView
+        scrollView.verticalRulerView = LineNumberRulerView(textView: textView, theme: theme)
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+        context.coordinator.textView = textView
+        context.coordinator.theme = theme
+        context.coordinator.filePath = filePath
+        apply(text: text, to: textView, theme: theme, filePath: filePath)
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        if let ruler = scrollView.verticalRulerView as? LineNumberRulerView {
+            ruler.theme = theme
+            ruler.needsDisplay = true
+        }
+        if textView.string != text || context.coordinator.theme != theme || context.coordinator.filePath != filePath {
+            context.coordinator.theme = theme
+            context.coordinator.filePath = filePath
+            apply(text: text, to: textView, theme: theme, filePath: filePath)
+        }
+    }
+
+    private func apply(text: String, to textView: NSTextView, theme: CodeEditorTheme, filePath: String?) {
+        let selected = textView.selectedRange()
+        textView.backgroundColor = theme.background
+        textView.insertionPointColor = theme.foreground
+        textView.textColor = theme.foreground
+        textView.font = Self.editorFont(size: 13)
+        textView.textStorage?.setAttributedString(Self.highlighted(text, filePath: filePath, theme: theme))
+        textView.setSelectedRange(NSRange(location: min(selected.location, (text as NSString).length), length: 0))
+        textView.needsDisplay = true
+        textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+    }
+
+    private static func editorFont(size: CGFloat) -> NSFont {
+        for name in ["JetBrainsMono Nerd Font Mono", "JetBrains Mono", "SFMono-Regular", "Menlo"] {
+            if let font = NSFont(name: name, size: size) { return font }
+        }
+        return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+    }
+
+    private static func highlighted(_ text: String, filePath: String?, theme: CodeEditorTheme) -> NSAttributedString {
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let output = NSMutableAttributedString(
+            string: text,
+            attributes: [.font: editorFont(size: 13), .foregroundColor: theme.foreground]
+        )
+        apply(pattern: #""(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`"#, color: theme.string, to: output, range: fullRange)
+        apply(pattern: #"(?m)(//.*$|#.*$)"#, color: theme.comment, to: output, range: fullRange)
+        apply(pattern: #"\b(import|export|from|func|function|let|const|var|struct|class|enum|protocol|extension|public|private|return|if|else|switch|case|for|while|guard|try|await|async|throws|type|interface|extends|implements|new|in|of)\b"#, color: theme.keyword, to: output, range: fullRange)
+        return output
+    }
+
+    private static func apply(pattern: String, color: NSColor, to output: NSMutableAttributedString, range: NSRange) {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+        regex.enumerateMatches(in: output.string, range: range) { match, _, _ in
+            guard let match else { return }
+            output.addAttribute(.foregroundColor, value: color, range: match.range)
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        @Binding var text: String
+        weak var textView: NSTextView?
+        var theme: CodeEditorTheme?
+        var filePath: String?
+
+        init(text: Binding<String>) {
+            _text = text
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            text = textView.string
+        }
+    }
+}
+
+private final class LineNumberRulerView: NSRulerView {
+    weak var textView: NSTextView?
+    var theme: CodeEditorTheme
+
+    init(textView: NSTextView, theme: CodeEditorTheme) {
+        self.textView = textView
+        self.theme = theme
+        super.init(scrollView: textView.enclosingScrollView, orientation: .verticalRuler)
+        clientView = textView
+        ruleThickness = 48
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func drawHashMarksAndLabels(in rect: NSRect) {
+        theme.gutterBackground.setFill()
+        rect.fill()
+        guard let textView, let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else { return }
+        let visible = textView.visibleRect
+        let glyphRange = layoutManager.glyphRange(forBoundingRect: visible, in: textContainer)
+        let text = textView.string as NSString
+        var line = 1
+        var index = 0
+        while index < glyphRange.location, index < text.length {
+            if text.character(at: index) == 10 { line += 1 }
+            index += 1
+        }
+        var glyphIndex = glyphRange.location
+        while glyphIndex < NSMaxRange(glyphRange) {
+            var effective = NSRange()
+            let rect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: &effective)
+            let y = rect.minY + textView.textContainerOrigin.y - visible.minY + 1
+            let label = "\(line)" as NSString
+            label.draw(
+                at: NSPoint(x: 8, y: y),
+                withAttributes: [
+                    .font: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular),
+                    .foregroundColor: theme.comment,
+                ]
+            )
+            glyphIndex = NSMaxRange(effective)
+            line += 1
+        }
+    }
+}
+#endif

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -879,7 +879,7 @@ private struct CodeReadOnlyPreview: View {
 
     var body: some View {
         ScrollView([.horizontal, .vertical]) {
-            VStack(alignment: .leading, spacing: 0) {
+            LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
                     HStack(alignment: .top, spacing: Spacing.x3) {
                         Text("\(index + 1)")

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -552,7 +552,7 @@ private struct TerminalsView: View {
         case .terminal:
             terminalSurface
         case .shell:
-            MatrixWebShellPanel(model: model, url: model.shellURL(), title: "Matrix OS Shell")
+            workbenchPlaceholder(title: "Matrix OS Shell", icon: "globe", message: "The web shell panel is added in the next stack layer.")
         case .app(let slug):
             switch slug {
             case "editor":
@@ -566,7 +566,7 @@ private struct TerminalsView: View {
             case "processes":
                 ProcessesPanel(model: model)
             case "whiteboard":
-                MatrixWebShellPanel(model: model, url: model.appURL(slug: "whiteboard"), title: "Excalidraw")
+                workbenchPlaceholder(title: "Excalidraw", icon: "scribble.variable", message: "Whiteboard opens once the web shell panel is available.")
             default:
                 let meta = panelMeta(slug)
                 workbenchPlaceholder(title: meta.title, icon: meta.icon, message: meta.message)

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -5,6 +5,7 @@
 // raw sessions OUT of the kanban (per product direction) while still one click away.
 #if os(macOS)
 import SwiftUI
+import AppKit
 import DesignSystem
 import MatrixTerminal
 
@@ -38,9 +39,14 @@ struct RootShellView: View {
     @ViewBuilder
     private var sectionContent: some View {
         switch model.section {
+        case .home:
+            MatrixComputerHomeView(
+                model: model,
+                onOpenShell: { model.section = .shell; model.createSession() }
+            )
         case .board:
             BoardView(model: model)
-        case .terminals:
+        case .shell:
             TerminalsView(model: model)
         }
     }
@@ -49,24 +55,94 @@ struct RootShellView: View {
 /// Narrow left rail with section icons + a context "+" (new task / new session).
 private struct Sidebar: View {
     @ObservedObject var model: AppModel
+    @State private var collapsed = false
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sidebarHeader
+                .padding(.horizontal, collapsed ? Spacing.x2 : Spacing.x4)
+                .padding(.top, Spacing.x4)
+                .padding(.bottom, Spacing.x3)
+
+            if collapsed {
+                collapsedRail
+            } else {
+                expandedSidebar
+            }
+        }
+        .frame(width: collapsed ? 88 : 320)
+        .frame(maxHeight: .infinity)
+        .background(Color.canvasVoid)
+        .overlay(alignment: .trailing) {
+            Rectangle().fill(Color.hairlineDark.opacity(0.65)).frame(width: 1)
+        }
+        .animation(Motion.columnReflow, value: collapsed)
+    }
+
+    private var sidebarHeader: some View {
+        HStack(spacing: Spacing.x3) {
+            AppMark(collapsed: collapsed)
+            if !collapsed {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Matrix")
+                        .font(.plexSans(17, weight: .semibold))
+                        .foregroundStyle(Color.inkPrimary)
+                    Text(model.hasSelectedProject ? model.activeProjectName : "Home")
+                        .font(.plexMono(10, weight: .medium))
+                        .foregroundStyle(Color.inkTertiary)
+                }
+                Spacer()
+            }
+            Button { collapsed.toggle() } label: {
+                Image(systemName: collapsed ? "sidebar.right" : "sidebar.left")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.inkTertiary)
+                    .iconHitTarget(32)
+            }
+            .buttonStyle(.plain)
+            .help(collapsed ? "Expand sidebar" : "Collapse sidebar")
+        }
+    }
+
+    private var collapsedRail: some View {
         VStack(spacing: Spacing.x2) {
-            ProjectPickerRail(model: model)
+            Button { model.openHome() } label: {
+                Image(systemName: "house")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(model.hasSelectedProject ? Color.inkTertiary : Color.signalLive)
+                    .iconHitTarget(44)
+            }
+            .buttonStyle(.plain)
+            .help("Matrix Home")
             Divider().overlay(Color.hairlineDark).padding(.vertical, Spacing.x1)
-            ForEach(AppSection.allCases, id: \.self) { section in
+            ProjectPickerRail(model: model, collapsed: true)
+            Divider().overlay(Color.hairlineDark).padding(.vertical, Spacing.x1)
+            ForEach(AppSection.allCases.filter { $0 != .home }, id: \.self) { section in
                 railButton(section)
             }
             Divider().overlay(Color.hairlineDark).padding(.vertical, Spacing.x1)
-            addButton
-            commandButton
+            addButton(compact: true)
             Spacer()
             handleBadge
         }
-        .padding(.vertical, Spacing.x3)
-        .frame(width: 60)
-        .frame(maxHeight: .infinity)
-        .background(Color.surfaceRail)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, Spacing.x2)
+        .padding(.bottom, Spacing.x3)
+    }
+
+    private var expandedSidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            projectsBlock
+            sessionsBlock
+            Spacer(minLength: Spacing.x4)
+            newTaskButton
+            Divider().overlay(Color.hairlineDark.opacity(0.7))
+                .padding(.horizontal, Spacing.x4)
+                .padding(.vertical, Spacing.x3)
+            handleBadge
+                .padding(.horizontal, Spacing.x4)
+                .padding(.bottom, Spacing.x4)
+        }
     }
 
     private func railButton(_ section: AppSection) -> some View {
@@ -75,65 +151,262 @@ private struct Sidebar: View {
             VStack(spacing: 3) {
                 Image(systemName: section.symbol)
                     .font(.system(size: 16, weight: .medium))
-                Text(section.title)
-                    .font(.plexMono(8, weight: .medium))
-                    .tracking(0.3)
             }
             .foregroundStyle(active ? Color.signalLive : Color.inkTertiary)
-            .frame(width: 48, height: 44)
+            .frame(width: 52, height: 48)
             .background(
                 RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
                     .fill(active ? Color.surfaceCardRaised : Color.clear)
             )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .strokeBorder(active ? Color.hairlineDark : Color.clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .help(section.title)
+        .accessibilityLabel(section.title)
+        .accessibilityAddTraits(active ? [.isSelected] : [])
     }
 
-    private var addButton: some View {
+    private func addButton(compact: Bool) -> some View {
         Button {
-            if model.section == .terminals { model.createSession() } else { model.createTask(status: .todo) }
+            if model.section == .shell { model.createSession() } else { model.createTask(status: .todo) }
         } label: {
             Image(systemName: "plus")
-                .font(.system(size: 14, weight: .bold))
+                .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(Color.canvasVoid)
-                .frame(width: 30, height: 30)
+                .iconHitTarget(compact ? 42 : 36)
                 .background(Circle().fill(Color.signalLive))
         }
         .buttonStyle(.plain)
         .disabled(model.isCreatingWorkItem)
-        .help(model.section == .terminals ? "New session" : "New task (⌘N)")
+        .help(model.section == .shell ? "New session" : "New task (⌘N)")
+        .accessibilityLabel(model.section == .shell ? "New session" : "New task")
     }
 
-    private var commandButton: some View {
-        Button { model.showCommandPalette = true } label: {
-            Image(systemName: "command")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Color.inkSecondary)
-                .frame(width: 30, height: 30)
-                .background(
-                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                        .fill(Color.surfaceCard)
-                        .overlay(RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                            .strokeBorder(Color.hairlineHighlight, lineWidth: 1))
-                )
+    private var projectsBlock: some View {
+        VStack(alignment: .leading, spacing: Spacing.x2) {
+            sectionLabel("Projects") {
+                NewProjectButton(model: model)
+            }
+            ProjectPickerRail(model: model, collapsed: false)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, Spacing.x4)
+        .padding(.bottom, Spacing.x4)
+    }
+
+    private var sessionsBlock: some View {
+        VStack(alignment: .leading, spacing: Spacing.x2) {
+            sectionLabel("Sessions") {
+                Button { model.createSession() } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Color.inkSecondary)
+                        .iconHitTarget(28)
+                }
+                .buttonStyle(.plain)
+                .disabled(model.isCreatingWorkItem)
+                .help("New terminal tab")
+            }
+
+            ScrollView {
+                LazyVStack(spacing: Spacing.x1) {
+                    let activeSessions = model.sessions.filter(\.isActive)
+                    if !activeSessions.isEmpty {
+                        sidebarSubhead("Active")
+                        ForEach(activeSessions) { session in
+                            sessionRow(session)
+                        }
+                    }
+                    let recentSessions = model.sessions.filter { !$0.isActive }
+                    if !recentSessions.isEmpty {
+                        sidebarSubhead("Recent")
+                            .padding(.top, Spacing.x3)
+                        ForEach(recentSessions) { session in
+                            sessionRow(session)
+                        }
+                    }
+                    if model.sessions.isEmpty {
+                        emptySessions
+                    }
+                }
+                .padding(.bottom, Spacing.x2)
+            }
+        }
+        .padding(.horizontal, Spacing.x4)
+    }
+
+    private func sectionLabel<Accessory: View>(_ title: String, @ViewBuilder accessory: () -> Accessory) -> some View {
+        HStack {
+            Text(title.uppercased())
+                .font(.plexMono(10, weight: .semibold))
+                .foregroundStyle(Color.inkTertiary)
+                .tracking(1.1)
+            Spacer()
+            accessory()
+        }
+    }
+
+    private func sidebarSubhead(_ title: String) -> some View {
+        Text(title)
+            .font(.plexSans(12, weight: .medium))
+            .foregroundStyle(Color.inkSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, Spacing.x1)
+            .padding(.bottom, Spacing.x1)
+    }
+
+    private func sessionRow(_ session: WorkspaceSession) -> some View {
+        let selected = model.activeTerminalSessionName == session.name
+        return Button { model.section = .shell; model.openSession(named: session.name) } label: {
+            HStack(spacing: Spacing.x2) {
+                Image(systemName: session.isActive ? "terminal" : "doc.text")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.inkTertiary)
+                    .frame(width: 18)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(session.name)
+                        .font(.plexSans(13, weight: selected ? .semibold : .regular))
+                        .foregroundStyle(Color.inkPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    HStack(spacing: Spacing.x1) {
+                        Circle()
+                            .fill(session.isActive ? Color.signalDone : Color.inkDisabled)
+                            .frame(width: 5, height: 5)
+                        Text(session.status.capitalized)
+                            .font(.plexSans(11, weight: .medium))
+                            .foregroundStyle(session.isActive ? Color.signalDone : Color.inkTertiary)
+                    }
+                }
+                Spacer()
+                Text(selected ? "now" : "")
+                    .font(.plexSans(11, weight: .medium))
+                    .foregroundStyle(Color.inkTertiary)
+            }
+            .padding(.horizontal, Spacing.x3)
+            .padding(.vertical, Spacing.x2)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+                    .fill(selected ? Color.surfaceCardRaised : Color.clear)
+                    .shadow(color: selected ? Color.black.opacity(0.06) : Color.clear, radius: 10, y: 4)
+            )
+            .overlay(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(selected ? Color.signalLive : Color.clear)
+                    .frame(width: 2)
+                    .padding(.vertical, Spacing.x2)
+            }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help("Command palette (⌘K)")
+        .help("Open \(session.name)")
+    }
+
+    private var emptySessions: some View {
+        VStack(alignment: .leading, spacing: Spacing.x2) {
+            Image(systemName: "terminal")
+                .font(.system(size: 18, weight: .light))
+                .foregroundStyle(Color.inkTertiary)
+            Text("No sessions yet")
+                .font(.plexSans(13, weight: .semibold))
+                .foregroundStyle(Color.inkPrimary)
+            Text("Start a Matrix computer terminal.")
+                .font(.plexSans(12))
+                .foregroundStyle(Color.inkTertiary)
+        }
+        .padding(Spacing.x3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
+    }
+
+    private var newTaskButton: some View {
+        Button {
+            if model.section == .shell { model.createSession() } else { model.createTask(status: .todo) }
+        } label: {
+            HStack(spacing: Spacing.x3) {
+                Image(systemName: "plus")
+                    .font(.system(size: 14, weight: .semibold))
+                Text(model.section == .shell ? "New session" : "New task / New agent")
+                    .font(.plexSans(14, weight: .semibold))
+                Spacer()
+                Text(model.section == .shell ? "⌘T" : "⌘N")
+                    .font(.plexMono(11, weight: .semibold))
+                    .padding(.horizontal, Spacing.x2)
+                    .padding(.vertical, 5)
+                    .background(Color.white.opacity(0.10), in: RoundedRectangle(cornerRadius: Radius.badge, style: .continuous))
+            }
+            .foregroundStyle(Color.canvasVoid)
+            .padding(.horizontal, Spacing.x4)
+            .frame(height: 52)
+            .background(
+                LinearGradient(
+                    colors: [Color.surfaceTerminal, Color.black.opacity(0.90)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                ),
+                in: RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+            )
+            .shadow(color: Color.black.opacity(0.16), radius: 16, y: 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, Spacing.x4)
+        .disabled(model.isCreatingWorkItem)
     }
 
     private var handleBadge: some View {
-        Text(String((model.profile?.handle ?? "?").prefix(2)).uppercased())
-            .font(.plexMono(10, weight: .semibold))
-            .foregroundStyle(Color.inkSecondary)
-            .frame(width: 30, height: 30)
-            .background(
-                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                    .fill(Color.surfaceCard)
-                    .overlay(RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                        .strokeBorder(Color.hairlineHighlight, lineWidth: 1))
-            )
-            .help(model.profile?.handle ?? "")
+        let handle = model.profile?.handle ?? "unknown"
+        return HStack(spacing: Spacing.x2) {
+            Text(String(handle.prefix(2)).uppercased())
+                .font(.plexMono(10, weight: .semibold))
+                .foregroundStyle(Color.canvasVoid)
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(Color.signalLive))
+            if !collapsed {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(handle)
+                        .font(.plexSans(12, weight: .semibold))
+                        .foregroundStyle(Color.inkPrimary)
+                        .lineLimit(1)
+                    Text("Matrix account")
+                        .font(.plexMono(9, weight: .medium))
+                        .foregroundStyle(Color.inkTertiary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.inkTertiary)
+            }
+        }
+        .padding(collapsed ? Spacing.x1 : Spacing.x3)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                .fill(Color.surfaceCard)
+                .overlay(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                    .strokeBorder(Color.hairlineDark.opacity(0.6), lineWidth: 1))
+        )
+        .help(handle)
+        .accessibilityLabel("Connected as \(handle)")
+    }
+}
+
+private struct AppMark: View {
+    let collapsed: Bool
+
+    var body: some View {
+        Image(nsImage: NSImage(named: NSImage.applicationIconName) ?? NSImage())
+            .resizable()
+            .interpolation(.high)
+            .frame(width: collapsed ? 46 : 52, height: collapsed ? 46 : 52)
+            .clipShape(RoundedRectangle(cornerRadius: collapsed ? 10 : 12, style: .continuous))
+            .shadow(color: Color.black.opacity(0.12), radius: 6, y: 2)
+            .help("Matrix OS")
+            .accessibilityLabel("Matrix OS")
     }
 }
 
@@ -143,89 +416,877 @@ private struct TerminalsView: View {
     @ObservedObject var model: AppModel
 
     var body: some View {
-        HSplitView {
-            sessionList
-                .frame(minWidth: 220, idealWidth: 300, maxWidth: 420, maxHeight: .infinity)
-            terminalPane
-                .frame(minWidth: 380, maxWidth: .infinity, maxHeight: .infinity)
-        }
+        workbench
+        .background(Color.canvasVoid)
     }
 
-    private var sessionList: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text("TERMINALS")
-                    .font(.plexMono(11, weight: .semibold)).tracking(1.32)
-                    .foregroundStyle(Color.inkTertiary)
-                Spacer()
-                Text("\(model.sessions.count)")
-                    .font(.plexMono(11)).foregroundStyle(Color.inkTertiary)
-                Button { model.createSession() } label: {
-                    Image(systemName: "plus").font(.system(size: 11, weight: .bold))
-                        .foregroundStyle(Color.inkSecondary)
-                }
-                .buttonStyle(.plain).disabled(model.isCreatingWorkItem)
-            }
-            .padding(.horizontal, Spacing.x3).padding(.vertical, Spacing.x3)
+    private var workbench: some View {
+        VStack(spacing: Spacing.x3) {
+            workbenchHeader
+            TerminalSessionTabStrip(
+                sessions: model.sessions,
+                activeName: model.activeTerminalSessionName,
+                isCreating: model.isCreatingWorkItem,
+                onSelect: model.openSession,
+                onClose: model.closeSession,
+                onCreate: model.createSession
+            )
+            terminalSurface
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(.horizontal, Spacing.x5)
+        .padding(.vertical, Spacing.x4)
+        .background(Color.canvasVoid)
+    }
 
-            ScrollView {
-                LazyVStack(spacing: Spacing.x1) {
-                    ForEach(model.sessions) { session in
-                        sessionRow(session)
+    private var workbenchHeader: some View {
+        VStack(spacing: Spacing.x3) {
+            HStack(spacing: Spacing.x2) {
+                Label("Matrix Shell", systemImage: "terminal")
+                    .font(.plexSans(13, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                Spacer()
+                searchButton
+                Spacer()
+                headerIcon("clock") { Task { await model.loadSessions() } }
+                headerIcon("square.and.arrow.up") {
+                    if let url = model.shellURL() {
+                        NSWorkspace.shared.open(url)
                     }
                 }
-                .padding(.horizontal, Spacing.x2)
+                headerIcon("ellipsis") { model.showCommandPalette = true }
             }
-            if model.sessions.isEmpty {
+
+            HStack(alignment: .top, spacing: Spacing.x3) {
+                VStack(alignment: .leading, spacing: Spacing.x3) {
+                    Text(model.terminal?.displayName ?? "Shell")
+                        .font(.plexSans(22, weight: .semibold))
+                        .foregroundStyle(Color.inkPrimary)
+                        .lineLimit(2)
+                    HStack(spacing: Spacing.x2) {
+                        statusChip(model.sessions.isEmpty ? "No sessions" : "\(model.sessions.count) sessions", icon: "terminal", tint: .signalDone)
+                        statusChip(model.terminal == nil ? "Detached" : "Attached", icon: "tray.and.arrow.up", tint: .inkSecondary)
+                    }
+                }
                 Spacer()
-                Text("No sessions yet — press + to start one.")
-                    .font(.plexSans(12)).foregroundStyle(Color.inkTertiary)
-                    .padding(Spacing.x4)
-                Spacer()
+                Button { model.createSession() } label: {
+                    Label("New shell", systemImage: "plus")
+                        .font(.plexSans(12, weight: .medium))
+                        .foregroundStyle(Color.inkPrimary)
+                }
+                .buttonStyle(.plain)
+                .disabled(model.isCreatingWorkItem)
             }
         }
-        .frame(maxHeight: .infinity, alignment: .top)
-        .background(Color.surfaceRail)
     }
 
-    private func sessionRow(_ session: WorkspaceSession) -> some View {
-        let selected = model.selectedCard?.id == session.name
-        return Button { model.openSession(named: session.name) } label: {
+    private var searchButton: some View {
+        Button { model.showCommandPalette = true } label: {
             HStack(spacing: Spacing.x2) {
-                Circle()
-                    .fill(session.isActive ? Color.signalLive : Color.inkTertiary)
-                    .frame(width: 7, height: 7)
-                Text(session.name)
-                    .font(.plexMono(12)).foregroundStyle(Color.inkPrimary)
-                    .lineLimit(1).truncationMode(.middle)
-                Spacer()
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("Search Matrix")
+                    .font(.plexSans(12, weight: .medium))
+                Text("⌘K")
+                    .font(.plexMono(10, weight: .semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: 5, style: .continuous))
             }
-            .padding(.horizontal, Spacing.x3).padding(.vertical, Spacing.x2)
-            .background(
-                RoundedRectangle(cornerRadius: Radius.badge, style: .continuous)
-                    .fill(selected ? Color.surfaceCardRaised : Color.clear)
+            .foregroundStyle(Color.inkTertiary)
+            .frame(width: 230, height: 34)
+            .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: 17, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 17, style: .continuous)
+                    .strokeBorder(Color.hairlineDark.opacity(0.7), lineWidth: 1)
             )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Command palette (⌘K)")
+    }
+
+    private func headerIcon(_ icon: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color.inkTertiary)
+                .iconHitTarget(32)
+                .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                        .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
+                )
         }
         .buttonStyle(.plain)
     }
 
+    private func statusChip(_ text: String, icon: String, tint: Color) -> some View {
+        HStack(spacing: Spacing.x1) {
+            Image(systemName: icon)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(tint)
+            Text(text)
+                .font(.plexSans(12, weight: .medium))
+                .foregroundStyle(Color.inkSecondary)
+        }
+        .padding(.horizontal, Spacing.x2)
+        .frame(height: 28)
+        .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .strokeBorder(Color.hairlineDark.opacity(0.75), lineWidth: 1)
+        )
+    }
+
     @ViewBuilder
-    private var terminalPane: some View {
+    private var taskWorkspaceSplit: some View {
+        selectedPane
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var selectedPane: some View {
+        switch model.activePanel {
+        case .terminal:
+            terminalSurface
+        case .shell:
+            MatrixWebShellPanel(model: model, url: model.shellURL(), title: "Matrix OS Shell")
+        case .app(let slug):
+            switch slug {
+            case "editor":
+                EditorPanel(model: model)
+            case "artifacts":
+                ArtifactsPanel(model: model)
+            case "git":
+                GitPanel(model: model)
+            case "settings":
+                SettingsPanel(model: model)
+            case "processes":
+                ProcessesPanel(model: model)
+            case "whiteboard":
+                MatrixWebShellPanel(model: model, url: model.appURL(slug: "whiteboard"), title: "Excalidraw")
+            default:
+                let meta = panelMeta(slug)
+                workbenchPlaceholder(title: meta.title, icon: meta.icon, message: meta.message)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var terminalSurface: some View {
         if let terminal = model.terminal {
             TerminalPanelView(session: terminal)
+                .id(terminal.id)
                 .background(Color.surfaceTerminal)
+                .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                        .strokeBorder(Color.black.opacity(0.35), lineWidth: 1)
+                )
+                .shadow(color: Color.black.opacity(0.18), radius: 18, y: 8)
         } else {
             ZStack {
                 Color.surfaceTerminal
                 VStack(spacing: Spacing.x2) {
                     Image(systemName: "terminal")
                         .font(.system(size: 28, weight: .light))
-                        .foregroundStyle(Color.inkTertiary)
+                        .foregroundStyle(Color.terminalMutedInk)
                     Text("Select a session to open its terminal")
-                        .font(.plexSans(13)).foregroundStyle(Color.inkSecondary)
+                        .font(.plexSans(13))
+                        .foregroundStyle(Color.terminalMutedInk)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+        }
+    }
+
+    private func panelMeta(_ slug: String) -> (title: String, icon: String, message: String) {
+        switch slug {
+        case "editor":
+            return ("Editor", "doc.text", "Code editor panel for this task.")
+        case "artifacts":
+            return ("Artifacts", "paperclip", "Generated files, previews, and links for this task.")
+        case "git":
+            return ("Git", "arrow.triangle.branch", "Branch, diff, commit, and PR controls for this task.")
+        case "settings":
+            return ("Settings", "slider.horizontal.3", "Task metadata is available in the inspector.")
+        case "processes":
+            return ("Processes", "cpu", "Running agents and background jobs for this task.")
+        case "whiteboard":
+            return ("Excalidraw", "scribble.variable", "Sketches and diagrams attached to this task.")
+        default:
+            return ("Panel", "square.grid.2x2", "Panel not available yet.")
+        }
+    }
+
+    private func workbenchPlaceholder(title: String, icon: String, message: String) -> some View {
+        VStack(spacing: Spacing.x3) {
+            Image(systemName: icon)
+                .font(.system(size: 34, weight: .light))
+                .foregroundStyle(Color.signalLive)
+            Text(title)
+                .font(.plexSans(18, weight: .semibold))
+                .foregroundStyle(Color.inkPrimary)
+            Text(message)
+                .font(.plexSans(13))
+                .foregroundStyle(Color.inkTertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.surfaceCard)
+    }
+
+    private var inspector: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.x3) {
+                inspectorHeader
+                inspectorSection("Description", icon: "text.alignleft") {
+                    Text("Add description...")
+                        .font(.plexSans(13))
+                        .foregroundStyle(Color.inkTertiary)
+                        .frame(maxWidth: .infinity, minHeight: 72, alignment: .topLeading)
+                }
+                inspectorSection("Sub-tasks", icon: "checklist") {
+                    inspectorAddRow("Add subtask")
+                }
+                inspectorSection("Artifacts", icon: "paperclip") {
+                    inspectorAddRow("Add artifact")
+                }
+                inspectorGrid
+                inspectorSection("Working Directory", icon: "folder") {
+                    Text(model.selectedCard?.linkedWorktreeId ?? "~/projects/\(model.projectSlug)")
+                        .font(.plexMono(11))
+                        .foregroundStyle(Color.inkSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(Spacing.x2)
+                        .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                }
+            }
+            .padding(Spacing.x3)
+        }
+        .background(Color.surfaceRail)
+        .overlay(alignment: .leading) {
+            Rectangle().fill(Color.hairlineDark).frame(width: 1)
+        }
+    }
+
+    private var inspectorHeader: some View {
+        HStack {
+            Label("Settings", systemImage: "slider.horizontal.3")
+                .font(.plexSans(14, weight: .semibold))
+                .foregroundStyle(Color.inkPrimary)
+            Spacer()
+            Text("View activity")
+                .font(.plexSans(11, weight: .medium))
+                .foregroundStyle(Color.inkTertiary)
+        }
+    }
+
+    private func inspectorSection<Content: View>(
+        _ title: String,
+        icon: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: Spacing.x2) {
+                Image(systemName: icon)
+                Text(title)
+                Spacer()
+            }
+            .font(.plexSans(12, weight: .semibold))
+            .foregroundStyle(Color.inkSecondary)
+            .padding(Spacing.x2)
+            .background(Color.surfaceRail)
+            Divider().overlay(Color.hairlineDark)
+            content()
+                .padding(Spacing.x2)
+        }
+        .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .strokeBorder(Color.hairlineDark, lineWidth: 1)
+        )
+    }
+
+    private func inspectorAddRow(_ title: String) -> some View {
+        Button {
+            model.createTask(status: .todo)
+        } label: {
+            Label(title, systemImage: "plus")
+                .font(.plexSans(12))
+                .foregroundStyle(Color.inkSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var inspectorGrid: some View {
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: Spacing.x2) {
+            inspectorField("Project", value: model.projects.first { $0.slug == model.projectSlug }?.name ?? model.projectSlug, icon: "folder")
+            inspectorField("Status", value: model.selectedCard?.status.rawValue ?? "running", icon: "circle")
+            inspectorField("Priority", value: model.selectedCard?.priority.rawValue ?? "normal", icon: "chart.bar")
+            inspectorField("Progress", value: model.terminal == nil ? "Not started" : "Attached", icon: "gauge.with.dots.needle.33percent")
+        }
+    }
+
+    private func inspectorField(_ label: String, value: String, icon: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.x1) {
+            Text(label)
+                .font(.plexSans(11, weight: .medium))
+                .foregroundStyle(Color.inkTertiary)
+            HStack(spacing: Spacing.x1) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color.signalLive)
+                Text(value)
+                    .font(.plexSans(12, weight: .medium))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(Color.inkPrimary)
+            .padding(Spacing.x2)
+            .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .strokeBorder(Color.hairlineDark, lineWidth: 1)
+            )
+        }
+    }
+}
+
+struct EditorPanel: View {
+    @ObservedObject var model: AppModel
+    @State private var theme: CodeEditorTheme = .matrixLight
+    @State private var viewMode: EditorViewMode = .preview
+
+    private var fileKind: EditorFileKind {
+        EditorFileKind(path: model.selectedFilePath)
+    }
+
+    var body: some View {
+        HSplitView {
+            VStack(spacing: 0) {
+                HStack(spacing: Spacing.x2) {
+                    Button { model.goUpInFiles() } label: {
+                        Image(systemName: "chevron.left")
+                            .iconHitTarget(28)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Up")
+                    Text(model.filePanelPath.isEmpty ? "projects/\(model.projectSlug)" : model.filePanelPath)
+                        .font(.plexMono(11))
+                        .foregroundStyle(Color.inkTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer()
+                    Button { Task { await model.loadPanelData(for: .app(slug: "editor")) } } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .iconHitTarget(28)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Refresh")
+                }
+                .padding(Spacing.x2)
+                .background(Color.surfaceRail)
+                .overlay(alignment: .bottom) { Rectangle().fill(Color.hairlineDark).frame(height: 1) }
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(model.fileTree) { node in
+                            FileTreeNodeRow(model: model, node: node, depth: 0)
+                        }
+                    }
+                    .padding(.vertical, Spacing.x1)
+                }
+            }
+            .frame(minWidth: 220, idealWidth: 280, maxWidth: 380)
+
+            VStack(spacing: 0) {
+                HStack {
+                    Text(model.selectedFilePath ?? "Select a file")
+                        .font(.plexSans(13, weight: .semibold))
+                        .foregroundStyle(Color.inkPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer()
+                    if fileKind == .markdown || fileKind == .code {
+                        Picker("View", selection: $viewMode) {
+                            Text("Preview").tag(EditorViewMode.preview)
+                            Text("Edit").tag(EditorViewMode.code)
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .frame(width: 150)
+                    }
+                    if fileKind == .code {
+                        Picker("Theme", selection: $theme) {
+                            ForEach(CodeEditorTheme.allCases) { theme in
+                                Text(theme.rawValue).tag(theme)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .frame(width: 230)
+                    }
+                    if let state = model.fileSaveState {
+                        Text(state)
+                            .font(.plexSans(12))
+                            .foregroundStyle(state == "Saved" ? Color.signalDone : Color.inkTertiary)
+                    }
+                    Button { model.saveSelectedFile() } label: {
+                        Label("Save", systemImage: "square.and.arrow.down")
+                    }
+                    .disabled(model.selectedFilePath == nil || fileKind == .image)
+                }
+                .padding(Spacing.x2)
+                .background(Color.surfaceRail)
+                .overlay(alignment: .bottom) { Rectangle().fill(Color.hairlineDark).frame(height: 1) }
+
+                if model.selectedFilePath == nil {
+                    ContentUnavailableView(
+                        "No file selected",
+                        systemImage: "doc.text.magnifyingglass",
+                        description: Text("Choose a project file to inspect or edit.")
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if fileKind == .image {
+                    ImageFilePreview(data: model.selectedFileData, path: model.selectedFilePath)
+                } else if fileKind == .markdown && viewMode == .preview {
+                    MarkdownRenderedPreview(markdown: model.selectedFileContent)
+                } else if fileKind == .code && viewMode == .preview {
+                    CodeReadOnlyPreview(text: model.selectedFileContent, filePath: model.selectedFilePath, theme: theme)
+                } else {
+                    SyntaxHighlightedCodeEditor(
+                        text: $model.selectedFileContent,
+                        filePath: model.selectedFilePath,
+                        theme: theme
+                    )
+                }
+            }
+            .frame(minWidth: 360, maxWidth: .infinity)
+        }
+        .background(Color.surfaceCard)
+    }
+}
+
+private struct CodeReadOnlyPreview: View {
+    let text: String
+    let filePath: String?
+    let theme: CodeEditorTheme
+
+    var body: some View {
+        ScrollView([.horizontal, .vertical]) {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
+                    HStack(alignment: .top, spacing: Spacing.x3) {
+                        Text("\(index + 1)")
+                            .font(.plexMono(12))
+                            .foregroundStyle(Color.inkTertiary)
+                            .frame(width: 42, alignment: .trailing)
+                        Text(line.isEmpty ? " " : line)
+                            .font(.plexMono(13))
+                            .foregroundStyle(theme == .terminalDark ? Color.terminalInk : Color.inkPrimary)
+                            .textSelection(.enabled)
+                    }
+                    .padding(.vertical, 1)
+                }
+            }
+            .padding(Spacing.x4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(theme == .terminalDark ? Color.surfaceTerminal : Color.surfaceCard)
+    }
+
+    private var lines: [String] {
+        text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    }
+}
+
+private enum EditorViewMode: String, CaseIterable, Identifiable {
+    case preview
+    case code
+    var id: String { rawValue }
+}
+
+private enum EditorFileKind {
+    case markdown
+    case image
+    case code
+
+    init(path: String?) {
+        let ext = URL(fileURLWithPath: path ?? "").pathExtension.lowercased()
+        if ["md", "markdown", "mdx"].contains(ext) {
+            self = .markdown
+        } else if ["png", "jpg", "jpeg", "gif", "tiff", "tif", "bmp", "webp", "svg", "heic"].contains(ext) {
+            self = .image
+        } else {
+            self = .code
+        }
+    }
+}
+
+private struct MarkdownRenderedPreview: View {
+    let markdown: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.x4) {
+                renderedText
+                    .font(.plexSans(15))
+                    .foregroundStyle(Color.inkPrimary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(Spacing.x5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color.surfaceCard)
+    }
+
+    @ViewBuilder
+    private var renderedText: some View {
+        if let attributed = try? AttributedString(markdown: markdown) {
+            Text(attributed)
+        } else {
+            Text(markdown)
+                .font(.plexMono(13))
+        }
+    }
+}
+
+private struct ImageFilePreview: View {
+    let data: Data?
+    let path: String?
+
+    var body: some View {
+        ZStack {
+            Color.surfaceCard
+            if let image {
+                ScrollView([.horizontal, .vertical]) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .interpolation(.high)
+                        .scaledToFit()
+                        .padding(Spacing.x5)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            } else {
+                ContentUnavailableView(
+                    "Preview unavailable",
+                    systemImage: "photo",
+                    description: Text(path ?? "This image format could not be rendered.")
+                )
+            }
+        }
+    }
+
+    private var image: NSImage? {
+        guard let data else { return nil }
+        return NSImage(data: data)
+    }
+}
+
+private struct FileTreeNodeRow: View {
+    @ObservedObject var model: AppModel
+    let node: WorkspaceFileTreeNode
+    let depth: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                model.openFileTreeNode(node)
+            } label: {
+                HStack(spacing: Spacing.x1) {
+                    Image(systemName: node.isDirectory ? (node.expanded ? "chevron.down" : "chevron.right") : "circle.fill")
+                        .font(.system(size: node.isDirectory ? 10 : 4, weight: .semibold))
+                        .foregroundStyle(Color.inkTertiary)
+                        .frame(width: 12)
+                    Image(systemName: node.isDirectory ? "folder" : "doc.text")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(node.isDirectory ? Color.signalLive : Color.inkTertiary)
+                    Text(node.name)
+                        .font(.plexSans(12, weight: model.selectedFilePath == node.path ? .semibold : .regular))
+                        .foregroundStyle(Color.inkPrimary)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    if let status = node.gitStatus {
+                        Text(status)
+                            .font(.plexMono(9, weight: .medium))
+                            .foregroundStyle(Color.signalWaiting)
+                    } else if let changed = node.changedCount, changed > 0 {
+                        Text("\(changed)")
+                            .font(.plexMono(9, weight: .medium))
+                            .foregroundStyle(Color.signalWaiting)
+                    }
+                }
+                .padding(.leading, CGFloat(depth) * 14 + Spacing.x2)
+                .padding(.trailing, Spacing.x2)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                        .fill(model.selectedFilePath == node.path ? Color.surfaceCardRaised : Color.clear)
+                )
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            if node.expanded, let children = node.children {
+                ForEach(children) { child in
+                    FileTreeNodeRow(model: model, node: child, depth: depth + 1)
                 }
             }
         }
+    }
+}
+
+struct GitPanel: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.x4) {
+                HStack {
+                    Label("Git", systemImage: "arrow.triangle.branch")
+                        .font(.plexSans(16, weight: .semibold))
+                    Spacer()
+                    Button { Task { await model.loadPanelData(for: .app(slug: "git")) } } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .iconHitTarget(30)
+                    }
+                    .buttonStyle(.plain)
+                }
+                quickActions
+                gitSection("Branches", icon: "point.3.connected.trianglepath.dotted") {
+                    if model.gitBranches.isEmpty {
+                        emptyLine("No branches loaded")
+                    } else {
+                        ForEach(model.gitBranches) { branch in
+                            gitRow(title: branch.name, subtitle: "Local branch", icon: "arrow.triangle.branch")
+                        }
+                    }
+                }
+                gitSection("Pull Requests", icon: "point.topleft.down.curvedto.point.bottomright.up") {
+                    if model.gitPullRequests.isEmpty {
+                        emptyLine("No pull requests loaded")
+                    } else {
+                        ForEach(model.gitPullRequests) { pr in
+                            gitRow(
+                                title: "#\(pr.number) \(pr.title)",
+                                subtitle: [pr.headRefName, pr.baseRefName].compactMap { $0 }.joined(separator: " → "),
+                                icon: "arrow.up.right.square"
+                            )
+                        }
+                    }
+                }
+                gitSection("Worktrees", icon: "folder.badge.gearshape") {
+                    if model.gitWorktrees.isEmpty {
+                        emptyLine("No worktrees")
+                    } else {
+                        ForEach(model.gitWorktrees) { worktree in
+                            gitRow(
+                                title: worktree.currentBranch,
+                                subtitle: "\(worktree.dirtyState) · \(worktree.path)",
+                                icon: "folder"
+                            )
+                        }
+                    }
+                }
+            }
+            .padding(Spacing.x4)
+        }
+        .background(Color.surfaceCard)
+    }
+
+    private var quickActions: some View {
+        HStack(spacing: Spacing.x2) {
+            actionButton("Status", icon: "list.bullet.rectangle") {
+                model.sendCommandToActiveTerminal("git -C ~/projects/\(model.projectSlug) status --short --branch")
+            }
+            actionButton("Pull", icon: "arrow.down") {
+                model.sendCommandToActiveTerminal("git -C ~/projects/\(model.projectSlug) pull --ff-only")
+            }
+            actionButton("Push", icon: "arrow.up") {
+                model.sendCommandToActiveTerminal("git -C ~/projects/\(model.projectSlug) push")
+            }
+            actionButton("Commit", icon: "checkmark.seal") {
+                model.sendCommandToActiveTerminal("git -C ~/projects/\(model.projectSlug) commit")
+            }
+        }
+    }
+
+    private func actionButton(_ title: String, icon: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: icon)
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private func gitSection<Content: View>(
+        _ title: String,
+        icon: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.x2) {
+            Label(title, systemImage: icon)
+                .font(.plexSans(13, weight: .semibold))
+                .foregroundStyle(Color.inkSecondary)
+            VStack(spacing: 0) {
+                content()
+            }
+            .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
+        }
+    }
+
+    private func gitRow(title: String, subtitle: String, icon: String) -> some View {
+        HStack(spacing: Spacing.x2) {
+            Image(systemName: icon).foregroundStyle(Color.signalLive)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.plexSans(13, weight: .medium)).foregroundStyle(Color.inkPrimary)
+                if !subtitle.isEmpty {
+                    Text(subtitle).font(.plexMono(11)).foregroundStyle(Color.inkTertiary).lineLimit(1)
+                }
+            }
+            Spacer()
+        }
+        .padding(Spacing.x2)
+        .overlay(alignment: .bottom) { Rectangle().fill(Color.hairlineDark).frame(height: 1) }
+    }
+
+    private func emptyLine(_ text: String) -> some View {
+        Text(text)
+            .font(.plexSans(12))
+            .foregroundStyle(Color.inkTertiary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Spacing.x2)
+    }
+}
+
+struct ArtifactsPanel: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.x3) {
+                HStack {
+                    Label("Artifacts", systemImage: "paperclip")
+                        .font(.plexSans(16, weight: .semibold))
+                    Spacer()
+                    Button { Task { await model.loadPanelData(for: .app(slug: "artifacts")) } } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .iconHitTarget(30)
+                    }
+                    .buttonStyle(.plain)
+                }
+                if model.previews.isEmpty {
+                    ContentUnavailableView(
+                        "No artifacts yet",
+                        systemImage: "tray",
+                        description: Text("Previews created by agents will appear here.")
+                    )
+                    .frame(maxWidth: .infinity, minHeight: 280)
+                } else {
+                    ForEach(model.previews) { preview in
+                        HStack(spacing: Spacing.x2) {
+                            Image(systemName: "link")
+                                .foregroundStyle(Color.signalLive)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(preview.label)
+                                    .font(.plexSans(13, weight: .semibold))
+                                Text(preview.url)
+                                    .font(.plexMono(11))
+                                    .foregroundStyle(Color.inkTertiary)
+                                    .lineLimit(1)
+                            }
+                            Spacer()
+                            if let url = URL(string: preview.url) {
+                                Link("Open", destination: url)
+                            }
+                        }
+                        .padding(Spacing.x3)
+                        .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
+                    }
+                }
+            }
+            .padding(Spacing.x4)
+        }
+        .background(Color.surfaceCard)
+    }
+}
+
+struct ProcessesPanel: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.x3) {
+            HStack {
+                Label("Processes", systemImage: "cpu")
+                    .font(.plexSans(16, weight: .semibold))
+                Spacer()
+                Button { Task { await model.loadSessions() } } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .iconHitTarget(30)
+                }
+                .buttonStyle(.plain)
+            }
+            List(model.sessions) { session in
+                HStack {
+                    Circle()
+                        .fill(session.isActive ? Color.signalDone : Color.signalIdle)
+                        .frame(width: 8, height: 8)
+                    VStack(alignment: .leading) {
+                        Text(session.name)
+                            .font(.plexMono(12))
+                        Text(session.status)
+                            .font(.plexSans(11))
+                            .foregroundStyle(Color.inkTertiary)
+                    }
+                    Spacer()
+                    Button("Open") { model.openSession(named: session.name) }
+                }
+            }
+            .listStyle(.inset)
+        }
+        .padding(Spacing.x4)
+        .background(Color.surfaceCard)
+    }
+}
+
+struct SettingsPanel: View {
+    @ObservedObject var model: AppModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.x4) {
+            Label("Task Settings", systemImage: "slider.horizontal.3")
+                .font(.plexSans(16, weight: .semibold))
+            inspectorLikeRow("Project", value: model.projectSlug, icon: "folder")
+            inspectorLikeRow("Card", value: model.selectedCard?.title ?? "No task selected", icon: "rectangle.and.text.magnifyingglass")
+            inspectorLikeRow("Session", value: model.selectedCard?.linkedSessionId ?? "No linked session", icon: "terminal")
+            inspectorLikeRow("Worktree", value: model.selectedCard?.linkedWorktreeId ?? "~/projects/\(model.projectSlug)", icon: "arrow.triangle.branch")
+            Spacer()
+        }
+        .padding(Spacing.x4)
+        .background(Color.surfaceCard)
+    }
+
+    private func inspectorLikeRow(_ title: String, value: String, icon: String) -> some View {
+        HStack(spacing: Spacing.x2) {
+            Image(systemName: icon)
+                .foregroundStyle(Color.signalLive)
+                .frame(width: 18)
+            Text(title)
+                .font(.plexSans(12, weight: .medium))
+                .foregroundStyle(Color.inkSecondary)
+            Spacer()
+            Text(value)
+                .font(.plexMono(11))
+                .foregroundStyle(Color.inkTertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(Spacing.x3)
+        .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
     }
 }
 #endif

--- a/macos/Sources/App/WorkspaceTabs.swift
+++ b/macos/Sources/App/WorkspaceTabs.swift
@@ -63,7 +63,7 @@ let taskPaneSpecs: [TaskPaneSpec] = [
     TaskPaneSpec(id: "artifacts", title: "Artifacts", icon: "paperclip", shortcut: "⌘⇧A", panel: .app(slug: "artifacts")),
     TaskPaneSpec(id: "git", title: "Git", icon: "arrow.triangle.branch", shortcut: "⌘G", panel: .app(slug: "git")),
     TaskPaneSpec(id: "settings", title: "Settings", icon: "slider.horizontal.3", shortcut: "⌘J", panel: .app(slug: "settings")),
-    TaskPaneSpec(id: "processes", title: "Processes", icon: "cpu", shortcut: "⌘P", panel: .app(slug: "processes")),
+    TaskPaneSpec(id: "processes", title: "Processes", icon: "cpu", shortcut: "⌘⇧P", panel: .app(slug: "processes")),
     TaskPaneSpec(id: "whiteboard", title: "Excalidraw", icon: "scribble.variable", shortcut: "⌘X", panel: .app(slug: "whiteboard")),
 ]
 
@@ -105,7 +105,7 @@ struct TaskPaneStrip: View {
     }
 
     private func shortcutModifiers(for id: String) -> EventModifiers {
-        id == "artifacts" ? [.command, .shift] : [.command]
+        ["artifacts", "processes"].contains(id) ? [.command, .shift] : [.command]
     }
 }
 

--- a/macos/Sources/App/WorkspaceTabs.swift
+++ b/macos/Sources/App/WorkspaceTabs.swift
@@ -1,0 +1,310 @@
+#if os(macOS)
+import SwiftUI
+import DesignSystem
+import MatrixModel
+
+struct WorkspaceTabStrip: View {
+    let tabs: [WorkspaceTab]
+    let activeID: String?
+    let isCreating: Bool
+    let onSelect: (String) -> Void
+    let onClose: (String) -> Void
+    let onCreate: () -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.x1) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Spacing.x1) {
+                    ForEach(tabs) { tab in
+                        WorkspaceTabPill(
+                            tab: tab,
+                            isActive: tab.id == activeID,
+                            onSelect: { onSelect(tab.id) },
+                            onClose: { onClose(tab.id) }
+                        )
+                    }
+                }
+                .padding(.leading, Spacing.x2)
+                .padding(.vertical, Spacing.x1)
+            }
+            Button(action: onCreate) {
+                Image(systemName: "plus")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Color.inkSecondary)
+                    .iconHitTarget(34)
+                    .background(Color.surfaceCardRaised, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .disabled(isCreating)
+            .help("New tab")
+            .padding(.trailing, Spacing.x2)
+        }
+        .frame(height: 42)
+        .background(Color.surfaceCard)
+        .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
+        )
+    }
+}
+
+struct TaskPaneSpec: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let icon: String
+    let shortcut: String
+    let panel: Panel
+}
+
+let taskPaneSpecs: [TaskPaneSpec] = [
+    TaskPaneSpec(id: "terminal", title: "Terminal", icon: "terminal", shortcut: "⌘T", panel: .terminal),
+    TaskPaneSpec(id: "editor", title: "Editor", icon: "doc.text", shortcut: "⌘E", panel: .app(slug: "editor")),
+    TaskPaneSpec(id: "artifacts", title: "Artifacts", icon: "paperclip", shortcut: "⌘⇧A", panel: .app(slug: "artifacts")),
+    TaskPaneSpec(id: "git", title: "Git", icon: "arrow.triangle.branch", shortcut: "⌘G", panel: .app(slug: "git")),
+    TaskPaneSpec(id: "settings", title: "Settings", icon: "slider.horizontal.3", shortcut: "⌘J", panel: .app(slug: "settings")),
+    TaskPaneSpec(id: "processes", title: "Processes", icon: "cpu", shortcut: "⌘P", panel: .app(slug: "processes")),
+    TaskPaneSpec(id: "whiteboard", title: "Excalidraw", icon: "scribble.variable", shortcut: "⌘X", panel: .app(slug: "whiteboard")),
+]
+
+struct TaskPaneStrip: View {
+    let activePanel: Panel
+    let onSelect: (Panel) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Spacing.x1) {
+                ForEach(taskPaneSpecs) { pane in
+                    TaskPaneButton(
+                        pane: pane,
+                        isActive: pane.panel == activePanel,
+                        action: { onSelect(pane.panel) }
+                    )
+                    .keyboardShortcut(shortcutKey(for: pane.id), modifiers: shortcutModifiers(for: pane.id))
+                }
+            }
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, Spacing.x3)
+            .padding(.vertical, Spacing.x1)
+        }
+        .frame(height: 38)
+        .background(Color.surfaceRail)
+    }
+
+    private func shortcutKey(for id: String) -> KeyEquivalent {
+        switch id {
+        case "terminal": return "t"
+        case "editor": return "e"
+        case "artifacts": return "a"
+        case "git": return "g"
+        case "settings": return "j"
+        case "processes": return "p"
+        case "whiteboard": return "x"
+        default: return "0"
+        }
+    }
+
+    private func shortcutModifiers(for id: String) -> EventModifiers {
+        id == "artifacts" ? [.command, .shift] : [.command]
+    }
+}
+
+private struct TaskPaneButton: View {
+    let pane: TaskPaneSpec
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Spacing.x1) {
+                Image(systemName: pane.icon)
+                    .font(.system(size: 12, weight: .semibold))
+                Text(pane.title)
+                    .font(.plexSans(12, weight: isActive ? .semibold : .medium))
+                    .lineLimit(1)
+                Text(pane.shortcut)
+                    .font(.plexMono(9, weight: .semibold))
+                    .foregroundStyle(isActive ? Color.inkSecondary : Color.inkTertiary)
+            }
+            .foregroundStyle(isActive ? Color.inkPrimary : Color.inkSecondary)
+            .padding(.horizontal, Spacing.x2)
+            .frame(height: 30)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(isActive ? Color.surfaceCard : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .strokeBorder(isActive ? Color.hairlineDark : Color.clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("\(pane.title) \(pane.shortcut)")
+        .accessibilityLabel(pane.title)
+        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+    }
+}
+
+struct TerminalSessionTabStrip: View {
+    let sessions: [WorkspaceSession]
+    let activeName: String?
+    let isCreating: Bool
+    let onSelect: (String) -> Void
+    let onClose: (String) -> Void
+    let onCreate: () -> Void
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Spacing.x1) {
+                    ForEach(sessions) { session in
+                        terminalTab(session)
+                    }
+                }
+                .padding(.horizontal, Spacing.x2)
+                .padding(.vertical, Spacing.x1)
+            }
+            Button(action: onCreate) {
+                Image(systemName: "plus")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.inkSecondary)
+                    .iconHitTarget(30)
+            }
+            .buttonStyle(.plain)
+            .disabled(isCreating)
+            .help("New terminal tab")
+        }
+        .frame(height: 36)
+        .background(Color.surfaceRail)
+    }
+
+    private func terminalTab(_ session: WorkspaceSession) -> some View {
+        let active = session.name == activeName
+        return HStack(spacing: Spacing.x1) {
+            Button { onSelect(session.name) } label: {
+                HStack(spacing: Spacing.x2) {
+                    Circle()
+                        .fill(session.isActive ? Color.signalLive : Color.inkTertiary)
+                        .frame(width: 6, height: 6)
+                    Image(systemName: "terminal")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text(session.name)
+                        .font(.plexMono(11, weight: active ? .semibold : .medium))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .foregroundStyle(active ? Color.inkPrimary : Color.inkSecondary)
+                .frame(minWidth: 118, maxWidth: 230, alignment: .leading)
+                .padding(.leading, Spacing.x2)
+                .frame(height: 28)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if active {
+                Button { onClose(session.name) } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.inkTertiary)
+                        .iconHitTarget(24)
+                }
+                .buttonStyle(.plain)
+                .help("Close terminal tab")
+            }
+        }
+        .padding(.trailing, active ? Spacing.x1 : Spacing.x2)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .fill(active ? Color.surfaceCard : Color.clear)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .strokeBorder(active ? Color.hairlineDark : Color.clear, lineWidth: 1)
+        )
+        .help(session.name)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Terminal \(session.name)")
+        .accessibilityAddTraits(active ? [.isSelected] : [])
+    }
+}
+
+private struct WorkspaceTabPill: View {
+    let tab: WorkspaceTab
+    let isActive: Bool
+    let onSelect: () -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        HStack(spacing: Spacing.x1) {
+            Button(action: onSelect) {
+                HStack(spacing: Spacing.x2) {
+                    Image(systemName: icon)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(isActive ? Color.signalLive : Color.inkTertiary)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(tab.title)
+                            .font(.plexSans(12, weight: isActive ? .semibold : .medium))
+                            .foregroundStyle(isActive ? Color.inkPrimary : Color.inkSecondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text(tab.projectName)
+                            .font(.plexMono(9, weight: .medium))
+                            .foregroundStyle(Color.inkTertiary)
+                            .lineLimit(1)
+                    }
+                }
+                .frame(minWidth: 132, maxWidth: 210, alignment: .leading)
+                .padding(.leading, Spacing.x2)
+                .padding(.vertical, 5)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if tab.kind != .home {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.inkTertiary)
+                        .iconHitTarget(24)
+                }
+                .buttonStyle(.plain)
+                .help("Close tab")
+            }
+        }
+        .padding(.trailing, Spacing.x1)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .fill(isActive ? Color.surfaceCard : Color.surfaceCardRaised.opacity(0.65))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .strokeBorder(isActive ? Color.hairlineDark : Color.hairlineHighlight, lineWidth: 1)
+        )
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(isActive ? Color.signalLive : Color.clear)
+                .frame(height: 2)
+                .padding(.horizontal, Spacing.x2)
+        }
+        .shadow(color: isActive ? Color.black.opacity(0.08) : Color.clear, radius: 7, y: 2)
+        .help("\(tab.title) · \(tab.projectName)")
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(tab.title), \(tab.projectName)")
+        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+    }
+
+    private var icon: String {
+        switch tab.kind {
+        case .home:
+            return "house"
+        case .task:
+            return "checklist"
+        case .session:
+            return "terminal"
+        case .app:
+            return "square.grid.2x2"
+        }
+    }
+}
+#endif

--- a/macos/Sources/DesignSystem/DesignTokens.swift
+++ b/macos/Sources/DesignSystem/DesignTokens.swift
@@ -1,10 +1,9 @@
-// OPERATOR design system tokens for the Matrix OS macOS app.
+// Matrix OS native design system tokens.
 //
-// These tokens are the single source of truth for the "OPERATOR" look defined in
-// specs/086-macos-native-shell/design.md (§2 color, §3 typography, §4 spacing/radius,
-// §5 motion). Component code MUST reference these tokens only — never inline hex,
-// sizes, or animation timings — so the look stays cohesive and themeable for the
-// later light mode.
+// These tokens bridge the Matrix OS landing-page design contract (`DESIGN.md`) with
+// the macOS native shell. The app shell is light-first: warm off-white canvas,
+// forest/cream navigation, ember accents, and deep text. Terminal surfaces remain
+// dark because terminal legibility and ANSI rendering need a high-contrast console.
 
 import SwiftUI
 
@@ -21,55 +20,59 @@ extension Color {
     }
 }
 
-// MARK: - §2 Color system (dark-first)
+// MARK: - Color system (Matrix OS light-first, DESIGN.md)
 
 extension Color {
     // Canvas & surfaces
-    /// `canvas.void` — window background (machined near-black). `#0A0B0D`
-    public static let canvasVoid = Color(hex: 0x0A0B0D)
-    /// `surface.rail` — column rails / sidebar. `#101216`
-    public static let surfaceRail = Color(hex: 0x101216)
-    /// `surface.card` — card body. `#15171C`
-    public static let surfaceCard = Color(hex: 0x15171C)
-    /// `surface.cardRaised` — hovered/dragging card. `#1B1E24`
-    public static let surfaceCardRaised = Color(hex: 0x1B1E24)
-    /// `surface.terminal` — terminal panel (deeper than cards). `#0C0D10`
+    /// `background` — warm off-white app canvas. `#FAFAF5`
+    public static let canvasVoid = Color(hex: 0xFAFAF5)
+    /// `muted` — sand/cream rail and sidebar surface. `#F0EDE4`
+    public static let surfaceRail = Color(hex: 0xF0EDE4)
+    /// `--card` — white card/panel surface. `#FFFFFF`
+    public static let surfaceCard = Color(hex: 0xFFFFFF)
+    /// Raised/hover surface: sand-light. `#F7F1E7`
+    public static let surfaceCardRaised = Color(hex: 0xF7F1E7)
+    /// Terminal panel remains dark. `#0C0D10`
     public static let surfaceTerminal = Color(hex: 0x0C0D10)
 
-    // Hairline (dual-tone engraved 1px borders, §2)
-    /// Dark line of the engraved hairline: `#000000 @ 60%`.
-    public static let hairlineDark = Color(hex: 0x000000, opacity: 0.60)
-    /// Top highlight of the engraved hairline: `#FFFFFF @ 6%`.
-    public static let hairlineHighlight = Color(hex: 0xFFFFFF, opacity: 0.06)
+    // Hairline / border
+    /// `border` — warm neutral. `#D6D3C8`
+    public static let hairlineDark = Color(hex: 0xD6D3C8)
+    /// Subtle card highlight edge.
+    public static let hairlineHighlight = Color(hex: 0xFFFFFF, opacity: 0.75)
 
     // Ink (text)
-    /// `ink.primary` — titles, terminal text. `#E8EAED`
-    public static let inkPrimary = Color(hex: 0xE8EAED)
-    /// `ink.secondary` — metadata. `#9BA1AC`
-    public static let inkSecondary = Color(hex: 0x9BA1AC)
-    /// `ink.tertiary` — timestamps, hints. `#5C636E`
-    public static let inkTertiary = Color(hex: 0x5C636E)
-    /// `ink.disabled`. `#3A3F47`
-    public static let inkDisabled = Color(hex: 0x3A3F47)
+    /// `foreground` / Deep. `#32352E`
+    public static let inkPrimary = Color(hex: 0x32352E)
+    /// Forest secondary text/emphasis. `#434E3F`
+    public static let inkSecondary = Color(hex: 0x434E3F)
+    /// `muted-foreground`. `#7A7768`
+    public static let inkTertiary = Color(hex: 0x7A7768)
+    /// Disabled/border neutral. `#D6D3C8`
+    public static let inkDisabled = Color(hex: 0xD6D3C8)
+    /// Terminal foreground, separate from app-shell ink.
+    public static let terminalInk = Color(hex: 0xE8EAED)
+    /// Terminal muted foreground.
+    public static let terminalMutedInk = Color(hex: 0x9BA1AC)
 
-    // Signal (the only saturated colors — reserved for state, §2)
-    /// `signal.live` — phosphor lime, running/streaming (the breathing glow). `#9EF01A`
-    public static let signalLive = Color(hex: 0x9EF01A)
-    /// `signal.waiting` — amber, waiting on input/approval. `#FFB020`
-    public static let signalWaiting = Color(hex: 0xFFB020)
-    /// `signal.blocked` — coral, blocked/error. `#FF5C5C`
-    public static let signalBlocked = Color(hex: 0xFF5C5C)
-    /// `signal.done` — teal, complete. `#43C59E`
-    public static let signalDone = Color(hex: 0x43C59E)
-    /// `signal.idle` — grey, todo/exited (no color = no life). `#5C636E`
-    public static let signalIdle = Color(hex: 0x5C636E)
-    /// `signal.glow.live` — edge bloom on active cards: `signal.live @ 22%`.
-    public static let signalGlowLive = Color(hex: 0x9EF01A, opacity: 0.22)
+    // Signal / semantic colors from DESIGN.md
+    /// `primary` / Forest. `#434E3F`
+    public static let signalLive = Color(hex: 0x434E3F)
+    /// `warning`. `#D49B2A`
+    public static let signalWaiting = Color(hex: 0xD49B2A)
+    /// `destructive`. `#C4342D`
+    public static let signalBlocked = Color(hex: 0xC4342D)
+    /// `success`. `#3A7D44`
+    public static let signalDone = Color(hex: 0x3A7D44)
+    /// Muted status gray. `#7A7768`
+    public static let signalIdle = Color(hex: 0x7A7768)
+    /// Ember glow, `rgba(208, 111, 37, 0.16)`.
+    public static let signalGlowLive = Color(hex: 0xD06F25, opacity: 0.16)
 }
 
 // MARK: - §4 Spacing (8pt base with 4pt sub-step)
 
-/// Spacing scale. `space.1=4 … space.7=48` (design.md §4).
+/// Spacing scale. `xs=4 … 2xl=48` (DESIGN.md).
 public enum Spacing {
     /// 4 pt
     public static let x1: CGFloat = 4
@@ -89,15 +92,15 @@ public enum Spacing {
 
 // MARK: - §4 Radius (engraved, not pill-soft)
 
-/// Corner radius scale (design.md §4).
+/// Corner radius scale adapted from DESIGN.md.
 public enum Radius {
-    /// Card corner radius. `radius.card=10`
+    /// Card corner radius. `rounded.md=10`
     public static let card: CGFloat = 10
-    /// Badge corner radius. `radius.badge=5`
-    public static let badge: CGFloat = 5
-    /// Panel corner radius. `radius.panel=14`
+    /// Badge corner radius, compact native adaptation.
+    public static let badge: CGFloat = 6
+    /// Panel corner radius. `rounded.lg=14`
     public static let panel: CGFloat = 14
-    /// Control corner radius. `radius.control=8`
+    /// Control corner radius, between `rounded.sm` and `rounded.md`.
     public static let control: CGFloat = 8
 }
 
@@ -145,7 +148,7 @@ extension Font {
         #endif
     }
 
-    /// IBM Plex Sans — display/chrome/titles (design.md §3).
+    /// Inter-ish UI/body fallback for display/chrome/titles (DESIGN.md typography).
     /// TODO(086): ships the IBM Plex Sans binaries per Resources/Fonts/README.md.
     /// Falls back to a humanist-leaning system font until then.
     public static func plexSans(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
@@ -155,7 +158,7 @@ extension Font {
         return .system(size: size, weight: weight, design: .default)
     }
 
-    /// IBM Plex Mono — mono/data/terminal/badges, "the voice of the machine" (design.md §3).
+    /// JetBrains Mono-ish mono/data/terminal/badges (DESIGN.md typography).
     /// TODO(086): ships the IBM Plex Mono binaries per Resources/Fonts/README.md.
     /// Falls back to a monospaced system font until then.
     public static func plexMono(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {

--- a/macos/Sources/Net/GatewayHTTPClient.swift
+++ b/macos/Sources/Net/GatewayHTTPClient.swift
@@ -43,6 +43,10 @@ public struct GatewayHTTPClient: Sendable {
         try await send(method: "GET", path: path, body: Optional<EmptyBody>.none, timeout: timeout)
     }
 
+    public func getData(_ path: String, timeout: TimeInterval? = nil) async throws -> Data {
+        try await sendRaw(method: "GET", path: path, body: Optional<EmptyBody>.none, timeout: timeout)
+    }
+
     public func post<Body: Encodable, Response: Decodable>(
         _ path: String,
         body: Body,
@@ -59,6 +63,23 @@ public struct GatewayHTTPClient: Sendable {
         timeout: TimeInterval? = nil
     ) async throws -> Response {
         try await send(method: "PATCH", path: path, body: body, timeout: timeout)
+    }
+
+    public func putData(
+        _ path: String,
+        data: Data,
+        contentType: String = "text/plain; charset=utf-8",
+        timeout: TimeInterval? = nil
+    ) async throws {
+        var request = try await makeRequest(
+            method: "PUT",
+            path: path,
+            body: Optional<EmptyBody>.none,
+            timeout: timeout
+        )
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+        _ = try await perform(request)
     }
 
     /// DELETE with no decoded response body.
@@ -92,7 +113,10 @@ public struct GatewayHTTPClient: Sendable {
         timeout: TimeInterval?
     ) async throws -> Data {
         let request = try await makeRequest(method: method, path: path, body: body, timeout: timeout)
+        return try await perform(request)
+    }
 
+    private func perform(_ request: URLRequest) async throws -> Data {
         let data: Data
         let response: URLResponse
         do {

--- a/macos/Sources/Terminal/TerminalSession.swift
+++ b/macos/Sources/Terminal/TerminalSession.swift
@@ -32,6 +32,11 @@ public enum TerminalConnectionState: Equatable, Sendable {
 /// - Track scroll-pin ("● LIVE" vs "↓ N new") so the view can render the affordance.
 @MainActor
 public final class TerminalSession: ObservableObject {
+    /// Stable identity used by SwiftUI/AppKit bridges. Terminal tabs must be keyed
+    /// by the session object, otherwise AppKit may reuse a `TerminalView` whose
+    /// delegate still points at a previous zellij session.
+    public let id = UUID()
+
     /// Human-readable session label shown in the top strip.
     public let displayName: String
 
@@ -52,6 +57,7 @@ public final class TerminalSession: ObservableObject {
     /// Sink for decoded PTY output text. The view installs this to feed SwiftTerm.
     /// Called on the main actor.
     private var outputSink: (@MainActor (String) -> Void)?
+    private var pendingOutput = ""
     private var attachHandler: (@MainActor () -> Void)?
     private var consumeTask: Task<Void, Never>?
     private var started = false
@@ -70,6 +76,7 @@ public final class TerminalSession: ObservableObject {
     /// Installs the output sink (the SwiftTerm feed) before/while starting.
     public func setOutputSink(_ sink: @escaping @MainActor (String) -> Void) {
         outputSink = sink
+        flushPendingOutput()
     }
 
     /// Runs once when the terminal first reaches an attached/output state.
@@ -166,7 +173,11 @@ public final class TerminalSession: ObservableObject {
             if case .connecting = connectionState { connectionState = .attached }
             if case .reconnecting = connectionState { connectionState = .attached }
             notifyAttached()
-            outputSink?(data)
+            if outputSink == nil {
+                pendingOutput += data
+            } else {
+                outputSink?(data)
+            }
             if !isPinnedToBottom {
                 unseenLines += 1
             }
@@ -188,5 +199,12 @@ public final class TerminalSession: ObservableObject {
         guard let attachHandler else { return }
         self.attachHandler = nil
         attachHandler()
+    }
+
+    private func flushPendingOutput() {
+        guard !pendingOutput.isEmpty, let outputSink else { return }
+        let chunk = pendingOutput
+        pendingOutput.removeAll(keepingCapacity: true)
+        outputSink(chunk)
     }
 }

--- a/macos/Tests/DesignSystemTests/DesignTokensTests.swift
+++ b/macos/Tests/DesignSystemTests/DesignTokensTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 @testable import DesignSystem
 
-/// Proves the OPERATOR token values from design.md §2–§5/§9 resolve exactly, and that the
-/// DesignSystem target compiles and tests run (Phase 1 gate). Color components are compared
+/// Proves the Matrix OS native token values from DESIGN.md resolve exactly, and that the
+/// DesignSystem target compiles and tests run. Color components are compared
 /// in sRGB with a small tolerance for floating-point division.
 final class DesignTokensTests: XCTestCase {
 
@@ -34,56 +34,58 @@ final class DesignTokensTests: XCTestCase {
         XCTAssertEqual(actual.a, opacity, accuracy: tolerance, "\(message) alpha", file: file, line: line)
     }
 
-    // MARK: §2 Signal colors (the load-bearing semantic tokens)
+    // MARK: Signal colors (the load-bearing semantic tokens)
 
-    func testSignalLiveIsPhosphorLime() {
-        assertColor(.signalLive, hex: 0x9EF01A, "signal.live")
+    func testSignalLiveIsForestPrimary() {
+        assertColor(.signalLive, hex: 0x434E3F, "signal.live")
     }
 
-    func testSignalWaitingIsAmber() {
-        assertColor(.signalWaiting, hex: 0xFFB020, "signal.waiting")
+    func testSignalWaitingIsWarmWarning() {
+        assertColor(.signalWaiting, hex: 0xD49B2A, "signal.waiting")
     }
 
-    func testSignalBlockedIsCoral() {
-        assertColor(.signalBlocked, hex: 0xFF5C5C, "signal.blocked")
+    func testSignalBlockedIsWarmDestructive() {
+        assertColor(.signalBlocked, hex: 0xC4342D, "signal.blocked")
     }
 
-    func testSignalDoneIsTeal() {
-        assertColor(.signalDone, hex: 0x43C59E, "signal.done")
+    func testSignalDoneIsWarmSuccessGreen() {
+        assertColor(.signalDone, hex: 0x3A7D44, "signal.done")
     }
 
-    func testSignalIdleIsGrey() {
-        assertColor(.signalIdle, hex: 0x5C636E, "signal.idle")
+    func testSignalIdleIsWarmMutedGrey() {
+        assertColor(.signalIdle, hex: 0x7A7768, "signal.idle")
     }
 
-    func testSignalGlowLiveIsLimeAt22Percent() {
-        assertColor(.signalGlowLive, hex: 0x9EF01A, opacity: 0.22, "signal.glow.live")
+    func testSignalGlowLiveIsEmberAt16Percent() {
+        assertColor(.signalGlowLive, hex: 0xD06F25, opacity: 0.16, "signal.glow.live")
     }
 
-    // MARK: §2 Canvas & surfaces
+    // MARK: Canvas & surfaces
 
     func testCanvasAndSurfaceTokens() {
-        assertColor(.canvasVoid, hex: 0x0A0B0D, "canvas.void")
-        assertColor(.surfaceRail, hex: 0x101216, "surface.rail")
-        assertColor(.surfaceCard, hex: 0x15171C, "surface.card")
-        assertColor(.surfaceCardRaised, hex: 0x1B1E24, "surface.cardRaised")
+        assertColor(.canvasVoid, hex: 0xFAFAF5, "canvas.void")
+        assertColor(.surfaceRail, hex: 0xF0EDE4, "surface.rail")
+        assertColor(.surfaceCard, hex: 0xFFFFFF, "surface.card")
+        assertColor(.surfaceCardRaised, hex: 0xF7F1E7, "surface.cardRaised")
         assertColor(.surfaceTerminal, hex: 0x0C0D10, "surface.terminal")
     }
 
-    // MARK: §2 Ink
+    // MARK: Ink
 
     func testInkTokens() {
-        assertColor(.inkPrimary, hex: 0xE8EAED, "ink.primary")
-        assertColor(.inkSecondary, hex: 0x9BA1AC, "ink.secondary")
-        assertColor(.inkTertiary, hex: 0x5C636E, "ink.tertiary")
-        assertColor(.inkDisabled, hex: 0x3A3F47, "ink.disabled")
+        assertColor(.inkPrimary, hex: 0x32352E, "ink.primary")
+        assertColor(.inkSecondary, hex: 0x434E3F, "ink.secondary")
+        assertColor(.inkTertiary, hex: 0x7A7768, "ink.tertiary")
+        assertColor(.inkDisabled, hex: 0xD6D3C8, "ink.disabled")
+        assertColor(.terminalInk, hex: 0xE8EAED, "terminal.ink")
+        assertColor(.terminalMutedInk, hex: 0x9BA1AC, "terminal.mutedInk")
     }
 
-    // MARK: §2 Hairline (dual-tone)
+    // MARK: Hairline
 
     func testHairlineTokens() {
-        assertColor(.hairlineDark, hex: 0x000000, opacity: 0.60, "hairline.dark")
-        assertColor(.hairlineHighlight, hex: 0xFFFFFF, opacity: 0.06, "hairline.highlight")
+        assertColor(.hairlineDark, hex: 0xD6D3C8, "hairline.dark")
+        assertColor(.hairlineHighlight, hex: 0xFFFFFF, opacity: 0.75, "hairline.highlight")
     }
 
     // MARK: §4 Spacing scale (4/8/12/16/24/32/48)
@@ -102,7 +104,7 @@ final class DesignTokensTests: XCTestCase {
 
     func testRadiusScale() {
         XCTAssertEqual(Radius.card, 10)
-        XCTAssertEqual(Radius.badge, 5)
+        XCTAssertEqual(Radius.badge, 6)
         XCTAssertEqual(Radius.panel, 14)
         XCTAssertEqual(Radius.control, 8)
     }

--- a/macos/Tests/TerminalTests/TerminalSessionTests.swift
+++ b/macos/Tests/TerminalTests/TerminalSessionTests.swift
@@ -77,6 +77,21 @@ final class TerminalSessionTests: XCTestCase {
         XCTAssertEqual(session.connectionState, .attached)
     }
 
+    func testOutputBeforeSinkIsFlushedWhenSinkIsInstalled() async {
+        let (session, source) = makeSession()
+        var fed: [String] = []
+        session.start()
+
+        await source.emit(.output(seq: 1, data: "boot "))
+        await source.emit(.output(seq: 2, data: "ready"))
+        await eventually({ session.lastSeq == 2 })
+        try? await Task.sleep(nanoseconds: 30_000_000)
+
+        session.setOutputSink { fed.append($0) }
+
+        await eventually({ fed == ["boot ready"] })
+    }
+
     func testOutWhileScrolledUpAccumulatesUnseen() async {
         let (session, source) = makeSession()
         session.start()


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 7/11.

## Summary

Splits the large workspace refinement into a core layer: native workspace state, tabs, hit targets, syntax-highlighted editor primitive, and design-token updates.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

No backend route, database, or auth behavior changes in this layer.