### PR TITLE
fix(086): compile symphony host bundle

### DIFF
--- a/packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex
@@ -1934,8 +1934,12 @@ defmodule SymphonyElixir.StatusDashboard do
   defp alternate_key(key) when is_atom(key), do: Atom.to_string(key)
   defp alternate_key(key), do: key
 
-  defp truncate(value, max) when String.length(value) > max do
-    value |> String.slice(0, max) |> Kernel.<>("...")
+  defp truncate(value, max) when is_binary(value) do
+    if String.length(value) > max do
+      value |> String.slice(0, max) |> Kernel.<>("...")
+    else
+      value
+    end
   end
 
   defp truncate(value, _max), do: value

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -159,7 +159,7 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(statusDashboard).toContain("defp tps_graph(samples, now_ms, _current_tokens)");
     expect(statusDashboard).toMatch(/samples\s*\|>\s*prune_graph_samples\(now_ms\)/);
     expect(statusDashboard).toContain("String.length(value) <= width");
-    expect(statusDashboard).toContain("when String.length(value) > max");
+    expect(statusDashboard).toContain("if String.length(value) > max do");
     expect(statusDashboard).not.toContain('Enum.map_join(", ", &format_retry_summary/1)');
     expect(statusDashboard).not.toContain("when byte_size(value) > max");
     expect(statusDashboard).toContain("String.trim_trailing");
@@ -256,10 +256,13 @@ describe("customer VPS Symphony systemd unit", () => {
   it("routes Linear through the Matrix-owned integration bridge by default", async () => {
     const linearClient = await readFile("packages/symphony-elixir/lib/symphony_elixir/linear/client.ex", "utf8");
     const presenter = await readFile("packages/symphony-elixir/lib/symphony_elixir_web/presenter.ex", "utf8");
+    const statusDashboard = await readFile("packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex", "utf8");
 
     expect(linearClient).toContain("Bridge.credential()");
     expect(linearClient).toContain("bridge_credential = Bridge.credential()");
     expect(linearClient).not.toMatch(/when\s+\w+\s*==\s*Bridge\.credential\(\)/);
+    expect(linearClient).not.toContain("when token == Bridge.credential()");
+    expect(statusDashboard).not.toContain("when String.length(");
     expect(presenter).toContain("is_binary(settings.tracker.api_key) and settings.tracker.api_key == Bridge.credential()");
     expect(linearClient).toContain("PLATFORM_INTERNAL_URL");
     expect(linearClient).toContain("UPGRADE_TOKEN");


### PR DESCRIPTION
## Summary
- fix Symphony Elixir guard expressions that failed host bundle compilation on main
- keep Matrix Linear bridge routing behavior unchanged while binding the bridge credential before case guards
- update deploy regression coverage so invalid remote-call guards do not come back

## Invariants
- Source of truth: existing Symphony Elixir config remains canonical for tracker credentials and dashboard rendering.
- Lock/transaction scope: no persistence, locks, transactions, or network calls are added.
- Acceptable orphan states: not applicable; this is a compile-only control-flow fix.
- Auth source of truth: unchanged; Matrix bridge credential still routes Linear calls through the platform integration bridge, direct tokens still use Linear authorization headers.
- Deferred scope: existing Elixir dependency warnings and File.realpath warnings are not changed in this PR.

## Verification
- pnpm test tests/deploy/customer-vps/symphony-systemd.test.ts
- mix compile