### PR TITLE
fix(platform): include clerk sync package in image

### DIFF
--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -6,6 +6,7 @@ RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY packages/clerk-sync/package.json packages/clerk-sync/package.json
 COPY packages/observability/package.json packages/observability/package.json
 COPY packages/platform/package.json packages/platform/package.json
 COPY scripts/fix-node-pty-perms.mjs scripts/fix-node-pty-perms.mjs
@@ -34,8 +35,10 @@ RUN adduser -D -u 1001 -h /home/matrix-platform -s /sbin/nologin matrix-platform
     chown matrix-platform:matrix-platform /app /home/matrix-platform
 
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/node_modules ./node_modules
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/package.json ./packages/clerk-sync/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/observability/package.json ./packages/observability/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/platform/package.json ./packages/platform/package.json
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/src ./packages/clerk-sync/src
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/platform/dist ./packages/platform/dist
 COPY --chown=matrix-platform:matrix-platform distro/customer-vps ./distro/customer-vps


### PR DESCRIPTION
## Summary
- include @matrix-os/clerk-sync package metadata in the platform Docker dependency stages
- copy packages/clerk-sync/src into the runtime image so platform dist can resolve the existing workspace package export
- fixes Cloud Run startup failure where platform dist imported @matrix-os/clerk-sync but the package was absent from the image

## Validation
- pnpm --filter '@matrix-os/platform' build
- docker build -f Dockerfile.platform -t matrix-platform:clerk-sync-image-fix .
- docker run --rm --entrypoint node matrix-platform:clerk-sync-image-fix --input-type=module -e "import('@matrix-os/clerk-sync').then((m)=>{ if (!m.getProvisionHandleCandidates) process.exit(1); console.log('clerk-sync import ok') })"

## Invariants
- Source of truth: platform runtime package resolution remains the production Docker image contents.
- Lock/transaction scope: no database writes or runtime state changes.
- Acceptable orphan states: old Cloud Run revision remains serving until the fixed image is deployed and smoked.
- Auth source of truth: unchanged.
- Deferred scope: package-wide compiled output standardization is tracked in #427; this hotfix keeps the current source-export package contract because production Cloud Run runs on Node 24 and the dist-export attempt broke the website preview.