### PR TITLE
fix(symphony): export host env to runtime service

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -79,6 +79,7 @@ write_files:
       User=matrix
       Group=matrix
       EnvironmentFile=/opt/matrix/env/host.env
+      Environment=SYMPHONY_PORT=4766
       WorkingDirectory=/opt/matrix
       ExecStart=/opt/matrix/bin/matrix-gateway
       Restart=on-failure
@@ -747,6 +748,13 @@ write_files:
       NEXT_PUBLIC_POSTHOG_HOST={{posthogHost}}
       NEXT_PUBLIC_POSTHOG_API_HOST={{posthogApiHost}}
       DATABASE_URL=postgresql://matrix:{{postgresPassword}}@127.0.0.1:5432/matrix
+  - path: /opt/matrix/env/symphony.env
+    owner: root:root
+    permissions: "0640"
+    content: |
+      MATRIX_HANDLE={{handle}}
+      PLATFORM_INTERNAL_URL={{platformInternalUrl}}
+      UPGRADE_TOKEN={{platformVerificationToken}}
   - path: /opt/matrix/env/r2.env
     owner: root:root
     permissions: "0640"
@@ -840,7 +848,7 @@ runcmd:
     fi
     install -d -o root -g root -m 0755 /home/matrixos
     ln -sfn /home/matrix/home /home/matrixos/home
-    chown root:matrix /opt/matrix/postgres-compose.yml /opt/matrix/bin/matrixctl /opt/matrix/bin/matrix-db-backup.sh /opt/matrix/bin/matrix-restore.sh /opt/matrix/env/host.env /opt/matrix/env/postgres.env /opt/matrix/env/registration.env
+    chown root:matrix /opt/matrix/postgres-compose.yml /opt/matrix/bin/matrixctl /opt/matrix/bin/matrix-db-backup.sh /opt/matrix/bin/matrix-restore.sh /opt/matrix/env/host.env /opt/matrix/env/symphony.env /opt/matrix/env/postgres.env /opt/matrix/env/registration.env
 
     . /opt/matrix/env/host.env
     [ -n "${MATRIX_HOST_BUNDLE_URL:-}" ] || { echo "matrix-host: MATRIX_HOST_BUNDLE_URL is required" >&2; exit 1; }

--- a/distro/customer-vps/host-bin/matrix-sync-agent
+++ b/distro/customer-vps/host-bin/matrix-sync-agent
@@ -28,6 +28,19 @@ readonly STAGING_CLEANUP_INTERVAL_SECONDS="${MATRIX_STAGING_CLEANUP_INTERVAL_SEC
 log() { echo "matrix-sync-agent: $(date -u +%Y-%m-%dT%H:%M:%SZ) $*"; }
 current_version() { cat "$VERSION_FILE" 2>/dev/null || echo "unknown"; }
 platform_url() { echo "${MATRIX_UPDATE_MANIFEST_BASE_URL:-${PLATFORM_INTERNAL_URL:-https://app.matrix-os.com}}"; }
