### PR TITLE
fix(shell): accept native and platform app-session markers in hosted shell

### DIFF
--- a/shell/proxy.ts
+++ b/shell/proxy.ts
@@ -90,9 +90,7 @@ function platformVerifiedResponse(request: ProxyRequestLike): NextResponse | nul
   const nativeAppSession = requestHeaders.get(MATRIX_NATIVE_APP_SESSION_HEADER)?.trim() === "1";
   requestHeaders.delete(MATRIX_NATIVE_APP_SESSION_HEADER);
   requestHeaders.delete(MATRIX_PLATFORM_SESSION_HEADER);
-  if (nativeAppSession) {
-    requestHeaders.set(MATRIX_PLATFORM_SESSION_HEADER, "native");
-  }
+  requestHeaders.set(MATRIX_PLATFORM_SESSION_HEADER, nativeAppSession ? "native" : "platform");
   return NextResponse.next({ request: { headers: requestHeaders } });
 }
 

--- a/shell/src/lib/platform-session.ts
+++ b/shell/src/lib/platform-session.ts
@@ -9,5 +9,5 @@ export function hasServerVerifiedMatrixSession(headers: PlatformSessionHeaders):
   const marker = headers.get(MATRIX_PLATFORM_SESSION_HEADER)?.trim();
   // Bound the header before marker interpretation; untrusted callers are also blocked in proxy.ts.
   if (!marker || marker.length > MAX_PLATFORM_HEADER_LENGTH) return false;
-  return marker === "native";
+  return marker === "native" || marker === "platform";
 }

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1497,6 +1497,128 @@ describe("platform proxy routing", () => {
     expect(nativeForwardHeaders.get("x-matrix-platform-session")).toBeNull();
   });
 
+  it("marks native app sessions behind Cloud Run forwarded-host routing", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://alice.matrix-os.com",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("shell", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      env: { ...process.env, EDGE_ROUTER_SECRET: "edge-secret" },
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue(null),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const exchange = await app.request("/api/auth/app-session", {
+      method: "POST",
+      headers: {
+        host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-matrix-edge-secret": "edge-secret",
+        authorization: `Bearer ${issued.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ redirectTo: "/" }),
+    });
+
+    expect(exchange.status).toBe(200);
+    const appSession = cookieHeaderFromSetCookie(exchange.headers, [
+      "matrix_app_session",
+      "matrix_native_app_session",
+    ]);
+    const shell = await app.request("/", {
+      headers: {
+        host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-matrix-edge-secret": "edge-secret",
+        cookie: appSession,
+      },
+    });
+
+    expect(shell.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://matrixos-alice:3000/");
+    const nativeForwardHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers as HeadersInit);
+    expect(nativeForwardHeaders.get("x-matrix-native-app-session")).toBe("1");
+    expect(nativeForwardHeaders.get("x-platform-user-id")).toBe("user_alice");
+    expect(nativeForwardHeaders.get("x-matrix-edge-secret")).toBeNull();
+  });
+
+  it("marks native app sessions on customer VPS routing behind Cloud Run", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    await insertUserMachine(db, {
+      machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff159",
+      clerkUserId: "user_alice",
+      handle: "alice",
+      status: "running",
+      hetznerServerId: 123459,
+      publicIPv4: "203.0.113.59",
+      imageVersion: "matrix-os-host-2026.06.08-1",
+      provisionedAt: "2026-06-08T12:00:00.000Z",
+    });
+    const issued = await issueSyncJwt({
+      secret: JWT_SECRET,
+      clerkUserId: "user_alice",
+      handle: "alice",
+      gatewayUrl: "https://alice.matrix-os.com",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("shell", { status: 200 }),
+    );
+    const app = createApp({
+      db,
+      env: { ...process.env, EDGE_ROUTER_SECRET: "edge-secret" },
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue(null),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const exchange = await app.request("/api/auth/app-session", {
+      method: "POST",
+      headers: {
+        host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-matrix-edge-secret": "edge-secret",
+        authorization: `Bearer ${issued.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ redirectTo: "/" }),
+    });
+
+    expect(exchange.status).toBe(200);
+    const appSession = cookieHeaderFromSetCookie(exchange.headers, [
+      "matrix_app_session",
+      "matrix_native_app_session",
+    ]);
+    const shell = await app.request("/", {
+      headers: {
+        host: "matrix-platform-jqxkjdhtkq-ey.a.run.app",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-matrix-edge-secret": "edge-secret",
+        cookie: appSession,
+      },
+    });
+
+    expect(shell.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://203.0.113.59:443/");
+    const nativeForwardHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers as HeadersInit);
+    expect(nativeForwardHeaders.get("x-matrix-native-app-session")).toBe("1");
+    expect(nativeForwardHeaders.get("x-platform-user-id")).toBe("user_alice");
+    expect(nativeForwardHeaders.get("x-forwarded-host")).toBe("app.matrix-os.com");
+    expect(nativeForwardHeaders.get("x-matrix-edge-secret")).toBeNull();
+  });
+
   it("uses x-forwarded-host for app-domain routing behind Cloud Run", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("shell", { status: 200 }),

--- a/tests/shell/platform-session.test.ts
+++ b/tests/shell/platform-session.test.ts
@@ -15,6 +15,12 @@ describe("platform session detection", () => {
     }))).toBe(true);
   });
 
