### PR TITLE
fix(platform): route signup billing through auth shell

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -106,11 +106,18 @@ jobs:
           set -euo pipefail
           image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:${GITHUB_SHA::12}"
           echo "IMAGE=$image" >> "$GITHUB_ENV"
+          next_public_clerk_publishable_key="$(gcloud secrets versions access latest --secret next-public-clerk-publishable-key --project "$GCP_PROJECT_ID" 2>/dev/null || true)"
+          next_public_posthog_key="$(gcloud secrets versions access latest --secret next-public-posthog-key --project "$GCP_PROJECT_ID" 2>/dev/null || true)"
+          next_public_posthog_project_token="$(gcloud secrets versions access latest --secret next-public-posthog-project-token --project "$GCP_PROJECT_ID" 2>/dev/null || true)"
+          if [ -z "$next_public_clerk_publishable_key" ]; then
+            echo "next-public-clerk-publishable-key is required to build the auth-shell billing surface." >&2
+            exit 1
+          fi
           build_id=$(gcloud builds submit . \
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
             --config cloudbuild.platform.yaml \
-            --substitutions "_IMAGE=$image" \
+            --substitutions "_IMAGE=$image,_NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$next_public_clerk_publishable_key,_NEXT_PUBLIC_POSTHOG_KEY=$next_public_posthog_key,_NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=$next_public_posthog_project_token,_NEXT_PUBLIC_POSTHOG_HOST=$POSTHOG_PUBLIC_HOST,_NEXT_PUBLIC_POSTHOG_API_HOST=$POSTHOG_PUBLIC_API_HOST,_NEXT_PUBLIC_MATRIX_APP_URL=$MATRIX_APP_URL" \
             --async \
             --format 'value(metadata.build.id)' \
             --timeout=1200s)
@@ -184,7 +191,7 @@ jobs:
             --ingress all \
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
             --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
             --format=json); then
             exit 1

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -8,21 +8,35 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY packages/observability/package.json packages/observability/package.json
 COPY packages/platform/package.json packages/platform/package.json
+COPY shell/package.json shell/package.json
 COPY scripts/fix-node-pty-perms.mjs scripts/fix-node-pty-perms.mjs
 
 FROM base AS deps
 
-RUN pnpm install --frozen-lockfile --ignore-scripts --filter '@matrix-os/platform...'
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter '@matrix-os/platform...' --filter './shell...'
 
 FROM deps AS builder
 
 COPY . .
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_POSTHOG_KEY
+ARG NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+ARG NEXT_PUBLIC_POSTHOG_HOST
+ARG NEXT_PUBLIC_POSTHOG_API_HOST
+ARG NEXT_PUBLIC_MATRIX_APP_URL
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
+ENV NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=$NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
+ENV NEXT_PUBLIC_POSTHOG_API_HOST=$NEXT_PUBLIC_POSTHOG_API_HOST
+ENV NEXT_PUBLIC_MATRIX_APP_URL=$NEXT_PUBLIC_MATRIX_APP_URL
 RUN pnpm --filter '@matrix-os/observability' build
 RUN pnpm --filter '@matrix-os/platform' build
+RUN pnpm --dir shell exec next build --webpack
 
 FROM base AS prod-deps
 
-RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/platform...'
+RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/platform...' --filter './shell...'
 
 FROM node:24-alpine AS runtime
 
@@ -36,16 +50,26 @@ RUN adduser -D -u 1001 -h /home/matrix-platform -s /sbin/nologin matrix-platform
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/node_modules ./node_modules
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/observability/package.json ./packages/observability/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/platform/package.json ./packages/platform/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/shell/package.json ./shell/package.json
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/platform/dist ./packages/platform/dist
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/shell ./shell
 COPY --chown=matrix-platform:matrix-platform distro/customer-vps ./distro/customer-vps
+COPY --chown=matrix-platform:matrix-platform scripts/start-platform-cloud-run.sh ./scripts/start-platform-cloud-run.sh
+
+RUN chmod 0755 ./scripts/start-platform-cloud-run.sh && \
+    mkdir -p ./shell/.next/cache ./shell/.next/server && \
+    chown -R matrix-platform:matrix-platform ./shell/.next/cache ./shell/.next/server
 
 ENV NODE_ENV=production
 ENV PLATFORM_PORT=8080
 ENV CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml
