### PR TITLE
feat(cli): support noninteractive run commands

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -206,6 +206,7 @@ import {
   ScrollbackStore,
   ShellPreferencesStore,
   createPendingTerminalInputQueue,
+  createShellCommandRunner,
   createShellWsHandler,
   createZellijAdapter,
   ShellRegistry as ZellijShellRegistry,
@@ -1648,6 +1649,7 @@ export async function createGateway(config: GatewayConfig) {
     preferences: shellPreferencesStore,
     workspace: zellijAdapter,
     layouts: shellLayoutStore,
+    commandRunner: createShellCommandRunner({ homePath }),
   };
   app.route("/api/terminal", createShellRoutes(shellRouteDeps));
   app.route("/api", createShellRoutes(shellRouteDeps));

--- a/packages/gateway/src/shell/command-runner.ts
+++ b/packages/gateway/src/shell/command-runner.ts
@@ -1,0 +1,180 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { shellError } from "./errors.js";
+import { resolveShellCwd } from "./names.js";
+
+type Spawn = typeof nodeSpawn;
+
+export interface ShellCommandRunInput {
+  command: string[];
+  cwd?: string;
+  timeoutMs?: number;
+}
+
+export interface ShellCommandRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: string | null;
+  timedOut: boolean;
+  truncated: boolean;
+  durationMs: number;
+}
+
+export interface ShellCommandRunner {
+  run(input: ShellCommandRunInput): Promise<ShellCommandRunResult>;
+}
+
+export interface ShellCommandRunnerOptions {
+  homePath: string;
+  spawn?: Spawn;
+  env?: NodeJS.ProcessEnv;
+  defaultTimeoutMs?: number;
+  maxTimeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+const SAFE_COMMAND_ENV_KEYS = new Set([
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TMPDIR",
+  "USER",
+  "XDG_RUNTIME_DIR",
+]);
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
+const SIGKILL_GRACE_MS = 5_000;
+
+function commandEnv(source: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value !== undefined && SAFE_COMMAND_ENV_KEYS.has(key)) {
+      env[key] = value;
+    }
+  }
+  env.TERM = "dumb";
+  return env;
+}
+
+function boundedTimeout(input: number | undefined, defaultTimeoutMs: number, maxTimeoutMs: number): number {
+  const value = input ?? Number.NaN;
+  if (!Number.isFinite(value)) {
+    return defaultTimeoutMs;
+  }
+  return Math.min(Math.max(Math.trunc(value), 1), maxTimeoutMs);
+}
+
+function appendBounded(chunks: Buffer[], chunk: Buffer, state: { bytes: number; truncated: boolean }, maxBytes: number): void {
+  if (state.bytes >= maxBytes) {
+    state.truncated = true;
+    return;
+  }
+  const remaining = maxBytes - state.bytes;
+  const next = chunk.byteLength <= remaining ? chunk : chunk.subarray(0, remaining);
+  chunks.push(next);
+  state.bytes += next.byteLength;
+  if (next.byteLength < chunk.byteLength) {
+    state.truncated = true;
+  }
+}
+
+export function createShellCommandRunner(options: ShellCommandRunnerOptions): ShellCommandRunner {
+  const spawnImpl = options.spawn ?? nodeSpawn;
+  const env = commandEnv(options.env);
+  const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxTimeoutMs = options.maxTimeoutMs ?? MAX_TIMEOUT_MS;
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+
+  return {
+    async run(input) {
+      const cwd = await resolveShellCwd(input.cwd, options.homePath);
+      const [command, ...args] = input.command;
+      if (!command) {
+        throw shellError("invalid_request", "Invalid request", 400);
+      }
+      const timeoutMs = boundedTimeout(input.timeoutMs, defaultTimeoutMs, maxTimeoutMs);
+      const startedAt = Date.now();
+
+      return await new Promise<ShellCommandRunResult>((resolve) => {
+        const stdout: Buffer[] = [];
+        const stderr: Buffer[] = [];
+        const stdoutState = { bytes: 0, truncated: false };
+        const stderrState = { bytes: 0, truncated: false };
+        let settled = false;
+        let timedOut = false;
+        let child: ReturnType<Spawn> | null = null;
+        let killTimer: NodeJS.Timeout | null = null;
+
+        const finish = (result: Omit<ShellCommandRunResult, "stdout" | "stderr" | "truncated" | "durationMs">) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (killTimer) {
+            clearTimeout(killTimer);
+          }
+          resolve({
+            ...result,
+            stdout: Buffer.concat(stdout).toString("utf8"),
+            stderr: Buffer.concat(stderr).toString("utf8"),
+            truncated: stdoutState.truncated || stderrState.truncated,
+            durationMs: Date.now() - startedAt,
+          });
+        };
+
+        const timer = setTimeout(() => {
+          timedOut = true;
+          child?.kill("SIGTERM");
+          killTimer = setTimeout(() => {
+            child?.kill("SIGKILL");
+          }, SIGKILL_GRACE_MS);
+          killTimer.unref?.();
+        }, timeoutMs);
+        timer.unref?.();
+
+        try {
+          child = spawnImpl(command, args, {
+            cwd,
+            env,
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+        } catch (err: unknown) {
+          if (!(err instanceof Error && "code" in err)) {
+            console.warn("[shell-run] Failed to start command:", err instanceof Error ? err.name : typeof err);
+          }
+          finish({
+            exitCode: 127,
+            signal: null,
+            timedOut: false,
+          });
+          return;
+        }
+
+        child.stdout?.on("data", (chunk: Buffer) => {
+          appendBounded(stdout, chunk, stdoutState, maxOutputBytes);
+        });
+        child.stderr?.on("data", (chunk: Buffer) => {
+          appendBounded(stderr, chunk, stderrState, maxOutputBytes);
+        });
+        child.on("error", (err: Error) => {
+          console.warn("[shell-run] Command error:", err.name);
+          finish({
+            exitCode: 127,
+            signal: null,
+            timedOut: false,
+          });
+        });
+        child.on("close", (exitCode, signal) => {
+          finish({
+            exitCode,
+            signal,
+            timedOut,
+          });
+        });
+      });
+    },
+  };
+}

--- a/packages/gateway/src/shell/index.ts
+++ b/packages/gateway/src/shell/index.ts
@@ -1,6 +1,7 @@
 export * from "./names.js";
 export * from "./osc133.js";
 export * from "./atomic-write.js";
+export * from "./command-runner.js";
 export * from "./errors.js";
 export * from "./layouts.js";
 export * from "./pending-input.js";

--- a/packages/gateway/src/shell/routes.ts
+++ b/packages/gateway/src/shell/routes.ts
@@ -6,6 +6,7 @@ import {
   ShellPreferencesSchema,
   type ShellPreferencesStore,
 } from "./preferences.js";
+import type { ShellCommandRunner } from "./command-runner.js";
 
 interface SessionRegistryRoutes {
   list(): Promise<unknown[]>;
@@ -41,6 +42,7 @@ export interface ShellRouteDeps {
   preferences?: ShellPreferencesStore;
   workspace?: ShellWorkspaceRoutes;
   layouts?: ShellLayoutRoutes;
+  commandRunner?: ShellCommandRunner;
 }
 
 const CreateSessionBodySchema = z.object({
@@ -66,6 +68,11 @@ const PaneBodySchema = z.object({
 const LayoutBodySchema = z.object({
   kdl: z.string().min(1).max(100_000),
 });
+const RunBodySchema = z.object({
+  command: z.array(z.string().min(1).max(4096)).min(1).max(64),
+  cwd: SafeCwdSchema.optional(),
+  timeoutMs: z.number().int().positive().max(30 * 60 * 1000).optional(),
+});
 
 function safeCwdSchema() {
   return z.string().min(1).max(1024)
@@ -80,6 +87,7 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
   const workspaceBodyLimit = bodyLimit({ maxSize: 8192 });
   const layoutBodyLimit = bodyLimit({ maxSize: 128_000 });
   const deleteBodyLimit = bodyLimit({ maxSize: 512 });
+  const runBodyLimit = bodyLimit({ maxSize: 16_384 });
 
   app.get("/sessions", async (c) => {
     try {
@@ -109,6 +117,16 @@ export function createShellRoutes(deps: ShellRouteDeps): Hono {
         force: new URL(c.req.url).searchParams.get("force") === "1",
       });
       return c.json({ ok: true });
+    } catch (err) {
+      return safeError(c, err);
+    }
+  });
+
+  app.post("/run", runBodyLimit, async (c) => {
+    try {
+      if (!deps.commandRunner) return unavailable(c, "run_unavailable");
+      const body = RunBodySchema.parse(await c.req.json());
+      return c.json(await deps.commandRunner.run(body));
     } catch (err) {
       return safeError(c, err);
     }

--- a/packages/sync-client/src/cli/commands/run.ts
+++ b/packages/sync-client/src/cli/commands/run.ts
@@ -5,7 +5,7 @@ import { formatCliError, formatCliErrorMessage, formatCliSuccess } from "../outp
 import { createShellClient, type ShellAttachOptions, type ShellClient } from "../shell-client.js";
 import { requireCliAuthToken } from "../auth-state.js";
 
-const RUN_USAGE = "Usage: matrix run -it [--session <name>] [-C <dir>] -- <command>";
+const RUN_USAGE = "Usage: matrix run [-it] [--session <name>] [-C <dir>] -- <command>";
 const RUN_VALUE_OPTIONS = new Set(["--gateway", "--profile", "--token", "--session", "-C", "--cwd"]);
 
 async function clientFromArgs(args: Record<string, unknown>) {
@@ -117,6 +117,16 @@ function writeError(err: unknown, json: boolean): void {
   );
 }
 
+export function exitCodeFromRunResult(result: { exitCode: number | null; timedOut: boolean }): number {
+  if (result.timedOut) {
+    return 124;
+  }
+  if (result.exitCode !== null && Number.isInteger(result.exitCode)) {
+    return Math.min(Math.max(result.exitCode, 0), 255);
+  }
+  return 1;
+}
+
 export const runCommand = defineCommand({
   meta: {
     name: "run",
@@ -166,16 +176,31 @@ export const runCommand = defineCommand({
       if (command.length === 0) {
         throw Object.assign(new Error(RUN_USAGE), { code: "invalid_request" });
       }
-      if (!isInteractive(args, rawArgs)) {
-        throw Object.assign(
-          new Error("Non-interactive matrix run will use the same zellij session primitive, but this gateway does not expose remote exit status yet. Use `matrix run -it -- <command>` for now."),
-          { code: "not_implemented" },
-        );
-      }
-
       const sessionProvided = typeof args.session === "string";
       const name = sessionProvided ? args.session as string : createEphemeralSessionName();
       const client = await clientFromArgs(args);
+
+      if (!isInteractive(args, rawArgs)) {
+        if (sessionProvided) {
+          throw Object.assign(new Error("--session is only supported with -it"), { code: "invalid_request" });
+        }
+        const result = await client.runCommand({
+          command,
+          cwd: typeof args.cwd === "string" ? args.cwd : undefined,
+        });
+        if (json) {
+          console.log(formatCliSuccess({ ...result }));
+        } else {
+          process.stdout.write(result.stdout);
+          process.stderr.write(result.stderr);
+          if (result.truncated) {
+            process.stderr.write("matrix: output truncated (limit reached)\n");
+          }
+        }
+        process.exitCode = exitCodeFromRunResult(result);
+        return;
+      }
+
       const result = await createOrAttachRunSession(client, {
         name,
         cwd: typeof args.cwd === "string" ? args.cwd : undefined,

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -9,6 +9,11 @@ export interface ShellClientOptions {
 
 export interface ShellClient {
   listSessions(): Promise<unknown[]>;
+  runCommand(input: {
+    command: string[];
+    cwd?: string;
+    timeoutMs?: number;
+  }): Promise<ShellRunResult>;
   createSession(input: {
     name: string;
     cwd?: string;
@@ -36,6 +41,16 @@ export interface ShellClientError extends Error {
   code: string;
 }
 
+export interface ShellRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: string | null;
+  timedOut: boolean;
+  truncated: boolean;
+  durationMs: number;
+}
+
 interface AttachWebSocket {
   send(data: string): void;
   close(): void;
@@ -55,6 +70,8 @@ export interface ShellAttachOptions {
 
 export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
 export { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ };
+const DEFAULT_RUN_TIMEOUT_MS = 10 * 60 * 1000;
+const RUN_RESPONSE_GRACE_MS = 30_000;
 const LOCAL_TERMINAL_INPUT_RESET = [
   "\u001b[?1000l",
   "\u001b[?1002l",
@@ -227,7 +244,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
     return url.toString();
   }
 
-  async function request(path: string, init: RequestInit = {}): Promise<unknown> {
+  async function request(path: string, init: RequestInit = {}, requestTimeoutMs = timeoutMs): Promise<unknown> {
     const headers: Record<string, string> = {};
     new Headers(init.headers).forEach((value, key) => {
       headers[key] = value;
@@ -242,7 +259,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
     const res = await fetchImpl(`${base}${path}`, {
       ...init,
       headers,
-      signal: AbortSignal.timeout(timeoutMs),
+      signal: AbortSignal.timeout(requestTimeoutMs),
     });
     let payload: unknown = {};
     try {
@@ -280,6 +297,25 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         return (payload as { sessions: unknown[] }).sessions;
       }
       return [];
+    },
+    async runCommand(input) {
+      const payload = await request("/api/terminal/run", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }, (input.timeoutMs ?? DEFAULT_RUN_TIMEOUT_MS) + RUN_RESPONSE_GRACE_MS);
+      if (typeof payload !== "object" || payload === null) {
+        throw Object.assign(new Error("Request failed"), { code: "invalid_response" });
+      }
+      const result = payload as Partial<ShellRunResult>;
+      return {
+        stdout: typeof result.stdout === "string" ? result.stdout : "",
+        stderr: typeof result.stderr === "string" ? result.stderr : "",
+        exitCode: typeof result.exitCode === "number" ? result.exitCode : null,
+        signal: typeof result.signal === "string" ? result.signal : null,
+        timedOut: result.timedOut === true,
+        truncated: result.truncated === true,
+        durationMs: typeof result.durationMs === "number" ? result.durationMs : 0,
+      };
     },
     async createSession(input) {
       return (await request(terminalSessionsPath, {

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -7,14 +7,24 @@ import { describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import {
   createOrAttachRunSession,
+  exitCodeFromRunResult,
   parseRunCommand,
   quoteCommandArg,
   runCommand,
 } from "../../packages/sync-client/src/cli/commands/run.js";
 import { PUBLISHED_CLI_COMMANDS, resolvePublishedCliRedirect } from "../../packages/cli/src/index.js";
 
-async function createFakeRunGateway() {
+async function createFakeRunGateway(runResult: Record<string, unknown> = {
+  stdout: "file.txt\n",
+  stderr: "warn\n",
+  exitCode: 7,
+  signal: null,
+  timedOut: false,
+  truncated: false,
+  durationMs: 8,
+}) {
   let createRequests = 0;
+  let runRequests: unknown[] = [];
   let wsConnections = 0;
   const server = http.createServer((req, res) => {
     if (req.method === "POST" && req.url === "/api/terminal/sessions") {
@@ -22,6 +32,16 @@ async function createFakeRunGateway() {
       req.resume();
       res.writeHead(201, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ name: "run-session", created: true }));
+      return;
+    }
+    if (req.method === "POST" && req.url === "/api/terminal/run") {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        runRequests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(runResult));
+      });
       return;
     }
     res.writeHead(404, { "Content-Type": "application/json" });
@@ -46,6 +66,9 @@ async function createFakeRunGateway() {
     gatewayUrl: `http://127.0.0.1:${address.port}`,
     get createRequests() {
       return createRequests;
+    },
+    get runRequests() {
+      return runRequests;
     },
     get wsConnections() {
       return wsConnections;
@@ -134,6 +157,12 @@ describe("run CLI command", () => {
     expect(client.attachSession).toHaveBeenCalledWith("setup", {});
   });
 
+  it("maps timed-out runs to 124 even when the remote process reports an exit code", () => {
+    expect(exitCodeFromRunResult({ exitCode: 0, timedOut: true })).toBe(124);
+    expect(exitCodeFromRunResult({ exitCode: 7, timedOut: false })).toBe(7);
+    expect(exitCodeFromRunResult({ exitCode: null, timedOut: false })).toBe(1);
+  });
+
   it("passes no-mouse mode through interactive run attach", async () => {
     const client = {
       createSession: vi.fn(async () => ({ name: "setup" })),
@@ -180,6 +209,89 @@ describe("run CLI command", () => {
       expect(result.stderr).toContain("\u001b[?1000l");
       expect(gateway.createRequests).toBe(1);
       expect(gateway.wsConnections).toBe(1);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("runs non-interactive commands and exits with the remote status", async () => {
+    const gateway = await createFakeRunGateway();
+    try {
+      const result = await runMatrixCli([
+        "run",
+        "--gateway",
+        gateway.gatewayUrl,
+        "--token",
+        "tok",
+        "-C",
+        "projects/app",
+        "--",
+        "ls",
+      ]);
+
+      expect(result.status).toBe(7);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).toBe("file.txt\n");
+      expect(result.stderr).toBe("warn\n");
+      expect(gateway.runRequests).toEqual([{ command: ["ls"], cwd: "projects/app" }]);
+      expect(gateway.createRequests).toBe(0);
+      expect(gateway.wsConnections).toBe(0);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("warns when non-interactive text output is truncated", async () => {
+    const gateway = await createFakeRunGateway({
+      stdout: "partial\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      truncated: true,
+      durationMs: 8,
+    });
+    try {
+      const result = await runMatrixCli([
+        "run",
+        "--gateway",
+        gateway.gatewayUrl,
+        "--token",
+        "tok",
+        "--",
+        "cat",
+        "large.log",
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("partial\n");
+      expect(result.stderr).toBe("matrix: output truncated (limit reached)\n");
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it("rejects --session without interactive mode", async () => {
+    const gateway = await createFakeRunGateway();
+    try {
+      const result = await runMatrixCli([
+        "run",
+        "--session",
+        "setup",
+        "--gateway",
+        gateway.gatewayUrl,
+        "--token",
+        "tok",
+        "--",
+        "ls",
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("--session is only supported with -it");
+      expect(gateway.runRequests).toEqual([]);
+      expect(gateway.createRequests).toBe(0);
+      expect(gateway.wsConnections).toBe(0);
     } finally {
       await gateway.close();
     }

--- a/tests/gateway/shell-command-runner.test.ts
+++ b/tests/gateway/shell-command-runner.test.ts
@@ -1,0 +1,73 @@
+import { writeFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createShellCommandRunner } from "../../packages/gateway/src/shell/command-runner.js";
+
+describe("shell command runner", () => {
+  it("captures stdout stderr and exit status in a home-contained cwd", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-shell-run-"));
+    try {
+      await writeFile(join(homePath, "file.txt"), "ok");
+      const runner = createShellCommandRunner({ homePath, defaultTimeoutMs: 1_000 });
+
+      const result = await runner.run({
+        command: [
+          process.execPath,
+          "-e",
+          "console.log(require('fs').readdirSync('.').join(',')); console.error('warn'); process.exit(7)",
+        ],
+        cwd: "~",
+      });
+
+      expect(result.stdout).toBe("file.txt\n");
+      expect(result.stderr).toBe("warn\n");
+      expect(result.exitCode).toBe(7);
+      expect(result.signal).toBeNull();
+      expect(result.timedOut).toBe(false);
+      expect(result.truncated).toBe(false);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("reports when stdout or stderr is truncated", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-shell-run-"));
+    try {
+      const runner = createShellCommandRunner({
+        homePath,
+        defaultTimeoutMs: 1_000,
+        maxOutputBytes: 4,
+      });
+
+      const result = await runner.run({
+        command: [
+          process.execPath,
+          "-e",
+          "process.stdout.write('abcdef'); process.stderr.write('warn')",
+        ],
+        cwd: "~",
+      });
+
+      expect(result.stdout).toBe("abcd");
+      expect(result.stderr).toBe("warn");
+      expect(result.truncated).toBe(true);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects cwd traversal before spawning", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "matrix-shell-run-"));
+    try {
+      const runner = createShellCommandRunner({ homePath });
+
+      await expect(runner.run({ command: ["ls"], cwd: "../outside" })).rejects.toMatchObject({
+        code: "invalid_cwd",
+      });
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/shell-routes.test.ts
+++ b/tests/gateway/shell-routes.test.ts
@@ -71,6 +71,45 @@ describe("gateway shell routes", () => {
     expect(registry.create).toHaveBeenCalledWith({ name: "main", cwd: "~/projects" });
   });
 
+  it("runs non-interactive commands through a bounded JSON route", async () => {
+    const registry = {
+      list: vi.fn(async () => []),
+      create: vi.fn(),
+      delete: vi.fn(),
+    };
+    const commandRunner = {
+      run: vi.fn(async () => ({
+        stdout: "file.txt\n",
+        stderr: "",
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        truncated: false,
+        durationMs: 12,
+      })),
+    };
+    const app = new Hono();
+    app.route("/api/terminal", createShellRoutes({ registry, commandRunner }));
+
+    const res = await app.request("/api/terminal/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ command: ["ls"], cwd: "projects/app" }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      stdout: "file.txt\n",
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      truncated: false,
+      durationMs: 12,
+    });
+    expect(commandRunner.run).toHaveBeenCalledWith({ command: ["ls"], cwd: "projects/app" });
+  });
+
   it("allows digit-leading session names consistently across create and route params", async () => {
     const registry = {
       list: vi.fn(async () => []),


### PR DESCRIPTION
## Summary
- add a bounded gateway command-runner endpoint for non-interactive Matrix CLI commands
- make `matrix run -- <command>` print remote stdout/stderr and exit with the remote status
- keep `matrix run -it -- <command>` on the zellij interactive session path

## Tests
- `pnpm exec vitest run tests/gateway/shell-command-runner.test.ts tests/gateway/shell-routes.test.ts tests/cli/run.test.ts`
- `pnpm exec tsc --noEmit --project packages/gateway/tsconfig.json`
- `pnpm --filter @finnaai/matrix exec tsc --noEmit`
- `bun run check:patterns`
- `git diff --check`

## Invariants
- Source of truth: non-interactive command output and status come from the gateway child-process runner response; interactive run sessions remain owned by the zellij shell registry.
- Lock/transaction scope: no database writes or multi-step persistent mutations are introduced; each command request is an isolated process execution with bounded timeout and output capture.
- Acceptable orphan states: if the client disconnects after request dispatch, the server-side command continues only until its configured timeout and then is terminated; no session metadata is created for non-interactive runs.
- Auth source of truth: the new route is mounted under the existing authenticated terminal API path and uses the same gateway auth middleware as other shell routes.
- Deferred scope: streaming non-interactive output, stdin piping, shell parsing, and named-session reuse for non-interactive runs are not included here.