### PR TITLE
fix(www): separate landing header wordmark

### DIFF
--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -71,7 +71,6 @@ type NavLinkConfig = {
 };
 
 const navLinks: NavLinkConfig[] = [
-  { label: "cloud dev", href: "#cloud-dev" },
   { label: "solutions", href: "/solutions" },
   { label: "symphony", href: "#symphony" },
   { label: "teams", href: "#teams" },
@@ -273,7 +272,7 @@ export default function LandingPage() {
             display: inline-flex;
             min-width: 0;
             align-items: center;
-            gap: 1.05rem;
+            gap: 1.35rem;
           }
           .nav-actions {
             grid-column: 3;
@@ -294,7 +293,7 @@ export default function LandingPage() {
           .nav-links {
             grid-column: 2;
             justify-self: center;
-            gap: 0.35rem;
+            gap: 1.65rem;
           }
           .nav-actions {
             grid-column: 3;


### PR DESCRIPTION
## Summary
- remove the redundant Cloud Dev item from the landing header nav so it no longer reads as part of the Matrix OS wordmark
- increase desktop nav spacing around the remaining links

## Validation
- flox activate -- pnpm --dir www build
- flox activate -- npx react-doctor@latest www --verbose --diff main
- previewed locally at http://localhost:3003/

## Invariants
- Source of truth: landing header links remain defined in www/src/app/page.tsx.
- Lock/transaction scope: no backend state, database writes, or transactions are touched.
- Acceptable orphan states: none; this is a presentational-only navigation change.
- Auth source of truth: unchanged; Clerk SignedIn/SignedOut rendering remains untouched.
- Deferred scope: broader landing redesign and responsive navigation restructuring are out of scope.