### PR TITLE
feat(shell): polish upgrade installing state

### DIFF
--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -83,20 +83,13 @@ interface SystemReleaseList {
 
 import {
   releaseActionLabel,
+  resolveUpgradeInstallCopy,
   severityBadgeStyle,
   resolveSystemUpdateState,
 } from "./system-update-state";
 
 const RELEASE_CHANNELS = ["stable", "canary", "beta", "dev"] as const;
 type ReleaseChannel = typeof RELEASE_CHANNELS[number];
-
-const UPGRADE_WAITING_MESSAGES = [
-  "The Matrix picked a new bundle. It still refuses to say whether there is a spoon.",
-  "Cloud computing update: this cloud is briefly pretending to be a very serious USB stick.",
-  "A coding agent is watching the progress bar and trying not to refactor it.",
-  "The VPS is swapping realities. Please keep all blue pills away from the deploy script.",
-  "Cloudflare is checking the guest list while the host bundle finds its seat.",
-] as const;
 
 function coerceReleaseChannel(value: unknown): ReleaseChannel {
   return RELEASE_CHANNELS.includes(value as ReleaseChannel) ? value as ReleaseChannel : "stable";
@@ -133,8 +126,8 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
   useEffect(() => {
     if (!upgrading) return;
     const jokeTimer = setInterval(() => {
-      setUpgradeWaitingIndex((index) => (index + 1) % UPGRADE_WAITING_MESSAGES.length);
-    }, 8_000);
+      setUpgradeWaitingIndex((index) => index + 1);
+    }, 7_000);
     return () => clearInterval(jokeTimer);
   }, [upgrading]);
 
@@ -211,7 +204,11 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
   const releaseRows = releaseList?.releases ?? [];
   const canInstallSelectedChannel = Boolean(latestVersion && (updateAvailable || selectedChannel !== installedChannel));
   const systemUpdatesLocked = !billingActive;