+ENV AUTH_SHELL_HOST=127.0.0.1
+ENV AUTH_SHELL_PORT=3200
 
 EXPOSE 8080
+EXPOSE 3200
 
 USER matrix-platform
 
-CMD ["node", "packages/platform/dist/main.js"]
+CMD ["./scripts/start-platform-cloud-run.sh"]

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -6,6 +6,7 @@ RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+COPY packages/clerk-sync/package.json packages/clerk-sync/package.json
 COPY packages/observability/package.json packages/observability/package.json
 COPY packages/platform/package.json packages/platform/package.json
 COPY shell/package.json shell/package.json
@@ -48,9 +49,11 @@ RUN adduser -D -u 1001 -h /home/matrix-platform -s /sbin/nologin matrix-platform
     chown matrix-platform:matrix-platform /app /home/matrix-platform
 
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/node_modules ./node_modules
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/package.json ./packages/clerk-sync/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/observability/package.json ./packages/observability/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/platform/package.json ./packages/platform/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/shell/package.json ./shell/package.json
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/src ./packages/clerk-sync/src
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/platform/dist ./packages/platform/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/shell ./shell

--- a/cloudbuild.platform.yaml
+++ b/cloudbuild.platform.yaml
@@ -1,5 +1,11 @@
 substitutions:
   _IMAGE: europe-west3-docker.pkg.dev/matrix-os-1144/matrix-os/matrix-platform:manual
+  _NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ''
+  _NEXT_PUBLIC_POSTHOG_KEY: ''
+  _NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: ''
+  _NEXT_PUBLIC_POSTHOG_HOST: ''
+  _NEXT_PUBLIC_POSTHOG_API_HOST: ''
+  _NEXT_PUBLIC_MATRIX_APP_URL: 'https://app.matrix-os.com'
 
 steps:
   - name: gcr.io/cloud-builders/docker
@@ -7,6 +13,18 @@ steps:
       - build
       - -f
       - Dockerfile.platform
+      - --build-arg
+      - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${_NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+      - --build-arg
+      - NEXT_PUBLIC_POSTHOG_KEY=${_NEXT_PUBLIC_POSTHOG_KEY}
+      - --build-arg
+      - NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=${_NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN}
+      - --build-arg
+      - NEXT_PUBLIC_POSTHOG_HOST=${_NEXT_PUBLIC_POSTHOG_HOST}
+      - --build-arg
+      - NEXT_PUBLIC_POSTHOG_API_HOST=${_NEXT_PUBLIC_POSTHOG_API_HOST}
+      - --build-arg
+      - NEXT_PUBLIC_MATRIX_APP_URL=${_NEXT_PUBLIC_MATRIX_APP_URL}
       - -t
       - ${_IMAGE}
       - .

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2407,6 +2407,10 @@ function getAuthPage(
             showNoRuntimeState();
             return null;
           }
+          if (res.status === 402) {
+            showBillingRequiredState();
+            return null;
+          }
           showSignedInRecoveryState();
           return null;
         })
