### PR TITLE
docs(system): specify activity monitor

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/083-elixir-symphony"
+  "feature_directory": "specs/087-system-activity-monitor"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,5 +374,5 @@ Five canonical roles using default label names. See `docs/agents/triage-labels.m
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/082-paid-beta-readiness/plan.md`.
+Current Spec Kit plan: `specs/087-system-activity-monitor/plan.md`.
 <!-- SPECKIT END -->

--- a/specs/087-system-activity-monitor/checklists/requirements.md
+++ b/specs/087-system-activity-monitor/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: System Activity Monitor
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-06-07  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on 2026-06-07.

--- a/specs/087-system-activity-monitor/contracts/system-activity-api.md
+++ b/specs/087-system-activity-monitor/contracts/system-activity-api.md
@@ -1,0 +1,280 @@
+# Contract: System Activity API
+
+All routes are owner-only gateway routes on the current Matrix computer. Responses must be sanitized for client display and must not include raw provider names, tokens, filesystem paths outside approved display labels, stack traces, command stderr, or database/systemd raw errors.
+
+## Auth Matrix
+
+| Route | Method | Auth | Public | Notes |
+| --- | --- | --- | --- | --- |
+| `/api/system/activity` | GET | Owner session or accepted Matrix bearer/JWT | No | Read-only snapshot |
+| `/api/system/activity/actions` | POST | Owner session or accepted Matrix bearer/JWT | No | Mutating cleanup action; `bodyLimit` required |
+| `/api/system/activity/policy` | GET | Owner session or accepted Matrix bearer/JWT | No | Read auto-clean policy |
+| `/api/system/activity/policy` | PUT | Owner session or accepted Matrix bearer/JWT | No | Mutating policy update; `bodyLimit` required |
+| `/api/system/activity/history` | GET | Owner session or accepted Matrix bearer/JWT | No | Bounded audit history |
+
+## GET `/api/system/activity`
+
+Returns a bounded activity snapshot for the current machine.
+
+### Query Parameters
+
+| Name | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `processLimit` | integer | No | 1-100, default 25 |
+| `includeSuggestions` | boolean | No | default true |
+
+### Response `200`
+
+```json
+{
+  "generatedAt": "2026-06-07T17:30:00.000Z",
+  "machine": {
+    "handle": "hamedmp",
+    "runtimeSlot": "primary",
+    "hostname": "matrix-hamedmp-bdbdbbb5",
+    "status": "healthy",
+    "releaseVersion": "v2026.06.07-316",
+    "releaseChannel": "dev",
+    "gitCommit": "e7e2ef8",
+    "uptimeSeconds": 2960000
+  },
+  "resources": {
+    "cpu": {
+      "cores": 2,
+      "load1": 0.58,
+      "load5": 0.88,
+      "load15": 0.60,
+      "pressureSome10": 5.23
+    },
+    "memory": {
+      "totalBytes": 4096000000,
+      "usedBytes": 1932735283,
+      "availableBytes": 2040109465,
+      "processRssBytes": 1600000000,
+      "cgroupAnonBytes": 450000000,
+      "cgroupFileBytes": 170000000,
+      "cgroupKernelBytes": 47000000
+    },
+    "swap": {
+      "totalBytes": 0,
+      "usedBytes": 0
+    },
+    "disk": [
+      {
+        "mount": "/",
+        "label": "System",
+        "usedBytes": 63350767616,
+        "totalBytes": 80530636800,
+        "usedPercent": 82
+      }
+    ]
+  },
+  "services": [
+    {
+      "serviceId": "matrix-gateway",
+      "state": "running",
+      "memoryBytes": 685232128,
+      "cpuSeconds": 815,
+      "tasks": 79
+    }
+  ],
+  "processes": [
+    {
+      "processRef": "proc_opaque_1",
+      "pid": 2336842,
+      "ownerClass": "matrix",
+      "classification": "matrix_service",
+      "displayName": "matrix-gateway",
+      "cpuPercent": 2,
+      "rssBytes": 360000000,
+      "elapsedSeconds": 3700,
+      "ports": [4000]
+    }
+  ],
+  "cleanupSuggestions": [
+    {
+      "candidateId": "cand_opaque_1",
+      "type": "stop_stale_app_server",
+      "targetLabel": "matrix-beta-crm preview server",
+      "reason": "No active connections and executable no longer matches the current runtime.",
+      "confidence": "high",
+      "risk": "low",
+      "estimatedReclaimBytes": 104857600,
+      "requiresConfirmation": true,
+      "confirmationToken": "confirm_opaque_1",
+      "expiresAt": "2026-06-07T17:35:00.000Z"
+    }
+  ],
+  "collectionWarnings": []
+}
+```
+
+### Error Responses
+
+- `401`: unauthenticated.
+- `403`: authenticated but not owner for this runtime.
+- `500`: generic collection failure.
+
+## POST `/api/system/activity/actions`
+
+Executes one typed cleanup action against a server-generated cleanup candidate.
+
+### Request
+
+```json
+{
+  "type": "stop_stale_app_server",
+  "candidateId": "cand_opaque_1",
+  "confirmationToken": "confirm_opaque_1",
+  "mode": "manual"
+}
+```
+
+### Validation
+
+- Request body limit: 16 KiB.
+- `type` must be one of:
+  - `stop_stale_app_server`
+  - `close_stale_terminal_session`
+  - `restart_idle_code_server`
+  - `clean_cache_scope`
+  - `prune_old_bundle`
+- `candidateId` and `confirmationToken` are opaque bounded strings issued by the latest `CleanupCandidate` response.
+- `mode` is `manual` or `automatic`.
+- When `mode` is `automatic`, the server must verify auto-clean policy is enabled, `type` is in `allowedTypes`, and the policy `maxActionsPerHour` budget has not been exhausted before executing.
+- Server must re-read the target and verify the candidate still matches before mutation.
+
+### Response `200`
+
+```json
+{
+  "actionId": "act_opaque_1",
+  "result": "completed",
+  "reclaimedBytes": 104857600,
+  "message": "Cleanup completed.",
+  "snapshotRefreshRecommended": true
+}
+```
+
+### Idempotent Response `200`
+
+```json
+{
+  "actionId": "act_opaque_2",
+  "result": "already_clean",
+  "message": "The target was already clean.",
+  "snapshotRefreshRecommended": true
+}
+```
+
+### Error Responses
+
+- `400`: invalid payload.
+- `401`: unauthenticated.
+- `403`: not owner or policy not allowed.
+- `409`: candidate expired, target changed, or confirmation mismatch.
+- `500`: generic cleanup failure.
+
+## GET `/api/system/activity/policy`
+
+Returns current auto-clean policy.
+
+### Response `200`
+
+```json
+{
+  "enabled": false,
+  "allowedTypes": [],
+  "gracePeriodSeconds": 1800,
+  "maxActionsPerHour": 3,
+  "lastUpdatedAt": "2026-06-07T17:30:00.000Z"
+}
+```
+
+## PUT `/api/system/activity/policy`
+
+Updates auto-clean policy.
+
+### Request
+
+```json
+{
+  "enabled": true,
+  "allowedTypes": ["stop_stale_app_server", "clean_cache_scope"],
+  "gracePeriodSeconds": 3600,
+  "maxActionsPerHour": 2
+}
+```
+
+### Validation
+
+- Request body limit: 16 KiB.
+- Only these conservative action types are accepted for automation in v1:
+  - `stop_stale_app_server` when confidence is `high`, risk is `low`, the executable is stale, and there are no active connections.
+  - `clean_cache_scope` for allowlisted cache scopes only.
+  - `prune_old_bundle` for inactive, non-rollback host bundles only.
+- `close_stale_terminal_session` and `restart_idle_code_server` are manual-only in v1.
+- `gracePeriodSeconds` must be 300-86400.
+- `maxActionsPerHour` must be 1-12.
+
+### Response `200`
+
+Returns the saved policy after validation and normalization.
+
+```json
+{
+  "enabled": true,
+  "allowedTypes": ["stop_stale_app_server", "clean_cache_scope"],
+  "gracePeriodSeconds": 3600,
+  "maxActionsPerHour": 2,
+  "lastUpdatedAt": "2026-06-07T17:45:00.000Z"
+}
+```
+
+### Error Responses
+
+| Status | Reason |
+| --- | --- |
+| 400 | Invalid policy body, unsupported action type, or bounds violation |
+| 401 | Missing owner authentication |
+| 403 | Authenticated principal is not the machine owner |
+| 500 | Policy could not be persisted |
+
+## GET `/api/system/activity/history`
+
+Returns bounded cleanup history.
+
+### Query Parameters
+
+| Name | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `limit` | integer | No | 1-100, default 25 |
+| `cursor` | string | No | opaque bounded cursor |
+
+### Response `200`
+
+```json
+{
+  "entries": [
+    {
+      "id": "hist_opaque_1",
+      "createdAt": "2026-06-07T17:31:00.000Z",
+      "actor": "owner",
+      "actionType": "stop_stale_app_server",
+      "targetLabel": "matrix-beta-crm preview server",
+      "result": "completed",
+      "reclaimedBytes": 104857600,
+      "reasonCode": "stale_app_server_no_connections"
+    }
+  ],
+  "nextCursor": null
+}
+```
+
+## Resource Management Requirements
+
+- Process and service collectors must use bounded subprocess timeouts.
+- Any in-memory candidate cache must have a maximum size and TTL eviction.
+- Cleanup history retention must be bounded.
+- Temp files used during cleanup must be created exclusively and removed through symlink-safe cleanup.
+- Shutdown drains must clear candidate timers and auto-clean intervals.

