### PR TITLE
feat(system): add activity monitor API

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -106,6 +106,10 @@ import type { GeminiLiveConnection } from "./onboarding/gemini-live.js";
 import { resolveBundledSystemIconPath, resolveDefaultAppIconUrl, resolveSystemIconUrl } from "./default-icons.js";
 import { securityHeadersMiddleware } from "./security/headers.js";
 import { getSystemInfo } from "./system-info.js";
+import { collectSystemActivity } from "./system-activity/collector.js";
+import { CleanupCandidateRegistry, executeCleanupAction } from "./system-activity/cleanup.js";
+import { ActivityHistoryStore, AutoCleanupPolicyStore } from "./system-activity/history.js";
+import { createSystemActivityRoutes } from "./system-activity/routes.js";
 import {
   checkForSystemUpdate,
   listSystemReleases,
@@ -1652,6 +1656,28 @@ export async function createGateway(config: GatewayConfig) {
     shellBackend: zellijAdapter,
     commandRunner: createShellCommandRunner({ homePath }),
   };
+  const systemActivityCandidates = new CleanupCandidateRegistry();
+  const systemActivityHistory = new ActivityHistoryStore({ homePath });
+  const systemActivityPolicy = new AutoCleanupPolicyStore({ homePath });
+  app.route("/api/system", createSystemActivityRoutes({
+    collect: async (collectOptions) => {
+      const policy = await systemActivityPolicy.read();
+      return collectSystemActivity({
+        homePath,
+        collectOptions,
+        candidates: systemActivityCandidates,
+        cleanupGracePeriodSeconds: policy.gracePeriodSeconds,
+      });
+    },
+    executeAction: (action) => executeCleanupAction({
+      action,
+      registry: systemActivityCandidates,
+      history: systemActivityHistory,
+    }),
+    readPolicy: () => systemActivityPolicy.read(),
+    savePolicy: (policy) => systemActivityPolicy.save(policy),
+    readHistory: (query) => systemActivityHistory.list(query),
+  }));
   app.route("/api/terminal", createShellRoutes(shellRouteDeps));
   app.route("/api", createShellRoutes(shellRouteDeps));
 
@@ -4392,6 +4418,7 @@ export async function createGateway(config: GatewayConfig) {
       cronService.stop();
       if (canvasCleanupTimer) clearInterval(canvasCleanupTimer);
       canvasSubscriptionHub?.close();
+      systemActivityCandidates.clear();
       await channelManager.stop();
       await processManager.shutdownAll();
       await forwardTunnelHub.close();

--- a/packages/gateway/src/system-activity/cleanup.ts
+++ b/packages/gateway/src/system-activity/cleanup.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import { ActivityConflictError, ActivityForbiddenError } from "./types.js";
+import type {
+  CleanupAction,
+  CleanupActionResult,
+  CleanupCandidate,
+  CleanupHistoryEntry,
+  ProcessSummary,
+} from "./types.js";
+import type { ActivityHistoryStore } from "./history.js";
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_CANDIDATES = 100;
+
+interface CandidateRecord {
+  public: CleanupCandidate;
+  pid?: number;
+  reasonCode: string;
+  createdAtMs: number;
+}
+
+export class CleanupCandidateRegistry {
+  private readonly candidates = new Map<string, CandidateRecord>();
+  private readonly ttlMs: number;
+  private readonly maxCandidates: number;
+
+  constructor(options: { ttlMs?: number; maxCandidates?: number } = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxCandidates = options.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
+  }
+
+  classify(processes: ProcessSummary[], now = Date.now(), options: { minElapsedSeconds?: number } = {}): CleanupCandidate[] {
+    this.evictExpired(now);
+    const suggestions: CleanupCandidate[] = [];
+    const minElapsedSeconds = options.minElapsedSeconds ?? 30 * 24 * 60 * 60;
+    for (const process of processes) {
+      if (
+        process.classification === "app_server"
+        && process.activeConnections === 0
+        && process.elapsedSeconds >= minElapsedSeconds
+        && process.pid !== undefined
+      ) {
+        suggestions.push(this.register({
+          pid: process.pid,
+          type: "stop_stale_app_server",
+          targetLabel: process.displayName,
+          reason: "No active connections and the app server appears stale.",
+          confidence: "high",
+          risk: "low",
+          estimatedReclaimBytes: process.rssBytes,
+          reasonCode: "stale_app_server_no_connections",
+          now,
+        }));
+      }
+    }
+    return suggestions;
+  }
+
+  get(action: CleanupAction, now = Date.now()): CandidateRecord {
+    this.evictExpired(now);
+    const record = this.candidates.get(action.candidateId);
+    if (!record) throw new ActivityConflictError("candidate expired");
+    if (record.public.type !== action.type) throw new ActivityConflictError("candidate type mismatch");
+    if (record.public.confirmationToken !== action.confirmationToken) {
+      throw new ActivityConflictError("confirmation mismatch");
+    }
+    if (action.mode === "automatic" && !isAutomaticType(action.type)) {
+      throw new ActivityForbiddenError("manual-only cleanup action");
+    }
+    return record;
+  }
+
+  clear(): void {
+    this.candidates.clear();
+  }
+
+  size(now = Date.now()): number {
+    this.evictExpired(now);
+    return this.candidates.size;
+  }
+
+  private register(input: {
+    pid?: number;
+    type: CleanupCandidate["type"];
+    targetLabel: string;
+    reason: string;
+    confidence: CleanupCandidate["confidence"];
+    risk: CleanupCandidate["risk"];
+    estimatedReclaimBytes?: number;
+    reasonCode: string;
+    now: number;
+  }): CleanupCandidate {
+    const candidateId = `cand_${randomUUID()}`;
+    const confirmationToken = `confirm_${randomUUID()}`;
+    const publicCandidate: CleanupCandidate = {
+      candidateId,
+      type: input.type,
+      targetLabel: sanitizeLabel(input.targetLabel),
+      reason: input.reason,
+      confidence: input.confidence,
+      risk: input.risk,
+      estimatedReclaimBytes: input.estimatedReclaimBytes,
+      requiresConfirmation: true,
+      confirmationToken,
+      expiresAt: new Date(input.now + this.ttlMs).toISOString(),
+    };
+    this.candidates.set(candidateId, {
+      public: publicCandidate,
+      pid: input.pid,
+      reasonCode: input.reasonCode,
+      createdAtMs: input.now,
+    });
+    this.evictOverflow();
+    return publicCandidate;
+  }
+
+  private evictExpired(now: number): void {
+    for (const [id, record] of this.candidates) {
+      if (now - record.createdAtMs >= this.ttlMs) this.candidates.delete(id);
+    }
+  }
+
+  private evictOverflow(): void {
+    while (this.candidates.size > this.maxCandidates) {
+      const oldest = this.candidates.keys().next().value as string | undefined;
+      if (!oldest) return;
+      this.candidates.delete(oldest);
+    }
+  }
+}
+
+export async function executeCleanupAction(options: {
+  action: CleanupAction;
+  registry: CleanupCandidateRegistry;
+  history: ActivityHistoryStore;
+  killProcess?: (pid: number, signal: NodeJS.Signals | 0) => void;
+}): Promise<CleanupActionResult> {
+  const killProcess = options.killProcess ?? process.kill.bind(process);
+  const record = options.registry.get(options.action);
+  let result: CleanupHistoryEntry["result"] = "skipped";
+  let message = "Cleanup skipped.";
+  let reclaimedBytes = record.public.estimatedReclaimBytes;
+
+  if (options.action.type === "stop_stale_app_server") {
+    if (record.pid === undefined) throw new ActivityConflictError("missing process target");
+    try {
+      killProcess(record.pid, 0);
+      killProcess(record.pid, "SIGTERM");
+      result = "completed";
+      message = "Cleanup completed.";
+    } catch (err) {
+      if (isNoSuchProcess(err)) {
+        result = "already_clean";
+        message = "The target was already clean.";
+        reclaimedBytes = undefined;
+      } else if (isPermissionDenied(err)) {
+        result = "failed";
+        message = "Cleanup failed.";
+        reclaimedBytes = undefined;
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const history = await options.history.append({
+    actor: options.action.mode === "automatic" ? "auto_policy" : "owner",
+    actionType: options.action.type,
+    targetLabel: record.public.targetLabel,
+    result,
+    reclaimedBytes,
+    reasonCode: record.reasonCode,
+  });
+
+  return {
+    actionId: `act_${history.id.replace(/^hist_/, "")}`,
+    result,
+    reclaimedBytes,
+    message,
+    snapshotRefreshRecommended: true,
+  };
+}
+
+function isAutomaticType(type: CleanupAction["type"]): boolean {
+  return type === "stop_stale_app_server" || type === "clean_cache_scope" || type === "prune_old_bundle";
+}
+
+function sanitizeLabel(value: string): string {
+  return value.replace(/[^\w .:@/-]/g, "").slice(0, 80) || "cleanup target";
+}
+
+function isNoSuchProcess(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "ESRCH";
+}
+
+function isPermissionDenied(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "EPERM";
+}

--- a/packages/gateway/src/system-activity/collector.ts
+++ b/packages/gateway/src/system-activity/collector.ts
@@ -1,0 +1,306 @@
+import { execFile } from "node:child_process";
+import { readFile, statfs } from "node:fs/promises";
+import { promisify } from "node:util";
+import { cpus, freemem, hostname, loadavg, totalmem, uptime } from "node:os";
+import type { ActivityCollectOptions, ActivitySnapshot, MachineIdentity, ProcessSummary, ServiceStatus } from "./types.js";
+import { getSystemInfo } from "../system-info.js";
+import type { CleanupCandidateRegistry } from "./cleanup.js";
+
+const execFileAsync = promisify(execFile);
+const PROCESS_TIMEOUT_MS = 2_000;
+const SERVICES = ["matrix-gateway", "matrix-shell", "matrix-code", "matrix-sync-agent"] as const;
+
+export async function collectSystemActivity(options: {
+  homePath: string;
+  collectOptions: ActivityCollectOptions;
+  candidates: CleanupCandidateRegistry;
+  cleanupGracePeriodSeconds?: number;
+}): Promise<ActivitySnapshot> {
+  const warnings: string[] = [];
+  const systemInfo = getSystemInfo(options.homePath);
+  const [load1 = 0, load5 = 0, load15 = 0] = loadavg();
+  const processes = await collectProcesses(options.collectOptions.processLimit, warnings);
+  const [rootDisk, homeDisk, pressureSome10, cgroupMemory, services] = await Promise.all([
+    readDisk("/", "System", warnings),
+    readDisk(options.homePath, "Home", warnings),
+    readCpuPressure(warnings),
+    readCgroupMemory(warnings),
+    collectServices(warnings),
+  ]);
+  const processRssBytes = processes.reduce((sum, process) => sum + process.rssBytes, 0);
+  const totalMemory = totalmem();
+  const availableMemory = freemem();
+  const cpuCores = cpus().length;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    machine: {
+      handle: systemInfo.runtime.handle,
+      runtimeSlot: systemInfo.runtime.runtimeSlot,
+      hostname: sanitizeDisplay(hostname()),
+      status: deriveMachineStatus({ load1, pressureSome10, services, cpuCores }),
+      releaseVersion: systemInfo.release?.version ?? systemInfo.installedVersion,
+      releaseChannel: systemInfo.release?.channel,
+      gitCommit: systemInfo.release?.gitCommit?.slice(0, 12) ?? systemInfo.build.sha,
+      uptimeSeconds: Math.floor(uptime()),
+    },
+    resources: {
+      cpu: {
+        cores: cpuCores,
+        load1,
+        load5,
+        load15,
+        pressureSome10,
+      },
+      memory: {
+        totalBytes: totalMemory,
+        usedBytes: Math.max(0, totalMemory - availableMemory),
+        availableBytes: availableMemory,
+        processRssBytes,
+        ...cgroupMemory,
+      },
+      swap: await readSwap(warnings),
+      disk: [rootDisk, homeDisk].filter((disk): disk is NonNullable<typeof disk> => Boolean(disk)),
+    },
+    services,
+    processes,
+    cleanupSuggestions: options.collectOptions.includeSuggestions
+      ? options.candidates.classify(processes, Date.now(), { minElapsedSeconds: options.cleanupGracePeriodSeconds })
+      : [],
+    collectionWarnings: warnings.slice(0, 8),
+  };
+}
+
+async function collectProcesses(limit: number, warnings: string[]): Promise<ProcessSummary[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-eo", "pid=,ppid=,user=,stat=,pcpu=,rss=,etimes=,comm=,args=", "--sort=-rss"],
+      { timeout: PROCESS_TIMEOUT_MS, maxBuffer: 512_000 },
+    );
+    const activeConnections = await collectActiveConnectionCounts(warnings);
+    return stdout
+      .split("\n")
+      .map((line) => parseProcessLine(line))
+      .filter((process): process is ProcessSummary => Boolean(process))
+      .map((process) => attachActiveConnections(process, activeConnections))
+      .slice(0, limit);
+  } catch (err) {
+    pushWarning(warnings, "process_collection_unavailable", err);
+    return [];
+  }
+}
+
+function parseProcessLine(line: string): ProcessSummary | null {
+  const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+([\d.]+)\s+(\d+)\s+(\d+)\s+(\S+)\s*(.*)$/);
+  if (!match) return null;
+  const [, pidRaw, , user, , cpuRaw, rssRaw, elapsedRaw, comm, args = ""] = match;
+  const pid = Number(pidRaw);
+  const displayName = displayNameFor(comm ?? "", args);
+  return {
+    processRef: `proc_${pid}`,
+    pid,
+    ownerClass: ownerClassFor(user ?? ""),
+    classification: classifyProcess(comm ?? "", args),
+    displayName,
+    cpuPercent: Number(cpuRaw) || 0,
+    rssBytes: (Number(rssRaw) || 0) * 1024,
+    elapsedSeconds: Number(elapsedRaw) || 0,
+    ports: [],
+    activeConnections: undefined,
+  };
+}
+
+async function collectActiveConnectionCounts(warnings: string[]): Promise<Map<number, number> | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "ss",
+      ["-H", "-tanp", "state", "established"],
+      { timeout: PROCESS_TIMEOUT_MS, maxBuffer: 512_000 },
+    );
+    return parseSocketConnectionCounts(stdout);
+  } catch (err) {
+    pushWarning(warnings, "connection_collection_unavailable", err);
+    return null;
+  }
+}
+
+function attachActiveConnections(process: ProcessSummary, connections: Map<number, number> | null): ProcessSummary {
+  if (process.classification !== "app_server" || process.pid === undefined || !connections) return process;
+  return { ...process, activeConnections: connections.get(process.pid) ?? 0 };
+}
+
+export function parseSocketConnectionCounts(output: string): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const line of output.split("\n")) {
+    for (const match of line.matchAll(/pid=(\d+)/g)) {
+      const pid = Number(match[1]);
+      if (Number.isInteger(pid) && pid > 0) counts.set(pid, (counts.get(pid) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+async function collectServices(warnings: string[]): Promise<ServiceStatus[]> {
+  const results = await Promise.all(SERVICES.map((serviceId) => readService(serviceId, warnings)));
+  return results;
+}
+
+async function readService(serviceId: string, warnings: string[]): Promise<ServiceStatus> {
+  try {
+    const { stdout } = await execFileAsync(
+      "systemctl",
+      ["show", `${serviceId}.service`, "--property=ActiveState,SubState,MemoryCurrent,CPUUsageNSec,TasksCurrent,NRestarts", "--no-pager"],
+      { timeout: PROCESS_TIMEOUT_MS, maxBuffer: 32_000 },
+    );
+    const properties = Object.fromEntries(stdout.trim().split("\n").map((line) => {
+      const [key, ...rest] = line.split("=");
+      return [key, rest.join("=")];
+    }));
+    return {
+      serviceId,
+      state: serviceState(properties.ActiveState, properties.SubState),
+      memoryBytes: numberProperty(properties.MemoryCurrent),
+      cpuSeconds: properties.CPUUsageNSec ? Math.round(Number(properties.CPUUsageNSec) / 1_000_000_000) : undefined,
+      tasks: numberProperty(properties.TasksCurrent),
+      restartCount: numberProperty(properties.NRestarts),
+    };
+  } catch (err) {
+    pushWarning(warnings, "service_collection_partial", err);
+    return { serviceId, state: "unknown" };
+  }
+}
+
+async function readDisk(path: string, label: string, warnings: string[]) {
+  try {
+    const stats = await statfs(path);
+    const totalBytes = Number(stats.blocks) * Number(stats.bsize);
+    const freeBytes = Number(stats.bavail) * Number(stats.bsize);
+    const usedBytes = Math.max(0, totalBytes - freeBytes);
+    return {
+      mount: label === "System" ? "/" : "home",
+      label,
+      usedBytes,
+      totalBytes,
+      usedPercent: totalBytes > 0 ? Math.round((usedBytes / totalBytes) * 100) : 0,
+    };
+  } catch (err) {
+    pushWarning(warnings, "disk_collection_partial", err);
+    return null;
+  }
+}
+
+async function readCpuPressure(warnings: string[]): Promise<number | undefined> {
+  try {
+    const content = await readFile("/proc/pressure/cpu", "utf8");
+    const some = content.split("\n").find((line) => line.startsWith("some "));
+    const avg10 = some?.match(/avg10=([\d.]+)/)?.[1];
+    return avg10 ? Number(avg10) : undefined;
+  } catch (err) {
+    pushWarning(warnings, "pressure_collection_unavailable", err);
+    return undefined;
+  }
+}
+
+async function readCgroupMemory(warnings: string[]) {
+  try {
+    const content = await readFile("/sys/fs/cgroup/memory.stat", "utf8");
+    const values = Object.fromEntries(content.split("\n").map((line) => {
+      const [key, value] = line.trim().split(/\s+/);
+      return [key, Number(value) || 0];
+    }));
+    return {
+      cgroupAnonBytes: values.anon ?? 0,
+      cgroupFileBytes: values.file ?? 0,
+      cgroupKernelBytes: values.kernel ?? 0,
+    };
+  } catch (err) {
+    pushWarning(warnings, "cgroup_memory_unavailable", err);
+    return {};
+  }
+}
+
+async function readSwap(warnings: string[]): Promise<{ totalBytes: number; usedBytes: number }> {
+  try {
+    const content = await readFile("/proc/meminfo", "utf8");
+    const values = Object.fromEntries(content.split("\n").map((line) => {
+      const [key, value] = line.split(":");
+      return [key, Number(value?.trim().split(/\s+/)[0]) * 1024 || 0];
+    }));
+    const total = values.SwapTotal ?? 0;
+    const free = values.SwapFree ?? 0;
+    return { totalBytes: total, usedBytes: Math.max(0, total - free) };
+  } catch (err) {
+    pushWarning(warnings, "swap_collection_unavailable", err);
+    return { totalBytes: 0, usedBytes: 0 };
+  }
+}
+
+export function classifyProcess(comm: string, args: string): ProcessSummary["classification"] {
+  const text = `${comm} ${args}`.toLowerCase();
+  if (text.includes("matrix-gateway") || text.includes("matrix-shell") || text.includes("sync-agent")) return "matrix_service";
+  if (text.includes("next-server") || isViteCommand(comm, args)) return "app_server";
+  if (text.includes("zellij")) return "terminal_session";
+  if (text.includes("code-server")) return "code_editor";
+  if (text.includes("postgres")) return "database";
+  if (comm.startsWith("systemd")) return "system";
+  return "unknown";
+}
+
+function ownerClassFor(user: string): ProcessSummary["ownerClass"] {
+  if (user === "matrix") return "matrix";
+  if (user === "root") return "root";
+  if (user.startsWith("_") || user === "systemd+") return "system";
+  return "unknown";
+}
+
+function displayNameFor(comm: string, args: string): string {
+  const text = `${comm} ${args}`;
+  if (text.includes("matrix-gateway")) return "matrix-gateway";
+  if (text.includes("matrix-shell")) return "matrix-shell";
+  if (text.includes("matrix-sync-agent")) return "matrix-sync-agent";
+  if (text.includes("code-server")) return "code-server";
+  if (text.includes("next-server")) return "Next.js app server";
+  if (isViteCommand(comm, args)) return "Vite app server";
+  return sanitizeDisplay(comm || "process");
+}
+
+function isViteCommand(comm: string, args: string): boolean {
+  return /\bvite\b/.test(`${comm} ${args}`.toLowerCase());
+}
+
+export function deriveMachineStatus(input: {
+  load1: number;
+  pressureSome10?: number;
+  services: ServiceStatus[];
+  cpuCores: number;
+}): MachineIdentity["status"] {
+  if (input.services.length > 0 && input.services.every((service) => service.state === "unknown")) return "unknown";
+  if (input.services.some((service) => service.state === "failed")) return "degraded";
+  if (input.load1 > input.cpuCores * 2) return "degraded";
+  if ((input.pressureSome10 ?? 0) >= 20) return "degraded";
+  return "healthy";
+}
+
+function serviceState(active?: string, sub?: string): ServiceStatus["state"] {
+  if (active === "active" && sub === "running") return "running";
+  if (active === "activating") return "starting";
+  if (active === "failed") return "failed";
+  if (active === "inactive") return "stopped";
+  return "unknown";
+}
+
+function numberProperty(value: string | undefined): number | undefined {
+  if (!value || value === "[not set]") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function sanitizeDisplay(value: string): string {
+  return value.replace(/[^\w .:@/-]/g, "").slice(0, 80) || "unknown";
+}
+
+function pushWarning(warnings: string[], code: string, err: unknown): void {
+  if (warnings.length < 8) warnings.push(code);
+  console.warn("[system-activity] collector warning:", code, err instanceof Error ? err.message : String(err));
+}

--- a/packages/gateway/src/system-activity/history.ts
+++ b/packages/gateway/src/system-activity/history.ts
@@ -1,0 +1,118 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+import type { AutoCleanupPolicy, CleanupHistoryEntry } from "./types.js";
+
+const HISTORY_LIMIT = 100;
+const DEFAULT_POLICY: Omit<AutoCleanupPolicy, "lastUpdatedAt"> = {
+  enabled: false,
+  allowedTypes: [],
+  gracePeriodSeconds: 1800,
+  maxActionsPerHour: 3,
+};
+
+export class ActivityHistoryStore {
+  private readonly filePath: string;
+
+  constructor(options: { homePath: string }) {
+    this.filePath = join(options.homePath, "system", "activity-monitor-history.json");
+  }
+
+  async append(entry: Omit<CleanupHistoryEntry, "id" | "createdAt">): Promise<CleanupHistoryEntry> {
+    const current = await this.readAll();
+    const nextEntry: CleanupHistoryEntry = {
+      ...entry,
+      id: `hist_${randomUUID()}`,
+      createdAt: new Date().toISOString(),
+    };
+    await writeJsonAtomic(this.filePath, [nextEntry, ...current].slice(0, HISTORY_LIMIT));
+    return nextEntry;
+  }
+
+  async list(query: { limit: number; cursor?: string }): Promise<{ entries: CleanupHistoryEntry[]; nextCursor: string | null }> {
+    const entries = await this.readAll();
+    const safeStart = query.cursor ? entries.findIndex((entry) => entry.id === query.cursor) + 1 : 0;
+    if (query.cursor && safeStart === 0) return { entries: [], nextCursor: null };
+    const page = entries.slice(safeStart, safeStart + query.limit);
+    const nextIndex = safeStart + page.length;
+    return {
+      entries: page,
+      nextCursor: nextIndex < entries.length && page.length > 0 ? page[page.length - 1]?.id ?? null : null,
+    };
+  }
+
+  private async readAll(): Promise<CleanupHistoryEntry[]> {
+    try {
+      const parsed = JSON.parse(await readFile(this.filePath, "utf8"));
+      return Array.isArray(parsed) ? parsed.slice(0, HISTORY_LIMIT).filter(isHistoryEntry) : [];
+    } catch (err) {
+      if (isMissingFile(err)) return [];
+      console.warn("[system-activity] failed to read cleanup history:", err instanceof Error ? err.message : String(err));
+      return [];
+    }
+  }
+}
+
+export class AutoCleanupPolicyStore {
+  private readonly filePath: string;
+
+  constructor(options: { homePath: string }) {
+    this.filePath = join(options.homePath, "system", "activity-monitor-policy.json");
+  }
+
+  async read(): Promise<AutoCleanupPolicy> {
+    try {
+      const parsed = JSON.parse(await readFile(this.filePath, "utf8"));
+      if (isPolicy(parsed)) return parsed;
+    } catch (err) {
+      if (!isMissingFile(err)) {
+        console.warn("[system-activity] failed to read cleanup policy:", err instanceof Error ? err.message : String(err));
+      }
+    }
+    return { ...DEFAULT_POLICY, lastUpdatedAt: new Date(0).toISOString() };
+  }
+
+  async save(policy: Omit<AutoCleanupPolicy, "lastUpdatedAt">): Promise<AutoCleanupPolicy> {
+    const next: AutoCleanupPolicy = {
+      enabled: policy.enabled,
+      allowedTypes: [...policy.allowedTypes],
+      gracePeriodSeconds: policy.gracePeriodSeconds,
+      maxActionsPerHour: policy.maxActionsPerHour,
+      lastUpdatedAt: new Date().toISOString(),
+    };
+    await writeJsonAtomic(this.filePath, next);
+    return next;
+  }
+}
+
+async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmpPath = `${path}.${randomUUID()}.tmp`;
+  await writeFile(tmpPath, `${JSON.stringify(value, null, 2)}\n`, { flag: "wx" });
+  await rename(tmpPath, path);
+}
+
+function isMissingFile(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT";
+}
+
+function isHistoryEntry(value: unknown): value is CleanupHistoryEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as CleanupHistoryEntry;
+  return typeof entry.id === "string"
+    && typeof entry.createdAt === "string"
+    && typeof entry.actionType === "string"
+    && typeof entry.targetLabel === "string"
+    && typeof entry.result === "string"
+    && typeof entry.reasonCode === "string";
+}
+
+function isPolicy(value: unknown): value is AutoCleanupPolicy {
+  if (typeof value !== "object" || value === null) return false;
+  const policy = value as AutoCleanupPolicy;
+  return typeof policy.enabled === "boolean"
+    && Array.isArray(policy.allowedTypes)
+    && typeof policy.gracePeriodSeconds === "number"
+    && typeof policy.maxActionsPerHour === "number"
+    && typeof policy.lastUpdatedAt === "string";
+}

--- a/packages/gateway/src/system-activity/routes.ts
+++ b/packages/gateway/src/system-activity/routes.ts
@@ -1,0 +1,190 @@
+import { Hono, type Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
+import { ActivityConflictError, ActivityForbiddenError } from "./types.js";
+import type {
+  ActivityCollectOptions,
+  ActivitySnapshot,
+  AutoCleanupPolicy,
+  CleanupAction,
+  CleanupActionResult,
+  CleanupActionType,
+  CleanupHistoryEntry,
+} from "./types.js";
+
+export interface SystemActivityRouteDeps {
+  collect(options: ActivityCollectOptions): Promise<ActivitySnapshot>;
+  executeAction?(action: CleanupAction): Promise<CleanupActionResult>;
+  readPolicy?(): Promise<AutoCleanupPolicy>;
+  savePolicy?(policy: Omit<AutoCleanupPolicy, "lastUpdatedAt">): Promise<AutoCleanupPolicy>;
+  readHistory?(query: { limit: number; cursor?: string }): Promise<{
+    entries: CleanupHistoryEntry[];
+    nextCursor: string | null;
+  }>;
+}
+
+const ActionTypeSchema = z.enum([
+  "stop_stale_app_server",
+  "close_stale_terminal_session",
+  "restart_idle_code_server",
+  "clean_cache_scope",
+  "prune_old_bundle",
+]);
+
+const conservativeAutomaticTypes = new Set<CleanupActionType>([
+  "stop_stale_app_server",
+  "clean_cache_scope",
+  "prune_old_bundle",
+]);
+
+const QueryBooleanSchema = z.union([z.literal("true"), z.literal("false"), z.boolean()])
+  .optional()
+  .transform((value) => value === undefined ? true : value === true || value === "true");
+
+const ActivityQuerySchema = z.object({
+  processLimit: z.coerce.number().int().min(1).max(100).default(25),
+  includeSuggestions: QueryBooleanSchema,
+});
+
+const ActionBodySchema = z.object({
+  type: ActionTypeSchema,
+  candidateId: z.string().min(1).max(128).regex(/^[a-zA-Z0-9_.:-]+$/),
+  confirmationToken: z.string().min(1).max(128).regex(/^[a-zA-Z0-9_.:-]+$/),
+  mode: z.enum(["manual", "automatic"]).default("manual"),
+});
+
+const PolicyBodySchema = z.object({
+  enabled: z.boolean(),
+  allowedTypes: z.array(ActionTypeSchema).max(8),
+  gracePeriodSeconds: z.number().int().min(300).max(86_400),
+  maxActionsPerHour: z.number().int().min(1).max(12),
+}).superRefine((policy, ctx) => {
+  for (const type of policy.allowedTypes) {
+    if (!conservativeAutomaticTypes.has(type)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["allowedTypes"],
+        message: "manual_only_action",
+      });
+    }
+  }
+});
+
+const HistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+  cursor: z.string().min(1).max(256).regex(/^[a-zA-Z0-9_.:-]+$/).optional(),
+});
+
+export function createSystemActivityRoutes(deps: SystemActivityRouteDeps): Hono {
+  const app = new Hono();
+  const mutationLimit = bodyLimit({ maxSize: 16_384 });
+  const automaticBudget = { inFlight: 0 };
+
+  app.get("/activity", async (c) => {
+    try {
+      const query = ActivityQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams));
+      return c.json(await deps.collect(query));
+    } catch (err) {
+      return safeError(c, err, "collection_failed");
+    }
+  });
+
+  app.post("/activity/actions", mutationLimit, async (c) => {
+    try {
+      if (!deps.executeAction) return unavailable(c);
+      const body = ActionBodySchema.parse(await c.req.json());
+      let releaseReservation: (() => void) | undefined;
+      if (body.mode === "automatic") {
+        releaseReservation = await reserveAutomaticCleanupBudget(deps, body.type, automaticBudget);
+      }
+      try {
+        const result = await deps.executeAction(body);
+        releaseReservation?.();
+        return c.json(result);
+      } catch (err) {
+        releaseReservation?.();
+        throw err;
+      }
+    } catch (err) {
+      return safeError(c, err, "cleanup_failed");
+    }
+  });
+
+  app.get("/activity/policy", async (c) => {
+    try {
+      if (!deps.readPolicy) return unavailable(c);
+      return c.json(await deps.readPolicy());
+    } catch (err) {
+      return safeError(c, err, "policy_failed");
+    }
+  });
+
+  app.put("/activity/policy", mutationLimit, async (c) => {
+    try {
+      if (!deps.savePolicy) return unavailable(c);
+      const body = PolicyBodySchema.parse(await c.req.json());
+      return c.json(await deps.savePolicy(body));
+    } catch (err) {
+      return safeError(c, err, "policy_failed");
+    }
+  });
+
+  app.get("/activity/history", async (c) => {
+    try {
+      if (!deps.readHistory) return unavailable(c);
+      const query = HistoryQuerySchema.parse(Object.fromEntries(new URL(c.req.url).searchParams));
+      return c.json(await deps.readHistory(query));
+    } catch (err) {
+      return safeError(c, err, "history_failed");
+    }
+  });
+
+  return app;
+}
+
+function unavailable(c: Context) {
+  return c.json({ error: { code: "activity_unavailable", message: "Request failed" } }, 503);
+}
+
+function safeError(c: Context, err: unknown, fallbackCode: string) {
+  if (err instanceof z.ZodError) {
+    return c.json({ error: { code: "invalid_request", message: "Invalid request" } }, 400);
+  }
+  if (err instanceof ActivityConflictError) {
+    console.warn("[system-activity] cleanup target changed:", err.message);
+    return c.json({ error: { code: "candidate_conflict", message: "Cleanup target changed" } }, 409);
+  }
+  if (err instanceof ActivityForbiddenError) {
+    console.warn("[system-activity] cleanup rejected:", err.message);
+    return c.json({ error: { code: "cleanup_forbidden", message: "Cleanup is not allowed" } }, 403);
+  }
+  console.warn("[system-activity] route failed:", err instanceof Error ? err.message : String(err));
+  return c.json({ error: { code: fallbackCode, message: "Request failed" } }, 500);
+}
+
+async function reserveAutomaticCleanupBudget(
+  deps: SystemActivityRouteDeps,
+  type: CleanupActionType,
+  budget: { inFlight: number },
+): Promise<() => void> {
+  const policy = await deps.readPolicy?.();
+  if (!policy?.enabled || !policy.allowedTypes.includes(type)) {
+    throw new ActivityForbiddenError("automatic cleanup policy rejected action");
+  }
+  if (!deps.readHistory) throw new ActivityForbiddenError("automatic cleanup budget unavailable");
+  const history = await deps.readHistory({ limit: 100 });
+  const cutoffMs = Date.now() - 60 * 60 * 1000;
+  const recentAutomaticActions = history.entries.filter((entry) => (
+    entry.actor === "auto_policy" && Date.parse(entry.createdAt) >= cutoffMs
+  )).length;
+  if (recentAutomaticActions + budget.inFlight >= policy.maxActionsPerHour) {
+    throw new ActivityForbiddenError("automatic cleanup rate limit reached");
+  }
+  budget.inFlight += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    budget.inFlight = Math.max(0, budget.inFlight - 1);
+  };
+}

