### PR TITLE
fix(shell): detach hidden zellij terminal clients

### DIFF
--- a/shell/src/components/terminal/TerminalPane.tsx
+++ b/shell/src/components/terminal/TerminalPane.tsx
@@ -991,7 +991,9 @@ export function TerminalPane({
       if (cached && canReuseCachedSocket) {
         bindWs(cached.ws, cached.ws.readyState === WebSocket.CONNECTING);
       } else {
-        discardStaleCachedTerminal(cached);
+        if (cached && !canReuseCachedTerminal) {
+          discardStaleCachedTerminal(cached);
+        }
         connectWs();
       }
 
@@ -1165,6 +1167,8 @@ export function TerminalPane({
             termElement.parentNode.removeChild(termElement);
           }
 
+          const cachedSessionId = sessionIdRef.current ?? "";
+          const retainSocket = !isCanonicalShellSessionId(cachedSessionId);
           cacheTerminal(paneId, {
             terminal: term,
             fitAddon,
@@ -1172,8 +1176,8 @@ export function TerminalPane({
             searchAddon,
             ws: wsRef.current,
             lastSeq: lastSeqRef.current,
-            sessionId: sessionIdRef.current ?? "",
-          });
+            sessionId: cachedSessionId,
+          }, { retainSocket });
         } else {
           // WS never established — dispose, don't cache
           log("cleanup-dispose-no-ws");

--- a/shell/src/components/terminal/terminal-cache.ts
+++ b/shell/src/components/terminal/terminal-cache.ts
@@ -10,6 +10,11 @@ export interface CachedTerminal {
   ws: WebSocket;
   lastSeq: number;
   sessionId: string;
+  socketRetained?: boolean;
+}
+
+interface CacheTerminalOptions {
+  retainSocket?: boolean;
 }
 
 const MAX_CACHED = 20;
@@ -22,14 +27,36 @@ function terminalCacheDebug(event: string, details: Record<string, unknown>): vo
   console.info("[terminal-debug][cache]", event, details);
 }
 
-export function cacheTerminal(paneId: string, entry: CachedTerminal): void {
+function detachAndCloseSocket(ws: WebSocket): void {
+  if (ws.readyState === WebSocket.OPEN) {
+    try {
+      ws.send(JSON.stringify({ type: "detach" }));
+    } catch (e: unknown) {
+      console.warn("Cache detach:", e instanceof Error ? e.message : e);
+    }
+  }
+  if (ws.readyState !== WebSocket.CLOSED) {
+    try {
+      ws.close();
+    } catch (e: unknown) {
+      console.warn("Cache ws.close:", e instanceof Error ? e.message : e);
+    }
+  }
+}
+
+export function cacheTerminal(paneId: string, entry: CachedTerminal, options: CacheTerminalOptions = {}): void {
   terminalCacheDebug("cache-put", {
     paneId,
     sessionId: entry.sessionId,
     lastSeq: entry.lastSeq,
     cacheSizeBefore: cache.size,
+    retainSocket: options.retainSocket !== false,
   });
   cache.delete(paneId);
+  if (options.retainSocket === false) {
+    detachAndCloseSocket(entry.ws);
+  }
+  entry.socketRetained = options.retainSocket !== false;
   while (cache.size >= MAX_CACHED) {
     const oldest = cache.keys().next().value!;
     const evicted = cache.get(oldest);
@@ -39,8 +66,7 @@ export function cacheTerminal(paneId: string, entry: CachedTerminal): void {
         paneId: oldest,
         sessionId: evicted.sessionId,
       });
-      try { evicted.ws.send(JSON.stringify({ type: "detach" })); } catch (e: unknown) { console.warn("Cache eviction detach:", e instanceof Error ? e.message : e); }
-      try { evicted.ws.close(); } catch (e: unknown) { console.warn("Cache eviction ws.close:", e instanceof Error ? e.message : e); }
+      detachAndCloseSocket(evicted.ws);
       try { evicted.terminal.dispose(); } catch (e: unknown) { console.warn("Cache eviction dispose:", e instanceof Error ? e.message : e); }
     }
   }

--- a/shell/src/components/terminal/terminal-restore.ts
+++ b/shell/src/components/terminal/terminal-restore.ts
@@ -19,15 +19,17 @@ export function getCachedTerminalRestorePlan(cached: CachedTerminal | null): Cac
     };
   }
 
-  const reuseSocket = cached.ws.readyState === WebSocket.OPEN || cached.ws.readyState === WebSocket.CONNECTING;
   const hasTerminalElement = Boolean((cached.terminal as { element?: HTMLElement }).element);
+  const reuseSocket = cached.ws.readyState === WebSocket.OPEN || cached.ws.readyState === WebSocket.CONNECTING;
+  const socketWasIntentionallyDetached = cached.socketRetained === false;
+  const reuseTerminal = hasTerminalElement && (reuseSocket || socketWasIntentionallyDetached);
 
   return {
     cached,
-    reuseTerminal: reuseSocket && hasTerminalElement,
+    reuseTerminal,
     reuseSocket,
     sessionId: cached.sessionId || null,
-    lastSeq: reuseSocket && hasTerminalElement ? cached.lastSeq : 0,
+    lastSeq: reuseTerminal ? cached.lastSeq : 0,
   };
 }
 