--- a/specs/087-system-activity-monitor/data-model.md
+++ b/specs/087-system-activity-monitor/data-model.md
@@ -1,0 +1,175 @@
+# Data Model: System Activity Monitor
+
+## ActivitySnapshot
+
+Point-in-time response returned to the owner dashboard.
+
+**Fields**:
+- `generatedAt`: ISO timestamp.
+- `machine`: MachineIdentity.
+- `resources`: ResourceSummary.
+- `services`: ServiceStatus[].
+- `processes`: ProcessSummary[].
+- `cleanupSuggestions`: CleanupCandidate[].
+- `collectionWarnings`: SanitizedCollectionWarning[].
+
+**Validation rules**:
+- `generatedAt` must be the server collection time.
+- Arrays must be capped by server configuration.
+- Warnings must be generic and must not include raw paths, command stderr, tokens, provider names, or stack traces.
+
+## SanitizedCollectionWarning
+
+Generic warning emitted when a collector partially fails.
+
+**Fields**:
+- `code`: opaque bounded warning code such as `process_collection_unavailable`.
+- `message`: optional sanitized operator-facing message selected from an allowlist.
+- `section`: optional source section such as `processes`, `services`, `disk`, `memory`, or `pressure`.
+
+**Validation rules**:
+- `code` must be a safe identifier and must not include raw command output.
+- `message` must be generic; raw paths, command stderr, tokens, provider names, host internals, and stack traces are never returned to clients.
+
+## MachineIdentity
+
+User-visible identity for the current Matrix computer.
+
+**Fields**:
+- `handle`: Matrix handle.
+- `runtimeSlot`: `primary`, `staging`, `preview`, or another platform-defined slot.
+- `hostname`: Sanitized hostname.
+- `status`: Coarse status such as `healthy`, `degraded`, or `unknown`.
+- `releaseVersion`: Installed host bundle version.
+- `releaseChannel`: Channel such as `dev`, `canary`, `beta`, or `stable`.
+- `gitCommit`: Optional short commit identifier.
+- `uptimeSeconds`: Host uptime.
+
+**Validation rules**:
+- Missing optional release fields render as unavailable, not as errors.
+- Hostname and handle are display strings only; clients must not use them as auth decisions.
+
+## ResourceSummary
+
+Current CPU, memory, disk, and swap state.
+
+**Fields**:
+- `cpu`: load average, current sample, core count, and `pressureSome10` when `/proc/pressure/cpu` is available.
+- `memory`: total, used, available, process RSS total, cgroup anon/file/kernel when available.
+- `swap`: total and used.
+- `disk`: filesystem usage for root, app, and owner home paths.
+
+**Validation rules**:
+- Byte values are non-negative integers.
+- Percentages are bounded from 0 to 100.
+- Missing sections include `status: "unavailable"` with a generic reason code.
+
+## ServiceStatus
+
+Sanitized service health for Matrix host services.
+
+**Fields**:
+- `serviceId`: allowlisted service id, such as `matrix-gateway`, `matrix-shell`, `matrix-code`, `matrix-sync-agent`, `nginx`, or `postgres`.
+- `state`: coarse state such as `running`, `starting`, `stopped`, `failed`, or `unknown`.
+- `memoryBytes`: optional systemd memory accounting.
+- `cpuSeconds`: optional accumulated CPU time.
+- `tasks`: optional task count.
+- `restartCount`: optional restart count.
+
+**Validation rules**:
+- Only allowlisted service ids are exposed.
+- Raw journal output is never included.
+
+## ProcessSummary
+
+Sanitized resource row for a running process.
+
+**Fields**:
+- `processRef`: opaque server-generated reference.
+- `pid`: optional display-only PID.
+- `ownerClass`: `matrix`, `root`, `system`, or `unknown`.
+- `classification`: `matrix_service`, `app_server`, `terminal_session`, `code_editor`, `database`, `system`, or `unknown`.
+- `displayName`: sanitized command name.
+- `cpuPercent`: sampled CPU usage.
+- `rssBytes`: resident memory.
+- `startedAt` or `elapsedSeconds`: process age.
+- `ports`: sanitized local listening ports when relevant.
+- `activeConnections`: optional connection count.
+
+**Validation rules**:
+- Command arguments are redacted or omitted unless they are known-safe display labels.
+- PIDs are never accepted back as the only cleanup authority.
+
+## CleanupCandidate
+
+Server-generated recommendation for a safe cleanup action.
+
+**Fields**:
+- `candidateId`: opaque id.
+- `type`: `stop_stale_app_server`, `close_stale_terminal_session`, `restart_idle_code_server`, `clean_cache_scope`, or `prune_old_bundle`.
+- `targetLabel`: sanitized user-facing target.
+- `reason`: generic explanation.
+- `confidence`: `high`, `medium`, or `manual_review`.
+- `risk`: `low`, `medium`, or `high`.
+- `estimatedReclaimBytes`: optional reclaim estimate.
+- `requiresConfirmation`: boolean.
+- `confirmationToken`: opaque bounded token issued with the candidate and echoed by all cleanup action requests, including automatic policy execution.
+- `expiresAt`: ISO timestamp.
+
+**Validation rules**:
+- Candidate ids expire and must be revalidated before action.
+- Confirmation tokens expire with the candidate and must never be logged or stored in cleanup history.
+- Only `high` or approved `medium` candidates can be executed by one-click action.
+- Critical services and active resources cannot become executable candidates.
+
+## CleanupAction
+
+Mutation request submitted by the owner or automatic policy.
+
+**Fields**:
+- `type`: action type matching a cleanup candidate type.
+- `candidateId`: server-generated id.
+- `confirmationToken`: required for every action and must match the server-issued cleanup candidate token.
+- `mode`: `manual` or `automatic`.
+
+**Validation rules**:
+- Must match an existing unexpired candidate.
+- Automatic policy execution still uses a server-issued `candidateId` and `confirmationToken`; it is not a token bypass.
+- Must re-check the live target before mutation.
+- Must be idempotent when the target is already gone.
+
+## CleanupHistoryEntry
+
+Owner-visible audit entry for a cleanup attempt.
+
+**Fields**:
+- `id`: unique entry id.
+- `createdAt`: ISO timestamp.
+- `actor`: `owner` or `auto_policy`.
+- `actionType`: CleanupAction type.
+- `targetLabel`: sanitized label.
+- `result`: `completed`, `skipped`, `already_clean`, or `failed`.
+- `reclaimedBytes`: optional measured or estimated value.
+- `reasonCode`: generic result reason.
+
+**Validation rules**:
+- Stored append-only with bounded retention.
+- Does not include raw paths, raw errors, command stderr, or tokens.
+
+## AutoCleanupPolicy
+
+Owner-controlled automatic cleanup configuration.
+
+**Fields**:
+- `enabled`: boolean.
+- `allowedTypes`: cleanup action types.
+- `gracePeriodSeconds`: minimum stale duration before auto-clean.
+- `maxActionsPerHour`: bounded action rate.
+- `lastUpdatedAt`: ISO timestamp.
+
+**Validation rules**:
+- Disabled by default.
+- Only `stop_stale_app_server`, `clean_cache_scope`, and `prune_old_bundle` can be enabled in v1 automation.
+- `stop_stale_app_server` requires high confidence, low risk, stale executable evidence, and no active connections before automatic execution.
+- `close_stale_terminal_session` and `restart_idle_code_server` remain manual-only in v1 because they can interrupt active work.
+- Rate limits prevent repeated cleanup loops and are enforced by the internal automatic action path before each mutation.