--- a/packages/gateway/src/system-activity/types.ts
+++ b/packages/gateway/src/system-activity/types.ts
@@ -1,0 +1,155 @@
+export type CleanupActionType =
+  | "stop_stale_app_server"
+  | "close_stale_terminal_session"
+  | "restart_idle_code_server"
+  | "clean_cache_scope"
+  | "prune_old_bundle";
+
+export type CleanupConfidence = "high" | "medium" | "manual_review";
+export type CleanupRisk = "low" | "medium" | "high";
+
+export interface MachineIdentity {
+  handle: string | null;
+  runtimeSlot: string;
+  hostname: string;
+  status: "healthy" | "degraded" | "unknown";
+  releaseVersion?: string;
+  releaseChannel?: string;
+  gitCommit?: string;
+  uptimeSeconds: number;
+}
+
+export interface ResourceSummary {
+  cpu: {
+    cores: number;
+    load1: number;
+    load5: number;
+    load15: number;
+    pressureSome10?: number;
+  };
+  memory: {
+    totalBytes: number;
+    usedBytes: number;
+    availableBytes: number;
+    processRssBytes: number;
+    cgroupAnonBytes?: number;
+    cgroupFileBytes?: number;
+    cgroupKernelBytes?: number;
+  };
+  swap: {
+    totalBytes: number;
+    usedBytes: number;
+  };
+  disk: Array<{
+    mount: string;
+    label: string;
+    usedBytes: number;
+    totalBytes: number;
+    usedPercent: number;
+  }>;
+}
+
+export interface ServiceStatus {
+  serviceId: string;
+  state: "running" | "starting" | "stopped" | "failed" | "unknown";
+  memoryBytes?: number;
+  cpuSeconds?: number;
+  tasks?: number;
+  restartCount?: number;
+}
+
+export interface ProcessSummary {
+  processRef: string;
+  pid?: number;
+  ownerClass: "matrix" | "root" | "system" | "unknown";
+  classification:
+    | "matrix_service"
+    | "app_server"
+    | "terminal_session"
+    | "code_editor"
+    | "database"
+    | "system"
+    | "unknown";
+  displayName: string;
+  cpuPercent: number;
+  rssBytes: number;
+  elapsedSeconds: number;
+  ports: number[];
+  activeConnections?: number;
+}
+
+export interface CleanupCandidate {
+  candidateId: string;
+  type: CleanupActionType;
+  targetLabel: string;
+  reason: string;
+  confidence: CleanupConfidence;
+  risk: CleanupRisk;
+  estimatedReclaimBytes?: number;
+  requiresConfirmation: boolean;
+  confirmationToken: string;
+  expiresAt: string;
+}
+
+export interface ActivitySnapshot {
+  generatedAt: string;
+  machine: MachineIdentity;
+  resources: ResourceSummary;
+  services: ServiceStatus[];
+  processes: ProcessSummary[];
+  cleanupSuggestions: CleanupCandidate[];
+  collectionWarnings: string[];
+}
+
+export interface CleanupAction {
+  type: CleanupActionType;
+  candidateId: string;
+  confirmationToken: string;
+  mode: "manual" | "automatic";
+}
+
+export interface CleanupActionResult {
+  actionId: string;
+  result: "completed" | "already_clean" | "skipped" | "failed";
+  reclaimedBytes?: number;
+  message: string;
+  snapshotRefreshRecommended: boolean;
+}
+
+export interface CleanupHistoryEntry {
+  id: string;
+  createdAt: string;
+  actor: "owner" | "auto_policy";
+  actionType: CleanupActionType;
+  targetLabel: string;
+  result: "completed" | "skipped" | "already_clean" | "failed";
+  reclaimedBytes?: number;
+  reasonCode: string;
+}
+
+export interface AutoCleanupPolicy {
+  enabled: boolean;
+  allowedTypes: CleanupActionType[];
+  gracePeriodSeconds: number;
+  maxActionsPerHour: number;
+  lastUpdatedAt: string;
+}
+
+export interface ActivityCollectOptions {
+  processLimit: number;
+  includeSuggestions: boolean;
+}
+
+export class ActivityConflictError extends Error {
+  constructor(message = "Cleanup target changed") {
+    super(message);
+    this.name = "ActivityConflictError";
+  }
+}
+
+export class ActivityForbiddenError extends Error {
+  constructor(message = "Cleanup policy rejected action") {
+    super(message);
+    this.name = "ActivityForbiddenError";
+  }
+}

