### PR TITLE
fix(086): route native auth and terminal nav

### DIFF
--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -106,5 +106,11 @@ let package = Package(
             path: "Tests/BoardTests",
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),
+        .testTarget(
+            name: "AppTests",
+            dependencies: ["MatrixOS"],
+            path: "Tests/AppTests",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
     ]
 )

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -81,19 +81,19 @@ public enum SignInState: Equatable, Sendable {
     case failed(String)
 }
 
-/// Top-level workspace sections (left rail). Board = task kanban; Terminals =
-/// the live zellij session list opened in a full/side terminal.
+/// Top-level workspace sections (left rail). Home is the web shell package;
+/// Terminal is the live zellij session list opened in a full terminal surface.
 public enum AppSection: String, CaseIterable, Sendable {
     case home
     case board
-    case shell
+    case terminal
     case browser
 
     public var title: String {
         switch self {
         case .home: return "Home"
         case .board: return "Board"
-        case .shell: return "Shell"
+        case .terminal: return "Terminal"
         case .browser: return "Browser"
         }
     }
@@ -102,7 +102,7 @@ public enum AppSection: String, CaseIterable, Sendable {
         switch self {
         case .home: return "house"
         case .board: return "rectangle.split.3x1"
-        case .shell: return "terminal"
+        case .terminal: return "terminal"
         case .browser: return "globe"
         }
     }
@@ -534,6 +534,13 @@ public final class AppModel: ObservableObject {
             phase = .needsProfile
             return
         }
+        guard await principal.token() != nil else {
+            phase = .needsProfile
+            terminal?.shutdown()
+            terminal = nil
+            openError = nil
+            return
+        }
         ensureHomeTab(select: activeTabID == nil)
         if phase == .ready {
             // Keep showing the board while refreshing; only drop to disconnected on failure.
@@ -712,7 +719,7 @@ public final class AppModel: ObservableObject {
         sessionAttachNames = nextAttachNames
         sessions = loaded
         if !loaded.isEmpty {
-            if section == .shell, terminal == nil, let first = sessions.first(where: \.isActive) ?? sessions.first {
+            if section == .terminal, terminal == nil, let first = sessions.first(where: \.isActive) ?? sessions.first {
                 openSession(named: first.name)
             }
         }
@@ -752,6 +759,11 @@ public final class AppModel: ObservableObject {
         activeTabID = "home"
         section = .home
         activePanel = .shell
+    }
+
+    public func openTerminalSection() {
+        section = .terminal
+        Task { await loadSessions() }
     }
 
     public var activeProjectName: String {
@@ -847,6 +859,7 @@ public final class AppModel: ObservableObject {
 
     /// Opens a raw zellij session (Terminals section) in the side terminal view.
     public func openSession(named name: String) {
+        section = .terminal
         let card = Card(
             id: name, projectSlug: projectSlug, title: name,
             status: .running, priority: .normal, order: 0,

--- a/macos/Sources/App/CommandPalette.swift
+++ b/macos/Sources/App/CommandPalette.swift
@@ -40,13 +40,13 @@ struct CommandPalette: View {
                 model.createSession()
             },
             PaletteAction(id: "go-home", title: "Switch to Home", symbol: "house") {
-                model.section = .home
+                model.openHome()
             },
             PaletteAction(id: "go-board", title: "Switch to Board", symbol: "rectangle.split.3x1") {
                 model.section = .board
             },
-            PaletteAction(id: "go-shell", title: "Switch to Shell", symbol: "terminal.fill") {
-                model.section = .shell
+            PaletteAction(id: "go-terminal", title: "Switch to Terminal", symbol: "terminal.fill") {
+                model.openTerminalSection()
             },
             PaletteAction(id: "go-browser", title: "Switch to Browser", symbol: "globe") {
                 model.section = .browser

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -79,11 +79,11 @@ private struct OperatorCommands: Commands {
             Button("New Session") { model.createSession() }
                 .keyboardShortcut("n", modifiers: [.command, .shift])
             Divider()
-            Button("Home") { model.section = .home }
+            Button("Home") { model.openHome() }
                 .keyboardShortcut("1", modifiers: .control)
             Button("Board") { model.section = .board }
                 .keyboardShortcut("2", modifiers: .control)
-            Button("Shell") { model.section = .shell }
+            Button("Terminal") { model.openTerminalSection() }
                 .keyboardShortcut("3", modifiers: .control)
             Button("Browser") { model.section = .browser }
                 .keyboardShortcut("4", modifiers: .control)

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -104,12 +104,8 @@ private struct WebShellView: NSViewRepresentable {
         coordinator.lastRequestedURL = url
         coordinator.destinationURL = url
         guard let bearerToken, !bearerToken.isEmpty, let request = appSessionExchangeRequest(for: url, token: bearerToken) else {
-<<<<<<< HEAD
             coordinator.exchangeInFlight = false
-            view.load(destinationRequest(for: url, token: bearerToken))
-=======
             view.load(webShellDestinationRequest(for: url, token: bearerToken))
->>>>>>> 81595539 (fix(086): harden native auth routing retries)
             return
         }
         coordinator.exchangeInFlight = true

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -100,19 +100,53 @@ private struct WebShellView: NSViewRepresentable {
     }
 
     private func load(_ url: URL, in view: WKWebView, coordinator: Coordinator) {
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 20
-        if let bearerToken, !bearerToken.isEmpty {
-            request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
-        }
         coordinator.lastBearerToken = bearerToken
         coordinator.lastRequestedURL = url
+        coordinator.destinationURL = url
+        guard let bearerToken, !bearerToken.isEmpty, let request = appSessionExchangeRequest(for: url, token: bearerToken) else {
+            coordinator.exchangeInFlight = false
+            view.load(destinationRequest(for: url, token: bearerToken))
+            return
+        }
+        coordinator.exchangeInFlight = true
         view.load(request)
+    }
+
+    private func appSessionExchangeRequest(for destination: URL, token: String) -> URLRequest? {
+        guard var comps = URLComponents(url: destination, resolvingAgainstBaseURL: false) else { return nil }
+        let redirectTo = destination.path.isEmpty
+            ? "/"
+            : destination.path + (destination.query.map { "?\($0)" } ?? "")
+        comps.path = "/api/auth/app-session"
+        comps.query = nil
+        guard let exchangeURL = comps.url else { return nil }
+        var request = URLRequest(url: exchangeURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 20
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(AppSessionExchangeBody(redirectTo: redirectTo))
+        return request
+    }
+
+    private func destinationRequest(for url: URL, token: String?) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 20
+        if let token, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private struct AppSessionExchangeBody: Encodable {
+        let redirectTo: String
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         var lastBearerToken: String?
         var lastRequestedURL: URL?
+        var destinationURL: URL?
+        var exchangeInFlight = false
 
         @MainActor
         func webView(
@@ -132,10 +166,46 @@ private struct WebShellView: NSViewRepresentable {
             decisionHandler(.allow)
         }
 
+        @MainActor
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard exchangeInFlight,
+                  webView.url?.path == "/api/auth/app-session",
+                  let destinationURL else { return }
+            exchangeInFlight = false
+            webView.load(Self.destinationRequest(for: destinationURL, token: lastBearerToken))
+        }
+
+        @MainActor
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            loadDestinationAfterExchangeFailure(in: webView)
+        }
+
+        @MainActor
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            loadDestinationAfterExchangeFailure(in: webView)
+        }
+
+        @MainActor
+        private func loadDestinationAfterExchangeFailure(in webView: WKWebView) {
+            guard exchangeInFlight, let destinationURL else { return }
+            exchangeInFlight = false
+            webView.load(Self.destinationRequest(for: destinationURL, token: lastBearerToken))
+        }
+
+        private static func destinationRequest(for url: URL, token: String?) -> URLRequest {
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 20
+            if let token, !token.isEmpty {
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+            return request
+        }
+
         private static func shouldOpenExternally(_ url: URL) -> Bool {
             guard let host = url.host()?.lowercased() else { return false }
             let path = url.path.lowercased()
             let firstSegment = url.pathComponents.dropFirst().first?.lowercased()
+            if path == "/api/auth/app-session" { return false }
             if host.contains("clerk") || host.contains("accounts.") {
                 return true
             }

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -104,8 +104,12 @@ private struct WebShellView: NSViewRepresentable {
         coordinator.lastRequestedURL = url
         coordinator.destinationURL = url
         guard let bearerToken, !bearerToken.isEmpty, let request = appSessionExchangeRequest(for: url, token: bearerToken) else {
+<<<<<<< HEAD
             coordinator.exchangeInFlight = false
             view.load(destinationRequest(for: url, token: bearerToken))
+=======
+            view.load(webShellDestinationRequest(for: url, token: bearerToken))
+>>>>>>> 81595539 (fix(086): harden native auth routing retries)
             return
         }
         coordinator.exchangeInFlight = true
@@ -126,15 +130,6 @@ private struct WebShellView: NSViewRepresentable {
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try? JSONEncoder().encode(AppSessionExchangeBody(redirectTo: redirectTo))
-        return request
-    }
-
-    private func destinationRequest(for url: URL, token: String?) -> URLRequest {
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 20
-        if let token, !token.isEmpty {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
         return request
     }
 
@@ -159,20 +154,51 @@ private struct WebShellView: NSViewRepresentable {
                 return
             }
             if Self.shouldOpenExternally(url) {
+                if exchangeInFlight {
+                    exchangeInFlight = false
+                }
                 NSWorkspace.shared.open(url)
                 decisionHandler(.cancel)
                 return
+            }
+            if exchangeInFlight, !Self.isAppSessionExchangeURL(url) {
+                exchangeInFlight = false
             }
             decisionHandler(.allow)
         }
 
         @MainActor
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationResponse: WKNavigationResponse,
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationResponsePolicy) -> Void
+        ) {
+            guard exchangeInFlight,
+                  let responseURL = navigationResponse.response.url,
+                  Self.isAppSessionExchangeURL(responseURL),
+                  let httpResponse = navigationResponse.response as? HTTPURLResponse,
+                  !(200..<300).contains(httpResponse.statusCode) else {
+                decisionHandler(.allow)
+                return
+            }
+            loadDestinationAfterExchangeFailure(in: webView)
+            decisionHandler(.cancel)
+        }
+
+        @MainActor
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             guard exchangeInFlight,
-                  webView.url?.path == "/api/auth/app-session",
+                  webView.url.map(Self.isAppSessionExchangeURL) == true,
                   let destinationURL else { return }
             exchangeInFlight = false
-            webView.load(Self.destinationRequest(for: destinationURL, token: lastBearerToken))
+            webView.load(webShellDestinationRequest(for: destinationURL, token: lastBearerToken))
+        }
+
+        @MainActor
+        func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+            if exchangeInFlight {
+                exchangeInFlight = false
+            }
         }
 
         @MainActor
@@ -189,16 +215,7 @@ private struct WebShellView: NSViewRepresentable {
         private func loadDestinationAfterExchangeFailure(in webView: WKWebView) {
             guard exchangeInFlight, let destinationURL else { return }
             exchangeInFlight = false
-            webView.load(Self.destinationRequest(for: destinationURL, token: lastBearerToken))
-        }
-
-        private static func destinationRequest(for url: URL, token: String?) -> URLRequest {
-            var request = URLRequest(url: url)
-            request.timeoutInterval = 20
-            if let token, !token.isEmpty {
-                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            }
-            return request
+            webView.load(webShellDestinationRequest(for: destinationURL, token: lastBearerToken))
         }
 
         private static func shouldOpenExternally(_ url: URL) -> Bool {
@@ -209,6 +226,7 @@ private struct WebShellView: NSViewRepresentable {
             if host.contains("clerk") || host.contains("accounts.") {
                 return true
             }
+<<<<<<< HEAD
             return firstSegment == "sign-in"
                 || firstSegment == "sign-up"
                 || firstSegment == "login"
@@ -216,7 +234,40 @@ private struct WebShellView: NSViewRepresentable {
                 || firstSegment == "sso"
                 || firstSegment == "auth"
                 || path == "/login"
+=======
+            return isAuthPath(path)
+        }
+
+        private static func isAppSessionExchangeURL(_ url: URL) -> Bool {
+            url.path == "/api/auth/app-session"
+        }
+
+        private static func isAuthPath(_ path: String) -> Bool {
+            path == "/sign-in"
+                || path.hasPrefix("/sign-in/")
+                || path == "/sign-up"
+                || path.hasPrefix("/sign-up/")
+                || path == "/login"
+                || path.hasPrefix("/login/")
+                || path == "/oauth"
+                || path.hasPrefix("/oauth/")
+                || path == "/sso"
+                || path.hasPrefix("/sso/")
+                || path == "/auth/device"
+                || path.hasPrefix("/auth/device/")
+                || path == "/auth/callback"
+                || path.hasPrefix("/auth/callback/")
+>>>>>>> 5ffea89c (fix(086): harden native auth routing retries)
         }
     }
+}
+
+private func webShellDestinationRequest(for url: URL, token: String?) -> URLRequest {
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 20
+    if let token, !token.isEmpty {
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+    return request
 }
 #endif

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -221,20 +221,10 @@ private struct WebShellView: NSViewRepresentable {
         private static func shouldOpenExternally(_ url: URL) -> Bool {
             guard let host = url.host()?.lowercased() else { return false }
             let path = url.path.lowercased()
-            let firstSegment = url.pathComponents.dropFirst().first?.lowercased()
             if path == "/api/auth/app-session" { return false }
             if host.contains("clerk") || host.contains("accounts.") {
                 return true
             }
-<<<<<<< HEAD
-            return firstSegment == "sign-in"
-                || firstSegment == "sign-up"
-                || firstSegment == "login"
-                || firstSegment == "oauth"
-                || firstSegment == "sso"
-                || firstSegment == "auth"
-                || path == "/login"
-=======
             return isAuthPath(path)
         }
 
@@ -257,7 +247,6 @@ private struct WebShellView: NSViewRepresentable {
                 || path.hasPrefix("/auth/device/")
                 || path == "/auth/callback"
                 || path.hasPrefix("/auth/callback/")
->>>>>>> 5ffea89c (fix(086): harden native auth routing retries)
         }
     }
 }

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -1,8 +1,7 @@
-// Matrix OS — workspace shell: left rail (Board / Terminals) + section content.
+// Matrix OS — workspace shell: left rail (Home / Board / Terminal / Browser) + section content.
 //
-// Board = task kanban (cards open a zellij session). Terminals = the live zellij
-// session list, opened in a side terminal (full terminal experience). This keeps
-// raw sessions OUT of the kanban (per product direction) while still one click away.
+// Board = task kanban (cards open a zellij session). Terminal = the live zellij
+// session list. Home is the hosted Matrix shell UI from the shell package.
 #if os(macOS)
 import SwiftUI
 import AppKit
@@ -40,13 +39,10 @@ struct RootShellView: View {
     private var sectionContent: some View {
         switch model.section {
         case .home:
-            MatrixComputerHomeView(
-                model: model,
-                onOpenShell: { model.section = .shell; model.createSession() }
-            )
+            MatrixWebShellPanel(model: model, url: model.shellURL(), title: "Matrix Home")
         case .board:
             BoardView(model: model)
-        case .shell:
+        case .terminal:
             TerminalsView(model: model)
         case .browser:
             BrowserPageView()
@@ -242,6 +238,8 @@ private struct Sidebar: View {
     private func selectSection(_ section: AppSection) {
         if section == .home {
             model.openHome()
+        } else if section == .terminal {
+            model.openTerminalSection()
         } else {
             model.section = section
         }
@@ -264,7 +262,7 @@ private struct Sidebar: View {
     }
 
     private func performPrimaryAction() {
-        if model.section == .shell {
+        if model.section == .terminal {
             model.createSession()
         } else if model.section == .board {
             model.createTask(status: .todo)
@@ -274,13 +272,13 @@ private struct Sidebar: View {
     }
 
     private var primaryActionTitle: String {
-        if model.section == .shell { return "New session" }
+        if model.section == .terminal { return "New session" }
         if model.section == .board { return "New task" }
         return "Command palette"
     }
 
     private var primaryActionShortcut: String {
-        if model.section == .shell { return "⌘T" }
+        if model.section == .terminal { return "⌘T" }
         if model.section == .board { return "⌘N" }
         return "⌘K"
     }
@@ -360,7 +358,7 @@ private struct Sidebar: View {
 
     private func sessionRow(_ session: WorkspaceSession) -> some View {
         let selected = model.activeTerminalSessionName == session.name
-        return Button { model.section = .shell; model.openSession(named: session.name) } label: {
+        return Button { model.openSession(named: session.name) } label: {
             HStack(spacing: Spacing.x2) {
                 Image(systemName: session.isActive ? "terminal" : "doc.text")
                     .font(.system(size: 12, weight: .medium))
@@ -543,7 +541,7 @@ private struct TerminalsView: View {
     private var workbenchHeader: some View {
         VStack(spacing: Spacing.x3) {
             HStack(spacing: Spacing.x2) {
-                Label("Matrix Shell", systemImage: "terminal")
+                Label("Terminal", systemImage: "terminal")
                     .font(.plexSans(13, weight: .semibold))
                     .foregroundStyle(Color.inkPrimary)
                 Spacer()
@@ -560,7 +558,7 @@ private struct TerminalsView: View {
 
             HStack(alignment: .top, spacing: Spacing.x3) {
                 VStack(alignment: .leading, spacing: Spacing.x3) {
-                    Text(model.terminal?.displayName ?? "Shell")
+                    Text(model.terminal?.displayName ?? "Terminal")
                         .font(.plexSans(22, weight: .semibold))
                         .foregroundStyle(Color.inkPrimary)
                         .lineLimit(2)
@@ -571,7 +569,7 @@ private struct TerminalsView: View {
                 }
                 Spacer()
                 Button { model.createSession() } label: {
-                    Label("New shell", systemImage: "plus")
+                    Label("New terminal", systemImage: "plus")
                         .font(.plexSans(12, weight: .medium))
                         .foregroundStyle(Color.inkPrimary)
                 }

--- a/macos/Sources/Terminal/ShellWSClient.swift
+++ b/macos/Sources/Terminal/ShellWSClient.swift
@@ -133,7 +133,11 @@ public actor ShellWSClient {
             if stopped || Task.isCancelled { break }
             isAttached = false
             attempt = cleanly ? 0 : attempt + 1
-            eventContinuation.yield(.reconnecting)
+            if !cleanly && attempt >= 2 {
+                eventContinuation.yield(.error(code: "connection_failed", message: "Terminal connection failed"))
+            } else {
+                eventContinuation.yield(.reconnecting)
+            }
             await clock.sleep(seconds: backoff.delay(forAttempt: attempt))
         }
     }

--- a/macos/Sources/Terminal/ShellWSClient.swift
+++ b/macos/Sources/Terminal/ShellWSClient.swift
@@ -133,7 +133,7 @@ public actor ShellWSClient {
             if stopped || Task.isCancelled { break }
             isAttached = false
             attempt = cleanly ? 0 : attempt + 1
-            if !cleanly && attempt >= 2 {
+            if !cleanly && attempt == 2 {
                 eventContinuation.yield(.error(code: "connection_failed", message: "Terminal connection failed"))
             } else {
                 eventContinuation.yield(.reconnecting)

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -1,0 +1,60 @@
+#if os(macOS)
+import XCTest
+@testable import MatrixOS
+import MatrixBoard
+import MatrixModel
+import MatrixNet
+
+@MainActor
+final class AppModelAuthTests: XCTestCase {
+    func testRefreshRequiresTokenEvenWhenProfileIsPersisted() async {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        let profile = ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com")
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "default",
+            profile: profile,
+            makeClient: { url, provider in GatewayHTTPClient(baseURL: url, tokenProvider: provider) },
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+
+        await model.refresh()
+
+        XCTAssertEqual(model.phase, .needsProfile)
+    }
+}
+
+private final class MemoryTokenStore: TokenStoring, @unchecked Sendable {
+    private var values: [String: String] = [:]
+
+    func get(key: String) throws -> String? {
+        values[key]
+    }
+
+    func set(key: String, value: String) throws {
+        values[key] = value
+    }
+
+    func delete(key: String) throws {
+        values.removeValue(forKey: key)
+    }
+}
+
+private struct EmptyBoardLoader: BoardLoading {
+    func fetchTasks(projectSlug: String) async throws -> [Card] {
+        []
+    }
+}
+
+private struct MockDeviceAuthorizer: DeviceAuthorizing {
+    func startDeviceAuth() async throws -> DeviceAuthStart {
+        throw GatewayError.server
+    }
+
+    func pollForToken(deviceCode: String) async throws -> DevicePollResult {
+        .pending
+    }
+}
+#endif

--- a/macos/Tests/TerminalTests/ShellWSClientTests.swift
+++ b/macos/Tests/TerminalTests/ShellWSClientTests.swift
@@ -264,6 +264,31 @@ final class ShellWSClientStateMachineTests: XCTestCase {
         await client.shutdown()
     }
 
+    func testRepeatedReconnectFailuresEmitConnectionErrorOnce() async throws {
+        let transport = MockShellTransport()
+        let clock = MockClock()
+        let client = makeClient(transport: transport, clock: clock)
+        await client.connect()
+
+        for connectionCount in 1...4 {
+            await transport.waitForConnect(count: connectionCount)
+            await transport.failCurrent()
+            await clock.waitForSleeper()
+            if connectionCount < 4 {
+                await clock.advanceAll()
+            }
+        }
+
+        let events = await drain(client, count: 4)
+        XCTAssertEqual(events, [
+            .reconnecting,
+            .error(code: "connection_failed", message: "Terminal connection failed"),
+            .reconnecting,
+            .reconnecting
+        ])
+        await client.shutdown()
+    }
+
     func testReplayEvictedResetsToLiveTail() async throws {
         let transport = MockShellTransport()
         let clock = MockClock()


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 10/11.

## Summary

Routes native shell auth and terminal navigation through the platform app-session path and verifies platform short-circuit/proxy behavior on current main.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

- Source of truth: platform device-code/session state remains canonical for browser and native auth; native app Keychain stores only the issued sync JWT after approval.
- Lock/transaction scope: existing platform auth/device persistence and gateway shell session flows are preserved; this layer changes routing/UI handoff behavior only.
- Acceptable orphan states: if native redirect delivery fails, polling can still complete; if a runtime is unavailable, the user sees an explicit no-runtime/setup state instead of silently entering hosted shell.
- Auth source of truth: Clerk authorizes browser approval and app-session exchange; sync JWT authorizes native app and gateway/VPS access.
- Deferred scope: production routing/deploy must route the device auth paths to the platform app-shell service; host-bundle deployment alone does not update pre-VPS auth pages.

## Deployment Notes

After merging the stack, redeploy the platform/app-shell service serving \`app.matrix-os.com\` and ensure the production router sends these paths to it:

- \`/api/auth/app-session\`
- \`/api/auth/device/*\`
- \`/auth/device\`
- \`/auth/device/*\`

Smoke:

```bash
curl -sS https://app.matrix-os.com/api/auth/device/code \\
  -H 'Content-Type: application/json' \\
  --data '{"clientId":"matrix-os-macos","redirectUri":"matrixos://auth?status=approved"}'
```

The returned \`verificationUri\` must include both \`redirect_uri=matrixos%3A%2F%2Fauth%3Fstatus%3Dapproved\` and \`redirect_sig=...\`. The browser page should say \`Approve Matrix OS app\`, then return through \`matrixos://auth?status=approved\`.