### PR TITLE
fix(086): stop native login refresh loop

### DIFF
--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -9,9 +9,7 @@ struct MatrixWebShellPanel: View {
     let url: URL?
     let title: String
 
-    @State private var token: String?
-    @State private var didResolveToken = false
-    @State private var authRequired = false
+    @State private var authState = WebShellAuthState()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -54,25 +52,24 @@ struct MatrixWebShellPanel: View {
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.surfaceCard)
-            } else if !didResolveToken {
+            } else if !authState.didResolveToken {
                 ProgressView()
                     .controlSize(.small)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(Color.canvasVoid)
-            } else if authRequired || token == nil {
+            } else if authState.shouldShowSignInPrompt {
                 NoProfileView(
                     onCreate: { model.beginSignIn(mode: .signUp) },
                     onSignIn: { model.beginSignIn(mode: .signIn) },
                     onCancelSignIn: { model.cancelSignIn() },
                     signIn: model.signIn
                 )
-            } else if let url {
+            } else if let url, let token = authState.token {
                 WebShellView(
                     url: url,
                     bearerToken: token,
                     onAuthRequired: {
-                        authRequired = true
-                        Task { await reloadBearerToken() }
+                        authState.markHostedAuthRequired()
                     }
                 )
             } else {
@@ -88,28 +85,57 @@ struct MatrixWebShellPanel: View {
         .task(id: url) {
             await reloadBearerToken()
         }
-        .onChange(of: model.signIn) { _, _ in
-            Task { await reloadBearerToken() }
+        .onChange(of: model.signIn) { oldValue, newValue in
+            Task {
+                let source: WebShellAuthState.TokenResolutionSource = oldValue != .idle && newValue == .idle
+                    ? .explicitSignIn
+                    : .automatic
+                await reloadBearerToken(source: source)
+            }
         }
     }
 
     @MainActor
-    private func reloadBearerToken() async {
+    private func reloadBearerToken(source: WebShellAuthState.TokenResolutionSource = .automatic) async {
         guard url != nil else {
-            token = nil
-            didResolveToken = true
-            authRequired = false
+            authState.resolveToken(nil, source: source)
             return
         }
-        didResolveToken = false
+        authState.markResolving()
         let current = await model.currentBearerToken()
-        token = current
+        authState.resolveToken(current, source: source)
+    }
+}
+
+struct WebShellAuthState: Equatable, Sendable {
+    enum TokenResolutionSource: Sendable {
+        case automatic
+        case explicitSignIn
+    }
+
+    private(set) var token: String?
+    private(set) var didResolveToken = false
+    private(set) var hostedAuthRequired = false
+
+    var shouldShowSignInPrompt: Bool {
+        didResolveToken && (token == nil || hostedAuthRequired)
+    }
+
+    mutating func markResolving() {
+        didResolveToken = false
+    }
+
+    mutating func resolveToken(_ nextToken: String?, source: TokenResolutionSource = .automatic) {
+        token = nextToken
         didResolveToken = true
-        if current != nil {
-            authRequired = false
-        } else {
-            authRequired = true
+        if nextToken == nil || source == .explicitSignIn {
+            hostedAuthRequired = false
         }
+    }
+
+    mutating func markHostedAuthRequired() {
+        hostedAuthRequired = true
+        didResolveToken = true
     }
 }
 

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -7,6 +7,28 @@ import MatrixNet
 
 @MainActor
 final class AppModelAuthTests: XCTestCase {
+    func testWebShellAuthStateKeepsPromptWhenHostedShellRequiresAuth() {
+        var state = WebShellAuthState()
+
+        state.resolveToken("native-token")
+        state.markHostedAuthRequired()
+        state.resolveToken("native-token")
+
+        XCTAssertTrue(state.shouldShowSignInPrompt)
+        XCTAssertEqual(state.token, "native-token")
+    }
+
+    func testWebShellAuthStateClearsPromptAfterExplicitSignInReload() {
+        var state = WebShellAuthState()
+
+        state.resolveToken("old-token")
+        state.markHostedAuthRequired()
+        state.resolveToken("new-token", source: .explicitSignIn)
+
+        XCTAssertFalse(state.shouldShowSignInPrompt)
+        XCTAssertEqual(state.token, "new-token")
+    }
+
     func testRefreshRequiresTokenEvenWhenProfileIsPersisted() async {
         let principal = PrincipalProvider(store: MemoryTokenStore())
         let profile = ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com")


### PR DESCRIPTION
## Summary
- Prevent the macOS native shell from looping when the hosted shell redirects to sign-in.
- Keep the native sign-in prompt visible until an explicit native sign-in completes.
- Add regression coverage for the native web shell auth state transition.

## Tests
- `swift test --package-path macos --filter AppModelAuthTests`
- `swift test --package-path macos`
- `./script/build_and_run.sh --verify`

## Invariants
- **Source of truth**: the native principal token remains the Keychain-backed Matrix token; the hosted app-session cookie is derived from that token by `/api/auth/app-session`.
- **Lock/transaction scope**: no database writes or transactions are introduced; this is local SwiftUI/WebView auth state only.
- **Acceptable orphan states**: if the hosted shell rejects the derived session, the native app stays on the sign-in prompt while preserving the existing token for debugging/retry; it does not reload the hosted login page in a loop.
- **Auth source of truth**: explicit native device sign-in is the only event that clears a hosted-auth rejection. Automatic keychain reloads cannot mark a previously rejected token valid again.
- **Deferred scope**: this does not change Clerk, platform routing, device auth issuance, or customer VPS gateway behavior.
