### PR TITLE
fix(cli): harden cloud shell runtime UX

### DIFF
--- a/bin/matrixos.mjs
+++ b/bin/matrixos.mjs
@@ -13,6 +13,9 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync } from 'node:fs';
 import { findTsxLoader } from '../packages/sync-client/src/lib/find-tsx-loader.mjs';
+import { assertSupportedNodeRuntime } from '../packages/sync-client/src/lib/node-runtime-guard.mjs';
+
+assertSupportedNodeRuntime(process.argv.slice(2), process.version);
 
 const here = dirname(fileURLToPath(import.meta.url));
 

--- a/docs/dev/agent-matrix-skills.md
+++ b/docs/dev/agent-matrix-skills.md
@@ -110,7 +110,7 @@ matrix login
 matrix run -it -- claude
 matrix run -it -- codex
 matrix run -it --session setup -- gh auth login
-matrix shell connect -c setup
+mos shell attach -c setup
 ```
 
 `matrix run -it` creates a zellij-backed Matrix shell session, starts the requested command in a pane, and attaches the local terminal over `/ws/terminal`. The local terminal is a dumb TTY: stdin is put in raw mode, Ctrl-C/Ctrl-D are forwarded to the remote process, terminal resizes are forwarded as `resize` frames, and `Ctrl-\ Ctrl-\` detaches without killing the remote session.
@@ -118,13 +118,13 @@ matrix shell connect -c setup
 Use named sessions for setup workflows so the user, Matrix web terminal, Claude, Codex, or Hermes can all reattach the same VPS context:
 
 ```bash
-matrix shell connect -c setup
+mos shell attach -c setup
 matrix run -it --session setup -- gh auth login
 matrix run -it --session setup -- claude
-matrix shell connect setup
+mos shell attach setup
 ```
 
-If `matrix run -it`, `matrix shell new`, or `matrix shell attach` fails with `zellij_failed`, do not keep retrying the same command. Run `matrix shell ls`, then use `matrix shell connect <session-name>` against an existing session. `matrix shell connect -c <session-name>` is the create-if-missing path; if creation fails, ask the human to create or choose a session from the Matrix web terminal and connect to that existing session.
+If `matrix run -it`, `matrix shell new`, or `mos shell attach` fails with `zellij_failed`, do not keep retrying the same command. Run `mos shell ls`, then use `mos shell attach <session-name>` against an existing session. `mos shell attach -c <session-name>` is the create-if-missing path; if creation fails, ask the human to create or choose a session from the Matrix web terminal and attach to that existing session.
 
 Non-interactive `matrix run -- <command>` should return the remote command exit status once the gateway exposes status-bearing command execution on top of the same zellij session model. Until then, developer setup docs should prefer `matrix run -it -- <interactive-command>`.
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1648,6 +1648,7 @@ export async function createGateway(config: GatewayConfig) {
     preferences: shellPreferencesStore,
     workspace: zellijAdapter,
     layouts: shellLayoutStore,
+    shellBackend: zellijAdapter,
   };
   app.route("/api/terminal", createShellRoutes(shellRouteDeps));
   app.route("/api", createShellRoutes(shellRouteDeps));

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -36,11 +36,16 @@ interface ShellLayoutRoutes {
   delete(name: string): Promise<void>;
 }
 
+interface ShellBackendHealthRoutes {
+  health(): Promise<{ ok: boolean; code: "ok" | "zellij_failed" }>;
+}
+
 export interface ShellRouteDeps {
   registry: SessionRegistryRoutes;
   preferences?: ShellPreferencesStore;
   workspace?: ShellWorkspaceRoutes;
   layouts?: ShellLayoutRoutes;
+  shellBackend?: ShellBackendHealthRoutes;
 }
 
 const CreateSessionBodySchema = z.object({
@@ -80,6 +85,20 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
   const workspaceBodyLimit = bodyLimit({ maxSize: 8192 });
   const layoutBodyLimit = bodyLimit({ maxSize: 128_000 });
   const deleteBodyLimit = bodyLimit({ maxSize: 512 });
+
+  app.get("/health", async (c) => {
+    if (!deps.shellBackend) {
+      console.warn("[shell] shell health route missing backend dependency");
+      return c.json({ shell: { ok: false, code: "shell_backend_unavailable" } }, 503);
+    }
+    try {
+      const health = await deps.shellBackend.health();
+      return c.json({ shell: health }, health.ok ? 200 : 503);
+    } catch (err: unknown) {
+      console.warn("[shell] shell health check failed:", err instanceof Error ? err.message : String(err));
+      return c.json({ shell: { ok: false, code: "zellij_failed" } }, 503);
+    }
+  });
 
   app.get("/sessions", async (c) => {
     try {

--- a/packages/gateway/src/shell/zellij.ts
+++ b/packages/gateway/src/shell/zellij.ts
@@ -66,6 +66,7 @@ export interface AttachOptions {
 }
 
 export interface ZellijAdapter {
+  health(): Promise<{ ok: boolean; code: "ok" | "zellij_failed" }>;
   listSessions(): Promise<string[]>;
   createSession(options: CreateSessionOptions): Promise<void>;
   deleteSession(name: string, options?: { force?: boolean }): Promise<void>;
@@ -269,6 +270,18 @@ export function createZellijAdapter(deps: ZellijAdapterDeps = {}): ZellijAdapter
   }
 
   return {
+    async health() {
+      try {
+        await run(["--version"]);
+        return { ok: true, code: "ok" };
+      } catch (err: unknown) {
+        const diagnostic = err instanceof Error && "diagnostic" in err
+          ? (err as { diagnostic?: unknown }).diagnostic
+          : classifyZellijFailure(err, "");
+        console.warn("[shell] backend health failed:", { code: "zellij_failed", diagnostic });
+        return { ok: false, code: "zellij_failed" };
+      }
+    },
     async listSessions() {
       let stdout: string;
       try {

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -563,19 +563,19 @@ function approvalPage(
 <body>
   <main>
     <section class="terminal" aria-label="Matrix CLI login preview">
-      <div class="bar"><span class="dot ok"></span><span class="dot"></span><span class="dot"></span><span>matrix login</span></div>
+      <div class="bar"><span class="dot ok"></span><span class="dot"></span><span class="dot"></span><span>mos login</span></div>
       <div class="screen">
-        <div><span class="prompt">matrix</span> login</div>
+        <div><span class="prompt">mos</span> login</div>
         <div class="muted">open app.matrix-os.com/auth/device</div>
         <div>verification code</div>
         <div class="code">${escapedCode}</div>
         <div id="instance-line" class="muted">waiting for signed-in Matrix instance...</div>
         <br>
-        <div><span class="prompt">matrix</span> whoami</div>
+        <div><span class="prompt">mos</span> whoami</div>
         <div class="muted">@handle on app.matrix-os.com</div>
         <div><span class="prompt">mos</span> shell attach -c main</div>
-        <div><span class="prompt">matrix</span> run -it -- claude</div>
-        <div><span class="prompt">matrix</span> doctor</div>
+        <div><span class="prompt">mos</span> run -it -- claude</div>
+        <div><span class="prompt">mos</span> doctor</div>
       </div>
     </section>
     <section class="panel">

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -573,7 +573,7 @@ function approvalPage(
         <br>
         <div><span class="prompt">matrix</span> whoami</div>
         <div class="muted">@handle on app.matrix-os.com</div>
-        <div><span class="prompt">matrix</span> shell connect -c main</div>
+        <div><span class="prompt">mos</span> shell attach -c main</div>
         <div><span class="prompt">matrix</span> run -it -- claude</div>
         <div><span class="prompt">matrix</span> doctor</div>
       </div>

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -23,7 +23,7 @@ matrix sync ~/matrixos    # start the sync daemon against the logged-in instance
 matrix run -it -- claude  # attach local TTY to Claude on your Matrix VPS
 matrix run -it -- codex   # same shared zellij session primitive for Codex
 matrix run -it --session setup -- gh auth login
-matrix shell connect setup # reattach the same session from local CLI or web terminal
+mos shell attach setup    # reattach the same session from local CLI or web terminal
 matrix peers              # list connected peers
 matrix logout             # clear local credentials
 ```

--- a/packages/sync-client/bin/matrix.mjs
+++ b/packages/sync-client/bin/matrix.mjs
@@ -13,6 +13,9 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync } from 'node:fs';
 import { findTsxLoader } from '../src/lib/find-tsx-loader.mjs';
+import { assertSupportedNodeRuntime } from '../src/lib/node-runtime-guard.mjs';
+
+assertSupportedNodeRuntime(process.argv.slice(2), process.version);
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, '..');

--- a/packages/sync-client/src/auth/oauth.ts
+++ b/packages/sync-client/src/auth/oauth.ts
@@ -19,15 +19,20 @@ export async function requestDeviceCode(
   config: OAuthConfig,
 ): Promise<DeviceCodeResponse> {
   const url = `${config.platformUrl}/api/auth/device/code`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ clientId: config.clientId }),
-    signal: AbortSignal.timeout(10_000),
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clientId: config.clientId }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err: unknown) {
+    throw classifyPlatformFetchError(err);
+  }
 
   if (!res.ok) {
-    throw new Error(`Device code request failed: ${res.status}`);
+    throw Object.assign(new Error("Request failed"), { code: "login_failed" });
   }
 
   return (await res.json()) as DeviceCodeResponse;
