### PR TITLE
fix(symphony): add runtime service controls

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -181,6 +181,11 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: 28
+          elixir-version: 1.19
+
       - name: Validate public build environment
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -873,7 +873,7 @@ runcmd:
       chown root:matrix /opt/matrix/release.json
       chmod 0644 /opt/matrix/release.json
     fi
-    for required_bin in matrixctl matrix-db-backup.sh matrix-restore.sh matrix-owner-env matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-symphony matrix-install-hermes; do
+    for required_bin in matrixctl matrix-db-backup.sh matrix-restore.sh matrix-owner-env matrix-gateway matrix-shell matrix-code matrix-sync-agent matrix-symphony matrix-symphony-control matrix-install-hermes; do
       chmod 0750 "/opt/matrix/bin/${required_bin}"
     done
     for optional_bin in matrix-install-linux-tools matrix-messaging-health matrix-messaging-backup matrix-messaging-restore; do

--- a/distro/customer-vps/host-bin/matrix-symphony
+++ b/distro/customer-vps/host-bin/matrix-symphony
@@ -10,7 +10,7 @@ if [ -r /opt/matrix/bin/matrix-owner-env ]; then
 fi
 
 APP_DIR="${MATRIX_APP_DIR:-/opt/matrix/app}"
-SYMPHONY_BIN="${SYMPHONY_BIN:-$APP_DIR/packages/symphony-elixir/bin/symphony}"
+SYMPHONY_BIN="${SYMPHONY_BIN:-$APP_DIR/packages/symphony-elixir/release/bin/symphony}"
 WORKFLOW_FILE="${SYMPHONY_WORKFLOW_FILE:-$APP_DIR/packages/symphony-elixir/WORKFLOW.md}"
 
 export MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
@@ -31,8 +31,6 @@ fi
 
 mkdir -p "$SYMPHONY_WORKSPACE_ROOT"
 mkdir -p "$MATRIX_HOME/system/symphony/logs"
-exec "$SYMPHONY_BIN" \
-  --i-understand-that-this-will-be-running-without-the-usual-guardrails \
-  --logs-root "$MATRIX_HOME/system/symphony/logs" \
-  --port "$SYMPHONY_PORT" \
-  "$WORKFLOW_FILE"
+export SYMPHONY_LOGS_ROOT="$MATRIX_HOME/system/symphony/logs"
+export SYMPHONY_WORKFLOW_FILE="$WORKFLOW_FILE"
+exec "$SYMPHONY_BIN" start

--- a/distro/customer-vps/host-bin/matrix-symphony-control
+++ b/distro/customer-vps/host-bin/matrix-symphony-control
@@ -44,15 +44,24 @@ credential_configured() {
 print_status() {
   local available=false running=false status=unavailable can_start=false can_stop=false credential=false
   if unit_available; then
+    local active_state
     available=true
-    if systemctl is-active --quiet "$UNIT"; then
-      running=true
-      status=running
-      can_stop=true
-    else
-      status=stopped
-      can_start=true
-    fi
+    active_state="$(systemctl is-active "$UNIT" 2>/dev/null || true)"
+    case "$active_state" in
+      active)
+        running=true
+        status=running
+        can_stop=true
+        ;;
+      activating|reloading)
+        status=starting
+        can_stop=true
+        ;;
+      *)
+        status=stopped
+        can_start=true
+        ;;
+    esac
   fi
   if credential_configured; then
     credential=true
@@ -74,7 +83,7 @@ fi
 case "$ACTION" in
   start)
     "${SUDO[@]}" systemctl enable "$UNIT" >/dev/null
-    "${SUDO[@]}" systemctl start "$UNIT"
+    "${SUDO[@]}" systemctl start --no-block "$UNIT"
     ;;
   stop)
     "${SUDO[@]}" systemctl stop "$UNIT"

--- a/distro/customer-vps/host-bin/matrix-symphony-control
+++ b/distro/customer-vps/host-bin/matrix-symphony-control
@@ -57,6 +57,10 @@ print_status() {
         status=starting
         can_stop=true
         ;;
+      deactivating)
+        status=stopping
+        can_stop=true
+        ;;
       *)
         status=stopped
         can_start=true
@@ -86,7 +90,7 @@ case "$ACTION" in
     "${SUDO[@]}" systemctl start --no-block "$UNIT"
     ;;
   stop)
-    "${SUDO[@]}" systemctl stop "$UNIT"
+    "${SUDO[@]}" systemctl stop --no-block "$UNIT"
     ;;
 esac
 

--- a/distro/customer-vps/host-bin/matrix-symphony-control
+++ b/distro/customer-vps/host-bin/matrix-symphony-control
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: matrix-symphony-control [status|start|stop]" >&2
+}
+
+ACTION="${1:-status}"
+case "$ACTION" in
+  status|start|stop) ;;
+  *) usage; exit 64 ;;
+esac
+
+UNIT="matrix-symphony.service"
+MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+if [ -f /opt/matrix/env/host.env ]; then
+  # shellcheck disable=SC1091
+  source /opt/matrix/env/host.env
+fi
+if [ -r /opt/matrix/bin/matrix-owner-env ]; then
+  # shellcheck disable=SC1091
+  source /opt/matrix/bin/matrix-owner-env
+  if declare -F matrix_export_owner_env >/dev/null 2>&1; then
+    matrix_export_owner_env
+  fi
+fi
+MATRIX_HOME="${MATRIX_HOME:-/home/matrix/home}"
+
+SUDO=()
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO=(sudo)
+fi
+
+unit_available() {
+  systemctl cat "$UNIT" >/dev/null 2>&1
+}
+
+credential_configured() {
+  local credential_dir="$MATRIX_HOME/system/symphony/credentials"
+  [ -d "$credential_dir" ] || return 1
+  find "$credential_dir" -maxdepth 1 -type f -name '*.linear' -size +0c -print -quit | grep -q .
+}
+
+print_status() {
+  local available=false running=false status=unavailable can_start=false can_stop=false credential=false
+  if unit_available; then
+    available=true
+    if systemctl is-active --quiet "$UNIT"; then
+      running=true
+      status=running
+      can_stop=true
+    else
+      status=stopped
+      can_start=true
+    fi
+  fi
+  if credential_configured; then
+    credential=true
+  fi
+  printf '{"available":%s,"running":%s,"status":"%s","canStart":%s,"canStop":%s,"credentialConfigured":%s,"managedBy":"systemd"}\n' \
+    "$available" "$running" "$status" "$can_start" "$can_stop" "$credential"
+}
+
+if [ "$ACTION" = "status" ]; then
+  print_status
+  exit 0
+fi
+
+if ! unit_available; then
+  print_status
+  exit 1
+fi
+
+case "$ACTION" in
+  start)
+    "${SUDO[@]}" systemctl enable "$UNIT" >/dev/null
+    "${SUDO[@]}" systemctl start "$UNIT"
+    ;;
+  stop)
+    "${SUDO[@]}" systemctl stop "$UNIT"
+    ;;
+esac
+
+print_status

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -59,20 +59,6 @@ fetch_manifest() {
   printf '%s' "$manifest"
 }
 
