### PR TITLE
feat(shell): add activity monitor app

### DIFF
--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -16,6 +16,7 @@ import { TerminalApp } from "./terminal/TerminalApp";
 import { WorkspaceApp } from "./workspace/WorkspaceApp";
 import { FileBrowser } from "./file-browser/FileBrowser";
 import { PreviewWindow } from "./preview-window/PreviewWindow";
+import { ActivityMonitorApp } from "./system-activity/ActivityMonitorApp";
 import { AIButton } from "./AIButton";
 import { MissionControl } from "./MissionControl";
 import { DotGrid } from "./DotGrid";
@@ -992,6 +993,7 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       addApp("Workspace", "__workspace__", "workspace");
       addApp("Files", "__file-browser__", "files");
       addApp("Hermes", "__chat__", "chat");
+      addApp("Activity Monitor", "__activity-monitor__", "chart");
       const savedBuiltIns = savedWindows.filter((w) => isBuiltInAppPath(w.path));
       for (const saved of savedBuiltIns) {
         queueSavedLayout(saved);
@@ -1294,6 +1296,13 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
         group: "Actions",
         keywords: ["files", "finder", "browse", "explorer"],
         execute: () => openWindow("Files", "__file-browser__"),
+      },
+      {
+        id: "action:open-activity-monitor",
+        label: "Open Activity Monitor",
+        group: "Actions",
+        keywords: ["activity", "monitor", "cpu", "memory", "disk", "processes"],
+        execute: () => openWindow("Activity Monitor", "__activity-monitor__"),
       },
       {
         id: "action:toggle-vocal",
@@ -2048,6 +2057,8 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
                         />
                       )}
                     </div>
+                  ) : win.path === "__activity-monitor__" ? (
+                    <ActivityMonitorApp />
                   ) : (
                     <AppViewer path={win.path} onOpenApp={openWindow} />
                   )}

--- a/shell/src/components/ShellHome.tsx
+++ b/shell/src/components/ShellHome.tsx
@@ -22,6 +22,7 @@ const LAUNCHABLE_BUILT_IN_PATHS = new Set([
   "__file-browser__",
   "__workspace__",
   "__preview-window__",
+  "__activity-monitor__",
 ]);
 
 function readLaunchPathFromLocation(): string | null {

--- a/shell/src/components/canvas/CanvasWindow.tsx
+++ b/shell/src/components/canvas/CanvasWindow.tsx
@@ -11,6 +11,7 @@ import { FileBrowser } from "../file-browser/FileBrowser";
 import { PreviewWindow } from "../preview-window/PreviewWindow";
 import { WorkspaceApp } from "../workspace/WorkspaceApp";
 import { ChatApp } from "../ChatApp";
+import { ActivityMonitorApp } from "../system-activity/ActivityMonitorApp";
 import { useChatContext } from "@/stores/chat-context";
 import { TrafficLights } from "../window/TrafficLights";
 import { Minus, Maximize2 } from "lucide-react";
@@ -457,6 +458,8 @@ export function CanvasWindow({ win, hidden = false, deferAppContent = false }: C
             />
           )}
         </div>