--- a/specs/087-system-activity-monitor/tasks.md
+++ b/specs/087-system-activity-monitor/tasks.md
@@ -17,8 +17,8 @@
 
 **Purpose**: Establish shared types, module boundaries, and built-in app entry points.
 
-- [ ] T001 Create `packages/gateway/src/system-activity/types.ts` with ActivitySnapshot, MachineIdentity, ResourceSummary, ServiceStatus, ProcessSummary, CleanupCandidate, CleanupAction, CleanupHistoryEntry, and AutoCleanupPolicy DTO types.
-- [ ] T002 Create `packages/gateway/src/system-activity/routes.ts` with placeholder Hono route factory and dependency interface wired for tests but not registered.
+- [X] T001 Create `packages/gateway/src/system-activity/types.ts` with ActivitySnapshot, MachineIdentity, ResourceSummary, ServiceStatus, ProcessSummary, CleanupCandidate, CleanupAction, CleanupHistoryEntry, and AutoCleanupPolicy DTO types.
+- [X] T002 Create `packages/gateway/src/system-activity/routes.ts` with placeholder Hono route factory and dependency interface wired for tests but not registered.
 - [ ] T003 [P] Create `shell/src/stores/systemActivityStore.ts` with serializable initial state, refresh status, cleanup status, and error fields.
 - [ ] T004 [P] Create `shell/src/components/system-activity/ActivityMonitorApp.tsx` as a minimal built-in app shell with loading and unavailable states.
 - [ ] T005 Add the System Activity Monitor built-in app manifest/icon wiring in the existing shell built-in app registry files discovered during implementation.