--- a/specs/087-system-activity-monitor/plan.md
+++ b/specs/087-system-activity-monitor/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: System Activity Monitor
+
+**Branch**: `087-system-activity-monitor` | **Date**: 2026-06-07 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/087-system-activity-monitor/spec.md`
+
+## Summary
+
+Create a first-party, owner-only System Activity Monitor that surfaces each user's Matrix computer identity, resource pressure, service health, top processes, and safe cleanup opportunities. The implementation uses the customer VPS gateway as the trusted collector and mutation boundary, exposes bounded typed endpoints for read-only snapshots and approved cleanup actions, and renders the experience as a Canvas-first built-in shell app. Cleanup starts as suggestions and explicit user actions; automatic cleanup is a later opt-in policy once classifiers have tests and audit history.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.5+ strict, ES modules, Node.js 24+, React 19, Next.js 16  
+**Primary Dependencies**: Hono gateway, Zod 4 via `zod/v4`, existing shell built-in app routing, Node `fs/promises`, `child_process`, `/proc` and cgroup filesystem readers, systemd host tools  
+**Storage**: Owner-controlled files for cleanup history and auto-clean policy under `~/system/`; no new database or ORM  
+**Testing**: Vitest for gateway, shell/store, and contract tests; React Doctor required for React changes  
+**Target Platform**: VPS-native Matrix customer runtime with Linux systemd services, plus browser shell through Canvas and Desktop renderers  
+**Project Type**: Web application with gateway backend and shell frontend  
+**Performance Goals**: Read-only snapshot p95 under 2 seconds on a small VPS; cleanup action result visible in the next refresh within 5 seconds; collectors avoid blocking the event loop  
+**Constraints**: Owner-only auth; all mutating routes use `bodyLimit`; all inputs validated by Zod; no arbitrary PID kill; subprocess probes have timeouts; no raw errors or filesystem paths to clients; bounded in-memory caches; protected owner paths are never deleted; health probes return coarse booleans and sanitized details  
+**Scale/Scope**: One owner-controlled customer VPS per runtime slot; v1 supports the local machine only, with platform/fleet links deferred to future multi-machine fleet views
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Data Belongs to Its Owner**: PASS. Runtime activity is observed on the owner-controlled VPS. Cleanup history and policy live under the owner's `~/system/` files. Owner data is protected from cleanup.
+- **AI Is the Kernel**: PASS. The monitor is a system app and does not bypass kernel ownership semantics. No model-specific dependency is introduced.
+- **Headless Core, Multi-Shell**: PASS. Collection and cleanup live in gateway/host services; shell is only a renderer. Future CLI or mobile clients can use the same contracts.
+- **Self-Healing and Self-Expanding**: PASS. The feature adds guarded self-healing actions with audit and opt-in automation.
+- **Quality Over Shortcuts**: PASS. Uses a real first-party shell experience, typed APIs, tests, and operations docs.
+- **App Ecosystem**: PASS. The monitor is a privileged built-in app, not a sandboxed app granted arbitrary host power.
+- **Multi-Tenancy**: PASS. Scope is the owner runtime; no cross-user or platform-wide data is exposed.
+- **Defense in Depth**: PASS. The design uses owner-only auth, route-boundary validation, body limits, generic client errors, subprocess timeouts, allowlisted cleanup actions, and protected path enforcement.
+- **TDD**: PASS. Tasks require failing tests before implementation for collectors, contracts, cleanup actions, and UI behavior.
+- **Worktree, PR, and Greptile 5/5**: PASS. This spec is created in a manual worktree PR and tasks include a Graphite split for later implementation layers.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/087-system-activity-monitor/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── system-activity-api.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+packages/gateway/src/system-activity/
+├── collector.ts              # host metric, service, and process snapshot collection
+├── cleanup.ts                # typed candidate classification and cleanup execution
+├── history.ts                # owner-file cleanup history and policy persistence
+├── routes.ts                 # Hono routes and Zod schemas
+└── types.ts                  # shared backend DTOs
+
+packages/gateway/src/server.ts # route registration and dependency wiring
+
+shell/src/stores/
+└── systemActivityStore.ts     # serializable dashboard state and actions
+
+shell/src/components/system-activity/
+├── ActivityMonitorApp.tsx
+├── CleanupSuggestions.tsx
+├── MachineSummary.tsx
+├── ProcessTable.tsx
+└── ResourceMeters.tsx
+
+shell/src/components/canvas/CanvasWindow.tsx # built-in app path handling
+shell/src/components/Desktop.tsx             # built-in app path handling
+
+tests/gateway/
+├── system-activity-collector.test.ts
+├── system-activity-cleanup.test.ts
+├── system-activity-routes.test.ts
+└── system-activity-history.test.ts
+
+tests/shell/
+└── system-activity-app.test.tsx
+
+www/content/docs/guide/
+└── system-activity-monitor.mdx
+```
+
+**Structure Decision**: Keep host observation and mutation in `packages/gateway` because the gateway already runs on the customer VPS and owns authenticated system routes. Keep the UI in `shell/` as a privileged built-in app reachable from Canvas and Desktop. Keep cleanup policy/history as owner files under `~/system/` to preserve the owner-data invariant and avoid new persistence.
+
+## Complexity Tracking
+
+No constitution violations are required for the planned design.
+
+## Phase 0: Research
+
+See [research.md](./research.md).
+
+## Phase 1: Design & Contracts
+
+See [data-model.md](./data-model.md), [contracts/system-activity-api.md](./contracts/system-activity-api.md), and [quickstart.md](./quickstart.md).
+
+## Post-Design Constitution Check
+
+- **Data ownership** remains satisfied: cleanup history and policy are owner files, and cleanup scopes explicitly exclude protected owner data.
+- **Defense in depth** remains satisfied: contracts require body limits, route-boundary Zod validation, typed cleanup actions, sanitized responses, subprocess timeouts, and bounded caches.
+- **TDD** remains satisfied: tasks require tests before implementation for collectors, routes, cleanup classifiers, shell state, and UI flows.
+- **Worktree/PR** remains satisfied: implementation is split into reviewable Graphite stack layers with the spec layer as the first PR.