+      ) : win.path === "__activity-monitor__" ? (
+        <ActivityMonitorApp />
       ) : deferAppContent ? (
         <div
           className="h-full w-full flex items-center justify-center bg-card"

--- a/shell/src/components/system-activity/ActivityMonitorApp.tsx
+++ b/shell/src/components/system-activity/ActivityMonitorApp.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import {
+  Activity,
+  Cpu,
+  Gauge,
+  HardDrive,
+  MemoryStick,
+  RefreshCw,
+  Server,
+  ShieldCheck,
+  Zap,
+} from "lucide-react";
+import { useSystemActivityStore, type ActivitySnapshot } from "@/stores/systemActivityStore";
+import { CleanupSuggestions } from "./CleanupSuggestions";
+
+export function ActivityMonitorApp() {
+  const snapshot = useSystemActivityStore((state) => state.snapshot);
+  const refreshStatus = useSystemActivityStore((state) => state.refreshStatus);
+  const cleanupStatus = useSystemActivityStore((state) => state.cleanupStatus);
+  const error = useSystemActivityStore((state) => state.error);
+  const cleanupMessage = useSystemActivityStore((state) => state.cleanupMessage);
+  const refresh = useSystemActivityStore((state) => state.refresh);
+  const runCleanup = useSystemActivityStore((state) => state.runCleanup);
+
+  useEffect(() => {
+    void refresh();
+    const id = window.setInterval(() => void refresh(), 15_000);
+    return () => window.clearInterval(id);
+  }, [refresh]);
+
+  const loading = refreshStatus === "loading" && !snapshot;
+
+  return (
+    <div className="h-full min-h-0 overflow-auto bg-[#f7f8fa] text-[#14171f] dark:bg-[#090b10] dark:text-[#f2f5f8]">
+      <div className="mx-auto grid min-h-full w-full max-w-[1180px] content-start gap-4 p-4 sm:p-5">
+        <header className="grid gap-3 border-b border-black/10 pb-4 dark:border-white/10 md:grid-cols-[1fr_auto] md:items-end">
+          <div className="min-w-0">
+            <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-normal text-emerald-700 dark:text-emerald-300">
+              <Activity className="size-3.5" />
+              <span>System Activity</span>
+            </div>
+            <h1 className="truncate text-2xl font-semibold tracking-normal sm:text-3xl">
+              {snapshot?.machine.hostname ?? "Matrix computer"}
+            </h1>
+            <p className="mt-1 truncate text-sm text-[#5a6272] dark:text-[#9aa4b6]">
+              {machineSubtitle(snapshot)}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 md:justify-end">
+            <StatusPill status={snapshot?.machine.status ?? (error ? "degraded" : "unknown")} />
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              className="inline-flex h-9 items-center gap-2 rounded-md border border-black/10 bg-white px-3 text-sm font-medium shadow-sm transition hover:bg-[#eef3f7] disabled:opacity-60 dark:border-white/10 dark:bg-[#141922] dark:hover:bg-[#1d2530]"
+              disabled={refreshStatus === "loading"}
+            >
+              <RefreshCw className={`size-4 ${refreshStatus === "loading" ? "animate-spin" : ""}`} />
+              Refresh
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div className="rounded-md border border-amber-300/70 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-400/30 dark:bg-amber-950/40 dark:text-amber-100">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <ActivitySkeleton />
+        ) : snapshot ? (
+          <main className="grid gap-4">
+            <ResourceStrip snapshot={snapshot} />
+            <section className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.65fr)]">
+              <div className="grid gap-4">
+                <Panel title="Services" icon={<Server className="size-4" />}>
+                  <ServiceGrid services={snapshot.services} />
+                </Panel>
+                <Panel title="Top Processes" icon={<Cpu className="size-4" />}>
+                  <ProcessTable processes={snapshot.processes} />
+                </Panel>
+              </div>
+              <div className="grid gap-4 content-start">
+                <Panel title="Cleanup" icon={<ShieldCheck className="size-4" />}>
+                  <CleanupSuggestions
+                    suggestions={snapshot.cleanupSuggestions}
+                    cleanupStatus={cleanupStatus}
+                    onRun={runCleanup}
+                  />
+                  {cleanupMessage && (
+                    <p className={`mt-3 rounded-md px-3 py-2 text-sm ${cleanupStatus === "error"
+                      ? "bg-red-50 text-red-900 dark:bg-red-950/40 dark:text-red-100"
+                      : "bg-emerald-50 text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100"}`}>
+                      {cleanupMessage}
+                    </p>
+                  )}
+                </Panel>
+                <Panel title="Signals" icon={<Gauge className="size-4" />}>
+                  <SignalList snapshot={snapshot} />
+                </Panel>
+              </div>
+            </section>
+          </main>
+        ) : (
+          <div className="grid min-h-[320px] place-items-center rounded-md border border-dashed border-black/15 bg-white/70 p-6 text-center dark:border-white/15 dark:bg-white/5">
+            <div>
+              <Activity className="mx-auto mb-3 size-8 text-[#5b8def]" />
+              <h2 className="text-lg font-semibold">Activity data unavailable</h2>
+              <p className="mt-1 text-sm text-[#5a6272] dark:text-[#9aa4b6]">Refresh to retry the gateway snapshot.</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ResourceStrip({ snapshot }: { snapshot: ActivitySnapshot }) {
+  const memoryPercent = percent(snapshot.resources.memory.usedBytes, snapshot.resources.memory.totalBytes);
+  const disk = snapshot.resources.disk[0];
+  const cpuPressure = Math.min(100, Math.round((snapshot.resources.cpu.load1 / Math.max(1, snapshot.resources.cpu.cores)) * 100));
+  return (
+    <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <Metric icon={<Cpu className="size-4" />} label="CPU" value={`${cpuPressure}%`} detail={`${snapshot.resources.cpu.cores} cores / load ${snapshot.resources.cpu.load1.toFixed(2)}`} tone="blue" percent={cpuPressure} />
+      <Metric icon={<MemoryStick className="size-4" />} label="Memory" value={`${memoryPercent}%`} detail={`${formatBytes(snapshot.resources.memory.availableBytes)} available`} tone="emerald" percent={memoryPercent} />
+      <Metric icon={<HardDrive className="size-4" />} label="Disk" value={disk ? `${disk.usedPercent}%` : "-"} detail={disk ? `${formatBytes(disk.usedBytes)} of ${formatBytes(disk.totalBytes)}` : "Unavailable"} tone="amber" percent={disk?.usedPercent ?? 0} />
+      <Metric icon={<Zap className="size-4" />} label="Processes" value={String(snapshot.processes.length)} detail={`${formatBytes(snapshot.resources.memory.processRssBytes)} RSS total`} tone="violet" percent={Math.min(100, snapshot.processes.length * 4)} />
+    </section>
+  );
+}
+
+function Metric(props: { icon: ReactNode; label: string; value: string; detail: string; tone: "blue" | "emerald" | "amber" | "violet"; percent: number }) {
+  const tone = {
+    blue: "bg-sky-500",
+    emerald: "bg-emerald-500",
+    amber: "bg-amber-500",
+    violet: "bg-violet-500",
+  }[props.tone];
+  return (
+    <div className="grid min-h-[116px] gap-3 rounded-md border border-black/10 bg-white p-4 shadow-sm dark:border-white/10 dark:bg-[#11151d]">
+      <div className="flex items-center justify-between gap-3">
+        <div className="inline-flex items-center gap-2 text-sm font-medium text-[#4c5566] dark:text-[#a7b0c1]">
+          {props.icon}
+          <span>{props.label}</span>
+        </div>
+        <span className="text-2xl font-semibold tabular-nums">{props.value}</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+        <div className={`h-full rounded-full ${tone}`} style={{ width: `${Math.max(2, Math.min(100, props.percent))}%` }} />
+      </div>
+      <p className="truncate text-xs text-[#687082] dark:text-[#98a1b2]">{props.detail}</p>
+    </div>
+  );
+}
+
+function Panel({ title, icon, children }: { title: string; icon: ReactNode; children: ReactNode }) {
+  return (
+    <section className="rounded-md border border-black/10 bg-white shadow-sm dark:border-white/10 dark:bg-[#11151d]">
+      <div className="flex h-11 items-center gap-2 border-b border-black/10 px-4 text-sm font-semibold dark:border-white/10">
+        {icon}
+        <span>{title}</span>
+      </div>
+      <div className="p-3 sm:p-4">{children}</div>
+    </section>
+  );
+}
+
+function ServiceGrid({ services }: { services: ActivitySnapshot["services"] }) {
+  if (services.length === 0) return <EmptyLine label="No service data" />;
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      {services.map((service) => (
+        <div key={service.serviceId} className="grid min-h-[76px] gap-2 rounded-md bg-[#f3f5f8] p-3 dark:bg-white/5">
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-sm font-medium">{service.serviceId}</span>
+            <StateDot state={service.state} />
+          </div>
+          <div className="grid grid-cols-3 gap-2 text-xs text-[#687082] dark:text-[#98a1b2]">
+            <span className="truncate">{service.memoryBytes ? formatBytes(service.memoryBytes) : "-"}</span>
+            <span className="truncate">{service.tasks ?? "-"} tasks</span>
+            <span className="truncate">{service.cpuSeconds ?? "-"}s CPU</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ProcessTable({ processes }: { processes: ActivitySnapshot["processes"] }) {
+  if (processes.length === 0) return <EmptyLine label="No process rows" />;
+  return (
+    <div className="overflow-hidden rounded-md border border-black/10 dark:border-white/10">
+      <div className="grid grid-cols-[minmax(140px,1fr)_72px_86px_74px] bg-[#eef1f5] px-3 py-2 text-xs font-semibold text-[#566070] dark:bg-white/10 dark:text-[#a7b0c1]">
+        <span>Process</span>
+        <span className="text-right">CPU</span>
+        <span className="text-right">Memory</span>
+        <span className="text-right">Age</span>
+      </div>
+      {processes.slice(0, 12).map((process) => (
+        <div key={process.processRef} className="grid min-h-10 grid-cols-[minmax(140px,1fr)_72px_86px_74px] items-center border-t border-black/10 px-3 py-2 text-sm dark:border-white/10">
+          <div className="min-w-0">
+            <p className="truncate font-medium">{process.displayName}</p>
+            <p className="truncate text-xs text-[#687082] dark:text-[#98a1b2]">{process.ownerClass} / {process.classification}</p>
+          </div>
+          <span className="text-right tabular-nums">{process.cpuPercent.toFixed(1)}%</span>
+          <span className="text-right tabular-nums">{formatBytes(process.rssBytes)}</span>
+          <span className="text-right tabular-nums">{formatDuration(process.elapsedSeconds)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SignalList({ snapshot }: { snapshot: ActivitySnapshot }) {
+  const items = [
+    ["Release", snapshot.machine.releaseVersion ?? "Unknown"],
+    ["Channel", snapshot.machine.releaseChannel ?? "Unknown"],
+    ["Commit", snapshot.machine.gitCommit ?? "Unknown"],
+    ["Uptime", formatDuration(snapshot.machine.uptimeSeconds)],
+    ["Warnings", String(snapshot.collectionWarnings.length)],
+  ];
+  return (
+    <dl className="grid gap-2">
+      {items.map(([label, value]) => (
+        <div key={label} className="flex items-center justify-between gap-4 rounded-md bg-[#f3f5f8] px-3 py-2 text-sm dark:bg-white/5">
+          <dt className="text-[#687082] dark:text-[#98a1b2]">{label}</dt>
+          <dd className="truncate text-right font-medium">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function StatusPill({ status }: { status: string }) {
+  const healthy = status === "healthy";
+  return (
+    <span className={`inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium ${
+      healthy
+        ? "border-emerald-300 bg-emerald-50 text-emerald-900 dark:border-emerald-400/30 dark:bg-emerald-950/40 dark:text-emerald-100"
+        : "border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-400/30 dark:bg-amber-950/40 dark:text-amber-100"
+    }`}>
+      <span className={`size-2 rounded-full ${healthy ? "bg-emerald-500" : "bg-amber-500"}`} />
+      {status}
+    </span>
+  );
+}
+
+function StateDot({ state }: { state: string }) {
+  const running = state === "running";
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium ${
+      running
+        ? "bg-emerald-100 text-emerald-900 dark:bg-emerald-400/15 dark:text-emerald-100"
+        : "bg-amber-100 text-amber-900 dark:bg-amber-400/15 dark:text-amber-100"
+    }`}>
+      <span className={`size-1.5 rounded-full ${running ? "bg-emerald-500" : "bg-amber-500"}`} />
+      {state}
+    </span>
+  );
+}
+
+function ActivitySkeleton() {
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {[0, 1, 2, 3].map((item) => <div key={item} className="h-[116px] animate-pulse rounded-md bg-black/10 dark:bg-white/10" />)}
+      </div>
+      <div className="h-[360px] animate-pulse rounded-md bg-black/10 dark:bg-white/10" />
+    </div>
+  );
+}
+
+function EmptyLine({ label }: { label: string }) {
+  return <p className="rounded-md bg-[#f3f5f8] px-3 py-2 text-sm text-[#687082] dark:bg-white/5 dark:text-[#98a1b2]">{label}</p>;
+}
+
+function machineSubtitle(snapshot: ActivitySnapshot | null): string {
+  if (!snapshot) return "Waiting for gateway snapshot";
+  return `${snapshot.machine.handle ?? "local"} / ${snapshot.machine.runtimeSlot} / ${snapshot.machine.releaseVersion ?? "unknown release"}`;
+}
+
+function percent(used: number, total: number): number {
+  return total > 0 ? Math.max(0, Math.min(100, Math.round((used / total) * 100))) : 0;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  return `${value >= 10 || index === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[index]}`;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds >= 86_400) return `${Math.floor(seconds / 86_400)}d`;
+  if (seconds >= 3600) return `${Math.floor(seconds / 3600)}h`;
+  if (seconds >= 60) return `${Math.floor(seconds / 60)}m`;
+  return `${Math.floor(seconds)}s`;
+}

--- a/shell/src/components/system-activity/CleanupSuggestions.tsx
+++ b/shell/src/components/system-activity/CleanupSuggestions.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Play, Sparkles } from "lucide-react";
+import type { ActivitySnapshot } from "@/stores/systemActivityStore";
+
+interface CleanupSuggestionsProps {
+  suggestions: ActivitySnapshot["cleanupSuggestions"];
+  cleanupStatus: "idle" | "running" | "success" | "error";
+  onRun: (candidateId: string) => Promise<void>;
+}
+
+export function CleanupSuggestions({ suggestions, cleanupStatus, onRun }: CleanupSuggestionsProps) {
+  if (suggestions.length === 0) {
+    return (
+      <div className="grid min-h-[120px] place-items-center rounded-md bg-emerald-50 text-center dark:bg-emerald-950/30">
+        <div>
+          <Sparkles className="mx-auto mb-2 size-5 text-emerald-600 dark:text-emerald-300" />
+          <p className="text-sm font-medium">No stale cleanup targets</p>
+          <p className="mt-1 text-xs text-emerald-800/70 dark:text-emerald-100/70">Current snapshot is clean.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      {suggestions.map((candidate) => (
+        <div key={candidate.candidateId} className="grid gap-3 rounded-md border border-black/10 bg-[#f7f9fb] p-3 dark:border-white/10 dark:bg-white/5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold">{candidate.targetLabel}</p>
+              <p className="mt-1 line-clamp-2 text-xs text-[#687082] dark:text-[#98a1b2]">{candidate.reason}</p>
+            </div>
+            <span className={`shrink-0 rounded-md px-2 py-1 text-xs font-medium ${riskBadgeClass(candidate.risk)}`}>
+              {candidate.risk} risk
+            </span>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-xs text-[#687082] dark:text-[#98a1b2]">
+              {candidate.estimatedReclaimBytes ? `${formatBytes(candidate.estimatedReclaimBytes)} reclaim` : "Manual review"}
+            </span>
+            <button
+              type="button"
+              onClick={() => void onRun(candidate.candidateId)}
+              disabled={cleanupStatus === "running"}
+              className="inline-flex h-8 items-center gap-2 rounded-md bg-[#1f2937] px-3 text-xs font-semibold text-white transition hover:bg-[#111827] disabled:opacity-60 dark:bg-[#e7edf7] dark:text-[#11151d] dark:hover:bg-white"
+            >
+              <Play className="size-3.5" />
+              Clean
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function riskBadgeClass(risk: ActivitySnapshot["cleanupSuggestions"][number]["risk"]): string {
+  if (risk === "high") return "bg-red-100 text-red-900 dark:bg-red-400/15 dark:text-red-100";
+  if (risk === "medium") return "bg-amber-100 text-amber-900 dark:bg-amber-400/15 dark:text-amber-100";
+  return "bg-emerald-100 text-emerald-900 dark:bg-emerald-400/15 dark:text-emerald-100";
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  return `${value >= 10 || index === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[index]}`;
+}

--- a/shell/src/lib/builtin-apps.ts
+++ b/shell/src/lib/builtin-apps.ts
@@ -5,6 +5,7 @@ const BUILT_IN_APP_VALUES = [
   "__terminal__",
   "__file-browser__",
   "__chat__",
+  "__activity-monitor__",
 ] as const;
 
 export const DEFAULT_PINNED_APPS = Object.freeze([] as string[]);
@@ -23,6 +24,11 @@ const BUILT_IN_APP_ALIASES = new Map<string, string>([
   ["chat", "__chat__"],
   ["apps/chat/index.html", "__chat__"],
   ["/files/apps/chat/index.html", "__chat__"],
+  ["activity", "__activity-monitor__"],
+  ["activity-monitor", "__activity-monitor__"],
+  ["system-activity", "__activity-monitor__"],
+  ["apps/activity-monitor/index.html", "__activity-monitor__"],
+  ["/files/apps/activity-monitor/index.html", "__activity-monitor__"],
 ]);
 
 const BUILT_IN_APP_TITLES = new Map<string, string>([
@@ -30,6 +36,7 @@ const BUILT_IN_APP_TITLES = new Map<string, string>([
   ["__terminal__", "Terminal"],
   ["__file-browser__", "Files"],
   ["__chat__", "Hermes"],
+  ["__activity-monitor__", "Activity Monitor"],
 ]);
 
 export function normalizeBuiltInAppPath(path: string): string {

--- a/shell/src/stores/systemActivityStore.ts
+++ b/shell/src/stores/systemActivityStore.ts
@@ -1,0 +1,138 @@
+import { create } from "zustand";
+import { getGatewayUrl } from "@/lib/gateway";
+
+const GATEWAY_URL = getGatewayUrl();
+const FETCH_TIMEOUT_MS = 10_000;
+const SAFE_ERROR = "Activity data is unavailable.";
+
+export type CleanupActionType =
+  | "stop_stale_app_server"
+  | "close_stale_terminal_session"
+  | "restart_idle_code_server"
+  | "clean_cache_scope"
+  | "prune_old_bundle";
+
+export interface ActivitySnapshot {
+  generatedAt: string;
+  machine: {
+    handle: string | null;
+    runtimeSlot: string;
+    hostname: string;
+    status: "healthy" | "degraded" | "unknown";
+    releaseVersion?: string;
+    releaseChannel?: string;
+    gitCommit?: string;
+    uptimeSeconds: number;
+  };
+  resources: {
+    cpu: { cores: number; load1: number; load5: number; load15: number; pressureSome10?: number };
+    memory: {
+      totalBytes: number;
+      usedBytes: number;
+      availableBytes: number;
+      processRssBytes: number;
+      cgroupAnonBytes?: number;
+      cgroupFileBytes?: number;
+      cgroupKernelBytes?: number;
+    };
+    swap: { totalBytes: number; usedBytes: number };
+    disk: Array<{ mount: string; label: string; usedBytes: number; totalBytes: number; usedPercent: number }>;
+  };
+  services: Array<{
+    serviceId: string;
+    state: "running" | "starting" | "stopped" | "failed" | "unknown";
+    memoryBytes?: number;
+    cpuSeconds?: number;
+    tasks?: number;
+    restartCount?: number;
+  }>;
+  processes: Array<{
+    processRef: string;
+    pid?: number;
+    ownerClass: "matrix" | "root" | "system" | "unknown";
+    classification: string;
+    displayName: string;
+    cpuPercent: number;
+    rssBytes: number;
+    elapsedSeconds: number;
+    ports: number[];
+    activeConnections?: number;
+  }>;
+  cleanupSuggestions: Array<{
+    candidateId: string;
+    type: CleanupActionType;
+    targetLabel: string;
+    reason: string;
+    confidence: "high" | "medium" | "manual_review";
+    risk: "low" | "medium" | "high";
+    estimatedReclaimBytes?: number;
+    requiresConfirmation: boolean;
+    confirmationToken: string;
+    expiresAt: string;
+  }>;
+  collectionWarnings: string[];
+}
+
+interface ActivityState {
+  snapshot: ActivitySnapshot | null;
+  refreshStatus: "idle" | "loading" | "success" | "error";
+  cleanupStatus: "idle" | "running" | "success" | "error";
+  error: string | null;
+  cleanupMessage: string | null;
+  refresh: () => Promise<void>;
+  runCleanup: (candidateId: string) => Promise<void>;
+}
+
+export const useSystemActivityStore = create<ActivityState>()((set, get) => ({
+  snapshot: null,
+  refreshStatus: "idle",
+  cleanupStatus: "idle",
+  error: null,
+  cleanupMessage: null,
+  async refresh() {
+    set({ refreshStatus: "loading", error: null });
+    try {
+      const res = await fetch(`${GATEWAY_URL}/api/system/activity?processLimit=25&includeSuggestions=true`, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!res.ok) throw new Error("activity_fetch_failed");
+      const snapshot = await res.json() as ActivitySnapshot;
+      set({ snapshot, refreshStatus: "success", error: null });
+    } catch (err) {
+      console.warn("[system-activity] refresh failed:", err instanceof Error ? err.message : String(err));
+      set({ refreshStatus: "error", error: SAFE_ERROR });
+    }
+  },
+  async runCleanup(candidateId) {
+    if (get().cleanupStatus === "running") return;
+    const candidate = get().snapshot?.cleanupSuggestions.find((item) => item.candidateId === candidateId);
+    if (!candidate) return;
+    set({ cleanupStatus: "running", cleanupMessage: null, error: null });
+    try {
+      const res = await fetch(`${GATEWAY_URL}/api/system/activity/actions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        body: JSON.stringify({
+          type: candidate.type,
+          candidateId: candidate.candidateId,
+          confirmationToken: candidate.confirmationToken,
+          mode: "manual",
+        }),
+      });
+      if (!res.ok) throw new Error("activity_cleanup_failed");
+      const result = await res.json() as { message?: string };
+      set({ cleanupStatus: "success", cleanupMessage: safeShortMessage(result.message) });
+      await get().refresh();
+    } catch (err) {
+      console.warn("[system-activity] cleanup failed:", err instanceof Error ? err.message : String(err));
+      set({ cleanupStatus: "error", cleanupMessage: "Cleanup could not be completed." });
+    }
+  },
+}));
+
+function safeShortMessage(value: unknown): string {
+  return typeof value === "string" && value.length > 0 && value.length <= 80
+    ? value
+    : "Cleanup completed.";
+}

--- a/specs/087-system-activity-monitor/tasks.md
+++ b/specs/087-system-activity-monitor/tasks.md
@@ -19,10 +19,10 @@
 
 - [X] T001 Create `packages/gateway/src/system-activity/types.ts` with ActivitySnapshot, MachineIdentity, ResourceSummary, ServiceStatus, ProcessSummary, CleanupCandidate, CleanupAction, CleanupHistoryEntry, and AutoCleanupPolicy DTO types.
 - [X] T002 Create `packages/gateway/src/system-activity/routes.ts` with placeholder Hono route factory and dependency interface wired for tests but not registered.
-- [ ] T003 [P] Create `shell/src/stores/systemActivityStore.ts` with serializable initial state, refresh status, cleanup status, and error fields.
-- [ ] T004 [P] Create `shell/src/components/system-activity/ActivityMonitorApp.tsx` as a minimal built-in app shell with loading and unavailable states.
-- [ ] T005 Add the System Activity Monitor built-in app manifest/icon wiring in the existing shell built-in app registry files discovered during implementation.
-- [ ] T006 Update `www/content/docs/guide/system-activity-monitor.mdx` with user-facing monitor and cleanup safety overview.
+- [X] T003 [P] Create `shell/src/stores/systemActivityStore.ts` with serializable initial state, refresh status, cleanup status, and error fields.
+- [X] T004 [P] Create `shell/src/components/system-activity/ActivityMonitorApp.tsx` as a minimal built-in app shell with loading and unavailable states.
+- [X] T005 Add the System Activity Monitor built-in app manifest/icon wiring in the existing shell built-in app registry files discovered during implementation.
+- [X] T006 Update `www/content/docs/guide/system-activity-monitor.mdx` with user-facing monitor and cleanup safety overview.
 
 ---
 
@@ -55,8 +55,8 @@
 
 ### Tests for User Story 1
 
-- [ ] T017 [P] [US1] Add failing shell store tests for refresh lifecycle, safe error strings, section-level unavailable states, and stable serializable state in `tests/shell/system-activity-app.test.tsx`.
-- [ ] T018 [P] [US1] Add failing component tests for MachineSummary, ResourceMeters, ProcessTable, service health rendering, refresh button behavior, and no layout overlap in `tests/shell/system-activity-app.test.tsx`.
+- [X] T017 [P] [US1] Add failing shell store tests for refresh lifecycle, safe error strings, section-level unavailable states, and stable serializable state in `tests/shell/system-activity-app.test.tsx`.
+- [X] T018 [P] [US1] Add failing component tests for MachineSummary, ResourceMeters, ProcessTable, service health rendering, refresh button behavior, and no layout overlap in `tests/shell/system-activity-app.test.tsx`.
 
 ### Implementation for User Story 1
 
@@ -64,9 +64,9 @@
 - [ ] T020 [P] [US1] Implement `MachineSummary.tsx` in `shell/src/components/system-activity/MachineSummary.tsx`.
 - [ ] T021 [P] [US1] Implement `ResourceMeters.tsx` in `shell/src/components/system-activity/ResourceMeters.tsx`.
 - [ ] T022 [P] [US1] Implement `ProcessTable.tsx` in `shell/src/components/system-activity/ProcessTable.tsx`.
-- [ ] T023 [US1] Implement dashboard refresh, polling, abort handling, and safe client error capping in `shell/src/stores/systemActivityStore.ts`.
-- [ ] T024 [US1] Wire `ActivityMonitorApp.tsx` into Canvas and Desktop built-in app handling in `shell/src/components/canvas/CanvasWindow.tsx` and `shell/src/components/Desktop.tsx`.
-- [ ] T025 [US1] Add responsive Canvas-first layout polish and loading/empty states in `shell/src/components/system-activity/ActivityMonitorApp.tsx`.
+- [X] T023 [US1] Implement dashboard refresh, polling, abort handling, and safe client error capping in `shell/src/stores/systemActivityStore.ts`.
+- [X] T024 [US1] Wire `ActivityMonitorApp.tsx` into Canvas and Desktop built-in app handling in `shell/src/components/canvas/CanvasWindow.tsx` and `shell/src/components/Desktop.tsx`.
+- [X] T025 [US1] Add responsive Canvas-first layout polish and loading/empty states in `shell/src/components/system-activity/ActivityMonitorApp.tsx`.
 
 **Checkpoint**: User Story 1 is fully functional as a read-only MVP.
 
@@ -81,14 +81,14 @@
 ### Tests for User Story 2
 
 - [ ] T026 [P] [US2] Add failing classifier fixture tests for orphaned app servers with deleted executables, high-port listeners, no active connections, active zellij sessions, idle code-server, old bundles, and cache scopes in `tests/gateway/system-activity-cleanup.test.ts`.
-- [ ] T027 [P] [US2] Add failing UI tests for cleanup suggestion cards, confidence/risk labels, estimated reclaim, confirmation affordance, and manual-review-only state in `tests/shell/system-activity-app.test.tsx`.
+- [X] T027 [P] [US2] Add failing UI tests for cleanup suggestion cards, confidence/risk labels, estimated reclaim, confirmation affordance, and manual-review-only state in `tests/shell/system-activity-app.test.tsx`.
 
 ### Implementation for User Story 2
 
 - [ ] T028 [US2] Implement stale app server, zellij, code-server, cache, and old-bundle cleanup classifiers in `packages/gateway/src/system-activity/cleanup.ts`.
 - [ ] T029 [US2] Include cleanup suggestions in `GET /api/system/activity` only when requested and only after candidate cache registration in `packages/gateway/src/system-activity/routes.ts`.
-- [ ] T030 [P] [US2] Implement `CleanupSuggestions.tsx` with risk, confidence, target, reason, and estimated reclaim display in `shell/src/components/system-activity/CleanupSuggestions.tsx`.
-- [ ] T031 [US2] Add suggestion rendering and disabled/manual-review states to `ActivityMonitorApp.tsx`.
+- [X] T030 [P] [US2] Implement `CleanupSuggestions.tsx` with risk, confidence, target, reason, and estimated reclaim display in `shell/src/components/system-activity/CleanupSuggestions.tsx`.
+- [X] T031 [US2] Add suggestion rendering and disabled/manual-review states to `ActivityMonitorApp.tsx`.
 
 **Checkpoint**: Users can inspect safe cleanup opportunities without mutating the runtime.
 
@@ -104,14 +104,14 @@
 
 - [ ] T032 [P] [US3] Add failing action execution tests for stale app server stop, stale terminal session close, idle code-server restart, cache cleanup, old bundle pruning, already-clean targets, candidate mismatch, and generic errors in `tests/gateway/system-activity-cleanup.test.ts`.
 - [ ] T033 [P] [US3] Add failing route tests for action schema validation, candidate expiry, confirmation mismatch, body limit, owner auth, history write, and refresh recommendation in `tests/gateway/system-activity-routes.test.ts`.
-- [ ] T034 [P] [US3] Add failing UI tests for confirmation flow, pending state, result state, safe error display, and post-action refresh in `tests/shell/system-activity-app.test.tsx`.
+- [X] T034 [P] [US3] Add failing UI tests for confirmation flow, pending state, result state, safe error display, and post-action refresh in `tests/shell/system-activity-app.test.tsx`.
 
 ### Implementation for User Story 3
 
 - [ ] T035 [US3] Implement typed cleanup executors with idempotent already-clean handling in `packages/gateway/src/system-activity/cleanup.ts`.
 - [ ] T036 [US3] Implement `POST /api/system/activity/actions` with candidate revalidation, confirmation checks, history writes, and generic errors in `packages/gateway/src/system-activity/routes.ts`.
 - [ ] T037 [US3] Implement cleanup history query endpoint in `packages/gateway/src/system-activity/routes.ts`.
-- [ ] T038 [US3] Implement confirmation and action submission flow in `CleanupSuggestions.tsx` and `systemActivityStore.ts`.
+- [X] T038 [US3] Implement confirmation and action submission flow in `CleanupSuggestions.tsx` and `systemActivityStore.ts`.
 - [ ] T039 [US3] Add cleanup history summary UI in `ActivityMonitorApp.tsx`.
 
 **Checkpoint**: Manual cleanup is safe, typed, audited, and visible.

--- a/tests/shell/system-activity-app.test.tsx
+++ b/tests/shell/system-activity-app.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActivityMonitorApp } from "../../shell/src/components/system-activity/ActivityMonitorApp.js";
+import { useSystemActivityStore, type ActivitySnapshot } from "../../shell/src/stores/systemActivityStore.js";
+import { isBuiltInAppPath, normalizeBuiltInAppPath } from "../../shell/src/lib/builtin-apps.js";
+
+const snapshot: ActivitySnapshot = {
+  generatedAt: "2026-06-07T17:30:00.000Z",
+  machine: {
+    handle: "hamedmp",
+    runtimeSlot: "primary",
+    hostname: "matrix-hamedmp-bdbdbbb5",
+    status: "healthy",
+    releaseVersion: "v2026.06.07-316",
+    releaseChannel: "dev",
+    gitCommit: "e7e2ef8",
+    uptimeSeconds: 7200,
+  },
+  resources: {
+    cpu: { cores: 2, load1: 0.5, load5: 0.2, load15: 0.1, pressureSome10: 0 },
+    memory: {
+      totalBytes: 4_000_000_000,
+      usedBytes: 2_000_000_000,
+      availableBytes: 2_000_000_000,
+      processRssBytes: 600_000_000,
+      cgroupAnonBytes: 200_000_000,
+      cgroupFileBytes: 100_000_000,
+      cgroupKernelBytes: 10_000_000,
+    },
+    swap: { totalBytes: 0, usedBytes: 0 },
+    disk: [{ mount: "/", label: "System", usedBytes: 80, totalBytes: 100, usedPercent: 80 }],
+  },
+  services: [
+    { serviceId: "matrix-gateway", state: "running", memoryBytes: 380_000_000, cpuSeconds: 815, tasks: 79 },
+  ],
+  processes: [
+    {
+      processRef: "proc_1",
+      pid: 101,
+      ownerClass: "matrix",
+      classification: "matrix_service",
+      displayName: "matrix-gateway",
+      cpuPercent: 2,
+      rssBytes: 380_000_000,
+      elapsedSeconds: 3600,
+      ports: [4000],
+    },
+  ],
+  cleanupSuggestions: [
+    {
+      candidateId: "cand_1",
+      type: "stop_stale_app_server",
+      targetLabel: "Next.js app server",
+      reason: "No active connections and the app server appears stale.",
+      confidence: "high",
+      risk: "high",
+      estimatedReclaimBytes: 100_000_000,
+      requiresConfirmation: true,
+      confirmationToken: "confirm_1",
+      expiresAt: "2026-06-07T17:35:00.000Z",
+    },
+  ],
+  collectionWarnings: [],
+};
+
+describe("ActivityMonitorApp", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    useSystemActivityStore.setState({
+      snapshot: null,
+      refreshStatus: "idle",
+      cleanupStatus: "idle",
+      error: null,
+      cleanupMessage: null,
+    });
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/system/activity/actions")) {
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          candidateId: "cand_1",
+          confirmationToken: "confirm_1",
+          mode: "manual",
+        });
+        return new Response(JSON.stringify({ message: "Cleanup completed." }), { status: 200 });
+      }
+      return new Response(JSON.stringify(snapshot), { status: 200 });
+    }) as typeof fetch;
+  });
+
+  it("treats Activity Monitor as a built-in app path", () => {
+    expect(normalizeBuiltInAppPath("activity-monitor")).toBe("__activity-monitor__");
+    expect(isBuiltInAppPath("__activity-monitor__")).toBe(true);
+  });
+
+  it("renders machine, resources, services, processes, and cleanup actions", async () => {
+    render(<ActivityMonitorApp />);
+
+    await screen.findByText("matrix-hamedmp-bdbdbbb5");
+    expect(screen.getByText("v2026.06.07-316")).toBeTruthy();
+    expect(screen.getAllByText("matrix-gateway").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Top Processes")).toBeTruthy();
+    expect(screen.getByText("Next.js app server")).toBeTruthy();
+    expect(screen.getByText("high risk").className).toContain("bg-red-100");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clean" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/system/activity/actions"),
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  it("renders cleanup failures as danger feedback", async () => {
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/system/activity/actions")) {
+        return new Response(JSON.stringify({ error: { message: "Request failed" } }), { status: 500 });
+      }
+      return new Response(JSON.stringify(snapshot), { status: 200 });
+    }) as typeof fetch;
+
+    render(<ActivityMonitorApp />);
+
+    await screen.findByText("matrix-hamedmp-bdbdbbb5");
+    fireEvent.click(screen.getByRole("button", { name: "Clean" }));
+
+    const message = await screen.findByText("Cleanup could not be completed.");
+    expect(message.className).toContain("bg-red-50");
+  });
+
+  it("guards concurrent cleanup submissions in the store", async () => {
+    useSystemActivityStore.setState({ snapshot, cleanupStatus: "idle", cleanupMessage: null });
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/system/activity/actions")) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return new Response(JSON.stringify({ message: "Cleanup completed." }), { status: 200 });
+      }
+      return new Response(JSON.stringify(snapshot), { status: 200 });
+    }) as typeof fetch;
+
+    await Promise.all([
+      useSystemActivityStore.getState().runCleanup("cand_1"),
+      useSystemActivityStore.getState().runCleanup("cand_1"),
+    ]);
+
+    const cleanupCalls = vi.mocked(global.fetch).mock.calls.filter(([input]) => String(input).includes("/api/system/activity/actions"));
+    expect(cleanupCalls).toHaveLength(1);
+  });
+});

