### PR TITLE
fix(086): keep native device auth on app origin

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -3562,15 +3562,17 @@ export function createApp(deps: {
   // the platform. Public endpoints; admin Bearer middleware below skips them.
   const platformJwtSecret = process.env.PLATFORM_JWT_SECRET ?? '';
   if (platformJwtSecret) {
-    const platformPublicUrl =
-      process.env.PLATFORM_PUBLIC_URL ?? `http://localhost:${process.env.PLATFORM_PORT ?? 9000}`;
+    const deviceAuthPublicUrl =
+      appEnv.NEXT_PUBLIC_MATRIX_APP_URL ??
+      appEnv.PLATFORM_PUBLIC_URL ??
+      `http://localhost:${appEnv.PLATFORM_PORT ?? 9000}`;
     app.route(
       '/',
       createAuthRoutes({
         db,
         clerkAuth,
         jwtSecret: platformJwtSecret,
-        platformUrl: platformPublicUrl,
+        platformUrl: deviceAuthPublicUrl,
         gatewayUrlForHandle: getGatewayUrlForHandle,
         captureEvent: (event, properties) => {
           capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.CLI_COMMAND_RUN, {

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -66,6 +66,8 @@ describe("device routes", () => {
     await destroyTestPlatformDb(db);
     delete process.env.PLATFORM_JWT_SECRET;
     delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    delete process.env.PLATFORM_PUBLIC_URL;
+    delete process.env.NEXT_PUBLIC_MATRIX_APP_URL;
   });
 
   describe("POST /api/auth/device/code", () => {
@@ -104,6 +106,37 @@ describe("device routes", () => {
         "matrixos://auth?status=approved",
       );
       expect(verificationUri.searchParams.get("redirect_sig")).toEqual(expect.any(String));
+    });
+
+    it("uses the app shell origin for macOS approval even when platform API origin differs", async () => {
+      process.env.PLATFORM_PUBLIC_URL = "https://api.matrix-os.com";
+      process.env.NEXT_PUBLIC_MATRIX_APP_URL = "https://app.matrix-os.com";
+      const { docker } = createMockDocker();
+      const routedApp = createApp({
+        db,
+        orchestrator: createOrchestrator({ db, docker: docker as any }),
+        clerkAuth: createClerkAuth({
+          verifyToken: async () => ({ sub: "user_alice" }),
+        }),
+      });
+
+      const res = await routedApp.request("/api/auth/device/code", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          clientId: "matrix-os-macos",
+          redirectUri: "matrixos://auth?status=approved",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const verificationUri = new URL(body.verificationUri);
+      expect(verificationUri.origin).toBe("https://app.matrix-os.com");
+      expect(verificationUri.pathname).toBe("/auth/device");
+      expect(verificationUri.searchParams.get("redirect_uri")).toBe(
+        "matrixos://auth?status=approved",
+      );
     });
 
     it("ignores native callbacks for other clients or invalid schemes", async () => {

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -137,6 +137,7 @@ describe("device routes", () => {
       expect(verificationUri.searchParams.get("redirect_uri")).toBe(
         "matrixos://auth?status=approved",
       );
+      expect(verificationUri.searchParams.get("redirect_sig")).toEqual(expect.any(String));
     });
 
     it("ignores native callbacks for other clients or invalid schemes", async () => {


### PR DESCRIPTION
## Summary
- make native macOS device-code verification URLs prefer the public app shell origin instead of the platform API origin
- add a regression test for Cloud Run configs where PLATFORM_PUBLIC_URL is api.matrix-os.com and NEXT_PUBLIC_MATRIX_APP_URL is app.matrix-os.com

## Invariants
- Source of truth: Clerk remains the identity provider; platform DB remains the source of runtime ownership and device-code state.
- Lock/transaction scope: no database write behavior changes; this only changes the public approval URL used when issuing device codes.
- Acceptable orphan states: existing unapproved device codes expire under the current device-flow TTL; no migration is required.
- Auth source of truth: browser approval stays on app.matrix-os.com so Clerk sessions and the Matrix native app exchange share the intended app origin.
- Deferred scope: this does not change VPS host bundles, terminal behavior, or Clerk tenant configuration.

## Tests
- bun run test tests/platform/device-routes.test.ts
- bun run test tests/platform/middleware-shortcircuit.test.ts