### PR TITLE
fix(platform): restore pre-vps auth shell routing

### DIFF
--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -598,7 +598,6 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   // routing selects the requested runtime; unqualified handle routing resolves
   // deterministically to primary first in the read helpers below.
   await sql`DROP INDEX IF EXISTS idx_user_machines_handle_active`.execute(db);
-  await sql`DROP INDEX IF EXISTS idx_user_machines_handle_slot_active`.execute(db);
   await sql`
     CREATE UNIQUE INDEX IF NOT EXISTS idx_user_machines_handle_slot_active
     ON user_machines(handle, runtime_slot)

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -3239,7 +3239,9 @@ export function createApp(deps: {
     }
     headers.set('host', new URL(getAuthShellOrigin(appEnv)).host);
     headers.set('x-forwarded-host', host);
-    headers.set('x-forwarded-proto', 'https');
+    // The auth shell is a local plain-HTTP Next server. Forwarding "https" here
+    // makes Next 16 attempt internal self-proxy requests to https://localhost:3200.
+    headers.set('x-forwarded-proto', 'http');
     headers.set('accept-encoding', 'identity');
     headers.set('connection', 'close');
 

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -897,7 +897,16 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
-  event.respondWith(fetch(event.request));
+  event.respondWith(fetch(event.request).catch((err) => {
+    console.warn("[app cleanup sw] fetch failed:", err?.message ?? err);
+    return new Response("offline", {
+      status: 504,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    });
+  }));
 });
 `.trim();
 

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2576,6 +2576,10 @@ describe("platform proxy routing", () => {
         signal: expect.any(AbortSignal),
       }),
     );
+    const proxiedHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers | undefined;
+    expect(proxiedHeaders?.get("host")).toBe("auth-shell.test:3200");
+    expect(proxiedHeaders?.get("x-forwarded-host")).toBe("app.matrix-os.com");
+    expect(proxiedHeaders?.get("x-forwarded-proto")).toBe("http");
     delete process.env.AUTH_SHELL_HOST;
     delete process.env.AUTH_SHELL_PORT;
   });

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -4061,7 +4061,10 @@ describe("platform proxy routing", () => {
       expect(res.headers.get("cache-control")).toBe("no-store, private");
       expect(res.headers.get("cdn-cache-control")).toBe("no-store");
       expect(res.headers.get("service-worker-allowed")).toBe("/");
-      expect(await res.text()).toContain("registration.unregister()");
+      const body = await res.text();
+      expect(body).toContain("registration.unregister()");
+      expect(body).toContain(".catch((err) =>");
+      expect(body).toContain('new Response("offline",');
       expect(verifyToken).not.toHaveBeenCalled();
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {


### PR DESCRIPTION
## Summary
- keep the platform-to-auth-shell hop on local HTTP so signed-in no-runtime users do not trigger Next's HTTPS localhost self-proxy failure
- stop dropping the active user-machine handle-slot index on every Cloud Run cold start, avoiding duplicate-index migration races
- catch app-domain cleanup service worker fetch failures and return a controlled offline response

## Invariants
- Source of truth: platform routing remains the source of truth for app.matrix-os.com identity resolution and pre-VPS auth-shell routing; platform Postgres remains the source of truth for user machine records and indexes.
- Lock/transaction scope: no new persistent writes are introduced; migration now leaves the existing handle-slot index in place instead of destructively recreating it on each startup.
- Acceptable orphan states: if the cleanup worker fetch fails during unregister/claim cleanup, the browser receives a no-store 504 response instead of an unhandled rejected FetchEvent. If a signed-in user has no runtime, the request stays on the auth-shell path instead of surfacing a 500 from a local HTTPS self-proxy attempt.
- Auth source of truth: Clerk remains the browser auth source; platform still verifies signed-in app-domain requests before unrouted users are sent to the auth shell.
- Deferred scope: this does not provision the hamed+khorma4 runtime by itself or alter Stripe entitlement semantics.

## Validation
- bun run test tests/platform/proxy-routing.test.ts
- bun run test tests/integrations/platform-db.test.ts
- pnpm --filter '@matrix-os/platform' build
- bun run check:patterns