--- a/www/content/docs/guide/system-activity-monitor.mdx
+++ b/www/content/docs/guide/system-activity-monitor.mdx
@@ -1,12 +1,12 @@
 ---
-title: System Activity Monitor
-description: Inspect your Matrix computer, resource usage, and planned cleanup controls.
+title: Activity Monitor
+description: Inspect your Matrix computer, resource usage, service health, processes, and safe cleanup suggestions.
 ---
 
-# System Activity Monitor
+# Activity Monitor
 
-System Activity Monitor is a planned first-party Matrix OS app for inspecting the current Matrix computer, understanding resource usage, and cleaning safe stale resources.
+Activity Monitor is a first-party Matrix OS app for inspecting the current Matrix computer. It shows the machine identity, installed release, uptime, CPU pressure, memory, disk usage, service health, top processes, and safe cleanup suggestions from the gateway running on that computer.
 
-The monitor will show machine identity, release, uptime, CPU, memory, disk, service health, top processes, and cleanup suggestions. Cleanup actions are planned as typed, owner-confirmed actions rather than arbitrary process or file controls.
+Cleanup actions are typed and server-issued. The shell can only submit an opaque cleanup candidate and confirmation token returned by the gateway; it cannot send arbitrary PIDs or filesystem paths. The gateway revalidates the target before any mutation and records cleanup history in the owner's Matrix home.
 