-ensure_symphony_runtime() {
-  if command -v elixir >/dev/null 2>&1 && command -v escript >/dev/null 2>&1; then
-    return 0
-  fi
-  if ! command -v apt-get >/dev/null 2>&1; then
-    log "WARN: apt-get missing; cannot provision Symphony runtime"
-    return 1
-  fi
-  log "Installing Symphony Erlang/Elixir runtime"
-  sudo apt-get update
-  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools
-}
-
 prepare_triggered_update() {
   local url="" target=""
   if [ -f "$UPDATE_VERSION_FILE" ]; then
@@ -228,13 +214,9 @@ apply_update() {
     sudo systemctl daemon-reload
     log "Installed systemd units"
     if [ -f "$extract_dir/systemd/matrix-symphony.service" ]; then
-      if ensure_symphony_runtime; then
-        sudo systemctl enable matrix-symphony.service
-        sudo systemctl start --no-block matrix-symphony.service || true
-        log "Symphony service enabled"
-      else
-        log "WARN: Symphony runtime unavailable; unit installed but not started"
-      fi
+      sudo systemctl enable matrix-symphony.service
+      sudo systemctl start --no-block matrix-symphony.service || true
+      log "Symphony service enabled"
     fi
     if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then
       sudo systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -59,6 +59,20 @@ fetch_manifest() {
   printf '%s' "$manifest"
 }
 
+ensure_symphony_runtime() {
+  if command -v elixir >/dev/null 2>&1 && command -v escript >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! command -v apt-get >/dev/null 2>&1; then
+    log "WARN: apt-get missing; cannot provision Symphony runtime"
+    return 1
+  fi
+  log "Installing Symphony Erlang/Elixir runtime"
+  sudo apt-get update
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    elixir erlang-base erlang-crypto erlang-inets erlang-public-key erlang-ssl erlang-tools
+}
+
 prepare_triggered_update() {
   local url="" target=""
   if [ -f "$UPDATE_VERSION_FILE" ]; then
@@ -188,7 +202,7 @@ apply_update() {
 
   # Stop services, backup, install
   log "Stopping services..."
-  sudo systemctl stop matrix-gateway matrix-shell || true
+  sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true
   sudo rm -rf "$APP_DIR.rollback"
   if [ -d "$APP_DIR" ]; then
     sudo mv "$APP_DIR" "$APP_DIR.rollback"
@@ -213,6 +227,15 @@ apply_update() {
     sudo find "$extract_dir/systemd" -maxdepth 1 -name 'matrix-*.service' -exec install -o root -g root -m 0644 {} /etc/systemd/system/ \;
     sudo systemctl daemon-reload
     log "Installed systemd units"
+    if [ -f "$extract_dir/systemd/matrix-symphony.service" ]; then
+      if ensure_symphony_runtime; then
+        sudo systemctl enable matrix-symphony.service
+        sudo systemctl start --no-block matrix-symphony.service || true
+        log "Symphony service enabled"
+      else
+        log "WARN: Symphony runtime unavailable; unit installed but not started"
+      fi
+    fi
     if [ -x /opt/matrix/messaging/bin/synapse ] && [ -x /opt/matrix/messaging/bin/mautrix-telegram ] && [ -x /opt/matrix/messaging/bin/mautrix-whatsapp ]; then
       sudo systemctl enable matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service
       sudo systemctl start --no-block matrix-homeserver.service matrix-bridge-telegram.service matrix-bridge-whatsapp.service || true
@@ -252,7 +275,7 @@ do_rollback() {
     log "ERROR: no rollback available at $APP_DIR.rollback"; return 1
   fi
   log "Rolling back..."
-  sudo systemctl stop matrix-gateway matrix-shell || true
+  sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true
   if [ -d "$APP_DIR" ]; then
     sudo mkdir -p "$STAGING_DIR"
     sudo chown matrix:matrix "$STAGING_DIR"
@@ -261,6 +284,7 @@ do_rollback() {
   sudo mv "$APP_DIR.rollback" "$APP_DIR"
   sudo chown -R matrix:matrix "$APP_DIR"
   sudo systemctl start matrix-gateway matrix-shell
+  sudo systemctl start --no-block matrix-symphony || true
   local healthy=false
   for _ in $(seq 1 18); do
     if curl --fail --silent --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then

--- a/distro/customer-vps/systemd/matrix-symphony.service
+++ b/distro/customer-vps/systemd/matrix-symphony.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 Requires=matrix-restore.service
 ConditionPathExists=/opt/matrix/restore-complete
 ConditionPathExists=/opt/matrix/bin/matrix-symphony
-ConditionPathExists=/opt/matrix/app/packages/symphony-elixir/bin/symphony
+ConditionPathExists=/opt/matrix/app/packages/symphony-elixir/release/bin/symphony
 
 [Service]
 User=matrix

--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -33,7 +33,7 @@ interface SymphonyState {
 interface SymphonyServiceControl {
   available: boolean;
   running: boolean;
-  status: "running" | "starting" | "stopped" | "unavailable";
+  status: "running" | "starting" | "stopping" | "stopped" | "unavailable";
   canStart: boolean;
   canStop: boolean;
   credentialConfigured?: boolean;

--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, ExternalLink, FolderOpen, RefreshCw, Square } from "lucide-react";
+import type { ReactNode } from "react";
+import { AlertTriangle, ExternalLink, FolderOpen, Play, Power, RefreshCw, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 
@@ -27,6 +28,20 @@ interface SymphonyState {
     generatedAt: string | null;
   };
   groups: Record<RunGroup, SymphonyRun[]>;
+}
+
+interface SymphonyServiceControl {
+  available: boolean;
+  running: boolean;
+  status: "running" | "stopped" | "unavailable";
+  canStart: boolean;
+  canStop: boolean;
+  credentialConfigured?: boolean;
+  managedBy?: string;
+}
+
+interface SymphonyServiceControlResponse {
+  service: SymphonyServiceControl;
 }
 
 interface SymphonyIssueDetail {
@@ -58,6 +73,14 @@ declare global {
 const EMPTY_STATE: SymphonyState = {
   service: { status: "unavailable", generatedAt: null },
   groups: { queue: [], running: [], needsAttention: [], done: [] },
+};
+
+const EMPTY_SERVICE_CONTROL: SymphonyServiceControl = {
+  available: false,
+  running: false,
+  status: "unavailable",
+  canStart: false,
+  canStop: false,
 };
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
@@ -142,6 +165,7 @@ function withTimeoutSignal(signal: AbortSignal, timeoutMs: number): AbortSignal 
 
 export default function App() {
   const [state, setState] = useState<SymphonyState>(EMPTY_STATE);
+  const [serviceControl, setServiceControl] = useState<SymphonyServiceControl>(EMPTY_SERVICE_CONTROL);
   const [selectedIssue, setSelectedIssue] = useState<string | null>(null);
   const [detail, setDetail] = useState<SymphonyIssueDetail | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -178,9 +202,22 @@ export default function App() {
     }
   }, []);
 
+  const loadServiceControl = useCallback(async () => {
+    const next = await fetchJson<SymphonyServiceControlResponse>("/api/symphony/service");
+    const service = next.service ?? EMPTY_SERVICE_CONTROL;
+    setServiceControl(service);
+    return service;
+  }, []);
+
   const loadState = useCallback(async (preferredIssue?: string | null) => {
     setError(null);
-    const next = await fetchJson<SymphonyState>("/api/symphony/state");
+    const [next] = await Promise.all([
+      fetchJson<SymphonyState>("/api/symphony/state"),
+      loadServiceControl().catch((err: unknown) => {
+        console.warn("[symphony] service status failed:", err instanceof Error ? err.message : String(err));
+        return null;
+      }),
+    ]);
     setState(next);
     const nextActive = chooseActiveIssue(next, selectedIssueRef.current, preferredIssue);
     setActiveIssue(nextActive);
@@ -197,15 +234,18 @@ export default function App() {
       detailAbortRef.current?.abort();
       setDetail(null);
     }
-  }, [loadIssueDetail, setActiveIssue]);
+  }, [loadIssueDetail, loadServiceControl, setActiveIssue]);
 
   useEffect(() => {
     void loadState().catch((err: unknown) => {
       console.warn("[symphony] state load failed:", err instanceof Error ? err.message : String(err));
       setError("Symphony is unavailable.");
       setLoading(false);
+      void loadServiceControl().catch((serviceErr: unknown) => {
+        console.warn("[symphony] service status failed:", serviceErr instanceof Error ? serviceErr.message : String(serviceErr));
+      });
     });
-  }, [loadState]);
+  }, [loadState, loadServiceControl]);
 
   useEffect(() => () => {
     detailAbortRef.current?.abort();
@@ -240,6 +280,48 @@ export default function App() {
     }
   }
 
+  async function startService() {
+    setBusy("service-start");
+    setError(null);
+    try {
+      const next = await fetchJson<SymphonyServiceControlResponse>("/api/symphony/service/start", { method: "POST", body: "{}" });
+      setServiceControl(next.service);
+      await loadState(activeIssue).catch((stateErr: unknown) => {
+        console.warn("[symphony] state load after service start failed:", stateErr instanceof Error ? stateErr.message : String(stateErr));
+        setLoading(false);
+        setError("Symphony is starting.");
+      });
+    } catch (err: unknown) {
+      console.warn("[symphony] service start failed:", err instanceof Error ? err.message : String(err));
+      setError("Symphony start failed.");
+      await loadServiceControl().catch((serviceErr: unknown) => {
+        console.warn("[symphony] service status failed:", serviceErr instanceof Error ? serviceErr.message : String(serviceErr));
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function stopService() {
+    setBusy("service-stop");
+    setError(null);
+    try {
+      const next = await fetchJson<SymphonyServiceControlResponse>("/api/symphony/service/stop", { method: "POST", body: "{}" });
+      setServiceControl(next.service);
+      setState(EMPTY_STATE);
+      setActiveIssue(null);
+      setDetail(null);
+    } catch (err: unknown) {
+      console.warn("[symphony] service stop failed:", err instanceof Error ? err.message : String(err));
+      setError("Symphony stop failed.");
+      await loadServiceControl().catch((serviceErr: unknown) => {
+        console.warn("[symphony] service status failed:", serviceErr instanceof Error ? serviceErr.message : String(serviceErr));
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
   function selectIssue(issueIdentifier: string | null | undefined) {
     const safe = safeIssue(issueIdentifier);
     if (!safe) return;
@@ -262,119 +344,171 @@ export default function App() {
 
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b bg-white px-5 py-4">
-        <div className="min-w-0">
-          <h1 className="text-xl font-semibold tracking-normal">Symphony</h1>
-          <p className="truncate text-sm text-muted-foreground">Elixir runtime via Codex app-server</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => void refresh()} disabled={Boolean(busy)}>
-            <RefreshCw className="size-4" /> Refresh
-          </Button>
-          <Button variant="outline" onClick={() => void stopCurrent()} disabled={!activeIssue || Boolean(busy)}>
-            <Square className="size-4" /> Stop
-          </Button>
-        </div>
-      </header>
+      <SymphonyHeader
+        activeIssue={activeIssue}
+        busy={busy}
+        serviceControl={serviceControl}
+        onRefresh={refresh}
+        onStartService={startService}
+        onStopCurrent={stopCurrent}
+        onStopService={stopService}
+      />
 
-      {error && (
-        <div className="mx-5 mt-4 flex items-center gap-2 border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-          <AlertTriangle className="size-4" /> {error}
-        </div>
-      )}
-
-      <section className="grid gap-3 p-5 sm:grid-cols-2 lg:grid-cols-4">
-        <Metric label="Queue" value={state.groups.queue.length} />
-        <Metric label="Running" value={state.groups.running.length} />
-        <Metric label="Needs Attention" value={state.groups.needsAttention.length} />
-        <Metric label="Done / Handoff" value={state.groups.done.length} />
-      </section>
-
-      {loading && (
-        <div className="mx-5 mb-4 border bg-white px-4 py-3 text-sm text-muted-foreground">
-          Loading Symphony state...
-        </div>
-      )}
-
+      {error && <Notice icon={<AlertTriangle className="size-4" />} tone="warning" text={error} />}
+      <Metrics state={state} />
+      {loading && <Notice tone="plain" text="Loading Symphony state..." />}
       {state.service.credentialStatus === "setup_required" && (
-        <div className="mx-5 mb-4 border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-          Connect Linear in Matrix Integrations to let Symphony poll assigned work.
-        </div>
+        <Notice tone="warning" text="Connect Linear in Matrix Integrations to let Symphony poll assigned work." />
       )}
 
       <section className="grid gap-5 px-5 pb-5 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
-        <div className="space-y-4">
-          {RUN_GROUPS.map((group) => (
-            <section key={group} className="border bg-white">
-              <div className="flex items-center justify-between border-b px-4 py-3">
-                <h2 className="text-sm font-semibold uppercase tracking-normal text-muted-foreground">{groupLabel(group)}</h2>
-                <span className="text-sm text-muted-foreground">{state.groups[group].length}</span>
-              </div>
-              <div className="divide-y">
-                {state.groups[group].length === 0 ? (
-                  <div className="px-4 py-6 text-sm text-muted-foreground">No runs in this group.</div>
-                ) : state.groups[group].map((run, index) => (
-                  <button
-                    key={`${group}-${run.issueIdentifier ?? run.issueId ?? run.sessionId ?? String(index)}`}
-                    type="button"
-                    className="block w-full px-4 py-3 text-left hover:bg-zinc-50 disabled:opacity-50"
-                    disabled={Boolean(busy)}
-                    onClick={() => selectIssue(run.issueIdentifier)}
-                  >
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-semibold">{run.issueIdentifier ?? "Unknown issue"}</span>
-                      <Badge className={tone(run.status)}>{run.status}</Badge>
-                      {run.sessionId && <span className="text-xs text-muted-foreground">session {run.sessionId}</span>}
-                    </div>
-                    <p className="mt-1 break-words text-sm text-muted-foreground">{eventText(run)}</p>
-                  </button>
-                ))}
-              </div>
-            </section>
-          ))}
-        </div>
-
-        <aside className="border bg-white p-4">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <h2 className="truncate text-base font-semibold">{detail?.issueIdentifier ?? activeIssue ?? "No active issue"}</h2>
-              <p className="text-sm text-muted-foreground">Service: {state.service.status}</p>
-              <p className="text-sm text-muted-foreground">Linear: {state.service.credentialStatus ?? "unavailable"}</p>
-            </div>
-            {detail?.workpadUrl && (
-              <Button variant="outline" size="sm" onClick={() => window.open(detail.workpadUrl!, "_blank", "noopener,noreferrer")}>
-                <ExternalLink className="size-4" /> Workpad
-              </Button>
-            )}
-          </div>
-
-          <div className="mt-4 space-y-2 text-sm">
-            <Info label="Status" value={detail?.status ?? "Idle"} />
-            <Info label="Session" value={detail?.sessionId ?? "None"} />
-            <Info label="Turns" value={String(detail?.turnCount ?? 0)} />
-            <Info label="Latest event" value={detail?.latestEvent ?? "None"} />
-            <Info label="Workspace" value={detail?.workspacePath ?? "Unavailable"} />
-          </div>
-
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Button variant="outline" size="sm" onClick={() => openWorkspace(detail?.workspacePath ?? null)} disabled={!detail?.workspacePath}>
-              <FolderOpen className="size-4" /> Workspace
-            </Button>
-          </div>
-
-          <section className="mt-5 border-t pt-4">
-            <h3 className="text-sm font-semibold">Logs</h3>
-            <div className="mt-2 max-h-72 overflow-auto bg-zinc-950 p-3 font-mono text-xs text-zinc-100">
-              {logLines.length === 0 ? (
-                <div className="text-zinc-400">No logs available.</div>
-              ) : logLines.map((line, index) => (
-                <div key={`${index}-${line.slice(0, 24)}`} className="break-words">{line}</div>
-              ))}
-            </div>
-          </section>
-        </aside>
+        <RunGroups busy={busy} state={state} onSelectIssue={selectIssue} />
+        <DetailPanel activeIssue={activeIssue} detail={detail} logLines={logLines} state={state} />
       </section>
     </main>
+  );
+}
+
+function SymphonyHeader({
+  activeIssue,
+  busy,
+  serviceControl,
+  onRefresh,
+  onStartService,
+  onStopCurrent,
+  onStopService,
+}: {
+  activeIssue: string | null;
+  busy: string | null;
+  serviceControl: SymphonyServiceControl;
+  onRefresh: () => Promise<void>;
+  onStartService: () => Promise<void>;
+  onStopCurrent: () => Promise<void>;
+  onStopService: () => Promise<void>;
+}) {
+  return (
+    <header className="flex flex-wrap items-center justify-between gap-3 border-b bg-white px-5 py-4">
+      <div className="min-w-0">
+        <h1 className="text-xl font-semibold tracking-normal">Symphony</h1>
+        <p className="truncate text-sm text-muted-foreground">Service: {serviceControl.status}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={() => void onStartService()} disabled={!serviceControl.canStart || Boolean(busy)}>
+          <Play className="size-4" /> Start
+        </Button>
+        <Button variant="outline" onClick={() => void onStopService()} disabled={!serviceControl.canStop || Boolean(busy)}>
+          <Power className="size-4" /> Stop Service
+        </Button>
+        <Button variant="outline" onClick={() => void onRefresh()} disabled={Boolean(busy)}>
+          <RefreshCw className="size-4" /> Refresh
+        </Button>
+        <Button variant="outline" onClick={() => void onStopCurrent()} disabled={!activeIssue || Boolean(busy)}>
+          <Square className="size-4" /> Stop Run
+        </Button>
+      </div>
+    </header>
+  );
+}
+
+function Notice({ icon, text, tone: noticeTone }: { icon?: ReactNode; text: string; tone: "plain" | "warning" }) {
+  const className = noticeTone === "warning"
+    ? "mx-5 mt-4 flex items-center gap-2 border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+    : "mx-5 mb-4 border bg-white px-4 py-3 text-sm text-muted-foreground";
+  return <div className={className}>{icon}{text}</div>;
+}
+
+function Metrics({ state }: { state: SymphonyState }) {
+  return (
+    <section className="grid gap-3 p-5 sm:grid-cols-2 lg:grid-cols-4">
+      <Metric label="Queue" value={state.groups.queue.length} />
+      <Metric label="Running" value={state.groups.running.length} />
+      <Metric label="Needs Attention" value={state.groups.needsAttention.length} />
+      <Metric label="Done / Handoff" value={state.groups.done.length} />
+    </section>
+  );
+}
+
+function RunGroups({ busy, state, onSelectIssue }: { busy: string | null; state: SymphonyState; onSelectIssue: (issueIdentifier: string | null | undefined) => void }) {
+  return (
+    <div className="space-y-4">
+      {RUN_GROUPS.map((group) => (
+        <section key={group} className="border bg-white">
+          <div className="flex items-center justify-between border-b px-4 py-3">
+            <h2 className="text-sm font-semibold uppercase tracking-normal text-muted-foreground">{groupLabel(group)}</h2>
+            <span className="text-sm text-muted-foreground">{state.groups[group].length}</span>
+          </div>
+          <div className="divide-y">
+            {state.groups[group].length === 0 ? (
+              <div className="px-4 py-6 text-sm text-muted-foreground">No runs in this group.</div>
+            ) : state.groups[group].map((run, index) => (
+              <button
+                key={`${group}-${run.issueIdentifier ?? run.issueId ?? run.sessionId ?? String(index)}`}
+                type="button"
+                className="block w-full px-4 py-3 text-left hover:bg-zinc-50 disabled:opacity-50"
+                disabled={Boolean(busy)}
+                onClick={() => onSelectIssue(run.issueIdentifier)}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-semibold">{run.issueIdentifier ?? "Unknown issue"}</span>
+                  <Badge className={tone(run.status)}>{run.status}</Badge>
+                  {run.sessionId && <span className="text-xs text-muted-foreground">session {run.sessionId}</span>}
+                </div>
+                <p className="mt-1 break-words text-sm text-muted-foreground">{eventText(run)}</p>
+              </button>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function DetailPanel({ activeIssue, detail, logLines, state }: {
+  activeIssue: string | null;
+  detail: SymphonyIssueDetail | null;
+  logLines: string[];
+  state: SymphonyState;
+}) {
+  return (
+    <aside className="border bg-white p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-semibold">{detail?.issueIdentifier ?? activeIssue ?? "No active issue"}</h2>
+          <p className="text-sm text-muted-foreground">Service: {state.service.status}</p>
+          <p className="text-sm text-muted-foreground">Linear: {state.service.credentialStatus ?? "unavailable"}</p>
+        </div>
+        {detail?.workpadUrl && (
+          <Button variant="outline" size="sm" onClick={() => window.open(detail.workpadUrl!, "_blank", "noopener,noreferrer")}>
+            <ExternalLink className="size-4" /> Workpad
+          </Button>
+        )}
+      </div>
+
+      <div className="mt-4 space-y-2 text-sm">
+        <Info label="Status" value={detail?.status ?? "Idle"} />
+        <Info label="Session" value={detail?.sessionId ?? "None"} />
+        <Info label="Turns" value={String(detail?.turnCount ?? 0)} />
+        <Info label="Latest event" value={detail?.latestEvent ?? "None"} />
+        <Info label="Workspace" value={detail?.workspacePath ?? "Unavailable"} />
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button variant="outline" size="sm" onClick={() => openWorkspace(detail?.workspacePath ?? null)} disabled={!detail?.workspacePath}>
+          <FolderOpen className="size-4" /> Workspace
+        </Button>
+      </div>
+
+      <section className="mt-5 border-t pt-4">
+        <h3 className="text-sm font-semibold">Logs</h3>
+        <div className="mt-2 max-h-72 overflow-auto bg-zinc-950 p-3 font-mono text-xs text-zinc-100">
+          {logLines.length === 0 ? (
+            <div className="text-zinc-400">No logs available.</div>
+          ) : logLines.map((line, index) => (
+            <div key={`${index}-${line.slice(0, 24)}`} className="break-words">{line}</div>
+          ))}
+        </div>
+      </section>
+    </aside>
   );
 }
 

--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -33,7 +33,7 @@ interface SymphonyState {
 interface SymphonyServiceControl {
   available: boolean;
   running: boolean;
-  status: "running" | "stopped" | "unavailable";
+  status: "running" | "starting" | "stopped" | "unavailable";
   canStart: boolean;
   canStop: boolean;
   credentialConfigured?: boolean;

--- a/packages/gateway/src/symphony/proxy.ts
+++ b/packages/gateway/src/symphony/proxy.ts
@@ -26,7 +26,7 @@ const SymphonyServiceActionSchema = z.enum(["status", "start", "stop"]);
 const HostSymphonyServiceStatusSchema = z.object({
   available: z.boolean(),
   running: z.boolean(),
-  status: z.enum(["running", "stopped", "unavailable"]).optional(),
+  status: z.enum(["running", "starting", "stopped", "unavailable"]).optional(),
   canStart: z.boolean(),
   canStop: z.boolean(),
   credentialConfigured: z.boolean().optional(),
@@ -35,7 +35,7 @@ const HostSymphonyServiceStatusSchema = z.object({
 
 export type SymphonyServiceAction = z.infer<typeof SymphonyServiceActionSchema>;
 export type SymphonyServiceStatus = z.infer<typeof HostSymphonyServiceStatusSchema> & {
-  status: "running" | "stopped" | "unavailable";
+  status: "running" | "starting" | "stopped" | "unavailable";
 };
 export type SymphonyServiceControl = (action: SymphonyServiceAction) => Promise<SymphonyServiceStatus>;
 
@@ -138,7 +138,7 @@ function normalizeServiceStatus(body: unknown): SymphonyServiceStatus {
   };
 }
 
-function createHostSymphonyServiceControl(controlPath = process.env.SYMPHONY_SERVICE_CONTROL_PATH ?? DEFAULT_SERVICE_CONTROL_PATH): SymphonyServiceControl {
+export function createHostSymphonyServiceControl(controlPath = process.env.SYMPHONY_SERVICE_CONTROL_PATH ?? DEFAULT_SERVICE_CONTROL_PATH): SymphonyServiceControl {
   return async (action) => {
     const parsedAction = SymphonyServiceActionSchema.parse(action);
     const output = await new Promise<string>((resolve, reject) => {
@@ -147,12 +147,22 @@ function createHostSymphonyServiceControl(controlPath = process.env.SYMPHONY_SER
         maxBuffer: 8 * 1024,
       }, (err, stdout) => {
         if (err) {
-          reject(err);
+          reject(Object.assign(err, { stdout }));
           return;
         }
         resolve(stdout);
       });
     }).catch((err: unknown) => {
+      const stdout = typeof err === "object" && err !== null && "stdout" in err && typeof err.stdout === "string"
+        ? err.stdout
+        : "";
+      if (stdout.trim().length > 0) {
+        try {
+          return JSON.stringify(normalizeServiceStatus(JSON.parse(stdout) as unknown));
+        } catch (parseErr: unknown) {
+          console.warn("[symphony] Host service control failure stdout was invalid JSON:", parseErr instanceof Error ? parseErr.message : String(parseErr));
+        }
+      }
       if (parsedAction === "status") {
         console.warn("[symphony] Host service status failed:", err instanceof Error ? err.message : String(err));
         return null;

--- a/packages/gateway/src/symphony/proxy.ts
+++ b/packages/gateway/src/symphony/proxy.ts
@@ -26,7 +26,7 @@ const SymphonyServiceActionSchema = z.enum(["status", "start", "stop"]);
 const HostSymphonyServiceStatusSchema = z.object({
   available: z.boolean(),
   running: z.boolean(),
-  status: z.enum(["running", "starting", "stopped", "unavailable"]).optional(),
+  status: z.enum(["running", "starting", "stopping", "stopped", "unavailable"]).optional(),
   canStart: z.boolean(),
   canStop: z.boolean(),
   credentialConfigured: z.boolean().optional(),
@@ -35,7 +35,7 @@ const HostSymphonyServiceStatusSchema = z.object({
 
 export type SymphonyServiceAction = z.infer<typeof SymphonyServiceActionSchema>;
 export type SymphonyServiceStatus = z.infer<typeof HostSymphonyServiceStatusSchema> & {
-  status: "running" | "starting" | "stopped" | "unavailable";
+  status: "running" | "starting" | "stopping" | "stopped" | "unavailable";
 };
 export type SymphonyServiceControl = (action: SymphonyServiceAction) => Promise<SymphonyServiceStatus>;
 

--- a/packages/gateway/src/symphony/proxy.ts
+++ b/packages/gateway/src/symphony/proxy.ts
@@ -1,6 +1,8 @@
+import { execFile as nodeExecFile } from "node:child_process";
 import { Hono, type Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { z } from "zod/v4";
 import { requestHasBody } from "../http-body.js";
 import { isRequestPrincipalError, mapRequestPrincipalError, requireRequestPrincipal, type RequestPrincipal } from "../request-principal.js";
 import {
@@ -15,13 +17,33 @@ import {
 } from "./proxy-contracts.js";
 
 const DEFAULT_UPSTREAM_ORIGIN = "http://127.0.0.1:4766";
+const DEFAULT_SERVICE_CONTROL_PATH = "/opt/matrix/bin/matrix-symphony-control";
 const DEFAULT_TIMEOUT_MS = 10_000;
+const SERVICE_CONTROL_TIMEOUT_MS = 12_000;
 const BODY_LIMIT_BYTES = 1024;
+
+const SymphonyServiceActionSchema = z.enum(["status", "start", "stop"]);
+const HostSymphonyServiceStatusSchema = z.object({
+  available: z.boolean(),
+  running: z.boolean(),
+  status: z.enum(["running", "stopped", "unavailable"]).optional(),
+  canStart: z.boolean(),
+  canStop: z.boolean(),
+  credentialConfigured: z.boolean().optional(),
+  managedBy: z.string().min(1).max(64).optional(),
+});
+
+export type SymphonyServiceAction = z.infer<typeof SymphonyServiceActionSchema>;
+export type SymphonyServiceStatus = z.infer<typeof HostSymphonyServiceStatusSchema> & {
+  status: "running" | "stopped" | "unavailable";
+};
+export type SymphonyServiceControl = (action: SymphonyServiceAction) => Promise<SymphonyServiceStatus>;
 
 export interface ElixirSymphonyProxyDeps {
   upstreamOrigin?: string;
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
+  serviceControl?: SymphonyServiceControl;
   getPrincipal?: (c: Context) => RequestPrincipal;
 }
 
@@ -94,6 +116,68 @@ async function fetchJson(deps: Required<Pick<ElixirSymphonyProxyDeps, "fetchImpl
   } catch (err: unknown) {
     console.warn("[symphony] Elixir proxy request failed:", err instanceof Error ? err.message : String(err));
     return { ok: false, status: 503, body: genericProxyError("service_unavailable", "Symphony is unavailable") };
+  }
+}
+
+function unavailableServiceStatus(): SymphonyServiceStatus {
+  return {
+    available: false,
+    running: false,
+    status: "unavailable",
+    canStart: false,
+    canStop: false,
+    managedBy: "systemd",
+  };
+}
+
+function normalizeServiceStatus(body: unknown): SymphonyServiceStatus {
+  const parsed = HostSymphonyServiceStatusSchema.parse(body);
+  return {
+    ...parsed,
+    status: parsed.status ?? (parsed.running ? "running" : parsed.available ? "stopped" : "unavailable"),
+  };
+}
+
+function createHostSymphonyServiceControl(controlPath = process.env.SYMPHONY_SERVICE_CONTROL_PATH ?? DEFAULT_SERVICE_CONTROL_PATH): SymphonyServiceControl {
+  return async (action) => {
+    const parsedAction = SymphonyServiceActionSchema.parse(action);
+    const output = await new Promise<string>((resolve, reject) => {
+      nodeExecFile(controlPath, [parsedAction], {
+        timeout: SERVICE_CONTROL_TIMEOUT_MS,
+        maxBuffer: 8 * 1024,
+      }, (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(stdout);
+      });
+    }).catch((err: unknown) => {
+      if (parsedAction === "status") {
+        console.warn("[symphony] Host service status failed:", err instanceof Error ? err.message : String(err));
+        return null;
+      }
+      throw err;
+    });
+
+    if (output === null) return unavailableServiceStatus();
+    try {
+      return normalizeServiceStatus(JSON.parse(output) as unknown);
+    } catch (err: unknown) {
+      console.warn("[symphony] Host service control returned invalid JSON:", err instanceof Error ? err.message : String(err));
+      if (parsedAction === "status") return unavailableServiceStatus();
+      throw err;
+    }
+  };
+}
+
+async function callServiceControl(c: Context, serviceControl: SymphonyServiceControl, action: SymphonyServiceAction): Promise<Response> {
+  try {
+    const service = await serviceControl(action);
+    return c.json({ service });
+  } catch (err: unknown) {
+    console.warn("[symphony] Host service control failed:", err instanceof Error ? err.message : String(err));
+    return c.json(genericProxyError("service_unavailable", "Symphony service control is unavailable"), status(503));
   }
 }
 
@@ -208,6 +292,7 @@ export function createElixirSymphonyProxyRoutes(deps: ElixirSymphonyProxyDeps = 
     fetchImpl: deps.fetchImpl ?? fetch,
     timeoutMs: deps.timeoutMs ?? DEFAULT_TIMEOUT_MS,
   };
+  const serviceControl = deps.serviceControl ?? createHostSymphonyServiceControl();
   const app = new Hono();
   const emptyLimited = bodyLimit({ maxSize: BODY_LIMIT_BYTES });
 
@@ -220,6 +305,22 @@ export function createElixirSymphonyProxyRoutes(deps: ElixirSymphonyProxyDeps = 
       console.warn("[symphony] Failed to normalize Elixir state:", err instanceof Error ? err.message : String(err));
       return c.json(genericProxyError("invalid_response", "Symphony returned an invalid response"), status(502));
     }
+  }));
+
+  app.get("/service", (c) => withPrincipal(c, deps, async () => {
+    return callServiceControl(c, serviceControl, "status");
+  }));
+
+  app.post("/service/start", emptyLimited, (c) => withPrincipal(c, deps, async () => {
+    const parsed = await parseEmptyJson(c);
+    if (!parsed.ok) return parsed.response;
+    return callServiceControl(c, serviceControl, "start");
+  }));
+
+  app.post("/service/stop", emptyLimited, (c) => withPrincipal(c, deps, async () => {
+    const parsed = await parseEmptyJson(c);
+    if (!parsed.ok) return parsed.response;
+    return callServiceControl(c, serviceControl, "stop");
   }));
 
   app.get("/issues/:issueIdentifier", (c) => withPrincipal(c, deps, async () => {

--- a/packages/symphony-elixir/lib/symphony_elixir.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir.ex
@@ -21,6 +21,7 @@ defmodule SymphonyElixir.Application do
 
   @impl true
   def start(_type, _args) do
+    configure_from_env()
     :ok = SymphonyElixir.LogFile.configure()
 
     children = [
@@ -43,5 +44,34 @@ defmodule SymphonyElixir.Application do
   def stop(_state) do
     SymphonyElixir.StatusDashboard.render_offline_status()
     :ok
+  end
+
+  defp configure_from_env do
+    case System.get_env("SYMPHONY_WORKFLOW_FILE") do
+      path when is_binary(path) and path != "" ->
+        SymphonyElixir.Workflow.set_workflow_file_path(Path.expand(path))
+
+      _ ->
+        :ok
+    end
+
+    case System.get_env("SYMPHONY_LOGS_ROOT") do
+      path when is_binary(path) and path != "" ->
+        Application.put_env(:symphony_elixir, :log_file, SymphonyElixir.LogFile.default_log_file(Path.expand(path)))
+
+      _ ->
+        :ok
+    end
+
+    case System.get_env("SYMPHONY_PORT") do
+      port when is_binary(port) ->
+        case Integer.parse(port) do
+          {value, ""} when value >= 0 -> Application.put_env(:symphony_elixir, :server_port_override, value)
+          _ -> :ok
+        end
+
+      _ ->
+        :ok
+    end
   end
 end

--- a/packages/symphony-elixir/mix.exs
+++ b/packages/symphony-elixir/mix.exs
@@ -92,7 +92,7 @@ defmodule SymphonyElixir.MixProject do
       app: nil,
       main_module: SymphonyElixir.CLI,
       name: "symphony",
-      path: "bin/symphony"
+      path: System.get_env("SYMPHONY_ESCRIPT_PATH") || "bin/symphony"
     ]
   end
 end

--- a/packages/symphony-elixir/mix.exs
+++ b/packages/symphony-elixir/mix.exs
@@ -46,6 +46,7 @@ defmodule SymphonyElixir.MixProject do
       dialyzer: [
         plt_add_apps: [:mix]
       ],
+      releases: releases(),
       escript: escript(),
       aliases: aliases(),
       deps: deps()
@@ -93,6 +94,16 @@ defmodule SymphonyElixir.MixProject do
       main_module: SymphonyElixir.CLI,
       name: "symphony",
       path: System.get_env("SYMPHONY_ESCRIPT_PATH") || "bin/symphony"
+    ]
+  end
+
+  defp releases do
+    [
+      symphony: [
+        include_erts: true,
+        include_executables_for: [:unix],
+        applications: [symphony_elixir: :permanent]
+      ]
     ]
   end
 end

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -47,6 +47,9 @@ else
 fi
 pnpm --filter '@finnaai/matrix' build
 node "$ROOT_DIR/scripts/build-default-apps.mjs" "$ROOT_DIR/home/apps"
+(cd "$ROOT_DIR/packages/symphony-elixir" && \
+  SYMPHONY_ESCRIPT_PATH="$DIST_DIR/symphony" MIX_DEPS_PATH="$DIST_DIR/symphony-deps" MIX_BUILD_PATH="$DIST_DIR/symphony-build" MIX_ENV=prod mix deps.get --only prod && \
+  SYMPHONY_ESCRIPT_PATH="$DIST_DIR/symphony" MIX_DEPS_PATH="$DIST_DIR/symphony-deps" MIX_BUILD_PATH="$DIST_DIR/symphony-build" MIX_ENV=prod mix escript.build)
 
 curl --fail --location --max-time 120 "$NODE_URL" -o "$DIST_DIR/$NODE_ARCHIVE"
 curl --fail --location --max-time 30 "$NODE_BASE_URL/SHASUMS256.txt" -o "$DIST_DIR/SHASUMS256.txt"
@@ -73,11 +76,12 @@ cp -a "$ROOT_DIR/distro/customer-vps/host-bin/." "$STAGE_DIR/bin/"
 cp -a "$ROOT_DIR/distro/customer-vps/systemd/." "$STAGE_DIR/systemd/"
 # The bundle is usually extracted as root:root during in-place upgrades, while
 # the systemd units execute these wrappers as the matrix user.
-chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
+chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$STAGE_DIR/bin/matrix-shell" "$STAGE_DIR/bin/matrix-code" "$STAGE_DIR/bin/matrix-sync-agent" "$STAGE_DIR/bin/matrix-symphony" "$STAGE_DIR/bin/matrix-symphony-control" "$STAGE_DIR/bin/matrix-update" "$STAGE_DIR/bin/matrix-install-hermes" "$STAGE_DIR/bin/matrix-install-linux-tools" "$STAGE_DIR/bin/matrix-install-tool-pack" "$STAGE_DIR/bin/matrix-messaging-health" "$STAGE_DIR/bin/matrix-messaging-backup" "$STAGE_DIR/bin/matrix-messaging-restore" "$STAGE_DIR/bin/zellij" "$STAGE_DIR/runtime/node/bin/gh"
 
 cp -a "$ROOT_DIR/node_modules" "$STAGE_DIR/app/node_modules"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"
 cp -a "$ROOT_DIR/packages" "$STAGE_DIR/app/packages"
+install -m 0755 "$DIST_DIR/symphony" "$STAGE_DIR/app/packages/symphony-elixir/bin/symphony"
 cp -a "$ROOT_DIR/shell" "$STAGE_DIR/app/shell"
 cp -a "$ROOT_DIR/home" "$STAGE_DIR/app/home"
 mkdir -p "$STAGE_DIR/app/scripts"

--- a/scripts/build-host-bundle.sh
+++ b/scripts/build-host-bundle.sh
@@ -48,8 +48,8 @@ fi
 pnpm --filter '@finnaai/matrix' build
 node "$ROOT_DIR/scripts/build-default-apps.mjs" "$ROOT_DIR/home/apps"
 (cd "$ROOT_DIR/packages/symphony-elixir" && \
-  SYMPHONY_ESCRIPT_PATH="$DIST_DIR/symphony" MIX_DEPS_PATH="$DIST_DIR/symphony-deps" MIX_BUILD_PATH="$DIST_DIR/symphony-build" MIX_ENV=prod mix deps.get --only prod && \
-  SYMPHONY_ESCRIPT_PATH="$DIST_DIR/symphony" MIX_DEPS_PATH="$DIST_DIR/symphony-deps" MIX_BUILD_PATH="$DIST_DIR/symphony-build" MIX_ENV=prod mix escript.build)
+  MIX_DEPS_PATH="$DIST_DIR/symphony-deps" MIX_BUILD_PATH="$DIST_DIR/symphony-build" MIX_ENV=prod mix deps.get --only prod && \
+  MIX_DEPS_PATH="$DIST_DIR/symphony-deps" MIX_BUILD_PATH="$DIST_DIR/symphony-build" MIX_ENV=prod mix release symphony --path "$DIST_DIR/symphony-release" --overwrite)
 
 curl --fail --location --max-time 120 "$NODE_URL" -o "$DIST_DIR/$NODE_ARCHIVE"
 curl --fail --location --max-time 30 "$NODE_BASE_URL/SHASUMS256.txt" -o "$DIST_DIR/SHASUMS256.txt"
@@ -81,7 +81,8 @@ chmod 0755 "$STAGE_DIR/bin/matrix-owner-env" "$STAGE_DIR/bin/matrix-gateway" "$S
 cp -a "$ROOT_DIR/node_modules" "$STAGE_DIR/app/node_modules"
 install -m 0755 "$DIST_DIR/$GH_DIST/bin/gh" "$STAGE_DIR/app/node_modules/.bin/gh"
 cp -a "$ROOT_DIR/packages" "$STAGE_DIR/app/packages"
-install -m 0755 "$DIST_DIR/symphony" "$STAGE_DIR/app/packages/symphony-elixir/bin/symphony"
+mkdir -p "$STAGE_DIR/app/packages/symphony-elixir/release"
+cp -a "$DIST_DIR/symphony-release/." "$STAGE_DIR/app/packages/symphony-elixir/release/"
 cp -a "$ROOT_DIR/shell" "$STAGE_DIR/app/shell"
 cp -a "$ROOT_DIR/home" "$STAGE_DIR/app/home"
 mkdir -p "$STAGE_DIR/app/scripts"

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -85,6 +85,12 @@ describe("Symphony app", () => {
       if (url === "/api/symphony/runs/MAT-32/stop") {
         return json({ stopped: true });
       }
+      if (url === "/api/symphony/service") {
+        return json({ service: { available: true, running: true, status: "running", canStart: false, canStop: true, credentialConfigured: true } });
+      }
+      if (url === "/api/symphony/service/start" || url === "/api/symphony/service/stop") {
+        return json({ service: { available: true, running: url.endsWith("/start"), status: url.endsWith("/start") ? "running" : "stopped", canStart: !url.endsWith("/start"), canStop: url.endsWith("/start"), credentialConfigured: true } });
+      }
       return json({ ok: true });
     }));
   });
@@ -198,16 +204,40 @@ describe("Symphony app", () => {
     expect(calls.some((call) => call.url === "/api/symphony/issues/MAT-33")).toBe(false);
   });
 
-  it("refreshes and stops through the Elixir proxy endpoints", async () => {
+  it("refreshes and stops runs through the Elixir proxy endpoints", async () => {
     render(<App />);
     await waitFor(() => expect(screen.getAllByText("MAT-32").length).toBeGreaterThan(0));
 
     fireEvent.click(screen.getByText("Refresh"));
     await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/refresh" && call.init?.method === "POST")).toBe(true));
 
-    fireEvent.click(screen.getByText("Stop"));
+    fireEvent.click(screen.getByText("Stop Run"));
     await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/runs/MAT-32/stop" && call.init?.method === "POST")).toBe(true));
     expect(calls.every((call) => call.init?.signal instanceof AbortSignal)).toBe(true);
+  });
+
+  it("lets the user start Symphony when the service is stopped", async () => {
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url === "/api/symphony/state") return json({ error: { code: "service_unavailable" } }, { status: 503 });
+      if (url === "/api/symphony/service") {
+        return json({ service: { available: true, running: false, status: "stopped", canStart: true, canStop: false, credentialConfigured: true } });
+      }
+      if (url === "/api/symphony/service/start") {
+        return json({ service: { available: true, running: true, status: "running", canStart: false, canStop: true, credentialConfigured: true } });
+      }
+      return json({ ok: true });
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText("Service: stopped")).toBeTruthy());
+    expect(screen.getByText("Symphony is unavailable.")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Start"));
+
+    await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/service/start" && call.init?.method === "POST")).toBe(true));
   });
 
   it("keeps rendered state when the active issue detail endpoint fails", async () => {
@@ -277,6 +307,8 @@ describe("Symphony app", () => {
     expect(appSource).toContain("minmax(0,1fr)");
     expect(appSource).toContain('const RUN_GROUPS: RunGroup[] = ["queue", "running", "needsAttention", "done"]');
     expect(appSource).toContain("AbortSignal.timeout(10_000)");
+    expect(appSource).toContain('"/api/symphony/service/start"');
+    expect(appSource).toContain('"/api/symphony/service/stop"');
     expect(appSource).toContain("withTimeoutSignal(controller.signal, 10_000)");
     expect(appSource).toContain("AbortSignal.any([signal, timeoutSignal])");
     expect(appSource).toContain("if (controller.signal.aborted) return;");

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -96,7 +96,9 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(control).toContain("Usage: matrix-symphony-control [status|start|stop]");
     expect(control).toContain("matrix-symphony.service");
     expect(control).toContain("systemctl start --no-block \"$UNIT\"");
-    expect(control).toContain("systemctl stop \"$UNIT\"");
+    expect(control).toContain("systemctl stop --no-block \"$UNIT\"");
+    expect(control).toContain("deactivating)");
+    expect(control).toContain("status=stopping");
     expect(control).toContain("\"credentialConfigured\"");
     expect(control).not.toContain("journalctl");
     expect(proxy).toContain('app.get("/service"');

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -32,6 +32,7 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(wrapper).toContain("\"$WORKFLOW_FILE\"");
 
     expect(buildScript).toContain("\"$STAGE_DIR/bin/matrix-symphony\"");
+    expect(buildScript).toContain("\"$STAGE_DIR/bin/matrix-symphony-control\"");
   });
 
   it("provisions Erlang runtime and enables Symphony during customer VPS bootstrap", async () => {
@@ -40,6 +41,7 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(cloudInit).toContain("erlang-base");
     expect(cloudInit).toContain("erlang-ssl");
     expect(cloudInit).toContain("matrix-symphony");
+    expect(cloudInit).toContain("matrix-symphony-control");
     expect(cloudInit).toContain("systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
     expect(cloudInit).toContain("systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
   });
@@ -70,6 +72,45 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(configSchema).toContain("SYMPHONY_LINEAR_API_KEY");
     expect(configSchema).toContain("SYMPHONY_LINEAR_PROJECT_SLUG");
     expect(buildScript).toContain("cp -a \"$ROOT_DIR/packages\" \"$STAGE_DIR/app/packages\"");
+  });
+
+  it("builds a runtime Symphony executable before packaging customer host bundles", async () => {
+    const mix = await readFile("packages/symphony-elixir/mix.exs", "utf8");
+    const buildScript = await readFile("scripts/build-host-bundle.sh", "utf8");
+    const workflow = await readFile(".github/workflows/host-bundle-release.yml", "utf8");
+
+    expect(mix).toContain('System.get_env("SYMPHONY_ESCRIPT_PATH")');
+    expect(buildScript).toContain("SYMPHONY_ESCRIPT_PATH=\"$DIST_DIR/symphony\"");
+    expect(buildScript).toContain("MIX_ENV=prod mix deps.get --only prod");
+    expect(buildScript).toContain("MIX_ENV=prod mix escript.build");
+    expect(buildScript).toContain("install -m 0755 \"$DIST_DIR/symphony\" \"$STAGE_DIR/app/packages/symphony-elixir/bin/symphony\"");
+    expect(buildScript).not.toContain("exec mix run --no-halt");
+    expect(workflow).toContain("erlef/setup-beam");
+    expect(workflow).toContain("elixir-version: 1.19");
+  });
+
+  it("lets the Matrix app control the host-managed Symphony service", async () => {
+    const control = await readFile("distro/customer-vps/host-bin/matrix-symphony-control", "utf8");
+    const proxy = await readFile("packages/gateway/src/symphony/proxy.ts", "utf8");
+
+    expect(control).toContain("Usage: matrix-symphony-control [status|start|stop]");
+    expect(control).toContain("matrix-symphony.service");
+    expect(control).toContain("systemctl start \"$UNIT\"");
+    expect(control).toContain("systemctl stop \"$UNIT\"");
+    expect(control).toContain("\"credentialConfigured\"");
+    expect(control).not.toContain("journalctl");
+    expect(proxy).toContain('app.get("/service"');
+    expect(proxy).toContain('app.post("/service/start"');
+    expect(proxy).toContain('app.post("/service/stop"');
+  });
+
+  it("enables and starts bundled Symphony units during existing VPS updates", async () => {
+    const syncAgent = await readFile("distro/customer-vps/host-bin/matrix-sync-agent", "utf8");
+
+    expect(syncAgent).toContain("ensure_symphony_runtime");
+    expect(syncAgent).toContain("sudo systemctl enable matrix-symphony.service");
+    expect(syncAgent).toContain("sudo systemctl start --no-block matrix-symphony.service");
+    expect(syncAgent).toContain("sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true");
   });
 
   it("keeps observability failures distinct from missing issues", async () => {

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -19,17 +19,17 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(unit).toContain("KillMode=mixed");
     expect(unit).toContain("KillSignal=SIGTERM");
     expect(unit).toContain("TimeoutStopSec=30");
-    expect(unit).toContain("ConditionPathExists=/opt/matrix/app/packages/symphony-elixir/bin/symphony");
+    expect(unit).toContain("ConditionPathExists=/opt/matrix/app/packages/symphony-elixir/release/bin/symphony");
 
     expect(wrapper).toContain("source /opt/matrix/env/host.env");
     expect(wrapper).toContain("export MATRIX_HOME=\"${MATRIX_HOME:-/home/matrix/home}\"");
     expect(wrapper).toContain("export SYMPHONY_HOST=\"${SYMPHONY_HOST:-127.0.0.1}\"");
     expect(wrapper).toContain("export SYMPHONY_PORT=\"${SYMPHONY_PORT:-4766}\"");
     expect(wrapper).toContain("export SYMPHONY_WORKSPACE_ROOT=\"${SYMPHONY_WORKSPACE_ROOT:-$MATRIX_HOME/projects/matrix-os/symphony-workspaces}\"");
-    expect(wrapper).toContain("--i-understand-that-this-will-be-running-without-the-usual-guardrails");
-    expect(wrapper).toContain("--logs-root \"$MATRIX_HOME/system/symphony/logs\"");
-    expect(wrapper).toContain("--port \"$SYMPHONY_PORT\"");
-    expect(wrapper).toContain("\"$WORKFLOW_FILE\"");
+    expect(wrapper).toContain("SYMPHONY_BIN=\"${SYMPHONY_BIN:-$APP_DIR/packages/symphony-elixir/release/bin/symphony}\"");
+    expect(wrapper).toContain("export SYMPHONY_LOGS_ROOT=\"$MATRIX_HOME/system/symphony/logs\"");
+    expect(wrapper).toContain("export SYMPHONY_WORKFLOW_FILE=\"$WORKFLOW_FILE\"");
+    expect(wrapper).toContain("exec \"$SYMPHONY_BIN\" start");
 
     expect(buildScript).toContain("\"$STAGE_DIR/bin/matrix-symphony\"");
     expect(buildScript).toContain("\"$STAGE_DIR/bin/matrix-symphony-control\"");
@@ -74,16 +74,20 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(buildScript).toContain("cp -a \"$ROOT_DIR/packages\" \"$STAGE_DIR/app/packages\"");
   });
 
-  it("builds a runtime Symphony executable before packaging customer host bundles", async () => {
+  it("builds a bundled-ERTS Symphony release before packaging customer host bundles", async () => {
     const mix = await readFile("packages/symphony-elixir/mix.exs", "utf8");
+    const application = await readFile("packages/symphony-elixir/lib/symphony_elixir.ex", "utf8");
     const buildScript = await readFile("scripts/build-host-bundle.sh", "utf8");
     const workflow = await readFile(".github/workflows/host-bundle-release.yml", "utf8");
 
-    expect(mix).toContain('System.get_env("SYMPHONY_ESCRIPT_PATH")');
-    expect(buildScript).toContain("SYMPHONY_ESCRIPT_PATH=\"$DIST_DIR/symphony\"");
+    expect(mix).toContain("releases: releases()");
+    expect(mix).toContain("include_erts: true");
+    expect(application).toContain('System.get_env("SYMPHONY_WORKFLOW_FILE")');
+    expect(application).toContain('System.get_env("SYMPHONY_LOGS_ROOT")');
+    expect(application).toContain('System.get_env("SYMPHONY_PORT")');
     expect(buildScript).toContain("MIX_ENV=prod mix deps.get --only prod");
-    expect(buildScript).toContain("MIX_ENV=prod mix escript.build");
-    expect(buildScript).toContain("install -m 0755 \"$DIST_DIR/symphony\" \"$STAGE_DIR/app/packages/symphony-elixir/bin/symphony\"");
+    expect(buildScript).toContain("MIX_ENV=prod mix release symphony --path \"$DIST_DIR/symphony-release\" --overwrite");
+    expect(buildScript).toContain("cp -a \"$DIST_DIR/symphony-release/.\" \"$STAGE_DIR/app/packages/symphony-elixir/release/\"");
     expect(buildScript).not.toContain("exec mix run --no-halt");
     expect(workflow).toContain("erlef/setup-beam");
     expect(workflow).toContain("elixir-version: 1.19");
@@ -109,7 +113,8 @@ describe("customer VPS Symphony systemd unit", () => {
   it("enables and starts bundled Symphony units during existing VPS updates", async () => {
     const syncAgent = await readFile("distro/customer-vps/host-bin/matrix-sync-agent", "utf8");
 
-    expect(syncAgent).toContain("ensure_symphony_runtime");
+    expect(syncAgent).not.toContain("ensure_symphony_runtime");
+    expect(syncAgent).not.toContain("apt-get install -y");
     expect(syncAgent).toContain("sudo systemctl enable matrix-symphony.service");
     expect(syncAgent).toContain("sudo systemctl start --no-block matrix-symphony.service");
     expect(syncAgent).toContain("sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true");

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -95,7 +95,7 @@ describe("customer VPS Symphony systemd unit", () => {
 
     expect(control).toContain("Usage: matrix-symphony-control [status|start|stop]");
     expect(control).toContain("matrix-symphony.service");
-    expect(control).toContain("systemctl start \"$UNIT\"");
+    expect(control).toContain("systemctl start --no-block \"$UNIT\"");
     expect(control).toContain("systemctl stop \"$UNIT\"");
     expect(control).toContain("\"credentialConfigured\"");
     expect(control).not.toContain("journalctl");

--- a/tests/gateway/symphony-proxy.test.ts
+++ b/tests/gateway/symphony-proxy.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { readFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createElixirSymphonyProxyRoutes } from "../../packages/gateway/src/symphony/proxy.js";
+import { createElixirSymphonyProxyRoutes, createHostSymphonyServiceControl } from "../../packages/gateway/src/symphony/proxy.js";
 import { MissingRequestPrincipalError } from "../../packages/gateway/src/request-principal.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -257,6 +258,33 @@ describe("Elixir Symphony proxy routes", () => {
 
     expect(res.status).toBe(503);
     expect(await res.json()).toEqual({ error: { code: "service_unavailable", message: "Symphony service control is unavailable" } });
+  });
+
+  it("preserves host service JSON stdout when start exits nonzero", async () => {
+    const dir = await mkdtemp(`${tmpdir()}/matrix-symphony-control-`);
+    const script = resolve(dir, "matrix-symphony-control");
+    await writeFile(script, [
+      "#!/usr/bin/env sh",
+      "printf '%s\\n' '{\"available\":false,\"running\":false,\"status\":\"unavailable\",\"canStart\":false,\"canStop\":false,\"credentialConfigured\":false,\"managedBy\":\"systemd\"}'",
+      "exit 1",
+      "",
+    ].join("\n"));
+    await chmod(script, 0o755);
+    try {
+      const control = createHostSymphonyServiceControl(script);
+
+      await expect(control("start")).resolves.toEqual({
+        available: false,
+        running: false,
+        status: "unavailable",
+        canStart: false,
+        canStop: false,
+        credentialConfigured: false,
+        managedBy: "systemd",
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("validates issue identifiers before proxying detail requests", async () => {

--- a/tests/gateway/symphony-proxy.test.ts
+++ b/tests/gateway/symphony-proxy.test.ts
@@ -172,6 +172,93 @@ describe("Elixir Symphony proxy routes", () => {
     expect(JSON.stringify(await res.json())).not.toContain("ECONNREFUSED");
   });
 
+  it("reports host-managed Symphony service status without contacting Elixir", async () => {
+    const fetchImpl = vi.fn();
+    const serviceControl = vi.fn(async () => ({
+      available: true,
+      running: false,
+      status: "stopped" as const,
+      canStart: true,
+      canStop: false,
+      credentialConfigured: true,
+      managedBy: "systemd",
+    }));
+    const app = createElixirSymphonyProxyRoutes({
+      fetchImpl,
+      serviceControl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/service");
+
+    expect(res.status).toBe(200);
+    expect(serviceControl).toHaveBeenCalledWith("status");
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual({
+      service: {
+        available: true,
+        running: false,
+        status: "stopped",
+        canStart: true,
+        canStop: false,
+        credentialConfigured: true,
+        managedBy: "systemd",
+      },
+    });
+  });
+
+  it("starts and stops the host-managed Symphony service with body limits", async () => {
+    const serviceControl = vi.fn(async (action: "status" | "start" | "stop") => ({
+      available: true,
+      running: action !== "stop",
+      status: action === "stop" ? "stopped" as const : "running" as const,
+      canStart: action === "stop",
+      canStop: action !== "stop",
+      credentialConfigured: true,
+      managedBy: "systemd",
+    }));
+    const app = createElixirSymphonyProxyRoutes({
+      serviceControl,
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const start = await app.request("/service/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    const stop = await app.request("/service/stop", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(start.status).toBe(200);
+    expect(stop.status).toBe(200);
+    expect(serviceControl).toHaveBeenNthCalledWith(1, "start");
+    expect(serviceControl).toHaveBeenNthCalledWith(2, "stop");
+    expect(await start.json()).toMatchObject({ service: { running: true, status: "running" } });
+    expect(await stop.json()).toMatchObject({ service: { running: false, status: "stopped" } });
+  });
+
+  it("maps host service control failures to generic unavailable errors", async () => {
+    const app = createElixirSymphonyProxyRoutes({
+      serviceControl: async () => {
+        throw new Error("systemctl failed with secret output");
+      },
+      getPrincipal: () => ({ userId: "user_123", source: "dev-default" }),
+    });
+
+    const res = await app.request("/service/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: { code: "service_unavailable", message: "Symphony service control is unavailable" } });
+  });
+
   it("validates issue identifiers before proxying detail requests", async () => {
     const fetchImpl = vi.fn();
     const app = createElixirSymphonyProxyRoutes({


### PR DESCRIPTION
## Summary
- Add authenticated Symphony service status/start/stop routes backed by a bounded host control script.
- Add Matrix app controls so users can start or stop the host-managed Symphony service when /state is unavailable.
- Build a bundled-ERTS Symphony Mix release in host bundles and ensure existing VPS updates install/enable/start matrix-symphony.service.

## Live diagnosis
- hamedmp VPS is healthy overall, but matrix-symphony.service was not installed and the packaged launcher failed with mix: not found.
- /api/symphony/state returned 503 because the loopback Symphony service was unavailable.

## Validation
- bun run test tests/gateway/symphony-proxy.test.ts tests/default-apps/symphony-app.test.tsx tests/deploy/customer-vps/symphony-systemd.test.ts tests/platform/customer-vps-host-bundle.test.ts
- bun run typecheck
- bun run check:patterns (0 violations; existing warning buckets only)
- pnpm dlx react-doctor@latest home/apps/symphony --verbose --diff (no issues found)
- GitHub CI on a09e965e7: Type Check, Pattern Scan, React Doctor, Sync Client Package, Unit Tests 1-4, E2E Tests, Docker Smoke, Vercel all passed
- Greptile reviewed a09e965e7 at 5/5

## Invariants
- Source of truth: systemd owns customer VPS Symphony process state; the gateway only exposes coarse service status and commands through /opt/matrix/bin/matrix-symphony-control.
- Lock/transaction scope: no database writes are introduced; service control is a single bounded execFile call with no shell interpolation.
- Acceptable orphan states: a bundle update may install the Symphony unit even if service start fails; the app reports unavailable/stopped/starting/stopping state and lets the user retry from Matrix.
- Auth source of truth: existing gateway request principal auth protects all /api/symphony routes, including service controls.
- Deferred scope: removing now-unused Erlang apt packages from cloud-init can follow after the bundled-release path is verified stable; existing packages are harmless and no longer part of the Symphony runtime contract.