### PR TITLE
fix(086): make shell and browser standalone

### DIFF
--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -87,12 +87,14 @@ public enum AppSection: String, CaseIterable, Sendable {
     case home
     case board
     case shell
+    case browser
 
     public var title: String {
         switch self {
         case .home: return "Home"
         case .board: return "Board"
         case .shell: return "Shell"
+        case .browser: return "Browser"
         }
     }
 
@@ -101,6 +103,7 @@ public enum AppSection: String, CaseIterable, Sendable {
         case .home: return "house"
         case .board: return "rectangle.split.3x1"
         case .shell: return "terminal"
+        case .browser: return "globe"
         }
     }
 }
@@ -1373,36 +1376,24 @@ public final class AppModel: ObservableObject {
         openError = nil
         isCreatingWorkItem = true
         let existingSessionNames = Set(sessions.map(\.name))
+        let name = generatedShellSessionName()
         Task { [weak self] in
             defer { Task { @MainActor in self?.isCreatingWorkItem = false } }
             struct CreateSessionRequest: Encodable {
-                let kind = "shell"
-                let runtimePreference = "zellij"
-                let projectSlug: String
+                let name: String
+                let cwd: String?
             }
             struct CreateSessionResponse: Decodable {
-                struct Session: Decodable {
-                    let name: String
-
-                    private enum CodingKeys: String, CodingKey { case name, id, sessionId }
-
-                    init(from decoder: Decoder) throws {
-                        let container = try decoder.container(keyedBy: CodingKeys.self)
-                        name = try container.decodeIfPresent(String.self, forKey: .name)
-                            ?? container.decodeIfPresent(String.self, forKey: .id)
-                            ?? container.decode(String.self, forKey: .sessionId)
-                    }
-                }
-                let session: Session?
+                let name: String?
             }
             do {
                 let response: CreateSessionResponse = try await client.post(
-                    "/api/sessions",
-                    body: CreateSessionRequest(projectSlug: self?.projectSlug ?? "default")
+                    "/api/terminal/sessions",
+                    body: CreateSessionRequest(name: name, cwd: nil)
                 )
                 await self?.loadSessions()
-                if let name = response.session?.name {
-                    await MainActor.run { self?.openSession(named: name) }
+                if let createdName = response.name {
+                    await MainActor.run { self?.openSession(named: createdName) }
                 } else if let created = self?.sessions.first(where: { !existingSessionNames.contains($0.name) }) {
                     await MainActor.run { self?.openSession(named: created.name) }
                 }
@@ -1410,6 +1401,11 @@ public final class AppModel: ObservableObject {
                 await MainActor.run { self?.openError = .createSessionFailed }
             }
         }
+    }
+
+    private func generatedShellSessionName() -> String {
+        let suffix = UUID().uuidString.prefix(8).lowercased()
+        return "shell-\(suffix)"
     }
 
     private func displayName(for card: Card) -> String {

--- a/macos/Sources/App/BrowserPageView.swift
+++ b/macos/Sources/App/BrowserPageView.swift
@@ -196,6 +196,7 @@ private struct BrowserWebView: NSViewRepresentable {
         view.navigationDelegate = context.coordinator
         view.allowsBackForwardNavigationGestures = true
         view.underPageBackgroundColor = .clear
+        context.coordinator.observeURLChanges(in: view)
         load(url, in: view, coordinator: context.coordinator)
         return view
     }
@@ -214,6 +215,7 @@ private struct BrowserWebView: NSViewRepresentable {
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         var lastURL: URL?
+        private var urlObservation: NSKeyValueObservation?
 
         private let onURLChange: @MainActor (URL) -> Void
 
@@ -222,11 +224,31 @@ private struct BrowserWebView: NSViewRepresentable {
             super.init()
         }
 
+        func observeURLChanges(in webView: WKWebView) {
+            urlObservation?.invalidate()
+            urlObservation = webView.observe(\.url, options: [.new]) { [weak self] _, change in
+                guard let self, let url = change.newValue.flatMap({ $0 }) else { return }
+                Task { @MainActor in
+                    self.syncURL(url)
+                }
+            }
+        }
+
         @MainActor
         func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
-            guard let url = webView.url, lastURL != url else { return }
+            guard let url = webView.url else { return }
+            syncURL(url)
+        }
+
+        @MainActor
+        private func syncURL(_ url: URL) {
+            guard lastURL != url else { return }
             lastURL = url
             onURLChange(url)
+        }
+
+        deinit {
+            urlObservation?.invalidate()
         }
     }
 }

--- a/macos/Sources/App/BrowserPageView.swift
+++ b/macos/Sources/App/BrowserPageView.swift
@@ -1,0 +1,215 @@
+#if os(macOS)
+import SwiftUI
+import WebKit
+import AppKit
+import DesignSystem
+
+struct BrowserPageView: View {
+    private struct DevTarget: Identifiable {
+        let id: String
+        let title: String
+        let subtitle: String
+        let url: String
+        let icon: String
+    }
+
+    @State private var address = ""
+    @State private var currentURL: URL?
+
+    private let commonTargets: [DevTarget] = [
+        DevTarget(id: "next", title: "Next.js", subtitle: "localhost:3000", url: "http://localhost:3000", icon: "bolt.horizontal"),
+        DevTarget(id: "vite", title: "Vite", subtitle: "localhost:5173", url: "http://localhost:5173", icon: "sparkles"),
+        DevTarget(id: "api", title: "API", subtitle: "localhost:8080", url: "http://localhost:8080", icon: "server.rack"),
+        DevTarget(id: "docs", title: "Docs", subtitle: "localhost:8000", url: "http://localhost:8000", icon: "doc.text"),
+        DevTarget(id: "preview", title: "Preview", subtitle: "localhost:3001", url: "http://localhost:3001", icon: "rectangle.and.text.magnifyingglass")
+    ]
+
+    var body: some View {
+        VStack(spacing: Spacing.x3) {
+            header
+            Group {
+                if let currentURL {
+                    BrowserWebView(url: currentURL)
+                        .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                                .strokeBorder(Color.hairlineDark.opacity(0.8), lineWidth: 1)
+                        )
+                        .shadow(color: Color.black.opacity(0.08), radius: 14, y: 7)
+                } else {
+                    emptyState
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(.horizontal, Spacing.x5)
+        .padding(.vertical, Spacing.x4)
+        .background(Color.canvasVoid)
+    }
+
+    private var header: some View {
+        VStack(spacing: Spacing.x3) {
+            HStack {
+                Label("Browser", systemImage: "globe")
+                    .font(.plexSans(13, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                Spacer()
+                Button {
+                    if let currentURL {
+                        NSWorkspace.shared.open(currentURL)
+                    }
+                } label: {
+                    Image(systemName: "arrow.up.forward.square")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.inkTertiary)
+                        .iconHitTarget(32)
+                        .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .disabled(currentURL == nil)
+                .help("Open in system browser")
+            }
+
+            HStack(spacing: Spacing.x2) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.inkTertiary)
+                TextField("localhost:3000 or https://example.com", text: $address)
+                    .textFieldStyle(.plain)
+                    .font(.plexSans(13, weight: .medium))
+                    .onSubmit { openAddress() }
+                Button("Open") { openAddress() }
+                    .font(.plexSans(12, weight: .semibold))
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, Spacing.x3)
+                    .frame(height: 28)
+                    .background(Color.surfaceTerminal, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                    .foregroundStyle(Color.canvasVoid)
+            }
+            .padding(.horizontal, Spacing.x3)
+            .frame(height: 42)
+            .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .strokeBorder(Color.hairlineDark.opacity(0.75), lineWidth: 1)
+            )
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Spacing.x5) {
+            Spacer(minLength: 0)
+            VStack(spacing: Spacing.x2) {
+                Image(systemName: "globe.badge.chevron.backward")
+                    .font(.system(size: 42, weight: .light))
+                    .foregroundStyle(Color.signalLive)
+                Text("Open a local preview")
+                    .font(.plexSans(24, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                Text("Choose a common dev server or enter a URL above. Port-forwarded previews will appear here later.")
+                    .font(.plexSans(14))
+                    .foregroundStyle(Color.inkTertiary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 560)
+            }
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 180), spacing: Spacing.x3)], spacing: Spacing.x3) {
+                ForEach(commonTargets) { target in
+                    Button {
+                        open(target.url)
+                    } label: {
+                        VStack(alignment: .leading, spacing: Spacing.x3) {
+                            Image(systemName: target.icon)
+                                .font(.system(size: 22, weight: .medium))
+                                .foregroundStyle(Color.signalLive)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(target.title)
+                                    .font(.plexSans(15, weight: .semibold))
+                                    .foregroundStyle(Color.inkPrimary)
+                                Text(target.subtitle)
+                                    .font(.plexMono(12, weight: .medium))
+                                    .foregroundStyle(Color.inkTertiary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(Spacing.x4)
+                        .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+                                .strokeBorder(Color.hairlineDark.opacity(0.75), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .frame(maxWidth: 760)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
+        )
+    }
+
+    private func openAddress() {
+        open(address)
+    }
+
+    private func open(_ raw: String) {
+        guard let url = normalizeURL(raw) else { return }
+        address = url.absoluteString
+        currentURL = url
+    }
+
+    private func normalizeURL(_ raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.contains("://") {
+            guard let url = URL(string: trimmed),
+                  let scheme = url.scheme?.lowercased(),
+                  ["http", "https"].contains(scheme) else {
+                return nil
+            }
+            return url
+        }
+        return URL(string: "http://\(trimmed)")
+    }
+}
+
+private struct BrowserWebView: NSViewRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+        let view = WKWebView(frame: .zero, configuration: configuration)
+        view.navigationDelegate = context.coordinator
+        view.allowsBackForwardNavigationGestures = true
+        view.drawsBackground = false
+        load(url, in: view, coordinator: context.coordinator)
+        return view
+    }
+
+    func updateNSView(_ view: WKWebView, context: Context) {
+        guard context.coordinator.lastURL != url else { return }
+        load(url, in: view, coordinator: context.coordinator)
+    }
+
+    private func load(_ url: URL, in view: WKWebView, coordinator: Coordinator) {
+        coordinator.lastURL = url
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 20
+        view.load(request)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        var lastURL: URL?
+    }
+}
+#endif

--- a/macos/Sources/App/BrowserPageView.swift
+++ b/macos/Sources/App/BrowserPageView.swift
@@ -29,7 +29,10 @@ struct BrowserPageView: View {
             header
             Group {
                 if let currentURL {
-                    BrowserWebView(url: currentURL)
+                    BrowserWebView(url: currentURL) { navigatedURL in
+                        address = navigatedURL.absoluteString
+                        self.currentURL = navigatedURL
+                    }
                         .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
                         .overlay(
                             RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
@@ -180,9 +183,10 @@ struct BrowserPageView: View {
 
 private struct BrowserWebView: NSViewRepresentable {
     let url: URL
+    let onURLChange: @MainActor (URL) -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(onURLChange: onURLChange)
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -191,7 +195,7 @@ private struct BrowserWebView: NSViewRepresentable {
         let view = WKWebView(frame: .zero, configuration: configuration)
         view.navigationDelegate = context.coordinator
         view.allowsBackForwardNavigationGestures = true
-        view.setValue(false, forKey: "drawsBackground")
+        view.underPageBackgroundColor = .clear
         load(url, in: view, coordinator: context.coordinator)
         return view
     }
@@ -210,6 +214,20 @@ private struct BrowserWebView: NSViewRepresentable {
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         var lastURL: URL?
+
+        private let onURLChange: @MainActor (URL) -> Void
+
+        init(onURLChange: @escaping @MainActor (URL) -> Void) {
+            self.onURLChange = onURLChange
+            super.init()
+        }
+
+        @MainActor
+        func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+            guard let url = webView.url, lastURL != url else { return }
+            lastURL = url
+            onURLChange(url)
+        }
     }
 }
 #endif

--- a/macos/Sources/App/BrowserPageView.swift
+++ b/macos/Sources/App/BrowserPageView.swift
@@ -191,7 +191,7 @@ private struct BrowserWebView: NSViewRepresentable {
         let view = WKWebView(frame: .zero, configuration: configuration)
         view.navigationDelegate = context.coordinator
         view.allowsBackForwardNavigationGestures = true
-        view.drawsBackground = false
+        view.setValue(false, forKey: "drawsBackground")
         load(url, in: view, coordinator: context.coordinator)
         return view
     }

--- a/macos/Sources/App/CommandPalette.swift
+++ b/macos/Sources/App/CommandPalette.swift
@@ -48,6 +48,9 @@ struct CommandPalette: View {
             PaletteAction(id: "go-shell", title: "Switch to Shell", symbol: "terminal.fill") {
                 model.section = .shell
             },
+            PaletteAction(id: "go-browser", title: "Switch to Browser", symbol: "globe") {
+                model.section = .browser
+            },
         ] + projectActions
     }
 

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -85,6 +85,8 @@ private struct OperatorCommands: Commands {
                 .keyboardShortcut("2", modifiers: .control)
             Button("Shell") { model.section = .shell }
                 .keyboardShortcut("3", modifiers: .control)
+            Button("Browser") { model.section = .browser }
+                .keyboardShortcut("4", modifiers: .control)
             Divider()
             Button("Terminal Panel") { model.switchPanel(.terminal) }
                 .keyboardShortcut("1", modifiers: .command)

--- a/macos/Sources/App/ProjectPicker.swift
+++ b/macos/Sources/App/ProjectPicker.swift
@@ -45,22 +45,6 @@ struct ProjectPickerRail: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.x2) {
-            if !collapsed {
-                Button { model.openHome() } label: {
-                    Label("Matrix Home", systemImage: "house")
-                        .font(.plexSans(12, weight: model.hasSelectedProject ? .medium : .semibold))
-                        .foregroundStyle(model.hasSelectedProject ? Color.inkSecondary : Color.inkPrimary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, Spacing.x2)
-                        .frame(height: 32)
-                        .background(
-                            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                                .fill(model.hasSelectedProject ? Color.clear : Color.surfaceCardRaised)
-                        )
-                }
-                .buttonStyle(.plain)
-            }
-
             if model.projects.isEmpty {
                 emptyProjectState
             } else if collapsed {
@@ -129,7 +113,7 @@ private struct NewProjectSquare: View {
                         .font(.system(size: compact ? 16 : 18, weight: .semibold))
                         .foregroundStyle(Color.signalLive)
                 }
-                .frame(width: compact ? 46 : 54, height: compact ? 46 : 54)
+                .frame(width: compact ? 42 : 54, height: compact ? 42 : 54)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .strokeBorder(Color.hairlineDark, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
@@ -140,7 +124,7 @@ private struct NewProjectSquare: View {
                         .foregroundStyle(Color.inkSecondary)
                 }
             }
-            .frame(maxWidth: compact ? 52 : .infinity)
+            .frame(maxWidth: compact ? 46 : .infinity)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -165,7 +149,7 @@ private struct ProjectSquareButton: View {
                         .font(.plexMono(compact ? 12 : 14, weight: .semibold))
                         .foregroundStyle(isActive ? Color.canvasVoid : Color.inkPrimary)
                 }
-                .frame(width: compact ? 46 : 54, height: compact ? 46 : 54)
+                .frame(width: compact ? 42 : 54, height: compact ? 42 : 54)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .strokeBorder(isActive ? Color.signalLive : Color.hairlineDark, lineWidth: 1)
@@ -179,7 +163,7 @@ private struct ProjectSquareButton: View {
                         .frame(maxWidth: 76)
                 }
             }
-            .frame(maxWidth: compact ? 52 : .infinity)
+            .frame(maxWidth: compact ? 46 : .infinity)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -249,13 +249,7 @@ private struct Sidebar: View {
 
     private func addButton(compact: Bool) -> some View {
         Button {
-            if model.section == .shell {
-                model.createSession()
-            } else if model.section == .board {
-                model.createTask(status: .todo)
-            } else {
-                model.showCommandPalette = true
-            }
+            performPrimaryAction()
         } label: {
             Image(systemName: "plus")
                 .font(.system(size: 16, weight: .bold))
@@ -269,10 +263,26 @@ private struct Sidebar: View {
         .accessibilityLabel(primaryActionTitle)
     }
 
+    private func performPrimaryAction() {
+        if model.section == .shell {
+            model.createSession()
+        } else if model.section == .board {
+            model.createTask(status: .todo)
+        } else {
+            model.showCommandPalette = true
+        }
+    }
+
     private var primaryActionTitle: String {
         if model.section == .shell { return "New session" }
         if model.section == .board { return "New task" }
         return "Command palette"
+    }
+
+    private var primaryActionShortcut: String {
+        if model.section == .shell { return "⌘T" }
+        if model.section == .board { return "⌘N" }
+        return "⌘K"
     }
 
     private var projectsBlock: some View {
@@ -414,15 +424,15 @@ private struct Sidebar: View {
 
     private var newTaskButton: some View {
         Button {
-            if model.section == .shell { model.createSession() } else { model.createTask(status: .todo) }
+            performPrimaryAction()
         } label: {
             HStack(spacing: Spacing.x3) {
                 Image(systemName: "plus")
                     .font(.system(size: 14, weight: .semibold))
-                Text(model.section == .shell ? "New session" : "New task / New agent")
+                Text(primaryActionTitle)
                     .font(.plexSans(14, weight: .semibold))
                 Spacer()
-                Text(model.section == .shell ? "⌘T" : "⌘N")
+                Text(primaryActionShortcut)
                     .font(.plexMono(11, weight: .semibold))
                     .padding(.horizontal, Spacing.x2)
                     .padding(.vertical, 5)
@@ -445,6 +455,8 @@ private struct Sidebar: View {
         .buttonStyle(.plain)
         .padding(.horizontal, Spacing.x4)
         .disabled(model.isCreatingWorkItem)
+        .help(primaryActionTitle)
+        .accessibilityLabel(primaryActionTitle)
     }
 
     private var handleBadge: some View {

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -48,6 +48,8 @@ struct RootShellView: View {
             BoardView(model: model)
         case .shell:
             TerminalsView(model: model)
+        case .browser:
+            BrowserPageView()
         }
     }
 }
@@ -70,7 +72,7 @@ private struct Sidebar: View {
                 expandedSidebar
             }
         }
-        .frame(width: collapsed ? 88 : 320)
+        .frame(width: collapsed ? 76 : 320)
         .frame(maxHeight: .infinity)
         .background(Color.canvasVoid)
         .overlay(alignment: .trailing) {
@@ -80,9 +82,28 @@ private struct Sidebar: View {
     }
 
     private var sidebarHeader: some View {
-        HStack(spacing: Spacing.x3) {
-            AppMark(collapsed: collapsed)
-            if !collapsed {
+        Group {
+            if collapsed {
+                VStack(spacing: Spacing.x2) {
+                    AppMark(collapsed: true)
+                    Button { collapsed.toggle() } label: {
+                        Image(systemName: "sidebar.right")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Color.inkTertiary)
+                            .frame(width: 40, height: 32)
+                            .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                                    .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .help("Expand sidebar")
+                }
+                .frame(maxWidth: .infinity)
+            } else {
+                HStack(spacing: Spacing.x3) {
+                    AppMark(collapsed: false)
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Matrix")
                         .font(.plexSans(17, weight: .semibold))
@@ -92,46 +113,45 @@ private struct Sidebar: View {
                         .foregroundStyle(Color.inkTertiary)
                 }
                 Spacer()
+                    Button { collapsed.toggle() } label: {
+                        Image(systemName: "sidebar.left")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Color.inkTertiary)
+                            .iconHitTarget(32)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Collapse sidebar")
+                }
             }
-            Button { collapsed.toggle() } label: {
-                Image(systemName: collapsed ? "sidebar.right" : "sidebar.left")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Color.inkTertiary)
-                    .iconHitTarget(32)
-            }
-            .buttonStyle(.plain)
-            .help(collapsed ? "Expand sidebar" : "Collapse sidebar")
         }
     }
 
     private var collapsedRail: some View {
-        VStack(spacing: Spacing.x2) {
-            Button { model.openHome() } label: {
-                Image(systemName: "house")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(model.hasSelectedProject ? Color.inkTertiary : Color.signalLive)
-                    .iconHitTarget(44)
+        VStack(spacing: 0) {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: Spacing.x2) {
+                    ForEach(AppSection.allCases, id: \.self) { section in
+                        railButton(section)
+                    }
+                    railDivider
+                    ProjectPickerRail(model: model, collapsed: true)
+                    railDivider
+                    addButton(compact: true)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, Spacing.x1)
             }
-            .buttonStyle(.plain)
-            .help("Matrix Home")
-            Divider().overlay(Color.hairlineDark).padding(.vertical, Spacing.x1)
-            ProjectPickerRail(model: model, collapsed: true)
-            Divider().overlay(Color.hairlineDark).padding(.vertical, Spacing.x1)
-            ForEach(AppSection.allCases.filter { $0 != .home }, id: \.self) { section in
-                railButton(section)
-            }
-            Divider().overlay(Color.hairlineDark).padding(.vertical, Spacing.x1)
-            addButton(compact: true)
-            Spacer()
             handleBadge
+                .padding(.top, Spacing.x3)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, Spacing.x2)
+        .padding(.horizontal, Spacing.x1)
         .padding(.bottom, Spacing.x3)
     }
 
     private var expandedSidebar: some View {
         VStack(alignment: .leading, spacing: 0) {
+            navigationBlock
             projectsBlock
             sessionsBlock
             Spacer(minLength: Spacing.x4)
@@ -145,15 +165,57 @@ private struct Sidebar: View {
         }
     }
 
+    private var navigationBlock: some View {
+        VStack(alignment: .leading, spacing: Spacing.x1) {
+            sectionLabel("Navigate") {
+                EmptyView()
+            }
+            ForEach(AppSection.allCases, id: \.self) { section in
+                sectionRow(section)
+            }
+        }
+        .padding(.horizontal, Spacing.x4)
+        .padding(.bottom, Spacing.x4)
+    }
+
+    private func sectionRow(_ section: AppSection) -> some View {
+        let active = model.section == section
+        return Button { selectSection(section) } label: {
+            HStack(spacing: Spacing.x2) {
+                Image(systemName: section.symbol)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(active ? Color.signalLive : Color.inkTertiary)
+                    .frame(width: 20)
+                Text(section.title)
+                    .font(.plexSans(13, weight: active ? .semibold : .medium))
+                    .foregroundStyle(active ? Color.inkPrimary : Color.inkSecondary)
+                Spacer()
+            }
+            .padding(.horizontal, Spacing.x3)
+            .frame(height: 34)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(active ? Color.surfaceCardRaised : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .strokeBorder(active ? Color.hairlineDark.opacity(0.75) : Color.clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(section.title)
+        .accessibilityLabel(section.title)
+        .accessibilityAddTraits(active ? [.isSelected] : [])
+    }
+
     private func railButton(_ section: AppSection) -> some View {
         let active = model.section == section
-        return Button { model.section = section } label: {
-            VStack(spacing: 3) {
-                Image(systemName: section.symbol)
-                    .font(.system(size: 16, weight: .medium))
-            }
+        return Button { selectSection(section) } label: {
+            Image(systemName: section.symbol)
+                .font(.system(size: 16, weight: active ? .semibold : .medium))
             .foregroundStyle(active ? Color.signalLive : Color.inkTertiary)
-            .frame(width: 52, height: 48)
+            .frame(width: 46, height: 44)
             .background(
                 RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
                     .fill(active ? Color.surfaceCardRaised : Color.clear)
@@ -170,9 +232,30 @@ private struct Sidebar: View {
         .accessibilityAddTraits(active ? [.isSelected] : [])
     }
 
+    private var railDivider: some View {
+        Rectangle()
+            .fill(Color.hairlineDark.opacity(0.7))
+            .frame(width: 46, height: 1)
+            .padding(.vertical, Spacing.x1)
+    }
+
+    private func selectSection(_ section: AppSection) {
+        if section == .home {
+            model.openHome()
+        } else {
+            model.section = section
+        }
+    }
+
     private func addButton(compact: Bool) -> some View {
         Button {
-            if model.section == .shell { model.createSession() } else { model.createTask(status: .todo) }
+            if model.section == .shell {
+                model.createSession()
+            } else if model.section == .board {
+                model.createTask(status: .todo)
+            } else {
+                model.showCommandPalette = true
+            }
         } label: {
             Image(systemName: "plus")
                 .font(.system(size: 16, weight: .bold))
@@ -182,8 +265,14 @@ private struct Sidebar: View {
         }
         .buttonStyle(.plain)
         .disabled(model.isCreatingWorkItem)
-        .help(model.section == .shell ? "New session" : "New task (⌘N)")
-        .accessibilityLabel(model.section == .shell ? "New session" : "New task")
+        .help(primaryActionTitle)
+        .accessibilityLabel(primaryActionTitle)
+    }
+
+    private var primaryActionTitle: String {
+        if model.section == .shell { return "New session" }
+        if model.section == .board { return "New task" }
+        return "Command palette"
     }
 
     private var projectsBlock: some View {


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 9/11.

## Summary

Makes Shell/Home and Browser first-class standalone native pages instead of task-only panels.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

No backend route, database, or auth behavior changes in this layer.