### PR TITLE
fix(symphony): compile Linear bridge credential checks

### DIFF
--- a/packages/symphony-elixir/lib/symphony_elixir/linear/client.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/linear/client.ex
@@ -387,11 +387,13 @@ defmodule SymphonyElixir.Linear.Client do
   end
 
   defp graphql_headers do
+    bridge_credential = Bridge.credential()
+
     case Config.settings!().tracker.api_key do
       nil ->
         {:error, :missing_linear_api_token}
 
-      token when token == Bridge.credential() ->
+      ^bridge_credential ->
         {:ok,
          [
            {"Content-Type", "application/json"}
@@ -407,8 +409,10 @@ defmodule SymphonyElixir.Linear.Client do
   end
 
   defp graphql_request_fun do
+    bridge_credential = Bridge.credential()
+
     case Config.settings!().tracker.api_key do
-      token when token == Bridge.credential() -> &post_matrix_linear_bridge_request/2
+      ^bridge_credential -> &post_matrix_linear_bridge_request/2
       _ -> &post_graphql_request/2
     end
   end

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -258,6 +258,8 @@ describe("customer VPS Symphony systemd unit", () => {
     const presenter = await readFile("packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex", "utf8");
 
     expect(linearClient).toContain("Bridge.credential()");
+    expect(linearClient).toContain("bridge_credential = Bridge.credential()");
+    expect(linearClient).not.toMatch(/when\s+\w+\s*==\s*Bridge\.credential\(\)/);
     expect(presenter).toContain("is_binary(settings.tracker.api_key) and settings.tracker.api_key == Bridge.credential()");
     expect(linearClient).toContain("PLATFORM_INTERNAL_URL");
     expect(linearClient).toContain("UPGRADE_TOKEN");


### PR DESCRIPTION
## Summary
- Precompute the Matrix Linear bridge credential before comparing tracker API keys.
- Add a regression assertion so Linear bridge comparisons cannot call `Bridge.credential()` inside guards again.

## Invariants
- Source of truth: Symphony Linear routing still uses `Config.settings!().tracker.api_key`; the bridge sentinel remains `Bridge.credential()`.
- Lock/transaction scope: no database or file writes are introduced.
- Acceptable orphan states: unchanged; this only affects request routing during Linear GraphQL calls.
- Auth source of truth: unchanged; Matrix-owned Linear bridge calls still require `PLATFORM_INTERNAL_URL`, `UPGRADE_TOKEN`, and `MATRIX_HANDLE`.
- Deferred scope: this PR does not change the Matrix app controls or VPS rollout; it unblocks the host-bundle release compile failure from run 27101113720.

## Verification
- `bun run test tests/deploy/customer-vps/symphony-systemd.test.ts`
- `bun run typecheck`
- `bun run check:patterns`