### PR TITLE
fix(shell): move proxy.ts into src so Next 16 compiles it

### DIFF
--- a/shell/src/proxy.ts
+++ b/shell/src/proxy.ts
@@ -3,12 +3,12 @@ import { NextResponse } from "next/server";
 import {
   MATRIX_NATIVE_APP_SESSION_HEADER,
   MATRIX_PLATFORM_SESSION_HEADER,
-} from "./src/lib/platform-session";
+} from "./lib/platform-session";
 import {
   isGatewayProxyPath,
   isPlatformMobileAppSessionRequest,
   isPublicShellPath,
-} from "./src/lib/proxy-routes";
+} from "./lib/proxy-routes";
 
 const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
 const authToken = process.env.MATRIX_AUTH_TOKEN;

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -207,7 +207,7 @@ describe("proxy auth: trusted platform native app sessions", () => {
     }
     vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
 
-    const { proxy } = await import("../../shell/proxy");
+    const { proxy } = await import("../../shell/src/proxy");
 
     proxy({
       headers: new Headers({
@@ -251,7 +251,7 @@ describe("proxy auth: trusted platform native app sessions", () => {
     }
     vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
 
-    const { proxy } = await import("../../shell/proxy");
+    const { proxy } = await import("../../shell/src/proxy");
 
     proxy({
       headers: new Headers({
@@ -289,7 +289,7 @@ describe("proxy auth: trusted platform native app sessions", () => {
     }
     vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
 
-    const { proxy } = await import("../../shell/proxy");
+    const { proxy } = await import("../../shell/src/proxy");
 
     const response = proxy({
       headers: new Headers({


### PR DESCRIPTION
## Summary
- move the shell proxy from shell/proxy.ts to shell/src/proxy.ts so Next 16 compiles it alongside src/app
- update proxy auth tests to import the relocated proxy module
- preserve the existing platform/native session marker logic unchanged

## Tests
- pnpm build (from shell) passed and printed `ƒ Proxy (Middleware)`
- local built runtime forged marker check: `x-matrix-platform-session: native` returns `403`
- local built runtime trusted bearer check: `grep -c 'Loading billing status'` returns `0` (local shell returns 500 afterward due missing production env, but the BillingGate marker is gone)
- `bun run test tests/shell/proxy-auth.test.ts tests/shell/platform-session.test.ts` passed (27 tests)
- `bun run check:patterns` passed with 0 violations and existing warnings only

## Review/Monitoring
- Needs CI and Greptile review on current head before merge.
- Deployment should publish a host bundle from merged main, deploy hamedmp, and verify forged marker 403 plus legit platform request grep 0.

## Invariants
- Source of truth: the VPS shell trusts only the server-side platform bearer proof and matching `x-platform-user-id`; user-owned data under MATRIX_HOME is untouched.
- Lock/transaction scope: no persistence or multi-write flow is changed.
- Acceptable orphan states: none introduced; this is a build-location fix for the existing proxy logic.
- Auth source of truth: `UPGRADE_TOKEN` remains the platform verification bearer; client-forged `x-matrix-platform-session` headers must be rejected.
- Deferred scope: no platform, native app, Clerk, or host-bundle deployment changes are included in this PR.