### PR TITLE
fix(neo): harden PostHog proxy worker

### DIFF
--- a/packages/neo-worker/src/index.ts
+++ b/packages/neo-worker/src/index.ts
@@ -1,16 +1,40 @@
 const API_HOST = "eu.i.posthog.com";
 const ASSET_HOST = "eu-assets.i.posthog.com";
 const UPSTREAM_TIMEOUT_MS = 10_000;
+const LEGACY_POSTHOG_LOADER_PATH = "/static/posthog.js";
+const CURRENT_POSTHOG_LOADER_PATH = "/static/array.js";
 
 interface WorkerExecutionContext {
   waitUntil(promise: Promise<unknown>): void;
 }
 
-export function classifyPostHogProxyPath(pathname: string): "health" | "asset" | "ingest" {
+export function classifyPostHogProxyPath(pathname: string): "health" | "service-worker" | "asset" | "ingest" {
   if (pathname === "/health") return "health";
+  if (pathname === "/service-worker.js") return "service-worker";
   if (pathname.startsWith("/static/") || pathname.startsWith("/array/")) return "asset";
   return "ingest";
 }
+
+const NEO_CLEANUP_SERVICE_WORKER = `
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys
+      .filter((key) => key.startsWith("matrix-os-"))
+      .map((key) => caches.delete(key)));
+    await self.clients.claim();
+    await self.registration.unregister();
+  })());
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(fetch(event.request));
+});
+`.trim();
 
 export async function handlePostHogProxyRequest(
   request: Request,
@@ -29,9 +53,20 @@ export async function handlePostHogProxyRequest(
       },
     });
   }
+  if (routeClass === "service-worker") {
+    return new Response(NEO_CLEANUP_SERVICE_WORKER, {
+      headers: {
+        "content-type": "text/javascript; charset=utf-8",
+        "cache-control": "no-store",
+        "cdn-cache-control": "no-store",
+        "service-worker-allowed": "/",
+      },
+    });
+  }
 
   const targetHost = routeClass === "asset" ? ASSET_HOST : API_HOST;
-  const upstreamUrl = `https://${targetHost}${url.pathname}${url.search}`;
+  const upstreamPath = normalizePostHogAssetPath(url.pathname);
+  const upstreamUrl = `https://${targetHost}${upstreamPath}${url.search}`;
   const upstreamRequest = await buildPostHogUpstreamRequest(request, upstreamUrl);
   let response: Response;
   try {
@@ -65,6 +100,10 @@ export async function handlePostHogProxyRequest(
     statusText: response.statusText,
     headers,
   });
