### PR TITLE
fix(086): keep native macOS auth in app flow

### DIFF
--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -81,6 +81,12 @@ public enum SignInState: Equatable, Sendable {
     case failed(String)
 }
 
+/// Which Clerk screen the device approval page should mount first.
+public enum SignInMode: String, Sendable {
+    case signIn = "sign-in"
+    case signUp = "sign-up"
+}
+
 /// Top-level workspace sections (left rail). Home is the web shell package;
 /// Terminal is the live zellij session list opened in a full terminal surface.
 public enum AppSection: String, CaseIterable, Sendable {
@@ -325,6 +331,7 @@ public final class AppModel: ObservableObject {
     /// Factory for a terminal session given a resolved WS URL, principal provider, and session id.
     /// Injected so tests can supply a mock event source instead of a real socket.
     private let makeTerminal: @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession
+    private var signInMode: SignInMode = .signUp
 
     // MARK: - Init
 
@@ -338,9 +345,9 @@ public final class AppModel: ObservableObject {
             GatewayHTTPClient(baseURL: url, tokenProvider: provider)
         },
         makeLoader: @escaping @Sendable (GatewayHTTPClient) -> any BoardLoading = { client in
-            // The board is project/task-first, but unlinked live zellij sessions are
-            // also surfaced so a fresh VPS never opens to an empty board.
-            CompositeBoardLoader(client: client)
+            // Project boards are task-first. Generic shells live in the Terminal
+            // section, not inside project kanban.
+            GatewayBoardLoader(client: client)
         },
         makeTerminal: @escaping @MainActor (URL, PrincipalProvider, String, String) -> TerminalSession = { url, provider, session, name in
             let tokenProvider = provider as any TokenProviding
@@ -427,8 +434,9 @@ public final class AppModel: ObservableObject {
     /// Starts the device-authorization sign-in: requests a device code, opens the
     /// verification page in the browser, and polls until approved. On success it
     /// stores the principal token, builds a profile, and loads the board.
-    public func beginSignIn() {
+    public func beginSignIn(mode: SignInMode = .signIn) {
         signInTask?.cancel()
+        signInMode = mode
         signIn = .starting
         signInTask = Task { [weak self] in await self?.runSignIn() }
     }
@@ -464,8 +472,9 @@ public final class AppModel: ObservableObject {
         do {
             let start = try await deviceAuth.startDeviceAuth()
             if Task.isCancelled { return }
-            signIn = .awaitingApproval(userCode: start.userCode, verificationUri: start.verificationUri)
-            if let url = URL(string: start.verificationUri) {
+            let verificationUri = verificationURI(start.verificationUri, mode: signInMode)
+            signIn = .awaitingApproval(userCode: start.userCode, verificationUri: verificationUri)
+            if let url = URL(string: verificationUri) {
                 openExternalURL(url)
             }
 
@@ -501,6 +510,15 @@ public final class AppModel: ObservableObject {
             // Generic, user-safe — never surface raw gateway/provider text.
             signIn = .failed("Sign-in failed. Check your connection and try again.")
         }
+    }
+
+    private func verificationURI(_ rawValue: String, mode: SignInMode) -> String {
+        guard var components = URLComponents(string: rawValue) else { return rawValue }
+        var items = components.queryItems ?? []
+        items.removeAll { $0.name == "mode" }
+        items.append(URLQueryItem(name: "mode", value: mode.rawValue))
+        components.queryItems = items
+        return components.url?.absoluteString ?? rawValue
     }
 
     // MARK: - Profile selection
@@ -739,7 +757,7 @@ public final class AppModel: ObservableObject {
 
     /// Switches the active project and reloads its board.
     public func openProject(slug: String) {
-        guard slug != projectSlug, let client = gatewayClient() else { return }
+        guard slug != projectSlug || !hasSelectedProject, let client = gatewayClient() else { return }
         openError = nil
         projectSlug = slug
         hasSelectedProject = true

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -241,7 +241,7 @@ public final class AppModel: ObservableObject {
     // MARK: - Published state (SwiftUI binds to these)
 
     /// The active top-level section (left rail selection).
-    @Published public var section: AppSection = .home
+    @Published public var section: AppSection = .board
     /// Live zellij sessions for the Terminals section.
     @Published public private(set) var sessions: [WorkspaceSession] = []
     /// Open task/session tabs in the workspace. Tabs are project-marked so work
@@ -538,7 +538,6 @@ public final class AppModel: ObservableObject {
             self.board = BoardStore(loader: UnconfiguredBoardLoader())
             self.phase = .needsProfile
         }
-        ensureHomeTab(select: activeTabID == nil)
     }
 
     // MARK: - Board lifecycle
@@ -559,7 +558,6 @@ public final class AppModel: ObservableObject {
             openError = nil
             return
         }
-        ensureHomeTab(select: activeTabID == nil)
         if phase == .ready {
             // Keep showing the board while refreshing; only drop to disconnected on failure.
         } else {
@@ -774,7 +772,7 @@ public final class AppModel: ObservableObject {
         hasSelectedProject = false
         selectedCard = nil
         terminal = nil
-        activeTabID = "home"
+        activeTabID = nil
         section = .home
         activePanel = .shell
     }

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1421,8 +1421,9 @@ public final class AppModel: ObservableObject {
                     body: CreateSessionRequest(name: name, cwd: nil)
                 )
                 await self?.loadSessions()
-                if let createdName = response.name {
-                    await MainActor.run { self?.openSession(named: createdName) }
+                let requestedName = response.name ?? name
+                if self?.sessions.contains(where: { $0.name == requestedName }) == true {
+                    await MainActor.run { self?.openSession(named: requestedName) }
                 } else if let created = self?.sessions.first(where: { !existingSessionNames.contains($0.name) }) {
                     await MainActor.run { self?.openSession(named: created.name) }
                 }

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -35,7 +35,7 @@ struct BoardView: View {
         case .needsProfile:
             NoProfileView(
                 onCreate: openCreateFlow,
-                onSignIn: { model.beginSignIn() },
+                onSignIn: { model.beginSignIn(mode: .signIn) },
                 onCancelSignIn: { model.cancelSignIn() },
                 signIn: model.signIn
             )
@@ -253,10 +253,27 @@ struct BoardView: View {
     private var toolbarContent: some ToolbarContent {
         ToolbarItem(placement: .navigation) {
             HStack(spacing: Spacing.x2) {
-                Circle().fill(Color.signalLive).frame(width: 7, height: 7)
-                Text(model.hasSelectedProject ? "\(model.activeProjectName) Board" : "Matrix")
-                    .font(.plexSans(12, weight: .semibold))
-                    .foregroundStyle(Color.inkSecondary)
+                if model.hasSelectedProject {
+                    ProjectAvatarIcon(
+                        name: model.activeProjectName,
+                        slug: model.projectSlug,
+                        isActive: true,
+                        size: 24
+                    )
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(model.activeProjectName)
+                            .font(.plexSans(12, weight: .semibold))
+                            .foregroundStyle(Color.inkPrimary)
+                        Text("Kanban")
+                            .font(.plexSans(10, weight: .medium))
+                            .foregroundStyle(Color.inkTertiary)
+                    }
+                } else {
+                    Circle().fill(Color.signalLive).frame(width: 7, height: 7)
+                    Text("Matrix OS")
+                        .font(.plexSans(12, weight: .semibold))
+                        .foregroundStyle(Color.inkSecondary)
+                }
             }
         }
         ToolbarItemGroup(placement: .primaryAction) {
@@ -302,10 +319,7 @@ struct BoardView: View {
     }
 
     private func openCreateFlow() {
-        // Hand off to the platform onboarding flow. In US1 this opens the web flow.
-        if let url = URL(string: "https://app.matrix-os.com/runtime") {
-            NSWorkspace.shared.open(url)
-        }
+        model.beginSignIn(mode: .signUp)
     }
 }
 

--- a/macos/Sources/App/BrowserPageView.swift
+++ b/macos/Sources/App/BrowserPageView.swift
@@ -177,6 +177,11 @@ struct BrowserPageView: View {
             }
             return url
         }
+        if trimmed.allSatisfy(\.isNumber),
+           let port = Int(trimmed),
+           (1...65_535).contains(port) {
+            return URL(string: "http://localhost:\(port)")
+        }
         return URL(string: "http://\(trimmed)")
     }
 }

--- a/macos/Sources/App/EmptyStates.swift
+++ b/macos/Sources/App/EmptyStates.swift
@@ -38,23 +38,23 @@ struct NoProfileView: View {
             VStack(alignment: .leading, spacing: Spacing.x5) {
                 glyph
                 VStack(alignment: .leading, spacing: Spacing.x2) {
-                    Text("Matrix")
+                    Text("Matrix OS")
                         .font(.plexSans(38, weight: .semibold))
                         .foregroundStyle(Color.canvasVoid)
-                    Text("Run cloud agents.\nShip reliable software.")
+                    Text("Code on your\ncloud computer.")
                         .font(.plexSans(30, weight: .semibold))
                         .foregroundStyle(Color.canvasVoid)
                         .lineSpacing(2)
                 }
-                Text("Matrix gives you a private cloud computer with terminal, files, projects, agents, and review tools in one native app.")
+                Text("Every user gets a private VPS with shell, files, projects, agents, and review tools in one native app.")
                     .font(.plexSans(15))
                     .foregroundStyle(Color.canvasVoid.opacity(0.82))
                     .lineSpacing(3)
                     .frame(maxWidth: 360, alignment: .leading)
                 VStack(alignment: .leading, spacing: Spacing.x3) {
-                    brandBullet("cloud", "Powerful cloud runtimes")
-                    brandBullet("terminal", "Agent-native development")
-                    brandBullet("checkmark.shield", "End-to-end visibility")
+                    brandBullet("checkmark.circle", "No local setup required")
+                    brandBullet("chevron.left.forwardslash.chevron.right", "Works with GitHub")
+                    brandBullet("sparkles", "Claude / Codex / OpenCode ready")
                 }
                 Spacer()
             }
@@ -65,10 +65,10 @@ struct NoProfileView: View {
     private var authCard: some View {
         VStack(spacing: Spacing.x4) {
             VStack(spacing: Spacing.x1) {
-                Text("Welcome to Matrix")
+                Text("Welcome to Matrix OS")
                     .font(.plexSans(24, weight: .semibold))
                     .foregroundStyle(Color.inkPrimary)
-                Text("Sign in or create your Matrix computer.")
+                Text("Sign in to your account or create a new one to get started.")
                     .font(.plexSans(13))
                     .foregroundStyle(Color.inkTertiary)
             }
@@ -327,7 +327,7 @@ struct ProjectSelectionRequiredView: View {
             Text("Choose a project")
                 .font(.plexSans(28, weight: .semibold))
                 .foregroundStyle(Color.inkPrimary)
-            Text("Kanban boards are project-specific. Select a project square in the sidebar or create a new project to open its tasks.")
+            Text("Kanban boards are project-specific. Select a project in the sidebar or create a new project to open its tasks.")
                 .font(.plexSans(15))
                 .foregroundStyle(Color.inkTertiary)
                 .multilineTextAlignment(.center)

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -87,10 +87,10 @@ private final class MatrixOSAppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     private static func recoverIfOffscreen(_ window: NSWindow) {
         let frame = window.frame
-        let isFullyVisible = NSScreen.screens.contains { screen in
-            screen.visibleFrame.contains(frame)
+        let isReachable = NSScreen.screens.contains { screen in
+            screen.visibleFrame.intersects(frame)
         }
-        guard !isFullyVisible else { return }
+        guard !isReachable else { return }
 
         if let screen = NSScreen.main ?? NSScreen.screens.first {
             let visibleFrame = screen.visibleFrame

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -81,7 +81,7 @@ private final class MatrixOSAppDelegate: NSObject, NSApplicationDelegate {
             recoverIfOffscreen(window)
             window.makeKeyAndOrderFront(nil)
         }
-        NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate()
     }
 
     @MainActor

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -77,7 +77,7 @@ private final class MatrixOSAppDelegate: NSObject, NSApplicationDelegate {
     private static func bringAppForward() {
         NSApp.setActivationPolicy(.regular)
 
-        if let window = NSApp.windows.first {
+        if let window = NSApp.mainWindow ?? NSApp.keyWindow ?? NSApp.windows.first {
             recoverIfOffscreen(window)
             window.makeKeyAndOrderFront(nil)
         }

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -12,12 +12,14 @@
 // VPS resolver already exist in MatrixNet and are composed here when a profile
 // is supplied. Set MATRIX_DEV_GATEWAY_HOST + MATRIX_DEV_HANDLE in the environment
 // to auto-select a dev profile for local source dev.
+import AppKit
 import SwiftUI
 import DesignSystem
 import MatrixNet
 
 @main
 struct MatrixOSApp: App {
+    @NSApplicationDelegateAdaptor(MatrixOSAppDelegate.self) private var appDelegate
     @StateObject private var model: AppModel
 
     init() {
@@ -50,6 +52,54 @@ struct MatrixOSApp: App {
         guard let handle = env["MATRIX_DEV_HANDLE"], !handle.isEmpty else { return nil }
         let slot = env["MATRIX_DEV_RUNTIME_SLOT"]
         return ConnectionProfile(handle: handle, gatewayHost: host, runtimeSlot: slot)
+    }
+}
+
+private final class MatrixOSAppDelegate: NSObject, NSApplicationDelegate {
+    nonisolated func applicationDidFinishLaunching(_ notification: Notification) {
+        Task { @MainActor in
+            MatrixOSAppDelegate.bringAppForward()
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            MatrixOSAppDelegate.bringAppForward()
+        }
+    }
+
+    nonisolated func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        Task { @MainActor in
+            MatrixOSAppDelegate.bringAppForward()
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            MatrixOSAppDelegate.bringAppForward()
+        }
+        return true
+    }
+
+    @MainActor
+    private static func bringAppForward() {
+        NSApp.setActivationPolicy(.regular)
+
+        if let window = NSApp.windows.first {
+            recoverIfOffscreen(window)
+            window.makeKeyAndOrderFront(nil)
+        }
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @MainActor
+    private static func recoverIfOffscreen(_ window: NSWindow) {
+        let frame = window.frame
+        let isFullyVisible = NSScreen.screens.contains { screen in
+            screen.visibleFrame.contains(frame)
+        }
+        guard !isFullyVisible else { return }
+
+        if let screen = NSScreen.main ?? NSScreen.screens.first {
+            let visibleFrame = screen.visibleFrame
+            let origin = NSPoint(
+                x: visibleFrame.midX - frame.width / 2,
+                y: visibleFrame.midY - frame.height / 2
+            )
+            window.setFrameOrigin(origin)
+        }
     }
 }
 

--- a/macos/Sources/App/ProjectPicker.swift
+++ b/macos/Sources/App/ProjectPicker.swift
@@ -24,8 +24,8 @@ enum ProjectSheetMode: Identifiable {
     var needsRemote: Bool { self == .clone }
 }
 
-/// Project switcher shown as direct project squares in the left rail. Project
-/// selection is explicit: clicking a square opens that project's kanban board.
+/// Project switcher shown directly in the left rail. Project selection is
+/// explicit: clicking a project opens that project's kanban board.
 struct ProjectPickerRail: View {
     @ObservedObject var model: AppModel
     let collapsed: Bool
@@ -33,14 +33,6 @@ struct ProjectPickerRail: View {
 
     private var activeName: String {
         model.projects.first { $0.slug == model.projectSlug }?.name ?? model.projectSlug
-    }
-
-    private var activeInitials: String {
-        let parts = activeName
-            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
-            .map(String.init)
-        let raw = parts.prefix(2).compactMap { $0.first }.map(String.init).joined()
-        return (raw.isEmpty ? String(activeName.prefix(2)) : raw).uppercased()
     }
 
     var body: some View {
@@ -60,16 +52,16 @@ struct ProjectPickerRail: View {
                     NewProjectSquare(compact: true) { sheet = .create }
                 }
             } else {
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 72), spacing: Spacing.x2)], spacing: Spacing.x2) {
+                VStack(spacing: Spacing.x1) {
                     ForEach(model.projects) { project in
-                        ProjectSquareButton(
+                        ProjectListRowButton(
                             project: project,
                             isActive: model.hasSelectedProject && project.slug == model.projectSlug,
-                            compact: false,
                             onOpen: { model.openProject(slug: project.slug) }
                         )
                     }
-                    NewProjectSquare(compact: false) { sheet = .create }
+                    Divider().overlay(Color.hairlineDark).padding(.vertical, Spacing.x1)
+                    NewProjectListRow { sheet = .create }
                 }
             }
         }
@@ -96,6 +88,137 @@ struct ProjectPickerRail: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: Radius.card, style: .continuous).strokeBorder(Color.hairlineDark, lineWidth: 1))
+    }
+}
+
+func projectAccentColor(slug: String) -> Color {
+    let palette: [Color] = [
+        .signalLive,
+        .signalWaiting,
+        .signalDone,
+        .signalBlocked,
+        .inkSecondary,
+    ]
+    let folded = slug.unicodeScalars.reduce(0) { partial, scalar in
+        (partial &* 31) &+ Int(scalar.value)
+    }
+    let index = folded == Int.min ? 0 : abs(folded) % palette.count
+    return palette[index]
+}
+
+struct ProjectAvatarIcon: View {
+    let name: String
+    let slug: String
+    let isActive: Bool
+    let size: CGFloat
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: min(12, size * 0.24), style: .continuous)
+                .fill(isActive ? projectAccentColor(slug: slug) : Color.surfaceCard)
+            Text(initials)
+                .font(.plexMono(size >= 44 ? 13 : 11, weight: .semibold))
+                .foregroundStyle(isActive ? Color.canvasVoid : projectAccentColor(slug: slug))
+        }
+        .frame(width: size, height: size)
+        .overlay(
+            RoundedRectangle(cornerRadius: min(12, size * 0.24), style: .continuous)
+                .strokeBorder(isActive ? projectAccentColor(slug: slug) : Color.hairlineDark, lineWidth: 1)
+        )
+        .shadow(color: isActive ? projectAccentColor(slug: slug).opacity(0.18) : .clear, radius: 10, y: 4)
+    }
+
+    private var initials: String {
+        let parts = name
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .map(String.init)
+        let raw = parts.prefix(2).compactMap { $0.first }.map(String.init).joined()
+        return (raw.isEmpty ? String(name.prefix(2)) : raw).uppercased()
+    }
+}
+
+private struct NewProjectListRow: View {
+    let onCreate: () -> Void
+
+    var body: some View {
+        Button(action: onCreate) {
+            HStack(spacing: Spacing.x3) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(Color.surfaceCard)
+                    Image(systemName: "plus")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.signalLive)
+                }
+                .frame(width: 34, height: 34)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(Color.hairlineDark, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("New project")
+                        .font(.plexSans(12, weight: .semibold))
+                        .foregroundStyle(Color.inkPrimary)
+                    Text("Create or clone a workspace")
+                        .font(.plexSans(11))
+                        .foregroundStyle(Color.inkTertiary)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, Spacing.x2)
+            .padding(.vertical, Spacing.x2)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("New project")
+        .accessibilityLabel("New project")
+    }
+}
+
+private struct ProjectListRowButton: View {
+    let project: ProjectSummary
+    let isActive: Bool
+    let onOpen: () -> Void
+
+    var body: some View {
+        Button(action: onOpen) {
+            HStack(spacing: Spacing.x3) {
+                ProjectAvatarIcon(name: project.name, slug: project.slug, isActive: isActive, size: 34)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(project.name)
+                        .font(.plexSans(12, weight: isActive ? .semibold : .medium))
+                        .foregroundStyle(Color.inkPrimary)
+                        .lineLimit(1)
+                    Text(project.remote ?? project.slug)
+                        .font(.plexSans(11))
+                        .foregroundStyle(Color.inkTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: Spacing.x2)
+                if isActive {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(projectAccentColor(slug: project.slug))
+                }
+            }
+            .padding(.horizontal, Spacing.x2)
+            .padding(.vertical, Spacing.x2)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(isActive ? Color.surfaceCardRaised : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .strokeBorder(isActive ? Color.hairlineDark : Color.clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(project.name)
+        .accessibilityLabel(project.name)
+        .accessibilityAddTraits(isActive ? [.isSelected] : [])
     }
 }
 
@@ -142,17 +265,11 @@ private struct ProjectSquareButton: View {
     var body: some View {
         Button(action: onOpen) {
             VStack(spacing: compact ? 0 : Spacing.x1) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(isActive ? Color.signalLive : Color.surfaceCard)
-                    Text(initials)
-                        .font(.plexMono(compact ? 12 : 14, weight: .semibold))
-                        .foregroundStyle(isActive ? Color.canvasVoid : Color.inkPrimary)
-                }
-                .frame(width: compact ? 42 : 54, height: compact ? 42 : 54)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(isActive ? Color.signalLive : Color.hairlineDark, lineWidth: 1)
+                ProjectAvatarIcon(
+                    name: project.name,
+                    slug: project.slug,
+                    isActive: isActive,
+                    size: compact ? 42 : 54
                 )
                 if !compact {
                     Text(project.name)
@@ -170,14 +287,6 @@ private struct ProjectSquareButton: View {
         .help(project.name)
         .accessibilityLabel(project.name)
         .accessibilityAddTraits(isActive ? [.isSelected] : [])
-    }
-
-    private var initials: String {
-        let parts = project.name
-            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
-            .map(String.init)
-        let raw = parts.prefix(2).compactMap { $0.first }.map(String.init).joined()
-        return (raw.isEmpty ? String(project.name.prefix(2)) : raw).uppercased()
     }
 }
 

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -70,7 +70,10 @@ struct MatrixWebShellPanel: View {
                 WebShellView(
                     url: url,
                     bearerToken: token,
-                    onAuthRequired: { authRequired = true }
+                    onAuthRequired: {
+                        authRequired = true
+                        Task { await reloadBearerToken() }
+                    }
                 )
             } else {
                 ContentUnavailableView(

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -275,7 +275,11 @@ private struct WebShellView: NSViewRepresentable {
                   let host = url.host()?.lowercased(),
                   host == destinationHost else { return false }
             let path = url.path.lowercased()
+<<<<<<< HEAD
             guard !Self.isAppSessionExchangeURL(url) else { return false }
+=======
+            guard path != "/api/auth/app-session" else { return false }
+>>>>>>> 6530c950 (fix(086): narrow native auth polish routing)
             return Self.isAuthPath(path)
         }
 

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -10,7 +10,8 @@ struct MatrixWebShellPanel: View {
     let title: String
 
     @State private var token: String?
-    @State private var tokenLoaded = false
+    @State private var didResolveToken = false
+    @State private var authRequired = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -45,12 +46,32 @@ struct MatrixWebShellPanel: View {
                 Rectangle().fill(Color.hairlineDark).frame(height: 1)
             }
 
-            if let url, tokenLoaded {
-                WebShellView(url: url, bearerToken: token)
-            } else if url != nil {
-                ProgressView("Opening \(title)...")
+            if url == nil {
+                ContentUnavailableView(
+                    "No Matrix shell",
+                    systemImage: "globe.badge.chevron.backward",
+                    description: Text("Connect a Matrix computer to open the online shell.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.surfaceCard)
+            } else if !didResolveToken {
+                ProgressView()
+                    .controlSize(.small)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.surfaceCard)
+                    .background(Color.canvasVoid)
+            } else if authRequired || token == nil {
+                NoProfileView(
+                    onCreate: { model.beginSignIn(mode: .signUp) },
+                    onSignIn: { model.beginSignIn(mode: .signIn) },
+                    onCancelSignIn: { model.cancelSignIn() },
+                    signIn: model.signIn
+                )
+            } else if let url {
+                WebShellView(
+                    url: url,
+                    bearerToken: token,
+                    onAuthRequired: { authRequired = true }
+                )
             } else {
                 ContentUnavailableView(
                     "No Matrix shell",
@@ -62,14 +83,29 @@ struct MatrixWebShellPanel: View {
             }
         }
         .task(id: url) {
-            guard url != nil else {
-                token = nil
-                tokenLoaded = false
-                return
-            }
-            tokenLoaded = false
-            token = await model.currentBearerToken()
-            tokenLoaded = true
+            await reloadBearerToken()
+        }
+        .onChange(of: model.signIn) { _, _ in
+            Task { await reloadBearerToken() }
+        }
+    }
+
+    @MainActor
+    private func reloadBearerToken() async {
+        guard url != nil else {
+            token = nil
+            didResolveToken = true
+            authRequired = false
+            return
+        }
+        didResolveToken = false
+        let current = await model.currentBearerToken()
+        token = current
+        didResolveToken = true
+        if current != nil {
+            authRequired = false
+        } else {
+            authRequired = true
         }
     }
 }
@@ -77,9 +113,10 @@ struct MatrixWebShellPanel: View {
 private struct WebShellView: NSViewRepresentable {
     let url: URL
     let bearerToken: String?
+    let onAuthRequired: @MainActor () -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(onAuthRequired: onAuthRequired)
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -105,11 +142,12 @@ private struct WebShellView: NSViewRepresentable {
         coordinator.destinationURL = url
         guard let bearerToken, !bearerToken.isEmpty, let request = appSessionExchangeRequest(for: url, token: bearerToken) else {
             coordinator.exchangeInFlight = false
+            coordinator.exchangeNavigation = nil
             view.load(webShellDestinationRequest(for: url, token: bearerToken))
             return
         }
         coordinator.exchangeInFlight = true
-        view.load(request)
+        coordinator.exchangeNavigation = view.load(request)
     }
 
     private func appSessionExchangeRequest(for destination: URL, token: String) -> URLRequest? {
@@ -138,6 +176,7 @@ private struct WebShellView: NSViewRepresentable {
         var lastRequestedURL: URL?
         var destinationURL: URL?
         var exchangeInFlight = false
+        var exchangeNavigation: WKNavigation?
 
         @MainActor
         func webView(
@@ -149,9 +188,15 @@ private struct WebShellView: NSViewRepresentable {
                 decisionHandler(.allow)
                 return
             }
+            if shouldHandleAsAuthRequired(url) {
+                onAuthRequired()
+                decisionHandler(.cancel)
+                return
+            }
             if Self.shouldOpenExternally(url) {
                 if exchangeInFlight {
                     exchangeInFlight = false
+                    exchangeNavigation = nil
                 }
                 NSWorkspace.shared.open(url)
                 decisionHandler(.cancel)
@@ -159,6 +204,7 @@ private struct WebShellView: NSViewRepresentable {
             }
             if exchangeInFlight, !Self.isAppSessionExchangeURL(url) {
                 exchangeInFlight = false
+                exchangeNavigation = nil
             }
             decisionHandler(.allow)
         }
@@ -184,9 +230,11 @@ private struct WebShellView: NSViewRepresentable {
         @MainActor
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             guard exchangeInFlight,
+                  navigation === exchangeNavigation,
                   webView.url.map(Self.isAppSessionExchangeURL) == true,
                   let destinationURL else { return }
             exchangeInFlight = false
+            exchangeNavigation = nil
             webView.load(webShellDestinationRequest(for: destinationURL, token: lastBearerToken))
         }
 
@@ -194,6 +242,7 @@ private struct WebShellView: NSViewRepresentable {
         func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
             if exchangeInFlight {
                 exchangeInFlight = false
+                exchangeNavigation = nil
             }
         }
 
@@ -211,7 +260,23 @@ private struct WebShellView: NSViewRepresentable {
         private func loadDestinationAfterExchangeFailure(in webView: WKWebView) {
             guard exchangeInFlight, let destinationURL else { return }
             exchangeInFlight = false
+            exchangeNavigation = nil
             webView.load(webShellDestinationRequest(for: destinationURL, token: lastBearerToken))
+        }
+
+        private let onAuthRequired: @MainActor () -> Void
+
+        init(onAuthRequired: @escaping @MainActor () -> Void) {
+            self.onAuthRequired = onAuthRequired
+        }
+
+        private func shouldHandleAsAuthRequired(_ url: URL) -> Bool {
+            guard let destinationHost = destinationURL?.host()?.lowercased(),
+                  let host = url.host()?.lowercased(),
+                  host == destinationHost else { return false }
+            let path = url.path.lowercased()
+            guard !Self.isAppSessionExchangeURL(url) else { return false }
+            return Self.isAuthPath(path)
         }
 
         private static func shouldOpenExternally(_ url: URL) -> Bool {

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -275,11 +275,7 @@ private struct WebShellView: NSViewRepresentable {
                   let host = url.host()?.lowercased(),
                   host == destinationHost else { return false }
             let path = url.path.lowercased()
-<<<<<<< HEAD
             guard !Self.isAppSessionExchangeURL(url) else { return false }
-=======
-            guard path != "/api/auth/app-session" else { return false }
->>>>>>> 6530c950 (fix(086): narrow native auth polish routing)
             return Self.isAuthPath(path)
         }
 

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -24,6 +24,29 @@ final class AppModelAuthTests: XCTestCase {
 
         XCTAssertEqual(model.phase, .needsProfile)
     }
+
+    func testOpenProjectSelectsCurrentSlugWhenNoProjectIsSelected() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        let profile = ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com")
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "main",
+            profile: profile,
+            makeClient: { url, provider in GatewayHTTPClient(baseURL: url, tokenProvider: provider) },
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+
+        XCTAssertFalse(model.hasSelectedProject)
+
+        model.openProject(slug: "main")
+
+        XCTAssertTrue(model.hasSelectedProject)
+        XCTAssertEqual(model.projectSlug, "main")
+        XCTAssertEqual(model.section, .board)
+    }
 }
 
 private final class MemoryTokenStore: TokenStoring, @unchecked Sendable {

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -47,6 +47,26 @@ final class AppModelAuthTests: XCTestCase {
         XCTAssertEqual(model.projectSlug, "main")
         XCTAssertEqual(model.section, .board)
     }
+
+    func testSelectingProfileKeepsNativeProjectSurface() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "main",
+            profile: nil,
+            makeClient: { url, provider in GatewayHTTPClient(baseURL: url, tokenProvider: provider) },
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+
+        model.selectProfile(ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"))
+
+        XCTAssertEqual(model.section, .board)
+        XCTAssertNil(model.activeTabID)
+        XCTAssertTrue(model.openTabs.isEmpty)
+    }
 }
 
 private final class MemoryTokenStore: TokenStoring, @unchecked Sendable {

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -163,6 +163,12 @@ function approvalPage(
     : null;
   const escapedNativeRedirectUri = nativeRedirectUri ? escapeHtmlAttr(nativeRedirectUri) : '';
   const escapedNativeRedirectSig = nativeRedirectSig ? escapeHtmlAttr(nativeRedirectSig) : '';
+  const isNativeApp = Boolean(nativeRedirectUri);
+  const productLabel = isNativeApp ? 'Matrix OS app' : 'Matrix CLI';
+  const setupTitle = isNativeApp ? 'Checking Matrix OS' : 'Setting up Matrix CLI';
+  const recoveryDetail = isNativeApp
+    ? 'Matrix could not finish connecting the desktop app. Try again after a moment.'
+    : 'Matrix could not finish connecting this terminal. Try again after a moment.';
   const clerkScript = publishableKey
     ? `
   <script nonce="${scriptNonce}">
@@ -170,6 +176,7 @@ function approvalPage(
     var csrf = "${escapedCsrf}";
     var approvalUrl = window.location.href;
     var authMode = new URL(window.location.href).searchParams.get('mode') === 'sign-in' ? 'sign-in' : 'sign-up';
+    var nativeApp = ${isNativeApp ? 'true' : 'false'};
     var runtimeReady = false;
 
     function deviceReturnPath() {
@@ -260,9 +267,20 @@ function approvalPage(
 
     function showLoadingState(message) {
       setConfirmReady(false);
-      renderActionState('Setting up Matrix CLI', message, 'Working...', function() {});
+      renderActionState('${setupTitle}', message, 'Working...', function() {});
       var button = document.querySelector('#signin-area button');
       if (button) button.disabled = true;
+    }
+
+    function showRuntimeSetupState() {
+      runtimeReady = false;
+      setConfirmReady(false);
+      renderActionState(
+        'Set up your Matrix computer',
+        'Create or activate your Matrix computer first, then return here to approve the desktop app.',
+        'Open setup',
+        redirectToBillingSetup
+      );
     }
 
     function showSignedInRecoveryState() {
@@ -270,7 +288,7 @@ function approvalPage(
       setConfirmReady(false);
       renderActionState(
         'Session needs a refresh',
-        'Matrix could not finish connecting this terminal. Try again after a moment.',
+        '${recoveryDetail}',
         'Try again',
         continueDeviceOnboarding
       );
@@ -358,6 +376,10 @@ function approvalPage(
           return;
         }
         if (res.status === 404) {
+          if (nativeApp) {
+            showRuntimeSetupState();
+            return;
+          }
           redirectToBillingSetup();
           return;
         }
@@ -562,26 +584,26 @@ function approvalPage(
 </head>
 <body>
   <main>
-    <section class="terminal" aria-label="Matrix CLI login preview">
-      <div class="bar"><span class="dot ok"></span><span class="dot"></span><span class="dot"></span><span>mos login</span></div>
+    <section class="terminal" aria-label="${productLabel} login preview">
+      <div class="bar"><span class="dot ok"></span><span class="dot"></span><span class="dot"></span><span>${isNativeApp ? 'matrix app sign in' : 'matrix login'}</span></div>
       <div class="screen">
-        <div><span class="prompt">mos</span> login</div>
+        <div><span class="prompt">matrix</span> login</div>
         <div class="muted">open app.matrix-os.com/auth/device</div>
         <div>verification code</div>
         <div class="code">${escapedCode}</div>
         <div id="instance-line" class="muted">waiting for signed-in Matrix instance...</div>
         <br>
-        <div><span class="prompt">mos</span> whoami</div>
+        <div><span class="prompt">matrix</span> whoami</div>
         <div class="muted">@handle on app.matrix-os.com</div>
-        <div><span class="prompt">mos</span> shell attach -c main</div>
-        <div><span class="prompt">mos</span> run -it -- claude</div>
-        <div><span class="prompt">mos</span> doctor</div>
+        <div><span class="prompt">matrix</span> shell attach -c main</div>
+        <div><span class="prompt">matrix</span> run -it -- claude</div>
+        <div><span class="prompt">matrix</span> doctor</div>
       </div>
     </section>
     <section class="panel">
       <div>
-        <h1>Approve Matrix CLI</h1>
-        <p>Authorize this terminal to connect to your Matrix OS cloud computer.</p>
+        <h1>Approve ${productLabel}</h1>
+        <p>Authorize ${isNativeApp ? 'the desktop app' : 'this terminal'} to connect to your Matrix OS cloud computer.</p>
       </div>
       <div id="signin-area" style="display:none"></div>
       <form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -66,8 +66,6 @@ cat >"$INFO_PLIST" <<PLIST
   <string>$MIN_SYSTEM_VERSION</string>
   <key>NSHighResolutionCapable</key>
   <true/>
-  <key>NSMainNibFile</key>
-  <string></string>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
   <key>CFBundleURLTypes</key>
@@ -84,6 +82,8 @@ cat >"$INFO_PLIST" <<PLIST
 </dict>
 </plist>
 PLIST
+
+codesign --force --deep --sign - "$APP_BUNDLE" >/dev/null
 
 LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 if [[ -x "$LSREGISTER" ]]; then

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -3,12 +3,15 @@ set -euo pipefail
 
 MODE="${1:-run}"
 APP_NAME="MatrixOS"
+APP_DISPLAY_NAME="Matrix OS"
 BUNDLE_ID="com.matrixos.native-shell"
 MIN_SYSTEM_VERSION="14.0"
 BUILD_CONFIGURATION="${MATRIX_BUILD_CONFIGURATION:-release}"
 if [[ "$MODE" == "--debug" || "$MODE" == "debug" ]]; then
   BUILD_CONFIGURATION="debug"
 fi
+APP_SHORT_VERSION="0.1.0"
+APP_VERSION="1"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE_DIR="$ROOT_DIR/macos"
@@ -44,13 +47,27 @@ cat >"$INFO_PLIST" <<PLIST
   <key>CFBundleIdentifier</key>
   <string>$BUNDLE_ID</string>
   <key>CFBundleName</key>
-  <string>$APP_NAME</string>
+  <string>$APP_DISPLAY_NAME</string>
+  <key>CFBundleDisplayName</key>
+  <string>$APP_DISPLAY_NAME</string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$APP_SHORT_VERSION</string>
+  <key>CFBundleVersion</key>
+  <string>$APP_VERSION</string>
   <key>CFBundleIconFile</key>
   <string>AppIcon</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.developer-tools</string>
   <key>LSMinimumSystemVersion</key>
   <string>$MIN_SYSTEM_VERSION</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSMainNibFile</key>
+  <string></string>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
   <key>CFBundleURLTypes</key>
@@ -67,6 +84,11 @@ cat >"$INFO_PLIST" <<PLIST
 </dict>
 </plist>
 PLIST
+
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+if [[ -x "$LSREGISTER" ]]; then
+  "$LSREGISTER" -f "$APP_BUNDLE" >/dev/null 2>&1 || true
+fi
 
 open_app() {
   /usr/bin/open -n "$APP_BUNDLE"

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -616,13 +616,11 @@ describe("device routes", () => {
       expect(cookie).toMatch(/device_csrf=[A-Fa-f0-9]+/);
       expect(cookie).toMatch(/HttpOnly/);
       const html = await res.text();
-      expect(html).toContain(">mos login<");
-      expect(html).toContain('<span class="prompt">mos</span> whoami');
+      expect(html).toContain(">matrix login<");
+      expect(html).toContain('<span class="prompt">matrix</span> whoami');
       expect(html).toContain("shell attach -c main");
       expect(html).toContain("run -it -- claude");
-      expect(html).toContain('<span class="prompt">mos</span> doctor');
-      expect(html).not.toContain('<span class="prompt">matrix</span>');
-      expect(html).not.toContain(">matrix login<");
+      expect(html).toContain('<span class="prompt">matrix</span> doctor');
       expect(html).toContain('id="instance-line"');
     });
 

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -654,6 +654,33 @@ describe("device routes", () => {
       );
     });
 
+    it("renders native macOS approval copy with a signed app redirect", async () => {
+      const codeRes = await app.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "matrix-os-macos",
+          redirectUri: "matrixos://auth?status=approved",
+        }),
+      });
+      const code = await codeRes.json();
+      const verificationUri = new URL(code.verificationUri);
+      const res = await app.request(`${verificationUri.pathname}${verificationUri.search}`);
+      const html = await res.text();
+
+      expect(html).toContain("Approve Matrix OS app");
+      expect(html).toContain("Authorize the desktop app");
+      expect(html).toContain("var nativeApp = true;");
+      expect(html).toContain("Checking Matrix OS");
+      expect(html).toContain("showRuntimeSetupState()");
+      expect(html).toContain("Create or activate your Matrix computer first");
+      expect(html).toContain('id="native-redirect-uri"');
+      expect(html).toContain('value="matrixos://auth?status=approved"');
+      expect(html).toContain('id="native-redirect-sig"');
+      expect(html).not.toContain("Approve Matrix CLI");
+      expect(html).not.toContain("Setting up Matrix CLI");
+    });
+
     it("submits approval with an explicit Clerk bearer token", async () => {
       const res = await app.request("/auth/device?user_code=BCDF-GHJK");
       const html = await res.text();


### PR DESCRIPTION
## Stack

Stack order: #398 -> #399 -> #400 -> #401 -> #402 -> #403 -> #404 -> #405 -> #406 -> #407 -> #408.\n\nThis is 11/11.

## Summary

Keeps native auth in the app flow: the macOS app stays on the native project/board surface after auth, registers foreground/deep-link behavior, and the approval page uses Matrix OS app copy with signed native redirect handling.

## Tests

Validated on the rebased top of stack:

- `bun run typecheck` passed after refreshing local dependencies with `pnpm install --frozen-lockfile`.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain in broad pre-existing areas.
- `swift test --package-path macos` passed: 126 tests.
- `pnpm vitest run tests/platform/device-routes.test.ts tests/platform/middleware-shortcircuit.test.ts tests/platform/proxy-routing.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/shell-names.test.ts` passed: 154 tests.
- Full `bun run test` was previously run on the monolithic branch and failed in baseline/environment suites: Node/better-sqlite3 ABI mismatch under Node 22, sandbox listen EPERM, watcher EMFILE, app-runtime build timeouts, and existing gateway/kernel failures.

## Invariants

- Source of truth: platform device-code/session state remains canonical for browser and native auth; native app Keychain stores only the issued sync JWT after approval.
- Lock/transaction scope: existing platform auth/device persistence and gateway shell session flows are preserved; this layer changes routing/UI handoff behavior only.
- Acceptable orphan states: if native redirect delivery fails, polling can still complete; if a runtime is unavailable, the user sees an explicit no-runtime/setup state instead of silently entering hosted shell.
- Auth source of truth: Clerk authorizes browser approval and app-session exchange; sync JWT authorizes native app and gateway/VPS access.
- Deferred scope: production routing/deploy must route the device auth paths to the platform app-shell service; host-bundle deployment alone does not update pre-VPS auth pages.

## Deployment Notes

After merging the stack, redeploy the platform/app-shell service serving \`app.matrix-os.com\` and ensure the production router sends these paths to it:

- \`/api/auth/app-session\`
- \`/api/auth/device/*\`
- \`/auth/device\`
- \`/auth/device/*\`

Smoke:

```bash
curl -sS https://app.matrix-os.com/api/auth/device/code \\
  -H 'Content-Type: application/json' \\
  --data '{"clientId":"matrix-os-macos","redirectUri":"matrixos://auth?status=approved"}'
```

The returned \`verificationUri\` must include both \`redirect_uri=matrixos%3A%2F%2Fauth%3Fstatus%3Dapproved\` and \`redirect_sig=...\`. The browser page should say \`Approve Matrix OS app\`, then return through \`matrixos://auth?status=approved\`.