### PR TITLE
fix(gateway): create zellij command sessions from layout files

### DIFF
--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -112,6 +112,7 @@ type RetainedCreatePty = {
   process: ShellAttachProcess;
   startedAtMs: number;
   exitDisposable: Disposable | null;
+  tempLayoutDir?: string;
 };
 
 function attachEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
@@ -230,6 +231,9 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
     retainedCreatePtys.delete(name);
     retained.exitDisposable?.dispose();
     retained.exitDisposable = null;
+    if (retained.tempLayoutDir) {
+      void cleanupTempLayoutDir(retained.tempLayoutDir);
+    }
     if (options.kill) {
       retained.process.kill();
     }
@@ -302,6 +306,7 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
 
       const args = ["--session", options.name];
       let tempLayoutDir: string | undefined;
+      let retainedRegistered = false;
       try {
         if (options.cmd) {
           tempLayoutDir = await mkdtemp(join(tmpdir(), "matrix-zellij-layout-"));
@@ -326,8 +331,10 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
           process: pty,
           startedAtMs: nowMs(),
           exitDisposable: null,
+          ...(tempLayoutDir ? { tempLayoutDir } : {}),
         };
         retainedCreatePtys.set(options.name, retained);
+        retainedRegistered = true;
         const exitDisposable = pty.onExit((event) => {
           startup.exited = event;
           releaseRetainedCreatePty(options.name);
@@ -349,7 +356,7 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
         }
         throw safeZellijError(err);
       } finally {
-        if (tempLayoutDir) {
+        if (tempLayoutDir && !retainedRegistered) {
           await cleanupTempLayoutDir(tempLayoutDir);
         }
       }

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -1,7 +1,10 @@
 import {
   execFile as nodeExecFile,
 } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { shellError, type ShellSafeError } from "./errors.js";
 
 type ExecFile = typeof nodeExecFile;
@@ -200,6 +203,14 @@ function isNoActiveSessionsFailure(err: unknown): boolean {
   return typeof stderr === "string" && /no active zellij sessions found/i.test(stderr);
 }
 
+async function cleanupTempLayoutDir(path: string): Promise<void> {
+  try {
+    await rm(path, { recursive: true, force: true });
+  } catch (err: unknown) {
+    console.warn("[shell] failed to remove zellij temp layout:", err instanceof Error ? err.message : String(err));
+  }
+}
+
 export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter {
   const execFile = deps.execFile ?? nodeExecFile;
   const timeoutMs = deps.timeoutMs ?? 10_000;
@@ -290,13 +301,18 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
       releaseRetainedCreatePty(options.name, { kill: true });
 
       const args = ["--session", options.name];
-      if (options.cmd) {
-        args.push("--layout-string", initialCommandLayout(options.cmd, options.cwd));
-      } else if (options.layout) {
-        args.push("--layout", options.layout);
-      }
-      let pty: ShellAttachProcess;
+      let tempLayoutDir: string | undefined;
       try {
+        if (options.cmd) {
+          tempLayoutDir = await mkdtemp(join(tmpdir(), "matrix-zellij-layout-"));
+          const layoutPath = join(tempLayoutDir, "layout.kdl");
+          await writeFile(layoutPath, initialCommandLayout(options.cmd, options.cwd), { mode: 0o600 });
+          args.push("--new-session-with-layout", layoutPath);
+        } else if (options.layout) {
+          args.push("--layout", options.layout);
+        }
+
+        let pty: ShellAttachProcess;
         pty = spawnPty("zellij", args, {
           name: "xterm-256color",
           cols: 120,
@@ -304,30 +320,38 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
           cwd: options.cwd ?? cwd,
           env: attachEnv(deps.env),
         });
-      } catch (err: unknown) {
-        throw safeZellijError(err);
-      }
-      const startup = { exited: null as PtyExitEvent | null };
-      const retained: RetainedCreatePty = {
-        process: pty,
-        startedAtMs: nowMs(),
-        exitDisposable: null,
-      };
-      retainedCreatePtys.set(options.name, retained);
-      const exitDisposable = pty.onExit((event) => {
-        startup.exited = event;
-        releaseRetainedCreatePty(options.name);
-      });
-      retained.exitDisposable = exitDisposable;
 
-      await delay(startupDelayMs);
-      if (startup.exited) {
-        releaseRetainedCreatePty(options.name);
-        const err = Object.assign(new Error("zellij exited during startup"), {
-          code: startup.exited.exitCode,
-          signal: startup.exited.signal == null ? undefined : String(startup.exited.signal),
+        const startup = { exited: null as PtyExitEvent | null };
+        const retained: RetainedCreatePty = {
+          process: pty,
+          startedAtMs: nowMs(),
+          exitDisposable: null,
+        };
+        retainedCreatePtys.set(options.name, retained);
+        const exitDisposable = pty.onExit((event) => {
+          startup.exited = event;
+          releaseRetainedCreatePty(options.name);
         });
+        retained.exitDisposable = exitDisposable;
+
+        await delay(startupDelayMs);
+        if (startup.exited) {
+          releaseRetainedCreatePty(options.name);
+          const err = Object.assign(new Error("zellij exited during startup"), {
+            code: startup.exited.exitCode,
+            signal: startup.exited.signal == null ? undefined : String(startup.exited.signal),
+          });
+          throw safeZellijError(err);
+        }
+      } catch (err: unknown) {
+        if (err instanceof Error && "code" in err && (err as { code?: unknown }).code === "zellij_failed") {
+          throw err;
+        }
         throw safeZellijError(err);
+      } finally {
+        if (tempLayoutDir) {
+          await cleanupTempLayoutDir(tempLayoutDir);
+        }
       }
     },
     async deleteSession(name, options = {}) {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -288,7 +288,13 @@ describe("zellij adapter", () => {
     expect(layoutText).toContain('command="node"');
     expect(layoutText).toContain('args "-e"');
     expect(layoutText).toContain("MATRIX_BENCH_READY");
-    expect(layoutPath && existsSync(layoutPath)).toBe(false);
+    expect(layoutPath).toEqual(expect.any(String));
+    expect(existsSync(layoutPath!)).toBe(true);
+
+    pty.emitExit(0);
+    await vi.waitFor(() => {
+      expect(existsSync(layoutPath!)).toBe(false);
+    });
   });
 
   it("rejects session creation when the retained PTY exits during startup", async () => {

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   classifyZellijFailure,
@@ -260,7 +261,13 @@ describe("zellij adapter", () => {
 
   it("creates command sessions with the command as the initial focused pane", async () => {
     const pty = ptyProcess();
-    const spawnPty = vi.fn(() => pty);
+    let layoutPath: string | undefined;
+    let layoutText = "";
+    const spawnPty = vi.fn((_command, args) => {
+      layoutPath = String(args[3]);
+      layoutText = readFileSync(layoutPath, "utf8");
+      return pty;
+    });
     const adapter = createZellijAdapter({ execFile: vi.fn(), spawnPty, timeoutMs: 25, startupDelayMs: 1 });
 
     await adapter.createSession({
@@ -274,12 +281,14 @@ describe("zellij adapter", () => {
     expect(args).toEqual([
       "--session",
       "bench",
-      "--layout-string",
-      expect.stringContaining('command="node"'),
+      "--new-session-with-layout",
+      expect.stringMatching(/matrix-zellij-layout-/),
     ]);
-    expect(String(args?.[3])).toContain('cwd="/home/alice/work"');
-    expect(String(args?.[3])).toContain('args "-e"');
-    expect(String(args?.[3])).toContain("MATRIX_BENCH_READY");
+    expect(layoutText).toContain('cwd="/home/alice/work"');
+    expect(layoutText).toContain('command="node"');
+    expect(layoutText).toContain('args "-e"');
+    expect(layoutText).toContain("MATRIX_BENCH_READY");
+    expect(layoutPath && existsSync(layoutPath)).toBe(false);
   });
 
   it("rejects session creation when the retained PTY exits during startup", async () => {


### PR DESCRIPTION
## Summary
- Fix zellij command-session startup by writing the generated KDL to a temp layout file and launching with `--new-session-with-layout`
- Keep the generated layout as the initial focused pane for `matrix run -it -- <command>`
- Add a regression test that captures the generated layout and proves the temp file is cleaned up

## Root Cause
`matrix run -it -- ls` creates a shell session with `cmd`, which made the gateway launch `zellij --session <name> --layout-string <kdl>`. Zellij treats `--layout-string` with `--session` as applying a layout to an existing active session; when the session does not exist yet it exits with `There is no active session!`, which the gateway returns as `zellij_failed`.

## Invariants
- Source of truth: zellij remains the live shell runtime; `~/system/shell-sessions.json` remains metadata only.
- Lock/transaction scope: session metadata writes still occur after zellij startup inside the existing registry mutation lock; no network calls are added.
- Acceptable orphan states: if metadata persistence fails after zellij starts, existing rollback still force-deletes the zellij session; temp layout files are removed in `finally`.
- Auth source of truth: unchanged; terminal session routes continue to use existing gateway auth.
- Deferred scope: this does not add non-interactive exit-status support for `matrix run` and does not change attach/WebSocket behavior.

## Verification
- `pnpm exec vitest run tests/gateway/shell-zellij.test.ts`
- `pnpm exec vitest run tests/cli/run.test.ts`
- `pnpm exec vitest run tests/gateway/shell-zellij.test.ts tests/cli/run.test.ts`
- `pnpm exec tsc --noEmit --project packages/gateway/tsconfig.json`
- `bun run check:patterns`
- `git diff --check`