### PR TITLE
feat(cli): add port forwarding

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,8 @@ export const PUBLISHED_CLI_COMMANDS = new Set([
   "whoami",
   "status",
   "run",
+  "port",
+  "forward",
   "doctor",
   "instance",
   "completion",

--- a/packages/gateway/src/forward-ws.ts
+++ b/packages/gateway/src/forward-ws.ts
@@ -1,0 +1,352 @@
+import { connect, type Socket } from "node:net";
+import { z } from "zod/v4";
+
+export const FORWARD_WS_MAX_CONTROL_BYTES = 2048;
+export const FORWARD_WS_MAX_FRAME_BYTES = 64 * 1024;
+export const FORWARD_WS_IDLE_TIMEOUT_MS = 60_000;
+export const FORWARD_WS_MAX_CONNECTIONS = 100;
+
+const ForwardPortSchema = z.number().int().min(1).max(65_535);
+const LoopbackHostSchema = z.union([
+  z.literal("127.0.0.1"),
+  z.literal("::1"),
+  z.literal("localhost"),
+]);
+
+export const ForwardOpenMessageSchema = z.object({
+  type: z.literal("open"),
+  host: LoopbackHostSchema,
+  port: ForwardPortSchema,
+});
+
+const ForwardControlMessageSchema = z.discriminatedUnion("type", [
+  ForwardOpenMessageSchema,
+  z.object({ type: z.literal("end") }),
+  z.object({ type: z.literal("close") }),
+]);
+
+export type ForwardOpenMessage = z.infer<typeof ForwardOpenMessageSchema>;
+export type ForwardTarget = { host: "127.0.0.1" | "::1"; port: number };
+
+export interface ForwardDialer {
+  (target: ForwardTarget): Socket;
+}
+
+interface ForwardWs {
+  send(data: string | ArrayBuffer | Uint8Array<ArrayBuffer>): void;
+  close(): void;
+}
+
+interface ForwardWsMessageEvent {
+  data: unknown;
+}
+
+interface ForwardConnectionState {
+  socket: Socket;
+  ws: ForwardWs;
+  opened: boolean;
+  closed: boolean;
+  idleTimer: ReturnType<typeof setTimeout>;
+}
+
+export interface ForwardTunnelHub {
+  createHandler(): {
+    onOpen?(evt: unknown, ws: ForwardWs): void;
+    onMessage?(evt: ForwardWsMessageEvent, ws: ForwardWs): void;
+    onClose?(): void;
+    onError?(): void;
+  };
+  close(): Promise<void>;
+  activeConnectionsForTest(): ForwardConnectionState[];
+}
+
+export interface ForwardTunnelHubOptions {
+  dial?: ForwardDialer;
+  maxConnections?: number;
+  maxFrameBytes?: number;
+  maxControlBytes?: number;
+  idleTimeoutMs?: number;
+}
+
+function forwardError(code: string): Error & { code: string } {
+  return Object.assign(new Error("Request failed"), { code });
+}
+
+function sendJson(ws: ForwardWs, frame: Record<string, unknown>): void {
+  try {
+    ws.send(JSON.stringify(frame));
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      console.warn("[forward/ws] send failed:", err.message);
+    }
+  }
+}
+
+function sendError(ws: ForwardWs, code: string): void {
+  sendJson(ws, { type: "error", code, message: "Request failed" });
+}
+
+function closeWs(ws: ForwardWs): void {
+  try {
+    ws.close();
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      console.warn("[forward/ws] close failed:", err.message);
+    }
+  }
+}
+
+export function normalizeForwardTarget(host: string, port: number): ForwardTarget {
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw forwardError("invalid_request");
+  }
+  if (host === "localhost" || host === "127.0.0.1") {
+    return { host: "127.0.0.1", port };
+  }
+  if (host === "::1") {
+    return { host: "::1", port };
+  }
+  throw forwardError("target_forbidden");
+}
+
+function bufferFromMessage(data: unknown): Buffer {
+  if (Buffer.isBuffer(data)) {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return Buffer.from(String(data));
+}
+
+function uint8ArrayFromBuffer(buffer: Buffer): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(buffer.byteLength);
+  out.set(buffer);
+  return out;
+}
+
+function isBinaryMessage(data: unknown): boolean {
+  return Buffer.isBuffer(data) || data instanceof ArrayBuffer || ArrayBuffer.isView(data);
+}
+
+function defaultDialer(target: ForwardTarget): Socket {
+  return connect({ host: target.host, port: target.port });
+}
+
+export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): ForwardTunnelHub {
+  const dial = options.dial ?? defaultDialer;
+  const maxConnections = options.maxConnections ?? FORWARD_WS_MAX_CONNECTIONS;
+  const maxFrameBytes = options.maxFrameBytes ?? FORWARD_WS_MAX_FRAME_BYTES;
+  const maxControlBytes = options.maxControlBytes ?? FORWARD_WS_MAX_CONTROL_BYTES;
+  const idleTimeoutMs = options.idleTimeoutMs ?? FORWARD_WS_IDLE_TIMEOUT_MS;
+  const active = new Set<ForwardConnectionState>();
+
+  function createHandler() {
+    let state: ForwardConnectionState | null = null;
+
+    const cleanup = () => {
+      const current = state;
+      if (!current || current.closed) {
+        return;
+      }
+      current.closed = true;
+      clearTimeout(current.idleTimer);
+      active.delete(current);
+      current.socket.removeAllListeners();
+      current.socket.destroy();
+      closeWs(current.ws);
+      state = null;
+    };
+
+    const touch = () => {
+      if (!state) {
+        return;
+      }
+      clearTimeout(state.idleTimer);
+      state.idleTimer = setTimeout(() => {
+        if (state) {
+          sendError(state.ws, "idle_timeout");
+        }
+        cleanup();
+      }, idleTimeoutMs);
+      state.idleTimer.unref?.();
+    };
+
+    const fail = (ws: ForwardWs, code: string) => {
+      sendError(ws, code);
+      cleanup();
+      if (!state) {
+        closeWs(ws);
+      }
+    };
+
+    const openTarget = (ws: ForwardWs, message: ForwardOpenMessage) => {
+      if (state) {
+        fail(ws, "invalid_request");
+        return;
+      }
+      if (active.size >= maxConnections) {
+        sendError(ws, "connection_limit");
+        closeWs(ws);
+        return;
+      }
+
+      let target: ForwardTarget;
+      try {
+        target = normalizeForwardTarget(message.host, message.port);
+      } catch (err: unknown) {
+        const code = err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
+          ? (err as { code: string }).code
+          : "invalid_request";
+        sendError(ws, code);
+        closeWs(ws);
+        return;
+      }
+
+      let socket: Socket;
+      try {
+        socket = dial(target);
+      } catch (err: unknown) {
+        console.warn("[forward/ws] loopback dial failed:", err instanceof Error ? err.message : String(err));
+        sendError(ws, "dial_failed");
+        closeWs(ws);
+        return;
+      }
+      state = {
+        socket,
+        ws,
+        opened: false,
+        closed: false,
+        idleTimer: setTimeout(() => {
+          sendError(ws, "idle_timeout");
+          cleanup();
+        }, idleTimeoutMs),
+      };
+      state.idleTimer.unref?.();
+      active.add(state);
+
+      socket.on("connect", () => {
+        if (!state || state.closed) {
+          return;
+        }
+        state.opened = true;
+        touch();
+        sendJson(ws, { type: "ready" });
+      });
+      socket.on("data", (chunk: Buffer) => {
+        if (!state || state.closed) {
+          return;
+        }
+        touch();
+        for (let offset = 0; offset < chunk.byteLength; offset += maxFrameBytes) {
+          try {
+            ws.send(uint8ArrayFromBuffer(Buffer.from(chunk.subarray(offset, offset + maxFrameBytes))));
+          } catch (err: unknown) {
+            if (err instanceof Error) {
+              console.warn("[forward/ws] send failed:", err.message);
+            }
+            cleanup();
+            return;
+          }
+        }
+      });
+      socket.on("end", () => {
+        sendJson(ws, { type: "end" });
+        cleanup();
+      });
+      socket.on("close", cleanup);
+      socket.on("error", (err: unknown) => {
+        console.warn("[forward/ws] loopback dial/socket failed:", err instanceof Error ? err.message : String(err));
+        sendError(ws, state?.opened ? "socket_failed" : "dial_failed");
+        cleanup();
+      });
+    };
+
+    return {
+      onOpen(_evt: unknown, ws: ForwardWs) {
+        if (active.size >= maxConnections) {
+          sendError(ws, "connection_limit");
+          closeWs(ws);
+        }
+      },
+      onMessage(evt: ForwardWsMessageEvent, ws: ForwardWs) {
+        if (isBinaryMessage(evt.data)) {
+          const chunk = bufferFromMessage(evt.data);
+          if (!state?.opened) {
+            fail(ws, "invalid_request");
+            return;
+          }
+          if (chunk.byteLength > maxFrameBytes) {
+            fail(ws, "frame_too_large");
+            return;
+          }
+          touch();
+          state.socket.write(chunk);
+          return;
+        }
+
+        const raw = String(evt.data);
+        if (Buffer.byteLength(raw, "utf8") > maxControlBytes) {
+          fail(ws, "invalid_request");
+          return;
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch (err: unknown) {
+          if (!(err instanceof SyntaxError)) {
+            console.warn("[forward/ws] control parse failed:", err);
+          }
+          fail(ws, "invalid_request");
+          return;
+        }
+
+        const result = ForwardControlMessageSchema.safeParse(parsed);
+        if (!result.success) {
+          const code =
+            parsed &&
+            typeof parsed === "object" &&
+            "type" in parsed &&
+            (parsed as { type?: unknown }).type === "open" &&
+            "host" in parsed &&
+            typeof (parsed as { host?: unknown }).host === "string" &&
+            !LoopbackHostSchema.safeParse((parsed as { host: string }).host).success
+              ? "target_forbidden"
+              : "invalid_request";
+          fail(ws, code);
+          return;
+        }
+
+        touch();
+        if (result.data.type === "open") {
+          openTarget(ws, result.data);
+          return;
+        }
+        sendJson(ws, { type: result.data.type });
+        cleanup();
+      },
+      onClose: cleanup,
+      onError: cleanup,
+    };
+  }
+
+  return {
+    createHandler,
+    async close() {
+      for (const connection of Array.from(active)) {
+        sendJson(connection.ws, { type: "close" });
+        clearTimeout(connection.idleTimer);
+        connection.socket.destroy();
+        closeWs(connection.ws);
+        active.delete(connection);
+      }
+    },
+    activeConnectionsForTest() {
+      return Array.from(active);
+    },
+  };
+}

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -215,6 +215,7 @@ import {
   ClientErrorReportSchema,
   writeClientErrorReport,
 } from "./client-error-log.js";
+import { createForwardTunnelHub } from "./forward-ws.js";
 
 const SAFE_ICON_STEM = /^[a-zA-Z0-9_-]+$/;
 
@@ -514,6 +515,7 @@ export async function createGateway(config: GatewayConfig) {
     adapter: zellijAdapter,
     scrollbackStore: shellScrollbackStore,
   });