--- a/specs/087-system-activity-monitor/quickstart.md
+++ b/specs/087-system-activity-monitor/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: System Activity Monitor
+
+## Prerequisites
+
+- Matrix OS worktree on the System Activity Monitor branch.
+- Node.js 24+, pnpm 10, bun available through Flox or local setup.
+- A local dev runtime for gateway and shell, or a disposable customer VPS for full host-service validation.
+
+## Read-Only MVP Validation
+
+1. Start gateway and shell:
+
+   ```bash
+   bun run dev:gateway
+   bun run dev:shell
+   ```
+
+2. Open the shell in Canvas mode.
+
+3. Open the built-in System Activity Monitor.
+
+4. Verify the dashboard shows:
+   - machine identity
+   - release/version
+   - uptime
+   - CPU load and pressure
+   - RAM with process/cache distinction
+   - disk usage
+   - Matrix service health
+   - top processes
+
+5. Run focused tests:
+
+   ```bash
+   pnpm exec vitest run \
+     tests/gateway/system-activity-collector.test.ts \
+     tests/gateway/system-activity-routes.test.ts \
+     tests/shell/system-activity-app.test.tsx
+   ```
+
+## Manual Cleanup Validation
+
+1. Create or identify a safe stale app server fixture.
+
+2. Confirm the monitor shows a cleanup suggestion with reason, risk, confidence, and estimated reclaim.
+
+3. Confirm cleanup from the UI.
+
+4. Verify:
+   - the stale resource is gone
+   - active Matrix services remain healthy
+   - cleanup history records the action
+   - the dashboard refreshes with updated resource values
+
+5. Run focused tests:
+
+   ```bash
+   pnpm exec vitest run \
+     tests/gateway/system-activity-cleanup.test.ts \
+     tests/gateway/system-activity-history.test.ts \
+     tests/gateway/system-activity-routes.test.ts
+   ```
+
+## Automatic Cleanup Validation
+
+1. Enable auto-clean only for high-confidence safe classes in the policy UI.
+
+2. Create stale fixture resources and wait for the grace period.
+
+3. Verify:
+   - eligible stale resources are cleaned
+   - active resources are skipped
+   - all automatic actions are visible in history
+   - rate limits prevent cleanup loops
+
+## Required Gates Before PR
+
+```bash
+bun run typecheck
+bun run check:patterns
+bun run test
+npx react-doctor@latest shell
+```
+
+If a change touches only the Spec Kit documents, run markdown/path validation and explain why runtime gates were skipped.

--- a/specs/087-system-activity-monitor/research.md
+++ b/specs/087-system-activity-monitor/research.md
@@ -1,0 +1,58 @@
+# Research: System Activity Monitor
+
+## Decision: Implement activity collection in the customer VPS gateway
+
+**Rationale**: The gateway already runs on the owner-controlled VPS, has authenticated owner routes, and can read local host/process/service state without exposing platform credentials or SSH. Keeping collection in the gateway makes the monitor useful from Canvas, Desktop, CLI, or mobile clients through the same contract.
+
+**Alternatives considered**:
+- Platform-only collection through fleet probes: rejected for v1 because platform snapshots are coarser, lagging, and cannot safely run local cleanup actions.
+- Shell-side collection: rejected because browsers cannot access host metrics and should not hold host privileges.
+- SSH-based operator collection: rejected because it does not serve end users and would require operator credentials.
+
+## Decision: Treat System Activity Monitor as a privileged built-in app
+
+**Rationale**: Ordinary default apps run in sandboxed `srcdoc` iframes and must use the Matrix bridge, which is not appropriate for host cleanup authority. A built-in shell app can call owner-authenticated system routes while still rendering inside the normal shell.
+
+**Alternatives considered**:
+- Default app under `home/apps/**`: rejected because it would blur sandbox boundaries and require adding privileged bridge methods to untrusted app surfaces.
+- External admin page: rejected because activity monitoring should be part of the OS and work in Canvas first.
+
+## Decision: Start with read-only snapshots and manual cleanup suggestions
+
+**Rationale**: Read-only visibility is the safest MVP. Cleanup classification must earn trust through tests and user-visible explanations before automatic cleanup mutates resources.
+
+**Alternatives considered**:
+- Ship automatic cleanup first: rejected because stale-process classification can be wrong without real-world evidence.
+- Offer arbitrary kill/delete controls: rejected because the blast radius is too high and violates defense-in-depth rules.
+
+## Decision: Cleanup actions are typed and bound to server-generated candidates
+
+**Rationale**: The server can classify a resource with context, issue a short-lived candidate id, and validate that the action still matches the current target before mutation. This prevents clients from sending arbitrary PIDs or paths.
+
+**Alternatives considered**:
+- Accept raw PID or path actions from the client: rejected because it enables accidental or malicious host mutation.
+- Store candidates only client-side: rejected because the server must be the source of truth for safety validation.
+
+## Decision: Use owner files for cleanup policy and history
+
+**Rationale**: Policy and history are configuration/audit state belonging to the owner, not platform data. Files under `~/system/` match Matrix OS ownership rules and avoid new persistence dependencies.
+
+**Alternatives considered**:
+- Platform database: rejected because host cleanup policy is per-owner runtime state.
+- New embedded database: rejected by the Matrix OS Kysely/Postgres-only persistence rule and unnecessary for small append-only history.
+
+## Decision: Split memory into process RSS, cgroup anon, file cache, and kernel accounting when available
+
+**Rationale**: Systemd cgroup memory can look inflated after bundle installs because it includes reclaimable file/kernel cache. Showing this decomposition avoids false leak conclusions and guides cleanup toward the right target.
+
+**Alternatives considered**:
+- Show one memory number: rejected because it misleads users on Linux.
+- Hide cgroup memory: rejected because service-level accounting is useful when explained correctly.
+
+## Decision: Keep automatic cleanup opt-in and conservative
+
+**Rationale**: Automatic cleanup should only handle high-confidence stale classes such as orphaned app servers with deleted executables and no active connections, expired cleanup candidates, or bounded cache retention. Owner-visible history and a disable switch are mandatory.
+
+**Alternatives considered**:
+- Global automatic cleanup enabled by default: rejected because active-work detection has too much product risk.
+- No automation ever: rejected because small VPSes benefit from self-healing once safe classes are proven.