@@ -3722,6 +3726,18 @@ export function createApp(deps: {
     if (!handle) {
       applyNoStoreHeaders(c);
       c.header('Set-Cookie', buildClearAppSessionCookie());
+      if (stripeBillingEntitlementsEnabled(appEnv)) {
+        const now = new Date();
+        const entitlement = await resolveEffectiveBillingEntitlement(db, result.userId, now);
+        const access = getRuntimeAccessDecision(entitlement, now);
+        if (!access.runtimeProxyAllowed) {
+          return jsonCustomerVpsError(
+            c,
+            new CustomerVpsError(402, 'billing_required', 'Billing upgrade required'),
+            '/api/auth/app-session',
+          );
+        }
+      }
       return c.json({ error: 'Matrix computer unavailable', code: 'no_runtime' }, 404);
     }
 

--- a/scripts/start-platform-cloud-run.sh
+++ b/scripts/start-platform-cloud-run.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+auth_shell_port="${AUTH_SHELL_PORT:-3200}"
+auth_shell_pid=""
+
+if [ "${AUTH_SHELL_ENABLED:-true}" = "true" ]; then
+  HOSTNAME=127.0.0.1 \
+    node node_modules/next/dist/bin/next start shell -p "$auth_shell_port" -H 127.0.0.1 &
+  auth_shell_pid="$!"
+fi
+
+node packages/platform/dist/main.js &
+platform_pid="$!"
+
+shutdown() {
+  if [ -n "$auth_shell_pid" ]; then
+    kill "$auth_shell_pid" 2>/dev/null || true
+  fi
+  kill "$platform_pid" 2>/dev/null || true
+  wait "$platform_pid" 2>/dev/null || true
+  if [ -n "$auth_shell_pid" ]; then
+    wait "$auth_shell_pid" 2>/dev/null || true
+  fi
+}
+
+trap shutdown INT TERM
+
+wait "$platform_pid"
+status="$?"
+
+if [ -n "$auth_shell_pid" ]; then
+  kill "$auth_shell_pid" 2>/dev/null || true
+  wait "$auth_shell_pid" 2>/dev/null || true
+fi
+
+exit "$status"

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -110,6 +110,7 @@ describe("platform proxy routing", () => {
     vi.restoreAllMocks();
     delete process.env.PLATFORM_JWT_SECRET;
     delete process.env.MATRIX_PAID_BETA_ENTITLEMENT_STATUS;
+    delete process.env.MATRIX_BILLING_PROVIDER;
     delete process.env.MATRIX_STRIPE_BILLING_ENABLED;
     delete process.env.STRIPE_SECRET_KEY;
     delete process.env.HETZNER_SERVER_TYPE;
@@ -2205,6 +2206,57 @@ describe("platform proxy routing", () => {
     expect(html).toContain("Loading your Matrix computer");
     expect(html).not.toContain("ask the operator to provision this account");
     expect(html).not.toContain("You are already signed in");
+  });
+
+  it("shows checkout instead of the no-runtime provision CTA when app-session billing is required", async () => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue(null),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/sign-up", {
+      headers: { host: "app.matrix-os.com" },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("if (res.status === 402) {\n            showBillingRequiredState();");
+  });
+
+  it("returns billing_required for signed-in app-session exchange before a Stripe entitlement exists", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    process.env.MATRIX_BILLING_PROVIDER = "stripe";
+    process.env.STRIPE_SECRET_KEY = "sk_test_matrix";
+    await deleteContainer(db, "alice");
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const exchange = await app.request("/api/auth/app-session", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+      },
+    });
+
+    expect(exchange.status).toBe(402);
+    await expect(exchange.json()).resolves.toEqual({
+      error: "Billing upgrade required",
+      code: "billing_required",
+    });
+    expect(exchange.headers.get("set-cookie")).toContain("matrix_app_session=;");
+    expect(exchange.headers.get("set-cookie")).toContain("Max-Age=0");
   });
 
   it("serves the shell billing gate from auth-shell for signed-in users before a VPS exists", async () => {


### PR DESCRIPTION
## Summary

- Route signed-in users with no Matrix computer to the shell auth surface so `BillingGate` opens Settings -> Billing after signup.
- Make `/api/auth/app-session` return `402 billing_required` before an unpaid user has a runtime, so the inline fallback cannot drive the old provision CTA.
- Build and run a local auth-shell process inside the Cloud Run platform image, and wire production Cloud Run to use it in VPS-native routing mode.

## Tests

- `bun run test tests/platform/proxy-routing.test.ts -- --runInBand`
- `bun run typecheck`
- `docker build -f Dockerfile.platform -t matrix-platform-authshell-test --build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_placeholder --build-arg NEXT_PUBLIC_POSTHOG_KEY= --build-arg NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN= --build-arg NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com --build-arg NEXT_PUBLIC_POSTHOG_API_HOST=https://eu.i.posthog.com --build-arg NEXT_PUBLIC_MATRIX_APP_URL=https://app.matrix-os.com .`

## Invariants

- Source of truth: Stripe/Neon billing entitlement state remains canonical for hosted runtime access; the auth shell only renders the billing UI.
- Lock/transaction scope: no new multi-write DB transaction is introduced; app-session checks read entitlement state before issuing an app session.
- Acceptable orphan states: a user can be signed in with no runtime and no entitlement; they are routed to billing settings and runtime provisioning stays blocked until Stripe entitlement exists.
- Auth source of truth: Clerk remains the browser session source; platform sync JWTs are only issued after a matching runtime exists.
- Deferred scope: this does not provision runtimes, change Stripe plan semantics, or migrate customer VPS data.
