### PR TITLE
fix(cli): preserve scoped Homebrew tarball URL

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -177,9 +177,18 @@ jobs:
             exit 1
           fi
 
-          perl -0pi -e "s|url \".*matrix-[^\"]+\\.tgz\"|url \"${TARBALL}\"|" "$FORMULA"
-          perl -0pi -e "s|sha256 \"[a-f0-9]{64}\"|sha256 \"${SHA256}\"|" "$FORMULA"
-          perl -0pi -e "s|version \"[^\"]+\"|version \"${VERSION}\"|" "$FORMULA"
+          python3 - <<'PY'
+          import os, re, pathlib
+          path = pathlib.Path("Formula/matrix.rb")
+          tarball = os.environ["TARBALL"]
+          sha = os.environ["SHA256"]
+          version = os.environ["VERSION"]
+          text = path.read_text()
+          text = re.sub(r'url\s+".*"', f'url "{tarball}"', text, count=1)
+          text = re.sub(r'sha256\s+".*"', f'sha256 "{sha}"', text, count=1)
+          text = re.sub(r'version\s+".*"', f'version "{version}"', text, count=1)
+          path.write_text(text)
+          PY
           git diff -- Formula/matrix.rb
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -169,6 +169,7 @@ jobs:
           }
 
           SHA256="$(curl -fsSL --max-time 60 "$TARBALL" | shasum -a 256 | awk '{print $1}')"
+          export TARBALL SHA256
 
           cd tap
           FORMULA="Formula/matrix.rb"


### PR DESCRIPTION
## Summary

- fix the dedicated `CLI Release` Homebrew formula update so scoped npm URLs keep `@finnaai`
- replace Perl string interpolation with the env-based Python replacement already used by the broader release workflow

## Validation

- `git diff --check`
- local replacement smoke test preserved `https://registry.npmjs.org/@finnaai/matrix/-/matrix-0.3.4.tgz`

## Invariants

- Source of truth: `packages/sync-client/package.json` remains the CLI version source; the release workflow only mirrors npm tarball metadata into the tap.
- Lock/transaction scope: no database writes or runtime state changes.
- Acceptable orphan states: if the tap update fails after npm publish, manually patch `FinnaAI/homebrew-tap` and rerun/verify the formula before announcing Homebrew availability.
- Auth source of truth: publishing still uses `NPM_TOKEN` and `TAP_PUSH_TOKEN` in GitHub Actions.
- Deferred scope: this does not republish `0.3.3`; the live tap was patched separately after detecting the bad URL.