+write_symphony_env() {
+  local status=0
+  local temp_file
+  temp_file="$(mktemp)"
+  {
+    printf 'MATRIX_HANDLE=%s\n' "${MATRIX_HANDLE:?MATRIX_HANDLE is required}"
+    printf 'PLATFORM_INTERNAL_URL=%s\n' "${PLATFORM_INTERNAL_URL:?PLATFORM_INTERNAL_URL is required}"
+    printf 'UPGRADE_TOKEN=%s\n' "${UPGRADE_TOKEN:?UPGRADE_TOKEN is required}"
+  } >"$temp_file"
+  sudo install -o root -g matrix -m 0640 "$temp_file" /opt/matrix/env/symphony.env || status=$?
+  rm -f "$temp_file"
+  return "$status"
+}
 default_update_channel() {
   local channel="${MATRIX_UPDATE_CHANNEL:-}"
   case "$channel" in
@@ -207,6 +220,8 @@ apply_update() {
     sudo find "$extract_dir/bin" -maxdepth 1 -type f -exec chmod 0755 {} +
     log "Updated bin scripts"
   fi
+  write_symphony_env
+  log "Updated Symphony env"
 
   if [ -d "$extract_dir/systemd" ]; then
     sudo install -d -o root -g root -m 0755 /etc/systemd/system

--- a/distro/customer-vps/systemd/matrix-gateway.service
+++ b/distro/customer-vps/systemd/matrix-gateway.service
@@ -9,6 +9,7 @@ ConditionPathExists=/opt/matrix/bin/matrix-gateway
 User=matrix
 Group=matrix
 EnvironmentFile=/opt/matrix/env/host.env
+Environment=SYMPHONY_PORT=4766
 WorkingDirectory=/opt/matrix
 ExecStart=/opt/matrix/bin/matrix-gateway
 Restart=on-failure

--- a/distro/customer-vps/systemd/matrix-symphony.service
+++ b/distro/customer-vps/systemd/matrix-symphony.service
@@ -10,6 +10,7 @@ ConditionPathExists=/opt/matrix/app/packages/symphony-elixir/release/bin/symphon
 [Service]
 User=matrix
 Group=matrix
+EnvironmentFile=/opt/matrix/env/symphony.env
 Environment=MATRIX_HOME=/home/matrix/home
 Environment=SYMPHONY_HOST=127.0.0.1
 Environment=SYMPHONY_PORT=4766

--- a/tests/deploy/customer-vps/symphony-systemd.test.ts
+++ b/tests/deploy/customer-vps/symphony-systemd.test.ts
@@ -4,22 +4,28 @@ import { describe, expect, it } from "vitest";
 describe("customer VPS Symphony systemd unit", () => {
   it("runs Elixir Symphony as a Matrix-owned loopback service", async () => {
     const unit = await readFile("distro/customer-vps/systemd/matrix-symphony.service", "utf8");
+    const gatewayUnit = await readFile("distro/customer-vps/systemd/matrix-gateway.service", "utf8");
     const wrapper = await readFile("distro/customer-vps/host-bin/matrix-symphony", "utf8");
     const buildScript = await readFile("scripts/build-host-bundle.sh", "utf8");
 
     expect(unit).toContain("Description=Matrix OS customer Symphony");
     expect(unit).toContain("User=matrix");
     expect(unit).toContain("Group=matrix");
+    expect(unit).toContain("EnvironmentFile=/opt/matrix/env/symphony.env");
+    expect(unit).not.toContain("EnvironmentFile=/opt/matrix/env/host.env");
+    expect(unit).not.toContain("EnvironmentFile=-/opt/matrix/env/registration.env");
     expect(unit).toContain("Environment=MATRIX_HOME=/home/matrix/home");
     expect(unit).toContain("Environment=SYMPHONY_HOST=127.0.0.1");
     expect(unit).toContain("Environment=SYMPHONY_PORT=4766");
     expect(unit).toContain("Environment=SYMPHONY_WORKSPACE_ROOT=/home/matrix/home/projects/matrix-os/symphony-workspaces");
     expect(unit).toContain("ExecStart=/opt/matrix/bin/matrix-symphony");
-    expect(unit).not.toContain("EnvironmentFile=/opt/matrix/env/host.env");
     expect(unit).toContain("KillMode=mixed");
     expect(unit).toContain("KillSignal=SIGTERM");
     expect(unit).toContain("TimeoutStopSec=30");
     expect(unit).toContain("ConditionPathExists=/opt/matrix/app/packages/symphony-elixir/release/bin/symphony");
+
+    expect(gatewayUnit).toContain("EnvironmentFile=/opt/matrix/env/host.env");
+    expect(gatewayUnit).toContain("Environment=SYMPHONY_PORT=4766");
 
     expect(wrapper).toContain("source /opt/matrix/env/host.env");
     expect(wrapper).toContain("export MATRIX_HOME=\"${MATRIX_HOME:-/home/matrix/home}\"");
@@ -42,6 +48,11 @@ describe("customer VPS Symphony systemd unit", () => {
     expect(cloudInit).toContain("erlang-ssl");
     expect(cloudInit).toContain("matrix-symphony");
     expect(cloudInit).toContain("matrix-symphony-control");
+    expect(cloudInit).toContain("path: /opt/matrix/env/symphony.env");
+    expect(cloudInit).toContain("MATRIX_HANDLE={{handle}}");
+    expect(cloudInit).toContain("PLATFORM_INTERNAL_URL={{platformInternalUrl}}");
+    expect(cloudInit).toContain("UPGRADE_TOKEN={{platformVerificationToken}}");
+    expect(cloudInit).toContain("Environment=SYMPHONY_PORT=4766");
     expect(cloudInit).toContain("systemctl enable matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
     expect(cloudInit).toContain("systemctl start matrix-restore.service matrix-gateway.service matrix-shell.service matrix-code.service matrix-sync-agent.service matrix-symphony.service");
   });
@@ -115,6 +126,14 @@ describe("customer VPS Symphony systemd unit", () => {
 
     expect(syncAgent).not.toContain("ensure_symphony_runtime");
     expect(syncAgent).not.toContain("apt-get install -y");
+    expect(syncAgent).toContain("write_symphony_env()");
+    expect(syncAgent).toContain("/opt/matrix/env/symphony.env");
+    expect(syncAgent).toContain("printf 'MATRIX_HANDLE=%s\\n'");
+    expect(syncAgent).toContain("printf 'PLATFORM_INTERNAL_URL=%s\\n'");
+    expect(syncAgent).toContain("printf 'UPGRADE_TOKEN=%s\\n'");
+    expect(syncAgent).toContain("sudo install -o root -g matrix -m 0640 \"$temp_file\" /opt/matrix/env/symphony.env || status=$?");
+    expect(syncAgent).toContain("rm -f \"$temp_file\"");
+    expect(syncAgent).toContain("return \"$status\"");
     expect(syncAgent).toContain("sudo systemctl enable matrix-symphony.service");
     expect(syncAgent).toContain("sudo systemctl start --no-block matrix-symphony.service");
     expect(syncAgent).toContain("sudo systemctl stop matrix-symphony matrix-gateway matrix-shell || true");

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -150,6 +150,9 @@ exit 99
     expect(rendered).toContain('MATRIX_AUTH_TOKEN=platform-verification-secret');
     expect(rendered).toContain('MATRIX_CODE_PROXY_TOKEN=platform-verification-secret');
     expect(rendered).toContain('PLATFORM_INTERNAL_URL=https://platform.example');
+    expect(rendered).toContain('path: /opt/matrix/env/symphony.env');
+    expect(rendered).toContain('MATRIX_HANDLE=alice');
+    expect(rendered).toContain('UPGRADE_TOKEN=platform-verification-secret');
     expect(rendered).not.toContain('UPGRADE_TOKEN=\n');
     expect(rendered).not.toContain('MATRIX_AUTH_TOKEN=\n');
     expect(rendered).not.toContain('MATRIX_CODE_PROXY_TOKEN=\n');

--- a/tests/platform/customer-vps-host-bundle.test.ts
+++ b/tests/platform/customer-vps-host-bundle.test.ts
@@ -376,6 +376,10 @@ describe('customer VPS host bundle', () => {
     const root = process.cwd();
     const syncAgent = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-sync-agent'), 'utf8');
 
+    expect(syncAgent).toContain('write_symphony_env()');
+    expect(syncAgent).toContain('/opt/matrix/env/symphony.env');
+    expect(syncAgent).toContain('sudo install -o root -g matrix -m 0640 "$temp_file" /opt/matrix/env/symphony.env || status=$?');
+    expect(syncAgent).toContain('rm -f "$temp_file"');
     expect(syncAgent).toContain("sudo find \"$extract_dir/systemd\" -maxdepth 1 -name 'matrix-*.service'");
     expect(syncAgent).toContain('sudo systemctl daemon-reload');
     expect(syncAgent).toContain('Messaging runtimes missing; units installed but not enabled');


### PR DESCRIPTION
## Summary
- add a dedicated least-privilege /opt/matrix/env/symphony.env containing only MATRIX_HANDLE, PLATFORM_INTERNAL_URL, and UPGRADE_TOKEN for the host-managed Symphony runtime
- pin matrix-gateway.service to SYMPHONY_PORT=4766 so stale legacy runner config cannot misroute the proxy
- generate symphony.env during customer VPS bootstrap and existing VPS host-bundle updates before enabling bundled units
- add static regression coverage for the shipped unit, cloud-init copy, and sync-agent update path

## Invariants
- Source of truth: platform host env remains the source of truth for machine metadata and tokens; symphony.env is a derived least-privilege runtime env for Symphony only.
- Lock/transaction scope: no database writes or runtime transactions are changed; this is systemd environment wiring and update-time env-file generation only.
- Acceptable orphan states: an existing host may still need a unit reinstall or service restart before the new environment applies; once the host bundle installs units, systemd owns restart behavior.
- Auth source of truth: Matrix gateway auth and platform bridge token validation are unchanged; Symphony receives only the bridge values it already needs.
- Deferred scope: this does not change Symphony issue selection, Linear credentials, or Codex agent execution behavior.

## Verification
- bun run test tests/deploy/customer-vps/symphony-systemd.test.ts
- bun run test tests/platform/customer-vps-cloud-init.test.ts
- bun run test tests/platform/customer-vps-host-bundle.test.ts
- bun run check:patterns