+  const forwardTunnelHub = createForwardTunnelHub();
   const captureTerminalEvent = (
     event: string,
     properties: Record<string, string | number | boolean | undefined> = {},
@@ -2269,6 +2271,11 @@ export async function createGateway(config: GatewayConfig) {
         },
       };
     }),
+  );
+
+  app.get(
+    "/ws/forward",
+    upgradeWebSocket(() => forwardTunnelHub.createHandler()),
   );
 
   app.get(
@@ -4384,6 +4391,7 @@ export async function createGateway(config: GatewayConfig) {
       canvasSubscriptionHub?.close();
       await channelManager.stop();
       await processManager.shutdownAll();
+      await forwardTunnelHub.close();
       await sessionRegistry.shutdown();
       await watcher.close();
       await homeMirror?.stop();

--- a/packages/sync-client/src/cli/commands/completion.ts
+++ b/packages/sync-client/src/cli/commands/completion.ts
@@ -11,6 +11,8 @@ const COMMANDS = [
   "whoami",
   "status",
   "run",
+  "port",
+  "forward",
   "upload",
   "download",
   "agent",

--- a/packages/sync-client/src/cli/commands/port.ts
+++ b/packages/sync-client/src/cli/commands/port.ts
@@ -1,0 +1,156 @@
+import { defineCommand } from "citty";
+import { requireCliAuthToken } from "../auth-state.js";
+import { formatCliError, formatCliErrorMessage, formatNdjsonEvent } from "../output.js";
+import { resolveCliProfile } from "../profiles.js";
+import {
+  parseForwardSpec,
+  startPortForward,
+  type PortForwardEventData,
+  type PortForwardHandle,
+  type StartPortForwardOptions,
+} from "../port-forward.js";
+
+type StartForward = (options: StartPortForwardOptions) => Promise<PortForwardHandle>;
+
+const commonArgs = {
+  profile: { type: "string", required: false },
+  dev: { type: "boolean", required: false, default: false },
+  gateway: { type: "string", required: false },
+  token: { type: "string", required: false },
+  json: { type: "boolean", required: false, default: false },
+} as const;
+
+function codeFromError(err: unknown): string {
+  return err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
+    ? (err as { code: string }).code
+    : "request_failed";
+}
+
+function writeError(err: unknown, json: boolean): void {
+  const code = codeFromError(err);
+  const canShowErrorMessage =
+    code === "not_authenticated" ||
+    (code === "auth_expired" && err instanceof Error && err.message !== "Request failed");
+  const safeMessage = canShowErrorMessage && err instanceof Error ? err.message : undefined;
+  console.error(
+    json
+      ? formatCliError(code, safeMessage)
+      : code === "auth_expired"
+        ? formatCliErrorMessage(code, safeMessage)
+        : safeMessage ?? `Error: Request failed (${code})`,
+  );
+}
+
+function publicEventData(data: PortForwardEventData, profile: string, gatewayUrl: string) {
+  const output: Record<string, unknown> = {
+    localHost: data.localHost,
+    localPort: data.localPort,
+    remoteHost: data.remoteHost,
+    remotePort: data.remotePort,
+  };
+  if (typeof data.connectionId === "number") {
+    output.connectionId = data.connectionId;
+  }
+  if (typeof data.code === "string") {
+    output.code = data.code;
+  }
+  if (data.connectionId === undefined && data.code === undefined) {
+    output.profile = profile;
+    output.gatewayUrl = gatewayUrl;
+  }
+  return output;
+}
+
+async function runForward(args: Record<string, unknown>): Promise<void> {
+  const json = args.json === true;
+  try {
+    const spec = parseForwardSpec(String(args.spec));
+    const profile = await resolveCliProfile(args);
+    const token = await requireCliAuthToken(profile);
+    const startForward = typeof args.startForward === "function"
+      ? args.startForward as StartForward
+      : startPortForward;
+
+    let readyPrinted = false;
+    const handle = await startForward({
+      gatewayUrl: profile.gatewayUrl,
+      token,
+      ...spec,
+      onEvent(type, data) {
+        if (type === "ready") {
+          readyPrinted = true;
+        }
+        if (json) {
+          process.stdout.write(formatNdjsonEvent(type, publicEventData(data, profile.name, profile.gatewayUrl)));
+        } else if (type === "ready") {
+          console.log(
+            `Forwarding ${data.localHost}:${data.localPort} -> ${data.remoteHost}:${data.remotePort}`,
+          );
+        }
+      },
+    });
+    await handle.ready;
+    if (!readyPrinted) {
+      const data = {
+        localHost: handle.localHost,
+        localPort: handle.localPort,
+        remoteHost: handle.remoteHost,
+        remotePort: handle.remotePort,
+      };
+      if (json) {
+        process.stdout.write(formatNdjsonEvent("ready", publicEventData(data, profile.name, profile.gatewayUrl)));
+      } else {
+        console.log(`Forwarding ${handle.localHost}:${handle.localPort} -> ${handle.remoteHost}:${handle.remotePort}`);
+      }
+    }
+
+    const close = () => {
+      void handle.close().catch((err: unknown) => {
+        if (err instanceof Error) {
+          console.error("Error: Request failed (close_failed)");
+        }
+      });
+    };
+    process.once("SIGINT", close);
+    process.once("SIGTERM", close);
+    try {
+      await handle.closed;
+    } finally {
+      process.off("SIGINT", close);
+      process.off("SIGTERM", close);
+    }
+  } catch (err: unknown) {
+    writeError(err, json);
+    process.exitCode = 1;
+  }
+}
+
+const forwardCommand = defineCommand({
+  meta: {
+    name: "forward",
+    description: "Forward a local loopback port to the Matrix computer",
+  },
+  args: {
+    spec: { type: "positional", required: true },
+    ...commonArgs,
+  },
+  run: async ({ args }) => runForward(args),
+});
+
+export const portCommand = defineCommand({
+  meta: {
+    name: "port",
+    description: "Manage Matrix computer port forwarding",
+  },
+  subCommands: {
+    forward: forwardCommand,
+  },
+});
+
+export const forwardAliasCommand = defineCommand({
+  ...forwardCommand,
+  meta: {
+    name: "forward",
+    description: "Forward a local loopback port to the Matrix computer",
+  },
+});

--- a/packages/sync-client/src/cli/index.ts
+++ b/packages/sync-client/src/cli/index.ts
@@ -15,6 +15,7 @@ import { runCommand } from "./commands/run.js";
 import { uploadCommand } from "./commands/upload.js";
 import { downloadCommand } from "./commands/download.js";
 import { agentCommand } from "./commands/agent.js";
+import { forwardAliasCommand, portCommand } from "./commands/port.js";
 import { normalizeLeadingGlobalFlags } from "./global-flags.js";
 
 const require = createRequire(import.meta.url);
@@ -40,6 +41,8 @@ const main = defineCommand({
     upload: uploadCommand,
     download: downloadCommand,
     agent: agentCommand,
+    port: portCommand,
+    forward: forwardAliasCommand,
     doctor: doctorCommand,
     instance: instanceCommand,
     completion: completionCommand,

--- a/packages/sync-client/src/cli/port-forward.ts
+++ b/packages/sync-client/src/cli/port-forward.ts
@@ -1,0 +1,381 @@
+import { createServer, type Socket } from "node:net";
+import type { AddressInfo } from "node:net";
+import { WebSocket as DefaultWebSocket } from "ws";
+
+export interface ForwardSpec {
+  localHost: "127.0.0.1";
+  localPort: number;
+  remoteHost: "127.0.0.1" | "::1" | "localhost";
+  remotePort: number;
+}
+
+export interface PortForwardEventData {
+  localHost: string;
+  localPort: number;
+  remoteHost: string;
+  remotePort: number;
+  connectionId?: number;
+  code?: string;
+}
+
+export interface PortForwardHandle extends ForwardSpec {
+  ready: Promise<void>;
+  closed: Promise<void>;
+  close(): Promise<void>;
+}
+
+interface ForwardWebSocket {
+  readyState: number;
+  binaryType?: string;
+  send(data: string | Buffer): void;
+  close(): void;
+  on(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void): ForwardWebSocket;
+  off?(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void): ForwardWebSocket;
+}
+
+export interface StartPortForwardOptions extends ForwardSpec {
+  gatewayUrl: string;
+  token: string;
+  maxConnections?: number;
+  maxFrameBytes?: number;
+  idleTimeoutMs?: number;
+  WebSocketImpl?: new (url: string, options?: { headers?: Record<string, string> }) => ForwardWebSocket;
+  onEvent?: (type: string, data: PortForwardEventData) => void;
+}
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+const DEFAULT_MAX_CONNECTIONS = 32;
+const DEFAULT_MAX_FRAME_BYTES = 64 * 1024;
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+const MAX_PENDING_TCP_BYTES = 256 * 1024;
+
+function invalidForwardSpec(): Error & { code: string } {
+  return Object.assign(new Error("Request failed"), { code: "invalid_forward_spec" });
+}
+
+function validatePort(value: string): number {
+  if (!/^(?:0|[1-9]\d*)$/.test(value)) {
+    throw invalidForwardSpec();
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65_535) {
+    throw invalidForwardSpec();
+  }
+  return parsed;
+}
+
+function parseExplicitSpec(spec: string): { localPort: number; remoteHost: ForwardSpec["remoteHost"]; remotePort: number } {
+  const bracketedIpv6 = spec.match(/^(\d+):\[::1\]:(\d+)$/);
+  if (bracketedIpv6) {
+    return {
+      localPort: validatePort(bracketedIpv6[1]!),
+      remoteHost: "::1",
+      remotePort: validatePort(bracketedIpv6[2]!),
+    };
+  }
+
+  const parts = spec.split(":");
+  if (parts.length !== 3) {
+    throw invalidForwardSpec();
+  }
+  const remoteHost = parts[1]!;
+  if (!LOOPBACK_HOSTS.has(remoteHost)) {
+    throw invalidForwardSpec();
+  }
+  return {
+    localPort: validatePort(parts[0]!),
+    remoteHost: remoteHost as ForwardSpec["remoteHost"],
+    remotePort: validatePort(parts[2]!),
+  };
+}
+
+export function parseForwardSpec(spec: string): ForwardSpec {
+  const trimmed = spec.trim();
+  if (/^(?:0|[1-9]\d*)$/.test(trimmed)) {
+    const port = validatePort(trimmed);
+    return {
+      localHost: "127.0.0.1",
+      localPort: port,
+      remoteHost: "127.0.0.1",
+      remotePort: port,
+    };
+  }
+  const explicit = parseExplicitSpec(trimmed);
+  return {
+    localHost: "127.0.0.1",
+    ...explicit,
+  };
+}
+
+export function createForwardWebSocketUrl(gatewayUrl: string): string {
+  const url = new URL("/ws/forward", gatewayUrl.replace(/\/+$/, ""));
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString();
+}
+
+function bufferFromWsMessage(data: unknown): Buffer {
+  if (Buffer.isBuffer(data)) {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return Buffer.from(String(data));
+}
+
+export async function startPortForward(options: StartPortForwardOptions): Promise<PortForwardHandle> {
+  const maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
+  const maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+  const WebSocketImpl = options.WebSocketImpl ?? (DefaultWebSocket as unknown as StartPortForwardOptions["WebSocketImpl"]);
+  if (!WebSocketImpl) {
+    throw Object.assign(new Error("Request failed"), { code: "websocket_unavailable" });
+  }
+  const eventData = (connectionId?: number, code?: string): PortForwardEventData => ({
+    localHost: options.localHost,
+    localPort: options.localPort,
+    remoteHost: options.remoteHost,
+    remotePort: options.remotePort,
+    connectionId,
+    code,
+  });
+
+  let nextConnectionId = 1;
+  const active = new Set<{
+    tcp: Socket;
+    ws: ForwardWebSocket;
+    idleTimer: ReturnType<typeof setTimeout>;
+  }>();
+  const server = createServer((tcp) => {
+    if (active.size >= maxConnections) {
+      options.onEvent?.("connection_rejected", {
+        ...eventData(undefined, "connection_limit"),
+      });
+      tcp.destroy();
+      return;
+    }
+
+    const connectionId = nextConnectionId++;
+    const ws = new WebSocketImpl(createForwardWebSocketUrl(options.gatewayUrl), {
+      headers: { Authorization: `Bearer ${options.token}` },
+    });
+    ws.binaryType = "arraybuffer";
+    let remoteReady = false;
+    let pendingTcpBytes = 0;
+    const pendingTcpChunks: Buffer[] = [];
+    const state = {
+      tcp,
+      ws,
+      idleTimer: setTimeout(() => {
+        options.onEvent?.("connection_idle_timeout", eventData(connectionId, "idle_timeout"));
+        cleanup();
+      }, idleTimeoutMs),
+    };
+    state.idleTimer.unref?.();
+    active.add(state);
+    options.onEvent?.("connection_open", eventData(connectionId));
+
+    const touch = () => {
+      clearTimeout(state.idleTimer);
+      state.idleTimer = setTimeout(() => {
+        options.onEvent?.("connection_idle_timeout", {
+          ...eventData(connectionId, "idle_timeout"),
+        });
+        cleanup();
+      }, idleTimeoutMs);
+      state.idleTimer.unref?.();
+    };
+
+    const cleanup = () => {
+      if (!active.delete(state)) {
+        return;
+      }
+      clearTimeout(state.idleTimer);
+      tcp.off("data", onTcpData);
+      tcp.off("close", cleanup);
+      tcp.off("error", onTcpError);
+      ws.off?.("open", onWsOpen);
+      ws.off?.("message", onWsMessage);
+      ws.off?.("close", cleanup);
+      ws.off?.("error", onWsError);
+      if (!tcp.destroyed) {
+        tcp.destroy();
+      }
+      try {
+        ws.close();
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          options.onEvent?.("connection_error", eventData(connectionId, "close_failed"));
+        }
+      }
+      options.onEvent?.("connection_close", eventData(connectionId));
+    };
+
+    const onTcpData = (chunk: Buffer) => {
+      touch();
+      if (chunk.byteLength > maxFrameBytes) {
+        options.onEvent?.("connection_error", eventData(connectionId, "frame_too_large"));
+        cleanup();
+        return;
+      }
+      if (!remoteReady) {
+        pendingTcpBytes += chunk.byteLength;
+        if (pendingTcpBytes > MAX_PENDING_TCP_BYTES) {
+          options.onEvent?.("connection_error", eventData(connectionId, "buffer_overflow"));
+          cleanup();
+          return;
+        }
+        pendingTcpChunks.push(Buffer.from(chunk));
+        return;
+      }
+      try {
+        ws.send(Buffer.from(chunk));
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          options.onEvent?.("connection_error", eventData(connectionId, "send_failed"));
+        }
+        cleanup();
+      }
+    };
+
+    const onTcpError = () => {
+      options.onEvent?.("connection_error", eventData(connectionId, "tcp_failed"));
+      cleanup();
+    };
+
+    const onWsOpen = () => {
+      touch();
+      try {
+        ws.send(JSON.stringify({ type: "open", host: options.remoteHost, port: options.remotePort }));
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          options.onEvent?.("connection_error", eventData(connectionId, "send_failed"));
+        }
+        cleanup();
+      }
+    };
+
+    const onWsMessage = (data: unknown, isBinary?: unknown) => {
+      touch();
+      const binaryFrame =
+        isBinary === true ||
+        (isBinary === undefined && (Buffer.isBuffer(data) || data instanceof ArrayBuffer || ArrayBuffer.isView(data)));
+      if (binaryFrame) {
+        const chunk = bufferFromWsMessage(data);
+        if (chunk.byteLength > maxFrameBytes) {
+          options.onEvent?.("connection_error", eventData(connectionId, "frame_too_large"));
+          cleanup();
+          return;
+        }
+        tcp.write(chunk);
+        return;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(String(data));
+      } catch (err: unknown) {
+        if (!(err instanceof SyntaxError)) {
+          options.onEvent?.("connection_error", eventData(connectionId, "control_failed"));
+        }
+        cleanup();
+        return;
+      }
+      if (parsed && typeof parsed === "object" && "type" in parsed) {
+        const type = (parsed as { type?: unknown }).type;
+        if (type === "ready") {
+          remoteReady = true;
+          try {
+            for (const pendingChunk of pendingTcpChunks.splice(0)) {
+              ws.send(pendingChunk);
+            }
+          } catch (err: unknown) {
+            if (err instanceof Error) {
+              options.onEvent?.("connection_error", eventData(connectionId, "send_failed"));
+            }
+            cleanup();
+            return;
+          }
+          pendingTcpBytes = 0;
+          return;
+        }
+        if (type === "error") {
+          const parsedRecord = parsed as Record<string, unknown>;
+          const code = typeof parsedRecord.code === "string"
+            ? parsedRecord.code
+            : "forward_failed";
+          options.onEvent?.("connection_error", eventData(connectionId, code));
+        }
+      }
+      cleanup();
+    };
+
+    const onWsError = () => {
+      options.onEvent?.("connection_error", eventData(connectionId, "websocket_failed"));
+      cleanup();
+    };
+
+    tcp.on("data", onTcpData);
+    tcp.on("close", cleanup);
+    tcp.on("error", onTcpError);
+    ws.on("open", onWsOpen);
+    ws.on("message", onWsMessage);
+    ws.on("close", cleanup);
+    ws.on("error", onWsError);
+  });
+
+  const ready = new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.localPort, options.localHost, () => {
+      server.off("error", reject);
+      const address = server.address() as AddressInfo;
+      options.localPort = address.port;
+      options.onEvent?.("ready", eventData());
+      resolve();
+    });
+  });
+  const closed = new Promise<void>((resolve) => {
+    server.once("close", resolve);
+  });
+
+  const closeServer = async () => {
+    for (const state of Array.from(active)) {
+      clearTimeout(state.idleTimer);
+      state.tcp.destroy();
+      try {
+        state.ws.close();
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          options.onEvent?.("connection_error", eventData(undefined, "close_failed"));
+        }
+      }
+      active.delete(state);
+    }
+    await new Promise<void>((resolve, reject) => {
+      if (!server.listening) {
+        resolve();
+        return;
+      }
+      server.close((err?: Error) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  };
+
+  await ready;
+  return {
+    localHost: options.localHost,
+    localPort: options.localPort,
+    remoteHost: options.remoteHost,
+    remotePort: options.remotePort,
+    ready,
+    closed,
+    close: closeServer,
+  };
+}

--- a/tests/cli/port-forward.test.ts
+++ b/tests/cli/port-forward.test.ts
@@ -1,0 +1,299 @@
+import { EventEmitter } from "node:events";
+import { createConnection, type Socket } from "node:net";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { portCommand } from "../../packages/sync-client/src/cli/commands/port.js";
+import {
+  createForwardWebSocketUrl,
+  parseForwardSpec,
+  startPortForward,
+  type PortForwardHandle,
+} from "../../packages/sync-client/src/cli/port-forward.js";
+import { saveProfileAuth } from "../../packages/sync-client/src/auth/token-store.js";
+
+const roots: string[] = [];
+const originalHome = process.env.HOME;
+
+async function tempHome() {
+  const root = await mkdtemp(join(tmpdir(), "matrix-port-forward-cli-"));
+  roots.push(root);
+  process.env.HOME = root;
+  return root;
+}
+
+async function writeProfiles(root: string) {
+  await mkdir(join(root, ".matrixos"), { recursive: true });
+  await writeFile(
+    join(root, ".matrixos", "profiles.json"),
+    JSON.stringify({
+      active: "cloud",
+      profiles: {
+        cloud: {
+          platformUrl: "https://platform.example",
+          gatewayUrl: "https://gateway.example",
+        },
+        local: {
+          platformUrl: "http://localhost:9000",
+          gatewayUrl: "http://127.0.0.1:4000",
+        },
+      },
+    }),
+    { flag: "wx" },
+  );
+}
+
+function captureLogs() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const stdout: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+    logs.push(String(line));
+  });
+  vi.spyOn(console, "error").mockImplementation((line?: unknown) => {
+    errors.push(String(line));
+  });
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array) => {
+    stdout.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk));
+    return true;
+  });
+  return { logs, errors, stdout };
+}
+
+afterEach(async () => {
+  process.env.HOME = originalHome;
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("matrix port forward", () => {
+  it("parses a single port as local loopback to remote loopback", () => {
+    expect(parseForwardSpec("3000")).toEqual({
+      localHost: "127.0.0.1",
+      localPort: 3000,
+      remoteHost: "127.0.0.1",
+      remotePort: 3000,
+    });
+  });
+
+  it("parses explicit local and remote targets", () => {
+    expect(parseForwardSpec("8080:127.0.0.1:3000")).toEqual({
+      localHost: "127.0.0.1",
+      localPort: 8080,
+      remoteHost: "127.0.0.1",
+      remotePort: 3000,
+    });
+  });
+
+  it("rejects malformed specs, invalid ports, and non-loopback remote hosts", () => {
+    for (const spec of ["", "abc", "0", "65536", "8080:example.com:3000", "8080:127.0.0.1:0"]) {
+      expect(() => parseForwardSpec(spec)).toThrowError(
+        expect.objectContaining({ code: "invalid_forward_spec" }),
+      );
+    }
+  });
+
+  it("builds forward websocket URLs without leaking bearer auth", () => {
+    expect(createForwardWebSocketUrl("https://gateway.example")).toBe("wss://gateway.example/ws/forward");
+    expect(createForwardWebSocketUrl("http://127.0.0.1:4000/")).toBe("ws://127.0.0.1:4000/ws/forward");
+  });
+
+  it("uses profile auth and gateway resolution for the command", async () => {
+    const root = await tempHome();
+    await writeProfiles(root);
+    await saveProfileAuth("cloud", {
+      accessToken: "cloud-token",
+      expiresAt: Date.now() + 60_000,
+      userId: "user_cloud",
+      handle: "cloud",
+    });
+    const { stdout } = captureLogs();
+    const startForward = vi.fn(async ({ onEvent }: Parameters<typeof startPortForward>[0]): Promise<PortForwardHandle> => {
+      onEvent?.("ready", {
+        localHost: "127.0.0.1",
+        localPort: 3000,
+        remoteHost: "127.0.0.1",
+        remotePort: 3000,
+      });
+      return {
+        localHost: "127.0.0.1",
+        localPort: 3000,
+        remoteHost: "127.0.0.1",
+        remotePort: 3000,
+        ready: Promise.resolve(),
+        closed: Promise.resolve(),
+        close: vi.fn(),
+      };
+    });
+
+    await portCommand.subCommands!.forward.run!({
+      args: { spec: "3000", json: true, startForward },
+    } as never);
+
+    expect(startForward).toHaveBeenCalledWith(expect.objectContaining({
+      gatewayUrl: "https://gateway.example",
+      token: "cloud-token",
+      localHost: "127.0.0.1",
+      localPort: 3000,
+      remoteHost: "127.0.0.1",
+      remotePort: 3000,
+    }));
+    expect(stdout.join("").trim().split("\n").map((line) => JSON.parse(line))).toEqual([
+      {
+        v: 1,
+        type: "ready",
+        data: {
+          localHost: "127.0.0.1",
+          localPort: 3000,
+          remoteHost: "127.0.0.1",
+          remotePort: 3000,
+          profile: "cloud",
+          gatewayUrl: "https://gateway.example",
+        },
+      },
+    ]);
+  });
+
+  it("emits safe JSON errors for invalid specs", async () => {
+    const root = await tempHome();
+    await writeProfiles(root);
+    const { errors } = captureLogs();
+
+    await portCommand.subCommands!.forward.run!({
+      args: { spec: "8080:example.com:3000", json: true },
+    } as never);
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(errors[0]!)).toEqual({
+      v: 1,
+      error: {
+        code: "invalid_forward_spec",
+        message: "Request failed",
+      },
+    });
+  });
+
+  it("opens a local listener and creates one websocket per accepted TCP connection", async () => {
+    class EchoWebSocket extends EventEmitter {
+      static instances: EchoWebSocket[] = [];
+      sent: unknown[] = [];
+      readyState = 1;
+      auth?: string;
+
+      constructor(_url: string, options?: { headers?: Record<string, string> }) {
+        super();
+        this.auth = options?.headers?.Authorization;
+        EchoWebSocket.instances.push(this);
+        queueMicrotask(() => this.emit("open"));
+      }
+
+      send(data: unknown) {
+        if (typeof data === "string") {
+          this.sent.push(JSON.parse(data));
+          queueMicrotask(() => this.emit("message", JSON.stringify({ type: "ready" }), false));
+          return;
+        }
+        const chunk = Buffer.from(data as Buffer);
+        this.sent.push(chunk);
+        queueMicrotask(() => this.emit("message", Buffer.from("remote-bytes"), true));
+      }
+
+      close() {
+        this.emit("close");
+      }
+    }
+
+    const events: string[] = [];
+    const handle = await startPortForward({
+      gatewayUrl: "http://gateway",
+      token: "bearer-token",
+      localHost: "127.0.0.1",
+      localPort: 0,
+      remoteHost: "127.0.0.1",
+      remotePort: 3000,
+      onEvent: (type) => {
+        events.push(type);
+      },
+      idleTimeoutMs: 30_000,
+      WebSocketImpl: EchoWebSocket as never,
+    });
+    await handle.ready;
+
+    const client = await new Promise<Socket>((resolve) => {
+      const socket = createConnection(handle.localPort, "127.0.0.1", () => resolve(socket));
+    });
+    const received = new Promise<Buffer>((resolve) => {
+      client.once("data", (chunk) => resolve(Buffer.from(chunk)));
+    });
+    client.write(Buffer.from("local-bytes"));
+
+    await expect(received).resolves.toEqual(Buffer.from("remote-bytes"));
+    expect(EchoWebSocket.instances).toHaveLength(1);
+    expect(EchoWebSocket.instances[0]!.auth).toBe("Bearer bearer-token");
+    expect(EchoWebSocket.instances[0]!.sent).toEqual([
+      { type: "open", host: "127.0.0.1", port: 3000 },
+      Buffer.from("local-bytes"),
+    ]);
+
+    client.destroy();
+    await handle.close();
+    expect(events).toContain("ready");
+    expect(events).toContain("connection_open");
+  });
+
+  it("enforces concurrent connection caps", async () => {
+    class HangingWebSocket extends EventEmitter {
+      static instances: HangingWebSocket[] = [];
+      readyState = 1;
+      sent: unknown[] = [];
+      closed = false;
+
+      constructor() {
+        super();
+        HangingWebSocket.instances.push(this);
+        queueMicrotask(() => this.emit("open"));
+      }
+
+      send(data: unknown) {
+        this.sent.push(data);
+        if (typeof data === "string") {
+          this.emit("message", JSON.stringify({ type: "ready" }));
+        }
+      }
+
+      close() {
+        this.closed = true;
+        this.emit("close");
+      }
+    }
+
+    const handle = await startPortForward({
+      gatewayUrl: "http://gateway",
+      token: "tok",
+      localHost: "127.0.0.1",
+      localPort: 0,
+      remoteHost: "127.0.0.1",
+      remotePort: 3000,
+      maxConnections: 1,
+      WebSocketImpl: HangingWebSocket as never,
+    });
+    await handle.ready;
+
+    const first = await new Promise<Socket>((resolve) => {
+      const socket = createConnection(handle.localPort, "127.0.0.1", () => resolve(socket));
+    });
+    const second = await new Promise<Socket>((resolve) => {
+      const socket = createConnection(handle.localPort, "127.0.0.1", () => resolve(socket));
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(HangingWebSocket.instances).toHaveLength(1);
+    expect(second.destroyed).toBe(true);
+
+    first.destroy();
+    second.destroy();
+    await handle.close();
+  });
+});

--- a/tests/cli/unified-command-tree.test.ts
+++ b/tests/cli/unified-command-tree.test.ts
@@ -19,6 +19,15 @@ describe("unified CLI command tree", () => {
       "cloud",
     ]);
     expect(resolvePublishedCliRedirect(["sh", "ls"])).toEqual(["sh", "ls"]);
+    expect(resolvePublishedCliRedirect(["port", "forward", "3000"])).toEqual([
+      "port",
+      "forward",
+      "3000",
+    ]);
+    expect(resolvePublishedCliRedirect(["forward", "3000"])).toEqual([
+      "forward",
+      "3000",
+    ]);
   });
 
   it("normalizes documented leading global flags before command dispatch", () => {
@@ -93,6 +102,8 @@ describe("unified CLI command tree", () => {
   it("keeps development-only commands out of the published redirect set", () => {
     expect(PUBLISHED_CLI_COMMANDS.has("start")).toBe(false);
     expect(PUBLISHED_CLI_COMMANDS.has("send")).toBe(false);
+    expect(PUBLISHED_CLI_COMMANDS.has("port")).toBe(true);
+    expect(PUBLISHED_CLI_COMMANDS.has("forward")).toBe(true);
     expect(resolvePublishedCliRedirect(["start", "--shell"])).toBeNull();
     expect(resolvePublishedCliRedirect(["send", "hello"])).toBeNull();
   });

--- a/tests/gateway/auth.test.ts
+++ b/tests/gateway/auth.test.ts
@@ -218,6 +218,23 @@ describe("T133: Auth token middleware", () => {
     expect(nextCalled).toBe(true);
   });
 
+  it("requires bearer auth for /ws/forward and rejects query-token fallback", async () => {
+    const mw = authMiddleware("secret-token");
+    let nextCalled = false;
+    const queryResult = await mw(
+      mockContext("/ws/forward", undefined, "secret-token", "10.0.0.1"),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(false);
+    expect(queryResult?.status).toBe(401);
+
+    await mw(
+      mockContext("/ws/forward", "Bearer secret-token", undefined, "10.0.0.1"),
+      async () => { nextCalled = true; },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
   it("allows canvas WebSocket paths with query token", async () => {
     const mw = authMiddleware("secret-token");
     let nextCalled = false;

--- a/tests/gateway/forward-ws.test.ts
+++ b/tests/gateway/forward-ws.test.ts
@@ -1,0 +1,224 @@
+import { createServer, type Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ForwardOpenMessageSchema,
+  createForwardTunnelHub,
+  normalizeForwardTarget,
+  type ForwardDialer,
+} from "../../packages/gateway/src/forward-ws.js";
+
+class FakeGatewayWebSocket {
+  sent: unknown[] = [];
+  closed = false;
+
+  send(data: unknown) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+class FakeDuplexSocket {
+  private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  writes: Buffer[] = [];
+  destroyed = false;
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    const handlers = this.handlers.get(event) ?? [];
+    handlers.push(handler);
+    this.handlers.set(event, handlers);
+    return this;
+  }
+
+  once(event: string, handler: (...args: unknown[]) => void) {
+    const wrapped = (...args: unknown[]) => {
+      this.off(event, wrapped);
+      handler(...args);
+    };
+    return this.on(event, wrapped);
+  }
+
+  off(event: string, handler: (...args: unknown[]) => void) {
+    this.handlers.set(event, (this.handlers.get(event) ?? []).filter((candidate) => candidate !== handler));
+    return this;
+  }
+
+  removeAllListeners() {
+    this.handlers.clear();
+    return this;
+  }
+
+  emit(event: string, ...args: unknown[]) {
+    for (const handler of this.handlers.get(event) ?? []) {
+      handler(...args);
+    }
+  }
+
+  write(chunk: Buffer) {
+    this.writes.push(Buffer.from(chunk));
+    return true;
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.emit("close");
+  }
+}
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+  vi.restoreAllMocks();
+});
+
+describe("forward websocket protocol", () => {
+  it("validates open control messages", () => {
+    expect(ForwardOpenMessageSchema.parse({ type: "open", host: "127.0.0.1", port: 3000 })).toEqual({
+      type: "open",
+      host: "127.0.0.1",
+      port: 3000,
+    });
+    expect(() => ForwardOpenMessageSchema.parse({ type: "open", host: "example.com", port: 3000 })).toThrow();
+    expect(() => ForwardOpenMessageSchema.parse({ type: "open", host: "127.0.0.1", port: 0 })).toThrow();
+  });
+
+  it("normalizes localhost targets to loopback and rejects non-loopback hosts", () => {
+    expect(normalizeForwardTarget("localhost", 3000)).toEqual({ host: "127.0.0.1", port: 3000 });
+    expect(normalizeForwardTarget("::1", 3000)).toEqual({ host: "::1", port: 3000 });
+    expect(() => normalizeForwardTarget("10.0.0.1", 3000)).toThrowError(
+      expect.objectContaining({ code: "target_forbidden" }),
+    );
+  });
+
+  it("rejects invalid control frames before dialing", () => {
+    const dial = vi.fn();
+    const hub = createForwardTunnelHub({ dial: dial as never });
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, ws as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "example.com", port: 3000 }) } as never, ws as never);
+
+    expect(dial).not.toHaveBeenCalled();
+    expect(JSON.parse(String(ws.sent[0]))).toEqual({
+      type: "error",
+      code: "target_forbidden",
+      message: "Request failed",
+    });
+    expect(ws.closed).toBe(true);
+  });
+
+  it("bridges bytes in both directions after ready", () => {
+    const socket = new FakeDuplexSocket();
+    const dial: ForwardDialer = vi.fn(() => socket as never);
+    const hub = createForwardTunnelHub({ dial });
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, ws as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3000 }) } as never, ws as never);
+    socket.emit("connect");
+    handler.onMessage?.({ data: Buffer.from("from-client") } as never, ws as never);
+    socket.emit("data", Buffer.from("from-remote"));
+
+    expect(dial).toHaveBeenCalledWith({ host: "127.0.0.1", port: 3000 });
+    expect(JSON.parse(String(ws.sent[0]))).toEqual({ type: "ready" });
+    expect(socket.writes).toEqual([Buffer.from("from-client")]);
+    expect(Buffer.from(ws.sent[1] as Uint8Array)).toEqual(Buffer.from("from-remote"));
+  });
+
+  it("rejects oversized websocket binary frames", () => {
+    const socket = new FakeDuplexSocket();
+    const hub = createForwardTunnelHub({ dial: () => socket as never, maxFrameBytes: 4 });
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, ws as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3000 }) } as never, ws as never);
+    socket.emit("connect");
+    handler.onMessage?.({ data: Buffer.from("too-large") } as never, ws as never);
+
+    expect(JSON.parse(String(ws.sent[1]))).toEqual({
+      type: "error",
+      code: "frame_too_large",
+      message: "Request failed",
+    });
+    expect(socket.destroyed).toBe(true);
+    expect(ws.closed).toBe(true);
+  });
+
+  it("returns generic client errors while logging dial failures", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const socket = new FakeDuplexSocket();
+    const hub = createForwardTunnelHub({ dial: () => socket as never });
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, ws as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3000 }) } as never, ws as never);
+    socket.emit("error", new Error("ECONNREFUSED /private/path"));
+
+    expect(JSON.parse(String(ws.sent[0]))).toEqual({
+      type: "error",
+      code: "dial_failed",
+      message: "Request failed",
+    });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("isolates per-connection failures", () => {
+    const sockets = [new FakeDuplexSocket(), new FakeDuplexSocket()];
+    const hub = createForwardTunnelHub({
+      dial: vi.fn(() => sockets.shift() as never),
+    });
+    const firstWs = new FakeGatewayWebSocket();
+    const secondWs = new FakeGatewayWebSocket();
+    const first = hub.createHandler();
+    const second = hub.createHandler();
+
+    first.onOpen?.({} as never, firstWs as never);
+    second.onOpen?.({} as never, secondWs as never);
+    first.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3000 }) } as never, firstWs as never);
+    second.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3001 }) } as never, secondWs as never);
+
+    const firstSocket = sockets.length === 0 ? null : undefined;
+    expect(firstSocket).toBeNull();
+    // The first emitted error should not close the second websocket.
+    (hub.activeConnectionsForTest()[0]!.socket as unknown as FakeDuplexSocket).emit("error", new Error("boom"));
+    expect(firstWs.closed).toBe(true);
+    expect(secondWs.closed).toBe(false);
+  });
+
+  it("proxies bytes to a loopback TCP server", async () => {
+    const tcp = createServer((socket) => {
+      socket.on("data", (chunk) => {
+        socket.write(Buffer.from(`echo:${chunk.toString("utf8")}`));
+      });
+    });
+    servers.push(tcp);
+    await new Promise<void>((resolve) => tcp.listen(0, "127.0.0.1", resolve));
+    const address = tcp.address();
+    if (!address || typeof address === "string") throw new Error("missing tcp port");
+
+    const hub = createForwardTunnelHub();
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+    try {
+      handler.onOpen?.({} as never, ws as never);
+      handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: address.port }) } as never, ws as never);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      handler.onMessage?.({ data: Buffer.from("hello") } as never, ws as never);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(JSON.parse(String(ws.sent[0]))).toEqual({ type: "ready" });
+      expect(ws.sent.some((value) =>
+        value instanceof Uint8Array && Buffer.from(value).toString("utf8") === "echo:hello",
+      )).toBe(true);
+    } finally {
+      await hub.close();
+    }
+  });
+});

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -122,6 +122,37 @@ matrix shell layout show --name dev        # print the KDL
 matrix shell layout rm --name dev
 ```
 
+## Port forwarding
+
+Forwarding opens a listener on your local machine and connects it to a service listening on your Matrix computer. V1 supports local-to-Matrix-computer forwarding only. Reverse tunnels and public/shareable HTTPS URLs are not part of this command yet.
+
+```bash
+# Local 127.0.0.1:3000 -> Matrix computer 127.0.0.1:3000
+matrix port forward 3000
+
+# Local 127.0.0.1:8080 -> Matrix computer 127.0.0.1:3000
+matrix port forward 8080:127.0.0.1:3000
+
+# Top-level alias
+matrix forward 3000
+matrix forward 8080:127.0.0.1:3000
+```
+
+The local listener always binds to `127.0.0.1`. The remote target must be loopback on the Matrix computer: `127.0.0.1:<port>`, `localhost:<port>`, or `[::1]:<port>`. To forward a dev server, start that server on the Matrix computer first, then run the CLI command from your local terminal.
+
+```bash
+matrix port forward 5173
+open http://127.0.0.1:5173
+```
+
+With `--json`, port forwarding emits NDJSON. The first event is `ready`, then connection lifecycle events follow until the command exits.
+
+```bash
+matrix port forward 3000 --json
+{"v":1,"type":"ready","data":{"localHost":"127.0.0.1","localPort":3000,"remoteHost":"127.0.0.1","remotePort":3000,"profile":"cloud","gatewayUrl":"https://app.matrix-os.com"}}
+{"v":1,"type":"connection_open","data":{"localHost":"127.0.0.1","localPort":3000,"remoteHost":"127.0.0.1","remotePort":3000,"connectionId":1}}
+```
+
 ## File sync
 
 The sync daemon mirrors a local folder against your instance's home directory. It runs as a background service installed by `matrix sync start`.
@@ -192,6 +223,7 @@ Every command supports `--json` for scripting and integration with the upcoming 
 ```bash
 matrix shell ls --json
 matrix sync status --json