@@ -32,16 +32,16 @@
 
 **CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T007 [P] Add failing contract tests for `GET /api/system/activity`, `POST /api/system/activity/actions`, policy routes, history route, auth failures, generic errors, and body limits in `tests/gateway/system-activity-routes.test.ts`.
+- [X] T007 [P] Add failing contract tests for `GET /api/system/activity`, `POST /api/system/activity/actions`, policy routes, history route, auth failures, generic errors, and body limits in `tests/gateway/system-activity-routes.test.ts`.
 - [ ] T008 [P] Add failing collector tests for CPU, memory, cgroup memory decomposition, disk, pressure, service accounting, process limits, subprocess timeouts, and sanitized warnings in `tests/gateway/system-activity-collector.test.ts`.
-- [ ] T009 [P] Add failing cleanup classifier tests for stale app servers, active app servers, zellij sessions, code-server, cache scopes, protected paths, candidate TTL, and bounded candidate cache in `tests/gateway/system-activity-cleanup.test.ts`.
-- [ ] T010 [P] Add failing history/policy tests for owner-file atomic writes, bounded retention, malformed file handling, and safe generic errors in `tests/gateway/system-activity-history.test.ts`.
-- [ ] T011 Implement host metric collectors with bounded readers and subprocess timeouts in `packages/gateway/src/system-activity/collector.ts`.
-- [ ] T012 Implement service and process snapshot collection with allowlisted service ids, capped process rows, sanitized display names, and no raw command stderr in `packages/gateway/src/system-activity/collector.ts`.
-- [ ] T013 Implement cleanup candidate cache with TTL, max size, opaque candidate ids, and shutdown drain in `packages/gateway/src/system-activity/cleanup.ts`.
+- [X] T009 [P] Add failing cleanup classifier tests for stale app servers, active app servers, zellij sessions, code-server, cache scopes, protected paths, candidate TTL, and bounded candidate cache in `tests/gateway/system-activity-cleanup.test.ts`.
+- [X] T010 [P] Add failing history/policy tests for owner-file atomic writes, bounded retention, malformed file handling, and safe generic errors in `tests/gateway/system-activity-history.test.ts`.
+- [X] T011 Implement host metric collectors with bounded readers and subprocess timeouts in `packages/gateway/src/system-activity/collector.ts`.
+- [X] T012 Implement service and process snapshot collection with allowlisted service ids, capped process rows, sanitized display names, and no raw command stderr in `packages/gateway/src/system-activity/collector.ts`.
+- [X] T013 Implement cleanup candidate cache with TTL, max size, opaque candidate ids, and shutdown drain in `packages/gateway/src/system-activity/cleanup.ts`.
 - [ ] T014 Implement protected path helpers and cleanup policy/history owner-file persistence with atomic writes and symlink-safe cleanup in `packages/gateway/src/system-activity/history.ts`.