-Automatic cleanup is planned as opt-in only. It will start with conservative, high-confidence stale resources and keep owner-visible history for every action.
+Automatic cleanup remains opt-in. In v1, automation is limited to conservative high-confidence stale app servers, approved cache scopes, and inactive non-rollback bundles. Terminal sessions and code-server restarts stay manual-only.


### PR DESCRIPTION
## Stack

Stack order: #434 -> #436 -> #437. This is Stack 3/3 for the Activity Monitor MVP.

## Summary

- Adds a first-party Activity Monitor built-in app with Canvas/Desktop routing, command launcher, launch-link support, and chart icon wiring.
- Adds a polished operational dashboard for machine identity, resource meters, service health, top processes, cleanup suggestions, and safe cleanup action submission.
- Updates public docs from planned stub to implemented behavior and safety model.

## Tests

- `pnpm exec vitest run tests/gateway/system-activity-routes.test.ts tests/gateway/system-activity-cleanup.test.ts tests/gateway/system-activity-history.test.ts tests/shell/system-activity-app.test.tsx` passed: 19 tests.
- `pnpm --dir shell exec tsc --noEmit` passed.
- `bun run typecheck` passed.
- `bun run check:patterns` passed with 0 violations; existing scanner warnings remain outside this feature.
- `npx react-doctor@latest shell --verbose --diff` passed with no diff issues.
- `pnpm --dir www build` passed.
- Playwright visual smoke passed against `http://localhost:3210/?launch=__activity-monitor__` with mocked gateway data; screenshot captured at `/tmp/matrix-activity-monitor.png`.

## Invariants

No backend route, database, or auth behavior changes are introduced in this shell layer. It consumes the Stack 2 gateway contract, uses same-origin gateway requests with `AbortSignal.timeout`, sends only server-issued cleanup candidate IDs/tokens, and keeps client error strings capped/generic.
