### PR TITLE
fix(symphony): compile status dashboard truncation

### DIFF
--- a/packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/packages/symphony-elixir/lib/symphony_elixir/status_dashboard.ex
@@ -1934,8 +1934,12 @@ defmodule SymphonyElixir.StatusDashboard do
   defp alternate_key(key) when is_atom(key), do: Atom.to_string(key)
   defp alternate_key(key), do: key
 
-  defp truncate(value, max) when String.length(value) > max do
-    value |> String.slice(0, max) |> Kernel.<>("...")
+  defp truncate(value, max) when is_binary(value) and is_integer(max) do
+    if String.length(value) > max do
+      value |> String.slice(0, max) |> Kernel.<>("...")
+    else
+      value
+    end
   end
 
   defp truncate(value, _max), do: value

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -159,7 +159,8 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(statusDashboard).toContain("defp tps_graph(samples, now_ms, _current_tokens)");
     expect(statusDashboard).toMatch(/samples\s*\|>\s*prune_graph_samples\(now_ms\)/);
     expect(statusDashboard).toContain("String.length(value) <= width");
-    expect(statusDashboard).toContain("when String.length(value) > max");
+    expect(statusDashboard).toContain("if String.length(value) > max do");
+    expect(statusDashboard).not.toContain("when String.length(value) > max");
     expect(statusDashboard).not.toContain('Enum.map_join(", ", &format_retry_summary/1)');
     expect(statusDashboard).not.toContain("when byte_size(value) > max");
     expect(statusDashboard).toContain("String.trim_trailing");


### PR DESCRIPTION
## Summary
- Move `String.length/1` out of the `truncate/2` guard in the Symphony status dashboard.
- Add a regression assertion so the release compiler failure cannot be reintroduced.

## Invariants
- Source of truth: terminal dashboard formatting remains local to `StatusDashboard`; no runtime state source changes.
- Lock/transaction scope: no database or file writes are introduced.
- Acceptable orphan states: unchanged; this only affects dashboard string truncation during Symphony startup/build.
- Auth source of truth: unchanged; no auth path or external API path changes.
- Deferred scope: this PR does not change Matrix app service controls or deploy hamedmp directly; it unblocks the host-bundle release failure from run 27103622889.

## Verification
- `bun run test tests/deploy/customer-vps/symphony-systemd.test.ts`
- `bun run typecheck`
- `bun run check:patterns`