-- [ ] T015 Implement Zod route schemas, `bodyLimit` on mutating endpoints, owner auth dependency checks, and generic error mapper in `packages/gateway/src/system-activity/routes.ts`.
-- [ ] T016 Register system activity routes at gateway startup with dependency resolution at registration time in `packages/gateway/src/server.ts`.
+- [X] T015 Implement Zod route schemas, `bodyLimit` on mutating endpoints, owner auth dependency checks, and generic error mapper in `packages/gateway/src/system-activity/routes.ts`.
+- [X] T016 Register system activity routes at gateway startup with dependency resolution at registration time in `packages/gateway/src/server.ts`.
 
 **Checkpoint**: Foundation ready - all user story slices can build on trusted collection, validation, and persistence.
 

--- a/tests/gateway/system-activity-cleanup.test.ts
+++ b/tests/gateway/system-activity-cleanup.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { CleanupCandidateRegistry, executeCleanupAction } from "../../packages/gateway/src/system-activity/cleanup.js";
+import { ActivityHistoryStore } from "../../packages/gateway/src/system-activity/history.js";
+import type { ProcessSummary } from "../../packages/gateway/src/system-activity/types.js";
+import { classifyProcess, deriveMachineStatus, parseSocketConnectionCounts } from "../../packages/gateway/src/system-activity/collector.js";
+
+function process(overrides: Partial<ProcessSummary> = {}): ProcessSummary {
+  return {
+    processRef: "proc_100",
+    pid: 100,
+    ownerClass: "matrix",
+    classification: "app_server",
+    displayName: "Next.js app server",
+    cpuPercent: 0,
+    rssBytes: 50_000_000,
+    elapsedSeconds: 31 * 24 * 60 * 60,
+    ports: [45679],
+    activeConnections: 0,
+    ...overrides,
+  };
+}
+
+describe("system activity cleanup", () => {
+  it("classifies stale inactive app servers and issues confirmation tokens", () => {
+    const registry = new CleanupCandidateRegistry({ ttlMs: 1_000, maxCandidates: 10 });
+
+    const suggestions = registry.classify([process()], 1000);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      type: "stop_stale_app_server",
+      confidence: "high",
+      risk: "low",
+      requiresConfirmation: true,
+    });
+    expect(suggestions[0].confirmationToken).toMatch(/^confirm_/);
+  });
+
+  it("skips active and young app servers", () => {
+    const registry = new CleanupCandidateRegistry();
+
+    expect(registry.classify([
+      process({ activeConnections: 2 }),
+      process({ elapsedSeconds: 300 }),
+      process({ activeConnections: undefined }),
+    ])).toEqual([]);
+  });
+
+  it("uses caller-provided grace period for stale app server suggestions", () => {
+    const registry = new CleanupCandidateRegistry();
+
+    expect(registry.classify([process({ elapsedSeconds: 3600 })])).toEqual([]);
+    expect(registry.classify([process({ elapsedSeconds: 3600 })], Date.now(), { minElapsedSeconds: 300 })).toHaveLength(1);
+  });
+
+  it("parses active socket counts by pid for app server safety checks", () => {
+    const counts = parseSocketConnectionCounts([
+      "ESTAB 0 0 127.0.0.1:45679 127.0.0.1:53000 users:((\"next-server\",pid=123,fd=20))",
+      "ESTAB 0 0 127.0.0.1:45679 127.0.0.1:53001 users:((\"next-server\",pid=123,fd=21))",
+      "ESTAB 0 0 127.0.0.1:45680 127.0.0.1:53002 users:((\"vite\",pid=456,fd=9))",
+    ].join("\n"));
+
+    expect(counts.get(123)).toBe(2);
+    expect(counts.get(456)).toBe(1);
+  });
+
+  it("does not classify vitest watch processes as vite app servers", () => {
+    expect(classifyProcess("vitest", "vitest --watch")).toBe("unknown");
+    expect(classifyProcess("node", "vite --host 0.0.0.0")).toBe("app_server");
+  });
+
+  it("derives degraded machine status from failed services and pressure", () => {
+    expect(deriveMachineStatus({
+      load1: 0.2,
+      pressureSome10: 0,
+      cpuCores: 2,
+      services: [{ serviceId: "matrix-gateway", state: "failed" }],
+    })).toBe("degraded");
+    expect(deriveMachineStatus({
+      load1: 0.2,
+      pressureSome10: 25,
+      cpuCores: 2,
+      services: [{ serviceId: "matrix-gateway", state: "running" }],
+    })).toBe("degraded");
+  });
+
+  it("expires candidates and enforces max cache size", () => {
+    const registry = new CleanupCandidateRegistry({ ttlMs: 1_000, maxCandidates: 2 });
+
+    registry.classify([process({ pid: 1 }), process({ pid: 2 }), process({ pid: 3 })], 1000);
+    expect(registry.size(1000)).toBe(2);
+
+    registry.classify([], 2500);
+    expect(registry.size(2500)).toBe(0);
+  });
+
+  it("executes only server-issued candidates and records history", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "activity-cleanup-"));
+    try {
+      const registry = new CleanupCandidateRegistry();
+      const [candidate] = registry.classify([process({ pid: 123 })], Date.now());
+      const killProcess = vi.fn();
+
+      const result = await executeCleanupAction({
+        action: {
+          type: candidate.type,
+          candidateId: candidate.candidateId,
+          confirmationToken: candidate.confirmationToken,
+          mode: "manual",
+        },
+        registry,
+        history: new ActivityHistoryStore({ homePath }),
+        killProcess,
+      });
+
+      expect(result.result).toBe("completed");
+      expect(killProcess).toHaveBeenCalledWith(123, 0);
+      expect(killProcess).toHaveBeenCalledWith(123, "SIGTERM");
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("records permission failures in cleanup history", async () => {
+    const homePath = await mkdtemp(join(tmpdir(), "activity-cleanup-"));
+    try {
+      const registry = new CleanupCandidateRegistry();
+      const [candidate] = registry.classify([process({ pid: 123 })], Date.now());
+      const permissionError = Object.assign(new Error("kill EPERM"), { code: "EPERM" });
+      const killProcess = vi.fn((pid: number, signal: NodeJS.Signals | 0) => {
+        if (signal === "SIGTERM") throw permissionError;
+      });
+      const history = new ActivityHistoryStore({ homePath });
+
+      const result = await executeCleanupAction({
+        action: {
+          type: candidate.type,
+          candidateId: candidate.candidateId,
+          confirmationToken: candidate.confirmationToken,
+          mode: "manual",
+        },
+        registry,
+        history,
+        killProcess,
+      });
+
+      expect(result.result).toBe("failed");
+      const page = await history.list({ limit: 1 });
+      expect(page.entries[0]).toMatchObject({
+        result: "failed",
+        actionType: "stop_stale_app_server",
+      });
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/system-activity-history.test.ts
+++ b/tests/gateway/system-activity-history.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ActivityHistoryStore, AutoCleanupPolicyStore } from "../../packages/gateway/src/system-activity/history.js";
+
+async function tmpHome() {
+  const homePath = await mkdtemp(join(tmpdir(), "activity-history-"));
+  await mkdir(join(homePath, "system"), { recursive: true });
+  return homePath;
+}
+
+describe("system activity history and policy stores", () => {
+  it("stores bounded cleanup history newest-first", async () => {
+    const homePath = await tmpHome();
+    try {
+      const store = new ActivityHistoryStore({ homePath });
+      await store.append({
+        actor: "owner",
+        actionType: "stop_stale_app_server",
+        targetLabel: "preview server",
+        result: "completed",
+        reclaimedBytes: 100,
+        reasonCode: "stale_app_server_no_connections",
+      });
+      await store.append({
+        actor: "owner",
+        actionType: "clean_cache_scope",
+        targetLabel: "npm cache",
+        result: "skipped",
+        reasonCode: "manual_review",
+      });
+
+      const page = await store.list({ limit: 1 });
+
+      expect(page.entries).toHaveLength(1);
+      expect(page.entries[0].actionType).toBe("clean_cache_scope");
+      expect(page.nextCursor).toBe(page.entries[0].id);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("uses stable id cursors when new history entries are prepended", async () => {
+    const homePath = await tmpHome();
+    try {
+      const store = new ActivityHistoryStore({ homePath });
+      await store.append({
+        actor: "owner",
+        actionType: "stop_stale_app_server",
+        targetLabel: "old preview server",
+        result: "completed",
+        reclaimedBytes: 100,
+        reasonCode: "stale_app_server_no_connections",
+      });
+      await store.append({
+        actor: "owner",
+        actionType: "clean_cache_scope",
+        targetLabel: "npm cache",
+        result: "skipped",
+        reasonCode: "manual_review",
+      });
+
+      const firstPage = await store.list({ limit: 1 });
+      await store.append({
+        actor: "owner",
+        actionType: "prune_old_bundle",
+        targetLabel: "old bundle",
+        result: "completed",
+        reclaimedBytes: 200,
+        reasonCode: "inactive_bundle",
+      });
+      const secondPage = await store.list({ limit: 1, cursor: firstPage.nextCursor ?? undefined });
+
+      expect(secondPage.entries).toHaveLength(1);
+      expect(secondPage.entries[0].actionType).toBe("stop_stale_app_server");
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to disabled policy for missing or malformed files", async () => {
+    const homePath = await tmpHome();
+    try {
+      const store = new AutoCleanupPolicyStore({ homePath });
+      expect(await store.read()).toMatchObject({
+        enabled: false,
+        allowedTypes: [],
+        gracePeriodSeconds: 1800,
+        maxActionsPerHour: 3,
+      });
+
+      await writeFile(join(homePath, "system", "activity-monitor-policy.json"), "{bad json");
+      expect(await store.read()).toMatchObject({ enabled: false, allowedTypes: [] });
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+
+  it("writes auto-clean policy atomically with a server timestamp", async () => {
+    const homePath = await tmpHome();
+    try {
+      const store = new AutoCleanupPolicyStore({ homePath });
+
+      const saved = await store.save({
+        enabled: true,
+        allowedTypes: ["stop_stale_app_server"],
+        gracePeriodSeconds: 3600,
+        maxActionsPerHour: 2,
+      });
+
+      expect(saved.lastUpdatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      await expect(store.read()).resolves.toEqual(saved);
+    } finally {
+      await rm(homePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gateway/system-activity-routes.test.ts
+++ b/tests/gateway/system-activity-routes.test.ts
@@ -1,0 +1,391 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createSystemActivityRoutes } from "../../packages/gateway/src/system-activity/routes.js";
+import { ActivityConflictError, type ActivitySnapshot, type CleanupCandidate } from "../../packages/gateway/src/system-activity/types.js";
+
+function snapshot(overrides: Partial<ActivitySnapshot> = {}): ActivitySnapshot {
+  return {
+    generatedAt: "2026-06-07T17:30:00.000Z",
+    machine: {
+      handle: "hamedmp",
+      runtimeSlot: "primary",
+      hostname: "matrix-hamedmp-bdbdbbb5",
+      status: "healthy",
+      releaseVersion: "v2026.06.07-316",
+      releaseChannel: "dev",
+      gitCommit: "e7e2ef8",
+      uptimeSeconds: 123,
+    },
+    resources: {
+      cpu: { cores: 2, load1: 0.5, load5: 0.2, load15: 0.1, pressureSome10: 0 },
+      memory: {
+        totalBytes: 4_000_000_000,
+        usedBytes: 2_000_000_000,
+        availableBytes: 2_000_000_000,
+        processRssBytes: 1_000_000_000,
+        cgroupAnonBytes: 0,
+        cgroupFileBytes: 0,
+        cgroupKernelBytes: 0,
+      },
+      swap: { totalBytes: 0, usedBytes: 0 },
+      disk: [{ mount: "/", label: "System", usedBytes: 10, totalBytes: 100, usedPercent: 10 }],
+    },
+    services: [],
+    processes: [],
+    cleanupSuggestions: [],
+    collectionWarnings: [],
+    ...overrides,
+  };
+}
+
+function appWith(deps: Parameters<typeof createSystemActivityRoutes>[0]) {
+  const app = new Hono();
+  app.route("/api/system", createSystemActivityRoutes(deps));
+  return app;
+}
+
+describe("system activity routes", () => {
+  it("returns a bounded system activity snapshot with cleanup suggestions", async () => {
+    const candidate: CleanupCandidate = {
+      candidateId: "cand_1",
+      type: "stop_stale_app_server",
+      targetLabel: "matrix-beta-crm preview server",
+      reason: "No active connections and executable no longer matches the current runtime.",
+      confidence: "high",
+      risk: "low",
+      estimatedReclaimBytes: 104_857_600,
+      requiresConfirmation: true,
+      confirmationToken: "confirm_1",
+      expiresAt: "2026-06-07T17:35:00.000Z",
+    };
+    const collect = vi.fn(async () => snapshot({ cleanupSuggestions: [candidate] }));
+    const app = appWith({ collect });
+
+    const res = await app.request("/api/system/activity?processLimit=10&includeSuggestions=true");
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      machine: { handle: "hamedmp", releaseVersion: "v2026.06.07-316" },
+      cleanupSuggestions: [{ candidateId: "cand_1", confirmationToken: "confirm_1" }],
+    });
+    expect(collect).toHaveBeenCalledWith({ processLimit: 10, includeSuggestions: true });
+  });
+
+  it("validates activity query params before collection", async () => {
+    const collect = vi.fn(async () => snapshot());
+    const app = appWith({ collect });
+
+    const res = await app.request("/api/system/activity?processLimit=999");
+
+    expect(res.status).toBe(400);
+    expect(collect).not.toHaveBeenCalled();
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "invalid_request", message: "Invalid request" },
+    });
+  });
+
+  it("parses includeSuggestions=false as false", async () => {
+    const collect = vi.fn(async () => snapshot());
+    const app = appWith({ collect });
+
+    const res = await app.request("/api/system/activity?includeSuggestions=false");
+
+    expect(res.status).toBe(200);
+    expect(collect).toHaveBeenCalledWith({ processLimit: 25, includeSuggestions: false });
+  });
+
+  it("uses generic client errors for collector failures", async () => {
+    const collect = vi.fn(async () => {
+      throw new Error("systemctl raw failure /opt/matrix/secret");
+    });
+    const app = appWith({ collect });
+
+    const res = await app.request("/api/system/activity");
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "collection_failed", message: "Request failed" },
+    });
+  });
+
+  it("executes a typed cleanup action with confirmation and writes history", async () => {
+    const executeAction = vi.fn(async () => ({
+      actionId: "act_1",
+      result: "completed" as const,
+      reclaimedBytes: 100,
+      message: "Cleanup completed.",
+      snapshotRefreshRecommended: true,
+    }));
+    const app = appWith({ collect: vi.fn(async () => snapshot()), executeAction });
+
+    const res = await app.request("/api/system/activity/actions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "stop_stale_app_server",
+        candidateId: "cand_1",
+        confirmationToken: "confirm_1",
+        mode: "manual",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      actionId: "act_1",
+      result: "completed",
+      snapshotRefreshRecommended: true,
+    });
+    expect(executeAction).toHaveBeenCalledWith({
+      type: "stop_stale_app_server",
+      candidateId: "cand_1",
+      confirmationToken: "confirm_1",
+      mode: "manual",
+    });
+  });
+
+  it("rejects oversized cleanup action bodies before JSON parsing", async () => {
+    const executeAction = vi.fn();
+    const app = appWith({ collect: vi.fn(async () => snapshot()), executeAction });
+
+    const res = await app.request("/api/system/activity/actions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Content-Length": "20000" },
+      body: JSON.stringify({ payload: "x".repeat(20_000) }),
+    });
+
+    expect(res.status).toBe(413);
+    expect(executeAction).not.toHaveBeenCalled();
+  });
+
+  it("maps candidate mismatches to a sanitized conflict", async () => {
+    const executeAction = vi.fn(async () => {
+      throw new ActivityConflictError("raw pid mismatch");
+    });
+    const app = appWith({ collect: vi.fn(async () => snapshot()), executeAction });
+
+    const res = await app.request("/api/system/activity/actions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "stop_stale_app_server",
+        candidateId: "cand_1",
+        confirmationToken: "wrong",
+        mode: "manual",
+      }),
+    });
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: { code: "candidate_conflict", message: "Cleanup target changed" },
+    });
+  });
+
+  it("requires enabled policy allowlist for automatic cleanup actions", async () => {
+    const executeAction = vi.fn(async () => ({
+      actionId: "act_1",
+      result: "completed" as const,
+      message: "Cleanup completed.",
+      snapshotRefreshRecommended: true,
+    }));
+    const app = appWith({
+      collect: vi.fn(async () => snapshot()),
+      executeAction,
+      readPolicy: vi.fn(async () => ({
+        enabled: false,
+        allowedTypes: ["stop_stale_app_server"],
+        gracePeriodSeconds: 1800,
+        maxActionsPerHour: 3,
+        lastUpdatedAt: "2026-06-07T17:30:00.000Z",
+      })),
+    });
+
+    const res = await app.request("/api/system/activity/actions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "stop_stale_app_server",
+        candidateId: "cand_1",
+        confirmationToken: "confirm_1",
+        mode: "automatic",
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(executeAction).not.toHaveBeenCalled();
+  });
+
+  it("enforces the automatic cleanup hourly action budget", async () => {
+    const executeAction = vi.fn(async () => ({
+      actionId: "act_1",
+      result: "completed" as const,
+      message: "Cleanup completed.",
+      snapshotRefreshRecommended: true,
+    }));
+    const app = appWith({
+      collect: vi.fn(async () => snapshot()),
+      executeAction,
+      readPolicy: vi.fn(async () => ({
+        enabled: true,
+        allowedTypes: ["stop_stale_app_server"],
+        gracePeriodSeconds: 1800,
+        maxActionsPerHour: 1,
+        lastUpdatedAt: "2026-06-07T17:30:00.000Z",
+      })),
+      readHistory: vi.fn(async () => ({
+        entries: [{
+          id: "hist_1",
+          createdAt: new Date().toISOString(),
+          actor: "auto_policy" as const,
+          actionType: "stop_stale_app_server" as const,
+          targetLabel: "preview server",
+          result: "completed" as const,
+          reasonCode: "stale_app_server_no_connections",
+        }],
+        nextCursor: null,
+      })),
+    });
+
+    const res = await app.request("/api/system/activity/actions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "stop_stale_app_server",
+        candidateId: "cand_1",
+        confirmationToken: "confirm_1",
+        mode: "automatic",
+      }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(executeAction).not.toHaveBeenCalled();
+  });
+
+  it("reserves automatic cleanup budget across concurrent requests", async () => {
+    const executeAction = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return {
+        actionId: "act_1",
+        result: "completed" as const,
+        message: "Cleanup completed.",
+        snapshotRefreshRecommended: true,
+      };
+    });
+    const app = appWith({
+      collect: vi.fn(async () => snapshot()),
+      executeAction,
+      readPolicy: vi.fn(async () => ({
+        enabled: true,
+        allowedTypes: ["stop_stale_app_server"],
+        gracePeriodSeconds: 1800,
+        maxActionsPerHour: 1,
+        lastUpdatedAt: "2026-06-07T17:30:00.000Z",
+      })),
+      readHistory: vi.fn(async () => ({ entries: [], nextCursor: null })),
+    });
+    const request = () => app.request("/api/system/activity/actions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "stop_stale_app_server",
+        candidateId: "cand_1",
+        confirmationToken: "confirm_1",
+        mode: "automatic",
+      }),
+    });
+
+    const responses = await Promise.all([request(), request()]);
+
+    expect(responses.map((res) => res.status).sort()).toEqual([200, 403]);
+    expect(executeAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases automatic cleanup budget after successful execution", async () => {
+    const executeAction = vi.fn(async () => ({
+      actionId: "act_1",
+      result: "completed" as const,
+      message: "Cleanup completed.",
+      snapshotRefreshRecommended: true,
+    }));
+    const app = appWith({
+      collect: vi.fn(async () => snapshot()),
+      executeAction,
+      readPolicy: vi.fn(async () => ({
+        enabled: true,
+        allowedTypes: ["stop_stale_app_server"],
+        gracePeriodSeconds: 1800,
+        maxActionsPerHour: 1,
+        lastUpdatedAt: "2026-06-07T17:30:00.000Z",
+      })),
+      readHistory: vi.fn(async () => ({ entries: [], nextCursor: null })),
+    });
+    const request = () => app.request("/api/system/activity/actions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "stop_stale_app_server",
+        candidateId: "cand_1",
+        confirmationToken: "confirm_1",
+        mode: "automatic",
+      }),
+    });
+
+    expect((await request()).status).toBe(200);
+    expect((await request()).status).toBe(200);
+    expect(executeAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("reads and updates auto-clean policy with a conservative allowlist", async () => {
+    const readPolicy = vi.fn(async () => ({
+      enabled: false,
+      allowedTypes: [],
+      gracePeriodSeconds: 1800,
+      maxActionsPerHour: 3,
+      lastUpdatedAt: "2026-06-07T17:30:00.000Z",
+    }));
+    const savePolicy = vi.fn(async (policy) => ({
+      ...policy,
+      lastUpdatedAt: "2026-06-07T17:31:00.000Z",
+    }));
+    const app = appWith({ collect: vi.fn(async () => snapshot()), readPolicy, savePolicy });
+
+    expect((await app.request("/api/system/activity/policy")).status).toBe(200);
+    const saved = await app.request("/api/system/activity/policy", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        enabled: true,
+        allowedTypes: ["stop_stale_app_server", "restart_idle_code_server"],
+        gracePeriodSeconds: 3600,
+        maxActionsPerHour: 2,
+      }),
+    });
+
+    expect(saved.status).toBe(400);
+    expect(savePolicy).not.toHaveBeenCalled();
+  });
+
+  it("returns bounded cleanup history", async () => {
+    const readHistory = vi.fn(async () => ({
+      entries: [
+        {
+          id: "hist_1",
+          createdAt: "2026-06-07T17:31:00.000Z",
+          actor: "owner" as const,
+          actionType: "stop_stale_app_server" as const,
+          targetLabel: "preview server",
+          result: "completed" as const,
+          reclaimedBytes: 100,
+          reasonCode: "stale_app_server_no_connections",
+        },
+      ],
+      nextCursor: null,
+    }));
+    const app = appWith({ collect: vi.fn(async () => snapshot()), readHistory });
+
+    const res = await app.request("/api/system/activity/history?limit=1");
+
+    expect(res.status).toBe(200);
+    expect(readHistory).toHaveBeenCalledWith({ limit: 1, cursor: undefined });
+    await expect(res.json()).resolves.toMatchObject({ entries: [{ id: "hist_1" }] });
+  });
+});


