### PR TITLE
chore(cli): prepare 0.3.4 release

### DIFF
--- a/docs/dev/cli-release.md
+++ b/docs/dev/cli-release.md
@@ -4,7 +4,7 @@ The installable Matrix CLI is the `@finnaai/matrix` package in `packages/sync-cl
 
 ## Current Prepared Release
 
-`0.3.3` is the prepared CLI patch release for the merged CLI fixes after `0.3.2`, including interactive JSON output isolation, leading global flag handling, profile-aware peer commands, agent credential transfer, and sync-client daemon upload/download fixes.
+`0.3.4` is the prepared CLI patch release for the merged CLI fixes after `0.3.3`, including non-interactive `matrix run -- <command>` support backed by the gateway command-runner endpoint.
 
 ## Versioning
 
@@ -33,7 +33,7 @@ git tag -l 'cli-v*'
 
 ## Release
 
-Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.3` and `update_homebrew=true`. The workflow:
+Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.4` and `update_homebrew=true`. The workflow:
 
 1. Validates the requested semver, local package version, npm availability, and `cli-v<version>` tag availability.
 2. Installs the workspace and runs the sync-client build, tests, and publish-shape check.
@@ -47,18 +47,18 @@ Use the manual GitHub Actions workflow named `CLI Release` with `version=0.3.3` 
 npm view @finnaai/matrix version
 npm view @finnaai/matrix dist.tarball
 brew update && brew info finnaai/tap/matrix
-MATRIX_VERSION=0.3.3 sh scripts/install.sh
+MATRIX_VERSION=0.3.4 sh scripts/install.sh
 matrix --version
 matrix login --help
 matrix run --help
 ```
 
-For macOS, also verify the GitHub release contains `MatrixSync-0.3.3.pkg` when the macOS job was enabled.
+For macOS, also verify the GitHub release contains `MatrixSync-0.3.4.pkg` when the macOS job was enabled.
 
 ## Rollback
 
-npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.3` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
+npm package versions are immutable. If a bad CLI release is published, ship a patch release such as `0.3.4` and update Homebrew through the release workflow. Only deprecate the bad npm version when the replacement is available:
 
 ```bash
-npm deprecate @finnaai/matrix@0.3.2 "Use @finnaai/matrix@0.3.3"
+npm deprecate @finnaai/matrix@0.3.3 "Use @finnaai/matrix@0.3.4"
 ```

--- a/packages/sync-client/package.json
+++ b/packages/sync-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finnaai/matrix",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Matrix OS command-line client — login, sync, and peer management for matrix-os.com",
   "type": "module",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump @finnaai/matrix to 0.3.4 for the noninteractive run release
- update the CLI release guide to dispatch the 0.3.4 npm/Homebrew workflow

## Tests
- pnpm install --frozen-lockfile
- pnpm --filter @finnaai/matrix build
- pnpm --filter @finnaai/matrix test
- pnpm --filter @finnaai/matrix exec node ./scripts/check-publish.mjs
- bun run check:patterns
- git diff --check
- npm view @finnaai/matrix@0.3.4 version (expected 404: version not published yet)

## Invariants
- Source of truth: packages/sync-client/package.json remains the CLI package version consumed by the release workflow; npm and Homebrew are updated only by the manual CLI Release workflow after merge.
- Lock/transaction scope: no runtime state, database state, or persistent user data is changed by this release-prep PR.
- Acceptable orphan states: if the release workflow is not dispatched after merge, users remain on 0.3.3 and no partial package publication occurs.
- Auth source of truth: publishing continues to rely on GitHub Actions npm provenance and the existing Homebrew tap token configuration.
- Deferred scope: this PR does not publish npm, update Homebrew, or change CLI behavior; those are handled by the already-merged implementation and the post-merge release workflow.