### PR TITLE
feat(releases): show bundle build IDs and stable notes

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -263,6 +263,8 @@ jobs:
       PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Download bundle artifact
         uses: actions/download-artifact@v8
@@ -303,13 +305,30 @@ jobs:
 
       - name: Resolve severity and changelog
         id: meta
+        env:
+          PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
+          PUBLISH_CHANNEL: ${{ needs.build.outputs.channel }}
+          INPUT_CHANGELOG: ${{ inputs.changelog || '' }}
         run: |
           set -euo pipefail
           # Default to "normal" for push-triggered runs
           SEVERITY="${{ inputs.severity || 'normal' }}"
-          CHANGELOG="${{ inputs.changelog || '' }}"
+          CHANGELOG="$INPUT_CHANGELOG"
+          if [ -z "$CHANGELOG" ] && [ "$PUBLISH_CHANNEL" = "stable" ]; then
+            BASE_SHA="$(curl --fail --silent --show-error --max-time 10 "${PLATFORM_PUBLIC_URL%/}/system-bundles/channels/stable.json" | jq -r '.gitCommit // ""' || true)"
+            if [ -n "$BASE_SHA" ] && git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+              CHANGELOG="$(node scripts/release-changelog.mjs --base "$BASE_SHA" --head "$GITHUB_SHA")"
+            else
+              CHANGELOG="$(node scripts/release-changelog.mjs --head "$GITHUB_SHA")"
+            fi
+          fi
           echo "severity=$SEVERITY" >> "$GITHUB_OUTPUT"