--- a/specs/087-system-activity-monitor/spec.md
+++ b/specs/087-system-activity-monitor/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: System Activity Monitor
+
+**Feature Branch**: `087-system-activity-monitor`  
+**Created**: 2026-06-07  
+**Status**: Draft  
+**Input**: User description: "Add an Activity Monitor-like Matrix app so users can see which machine they have, RAM/CPU/disk usage, active services and processes, and clean up stale processes automatically or by a click."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Inspect My Matrix Computer (Priority: P1)
+
+As a Matrix OS owner, I can open a built-in System Activity Monitor and see the current health of my Matrix computer in one place: machine identity, release, uptime, CPU, memory, disk, swap, service status, and top resource consumers.
+
+**Why this priority**: Users need trustworthy visibility before Matrix can safely offer cleanup. This is the MVP and has no destructive behavior.
+
+**Independent Test**: On a running Matrix computer, open the System Activity Monitor and verify the dashboard shows current machine identity and resource values that match an operator-side health snapshot within a short refresh window.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has an active Matrix computer, **When** they open System Activity Monitor, **Then** they see handle, runtime slot, hostname, installed release, uptime, and machine status.
+2. **Given** the dashboard is open, **When** resource usage changes, **Then** CPU, memory, disk, swap, pressure, service, and process summaries refresh without requiring a page reload.
+3. **Given** system memory includes reclaimable cache, **When** memory is displayed, **Then** the dashboard separates app memory from reclaimable file/kernel cache so the user does not mistake cache for a leak.
+4. **Given** a health probe cannot collect one section, **When** the dashboard renders, **Then** available sections still render and the failed section shows a generic unavailable state.
+
+---
+
+### User Story 2 - Review Cleanup Suggestions (Priority: P2)
+
+As a Matrix OS owner, I can see safe cleanup suggestions with clear explanations, estimated resource recovery, confidence, and risk before taking action.
+
+**Why this priority**: Cleanup decisions need user trust. Suggestions should be explainable and bounded before any button mutates the machine.
+
+**Independent Test**: Create known stale resource candidates, open the monitor, and verify suggestions appear only for resources that match documented cleanup rules and never for active user work.
+
+**Acceptance Scenarios**:
+
+1. **Given** an orphaned app server is still running with no active connections, **When** the monitor evaluates cleanup candidates, **Then** it suggests stopping that app server and explains why it is safe.
+2. **Given** a zellij session or code editor is active or recently used, **When** suggestions are generated, **Then** no cleanup suggestion is shown for that active resource.
+3. **Given** old cache or rollback files can be cleaned, **When** suggestions are generated, **Then** the user sees expected reclaimed space and which directories or retained versions are affected.
+4. **Given** the system cannot determine whether a process is stale, **When** suggestions are generated, **Then** it is omitted or marked as manual-review-only rather than offered as a one-click cleanup.
+
+---
+
+### User Story 3 - Clean Up Safely by Click (Priority: P3)
+
+As a Matrix OS owner, I can run approved cleanup actions from the System Activity Monitor and see the result without raw internal errors or accidental termination of active work.
+
+**Why this priority**: Manual cleanup makes the monitor actionable, but it must be guarded by typed actions and confirmations.
+
+**Independent Test**: Select each approved cleanup type against a safe fixture resource and verify only that resource is affected, the monitor refreshes, and an audit event records the action.
+
+**Acceptance Scenarios**:
+
+1. **Given** a stale app server suggestion exists, **When** the user confirms cleanup, **Then** the server is stopped, the dashboard refreshes, and active services remain healthy.
+2. **Given** a stale zellij session suggestion exists, **When** the user confirms cleanup, **Then** only that session is closed and other sessions remain available.
+3. **Given** a cache cleanup suggestion exists, **When** the user confirms cleanup, **Then** only the approved cache scope is cleaned and owner data is preserved.
+4. **Given** a cleanup target disappears before the action runs, **When** the action executes, **Then** it returns an already-clean result and does not fail as an error.
+
+---
+
+### User Story 4 - Enable Automatic Cleanup Policy (Priority: P4)
+
+As a Matrix OS owner, I can opt into conservative automatic cleanup for high-confidence stale resources and review what happened afterward.
+
+**Why this priority**: Automatic cleanup can keep small VPSes healthy, but it should only ship after the monitor and manual cleanup path prove the classifier.
+
+**Independent Test**: Enable auto-clean for a known safe class, create stale resources, and verify the policy cleans only eligible resources after the grace period while recording visible history.
+
+**Acceptance Scenarios**:
+
+1. **Given** automatic cleanup is disabled, **When** stale resources are detected, **Then** the system only suggests actions and does not mutate the machine.
+2. **Given** automatic cleanup is enabled for high-confidence app servers, **When** an eligible resource remains stale past the grace period, **Then** it is cleaned and a history entry records the reason.
+3. **Given** a resource becomes active during the grace period, **When** auto-clean evaluates it, **Then** the cleanup is skipped.
+
+### Edge Cases
+
+- The Matrix computer is provisioned but unreachable or still booting.
+- A process exits between snapshot collection and cleanup action execution.
+- A process belongs to the OS or another critical service and must never be offered for direct termination.
+- Disk usage is high because of owner data, not reclaimable system/cache files.
+- Resource counters are temporarily unavailable because the host lacks an optional tool.
+- The user has multiple runtime slots and needs to distinguish primary, staging, and preview machines.
+- Cleanup succeeds but a later health refresh fails.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide an owner-only System Activity Monitor entry point in Matrix shell.
+- **FR-002**: System MUST show machine identity including handle, runtime slot, hostname, machine status, installed release, release channel, and uptime.
+- **FR-003**: System MUST show current CPU load, memory, swap, disk usage, pressure indicators, running service status, and top resource-consuming processes.
+- **FR-004**: System MUST distinguish live process memory from reclaimable cache or kernel/file accounting where available.
+- **FR-005**: System MUST refresh activity data periodically and allow manual refresh without reloading the shell.
+- **FR-006**: System MUST degrade section-by-section when a metric cannot be collected.
+- **FR-007**: System MUST classify cleanup candidates into explicit resource types before presenting suggestions.
+- **FR-008**: System MUST NOT expose arbitrary process termination; cleanup actions must be typed, allowlisted, and tied to a server-generated candidate.
+- **FR-009**: System MUST show cleanup reason, confidence, risk, target, and estimated reclaimed resources before action.
+- **FR-010**: System MUST require confirmation for actions that stop a process, close a session, restart a service, or delete files.
+- **FR-011**: System MUST preserve owner data and protected system files during cleanup.
+- **FR-012**: System MUST record cleanup attempts and outcomes in an owner-visible history.
+- **FR-013**: System MUST return generic user-facing errors while retaining enough operator-side detail for diagnosis.
+- **FR-014**: System MUST support an opt-in automatic cleanup policy limited to high-confidence, documented cleanup classes.
+- **FR-015**: System MUST allow users to disable automatic cleanup and review the last automatic actions.
+- **FR-016**: System MUST keep cleanup candidate registries and any in-memory state bounded with eviction.
+- **FR-017**: System MUST validate all action inputs and reject stale, unknown, or mismatched cleanup targets.
+- **FR-018**: System MUST notify the dashboard after cleanup so service health and resource summaries refresh.
+
+### Key Entities *(include if feature involves data)*
+
+- **Activity Snapshot**: Point-in-time machine identity, resource, service, process, and cleanup suggestion view.
+- **Machine Identity**: User-visible runtime identity including handle, slot, hostname, release, and status.
+- **Resource Metric**: CPU, memory, disk, swap, pressure, and service accounting values with collection status.
+- **Process Summary**: Sanitized process identity, owner class, CPU, memory, runtime, listening ports, and classification.
+- **Cleanup Candidate**: Server-generated, typed recommendation for a safe cleanup action.
+- **Cleanup Action**: User-initiated or policy-initiated request to clean a specific candidate.
+- **Cleanup History Entry**: Owner-visible record of action, reason, actor, result, reclaimed resources, and timestamp.
+- **Auto-Cleanup Policy**: Owner-controlled configuration for conservative automatic cleanup classes and grace periods.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can identify their current Matrix computer, installed release, and top three memory and CPU consumers in under 10 seconds after opening the monitor.
+- **SC-002**: Read-only activity refresh completes within 2 seconds for at least 95% of requests on a small customer VPS under normal load.
+- **SC-003**: Cleanup suggestions never include critical Matrix services or active user work in documented active-resource scenarios.
+- **SC-004**: A safe stale app server or stale session can be cleaned from the dashboard and reflected in the next refresh within 5 seconds.
+- **SC-005**: Disk cleanup preserves owner data paths in all protected-path test cases.
+- **SC-006**: Automatic cleanup, when enabled, records 100% of actions in user-visible history.