+  it("accepts the shell proxy's trusted platform session marker", () => {
+    expect(hasServerVerifiedMatrixSession(headers({
+      [MATRIX_PLATFORM_SESSION_HEADER]: "platform",
+    }))).toBe(true);
+  });
+
   it("does not trust forwarded platform identity headers directly", () => {
     expect(hasServerVerifiedMatrixSession(headers({
       "x-platform-user-id": "user_alice",

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   isPlatformMobileAppSessionRequest,
   isPublicShellPath,
@@ -174,6 +174,137 @@ describe("proxy auth: platform mobile app sessions", () => {
       "?session=mobile.session-token_1",
       null,
     )).toBe(false);
+  });
+});
+
+describe("proxy auth: trusted platform native app sessions", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.doUnmock("@clerk/nextjs/server");
+    vi.doUnmock("next/server");
+  });
+
+  it("converts the platform native marker into the shell's internal session marker", async () => {
+    vi.resetModules();
+    vi.stubEnv("UPGRADE_TOKEN", "platform-upgrade-token");
+    vi.stubEnv("MATRIX_CLERK_USER_ID", "user_alice");
+
+    vi.doMock("@clerk/nextjs/server", () => ({
+      clerkMiddleware: vi.fn((handler) => async (request: unknown, event: unknown) =>
+        handler(async () => ({ userId: null }), request, event)
+      ),
+    }));
+
+    const nextResponseNext = vi.fn((init?: { request?: { headers?: Headers } }) => ({
+      kind: "next",
+      init,
+    }));
+    class MockNextResponse extends Response {
+      static next = nextResponseNext;
+      static rewrite = vi.fn((url: URL, init?: unknown) => ({ kind: "rewrite", url, init }));
+      static redirect = vi.fn((url: URL) => ({ kind: "redirect", url }));
+    }
+    vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
+
+    const { proxy } = await import("../../shell/proxy");
+
+    proxy({
+      headers: new Headers({
+        authorization: "Bearer platform-upgrade-token",
+        "x-platform-user-id": "user_alice",
+        "x-matrix-native-app-session": "1",
+      }),
+      nextUrl: {
+        host: "app.matrix-os.com",
+        pathname: "/",
+        protocol: "https:",
+        search: "",
+      },
+    } as Parameters<typeof proxy>[0], {} as Parameters<typeof proxy>[1]);
+
+    expect(nextResponseNext).toHaveBeenCalledTimes(1);
+    const headers = nextResponseNext.mock.calls[0]?.[0]?.request?.headers;
+    expect(headers?.get("x-matrix-platform-session")).toBe("native");
+    expect(headers?.get("x-matrix-native-app-session")).toBeNull();
+  });
+
+  it("marks trusted platform page requests as server-verified sessions", async () => {
+    vi.resetModules();
+    vi.stubEnv("UPGRADE_TOKEN", "platform-upgrade-token");
+    vi.stubEnv("MATRIX_CLERK_USER_ID", "user_alice");
+
+    vi.doMock("@clerk/nextjs/server", () => ({
+      clerkMiddleware: vi.fn((handler) => async (request: unknown, event: unknown) =>
+        handler(async () => ({ userId: null }), request, event)
+      ),
+    }));
+
+    const nextResponseNext = vi.fn((init?: { request?: { headers?: Headers } }) => ({
+      kind: "next",
+      init,
+    }));
+    class MockNextResponse extends Response {
+      static next = nextResponseNext;
+      static rewrite = vi.fn((url: URL, init?: unknown) => ({ kind: "rewrite", url, init }));
+      static redirect = vi.fn((url: URL) => ({ kind: "redirect", url }));
+    }
+    vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
+
+    const { proxy } = await import("../../shell/proxy");
+
+    proxy({
+      headers: new Headers({
+        authorization: "Bearer platform-upgrade-token",
+        "x-platform-user-id": "user_alice",
+      }),
+      nextUrl: {
+        host: "app.matrix-os.com",
+        pathname: "/",
+        protocol: "https:",
+        search: "",
+      },
+    } as Parameters<typeof proxy>[0], {} as Parameters<typeof proxy>[1]);
+
+    expect(nextResponseNext).toHaveBeenCalledTimes(1);
+    const headers = nextResponseNext.mock.calls[0]?.[0]?.request?.headers;
+    expect(headers?.get("x-matrix-platform-session")).toBe("platform");
+    expect(headers?.get("x-matrix-native-app-session")).toBeNull();
+  });
+
+  it("rejects untrusted native session markers from browser requests", async () => {
+    vi.resetModules();
+    vi.stubEnv("UPGRADE_TOKEN", "platform-upgrade-token");
+
+    vi.doMock("@clerk/nextjs/server", () => ({
+      clerkMiddleware: vi.fn((handler) => async (request: unknown, event: unknown) =>
+        handler(async () => ({ userId: null }), request, event)
+      ),
+    }));
+
+    class MockNextResponse extends Response {
+      static next = vi.fn((init?: unknown) => ({ kind: "next", init }));
+      static rewrite = vi.fn((url: URL, init?: unknown) => ({ kind: "rewrite", url, init }));
+      static redirect = vi.fn((url: URL) => ({ kind: "redirect", url }));
+    }
+    vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
+
+    const { proxy } = await import("../../shell/proxy");
+
+    const response = proxy({
+      headers: new Headers({
+        "x-matrix-native-app-session": "1",
+      }),
+      nextUrl: {
+        host: "app.matrix-os.com",
+        pathname: "/",
+        protocol: "https:",
+        search: "",
+      },
+    } as Parameters<typeof proxy>[0], {} as Parameters<typeof proxy>[1]);
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(403);
   });
 });
 


