### PR TITLE
test(releases): isolate changelog git fixture

### DIFF
--- a/tests/scripts/release-changelog.test.ts
+++ b/tests/scripts/release-changelog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -38,21 +38,25 @@ describe("release changelog generation", () => {
 
   it("caps the no-base fallback so it cannot emit the whole repository history", () => {
     const repo = mkdtempSync(join(tmpdir(), "matrix-release-changelog-"));
+    const gitHome = join(repo, ".git-home");
+    mkdirSync(gitHome);
+    const env = isolatedGitEnv(repo, gitHome);
     const script = join(process.cwd(), "scripts/release-changelog.mjs");
 
     try {
-      runGit(repo, "init");
-      runGit(repo, "config", "user.email", "ci@example.com");
-      runGit(repo, "config", "user.name", "Matrix CI");
+      runGit(repo, env, "init");
+      runGit(repo, env, "config", "user.email", "ci@example.com");
+      runGit(repo, env, "config", "user.name", "Matrix CI");
 
       for (let index = 1; index <= 105; index += 1) {
         writeFileSync(join(repo, "note.txt"), `${index}\n`);
-        runGit(repo, "add", "note.txt");
-        runGit(repo, "commit", "-m", `fix: fallback note ${String(index).padStart(3, "0")}`);
+        runGit(repo, env, "add", "note.txt");
+        runGit(repo, env, "commit", "-m", `fix: fallback note ${String(index).padStart(3, "0")}`);
       }
 
       const result = spawnSync(process.execPath, [script, "--head", "HEAD"], {
         cwd: repo,
+        env,
         encoding: "utf8",
       });
 
@@ -68,9 +72,23 @@ describe("release changelog generation", () => {
   });
 });
 
-function runGit(cwd: string, ...args: string[]) {
+function isolatedGitEnv(repo: string, home: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("GIT_")) delete env[key];
+  }
+  env.HOME = home;
+  env.XDG_CONFIG_HOME = join(home, ".config");
+  env.GIT_CONFIG_NOSYSTEM = "1";
+  env.GIT_CONFIG_GLOBAL = join(home, ".gitconfig");
+  env.GIT_CEILING_DIRECTORIES = repo;
+  return env;
+}
+
+function runGit(cwd: string, env: NodeJS.ProcessEnv, ...args: string[]) {
   const result = spawnSync("git", args, {
     cwd,
+    env,
     encoding: "utf8",
   });
   expect(result.status, result.stderr || result.stdout).toBe(0);


### PR DESCRIPTION
## Summary
- fix the main CI failure in `tests/scripts/release-changelog.test.ts` by isolating the temporary Git repo from inherited GitHub Actions Git environment/config
- pass the sanitized Git env into both fixture `git` commands and the release-changelog subprocess

## CI failure addressed
- `CI / Unit Tests (1/4)` failed on main because the changelog fallback fixture hit `fatal: unable to read 04f9fe46068b397a6fc24d647b7e3ec4315c15e7` in the shallow Actions checkout.
- `CI Results` and `Host Bundle Release / Same-SHA CI gate` were downstream failures from that unit shard.

## Tests
- `bun run test tests/scripts/release-changelog.test.ts`
- `GIT_OBJECT_DIRECTORY=/missing/object-dir GIT_ALTERNATE_OBJECT_DIRECTORIES=/missing/alternate GIT_DIR=/missing/git-dir bun run test tests/scripts/release-changelog.test.ts`

## Invariants
- Source of truth: unchanged; this only changes a test fixture.
- Lock/transaction scope: no runtime database or file-write behavior changes.
- Acceptable orphan states: not applicable; no persisted product state changes.
- Auth source of truth: unchanged.
- Deferred scope: does not change release changelog generation logic or host bundle publishing behavior.