### PR DESCRIPTION
## Stack

Stack order: #434 -> #436 -> #437. This is Stack 2/3 for Activity Monitor.

## Summary

- Adds the authenticated `/api/system/activity` gateway routes for machine/resource/service/process snapshots, cleanup actions, policy, and history.
- Adds host collectors for CPU, memory, disk, pressure, systemd services, and top processes with subprocess timeouts and sanitized warnings.
- Adds a bounded cleanup candidate registry with TTL, confirmation tokens, automatic-policy enforcement, and owner-file policy/history stores.

## Tests

- `pnpm exec vitest run tests/gateway/system-activity-routes.test.ts tests/gateway/system-activity-cleanup.test.ts tests/gateway/system-activity-history.test.ts tests/shell/system-activity-app.test.tsx` passed: 19 tests.
- `bun run typecheck` passed.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain outside this feature.
- `pnpm --dir www build` passed on the stack top.

## Invariants

- Source of truth: live VPS OS state (`/proc`, systemd, filesystem stats, process table) is canonical for snapshots; cleanup policy/history live in owner-controlled files under `~/system/`.
- Lock/transaction scope: there are no database writes. Cleanup actions execute only from server-issued candidate IDs plus confirmation tokens stored in a bounded TTL cache; no client-supplied PID or path is accepted as authority.
- Acceptable orphan states: if a target disappears before cleanup, the action returns `already_clean`; if history persistence fails after a mutation, the route returns a generic failure and the next snapshot reflects live state.
- Auth source of truth: routes are mounted behind the existing gateway owner auth middleware; automatic actions additionally require enabled policy and allowed type.
- Deferred scope: automatic scheduler execution, broader cache/bundle cleanup executors, and detailed history UI remain in later stack/tasks.