--- a/specs/087-system-activity-monitor/tasks.md
+++ b/specs/087-system-activity-monitor/tasks.md
@@ -1,0 +1,229 @@
+# Tasks: System Activity Monitor
+
+**Input**: Design documents from `/specs/087-system-activity-monitor/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: TDD is mandatory for this feature. Test tasks are included before implementation tasks and must fail before corresponding implementation work begins.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish shared types, module boundaries, and built-in app entry points.
+
+- [ ] T001 Create `packages/gateway/src/system-activity/types.ts` with ActivitySnapshot, MachineIdentity, ResourceSummary, ServiceStatus, ProcessSummary, CleanupCandidate, CleanupAction, CleanupHistoryEntry, and AutoCleanupPolicy DTO types.
+- [ ] T002 Create `packages/gateway/src/system-activity/routes.ts` with placeholder Hono route factory and dependency interface wired for tests but not registered.
+- [ ] T003 [P] Create `shell/src/stores/systemActivityStore.ts` with serializable initial state, refresh status, cleanup status, and error fields.
+- [ ] T004 [P] Create `shell/src/components/system-activity/ActivityMonitorApp.tsx` as a minimal built-in app shell with loading and unavailable states.
+- [ ] T005 Add the System Activity Monitor built-in app manifest/icon wiring in the existing shell built-in app registry files discovered during implementation.
+- [ ] T006 Update `www/content/docs/guide/system-activity-monitor.mdx` with user-facing monitor and cleanup safety overview.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared collectors, route validation, error policy, and protected cleanup primitives that all user stories rely on.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T007 [P] Add failing contract tests for `GET /api/system/activity`, `POST /api/system/activity/actions`, policy routes, history route, auth failures, generic errors, and body limits in `tests/gateway/system-activity-routes.test.ts`.
+- [ ] T008 [P] Add failing collector tests for CPU, memory, cgroup memory decomposition, disk, pressure, service accounting, process limits, subprocess timeouts, and sanitized warnings in `tests/gateway/system-activity-collector.test.ts`.
+- [ ] T009 [P] Add failing cleanup classifier tests for stale app servers, active app servers, zellij sessions, code-server, cache scopes, protected paths, candidate TTL, and bounded candidate cache in `tests/gateway/system-activity-cleanup.test.ts`.
+- [ ] T010 [P] Add failing history/policy tests for owner-file atomic writes, bounded retention, malformed file handling, and safe generic errors in `tests/gateway/system-activity-history.test.ts`.
+- [ ] T011 Implement host metric collectors with bounded readers and subprocess timeouts in `packages/gateway/src/system-activity/collector.ts`.
+- [ ] T012 Implement service and process snapshot collection with allowlisted service ids, capped process rows, sanitized display names, and no raw command stderr in `packages/gateway/src/system-activity/collector.ts`.
+- [ ] T013 Implement cleanup candidate cache with TTL, max size, opaque candidate ids, and shutdown drain in `packages/gateway/src/system-activity/cleanup.ts`.
+- [ ] T014 Implement protected path helpers and cleanup policy/history owner-file persistence with atomic writes and symlink-safe cleanup in `packages/gateway/src/system-activity/history.ts`.
+- [ ] T015 Implement Zod route schemas, `bodyLimit` on mutating endpoints, owner auth dependency checks, and generic error mapper in `packages/gateway/src/system-activity/routes.ts`.
+- [ ] T016 Register system activity routes at gateway startup with dependency resolution at registration time in `packages/gateway/src/server.ts`.
+
+**Checkpoint**: Foundation ready - all user story slices can build on trusted collection, validation, and persistence.
+
+---
+
+## Phase 3: User Story 1 - Inspect My Matrix Computer (Priority: P1) MVP
+
+**Goal**: Users can open a read-only monitor and understand their current machine, resource pressure, service health, and top processes.
+
+**Independent Test**: Open the built-in monitor on a running Matrix computer and verify identity, release, CPU, RAM, disk, service, and process sections refresh without destructive actions.
+
+### Tests for User Story 1
+
+- [ ] T017 [P] [US1] Add failing shell store tests for refresh lifecycle, safe error strings, section-level unavailable states, and stable serializable state in `tests/shell/system-activity-app.test.tsx`.
+- [ ] T018 [P] [US1] Add failing component tests for MachineSummary, ResourceMeters, ProcessTable, service health rendering, refresh button behavior, and no layout overlap in `tests/shell/system-activity-app.test.tsx`.
+
+### Implementation for User Story 1
+
+- [ ] T019 [US1] Implement `GET /api/system/activity` snapshot assembly and process limit handling in `packages/gateway/src/system-activity/routes.ts`.
+- [ ] T020 [P] [US1] Implement `MachineSummary.tsx` in `shell/src/components/system-activity/MachineSummary.tsx`.
+- [ ] T021 [P] [US1] Implement `ResourceMeters.tsx` in `shell/src/components/system-activity/ResourceMeters.tsx`.
+- [ ] T022 [P] [US1] Implement `ProcessTable.tsx` in `shell/src/components/system-activity/ProcessTable.tsx`.
+- [ ] T023 [US1] Implement dashboard refresh, polling, abort handling, and safe client error capping in `shell/src/stores/systemActivityStore.ts`.
+- [ ] T024 [US1] Wire `ActivityMonitorApp.tsx` into Canvas and Desktop built-in app handling in `shell/src/components/canvas/CanvasWindow.tsx` and `shell/src/components/Desktop.tsx`.
+- [ ] T025 [US1] Add responsive Canvas-first layout polish and loading/empty states in `shell/src/components/system-activity/ActivityMonitorApp.tsx`.
+
+**Checkpoint**: User Story 1 is fully functional as a read-only MVP.
+
+---
+
+## Phase 4: User Story 2 - Review Cleanup Suggestions (Priority: P2)
+
+**Goal**: Users can see explainable cleanup suggestions without taking action.
+
+**Independent Test**: Known stale and active fixtures produce correct suggestions and omissions.
+
+### Tests for User Story 2
+
+- [ ] T026 [P] [US2] Add failing classifier fixture tests for orphaned app servers with deleted executables, high-port listeners, no active connections, active zellij sessions, idle code-server, old bundles, and cache scopes in `tests/gateway/system-activity-cleanup.test.ts`.
+- [ ] T027 [P] [US2] Add failing UI tests for cleanup suggestion cards, confidence/risk labels, estimated reclaim, confirmation affordance, and manual-review-only state in `tests/shell/system-activity-app.test.tsx`.
+
+### Implementation for User Story 2
+
+- [ ] T028 [US2] Implement stale app server, zellij, code-server, cache, and old-bundle cleanup classifiers in `packages/gateway/src/system-activity/cleanup.ts`.
+- [ ] T029 [US2] Include cleanup suggestions in `GET /api/system/activity` only when requested and only after candidate cache registration in `packages/gateway/src/system-activity/routes.ts`.
+- [ ] T030 [P] [US2] Implement `CleanupSuggestions.tsx` with risk, confidence, target, reason, and estimated reclaim display in `shell/src/components/system-activity/CleanupSuggestions.tsx`.
+- [ ] T031 [US2] Add suggestion rendering and disabled/manual-review states to `ActivityMonitorApp.tsx`.
+
+**Checkpoint**: Users can inspect safe cleanup opportunities without mutating the runtime.
+
+---
+
+## Phase 5: User Story 3 - Clean Up Safely by Click (Priority: P3)
+
+**Goal**: Users can execute approved cleanup suggestions and see audited results.
+
+**Independent Test**: Each approved action affects only its target, active work remains intact, and cleanup history records the outcome.
+
+### Tests for User Story 3
+
+- [ ] T032 [P] [US3] Add failing action execution tests for stale app server stop, stale terminal session close, idle code-server restart, cache cleanup, old bundle pruning, already-clean targets, candidate mismatch, and generic errors in `tests/gateway/system-activity-cleanup.test.ts`.
+- [ ] T033 [P] [US3] Add failing route tests for action schema validation, candidate expiry, confirmation mismatch, body limit, owner auth, history write, and refresh recommendation in `tests/gateway/system-activity-routes.test.ts`.
+- [ ] T034 [P] [US3] Add failing UI tests for confirmation flow, pending state, result state, safe error display, and post-action refresh in `tests/shell/system-activity-app.test.tsx`.
+
+### Implementation for User Story 3
+
+- [ ] T035 [US3] Implement typed cleanup executors with idempotent already-clean handling in `packages/gateway/src/system-activity/cleanup.ts`.
+- [ ] T036 [US3] Implement `POST /api/system/activity/actions` with candidate revalidation, confirmation checks, history writes, and generic errors in `packages/gateway/src/system-activity/routes.ts`.
+- [ ] T037 [US3] Implement cleanup history query endpoint in `packages/gateway/src/system-activity/routes.ts`.
+- [ ] T038 [US3] Implement confirmation and action submission flow in `CleanupSuggestions.tsx` and `systemActivityStore.ts`.
+- [ ] T039 [US3] Add cleanup history summary UI in `ActivityMonitorApp.tsx`.
+
+**Checkpoint**: Manual cleanup is safe, typed, audited, and visible.
+
+---
+
+## Phase 6: User Story 4 - Enable Automatic Cleanup Policy (Priority: P4)
+
+**Goal**: Users can opt into conservative automatic cleanup and review actions.
+
+**Independent Test**: Auto-clean handles only enabled high-confidence stale classes after grace period and records every action.
+
+### Tests for User Story 4
+
+- [ ] T040 [P] [US4] Add failing auto-clean policy tests for disabled default, allowed type validation, grace period, rate limiting, active-resource skip, and shutdown drain in `tests/gateway/system-activity-cleanup.test.ts`.
+- [ ] T041 [P] [US4] Add failing policy UI tests for enable/disable, allowed type controls, grace period display, and history visibility in `tests/shell/system-activity-app.test.tsx`.
+
+### Implementation for User Story 4
+
+- [ ] T042 [US4] Implement auto-clean policy read/update routes with body limits and bounded validation in `packages/gateway/src/system-activity/routes.ts`.
+- [ ] T043 [US4] Implement conservative auto-clean scheduler with TTL/rate limits and shutdown drain in `packages/gateway/src/system-activity/cleanup.ts`.
+- [ ] T044 [US4] Implement policy controls and auto-clean history indicators in `ActivityMonitorApp.tsx`.
+- [ ] T045 [US4] Document auto-clean safety, defaults, and rollback guidance in `www/content/docs/guide/system-activity-monitor.mdx`.
+
+**Checkpoint**: Automatic cleanup is opt-in, conservative, and auditable.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation, operations docs, release readiness, and review hardening.
+
+- [ ] T046 [P] Run and fix focused gateway tests in `tests/gateway/system-activity-collector.test.ts`, `tests/gateway/system-activity-cleanup.test.ts`, `tests/gateway/system-activity-routes.test.ts`, and `tests/gateway/system-activity-history.test.ts`.
+- [ ] T047 [P] Run and fix focused shell tests in `tests/shell/system-activity-app.test.tsx`.
+- [ ] T048 Run `bun run typecheck` and fix all issues.
+- [ ] T049 Run `bun run check:patterns` and fix all violations.
+- [ ] T050 Run `bun run test` or document exact unrelated failures.
+- [ ] T051 Run `npx react-doctor@latest shell` and resolve findings for React changes.
+- [ ] T052 Validate quickstart flows on a disposable customer VPS and update `specs/087-system-activity-monitor/quickstart.md`.
+- [ ] T053 Add PR body invariants for source of truth, lock/transaction scope, acceptable orphan states, auth source of truth, and deferred scope in the GitHub PR description.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories.
+- **US1 Read-only Monitor (Phase 3)**: Depends on Foundational; MVP.
+- **US2 Cleanup Suggestions (Phase 4)**: Depends on Foundational and benefits from US1 UI surfaces.
+- **US3 Manual Cleanup (Phase 5)**: Depends on US2 candidates.
+- **US4 Automatic Cleanup (Phase 6)**: Depends on US3 audited manual cleanup.
+- **Polish (Phase 7)**: Depends on implemented story phases.
+
+### Graphite Stack Plan
+
+This feature should ship as a stacked series, not one oversized PR:
+
+- **Stack 1**: Spec Kit artifacts only: `specs/087-system-activity-monitor/**`, `.specify/feature.json`, and agent context update.
+- **Stack 2**: Gateway read-only collector, route scaffolding, contracts, and US1 backend tests.
+- **Stack 3**: Shell built-in read-only System Activity Monitor UI for Canvas and Desktop.
+- **Stack 4**: Cleanup suggestions and classifier tests.
+- **Stack 5**: Manual cleanup actions and cleanup history.
+- **Stack 6**: Opt-in automatic cleanup policy and operations docs.
+
+Each layer should stay below Matrix OS PR size limits and follow `docs/dev/stacked-prs.md`.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Starts after Foundational; no dependency on cleanup.
+- **User Story 2 (P2)**: Starts after Foundational; can be backend-first while US1 UI lands.
+- **User Story 3 (P3)**: Requires US2 candidates.
+- **User Story 4 (P4)**: Requires US3 action execution and history.
+
+### Parallel Opportunities
+
+- T003, T004, and T006 can run in parallel after T001.
+- T007-T010 can run in parallel.
+- T020-T022 can run in parallel after T019 contract shape is stable.
+- T026 and T027 can run in parallel.
+- T032-T034 can run in parallel.
+- T040 and T041 can run in parallel.
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "T020 [US1] Implement MachineSummary.tsx in shell/src/components/system-activity/MachineSummary.tsx"
+Task: "T021 [US1] Implement ResourceMeters.tsx in shell/src/components/system-activity/ResourceMeters.tsx"
+Task: "T022 [US1] Implement ProcessTable.tsx in shell/src/components/system-activity/ProcessTable.tsx"
+```
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Setup.
+2. Complete Foundational collectors and route validation.
+3. Complete US1 read-only dashboard.
+4. Stop and validate on local dev plus one disposable VPS.
+
+### Incremental Delivery
+
+1. Ship read-only dashboard.
+2. Add suggestions without mutation.
+3. Add manual cleanup with confirmation and audit.
+4. Add opt-in automatic cleanup only after manual cleanup proves safe.
+
+### Notes
+
+- Do not introduce arbitrary process kill or arbitrary path deletion.
+- Do not use Docker Compose as the production customer runtime path.
+- Do not expose raw command output, filesystem paths, stack traces, provider names, or database/systemd errors to clients.
+- Keep UI state serializable and selectors stable.
+- Use Canvas as the primary manual verification surface before Desktop.

--- a/www/content/docs/guide/meta.json
+++ b/www/content/docs/guide/meta.json
@@ -3,5 +3,5 @@
   "title": "Guide",
   "description": "Learn how to use Matrix OS",
   "icon": "BookOpen",
-  "pages": ["index", "getting-started", "mobile", "integrations", "apps", "app-store", "channels", "social", "storage", "agents", "file-system", "cloud-coding", "developer-workflow"]
+  "pages": ["index", "getting-started", "mobile", "integrations", "apps", "app-store", "channels", "social", "storage", "agents", "file-system", "cloud-coding", "developer-workflow", "system-activity-monitor"]
 }

--- a/www/content/docs/guide/system-activity-monitor.mdx
+++ b/www/content/docs/guide/system-activity-monitor.mdx
@@ -1,0 +1,12 @@
+---
+title: System Activity Monitor
+description: Inspect your Matrix computer, resource usage, and planned cleanup controls.
+---
+
+# System Activity Monitor
+
+System Activity Monitor is a planned first-party Matrix OS app for inspecting the current Matrix computer, understanding resource usage, and cleaning safe stale resources.
+
+The monitor will show machine identity, release, uptime, CPU, memory, disk, service health, top processes, and cleanup suggestions. Cleanup actions are planned as typed, owner-confirmed actions rather than arbitrary process or file controls.
+
+Automatic cleanup is planned as opt-in only. It will start with conservative, high-confidence stale resources and keep owner-visible history for every action.


### PR DESCRIPTION
## Summary
- Add Spec Kit artifacts for a first-party System Activity Monitor built-in app.
- Define owner-only activity snapshot, cleanup suggestion/action, policy, and history contracts.
- Break implementation into Graphite-friendly phases for read-only monitor, suggestions, manual cleanup, and opt-in automation.

## Tests
- `SPECIFY_FEATURE=087-system-activity-monitor .specify/scripts/bash/check-prerequisites.sh --json --include-tasks`
- task format validation script: 53 tasks, 0 format/path issues
- placeholder/clarification scan
- `git diff --check`
- `bun run check:patterns` (0 violations; existing warnings only)

Skipped: `bun run typecheck`, `bun run test`, and `npx react-doctor@latest shell` because this PR is Spec Kit/docs-only and does not change runtime TypeScript or React files.

## Review/Monitoring
- Ready for CI and Greptile review.
- This is intended as Stack 1 only; implementation should follow the Graphite stack plan in `specs/087-system-activity-monitor/tasks.md`.

## Invariants
- Source of truth: this PR only updates Spec Kit planning artifacts. The planned runtime source of truth is the current owner VPS gateway snapshot plus owner files under `~/system/` for cleanup policy/history.
- Lock/transaction scope: no runtime writes in this PR. Future cleanup actions must revalidate server-generated candidates immediately before mutation and use atomic owner-file writes for policy/history.
- Acceptable orphan states: none introduced by this PR. Future accepted orphan state is an already-clean target after a stale candidate disappears before action execution.
- Auth source of truth: no auth behavior changes in this PR. The planned API requires owner session or accepted Matrix bearer/JWT at the gateway boundary.
- Deferred scope: no collector, endpoint, UI, or cleanup implementation in this PR; those are split into follow-up stack layers.