-          echo "changelog=$CHANGELOG" >> "$GITHUB_OUTPUT"
+          DELIMITER="CHANGELOG_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_${GITHUB_SHA}"
+          {
+            echo "changelog<<$DELIMITER"
+            printf '%s\n' "$CHANGELOG"
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Publish release
         env:

--- a/packages/sync-client/tests/unit/shell-client.test.ts
+++ b/packages/sync-client/tests/unit/shell-client.test.ts
@@ -121,10 +121,11 @@ describe("createShellClient attachSession", () => {
       WebSocketImpl: FakeWebSocket as never,
     });
 
+    expect(FakeWebSocket.last?.url).toContain(`fromSeq=${SHELL_ATTACH_LIVE_TAIL_FROM_SEQ}`);
+
+    FakeWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     FakeWebSocket.last?.emit("close");
     await attach;
-
-    expect(FakeWebSocket.last?.url).toContain(`fromSeq=${SHELL_ATTACH_LIVE_TAIL_FROM_SEQ}`);
   });
 
   it("forwards SIGINT after attach so terminals that still emit signals can interrupt remote programs", async () => {

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const GROUPS = [
+  ["New", new Set(["feat"])],
+  ["Fixed", new Set(["fix", "revert"])],
+  ["Faster", new Set(["perf"])],
+  ["Polish and reliability", new Set(["build", "chore", "ci", "docs", "refactor", "style", "test"])],
+];
+const FALLBACK_MAX_COMMITS = 100;
+
+function capitalizeSentence(value) {
+  if (!value) return value;
+  const text = value.replace(/\s+/g, " ").trim();
+  return `${text.charAt(0).toUpperCase()}${text.slice(1)}`.replace(/[.!?]?$/, ".");
+}
+
+export function humanizeCommitSubject(subject) {
+  const withoutPrNumber = subject.replace(/\s+\(#\d+\)\s*$/, "").trim();
+  const conventional = withoutPrNumber.match(/^([a-z]+)(?:\([^)]+\))?!?:\s*(.+)$/i);
+  const text = conventional ? conventional[2] : withoutPrNumber;
+  return capitalizeSentence(text.replace(/\bdb\b/gi, "database"));
+}
+
+function commitType(subject) {
+  const match = subject.match(/^([a-z]+)(?:\([^)]+\))?!?:/i);
+  return match?.[1]?.toLowerCase() ?? "other";
+}
+
+function groupNameForType(type) {
+  for (const [name, types] of GROUPS) {
+    if (types.has(type)) return name;
+  }
+  return "Polish and reliability";
+}
+
+export function buildReleaseChangelog(subjects) {
+  const grouped = new Map(GROUPS.map(([name]) => [name, []]));
+  for (const subject of subjects) {
+    const note = humanizeCommitSubject(subject);
+    if (!note) continue;
+    grouped.get(groupNameForType(commitType(subject)))?.push(note);
+  }
+
+  const lines = ["What's changed", ""];
+  for (const [name, notes] of grouped) {
+    if (notes.length === 0) continue;
+    lines.push(name);
+    for (const note of notes) {
+      lines.push(`- ${note}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n").trim();
+}
+
+function parseArgs(argv) {
+  const args = { base: "", head: "HEAD" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--base") args.base = argv[++i] ?? "";
+    else if (arg === "--head") args.head = argv[++i] ?? "HEAD";
+  }
+  return args;
+}
+
+function gitLogSubjects({ base, head }) {
+  const range = base ? `${base}..${head}` : head;
+  const args = ["log", "--reverse", "--format=%s"];
+  if (!base) {
+    args.push(`--max-count=${FALLBACK_MAX_COMMITS}`);
+  }
+  args.push(range);
+  const output = execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  return output.split("\n").map((line) => line.trim()).filter(Boolean);
+}
+
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isCli) {
+  const args = parseArgs(process.argv.slice(2));
+  const subjects = gitLogSubjects(args);
+  const changelog = subjects.length > 0
+    ? buildReleaseChangelog(subjects)
+    : "What's changed\n\n- This release keeps Matrix OS up to date.";
+  process.stdout.write(`${changelog}\n`);
+}

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -83,6 +83,7 @@ interface SystemReleaseList {
 
 import {
   formatReleaseBuildId,
+  formatReleaseBuildShortId,
   releaseActionLabel,
   resolveUpgradeInstallCopy,
   severityBadgeStyle,
@@ -126,10 +127,10 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
 
   useEffect(() => {
     if (!upgrading) return;
-    const jokeTimer = setInterval(() => {
+    const progressMessageTimer = setInterval(() => {
       setUpgradeWaitingIndex((index) => index + 1);
     }, 7_000);
-    return () => clearInterval(jokeTimer);
+    return () => clearInterval(progressMessageTimer);
   }, [upgrading]);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- stable identity is consumed by the mount-bootstrap useEffect dependency array below; removing useCallback would re-run that effect on every render and refetch system info/health in a loop.
@@ -588,7 +589,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
             ["Version", info.version ?? "0.1.0"],
             ["Host Bundle", info.release?.version],
             ["Channel", info.release?.channel],
-            ["Build ID", formatReleaseBuildId(info.release?.gitCommit)],
+            ["Build ID", formatReleaseBuildShortId(info.release?.gitCommit)],
             ["Git Ref", info.release?.gitRef],
             ["Bundle Build Time", info.release?.buildTime],
             ["Installed At", info.release?.installedAt],

--- a/shell/src/components/settings/sections/SystemSection.tsx
+++ b/shell/src/components/settings/sections/SystemSection.tsx
@@ -82,6 +82,7 @@ interface SystemReleaseList {
 }
 
 import {
+  formatReleaseBuildId,
   releaseActionLabel,
   resolveUpgradeInstallCopy,
   severityBadgeStyle,
@@ -551,8 +552,13 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
                         )}
                       </div>
                       <p className="truncate text-xs text-muted-foreground">
-                        {[release.gitCommit?.slice(0, 12), release.buildTime].filter(Boolean).join(" · ")}
+                        {[formatReleaseBuildId(release.gitCommit), release.buildTime].filter(Boolean).join(" · ")}
                       </p>
+                      {selectedChannel === "stable" && release.changelog && (
+                        <p className="whitespace-pre-line text-xs leading-5 text-muted-foreground">
+                          {release.changelog}
+                        </p>
+                      )}
                     </div>
                     <button
                       type="button"
@@ -582,7 +588,7 @@ export function SystemSection({ billingActive = true }: { billingActive?: boolea
             ["Version", info.version ?? "0.1.0"],
             ["Host Bundle", info.release?.version],
             ["Channel", info.release?.channel],
-            ["Git Commit", info.release?.gitCommit],
+            ["Build ID", formatReleaseBuildId(info.release?.gitCommit)],
             ["Git Ref", info.release?.gitRef],
             ["Bundle Build Time", info.release?.buildTime],
             ["Installed At", info.release?.installedAt],

--- a/shell/src/components/settings/sections/system-update-state.ts
+++ b/shell/src/components/settings/sections/system-update-state.ts
@@ -87,8 +87,14 @@ export function severityBadgeStyle(severity?: string): string {
 }
 
 export function formatReleaseBuildId(gitCommit?: string): string | null {
+  const shortId = formatReleaseBuildShortId(gitCommit);
+  if (!shortId) return null;
+  return `Build ID ${shortId}`;
+}
+
+export function formatReleaseBuildShortId(gitCommit?: string): string | null {
   if (!gitCommit) return null;
-  return `Build ID ${gitCommit.slice(0, 12)}`;
+  return gitCommit.slice(0, 12);
 }
 
 export const UPGRADE_INSTALL_STATUS_LINES = [

--- a/shell/src/components/settings/sections/system-update-state.ts
+++ b/shell/src/components/settings/sections/system-update-state.ts
@@ -86,13 +86,18 @@ export function severityBadgeStyle(severity?: string): string {
   }
 }
 
+export function formatReleaseBuildId(gitCommit?: string): string | null {
+  if (!gitCommit) return null;
+  return `Build ID ${gitCommit.slice(0, 12)}`;
+}
+
 export const UPGRADE_INSTALL_STATUS_LINES = [
-  "Reading the Matrix release notes between packets.",
-  "Cloud status: one host bundle, lightly compressed, coming right up.",
-  "A coding agent is watching the logs and resisting the urge to refactor them.",
-  "The VPS is swapping in the new shell without touching your home files.",
-  "Cloudflare has the route. The updater has the bundle. Everyone has one job.",
-  "Checking that the new reality answers /health before we reload.",
+  "Putting the new version in place. Your files stay where they are.",
+  "Almost there. We are making sure everything opens cleanly.",
+  "Your workspace is getting the new version ready.",
+  "Finishing the install and checking everything responds.",
+  "Your workspace is staying put while the update lands.",
+  "One last check before the screen refreshes.",
 ] as const;
 
 export function upgradeInstallStatusLine(index: number): string {
@@ -107,7 +112,7 @@ export function resolveUpgradeInstallCopy(input: {
 }) {
   return {
     title: `Installing ${input.target ?? "update"}`,
-    detail: input.message ?? "Downloading the host bundle and waiting for the shell to return.",
+    detail: input.message ?? "Downloading the update and waiting for your workspace to return.",
     statusLine: upgradeInstallStatusLine(input.statusIndex),
   };
 }

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -282,6 +282,17 @@ describe('customer VPS host bundle', () => {
     expect(workflow).not.toContain('cancel-in-progress: false');
   });
 
+  it('host bundle release workflow generates friendly stable changelogs from commit subjects', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/host-bundle-release.yml'), 'utf8');
+
+    expect(workflow).toContain('fetch-depth: 0');
+    expect(workflow).toContain('node scripts/release-changelog.mjs --base "$BASE_SHA" --head "$GITHUB_SHA"');
+    expect(workflow).toContain('DELIMITER="CHANGELOG_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_${GITHUB_SHA}"');
+    expect(workflow).toContain('changelog<<$DELIMITER');
+    expect(workflow).not.toContain('changelog<<EOF');
+  });
+
   it('dev bundle gate builds branch pushes even when commit messages request a skip', () => {
     const result = runDevBundleGate({
       GITHUB_EVENT_NAME: 'push',

--- a/tests/scripts/release-changelog.test.ts
+++ b/tests/scripts/release-changelog.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 import {
   buildReleaseChangelog,
   humanizeCommitSubject,
@@ -35,9 +37,41 @@ describe("release changelog generation", () => {
   });
 
   it("caps the no-base fallback so it cannot emit the whole repository history", () => {
-    const source = readFileSync(join(process.cwd(), "scripts/release-changelog.mjs"), "utf8");
+    const repo = mkdtempSync(join(tmpdir(), "matrix-release-changelog-"));
+    const script = join(process.cwd(), "scripts/release-changelog.mjs");
 
-    expect(source).toContain("FALLBACK_MAX_COMMITS = 100");
-    expect(source).toContain("args.push(`--max-count=${FALLBACK_MAX_COMMITS}`)");
+    try {
+      runGit(repo, "init");
+      runGit(repo, "config", "user.email", "ci@example.com");
+      runGit(repo, "config", "user.name", "Matrix CI");
+
+      for (let index = 1; index <= 105; index += 1) {
+        writeFileSync(join(repo, "note.txt"), `${index}\n`);
+        runGit(repo, "add", "note.txt");
+        runGit(repo, "commit", "-m", `fix: fallback note ${String(index).padStart(3, "0")}`);
+      }
+
+      const result = spawnSync(process.execPath, [script, "--head", "HEAD"], {
+        cwd: repo,
+        encoding: "utf8",
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).not.toContain("Fallback note 001.");
+      expect(result.stdout).not.toContain("Fallback note 005.");
+      expect(result.stdout).toContain("Fallback note 006.");
+      expect(result.stdout).toContain("Fallback note 105.");
+      expect(result.stdout.match(/^- /gm)).toHaveLength(100);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 });
+
+function runGit(cwd: string, ...args: string[]) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+  });
+  expect(result.status, result.stderr || result.stdout).toBe(0);
+}

--- a/tests/scripts/release-changelog.test.ts
+++ b/tests/scripts/release-changelog.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildReleaseChangelog,
+  humanizeCommitSubject,
+} from "../../scripts/release-changelog.mjs";
+
+describe("release changelog generation", () => {
+  it("turns conventional commit subjects into reader-friendly notes", () => {
+    expect(humanizeCommitSubject("fix(platform): sync Clerk users into platform db (#423)")).toBe(
+      "Sync Clerk users into platform database.",
+    );
+    expect(humanizeCommitSubject("feat(cli): document package runner launch path")).toBe(
+      "Document package runner launch path.",
+    );
+  });
+
+  it("groups every included commit without showing hashes", () => {
+    const changelog = buildReleaseChangelog([
+      "feat(shell): add billing plan chooser",
+      "fix(platform): route signup billing through auth shell",
+      "chore(ci): refresh bundle release workflow",
+    ]);
+
+    expect(changelog).toContain("What's changed");
+    expect(changelog).toContain("New");
+    expect(changelog).toContain("- Add billing plan chooser.");
+    expect(changelog).toContain("Fixed");
+    expect(changelog).toContain("- Route signup billing through auth shell.");
+    expect(changelog).toContain("Polish and reliability");
+    expect(changelog).toContain("- Refresh bundle release workflow.");
+    expect(changelog).not.toContain("feat(shell)");
+    expect(changelog).not.toContain("abc123");
+  });
+
+  it("caps the no-base fallback so it cannot emit the whole repository history", () => {
+    const source = readFileSync(join(process.cwd(), "scripts/release-changelog.mjs"), "utf8");
+
+    expect(source).toContain("FALLBACK_MAX_COMMITS = 100");
+    expect(source).toContain("args.push(`--max-count=${FALLBACK_MAX_COMMITS}`)");
+  });
+});

--- a/tests/shell/system-section-refresh.test.tsx
+++ b/tests/shell/system-section-refresh.test.tsx
@@ -211,7 +211,7 @@ describe("SystemSection release refresh", () => {
     expect(screen.getByRole("status")).toBeTruthy();
     expect(screen.getByText("Installing stable")).toBeTruthy();
     expect(screen.getByText("Installing stable. This can take a few minutes...")).toBeTruthy();
-    expect(screen.getByText("Reading the Matrix release notes between packets.")).toBeTruthy();
+    expect(screen.getByText("Putting the new version in place. Your files stay where they are.")).toBeTruthy();
     expect(screen.getByText("Download")).toBeTruthy();
     expect(screen.getByText("Install")).toBeTruthy();
     expect(screen.getByText("Verify")).toBeTruthy();
@@ -220,7 +220,7 @@ describe("SystemSection release refresh", () => {
       await vi.advanceTimersByTimeAsync(7_000);
     });
 
-    expect(screen.getByText("Cloud status: one host bundle, lightly compressed, coming right up.")).toBeTruthy();
+    expect(screen.getByText("Almost there. We are making sure everything opens cleanly.")).toBeTruthy();
     expect(screen.getByText("Installing... checking status")).toBeTruthy();
     expect(screen.getByText("Installing stable. This can take a few minutes...")).toBeTruthy();
 

--- a/tests/shell/system-section-version.test.ts
+++ b/tests/shell/system-section-version.test.ts
@@ -8,6 +8,7 @@ import {
   resolveSystemUpdateState,
   severityBadgeStyle,
   formatReleaseBuildId,
+  formatReleaseBuildShortId,
   upgradeInstallStatusLine,
 } from "../../shell/src/components/settings/sections/system-update-state.js";
 
@@ -136,6 +137,11 @@ describe("SystemSection version helpers", () => {
   it("formats release build IDs without exposing full commit hashes by default", () => {
     expect(formatReleaseBuildId("0f7e2f12554e1941d10c29b2209e0a6c2d7e2438")).toBe("Build ID 0f7e2f12554e");
     expect(formatReleaseBuildId(undefined)).toBeNull();
+  });
+
+  it("formats short build ID values for labeled fields", () => {
+    expect(formatReleaseBuildShortId("0f7e2f12554e1941d10c29b2209e0a6c2d7e2438")).toBe("0f7e2f12554e");
+    expect(formatReleaseBuildShortId(undefined)).toBeNull();
   });
 
   it("normalizes rotating upgrade install status lines", () => {

--- a/tests/shell/system-section-version.test.ts
+++ b/tests/shell/system-section-version.test.ts
@@ -7,6 +7,7 @@ import {
   resolveUpgradeInstallCopy,
   resolveSystemUpdateState,
   severityBadgeStyle,
+  formatReleaseBuildId,
   upgradeInstallStatusLine,
 } from "../../shell/src/components/settings/sections/system-update-state.js";
 
@@ -132,10 +133,15 @@ describe("SystemSection version helpers", () => {
     expect(severityBadgeStyle(undefined)).toContain("blue");
   });
 
+  it("formats release build IDs without exposing full commit hashes by default", () => {
+    expect(formatReleaseBuildId("0f7e2f12554e1941d10c29b2209e0a6c2d7e2438")).toBe("Build ID 0f7e2f12554e");
+    expect(formatReleaseBuildId(undefined)).toBeNull();
+  });
+
   it("normalizes rotating upgrade install status lines", () => {
-    expect(upgradeInstallStatusLine(0)).toBe("Reading the Matrix release notes between packets.");
-    expect(upgradeInstallStatusLine(6)).toBe("Reading the Matrix release notes between packets.");
-    expect(upgradeInstallStatusLine(-1)).toBe("Reading the Matrix release notes between packets.");
+    expect(upgradeInstallStatusLine(0)).toBe("Putting the new version in place. Your files stay where they are.");
+    expect(upgradeInstallStatusLine(6)).toBe("Putting the new version in place. Your files stay where they are.");
+    expect(upgradeInstallStatusLine(-1)).toBe("Putting the new version in place. Your files stay where they are.");
   });
 
   it("builds accessible upgrade install copy", () => {
@@ -145,8 +151,8 @@ describe("SystemSection version helpers", () => {
       statusIndex: 1,
     })).toEqual({
       title: "Installing dev",
-      detail: "Downloading the host bundle and waiting for the shell to return.",
-      statusLine: "Cloud status: one host bundle, lightly compressed, coming right up.",
+      detail: "Downloading the update and waiting for your workspace to return.",
+      statusLine: "Almost there. We are making sure everything opens cleanly.",
     });
 
     expect(resolveUpgradeInstallCopy({
@@ -156,7 +162,7 @@ describe("SystemSection version helpers", () => {
     })).toEqual({
       title: "Installing update",
       detail: "Upgrade started. Waiting for services to come back...",
-      statusLine: "A coding agent is watching the logs and resisting the urge to refactor them.",
+      statusLine: "Your workspace is getting the new version ready.",
     });
   });
 });


### PR DESCRIPTION
## Summary
- show release commit provenance as a plain Build ID in System settings and release rows
- replace the upgrade waiting copy with calm, non-technical status lines
- generate stable release notes from every commit since the previous stable build when no manual changelog is provided, with a bounded fallback if the previous stable build cannot be found

## Tests
- `pnpm exec vitest run tests/scripts/release-changelog.test.ts tests/shell/system-section-version.test.ts tests/shell/system-section-refresh.test.tsx tests/platform/customer-vps-host-bundle.test.ts`
- `pnpm --filter @finnaai/matrix test`
- `bun run typecheck`
- `bun run check:patterns`
- `npx react-doctor@latest shell --diff origin/main --no-score --verbose`

Full `bun run test` was attempted. It is blocked in this local worktree by native bindings that were not built after the initial `pnpm install --ignore-scripts`: `node-pty` is missing for zellij/E2E suites, and `better-sqlite3` initially caused SQLite-backed suites to fail. After `pnpm rebuild node-pty better-sqlite3`, `better-sqlite3` suites passed in a focused rerun, but `node-pty` remains unavailable locally. The release-focused suites and the full sync-client package test above pass.

## Invariants
- Source of truth: release metadata remains the platform host-bundle release record and existing `gitCommit` field; the UI only formats it as a Build ID.
- Lock/transaction scope: no database writes or release registration semantics change in this PR; stable notes are generated before publish registration.
- Acceptable orphan states: if previous stable metadata is unavailable, stable notes fall back to a bounded recent commit set instead of blocking release publication or emitting the full repository history.
- Auth source of truth: unchanged; host-bundle publish still uses the existing platform admin bearer token and public channel metadata reads.
- Deferred scope: this does not add a release-notes editor, retroactively backfill old changelogs, or change how dev bundles are promoted.