### PR DESCRIPTION
## Problem

The hosted shell only treated a server-verified session marker of `"native"` as a valid Matrix session. Platform-verified page requests — including the macOS native app's app-session exchange — were redirected to `/login` even though they presented valid `matrix_app_session` / `matrix_native_app_session` cookies.

Live impact (macOS native shell, observed in telemetry):
```
exchange → 200, cookies installed → loads / → redirects to matrix-os.com/login
```
So the authenticated native shell never loaded; the user saw the hosted login page inside Home.

## Change

- `shell/proxy.ts`: for platform-verified page requests, always set the internal `MATRIX_PLATFORM_SESSION` header to `"native"` or `"platform"` (previously only `"native"` was set, and only for native app sessions).
- `shell/src/lib/platform-session.ts`: `hasServerVerifiedMatrixSession()` accepts both `"native"` and `"platform"` markers.

The header is still **deleted from untrusted inbound requests before being re-set** inside `platformVerifiedResponse`, so external callers cannot forge it.

## Why now (deploy ordering)

This is the server-side half of the macOS native session work (branch `091-macos-native-session-cookies`). It is split out so it can be merged and **deployed to app.matrix-os.com independently**; the native client gating work continues locally and depends on this being live.

## Invariants

- **Source of truth**: the hosted-shell session is authoritative via the internal `MATRIX_PLATFORM_SESSION` request header, which is set *only* by `platformVerifiedResponse` after the platform verifies the request. Client cookies are inputs to that verification, not the source of truth.
- **Auth source of truth**: primary = platform verification of the page request (sets `native`/`platform`). Fallback = existing Clerk auth path (unchanged). No new bypass is introduced.
- **Trust boundary**: `MATRIX_PLATFORM_SESSION` and `MATRIX_NATIVE_APP_SESSION` headers are stripped from the incoming request before the verified marker is written, so a forged inbound header cannot be honored.
- **Acceptable orphan states**: none — single header write per request; no multi-step or cross-store mutation.
- **Deferred scope**: the macOS client-side workspace gating on hosted-shell auth is NOT in this PR; it ships from the `091` branch after this deploys.

## Tests

- `tests/platform/proxy-routing.test.ts` — native + platform app-session routing
- `tests/shell/proxy-auth.test.ts`, `tests/shell/platform-session.test.ts` — marker acceptance + forgery stripping

129 tests pass with workspace deps installed.