+matrix port forward 3000 --json
 matrix shell tab ls main --json | jq '.[] | .name'
 ```
 
@@ -252,6 +284,14 @@ Usually means the zellij session exited on your instance. Check `matrix shell ls
 **`session "foo" not found` when connecting**
 
 The session does not exist on your instance. `matrix shell connect` is intentionally strict unless you pass `-c`. Use `matrix shell new foo` or `matrix shell connect -c foo` to create it.
+
+**`matrix port forward` returns `invalid_forward_spec`**
+
+Check the spec shape and port ranges. Valid examples are `3000`, `8080:127.0.0.1:3000`, `8080:localhost:3000`, and `8080:[::1]:3000`. Ports must be integers from 1 through 65535.
+
+**`matrix port forward` connects but the browser shows connection refused**
+
+The target service must be running on the Matrix computer loopback interface, not on your laptop. Attach with `matrix shell connect <session>` and verify the service is listening on `127.0.0.1:<port>` inside the Matrix computer.
 
 **Local stack returns connection refused**
 


### PR DESCRIPTION
## Summary

- Add `matrix port forward <spec>` and top-level `matrix forward <spec>` for local-to-Matrix-computer loopback forwarding.
- Add a sync-client tunnel client that binds local `127.0.0.1`, opens one authenticated WebSocket per TCP connection, bridges binary frames, caps frames/connections, and cleans up on close/error/idle timeout.
- Add gateway `/ws/forward` with authenticated bearer WebSocket access, loopback-only remote target validation, generic client-visible errors, frame/control caps, idle timeout, and shutdown cleanup.
- Document syntax, `--json` NDJSON behavior, loopback-only v1 scope, and troubleshooting in the CLI guide.

