### PR TITLE
test(www): update landing quickstart link assertion

### DIFF
--- a/tests/www/landing-mobile-polish.test.ts
+++ b/tests/www/landing-mobile-polish.test.ts
@@ -30,7 +30,8 @@ describe("www landing mobile polish", () => {
     expect(landing).toContain("<nav className=\"mt-4 grid grid-cols-2");
     expect(landing).toContain("grid grid-cols-2");
     expect(landing).toContain("Open skills.md");
-    expect(landing).toContain("Developer workflow");
+    expect(landing).toContain('href="/docs/users/quickstart"');
+    expect(landing).toContain("Quickstart");
   });
 
   it("uses tighter landing section spacing than the original blanket rhythm", async () => {


### PR DESCRIPTION
## Summary
- Update the landing mobile polish test after the landing page changed the agent setup secondary link from the old Developer workflow label to the new Quickstart link.
- Assert the current `/docs/users/quickstart` href and visible `Quickstart` text.

## Validation
- `bun run test tests/www/landing-mobile-polish.test.ts`
- `git diff --check`

## Invariants
- Source of truth: `www/src/app/page.tsx` remains the source for landing page copy and links.
- Lock/transaction scope: no data writes or transactions.
- Acceptable orphan states: no runtime state changes.
- Auth source of truth: unchanged.
- Deferred scope: no landing page copy changes; this only updates a stale test assertion.
