### PR TITLE
ci(platform): deploy Cloud Run on platform changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,6 +31,7 @@ logs and artifacts.
 | `ci.yml` | Core code validation | `ready-for-ci`, ready PRs, merge queue, `main`, manual | Yes, via `CI Results` |
 | `docker-test.yml` | Legacy/local Docker scenario validation | `ready-for-ci`, ready PRs, merge queue, `main`, nightly, manual | Required when Docker/runtime paths are touched |
 | `host-bundle-release.yml` | VPS-native customer runtime release | `main`, `v*` tags, manual | Required for host bundle publishing |
+| `platform-cloud-run.yml` | Platform/app-shell Cloud Run deployment | `main` when platform/auth-shell inputs change, manual | Required for app.matrix-os.com platform changes |
 | `release.yml` / `cli-release.yml` | Installable `@finnaai/matrix` CLI release | Manual CLI release | Required for CLI publishing |
 | `pr-title.yml` | Conventional Commit PR title policy | PR title changes | Yes |
 | `docker.yml` | Legacy Docker image publishing/deploy path | `v*` tags, manual | Legacy only, not the customer runtime path |

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -12,9 +12,6 @@ on:
       - "scripts/start-platform-cloud-run.sh"
       - "Dockerfile.platform"
       - "cloudbuild.platform.yaml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -1,6 +1,20 @@
 name: Platform Cloud Run
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/platform/**"
+      - "packages/observability/**"
+      - "packages/clerk-sync/**"
+      - "shell/**"
+      - "distro/customer-vps/**"
+      - "scripts/start-platform-cloud-run.sh"
+      - "Dockerfile.platform"
+      - "cloudbuild.platform.yaml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
   workflow_dispatch:
     inputs:
       environment:
@@ -22,14 +36,14 @@ permissions:
   id-token: write
 
 concurrency:
-  group: platform-cloud-run-${{ inputs.environment }}
+  group: platform-cloud-run-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
   cancel-in-progress: false
 
 jobs:
   deploy:
     name: Build and deploy platform
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
     env:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_REGION: ${{ vars.GCP_REGION }}
@@ -253,7 +267,7 @@ jobs:
           curl --fail --silent --show-error --max-time 20 --range 0-0 "$bundle_url" >/dev/null
 
       - name: Promote revision
-        if: ${{ inputs.promote }}
+        if: ${{ github.event_name == 'push' || inputs.promote }}
         run: |
           set -euo pipefail
           if [ -z "${CANDIDATE_REVISION:-}" ]; then

--- a/docs/platform/dev/deployment.md
+++ b/docs/platform/dev/deployment.md
@@ -78,12 +78,12 @@ Do not copy `PIPEDREAM_*`, Clerk server secrets, platform DB credentials, or `PL
 ## Updating Platform Auth and Device-Login Pages
 
 `app.matrix-os.com` sign-in, sign-up, billing handoff, provisioning handoff, and
-CLI device-login pages are served by the platform Docker service. Pulling
-`main` on the platform VPS is not enough: the running `distro-platform-1`
-container keeps serving the previously built image until the platform service is
-rebuilt and recreated.
+CLI/native device-login pages are served by the platform Cloud Run service.
+Publishing a customer host bundle is not enough for these routes: Cloud Run
+keeps serving the previously deployed image until the platform service is
+rebuilt and promoted.
 
-Rebuild the platform Docker service whenever a PR changes:
+Deploy the platform Cloud Run service whenever a PR changes:
 
 - `packages/platform/src/auth-routes.ts`
 - `packages/platform/src/main.ts` auth, sign-in, sign-up, billing, or provisioning routes
@@ -91,8 +91,14 @@ Rebuild the platform Docker service whenever a PR changes:
 - `distro/docker-compose.platform.yml` for `platform` or `auth-shell`
 - platform pages that users reach at `app.matrix-os.com`
 
-On the platform VPS, keep the main checkout clean and deploy from a manual
-worktree pointed at `origin/main`:
+`.github/workflows/platform-cloud-run.yml` automatically builds, smokes, and
+promotes the production Cloud Run revision on `main` when platform/app-shell
+inputs change. For an immediate manual deployment, dispatch `Platform Cloud Run`
+with `environment=production` and `promote=true`.
+
+Legacy platform VPS Docker deployments should only be used if Cloud Run is not
+the active serving path. On the platform VPS, keep the main checkout clean and
+deploy from a manual worktree pointed at `origin/main`:
 
 ```bash
 git fetch origin main


### PR DESCRIPTION
## Summary
- Run `Platform Cloud Run` automatically on `main` pushes that change platform/app-shell inputs.
- Default push-triggered deployments to the production GitHub environment and promote the smoked candidate revision.
- Update workflow/deployment docs so `app.matrix-os.com` platform routes are tied to Cloud Run, not host-bundle-only deploys.

## Tests
- `git diff --check`
- Marker inspection for push trigger, production fallback, and push promotion expression
- Could not run `actionlint` or Prettier locally because they are not installed in this checkout.

## Invariants
- Source of truth: GitHub Actions remains the deployment control plane for platform Cloud Run; Cloud Run revision traffic is the live serving state.
- Lock/transaction scope: Not applicable; workflow-only change. GitHub Actions concurrency serializes deployments per environment.
- Acceptable orphan states: A failed build/deploy leaves the previous Cloud Run revision serving traffic because promotion happens after candidate smoke.
- Auth source of truth: Existing GitHub environment secrets and GCP Workload Identity remain unchanged.
- Deferred scope: This does not change customer host-bundle release automation or platform DB migrations.
