### PR TITLE
fix(cli): prepare 0.3.3 release

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -47,13 +47,13 @@ Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.3` 
 npm view @finnaai/matrix version
 npm view @finnaai/matrix dist.tarball
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.0 sh scripts/install.sh
+MATRIX_VERSION=0.3.3 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
 ```
 
-For macOS, also verify the GitHub release contains `MatrixSync-0.3.0.pkg` when the macOS job was enabled.
+For macOS, also verify the GitHub release contains `MatrixSync-0.3.3.pkg` when the macOS job was enabled.
 
 ## Rollback
 

--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.2` is the prepared CLI patch release for terminal attach input handling. It keeps the `0.3.1` shell/session features and adds stronger local terminal cleanup plus stale mouse/focus filtering so returning to an inactive attach tab does not forward mouse escape sequences into the remote shell.
+`0.3.3` is the prepared CLI patch release for the merged CLI fixes after `0.3.2`, including interactive JSON output isolation, leading global flag handling, profile-aware peer commands, agent credential transfer, and sync-client daemon upload/download fixes.
 
 ## Versioning
 
@@ -33,7 +33,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.2`. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.3` and `update_homebrew=true`. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -57,8 +57,8 @@ For macOS, also verify the GitHub release contains `MatrixSync-0.3.0.pkg` when t
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.2` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.3` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.1 "Use @finnaai/matrix@0.3.2"
+npm deprecate @finnaai/matrix@0.3.2 "Use @finnaai/matrix@0.3.3"
 ```

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/packages/sync-client/src/cli/file-transfer-client.ts
+++ b/packages/sync-client/src/cli/file-transfer-client.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 
@@ -127,11 +127,31 @@ export async function downloadRemoteFile(
   }
 
   const bytes = Buffer.from(await res.arrayBuffer());
-  await mkdir(dirname(resolvedLocal), { recursive: true, mode: options.secret ? 0o700 : 0o755 });
+  const parentDir = dirname(resolvedLocal);
+  const directoryMode = options.secret ? 0o700 : 0o755;
+  let createdParentDir = false;
+  try {
+    await lstat(parentDir);
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      createdParentDir = true;
+    } else {
+      throw err;
+    }
+  }
+  await mkdir(parentDir, { recursive: true, mode: directoryMode });
+  if (createdParentDir) {
+    await chmod(parentDir, directoryMode);
+  }
   const tmpPath = `${resolvedLocal}.matrix-download-${randomUUID()}.tmp`;
   const mode = options.secret ? 0o600 : 0o644;
   try {
     await writeFile(tmpPath, bytes, { flag: "wx", mode });
+    await chmod(tmpPath, mode);
     await rename(tmpPath, resolvedLocal);
   } catch (err) {
     try {

--- a/packages/sync-client/src/cli/file-transfer-client.ts
+++ b/packages/sync-client/src/cli/file-transfer-client.ts
@@ -129,23 +129,30 @@ export async function downloadRemoteFile(
   const bytes = Buffer.from(await res.arrayBuffer());
   const parentDir = dirname(resolvedLocal);
   const directoryMode = options.secret ? 0o700 : 0o755;
-  let createdParentDir = false;
-  try {
-    await lstat(parentDir);
-  } catch (err: unknown) {
-    if (
-      err instanceof Error &&
-      "code" in err &&
-      (err as NodeJS.ErrnoException).code === "ENOENT"
-    ) {
-      createdParentDir = true;
-    } else {
+  const missingParentDirs: string[] = [];
+  for (let currentDir = parentDir; ; currentDir = dirname(currentDir)) {
+    try {
+      await lstat(currentDir);
+      break;
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        missingParentDirs.push(currentDir);
+        const nextDir = dirname(currentDir);
+        if (nextDir === currentDir) {
+          break;
+        }
+        continue;
+      }
       throw err;
     }
   }
   await mkdir(parentDir, { recursive: true, mode: directoryMode });
-  if (createdParentDir) {
-    await chmod(parentDir, directoryMode);
+  for (const createdDir of missingParentDirs.reverse()) {
+    await chmod(createdDir, directoryMode);
   }
   const tmpPath = `${resolvedLocal}.matrix-download-${randomUUID()}.tmp`;
   const mode = options.secret ? 0o600 : 0o644;

--- a/packages/sync-client/tests/unit/file-transfer-client.test.ts
+++ b/packages/sync-client/tests/unit/file-transfer-client.test.ts
@@ -86,7 +86,8 @@ describe("cli/file-transfer-client", () => {
   });
 
   it("downloads atomically and refuses to replace local symlinks", async () => {
-    const parent = join(tempDir, "downloads");
+    const intermediate = join(tempDir, "downloads");
+    const parent = join(intermediate, "nested");
     const destination = join(parent, "downloaded.txt");
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("downloaded", { status: 200 }));
 
@@ -97,6 +98,7 @@ describe("cli/file-transfer-client", () => {
     );
 
     expect(await readFile(destination, "utf8")).toBe("downloaded");
+    expect((await stat(intermediate)).mode & 0o777).toBe(0o755);
     expect((await stat(parent)).mode & 0o777).toBe(0o755);
     expect((await stat(destination)).mode & 0o777).toBe(0o644);
 


### PR DESCRIPTION
## Summary

- bump `@finnaai/matrix` to `0.3.3` for the next installable CLI release
- document the `CLI Release` dispatch with `update_homebrew=true`
- make CLI download mode assertions pass under restrictive umask by chmodding only newly-created download paths

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @finnaai/matrix build`
- `pnpm --filter @finnaai/matrix test`
- `pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs`
- `npm --cache /tmp/matrix-npm-cache pack --dry-run`
- `bun run check:patterns` (0 violations; existing warnings only)
- `git diff --check`
- `npm view @finnaai/matrix@0.3.3 version` returned 404, so the version is available

## Invariants

- Source of truth: `packages/sync-client/package.json` is the CLI version source for the manual `CLI Release` workflow and npm package.
- Lock/transaction scope: no database writes or cross-system transactions are introduced; file download writes remain temp-file plus atomic rename.
- Acceptable orphan states: if npm publishes but GitHub release or Homebrew update fails, rerun `CLI Release` in recovery mode only after verifying npm and tag state.
- Auth source of truth: release publishing continues to use GitHub Actions secrets (`NPM_TOKEN`, `TAP_PUSH_TOKEN`) and npm provenance.
- Deferred scope: this does not change zellij runtime behavior; it only prepares a new CLI package containing already-merged CLI fixes and keeps local download permissions deterministic.
