### PR TITLE
fix(macos): preserve native shell session cookie

### DIFF
--- a/macos/Package.resolved
+++ b/macos/Package.resolved
@@ -1,6 +1,42 @@
 {
-  "originHash" : "76df76a2d249c98749db73d482ec32c708d4b71e92c369aa06edf4ebff59ff47",
+  "originHash" : "103d0ccde6a5a4ef99bf2a2965a555af2a03fdf2f1779b53a7453cf4a6d45af5",
   "pins" : [
+    {
+      "identity" : "codeeditlanguages",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditLanguages.git",
+      "state" : {
+        "revision" : "331d5dbc5fc8513be5848fce8a2a312908f36a11",
+        "version" : "0.1.20"
+      }
+    },
+    {
+      "identity" : "codeeditsourceeditor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditSourceEditor",
+      "state" : {
+        "revision" : "412b0a26cbeb3f3148a1933dd598c976defe92a6",
+        "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "codeedittextview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CodeEditApp/CodeEditTextView.git",
+      "state" : {
+        "revision" : "a5912e60f6bac25cd1cdf8bb532e1125b21cf7f7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "rearrange",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/Rearrange",
+      "state" : {
+        "revision" : "4de8be41dba304192e87dc0a11e0aa39e72aa2e8",
+        "version" : "2.1.1"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -11,12 +47,66 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swiftlintplugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
+      "state" : {
+        "revision" : "a3877065a7d72ee40e1fa64e13b9e33e846c667c",
+        "version" : "0.63.1"
+      }
+    },
+    {
       "identity" : "swiftterm",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm",
       "state" : {
         "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
         "version" : "1.13.0"
+      }
+    },
+    {
+      "identity" : "swifttreesitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/SwiftTreeSitter.git",
+      "state" : {
+        "revision" : "08ef81eb8620617b55b08868126707ad72bf754f",
+        "version" : "0.25.0"
+      }
+    },
+    {
+      "identity" : "textformation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/TextFormation",
+      "state" : {
+        "revision" : "b1ce9a14bd86042bba4de62236028dc4ce9db6a1",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "textstory",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/TextStory",
+      "state" : {
+        "revision" : "a52db1a2eca74d37c8c19bf3165416941632ed45",
+        "version" : "0.9.2"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+        "version" : "0.25.10"
       }
     }
   ],

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -21,6 +21,12 @@ let package = Package(
         // offline and this fails to resolve, temporarily comment this dependency and the
         // matching target dependency below — the rest of the package builds without it.
         .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.0"),
+        // Native Swift code editor powered by tree-sitter.
+        .package(url: "https://github.com/CodeEditApp/CodeEditSourceEditor", exact: "0.12.0"),
+        // CodeEditSourceEditor 0.12.0 declares CodeEditTextView from 0.10.1, but
+        // newer 0.12.x CodeEditTextView releases changed minimap APIs. Constrain
+        // the resolver to the compatible release used by this source-editor tag.
+        .package(url: "https://github.com/CodeEditApp/CodeEditTextView.git", exact: "0.10.1"),
     ],
     targets: [
         .target(
@@ -68,6 +74,8 @@ let package = Package(
                 "MatrixNet",
                 "MatrixTerminal",
                 "MatrixBoard",
+                .product(name: "CodeEditSourceEditor", package: "CodeEditSourceEditor"),
+                .product(name: "CodeEditTextView", package: "CodeEditTextView"),
             ],
             path: "Sources/App",
             swiftSettings: [

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1330,14 +1330,24 @@ public final class AppModel: ObservableObject {
             guard let self, let client = self.gatewayClient() else { return }
             guard await self.resolveProjectIfNeeded() else { return }
             let slug = self.projectSlug
-            struct CreateTaskRequest: Encodable { let title: String; let status: String }
+            struct CreateTaskRequest: Encodable {
+                let title: String
+                let status: String
+                let linkedSessionId: String?
+            }
             struct CreateTaskResponse: Decodable {
                 let task: GatewayTaskDTO?
             }
             do {
+                let sessionName = self.generatedShellSessionName()
+                let linkedSessionId = try await self.createTerminalSession(
+                    client: client,
+                    name: sessionName,
+                    cwd: self.terminalCwd(forProjectSlug: slug)
+                )
                 let response: CreateTaskResponse = try await client.post(
                     "/api/projects/\(slug)/tasks",
-                    body: CreateTaskRequest(title: "New task", status: status.rawValue)
+                    body: CreateTaskRequest(title: "New task", status: status.rawValue, linkedSessionId: linkedSessionId)
                 )
                 if let task = response.task {
                     let card = task.toCard()
@@ -2127,20 +2137,9 @@ public final class AppModel: ObservableObject {
         let name = generatedShellSessionName()
         Task { [weak self] in
             defer { Task { @MainActor in self?.isCreatingWorkItem = false } }
-            struct CreateSessionRequest: Encodable {
-                let name: String
-                let cwd: String?
-            }
-            struct CreateSessionResponse: Decodable {
-                let name: String?
-            }
             do {
-                let response: CreateSessionResponse = try await client.post(
-                    "/api/terminal/sessions",
-                    body: CreateSessionRequest(name: name, cwd: nil)
-                )
+                let requestedName = try await self?.createTerminalSession(client: client, name: name, cwd: nil) ?? name
                 await self?.loadSessions()
-                let requestedName = response.name ?? name
                 if self?.sessions.contains(where: { $0.name == requestedName }) == true {
                     await MainActor.run { self?.openSession(named: requestedName) }
                 } else if let created = self?.sessions.first(where: { !existingSessionNames.contains($0.name) }) {
@@ -2150,6 +2149,27 @@ public final class AppModel: ObservableObject {
                 await MainActor.run { self?.openError = .createSessionFailed }
             }
         }
+    }
+
+    private struct CreateTerminalSessionRequest: Encodable {
+        let name: String
+        let cwd: String?
+    }
+
+    private struct CreateTerminalSessionResponse: Decodable {
+        let name: String?
+    }
+
+    private func createTerminalSession(
+        client: GatewayHTTPClient,
+        name: String,
+        cwd: String?
+    ) async throws -> String {
+        let response: CreateTerminalSessionResponse = try await client.post(
+            "/api/terminal/sessions",
+            body: CreateTerminalSessionRequest(name: name, cwd: cwd)
+        )
+        return response.name ?? name
     }
 
     private func generatedShellSessionName() -> String {

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -422,6 +422,7 @@ public final class AppModel: ObservableObject {
     /// Terminal sessions are retained per terminal tab so tab switching does not
     /// tear down sockets or drop zellij output.
     @Published public private(set) var terminalSessions: [String: TerminalSession] = [:]
+    private var terminalSessionTabIDsByAttachName: [String: String] = [:]
     /// The user's projects (for the project picker / Projects UI).
     @Published public private(set) var projects: [ProjectSummary] = []
     /// Files for the active project/editor panel.
@@ -436,6 +437,11 @@ public final class AppModel: ObservableObject {
     @Published public var selectedFileContent: String = ""
     @Published public private(set) var fileSaveState: String?
     @Published public private(set) var isLoadingSelectedFile = false
+    /// Task/project-scoped quick-open file index for Cmd+O.
+    @Published public var showFileOpenPalette = false
+    @Published public var fileOpenQuery = ""
+    @Published public private(set) var indexedFilePaths: [String] = []
+    @Published public private(set) var isIndexingFiles = false
     /// Git branches for the active project.
     @Published public private(set) var gitBranches: [GitBranchSummary] = []
     /// Pull requests for the active project, when GitHub is linked.
@@ -514,6 +520,10 @@ public final class AppModel: ObservableObject {
     private var sessionAttachNames: [String: String] = [:]
     private let maxCachedTerminalSessions = 8
     private var terminalSessionAccessOrder: [String] = []
+    private var fileIndexTask: Task<Void, Never>?
+    private let maxIndexedFiles = 1_500
+    private let maxIndexedDirectories = 300
+    private let maxFileIndexDepth = 9
 
     /// Factory for the gateway client given a resolved base URL + token provider.
     /// Injected so tests can stub it without real networking.
@@ -784,6 +794,7 @@ public final class AppModel: ObservableObject {
         selectedCard = nil
         terminal = nil
         terminalSessions = [:]
+        terminalSessionTabIDsByAttachName = [:]
         terminalSessionAccessOrder = []
         sessions = []
         projects = []
@@ -797,6 +808,9 @@ public final class AppModel: ObservableObject {
         selectedFilePath = nil
         selectedFileData = nil
         selectedFileContent = ""
+        fileOpenQuery = ""
+        indexedFilePaths = []
+        showFileOpenPalette = false
         isLoadingSelectedFile = false
         fileSaveState = nil
         gitBranches = []
@@ -1402,6 +1416,14 @@ public final class AppModel: ObservableObject {
         let requestedSession = card.linkedSessionId ?? ""
         let attachSession = sessionAttachName(for: requestedSession)
         let hasSession = !attachSession.isEmpty
+        if hasSession,
+           let existingTabID = terminalSessionTabIDsByAttachName[attachSession],
+           let existing = terminalSessions[existingTabID] {
+            terminalSessions[tabID] = existing
+            markTerminalSessionUsed(tabID)
+            terminal = existing
+            return existing
+        }
         let wsURL: URL
         do {
             if hasSession {
@@ -1411,7 +1433,7 @@ public final class AppModel: ObservableObject {
                     fromSeq: Int?.none
                 )
             } else {
-                wsURL = try profile.autoCreateTerminalURL(cwd: nil)
+                wsURL = try profile.autoCreateTerminalURL(cwd: terminalCwd(forProjectSlug: card.projectSlug))
             }
         } catch {
             let err = OperatorError.misconfigured
@@ -1421,7 +1443,7 @@ public final class AppModel: ObservableObject {
 
         let label = hasSession ? attachSession : card.title
         let session = makeTerminal(wsURL, principal, attachSession, label)
-        cacheTerminalSession(session, for: tabID)
+        cacheTerminalSession(session, for: tabID, attachName: hasSession ? attachSession : nil)
         terminal = session
         if !hasSession {
             session.onNextAttach { [weak self] in
@@ -1575,6 +1597,11 @@ public final class AppModel: ObservableObject {
 
     public func focusPreviousTab() {
         focusTab(offset: -1)
+    }
+
+    public func focusTab(at index: Int) {
+        guard openTabs.indices.contains(index) else { return }
+        focusTab(id: openTabs[index].id)
     }
 
     private func focusTab(offset: Int) {
@@ -1736,6 +1763,112 @@ public final class AppModel: ObservableObject {
                 )
             }
         }
+    }
+
+    public var fileOpenSearchResults: [WorkspaceFileSearchItem] {
+        WorkspaceFileSearchItem.filtered(paths: indexedFilePaths, query: fileOpenQuery)
+    }
+
+    public func showFileOpenSearch() {
+        showFileOpenPalette = true
+        if indexedFilePaths.isEmpty {
+            refreshFileOpenIndex()
+        }
+    }
+
+    public func hideFileOpenSearch() {
+        showFileOpenPalette = false
+        fileOpenQuery = ""
+    }
+
+    public func refreshFileOpenIndex() {
+        guard let client = gatewayClient() else { return }
+        let rootPath = "projects/\(projectSlug)"
+        fileIndexTask?.cancel()
+        fileIndexTask = Task { [weak self] in
+            await self?.rebuildFileSearchIndex(rootPath: rootPath, client: client)
+        }
+    }
+
+    public func openFileFromSearch(_ item: WorkspaceFileSearchItem) {
+        guard let client = gatewayClient() else { return }
+        hideFileOpenSearch()
+        switchPanel(.app(slug: "editor"))
+        openFile(path: item.path, client: client)
+    }
+
+    private func rebuildFileSearchIndex(rootPath: String, client: GatewayHTTPClient) async {
+        isIndexingFiles = true
+        var indexedFiles: [String] = []
+        var visitedDirectories = 0
+        await collectIndexedFiles(
+            path: rootPath,
+            depth: 0,
+            client: client,
+            indexedFiles: &indexedFiles,
+            visitedDirectories: &visitedDirectories
+        )
+        if Task.isCancelled { return }
+        indexedFilePaths = indexedFiles.sorted { lhs, rhs in
+            lhs.localizedStandardCompare(rhs) == .orderedAscending
+        }
+        isIndexingFiles = false
+    }
+
+    private func collectIndexedFiles(
+        path: String,
+        depth: Int,
+        client: GatewayHTTPClient,
+        indexedFiles: inout [String],
+        visitedDirectories: inout Int
+    ) async {
+        guard !Task.isCancelled,
+              depth <= maxFileIndexDepth,
+              indexedFiles.count < maxIndexedFiles,
+              visitedDirectories < maxIndexedDirectories else {
+            return
+        }
+        visitedDirectories += 1
+        let entries: [FileTreeDTO]
+        do {
+            entries = try await client.get("/api/files/tree?path=\(queryValue(path))")
+        } catch let error as URLError {
+            appModelLogger.error("File index load failed with URL error code \(error.code.rawValue, privacy: .public)")
+            return
+        } catch {
+            appModelLogger.error("File index load failed with error type \(String(describing: type(of: error)), privacy: .public)")
+            return
+        }
+
+        for entry in entries.sorted(by: { $0.name.localizedStandardCompare($1.name) == .orderedAscending }) {
+            guard indexedFiles.count < maxIndexedFiles else { return }
+            let childPath = path.isEmpty ? entry.name : "\(path)/\(entry.name)"
+            if entry.type == "directory" {
+                guard !shouldSkipIndexedDirectory(entry.name) else { continue }
+                await collectIndexedFiles(
+                    path: childPath,
+                    depth: depth + 1,
+                    client: client,
+                    indexedFiles: &indexedFiles,
+                    visitedDirectories: &visitedDirectories
+                )
+            } else {
+                indexedFiles.append(childPath)
+            }
+        }
+    }
+
+    private func shouldSkipIndexedDirectory(_ name: String) -> Bool {
+        [
+            ".build",
+            ".git",
+            ".next",
+            ".turbo",
+            "DerivedData",
+            "dist",
+            "node_modules",
+            "target",
+        ].contains(name)
     }
 
     private struct FileTreeDTO: Decodable {
@@ -2024,6 +2157,15 @@ public final class AppModel: ObservableObject {
         return "shell-\(suffix)"
     }
 
+    private func terminalCwd(forProjectSlug slug: String) -> String {
+        let trimmed = slug.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "projects" }
+        guard trimmed.range(of: #"^[A-Za-z0-9._-]+$"#, options: .regularExpression) != nil else {
+            return "projects"
+        }
+        return "projects/\(trimmed)"
+    }
+
     private func displayName(for card: Card) -> String {
         if let session = card.linkedSessionId, !session.isEmpty {
             return sessionAttachName(for: session)
@@ -2035,8 +2177,11 @@ public final class AppModel: ObservableObject {
         sessionAttachNames[session] ?? session
     }
 
-    private func cacheTerminalSession(_ session: TerminalSession, for tabID: String) {
+    private func cacheTerminalSession(_ session: TerminalSession, for tabID: String, attachName: String? = nil) {
         terminalSessions[tabID] = session
+        if let attachName, !attachName.isEmpty {
+            terminalSessionTabIDsByAttachName[attachName] = tabID
+        }
         markTerminalSessionUsed(tabID)
         evictCachedTerminalSessionsIfNeeded()
     }
@@ -2058,7 +2203,16 @@ public final class AppModel: ObservableObject {
 
     private func removeCachedTerminalSession(for tabID: String) {
         terminalSessionAccessOrder.removeAll { $0 == tabID }
-        terminalSessions.removeValue(forKey: tabID)?.shutdown()
+        guard let removed = terminalSessions.removeValue(forKey: tabID) else { return }
+        for (attachName, existingTabID) in terminalSessionTabIDsByAttachName where existingTabID == tabID {
+            if let replacement = terminalSessions.first(where: { $0.value === removed })?.key {
+                terminalSessionTabIDsByAttachName[attachName] = replacement
+            } else {
+                terminalSessionTabIDsByAttachName.removeValue(forKey: attachName)
+            }
+        }
+        guard !terminalSessions.values.contains(where: { $0 === removed }) else { return }
+        removed.shutdown()
     }
 
     private func queryValue(_ value: String) -> String {

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1210,28 +1210,6 @@ public final class AppModel: ObservableObject {
         selectedCard?.linkedSessionId ?? selectedCard?.id
     }
 
-    /// All live (cached) terminal sessions, ordered least→most recently used, with the
-    /// active session guaranteed present. The terminal surface renders these together
-    /// (only the active one visible) so switching sessions is instant: inactive views
-    /// stay mounted with their PTY stream + scrollback alive instead of tearing down
-    /// and re-attaching from scratch.
-    public var liveTerminalSessions: [TerminalSession] {
-        var ordered: [TerminalSession] = []
-        var seen = Set<UUID>()
-        for tabID in terminalSessionAccessOrder {
-            if let s = terminalSessions[tabID], seen.insert(s.id).inserted {
-                ordered.append(s)
-            }
-        }
-        for s in terminalSessions.values where seen.insert(s.id).inserted {
-            ordered.append(s)
-        }
-        if let active = terminal, seen.insert(active.id).inserted {
-            ordered.append(active)
-        }
-        return ordered
-    }
-
     /// Creates a project (optionally from a git remote) and opens it.
     public func createProject(name: String, remote: String?, startMode: ProjectStartMode = .scratch) {
         guard let client = gatewayClient() else { return }

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1210,6 +1210,28 @@ public final class AppModel: ObservableObject {
         selectedCard?.linkedSessionId ?? selectedCard?.id
     }
 
+    /// All live (cached) terminal sessions, ordered least→most recently used, with the
+    /// active session guaranteed present. The terminal surface renders these together
+    /// (only the active one visible) so switching sessions is instant: inactive views
+    /// stay mounted with their PTY stream + scrollback alive instead of tearing down
+    /// and re-attaching from scratch.
+    public var liveTerminalSessions: [TerminalSession] {
+        var ordered: [TerminalSession] = []
+        var seen = Set<UUID>()
+        for tabID in terminalSessionAccessOrder {
+            if let s = terminalSessions[tabID], seen.insert(s.id).inserted {
+                ordered.append(s)
+            }
+        }
+        for s in terminalSessions.values where seen.insert(s.id).inserted {
+            ordered.append(s)
+        }
+        if let active = terminal, seen.insert(active.id).inserted {
+            ordered.append(active)
+        }
+        return ordered
+    }
+
     /// Creates a project (optionally from a git remote) and opens it.
     public func createProject(name: String, remote: String?, startMode: ProjectStartMode = .scratch) {
         guard let client = gatewayClient() else { return }

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -485,6 +485,10 @@ public final class AppModel: ObservableObject {
     /// Monotonic marker for completed sign-ins. Cancellation returns `signIn` to
     /// idle too, so hosted-shell recovery listens to this instead of idle alone.
     @Published public private(set) var signInCompletionID = 0
+    /// True when the hosted web shell reported it needs (re)authentication. The
+    /// native principal/gateway session remain valid; this only gates the hosted
+    /// shell panel's sign-in prompt and prevents a redirect/sign-out loop.
+    @Published public private(set) var hostedShellNeedsSignIn = false
 
     // MARK: - Dependencies
 
@@ -741,6 +745,21 @@ public final class AppModel: ObservableObject {
         Task { await signOutNow() }
     }
 
+    /// Hosted web shell (WKWebView at app.matrix-os.com) needs (re)authentication.
+    /// Non-destructive: the native device-auth principal and gateway session stay
+    /// valid, so we DO NOT sign out — that previously caused a redirect-to-/login
+    /// -> native sign-out -> workspace re-show loop. We only flag the hosted shell
+    /// so its panel shows the sign-in prompt without retrying forever.
+    public func markHostedShellAuthRequired() {
+        appModelLogger.warning("Hosted shell needs sign-in; keeping native session (no sign-out)")
+        hostedShellNeedsSignIn = true
+    }
+
+    /// Hosted web shell authenticated (loaded a non-auth page on the app host).
+    public func markHostedShellAuthorized() {
+        hostedShellNeedsSignIn = false
+    }
+
     public func signOutNow() async {
         signInTask?.cancel()
         signInTask = nil
@@ -758,6 +777,7 @@ public final class AppModel: ObservableObject {
         profile = nil
         phase = .needsProfile
         signIn = .idle
+        hostedShellNeedsSignIn = false
         hasSelectedProject = false
         section = .board
         nativeSettingsSection = .account
@@ -816,6 +836,7 @@ public final class AppModel: ObservableObject {
                 case let .approved(token):
                     try await principal.setToken(token.accessToken)
                     signIn = .idle
+                    hostedShellNeedsSignIn = false
                     let handle = (token.handle?.isEmpty == false ? token.handle : nil) ?? "me"
                     let newProfile = ConnectionProfile(handle: handle, gatewayHost: signInGatewayHost, runtimeSlot: nil)
                     persistProfile(newProfile)
@@ -2136,16 +2157,11 @@ private final class NativeAuthBrowser: NSObject, ASWebAuthenticationPresentation
 
     func open(_ url: URL) {
         session?.cancel()
-        let nextSession = ASWebAuthenticationSession(url: url, callbackURLScheme: "matrixos") { [weak self] callbackURL, error in
-            Task { @MainActor in
-                self?.session = nil
-                if callbackURL != nil {
-                    NSApp.activate(ignoringOtherApps: true)
-                } else if let error {
-                    appModelLogger.warning("Native auth browser ended without callback: \(String(describing: error), privacy: .private)")
-                }
-            }
-        }
+        let nextSession = ASWebAuthenticationSession(
+            url: url,
+            callbackURLScheme: "matrixos",
+            completionHandler: Self.makeCompletionHandler()
+        )
         nextSession.prefersEphemeralWebBrowserSession = false
         nextSession.presentationContextProvider = self
         session = nextSession
@@ -2162,6 +2178,23 @@ private final class NativeAuthBrowser: NSObject, ASWebAuthenticationPresentation
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first ?? ASPresentationAnchor()
+    }
+
+    nonisolated private static func makeCompletionHandler() -> (URL?, Error?) -> Void {
+        { callbackURL, error in
+            Task { @MainActor in
+                NativeAuthBrowser.shared.finish(callbackURL: callbackURL, error: error)
+            }
+        }
+    }
+
+    private func finish(callbackURL: URL?, error: Error?) {
+        session = nil
+        if callbackURL != nil {
+            NSApp.activate(ignoringOtherApps: true)
+        } else if let error {
+            appModelLogger.warning("Native auth browser ended without callback: \(String(describing: error), privacy: .private)")
+        }
     }
 }
 #endif

--- a/macos/Sources/App/AppModel.swift
+++ b/macos/Sources/App/AppModel.swift
@@ -1281,17 +1281,52 @@ public final class AppModel: ObservableObject {
     /// Moves a card to a new column/order (drag-to-move). Persists via PATCH and
     /// refreshes on completion to reconcile.
     public func updateTaskStatus(cardId: String, to status: TaskStatus, order: Double?) {
+        updateTask(cardId: cardId, status: status, order: order)
+    }
+
+    public func updateTask(
+        cardId: String,
+        title: String? = nil,
+        description: String? = nil,
+        status: TaskStatus? = nil,
+        priority: TaskPriority? = nil,
+        order: Double? = nil
+    ) {
         guard let client = gatewayClient() else { return }
         openError = nil
         let slug = projectSlug
         Task { [weak self] in
-            struct UpdateTaskRequest: Encodable { let status: String; let order: Double? }
-            struct UpdateTaskResponse: Decodable {}
+            struct UpdateTaskRequest: Encodable {
+                let title: String?
+                let description: String?
+                let status: String?
+                let priority: String?
+                let order: Double?
+            }
+            struct UpdateTaskResponse: Decodable {
+                let task: GatewayTaskDTO?
+            }
+            let trimmedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
             do {
-                let _: UpdateTaskResponse = try await client.patch(
+                let response: UpdateTaskResponse = try await client.patch(
                     "/api/projects/\(slug)/tasks/\(cardId)",
-                    body: UpdateTaskRequest(status: status.rawValue, order: order)
+                    body: UpdateTaskRequest(
+                        title: trimmedTitle?.isEmpty == false ? trimmedTitle : nil,
+                        description: description?.trimmingCharacters(in: .whitespacesAndNewlines),
+                        status: status?.rawValue,
+                        priority: priority?.rawValue,
+                        order: order
+                    )
                 )
+                if let task = response.task {
+                    await MainActor.run {
+                        let card = task.toCard()
+                        if self?.selectedCard?.id == card.id {
+                            self?.selectedCard = card
+                            _ = self?.upsertTab(for: card)
+                        }
+                    }
+                }
                 await self?.refresh()
             } catch {
                 appModelLogger.error("Task status update failed: \(String(describing: error), privacy: .private)")
@@ -1321,7 +1356,12 @@ public final class AppModel: ObservableObject {
     }
 
     /// Creates a new task in the given column and refreshes the board (TE01/US7).
-    public func createTask(status: TaskStatus = .todo) {
+    public func createTask(
+        title rawTitle: String = "New task",
+        description rawDescription: String? = nil,
+        status: TaskStatus = .todo,
+        priority: TaskPriority = .normal
+    ) {
         guard !isCreatingWorkItem else { return }
         openError = nil
         isCreatingWorkItem = true
@@ -1332,13 +1372,17 @@ public final class AppModel: ObservableObject {
             let slug = self.projectSlug
             struct CreateTaskRequest: Encodable {
                 let title: String
+                let description: String?
                 let status: String
+                let priority: String
                 let linkedSessionId: String?
             }
             struct CreateTaskResponse: Decodable {
                 let task: GatewayTaskDTO?
             }
             do {
+                let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+                let description = rawDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
                 let sessionName = self.generatedShellSessionName()
                 let linkedSessionId = try await self.createTerminalSession(
                     client: client,
@@ -1347,7 +1391,13 @@ public final class AppModel: ObservableObject {
                 )
                 let response: CreateTaskResponse = try await client.post(
                     "/api/projects/\(slug)/tasks",
-                    body: CreateTaskRequest(title: "New task", status: status.rawValue, linkedSessionId: linkedSessionId)
+                    body: CreateTaskRequest(
+                        title: title.isEmpty ? "New task" : title,
+                        description: description?.isEmpty == false ? description : nil,
+                        status: status.rawValue,
+                        priority: priority.rawValue,
+                        linkedSessionId: linkedSessionId
+                    )
                 )
                 if let task = response.task {
                     let card = task.toCard()
@@ -1361,6 +1411,35 @@ public final class AppModel: ObservableObject {
                 await self.refresh()
             } catch {
                 await MainActor.run { self.openError = .taskMutationFailed }
+            }
+        }
+    }
+
+    public func archiveTask(cardId: String) {
+        updateTask(cardId: cardId, status: .archived)
+    }
+
+    public func deleteTask(cardId: String) {
+        guard let client = gatewayClient() else { return }
+        openError = nil
+        let slug = projectSlug
+        Task { [weak self] in
+            do {
+                try await client.delete("/api/projects/\(slug)/tasks/\(cardId)")
+                await MainActor.run {
+                    if self?.selectedCard?.id == cardId {
+                        self?.selectedCard = nil
+                        self?.terminal = nil
+                    }
+                    if let tab = self?.openTabs.first(where: { $0.card?.id == cardId }) {
+                        self?.closeTab(id: tab.id)
+                    }
+                }
+                await self?.refresh()
+            } catch {
+                appModelLogger.error("Task delete failed: \(String(describing: error), privacy: .private)")
+                await MainActor.run { self?.openError = .taskMutationFailed }
+                await self?.refresh()
             }
         }
     }
@@ -1551,6 +1630,9 @@ public final class AppModel: ObservableObject {
         let closedTab = openTabs[index]
         let wasActive = activeTabID == id
         openTabs.remove(at: index)
+        if pendingTerminalSessionTabID == id {
+            pendingTerminalSessionTabID = nil
+        }
         removeCachedTerminalSession(for: id)
         reconcileProjectSelectionAfterClosing(closedTab)
         if !wasActive { return }
@@ -2127,14 +2209,70 @@ public final class AppModel: ObservableObject {
 
     /// Whether a task or terminal-session create request is in flight.
     @Published public private(set) var isCreatingWorkItem = false
+    @Published public private(set) var pendingTerminalSessionTabID: String?
+
+    public func createWorkspaceTabFromCurrentContext() {
+        if section == .terminal || activeTabKind == .session {
+            beginTerminalSessionCreation()
+        } else {
+            createTask(status: .todo)
+        }
+    }
+
+    private var activeTabKind: WorkspaceTab.Kind? {
+        guard let activeTabID else { return nil }
+        return openTabs.first(where: { $0.id == activeTabID })?.kind
+    }
+
+    public func beginTerminalSessionCreation() {
+        guard !isCreatingWorkItem else { return }
+        let tabID = "session:\(projectSlug):__new_session__"
+        let tab = WorkspaceTab(
+            id: tabID,
+            title: "New terminal",
+            projectSlug: projectSlug,
+            projectName: activeProjectName,
+            kind: .session,
+            panel: .terminal
+        )
+        if let index = openTabs.firstIndex(where: { $0.id == tabID }) {
+            openTabs[index] = tab
+        } else {
+            openTabs.append(tab)
+            trimOpenTabsToLimit(protecting: tabID)
+        }
+        section = .terminal
+        activeTabID = tabID
+        pendingTerminalSessionTabID = tabID
+        terminal = nil
+        selectedCard = nil
+    }
+
+    public func cancelPendingTerminalSessionCreation() {
+        guard let tabID = pendingTerminalSessionTabID else { return }
+        pendingTerminalSessionTabID = nil
+        closeTab(id: tabID)
+    }
+
+    public func commitPendingTerminalSessionName(_ rawName: String) {
+        guard let tabID = pendingTerminalSessionTabID else { return }
+        pendingTerminalSessionTabID = nil
+        closeTab(id: tabID)
+        createSession(named: rawName)
+    }
 
     /// Creates a new zellij session (Terminals section "+") and reloads the list.
-    public func createSession() {
+    public func createSession(named rawName: String? = nil) {
         guard !isCreatingWorkItem, let client = gatewayClient() else { return }
         openError = nil
         isCreatingWorkItem = true
         let existingSessionNames = Set(sessions.map(\.name))
-        let name = generatedShellSessionName()
+        let name = sanitizedShellSessionName(rawName) ?? generatedShellSessionName()
+        if existingSessionNames.contains(name) {
+            isCreatingWorkItem = false
+            openSession(named: name)
+            return
+        }
         Task { [weak self] in
             defer { Task { @MainActor in self?.isCreatingWorkItem = false } }
             do {
@@ -2149,6 +2287,28 @@ public final class AppModel: ObservableObject {
                 await MainActor.run { self?.openError = .createSessionFailed }
             }
         }
+    }
+
+    private func sanitizedShellSessionName(_ rawName: String?) -> String? {
+        guard let rawName else { return nil }
+        let lowercased = rawName.lowercased()
+        var output = ""
+        var previousWasDash = false
+        for character in lowercased {
+            if character.isASCII && (character.isLetter || character.isNumber) {
+                output.append(character)
+                previousWasDash = false
+            } else if !previousWasDash {
+                output.append("-")
+                previousWasDash = true
+            }
+            if output.count >= 31 { break }
+        }
+        let normalized = output.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        guard normalized.range(of: #"^[a-z0-9][a-z0-9-]{0,30}$"#, options: .regularExpression) != nil else {
+            return nil
+        }
+        return normalized
     }
 
     private struct CreateTerminalSessionRequest: Encodable {

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -15,6 +15,10 @@ struct BoardView: View {
     @ObservedObject var model: AppModel
     /// Board zoom (Conductor-style). ⌘+/⌘-/⌘0 and pinch.
     @State private var zoom: CGFloat = 1
+    @State private var taskEditor: TaskEditorState?
+    @State private var pendingDeleteCard: Card?
+    @State private var editingDetailTitle: String?
+    @FocusState private var detailTitleFocused: Bool
     @GestureState private var pinch: CGFloat = 1
 
     private static let minZoom: CGFloat = 0.5
@@ -27,6 +31,28 @@ struct BoardView: View {
             content
         }
         .toolbar { toolbarContent }
+        .sheet(item: $taskEditor) { editor in
+            TaskEditorSheet(
+                state: editor,
+                onCancel: { taskEditor = nil },
+                onSave: saveTaskEditor
+            )
+        }
+        .confirmationDialog(
+            "Delete task?",
+            isPresented: Binding(
+                get: { pendingDeleteCard != nil },
+                set: { if !$0 { pendingDeleteCard = nil } }
+            ),
+            presenting: pendingDeleteCard
+        ) { card in
+            Button("Delete \(card.title)", role: .destructive) {
+                model.deleteTask(cardId: card.id)
+                pendingDeleteCard = nil
+            }
+        } message: { card in
+            Text("This removes \(card.title) from the project task board.")
+        }
     }
 
     @ViewBuilder
@@ -97,7 +123,16 @@ struct BoardView: View {
                         column: column,
                         selectedCardID: selectedBoardCard?.id,
                         onOpenCard: openCard,
-                        onAddCard: { model.createTask(status: $0) },
+                        onAddCard: { taskEditor = TaskEditorState(createIn: $0) },
+                        onEditCard: { taskEditor = TaskEditorState(editing: $0) },
+                        onArchiveCard: { model.archiveTask(cardId: $0.id) },
+                        onDeleteCard: { pendingDeleteCard = $0 },
+                        onSetCardStatus: { card, status in
+                            model.updateTask(cardId: card.id, status: status)
+                        },
+                        onSetCardPriority: { card, priority in
+                            model.updateTask(cardId: card.id, priority: priority)
+                        },
                         onMoveCard: { id, status in
                             model.updateTaskStatus(cardId: id, to: status, order: nil)
                         }
@@ -119,6 +154,26 @@ struct BoardView: View {
         )
         .background(zoomShortcuts)
         .animation(Motion.columnReflow, value: effectiveZoom)
+    }
+
+    private func saveTaskEditor(_ state: TaskEditorState) {
+        if let cardId = state.cardId {
+            model.updateTask(
+                cardId: cardId,
+                title: state.title,
+                description: state.description,
+                status: state.status,
+                priority: state.priority
+            )
+        } else {
+            model.createTask(
+                title: state.title,
+                description: state.description,
+                status: state.status,
+                priority: state.priority
+            )
+        }
+        taskEditor = nil
     }
 
     /// Hidden buttons providing ⌘+/⌘-/⌘0 zoom shortcuts.
@@ -169,12 +224,19 @@ struct BoardView: View {
     }
 
     private var detailHeader: some View {
-        HStack {
-            Text(activeDetailCard?.title ?? "Task")
-                .font(.plexSans(13, weight: .semibold))
-                .foregroundStyle(Color.inkPrimary)
-                .lineLimit(1)
+        HStack(spacing: Spacing.x2) {
+            if let card = activeDetailCard {
+                detailTitleControl(card)
+            } else {
+                Text("Task")
+                    .font(.plexSans(13, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                    .lineLimit(1)
+            }
             Spacer()
+            if let card = activeDetailCard {
+                detailSettingsMenu(card)
+            }
             Button(action: model.closeCard) {
                 Image(systemName: "xmark")
                     .font(.system(size: 11, weight: .semibold))
@@ -187,6 +249,107 @@ struct BoardView: View {
         .padding(.horizontal, Spacing.x4)
         .padding(.vertical, Spacing.x2)
         .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private func detailTitleControl(_ card: Card) -> some View {
+        if editingDetailTitle != nil {
+            TextField("Task title", text: Binding(
+                get: { editingDetailTitle ?? card.title },
+                set: { editingDetailTitle = $0 }
+            ))
+            .textFieldStyle(.plain)
+            .font(.plexSans(13, weight: .semibold))
+            .foregroundStyle(Color.inkPrimary)
+            .focused($detailTitleFocused)
+            .onSubmit { commitDetailTitle(card) }
+            .onExitCommand { editingDetailTitle = nil }
+            .frame(minWidth: 160, maxWidth: 420, alignment: .leading)
+        } else {
+            Button {
+                editingDetailTitle = card.title
+                DispatchQueue.main.async { detailTitleFocused = true }
+            } label: {
+                HStack(spacing: Spacing.x1) {
+                    Text(card.title)
+                        .font(.plexSans(13, weight: .semibold))
+                        .foregroundStyle(Color.inkPrimary)
+                        .lineLimit(1)
+                    Image(systemName: "pencil")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.inkTertiary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Rename task")
+        }
+    }
+
+    private func detailSettingsMenu(_ card: Card) -> some View {
+        Menu {
+            Button("Edit Task") { taskEditor = TaskEditorState(editing: card) }
+            Divider()
+            Menu("Status") {
+                ForEach(TaskStatus.allCases, id: \.self) { status in
+                    Button(status.displayTitle) {
+                        model.updateTask(cardId: card.id, status: status)
+                    }
+                }
+            }
+            Menu("Priority") {
+                ForEach(TaskPriority.allCases, id: \.self) { priority in
+                    Button(priority.displayTitle) {
+                        model.updateTask(cardId: card.id, priority: priority)
+                    }
+                }
+            }
+            Menu("Tags") {
+                Button("Tags are not persisted yet") {}
+                    .disabled(true)
+            }
+            Button("Blocked") {
+                model.updateTask(cardId: card.id, status: .blocked)
+            }
+            Menu("Blocked by") {
+                Button("Dependency links are not persisted yet") {}
+                    .disabled(true)
+            }
+            Menu("Snooze") {
+                Button("Snooze is not persisted yet") {}
+                    .disabled(true)
+            }
+            Divider()
+            Menu("Move to") {
+                ForEach(TaskStatus.allCases, id: \.self) { status in
+                    Button(status.displayTitle) {
+                        model.updateTask(cardId: card.id, status: status)
+                    }
+                }
+            }
+            Button("Copy") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(card.id, forType: .string)
+            }
+            Divider()
+            Button("Archive") { model.archiveTask(cardId: card.id) }
+            Button("Delete", role: .destructive) { pendingDeleteCard = card }
+        } label: {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.inkTertiary)
+                .iconHitTarget(30)
+        }
+        .menuStyle(.borderlessButton)
+        .buttonStyle(.plain)
+        .help("Task settings")
+    }
+
+    private func commitDetailTitle(_ card: Card) {
+        let nextTitle = editingDetailTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        editingDetailTitle = nil
+        guard !nextTitle.isEmpty, nextTitle != card.title else { return }
+        model.updateTask(cardId: card.id, title: nextTitle)
     }
 
     @ViewBuilder
@@ -388,6 +551,166 @@ struct BoardView: View {
 
     private func openCreateFlow() {
         model.beginSignIn(mode: .signUp)
+    }
+}
+
+private struct TaskEditorState: Identifiable {
+    let id: String
+    let cardId: String?
+    var title: String
+    var description: String
+    var status: TaskStatus
+    var priority: TaskPriority
+
+    init(createIn status: TaskStatus) {
+        self.id = "create:\(status.rawValue)"
+        self.cardId = nil
+        self.title = ""
+        self.description = ""
+        self.status = status
+        self.priority = .normal
+    }
+
+    init(editing card: Card) {
+        self.id = "edit:\(card.id)"
+        self.cardId = card.id
+        self.title = card.title
+        self.description = card.description ?? ""
+        self.status = card.status
+        self.priority = card.priority
+    }
+
+    var isCreating: Bool { cardId == nil }
+}
+
+private struct TaskEditorSheet: View {
+    @State var state: TaskEditorState
+    let onCancel: () -> Void
+    let onSave: (TaskEditorState) -> Void
+    @FocusState private var titleFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.x4) {
+            HStack {
+                Text(state.isCreating ? "Create Task" : "Edit Task")
+                    .font(.plexSans(22, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.inkTertiary)
+                        .iconHitTarget(30)
+                }
+                .buttonStyle(.plain)
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.x2) {
+                Text("Title")
+                    .font(.plexSans(12, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                TextField("Task title", text: $state.title)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.plexSans(15))
+                    .focused($titleFocused)
+                    .onSubmit(commit)
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.x2) {
+                Text("Description")
+                    .font(.plexSans(12, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                TextEditor(text: $state.description)
+                    .font(.plexSans(13))
+                    .frame(height: 86)
+                    .scrollContentBackground(.hidden)
+                    .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                            .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
+                    )
+            }
+
+            HStack(spacing: Spacing.x3) {
+                Picker("Status", selection: $state.status) {
+                    ForEach(TaskStatus.allCases, id: \.self) { status in
+                        Text(status.displayTitle).tag(status)
+                    }
+                }
+                Picker("Priority", selection: $state.priority) {
+                    ForEach(TaskPriority.allCases, id: \.self) { priority in
+                        Text(priority.displayTitle).tag(priority)
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.x2) {
+                disabledSettingRow(icon: "calendar", title: "Due date", value: "Not synced yet")
+                disabledSettingRow(icon: "tag", title: "Tags", value: "Not synced yet")
+                disabledSettingRow(icon: "folder", title: "Project", value: "Current project")
+            }
+
+            HStack {
+                Button("Cancel", action: onCancel)
+                Spacer()
+                Button(state.isCreating ? "Create" : "Save", action: commit)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(state.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(Spacing.x5)
+        .frame(width: 520)
+        .onAppear {
+            DispatchQueue.main.async { titleFocused = true }
+        }
+    }
+
+    private func disabledSettingRow(icon: String, title: String, value: String) -> some View {
+        HStack(spacing: Spacing.x2) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.inkTertiary)
+                .frame(width: 18)
+            Text(title)
+                .font(.plexSans(12, weight: .semibold))
+                .foregroundStyle(Color.inkSecondary)
+            Spacer()
+            Text(value)
+                .font(.plexSans(12, weight: .medium))
+                .foregroundStyle(Color.inkTertiary)
+        }
+        .padding(.horizontal, Spacing.x3)
+        .frame(height: 32)
+        .background(Color.surfaceRail.opacity(0.8), in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+    }
+
+    private func commit() {
+        guard !state.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        onSave(state)
+    }
+}
+
+private extension TaskStatus {
+    var displayTitle: String {
+        switch self {
+        case .todo: return "Backlog"
+        case .running: return "Running"
+        case .waiting: return "Waiting"
+        case .blocked: return "Blocked"
+        case .complete: return "Complete"
+        case .archived: return "Archived"
+        }
+    }
+}
+
+private extension TaskPriority {
+    var displayTitle: String {
+        switch self {
+        case .low: return "Low"
+        case .normal: return "Medium"
+        case .high: return "High"
+        case .urgent: return "Urgent"
+        }
     }
 }
 

--- a/macos/Sources/App/BoardView.swift
+++ b/macos/Sources/App/BoardView.swift
@@ -155,6 +155,7 @@ struct BoardView: View {
             TaskPaneStrip(
                 activePanel: model.activePanel,
                 enabledPanels: model.enabledPanels,
+                onToggle: model.togglePanel,
                 onFocus: model.switchPanel
             )
             Divider().overlay(Color.hairlineDark)
@@ -191,11 +192,71 @@ struct BoardView: View {
     @ViewBuilder
     private var enabledPanelBody: some View {
         let panes = taskPaneSpecs.filter { model.enabledPanels.contains($0.panel) }
-        let active = model.enabledPanels.contains(model.activePanel) ? model.activePanel : panes.first?.panel
-        if let active {
-            panelBody(for: active)
-        } else {
+        if panes.isEmpty {
             placeholderPane("Choose a task pane to continue.")
+        } else if panes.count == 1, let pane = panes.first {
+            panelBody(for: pane.panel)
+        } else {
+            HSplitView {
+                ForEach(panes) { pane in
+                    taskPaneContainer(pane)
+                        .frame(minWidth: paneMinimumWidth(pane.panel), maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+        }
+    }
+
+    private func taskPaneContainer(_ pane: TaskPaneSpec) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: Spacing.x2) {
+                Label(pane.title, systemImage: pane.icon)
+                    .font(.plexSans(12, weight: .semibold))
+                    .foregroundStyle(pane.panel == model.activePanel ? Color.inkPrimary : Color.inkSecondary)
+                Spacer()
+                Text(pane.shortcut)
+                    .font(.plexMono(10))
+                    .foregroundStyle(Color.inkTertiary)
+                Button {
+                    model.togglePanel(pane.panel)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.inkTertiary)
+                        .iconHitTarget(24)
+                }
+                .buttonStyle(.plain)
+                .disabled(model.enabledPanels.count <= 1)
+                .help("Close pane")
+            }
+            .padding(.horizontal, Spacing.x3)
+            .frame(height: 34)
+            .background(pane.panel == model.activePanel ? Color.surfaceCardRaised : Color.surfaceRail)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(pane.panel == model.activePanel ? Color.signalLive.opacity(0.65) : Color.hairlineDark)
+                    .frame(height: 1)
+            }
+            .contentShape(Rectangle())
+            .onTapGesture { model.switchPanel(pane.panel) }
+            panelBody(for: pane.panel)
+        }
+    }
+
+    private func paneMinimumWidth(_ panel: Panel) -> CGFloat {
+        switch panel {
+        case .terminal:
+            return 360
+        case .shell:
+            return 420
+        case .app(let slug):
+            switch slug {
+            case "settings", "processes":
+                return 380
+            case "editor", "git":
+                return 460
+            default:
+                return 340
+            }
         }
     }
 

--- a/macos/Sources/App/CardView.swift
+++ b/macos/Sources/App/CardView.swift
@@ -17,6 +17,11 @@ struct CardView: View {
     let card: Card
     let isSelected: Bool
     let onOpen: () -> Void
+    var onEdit: () -> Void = {}
+    var onArchive: () -> Void = {}
+    var onDelete: () -> Void = {}
+    var onSetStatus: (TaskStatus) -> Void = { _ in }
+    var onSetPriority: (TaskPriority) -> Void = { _ in }
 
     @State private var isHovered = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -47,6 +52,21 @@ struct CardView: View {
         }
         .contextMenu {
             Button("Open Task", action: onOpen)
+            Button("Edit Task", action: onEdit)
+            Menu("Status") {
+                ForEach(TaskStatus.allCases, id: \.self) { status in
+                    Button(status.menuTitle) { onSetStatus(status) }
+                }
+            }
+            Menu("Priority") {
+                ForEach(TaskPriority.allCases, id: \.self) { priority in
+                    Button(priority.menuTitle) { onSetPriority(priority) }
+                }
+            }
+            Divider()
+            Button("Archive", action: onArchive)
+            Button("Delete", role: .destructive, action: onDelete)
+            Divider()
             Button("Copy Task ID") {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(card.id, forType: .string)
@@ -346,6 +366,30 @@ private struct LiveEdgeGlow: View {
         .opacity(reduceMotion ? 0.20 : (bright ? 0.26 : 0.12))
         .animation(reduceMotion ? nil : Motion.liveBreathe, value: bright)
         .onAppear { if !reduceMotion { bright = true } }
+    }
+}
+
+private extension TaskStatus {
+    var menuTitle: String {
+        switch self {
+        case .todo: return "Backlog"
+        case .running: return "Running"
+        case .waiting: return "Waiting"
+        case .blocked: return "Blocked"
+        case .complete: return "Complete"
+        case .archived: return "Archived"
+        }
+    }
+}
+
+private extension TaskPriority {
+    var menuTitle: String {
+        switch self {
+        case .low: return "Low"
+        case .normal: return "Medium"
+        case .high: return "High"
+        case .urgent: return "Urgent"
+        }
     }
 }
 #endif

--- a/macos/Sources/App/ColumnView.swift
+++ b/macos/Sources/App/ColumnView.swift
@@ -18,6 +18,11 @@ struct ColumnView: View {
     let selectedCardID: Card.ID?
     let onOpenCard: (Card) -> Void
     var onAddCard: (TaskStatus) -> Void = { _ in }
+    var onEditCard: (Card) -> Void = { _ in }
+    var onArchiveCard: (Card) -> Void = { _ in }
+    var onDeleteCard: (Card) -> Void = { _ in }
+    var onSetCardStatus: (Card, TaskStatus) -> Void = { _, _ in }
+    var onSetCardPriority: (Card, TaskPriority) -> Void = { _, _ in }
     /// Called when a card is dropped onto this lane. The board wires this to
     /// `model.updateTaskStatus(cardId:to:order:)`.
     var onMoveCard: (String, TaskStatus) -> Void = { _, _ in }
@@ -40,7 +45,12 @@ struct ColumnView: View {
                             CardView(
                                 card: card,
                                 isSelected: card.id == selectedCardID,
-                                onOpen: { onOpenCard(card) }
+                                onOpen: { onOpenCard(card) },
+                                onEdit: { onEditCard(card) },
+                                onArchive: { onArchiveCard(card) },
+                                onDelete: { onDeleteCard(card) },
+                                onSetStatus: { onSetCardStatus(card, $0) },
+                                onSetPriority: { onSetCardPriority(card, $0) }
                             )
                         }
                     }

--- a/macos/Sources/App/CommandPalette.swift
+++ b/macos/Sources/App/CommandPalette.swift
@@ -37,7 +37,7 @@ struct CommandPalette: View {
                 model.createTask(status: .todo)
             },
             PaletteAction(id: "new-session", title: "New session", symbol: "terminal") {
-                model.createSession()
+                model.beginTerminalSessionCreation()
             },
             PaletteAction(id: "go-home", title: "Switch to Home", symbol: "house") {
                 model.openHome()

--- a/macos/Sources/App/EditorEngine.swift
+++ b/macos/Sources/App/EditorEngine.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum EditorEngineKind: String, CaseIterable, Equatable, Sendable {
     case textKitNative = "textkit-native"
+    case codeEditSourceEditor = "codeedit-source-editor"
     case codeMirror = "codemirror"
     case monaco
 }
@@ -13,12 +14,14 @@ struct EditorEngineConfiguration: Equatable, Sendable {
         self.kind = kind
     }
 
-    static let `default` = EditorEngineConfiguration(kind: .textKitNative)
+    static let `default` = EditorEngineConfiguration(kind: .codeEditSourceEditor)
 
     var displayName: String {
         switch kind {
         case .textKitNative:
             return "Native TextKit"
+        case .codeEditSourceEditor:
+            return "CodeEditSourceEditor"
         case .codeMirror:
             return "CodeMirror"
         case .monaco:
@@ -28,7 +31,7 @@ struct EditorEngineConfiguration: Equatable, Sendable {
 
     var isLaunchSafe: Bool {
         switch kind {
-        case .textKitNative, .codeMirror:
+        case .textKitNative, .codeEditSourceEditor, .codeMirror:
             return true
         case .monaco:
             return false
@@ -39,7 +42,7 @@ struct EditorEngineConfiguration: Equatable, Sendable {
         switch kind {
         case .codeMirror:
             return true
-        case .textKitNative, .monaco:
+        case .textKitNative, .codeEditSourceEditor, .monaco:
             return false
         }
     }

--- a/macos/Sources/App/FileNavigatorOutlineView.swift
+++ b/macos/Sources/App/FileNavigatorOutlineView.swift
@@ -1,0 +1,254 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import DesignSystem
+
+struct FileNavigatorOutlineView: NSViewRepresentable {
+    let nodes: [WorkspaceFileTreeNode]
+    let selectedPath: String?
+    let onOpen: (WorkspaceFileTreeNode) -> Void
+    let onToggle: (WorkspaceFileTreeNode) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onOpen: onOpen, onToggle: onToggle)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let outlineView = NSOutlineView()
+        outlineView.headerView = nil
+        outlineView.rowSizeStyle = .custom
+        outlineView.rowHeight = 28
+        outlineView.indentationPerLevel = 16
+        outlineView.backgroundColor = .clear
+        outlineView.appearance = NSAppearance(named: .aqua)
+        outlineView.selectionHighlightStyle = .regular
+        outlineView.allowsMultipleSelection = false
+        outlineView.allowsEmptySelection = true
+
+        let column = NSTableColumn(identifier: .init("file"))
+        column.resizingMask = .autoresizingMask
+        column.minWidth = 180
+        column.width = 320
+        outlineView.addTableColumn(column)
+        outlineView.outlineTableColumn = column
+        outlineView.delegate = context.coordinator
+        outlineView.dataSource = context.coordinator
+        outlineView.target = context.coordinator
+        outlineView.doubleAction = #selector(Coordinator.doubleClick(_:))
+
+        let scrollView = NSScrollView()
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.documentView = outlineView
+        context.coordinator.outlineView = outlineView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let outlineView = scrollView.documentView as? NSOutlineView else { return }
+        context.coordinator.onOpen = onOpen
+        context.coordinator.onToggle = onToggle
+        context.coordinator.apply(nodes: nodes, selectedPath: selectedPath, to: outlineView)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate {
+        var onOpen: (WorkspaceFileTreeNode) -> Void
+        var onToggle: (WorkspaceFileTreeNode) -> Void
+        weak var outlineView: NSOutlineView?
+        private var roots: [NodeBox] = []
+        private var boxesByPath: [String: NodeBox] = [:]
+        private var isApplyingSnapshot = false
+
+        init(onOpen: @escaping (WorkspaceFileTreeNode) -> Void, onToggle: @escaping (WorkspaceFileTreeNode) -> Void) {
+            self.onOpen = onOpen
+            self.onToggle = onToggle
+        }
+
+        func apply(nodes: [WorkspaceFileTreeNode], selectedPath: String?, to outlineView: NSOutlineView) {
+            isApplyingSnapshot = true
+            roots = nodes.map(NodeBox.init)
+            boxesByPath = Dictionary(uniqueKeysWithValues: roots.flatMap { $0.flattened().map { ($0.node.path, $0) } })
+            outlineView.reloadData()
+            for box in boxesByPath.values where box.node.expanded {
+                outlineView.expandItem(box)
+            }
+            if let selectedPath,
+               let selected = boxesByPath[selectedPath] {
+                let row = outlineView.row(forItem: selected)
+                if row >= 0 {
+                    outlineView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+                    outlineView.scrollRowToVisible(row)
+                }
+            } else {
+                outlineView.deselectAll(nil)
+            }
+            isApplyingSnapshot = false
+        }
+
+        func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
+            box(for: item)?.children.count ?? roots.count
+        }
+
+        func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
+            let children = box(for: item)?.children ?? roots
+            return children[index]
+        }
+
+        func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
+            box(for: item)?.node.isDirectory ?? false
+        }
+
+        func outlineView(
+            _ outlineView: NSOutlineView,
+            viewFor tableColumn: NSTableColumn?,
+            item: Any
+        ) -> NSView? {
+            guard let box = box(for: item) else { return nil }
+            let cell = outlineView.makeView(withIdentifier: FileCell.identifier, owner: self) as? FileCell ?? FileCell()
+            cell.configure(with: box.node, isSelected: outlineView.selectedRow == outlineView.row(forItem: item))
+            return cell
+        }
+
+        func outlineViewSelectionDidChange(_ notification: Notification) {
+            guard !isApplyingSnapshot,
+                  let outlineView,
+                  outlineView.selectedRow >= 0,
+                  let box = outlineView.item(atRow: outlineView.selectedRow) as? NodeBox else {
+                return
+            }
+            outlineView.reloadData()
+            if box.node.isDirectory {
+                onToggle(box.node)
+            } else {
+                onOpen(box.node)
+            }
+        }
+
+        func outlineViewItemDidExpand(_ notification: Notification) {
+            guard !isApplyingSnapshot,
+                  let box = notification.userInfo?["NSObject"] as? NodeBox,
+                  !box.node.expanded else {
+                return
+            }
+            onToggle(box.node)
+        }
+
+        func outlineViewItemDidCollapse(_ notification: Notification) {
+            guard !isApplyingSnapshot,
+                  let box = notification.userInfo?["NSObject"] as? NodeBox,
+                  box.node.expanded else {
+                return
+            }
+            onToggle(box.node)
+        }
+
+        @objc func doubleClick(_ sender: NSOutlineView) {
+            guard sender.clickedRow >= 0,
+                  let box = sender.item(atRow: sender.clickedRow) as? NodeBox else {
+                return
+            }
+            if box.node.isDirectory {
+                if sender.isItemExpanded(box) {
+                    sender.collapseItem(box)
+                } else {
+                    sender.expandItem(box)
+                }
+            } else {
+                onOpen(box.node)
+            }
+        }
+
+        private func box(for item: Any?) -> NodeBox? {
+            item as? NodeBox
+        }
+    }
+}
+
+@MainActor
+private final class NodeBox: NSObject {
+    let node: WorkspaceFileTreeNode
+    let children: [NodeBox]
+
+    init(node: WorkspaceFileTreeNode) {
+        self.node = node
+        self.children = (node.children ?? []).map(NodeBox.init)
+    }
+
+    func flattened() -> [NodeBox] {
+        [self] + children.flatMap { $0.flattened() }
+    }
+}
+
+private final class FileCell: NSTableCellView {
+    static let identifier = NSUserInterfaceItemIdentifier("FileNavigatorOutlineCell")
+    private let symbol = NSImageView()
+    private let title = NSTextField(labelWithString: "")
+    private let badge = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        identifier = Self.identifier
+        wantsLayer = true
+
+        symbol.translatesAutoresizingMaskIntoConstraints = false
+        symbol.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
+        title.translatesAutoresizingMaskIntoConstraints = false
+        title.lineBreakMode = .byTruncatingMiddle
+        title.font = NSFont.systemFont(ofSize: 13)
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.font = NSFont.monospacedSystemFont(ofSize: 10, weight: .semibold)
+        badge.alignment = .right
+
+        addSubview(symbol)
+        addSubview(title)
+        addSubview(badge)
+
+        NSLayoutConstraint.activate([
+            symbol.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
+            symbol.centerYAnchor.constraint(equalTo: centerYAnchor),
+            symbol.widthAnchor.constraint(equalToConstant: 18),
+            title.leadingAnchor.constraint(equalTo: symbol.trailingAnchor, constant: 6),
+            title.centerYAnchor.constraint(equalTo: centerYAnchor),
+            badge.leadingAnchor.constraint(greaterThanOrEqualTo: title.trailingAnchor, constant: 8),
+            badge.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            badge.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+        textField = title
+        imageView = symbol
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with node: WorkspaceFileTreeNode, isSelected: Bool) {
+        title.stringValue = node.name
+        badge.stringValue = statusText(for: node)
+        symbol.image = NSImage(systemSymbolName: symbolName(for: node), accessibilityDescription: nil)
+        title.textColor = isSelected ? NSColor.white : NSColor(calibratedWhite: 0.18, alpha: 1)
+        badge.textColor = isSelected ? NSColor(calibratedWhite: 0.86, alpha: 1) : NSColor(calibratedWhite: 0.48, alpha: 1)
+        symbol.contentTintColor = node.isDirectory
+            ? NSColor.systemBlue
+            : (isSelected ? NSColor(calibratedWhite: 0.84, alpha: 1) : NSColor(calibratedWhite: 0.52, alpha: 1))
+    }
+
+    private func symbolName(for node: WorkspaceFileTreeNode) -> String {
+        if node.isDirectory { return node.expanded ? "folder.fill" : "folder" }
+        switch URL(fileURLWithPath: node.name).pathExtension.lowercased() {
+        case "swift": return "swift"
+        case "json", "yml", "yaml", "toml": return "curlybraces"
+        case "md", "markdown": return "doc.richtext"
+        case "js", "jsx", "ts", "tsx": return "chevron.left.forwardslash.chevron.right"
+        default: return "doc.text"
+        }
+    }
+
+    private func statusText(for node: WorkspaceFileTreeNode) -> String {
+        if let gitStatus = node.gitStatus, !gitStatus.isEmpty { return gitStatus }
+        if let changedCount = node.changedCount, changedCount > 0 { return "\(changedCount)" }
+        return ""
+    }
+}
+#endif

--- a/macos/Sources/App/FileOpenPalette.swift
+++ b/macos/Sources/App/FileOpenPalette.swift
@@ -1,0 +1,253 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import DesignSystem
+
+struct FileOpenPalette: View {
+    @ObservedObject var model: AppModel
+    @State private var selection = 0
+    @FocusState private var fieldFocused: Bool
+
+    private var results: [WorkspaceFileSearchItem] {
+        model.fileOpenSearchResults
+    }
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Color.black.opacity(0.35)
+                .ignoresSafeArea()
+                .onTapGesture { close() }
+
+            palette
+                .padding(.top, 96)
+        }
+        .onAppear {
+            fieldFocused = true
+            selection = 0
+            model.refreshFileOpenIndex()
+        }
+        .onChange(of: model.fileOpenQuery) { _, _ in selection = 0 }
+        .onChange(of: results.count) { _, count in
+            if count == 0 {
+                selection = 0
+            } else if selection >= count {
+                selection = count - 1
+            }
+        }
+        .background(
+            FileOpenKeyCatcher(
+                onUp: { moveSelection(-1) },
+                onDown: { moveSelection(1) },
+                onReturn: openSelected,
+                onEscape: close
+            )
+        )
+    }
+
+    private var palette: some View {
+        VStack(spacing: 0) {
+            searchField
+            Rectangle().fill(Color.hairlineDark).frame(height: 1)
+            resultList
+        }
+        .frame(width: 680)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                .fill(Color.surfaceCard)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                        .strokeBorder(Color.hairlineHighlight, lineWidth: 1)
+                )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+        .shadow(color: .black.opacity(0.5), radius: 30, y: 12)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: Spacing.x3) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color.signalLive)
+            TextField("Open file in current task…", text: $model.fileOpenQuery)
+                .textFieldStyle(.plain)
+                .font(.plexSans(15))
+                .foregroundStyle(Color.inkPrimary)
+                .focused($fieldFocused)
+                .onSubmit(openSelected)
+            if model.isIndexingFiles {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, Spacing.x4)
+        .padding(.vertical, Spacing.x4)
+    }
+
+    @ViewBuilder
+    private var resultList: some View {
+        if results.isEmpty {
+            VStack(alignment: .leading, spacing: Spacing.x1) {
+                Text(model.isIndexingFiles ? "Indexing files…" : "No matching files")
+                    .font(.plexSans(13, weight: .semibold))
+                    .foregroundStyle(Color.inkSecondary)
+                Text("Search is scoped to projects/\(model.projectSlug).")
+                    .font(.plexSans(12))
+                    .foregroundStyle(Color.inkTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Spacing.x4)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(Array(results.enumerated()), id: \.element.id) { index, item in
+                        row(item, active: index == selection)
+                            .onTapGesture { open(item) }
+                            .onHover { if $0 { selection = index } }
+                    }
+                }
+                .padding(Spacing.x2)
+            }
+            .frame(maxHeight: 390)
+        }
+    }
+
+    private func row(_ item: WorkspaceFileSearchItem, active: Bool) -> some View {
+        HStack(spacing: Spacing.x3) {
+            Image(systemName: iconName(for: item.name))
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(active ? Color.signalLive : Color.inkTertiary)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.name)
+                    .font(.plexSans(14, weight: .semibold))
+                    .foregroundStyle(Color.inkPrimary)
+                Text(item.directory)
+                    .font(.plexMono(11))
+                    .foregroundStyle(Color.inkTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Spacing.x3)
+        .padding(.vertical, Spacing.x2)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .fill(active ? Color.surfaceCardRaised : Color.clear)
+        )
+        .contentShape(Rectangle())
+    }
+
+    private func moveSelection(_ delta: Int) {
+        let count = results.count
+        guard count > 0 else { return }
+        selection = (selection + delta + count) % count
+    }
+
+    private func openSelected() {
+        guard results.indices.contains(selection) else { return }
+        open(results[selection])
+    }
+
+    private func open(_ item: WorkspaceFileSearchItem) {
+        model.openFileFromSearch(item)
+    }
+
+    private func close() {
+        model.hideFileOpenSearch()
+    }
+
+    private func iconName(for name: String) -> String {
+        switch URL(fileURLWithPath: name).pathExtension.lowercased() {
+        case "swift": return "swift"
+        case "md", "markdown": return "doc.richtext"
+        case "json", "yml", "yaml", "toml": return "curlybraces"
+        case "js", "jsx", "ts", "tsx": return "chevron.left.forwardslash.chevron.right"
+        default: return "doc.text"
+        }
+    }
+}
+
+private struct FileOpenKeyCatcher: NSViewRepresentable {
+    let onUp: () -> Void
+    let onDown: () -> Void
+    let onReturn: () -> Void
+    let onEscape: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onUp: onUp, onDown: onDown, onReturn: onReturn, onEscape: onEscape)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        context.coordinator.install()
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onUp = onUp
+        context.coordinator.onDown = onDown
+        context.coordinator.onReturn = onReturn
+        context.coordinator.onEscape = onEscape
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.uninstall()
+    }
+
+    final class Coordinator {
+        var onUp: () -> Void
+        var onDown: () -> Void
+        var onReturn: () -> Void
+        var onEscape: () -> Void
+        private var monitor: Any?
+
+        init(onUp: @escaping () -> Void, onDown: @escaping () -> Void, onReturn: @escaping () -> Void, onEscape: @escaping () -> Void) {
+            self.onUp = onUp
+            self.onDown = onDown
+            self.onReturn = onReturn
+            self.onEscape = onEscape
+        }
+
+        func install() {
+            guard monitor == nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self else { return event }
+                let searchFieldHasFocus = MainActor.assumeIsolated {
+                    Self.paletteSearchFieldHasFocus()
+                }
+                guard searchFieldHasFocus else { return event }
+                switch event.keyCode {
+                case 125:
+                    onDown()
+                    return nil
+                case 126:
+                    onUp()
+                    return nil
+                case 36, 76:
+                    onReturn()
+                    return nil
+                case 53:
+                    onEscape()
+                    return nil
+                default:
+                    return event
+                }
+            }
+        }
+
+        @MainActor
+        private static func paletteSearchFieldHasFocus() -> Bool {
+            guard let responder = NSApp.keyWindow?.firstResponder else { return false }
+            return responder is NSTextView
+        }
+
+        func uninstall() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+            monitor = nil
+        }
+    }
+}
+#endif

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -122,6 +122,8 @@ private struct OperatorCommands: Commands {
         CommandMenu("Matrix") {
             Button("Command Palette…") { model.showCommandPalette.toggle() }
                 .keyboardShortcut("k", modifiers: .command)
+            Button("Open File…") { model.showFileOpenSearch() }
+                .keyboardShortcut("o", modifiers: .command)
             Divider()
             Button("New Task") { model.newCardPlaceholder() }
                 .keyboardShortcut("n", modifiers: .command)
@@ -150,12 +152,31 @@ private struct OperatorCommands: Commands {
             Button("Previous Tab") { model.focusPreviousTab() }
                 .keyboardShortcut("[", modifiers: .command)
             Divider()
-            Button("Terminal Panel") { model.switchPanel(.terminal) }
+            Button("Tab 1") { model.focusTab(at: 0) }
                 .keyboardShortcut("1", modifiers: .command)
-            Button("Editor Panel") { model.switchPanel(.app(slug: "editor")) }
+            Button("Tab 2") { model.focusTab(at: 1) }
                 .keyboardShortcut("2", modifiers: .command)
-            Button("Git Panel") { model.switchPanel(.app(slug: "git")) }
+            Button("Tab 3") { model.focusTab(at: 2) }
                 .keyboardShortcut("3", modifiers: .command)
+            Button("Tab 4") { model.focusTab(at: 3) }
+                .keyboardShortcut("4", modifiers: .command)
+            Button("Tab 5") { model.focusTab(at: 4) }
+                .keyboardShortcut("5", modifiers: .command)
+            Button("Tab 6") { model.focusTab(at: 5) }
+                .keyboardShortcut("6", modifiers: .command)
+            Button("Tab 7") { model.focusTab(at: 6) }
+                .keyboardShortcut("7", modifiers: .command)
+            Button("Tab 8") { model.focusTab(at: 7) }
+                .keyboardShortcut("8", modifiers: .command)
+            Button("Tab 9") { model.focusTab(at: 8) }
+                .keyboardShortcut("9", modifiers: .command)
+            Divider()
+            Button("Terminal Panel") { model.switchPanel(.terminal) }
+                .keyboardShortcut("1", modifiers: [.command, .option])
+            Button("Editor Panel") { model.switchPanel(.app(slug: "editor")) }
+                .keyboardShortcut("2", modifiers: [.command, .option])
+            Button("Git Panel") { model.switchPanel(.app(slug: "git")) }
+                .keyboardShortcut("4", modifiers: [.command, .option])
             Divider()
             Button("Close Card") { model.closeCard() }
                 .keyboardShortcut(.escape, modifiers: [])

--- a/macos/Sources/App/MatrixOSApp.swift
+++ b/macos/Sources/App/MatrixOSApp.swift
@@ -76,12 +76,23 @@ private final class MatrixOSAppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     private static func bringAppForward() {
         NSApp.setActivationPolicy(.regular)
+        NSApp.windows.forEach(configureNativeChrome)
 
         if let window = NSApp.mainWindow ?? NSApp.keyWindow ?? NSApp.windows.first {
+            configureNativeChrome(window)
             recoverIfOffscreen(window)
             window.makeKeyAndOrderFront(nil)
         }
         NSApp.activate()
+    }
+
+    @MainActor
+    private static func configureNativeChrome(_ window: NSWindow) {
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.toolbarStyle = .unifiedCompact
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = .windowBackgroundColor
     }
 
     @MainActor
@@ -127,7 +138,7 @@ private struct OperatorCommands: Commands {
             Divider()
             Button("New Task") { model.newCardPlaceholder() }
                 .keyboardShortcut("n", modifiers: .command)
-            Button("New Session") { model.createSession() }
+            Button("New Session") { model.beginTerminalSessionCreation() }
                 .keyboardShortcut("t", modifiers: .command)
             Divider()
             Button("Home") { model.openHome() }

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -1,6 +1,8 @@
 #if os(macOS)
 import SwiftUI
 import AppKit
+import CodeEditLanguages
+import CodeEditSourceEditor
 import DesignSystem
 
 public enum CodeEditorTheme: String, CaseIterable, Identifiable {
@@ -8,6 +10,7 @@ public enum CodeEditorTheme: String, CaseIterable, Identifiable {
     case xcodeLight = "Xcode"
     case xcodeDark = "Xcode Dark"
     case solarizedLight = "Solarized"
+    case solarizedDark = "Solarized Dark"
     case terminalDark = "Terminal"
     case oneDark = "One Dark"
 
@@ -15,7 +18,7 @@ public enum CodeEditorTheme: String, CaseIterable, Identifiable {
 
     public var isDark: Bool {
         switch self {
-        case .xcodeDark, .terminalDark, .oneDark:
+        case .xcodeDark, .solarizedDark, .terminalDark, .oneDark:
             return true
         case .matrixLight, .xcodeLight, .solarizedLight:
             return false
@@ -28,6 +31,7 @@ public enum CodeEditorTheme: String, CaseIterable, Identifiable {
         case .xcodeLight: return NSColor(calibratedWhite: 0.99, alpha: 1)
         case .xcodeDark: return NSColor.matrixHex(0x1F2024)
         case .solarizedLight: return NSColor.matrixHex(0xFDF6E3)
+        case .solarizedDark: return NSColor.matrixHex(0x002B36)
         case .terminalDark: return NSColor.matrixHex(0x0C0D10)
         case .oneDark: return NSColor.matrixHex(0x282C34)
         }
@@ -37,6 +41,7 @@ public enum CodeEditorTheme: String, CaseIterable, Identifiable {
         switch self {
         case .matrixLight, .xcodeLight: return NSColor.matrixHex(0x32352E)
         case .solarizedLight: return NSColor.matrixHex(0x586E75)
+        case .solarizedDark: return NSColor.matrixHex(0x839496)
         case .xcodeDark, .terminalDark, .oneDark: return NSColor.matrixHex(0xE8EAED)
         }
     }
@@ -46,7 +51,7 @@ public enum CodeEditorTheme: String, CaseIterable, Identifiable {
         case .matrixLight: return NSColor(Color.signalLive)
         case .xcodeLight: return NSColor(calibratedRed: 0.58, green: 0.16, blue: 0.66, alpha: 1)
         case .xcodeDark: return NSColor.matrixHex(0xFC5FA3)
-        case .solarizedLight: return NSColor.matrixHex(0x859900)
+        case .solarizedLight, .solarizedDark: return NSColor.matrixHex(0x859900)
         case .terminalDark: return NSColor(calibratedRed: 0.67, green: 0.82, blue: 1.0, alpha: 1)
         case .oneDark: return NSColor.matrixHex(0xC678DD)
         }
@@ -57,7 +62,7 @@ public enum CodeEditorTheme: String, CaseIterable, Identifiable {
         case .matrixLight: return NSColor(calibratedRed: 0.62, green: 0.31, blue: 0.12, alpha: 1)
         case .xcodeLight: return NSColor(calibratedRed: 0.74, green: 0.25, blue: 0.12, alpha: 1)
         case .xcodeDark: return NSColor.matrixHex(0xFC6A5D)
-        case .solarizedLight: return NSColor.matrixHex(0x2AA198)
+        case .solarizedLight, .solarizedDark: return NSColor.matrixHex(0x2AA198)
         case .terminalDark: return NSColor(calibratedRed: 0.84, green: 0.70, blue: 0.45, alpha: 1)
         case .oneDark: return NSColor.matrixHex(0x98C379)
         }
@@ -67,39 +72,60 @@ public enum CodeEditorTheme: String, CaseIterable, Identifiable {
         switch self {
         case .matrixLight, .xcodeLight: return NSColor.matrixHex(0x7A7768)
         case .solarizedLight: return NSColor.matrixHex(0x93A1A1)
+        case .solarizedDark: return NSColor.matrixHex(0x586E75)
         case .xcodeDark: return NSColor.matrixHex(0x6C7986)
         case .terminalDark: return NSColor.matrixHex(0x9BA1AC)
         case .oneDark: return NSColor.matrixHex(0x7F848E)
         }
     }
 
-    var gutterBackground: NSColor {
+    private var number: NSColor {
+        switch self {
+        case .matrixLight: return NSColor(calibratedRed: 0.17, green: 0.40, blue: 0.75, alpha: 1)
+        case .xcodeLight: return NSColor(calibratedRed: 0.15, green: 0.37, blue: 0.71, alpha: 1)
+        case .xcodeDark: return NSColor.matrixHex(0xD9C97C)
+        case .solarizedLight, .solarizedDark: return NSColor.matrixHex(0xCB4B16)
+        case .terminalDark: return NSColor(calibratedRed: 0.8, green: 0.62, blue: 0.45, alpha: 1)
+        case .oneDark: return NSColor.matrixHex(0xD19A66)
+        }
+    }
+
+    private var gutterBackground: NSColor {
         switch self {
         case .matrixLight: return NSColor.matrixHex(0xF0EDE4)
         case .xcodeLight: return NSColor(calibratedWhite: 0.95, alpha: 1)
         case .xcodeDark: return NSColor.matrixHex(0x25262B)
         case .solarizedLight: return NSColor.matrixHex(0xEEE8D5)
+        case .solarizedDark: return NSColor.matrixHex(0x073642)
         case .terminalDark: return NSColor(calibratedWhite: 0.08, alpha: 1)
         case .oneDark: return NSColor.matrixHex(0x21252B)
         }
     }
 
-    var findHighlight: NSColor {
-        switch self {
-        case .matrixLight, .xcodeLight, .solarizedLight:
-            return NSColor(calibratedRed: 1.0, green: 0.88, blue: 0.2, alpha: 0.55)
-        case .xcodeDark, .terminalDark, .oneDark:
-            return NSColor(calibratedRed: 0.9, green: 0.7, blue: 0.0, alpha: 0.45)
-        }
-    }
-
-    var findActiveHighlight: NSColor {
-        switch self {
-        case .matrixLight, .xcodeLight, .solarizedLight:
-            return NSColor(calibratedRed: 1.0, green: 0.65, blue: 0.0, alpha: 0.75)
-        case .xcodeDark, .terminalDark, .oneDark:
-            return NSColor(calibratedRed: 1.0, green: 0.75, blue: 0.1, alpha: 0.70)
-        }
+    var sourceEditorTheme: EditorTheme {
+        let foreground = EditorTheme.Attribute(color: foreground)
+        let muted = EditorTheme.Attribute(color: comment)
+        let keyword = EditorTheme.Attribute(color: keyword, bold: true)
+        let string = EditorTheme.Attribute(color: string)
+        let number = EditorTheme.Attribute(color: number)
+        return EditorTheme(
+            text: foreground,
+            insertionPoint: self.foreground,
+            invisibles: EditorTheme.Attribute(color: comment.withAlphaComponent(0.55)),
+            background: background,
+            lineHighlight: gutterBackground.withAlphaComponent(isDark ? 0.55 : 0.75),
+            selection: NSColor(calibratedRed: 0.28, green: 0.48, blue: 0.85, alpha: isDark ? 0.35 : 0.22),
+            keywords: keyword,
+            commands: keyword,
+            types: EditorTheme.Attribute(color: self.keyword.withAlphaComponent(0.92), bold: false),
+            attributes: muted,
+            variables: foreground,
+            values: string,
+            numbers: number,
+            strings: string,
+            characters: string,
+            comments: muted
+        )
     }
 }
 
@@ -135,16 +161,8 @@ private extension NSColor {
     }
 }
 
-private extension NSFont {
-    var spaceWidth: CGFloat {
-        (" " as NSString).size(withAttributes: [.font: self]).width
-    }
-}
-
-// MARK: - SyntaxHighlightedCodeEditor
-
-struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
-    nonisolated static let engineConfiguration = EditorEngineConfiguration(kind: .textKitNative)
+struct SyntaxHighlightedCodeEditor: View {
+    nonisolated static let engineConfiguration = EditorEngineConfiguration(kind: .codeEditSourceEditor)
 
     @Binding var text: String
     let filePath: String?
@@ -152,179 +170,30 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
     var preferences: CodeEditorPreferences = .default
     var isEditable = true
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
-    }
+    @State private var cursorPositions: [CursorPosition] = []
 
-    func makeNSView(context: Context) -> EditorScrollHost {
-        let host = EditorScrollHost()
-        let scrollView = host.scrollView
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = true
-        scrollView.autohidesScrollers = true
-        scrollView.drawsBackground = true
-
-        let textView = EditorTextView()
-        textView.isRichText = false
-        textView.isEditable = isEditable
-        textView.isSelectable = true
-        textView.drawsBackground = true
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.isContinuousSpellCheckingEnabled = false
-        textView.isGrammarCheckingEnabled = false
-        textView.allowsUndo = true
-        textView.delegate = context.coordinator
-        textView.textContainerInset = NSSize(width: 14, height: 14)
-        textView.textContainer?.lineFragmentPadding = 0
-        textView.minSize = NSSize(width: 0, height: 0)
-        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        textView.isHorizontallyResizable = !preferences.wrapsLines
-        textView.isVerticallyResizable = true
-        textView.autoresizingMask = preferences.wrapsLines ? [.width] : []
-        textView.usesFindBar = false
-        textView.isIncrementalSearchingEnabled = false
-
-        scrollView.documentView = textView
-        // Layout preferences applied after documentView is set so contentSize is valid.
-        applyLayoutPreferences(to: textView, in: scrollView, preferences: preferences)
-
-        let ruler = LineNumberRulerView(textView: textView, theme: theme)
-        scrollView.verticalRulerView = ruler
-        scrollView.hasVerticalRuler = true
-        scrollView.rulersVisible = true
-
-        // Search bar: inserted above the scroll view inside the host.
-        let searchBar = FindBar(theme: theme)
-        searchBar.isHidden = true
-        let coordinator = context.coordinator
-        searchBar.onFind = { [weak coordinator] query, caseSensitive in
-            coordinator?.performFind(query: query, caseSensitive: caseSensitive)
-        }
-        searchBar.onFindNext = { [weak coordinator] in
-            coordinator?.findNext()
-        }
-        searchBar.onFindPrev = { [weak coordinator] in
-            coordinator?.findPrevious()
-        }
-        searchBar.onClose = { [weak coordinator, weak host] in
-            host?.setSearchVisible(false)
-            coordinator?.showFindBar = false
-            if let tv = coordinator?.textView {
-                coordinator?.clearFindHighlights(in: tv)
-                coordinator?.findMatches = []
-            }
-        }
-
-        host.findBar = searchBar
-        host.addSubview(searchBar)
-        host.addSubview(scrollView)
-
-        context.coordinator.textView = textView
-        context.coordinator.theme = theme
-        context.coordinator.preferences = preferences
-        context.coordinator.filePath = filePath
-        context.coordinator.isEditable = isEditable
-        context.coordinator.host = host
-        textView.coordinator = context.coordinator
-
-        // Apply initial content. The text container width may be zero here if the
-        // host hasn't been laid out yet; we track whether a real-size re-apply is
-        // still needed via `needsInitialLayout`.
-        context.coordinator.applyHighlight {
-            applyContent(text: text, to: textView, theme: theme, filePath: filePath, preferences: preferences)
-        }
-        context.coordinator.pendingText = text
-        context.coordinator.needsInitialLayout = true
-
-        return host
-    }
-
-    func updateNSView(_ host: EditorScrollHost, context: Context) {
-        let scrollView = host.scrollView
-        guard let textView = scrollView.documentView as? NSTextView else { return }
-
-        if let ruler = scrollView.verticalRulerView as? LineNumberRulerView {
-            ruler.theme = theme
-            ruler.needsDisplay = true
-        }
-
-        applyLayoutPreferences(to: textView, in: scrollView, preferences: preferences)
-        textView.isEditable = isEditable
-
-        let themeChanged = context.coordinator.theme != theme
-        let prefsChanged = context.coordinator.preferences != preferences
-        let pathChanged = context.coordinator.filePath != filePath
-        let editableChanged = context.coordinator.isEditable != isEditable
-        let textChanged = textView.string != text
-        let needsLayout = context.coordinator.needsInitialLayout && scrollView.contentSize.width > 0
-
-        if textChanged || themeChanged || prefsChanged || pathChanged || editableChanged
-            || context.coordinator.needsHighlight || needsLayout {
-            context.coordinator.theme = theme
-            context.coordinator.preferences = preferences
-            context.coordinator.filePath = filePath
-            context.coordinator.isEditable = isEditable
-            context.coordinator.needsHighlight = false
-            if needsLayout {
-                context.coordinator.needsInitialLayout = false
-            }
-            context.coordinator.applyHighlight {
-                applyContent(text: text, to: textView, theme: theme, filePath: filePath, preferences: preferences)
-            }
-        }
-
-        // Update search-bar theme whenever theme changes.
-        if let findBar = host.findBar {
-            findBar.theme = theme
-        }
-    }
-
-    // MARK: - Layout helpers
-
-    private func applyLayoutPreferences(to textView: NSTextView, in scrollView: NSScrollView, preferences: CodeEditorPreferences) {
-        textView.isHorizontallyResizable = !preferences.wrapsLines
-        textView.autoresizingMask = preferences.wrapsLines ? [.width] : []
-        textView.textContainer?.widthTracksTextView = preferences.wrapsLines
-        let width = Self.resolvedTextContainerWidth(
-            contentWidth: scrollView.contentSize.width,
-            boundsWidth: scrollView.bounds.width,
-            wrapsLines: preferences.wrapsLines
+    var body: some View {
+        CodeEditSourceEditor(
+            $text,
+            language: Self.codeLanguage(for: filePath, text: text),
+            theme: theme.sourceEditorTheme,
+            font: Self.editorFont(size: preferences.fontSize),
+            tabWidth: preferences.tabWidth,
+            indentOption: .spaces(count: preferences.tabWidth),
+            lineHeight: 1.2,
+            wrapLines: preferences.wrapsLines,
+            editorOverscroll: 0.2,
+            cursorPositions: $cursorPositions,
+            contentInsets: NSEdgeInsets(top: 12, left: 0, bottom: 12, right: 0),
+            additionalTextInsets: NSEdgeInsets(top: 0, left: 12, bottom: 0, right: 12),
+            isEditable: isEditable,
+            isSelectable: true,
+            letterSpacing: 1.0,
+            showMinimap: false
         )
-        textView.textContainer?.containerSize = NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-        textView.minSize = NSSize(width: preferences.wrapsLines ? width : 320, height: 0)
-        textView.maxSize = NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-        if preferences.wrapsLines, textView.frame.width < width {
-            textView.frame.size.width = width
-        }
+        .id(Self.editorIdentity(for: filePath, text: text))
+        .background(Color(nsColor: theme.background))
     }
-
-    nonisolated static func resolvedTextContainerWidth(contentWidth: CGFloat, boundsWidth: CGFloat, wrapsLines: Bool) -> CGFloat {
-        guard wrapsLines else { return CGFloat.greatestFiniteMagnitude }
-        return max(contentWidth, boundsWidth, 320)
-    }
-
-    // MARK: - Content application
-
-    private func applyContent(text: String, to textView: NSTextView, theme: CodeEditorTheme, filePath: String?, preferences: CodeEditorPreferences) {
-        let selected = textView.selectedRange()
-        textView.backgroundColor = theme.background
-        textView.insertionPointColor = theme.foreground
-        textView.textColor = theme.foreground
-        textView.font = Self.editorFont(size: preferences.fontSize)
-        textView.defaultParagraphStyle = Self.paragraphStyle(tabWidth: preferences.tabWidth, fontSize: preferences.fontSize, wrapsLines: preferences.wrapsLines)
-        textView.textStorage?.setAttributedString(Self.highlightedText(text, filePath: filePath, theme: theme, preferences: preferences))
-        let safeLocation = min(selected.location, (text as NSString).length)
-        textView.setSelectedRange(NSRange(location: safeLocation, length: 0))
-        textView.needsDisplay = true
-        if let container = textView.textContainer {
-            textView.layoutManager?.ensureLayout(for: container)
-        }
-    }
-
-    // MARK: - Font & paragraph style
 
     static func editorFont(size: Double) -> NSFont {
         let pointSize = CGFloat(size)
@@ -334,651 +203,22 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
         return NSFont.monospacedSystemFont(ofSize: pointSize, weight: .regular)
     }
 
-    private static func paragraphStyle(tabWidth: Int, fontSize: Double, wrapsLines: Bool) -> NSParagraphStyle {
-        let style = NSMutableParagraphStyle()
-        let width = max(2, min(tabWidth, 8))
-        style.defaultTabInterval = CGFloat(width) * editorFont(size: fontSize).spaceWidth
-        style.lineBreakMode = wrapsLines ? .byWordWrapping : .byClipping
-        return style
-    }
-
-    // MARK: - Syntax highlighting
-
-    static func highlightedText(_ text: String, filePath: String?, theme: CodeEditorTheme, preferences: CodeEditorPreferences) -> NSAttributedString {
-        let nsText = text as NSString
-        let fullRange = NSRange(location: 0, length: nsText.length)
-        let language = syntaxLanguage(for: filePath)
-        let output = NSMutableAttributedString(
-            string: text,
-            attributes: [
-                .font: editorFont(size: preferences.fontSize),
-                .foregroundColor: theme.foreground,
-                .paragraphStyle: paragraphStyle(tabWidth: preferences.tabWidth, fontSize: preferences.fontSize, wrapsLines: preferences.wrapsLines),
-            ]
+    static func codeLanguage(for filePath: String?, text: String) -> CodeLanguage {
+        let url = URL(fileURLWithPath: filePath?.isEmpty == false ? filePath! : "untitled.txt")
+        return CodeLanguage.detectLanguageFrom(
+            url: url,
+            prefixBuffer: String(text.prefix(2048)),
+            suffixBuffer: String(text.suffix(2048))
         )
-        if preferences.showsInvisibleCharacters {
-            applyPattern(#" |\t"#, color: theme.comment.withAlphaComponent(0.55), to: output, range: fullRange)
-        }
-        applyPattern(#""(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`"#, color: theme.string, to: output, range: fullRange)
-        if language.supportsBlockComments {
-            applyPattern(language.blockCommentPattern, color: theme.comment, to: output, range: fullRange)
-        }
-        if language.supportsLineComments {
-            applyPattern(language.commentPattern, color: theme.comment, to: output, range: fullRange)
-        }
-        if language.supportsKeywords {
-            applyPattern(language.keywordPattern, color: theme.keyword, to: output, range: fullRange)
-        }
-        if language.supportsNumbers {
-            applyPattern(#"\b\d+\.?\d*\b"#, color: theme.number, to: output, range: fullRange)
-        }
-        return output
     }
 
-    private struct SyntaxLanguage {
-        var supportsLineComments: Bool
-        var supportsBlockComments: Bool
-        var supportsKeywords: Bool
-        var supportsNumbers: Bool
-        var commentPattern: String
-        var blockCommentPattern: String
-        var keywordPattern: String
+    static func languageName(for filePath: String?, text: String = "") -> String {
+        codeLanguage(for: filePath, text: text).tsName
     }
 
-    private static func syntaxLanguage(for filePath: String?) -> SyntaxLanguage {
-        let noHighlight = SyntaxLanguage(
-            supportsLineComments: false,
-            supportsBlockComments: false,
-            supportsKeywords: false,
-            supportsNumbers: false,
-            commentPattern: "",
-            blockCommentPattern: "",
-            keywordPattern: ""
-        )
-        let jsKeywords = #"\b(import|export|from|as|default|function|let|const|var|class|extends|implements|interface|type|enum|namespace|module|declare|return|if|else|switch|case|break|continue|for|while|do|try|catch|finally|throw|new|delete|typeof|instanceof|in|of|await|async|yield|true|false|null|undefined|void|this|super|static|public|private|protected|abstract|override|readonly|keyof|infer|never|any|unknown)\b"#
-        let swiftKeywords = #"\b(import|func|let|var|struct|class|enum|protocol|extension|public|private|internal|fileprivate|open|override|final|static|lazy|weak|unowned|mutating|nonmutating|inout|guard|return|if|else|switch|case|for|while|repeat|do|try|catch|throw|throws|rethrows|async|await|actor|nonisolated|some|any|self|Self|super|init|deinit|subscript|get|set|willSet|didSet|defer|typealias|associatedtype|where|in|as|is|nil|true|false)\b"#
-        let pyKeywords = #"\b(import|from|as|def|class|return|if|elif|else|for|while|try|except|finally|raise|with|lambda|yield|pass|break|continue|del|global|nonlocal|and|or|not|in|is|True|False|None|async|await)\b"#
-        let genericKeywords = #"\b(import|export|from|func|function|let|const|var|struct|class|enum|protocol|extension|public|private|return|if|else|switch|case|for|while|guard|try|await|async|throws|type|interface|extends|implements|new|in|of)\b"#
-
-        guard let filePath, !filePath.isEmpty else {
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)(//.*$|#.*$)"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: genericKeywords
-            )
-        }
-        let ext = URL(fileURLWithPath: filePath).pathExtension.lowercased()
-        switch ext {
-        case "md", "markdown", "mdx", "txt", "log", "csv":
-            return noHighlight
-        case "json", "jsonc":
-            return SyntaxLanguage(
-                supportsLineComments: false, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: "",
-                blockCommentPattern: "",
-                keywordPattern: #"\b(true|false|null)\b"#
-            )
-        case "yaml", "yml":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: false, supportsNumbers: true,
-                commentPattern: #"(?m)#.*$"#,
-                blockCommentPattern: "",
-                keywordPattern: ""
-            )
-        case "toml":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)#.*$"#,
-                blockCommentPattern: "",
-                keywordPattern: #"\b(true|false)\b"#
-            )
-        case "xml", "html", "htm", "svg":
-            return SyntaxLanguage(
-                supportsLineComments: false, supportsBlockComments: true, supportsKeywords: false, supportsNumbers: false,
-                commentPattern: "",
-                blockCommentPattern: #"<!--[\s\S]*?-->"#,
-                keywordPattern: ""
-            )
-        case "py":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)#.*$"#,
-                blockCommentPattern: "",
-                keywordPattern: pyKeywords
-            )
-        case "rb":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)#.*$"#,
-                blockCommentPattern: "",
-                keywordPattern: #"\b(def|class|module|end|if|elsif|else|unless|case|when|while|until|for|do|begin|rescue|ensure|raise|return|require|require_relative|include|extend|attr|attr_reader|attr_writer|attr_accessor|true|false|nil|self|super|yield|and|or|not|in)\b"#
-            )
-        case "sh", "bash", "zsh", "fish":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: false,
-                commentPattern: #"(?m)#.*$"#,
-                blockCommentPattern: "",
-                keywordPattern: #"\b(if|then|else|elif|fi|for|do|done|while|until|case|esac|function|return|local|export|readonly|declare|source|echo|exit|break|continue|shift|set|unset|trap)\b"#
-            )
-        case "swift":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: swiftKeywords
-            )
-        case "ts", "tsx":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: jsKeywords
-            )
-        case "js", "jsx", "mjs", "cjs":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: jsKeywords
-            )
-        case "go":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: #"\b(package|import|func|var|const|type|struct|interface|map|chan|go|defer|return|if|else|switch|case|for|range|break|continue|fallthrough|select|default|make|new|len|cap|append|copy|delete|close|panic|recover|nil|true|false)\b"#
-            )
-        case "rs":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: #"\b(use|mod|fn|let|mut|const|static|struct|enum|trait|impl|pub|priv|crate|super|self|Self|where|type|return|if|else|match|for|while|loop|break|continue|in|move|ref|as|async|await|dyn|unsafe|extern|true|false)\b"#
-            )
-        case "kt", "kts":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: #"\b(package|import|class|interface|object|fun|val|var|constructor|init|return|if|else|when|for|while|do|try|catch|finally|throw|override|open|final|abstract|sealed|data|inner|companion|suspend|inline|reified|crossinline|noinline|lateinit|lazy|const|by|in|is|as|null|true|false)\b"#
-            )
-        case "java":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: #"\b(package|import|class|interface|enum|extends|implements|public|private|protected|static|final|abstract|synchronized|volatile|native|return|if|else|switch|case|for|while|do|try|catch|finally|throw|throws|new|instanceof|this|super|null|true|false|void|int|long|float|double|boolean|char|byte|short)\b"#
-            )
-        case "c", "h":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: #"\b(include|define|ifdef|ifndef|endif|if|else|switch|case|for|while|do|return|break|continue|struct|union|enum|typedef|const|static|extern|register|volatile|auto|sizeof|void|int|long|float|double|char|unsigned|signed|short)\b"#
-            )
-        case "cpp", "cc", "cxx", "hpp":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: #"\b(include|define|namespace|class|struct|template|typename|virtual|override|final|public|private|protected|static|const|constexpr|inline|explicit|operator|new|delete|return|if|else|switch|case|for|while|do|try|catch|throw|nullptr|true|false|void|int|long|float|double|char|bool|auto)\b"#
-            )
-        case "css", "scss", "less":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: false, supportsNumbers: true,
-                commentPattern: #"(?m)//.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: ""
-            )
-        case "sql":
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)--.*$"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: #"(?i)\b(SELECT|FROM|WHERE|AND|OR|NOT|IN|BETWEEN|LIKE|IS|NULL|ORDER|BY|GROUP|HAVING|LIMIT|OFFSET|JOIN|INNER|LEFT|RIGHT|FULL|OUTER|ON|AS|INSERT|INTO|VALUES|UPDATE|SET|DELETE|CREATE|TABLE|INDEX|VIEW|DROP|ALTER|ADD|COLUMN|PRIMARY|KEY|FOREIGN|REFERENCES|UNIQUE|DEFAULT|NOT|NULL|CHECK|CONSTRAINT|BEGIN|COMMIT|ROLLBACK|TRANSACTION)\b"#
-            )
-        default:
-            return SyntaxLanguage(
-                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
-                commentPattern: #"(?m)(//.*$|#.*$)"#,
-                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
-                keywordPattern: genericKeywords
-            )
-        }
-    }
-
-    private static func applyPattern(_ pattern: String, color: NSColor, to output: NSMutableAttributedString, range: NSRange) {
-        guard !pattern.isEmpty,
-              let regex = try? NSRegularExpression(pattern: pattern) else { return }
-        regex.enumerateMatches(in: output.string, range: range) { match, _, _ in
-            guard let match else { return }
-            output.addAttribute(.foregroundColor, value: color, range: match.range)
-        }
-    }
-
-    // MARK: - Coordinator
-
-    @MainActor
-    final class Coordinator: NSObject, NSTextViewDelegate {
-        @Binding var text: String
-        weak var textView: NSTextView?
-        weak var host: EditorScrollHost?
-        var theme: CodeEditorTheme?
-        var preferences: CodeEditorPreferences?
-        var filePath: String?
-        var isEditable = true
-        var needsHighlight = false
-        var needsInitialLayout = false
-        var pendingText: String = ""
-        var showFindBar = false
-        private var isApplyingHighlight = false
-
-        // Find state
-        var findMatches: [NSRange] = []
-        var findMatchIndex: Int = 0
-
-        init(text: Binding<String>) {
-            _text = text
-        }
-
-        func applyHighlight(_ body: () -> Void) {
-            isApplyingHighlight = true
-            defer { isApplyingHighlight = false }
-            body()
-        }
-
-        func textDidChange(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else { return }
-            guard !isApplyingHighlight else { return }
-            needsHighlight = true
-            text = textView.string
-        }
-
-        // MARK: Find
-
-        func performFind(query: String, caseSensitive: Bool) {
-            guard let textView, let textStorage = textView.textStorage else { return }
-            clearFindHighlights(in: textView)
-            guard !query.isEmpty else {
-                findMatches = []
-                findMatchIndex = 0
-                host?.findBar?.updateMatchCount(0, index: 0)
-                return
-            }
-            let options: NSRegularExpression.Options = caseSensitive ? [] : [.caseInsensitive]
-            let escapedQuery = NSRegularExpression.escapedPattern(for: query)
-            guard let regex = try? NSRegularExpression(pattern: escapedQuery, options: options) else {
-                findMatches = []
-                return
-            }
-            let fullRange = NSRange(location: 0, length: textStorage.length)
-            var matches: [NSRange] = []
-            regex.enumerateMatches(in: textStorage.string, range: fullRange) { match, _, _ in
-                guard let match else { return }
-                matches.append(match.range)
-            }
-            findMatches = matches
-            findMatchIndex = 0
-            guard let theme else { return }
-            for (i, range) in matches.enumerated() {
-                let color = i == 0 ? theme.findActiveHighlight : theme.findHighlight
-                textStorage.addAttribute(.backgroundColor, value: color, range: range)
-            }
-            if !matches.isEmpty {
-                textView.scrollRangeToVisible(matches[0])
-                textView.setSelectedRange(matches[0])
-            }
-            host?.findBar?.updateMatchCount(matches.count, index: findMatchIndex)
-        }
-
-        func findNext() {
-            guard !findMatches.isEmpty else { return }
-            clearActiveHighlight()
-            findMatchIndex = (findMatchIndex + 1) % findMatches.count
-            activateMatch(at: findMatchIndex)
-        }
-
-        func findPrevious() {
-            guard !findMatches.isEmpty else { return }
-            clearActiveHighlight()
-            findMatchIndex = (findMatchIndex - 1 + findMatches.count) % findMatches.count
-            activateMatch(at: findMatchIndex)
-        }
-
-        private func activateMatch(at index: Int) {
-            guard let textView, let textStorage = textView.textStorage,
-                  index < findMatches.count, let theme else { return }
-            let range = findMatches[index]
-            textStorage.addAttribute(.backgroundColor, value: theme.findActiveHighlight, range: range)
-            textView.scrollRangeToVisible(range)
-            textView.setSelectedRange(range)
-            host?.findBar?.updateMatchCount(findMatches.count, index: index)
-        }
-
-        private func clearActiveHighlight() {
-            guard let textView, let textStorage = textView.textStorage, let theme else { return }
-            if findMatchIndex < findMatches.count {
-                textStorage.addAttribute(.backgroundColor, value: theme.findHighlight, range: findMatches[findMatchIndex])
-            }
-        }
-
-        func clearFindHighlights(in textView: NSTextView) {
-            guard let textStorage = textView.textStorage else { return }
-            let fullRange = NSRange(location: 0, length: textStorage.length)
-            textStorage.removeAttribute(.backgroundColor, range: fullRange)
-        }
-
-        func toggleFindBar() {
-            guard let host else { return }
-            let nowVisible = !(host.findBar?.isHidden ?? true)
-            showFindBar = !nowVisible
-            host.setSearchVisible(showFindBar)
-            if showFindBar {
-                host.findBar?.focusSearchField()
-            } else if let textView {
-                clearFindHighlights(in: textView)
-                findMatches = []
-                textView.window?.makeFirstResponder(textView)
-            }
-        }
-    }
-}
-
-// MARK: - Number color extension
-
-private extension CodeEditorTheme {
-    var number: NSColor {
-        switch self {
-        case .matrixLight: return NSColor(calibratedRed: 0.17, green: 0.40, blue: 0.75, alpha: 1)
-        case .xcodeLight: return NSColor(calibratedRed: 0.15, green: 0.37, blue: 0.71, alpha: 1)
-        case .xcodeDark: return NSColor.matrixHex(0xD9C97C)
-        case .solarizedLight: return NSColor.matrixHex(0xCB4B16)
-        case .terminalDark: return NSColor(calibratedRed: 0.8, green: 0.62, blue: 0.45, alpha: 1)
-        case .oneDark: return NSColor.matrixHex(0xD19A66)
-        }
-    }
-}
-
-// MARK: - EditorTextView (handles Find shortcut)
-
-private final class EditorTextView: NSTextView {
-    weak var coordinator: SyntaxHighlightedCodeEditor.Coordinator?
-
-    override func keyDown(with event: NSEvent) {
-        // Cmd+F → toggle find bar
-        if event.modifierFlags.contains(.command), event.charactersIgnoringModifiers == "f" {
-            coordinator?.toggleFindBar()
-            return
-        }
-        // Cmd+G → find next
-        if event.modifierFlags.contains(.command), event.charactersIgnoringModifiers == "g" {
-            if event.modifierFlags.contains(.shift) {
-                coordinator?.findPrevious()
-            } else {
-                coordinator?.findNext()
-            }
-            return
-        }
-        super.keyDown(with: event)
-    }
-}
-
-// MARK: - EditorScrollHost (NSView wrapping scroll + find bar)
-
-final class EditorScrollHost: NSView {
-    let scrollView = NSScrollView()
-    var findBar: FindBar?
-    private let findBarHeight: CGFloat = 36
-
-    override init(frame: NSRect) {
-        super.init(frame: frame)
-        autoresizesSubviews = false
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func setSearchVisible(_ visible: Bool) {
-        findBar?.isHidden = !visible
-        needsLayout = true
-    }
-
-    override func layout() {
-        super.layout()
-        let barHeight = (findBar?.isHidden ?? true) ? 0 : findBarHeight
-        findBar?.frame = NSRect(x: 0, y: bounds.height - barHeight, width: bounds.width, height: findBarHeight)
-        scrollView.frame = NSRect(x: 0, y: 0, width: bounds.width, height: bounds.height - barHeight)
-    }
-}
-
-// MARK: - FindBar
-
-final class FindBar: NSView {
-    var theme: CodeEditorTheme {
-        didSet { applyTheme() }
-    }
-
-    var onFind: ((String, Bool) -> Void)?
-    var onFindNext: (() -> Void)?
-    var onFindPrev: (() -> Void)?
-    var onClose: (() -> Void)?
-
-    private let searchField = NSSearchField()
-    private let caseButton = NSButton()
-    private let prevButton = NSButton()
-    private let nextButton = NSButton()
-    private let closeButton = NSButton()
-    private let matchLabel = NSTextField(labelWithString: "")
-
-    private var caseSensitive = false
-
-    init(theme: CodeEditorTheme) {
-        self.theme = theme
-        super.init(frame: .zero)
-        setupViews()
-        applyTheme()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    private func setupViews() {
-        wantsLayer = true
-
-        searchField.placeholderString = "Find…"
-        searchField.sendsSearchStringImmediately = true
-        searchField.target = self
-        searchField.action = #selector(searchChanged)
-        searchField.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(searchField)
-
-        caseButton.title = "Aa"
-        caseButton.setButtonType(.toggle)
-        caseButton.bezelStyle = .texturedRounded
-        caseButton.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
-        caseButton.target = self
-        caseButton.action = #selector(caseToggled)
-        caseButton.toolTip = "Case sensitive"
-        caseButton.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(caseButton)
-
-        prevButton.image = NSImage(systemSymbolName: "chevron.up", accessibilityDescription: "Previous")
-        prevButton.bezelStyle = .texturedRounded
-        prevButton.target = self
-        prevButton.action = #selector(prevTapped)
-        prevButton.toolTip = "Previous match (⌘⇧G)"
-        prevButton.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(prevButton)
-
-        nextButton.image = NSImage(systemSymbolName: "chevron.down", accessibilityDescription: "Next")
-        nextButton.bezelStyle = .texturedRounded
-        nextButton.target = self
-        nextButton.action = #selector(nextTapped)
-        nextButton.toolTip = "Next match (⌘G)"
-        nextButton.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(nextButton)
-
-        matchLabel.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
-        matchLabel.alignment = .right
-        matchLabel.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(matchLabel)
-
-        closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Close")
-        closeButton.bezelStyle = .texturedRounded
-        closeButton.target = self
-        closeButton.action = #selector(closeTapped)
-        closeButton.toolTip = "Close (Esc)"
-        closeButton.isBordered = false
-        closeButton.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(closeButton)
-
-        NSLayoutConstraint.activate([
-            closeButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
-            closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            closeButton.widthAnchor.constraint(equalToConstant: 22),
-
-            searchField.leadingAnchor.constraint(equalTo: closeButton.trailingAnchor, constant: 6),
-            searchField.centerYAnchor.constraint(equalTo: centerYAnchor),
-            searchField.widthAnchor.constraint(greaterThanOrEqualToConstant: 160),
-            searchField.widthAnchor.constraint(lessThanOrEqualToConstant: 320),
-
-            caseButton.leadingAnchor.constraint(equalTo: searchField.trailingAnchor, constant: 6),
-            caseButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            caseButton.widthAnchor.constraint(equalToConstant: 32),
-
-            prevButton.leadingAnchor.constraint(equalTo: caseButton.trailingAnchor, constant: 4),
-            prevButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            prevButton.widthAnchor.constraint(equalToConstant: 26),
-
-            nextButton.leadingAnchor.constraint(equalTo: prevButton.trailingAnchor, constant: 2),
-            nextButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-            nextButton.widthAnchor.constraint(equalToConstant: 26),
-
-            matchLabel.leadingAnchor.constraint(equalTo: nextButton.trailingAnchor, constant: 8),
-            matchLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            matchLabel.widthAnchor.constraint(equalToConstant: 80),
-            matchLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -8),
-        ])
-    }
-
-    private func applyTheme() {
-        layer?.backgroundColor = theme.gutterBackground.cgColor
-        matchLabel.textColor = theme.comment
-        closeButton.contentTintColor = theme.comment
-        prevButton.contentTintColor = theme.comment
-        nextButton.contentTintColor = theme.comment
-    }
-
-    func focusSearchField() {
-        searchField.selectText(nil)
-        window?.makeFirstResponder(searchField)
-    }
-
-    func updateMatchCount(_ count: Int, index: Int) {
-        if count == 0 {
-            matchLabel.stringValue = "No results"
-        } else {
-            matchLabel.stringValue = "\(index + 1) of \(count)"
-        }
-    }
-
-    override func keyDown(with event: NSEvent) {
-        if event.keyCode == 53 { // Escape
-            closeTapped()
-            return
-        }
-        if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "g" {
-            if event.modifierFlags.contains(.shift) {
-                prevTapped()
-            } else {
-                nextTapped()
-            }
-            return
-        }
-        super.keyDown(with: event)
-    }
-
-    @objc private func searchChanged() {
-        onFind?(searchField.stringValue, caseSensitive)
-    }
-
-    @objc private func caseToggled() {
-        caseSensitive = caseButton.state == .on
-        onFind?(searchField.stringValue, caseSensitive)
-    }
-
-    @objc private func prevTapped() {
-        onFindPrev?()
-    }
-
-    @objc private func nextTapped() {
-        onFindNext?()
-    }
-
-    @objc private func closeTapped() {
-        onClose?()
-    }
-}
-
-// MARK: - LineNumberRulerView
-
-private final class LineNumberRulerView: NSRulerView {
-    weak var textView: NSTextView?
-    var theme: CodeEditorTheme
-
-    init(textView: NSTextView, theme: CodeEditorTheme) {
-        self.textView = textView
-        self.theme = theme
-        // scrollView is set on the enclosing scroll view after documentView assignment.
-        super.init(scrollView: textView.enclosingScrollView, orientation: .verticalRuler)
-        clientView = textView
-        ruleThickness = 48
-    }
-
-    required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func drawHashMarksAndLabels(in rect: NSRect) {
-        theme.gutterBackground.setFill()
-        rect.fill()
-        guard let textView,
-              let layoutManager = textView.layoutManager,
-              let textContainer = textView.textContainer else { return }
-        let visible = textView.visibleRect
-        guard visible.height > 0 else { return }
-        let glyphRange = layoutManager.glyphRange(forBoundingRect: visible, in: textContainer)
-        let text = textView.string as NSString
-        var glyphIndex = glyphRange.location
-        var scanIndex = 0
-        var line = 1
-        let labelAttrs: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular),
-            .foregroundColor: theme.comment,
-        ]
-        while glyphIndex < NSMaxRange(glyphRange) {
-            var effective = NSRange()
-            let fragmentRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: &effective)
-            guard effective.length > 0 else { break }
-            let y = fragmentRect.minY + textView.textContainerOrigin.y - visible.minY + 1
-            let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
-            advanceLineNumber(upTo: characterIndex, in: text, scanIndex: &scanIndex, line: &line)
-            let label = "\(line)" as NSString
-            let labelSize = label.size(withAttributes: labelAttrs)
-            let x = ruleThickness - labelSize.width - 6
-            label.draw(at: NSPoint(x: x, y: y), withAttributes: labelAttrs)
-            glyphIndex = NSMaxRange(effective)
-        }
-    }
-
-    private func advanceLineNumber(upTo characterIndex: Int, in text: NSString, scanIndex: inout Int, line: inout Int) {
-        while scanIndex < characterIndex, scanIndex < text.length {
-            if text.character(at: scanIndex) == 10 { line += 1 }
-            scanIndex += 1
-        }
+    private static func editorIdentity(for filePath: String?, text: String) -> String {
+        let language = codeLanguage(for: filePath, text: text)
+        return "\(filePath ?? "untitled"):\(language.id.rawValue)"
     }
 }
 #endif

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -745,21 +745,8 @@ final class EditorScrollHost: NSView {
         needsLayout = true
     }
 
-    override func setFrameSize(_ newSize: NSSize) {
-        super.setFrameSize(newSize)
-        // SwiftUI resizes the host by setting its frame, which does not trigger layout()
-        // on a non-autoresizing view. Re-lay the scroll view here so it always fills the
-        // host; otherwise the scroll view stays latched at its initial (narrow) width and
-        // the wrapped text renders in a thin, off-center column.
-        layoutContents()
-    }
-
     override func layout() {
         super.layout()
-        layoutContents()
-    }
-
-    private func layoutContents() {
         let barHeight = (findBar?.isHidden ?? true) ? 0 : findBarHeight
         findBar?.frame = NSRect(x: 0, y: bounds.height - barHeight, width: bounds.width, height: findBarHeight)
         scrollView.frame = NSRect(x: 0, y: 0, width: bounds.width, height: bounds.height - barHeight)

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -83,6 +83,24 @@ public enum CodeEditorTheme: String, CaseIterable, Identifiable {
         case .oneDark: return NSColor.matrixHex(0x21252B)
         }
     }
+
+    var findHighlight: NSColor {
+        switch self {
+        case .matrixLight, .xcodeLight, .solarizedLight:
+            return NSColor(calibratedRed: 1.0, green: 0.88, blue: 0.2, alpha: 0.55)
+        case .xcodeDark, .terminalDark, .oneDark:
+            return NSColor(calibratedRed: 0.9, green: 0.7, blue: 0.0, alpha: 0.45)
+        }
+    }
+
+    var findActiveHighlight: NSColor {
+        switch self {
+        case .matrixLight, .xcodeLight, .solarizedLight:
+            return NSColor(calibratedRed: 1.0, green: 0.65, blue: 0.0, alpha: 0.75)
+        case .xcodeDark, .terminalDark, .oneDark:
+            return NSColor(calibratedRed: 1.0, green: 0.75, blue: 0.1, alpha: 0.70)
+        }
+    }
 }
 
 public struct CodeEditorPreferences: Equatable, Sendable {
@@ -123,6 +141,8 @@ private extension NSFont {
     }
 }
 
+// MARK: - SyntaxHighlightedCodeEditor
+
 struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
     nonisolated static let engineConfiguration = EditorEngineConfiguration(kind: .textKitNative)
 
@@ -136,14 +156,15 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
         Coordinator(text: $text)
     }
 
-    func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSScrollView()
+    func makeNSView(context: Context) -> EditorScrollHost {
+        let host = EditorScrollHost()
+        let scrollView = host.scrollView
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = true
         scrollView.autohidesScrollers = true
         scrollView.drawsBackground = true
 
-        let textView = NSTextView()
+        let textView = EditorTextView()
         textView.isRichText = false
         textView.isEditable = isEditable
         textView.isSelectable = true
@@ -163,42 +184,105 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
         textView.isHorizontallyResizable = !preferences.wrapsLines
         textView.isVerticallyResizable = true
         textView.autoresizingMask = preferences.wrapsLines ? [.width] : []
-        applyLayoutPreferences(to: textView, in: scrollView, preferences: preferences)
+        textView.usesFindBar = false
+        textView.isIncrementalSearchingEnabled = false
 
         scrollView.documentView = textView
-        scrollView.verticalRulerView = LineNumberRulerView(textView: textView, theme: theme)
+        // Layout preferences applied after documentView is set so contentSize is valid.
+        applyLayoutPreferences(to: textView, in: scrollView, preferences: preferences)
+
+        let ruler = LineNumberRulerView(textView: textView, theme: theme)
+        scrollView.verticalRulerView = ruler
         scrollView.hasVerticalRuler = true
         scrollView.rulersVisible = true
+
+        // Search bar: inserted above the scroll view inside the host.
+        let searchBar = FindBar(theme: theme)
+        searchBar.isHidden = true
+        let coordinator = context.coordinator
+        searchBar.onFind = { [weak coordinator] query, caseSensitive in
+            coordinator?.performFind(query: query, caseSensitive: caseSensitive)
+        }
+        searchBar.onFindNext = { [weak coordinator] in
+            coordinator?.findNext()
+        }
+        searchBar.onFindPrev = { [weak coordinator] in
+            coordinator?.findPrevious()
+        }
+        searchBar.onClose = { [weak coordinator, weak host] in
+            host?.setSearchVisible(false)
+            coordinator?.showFindBar = false
+            if let tv = coordinator?.textView {
+                coordinator?.clearFindHighlights(in: tv)
+                coordinator?.findMatches = []
+            }
+        }
+
+        host.findBar = searchBar
+        host.addSubview(searchBar)
+        host.addSubview(scrollView)
+
         context.coordinator.textView = textView
         context.coordinator.theme = theme
         context.coordinator.preferences = preferences
         context.coordinator.filePath = filePath
         context.coordinator.isEditable = isEditable
+        context.coordinator.host = host
+        textView.coordinator = context.coordinator
+
+        // Apply initial content. The text container width may be zero here if the
+        // host hasn't been laid out yet; we track whether a real-size re-apply is
+        // still needed via `needsInitialLayout`.
         context.coordinator.applyHighlight {
-            apply(text: text, to: textView, theme: theme, filePath: filePath, preferences: preferences)
+            applyContent(text: text, to: textView, theme: theme, filePath: filePath, preferences: preferences)
         }
-        return scrollView
+        context.coordinator.pendingText = text
+        context.coordinator.needsInitialLayout = true
+
+        return host
     }
 
-    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+    func updateNSView(_ host: EditorScrollHost, context: Context) {
+        let scrollView = host.scrollView
         guard let textView = scrollView.documentView as? NSTextView else { return }
+
         if let ruler = scrollView.verticalRulerView as? LineNumberRulerView {
             ruler.theme = theme
             ruler.needsDisplay = true
         }
+
         applyLayoutPreferences(to: textView, in: scrollView, preferences: preferences)
         textView.isEditable = isEditable
-        if textView.string != text || context.coordinator.needsHighlight || context.coordinator.theme != theme || context.coordinator.preferences != preferences || context.coordinator.filePath != filePath || context.coordinator.isEditable != isEditable {
+
+        let themeChanged = context.coordinator.theme != theme
+        let prefsChanged = context.coordinator.preferences != preferences
+        let pathChanged = context.coordinator.filePath != filePath
+        let editableChanged = context.coordinator.isEditable != isEditable
+        let textChanged = textView.string != text
+        let needsLayout = context.coordinator.needsInitialLayout && scrollView.contentSize.width > 0
+
+        if textChanged || themeChanged || prefsChanged || pathChanged || editableChanged
+            || context.coordinator.needsHighlight || needsLayout {
             context.coordinator.theme = theme
             context.coordinator.preferences = preferences
             context.coordinator.filePath = filePath
             context.coordinator.isEditable = isEditable
             context.coordinator.needsHighlight = false
+            if needsLayout {
+                context.coordinator.needsInitialLayout = false
+            }
             context.coordinator.applyHighlight {
-                apply(text: text, to: textView, theme: theme, filePath: filePath, preferences: preferences)
+                applyContent(text: text, to: textView, theme: theme, filePath: filePath, preferences: preferences)
             }
         }
+
+        // Update search-bar theme whenever theme changes.
+        if let findBar = host.findBar {
+            findBar.theme = theme
+        }
     }
+
+    // MARK: - Layout helpers
 
     private func applyLayoutPreferences(to textView: NSTextView, in scrollView: NSScrollView, preferences: CodeEditorPreferences) {
         textView.isHorizontallyResizable = !preferences.wrapsLines
@@ -222,7 +306,9 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
         return max(contentWidth, boundsWidth, 320)
     }
 
-    private func apply(text: String, to textView: NSTextView, theme: CodeEditorTheme, filePath: String?, preferences: CodeEditorPreferences) {
+    // MARK: - Content application
+
+    private func applyContent(text: String, to textView: NSTextView, theme: CodeEditorTheme, filePath: String?, preferences: CodeEditorPreferences) {
         let selected = textView.selectedRange()
         textView.backgroundColor = theme.background
         textView.insertionPointColor = theme.foreground
@@ -230,12 +316,17 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
         textView.font = Self.editorFont(size: preferences.fontSize)
         textView.defaultParagraphStyle = Self.paragraphStyle(tabWidth: preferences.tabWidth, fontSize: preferences.fontSize, wrapsLines: preferences.wrapsLines)
         textView.textStorage?.setAttributedString(Self.highlightedText(text, filePath: filePath, theme: theme, preferences: preferences))
-        textView.setSelectedRange(NSRange(location: min(selected.location, (text as NSString).length), length: 0))
+        let safeLocation = min(selected.location, (text as NSString).length)
+        textView.setSelectedRange(NSRange(location: safeLocation, length: 0))
         textView.needsDisplay = true
-        textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+        if let container = textView.textContainer {
+            textView.layoutManager?.ensureLayout(for: container)
+        }
     }
 
-    private static func editorFont(size: Double) -> NSFont {
+    // MARK: - Font & paragraph style
+
+    static func editorFont(size: Double) -> NSFont {
         let pointSize = CGFloat(size)
         for name in ["JetBrainsMono Nerd Font Mono", "JetBrains Mono", "SFMono-Regular", "Menlo"] {
             if let font = NSFont(name: name, size: pointSize) { return font }
@@ -251,6 +342,8 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
         return style
     }
 
+    // MARK: - Syntax highlighting
+
     static func highlightedText(_ text: String, filePath: String?, theme: CodeEditorTheme, preferences: CodeEditorPreferences) -> NSAttributedString {
         let nsText = text as NSString
         let fullRange = NSRange(location: 0, length: nsText.length)
@@ -264,71 +357,226 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
             ]
         )
         if preferences.showsInvisibleCharacters {
-            apply(pattern: #" |\t"#, color: theme.comment.withAlphaComponent(0.55), to: output, range: fullRange)
+            applyPattern(#" |\t"#, color: theme.comment.withAlphaComponent(0.55), to: output, range: fullRange)
         }
-        apply(pattern: #""(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`"#, color: theme.string, to: output, range: fullRange)
+        applyPattern(#""(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`"#, color: theme.string, to: output, range: fullRange)
+        if language.supportsBlockComments {
+            applyPattern(language.blockCommentPattern, color: theme.comment, to: output, range: fullRange)
+        }
         if language.supportsLineComments {
-            apply(pattern: language.commentPattern, color: theme.comment, to: output, range: fullRange)
+            applyPattern(language.commentPattern, color: theme.comment, to: output, range: fullRange)
         }
         if language.supportsKeywords {
-            apply(pattern: language.keywordPattern, color: theme.keyword, to: output, range: fullRange)
+            applyPattern(language.keywordPattern, color: theme.keyword, to: output, range: fullRange)
+        }
+        if language.supportsNumbers {
+            applyPattern(#"\b\d+\.?\d*\b"#, color: theme.number, to: output, range: fullRange)
         }
         return output
     }
 
     private struct SyntaxLanguage {
         var supportsLineComments: Bool
+        var supportsBlockComments: Bool
         var supportsKeywords: Bool
+        var supportsNumbers: Bool
         var commentPattern: String
+        var blockCommentPattern: String
         var keywordPattern: String
     }
 
     private static func syntaxLanguage(for filePath: String?) -> SyntaxLanguage {
-        let fallback = SyntaxLanguage(
-            supportsLineComments: true,
-            supportsKeywords: true,
-            commentPattern: #"(?m)(//.*$|#.*$)"#,
-            keywordPattern: #"\b(import|export|from|func|function|let|const|var|struct|class|enum|protocol|extension|public|private|return|if|else|switch|case|for|while|guard|try|await|async|throws|type|interface|extends|implements|new|in|of)\b"#
+        let noHighlight = SyntaxLanguage(
+            supportsLineComments: false,
+            supportsBlockComments: false,
+            supportsKeywords: false,
+            supportsNumbers: false,
+            commentPattern: "",
+            blockCommentPattern: "",
+            keywordPattern: ""
         )
-        guard let filePath, !filePath.isEmpty else { return fallback }
+        let jsKeywords = #"\b(import|export|from|as|default|function|let|const|var|class|extends|implements|interface|type|enum|namespace|module|declare|return|if|else|switch|case|break|continue|for|while|do|try|catch|finally|throw|new|delete|typeof|instanceof|in|of|await|async|yield|true|false|null|undefined|void|this|super|static|public|private|protected|abstract|override|readonly|keyof|infer|never|any|unknown)\b"#
+        let swiftKeywords = #"\b(import|func|let|var|struct|class|enum|protocol|extension|public|private|internal|fileprivate|open|override|final|static|lazy|weak|unowned|mutating|nonmutating|inout|guard|return|if|else|switch|case|for|while|repeat|do|try|catch|throw|throws|rethrows|async|await|actor|nonisolated|some|any|self|Self|super|init|deinit|subscript|get|set|willSet|didSet|defer|typealias|associatedtype|where|in|as|is|nil|true|false)\b"#
+        let pyKeywords = #"\b(import|from|as|def|class|return|if|elif|else|for|while|try|except|finally|raise|with|lambda|yield|pass|break|continue|del|global|nonlocal|and|or|not|in|is|True|False|None|async|await)\b"#
+        let genericKeywords = #"\b(import|export|from|func|function|let|const|var|struct|class|enum|protocol|extension|public|private|return|if|else|switch|case|for|while|guard|try|await|async|throws|type|interface|extends|implements|new|in|of)\b"#
+
+        guard let filePath, !filePath.isEmpty else {
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)(//.*$|#.*$)"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: genericKeywords
+            )
+        }
         let ext = URL(fileURLWithPath: filePath).pathExtension.lowercased()
         switch ext {
-        case "json", "jsonc", "yaml", "yml", "toml", "xml", "html", "htm", "md", "markdown", "txt", "log", "csv":
+        case "md", "markdown", "mdx", "txt", "log", "csv":
+            return noHighlight
+        case "json", "jsonc":
             return SyntaxLanguage(
-                supportsLineComments: false,
-                supportsKeywords: false,
-                commentPattern: fallback.commentPattern,
-                keywordPattern: fallback.keywordPattern
+                supportsLineComments: false, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: "",
+                blockCommentPattern: "",
+                keywordPattern: #"\b(true|false|null)\b"#
             )
-        case "py", "rb", "sh", "bash", "zsh":
+        case "yaml", "yml":
             return SyntaxLanguage(
-                supportsLineComments: true,
-                supportsKeywords: true,
+                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: false, supportsNumbers: true,
                 commentPattern: #"(?m)#.*$"#,
-                keywordPattern: fallback.keywordPattern
+                blockCommentPattern: "",
+                keywordPattern: ""
+            )
+        case "toml":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)#.*$"#,
+                blockCommentPattern: "",
+                keywordPattern: #"\b(true|false)\b"#
+            )
+        case "xml", "html", "htm", "svg":
+            return SyntaxLanguage(
+                supportsLineComments: false, supportsBlockComments: true, supportsKeywords: false, supportsNumbers: false,
+                commentPattern: "",
+                blockCommentPattern: #"<!--[\s\S]*?-->"#,
+                keywordPattern: ""
+            )
+        case "py":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)#.*$"#,
+                blockCommentPattern: "",
+                keywordPattern: pyKeywords
+            )
+        case "rb":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)#.*$"#,
+                blockCommentPattern: "",
+                keywordPattern: #"\b(def|class|module|end|if|elsif|else|unless|case|when|while|until|for|do|begin|rescue|ensure|raise|return|require|require_relative|include|extend|attr|attr_reader|attr_writer|attr_accessor|true|false|nil|self|super|yield|and|or|not|in)\b"#
+            )
+        case "sh", "bash", "zsh", "fish":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: false, supportsKeywords: true, supportsNumbers: false,
+                commentPattern: #"(?m)#.*$"#,
+                blockCommentPattern: "",
+                keywordPattern: #"\b(if|then|else|elif|fi|for|do|done|while|until|case|esac|function|return|local|export|readonly|declare|source|echo|exit|break|continue|shift|set|unset|trap)\b"#
+            )
+        case "swift":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: swiftKeywords
+            )
+        case "ts", "tsx":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: jsKeywords
+            )
+        case "js", "jsx", "mjs", "cjs":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: jsKeywords
+            )
+        case "go":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: #"\b(package|import|func|var|const|type|struct|interface|map|chan|go|defer|return|if|else|switch|case|for|range|break|continue|fallthrough|select|default|make|new|len|cap|append|copy|delete|close|panic|recover|nil|true|false)\b"#
+            )
+        case "rs":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: #"\b(use|mod|fn|let|mut|const|static|struct|enum|trait|impl|pub|priv|crate|super|self|Self|where|type|return|if|else|match|for|while|loop|break|continue|in|move|ref|as|async|await|dyn|unsafe|extern|true|false)\b"#
+            )
+        case "kt", "kts":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: #"\b(package|import|class|interface|object|fun|val|var|constructor|init|return|if|else|when|for|while|do|try|catch|finally|throw|override|open|final|abstract|sealed|data|inner|companion|suspend|inline|reified|crossinline|noinline|lateinit|lazy|const|by|in|is|as|null|true|false)\b"#
+            )
+        case "java":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: #"\b(package|import|class|interface|enum|extends|implements|public|private|protected|static|final|abstract|synchronized|volatile|native|return|if|else|switch|case|for|while|do|try|catch|finally|throw|throws|new|instanceof|this|super|null|true|false|void|int|long|float|double|boolean|char|byte|short)\b"#
+            )
+        case "c", "h":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: #"\b(include|define|ifdef|ifndef|endif|if|else|switch|case|for|while|do|return|break|continue|struct|union|enum|typedef|const|static|extern|register|volatile|auto|sizeof|void|int|long|float|double|char|unsigned|signed|short)\b"#
+            )
+        case "cpp", "cc", "cxx", "hpp":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: #"\b(include|define|namespace|class|struct|template|typename|virtual|override|final|public|private|protected|static|const|constexpr|inline|explicit|operator|new|delete|return|if|else|switch|case|for|while|do|try|catch|throw|nullptr|true|false|void|int|long|float|double|char|bool|auto)\b"#
+            )
+        case "css", "scss", "less":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: false, supportsNumbers: true,
+                commentPattern: #"(?m)//.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: ""
+            )
+        case "sql":
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)--.*$"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: #"(?i)\b(SELECT|FROM|WHERE|AND|OR|NOT|IN|BETWEEN|LIKE|IS|NULL|ORDER|BY|GROUP|HAVING|LIMIT|OFFSET|JOIN|INNER|LEFT|RIGHT|FULL|OUTER|ON|AS|INSERT|INTO|VALUES|UPDATE|SET|DELETE|CREATE|TABLE|INDEX|VIEW|DROP|ALTER|ADD|COLUMN|PRIMARY|KEY|FOREIGN|REFERENCES|UNIQUE|DEFAULT|NOT|NULL|CHECK|CONSTRAINT|BEGIN|COMMIT|ROLLBACK|TRANSACTION)\b"#
             )
         default:
-            return fallback
+            return SyntaxLanguage(
+                supportsLineComments: true, supportsBlockComments: true, supportsKeywords: true, supportsNumbers: true,
+                commentPattern: #"(?m)(//.*$|#.*$)"#,
+                blockCommentPattern: #"/\*[\s\S]*?\*/"#,
+                keywordPattern: genericKeywords
+            )
         }
     }
 
-    private static func apply(pattern: String, color: NSColor, to output: NSMutableAttributedString, range: NSRange) {
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+    private static func applyPattern(_ pattern: String, color: NSColor, to output: NSMutableAttributedString, range: NSRange) {
+        guard !pattern.isEmpty,
+              let regex = try? NSRegularExpression(pattern: pattern) else { return }
         regex.enumerateMatches(in: output.string, range: range) { match, _, _ in
             guard let match else { return }
             output.addAttribute(.foregroundColor, value: color, range: match.range)
         }
     }
 
+    // MARK: - Coordinator
+
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         @Binding var text: String
         weak var textView: NSTextView?
+        weak var host: EditorScrollHost?
         var theme: CodeEditorTheme?
         var preferences: CodeEditorPreferences?
         var filePath: String?
         var isEditable = true
         var needsHighlight = false
+        var needsInitialLayout = false
+        var pendingText: String = ""
+        var showFindBar = false
         private var isApplyingHighlight = false
+
+        // Find state
+        var findMatches: [NSRange] = []
+        var findMatchIndex: Int = 0
 
         init(text: Binding<String>) {
             _text = text
@@ -346,8 +594,336 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
             needsHighlight = true
             text = textView.string
         }
+
+        // MARK: Find
+
+        func performFind(query: String, caseSensitive: Bool) {
+            guard let textView, let textStorage = textView.textStorage else { return }
+            clearFindHighlights(in: textView)
+            guard !query.isEmpty else {
+                findMatches = []
+                findMatchIndex = 0
+                host?.findBar?.updateMatchCount(0, index: 0)
+                return
+            }
+            let options: NSRegularExpression.Options = caseSensitive ? [] : [.caseInsensitive]
+            let escapedQuery = NSRegularExpression.escapedPattern(for: query)
+            guard let regex = try? NSRegularExpression(pattern: escapedQuery, options: options) else {
+                findMatches = []
+                return
+            }
+            let fullRange = NSRange(location: 0, length: textStorage.length)
+            var matches: [NSRange] = []
+            regex.enumerateMatches(in: textStorage.string, range: fullRange) { match, _, _ in
+                guard let match else { return }
+                matches.append(match.range)
+            }
+            findMatches = matches
+            findMatchIndex = 0
+            guard let theme else { return }
+            for (i, range) in matches.enumerated() {
+                let color = i == 0 ? theme.findActiveHighlight : theme.findHighlight
+                textStorage.addAttribute(.backgroundColor, value: color, range: range)
+            }
+            if !matches.isEmpty {
+                textView.scrollRangeToVisible(matches[0])
+                textView.setSelectedRange(matches[0])
+            }
+            host?.findBar?.updateMatchCount(matches.count, index: findMatchIndex)
+        }
+
+        func findNext() {
+            guard !findMatches.isEmpty else { return }
+            clearActiveHighlight()
+            findMatchIndex = (findMatchIndex + 1) % findMatches.count
+            activateMatch(at: findMatchIndex)
+        }
+
+        func findPrevious() {
+            guard !findMatches.isEmpty else { return }
+            clearActiveHighlight()
+            findMatchIndex = (findMatchIndex - 1 + findMatches.count) % findMatches.count
+            activateMatch(at: findMatchIndex)
+        }
+
+        private func activateMatch(at index: Int) {
+            guard let textView, let textStorage = textView.textStorage,
+                  index < findMatches.count, let theme else { return }
+            let range = findMatches[index]
+            textStorage.addAttribute(.backgroundColor, value: theme.findActiveHighlight, range: range)
+            textView.scrollRangeToVisible(range)
+            textView.setSelectedRange(range)
+            host?.findBar?.updateMatchCount(findMatches.count, index: index)
+        }
+
+        private func clearActiveHighlight() {
+            guard let textView, let textStorage = textView.textStorage, let theme else { return }
+            if findMatchIndex < findMatches.count {
+                textStorage.addAttribute(.backgroundColor, value: theme.findHighlight, range: findMatches[findMatchIndex])
+            }
+        }
+
+        func clearFindHighlights(in textView: NSTextView) {
+            guard let textStorage = textView.textStorage else { return }
+            let fullRange = NSRange(location: 0, length: textStorage.length)
+            textStorage.removeAttribute(.backgroundColor, range: fullRange)
+        }
+
+        func toggleFindBar() {
+            guard let host else { return }
+            let nowVisible = !(host.findBar?.isHidden ?? true)
+            showFindBar = !nowVisible
+            host.setSearchVisible(showFindBar)
+            if showFindBar {
+                host.findBar?.focusSearchField()
+            } else if let textView {
+                clearFindHighlights(in: textView)
+                findMatches = []
+                textView.window?.makeFirstResponder(textView)
+            }
+        }
     }
 }
+
+// MARK: - Number color extension
+
+private extension CodeEditorTheme {
+    var number: NSColor {
+        switch self {
+        case .matrixLight: return NSColor(calibratedRed: 0.17, green: 0.40, blue: 0.75, alpha: 1)
+        case .xcodeLight: return NSColor(calibratedRed: 0.15, green: 0.37, blue: 0.71, alpha: 1)
+        case .xcodeDark: return NSColor.matrixHex(0xD9C97C)
+        case .solarizedLight: return NSColor.matrixHex(0xCB4B16)
+        case .terminalDark: return NSColor(calibratedRed: 0.8, green: 0.62, blue: 0.45, alpha: 1)
+        case .oneDark: return NSColor.matrixHex(0xD19A66)
+        }
+    }
+}
+
+// MARK: - EditorTextView (handles Find shortcut)
+
+private final class EditorTextView: NSTextView {
+    weak var coordinator: SyntaxHighlightedCodeEditor.Coordinator?
+
+    override func keyDown(with event: NSEvent) {
+        // Cmd+F → toggle find bar
+        if event.modifierFlags.contains(.command), event.charactersIgnoringModifiers == "f" {
+            coordinator?.toggleFindBar()
+            return
+        }
+        // Cmd+G → find next
+        if event.modifierFlags.contains(.command), event.charactersIgnoringModifiers == "g" {
+            if event.modifierFlags.contains(.shift) {
+                coordinator?.findPrevious()
+            } else {
+                coordinator?.findNext()
+            }
+            return
+        }
+        super.keyDown(with: event)
+    }
+}
+
+// MARK: - EditorScrollHost (NSView wrapping scroll + find bar)
+
+final class EditorScrollHost: NSView {
+    let scrollView = NSScrollView()
+    var findBar: FindBar?
+    private let findBarHeight: CGFloat = 36
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        autoresizesSubviews = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setSearchVisible(_ visible: Bool) {
+        findBar?.isHidden = !visible
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        let barHeight = (findBar?.isHidden ?? true) ? 0 : findBarHeight
+        findBar?.frame = NSRect(x: 0, y: bounds.height - barHeight, width: bounds.width, height: findBarHeight)
+        scrollView.frame = NSRect(x: 0, y: 0, width: bounds.width, height: bounds.height - barHeight)
+    }
+}
+
+// MARK: - FindBar
+
+final class FindBar: NSView {
+    var theme: CodeEditorTheme {
+        didSet { applyTheme() }
+    }
+
+    var onFind: ((String, Bool) -> Void)?
+    var onFindNext: (() -> Void)?
+    var onFindPrev: (() -> Void)?
+    var onClose: (() -> Void)?
+
+    private let searchField = NSSearchField()
+    private let caseButton = NSButton()
+    private let prevButton = NSButton()
+    private let nextButton = NSButton()
+    private let closeButton = NSButton()
+    private let matchLabel = NSTextField(labelWithString: "")
+
+    private var caseSensitive = false
+
+    init(theme: CodeEditorTheme) {
+        self.theme = theme
+        super.init(frame: .zero)
+        setupViews()
+        applyTheme()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupViews() {
+        wantsLayer = true
+
+        searchField.placeholderString = "Find…"
+        searchField.sendsSearchStringImmediately = true
+        searchField.target = self
+        searchField.action = #selector(searchChanged)
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(searchField)
+
+        caseButton.title = "Aa"
+        caseButton.setButtonType(.toggle)
+        caseButton.bezelStyle = .texturedRounded
+        caseButton.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        caseButton.target = self
+        caseButton.action = #selector(caseToggled)
+        caseButton.toolTip = "Case sensitive"
+        caseButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(caseButton)
+
+        prevButton.image = NSImage(systemSymbolName: "chevron.up", accessibilityDescription: "Previous")
+        prevButton.bezelStyle = .texturedRounded
+        prevButton.target = self
+        prevButton.action = #selector(prevTapped)
+        prevButton.toolTip = "Previous match (⌘⇧G)"
+        prevButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(prevButton)
+
+        nextButton.image = NSImage(systemSymbolName: "chevron.down", accessibilityDescription: "Next")
+        nextButton.bezelStyle = .texturedRounded
+        nextButton.target = self
+        nextButton.action = #selector(nextTapped)
+        nextButton.toolTip = "Next match (⌘G)"
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(nextButton)
+
+        matchLabel.font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        matchLabel.alignment = .right
+        matchLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(matchLabel)
+
+        closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Close")
+        closeButton.bezelStyle = .texturedRounded
+        closeButton.target = self
+        closeButton.action = #selector(closeTapped)
+        closeButton.toolTip = "Close (Esc)"
+        closeButton.isBordered = false
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(closeButton)
+
+        NSLayoutConstraint.activate([
+            closeButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            closeButton.widthAnchor.constraint(equalToConstant: 22),
+
+            searchField.leadingAnchor.constraint(equalTo: closeButton.trailingAnchor, constant: 6),
+            searchField.centerYAnchor.constraint(equalTo: centerYAnchor),
+            searchField.widthAnchor.constraint(greaterThanOrEqualToConstant: 160),
+            searchField.widthAnchor.constraint(lessThanOrEqualToConstant: 320),
+
+            caseButton.leadingAnchor.constraint(equalTo: searchField.trailingAnchor, constant: 6),
+            caseButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            caseButton.widthAnchor.constraint(equalToConstant: 32),
+
+            prevButton.leadingAnchor.constraint(equalTo: caseButton.trailingAnchor, constant: 4),
+            prevButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            prevButton.widthAnchor.constraint(equalToConstant: 26),
+
+            nextButton.leadingAnchor.constraint(equalTo: prevButton.trailingAnchor, constant: 2),
+            nextButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            nextButton.widthAnchor.constraint(equalToConstant: 26),
+
+            matchLabel.leadingAnchor.constraint(equalTo: nextButton.trailingAnchor, constant: 8),
+            matchLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            matchLabel.widthAnchor.constraint(equalToConstant: 80),
+            matchLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -8),
+        ])
+    }
+
+    private func applyTheme() {
+        layer?.backgroundColor = theme.gutterBackground.cgColor
+        matchLabel.textColor = theme.comment
+        closeButton.contentTintColor = theme.comment
+        prevButton.contentTintColor = theme.comment
+        nextButton.contentTintColor = theme.comment
+    }
+
+    func focusSearchField() {
+        searchField.selectText(nil)
+        window?.makeFirstResponder(searchField)
+    }
+
+    func updateMatchCount(_ count: Int, index: Int) {
+        if count == 0 {
+            matchLabel.stringValue = "No results"
+        } else {
+            matchLabel.stringValue = "\(index + 1) of \(count)"
+        }
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 { // Escape
+            closeTapped()
+            return
+        }
+        if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "g" {
+            if event.modifierFlags.contains(.shift) {
+                prevTapped()
+            } else {
+                nextTapped()
+            }
+            return
+        }
+        super.keyDown(with: event)
+    }
+
+    @objc private func searchChanged() {
+        onFind?(searchField.stringValue, caseSensitive)
+    }
+
+    @objc private func caseToggled() {
+        caseSensitive = caseButton.state == .on
+        onFind?(searchField.stringValue, caseSensitive)
+    }
+
+    @objc private func prevTapped() {
+        onFindPrev?()
+    }
+
+    @objc private func nextTapped() {
+        onFindNext?()
+    }
+
+    @objc private func closeTapped() {
+        onClose?()
+    }
+}
+
+// MARK: - LineNumberRulerView
 
 private final class LineNumberRulerView: NSRulerView {
     weak var textView: NSTextView?
@@ -356,6 +932,7 @@ private final class LineNumberRulerView: NSRulerView {
     init(textView: NSTextView, theme: CodeEditorTheme) {
         self.textView = textView
         self.theme = theme
+        // scrollView is set on the enclosing scroll view after documentView assignment.
         super.init(scrollView: textView.enclosingScrollView, orientation: .verticalRuler)
         clientView = textView
         ruleThickness = 48
@@ -368,27 +945,31 @@ private final class LineNumberRulerView: NSRulerView {
     override func drawHashMarksAndLabels(in rect: NSRect) {
         theme.gutterBackground.setFill()
         rect.fill()
-        guard let textView, let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else { return }
+        guard let textView,
+              let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else { return }
         let visible = textView.visibleRect
+        guard visible.height > 0 else { return }
         let glyphRange = layoutManager.glyphRange(forBoundingRect: visible, in: textContainer)
         let text = textView.string as NSString
         var glyphIndex = glyphRange.location
         var scanIndex = 0
         var line = 1
+        let labelAttrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular),
+            .foregroundColor: theme.comment,
+        ]
         while glyphIndex < NSMaxRange(glyphRange) {
             var effective = NSRange()
-            let rect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: &effective)
-            let y = rect.minY + textView.textContainerOrigin.y - visible.minY + 1
+            let fragmentRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: &effective)
+            guard effective.length > 0 else { break }
+            let y = fragmentRect.minY + textView.textContainerOrigin.y - visible.minY + 1
             let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
             advanceLineNumber(upTo: characterIndex, in: text, scanIndex: &scanIndex, line: &line)
             let label = "\(line)" as NSString
-            label.draw(
-                at: NSPoint(x: 8, y: y),
-                withAttributes: [
-                    .font: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular),
-                    .foregroundColor: theme.comment,
-                ]
-            )
+            let labelSize = label.size(withAttributes: labelAttrs)
+            let x = ruleThickness - labelSize.width - 6
+            label.draw(at: NSPoint(x: x, y: y), withAttributes: labelAttrs)
             glyphIndex = NSMaxRange(effective)
         }
     }

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -189,6 +189,7 @@ struct SyntaxHighlightedCodeEditor: View {
             isEditable: isEditable,
             isSelectable: true,
             letterSpacing: 1.0,
+            coordinators: [InitialHighlightRefreshCoordinator()],
             showMinimap: false
         )
         .id(Self.editorIdentity(for: filePath, text: text))
@@ -219,6 +220,19 @@ struct SyntaxHighlightedCodeEditor: View {
     private static func editorIdentity(for filePath: String?, text: String) -> String {
         let language = codeLanguage(for: filePath, text: text)
         return "\(filePath ?? "untitled"):\(language.id.rawValue)"
+    }
+}
+
+private final class InitialHighlightRefreshCoordinator: TextViewCoordinator {
+    func prepareCoordinator(controller: TextViewController) {
+        Task { @MainActor [weak controller] in
+            guard let controller else { return }
+            let language = controller.language
+            controller.language = language
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            guard !Task.isCancelled else { return }
+            controller.language = language
+        }
     }
 }
 #endif

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -294,12 +294,8 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
             wrapsLines: preferences.wrapsLines
         )
         textView.textContainer?.containerSize = NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-        textView.minSize = NSSize(width: 0, height: 0)
-        // Never cap max width. When wrapping, the container tracks the text view, which the
-        // scroll view sizes to full width via autoresizing; capping max width at an early,
-        // narrow contentSize was pinning the editor into a thin centered column (and, for
-        // dense files like JSON, wrapping to one character per line).
-        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.minSize = NSSize(width: preferences.wrapsLines ? width : 320, height: 0)
+        textView.maxSize = NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
         if preferences.wrapsLines, textView.frame.width < width {
             textView.frame.size.width = width
         }

--- a/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
+++ b/macos/Sources/App/SyntaxHighlightedCodeEditor.swift
@@ -294,8 +294,12 @@ struct SyntaxHighlightedCodeEditor: NSViewRepresentable {
             wrapsLines: preferences.wrapsLines
         )
         textView.textContainer?.containerSize = NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
-        textView.minSize = NSSize(width: preferences.wrapsLines ? width : 320, height: 0)
-        textView.maxSize = NSSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        textView.minSize = NSSize(width: 0, height: 0)
+        // Never cap max width. When wrapping, the container tracks the text view, which the
+        // scroll view sizes to full width via autoresizing; capping max width at an early,
+        // narrow contentSize was pinning the editor into a thin centered column (and, for
+        // dense files like JSON, wrapping to one character per line).
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         if preferences.wrapsLines, textView.frame.width < width {
             textView.frame.size.width = width
         }
@@ -745,8 +749,21 @@ final class EditorScrollHost: NSView {
         needsLayout = true
     }
 
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        // SwiftUI resizes the host by setting its frame, which does not trigger layout()
+        // on a non-autoresizing view. Re-lay the scroll view here so it always fills the
+        // host; otherwise the scroll view stays latched at its initial (narrow) width and
+        // the wrapped text renders in a thin, off-center column.
+        layoutContents()
+    }
+
     override func layout() {
         super.layout()
+        layoutContents()
+    }
+
+    private func layoutContents() {
         let barHeight = (findBar?.isHidden ?? true) ? 0 : findBarHeight
         findBar?.frame = NSRect(x: 0, y: bounds.height - barHeight, width: bounds.width, height: findBarHeight)
         scrollView.frame = NSRect(x: 0, y: 0, width: bounds.width, height: bounds.height - barHeight)

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -371,26 +371,106 @@ struct NativeAppSessionExchange {
     }
 
     static func perform(request: URLRequest) async throws -> Response {
-        let session = URLSession(configuration: .ephemeral)
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = true
+        configuration.httpCookieAcceptPolicy = .always
+        let cookieStorage = configuration.httpCookieStorage
+        let session = URLSession(configuration: configuration)
         defer { session.invalidateAndCancel() }
         let (_, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw NativeAppSessionExchangeError.invalidResponse }
         guard (200..<300).contains(http.statusCode) else { throw NativeAppSessionExchangeError.unauthorized }
         guard let url = request.url else { throw NativeAppSessionExchangeError.invalidResponse }
-        return try Response(cookies: appSessionCookies(from: http, for: url))
+        return try Response(cookies: appSessionCookies(
+            from: http,
+            storedCookies: cookieStorage?.cookies(for: url) ?? [],
+            for: url
+        ))
     }
 
-    static func appSessionCookies(from response: HTTPURLResponse, for url: URL) throws -> [HTTPCookie] {
-        let fields = response.allHeaderFields.reduce(into: [String: String]()) { result, entry in
-            if let key = entry.key as? String, let value = entry.value as? String {
-                result[key] = value
+    static func appSessionCookies(
+        from response: HTTPURLResponse,
+        storedCookies: [HTTPCookie] = [],
+        for url: URL
+    ) throws -> [HTTPCookie] {
+        let headerCookies = response.allHeaderFields.flatMap { entry -> [HTTPCookie] in
+            guard let key = entry.key as? String,
+                  key.caseInsensitiveCompare("Set-Cookie") == .orderedSame else { return [] }
+
+            let values: [String]
+            if let value = entry.value as? String {
+                values = splitSetCookieHeader(value)
+            } else if let value = entry.value as? [String] {
+                values = value.flatMap(splitSetCookieHeader)
+            } else {
+                values = []
+            }
+            return values.flatMap { value in
+                HTTPCookie.cookies(withResponseHeaderFields: ["Set-Cookie": value], for: url)
             }
         }
-        let cookies = HTTPCookie.cookies(withResponseHeaderFields: fields, for: url)
-        guard cookies.contains(where: { $0.name == "matrix_app_session" || $0.name.hasPrefix("matrix_app_session__") }) else {
+
+        var seen = Set<String>()
+        let cookies = (storedCookies + headerCookies).filter { cookie in
+            let key = "\(cookie.name)\u{1f}\(cookie.domain)\u{1f}\(cookie.path)"
+            return seen.insert(key).inserted
+        }
+        guard cookies.contains(where: { $0.name == "matrix_app_session" && !$0.value.isEmpty }),
+              cookies.contains(where: { $0.name == "matrix_native_app_session" && !$0.value.isEmpty }) else {
             throw NativeAppSessionExchangeError.invalidResponse
         }
         return cookies
+    }
+
+    private static func splitSetCookieHeader(_ value: String) -> [String] {
+        value
+            .split(whereSeparator: { $0 == "\n" || $0 == "\r" })
+            .flatMap { splitConcatenatedSetCookieLine(String($0)) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func splitConcatenatedSetCookieLine(_ line: String) -> [String] {
+        var values: [String] = []
+        var start = line.startIndex
+        var index = line.startIndex
+        while index < line.endIndex {
+            guard line[index] == "," else {
+                index = line.index(after: index)
+                continue
+            }
+            var candidate = line.index(after: index)
+            while candidate < line.endIndex, line[candidate] == " " {
+                candidate = line.index(after: candidate)
+            }
+            if beginsCookieName(at: candidate, in: line) {
+                values.append(String(line[start..<index]))
+                start = candidate
+                index = candidate
+                continue
+            }
+            index = line.index(after: index)
+        }
+        values.append(String(line[start..<line.endIndex]))
+        return values
+    }
+
+    private static func beginsCookieName(at index: String.Index, in line: String) -> Bool {
+        var cursor = index
+        var hasName = false
+        while cursor < line.endIndex {
+            let character = line[cursor]
+            if character == "=" {
+                return hasName
+            }
+            guard character.isASCII,
+                  (character.isLetter || character.isNumber || character == "_" || character == "-") else {
+                return false
+            }
+            hasName = true
+            cursor = line.index(after: cursor)
+        }
+        return false
     }
 
     @MainActor

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -185,6 +185,9 @@ private struct WebShellView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+        // Persist the hosted-shell data store so the Home tab keeps its cache across visits
+        // (a non-persistent store forces a full reload every time). Stale Clerk client cookies
+        // are stripped per-load by clearInterferingClerkCookies instead.
         let view = WKWebView(frame: .zero, configuration: configuration)
         view.navigationDelegate = context.coordinator
         view.allowsBackForwardNavigationGestures = true
@@ -288,11 +291,20 @@ private struct WebShellView: NSViewRepresentable {
                     await MainActor.run {
                         guard let self, let webView, self.exchangeGeneration == generation else { return }
                         self.exchangeTask = nil
-                        NativeAppSessionExchange.installCookies(response.cookies, in: webView.configuration.websiteDataStore.httpCookieStore) {
+                        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
+                        NativeAppSessionExchange.installCookies(response.cookies, in: cookieStore) {
                             guard self.exchangeGeneration == generation else { return }
                             let names = response.cookies.map(\.name).joined(separator: ",")
                             webShellLogger.info("Native app session cookies installed names=\(names, privacy: .public)")
-                            webView.load(webShellDestinationRequest(for: destination, token: token))
+                            // The hosted shell authenticates via the native app-session cookies
+                            // (matrix_app_session / matrix_native_app_session). Stale Clerk client
+                            // cookies (accumulated from prior /login redirects) make the platform's
+                            // identity resolution fall back to an unrouted Clerk identity and serve
+                            // the sign-in page. Strip them so we present a clean native-only session.
+                            NativeAppSessionExchange.clearInterferingClerkCookies(in: cookieStore) {
+                                guard self.exchangeGeneration == generation else { return }
+                                webView.load(webShellDestinationRequest(for: destination, token: token))
+                            }
                         }
                     }
                 } catch is CancellationError {
@@ -594,6 +606,33 @@ struct NativeAppSessionExchange {
                 installCookie(at: index + 1, cookies: cookies, store: store, completion: completion)
             }
         }
+    }
+
+    /// Clerk client cookies (`__client*`, `__session*`) and Clerk-domain cookies linger in the
+    /// WKWebView store after a `/login` redirect. When present alongside a valid native app-session,
+    /// the platform resolves an unrouted Clerk identity and serves the sign-in page instead of the
+    /// shell. Remove them so the hosted shell load presents only the native app-session.
+    @MainActor
+    static func clearInterferingClerkCookies(in store: WKHTTPCookieStore, completion: @escaping @MainActor () -> Void) {
+        store.getAllCookies { cookies in
+            let clerkCookies = cookies.filter(isClerkCookie)
+            guard !clerkCookies.isEmpty else {
+                completion()
+                return
+            }
+            let names = clerkCookies.map(\.name).joined(separator: ",")
+            webShellLogger.info("Clearing interfering Clerk cookies before hosted shell load names=\(names, privacy: .public)")
+            Task { @MainActor in
+                deleteCookie(at: 0, cookies: clerkCookies, store: store, completion: completion)
+            }
+        }
+    }
+
+    private static func isClerkCookie(_ cookie: HTTPCookie) -> Bool {
+        let domain = cookie.domain.lowercased()
+        if domain.contains("clerk") { return true }
+        let name = cookie.name
+        return name.hasPrefix("__client") || name.hasPrefix("__session")
     }
 }
 

--- a/macos/Sources/App/WebShellView.swift
+++ b/macos/Sources/App/WebShellView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 import WebKit
 import AppKit
 import DesignSystem
+import OSLog
+
+private let webShellLogger = Logger(subsystem: "com.matrixos.native-shell", category: "WebShell")
 
 struct MatrixWebShellPanel: View {
     @ObservedObject var model: AppModel
@@ -73,10 +76,18 @@ struct MatrixWebShellPanel: View {
                     openSettingsOnLoad: openSettingsOnLoad,
                     onAuthRequired: {
                         let shouldRetry = authState.markHostedAuthRequired()
-                        guard shouldRetry else { return }
-                        authState.markResolving()
-                        Task {
-                            await reloadBearerToken()
+                        if shouldRetry {
+                            authState.markResolving()
+                            Task {
+                                await reloadBearerToken()
+                            }
+                        } else {
+                            // Retry exhausted: the hosted web session needs sign-in.
+                            // `markHostedAuthRequired()` already set the panel to show
+                            // the native sign-in prompt. Do NOT sign out — the native
+                            // principal/gateway session is still valid; signing out
+                            // here caused a redirect -> sign-out -> re-show loop.
+                            model.markHostedShellAuthRequired()
                         }
                     }
                 )
@@ -91,24 +102,31 @@ struct MatrixWebShellPanel: View {
             }
         }
         .task(id: url) {
-            await reloadBearerToken()
+            await reloadBearerToken(resetHostedRetry: true)
         }
         .onChange(of: model.signInCompletionID) { _, _ in
             Task {
-                await reloadBearerToken()
+                await reloadBearerToken(resetHostedRetry: true)
             }
         }
     }
 
     @MainActor
-    private func reloadBearerToken() async {
+    private func reloadBearerToken(resetHostedRetry: Bool = false) async {
         guard url != nil else {
-            authState.resolveToken(nil)
+            webShellLogger.info("Hosted shell token skipped because url is nil")
+            authState.resolveToken(nil, resetHostedRetry: true)
             return
+        }
+        if resetHostedRetry {
+            // A fresh attempt (URL change or completed sign-in): re-arm the hosted
+            // shell so a previously-flagged needs-sign-in state does not stick.
+            model.markHostedShellAuthorized()
         }
         authState.markResolving()
         let current = await model.currentBearerToken()
-        authState.resolveToken(current)
+        webShellLogger.info("Hosted shell token resolved present=\(current != nil, privacy: .public)")
+        authState.resolveToken(current, resetHostedRetry: resetHostedRetry)
     }
 }
 
@@ -127,7 +145,8 @@ struct WebShellAuthState: Equatable, Sendable {
         didResolveToken = false
     }
 
-    mutating func resolveToken(_ nextToken: String?) {
+    mutating func resolveToken(_ nextToken: String?, resetHostedRetry: Bool = false) {
+        let tokenChanged = nextToken != token
         token = nextToken
         didResolveToken = true
         if nextToken == nil {
@@ -137,7 +156,9 @@ struct WebShellAuthState: Equatable, Sendable {
             return
         }
         hostedAuthRequired = false
-        hostedRetryAttempted = false
+        if resetHostedRetry || tokenChanged {
+            hostedRetryAttempted = false
+        }
         authRevision += 1
     }
 
@@ -185,8 +206,10 @@ private struct WebShellView: NSViewRepresentable {
         coordinator.lastAuthRevision = authRevision
         coordinator.openSettingsOnLoad = openSettingsOnLoad
         coordinator.destinationURL = url
+        webShellLogger.info("Hosted shell load requested host=\(url.host() ?? "unknown", privacy: .public) path=\(url.path, privacy: .public) tokenPresent=\((bearerToken?.isEmpty == false), privacy: .public)")
         guard let bearerToken, !bearerToken.isEmpty else {
             coordinator.cancelExchange()
+            webShellLogger.warning("Hosted shell loading without bearer token")
             view.load(webShellDestinationRequest(for: url, token: bearerToken))
             return
         }
@@ -212,35 +235,52 @@ private struct WebShellView: NSViewRepresentable {
                 decisionHandler(.allow)
                 return
             }
-            if shouldHandleAsAuthRequired(url) {
+            webShellLogger.info("WK navigation requested host=\(url.host() ?? "unknown", privacy: .public) path=\(url.path, privacy: .public)")
+            switch WebShellNavigationPolicy.decision(for: url, destinationURL: destinationURL) {
+            case .authRequired:
+                webShellLogger.warning("WK navigation treated as hosted auth required path=\(url.path, privacy: .public)")
                 onAuthRequired()
                 decisionHandler(.cancel)
-                return
-            }
-            if Self.shouldOpenExternally(url) {
+            case .external:
                 cancelExchange()
+                webShellLogger.info("WK navigation opened externally host=\(url.host() ?? "unknown", privacy: .public) path=\(url.path, privacy: .public)")
                 NSWorkspace.shared.open(url)
                 decisionHandler(.cancel)
-                return
+            case .allow:
+                decisionHandler(.allow)
             }
-            decisionHandler(.allow)
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            if let url = webView.url {
+                webShellLogger.info("WK navigation finished host=\(url.host() ?? "unknown", privacy: .public) path=\(url.path, privacy: .public)")
+            } else {
+                webShellLogger.info("WK navigation finished without current url")
+            }
             guard openSettingsOnLoad else { return }
             openSettingsOnLoad = false
             webView.evaluateJavaScript(HostedShellSettingsBridge.openSettingsScript, completionHandler: nil)
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            webShellLogger.warning("WK navigation failed error=\(String(describing: error), privacy: .private)")
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            webShellLogger.warning("WK provisional navigation failed error=\(String(describing: error), privacy: .private)")
         }
 
         @MainActor
         func exchangeAppSession(for destination: URL, token: String, in webView: WKWebView) {
             cancelExchange()
             guard let request = NativeAppSessionExchange.request(for: destination, token: token) else {
+                webShellLogger.warning("Native app session exchange request could not be built")
                 onAuthRequired()
                 return
             }
             exchangeGeneration += 1
             let generation = exchangeGeneration
+            webShellLogger.info("Native app session exchange started host=\(destination.host() ?? "unknown", privacy: .public) path=\(destination.path, privacy: .public)")
             exchangeTask = Task { [weak self, weak webView] in
                 do {
                     let response = try await NativeAppSessionExchange.perform(request: request)
@@ -250,6 +290,8 @@ private struct WebShellView: NSViewRepresentable {
                         self.exchangeTask = nil
                         NativeAppSessionExchange.installCookies(response.cookies, in: webView.configuration.websiteDataStore.httpCookieStore) {
                             guard self.exchangeGeneration == generation else { return }
+                            let names = response.cookies.map(\.name).joined(separator: ",")
+                            webShellLogger.info("Native app session cookies installed names=\(names, privacy: .public)")
                             webView.load(webShellDestinationRequest(for: destination, token: token))
                         }
                     }
@@ -261,6 +303,7 @@ private struct WebShellView: NSViewRepresentable {
                     await MainActor.run {
                         guard let self, self.exchangeGeneration == generation else { return }
                         self.exchangeTask = nil
+                        webShellLogger.warning("Native app session exchange failed error=\(String(describing: error), privacy: .private)")
                         self.onAuthRequired()
                     }
                 }
@@ -279,40 +322,46 @@ private struct WebShellView: NSViewRepresentable {
         init(onAuthRequired: @escaping @MainActor () -> Void) {
             self.onAuthRequired = onAuthRequired
         }
+    }
+}
 
-        private func shouldHandleAsAuthRequired(_ url: URL) -> Bool {
-            guard let destinationHost = destinationURL?.host()?.lowercased(),
-                  let host = url.host()?.lowercased(),
-                  host == destinationHost else { return false }
-            let path = url.path.lowercased()
-            return Self.isAuthPath(path)
-        }
+enum WebShellNavigationDecision: Equatable {
+    case allow
+    case authRequired
+    case external
+}
 
-        private static func shouldOpenExternally(_ url: URL) -> Bool {
-            guard let host = url.host()?.lowercased() else { return false }
-            let path = url.path.lowercased()
-            if host.contains("clerk") || host.contains("accounts.") {
-                return true
-            }
-            return isAuthPath(path)
+enum WebShellNavigationPolicy {
+    static func decision(for url: URL, destinationURL: URL?) -> WebShellNavigationDecision {
+        if isAuthNavigation(url) {
+            return .authRequired
         }
+        return .allow
+    }
 
-        private static func isAuthPath(_ path: String) -> Bool {
-            path == "/sign-in"
-                || path.hasPrefix("/sign-in/")
-                || path == "/sign-up"
-                || path.hasPrefix("/sign-up/")
-                || path == "/login"
-                || path.hasPrefix("/login/")
-                || path == "/oauth"
-                || path.hasPrefix("/oauth/")
-                || path == "/sso"
-                || path.hasPrefix("/sso/")
-                || path == "/auth/device"
-                || path.hasPrefix("/auth/device/")
-                || path == "/auth/callback"
-                || path.hasPrefix("/auth/callback/")
+    private static func isAuthNavigation(_ url: URL) -> Bool {
+        guard let host = url.host()?.lowercased() else { return false }
+        if host.contains("clerk") || host.contains("accounts.") {
+            return true
         }
+        return isAuthPath(url.path.lowercased())
+    }
+
+    private static func isAuthPath(_ path: String) -> Bool {
+        path == "/sign-in"
+            || path.hasPrefix("/sign-in/")
+            || path == "/sign-up"
+            || path.hasPrefix("/sign-up/")
+            || path == "/login"
+            || path.hasPrefix("/login/")
+            || path == "/oauth"
+            || path.hasPrefix("/oauth/")
+            || path == "/sso"
+            || path.hasPrefix("/sso/")
+            || path == "/auth/device"
+            || path.hasPrefix("/auth/device/")
+            || path == "/auth/callback"
+            || path.hasPrefix("/auth/callback/")
     }
 }
 
@@ -346,6 +395,11 @@ enum HostedShellSettingsBridge {
 }
 
 struct NativeAppSessionExchange {
+    private static let sessionCookieNames = Set([
+        "matrix_app_session",
+        "matrix_native_app_session",
+    ])
+
     private struct Body: Encodable {
         let redirectTo: String
     }
@@ -379,6 +433,7 @@ struct NativeAppSessionExchange {
         defer { session.invalidateAndCancel() }
         let (_, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw NativeAppSessionExchangeError.invalidResponse }
+        webShellLogger.info("Native app session response status=\(http.statusCode, privacy: .public)")
         guard (200..<300).contains(http.statusCode) else { throw NativeAppSessionExchangeError.unauthorized }
         guard let url = request.url else { throw NativeAppSessionExchangeError.invalidResponse }
         return try Response(cookies: appSessionCookies(
@@ -417,8 +472,12 @@ struct NativeAppSessionExchange {
         }
         guard cookies.contains(where: { $0.name == "matrix_app_session" && !$0.value.isEmpty }),
               cookies.contains(where: { $0.name == "matrix_native_app_session" && !$0.value.isEmpty }) else {
+            let names = cookies.map(\.name).joined(separator: ",")
+            webShellLogger.warning("Native app session response missing required cookies names=\(names, privacy: .public)")
             throw NativeAppSessionExchangeError.invalidResponse
         }
+        let names = cookies.map(\.name).joined(separator: ",")
+        webShellLogger.info("Native app session cookies parsed names=\(names, privacy: .public)")
         return cookies
     }
 
@@ -475,23 +534,66 @@ struct NativeAppSessionExchange {
 
     @MainActor
     static func installCookies(_ cookies: [HTTPCookie], in store: WKHTTPCookieStore, completion: @escaping @MainActor () -> Void) {
-        guard !cookies.isEmpty else {
+        let sessionCookies = cookies.filter { sessionCookieNames.contains($0.name) }
+        guard !sessionCookies.isEmpty else {
             completion()
             return
         }
-        func installCookie(at index: Int) {
-            guard cookies.indices.contains(index) else {
-                completion()
-                return
-            }
-            let cookie = cookies[index]
-            store.setCookie(cookie) {
-                Task { @MainActor in
-                    installCookie(at: index + 1)
+
+        store.getAllCookies { existingCookies in
+            let staleCookies = existingCookies.filter(shouldReplaceExistingCookie)
+            let staleNames = staleCookies.map(\.name).joined(separator: ",")
+            webShellLogger.info("Replacing stale native session cookies count=\(staleCookies.count, privacy: .public) names=\(staleNames, privacy: .public)")
+            Task { @MainActor in
+                deleteCookie(at: 0, cookies: staleCookies, store: store) {
+                    installCookie(at: 0, cookies: sessionCookies, store: store, completion: completion)
                 }
             }
         }
-        installCookie(at: 0)
+    }
+
+    private static func shouldReplaceExistingCookie(_ cookie: HTTPCookie) -> Bool {
+        guard sessionCookieNames.contains(cookie.name) else { return false }
+        let normalizedDomain = cookie.domain
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        return normalizedDomain == "app.matrix-os.com" || normalizedDomain == "matrix-os.com"
+    }
+
+    @MainActor
+    private static func deleteCookie(
+        at index: Int,
+        cookies: [HTTPCookie],
+        store: WKHTTPCookieStore,
+        completion: @escaping @MainActor () -> Void
+    ) {
+        guard cookies.indices.contains(index) else {
+            completion()
+            return
+        }
+        store.delete(cookies[index]) {
+            Task { @MainActor in
+                deleteCookie(at: index + 1, cookies: cookies, store: store, completion: completion)
+            }
+        }
+    }
+
+    @MainActor
+    private static func installCookie(
+        at index: Int,
+        cookies: [HTTPCookie],
+        store: WKHTTPCookieStore,
+        completion: @escaping @MainActor () -> Void
+    ) {
+        guard cookies.indices.contains(index) else {
+            completion()
+            return
+        }
+        store.setCookie(cookies[index]) {
+            Task { @MainActor in
+                installCookie(at: index + 1, cookies: cookies, store: store, completion: completion)
+            }
+        }
     }
 }
 
@@ -500,9 +602,11 @@ enum NativeAppSessionExchangeError: Error, Equatable {
     case unauthorized
 }
 
-private func webShellDestinationRequest(for url: URL, token: String?) -> URLRequest {
-    var request = URLRequest(url: url)
+func webShellDestinationRequest(for url: URL, token: String?) -> URLRequest {
+    var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData)
     request.timeoutInterval = 20
+    request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
+    request.setValue("no-cache", forHTTPHeaderField: "Pragma")
     if let token, !token.isEmpty {
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -70,9 +70,23 @@ struct RootShellView: View {
 
     @ViewBuilder
     private var sectionContent: some View {
+        ZStack {
+            // Keep the hosted web shell mounted like a persistent browser tab, so
+            // returning to Home never triggers a full reload / re-auth. Other sections
+            // render on top when active.
+            MatrixWebShellPanel(model: model, url: model.shellURL(), title: "Matrix Home")
+                .opacity(model.section == .home ? 1 : 0)
+                .allowsHitTesting(model.section == .home)
+                .accessibilityHidden(model.section != .home)
+            nonHomeSection
+        }
+    }
+
+    @ViewBuilder
+    private var nonHomeSection: some View {
         switch model.section {
         case .home:
-            MatrixWebShellPanel(model: model, url: model.shellURL(), title: "Matrix Home")
+            EmptyView()
         case .board:
             BoardView(model: model)
         case .terminal:

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -12,52 +12,7 @@ struct RootShellView: View {
     @ObservedObject var model: AppModel
 
     var body: some View {
-        Group {
-            if model.phase == .needsProfile {
-                // Onboarding/sign-in takes the whole window (no rail yet).
-                BoardView(model: model)
-            } else {
-                HStack(spacing: 0) {
-                    Sidebar(model: model)
-                    Rectangle().fill(Color.hairlineDark).frame(width: 1)
-                    VStack(spacing: 0) {
-                        if !model.openTabs.isEmpty {
-                            HStack(spacing: Spacing.x2) {
-                                WorkspaceTabStrip(
-                                    tabs: model.filteredOpenTabs(matching: model.workspaceSearchQuery),
-                                    activeID: model.activeTabID,
-                                    isCreating: model.isCreatingWorkItem,
-                                    onSelect: model.focusTab,
-                                    onClose: model.closeTab,
-                                    onCreate: { model.createTask(status: .todo) }
-                                )
-                                .frame(maxWidth: .infinity)
-                                HStack(spacing: Spacing.x1) {
-                                    Image(systemName: "magnifyingglass")
-                                        .font(.system(size: 11, weight: .semibold))
-                                        .foregroundStyle(Color.inkTertiary)
-                                    TextField("Filter", text: $model.workspaceSearchQuery)
-                                        .textFieldStyle(.plain)
-                                        .font(.plexSans(12))
-                                }
-                                .padding(.horizontal, Spacing.x2)
-                                .frame(width: 180, height: 34)
-                                .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                                        .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
-                                )
-                            }
-                            .padding(.horizontal, Spacing.x3)
-                            .padding(.vertical, Spacing.x2)
-                            Divider().overlay(Color.hairlineDark)
-                        }
-                        sectionContent
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    }
-                }
-            }
-        }
+        rootContent
         .background(Color.canvasVoid)
         .overlay {
             if model.showCommandPalette {
@@ -71,6 +26,60 @@ struct RootShellView: View {
         }
         .animation(Motion.hover, value: model.showCommandPalette)
         .animation(Motion.hover, value: model.showFileOpenPalette)
+    }
+
+    @ViewBuilder
+    private var rootContent: some View {
+        if model.phase == .needsProfile {
+            // Onboarding/sign-in takes the whole window (no rail yet).
+            BoardView(model: model)
+        } else if model.section == .settings {
+            NativeSettingsPanel(model: model)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else {
+            HStack(spacing: 0) {
+                Sidebar(model: model)
+                Rectangle().fill(Color.hairlineDark).frame(width: 1)
+                VStack(spacing: 0) {
+                    if !model.openTabs.isEmpty {
+                        HStack(spacing: Spacing.x2) {
+                            WorkspaceTabStrip(
+                                tabs: model.filteredOpenTabs(matching: model.workspaceSearchQuery),
+                                activeID: model.activeTabID,
+                                isCreating: model.isCreatingWorkItem,
+                                pendingTerminalTabID: model.pendingTerminalSessionTabID,
+                                onSelect: model.focusTab,
+                                onClose: model.closeTab,
+                                onCreate: model.createWorkspaceTabFromCurrentContext,
+                                onCommitPendingTerminalName: model.commitPendingTerminalSessionName,
+                                onCancelPendingTerminalName: model.cancelPendingTerminalSessionCreation
+                            )
+                            .frame(maxWidth: .infinity)
+                            HStack(spacing: Spacing.x1) {
+                                Image(systemName: "magnifyingglass")
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .foregroundStyle(Color.inkTertiary)
+                                TextField("Filter", text: $model.workspaceSearchQuery)
+                                    .textFieldStyle(.plain)
+                                    .font(.plexSans(12))
+                            }
+                            .padding(.horizontal, Spacing.x2)
+                            .frame(width: 180, height: 34)
+                            .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                                    .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
+                            )
+                        }
+                        .padding(.horizontal, Spacing.x3)
+                        .padding(.vertical, Spacing.x2)
+                        Divider().overlay(Color.hairlineDark)
+                    }
+                    sectionContent
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+        }
     }
 
     @ViewBuilder
@@ -96,6 +105,10 @@ struct RootShellView: View {
 private struct Sidebar: View {
     @ObservedObject var model: AppModel
     @State private var collapsed = false
+    @State private var sessionsCollapsed = false
+    @State private var sidebarWidth: CGFloat = 320
+    @State private var showSessionSearch = false
+    @State private var sessionSearchQuery = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -110,11 +123,16 @@ private struct Sidebar: View {
                 expandedSidebar
             }
         }
-        .frame(width: collapsed ? 76 : 320)
+        .frame(width: collapsed ? 76 : sidebarWidth)
         .frame(maxHeight: .infinity)
         .background(Color.canvasVoid)
         .overlay(alignment: .trailing) {
             Rectangle().fill(Color.hairlineDark.opacity(0.65)).frame(width: 1)
+        }
+        .overlay(alignment: .trailing) {
+            if !collapsed {
+                SidebarResizeHandle(width: $sidebarWidth)
+            }
         }
         .animation(Motion.columnReflow, value: collapsed)
     }
@@ -192,12 +210,14 @@ private struct Sidebar: View {
             navigationBlock
             projectsBlock
             sessionsBlock
-            Spacer(minLength: Spacing.x4)
-            newTaskButton
-            Divider().overlay(Color.hairlineDark.opacity(0.7))
+                .frame(maxHeight: .infinity, alignment: .top)
+            Divider().overlay(Color.hairlineDark.opacity(0.55))
                 .padding(.horizontal, Spacing.x4)
-                .padding(.vertical, Spacing.x3)
+                .padding(.vertical, Spacing.x2)
             handleBadge
+                .padding(.horizontal, Spacing.x4)
+                .padding(.bottom, Spacing.x2)
+            commandPaletteCallout
                 .padding(.horizontal, Spacing.x4)
                 .padding(.bottom, Spacing.x4)
         }
@@ -309,7 +329,7 @@ private struct Sidebar: View {
 
     private func performPrimaryAction() {
         if model.section == .terminal {
-            model.createSession()
+            model.beginTerminalSessionCreation()
         } else if model.section == .board {
             model.createTask(status: .todo)
         } else {
@@ -343,8 +363,34 @@ private struct Sidebar: View {
 
     private var sessionsBlock: some View {
         VStack(alignment: .leading, spacing: Spacing.x2) {
-            sectionLabel("Sessions") {
-                Button { model.createSession() } label: {
+            HStack(spacing: Spacing.x1) {
+                Button { sessionsCollapsed.toggle() } label: {
+                    HStack(spacing: Spacing.x2) {
+                        Text("SESSIONS")
+                            .font(.plexMono(10, weight: .semibold))
+                            .foregroundStyle(Color.inkTertiary)
+                            .tracking(1.1)
+                        Image(systemName: sessionsCollapsed ? "chevron.right" : "chevron.down")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(Color.inkTertiary)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(sessionsCollapsed ? "Show sessions" : "Hide sessions")
+
+                Spacer()
+
+                Button { showSessionSearch.toggle() } label: {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(showSessionSearch ? Color.inkPrimary : Color.inkTertiary)
+                        .iconHitTarget(28)
+                }
+                .buttonStyle(.plain)
+                .help("Search sessions")
+
+                Button { model.beginTerminalSessionCreation() } label: {
                     Image(systemName: "plus")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(Color.inkSecondary)
@@ -355,28 +401,57 @@ private struct Sidebar: View {
                 .help("New terminal tab")
             }
 
-            ScrollView {
-                LazyVStack(spacing: Spacing.x1) {
-                    let activeSessions = model.sessions.filter(\.isActive)
-                    if !activeSessions.isEmpty {
-                        sidebarSubhead("Active")
-                        ForEach(activeSessions) { session in
-                            sessionRow(session)
-                        }
+            if !sessionsCollapsed {
+                if showSessionSearch {
+                    HStack(spacing: Spacing.x2) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Color.inkTertiary)
+                        TextField("Search sessions", text: $sessionSearchQuery)
+                            .textFieldStyle(.plain)
+                            .font(.plexSans(12))
                     }
-                    let recentSessions = model.sessions.filter { !$0.isActive }
-                    if !recentSessions.isEmpty {
-                        sidebarSubhead("Recent")
-                            .padding(.top, Spacing.x3)
-                        ForEach(recentSessions) { session in
-                            sessionRow(session)
-                        }
-                    }
-                    if model.sessions.isEmpty {
-                        emptySessions
-                    }
+                    .padding(.horizontal, Spacing.x3)
+                    .frame(height: 30)
+                    .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                            .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
+                    )
                 }
-                .padding(.bottom, Spacing.x2)
+                ScrollView {
+                    LazyVStack(spacing: 2) {
+                        let sessionQuery = sessionSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                        let filteredSessions = sessionQuery.isEmpty
+                            ? model.sessions
+                            : model.sessions.filter { $0.name.lowercased().contains(sessionQuery) || $0.status.lowercased().contains(sessionQuery) }
+                        let activeSessions = filteredSessions.filter(\.isActive)
+                        if !activeSessions.isEmpty {
+                            sidebarSubhead("Active")
+                            ForEach(activeSessions) { session in
+                                sessionRow(session)
+                            }
+                        }
+                        let recentSessions = filteredSessions.filter { !$0.isActive }
+                        if !recentSessions.isEmpty {
+                            sidebarSubhead("Recent")
+                                .padding(.top, Spacing.x2)
+                            ForEach(recentSessions) { session in
+                                sessionRow(session)
+                            }
+                        }
+                        if model.sessions.isEmpty {
+                            emptySessions
+                        } else if filteredSessions.isEmpty {
+                            Text("No matching sessions")
+                                .font(.plexSans(12, weight: .medium))
+                                .foregroundStyle(Color.inkTertiary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.vertical, Spacing.x2)
+                        }
+                    }
+                    .padding(.bottom, Spacing.x2)
+                }
             }
         }
         .padding(.horizontal, Spacing.x4)
@@ -416,26 +491,18 @@ private struct Sidebar: View {
                         .foregroundStyle(Color.inkPrimary)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                    HStack(spacing: Spacing.x1) {
-                        Circle()
-                            .fill(session.isActive ? Color.signalDone : Color.inkDisabled)
-                            .frame(width: 5, height: 5)
-                        Text(session.status.capitalized)
-                            .font(.plexSans(11, weight: .medium))
-                            .foregroundStyle(session.isActive ? Color.signalDone : Color.inkTertiary)
-                    }
                 }
                 Spacer()
-                Text(selected ? "now" : "")
-                    .font(.plexSans(11, weight: .medium))
-                    .foregroundStyle(Color.inkTertiary)
+                Circle()
+                    .fill(session.isActive ? Color.signalDone : Color.inkDisabled)
+                    .frame(width: 7, height: 7)
+                    .help(session.status.capitalized)
             }
             .padding(.horizontal, Spacing.x3)
-            .padding(.vertical, Spacing.x2)
+            .frame(height: 32)
             .background(
-                RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
-                    .fill(selected ? Color.surfaceCardRaised : Color.clear)
-                    .shadow(color: selected ? Color.black.opacity(0.06) : Color.clear, radius: 10, y: 4)
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(selected ? Color.surfaceCardRaised.opacity(0.85) : Color.clear)
             )
             .overlay(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 1)
@@ -455,7 +522,7 @@ private struct Sidebar: View {
                 NSPasteboard.general.setString(session.name, forType: .string)
             }
             Divider()
-            Button("New Terminal") { model.createSession() }
+            Button("New Terminal") { model.beginTerminalSessionCreation() }
         }
     }
 
@@ -476,41 +543,36 @@ private struct Sidebar: View {
         .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.card, style: .continuous))
     }
 
-    private var newTaskButton: some View {
+    private var commandPaletteCallout: some View {
         Button {
-            performPrimaryAction()
+            model.showCommandPalette = true
         } label: {
             HStack(spacing: Spacing.x3) {
-                Image(systemName: "plus")
-                    .font(.system(size: 14, weight: .semibold))
-                Text(primaryActionTitle)
+                Image(systemName: "command")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Command palette")
                     .font(.plexSans(14, weight: .semibold))
                 Spacer()
-                Text(primaryActionShortcut)
+                Text("⌘K")
                     .font(.plexMono(11, weight: .semibold))
-                    .padding(.horizontal, Spacing.x2)
-                    .padding(.vertical, 5)
-                    .background(Color.white.opacity(0.10), in: RoundedRectangle(cornerRadius: Radius.badge, style: .continuous))
+                    .foregroundStyle(Color.inkSecondary)
+                    .frame(width: 42, height: 28)
+                    .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
             }
-            .foregroundStyle(Color.canvasVoid)
+            .foregroundStyle(Color.inkPrimary)
             .padding(.horizontal, Spacing.x4)
-            .frame(height: 52)
-            .background(
-                LinearGradient(
-                    colors: [Color.surfaceTerminal, Color.black.opacity(0.90)],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                ),
-                in: RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+            .frame(height: 46)
+            .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                    .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
             )
-            .shadow(color: Color.black.opacity(0.16), radius: 16, y: 8)
+            .shadow(color: Color.black.opacity(0.06), radius: 10, y: 4)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, Spacing.x4)
-        .disabled(model.isCreatingWorkItem)
-        .help(primaryActionTitle)
-        .accessibilityLabel(primaryActionTitle)
+        .help("Command palette")
+        .accessibilityLabel("Command palette")
     }
 
     private var handleBadge: some View {
@@ -544,7 +606,7 @@ private struct Sidebar: View {
                             .font(.plexSans(12, weight: .semibold))
                             .foregroundStyle(Color.inkPrimary)
                             .lineLimit(1)
-                        Text("Matrix account")
+                        Text(profileSubtitle)
                             .font(.plexMono(9, weight: .medium))
                             .foregroundStyle(Color.inkTertiary)
                             .lineLimit(1)
@@ -568,20 +630,75 @@ private struct Sidebar: View {
         .help(handle)
         .accessibilityLabel("Connected as \(handle)")
     }
+
+    private var profileSubtitle: String {
+        guard let profile = model.profile else { return "Not signed in" }
+        if let slot = profile.runtimeSlot, !slot.isEmpty {
+            return "\(profile.gatewayHost) · \(slot)"
+        }
+        return profile.gatewayHost
+    }
 }
 
 private struct AppMark: View {
     let collapsed: Bool
 
     var body: some View {
-        Image(nsImage: NSImage(named: NSImage.applicationIconName) ?? NSImage())
-            .resizable()
-            .interpolation(.high)
-            .frame(width: collapsed ? 46 : 52, height: collapsed ? 46 : 52)
-            .clipShape(RoundedRectangle(cornerRadius: collapsed ? 10 : 12, style: .continuous))
-            .shadow(color: Color.black.opacity(0.12), radius: 6, y: 2)
-            .help("Matrix OS")
-            .accessibilityLabel("Matrix OS")
+        Group {
+            if let image = Self.appIcon {
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.high)
+            } else {
+                Text("M")
+                    .font(.plexMono(collapsed ? 18 : 20, weight: .semibold))
+                    .foregroundStyle(Color.canvasVoid)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.signalLive)
+            }
+        }
+        .frame(width: collapsed ? 46 : 52, height: collapsed ? 46 : 52)
+        .clipShape(RoundedRectangle(cornerRadius: collapsed ? 10 : 12, style: .continuous))
+        .shadow(color: Color.black.opacity(0.12), radius: 6, y: 2)
+        .help("Matrix OS")
+        .accessibilityLabel("Matrix OS")
+    }
+
+    private static var appIcon: NSImage? {
+        if let resourceURL = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),
+           let image = NSImage(contentsOf: resourceURL) {
+            return image
+        }
+        return NSApp.applicationIconImage
+    }
+}
+
+private struct SidebarResizeHandle: View {
+    @Binding var width: CGFloat
+    @State private var startWidth: CGFloat?
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.clear)
+            .frame(width: 8)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged { value in
+                        let base = startWidth ?? width
+                        startWidth = base
+                        width = min(460, max(240, base + value.translation.width))
+                    }
+                    .onEnded { _ in startWidth = nil }
+            )
+            .onHover { hovering in
+                if hovering {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .help("Resize sidebar")
     }
 }
 
@@ -596,89 +713,52 @@ private struct TerminalsView: View {
     }
 
     private var workbench: some View {
-        VStack(spacing: Spacing.x3) {
+        VStack(spacing: Spacing.x2) {
             workbenchHeader
-            TerminalSessionTabStrip(
-                sessions: model.sessions,
-                activeName: model.activeTerminalSessionName,
-                isCreating: model.isCreatingWorkItem,
-                onSelect: model.openSession,
-                onClose: model.closeSession,
-                onCreate: model.createSession
-            )
             terminalSurface
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .padding(.horizontal, Spacing.x5)
-        .padding(.vertical, Spacing.x4)
+        .padding(.horizontal, Spacing.x4)
+        .padding(.top, Spacing.x3)
+        .padding(.bottom, Spacing.x4)
         .background(Color.canvasVoid)
     }
 
     private var workbenchHeader: some View {
-        VStack(spacing: Spacing.x3) {
-            HStack(spacing: Spacing.x2) {
-                Label("Terminal", systemImage: "terminal")
-                    .font(.plexSans(13, weight: .semibold))
-                    .foregroundStyle(Color.inkPrimary)
-                Spacer()
-                searchButton
-                Spacer()
-                headerIcon("clock") { Task { await model.loadSessions() } }
-                headerIcon("square.and.arrow.up") {
-                    if let url = model.shellURL() {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
-                headerIcon("ellipsis") { model.showCommandPalette = true }
-            }
+        HStack(spacing: Spacing.x2) {
+            Label(model.terminal?.displayName ?? "Terminal", systemImage: "terminal")
+                .font(.plexSans(13, weight: .semibold))
+                .foregroundStyle(Color.inkPrimary)
+                .lineLimit(1)
+                .truncationMode(.middle)
 
-            HStack(alignment: .top, spacing: Spacing.x3) {
-                VStack(alignment: .leading, spacing: Spacing.x3) {
-                    Text(model.terminal?.displayName ?? "Terminal")
-                        .font(.plexSans(22, weight: .semibold))
-                        .foregroundStyle(Color.inkPrimary)
-                        .lineLimit(2)
-                    HStack(spacing: Spacing.x2) {
-                        statusChip(model.sessions.isEmpty ? "No sessions" : "\(model.sessions.count) sessions", icon: "terminal", tint: .signalDone)
-                        statusChip(model.terminal == nil ? "Detached" : "Attached", icon: "tray.and.arrow.up", tint: .inkSecondary)
-                    }
+            statusText
+
+            Spacer()
+
+            headerIcon("clock") { Task { await model.loadSessions() } }
+            headerIcon("square.and.arrow.up") {
+                if let url = model.shellURL() {
+                    NSWorkspace.shared.open(url)
                 }
-                Spacer()
-                Button { model.createSession() } label: {
-                    Label("New terminal", systemImage: "plus")
-                        .font(.plexSans(12, weight: .medium))
-                        .foregroundStyle(Color.inkPrimary)
-                }
-                .buttonStyle(.plain)
-                .disabled(model.isCreatingWorkItem)
             }
+            headerIcon("ellipsis") { model.showCommandPalette = true }
         }
+        .frame(height: 32)
     }
 
-    private var searchButton: some View {
-        Button { model.showCommandPalette = true } label: {
-            HStack(spacing: Spacing.x2) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 12, weight: .semibold))
-                Text("Search Matrix")
-                    .font(.plexSans(12, weight: .medium))
-                Text("⌘K")
-                    .font(.plexMono(10, weight: .semibold))
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Color.surfaceRail, in: RoundedRectangle(cornerRadius: 5, style: .continuous))
-            }
-            .foregroundStyle(Color.inkTertiary)
-            .frame(width: 230, height: 34)
-            .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: 17, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 17, style: .continuous)
-                    .strokeBorder(Color.hairlineDark.opacity(0.7), lineWidth: 1)
-            )
-            .contentShape(Rectangle())
+    private var statusText: some View {
+        HStack(spacing: Spacing.x1) {
+            Circle()
+                .fill(model.terminal == nil ? Color.inkDisabled : Color.signalLive)
+                .frame(width: 5, height: 5)
+            Text(model.terminal == nil ? "detached" : "attached")
+            Text("·")
+            Text(model.sessions.isEmpty ? "0 sessions" : "\(model.sessions.count) sessions")
         }
-        .buttonStyle(.plain)
-        .help("Command palette (⌘K)")
+        .font(.plexMono(10, weight: .medium))
+        .foregroundStyle(Color.inkTertiary)
+        .lineLimit(1)
     }
 
     private func headerIcon(_ icon: String, action: @escaping () -> Void) -> some View {
@@ -694,24 +774,6 @@ private struct TerminalsView: View {
                 )
         }
         .buttonStyle(.plain)
-    }
-
-    private func statusChip(_ text: String, icon: String, tint: Color) -> some View {
-        HStack(spacing: Spacing.x1) {
-            Image(systemName: icon)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(tint)
-            Text(text)
-                .font(.plexSans(12, weight: .medium))
-                .foregroundStyle(Color.inkSecondary)
-        }
-        .padding(.horizontal, Spacing.x2)
-        .frame(height: 28)
-        .background(Color.surfaceCard, in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                .strokeBorder(Color.hairlineDark.opacity(0.75), lineWidth: 1)
-        )
     }
 
     @ViewBuilder

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -64,8 +64,13 @@ struct RootShellView: View {
                 CommandPalette(model: model)
                     .transition(.opacity)
             }
+            if model.showFileOpenPalette {
+                FileOpenPalette(model: model)
+                    .transition(.opacity)
+            }
         }
         .animation(Motion.hover, value: model.showCommandPalette)
+        .animation(Motion.hover, value: model.showFileOpenPalette)
     }
 
     @ViewBuilder
@@ -962,14 +967,12 @@ struct EditorPanel: View {
                 .background(Color.surfaceRail)
                 .overlay(alignment: .bottom) { Rectangle().fill(Color.hairlineDark).frame(height: 1) }
 
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(model.fileTree) { node in
-                            FileTreeNodeRow(model: model, node: node, depth: 0)
-                        }
-                    }
-                    .padding(.vertical, Spacing.x1)
-                }
+                FileNavigatorOutlineView(
+                    nodes: model.fileTree,
+                    selectedPath: model.selectedFilePath,
+                    onOpen: { model.openFileTreeNode($0) },
+                    onToggle: { model.toggleFileTreeNode($0) }
+                )
             }
             .frame(minWidth: 220, idealWidth: 280, maxWidth: 380)
 

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -746,29 +746,45 @@ private struct TerminalsView: View {
 
     @ViewBuilder
     private var terminalSurface: some View {
-        if let terminal = model.terminal {
-            TerminalPanelView(session: terminal)
-                .id(terminal.id)
-                .background(Color.surfaceTerminal)
-                .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
-                        .strokeBorder(Color.black.opacity(0.35), lineWidth: 1)
-                )
-                .shadow(color: Color.black.opacity(0.18), radius: 18, y: 8)
-        } else {
-            ZStack {
-                Color.surfaceTerminal
-                VStack(spacing: Spacing.x2) {
-                    Image(systemName: "terminal")
-                        .font(.system(size: 28, weight: .light))
-                        .foregroundStyle(Color.terminalMutedInk)
-                    Text("Select a session to open its terminal")
-                        .font(.plexSans(13))
-                        .foregroundStyle(Color.terminalMutedInk)
-                }
+        ZStack {
+            // Keep every live session mounted so switching is instant: inactive
+            // terminals stay alive (PTY stream + scrollback) instead of re-attaching.
+            ForEach(model.liveTerminalSessions, id: \.id) { session in
+                terminalLayer(for: session)
             }
-            .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+            if model.terminal == nil {
+                terminalEmptyState
+            }
+        }
+        .background(Color.surfaceTerminal)
+        .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                .strokeBorder(Color.black.opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.18), radius: 18, y: 8)
+        .animation(.easeInOut(duration: 0.14), value: model.terminal?.id)
+    }
+
+    private func terminalLayer(for session: TerminalSession) -> some View {
+        let isActive = session.id == model.terminal?.id
+        return TerminalPanelView(session: session, isActive: isActive)
+            .opacity(isActive ? 1 : 0)
+            .allowsHitTesting(isActive)
+            .accessibilityHidden(!isActive)
+    }
+
+    private var terminalEmptyState: some View {
+        ZStack {
+            Color.surfaceTerminal
+            VStack(spacing: Spacing.x2) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 28, weight: .light))
+                    .foregroundStyle(Color.terminalMutedInk)
+                Text("Select a session to open its terminal")
+                    .font(.plexSans(13))
+                    .foregroundStyle(Color.terminalMutedInk)
+            }
         }
     }
 

--- a/macos/Sources/App/Workspace.swift
+++ b/macos/Sources/App/Workspace.swift
@@ -70,23 +70,9 @@ struct RootShellView: View {
 
     @ViewBuilder
     private var sectionContent: some View {
-        ZStack {
-            // Keep the hosted web shell mounted like a persistent browser tab, so
-            // returning to Home never triggers a full reload / re-auth. Other sections
-            // render on top when active.
-            MatrixWebShellPanel(model: model, url: model.shellURL(), title: "Matrix Home")
-                .opacity(model.section == .home ? 1 : 0)
-                .allowsHitTesting(model.section == .home)
-                .accessibilityHidden(model.section != .home)
-            nonHomeSection
-        }
-    }
-
-    @ViewBuilder
-    private var nonHomeSection: some View {
         switch model.section {
         case .home:
-            EmptyView()
+            MatrixWebShellPanel(model: model, url: model.shellURL(), title: "Matrix Home")
         case .board:
             BoardView(model: model)
         case .terminal:
@@ -760,45 +746,29 @@ private struct TerminalsView: View {
 
     @ViewBuilder
     private var terminalSurface: some View {
-        ZStack {
-            // Keep every live session mounted so switching is instant: inactive
-            // terminals stay alive (PTY stream + scrollback) instead of re-attaching.
-            ForEach(model.liveTerminalSessions, id: \.id) { session in
-                terminalLayer(for: session)
+        if let terminal = model.terminal {
+            TerminalPanelView(session: terminal)
+                .id(terminal.id)
+                .background(Color.surfaceTerminal)
+                .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
+                        .strokeBorder(Color.black.opacity(0.35), lineWidth: 1)
+                )
+                .shadow(color: Color.black.opacity(0.18), radius: 18, y: 8)
+        } else {
+            ZStack {
+                Color.surfaceTerminal
+                VStack(spacing: Spacing.x2) {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 28, weight: .light))
+                        .foregroundStyle(Color.terminalMutedInk)
+                    Text("Select a session to open its terminal")
+                        .font(.plexSans(13))
+                        .foregroundStyle(Color.terminalMutedInk)
+                }
             }
-            if model.terminal == nil {
-                terminalEmptyState
-            }
-        }
-        .background(Color.surfaceTerminal)
-        .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
-                .strokeBorder(Color.black.opacity(0.35), lineWidth: 1)
-        )
-        .shadow(color: Color.black.opacity(0.18), radius: 18, y: 8)
-        .animation(.easeInOut(duration: 0.14), value: model.terminal?.id)
-    }
-
-    private func terminalLayer(for session: TerminalSession) -> some View {
-        let isActive = session.id == model.terminal?.id
-        return TerminalPanelView(session: session, isActive: isActive)
-            .opacity(isActive ? 1 : 0)
-            .allowsHitTesting(isActive)
-            .accessibilityHidden(!isActive)
-    }
-
-    private var terminalEmptyState: some View {
-        ZStack {
-            Color.surfaceTerminal
-            VStack(spacing: Spacing.x2) {
-                Image(systemName: "terminal")
-                    .font(.system(size: 28, weight: .light))
-                    .foregroundStyle(Color.terminalMutedInk)
-                Text("Select a session to open its terminal")
-                    .font(.plexSans(13))
-                    .foregroundStyle(Color.terminalMutedInk)
-            }
+            .clipShape(RoundedRectangle(cornerRadius: Radius.panel, style: .continuous))
         }
     }
 

--- a/macos/Sources/App/WorkspaceFileSearch.swift
+++ b/macos/Sources/App/WorkspaceFileSearch.swift
@@ -1,0 +1,49 @@
+#if os(macOS)
+import Foundation
+
+public struct WorkspaceFileSearchItem: Identifiable, Equatable, Sendable {
+    public let path: String
+    public let name: String
+    public let directory: String
+    public let score: Int
+
+    public var id: String { path }
+
+    public init(path: String, query: String = "") {
+        self.path = path
+        self.name = URL(fileURLWithPath: path).lastPathComponent
+        let parts = path.split(separator: "/").map(String.init)
+        self.directory = parts.dropLast().joined(separator: "/")
+        self.score = Self.score(path: path, name: name, query: query)
+    }
+
+    public static func filtered(paths: [String], query: String, limit: Int = 80) -> [WorkspaceFileSearchItem] {
+        let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let items = paths
+            .filter { path in
+                guard !normalizedQuery.isEmpty else { return true }
+                return path.lowercased().contains(normalizedQuery)
+                    || URL(fileURLWithPath: path).lastPathComponent.lowercased().contains(normalizedQuery)
+            }
+            .map { WorkspaceFileSearchItem(path: $0, query: normalizedQuery) }
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                if lhs.name != rhs.name { return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending }
+                return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
+            }
+        return Array(items.prefix(limit))
+    }
+
+    private static func score(path: String, name: String, query: String) -> Int {
+        guard !query.isEmpty else { return 0 }
+        let lowerPath = path.lowercased()
+        let lowerName = name.lowercased()
+        if lowerName == query { return 1000 }
+        if lowerName.hasPrefix(query) { return 800 }
+        if lowerName.contains(query) { return 600 }
+        if lowerPath.hasSuffix(query) { return 500 }
+        if lowerPath.contains(query) { return 300 }
+        return 0
+    }
+}
+#endif

--- a/macos/Sources/App/WorkspaceTabs.swift
+++ b/macos/Sources/App/WorkspaceTabs.swift
@@ -59,18 +59,19 @@ struct TaskPaneSpec: Identifiable, Equatable {
 }
 
 let taskPaneSpecs: [TaskPaneSpec] = [
-    TaskPaneSpec(id: "terminal", title: "Terminal", icon: "terminal", shortcut: "⌘T", panel: .terminal),
-    TaskPaneSpec(id: "editor", title: "Editor", icon: "doc.text", shortcut: "⌘E", panel: .app(slug: "editor")),
-    TaskPaneSpec(id: "artifacts", title: "Artifacts", icon: "paperclip", shortcut: "⌘⇧A", panel: .app(slug: "artifacts")),
-    TaskPaneSpec(id: "git", title: "Git", icon: "arrow.triangle.branch", shortcut: "⌘G", panel: .app(slug: "git")),
-    TaskPaneSpec(id: "settings", title: "Settings", icon: "slider.horizontal.3", shortcut: "⌘J", panel: .app(slug: "settings")),
-    TaskPaneSpec(id: "processes", title: "Processes", icon: "cpu", shortcut: "⌘⇧P", panel: .app(slug: "processes")),
-    TaskPaneSpec(id: "whiteboard", title: "Excalidraw", icon: "scribble.variable", shortcut: "⌘X", panel: .app(slug: "whiteboard")),
+    TaskPaneSpec(id: "terminal", title: "Terminal", icon: "terminal", shortcut: "⌥⌘1", panel: .terminal),
+    TaskPaneSpec(id: "editor", title: "Editor", icon: "doc.text", shortcut: "⌥⌘2", panel: .app(slug: "editor")),
+    TaskPaneSpec(id: "artifacts", title: "Artifacts", icon: "paperclip", shortcut: "⌥⌘3", panel: .app(slug: "artifacts")),
+    TaskPaneSpec(id: "git", title: "Git", icon: "arrow.triangle.branch", shortcut: "⌥⌘4", panel: .app(slug: "git")),
+    TaskPaneSpec(id: "settings", title: "Settings", icon: "slider.horizontal.3", shortcut: "⌥⌘5", panel: .app(slug: "settings")),
+    TaskPaneSpec(id: "processes", title: "Processes", icon: "cpu", shortcut: "⌥⌘6", panel: .app(slug: "processes")),
+    TaskPaneSpec(id: "whiteboard", title: "Excalidraw", icon: "scribble.variable", shortcut: "⌥⌘7", panel: .app(slug: "whiteboard")),
 ]
 
 struct TaskPaneStrip: View {
     let activePanel: Panel
     let enabledPanels: [Panel]
+    let onToggle: (Panel) -> Void
     let onFocus: (Panel) -> Void
 
     var body: some View {
@@ -79,9 +80,9 @@ struct TaskPaneStrip: View {
                 ForEach(taskPaneSpecs) { pane in
                     TaskPaneButton(
                         pane: pane,
-                        isAvailable: enabledPanels.contains(pane.panel),
+                        isEnabled: enabledPanels.contains(pane.panel),
                         isFocused: pane.panel == activePanel,
-                        action: { onFocus(pane.panel) }
+                        action: { onToggle(pane.panel) }
                     )
                     .keyboardShortcut(shortcutKey(for: pane.id), modifiers: shortcutModifiers(for: pane.id))
                     .contextMenu {
@@ -99,25 +100,25 @@ struct TaskPaneStrip: View {
 
     private func shortcutKey(for id: String) -> KeyEquivalent {
         switch id {
-        case "terminal": return "t"
-        case "editor": return "e"
-        case "artifacts": return "a"
-        case "git": return "g"
-        case "settings": return "j"
-        case "processes": return "p"
-        case "whiteboard": return "x"
+        case "terminal": return "1"
+        case "editor": return "2"
+        case "artifacts": return "3"
+        case "git": return "4"
+        case "settings": return "5"
+        case "processes": return "6"
+        case "whiteboard": return "7"
         default: return "0"
         }
     }
 
     private func shortcutModifiers(for id: String) -> EventModifiers {
-        ["artifacts", "processes"].contains(id) ? [.command, .shift] : [.command]
+        [.command, .option]
     }
 }
 
 private struct TaskPaneButton: View {
     let pane: TaskPaneSpec
-    let isAvailable: Bool
+    let isEnabled: Bool
     let isFocused: Bool
     let action: () -> Void
 
@@ -128,6 +129,11 @@ private struct TaskPaneButton: View {
                 Text(pane.title)
                     .font(.plexSans(12, weight: isFocused ? .semibold : .medium))
                     .lineLimit(1)
+                if isEnabled {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(isFocused ? Color.signalLive : Color.inkTertiary)
+                }
                 Text(pane.shortcut)
                     .font(.plexMono(9, weight: .semibold))
                     .foregroundStyle(isFocused ? Color.inkSecondary : Color.inkTertiary)
@@ -137,18 +143,21 @@ private struct TaskPaneButton: View {
             .frame(height: 30)
             .background(
                 RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                    .fill(isFocused ? Color.surfaceCard : Color.clear)
+                    .fill(isFocused ? Color.surfaceCard : (isEnabled ? Color.surfaceCardRaised.opacity(0.7) : Color.clear))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                    .strokeBorder(isFocused ? Color.signalLive.opacity(0.7) : Color.clear, lineWidth: 1)
+                    .strokeBorder(
+                        isFocused ? Color.signalLive.opacity(0.7) : (isEnabled ? Color.hairlineDark : Color.clear),
+                        lineWidth: 1
+                    )
             )
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help("\(pane.title) \(pane.shortcut)")
+        .help("\(isEnabled ? "Hide" : "Show") \(pane.title) \(pane.shortcut)")
         .accessibilityLabel(pane.title)
-        .accessibilityHint(isAvailable ? "Available" : "Opens this pane")
+        .accessibilityHint(isEnabled ? "Enabled pane" : "Disabled pane")
         .accessibilityAddTraits(isFocused ? [.isSelected] : [])
     }
 }

--- a/macos/Sources/App/WorkspaceTabs.swift
+++ b/macos/Sources/App/WorkspaceTabs.swift
@@ -8,21 +8,32 @@ struct WorkspaceTabStrip: View {
     let tabs: [WorkspaceTab]
     let activeID: String?
     let isCreating: Bool
+    let pendingTerminalTabID: String?
     let onSelect: (String) -> Void
     let onClose: (String) -> Void
     let onCreate: () -> Void
+    let onCommitPendingTerminalName: (String) -> Void
+    let onCancelPendingTerminalName: () -> Void
 
     var body: some View {
         HStack(spacing: Spacing.x1) {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Spacing.x1) {
                     ForEach(tabs) { tab in
-                        WorkspaceTabPill(
-                            tab: tab,
-                            isActive: tab.id == activeID,
-                            onSelect: { onSelect(tab.id) },
-                            onClose: { onClose(tab.id) }
-                        )
+                        if tab.id == pendingTerminalTabID {
+                            PendingTerminalTabPill(
+                                projectName: tab.projectName,
+                                onCommit: onCommitPendingTerminalName,
+                                onCancel: onCancelPendingTerminalName
+                            )
+                        } else {
+                            WorkspaceTabPill(
+                                tab: tab,
+                                isActive: tab.id == activeID,
+                                onSelect: { onSelect(tab.id) },
+                                onClose: { onClose(tab.id) }
+                            )
+                        }
                     }
                 }
                 .padding(.leading, Spacing.x2)
@@ -47,6 +58,74 @@ struct WorkspaceTabStrip: View {
             RoundedRectangle(cornerRadius: Radius.panel, style: .continuous)
                 .strokeBorder(Color.hairlineDark.opacity(0.65), lineWidth: 1)
         )
+    }
+}
+
+private struct PendingTerminalTabPill: View {
+    let projectName: String
+    let onCommit: (String) -> Void
+    let onCancel: () -> Void
+
+    @State private var name = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack(spacing: Spacing.x1) {
+            HStack(spacing: Spacing.x2) {
+                AppGlyphTile(symbol: "terminal", palette: .terminal, size: 26, isActive: true)
+                VStack(alignment: .leading, spacing: 1) {
+                    TextField("session-name", text: $name)
+                        .textFieldStyle(.plain)
+                        .font(.plexSans(12, weight: .semibold))
+                        .foregroundStyle(Color.inkPrimary)
+                        .focused($focused)
+                        .frame(width: 118)
+                        .onSubmit(commit)
+                    Text(projectName)
+                        .font(.plexMono(9, weight: .medium))
+                        .foregroundStyle(Color.inkTertiary)
+                        .lineLimit(1)
+                }
+            }
+            .padding(.leading, Spacing.x2)
+            .padding(.vertical, 5)
+
+            Button(action: onCancel) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.inkTertiary)
+                    .iconHitTarget(24)
+            }
+            .buttonStyle(.plain)
+            .help("Cancel")
+        }
+        .padding(.trailing, Spacing.x1)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .fill(Color.surfaceCard)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .strokeBorder(Color.signalLive.opacity(0.7), lineWidth: 1)
+        )
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.signalLive)
+                .frame(height: 2)
+                .padding(.horizontal, Spacing.x2)
+        }
+        .onAppear {
+            DispatchQueue.main.async {
+                focused = true
+            }
+        }
+        .onExitCommand(perform: onCancel)
+        .help("Name terminal session")
+        .accessibilityLabel("Name terminal session")
+    }
+
+    private func commit() {
+        onCommit(name)
     }
 }
 
@@ -179,19 +258,18 @@ struct TerminalSessionTabStrip: View {
                     }
                 }
                 .padding(.horizontal, Spacing.x2)
-                .padding(.vertical, Spacing.x1)
             }
             Button(action: onCreate) {
                 Image(systemName: "plus")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(Color.inkSecondary)
-                    .iconHitTarget(30)
+                    .iconHitTarget(28)
             }
             .buttonStyle(.plain)
             .disabled(isCreating)
             .help("New terminal tab")
         }
-        .frame(height: 36)
+        .frame(height: 30)
         .background(Color.surfaceRail)
     }
 
@@ -212,7 +290,7 @@ struct TerminalSessionTabStrip: View {
                 .foregroundStyle(active ? Color.inkPrimary : Color.inkSecondary)
                 .frame(minWidth: 118, maxWidth: 230, alignment: .leading)
                 .padding(.leading, Spacing.x2)
-                .frame(height: 28)
+                .frame(height: 24)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
@@ -222,7 +300,7 @@ struct TerminalSessionTabStrip: View {
                     Image(systemName: "xmark")
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(Color.inkTertiary)
-                        .iconHitTarget(24)
+                        .iconHitTarget(22)
                 }
                 .buttonStyle(.plain)
                 .help("Close terminal tab")

--- a/macos/Sources/Terminal/ShellMessages.swift
+++ b/macos/Sources/Terminal/ShellMessages.swift
@@ -101,7 +101,7 @@ extension ServerMessage: Decodable {
             self = .exit(code: try container.decode(Int.self, forKey: .code))
         case "error":
             self = .error(
-                code: try container.decode(String.self, forKey: .code),
+                code: try container.decodeIfPresent(String.self, forKey: .code) ?? "terminal_error",
                 message: try container.decodeIfPresent(String.self, forKey: .message) ?? ""
             )
         case "pong":

--- a/macos/Sources/Terminal/TerminalPanelView.swift
+++ b/macos/Sources/Terminal/TerminalPanelView.swift
@@ -18,14 +18,10 @@ public struct TerminalPanelView: View {
     public nonisolated static let rendererConfiguration = TerminalRendererConfiguration(kind: .swiftTerm)
 
     @ObservedObject private var session: TerminalSession
-    /// Whether this is the visible/foreground terminal. Inactive terminals stay mounted
-    /// (alive) but must not grab keyboard focus from the active one.
-    private let isActive: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    public init(session: TerminalSession, isActive: Bool = true) {
+    public init(session: TerminalSession) {
         self.session = session
-        self.isActive = isActive
     }
 
     public var body: some View {
@@ -132,7 +128,7 @@ public struct TerminalPanelView: View {
     // MARK: - Terminal surface
 
     private var terminalSurface: some View {
-        SwiftTermView(session: session, isActive: isActive)
+        SwiftTermView(session: session)
             .id(session.id)
             .background(Color.surfaceTerminal)
     }
@@ -192,7 +188,6 @@ private struct AnimatedEllipsis: View {
 /// - reports size changes back to the session (`resize`).
 private struct SwiftTermView: NSViewRepresentable {
     let session: TerminalSession
-    var isActive: Bool = true
 
     func makeCoordinator() -> Coordinator {
         Coordinator(session: session)
@@ -200,7 +195,6 @@ private struct SwiftTermView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> TerminalView {
         let view = FocusableTerminalView(frame: .zero)
-        view.isActive = isActive
         view.terminalDelegate = context.coordinator
         context.coordinator.terminalView = view
         let clickRecognizer = NSClickGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.focusTerminal(_:)))
@@ -242,23 +236,9 @@ private struct SwiftTermView: NSViewRepresentable {
     func updateNSView(_ nsView: TerminalView, context: Context) {
         // Keep the coordinator's reference fresh; sizing is reported via the delegate.
         context.coordinator.terminalView = nsView
-        (nsView as? FocusableTerminalView)?.isActive = isActive
-        // Only the foreground terminal takes keyboard focus. Inactive (hidden-but-alive)
-        // terminals must never steal first responder from the visible one.
-        guard isActive else {
-            context.coordinator.didRequestInitialFocus = false
-            return
-        }
-        // updateNSView re-runs on every session update (output/state changes, because
-        // TerminalPanelView observes the session), so this naturally retries focus until
-        // it succeeds — including once the session attaches and is ready for input.
         guard !context.coordinator.didRequestInitialFocus else { return }
         DispatchQueue.main.async {
-            // .userInitiated forces focus to the newly-active terminal: switching
-            // sessions must move first responder off the previously-focused terminal,
-            // which .initial mode deliberately refuses to do. Gated by
-            // didRequestInitialFocus so it fires once per activation, not every update.
-            if TerminalFocusPolicy.requestFocus(nsView, mode: .userInitiated) {
+            if TerminalFocusPolicy.requestFocus(nsView) {
                 context.coordinator.didRequestInitialFocus = true
             }
         }
@@ -270,18 +250,23 @@ private struct SwiftTermView: NSViewRepresentable {
 
     /// Resolves the best available monospaced font for terminal rendering.
     ///
-    /// Priority: Nerd Fonts first so zellij's powerline separators and glyph icons
-    /// render correctly when one is installed (MesloLGS NF is the common choice),
-    /// then the OPERATOR design font (IBM Plex Mono), then Menlo / Courier as the
-    /// universally-present fallbacks. `NSFont(name:)` lookups are cheap and cached,
-    /// so probing missing families adds no meaningful cost.
+    /// Priority:
+    ///  1. IBM Plex Mono — the OPERATOR design font (bundled or user-installed).
+    ///  2. Menlo — always present on macOS; excellent monospace legibility.
+    ///  3. Courier New — universal fallback.
+    ///  4. System monospaced — last resort.
+    ///
+    /// Nerd Font variants are intentionally excluded: they are almost never
+    /// installed on a standard macOS machine, and falling through the entire list
+    /// on every view creation adds measurable startup latency. If the user wants
+    /// Nerd Font glyphs they can set the font via a future preferences surface.
     private static func terminalFont(size: CGFloat) -> NSFont {
         let preferredFamilies: [String] = [
+            // Nerd Fonts first so zellij powerline/glyph icons render when installed.
             "MesloLGS NF",
             "MesloLGS Nerd Font Mono",
             "JetBrainsMono Nerd Font",
             "Hack Nerd Font",
-            "FiraCode Nerd Font",
             "IBMPlexMono",
             "IBM Plex Mono",
             "Menlo",
@@ -348,13 +333,8 @@ private struct SwiftTermView: NSViewRepresentable {
 }
 
 final class FocusableTerminalView: TerminalView {
-    /// Only the foreground terminal schedules initial focus; hidden-but-alive terminals
-    /// must not grab first responder when they mount.
-    var isActive = true
-
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard isActive else { return }
         TerminalFocusPolicy.scheduleInitialFocus(for: self)
     }
 }

--- a/macos/Sources/Terminal/TerminalPanelView.swift
+++ b/macos/Sources/Terminal/TerminalPanelView.swift
@@ -11,7 +11,7 @@ private typealias Color = SwiftUI.Color
 ///
 /// OPERATOR treatment (design.md §6.4):
 /// - `surface.terminal` background, `radius.panel`, engraved hairline.
-/// - IBM Plex Mono 12.5 / 1.45 line height, phosphor selection tint, block cursor.
+/// - IBM Plex Mono 13 / natural line height, phosphor amber block cursor + selection tint.
 /// - Top strip: session name + status badge + "● LIVE" / "↓ N new" affordance.
 /// - Calm inline states: `reconnecting…` (amber), `session exited` (grey) — never raw errors.
 public struct TerminalPanelView: View {
@@ -202,19 +202,33 @@ private struct SwiftTermView: NSViewRepresentable {
         clickRecognizer.delaysPrimaryMouseButtonEvents = false
         view.addGestureRecognizer(clickRecognizer)
 
-        // OPERATOR look: deep terminal surface + phosphor ink, Plex Mono 12.5.
+        // OPERATOR look: deep terminal surface + phosphor ink.
+        // Background/foreground are applied before font so resetFont() sees the right colors.
         view.nativeBackgroundColor = NSColor(Color.surfaceTerminal)
         view.nativeForegroundColor = NSColor(Color.terminalInk)
-        view.font = Self.terminalFont(size: 12.5)
+
+        // Phosphor amber block cursor — matches the OPERATOR ember accent (#D06F25).
+        view.caretColor = NSColor(red: 0.816, green: 0.435, blue: 0.145, alpha: 0.9)
+
+        // Dim phosphor selection tint so highlighted text stays readable on the dark surface.
+        view.selectedTextBackgroundColor = NSColor(
+            red: 0.816, green: 0.435, blue: 0.145, alpha: 0.28
+        )
+
+        // Set font after colors so the initial display uses the right palette.
+        view.font = Self.terminalFont(size: Self.terminalFontSize)
 
         // Install the output sink so future server `output` events feed SwiftTerm.
+        // We feed raw PTY bytes; SwiftTerm's VT100/xterm parser handles all ANSI/OSC
+        // sequences (including zellij's box-drawing borders) correctly.
         session.setOutputSink { [weak view] text in
             view?.feed(text: text)
         }
 
-        // Report the initial size once the view has a backing dimension, and start.
-        let dims = view.getTerminal().getDims()
-        session.resize(cols: dims.cols, rows: dims.rows)
+        // Do NOT report size on a zero-frame view; the real resize fires via
+        // sizeChanged(source:newCols:newRows:) once the view is laid out.
+        // Calling session.start() here triggers the WS connect; the first
+        // attached + resize handshake then uses the real frame dimensions.
         session.start()
         return view
     }
@@ -230,19 +244,29 @@ private struct SwiftTermView: NSViewRepresentable {
         }
     }
 
+    /// Target font size for the terminal surface (OPERATOR spec: Plex Mono 13).
+    /// Slightly larger than the previous 12.5 for better legibility on Retina.
+    static let terminalFontSize: CGFloat = 13.0
+
+    /// Resolves the best available monospaced font for terminal rendering.
+    ///
+    /// Priority:
+    ///  1. IBM Plex Mono — the OPERATOR design font (bundled or user-installed).
+    ///  2. Menlo — always present on macOS; excellent monospace legibility.
+    ///  3. Courier New — universal fallback.
+    ///  4. System monospaced — last resort.
+    ///
+    /// Nerd Font variants are intentionally excluded: they are almost never
+    /// installed on a standard macOS machine, and falling through the entire list
+    /// on every view creation adds measurable startup latency. If the user wants
+    /// Nerd Font glyphs they can set the font via a future preferences surface.
     private static func terminalFont(size: CGFloat) -> NSFont {
-        let preferredFamilies = [
-            "MesloLGS NF",
-            "MesloLGS Nerd Font Mono",
-            "MesloLGS NF Regular",
-            "JetBrainsMono Nerd Font",
-            "JetBrainsMono Nerd Font Mono",
-            "Hack Nerd Font",
-            "Hack Nerd Font Mono",
-            "FiraCode Nerd Font",
-            "FiraCode Nerd Font Mono",
-            "Menlo",
+        let preferredFamilies: [String] = [
             "IBMPlexMono",
+            "IBM Plex Mono",
+            "Menlo",
+            "Menlo Regular",
+            "Courier New",
         ]
         for family in preferredFamilies {
             if let font = NSFont(name: family, size: size) {
@@ -280,9 +304,12 @@ private struct SwiftTermView: NSViewRepresentable {
         }
 
         // Terminal grid resized (font/frame change) → tell the server.
+        // Clamp to [1, 500] on both axes (mirrors the SlayZone/xterm safety clamp).
         func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {
+            let clampedCols = max(1, min(500, newCols))
+            let clampedRows = max(1, min(500, newRows))
             let session = self.session
-            MainActor.assumeIsolated { session.resize(cols: newCols, rows: newRows) }
+            MainActor.assumeIsolated { session.resize(cols: clampedCols, rows: clampedRows) }
         }
 
         // Scroll position → drive the LIVE / "↓ N new" affordance. 1.0 == bottom.

--- a/macos/Sources/Terminal/TerminalPanelView.swift
+++ b/macos/Sources/Terminal/TerminalPanelView.swift
@@ -128,9 +128,88 @@ public struct TerminalPanelView: View {
     // MARK: - Terminal surface
 
     private var terminalSurface: some View {
-        SwiftTermView(session: session)
-            .id(session.id)
-            .background(Color.surfaceTerminal)
+        let showOverlay = TerminalConnectionOverlayPolicy.shouldShowOverlay(
+            for: session.connectionState,
+            isStartupSettling: session.isStartupSettling
+        )
+        return ZStack {
+            SwiftTermView(session: session)
+                .id(session.id)
+                .background(Color.surfaceTerminal)
+                .allowsHitTesting(!showOverlay)
+
+            if showOverlay {
+                TerminalConnectionOverlay(
+                    state: session.connectionState,
+                    isStartupSettling: session.isStartupSettling,
+                    reduceMotion: reduceMotion
+                )
+                    .transition(.opacity)
+            }
+        }
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.16), value: showOverlay)
+    }
+}
+
+enum TerminalConnectionOverlayPolicy {
+    static func shouldShowOverlay(for state: TerminalConnectionState) -> Bool {
+        shouldShowOverlay(for: state, isStartupSettling: false)
+    }
+
+    static func shouldShowOverlay(
+        for state: TerminalConnectionState,
+        isStartupSettling: Bool
+    ) -> Bool {
+        switch state {
+        case .connecting, .reconnecting:
+            return true
+        case .attached:
+            return isStartupSettling
+        case .exited, .error:
+            return false
+        }
+    }
+}
+
+private struct TerminalConnectionOverlay: View {
+    let state: TerminalConnectionState
+    let isStartupSettling: Bool
+    let reduceMotion: Bool
+
+    private var title: String {
+        switch state {
+        case .attached where isStartupSettling:
+            return "Settling terminal"
+        case .reconnecting:
+            return "Reconnecting"
+        default:
+            return "Connecting"
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color.surfaceTerminal.opacity(0.92)
+            HStack(spacing: Spacing.x2) {
+                ProgressView()
+                    .controlSize(.small)
+                    .progressViewStyle(.circular)
+                Text(title)
+                    .font(.plexMono(12, weight: .medium))
+                    .foregroundStyle(Color.terminalInk)
+                AnimatedEllipsis(color: .terminalMutedInk, reduceMotion: reduceMotion)
+            }
+            .padding(.horizontal, Spacing.x4)
+            .padding(.vertical, Spacing.x3)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(Color.black.opacity(0.28))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+            )
+        }
     }
 }
 
@@ -223,6 +302,9 @@ private struct SwiftTermView: NSViewRepresentable {
         // sequences (including zellij's box-drawing borders) correctly.
         session.setOutputSink { [weak view] text in
             view?.feed(text: text)
+        }
+        session.onNextAttach { [weak view] in
+            TerminalFocusPolicy.scheduleAttachedFocus(for: view)
         }
 
         // Do NOT report size on a zero-frame view; the real resize fires via
@@ -346,6 +428,7 @@ enum TerminalFocusPolicy {
     }
 
     static let initialFocusRetryDelays: [TimeInterval] = [0, 0.05, 0.15, 0.35]
+    static let attachedFocusRetryDelays: [TimeInterval] = [0, 0.05, 0.15]
 
     static func shouldRequestInitialFocus(
         hasFirstResponder: Bool,
@@ -362,6 +445,17 @@ enum TerminalFocusPolicy {
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak view] in
                 Task { @MainActor in
                     _ = requestFocus(view)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    static func scheduleAttachedFocus(for view: TerminalView?) {
+        for delay in attachedFocusRetryDelays {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak view] in
+                Task { @MainActor in
+                    _ = requestFocus(view, mode: .userInitiated)
                 }
             }
         }

--- a/macos/Sources/Terminal/TerminalPanelView.swift
+++ b/macos/Sources/Terminal/TerminalPanelView.swift
@@ -18,10 +18,14 @@ public struct TerminalPanelView: View {
     public nonisolated static let rendererConfiguration = TerminalRendererConfiguration(kind: .swiftTerm)
 
     @ObservedObject private var session: TerminalSession
+    /// Whether this is the visible/foreground terminal. Inactive terminals stay mounted
+    /// (alive) but must not grab keyboard focus from the active one.
+    private let isActive: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    public init(session: TerminalSession) {
+    public init(session: TerminalSession, isActive: Bool = true) {
         self.session = session
+        self.isActive = isActive
     }
 
     public var body: some View {
@@ -128,7 +132,7 @@ public struct TerminalPanelView: View {
     // MARK: - Terminal surface
 
     private var terminalSurface: some View {
-        SwiftTermView(session: session)
+        SwiftTermView(session: session, isActive: isActive)
             .id(session.id)
             .background(Color.surfaceTerminal)
     }
@@ -188,6 +192,7 @@ private struct AnimatedEllipsis: View {
 /// - reports size changes back to the session (`resize`).
 private struct SwiftTermView: NSViewRepresentable {
     let session: TerminalSession
+    var isActive: Bool = true
 
     func makeCoordinator() -> Coordinator {
         Coordinator(session: session)
@@ -195,6 +200,7 @@ private struct SwiftTermView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> TerminalView {
         let view = FocusableTerminalView(frame: .zero)
+        view.isActive = isActive
         view.terminalDelegate = context.coordinator
         context.coordinator.terminalView = view
         let clickRecognizer = NSClickGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.focusTerminal(_:)))
@@ -236,9 +242,23 @@ private struct SwiftTermView: NSViewRepresentable {
     func updateNSView(_ nsView: TerminalView, context: Context) {
         // Keep the coordinator's reference fresh; sizing is reported via the delegate.
         context.coordinator.terminalView = nsView
+        (nsView as? FocusableTerminalView)?.isActive = isActive
+        // Only the foreground terminal takes keyboard focus. Inactive (hidden-but-alive)
+        // terminals must never steal first responder from the visible one.
+        guard isActive else {
+            context.coordinator.didRequestInitialFocus = false
+            return
+        }
+        // updateNSView re-runs on every session update (output/state changes, because
+        // TerminalPanelView observes the session), so this naturally retries focus until
+        // it succeeds — including once the session attaches and is ready for input.
         guard !context.coordinator.didRequestInitialFocus else { return }
         DispatchQueue.main.async {
-            if TerminalFocusPolicy.requestFocus(nsView) {
+            // .userInitiated forces focus to the newly-active terminal: switching
+            // sessions must move first responder off the previously-focused terminal,
+            // which .initial mode deliberately refuses to do. Gated by
+            // didRequestInitialFocus so it fires once per activation, not every update.
+            if TerminalFocusPolicy.requestFocus(nsView, mode: .userInitiated) {
                 context.coordinator.didRequestInitialFocus = true
             }
         }
@@ -250,22 +270,21 @@ private struct SwiftTermView: NSViewRepresentable {
 
     /// Resolves the best available monospaced font for terminal rendering.
     ///
-    /// Priority:
-    ///  1. IBM Plex Mono — the OPERATOR design font (bundled or user-installed).
-    ///  2. Menlo — always present on macOS; excellent monospace legibility.
-    ///  3. Courier New — universal fallback.
-    ///  4. System monospaced — last resort.
-    ///
-    /// Nerd Font variants are intentionally excluded: they are almost never
-    /// installed on a standard macOS machine, and falling through the entire list
-    /// on every view creation adds measurable startup latency. If the user wants
-    /// Nerd Font glyphs they can set the font via a future preferences surface.
+    /// Priority: Nerd Fonts first so zellij's powerline separators and glyph icons
+    /// render correctly when one is installed (MesloLGS NF is the common choice),
+    /// then the OPERATOR design font (IBM Plex Mono), then Menlo / Courier as the
+    /// universally-present fallbacks. `NSFont(name:)` lookups are cheap and cached,
+    /// so probing missing families adds no meaningful cost.
     private static func terminalFont(size: CGFloat) -> NSFont {
         let preferredFamilies: [String] = [
+            "MesloLGS NF",
+            "MesloLGS Nerd Font Mono",
+            "JetBrainsMono Nerd Font",
+            "Hack Nerd Font",
+            "FiraCode Nerd Font",
             "IBMPlexMono",
             "IBM Plex Mono",
             "Menlo",
-            "Menlo Regular",
             "Courier New",
         ]
         for family in preferredFamilies {
@@ -329,8 +348,13 @@ private struct SwiftTermView: NSViewRepresentable {
 }
 
 final class FocusableTerminalView: TerminalView {
+    /// Only the foreground terminal schedules initial focus; hidden-but-alive terminals
+    /// must not grab first responder when they mount.
+    var isActive = true
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        guard isActive else { return }
         TerminalFocusPolicy.scheduleInitialFocus(for: self)
     }
 }

--- a/macos/Sources/Terminal/TerminalSession.swift
+++ b/macos/Sources/Terminal/TerminalSession.swift
@@ -19,6 +19,13 @@ public enum TerminalConnectionState: Equatable, Sendable {
     case error(code: String)
 }
 
+enum TerminalStartupSettlePolicy {
+    static let steadyResizeDebounceNanoseconds: UInt64 = 90_000_000
+    static let startupResizeDebounceNanoseconds: UInt64 = 220_000_000
+    static let postStableAttachSettleNanoseconds: UInt64 = 300_000_000
+    static let attachWithoutResizeFallbackNanoseconds: UInt64 = 900_000_000
+}
+
 /// `@MainActor` view-model that owns a `ShellEventSource` (the shell-WS client),
 /// consumes its `AsyncStream<ServerEvent>`, and publishes UI-facing state for the
 /// SwiftTerm-backed `TerminalPanelView`.
@@ -53,11 +60,16 @@ public final class TerminalSession: ObservableObject {
     /// Count of output flushes received while scrolled up (for the "↓ N new" badge).
     @Published public private(set) var unseenLines: Int = 0
 
+    /// Keeps SwiftTerm covered during the attach replay/first-layout burst. This
+    /// prevents early clicks/focus and the visible fast cursor repaint until zellij
+    /// has attached and the terminal has sent one settled size.
+    @Published public private(set) var isStartupSettling: Bool = true
+
     private let client: ShellEventSource
     /// Sink for decoded PTY output text. The view installs this to feed SwiftTerm.
     /// Called on the main actor.
     private var outputSink: (@MainActor (String) -> Void)?
-    private var attachHandler: (@MainActor () -> Void)?
+    private var attachHandlers: [@MainActor () -> Void] = []
     /// Coalesced output waiting to be fed into SwiftTerm. Feeding SwiftTerm once
     /// per websocket frame can fall behind under zellij bursts, causing zellij to
     /// disconnect the client. Drain at UI cadence instead.
@@ -70,6 +82,9 @@ public final class TerminalSession: ObservableObject {
     /// Coalesced pending resize and its debounce task (see `resize`).
     private var pendingResize: (cols: Int, rows: Int)?
     private var resizeDebounceTask: Task<Void, Never>?
+    private var hasAttachedSinceStartup = false
+    private var hasStableResizeSinceStartup = false
+    private var startupSettleTask: Task<Void, Never>?
 
     public init(displayName: String, client: ShellEventSource) {
         self.displayName = displayName
@@ -80,6 +95,7 @@ public final class TerminalSession: ObservableObject {
         consumeTask?.cancel()
         outputFlushTask?.cancel()
         resizeDebounceTask?.cancel()
+        startupSettleTask?.cancel()
     }
 
     /// Installs the output sink (the SwiftTerm feed) before/while starting.
@@ -90,7 +106,7 @@ public final class TerminalSession: ObservableObject {
 
     /// Runs once when the terminal first reaches an attached/output state.
     public func onNextAttach(_ handler: @escaping @MainActor () -> Void) {
-        attachHandler = handler
+        attachHandlers.append(handler)
     }
 
     /// Connects the client and begins consuming its event stream. Idempotent.
@@ -127,8 +143,11 @@ public final class TerminalSession: ObservableObject {
         // server (the client re-sends it after each attach).
         pendingResize = (cols, rows)
         resizeDebounceTask?.cancel()
+        let debounce = hasStableResizeSinceStartup
+            ? TerminalStartupSettlePolicy.steadyResizeDebounceNanoseconds
+            : TerminalStartupSettlePolicy.startupResizeDebounceNanoseconds
         resizeDebounceTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 90_000_000)
+            try? await Task.sleep(nanoseconds: debounce)
             guard !Task.isCancelled else { return }
             self?.flushPendingResize()
         }
@@ -137,8 +156,12 @@ public final class TerminalSession: ObservableObject {
     private func flushPendingResize() {
         guard let size = pendingResize else { return }
         pendingResize = nil
-        if let last = lastSize, last.cols == size.cols, last.rows == size.rows { return }
+        if let last = lastSize, last.cols == size.cols, last.rows == size.rows {
+            markStableResize()
+            return
+        }
         lastSize = size
+        markStableResize()
         let client = self.client
         Task { await client.resize(cols: size.cols, rows: size.rows) }
     }
@@ -157,6 +180,10 @@ public final class TerminalSession: ObservableObject {
         flushPendingOutput()
         outputFlushTask?.cancel()
         outputFlushTask = nil
+        resizeDebounceTask?.cancel()
+        resizeDebounceTask = nil
+        startupSettleTask?.cancel()
+        startupSettleTask = nil
         let client = self.client
         Task { await client.shutdown() }
     }
@@ -170,6 +197,7 @@ public final class TerminalSession: ObservableObject {
             return // terminal states are not overridden by a transient drop
         default:
             connectionState = .reconnecting
+            resetStartupSettling(keepStableResize: lastSize != nil)
         }
     }
 
@@ -189,8 +217,7 @@ public final class TerminalSession: ObservableObject {
     private func apply(_ event: ServerEvent) {
         switch event {
         case .attached:
-            connectionState = .attached
-            notifyAttached()
+            markAttached()
             // Re-send the last known size once after attach (protocol requirement).
             if let size = lastSize {
                 let client = self.client
@@ -199,18 +226,21 @@ public final class TerminalSession: ObservableObject {
         case let .output(seq, data):
             lastSeq = max(lastSeq, seq)
             // A late output frame while still "connecting" implies we're attached.
-            if case .connecting = connectionState { connectionState = .attached }
-            if case .reconnecting = connectionState { connectionState = .attached }
-            notifyAttached()
+            if case .connecting = connectionState { markAttached() }
+            if case .reconnecting = connectionState { markAttached() }
             enqueueOutput(data)
             if !isPinnedToBottom {
                 unseenLines += 1
             }
         case let .exit(code):
             connectionState = .exited(code: code)
+            isStartupSettling = false
+            startupSettleTask?.cancel()
         case let .error(code, _):
             // Never surface raw `message`; keep only the internal code.
             connectionState = .error(code: code)
+            isStartupSettling = false
+            startupSettleTask?.cancel()
         case .reconnecting:
             markReconnecting()
         case .replayEvicted:
@@ -219,13 +249,61 @@ public final class TerminalSession: ObservableObject {
             lastSeq = 0
             unseenLines = 0
             connectionState = .connecting
+            resetStartupSettling(keepStableResize: lastSize != nil)
+        }
+    }
+
+    private func markAttached() {
+        connectionState = .attached
+        hasAttachedSinceStartup = true
+        notifyAttached()
+        scheduleStartupSettlingIfReady()
+        scheduleAttachFallbackIfNeeded()
+    }
+
+    private func markStableResize() {
+        hasStableResizeSinceStartup = true
+        scheduleStartupSettlingIfReady()
+    }
+
+    private func resetStartupSettling(keepStableResize: Bool) {
+        hasAttachedSinceStartup = false
+        hasStableResizeSinceStartup = keepStableResize
+        isStartupSettling = true
+        startupSettleTask?.cancel()
+        startupSettleTask = nil
+    }
+
+    private func scheduleStartupSettlingIfReady() {
+        guard isStartupSettling, hasAttachedSinceStartup, hasStableResizeSinceStartup else { return }
+        startupSettleTask?.cancel()
+        startupSettleTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: TerminalStartupSettlePolicy.postStableAttachSettleNanoseconds)
+            guard !Task.isCancelled else { return }
+            self?.isStartupSettling = false
+            self?.startupSettleTask = nil
+        }
+    }
+
+    private func scheduleAttachFallbackIfNeeded() {
+        guard isStartupSettling, !hasStableResizeSinceStartup else { return }
+        startupSettleTask?.cancel()
+        startupSettleTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: TerminalStartupSettlePolicy.attachWithoutResizeFallbackNanoseconds)
+            guard let self, !Task.isCancelled else { return }
+            guard self.isStartupSettling, self.hasAttachedSinceStartup else { return }
+            self.isStartupSettling = false
+            self.startupSettleTask = nil
         }
     }
 
     private func notifyAttached() {
-        guard let attachHandler else { return }
-        self.attachHandler = nil
-        attachHandler()
+        guard !attachHandlers.isEmpty else { return }
+        let handlers = attachHandlers
+        attachHandlers.removeAll(keepingCapacity: true)
+        for handler in handlers {
+            handler()
+        }
     }
 
     private func enqueueOutput(_ data: String) {

--- a/macos/Sources/Terminal/TerminalSession.swift
+++ b/macos/Sources/Terminal/TerminalSession.swift
@@ -67,6 +67,9 @@ public final class TerminalSession: ObservableObject {
     private var started = false
     /// Latest requested terminal size, re-sent once after each successful attach.
     private var lastSize: (cols: Int, rows: Int)?
+    /// Coalesced pending resize and its debounce task (see `resize`).
+    private var pendingResize: (cols: Int, rows: Int)?
+    private var resizeDebounceTask: Task<Void, Never>?
 
     public init(displayName: String, client: ShellEventSource) {
         self.displayName = displayName
@@ -76,6 +79,7 @@ public final class TerminalSession: ObservableObject {
     deinit {
         consumeTask?.cancel()
         outputFlushTask?.cancel()
+        resizeDebounceTask?.cancel()
     }
 
     /// Installs the output sink (the SwiftTerm feed) before/while starting.
@@ -116,10 +120,27 @@ public final class TerminalSession: ObservableObject {
     /// not spam the server (which made zellij thrash/rearrange panes).
     public func resize(cols: Int, rows: Int) {
         guard cols > 0, rows > 0 else { return }
-        if let last = lastSize, last.cols == cols, last.rows == rows { return }
-        lastSize = (cols, rows)
+        // Coalesce rapid size reports (initial layout, window drags, font changes).
+        // SwiftTerm emits many intermediate grid sizes before settling; forwarding each
+        // makes zellij thrash/rearrange panes and can leave it stuck at an early,
+        // smaller-than-the-view grid. Debounce so only the settled size reaches the
+        // server (the client re-sends it after each attach).
+        pendingResize = (cols, rows)
+        resizeDebounceTask?.cancel()
+        resizeDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 90_000_000)
+            guard !Task.isCancelled else { return }
+            self?.flushPendingResize()
+        }
+    }
+
+    private func flushPendingResize() {
+        guard let size = pendingResize else { return }
+        pendingResize = nil
+        if let last = lastSize, last.cols == size.cols, last.rows == size.rows { return }
+        lastSize = size
         let client = self.client
-        Task { await client.resize(cols: cols, rows: rows) }
+        Task { await client.resize(cols: size.cols, rows: size.rows) }
     }
 
     /// Detaches (leaves the session running) and stops consuming.

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -18,6 +18,8 @@ final class AppModelAuthTests: XCTestCase {
 
         XCTAssertFalse(state.shouldShowSignInPrompt)
         XCTAssertEqual(state.token, "native-token")
+        XCTAssertFalse(state.markHostedAuthRequired())
+        XCTAssertTrue(state.shouldShowSignInPrompt)
     }
 
     func testWebShellAuthStateClearsPromptAfterExplicitSignInReload() {
@@ -42,18 +44,20 @@ final class AppModelAuthTests: XCTestCase {
 
         XCTAssertFalse(state.shouldShowSignInPrompt)
         XCTAssertEqual(state.token, "native-token")
-        XCTAssertTrue(state.markHostedAuthRequired())
+        XCTAssertFalse(state.markHostedAuthRequired())
+        XCTAssertTrue(state.shouldShowSignInPrompt)
     }
 
-    func testWebShellAuthStateClearsHostedPromptForFreshAutomaticReload() {
+    func testWebShellAuthStateClearsHostedPromptForExplicitReload() {
         var state = WebShellAuthState()
 
         state.resolveToken("native-token")
         _ = state.markHostedAuthRequired()
-        state.resolveToken("native-token")
+        state.resolveToken("native-token", resetHostedRetry: true)
 
         XCTAssertFalse(state.shouldShowSignInPrompt)
         XCTAssertEqual(state.token, "native-token")
+        XCTAssertTrue(state.markHostedAuthRequired())
     }
 
     func testRefreshRequiresTokenEvenWhenProfileIsPersisted() async {
@@ -893,6 +897,73 @@ final class AppModelAuthTests: XCTestCase {
         XCTAssertNil(model.terminal)
         XCTAssertEqual(model.workspaceSearchQuery, "")
         XCTAssertEqual(cancelCount, 1)
+    }
+
+    func testHostedShellAuthRequiredKeepsNativeSessionAndDoesNotSignOut() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "main",
+            profile: ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"),
+            makeClient: { url, provider in GatewayHTTPClient(baseURL: url, tokenProvider: provider) },
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+        model.openHome()
+        model.openProject(slug: "main")
+
+        // The hosted web shell reported it needs re-auth (server redirected to
+        // /login). The native device-auth principal + gateway session are still
+        // valid, so this must NOT sign the user out — doing so caused the redirect
+        // -> sign-out -> re-show login loop. It only flags the hosted shell.
+        model.markHostedShellAuthRequired()
+
+        let token = await principal.token()
+        XCTAssertEqual(token, "token")
+        XCTAssertNotNil(model.profile)
+        XCTAssertNotEqual(model.phase, .needsProfile)
+        XCTAssertFalse(model.openTabs.isEmpty)
+        XCTAssertTrue(model.hostedShellNeedsSignIn)
+    }
+
+    func testHostedShellAuthorizedClearsNeedsSignInFlag() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "main",
+            profile: ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"),
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+
+        model.markHostedShellAuthRequired()
+        XCTAssertTrue(model.hostedShellNeedsSignIn)
+
+        model.markHostedShellAuthorized()
+        XCTAssertFalse(model.hostedShellNeedsSignIn)
+    }
+
+    func testSignOutClearsHostedShellNeedsSignInFlag() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "main",
+            profile: ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"),
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+
+        model.markHostedShellAuthRequired()
+        await model.signOutNow()
+
+        XCTAssertFalse(model.hostedShellNeedsSignIn)
+        XCTAssertEqual(model.phase, .needsProfile)
     }
 
     func testTabKeyboardNavigationAndCloseActiveTab() async throws {

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -862,6 +862,64 @@ final class AppModelAuthTests: XCTestCase {
         XCTAssertEqual(url.queryValue("cwd"), "projects/matrix-os")
     }
 
+    func testCreateTaskProvisionsLinkedTerminalSessionBeforeTask() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        AppTestURLProtocol.setHandler { req in
+            switch (req.httpMethod, req.url?.path) {
+            case ("POST", "/api/terminal/sessions"):
+                let body = try XCTUnwrap(req.jsonBodyDictionary())
+                XCTAssertEqual(body["cwd"] as? String, "projects/matrix-os")
+                XCTAssertTrue((body["name"] as? String)?.hasPrefix("shell-") ?? false)
+                let json = #"{"name":"task-linked-session"}"#
+                return (appTestHTTPResponse(req.url!, 200), Data(json.utf8))
+            case ("POST", "/api/projects/matrix-os/tasks"):
+                let body = try XCTUnwrap(req.jsonBodyDictionary())
+                XCTAssertEqual(body["title"] as? String, "New task")
+                XCTAssertEqual(body["status"] as? String, "todo")
+                XCTAssertEqual(body["linkedSessionId"] as? String, "task-linked-session")
+                let json = """
+                {
+                  "task": {
+                    "id": "task_1",
+                    "projectSlug": "matrix-os",
+                    "title": "New task",
+                    "status": "todo",
+                    "priority": "normal",
+                    "order": 1,
+                    "linkedSessionId": "task-linked-session",
+                    "updatedAt": "2026-06-09T10:00:00.000Z"
+                  }
+                }
+                """
+                return (appTestHTTPResponse(req.url!, 200), Data(json.utf8))
+            default:
+                return (appTestHTTPResponse(req.url!, 200), Data(#"{"tasks":[]}"#.utf8))
+            }
+        }
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "matrix-os",
+            profile: ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"),
+            makeClient: { url, provider in
+                GatewayHTTPClient(baseURL: url, tokenProvider: provider, sessionConfiguration: .appTestMocked())
+            },
+            makeLoader: { _ in EmptyBoardLoader() },
+            makeTerminal: { _, _, _, name in TerminalSession(displayName: name, client: IdleShellEventSource()) },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+
+        model.createTask()
+        await eventuallyAsync {
+            model.selectedCard?.linkedSessionId == "task-linked-session"
+        }
+
+        XCTAssertEqual(model.selectedCard?.id, "task_1")
+        XCTAssertEqual(model.activePanel, .terminal)
+        XCTAssertTrue(model.openTabs.contains(where: { $0.card?.linkedSessionId == "task-linked-session" }))
+    }
+
     func testFocusTabByIndexUsesGlobalTabOrder() async throws {
         let principal = PrincipalProvider(store: MemoryTokenStore())
         try await principal.setToken("token")
@@ -1347,5 +1405,32 @@ private extension URLSessionConfiguration {
 
 private func appTestHTTPResponse(_ url: URL, _ status: Int) -> HTTPURLResponse {
     HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: nil)!
+}
+
+private extension URLRequest {
+    func jsonBodyDictionary() throws -> [String: Any] {
+        let data: Data?
+        if let httpBody {
+            data = httpBody
+        } else if let httpBodyStream {
+            httpBodyStream.open()
+            defer { httpBodyStream.close() }
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            var chunks = Data()
+            while httpBodyStream.hasBytesAvailable {
+                let count = httpBodyStream.read(&buffer, maxLength: buffer.count)
+                if count <= 0 { break }
+                chunks.append(buffer, count: count)
+            }
+            data = chunks
+        } else {
+            data = nil
+        }
+        guard let data, !data.isEmpty else {
+            return [:]
+        }
+        let value = try JSONSerialization.jsonObject(with: data, options: [])
+        return value as? [String: Any] ?? [:]
+    }
 }
 #endif

--- a/macos/Tests/AppTests/AppModelAuthTests.swift
+++ b/macos/Tests/AppTests/AppModelAuthTests.swift
@@ -9,6 +9,19 @@ import MatrixTerminal
 
 @MainActor
 final class AppModelAuthTests: XCTestCase {
+    private func eventuallyAsync(
+        _ predicate: @escaping () async -> Bool,
+        timeout: TimeInterval = 2.0,
+        _ message: String = "condition not met"
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await predicate() { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail(message)
+    }
+
     func testWebShellAuthStateClearsPromptOnAutomaticValidTokenReload() {
         var state = WebShellAuthState()
 
@@ -781,6 +794,103 @@ final class AppModelAuthTests: XCTestCase {
         XCTAssertEqual(model.selectedCard?.id, "matrix_session_alpha")
     }
 
+    func testCardsWithSameLinkedSessionShareOneTerminalClient() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        var terminalBuilds = 0
+        var sources: [RecordingShellEventSource] = []
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "main",
+            profile: ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"),
+            makeClient: { url, provider in GatewayHTTPClient(baseURL: url, tokenProvider: provider) },
+            makeLoader: { _ in EmptyBoardLoader() },
+            makeTerminal: { _, _, _, name in
+                terminalBuilds += 1
+                let source = RecordingShellEventSource()
+                sources.append(source)
+                return TerminalSession(displayName: name, client: source)
+            },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+        let firstCard = Card(id: "matrix_session_alpha", projectSlug: "main", title: "Alpha", status: .running, priority: .normal, order: 1, linkedSessionId: "shared-zellij", updatedAt: "now")
+        let secondCard = Card(id: "matrix_session_beta", projectSlug: "main", title: "Beta", status: .running, priority: .normal, order: 2, linkedSessionId: "shared-zellij", updatedAt: "now")
+
+        _ = try await model.openCard(firstCard)
+        _ = try await model.openCard(secondCard)
+
+        XCTAssertEqual(terminalBuilds, 1)
+        let firstSession = try XCTUnwrap(model.terminalSessions["session:main:matrix_session_alpha"])
+        let secondSession = try XCTUnwrap(model.terminalSessions["session:main:matrix_session_beta"])
+        XCTAssertTrue(firstSession === secondSession)
+
+        model.closeTab(id: "session:main:matrix_session_alpha")
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        let shutdownCountAfterFirstClose = await sources[0].shutdownCount
+        XCTAssertEqual(shutdownCountAfterFirstClose, 0)
+
+        model.closeTab(id: "session:main:matrix_session_beta")
+        await eventuallyAsync {
+            await sources[0].shutdownCount == 1
+        }
+    }
+
+    func testTaskTerminalAutoCreateUsesProjectCwd() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        var openedURL: URL?
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "matrix-os",
+            profile: ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"),
+            makeClient: { url, provider in GatewayHTTPClient(baseURL: url, tokenProvider: provider) },
+            makeLoader: { _ in EmptyBoardLoader() },
+            makeTerminal: { url, _, _, name in
+                openedURL = url
+                return TerminalSession(displayName: name, client: IdleShellEventSource())
+            },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+        let card = Card(id: "task_terminal", projectSlug: "matrix-os", title: "Terminal task", status: .todo, priority: .normal, order: 1, linkedSessionId: nil, updatedAt: "now")
+
+        _ = try await model.openCard(card)
+
+        let url = try XCTUnwrap(openedURL)
+        XCTAssertEqual(url.path, "/ws/terminal")
+        XCTAssertEqual(url.queryValue("cwd"), "projects/matrix-os")
+    }
+
+    func testFocusTabByIndexUsesGlobalTabOrder() async throws {
+        let principal = PrincipalProvider(store: MemoryTokenStore())
+        try await principal.setToken("token")
+        let model = AppModel(
+            principal: principal,
+            projectSlug: "main",
+            profile: ConnectionProfile(handle: "alice", gatewayHost: "app.matrix-os.com"),
+            makeClient: { url, provider in GatewayHTTPClient(baseURL: url, tokenProvider: provider) },
+            makeLoader: { _ in EmptyBoardLoader() },
+            deviceAuth: MockDeviceAuthorizer(),
+            openExternalURL: { _ in }
+        )
+        let first = Card(id: "task_one", projectSlug: "main", title: "One", status: .todo, priority: .normal, order: 1, linkedSessionId: nil, updatedAt: "now")
+        let second = Card(id: "task_two", projectSlug: "main", title: "Two", status: .todo, priority: .normal, order: 2, linkedSessionId: nil, updatedAt: "now")
+
+        model.openProject(slug: "main")
+        _ = try? await model.openCard(first)
+        _ = try? await model.openCard(second)
+
+        model.focusTab(at: 0)
+        XCTAssertEqual(model.activeTabID, "board:main")
+
+        model.focusTab(at: 1)
+        XCTAssertEqual(model.activeTabID, "task:main:task_one")
+
+        model.focusTab(at: 99)
+        XCTAssertEqual(model.activeTabID, "task:main:task_one")
+    }
+
     func testApprovedSignInOpensHomeWhenNoProjectIsSelected() async throws {
         let principal = PrincipalProvider(store: MemoryTokenStore())
         let openedURL = OpenedURLRecorder()
@@ -1129,6 +1239,27 @@ private struct IdleShellEventSource: ShellEventSource {
     func resize(cols: Int, rows: Int) async {}
     func detach() async {}
     func shutdown() async {}
+}
+
+private actor RecordingShellEventSource: ShellEventSource {
+    private let stream: AsyncStream<ServerEvent>
+    private(set) var shutdownCount = 0
+
+    init() {
+        self.stream = AsyncStream { _ in }
+    }
+
+    var events: AsyncStream<ServerEvent> {
+        get async { stream }
+    }
+
+    func connect() async {}
+    func sendInput(_ data: String) async {}
+    func resize(cols: Int, rows: Int) async {}
+    func detach() async {}
+    func shutdown() async {
+        shutdownCount += 1
+    }
 }
 
 private final class MockDeviceAuthorizer: DeviceAuthorizing, @unchecked Sendable {

--- a/macos/Tests/AppTests/EditorEngineTests.swift
+++ b/macos/Tests/AppTests/EditorEngineTests.swift
@@ -1,19 +1,21 @@
 #if os(macOS)
 import XCTest
 import AppKit
+import SwiftUI
 @testable import MatrixOS
 
 final class EditorEngineTests: XCTestCase {
-    func testNativeTextKitIsTheDefaultCurrentEditorEngine() {
+    func testCodeEditSourceEditorIsTheDefaultCurrentEditorEngine() {
         let config = EditorEngineConfiguration.default
 
-        XCTAssertEqual(config.kind, .textKitNative)
-        XCTAssertEqual(config.displayName, "Native TextKit")
+        XCTAssertEqual(config.kind, .codeEditSourceEditor)
+        XCTAssertEqual(config.displayName, "CodeEditSourceEditor")
         XCTAssertTrue(config.isLaunchSafe)
+        XCTAssertFalse(config.isLightweight)
         XCTAssertFalse(config.isVSCodeClassTarget)
     }
 
-    func testCodeMirrorIsLightweightPreviewAndEditingEngine() {
+    func testCodeMirrorRemainsLightweightPreviewOption() {
         let config = EditorEngineConfiguration(kind: .codeMirror)
 
         XCTAssertEqual(config.displayName, "CodeMirror")
@@ -30,16 +32,18 @@ final class EditorEngineTests: XCTestCase {
         XCTAssertTrue(config.isVSCodeClassTarget)
     }
 
-    func testSyntaxHighlightedCodeEditorReportsNativeEngineMetadata() {
-        XCTAssertEqual(SyntaxHighlightedCodeEditor.engineConfiguration.kind, .textKitNative)
+    func testSyntaxHighlightedCodeEditorReportsCodeEditSourceEditorMetadata() {
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.engineConfiguration.kind, .codeEditSourceEditor)
     }
 
     func testNativeEditorHasAwardGradeThemeChoicesAndPreferences() {
         XCTAssertTrue(CodeEditorTheme.allCases.contains(.xcodeDark))
         XCTAssertTrue(CodeEditorTheme.allCases.contains(.solarizedLight))
+        XCTAssertTrue(CodeEditorTheme.allCases.contains(.solarizedDark))
         XCTAssertTrue(CodeEditorTheme.allCases.contains(.oneDark))
         XCTAssertTrue(CodeEditorTheme.xcodeDark.isDark)
         XCTAssertFalse(CodeEditorTheme.solarizedLight.isDark)
+        XCTAssertTrue(CodeEditorTheme.solarizedDark.isDark)
 
         let preferences = CodeEditorPreferences.default
         XCTAssertEqual(preferences.fontSize, 13)
@@ -47,40 +51,79 @@ final class EditorEngineTests: XCTestCase {
         XCTAssertTrue(preferences.wrapsLines)
     }
 
-    func testWrappedEditorNeverStartsWithZeroWidthTextContainer() {
-        XCTAssertEqual(
-            SyntaxHighlightedCodeEditor.resolvedTextContainerWidth(contentWidth: 0, boundsWidth: 0, wrapsLines: true),
-            320
+    @MainActor
+    func testCodeEditSourceEditorLanguageDetectionUsesFilePath() {
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "package.json"), "json")
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "Sources/App.swift"), "swift")
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "home/templates/sqlite-client.js"), "javascript")
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "shell/src/app/page.tsx"), "typescript")
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "README.md"), "markdown")
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "docker-compose.yml"), "yaml")
+    }
+
+    func testWorkspaceFileSearchRanksNameMatchesBeforePathMatches() {
+        let results = WorkspaceFileSearchItem.filtered(
+            paths: [
+                "projects/matrix-os/home/templates/sqlite-client.js",
+                "projects/matrix-os/shell/src/lib/platform-session.ts",
+                "projects/matrix-os/packages/sql/client.ts",
+            ],
+            query: "sqlite"
         )
-        XCTAssertEqual(
-            SyntaxHighlightedCodeEditor.resolvedTextContainerWidth(contentWidth: 180, boundsWidth: 260, wrapsLines: true),
-            320
+
+        XCTAssertEqual(results.first?.path, "projects/matrix-os/home/templates/sqlite-client.js")
+        XCTAssertEqual(results.map(\.path), [
+            "projects/matrix-os/home/templates/sqlite-client.js",
+        ])
+    }
+
+    func testWorkspaceFileSearchReturnsStableTopResultsForEmptyQuery() {
+        let results = WorkspaceFileSearchItem.filtered(
+            paths: [
+                "projects/matrix-os/zeta.swift",
+                "projects/matrix-os/App.swift",
+                "projects/matrix-os/README.md",
+            ],
+            query: "",
+            limit: 2
         )
-        XCTAssertEqual(
-            SyntaxHighlightedCodeEditor.resolvedTextContainerWidth(contentWidth: 900, boundsWidth: 700, wrapsLines: true),
-            900
-        )
-        XCTAssertEqual(
-            SyntaxHighlightedCodeEditor.resolvedTextContainerWidth(contentWidth: 0, boundsWidth: 0, wrapsLines: false),
-            CGFloat.greatestFiniteMagnitude
-        )
+
+        XCTAssertEqual(results.map(\.name), ["App.swift", "README.md"])
     }
 
     @MainActor
-    func testPreviewSyntaxHighlighterColorsKeywordsAndStrings() {
-        let highlighted = SyntaxHighlightedCodeEditor.highlightedText(
-            #"let title = "Matrix""#,
-            filePath: "App.swift",
+    func testCodeEditSourceEditorThemeMapsPlainTextAndSyntaxColors() {
+        let theme = CodeEditorTheme.solarizedDark.sourceEditorTheme
+
+        XCTAssertEqual(theme.background, CodeEditorTheme.solarizedDark.background)
+        XCTAssertEqual(theme.text.color, CodeEditorTheme.solarizedDark.foreground)
+        XCTAssertEqual(theme.keywords.color, CodeEditorTheme.solarizedDark.keyword)
+        XCTAssertEqual(theme.strings.color, CodeEditorTheme.solarizedDark.string)
+        XCTAssertEqual(theme.comments.color, CodeEditorTheme.solarizedDark.comment)
+    }
+
+    @MainActor
+    func testCodeEditSourceEditorWrapperInstantiatesForLoadedJSON() {
+        let source = """
+        {
+          "name": "matrix-os",
+          "scripts": {
+            "test": "vitest"
+          }
+        }
+        """
+        let view = NSHostingView(rootView: SyntaxHighlightedCodeEditor(
+            text: .constant(source),
+            filePath: "package.json",
             theme: .xcodeDark,
             preferences: .default
-        )
+        ))
+        view.frame = NSRect(x: 0, y: 0, width: 720, height: 360)
+        view.layoutSubtreeIfNeeded()
 
-        let nsText = highlighted.string as NSString
-        let keywordRange = nsText.range(of: "let")
-        let stringRange = nsText.range(of: "\"Matrix\"")
-
-        XCTAssertNotNil(highlighted.attribute(.foregroundColor, at: keywordRange.location, effectiveRange: nil))
-        XCTAssertNotNil(highlighted.attribute(.foregroundColor, at: stringRange.location, effectiveRange: nil))
+        XCTAssertEqual(view.frame.size.width, 720)
+        XCTAssertEqual(view.frame.size.height, 360)
+        XCTAssertFalse(view.subviews.isEmpty)
     }
 }
 #endif

--- a/macos/Tests/AppTests/EditorEngineTests.swift
+++ b/macos/Tests/AppTests/EditorEngineTests.swift
@@ -56,6 +56,8 @@ final class EditorEngineTests: XCTestCase {
         XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "package.json"), "json")
         XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "Sources/App.swift"), "swift")
         XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "home/templates/sqlite-client.js"), "javascript")
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "shell/eslint.config.mjs"), "javascript")
+        XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "scripts/build.cjs"), "javascript")
         XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "shell/src/app/page.tsx"), "typescript")
         XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "README.md"), "markdown")
         XCTAssertEqual(SyntaxHighlightedCodeEditor.languageName(for: "docker-compose.yml"), "yaml")

--- a/macos/Tests/AppTests/WebShellViewTests.swift
+++ b/macos/Tests/AppTests/WebShellViewTests.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import XCTest
+import WebKit
 @testable import MatrixOS
 
 final class WebShellViewTests: XCTestCase {
@@ -26,6 +27,37 @@ final class WebShellViewTests: XCTestCase {
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
         XCTAssertEqual(json["redirectTo"], "/vm/alice?runtime=staging")
+    }
+
+    func testHostedShellDestinationRequestBypassesUnauthenticatedCache() throws {
+        let destination = try XCTUnwrap(URL(string: "https://app.matrix-os.com/"))
+
+        let request = webShellDestinationRequest(for: destination, token: "principal-token")
+
+        XCTAssertEqual(request.cachePolicy, .reloadIgnoringLocalAndRemoteCacheData)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer principal-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Cache-Control"), "no-store")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Pragma"), "no-cache")
+    }
+
+    func testHostedShellLoginRedirectShowsNativeSignInInsteadOfExternalBrowser() throws {
+        let destination = try XCTUnwrap(URL(string: "https://app.matrix-os.com/"))
+        let login = try XCTUnwrap(URL(string: "https://matrix-os.com/login"))
+
+        XCTAssertEqual(
+            WebShellNavigationPolicy.decision(for: login, destinationURL: destination),
+            .authRequired
+        )
+    }
+
+    func testHostedShellClerkRedirectShowsNativeSignInInsteadOfExternalBrowser() throws {
+        let destination = try XCTUnwrap(URL(string: "https://app.matrix-os.com/"))
+        let clerk = try XCTUnwrap(URL(string: "https://accounts.clerk.com/sign-in"))
+
+        XCTAssertEqual(
+            WebShellNavigationPolicy.decision(for: clerk, destinationURL: destination),
+            .authRequired
+        )
     }
 
     func testNativeAppSessionExchangeUsesRootRedirectForRootDestination() throws {
@@ -124,6 +156,68 @@ final class WebShellViewTests: XCTestCase {
 
         XCTAssertThrowsError(try NativeAppSessionExchange.appSessionCookies(from: response, for: url)) { error in
             XCTAssertEqual(error as? NativeAppSessionExchangeError, .invalidResponse)
+        }
+    }
+
+    @MainActor
+    func testNativeAppSessionInstallReplacesStaleMatrixSessionCookies() async throws {
+        let dataStore = WKWebsiteDataStore.nonPersistent()
+        let store = dataStore.httpCookieStore
+        let staleAppCookie = try makeCookie(name: "matrix_app_session", value: "old-jwt", domain: ".matrix-os.com")
+        let staleNativeCookie = try makeCookie(name: "matrix_native_app_session", value: "old-proof", domain: "app.matrix-os.com")
+        let unrelatedCookie = try makeCookie(name: "unrelated", value: "keep", domain: "app.matrix-os.com")
+        try await setCookie(staleAppCookie, in: store)
+        try await setCookie(staleNativeCookie, in: store)
+        try await setCookie(unrelatedCookie, in: store)
+
+        let freshAppCookie = try makeCookie(name: "matrix_app_session", value: "new-jwt", domain: "app.matrix-os.com")
+        let freshNativeCookie = try makeCookie(name: "matrix_native_app_session", value: "new-proof", domain: "app.matrix-os.com")
+
+        await installCookies([freshAppCookie, freshNativeCookie], in: store)
+
+        let cookies = await allCookies(in: store)
+        let sessionCookies = cookies.filter { $0.name == "matrix_app_session" || $0.name == "matrix_native_app_session" }
+        let valuesByName = Dictionary(uniqueKeysWithValues: sessionCookies.map { ($0.name, $0.value) })
+        XCTAssertEqual(valuesByName["matrix_app_session"], "new-jwt")
+        XCTAssertEqual(valuesByName["matrix_native_app_session"], "new-proof")
+        XCTAssertFalse(sessionCookies.contains { $0.value == "old-jwt" || $0.value == "old-proof" })
+        XCTAssertEqual(cookies.first(where: { $0.name == "unrelated" })?.value, "keep")
+    }
+
+    private func makeCookie(name: String, value: String, domain: String) throws -> HTTPCookie {
+        try XCTUnwrap(HTTPCookie(properties: [
+            .domain: domain,
+            .path: "/",
+            .name: name,
+            .value: value,
+            .secure: true,
+        ]))
+    }
+
+    @MainActor
+    private func setCookie(_ cookie: HTTPCookie, in store: WKHTTPCookieStore) async throws {
+        await withCheckedContinuation { continuation in
+            store.setCookie(cookie) {
+                continuation.resume()
+            }
+        }
+    }
+
+    @MainActor
+    private func installCookies(_ cookies: [HTTPCookie], in store: WKHTTPCookieStore) async {
+        await withCheckedContinuation { continuation in
+            NativeAppSessionExchange.installCookies(cookies, in: store) {
+                continuation.resume()
+            }
+        }
+    }
+
+    @MainActor
+    private func allCookies(in store: WKHTTPCookieStore) async -> [HTTPCookie] {
+        await withCheckedContinuation { continuation in
+            store.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
         }
     }
 }

--- a/macos/Tests/AppTests/WebShellViewTests.swift
+++ b/macos/Tests/AppTests/WebShellViewTests.swift
@@ -48,7 +48,58 @@ final class WebShellViewTests: XCTestCase {
         XCTAssertEqual(json["redirectTo"], "/?runtime=staging")
     }
 
-    func testNativeAppSessionExchangeAcceptsMatrixAppSessionCookie() throws {
+    func testNativeAppSessionExchangeAcceptsNativeSessionCookies() throws {
+        let url = try XCTUnwrap(URL(string: "https://app.matrix-os.com/api/auth/app-session"))
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: [
+                "Set-Cookie": [
+                    "matrix_app_session=jwt; Path=/; Secure; HttpOnly; SameSite=Lax",
+                    "matrix_native_app_session=proof; Path=/; Secure; HttpOnly; SameSite=Lax",
+                ].joined(separator: ", ")
+            ]
+        ))
+
+        let cookies = try NativeAppSessionExchange.appSessionCookies(from: response, for: url)
+
+        XCTAssertEqual(cookies.map(\.name), ["matrix_app_session", "matrix_native_app_session"])
+    }
+
+    func testNativeAppSessionExchangeAcceptsURLSessionStoredNativeCookies() throws {
+        let url = try XCTUnwrap(URL(string: "https://app.matrix-os.com/api/auth/app-session"))
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: [:]
+        ))
+        let appCookie = try XCTUnwrap(HTTPCookie(properties: [
+            .domain: "app.matrix-os.com",
+            .path: "/",
+            .name: "matrix_app_session",
+            .value: "jwt",
+            .secure: true,
+        ]))
+        let nativeCookie = try XCTUnwrap(HTTPCookie(properties: [
+            .domain: "app.matrix-os.com",
+            .path: "/",
+            .name: "matrix_native_app_session",
+            .value: "proof",
+            .secure: true,
+        ]))
+
+        let cookies = try NativeAppSessionExchange.appSessionCookies(
+            from: response,
+            storedCookies: [appCookie, nativeCookie],
+            for: url
+        )
+
+        XCTAssertEqual(cookies.map(\.name), ["matrix_app_session", "matrix_native_app_session"])
+    }
+
+    func testNativeAppSessionExchangeRejectsResponseWithoutNativeSessionProofCookie() throws {
         let url = try XCTUnwrap(URL(string: "https://app.matrix-os.com/api/auth/app-session"))
         let response = try XCTUnwrap(HTTPURLResponse(
             url: url,
@@ -57,12 +108,12 @@ final class WebShellViewTests: XCTestCase {
             headerFields: ["Set-Cookie": "matrix_app_session=jwt; Path=/; Secure; HttpOnly; SameSite=Lax"]
         ))
 
-        let cookies = try NativeAppSessionExchange.appSessionCookies(from: response, for: url)
-
-        XCTAssertEqual(cookies.map(\.name), ["matrix_app_session"])
+        XCTAssertThrowsError(try NativeAppSessionExchange.appSessionCookies(from: response, for: url)) { error in
+            XCTAssertEqual(error as? NativeAppSessionExchangeError, .invalidResponse)
+        }
     }
 
-    func testNativeAppSessionExchangeRejectsResponseWithoutMatrixAppSessionCookie() throws {
+    func testNativeAppSessionExchangeRejectsResponseWithoutMatrixSessionCookie() throws {
         let url = try XCTUnwrap(URL(string: "https://app.matrix-os.com/api/auth/app-session"))
         let response = try XCTUnwrap(HTTPURLResponse(
             url: url,

--- a/macos/Tests/TerminalTests/ShellWSClientTests.swift
+++ b/macos/Tests/TerminalTests/ShellWSClientTests.swift
@@ -118,6 +118,16 @@ final class ShellMessageCodecTests: XCTestCase {
         XCTAssertEqual(text, "Session not found")
     }
 
+    func testServerErrorWithoutCodeDecodesAsGenericTerminalError() throws {
+        let json = #"{"type":"error","message":"Failed to create session"}"#
+        let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))
+        guard case let .error(code, text) = message else {
+            return XCTFail("expected error, got \(message)")
+        }
+        XCTAssertEqual(code, "terminal_error")
+        XCTAssertEqual(text, "Failed to create session")
+    }
+
     func testServerPongDecodes() throws {
         let json = #"{"type":"pong"}"#
         let message = try decoder.decode(ServerMessage.self, from: Data(json.utf8))

--- a/macos/Tests/TerminalTests/TerminalRendererTests.swift
+++ b/macos/Tests/TerminalTests/TerminalRendererTests.swift
@@ -26,6 +26,7 @@ final class TerminalRendererTests: XCTestCase {
 
     func testTerminalFocusUsesRetryPolicyAfterWindowAttachment() {
         XCTAssertEqual(TerminalFocusPolicy.initialFocusRetryDelays, [0, 0.05, 0.15, 0.35])
+        XCTAssertEqual(TerminalFocusPolicy.attachedFocusRetryDelays, [0, 0.05, 0.15])
     }
 
     func testInitialTerminalFocusDoesNotStealFromActiveControls() {
@@ -66,5 +67,24 @@ final class TerminalRendererTests: XCTestCase {
             TerminalRendererConfiguration.available(includeExperimental: true).map(\.kind),
             [.swiftTerm, .ghostty, .xtermWebView]
         )
+    }
+
+    func testTerminalLiveOverlayOnlyShowsBeforeAttach() {
+        XCTAssertTrue(TerminalConnectionOverlayPolicy.shouldShowOverlay(for: .connecting))
+        XCTAssertTrue(TerminalConnectionOverlayPolicy.shouldShowOverlay(for: .reconnecting))
+        XCTAssertFalse(TerminalConnectionOverlayPolicy.shouldShowOverlay(for: .attached))
+        XCTAssertFalse(TerminalConnectionOverlayPolicy.shouldShowOverlay(for: .exited(code: 0)))
+        XCTAssertFalse(TerminalConnectionOverlayPolicy.shouldShowOverlay(for: .error(code: "internal")))
+    }
+
+    func testTerminalOverlayStaysUpDuringStartupSettling() {
+        XCTAssertTrue(TerminalConnectionOverlayPolicy.shouldShowOverlay(
+            for: .attached,
+            isStartupSettling: true
+        ))
+        XCTAssertFalse(TerminalConnectionOverlayPolicy.shouldShowOverlay(
+            for: .attached,
+            isStartupSettling: false
+        ))
     }
 }

--- a/macos/Tests/TerminalTests/TerminalSessionTests.swift
+++ b/macos/Tests/TerminalTests/TerminalSessionTests.swift
@@ -47,6 +47,7 @@ final class TerminalSessionTests: XCTestCase {
         XCTAssertEqual(session.connectionState, .connecting)
         XCTAssertEqual(session.lastSeq, 0)
         XCTAssertTrue(session.isPinnedToBottom)
+        XCTAssertTrue(session.isStartupSettling)
     }
 
     func testStartConnectsTheClient() async {
@@ -60,6 +61,21 @@ final class TerminalSessionTests: XCTestCase {
         session.start()
         await source.emit(.attached(state: "running", fromSeq: 0))
         await eventually({ session.connectionState == .attached })
+    }
+
+    func testMultipleAttachHandlersRunOnceOnFirstAttach() async {
+        let (session, source) = makeSession()
+        var calls: [String] = []
+        session.onNextAttach { calls.append("focus") }
+        session.onNextAttach { calls.append("reload") }
+        session.start()
+
+        await source.emit(.attached(state: "running", fromSeq: 0))
+        await eventually({ calls == ["focus", "reload"] })
+
+        await source.emit(.output(seq: 1, data: "still live"))
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        XCTAssertEqual(calls, ["focus", "reload"])
     }
 
     func testOutputAdvancesSeqAndFeedsSink() async {
@@ -214,6 +230,47 @@ final class TerminalSessionTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(resizes.count, 2)
         XCTAssertEqual(resizes.last?.cols, 100)
         XCTAssertEqual(resizes.last?.rows, 30)
+    }
+
+    func testStartupSettlingClearsAfterAttachAndStableResize() async {
+        let (session, source) = makeSession()
+        session.start()
+
+        await source.emit(.attached(state: "running", fromSeq: 0))
+        session.resize(cols: 110, rows: 34)
+
+        await eventuallyAsync({ await source.resizes.first?.cols == 110 })
+        await eventually({ !session.isStartupSettling })
+    }
+
+    func testAttachWithoutResizeEventuallyClearsStartupSettling() async {
+        let (session, source) = makeSession()
+        session.start()
+
+        await source.emit(.attached(state: "running", fromSeq: 0))
+
+        await eventually(
+            { !session.isStartupSettling },
+            timeout: 1.5,
+            "startup settling should fall back after attach when no size arrives"
+        )
+    }
+
+    func testStartupResizeBurstOnlyForwardsSettledSize() async {
+        let (session, source) = makeSession()
+
+        session.resize(cols: 80, rows: 24)
+        session.resize(cols: 100, rows: 28)
+        session.resize(cols: 132, rows: 41)
+
+        try? await Task.sleep(nanoseconds: 120_000_000)
+        let earlyResizes = await source.resizes
+        XCTAssertTrue(earlyResizes.isEmpty)
+
+        await eventuallyAsync({ await source.resizes.count == 1 })
+        let resizes = await source.resizes
+        XCTAssertEqual(resizes.first?.cols, 132)
+        XCTAssertEqual(resizes.first?.rows, 41)
     }
 
     func testDetachAndShutdownForward() async {

--- a/packages/gateway/src/task-manager.ts
+++ b/packages/gateway/src/task-manager.ts
@@ -37,7 +37,7 @@ type Result<T> = { ok: true; status?: number } & T;
 
 const TaskIdSchema = z.string().regex(/^task_[A-Za-z0-9_-]{1,128}$/);
 const ProjectSlugSchema = z.string().regex(PROJECT_SLUG_REGEX);
-const SessionIdSchema = z.string().regex(/^sess_[A-Za-z0-9_-]{1,128}$/);
+const SessionIdSchema = z.string().regex(/^[A-Za-z0-9_-]{1,128}$/);
 const WorktreeIdSchema = z.string().regex(/^wt_[A-Za-z0-9_-]{1,128}$/);
 const PreviewIdSchema = z.string().regex(/^prev_[A-Za-z0-9_-]{1,128}$/);
 

--- a/packages/gateway/src/workspace-routes.ts
+++ b/packages/gateway/src/workspace-routes.ts
@@ -369,8 +369,6 @@ export function createWorkspaceRoutes(options: {
   });
 
   app.delete("/api/projects/:slug/tasks/:taskId", limited, async (c) => {
-    const body = await parseJson(c, EmptyObjectSchema);
-    if (!body.ok) return c.json(errorBody(body.code, body.message), status(body.status));
     const projectSlug = c.req.param("slug");
     const taskId = c.req.param("taskId");
     const result = await taskManager.deleteTask(projectSlug, taskId);

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -27,7 +27,8 @@ APP_ICON="$PACKAGE_DIR/Resources/AppIcon.icns"
 pkill -x "$APP_NAME" >/dev/null 2>&1 || true
 
 swift build --package-path "$PACKAGE_DIR" --product "$APP_NAME" --configuration "$BUILD_CONFIGURATION"
-BUILD_BINARY="$(swift build --package-path "$PACKAGE_DIR" --configuration "$BUILD_CONFIGURATION" --show-bin-path)/$APP_NAME"
+BUILD_PRODUCTS_DIR="$(swift build --package-path "$PACKAGE_DIR" --configuration "$BUILD_CONFIGURATION" --show-bin-path)"
+BUILD_BINARY="$BUILD_PRODUCTS_DIR/$APP_NAME"
 
 rm -rf "$APP_BUNDLE"
 mkdir -p "$APP_MACOS" "$APP_RESOURCES"
@@ -35,6 +36,13 @@ cp "$BUILD_BINARY" "$APP_BINARY"
 chmod +x "$APP_BINARY"
 if [[ -f "$APP_ICON" ]]; then
   cp "$APP_ICON" "$APP_RESOURCES/AppIcon.icns"
+fi
+while IFS= read -r resource_bundle; do
+  cp -R "$resource_bundle" "$APP_RESOURCES/"
+done < <(find "$BUILD_PRODUCTS_DIR" -maxdepth 1 -type d -name '*.bundle' -print)
+
+if [[ ! -d "$APP_RESOURCES/CodeEditLanguages_CodeEditLanguages.bundle/Resources" ]]; then
+  echo "warning: CodeEditLanguages resources were not staged; syntax highlighting may be unavailable" >&2
 fi
 
 cat >"$INFO_PLIST" <<PLIST

--- a/tests/gateway/task-manager.test.ts
+++ b/tests/gateway/task-manager.test.ts
@@ -29,7 +29,7 @@ describe("task-manager", () => {
       title: "Wire task workflow",
       description: "Build project-scoped task records",
       priority: "high",
-      linkedSessionId: "sess_abc123",
+      linkedSessionId: "shell-abc123",
       linkedWorktreeId: "wt_abc123def456",
     });
     const second = await manager.createTask("repo", {
@@ -48,7 +48,7 @@ describe("task-manager", () => {
         status: "todo",
         priority: "high",
         order: 0,
-        linkedSessionId: "sess_abc123",
+        linkedSessionId: "shell-abc123",
         linkedWorktreeId: "wt_abc123def456",
       },
     });

--- a/tests/gateway/workspace-routes.test.ts
+++ b/tests/gateway/workspace-routes.test.ts
@@ -552,7 +552,7 @@ exit 1
     await expect((await app.request(patchJsonRequest("/api/projects/repo/tasks/task_abc123", { status: "running" }))).json()).resolves.toMatchObject({
       task: expect.objectContaining({ status: "running" }),
     });
-    await expect((await app.request(deleteJsonRequest("/api/projects/repo/tasks/task_abc123", {}))).json()).resolves.toEqual({ ok: true });
+    await expect((await app.request("/api/projects/repo/tasks/task_abc123", { method: "DELETE" })).json()).resolves.toEqual({ ok: true });
 
     const createdPreview = await app.request(jsonRequest("/api/projects/repo/previews", {
       taskId: "task_abc123",


### PR DESCRIPTION
fix(macos): preserve native shell session cookie

fix(macos): stop hosted-shell auth loop without signing out native session

When the hosted web shell at app.matrix-os.com redirected an authenticated
native request to /login, the app retried the app-session exchange once and
then signed out the native principal (clearSessionAfterHostedAuthFailure ->
signOutNow). That wiped a valid device-auth token, dropped the user to
onboarding, and looped: re-sign-in -> workspace -> Home -> /login -> sign-out.

The native principal and gateway session are valid; only the hosted *web*
session needs re-auth. Replace the destructive path with a non-destructive
markHostedShellAuthRequired() that flags the hosted shell needs sign-in while
keeping the native session. WebShellAuthState already caps automatic retries at
one, so the Home panel settles on the native sign-in prompt with no loop.

Also keeps the verified ASWebAuthenticationSession completion-handler fix
(nonisolated factory + MainActor hop) that resolves the post-approval crash.

Tests: 192 macOS tests pass. Telemetry confirms one retry then a stable
"keeping native session (no sign-out)" with a single app instance.

fix(macos): persist hosted-shell data store, strip stale Clerk cookies

Revert the non-persistent WKWebView data store (it forced a full Home-tab
reload every visit). The real /login root cause was the shell proxy path, now
fixed. Keep clearInterferingClerkCookies as a per-load guard so leftover Clerk
client cookies cannot override the native app session.

feat(macos): real code editor with content, highlighting, and find

Fix the empty-editor bug: applyLayoutPreferences ran before the view had
geometry, so the text container width was zero and content never laid out
(only the gutter rendered). Defer the first content apply until the scroll
view has real width. Add per-language syntax highlighting (Swift, TS/JS, Go,
Rust, etc.), number/block-comment coloring, right-aligned line numbers, and a
native in-file find bar (Cmd+F/Cmd+G, case toggle, match count).

fix(macos): clean terminal rendering

Drop the zero-frame initial resize that connected the PTY at a default size
then reflowed; set caret and selection colors for the dark surface; replace the
never-installed Nerd Font fallback list with IBM Plex Mono/Menlo at 13pt; clamp
reported cols/rows to [1,500] before forwarding to the session.

fix(macos): editor fills its pane instead of a thin centered column

EditorScrollHost only laid out on the first pass; SwiftUI resizes the host by
setting its frame, which does not trigger layout() on a non-autoresizing view,
so the scroll view stayed latched at its initial narrow width. Re-lay contents
on setFrameSize, and stop capping the text view's max width at that early
contentSize (which pinned dense files like JSON to one character per line).

fix(macos): debounce terminal resize to settle full-size grid

SwiftTerm emits many intermediate grid sizes during initial layout and window
drags; forwarding each made zellij thrash and could leave it stuck at an early,
smaller-than-the-view grid. Coalesce resizes with a 90ms settle so only the
final full size reaches the server (re-sent after attach by the WS client).

feat(macos): keep terminals alive across switches + Meslo glyphs

Mount every live (cached) terminal session at once and show only the active one
(opacity + hit-testing), so switching sessions is instant: inactive terminals stay
alive with their PTY stream and scrollback instead of tearing down and re-attaching
from scratch. Gate keyboard focus to the foreground terminal, and force-focus the
newly-active one on switch so input lands immediately. Restore Nerd Font priority
(MesloLGS NF first) so zellij powerline/glyph icons render, with Plex Mono/Menlo
fallback. Subtle crossfade on switch.

feat(macos): keep hosted web shell mounted like a browser tab

Home was a switch arm, so leaving and returning tore down the WKWebView and
forced a full reload + re-auth exchange. Keep MatrixWebShellPanel mounted at all
times (opacity + hit-testing gated on the active section) so the shell persists
its page, scroll, and auth state across section switches; other sections render
on top when active.

fix(macos): restore editor content (revert max-width uncap)

The earlier max-width uncap (maxSize=greatest / minSize=0) regressed dense files
to a blank pane (only the gutter rendered). The scroll-view relayout on
setFrameSize is what actually fixes the narrow-column bug, so keep that and
restore the bounded maxSize/minSize that lays content out correctly.

fix(macos): revert editor setFrameSize override that blanked all files

The setFrameSize override (1fb41befd) latched the scroll view at a bad frame on
SwiftUI-driven resizes, leaving every file rendered as an empty pane (gutter only).
Restore the original layout() so content renders again. The full-width layout
polish will be redone correctly.

fix(macos): revert keep-alive that blanked editor and piled up zellij clients

The keep-alive experiment caused two regressions: the always-mounted hosted-shell
WKWebView overlapped the editor's NSView and blanked it, and mounting every cached
terminal session opened a WebSocket client per session (plus leaks on remount),
piling clients onto one zellij session and making it laggy. Restore the single
active terminal + plain section switch (snappy, one client, like the web shell).
Keep the resize debounce and restore the Meslo Nerd Font for zellij glyphs.

feat(macos): upgrade native workspace surfaces

Summary:
- Replace the native editor wrapper with CodeEditSourceEditor and copy SwiftPM resource bundles into the app bundle so language assets are present at runtime.
- Add Cmd+O file search, an AppKit file navigator, multi-pane task layout, pane toggles, and Cmd+1 through Cmd+9 global tab focus.
- Stabilize terminal startup with attach/resize settling, shared named session clients, safer terminal error decoding, and project-scoped task terminal cwd.

Rationale:
- The previous native shell relied on hand-rolled editor, tree, and pane controls that made common task workflows feel incomplete.
- Terminal startup needed to avoid resize bursts and duplicate named-session sockets while still preserving tab reuse.

Tests:
- swift test --package-path macos --filter AppModelAuthTests --filter ShellMessageCodecTests --filter TerminalRendererTests
- swift test --package-path macos
- ./script/build_and_run.sh run