### PR TITLE
fix(cli): harden port forwarding tunnel

### DIFF
--- a/packages/gateway/src/forward-ws.ts
+++ b/packages/gateway/src/forward-ws.ts
@@ -5,6 +5,10 @@ export const FORWARD_WS_MAX_CONTROL_BYTES = 2048;
 export const FORWARD_WS_MAX_FRAME_BYTES = 64 * 1024;
 export const FORWARD_WS_IDLE_TIMEOUT_MS = 60_000;
 export const FORWARD_WS_MAX_CONNECTIONS = 100;
+const FORWARD_WS_MAX_PENDING_SOCKET_WRITE_BYTES = 256 * 1024;
+const FORWARD_WS_BUFFER_HIGH_WATER_BYTES = 256 * 1024;
+const FORWARD_WS_BUFFER_LOW_WATER_BYTES = 128 * 1024;
+const FORWARD_WS_BACKPRESSURE_POLL_MS = 10;
 
 const ForwardPortSchema = z.number().int().min(1).max(65_535);
 const LoopbackHostSchema = z.union([
@@ -33,6 +37,7 @@ export interface ForwardDialer {
 }
 
 interface ForwardWs {
+  bufferedAmount?: number;
   send(data: string | ArrayBuffer | Uint8Array<ArrayBuffer>): void;
   close(): void;
 }
@@ -44,7 +49,15 @@ interface ForwardWsMessageEvent {
 interface ForwardConnectionState {
   socket: Socket;
   ws: ForwardWs;
+  socketWriter: { write(chunk: Buffer): void; close(): void };
+  wsBackpressure: { afterSend(): void; close(): void };
   opened: boolean;
+  closed: boolean;
+  idleTimer: ReturnType<typeof setTimeout>;
+}
+
+interface PendingForwardConnectionState {
+  ws: ForwardWs;
   closed: boolean;
   idleTimer: ReturnType<typeof setTimeout>;
 }
@@ -136,6 +149,120 @@ function defaultDialer(target: ForwardTarget): Socket {
   return connect({ host: target.host, port: target.port });
 }
 
+function createBoundedSocketWriter(
+  socket: Socket,
+  maxPendingBytes: number,
+  onOverflow: () => void,
+): { write(chunk: Buffer): void; close(): void } {
+  const pending: Buffer[] = [];
+  let pendingBytes = 0;
+  let waitingDrain = false;
+  let closed = false;
+
+  const enqueue = (chunk: Buffer) => {
+    pendingBytes += chunk.byteLength;
+    if (pendingBytes > maxPendingBytes) {
+      onOverflow();
+      return;
+    }
+    pending.push(Buffer.from(chunk));
+  };
+
+  const flush = () => {
+    if (closed) {
+      return;
+    }
+    waitingDrain = false;
+    while (pending.length > 0) {
+      const next = pending.shift()!;
+      pendingBytes -= next.byteLength;
+      if (!socket.write(next)) {
+        waitingDrain = true;
+        return;
+      }
+    }
+  };
+
+  socket.on("drain", flush);
+
+  return {
+    write(chunk: Buffer) {
+      if (closed || socket.destroyed) {
+        return;
+      }
+      if (waitingDrain || pending.length > 0) {
+        enqueue(chunk);
+        return;
+      }
+      if (!socket.write(chunk)) {
+        waitingDrain = true;
+      }
+    },
+    close() {
+      closed = true;
+      pending.splice(0);
+      pendingBytes = 0;
+      socket.off("drain", flush);
+    },
+  };
+}
+
+function createWsBackpressureMonitor(
+  source: Socket,
+  ws: ForwardWs,
+): { afterSend(): void; close(): void } {
+  let closed = false;
+  let paused = false;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const bufferedBytes = () => typeof ws.bufferedAmount === "number" ? ws.bufferedAmount : 0;
+
+  const clearPoll = () => {
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  };
+
+  const schedulePoll = () => {
+    if (closed || pollTimer) {
+      return;
+    }
+    pollTimer = setTimeout(() => {
+      pollTimer = null;
+      if (closed) {
+        return;
+      }
+      if (bufferedBytes() <= FORWARD_WS_BUFFER_LOW_WATER_BYTES) {
+        if (paused && !source.destroyed) {
+          source.resume();
+        }
+        paused = false;
+        return;
+      }
+      schedulePoll();
+    }, FORWARD_WS_BACKPRESSURE_POLL_MS);
+    pollTimer.unref?.();
+  };
+
+  return {
+    afterSend() {
+      if (closed || bufferedBytes() <= FORWARD_WS_BUFFER_HIGH_WATER_BYTES) {
+        return;
+      }
+      if (!source.isPaused()) {
+        source.pause();
+        paused = true;
+      }
+      schedulePoll();
+    },
+    close() {
+      closed = true;
+      clearPoll();
+    },
+  };
+}
+
 export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): ForwardTunnelHub {
   const dial = options.dial ?? defaultDialer;
   const maxConnections = options.maxConnections ?? FORWARD_WS_MAX_CONNECTIONS;
@@ -143,9 +270,25 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
   const maxControlBytes = options.maxControlBytes ?? FORWARD_WS_MAX_CONTROL_BYTES;
   const idleTimeoutMs = options.idleTimeoutMs ?? FORWARD_WS_IDLE_TIMEOUT_MS;
   const active = new Set<ForwardConnectionState>();
+  const pending = new Set<PendingForwardConnectionState>();
 
   function createHandler() {
     let state: ForwardConnectionState | null = null;
+    let pendingState: PendingForwardConnectionState | null = null;
+
+    const cleanupPending = (close = true) => {
+      const current = pendingState;
+      if (!current || current.closed) {
+        return;
+      }
+      current.closed = true;
+      clearTimeout(current.idleTimer);
+      pending.delete(current);
+      pendingState = null;
+      if (close) {
+        closeWs(current.ws);
+      }
+    };
 
     const cleanup = () => {
       const current = state;
@@ -155,14 +298,31 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
       current.closed = true;
       clearTimeout(current.idleTimer);
       active.delete(current);
+      current.socketWriter.close();
+      current.wsBackpressure.close();
       current.socket.removeAllListeners();
       current.socket.destroy();
       closeWs(current.ws);
       state = null;
     };
 
+    const touchPending = () => {
+      if (!pendingState || pendingState.closed) {
+        return;
+      }
+      clearTimeout(pendingState.idleTimer);
+      pendingState.idleTimer = setTimeout(() => {
+        if (pendingState && !pendingState.closed) {
+          sendError(pendingState.ws, "idle_timeout");
+        }
+        cleanupPending();
+      }, idleTimeoutMs);
+      pendingState.idleTimer.unref?.();
+    };
+
     const touch = () => {
       if (!state) {
+        touchPending();
         return;
       }
       clearTimeout(state.idleTimer);
@@ -176,9 +336,15 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
     };
 
     const fail = (ws: ForwardWs, code: string) => {
+      const hadOpenState = state !== null;
+      const hadPendingState = pendingState !== null;
       sendError(ws, code);
       cleanup();
-      if (!state) {
+      if (hadPendingState) {
+        cleanupPending();
+        return;
+      }
+      if (!hadOpenState) {
         closeWs(ws);
       }
     };
@@ -188,9 +354,14 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
         fail(ws, "invalid_request");
         return;
       }
-      if (active.size >= maxConnections) {
+      const pendingReservation = pendingState ? 1 : 0;
+      if (active.size + pending.size - pendingReservation >= maxConnections) {
         sendError(ws, "connection_limit");
-        closeWs(ws);
+        if (pendingState) {
+          cleanupPending();
+        } else {
+          closeWs(ws);
+        }
         return;
       }
 
@@ -202,7 +373,11 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
           ? (err as { code: string }).code
           : "invalid_request";
         sendError(ws, code);
-        closeWs(ws);
+        if (pendingState) {
+          cleanupPending();
+        } else {
+          closeWs(ws);
+        }
         return;
       }
 
@@ -212,12 +387,25 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
       } catch (err: unknown) {
         console.warn("[forward/ws] loopback dial failed:", err instanceof Error ? err.message : String(err));
         sendError(ws, "dial_failed");
-        closeWs(ws);
+        if (pendingState) {
+          cleanupPending();
+        } else {
+          closeWs(ws);
+        }
         return;
       }
+      cleanupPending(false);
+      let cleanupConnection = () => {};
+      const socketWriter = createBoundedSocketWriter(socket, FORWARD_WS_MAX_PENDING_SOCKET_WRITE_BYTES, () => {
+        sendError(ws, "buffer_overflow");
+        cleanupConnection();
+      });
+      const wsBackpressure = createWsBackpressureMonitor(socket, ws);
       state = {
         socket,
         ws,
+        socketWriter,
+        wsBackpressure,
         opened: false,
         closed: false,
         idleTimer: setTimeout(() => {
@@ -244,6 +432,7 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
         for (let offset = 0; offset < chunk.byteLength; offset += maxFrameBytes) {
           try {
             ws.send(uint8ArrayFromBuffer(Buffer.from(chunk.subarray(offset, offset + maxFrameBytes))));
+            state.wsBackpressure.afterSend();
           } catch (err: unknown) {
             if (err instanceof Error) {
               console.warn("[forward/ws] send failed:", err.message);
@@ -253,6 +442,7 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
           }
         }
       });
+      cleanupConnection = cleanup;
       socket.on("end", () => {
         sendJson(ws, { type: "end" });
         cleanup();
@@ -267,10 +457,26 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
 
     return {
       onOpen(_evt: unknown, ws: ForwardWs) {
-        if (active.size >= maxConnections) {
+        if (state || pendingState) {
+          return;
+        }
+        if (active.size + pending.size >= maxConnections) {
           sendError(ws, "connection_limit");
           closeWs(ws);
+          return;
         }
+        pendingState = {
+          ws,
+          closed: false,
+          idleTimer: setTimeout(() => {
+            if (pendingState && !pendingState.closed) {
+              sendError(ws, "idle_timeout");
+            }
+            cleanupPending();
+          }, idleTimeoutMs),
+        };
+        pendingState.idleTimer.unref?.();
+        pending.add(pendingState);
       },
       onMessage(evt: ForwardWsMessageEvent, ws: ForwardWs) {
         if (isBinaryMessage(evt.data)) {
@@ -284,7 +490,7 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
             return;
           }
           touch();
-          state.socket.write(chunk);
+          state.socketWriter.write(chunk);
           return;
         }
 
@@ -327,19 +533,40 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
           return;
         }
         sendJson(ws, { type: result.data.type });
-        cleanup();
+        if (state) {
+          cleanup();
+        } else {
+          cleanupPending();
+        }
       },
-      onClose: cleanup,
-      onError: cleanup,
+      onClose() {
+        cleanup();
+        cleanupPending(false);
+      },
+      onError() {
+        cleanup();
+        cleanupPending(false);
+      },
     };
   }
 
   return {
     createHandler,
     async close() {
+      for (const connection of Array.from(pending)) {
+        sendJson(connection.ws, { type: "close" });
+        clearTimeout(connection.idleTimer);
+        connection.closed = true;
+        closeWs(connection.ws);
+        pending.delete(connection);
+      }
       for (const connection of Array.from(active)) {
         sendJson(connection.ws, { type: "close" });
         clearTimeout(connection.idleTimer);
+        connection.closed = true;
+        connection.socketWriter.close();
+        connection.wsBackpressure.close();
+        connection.socket.removeAllListeners();
         connection.socket.destroy();
         closeWs(connection.ws);
         active.delete(connection);

--- a/packages/gateway/src/forward-ws.ts
+++ b/packages/gateway/src/forward-ws.ts
@@ -278,7 +278,12 @@ export function createForwardTunnelHub(options: ForwardTunnelHubOptions = {}): F
 
     const cleanupPending = (close = true) => {
       const current = pendingState;
-      if (!current || current.closed) {
+      if (!current) {
+        return;
+      }
+      if (current.closed) {
+        pending.delete(current);
+        pendingState = null;
         return;
       }
       current.closed = true;

--- a/packages/gateway/src/forward-ws.ts
+++ b/packages/gateway/src/forward-ws.ts
@@ -160,12 +160,12 @@ function createBoundedSocketWriter(
   let closed = false;
 
   const enqueue = (chunk: Buffer) => {
-    pendingBytes += chunk.byteLength;
-    if (pendingBytes > maxPendingBytes) {
+    if (pendingBytes + chunk.byteLength > maxPendingBytes) {
       onOverflow();
       return;
     }
     pending.push(Buffer.from(chunk));
+    pendingBytes += chunk.byteLength;
   };
 
   const flush = () => {

--- a/packages/sync-client/src/cli/port-forward.ts
+++ b/packages/sync-client/src/cli/port-forward.ts
@@ -148,12 +148,12 @@ function createBoundedSocketWriter(
   let closed = false;
 
   const enqueue = (chunk: Buffer) => {
-    pendingBytes += chunk.byteLength;
-    if (pendingBytes > maxPendingBytes) {
+    if (pendingBytes + chunk.byteLength > maxPendingBytes) {
       onOverflow();
       return;
     }
     pending.push(Buffer.from(chunk));
+    pendingBytes += chunk.byteLength;
   };
 
   const flush = () => {
@@ -279,6 +279,7 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
     socketWriter: BoundedSocketWriter;
     wsBackpressure: WsBackpressureMonitor;
     idleTimer: ReturnType<typeof setTimeout>;
+    close(): void;
   }>();
   const server = createServer((tcp) => {
     if (active.size >= maxConnections) {
@@ -308,6 +309,7 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
       ws,
       socketWriter,
       wsBackpressure,
+      close: () => cleanupConnection(),
       idleTimer: setTimeout(() => {
         options.onEvent?.("connection_idle_timeout", eventData(connectionId, "idle_timeout"));
         cleanup();
@@ -484,18 +486,7 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
 
   const closeServer = async () => {
     for (const state of Array.from(active)) {
-      clearTimeout(state.idleTimer);
-      state.socketWriter.close();
-      state.wsBackpressure.close();
-      state.tcp.destroy();
-      try {
-        state.ws.close();
-      } catch (err: unknown) {
-        if (err instanceof Error) {
-          options.onEvent?.("connection_error", eventData(undefined, "close_failed"));
-        }
-      }
-      active.delete(state);
+      state.close();
     }
     await new Promise<void>((resolve, reject) => {
       if (!server.listening) {

--- a/packages/sync-client/src/cli/port-forward.ts
+++ b/packages/sync-client/src/cli/port-forward.ts
@@ -251,6 +251,9 @@ function createWsBackpressureMonitor(
   };
 }
 
+type BoundedSocketWriter = ReturnType<typeof createBoundedSocketWriter>;
+type WsBackpressureMonitor = ReturnType<typeof createWsBackpressureMonitor>;
+
 export async function startPortForward(options: StartPortForwardOptions): Promise<PortForwardHandle> {
   const maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
   const maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
@@ -273,6 +276,8 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
   const active = new Set<{
     tcp: Socket;
     ws: ForwardWebSocket;
+    socketWriter: BoundedSocketWriter;
+    wsBackpressure: WsBackpressureMonitor;
     idleTimer: ReturnType<typeof setTimeout>;
   }>();
   const server = createServer((tcp) => {
@@ -301,6 +306,8 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
     const state = {
       tcp,
       ws,
+      socketWriter,
+      wsBackpressure,
       idleTimer: setTimeout(() => {
         options.onEvent?.("connection_idle_timeout", eventData(connectionId, "idle_timeout"));
         cleanup();
@@ -329,8 +336,8 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
       tcp.off("data", onTcpData);
       tcp.off("close", cleanup);
       tcp.off("error", onTcpError);
-      socketWriter.close();
-      wsBackpressure.close();
+      state.socketWriter.close();
+      state.wsBackpressure.close();
       ws.off?.("open", onWsOpen);
       ws.off?.("message", onWsMessage);
       ws.off?.("close", cleanup);
@@ -478,6 +485,8 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
   const closeServer = async () => {
     for (const state of Array.from(active)) {
       clearTimeout(state.idleTimer);
+      state.socketWriter.close();
+      state.wsBackpressure.close();
       state.tcp.destroy();
       try {
         state.ws.close();

--- a/packages/sync-client/src/cli/port-forward.ts
+++ b/packages/sync-client/src/cli/port-forward.ts
@@ -26,6 +26,7 @@ export interface PortForwardHandle extends ForwardSpec {
 
 interface ForwardWebSocket {
   readyState: number;
+  bufferedAmount?: number;
   binaryType?: string;
   send(data: string | Buffer): void;
   close(): void;
@@ -48,6 +49,10 @@ const DEFAULT_MAX_CONNECTIONS = 32;
 const DEFAULT_MAX_FRAME_BYTES = 64 * 1024;
 const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
 const MAX_PENDING_TCP_BYTES = 256 * 1024;
+const MAX_PENDING_SOCKET_WRITE_BYTES = 256 * 1024;
+const WS_BUFFER_HIGH_WATER_BYTES = 256 * 1024;
+const WS_BUFFER_LOW_WATER_BYTES = 128 * 1024;
+const WS_BACKPRESSURE_POLL_MS = 10;
 
 function invalidForwardSpec(): Error & { code: string } {
   return Object.assign(new Error("Request failed"), { code: "invalid_forward_spec" });
@@ -126,6 +131,126 @@ function bufferFromWsMessage(data: unknown): Buffer {
   return Buffer.from(String(data));
 }
 
+function* splitBuffer(buffer: Buffer, maxBytes: number): Generator<Buffer> {
+  for (let offset = 0; offset < buffer.byteLength; offset += maxBytes) {
+    yield Buffer.from(buffer.subarray(offset, offset + maxBytes));
+  }
+}
+
+function createBoundedSocketWriter(
+  socket: Socket,
+  maxPendingBytes: number,
+  onOverflow: () => void,
+): { write(chunk: Buffer): void; close(): void } {
+  const pending: Buffer[] = [];
+  let pendingBytes = 0;
+  let waitingDrain = false;
+  let closed = false;
+
+  const enqueue = (chunk: Buffer) => {
+    pendingBytes += chunk.byteLength;
+    if (pendingBytes > maxPendingBytes) {
+      onOverflow();
+      return;
+    }
+    pending.push(Buffer.from(chunk));
+  };
+
+  const flush = () => {
+    if (closed) {
+      return;
+    }
+    waitingDrain = false;
+    while (pending.length > 0) {
+      const next = pending.shift()!;
+      pendingBytes -= next.byteLength;
+      if (!socket.write(next)) {
+        waitingDrain = true;
+        return;
+      }
+    }
+  };
+
+  socket.on("drain", flush);
+
+  return {
+    write(chunk: Buffer) {
+      if (closed || socket.destroyed) {
+        return;
+      }
+      if (waitingDrain || pending.length > 0) {
+        enqueue(chunk);
+        return;
+      }
+      if (!socket.write(chunk)) {
+        waitingDrain = true;
+      }
+    },
+    close() {
+      closed = true;
+      pending.splice(0);
+      pendingBytes = 0;
+      socket.off("drain", flush);
+    },
+  };
+}
+
+function createWsBackpressureMonitor(
+  source: Socket,
+  ws: ForwardWebSocket,
+): { afterSend(): void; close(): void } {
+  let closed = false;
+  let paused = false;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const bufferedBytes = () => typeof ws.bufferedAmount === "number" ? ws.bufferedAmount : 0;
+
+  const clearPoll = () => {
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  };
+
+  const schedulePoll = () => {
+    if (closed || pollTimer) {
+      return;
+    }
+    pollTimer = setTimeout(() => {
+      pollTimer = null;
+      if (closed) {
+        return;
+      }
+      if (bufferedBytes() <= WS_BUFFER_LOW_WATER_BYTES) {
+        if (paused && !source.destroyed) {
+          source.resume();
+        }
+        paused = false;
+        return;
+      }
+      schedulePoll();
+    }, WS_BACKPRESSURE_POLL_MS);
+    pollTimer.unref?.();
+  };
+
+  return {
+    afterSend() {
+      if (closed || bufferedBytes() <= WS_BUFFER_HIGH_WATER_BYTES) {
+        return;
+      }
+      if (!source.isPaused()) {
+        source.pause();
+        paused = true;
+      }
+      schedulePoll();
+    },
+    close() {
+      closed = true;
+      clearPoll();
+    },
+  };
+}
+
 export async function startPortForward(options: StartPortForwardOptions): Promise<PortForwardHandle> {
   const maxConnections = options.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
   const maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
@@ -134,9 +259,10 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
   if (!WebSocketImpl) {
     throw Object.assign(new Error("Request failed"), { code: "websocket_unavailable" });
   }
+  let resolvedLocalPort = options.localPort;
   const eventData = (connectionId?: number, code?: string): PortForwardEventData => ({
     localHost: options.localHost,
-    localPort: options.localPort,
+    localPort: resolvedLocalPort,
     remoteHost: options.remoteHost,
     remotePort: options.remotePort,
     connectionId,
@@ -166,6 +292,12 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
     let remoteReady = false;
     let pendingTcpBytes = 0;
     const pendingTcpChunks: Buffer[] = [];
+    let cleanupConnection = () => {};
+    const socketWriter = createBoundedSocketWriter(tcp, MAX_PENDING_SOCKET_WRITE_BYTES, () => {
+      options.onEvent?.("connection_error", eventData(connectionId, "buffer_overflow"));
+      cleanupConnection();
+    });
+    const wsBackpressure = createWsBackpressureMonitor(tcp, ws);
     const state = {
       tcp,
       ws,
@@ -197,6 +329,8 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
       tcp.off("data", onTcpData);
       tcp.off("close", cleanup);
       tcp.off("error", onTcpError);
+      socketWriter.close();
+      wsBackpressure.close();
       ws.off?.("open", onWsOpen);
       ws.off?.("message", onWsMessage);
       ws.off?.("close", cleanup);
@@ -213,31 +347,38 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
       }
       options.onEvent?.("connection_close", eventData(connectionId));
     };
+    cleanupConnection = cleanup;
 
-    const onTcpData = (chunk: Buffer) => {
-      touch();
-      if (chunk.byteLength > maxFrameBytes) {
-        options.onEvent?.("connection_error", eventData(connectionId, "frame_too_large"));
-        cleanup();
-        return;
-      }
-      if (!remoteReady) {
-        pendingTcpBytes += chunk.byteLength;
-        if (pendingTcpBytes > MAX_PENDING_TCP_BYTES) {
-          options.onEvent?.("connection_error", eventData(connectionId, "buffer_overflow"));
-          cleanup();
-          return;
-        }
-        pendingTcpChunks.push(Buffer.from(chunk));
-        return;
-      }
+    const sendWsFrame = (chunk: Buffer): boolean => {
       try {
         ws.send(Buffer.from(chunk));
+        wsBackpressure.afterSend();
+        return true;
       } catch (err: unknown) {
         if (err instanceof Error) {
           options.onEvent?.("connection_error", eventData(connectionId, "send_failed"));
         }
         cleanup();
+        return false;
+      }
+    };
+
+    const onTcpData = (chunk: Buffer) => {
+      touch();
+      for (const frame of splitBuffer(chunk, maxFrameBytes)) {
+        if (!remoteReady) {
+          pendingTcpBytes += frame.byteLength;
+          if (pendingTcpBytes > MAX_PENDING_TCP_BYTES) {
+            options.onEvent?.("connection_error", eventData(connectionId, "buffer_overflow"));
+            cleanup();
+            return;
+          }
+          pendingTcpChunks.push(frame);
+          continue;
+        }
+        if (!sendWsFrame(frame)) {
+          return;
+        }
       }
     };
 
@@ -270,7 +411,7 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
           cleanup();
           return;
         }
-        tcp.write(chunk);
+        socketWriter.write(chunk);
         return;
       }
       let parsed: unknown;
@@ -287,16 +428,10 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
         const type = (parsed as { type?: unknown }).type;
         if (type === "ready") {
           remoteReady = true;
-          try {
-            for (const pendingChunk of pendingTcpChunks.splice(0)) {
-              ws.send(pendingChunk);
+          for (const pendingChunk of pendingTcpChunks.splice(0)) {
+            if (!sendWsFrame(pendingChunk)) {
+              return;
             }
-          } catch (err: unknown) {
-            if (err instanceof Error) {
-              options.onEvent?.("connection_error", eventData(connectionId, "send_failed"));
-            }
-            cleanup();
-            return;
           }
           pendingTcpBytes = 0;
           return;
@@ -331,7 +466,7 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
     server.listen(options.localPort, options.localHost, () => {
       server.off("error", reject);
       const address = server.address() as AddressInfo;
-      options.localPort = address.port;
+      resolvedLocalPort = address.port;
       options.onEvent?.("ready", eventData());
       resolve();
     });
@@ -371,7 +506,7 @@ export async function startPortForward(options: StartPortForwardOptions): Promis
   await ready;
   return {
     localHost: options.localHost,
-    localPort: options.localPort,
+    localPort: resolvedLocalPort,
     remoteHost: options.remoteHost,
     remotePort: options.remotePort,
     ready,

--- a/tests/cli/port-forward.test.ts
+++ b/tests/cli/port-forward.test.ts
@@ -241,6 +241,7 @@ describe("matrix port forward", () => {
     await handle.close();
     expect(events).toContain("ready");
     expect(events).toContain("connection_open");
+    expect(events).toContain("connection_close");
   });
 
   it("splits pending local TCP bytes into bounded websocket frames without mutating options", async () => {

--- a/tests/cli/port-forward.test.ts
+++ b/tests/cli/port-forward.test.ts
@@ -243,6 +243,64 @@ describe("matrix port forward", () => {
     expect(events).toContain("connection_open");
   });
 
+  it("splits pending local TCP bytes into bounded websocket frames without mutating options", async () => {
+    class DelayedReadyWebSocket extends EventEmitter {
+      static instances: DelayedReadyWebSocket[] = [];
+      sent: unknown[] = [];
+      readyState = 1;
+
+      constructor() {
+        super();
+        DelayedReadyWebSocket.instances.push(this);
+        queueMicrotask(() => this.emit("open"));
+      }
+
+      send(data: unknown) {
+        this.sent.push(typeof data === "string" ? JSON.parse(data) : Buffer.from(data as Buffer));
+      }
+
+      close() {
+        this.emit("close");
+      }
+    }
+
+    const options = {
+      gatewayUrl: "http://gateway",
+      token: "tok",
+      localHost: "127.0.0.1" as const,
+      localPort: 0,
+      remoteHost: "127.0.0.1" as const,
+      remotePort: 3000,
+      maxFrameBytes: 4,
+      WebSocketImpl: DelayedReadyWebSocket as never,
+    };
+    const handle = await startPortForward(options);
+    await handle.ready;
+
+    expect(options.localPort).toBe(0);
+    expect(handle.localPort).toBeGreaterThan(0);
+
+    const client = await new Promise<Socket>((resolve) => {
+      const socket = createConnection(handle.localPort, "127.0.0.1", () => resolve(socket));
+    });
+    const payload = Buffer.from("abcdefghijk");
+    client.write(payload);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const ws = DelayedReadyWebSocket.instances[0]!;
+    expect(ws.sent).toEqual([{ type: "open", host: "127.0.0.1", port: 3000 }]);
+
+    ws.emit("message", JSON.stringify({ type: "ready" }), false);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const binaryFrames = ws.sent.slice(1) as Buffer[];
+    expect(binaryFrames.map((frame) => frame.byteLength)).toEqual([4, 4, 3]);
+    expect(Buffer.concat(binaryFrames)).toEqual(payload);
+
+    client.destroy();
+    await handle.close();
+  });
+
   it("enforces concurrent connection caps", async () => {
     class HangingWebSocket extends EventEmitter {
       static instances: HangingWebSocket[] = [];

--- a/tests/gateway/forward-ws.test.ts
+++ b/tests/gateway/forward-ws.test.ts
@@ -10,12 +10,14 @@ import {
 class FakeGatewayWebSocket {
   sent: unknown[] = [];
   closed = false;
+  closeCount = 0;
 
   send(data: unknown) {
     this.sent.push(data);
   }
 
   close() {
+    this.closeCount += 1;
     this.closed = true;
   }
 }
@@ -23,6 +25,7 @@ class FakeGatewayWebSocket {
 class FakeDuplexSocket {
   private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
   writes: Buffer[] = [];
+  writeResults: boolean[] = [];
   destroyed = false;
 
   on(event: string, handler: (...args: unknown[]) => void) {
@@ -58,7 +61,7 @@ class FakeDuplexSocket {
 
   write(chunk: Buffer) {
     this.writes.push(Buffer.from(chunk));
-    return true;
+    return this.writeResults.shift() ?? true;
   }
 
   destroy() {
@@ -111,6 +114,45 @@ describe("forward websocket protocol", () => {
     expect(ws.closed).toBe(true);
   });
 
+  it("counts pre-open websocket connections against the cap and times them out", async () => {
+    const hub = createForwardTunnelHub({ maxConnections: 1, idleTimeoutMs: 5 });
+    const firstWs = new FakeGatewayWebSocket();
+    const secondWs = new FakeGatewayWebSocket();
+    const first = hub.createHandler();
+    const second = hub.createHandler();
+
+    first.onOpen?.({} as never, firstWs as never);
+    second.onOpen?.({} as never, secondWs as never);
+
+    expect(JSON.parse(String(secondWs.sent[0]))).toEqual({
+      type: "error",
+      code: "connection_limit",
+      message: "Request failed",
+    });
+    expect(secondWs.closed).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(JSON.parse(String(firstWs.sent[0]))).toEqual({
+      type: "error",
+      code: "idle_timeout",
+      message: "Request failed",
+    });
+    expect(firstWs.closed).toBe(true);
+  });
+
+  it("closes pre-open websocket close frames", () => {
+    const hub = createForwardTunnelHub();
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, ws as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "close" }) } as never, ws as never);
+
+    expect(JSON.parse(String(ws.sent[0]))).toEqual({ type: "close" });
+    expect(ws.closeCount).toBe(1);
+  });
+
   it("bridges bytes in both directions after ready", () => {
     const socket = new FakeDuplexSocket();
     const dial: ForwardDialer = vi.fn(() => socket as never);
@@ -148,6 +190,57 @@ describe("forward websocket protocol", () => {
     });
     expect(socket.destroyed).toBe(true);
     expect(ws.closed).toBe(true);
+  });
+
+  it("closes active websocket failures once", () => {
+    const socket = new FakeDuplexSocket();
+    const hub = createForwardTunnelHub({ dial: () => socket as never });
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, ws as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3000 }) } as never, ws as never);
+    socket.emit("connect");
+    handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3000 }) } as never, ws as never);
+
+    expect(ws.closeCount).toBe(1);
+  });
+
+  it("queues websocket binary writes until the loopback socket drains", () => {
+    const socket = new FakeDuplexSocket();
+    socket.writeResults = [false, true];
+    const hub = createForwardTunnelHub({ dial: () => socket as never });
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, ws as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3000 }) } as never, ws as never);
+    socket.emit("connect");
+    handler.onMessage?.({ data: Buffer.from("first") } as never, ws as never);
+    handler.onMessage?.({ data: Buffer.from("second") } as never, ws as never);
+
+    expect(socket.writes).toEqual([Buffer.from("first")]);
+
+    socket.emit("drain");
+
+    expect(socket.writes).toEqual([Buffer.from("first"), Buffer.from("second")]);
+  });
+
+  it("closes active hub connections once on shutdown", async () => {
+    const socket = new FakeDuplexSocket();
+    const hub = createForwardTunnelHub({ dial: () => socket as never });
+    const ws = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, ws as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "open", host: "127.0.0.1", port: 3000 }) } as never, ws as never);
+    socket.emit("connect");
+
+    await hub.close();
+    socket.emit("close");
+
+    expect(ws.closeCount).toBe(1);
+    expect(hub.activeConnectionsForTest()).toEqual([]);
   });
 
   it("returns generic client errors while logging dial failures", () => {

--- a/tests/gateway/forward-ws.test.ts
+++ b/tests/gateway/forward-ws.test.ts
@@ -153,6 +153,21 @@ describe("forward websocket protocol", () => {
     expect(ws.closeCount).toBe(1);
   });
 
+  it("clears pending handler state after hub shutdown", async () => {
+    const hub = createForwardTunnelHub();
+    const firstWs = new FakeGatewayWebSocket();
+    const secondWs = new FakeGatewayWebSocket();
+    const handler = hub.createHandler();
+
+    handler.onOpen?.({} as never, firstWs as never);
+    await hub.close();
+    handler.onClose?.();
+    handler.onOpen?.({} as never, secondWs as never);
+    handler.onMessage?.({ data: JSON.stringify({ type: "close" }) } as never, secondWs as never);
+
+    expect(secondWs.closeCount).toBe(1);
+  });
+
   it("bridges bytes in both directions after ready", () => {
     const socket = new FakeDuplexSocket();
     const dial: ForwardDialer = vi.fn(() => socket as never);


### PR DESCRIPTION
## Summary

- Fixes the Greptile findings from #415 for CLI port forwarding tunnel lifecycle and resource handling.
- Splits local TCP reads into max-frame-sized WebSocket frames, including bytes buffered before gateway `ready`.
- Adds bounded socket-write queues/backpressure handling on CLI and gateway tunnel paths.
- Tracks pre-open gateway WebSocket connections with the same cap and idle timeout as opened tunnels.
- Fixes double-close paths in gateway failure and shutdown handling, and avoids mutating the caller's `startPortForward` options.

## Tests

- `/home/nima/matrix-os/node_modules/.bin/vitest run tests/cli/port-forward.test.ts tests/gateway/forward-ws.test.ts tests/gateway/auth.test.ts tests/cli/unified-command-tree.test.ts` (68 tests, passed; run with loopback socket permission)
- `pnpm --filter @finnaai/matrix exec tsc --noEmit`
- `pnpm --filter @matrix-os/gateway exec tsc --noEmit`
- `./scripts/review/check-patterns.sh` (0 violations; existing repo warnings only)

## Review/Monitoring

- Follow-up for Greptile comments on #415.
- Please wait for the latest Greptile review on this PR; target is 5/5 before merge.

## Invariants

- **Source of truth**: forwarding state is process-local only. The CLI listener and each gateway WebSocket connection own their sockets for the lifetime of the tunnel; there is no persistence or registry beyond bounded in-memory connection sets.
- **Lock/transaction scope**: no database writes or transactions are involved. Socket and WebSocket cleanup is guarded by per-connection closed flags or active-set deletion.
- **Acceptable orphan states**: if either TCP or WebSocket side fails, the paired side is closed and pending buffers/timers are cleared. Pre-open gateway WebSockets are capped, timed out, and cleaned up before promotion to active tunnel state.
- **Auth source of truth**: `/ws/forward` remains authenticated by the existing gateway bearer-token WebSocket path; this PR does not add query-token auth.
- **Deferred scope**: still forward-only. No reverse tunnels, multiplexing, public bind address, public preview URL, persistent tunnel registry, or shareable HTTPS publishing.