@@ -72,12 +77,17 @@ export async function pollForToken(
   while (Date.now() < deadline) {
     await sleep(interval * 1000);
 
-    const res = await fetch(pollUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ deviceCode, clientId: config.clientId }),
-      signal: AbortSignal.timeout(10_000),
-    });
+    let res: Response;
+    try {
+      res = await fetch(pollUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ deviceCode, clientId: config.clientId }),
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch (err: unknown) {
+      throw classifyPlatformFetchError(err);
+    }
 
     if (res.ok) {
       const data = AuthDataSchema.parse(await res.json());
@@ -97,13 +107,13 @@ export async function pollForToken(
     }
 
     if (res.status === 410) {
-      throw new Error("Device code expired before authorization completed");
+      throw Object.assign(new Error("Device code expired before authorization completed"), { code: "login_failed" });
     }
 
-    throw new Error(`Token polling failed with status ${res.status}`);
+    throw Object.assign(new Error(`Token polling failed with status ${res.status}`), { code: "login_failed" });
   }
 
-  throw new Error("Device authorization timed out");
+  throw Object.assign(new Error("Device authorization timed out"), { code: "request_timeout" });
 }
 
 function sleep(ms: number): Promise<void> {
@@ -112,13 +122,16 @@ function sleep(ms: number): Promise<void> {
 
 export interface LoginOptions extends OAuthConfig {
   tokenStorePath?: string;
+  quiet?: boolean;
 }
 
 export async function login(options: LoginOptions): Promise<AuthData> {
   const deviceCode = await requestDeviceCode(options);
 
-  console.log(`\nVisit: ${deviceCode.verificationUri}`);
-  console.log(`Enter code: ${deviceCode.userCode}\n`);
+  if (!options.quiet) {
+    console.log(`\nVisit: ${deviceCode.verificationUri}`);
+    console.log(`Enter code: ${deviceCode.userCode}\n`);
+  }
 
   openBrowser(deviceCode.verificationUri);
 
@@ -129,4 +142,11 @@ export async function login(options: LoginOptions): Promise<AuthData> {
     deviceCode.expiresIn,
     options.tokenStorePath,
   );
+}
+
+function classifyPlatformFetchError(err: unknown): Error & { code: string } {
+  if (err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError")) {
+    return Object.assign(new Error("Request failed"), { code: "request_timeout" });
+  }
+  return Object.assign(new Error("Request failed"), { code: "platform_unreachable" });
 }

--- a/packages/sync-client/src/auth/oauth.ts
+++ b/packages/sync-client/src/auth/oauth.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { platform } from "node:os";
 import { AuthDataSchema, saveAuth, type AuthData } from "./token-store.js";
+import { cliError, cliFetchError } from "../cli/output.js";
 
 export interface DeviceCodeResponse {
   deviceCode: string;
@@ -28,7 +29,7 @@ export async function requestDeviceCode(
       signal: AbortSignal.timeout(10_000),
     });
   } catch (err: unknown) {
-    throw classifyPlatformFetchError(err);
+    throw cliFetchError(err, { timeout: "request_timeout", network: "platform_unreachable" });
   }
 
   if (!res.ok) {
@@ -38,7 +39,7 @@ export async function requestDeviceCode(
   return (await res.json()) as DeviceCodeResponse;
 }
 
-export function openBrowser(url: string): void {
+export function openBrowser(url: string, userCode?: string): void {
   const parsed = new URL(url);
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error(`Refusing to open non-http(s) verification URL: ${parsed.protocol}`);
@@ -51,7 +52,7 @@ export function openBrowser(url: string): void {
 
   execFile(cmd, args, (err) => {
     if (err) {
-      console.error(`Could not open browser. Visit: ${url}`);
+      console.error(`Could not open browser. Visit: ${url}${userCode ? `\nEnter code: ${userCode}` : ""}`);
     }
   });
 }
@@ -86,7 +87,7 @@ export async function pollForToken(
         signal: AbortSignal.timeout(10_000),
       });
     } catch (err: unknown) {
-      throw classifyPlatformFetchError(err);
+      throw cliFetchError(err, { timeout: "request_timeout", network: "platform_unreachable" });
     }
 
     if (res.ok) {
@@ -113,7 +114,7 @@ export async function pollForToken(
     throw Object.assign(new Error(`Token polling failed with status ${res.status}`), { code: "login_failed" });
   }
 
-  throw Object.assign(new Error("Device authorization timed out"), { code: "request_timeout" });
+  throw cliError("login_failed", "Device authorization timed out");
 }
 
 function sleep(ms: number): Promise<void> {
@@ -133,7 +134,7 @@ export async function login(options: LoginOptions): Promise<AuthData> {
     console.log(`Enter code: ${deviceCode.userCode}\n`);
   }
 
-  openBrowser(deviceCode.verificationUri);
+  openBrowser(deviceCode.verificationUri, deviceCode.userCode);
 
   return pollForToken(
     options,
@@ -142,11 +143,4 @@ export async function login(options: LoginOptions): Promise<AuthData> {
     deviceCode.expiresIn,
     options.tokenStorePath,
   );
-}
-
-function classifyPlatformFetchError(err: unknown): Error & { code: string } {
-  if (err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError")) {
-    return Object.assign(new Error("Request failed"), { code: "request_timeout" });
-  }
-  return Object.assign(new Error("Request failed"), { code: "platform_unreachable" });
 }

--- a/packages/sync-client/src/cli/auth-state.ts
+++ b/packages/sync-client/src/cli/auth-state.ts
@@ -7,11 +7,11 @@ export type CliAuthStatus =
   | { status: "missing"; auth: null };
 
 export function notAuthenticatedMessage(profileName: string): string {
-  return `Not logged in for profile "${profileName}". Run \`matrix login\` first.`;
+  return `Not logged in for profile "${profileName}". Run \`mos login\` first.`;
 }
 
 export function authExpiredMessage(profileName: string, expiresAt: number): string {
-  return `Auth for profile "${profileName}" expired on ${new Date(expiresAt).toISOString()}. Run \`matrix login --profile ${profileName}\` to refresh.`;
+  return `Auth for profile "${profileName}" expired on ${new Date(expiresAt).toISOString()}. Run \`mos login --profile ${profileName}\` to refresh.`;
 }
 
 export function createNotAuthenticatedError(profileName: string): Error {

--- a/packages/sync-client/src/cli/commands/doctor.ts
+++ b/packages/sync-client/src/cli/commands/doctor.ts
@@ -12,6 +12,35 @@ interface DoctorCheck {
   hint?: string;
 }
 
+const SAFE_SHELL_HEALTH_CODE = /^[a-z][a-z0-9_-]{0,31}$/;
+
+async function probeShellBackendHealth(gatewayUrl: string, token?: string): Promise<{ ok: boolean; code: string }> {
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+  const res = await fetch(`${gatewayUrl.replace(/\/+$/, "")}/api/terminal/health`, {
+    ...(headers ? { headers } : {}),
+    signal: AbortSignal.timeout(10_000),
+  });
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch (err: unknown) {
+    if (!(err instanceof SyntaxError) && !(err instanceof TypeError)) {
+      throw err;
+    }
+  }
+  const code =
+    typeof body === "object" &&
+    body !== null &&
+    "shell" in body &&
+    typeof (body as { shell?: { code?: unknown } }).shell?.code === "string" &&
+    SAFE_SHELL_HEALTH_CODE.test((body as { shell: { code: string } }).shell.code)
+      ? (body as { shell: { code: string } }).shell.code
+      : res.ok
+        ? "ok"
+        : "zellij_failed";
+  return { ok: res.ok && code === "ok", code };
+}
+
 export const doctorCommand = defineCommand({
   meta: {
     name: "doctor",
@@ -33,7 +62,7 @@ export const doctorCommand = defineCommand({
       profile = await resolveCliProfile(args);
       checks.push({ name: "profile", ok: true });
     } catch (_err: unknown) {
-      checks.push({ name: "profile", ok: false, code: "profile_not_found", hint: "Run `matrix profile ls`." });
+      checks.push({ name: "profile", ok: false, code: "profile_not_found", hint: "Run `mos profile ls`." });
     }
 
     let token: string | undefined;
@@ -47,11 +76,11 @@ export const doctorCommand = defineCommand({
               name: "auth",
               ok: false,
               code: "auth_expired",
-              hint: `Run \`matrix login --profile ${profile.name}\` to refresh.`,
+              hint: `Run \`mos login --profile ${profile.name}\` to refresh.`,
             }
-          : { name: "auth", ok: false, code: "not_authenticated", hint: "Run `matrix login`." });
+          : { name: "auth", ok: false, code: "not_authenticated", hint: "Run `mos login`." });
     } else {
-      checks.push({ name: "auth", ok: false, code: "profile_not_found", hint: "Run `matrix login`." });
+      checks.push({ name: "auth", ok: false, code: "profile_not_found", hint: "Run `mos login`." });
     }
 
     checks.push((await isDaemonRunning())
@@ -59,16 +88,41 @@ export const doctorCommand = defineCommand({
       : { name: "daemon", ok: false, code: "daemon_unavailable", hint: "Start sync with `matrix sync`." });
 
     if (profile) {
+      let gatewayReachable = false;
       try {
         const gateway = await probeGatewayHealth(profile.gatewayUrl, token);
+        gatewayReachable = gateway.reachable;
         checks.push(gateway.reachable
           ? { name: "gateway", ok: true }
           : { name: "gateway", ok: false, code: "gateway_unavailable", hint: "Check the selected profile gateway URL." });
       } catch (_err: unknown) {
         checks.push({ name: "gateway", ok: false, code: "gateway_unavailable", hint: "Check the selected profile gateway URL." });
       }
+      if (gatewayReachable) {
+        try {
+          const shell = await probeShellBackendHealth(profile.gatewayUrl, token);
+          checks.push(shell.ok
+            ? { name: "shell-backend", ok: true }
+            : {
+                name: "shell-backend",
+                ok: false,
+                code: shell.code === "ok" ? "zellij_failed" : shell.code,
+                hint: `Run \`mos doctor --profile ${profile.name}\`; managed VPSes may need the latest host bundle deployed.`,
+              });
+        } catch (_err: unknown) {
+          checks.push({
+            name: "shell-backend",
+            ok: false,
+            code: "gateway_unreachable",
+            hint: "Gateway reachable check passed, but shell health did not respond. Try again or verify the host bundle.",
+          });
+        }
+      } else {
+        checks.push({ name: "shell-backend", ok: false, code: "gateway_unavailable", hint: "Fix gateway reachability first." });
+      }
     } else {
       checks.push({ name: "gateway", ok: false, code: "profile_not_found", hint: "Select a profile first." });
+      checks.push({ name: "shell-backend", ok: false, code: "profile_not_found", hint: "Select a profile first." });
     }
 
     checks.push({ name: "protocol", ok: true });

--- a/packages/sync-client/src/cli/commands/login.ts
+++ b/packages/sync-client/src/cli/commands/login.ts
@@ -15,7 +15,12 @@ import {
   type SyncConfig,
 } from "../../lib/config.js";
 import { loadProfiles, saveProfiles, type ProfilesFile } from "../../lib/profiles.js";
-import { formatCliError, formatCliErrorMessage, formatCliSuccess } from "../output.js";
+import {
+  cliFetchError,
+  formatCliError,
+  formatCliErrorMessage,
+  formatCliSuccess,
+} from "../output.js";
 
 function localProfileFromArgs(args: Record<string, unknown>) {
   return {
@@ -50,14 +55,6 @@ function writeLoginError(err: unknown, json: boolean): void {
       ? (err as { code: string }).code
       : "login_failed";
   console.error(json ? formatCliError(code) : `Error: ${formatCliErrorMessage(code)}`);
-}
-
-function classifyPlatformFetchError(err: unknown): Error & { code: string } {
-  return Object.assign(new Error("Request failed"), {
-    code: err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError")
-      ? "request_timeout"
-      : "platform_unreachable",
-  });
 }
 
 export const loginCommand = defineCommand({
@@ -175,7 +172,7 @@ export const loginCommand = defineCommand({
         signal: AbortSignal.timeout(10_000),
       });
     } catch (err) {
-      const safeErr = classifyPlatformFetchError(err);
+      const safeErr = cliFetchError(err, { timeout: "request_timeout", network: "platform_unreachable" });
       const hint = `Your auth token was saved. Re-run \`mos login --profile ${profileName}\` after the platform is reachable.`;
       console.error(json ? formatCliError(safeErr.code) : `Error: ${formatCliErrorMessage(safeErr.code)} ${hint}`);
       process.exitCode = 1;

--- a/packages/sync-client/src/cli/commands/login.ts
+++ b/packages/sync-client/src/cli/commands/login.ts
@@ -15,7 +15,7 @@ import {
   type SyncConfig,
 } from "../../lib/config.js";
 import { loadProfiles, saveProfiles, type ProfilesFile } from "../../lib/profiles.js";
-import { formatCliError, formatCliSuccess } from "../output.js";
+import { formatCliError, formatCliErrorMessage, formatCliSuccess } from "../output.js";
 
 function localProfileFromArgs(args: Record<string, unknown>) {
   return {
@@ -49,7 +49,15 @@ function writeLoginError(err: unknown, json: boolean): void {
     err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
       ? (err as { code: string }).code
       : "login_failed";
-  console.error(json ? formatCliError(code) : `Error: Request failed (${code})`);
+  console.error(json ? formatCliError(code) : `Error: ${formatCliErrorMessage(code)}`);
+}
+
+function classifyPlatformFetchError(err: unknown): Error & { code: string } {
+  return Object.assign(new Error("Request failed"), {
+    code: err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError")
+      ? "request_timeout"
+      : "platform_unreachable",
+  });
 }
 
 export const loginCommand = defineCommand({
@@ -142,12 +150,15 @@ export const loginCommand = defineCommand({
       existing?.platformUrl ||
       defaultPlatformUrl();
 
-    console.log(`Opening browser for authentication at ${platformUrl}...`);
+    if (!json) {
+      console.log(`Opening browser for authentication at ${platformUrl}...`);
+    }
 
     const auth = await login({
       platformUrl,
       clientId: "matrixos-cli",
       tokenStorePath: authFilePathForProfile(profileName),
+      quiet: json,
     });
 
     // Discover the user's gateway URL via /api/me. Contract: 404 means the
@@ -164,9 +175,10 @@ export const loginCommand = defineCommand({
         signal: AbortSignal.timeout(10_000),
       });
     } catch (err) {
-      console.error(
-        `Could not reach ${platformUrl}/api/me (${err instanceof Error ? err.message : "network error"}). Your auth token was saved — re-run \`matrix login\` once the platform is reachable.`,
-      );
+      const safeErr = classifyPlatformFetchError(err);
+      const hint = `Your auth token was saved. Re-run \`mos login --profile ${profileName}\` after the platform is reachable.`;
+      console.error(json ? formatCliError(safeErr.code) : `Error: ${formatCliErrorMessage(safeErr.code)} ${hint}`);
+      process.exitCode = 1;
       return;
     }
 
@@ -175,13 +187,22 @@ export const loginCommand = defineCommand({
       // auth.json (pollForToken persisted it inside `login()`) — otherwise
       // `matrix sync` would appear to work while every gateway call 404s.
       await clearProfileAuth(profileName);
+      if (json) {
+        console.error(formatCliError(
+          "instance_not_found",
+          "Matrix instance not found. Sign up at https://app.matrix-os.com, then rerun `mos login`.",
+        ));
+        process.exitCode = 1;
+        return;
+      }
       console.log(
         "You're signed in, but there's no Matrix instance for this account yet.",
       );
       console.log("");
       console.log(
-        "Sign up at https://app.matrix-os.com first, then re-run `matrix login`.",
+        "Sign up at https://app.matrix-os.com first, then re-run `mos login`.",
       );
+      process.exitCode = 1;
       return;
     }
 
@@ -189,9 +210,10 @@ export const loginCommand = defineCommand({
       // 5xx, 400, 502, etc. Keep the auth token (transient server issue) and
       // skip the config write — writing a config with a guessed gatewayUrl
       // is the exact half-provisioned state the 404 branch above prevents.
-      console.error(
-        `/api/me returned ${meRes.status}. Your auth token was saved — re-run \`matrix login\` once the platform recovers.`,
-      );
+      console.error(json
+        ? formatCliError("login_failed")
+        : `Error: Login failed. Your auth token was saved. Re-run \`mos login --profile ${profileName}\` once the platform recovers.`);
+      process.exitCode = 1;
       return;
     }
 

--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -187,7 +187,7 @@ export const runCommand = defineCommand({
       console.log(
         json
           ? formatCliSuccess({ detached: result.detached, session: name })
-          : `Detached. Reattach: matrix shell connect ${name}`,
+          : `Detached. Reattach: mos shell attach ${name}`,
       );
     } catch (err) {
       writeError(err, json);

--- a/packages/sync-client/src/cli/commands/shell.ts
+++ b/packages/sync-client/src/cli/commands/shell.ts
@@ -5,7 +5,7 @@ import { createShellClient } from "../shell-client.js";
 import type { ShellAttachOptions } from "../shell-client.js";
 import { requireCliAuthToken } from "../auth-state.js";
 
-const SHELL_USAGE = "Usage: matrix shell list|new|connect|rm|tab|pane|layout";
+const SHELL_USAGE = "Usage: mos shell list|new|attach|rm|tab|pane|layout";
 const SHELL_SUBCOMMANDS = new Set([
   "ls", "list",
   "new",
@@ -82,9 +82,9 @@ function writeError(err: unknown, json: boolean): void {
       : undefined;
   const output = json
     ? formatCliError(code, safeMessage)
-    : code === "auth_expired"
+    : code === "auth_expired" || code === "gateway_unreachable" || code === "request_timeout" || code === "zellij_failed" || code === "attach_failed"
       ? formatCliErrorMessage(code, safeMessage)
-      : safeMessage ?? `Error: Request failed (${code})`;
+      : safeMessage ?? formatCliErrorMessage(code);
   console.error(output);
 }
 
@@ -223,7 +223,9 @@ function attachCommand(name: string, description: string) {
         console.log(
           json
             ? formatCliSuccess({ detached: result.detached })
-            : `Detached. Reattach: matrix shell connect ${args.name}`,
+            : result.detached
+              ? `Detached. Reattach: mos shell attach ${args.name}`
+              : `Shell attach ended. Reattach: mos shell attach ${args.name}`,
         );
       } catch (err) {
         writeError(err, json);
@@ -275,7 +277,9 @@ export const shellCommand = defineCommand({
           console.log(
             json
               ? formatCliSuccess({ created: data, detached: result.detached })
-              : `Detached. Reattach: matrix shell connect ${args.name}`,
+              : result.detached
+                ? `Detached. Reattach: mos shell attach ${args.name}`
+                : `Shell attach ended. Reattach: mos shell attach ${args.name}`,
           );
         } catch (err) {
           writeError(err, json);

--- a/packages/sync-client/src/cli/commands/whoami.ts
+++ b/packages/sync-client/src/cli/commands/whoami.ts
@@ -42,7 +42,7 @@ export const whoamiCommand = defineCommand({
       } else if (data.authenticated) {
         console.log(`Authenticated with explicit token (${data.profile}).`);
       } else if ("auth" in data && data.auth === "expired") {
-        console.log(`Login expired (${data.profile}). Run \`matrix login --profile ${data.profile}\` to refresh.`);
+        console.log(`Login expired (${data.profile}). Run \`mos login --profile ${data.profile}\` to refresh.`);
       } else {
         console.log(`Not logged in (${data.profile}).`);
       }

--- a/packages/sync-client/src/cli/output.ts
+++ b/packages/sync-client/src/cli/output.ts
@@ -1,10 +1,15 @@
 export const CLI_OUTPUT_VERSION = 1;
 
 const GENERIC_MESSAGES: Record<string, string> = {
-  zellij_failed: "Request failed",
+  platform_unreachable: "Platform unreachable. Matrix CLI could not contact the Matrix OS platform.",
+  gateway_unreachable: "Gateway unreachable. Matrix CLI could not contact your Matrix OS instance.",
+  request_timeout: "Request timed out. Try again or run `mos doctor`.",
+  zellij_failed: "Shell backend unavailable. Your Matrix OS instance could not start a shell session.",
+  unsupported_node: "Matrix CLI requires Node.js 24 or newer.",
+  attach_failed: "Shell attach failed.",
   unknown_command: "Request failed",
   unsupported_version: "Request failed",
-  auth_expired: "Matrix CLI auth expired. Run `matrix login` to refresh your session.",
+  auth_expired: "Matrix CLI auth expired. Run `mos login` to refresh your session.",
 };
 
 export function formatCliSuccess(data: Record<string, unknown>): string {
@@ -23,6 +28,24 @@ export function formatCliError(code: string, message?: string): string {
       message: formatCliErrorMessage(code, message),
     },
   });
+}
+
+export function cliError(code: string, message?: string): Error & { code: string } {
+  return Object.assign(new Error(message ?? "Request failed"), { code });
+}
+
+export function safeCliErrorCode(err: unknown, fallback = "request_failed"): string {
+  return err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
+    ? (err as { code: string }).code
+    : fallback;
+}
+
+export function isFetchTimeoutError(err: unknown): boolean {
+  return err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError");
+}
+
+export function isFetchNetworkError(err: unknown): boolean {
+  return err instanceof TypeError;
 }
 
 export function formatNdjsonEvent(

--- a/packages/sync-client/src/cli/output.ts
+++ b/packages/sync-client/src/cli/output.ts
@@ -48,6 +48,19 @@ export function isFetchNetworkError(err: unknown): boolean {
   return err instanceof TypeError;
 }
 
+export function cliFetchError(
+  err: unknown,
+  codes: { timeout: string; network: string; fallback?: string },
+): Error & { code: string } {
+  if (isFetchTimeoutError(err)) {
+    return cliError(codes.timeout);
+  }
+  if (isFetchNetworkError(err)) {
+    return cliError(codes.network);
+  }
+  return cliError(codes.fallback ?? codes.network);
+}
+
 export function formatNdjsonEvent(
   type: string,
   data: Record<string, unknown>,

--- a/packages/sync-client/src/cli/recovery-hints.ts
+++ b/packages/sync-client/src/cli/recovery-hints.ts
@@ -1,14 +1,18 @@
 const HINTS: Record<string, string> = {
-  session_not_found: "Session not found. Create one with `matrix shell new <name>`.",
-  session_exists: "Session already exists. Reattach with `matrix shell connect <name>`.",
-  invalid_layout: "Layout is invalid. Inspect it with `matrix shell layout show <name>` before applying it.",
-  timeout: "The request timed out. Check `matrix doctor` and retry.",
-  attach_failed: "Terminal attach failed. reattach with `matrix shell connect <name>`.",
-  auth_expired: "Auth expired. Run `matrix login` to refresh this profile.",
+  session_not_found: "Session not found. Create one with `mos shell new <name>`.",
+  session_exists: "Session already exists. Reattach with `mos shell attach <name>`.",
+  invalid_layout: "Layout is invalid. Inspect it with `mos shell layout show <name>` before applying it.",
+  timeout: "The request timed out. Check `mos doctor` and retry.",
+  request_timeout: "The request timed out. Check `mos doctor` and retry.",
+  attach_failed: "Terminal attach failed. Reattach with `mos shell attach <name>`.",
+  zellij_failed: "Shell backend unavailable. Run `mos doctor --profile cloud`.",
+  gateway_unreachable: "Gateway unreachable. Start local dev services or run `mos profile use cloud`.",
+  platform_unreachable: "Platform unreachable. Start local platform services, run `mos login --dev`, or run `mos profile use cloud`.",
+  auth_expired: "Auth expired. Run `mos login` to refresh this profile.",
   unsupported_version: "Daemon protocol is incompatible. Please update the Matrix CLI and restart the daemon.",
   unknown_command: "Daemon command is not supported. Please update the Matrix CLI and daemon together.",
 };
 
 export function recoveryHintForCode(code: string): string {
-  return HINTS[code] ?? "Run `matrix doctor` for recovery guidance.";
+  return HINTS[code] ?? "Run `mos doctor` for recovery guidance.";
 }

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -570,7 +570,9 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             inputFilter.noteRemoteOutput();
             output.write(msg.data);
           } else if (msg.type === "error") {
-            const code = typeof msg.code === "string" ? msg.code : "attach_failed";
+            const code = typeof msg.code === "string" && SAFE_SHELL_SERVER_ERROR_CODES.has(msg.code)
+              ? msg.code
+              : "attach_failed";
             settle(() => reject(Object.assign(new Error("Request failed"), { code })));
           } else if (msg.type === "exit") {
             settle(() => resolve({ detached: false }));

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -69,6 +69,11 @@ const LOCAL_TERMINAL_INPUT_RESET = [
 const MAX_PENDING_ESCAPE_SEQUENCE_CHARS = 128;
 const STALE_MOUSE_FOCUS_GUARD_MS = 5_000;
 const FOCUS_MOUSE_SUPPRESS_MS = 1_000;
+const SAFE_SHELL_SERVER_ERROR_CODES = new Set([
+  "auth_expired",
+  "session_not_found",
+  "zellij_failed",
+]);
 
 type MaybeTtyStream = NodeJS.ReadStream & {
   isTTY?: boolean;
@@ -239,11 +244,20 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       headers["Content-Type"] = "application/json";
     }
 
-    const res = await fetchImpl(`${base}${path}`, {
-      ...init,
-      headers,
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    let res: Response;
+    try {
+      res = await fetchImpl(`${base}${path}`, {
+        ...init,
+        headers,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err: unknown) {
+      throw Object.assign(new Error("Request failed"), {
+        code: err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError")
+          ? "request_timeout"
+          : "gateway_unreachable",
+      });
+    }
     let payload: unknown = {};
     try {
       payload = await res.json();
@@ -261,7 +275,11 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         typeof (payload as { error?: { code?: unknown } }).error?.code === "string"
           ? (payload as { error: { code: string } }).error.code
           : undefined;
-      const code = payloadCode ?? (res.status === 401 ? "auth_expired" : "request_failed");
+      const code = payloadCode && SAFE_SHELL_SERVER_ERROR_CODES.has(payloadCode)
+        ? payloadCode
+        : res.status === 401
+          ? "auth_expired"
+          : "request_failed";
       throw Object.assign(new Error("Request failed"), { code });
     }
 
@@ -390,8 +408,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         const queuedFrames: string[] = [];
         let queuedFrameBytes = 0;
         const timeout = setTimeout(() => {
-          ws.close();
           settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_timeout" })));
+          ws.close();
         }, timeoutMs);
         timeout.unref?.();
         const cleanup = () => {
@@ -559,6 +577,10 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           }
         };
         const onClose = () => {
+          if (!remoteAttached) {
+            settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_failed" })));
+            return;
+          }
           settle(() => resolve({ detached: true }));
         };
         const onError = (err: unknown) => {

--- a/packages/sync-client/src/lib/node-runtime-guard.mjs
+++ b/packages/sync-client/src/lib/node-runtime-guard.mjs
@@ -1,0 +1,41 @@
+export const MIN_NODE_MAJOR = 24;
+
+export function nodeMajor(version) {
+  const match = /^v?(\d+)\./.exec(String(version));
+  return match ? Number(match[1]) : null;
+}
+
+export function isSupportedNodeVersion(version) {
+  const major = nodeMajor(version);
+  return typeof major === "number" && major >= MIN_NODE_MAJOR;
+}
+
+export function unsupportedNodeMessage(version) {
+  return `Matrix CLI requires Node.js 24 or newer (current: ${version}).`;
+}
+
+export function hasJsonFlag(argv) {
+  return Array.isArray(argv) && argv.includes("--json");
+}
+
+export function formatUnsupportedNodeError(version, json) {
+  const message = unsupportedNodeMessage(version);
+  if (json) {
+    return JSON.stringify({
+      v: 1,
+      error: {
+        code: "unsupported_node",
+        message,
+      },
+    });
+  }
+  return `Error: ${message}`;
+}
+
+export function assertSupportedNodeRuntime(argv = process.argv.slice(2), version = process.version) {
+  if (isSupportedNodeVersion(version)) {
+    return;
+  }
+  console.error(formatUnsupportedNodeError(version, hasJsonFlag(argv)));
+  process.exit(1);
+}

--- a/packages/sync-client/tests/unit/node-runtime-guard.test.ts
+++ b/packages/sync-client/tests/unit/node-runtime-guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatUnsupportedNodeError,
+  isSupportedNodeVersion,
+} from "../../src/lib/node-runtime-guard.mjs";
+
+describe("node runtime guard", () => {
+  it("rejects Node versions older than 24", () => {
+    expect(isSupportedNodeVersion("v20.17.0")).toBe(false);
+    expect(isSupportedNodeVersion("v22.12.0")).toBe(false);
+  });
+
+  it("allows Node 24 and newer", () => {
+    expect(isSupportedNodeVersion("v24.0.0")).toBe(true);
+    expect(isSupportedNodeVersion("v25.1.0")).toBe(true);
+  });
+
+  it("formats safe human and JSON unsupported-node errors", () => {
+    expect(formatUnsupportedNodeError("v20.17.0", false)).toBe(
+      "Error: Matrix CLI requires Node.js 24 or newer (current: v20.17.0).",
+    );
+    expect(JSON.parse(formatUnsupportedNodeError("v20.17.0", true))).toEqual({
+      v: 1,
+      error: {
+        code: "unsupported_node",
+        message: "Matrix CLI requires Node.js 24 or newer (current: v20.17.0).",
+      },
+    });
+  });
+});

--- a/packages/sync-client/tests/unit/oauth.test.ts
+++ b/packages/sync-client/tests/unit/oauth.test.ts
@@ -67,6 +67,28 @@ describe("requestDeviceCode", () => {
     expect(result.deviceCode).toBe("abc");
     expect(result.userCode).toBe("BCDF-GHJK");
   });
+
+  it("maps device-code network errors to platform_unreachable", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new TypeError("connect ECONNREFUSED 127.0.0.1:9000");
+    }));
+
+    await expect(requestDeviceCode(config)).rejects.toMatchObject({
+      code: "platform_unreachable",
+      message: "Request failed",
+    });
+  });
+
+  it("maps device-code aborts to request_timeout", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new DOMException("timed out", "TimeoutError");
+    }));
+
+    await expect(requestDeviceCode(config)).rejects.toMatchObject({
+      code: "request_timeout",
+      message: "Request failed",
+    });
+  });
 });
 
 describe("openBrowser", () => {
@@ -219,6 +241,23 @@ describe("pollForToken", () => {
     await vi.advanceTimersByTimeAsync(5_000);
     await assertion;
     await expect(promise.catch((err: unknown) => String(err))).resolves.not.toMatch(/stack trace/i);
+  });
+
+  it("maps token polling network failures to platform_unreachable", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError("fetch failed with token details");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tokenStorePath = await createTokenStorePath("auth.json");
+    const promise = pollForToken(config, "device-1", 5, 60, tokenStorePath);
+    const assertion = expect(promise).rejects.toMatchObject({
+      code: "platform_unreachable",
+      message: "Request failed",
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await assertion;
   });
 
   it("rejects malformed auth payloads before writing them to disk", async () => {

--- a/packages/sync-client/tests/unit/oauth.test.ts
+++ b/packages/sync-client/tests/unit/oauth.test.ts
@@ -9,6 +9,7 @@ vi.mock("node:child_process", () => ({
   execFile: execFileMock,
 }));
 import {
+  login,
   openBrowser,
   pollForToken,
   requestDeviceCode,
@@ -95,6 +96,19 @@ describe("openBrowser", () => {
   it("opens http(s) verification URLs via execFile", () => {
     openBrowser("https://platform.matrix-os.com/auth/device?user_code=BCDF-GHJK");
     expect(execFileMock).toHaveBeenCalled();
+  });
+
+  it("prints the user code to stderr if browser open fails", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    execFileMock.mockImplementationOnce((_cmd, _args, callback) => {
+      callback(new Error("xdg-open unavailable"));
+    });
+
+    openBrowser("https://platform.matrix-os.com/auth/device", "BCDF-GHJK");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Could not open browser. Visit: https://platform.matrix-os.com/auth/device\nEnter code: BCDF-GHJK",
+    );
   });
 
   it("rejects non-http(s) verification URLs", () => {
@@ -201,6 +215,7 @@ describe("pollForToken", () => {
 
     await vi.advanceTimersByTimeAsync(15_000);
     await assertion;
+    await expect(promise).rejects.toMatchObject({ code: "login_failed" });
   });
 
   it("persists the returned token to the configured path", async () => {
@@ -279,5 +294,45 @@ describe("pollForToken", () => {
 
     await vi.advanceTimersByTimeAsync(5_000);
     await assertion;
+  });
+});
+
+describe("login", () => {
+  it("keeps JSON-mode stdout clean while preserving manual device-flow recovery on stderr", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    execFileMock.mockImplementationOnce((_cmd, _args, callback) => {
+      callback(new Error("xdg-open unavailable"));
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            deviceCode: "device-1",
+            userCode: "BCDF-GHJK",
+            verificationUri: "https://platform.matrix-os.com/auth/device",
+            expiresIn: 10,
+            interval: 5,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValue(
+        new Response(JSON.stringify({ error: "authorization_pending" }), { status: 428 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tokenStorePath = await createTokenStorePath("auth.json");
+    const promise = login({ ...config, tokenStorePath, quiet: true });
+    const assertion = expect(promise).rejects.toMatchObject({ code: "login_failed" });
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    await assertion;
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Could not open browser. Visit: https://platform.matrix-os.com/auth/device\nEnter code: BCDF-GHJK",
+    );
   });
 });

--- a/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
+++ b/plugins/matrix-onboarding/skills/matrix-onboarding/SKILL.md
@@ -37,15 +37,15 @@ Guide the human through a complete developer onboarding path without collecting 
    - Prefer a named shell so the human, web terminal, and agent can reattach:
 
 ```bash
-matrix shell connect -c setup
+mos shell attach -c setup
 ```
 
    - If the human already has a useful shell session, reuse it instead of forcing the `setup` name.
    - For `zellij_failed`, do not retry the same command repeatedly. Use:
 
 ```bash
-matrix shell ls
-matrix shell connect <session-name>
+mos shell ls
+mos shell attach <session-name>
 ```
 
    - Set the chosen name as `<setup-session>` for every later command. Use `setup` only if that is the session actually chosen.
@@ -97,6 +97,6 @@ curl -fsS http://127.0.0.1:<port>/ >/dev/null
 
 ```bash
 matrix doctor
-matrix shell ls
-matrix shell connect <session-name>
+mos shell ls
+mos shell attach <session-name>
 ```

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -58,6 +58,7 @@ mv "$STAGE_DIR/runtime/$NODE_DIST" "$STAGE_DIR/runtime/node"
 curl --fail --location --max-time 180 "$ZELLIJ_URL" -o "$DIST_DIR/$ZELLIJ_ARCHIVE"
 tar -xzf "$DIST_DIR/$ZELLIJ_ARCHIVE" -C "$STAGE_DIR/bin" zellij
 chmod 0755 "$STAGE_DIR/bin/zellij"
+test -x "$STAGE_DIR/bin/zellij"
 curl --fail --location --max-time 180 "$GH_URL" -o "$DIST_DIR/$GH_ARCHIVE"
 tar -xzf "$DIST_DIR/$GH_ARCHIVE" -C "$DIST_DIR"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/runtime/node/bin/gh"

--- a/shell/src/components/terminal/TerminalApp.tsx
+++ b/shell/src/components/terminal/TerminalApp.tsx
@@ -2168,7 +2168,7 @@ function ShellCard({
   const [copied, setCopied] = useState(false);
   const copyAttachCommand = async () => {
     try {
-      await copyTextToClipboard(`matrix shell connect ${shell.name}`);
+      await copyTextToClipboard(`mos shell attach ${shell.name}`);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1200);
     } catch (err: unknown) {
@@ -2202,7 +2202,7 @@ function ShellCard({
           aria-label={`Copy attach command for ${shell.name}`}
           className="min-w-0 flex-1 truncate"
           style={SHELL_CARD_NAME_BUTTON_STYLE}
-          title={copied ? "Copied" : `Copy: matrix shell connect ${shell.name}`}
+          title={copied ? "Copied" : `Copy: mos shell attach ${shell.name}`}
           onClick={() => void copyAttachCommand()}
         >
           {shell.name}

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -32,11 +32,40 @@ describe("doctor CLI command", () => {
       "auth",
       "daemon",
       "gateway",
+      "shell-backend",
       "protocol",
     ]);
     expect(fetchImpl).toHaveBeenCalledWith("http://localhost:4000/api/system/info", {
       headers: { Authorization: "Bearer tok" },
       signal: expect.any(AbortSignal),
+    });
+    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:4000/api/terminal/health", {
+      headers: { Authorization: "Bearer tok" },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("reports shell backend failures with a safe doctor hint", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/terminal/health")) {
+        return new Response(JSON.stringify({ shell: { ok: false, code: "zellij_failed" } }), { status: 503 });
+      }
+      return new Response(JSON.stringify({ status: "ok" }));
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      logs.push(String(line));
+    });
+
+    await doctorCommand.run!({ args: { dev: true, token: "tok", json: true } } as never);
+
+    const parsed = JSON.parse(logs[0]);
+    expect(parsed.data.checks.find((check: { name: string }) => check.name === "shell-backend")).toEqual({
+      name: "shell-backend",
+      ok: false,
+      code: "zellij_failed",
+      hint: "Run `mos doctor --profile local`; managed VPSes may need the latest host bundle deployed.",
     });
   });
 
@@ -90,7 +119,7 @@ describe("doctor CLI command", () => {
       name: "auth",
       ok: false,
       code: "auth_expired",
-      hint: "Run `matrix login --profile cloud` to refresh.",
+      hint: "Run `mos login --profile cloud` to refresh.",
     });
     expect(fetchImpl).toHaveBeenCalledWith("https://app.matrix-os.com/api/system/info", {
       signal: expect.any(AbortSignal),

--- a/tests/cli/global-flags.test.ts
+++ b/tests/cli/global-flags.test.ts
@@ -80,7 +80,7 @@ describe("CLI leading global flags", () => {
       v: 1,
       error: {
         code: "not_authenticated",
-        message: 'Not logged in for profile "local". Run `matrix login` first.',
+        message: 'Not logged in for profile "local". Run `mos login` first.',
       },
     });
   });

--- a/tests/cli/json-output.test.ts
+++ b/tests/cli/json-output.test.ts
@@ -16,9 +16,29 @@ describe("CLI machine-readable output", () => {
     expect(formatCliError("zellij_failed")).toBe(
       JSON.stringify({
         v: 1,
-        error: { code: "zellij_failed", message: "Request failed" },
+        error: {
+          code: "zellij_failed",
+          message: "Shell backend unavailable. Your Matrix OS instance could not start a shell session.",
+        },
       }),
     );
+  });
+
+  it("formats known CLI network errors with safe messages", () => {
+    expect(JSON.parse(formatCliError("platform_unreachable"))).toEqual({
+      v: 1,
+      error: {
+        code: "platform_unreachable",
+        message: "Platform unreachable. Matrix CLI could not contact the Matrix OS platform.",
+      },
+    });
+    expect(JSON.parse(formatCliError("gateway_unreachable"))).toEqual({
+      v: 1,
+      error: {
+        code: "gateway_unreachable",
+        message: "Gateway unreachable. Matrix CLI could not contact your Matrix OS instance.",
+      },
+    });
   });
 
   it("formats NDJSON stream events", () => {

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -291,6 +291,24 @@ describe("shell REST client", () => {
     await expect(attached).rejects.toMatchObject({ code: "attach_failed" });
   });
 
+  it("allowlists terminal websocket error frame codes", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "error", code: "internal_path_leak" }));
+
+    await expect(attached).rejects.toMatchObject({ code: "attach_failed" });
+  });
+
   it("distinguishes remote exit from explicit local detach", async () => {
     const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
     const input = new EventEmitter() as NodeJS.ReadStream;

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -117,6 +117,38 @@ describe("shell REST client", () => {
     });
   });
 
+  it("maps gateway fetch failures to gateway_unreachable", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("connect ECONNREFUSED 127.0.0.1:4000");
+    });
+    const client = createShellClient({
+      gatewayUrl: "http://gateway",
+      token: "tok",
+      fetch: fetchImpl,
+    });
+
+    await expect(client.listSessions()).rejects.toMatchObject({
+      code: "gateway_unreachable",
+      message: "Request failed",
+    });
+  });
+
+  it("maps gateway fetch aborts to request_timeout", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new DOMException("The operation was aborted", "AbortError");
+    });
+    const client = createShellClient({
+      gatewayUrl: "http://gateway",
+      token: "tok",
+      fetch: fetchImpl,
+    });
+
+    await expect(client.listSessions()).rejects.toMatchObject({
+      code: "request_timeout",
+      message: "Request failed",
+    });
+  });
+
   it("keeps gateway forbidden responses generic", async () => {
     const fetchImpl = vi.fn(async () => new Response(
       JSON.stringify({ error: "Forbidden" }),
@@ -208,6 +240,7 @@ describe("shell REST client", () => {
     });
     ControlledWebSocket.last?.emit("open");
     await new Promise((resolve) => setTimeout(resolve, 10));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     ControlledWebSocket.last?.emit("close");
 
     await expect(attached).resolves.toEqual({ detached: true });
@@ -233,10 +266,48 @@ describe("shell REST client", () => {
       fromSeq: 0,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     ControlledWebSocket.last?.emit("close");
 
     await expect(attached).resolves.toEqual({ detached: true });
     expect(ControlledWebSocket.lastUrl).toBe("ws://gateway/ws/terminal/session?session=main&fromSeq=0");
+  });
+
+  it("rejects attach when the websocket closes before an attached, error, or exit frame", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("close");
+
+    await expect(attached).rejects.toMatchObject({ code: "attach_failed" });
+  });
+
+  it("distinguishes remote exit from explicit local detach", async () => {
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+
+    await expect(attached).resolves.toEqual({ detached: false });
   });
 
   it("queues stdin frames until the websocket is open", async () => {
@@ -258,6 +329,7 @@ describe("shell REST client", () => {
     expect(ControlledWebSocket.last?.sent).toEqual([
       JSON.stringify({ type: "input", data: "pwd\r" }),
     ]);
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     ControlledWebSocket.last?.emit("close");
     await expect(attached).resolves.toEqual({ detached: true });
   });
@@ -297,6 +369,7 @@ describe("shell REST client", () => {
     });
 
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     process.emit("SIGWINCH", "SIGWINCH");
     ControlledWebSocket.last?.emit("close");
 
@@ -322,6 +395,7 @@ describe("shell REST client", () => {
       errorOutput,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "a");
     input.emit("data", "\u001c");
     input.emit("data", "b");
@@ -372,6 +446,7 @@ describe("shell REST client", () => {
       mouse: false,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "a\u001b[<0;10;20M\u001b[Mabc\u001b[I\u001b[O");
     ControlledWebSocket.last?.emit("close");
 
@@ -395,6 +470,7 @@ describe("shell REST client", () => {
       errorOutput,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "\u001b[Ia\u001b[O\u001b[<0;10;20M");
     ControlledWebSocket.last?.emit("close");
 
@@ -419,6 +495,7 @@ describe("shell REST client", () => {
       errorOutput,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready" }));
     nowSpy.mockReturnValue(6_000);
     input.emit("data", "\u001b[I\u001b[<0;10;20M\u001b[Mabcx");
@@ -447,6 +524,7 @@ describe("shell REST client", () => {
       errorOutput,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready" }));
     nowSpy.mockReturnValue(6_000);
     input.emit("data", "\u001b[I\u001b[99;5u\u001b[100;5uok");
@@ -474,6 +552,7 @@ describe("shell REST client", () => {
       errorOutput,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "\u001b[99;5u");
     ControlledWebSocket.last?.emit("close");
 
@@ -497,6 +576,7 @@ describe("shell REST client", () => {
       errorOutput,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "a\u001b[99");
     input.emit("data", ";5ub");
     ControlledWebSocket.last?.emit("close");
@@ -523,6 +603,7 @@ describe("shell REST client", () => {
       mouse: false,
     });
     ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "a\u001b[<0;10;");
     input.emit("data", "20Mbc");
     ControlledWebSocket.last?.emit("close");

--- a/tests/cli/shell-recovery.test.ts
+++ b/tests/cli/shell-recovery.test.ts
@@ -3,11 +3,11 @@ import { recoveryHintForCode } from "../../packages/sync-client/src/cli/recovery
 
 describe("CLI recovery hints", () => {
   it("maps stable shell and daemon codes to actionable hints", () => {
-    expect(recoveryHintForCode("session_not_found")).toContain("matrix shell new");
-    expect(recoveryHintForCode("session_exists")).toContain("matrix shell connect");
-    expect(recoveryHintForCode("invalid_layout")).toContain("matrix shell layout");
+    expect(recoveryHintForCode("session_not_found")).toContain("mos shell new");
+    expect(recoveryHintForCode("session_exists")).toContain("mos shell attach");
+    expect(recoveryHintForCode("invalid_layout")).toContain("mos shell layout");
     expect(recoveryHintForCode("unsupported_version")).toContain("update");
-    expect(recoveryHintForCode("attach_failed")).toContain("reattach");
-    expect(recoveryHintForCode("auth_expired")).toContain("matrix login");
+    expect(recoveryHintForCode("attach_failed")).toContain("Reattach");
+    expect(recoveryHintForCode("auth_expired")).toContain("mos login");
   });
 });

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -129,7 +129,7 @@ describe("shell CLI command", () => {
 
     await shellCommand.run?.({ args: {} } as never);
 
-    expect(logs).toEqual(["Usage: matrix shell list|new|connect|rm|tab|pane|layout"]);
+    expect(logs).toEqual(["Usage: mos shell list|new|attach|rm|tab|pane|layout"]);
   });
 
   it("prints usage for the bare shell command with valued root flags", async () => {
@@ -143,7 +143,7 @@ describe("shell CLI command", () => {
       args: {},
     } as never);
 
-    expect(logs).toEqual(["Usage: matrix shell list|new|connect|rm|tab|pane|layout"]);
+    expect(logs).toEqual(["Usage: mos shell list|new|attach|rm|tab|pane|layout"]);
   });
 
   it("prints usage when a root flag value matches a shell subcommand", async () => {
@@ -157,7 +157,7 @@ describe("shell CLI command", () => {
       args: {},
     } as never);
 
-    expect(logs).toEqual(["Usage: matrix shell list|new|connect|rm|tab|pane|layout"]);
+    expect(logs).toEqual(["Usage: mos shell list|new|attach|rm|tab|pane|layout"]);
   });
 
   it("does not print usage after subcommands run", async () => {
@@ -216,7 +216,7 @@ describe("shell CLI command", () => {
         v: 1,
         error: {
           code: "not_authenticated",
-          message: 'Not logged in for profile "local". Run `matrix login` first.',
+          message: 'Not logged in for profile "local". Run `mos login` first.',
         },
       },
     ]);
@@ -246,7 +246,7 @@ describe("shell CLI command", () => {
       v: 1,
       error: {
         code: "auth_expired",
-        message: 'Auth for profile "local" expired on 2026-05-29T23:24:06.000Z. Run `matrix login --profile local` to refresh.',
+        message: 'Auth for profile "local" expired on 2026-05-29T23:24:06.000Z. Run `mos login --profile local` to refresh.',
       },
     });
   });
@@ -276,7 +276,7 @@ describe("shell CLI command", () => {
       v: 1,
       error: {
         code: "auth_expired",
-        message: "Matrix CLI auth expired. Run `matrix login` to refresh your session.",
+        message: "Matrix CLI auth expired. Run `mos login` to refresh your session.",
       },
     });
   });
@@ -297,7 +297,7 @@ describe("shell CLI command", () => {
         v: 1,
         error: {
           code: "not_authenticated",
-          message: 'Not logged in for profile "local". Run `matrix login` first.',
+          message: 'Not logged in for profile "local". Run `mos login` first.',
         },
       }),
     );
@@ -406,8 +406,12 @@ describe("shell CLI command", () => {
       send() {}
       close() {}
       on(event: "open" | "message" | "close" | "error", listener: (...args: unknown[]) => void) {
-        if (event === "open" || event === "close") {
+        if (event === "open") {
           queueMicrotask(() => listener());
+        }
+        if (event === "message") {
+          queueMicrotask(() => listener(JSON.stringify({ type: "attached" })));
+          queueMicrotask(() => listener(JSON.stringify({ type: "exit", code: 0 })));
         }
         return this;
       }
@@ -427,7 +431,7 @@ describe("shell CLI command", () => {
     expect(ClosingWebSocket.instances).toBe(1);
     expect(logs).toEqual([
       "Created shell session main. Attaching...",
-      "Detached. Reattach: matrix shell connect main",
+      "Shell attach ended. Reattach: mos shell attach main",
     ]);
   });
 
@@ -451,6 +455,7 @@ describe("shell CLI command", () => {
           queueMicrotask(() => listener());
         }
         if (event === "message") {
+          queueMicrotask(() => listener(JSON.stringify({ type: "attached" })));
           queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "REMOTE_BYTES" })));
         }
         if (event === "close") {
@@ -502,6 +507,7 @@ describe("shell CLI command", () => {
           queueMicrotask(() => listener());
         }
         if (event === "message") {
+          queueMicrotask(() => listener(JSON.stringify({ type: "attached" })));
           queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "CONNECT_BYTES" })));
         }
         if (event === "close") {
@@ -565,6 +571,7 @@ describe("shell CLI command", () => {
           queueMicrotask(() => listener(JSON.stringify({ type: "error", code: "session_not_found" })));
         }
         if (event === "message" && this.instance === 2) {
+          queueMicrotask(() => listener(JSON.stringify({ type: "attached" })));
           queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "CREATED_CONNECT_BYTES" })));
         }
         if (event === "close" && this.instance === 2) {
@@ -628,7 +635,11 @@ describe("shell CLI command", () => {
         if (event === "message" && this.instance === 1) {
           queueMicrotask(() => listener(JSON.stringify({ type: "error", code: "session_not_found" })));
         }
-        if (event === "open" || (event === "close" && this.instance === 2)) {
+        if (event === "message" && this.instance === 2) {
+          queueMicrotask(() => listener(JSON.stringify({ type: "attached" })));
+          queueMicrotask(() => listener(JSON.stringify({ type: "exit", code: 0 })));
+        }
+        if (event === "open") {
           queueMicrotask(() => listener());
         }
         return this;
@@ -651,6 +662,6 @@ describe("shell CLI command", () => {
       expect.objectContaining({ method: "POST" }),
     );
     expect(logs).toContain("Created shell session 1. Connecting...");
-    expect(logs).toContain("Detached. Reattach: matrix shell connect 1");
+    expect(logs).toContain("Shell attach ended. Reattach: mos shell attach 1");
   });
 });

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -7,10 +7,10 @@ describe("gateway shell routes", () => {
     list: () => Promise<unknown[]>;
     create: (input: unknown) => Promise<unknown>;
     delete: (name: string, options?: { force?: boolean }) => Promise<void>;
-  }) {
+  }, shellBackend?: { health: () => Promise<{ ok: boolean; code: string }> }) {
     const app = new Hono();
-    app.route("/api/terminal", createShellRoutes({ registry }));
-    app.route("/api", createShellRoutes({ registry }));
+    app.route("/api/terminal", createShellRoutes({ registry, shellBackend }));
+    app.route("/api", createShellRoutes({ registry, shellBackend }));
     return app;
   }
 
@@ -203,5 +203,41 @@ describe("gateway shell routes", () => {
     await expect(res.json()).resolves.toEqual({
       error: { code: "session_not_found", message: "Session not found" },
     });
+  });
+
+  it("checks shell backend health without listing or mutating sessions", async () => {
+    const registry = {
+      list: vi.fn(async () => [{ name: "main" }]),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const shellBackend = {
+      health: vi.fn(async () => ({ ok: true, code: "ok" })),
+    };
+    const app = appWithRegistry(registry, shellBackend);
+
+    const res = await app.request("/api/terminal/health");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ shell: { ok: true, code: "ok" } });
+    expect(shellBackend.health).toHaveBeenCalledTimes(1);
+    expect(registry.list).not.toHaveBeenCalled();
+    expect(registry.create).not.toHaveBeenCalled();
+    expect(registry.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns coarse shell backend health failures only", async () => {
+    const app = appWithRegistry({
+      list: vi.fn(async () => []),
+      create: vi.fn(),
+      delete: vi.fn(),
+    }, {
+      health: vi.fn(async () => ({ ok: false, code: "zellij_failed" })),
+    });
+
+    const res = await app.request("/api/terminal/health");
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ shell: { ok: false, code: "zellij_failed" } });
   });
 });

--- a/tests/gateway/shell-zellij.test.ts
+++ b/tests/gateway/shell-zellij.test.ts
@@ -59,6 +59,23 @@ describe("zellij adapter", () => {
     );
   });
 
+  it("checks backend health with bounded zellij --version", async () => {
+    const child = childProcess();
+    const execFile = vi.fn((_file, _args, _opts, cb) => {
+      cb(null, "zellij 0.44.1\n", "");
+      return child;
+    });
+    const adapter = createZellijAdapter({ execFile, spawn: vi.fn(), timeoutMs: 25 });
+
+    await expect(adapter.health()).resolves.toEqual({ ok: true, code: "ok" });
+    expect(execFile).toHaveBeenCalledWith(
+      "zellij",
+      ["--version"],
+      expect.objectContaining({ timeout: 25, signal: expect.any(AbortSignal) }),
+      expect.any(Function),
+    );
+  });
+
   it("treats zellij's no-active-sessions response as an empty session list", async () => {
     const execFile = vi.fn((_file, _args, _opts, cb) => {
       cb(Object.assign(new Error("zellij exited"), { code: 1 }), "", "NO ACTIVE ZELLIJ SESSIONS FOUND\n");

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -57,6 +57,8 @@ describe('customer VPS host bundle', () => {
     expect(script).toContain('install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/runtime/node/bin/gh"');
     expect(script).toContain('install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"');
     expect(script).toContain('chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway"');
+    expect(script).toContain('tar -xzf "$DIST_DIR/$ZELLIJ_ARCHIVE" -C "$STAGE_DIR/bin" zellij');
+    expect(script).toContain('test -x "$STAGE_DIR/bin/zellij"');
     expect(script).toContain('rm -rf "$STAGE_DIR/app/shell/.next/cache" "$STAGE_DIR/app/shell/e2e" "$STAGE_DIR/app/shell/node_modules"');
     expect(script).toContain('find "$STAGE_DIR/app/home/apps" -type d -name node_modules -prune -exec rm -rf {} +');
     expect(script).toContain('matrix-update');
@@ -104,6 +106,7 @@ describe('customer VPS host bundle', () => {
     expect(ownerEnv).toContain('export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"');
     expect(ownerEnv).toContain('matrix_prepend_path_once()');
     expect(ownerEnv).toContain('matrix_prepend_path_once "$HOME/.local/bin"');
+    expect(ownerEnv).toContain('matrix_prepend_path_once "/opt/matrix/bin"');
     expect(ownerEnv).toContain('failed to copy %s to %s; leaving legacy directory in place');
     expect(hermesInstaller).toContain('source /opt/matrix/bin/matrix-owner-env');
     expect(hermesInstaller).toContain('matrix_install_owner_dirs "$MATRIX_RUNTIME_USER" "$MATRIX_RUNTIME_USER"');

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -616,8 +616,13 @@ describe("device routes", () => {
       expect(cookie).toMatch(/device_csrf=[A-Fa-f0-9]+/);
       expect(cookie).toMatch(/HttpOnly/);
       const html = await res.text();
+      expect(html).toContain(">mos login<");
+      expect(html).toContain('<span class="prompt">mos</span> whoami');
       expect(html).toContain("shell attach -c main");
       expect(html).toContain("run -it -- claude");
+      expect(html).toContain('<span class="prompt">mos</span> doctor');
+      expect(html).not.toContain('<span class="prompt">matrix</span>');
+      expect(html).not.toContain(">matrix login<");
       expect(html).toContain('id="instance-line"');
     });
 

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -616,7 +616,7 @@ describe("device routes", () => {
       expect(cookie).toMatch(/device_csrf=[A-Fa-f0-9]+/);
       expect(cookie).toMatch(/HttpOnly/);
       const html = await res.text();
-      expect(html).toContain("shell connect -c main");
+      expect(html).toContain("shell attach -c main");
       expect(html).toContain("run -it -- claude");
       expect(html).toContain('id="instance-line"');
     });

--- a/tests/shell/terminal-app-component.test.tsx
+++ b/tests/shell/terminal-app-component.test.tsx
@@ -344,7 +344,7 @@ describe("TerminalApp", () => {
       await Promise.resolve();
     });
 
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("matrix shell connect main");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("mos shell attach main");
   });
 
   it("does not persist the mobile-forced sidebar state into shared terminal layout", async () => {

--- a/www/content/docs/guide/cli.mdx
+++ b/www/content/docs/guide/cli.mdx
@@ -43,7 +43,7 @@ matrix shell new main --attach # creates and attaches in one step
 
 If you do not have a Matrix account yet, `matrix login --profile cloud` keeps waiting while the browser walks you through signup, hosted trial checkout, and provisioning your Matrix computer. When setup finishes, approve the CLI in that same browser tab and return to your terminal.
 
-`Ctrl-\ Ctrl-\` detaches from a session without killing it. Reattach any time with `matrix shell connect main`.
+`Ctrl-\ Ctrl-\` detaches from a session without killing it. Reattach any time with `mos shell attach main`.
 
 ## Profiles
 
@@ -80,8 +80,8 @@ matrix shell new code                   # create a session
 matrix shell new code --attach          # create + attach
 matrix shell new code --layout dev      # create with a saved layout
 matrix shell new agent --cmd "claude"   # create with an inline command
-matrix shell connect code               # reattach to an existing session
-matrix shell connect -c review          # create if missing, then connect
+mos shell attach code                   # reattach to an existing session
+mos shell attach -c review              # create if missing, then attach
 matrix shell rm code --force            # destroy a session
 ```
 
@@ -277,13 +277,13 @@ The sync daemon is installed but not running. Start it with `matrix sync start`.
 
 Your token expired. Run `matrix login` again. Tokens are valid for the duration set by the platform (typically a few hours).
 
-**`matrix shell connect` shows a blank screen**
+**`mos shell attach` shows a blank screen**
 
 Usually means the zellij session exited on your instance. Check `matrix shell ls` — if the session is in the `exited` state, recreate it with `matrix shell new <name>`.
 
 **`session "foo" not found` when connecting**
 
-The session does not exist on your instance. `matrix shell connect` is intentionally strict unless you pass `-c`. Use `matrix shell new foo` or `matrix shell connect -c foo` to create it.
+The session does not exist on your instance. `mos shell attach` is intentionally strict unless you pass `-c`. Use `mos shell new foo` or `mos shell attach -c foo` to create it.
 
 **`matrix port forward` returns `invalid_forward_spec`**
 
@@ -291,7 +291,7 @@ Check the spec shape and port ranges. Valid examples are `3000`, `8080:127.0.0.1
 
 **`matrix port forward` connects but the browser shows connection refused**
 
-The target service must be running on the Matrix computer loopback interface, not on your laptop. Attach with `matrix shell connect <session>` and verify the service is listening on `127.0.0.1:<port>` inside the Matrix computer.
+The target service must be running on the Matrix computer loopback interface, not on your laptop. Attach with `mos shell attach <session>` and verify the service is listening on `127.0.0.1:<port>` inside the Matrix computer.
 
 **Local stack returns connection refused**
 

--- a/www/public/skills.md
+++ b/www/public/skills.md
@@ -116,7 +116,7 @@ Use these commands:
 
 ```bash
 # Use a named setup session so the human and web terminal can reattach.
-matrix shell connect -c setup
+mos shell attach -c setup
 matrix run -it --session setup -- gh auth login
 matrix run -it --session setup -- claude
 matrix run -it --session setup -- codex
@@ -124,7 +124,7 @@ matrix run -it --session setup -- codex
 
 Run either Claude or Codex according to the human's choice; do not start both unless the human explicitly asks.
 
-`matrix shell connect -c setup` creates the named session if it does not exist, then connects to it. If the human already has a working web terminal or CLI session, reuse that session instead of requiring a new one named `setup`.
+`mos shell attach -c setup` creates the named session if it does not exist, then attaches to it. If the human already has a working web terminal or CLI session, reuse that session instead of requiring a new one named `setup`.
 
 Detach from an interactive session with:
 
@@ -135,7 +135,7 @@ Ctrl-\ Ctrl-\
 Detaching leaves the remote zellij session alive. Reattach with:
 
 ```bash
-matrix shell connect setup
+mos shell attach setup
 ```
 
 ## Terminal Session Fallbacks
@@ -155,20 +155,20 @@ matrix shell ls
 Then connect to an existing session:
 
 ```bash
-matrix shell connect <session-name>
+mos shell attach <session-name>
 ```
 
 For setup, prefer an existing human-created session if one is available. If no setup session exists, create-or-connect with:
 
 ```bash
-matrix shell connect -c setup
+mos shell attach -c setup
 ```
 
 `connect -c <session-name>` creates the session if missing and then connects to it. If creation still fails with `zellij_failed`, ask the human to create or choose a session from the Matrix web terminal, then connect to that existing session:
 
 ```bash
 matrix shell ls
-matrix shell connect <existing-session>
+mos shell attach <existing-session>
 ```
 
 `connect` may succeed even when `attach` and `run -it` fail.
@@ -186,7 +186,7 @@ matrix sync
 matrix doctor
 ```
 
-If `matrix doctor` passes but terminal commands still return `zellij_failed`, switch to `matrix shell connect`.
+If `matrix doctor` passes but terminal commands still return `zellij_failed`, switch to `mos shell attach`.
 
 ## GitHub Setup For Coding
 
@@ -271,8 +271,8 @@ matrix instance logs
 matrix agent auth scan
 matrix shell ls
 matrix shell new setup --cmd bash
-matrix shell connect setup
-matrix shell connect -c setup
+mos shell attach setup
+mos shell attach -c setup
 matrix upload --secret ~/.codex/auth.json .codex/auth.json
 matrix upload --secret ~/.claude/.credentials.json .claude/.credentials.json
 matrix run -it --session setup -- claude
@@ -306,13 +306,13 @@ matrix shell ls
 If an interactive command looks stuck, detach with `Ctrl-\ Ctrl-\`, then reconnect:
 
 ```bash
-matrix shell connect setup
+mos shell attach setup
 ```
 
 If the named session is missing and should be created, use:
 
 ```bash
-matrix shell connect -c setup
+mos shell attach -c setup
 ```
 
 If the VPS is not ready yet, wait for provisioning in `https://app.matrix-os.com`, then retry `matrix login --profile cloud`.


### PR DESCRIPTION
## Summary

- Add safe Matrix CLI error codes/messages for platform and gateway reachability, request timeouts, zellij backend failures, attach failures, auth expiry, and unsupported Node runtimes.
- Classify OAuth, login `/api/me`, shell REST, and attach failures without exposing raw network errors, provider names, paths, stderr, stack traces, or backend details to CLI users.
- Add Node 24+ runtime guards before TS entrypoint loading in both CLI entrypoints.
- Add an authenticated, non-mutating terminal shell health route backed by a bounded zellij health check for `mos doctor`.
- Tighten attach UX around pre-attach close, remote exit, local detach, cleanup, JSON stdout/stderr separation, and `mos shell attach` recovery copy.
- Strengthen host-bundle verification for `/opt/matrix/bin` PATH and bundled executable `zellij`; update public/docs/shell copy from `matrix shell connect` to `mos shell attach`.
- Address Greptile review findings around device-flow deadline classification, quiet-mode browser fallback, shared fetch classification, WebSocket error-code allowlisting, and approval-page CLI copy.

## Invariants

- **Source of truth**: CLI profile/auth state remains in the existing profile store. Shell session state remains the gateway terminal/shell registry and zellij adapter; the new health route is diagnostic only and does not list sessions or reconcile metadata.
- **Lock/transaction scope**: This change does not add multi-write database flows. The shell health check performs one bounded `zellij --version` probe and does not hold locks or perform network calls inside a transaction.
- **Acceptable orphan states**: Login still saves the auth token before gateway discovery, as before. If post-auth `/api/me` fails, the CLI now exits with a safe platform reachability error and tells the user to retry login after the platform is reachable.
- **Auth source of truth**: Terminal shell health uses the existing terminal API authentication path. Missing backend dependencies are treated as server misconfiguration and returned as a coarse 503 shell health response with sanitized server-side logging.
- **Deferred scope**: This PR does not publish the npm patch, publish/deploy a new host bundle, restart customer VPS services, or add `MATRIX_ZELLIJ_BIN`; those remain rollout actions after PR validation.

## Tests

- `pnpm --filter @finnaai/matrix exec vitest run tests/unit/oauth.test.ts tests/unit/node-runtime-guard.test.ts` - 18 passed.
- `pnpm exec vitest run tests/cli/shell-client.test.ts tests/cli/json-output.test.ts tests/cli/profile-auth.test.ts tests/cli/profile.test.ts tests/cli/shell.test.ts tests/cli/shell-recovery.test.ts tests/cli/doctor.test.ts tests/cli/cli.test.ts tests/gateway/shell-zellij.test.ts tests/gateway/terminal-zellij-ws.test.ts tests/gateway/shell-routes.test.ts tests/platform/customer-vps-host-bundle.test.ts tests/platform/customer-vps-cloud-init.test.ts tests/platform/device-routes.test.ts` - 220 passed.
- Expanded pnpm typecheck substitute passed.
- `./scripts/review/check-patterns.sh` - 0 violations; scanner warnings only.
- `npx react-doctor@latest shell --verbose --diff` - no diff issues.
- Stale `shell connect` copy search is clean.

## Review/Monitoring

- First Greptile pass on `7ccf6971` reported 4/5 with five findings.
- Follow-up commit `b962359c` addresses the reported findings and all visible inline threads from Greptile are resolved.
- Latest head is `a7c94cbac675b246e6a05932565617c76e06e88e`, after merging current `origin/main` into the hotfix branch.
- Vercel is green on latest head.
- Awaiting a fresh Greptile result for latest head; the visible Greptile summary is still stale from the first reviewed commit and therefore is not a trusted latest-head 5/5 result yet.

## Environment Blockers

- `bun run typecheck`, `bun run check:patterns`, and `bun run test` could not run because `bun` is not installed in this environment.
- `flox activate -- ...` focused commands could not run because `flox` is not installed in this environment.
- A full `pnpm run test` substitute was attempted earlier and failed only on unrelated environment write-permission errors under `/tmp` in `tests/mcp-browser/server.test.ts` and `tests/gateway/sync/home-mirror.test.ts`.
- Local `gh auth status` reports an invalid token for `Nima-Naderi`; this PR was created/updated through the GitHub connector instead.