### PR TITLE
fix(platform): normalize Clerk callback redirects

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -561,7 +561,7 @@ export function buildPostAuthRedirectPath(rawUrl: string): string {
   try {
     const url = new URL(rawUrl, 'https://app.matrix-os.com');
     const normalizedPath = url.pathname.replace(/^\/{2,}/, '/');
-    const path = /^\/sign-(?:in|up)\/?$/.test(normalizedPath) ? '/' : normalizedPath;
+    const path = /^\/sign-(?:in|up)(?:\/.*)?$/.test(normalizedPath) ? '/' : normalizedPath;
     const runtime = url.searchParams.get('runtime');
     if (runtime && RuntimeSlotSchema.safeParse(runtime).success) {
       return `${path}?runtime=${encodeURIComponent(runtime)}`;

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -146,6 +146,10 @@ describe("platform proxy routing", () => {
       "/?runtime=staging",
     );
     expect(buildPostAuthRedirectPath("https://app.matrix-os.com/sign-up/?session=secret")).toBe("/");
+    expect(buildPostAuthRedirectPath("https://app.matrix-os.com/sign-up/verify-email-address?session=secret")).toBe("/");
+    expect(buildPostAuthRedirectPath("https://app.matrix-os.com/sign-in/sso-callback?runtime=staging&session=secret")).toBe(
+      "/?runtime=staging",
+    );
   });
 
   it("adds a timeout and a derived platform verification token on app-domain proxy fetches", async () => {


### PR DESCRIPTION
## Summary
- Normalize nested Clerk auth callback paths such as /sign-up/verify-email-address and /sign-in/sso-callback to / after successful Matrix app-session exchange.
- Preserve valid runtime selectors while dropping Clerk-only callback/session query state.
- Add regression coverage for OTP/SSO callback redirect normalization.

## Invariants
- Source of truth: app.matrix-os.com platform routing remains the source of truth for post-auth destinations; customer VPS shells should not receive Clerk-owned callback paths after platform session exchange.
- Lock/transaction scope: no database writes or transactions changed; this is pure URL normalization before route/session handling.
- Acceptable orphan states: none introduced. Existing Clerk session exchange, billing, and provisioning flows continue to own their failure handling.
- Auth source of truth: Clerk remains the browser identity source; Matrix app-session exchange continues to issue platform sync cookies only after Clerk verification.
- Deferred scope: this does not alter Clerk widget behavior, billing policy, provisioning, or Cloud Run deployment wiring.

## Validation
- RED: pnpm exec vitest run tests/platform/proxy-routing.test.ts failed on /sign-up/verify-email-address returning itself instead of /.
- GREEN: pnpm exec vitest run tests/platform/proxy-routing.test.ts (102 passed)
- bun run check:patterns (0 violations, existing warnings only)