## Tests

- Passed: `pnpm --filter '@finnaai/matrix' exec tsc --noEmit`
- Passed: `pnpm --filter '@matrix-os/gateway' exec tsc --noEmit`
- Passed: `./scripts/review/check-patterns.sh` with 0 violations
- Passed: `/home/nima/matrix-os/node_modules/.bin/vitest run tests/cli/port-forward.test.ts tests/cli/unified-command-tree.test.ts tests/gateway/forward-ws.test.ts tests/gateway/auth.test.ts`
- Broad run: `/home/nima/matrix-os/node_modules/.bin/vitest run tests/cli tests/gateway` passed the new forwarding tests but failed 2 existing sandbox-dependent tests in `tests/gateway/sync/home-mirror.test.ts` because this environment denied writing `/tmp/outside-target.txt` and `/tmp/escaped-delete.txt`.

## Review/Monitoring

- Ready for CI, GitHub review, and Greptile review.
- Monitoring loop will continue until CI is green and latest trusted Greptile result is 5/5.

## Invariants

- Source of truth: forwarding state is process-local only. No persistent tunnel registry is introduced. TCP bytes remain ephemeral and are not stored.
- Lock/transaction scope: no database writes or transactions are added. Each accepted local TCP connection owns exactly one gateway WebSocket and one remote loopback TCP socket.
- Acceptable orphan states: if local TCP, WebSocket, or remote dial fails, both paired sides are closed. No durable state remains after process exit, gateway shutdown, idle timeout, or connection failure.
- Auth source of truth: gateway `authMiddleware` remains authoritative. CLI uses bearer WebSocket headers from the resolved profile token. `/ws/forward` does not accept browser query-token fallback in v1.
- Deferred scope: reverse tunnels, public/shareable HTTPS publishing, multiplexing, persistent tunnel registries, and public bind flags are intentionally not included.