-  const upgradeWaitingMessage = UPGRADE_WAITING_MESSAGES[upgradeWaitingIndex];
+  const upgradeInstallCopy = resolveUpgradeInstallCopy({
+    target: installingTarget,
+    message: upgradeMessage,
+    statusIndex: upgradeWaitingIndex,
+  });
 
   const waitForInstalledUpdate = async (
     target: { channel?: ReleaseChannel; version?: string },
@@ -457,30 +454,39 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
           )}
           {upgrading && (
             <output
-              className="overflow-hidden rounded-lg border border-blue-500/20 bg-blue-500/10"
+              aria-live="polite"
+              aria-label={`${upgradeInstallCopy.title}. ${upgradeInstallCopy.detail}`}
+              className="overflow-hidden rounded-lg border border-blue-500/20 bg-blue-500/10 shadow-sm"
             >
               <div className="flex gap-3 p-4">
-                <div className="relative flex size-10 shrink-0 items-center justify-center rounded-md bg-blue-600 text-white">
-                  <ArrowUpCircleIcon className="size-5 animate-pulse" />
+                <div className="relative flex size-11 shrink-0 items-center justify-center rounded-md bg-blue-600 text-white">
+                  <ArrowUpCircleIcon className="size-5 animate-pulse" aria-hidden="true" />
                   <span className="absolute -right-1 -top-1 flex size-5 items-center justify-center rounded-full border border-background bg-background text-blue-600">
-                    <CloudIcon className="size-3" />
+                    <CloudIcon className="size-3" aria-hidden="true" />
                   </span>
                 </div>
-                <div className="min-w-0 flex-1 space-y-3">
+                <div className="min-w-0 flex-1 space-y-3.5">
                   <div className="space-y-1">
                     <p className="text-sm font-medium text-foreground">
-                      Installing {installingTarget ?? "update"}
+                      {upgradeInstallCopy.title}
                     </p>
                     <p className="text-xs leading-5 text-muted-foreground">
-                      {upgradeMessage ?? "The VPS is downloading and swapping the host bundle. Services may blink while the new shell comes online."}
+                      {upgradeInstallCopy.detail}
                     </p>
                   </div>
-                  <div className="h-1.5 overflow-hidden rounded-full bg-background">
-                    <div className="h-full w-1/2 rounded-full bg-blue-600 animate-pulse" />
+                  <div className="space-y-1.5">
+                    <div className="h-1.5 overflow-hidden rounded-full bg-background">
+                      <div className="h-full w-1/2 rounded-full bg-blue-600 animate-pulse" />
+                    </div>
+                    <div className="grid grid-cols-3 gap-1 text-[11px] leading-4 text-muted-foreground">
+                      <span className="truncate">Download</span>
+                      <span className="truncate text-center">Install</span>
+                      <span className="truncate text-right">Verify</span>
+                    </div>
                   </div>
                   <div className="flex items-start gap-2 rounded-md border border-border/70 bg-background/70 p-2.5">
-                    <Code2Icon className="mt-0.5 size-3.5 shrink-0 text-blue-600" />
-                    <p className="text-xs leading-5 text-muted-foreground">{upgradeWaitingMessage}</p>
+                    <Code2Icon className="mt-0.5 size-3.5 shrink-0 text-blue-600" aria-hidden="true" />
+                    <p className="text-xs leading-5 text-muted-foreground">{upgradeInstallCopy.statusLine}</p>
                   </div>
                 </div>
               </div>

--- a/shell/src/components/settings/sections/system-update-state.ts
+++ b/shell/src/components/settings/sections/system-update-state.ts
@@ -86,6 +86,32 @@ export function severityBadgeStyle(severity?: string): string {
   }
 }
 
+export const UPGRADE_INSTALL_STATUS_LINES = [
+  "Reading the Matrix release notes between packets.",
+  "Cloud status: one host bundle, lightly compressed, coming right up.",
+  "A coding agent is watching the logs and resisting the urge to refactor them.",
+  "The VPS is swapping in the new shell without touching your home files.",
+  "Cloudflare has the route. The updater has the bundle. Everyone has one job.",
+  "Checking that the new reality answers /health before we reload.",
+] as const;
+
+export function upgradeInstallStatusLine(index: number): string {
+  if (!Number.isInteger(index) || index < 0) return UPGRADE_INSTALL_STATUS_LINES[0];
+  return UPGRADE_INSTALL_STATUS_LINES[index % UPGRADE_INSTALL_STATUS_LINES.length];
+}
+
+export function resolveUpgradeInstallCopy(input: {
+  target?: string | null;
+  message?: string | null;
+  statusIndex: number;
+}) {
+  return {
+    title: `Installing ${input.target ?? "update"}`,
+    detail: input.message ?? "Downloading the host bundle and waiting for the shell to return.",
+    statusLine: upgradeInstallStatusLine(input.statusIndex),
+  };
+}
+
 export function resolveSystemUpdateState(input: {
   installedVersion?: string;
   latestVersion?: string | null;

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -211,18 +211,21 @@ describe("SystemSection release refresh", () => {
     expect(screen.getByRole("status")).toBeTruthy();
     expect(screen.getByText("Installing stable")).toBeTruthy();
     expect(screen.getByText("Installing stable. This can take a few minutes...")).toBeTruthy();
-    expect(screen.getByText("The Matrix picked a new bundle. It still refuses to say whether there is a spoon.")).toBeTruthy();
+    expect(screen.getByText("Reading the Matrix release notes between packets.")).toBeTruthy();
+    expect(screen.getByText("Download")).toBeTruthy();
+    expect(screen.getByText("Install")).toBeTruthy();
+    expect(screen.getByText("Verify")).toBeTruthy();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(8_000);
+      await vi.advanceTimersByTimeAsync(7_000);
     });
 
-    expect(screen.getByText("Cloud computing update: this cloud is briefly pretending to be a very serious USB stick.")).toBeTruthy();
+    expect(screen.getByText("Cloud status: one host bundle, lightly compressed, coming right up.")).toBeTruthy();
     expect(screen.getByText("Installing... checking status")).toBeTruthy();
     expect(screen.getByText("Installing stable. This can take a few minutes...")).toBeTruthy();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(12_000);
+      await vi.advanceTimersByTimeAsync(13_000);
     });
 
     expect(screen.getByText("Installed. Reloading...")).toBeTruthy();

--- a/tests/shell/system-section-version.test.ts
+++ b/tests/shell/system-section-version.test.ts
@@ -4,8 +4,10 @@ import {
   isNewer,
   normalizeMatrixReleaseTag,
   releaseActionLabel,
+  resolveUpgradeInstallCopy,
   resolveSystemUpdateState,
   severityBadgeStyle,
+  upgradeInstallStatusLine,
 } from "../../shell/src/components/settings/sections/system-update-state.js";
 
 describe("SystemSection version helpers", () => {
@@ -128,5 +130,33 @@ describe("SystemSection version helpers", () => {
     expect(severityBadgeStyle("critical")).toContain("orange");
     expect(severityBadgeStyle("normal")).toContain("blue");
     expect(severityBadgeStyle(undefined)).toContain("blue");
+  });
+
+  it("normalizes rotating upgrade install status lines", () => {
+    expect(upgradeInstallStatusLine(0)).toBe("Reading the Matrix release notes between packets.");
+    expect(upgradeInstallStatusLine(6)).toBe("Reading the Matrix release notes between packets.");
+    expect(upgradeInstallStatusLine(-1)).toBe("Reading the Matrix release notes between packets.");
+  });
+
+  it("builds accessible upgrade install copy", () => {
+    expect(resolveUpgradeInstallCopy({
+      target: "dev",
+      message: null,
+      statusIndex: 1,
+    })).toEqual({
+      title: "Installing dev",
+      detail: "Downloading the host bundle and waiting for the shell to return.",
+      statusLine: "Cloud status: one host bundle, lightly compressed, coming right up.",
+    });
+
+    expect(resolveUpgradeInstallCopy({
+      target: null,
+      message: "Upgrade started. Waiting for services to come back...",
+      statusIndex: 2,
+    })).toEqual({
+      title: "Installing update",
+      detail: "Upgrade started. Waiting for services to come back...",
+      statusLine: "A coding agent is watching the logs and resisting the urge to refactor them.",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Moves upgrade/install waiting copy into tested helper functions.
- Improves the System settings installing panel with accessible live status copy, compact Download/Install/Verify progress labels, and rotating Matrix/cloud/coding-agent status lines.
- Keeps the existing upgrade polling/backend behavior unchanged.

## Tests
- `pnpm vitest run tests/shell/system-section-version.test.ts tests/shell/system-section-refresh.test.tsx`
- `bun run typecheck`
- `bun run check:patterns` (0 violations; existing repo warnings only)
- `npx react-doctor@latest shell --verbose --diff origin/main` (100/100, no issues)

## Review/Monitoring
- Opened for CI and Greptile review. Do not merge until current-head CI is green and Greptile reports 5/5.

## Invariants
- Source of truth: upgrade state remains the existing gateway `/api/system/update` and `/api/system/info` responses; this PR only changes shell presentation and helper-derived copy.
- Lock/transaction scope: no backend, filesystem, or database writes are added or changed.
- Acceptable orphan states: if update polling times out or the request fails, the existing UI error paths still re-enable controls and preserve the current installed-version display.
- Auth source of truth: unchanged; existing shell/gateway auth and billing lock behavior continue to gate upgrade actions.
- Deferred scope: no backend deployment behavior, progress streaming, Neon migration, Docker shutdown, or release fan-out automation is included.