+}
+
+function normalizePostHogAssetPath(pathname: string): string {
+  return pathname === LEGACY_POSTHOG_LOADER_PATH ? CURRENT_POSTHOG_LOADER_PATH : pathname;
 }
 
 async function buildPostHogUpstreamRequest(request: Request, upstreamUrl: string): Promise<Request> {

--- a/packages/neo-worker/src/index.ts
+++ b/packages/neo-worker/src/index.ts
@@ -32,7 +32,16 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
-  event.respondWith(fetch(event.request));
+  event.respondWith(fetch(event.request).catch((err) => {
+    console.warn("[neo-worker cleanup sw] fetch failed:", err?.message ?? err);
+    return new Response("offline", {
+      status: 504,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    });
+  }));
 });
 `.trim();
 

--- a/shell/public/service-worker.js
+++ b/shell/public/service-worker.js
@@ -7,7 +7,7 @@
 //     WebSocket upgrades, anything cross-origin we don't serve.
 // On version bump, old caches are pruned during activate.
 
-const VERSION = "v1";
+const VERSION = "v2";
 const CACHE_STATIC = `matrix-os-static-${VERSION}`;
 const CACHE_HTML = `matrix-os-html-${VERSION}`;
 const PRECACHE = [
@@ -122,13 +122,24 @@ async function cacheFirst(req) {
   const cache = await caches.open(CACHE_STATIC);
   const cached = await cache.match(req);
   if (cached) return cached;
-  const res = await fetch(req, { signal: AbortSignal.timeout(30_000) });
-  if (res.ok && res.type === "basic") {
-    cache.put(req, res.clone()).catch((err) => {
-      console.warn("[sw] static cache put failed:", err?.message ?? err);
+  try {
+    const res = await fetch(req, { signal: AbortSignal.timeout(30_000) });
+    if (res.ok && res.type === "basic") {
+      cache.put(req, res.clone()).catch((err) => {
+        console.warn("[sw] static cache put failed:", err?.message ?? err);
+      });
+    }
+    return res;
+  } catch (err) {
+    console.warn("[sw] static fetch failed:", err?.message ?? err);
+    return new Response("offline", {
+      status: 504,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
     });
   }
-  return res;
 }
 
 self.addEventListener("message", (event) => {

--- a/tests/neo-worker/index.test.ts
+++ b/tests/neo-worker/index.test.ts
@@ -59,7 +59,10 @@ describe("Neo Worker", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("cdn-cache-control")).toBe("no-store");
     expect(response.headers.get("service-worker-allowed")).toBe("/");
-    await expect(response.text()).resolves.toContain("registration.unregister()");
+    const body = await response.text();
+    expect(body).toContain("registration.unregister()");
+    expect(body).toContain(".catch((err) =>");
+    expect(body).toContain('new Response("offline",');
     expect(fetchMock).not.toHaveBeenCalled();
 
     fetchMock.mockRestore();

--- a/tests/neo-worker/index.test.ts
+++ b/tests/neo-worker/index.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { classifyPostHogProxyPath, handlePostHogProxyRequest } from "../../packages/neo-worker/src/index";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function createContext() {
   return {
@@ -35,9 +39,30 @@ function stubWorkerCache() {
 describe("Neo Worker", () => {
   it("classifies PostHog asset, ingest, and health routes", () => {
     expect(classifyPostHogProxyPath("/health")).toBe("health");
+    expect(classifyPostHogProxyPath("/service-worker.js")).toBe("service-worker");
     expect(classifyPostHogProxyPath("/static/posthog.js")).toBe("asset");
     expect(classifyPostHogProxyPath("/array/config")).toBe("asset");
     expect(classifyPostHogProxyPath("/i/v0/e")).toBe("ingest");
+  });
+
+  it("serves a cleanup service worker for browsers that previously loaded the shell from neo", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const response = await handlePostHogProxyRequest(
+      new Request("https://neo.matrix-os.com/service-worker.js"),
+      {},
+      createContext(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/javascript");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("cdn-cache-control")).toBe("no-store");
+    expect(response.headers.get("service-worker-allowed")).toBe("/");
+    await expect(response.text()).resolves.toContain("registration.unregister()");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    fetchMock.mockRestore();
   });
 
   it("forwards static assets to the EU asset host without cookies", async () => {
@@ -59,12 +84,24 @@ describe("Neo Worker", () => {
     const upstream = fetchMock.mock.calls[0]?.[0];
     expect(upstream).toBeInstanceOf(Request);
     const upstreamRequest = upstream as Request;
-    expect(upstreamRequest.url).toBe("https://eu-assets.i.posthog.com/static/posthog.js?v=1");
+    expect(upstreamRequest.url).toBe("https://eu-assets.i.posthog.com/static/array.js?v=1");
     expect(upstreamRequest.headers.get("cookie")).toBeNull();
     expect(upstreamRequest.headers.get("X-Forwarded-For")).toBe("203.0.113.10");
     expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+  });
 
-    fetchMock.mockRestore();
+  it("aliases the legacy PostHog loader path to the current array.js asset", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("asset"));
+
+    await handlePostHogProxyRequest(
+      new Request("https://neo.matrix-os.com/static/posthog.js?v=1.376.0"),
+      {},
+      createContext(),
+    );
+
+    const upstream = fetchMock.mock.calls[0]?.[0];
+    expect(upstream).toBeInstanceOf(Request);
+    expect((upstream as Request).url).toBe("https://eu-assets.i.posthog.com/static/array.js?v=1.376.0");
   });
 
   it("caches successful GET asset responses through the Worker cache", async () => {

--- a/tests/shell/service-worker.test.ts
+++ b/tests/shell/service-worker.test.ts
@@ -1,0 +1,12 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("shell service worker", () => {
+  it("turns uncached static fetch failures into a response instead of rejecting the FetchEvent", async () => {
+    const source = await readFile("shell/public/service-worker.js", "utf8");
+
+    expect(source).toContain("[sw] static fetch failed:");
+    expect(source).toContain('new Response("offline",');
+    expect(source).toContain("status: 504");
+  });
+});


### PR DESCRIPTION
## Summary
- serve a cleanup service worker from `neo.matrix-os.com` for browsers that previously registered the shell PWA on that host
- alias legacy `/static/posthog.js` requests to PostHog EU assets `/static/array.js` so older bundles do not hit a 404
- make the shell PWA service worker return a controlled 504 for uncached static fetch failures instead of rejecting the FetchEvent

## Invariants
- **Source of truth**: `neo.matrix-os.com` remains the dedicated PostHog proxy Worker; Matrix app/runtime routing stays on `app.matrix-os.com` and Cloud Run.
- **Lock/transaction scope**: no database writes or shared mutable state are introduced. Worker cache writes remain best-effort and only happen for successful GET asset responses.
- **Acceptable orphan states**: if PostHog is unavailable, ingest/assets return an upstream-unavailable response; stale `neo` service workers unregister on next activation and clear Matrix OS caches.
- **Auth source of truth**: PostHog proxy paths are public analytics endpoints; cookies are stripped before upstream forwarding and no Matrix auth is accepted or required.
- **Deferred scope**: this does not migrate wildcard Matrix OS handle subdomains off the old Docker/cloudflared path.

## Validation
- `pnpm --filter @matrix-os/neo-worker test`
- `pnpm exec vitest run tests/neo-worker/index.test.ts tests/shell/service-worker.test.ts`
- `pnpm --filter @matrix-os/neo-worker typecheck`
- `pnpm --filter @matrix-os/neo-worker exec wrangler deploy --dry-run`
- `bun run typecheck`
- `bun run check:patterns` (0 violations, existing warnings only)