--- a/tests/shell/terminal-cache.test.ts
+++ b/tests/shell/terminal-cache.test.ts
@@ -13,7 +13,7 @@ function createMockCachedTerminal(overrides: Partial<CachedTerminal> = {}): Cach
     fitAddon: {} as CachedTerminal["fitAddon"],
     webglAddon: null,
     searchAddon: null,
-    ws: { send: vi.fn(), close: vi.fn() } as unknown as WebSocket,
+    ws: { readyState: WebSocket.OPEN, send: vi.fn(), close: vi.fn() } as unknown as WebSocket,
     lastSeq: 0,
     sessionId: "test-session-id",
     ...overrides,
@@ -34,6 +34,19 @@ describe("Terminal Cache", () => {
     const cached = getCached("pane-1");
     expect(cached).not.toBeNull();
     expect(cached!.sessionId).toBe("session-abc");
+  });
+
+  it("detaches and closes the socket before caching when socket retention is disabled", () => {
+    const entry = createMockCachedTerminal({ sessionId: "main", lastSeq: 42 });
+
+    cacheTerminal("pane-1", entry, { retainSocket: false });
+
+    expect((entry.ws as unknown as { send: ReturnType<typeof vi.fn> }).send).toHaveBeenCalledWith(JSON.stringify({ type: "detach" }));
+    expect((entry.ws as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
+    expect(getCached("pane-1")).toMatchObject({
+      sessionId: "main",
+      lastSeq: 42,
+    });
   });
 
   it("getCached returns null for cache miss", () => {

--- a/tests/shell/terminal-cache.test.ts
+++ b/tests/shell/terminal-cache.test.ts
@@ -49,6 +49,22 @@ describe("Terminal Cache", () => {
     });
   });
 
+  it("closes but does not detach a connecting socket when socket retention is disabled", () => {
+    const entry = createMockCachedTerminal({
+      sessionId: "main",
+      ws: {
+        readyState: WebSocket.CONNECTING,
+        send: vi.fn(),
+        close: vi.fn(),
+      } as unknown as WebSocket,
+    });
+
+    cacheTerminal("pane-1", entry, { retainSocket: false });
+
+    expect((entry.ws as unknown as { send: ReturnType<typeof vi.fn> }).send).not.toHaveBeenCalled();
+    expect((entry.ws as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalledOnce();
+  });
+
   it("getCached returns null for cache miss", () => {
     expect(getCached("nonexistent")).toBeNull();
   });

--- a/tests/shell/terminal-pane.test.tsx
+++ b/tests/shell/terminal-pane.test.tsx
@@ -25,6 +25,26 @@ describe("getCachedTerminalRestorePlan", () => {
     expect(plan.lastSeq).toBe(0);
   });
 
+  it("reuses terminal DOM and replay position when a cached canonical shell socket was detached", () => {
+    const cached = {
+      terminal: { element: {} as HTMLElement } as CachedTerminal["terminal"],
+      fitAddon: {} as CachedTerminal["fitAddon"],
+      webglAddon: null,
+      searchAddon: null,
+      ws: { readyState: WebSocket.CLOSED } as WebSocket,
+      lastSeq: 42,
+      sessionId: "main",
+      socketRetained: false,
+    } satisfies CachedTerminal;
+
+    const plan = getCachedTerminalRestorePlan(cached);
+
+    expect(plan.reuseTerminal).toBe(true);
+    expect(plan.reuseSocket).toBe(false);
+    expect(plan.sessionId).toBe("main");
+    expect(plan.lastSeq).toBe(42);
+  });
+
   it("closes and disposes a stale cached terminal before reconnecting", () => {
     const close = vi.fn();
     const dispose = vi.fn();


### PR DESCRIPTION
## Summary
- Detach and close hidden web terminal sockets for canonical zellij sessions instead of retaining them in the terminal cache.
- Preserve cached terminal DOM and replay position so returning to a hidden terminal reconnects quickly without accumulating zellij clients.
- Keep legacy non-canonical PTY cache behavior unchanged.

## Tests
- pnpm exec vitest run tests/shell/terminal-pane.test.tsx tests/shell/terminal-cache.test.ts
- pnpm exec vitest run tests/shell/terminal.test.ts tests/shell/terminal-pane.test.tsx tests/shell/terminal-cache.test.ts tests/shell/terminal-app-component.test.tsx tests/gateway/terminal-zellij-ws.test.ts
- pnpm exec vitest run tests/shell/terminal-pane.test.tsx tests/shell/terminal-cache.test.ts tests/shell/terminal-app-component.test.tsx tests/gateway/terminal-zellij-ws.test.ts
- pnpm exec tsc --noEmit --project shell/tsconfig.json
- bun run typecheck
- bun run check:patterns
- npx react-doctor@latest shell
- npx react-doctor@latest shell --verbose --diff
- git diff --check
- bun run test (556 files passed, 6293 tests passed, 20 skipped)

## Review/Monitoring
Will monitor CI, GitHub review comments, and the latest trusted Greptile result until 5/5.

## Invariants
- Source of truth: zellij remains the durable session source of truth; the shell terminal cache is only a client-side view/replay optimization.
- Lock/transaction scope: no backend writes, locks, or database transactions are introduced by this frontend-only cache change.
- Acceptable orphan states: a hidden web client may detach and reconnect later; the zellij session and running CLI/coding-agent process remain alive.
- Auth source of truth: unchanged; terminal WebSocket authentication and session authorization remain owned by the existing gateway routes.
- Deferred scope: this PR does not change local CLI or upcoming macOS app attach semantics, and does not destroy or garbage-collect zellij sessions.