### PR TITLE
fix(platform): harden pre-vps billing availability

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -132,16 +132,19 @@ jobs:
             secret_name="${entry#*=}"
             gcloud secrets describe "$secret_name" \
               --project "$GCP_PROJECT_ID" >/dev/null
+            price_secret_tmpfile="$(mktemp)"
             if ! gcloud secrets versions access latest --secret "$secret_name" \
-              --project "$GCP_PROJECT_ID" >/tmp/matrix-price-secret-value; then
+              --project "$GCP_PROJECT_ID" >"$price_secret_tmpfile"; then
+              rm -f "$price_secret_tmpfile"
               echo "$secret_name must have an accessible latest version for $env_name." >&2
               exit 1
             fi
-            if [ ! -s /tmp/matrix-price-secret-value ]; then
+            if [ ! -s "$price_secret_tmpfile" ]; then
+              rm -f "$price_secret_tmpfile"
               echo "$secret_name must not be empty for $env_name." >&2
               exit 1
             fi
-            rm -f /tmp/matrix-price-secret-value
+            rm -f "$price_secret_tmpfile"
             accessor_member="$(
               gcloud secrets get-iam-policy "$secret_name" \
                 --project "$GCP_PROJECT_ID" \
@@ -291,8 +294,8 @@ jobs:
             echo "Candidate pre-VPS auth shell does not expose the billing checkout handoff." >&2
             exit 1
           fi
-          if ! printf '%s\n' "$auth_shell_html" | grep -Fq "billing_unavailable"; then
-            echo "Candidate pre-VPS auth shell does not expose the controlled billing_unavailable failure path." >&2
+          if ! printf '%s\n' "$auth_shell_html" | grep -Fq "Checkout unavailable"; then
+            echo "Candidate pre-VPS auth shell does not expose the controlled checkout failure state." >&2
             exit 1
           fi
           manifest="$(curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/system-bundles/channels/dev.json")"

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -54,6 +54,7 @@ jobs:
       CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}
       POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
       POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || 'https://neo.matrix-os.com' }}
+      DEPLOY_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -111,6 +112,49 @@ jobs:
             echo "edge-router-secret must grant roles/secretmanager.secretAccessor to ${CLOUD_RUN_SERVICE_ACCOUNT}" >&2
             exit 1
           fi
+
+      - name: Verify Stripe billing price secrets
+        run: |
+          set -euo pipefail
+          required_price_secrets=(
+            STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly
+            STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual
+            STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly
+            STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual
+            STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly
+            STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual
+            STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY=stripe-price-extra-runtime-monthly
+            STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL=stripe-price-extra-runtime-annual
+          )
+
+          for entry in "${required_price_secrets[@]}"; do
+            env_name="${entry%%=*}"
+            secret_name="${entry#*=}"
+            gcloud secrets describe "$secret_name" \
+              --project "$GCP_PROJECT_ID" >/dev/null
+            if ! gcloud secrets versions access latest --secret "$secret_name" \
+              --project "$GCP_PROJECT_ID" >/tmp/matrix-price-secret-value; then
+              echo "$secret_name must have an accessible latest version for $env_name." >&2
+              exit 1
+            fi
+            if [ ! -s /tmp/matrix-price-secret-value ]; then
+              echo "$secret_name must not be empty for $env_name." >&2
+              exit 1
+            fi
+            rm -f /tmp/matrix-price-secret-value
+            accessor_member="$(
+              gcloud secrets get-iam-policy "$secret_name" \
+                --project "$GCP_PROJECT_ID" \
+                --flatten='bindings[].members' \
+                --filter="bindings.role:roles/secretmanager.secretAccessor AND bindings.members:serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" \
+                --format='value(bindings.members)' \
+                | head -1
+            )"
+            if [ "$accessor_member" != "serviceAccount:${CLOUD_RUN_SERVICE_ACCOUNT}" ]; then
+              echo "$secret_name must grant roles/secretmanager.secretAccessor to ${CLOUD_RUN_SERVICE_ACCOUNT}" >&2
+              exit 1
+            fi
+          done
 
       - name: Build platform image
         run: |
@@ -185,6 +229,11 @@ jobs:
             traffic_flags+=(--no-traffic)
           fi
 
+          min_instances=0
+          if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then
+            min_instances=1
+          fi
+
           # TODO(#410): flip CUSTOMER_VPS_TLS_VERIFY back to true once customer VPS origins present trusted certs.
           if ! deploy_json=$(gcloud run deploy "$CLOUD_RUN_SERVICE" \
             --project "$GCP_PROJECT_ID" \
@@ -197,13 +246,13 @@ jobs:
             --memory 1Gi \
             --concurrency 30 \
             --timeout 300 \
-            --min-instances 0 \
+            --min-instances "$min_instances" \
             --max-instances 10 \
             --ingress all \
             --allow-unauthenticated \
             "${traffic_flags[@]}" \
             --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PUBLIC_URL=${PLATFORM_PUBLIC_URL},CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_TLS_VERIFY=false,CUSTOMER_VPS_IMAGE_VERSION=${CUSTOMER_VPS_IMAGE_VERSION},CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_APP_DOMAIN_HOSTS=${MATRIX_APP_DOMAIN_HOSTS},MATRIX_CODE_DOMAIN_HOSTS=${MATRIX_CODE_DOMAIN_HOSTS},NEXT_PUBLIC_MATRIX_APP_URL=${MATRIX_APP_URL},MATRIX_BILLING_PROVIDER=stripe,POSTHOG_HOST=https://eu.i.posthog.com,POSTHOG_API_HOST=https://eu.i.posthog.com,NEXT_PUBLIC_POSTHOG_HOST=${POSTHOG_PUBLIC_HOST},NEXT_PUBLIC_POSTHOG_API_HOST=${POSTHOG_PUBLIC_API_HOST},R2_PREFIX_ROOT=matrixos-sync" \
-            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url:latest,PLATFORM_SECRET=platform-secret:latest,PLATFORM_JWT_SECRET=platform-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,STRIPE_SECRET_KEY=stripe-secret-key:latest,STRIPE_WEBHOOK_SECRET=stripe-webhook-secret:latest,STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly:latest,STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual:latest,STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly:latest,STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual:latest,STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly:latest,STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual:latest,STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY=stripe-price-extra-runtime-monthly:latest,STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL=stripe-price-extra-runtime-annual:latest,PIPEDREAM_CLIENT_ID=pipedream-client-id:latest,PIPEDREAM_CLIENT_SECRET=pipedream-client-secret:latest,PIPEDREAM_PROJECT_ID=pipedream-project-id:latest,R2_ACCOUNT_ID=r2-account-id:latest,R2_BUCKET=r2-bucket:latest,R2_ACCESS_KEY_ID=r2-access-key-id:latest,R2_SECRET_ACCESS_KEY=r2-secret-access-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest,HETZNER_API_TOKEN=hetzner-api-token:latest,POSTHOG_TOKEN=posthog-token:latest,POSTHOG_PROJECT_TOKEN=posthog-project-token:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,NEXT_PUBLIC_POSTHOG_KEY=next-public-posthog-key:latest,NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=next-public-posthog-project-token:latest" \
             --format=json); then
             exit 1
           fi
@@ -237,6 +286,15 @@ jobs:
             exit 1
           fi
           curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/health" >/dev/null
+          auth_shell_html="$(curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/sign-in")"
+          if ! printf '%s\n' "$auth_shell_html" | grep -Fq "fetch('/billing/checkout'"; then
+            echo "Candidate pre-VPS auth shell does not expose the billing checkout handoff." >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$auth_shell_html" | grep -Fq "billing_unavailable"; then
+            echo "Candidate pre-VPS auth shell does not expose the controlled billing_unavailable failure path." >&2
+            exit 1
+          fi
           manifest="$(curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/system-bundles/channels/dev.json")"
           bundle_url="$(printf '%s\n' "$manifest" | jq -r '.url // empty')"
           if [ -z "$bundle_url" ]; then
@@ -275,3 +333,22 @@ jobs:
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
             --to-revisions "$CANDIDATE_REVISION=100"
+
+      - name: Verify promoted revision traffic
+        if: ${{ github.event_name == 'push' || inputs.promote }}
+        run: |
+          set -euo pipefail
+          service_json="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format=json)"
+          candidate_percent="$(printf '%s\n' "$service_json" | jq -r '(.status.traffic[]? | select(.revisionName == env.CANDIDATE_REVISION) | .percent) // empty' | head -1)"
+          if [ "$candidate_percent" != "100" ]; then
+            echo "Candidate revision ${CANDIDATE_REVISION} does not have 100% traffic." >&2
+            exit 1
+          fi
+          stale_revision="$(printf '%s\n' "$service_json" | jq -r '(.status.traffic[]? | select(.revisionName != env.CANDIDATE_REVISION and (.percent // 0) > 0) | "\(.revisionName)=\(.percent)") // empty' | head -1)"
+          if [ -n "$stale_revision" ]; then
+            echo "Stale Cloud Run revision is still receiving traffic: $stale_revision" >&2
+            exit 1
+          fi

--- a/docs/platform/dev/deployment.md
+++ b/docs/platform/dev/deployment.md
@@ -75,6 +75,27 @@ PIPEDREAM_WEBHOOK_SECRET=...
 
 Do not copy `PIPEDREAM_*`, Clerk server secrets, platform DB credentials, or `PLATFORM_SECRET` into customer VPS env files. Customer VPS gateways call the platform through `PLATFORM_INTERNAL_URL` with a per-host `UPGRADE_TOKEN`.
 
+Hosted billing must be configured before promoting production Cloud Run
+revisions. Missing Stripe price IDs break the signed-in no-VPS path because the
+pre-VPS billing gate uses `matrix_builder` monthly checkout by default. Store
+the Price IDs in Secret Manager with these names and grant the Cloud Run service
+account `roles/secretmanager.secretAccessor`:
+
+```bash
+STRIPE_PRICE_MATRIX_STARTER_MONTHLY=stripe-price-matrix-starter-monthly
+STRIPE_PRICE_MATRIX_STARTER_ANNUAL=stripe-price-matrix-starter-annual
+STRIPE_PRICE_MATRIX_BUILDER_MONTHLY=stripe-price-matrix-builder-monthly
+STRIPE_PRICE_MATRIX_BUILDER_ANNUAL=stripe-price-matrix-builder-annual
+STRIPE_PRICE_MATRIX_MAX_MONTHLY=stripe-price-matrix-max-monthly
+STRIPE_PRICE_MATRIX_MAX_ANNUAL=stripe-price-matrix-max-annual
+STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY=stripe-price-extra-runtime-monthly
+STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL=stripe-price-extra-runtime-annual
+```
+
+The `Platform Cloud Run` workflow preflights these secrets, mounts them into
+the deployed revision, smokes `/sign-in` for the pre-VPS billing shell, and
+keeps production at `min-instances=1`. Staging may still scale to zero.
+
 ## Updating Platform Auth and Device-Login Pages
 
 `app.matrix-os.com` sign-in, sign-up, billing handoff, provisioning handoff, and

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -175,7 +175,7 @@ export function createBillingRoutes(options: {
       return c.json({ entitlement, access }, 200);
     } catch (err: unknown) {
       console.error('[billing] status lookup failed:', err instanceof Error ? err.message : String(err));
-      return c.json({ error: 'Billing unavailable' }, 503);
+      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
     }
   });
 

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -156,7 +156,7 @@ export function createBillingRoutes(options: {
       return c.json({ url: session.url }, 200);
     } catch (err: unknown) {
       console.error('[billing] portal creation failed:', err instanceof Error ? err.message : String(err));
-      return c.json({ error: 'Billing unavailable' }, 503);
+      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
     }
   });
 

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -31,6 +31,10 @@ const BILLING_BODY_LIMIT = 16 * 1024;
 const STRIPE_WEBHOOK_BODY_LIMIT = 1024 * 1024;
 const MAX_STRIPE_API_TIMEOUT_MS = 10_000;
 const CLERK_USER_ID_PATTERN = /^user_[A-Za-z0-9]{1,128}$/;
+const BILLING_UNAVAILABLE_RESPONSE = {
+  error: 'Billing unavailable',
+  code: 'billing_unavailable',
+} as const;
 
 const CheckoutRequestSchema = z.object({
   planSlug: z.enum(['matrix_starter', 'matrix_builder', 'matrix_max']),
@@ -110,7 +114,7 @@ export function createBillingRoutes(options: {
     if (!parsed.success) return c.json({ error: 'Invalid request' }, 400);
 
     const priceId = resolvePriceId(env, parsed.data.planSlug, parsed.data.interval);
-    if (!priceId) return c.json({ error: 'Billing unavailable' }, 503);
+    if (!priceId) return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
 
     try {
       if (options.stripe.apiTimeoutMs > MAX_STRIPE_API_TIMEOUT_MS) {
@@ -131,7 +135,7 @@ export function createBillingRoutes(options: {
       return c.json({ url: session.url }, 200);
     } catch (err: unknown) {
       console.error('[billing] checkout creation failed:', err instanceof Error ? err.message : String(err));
-      return c.json({ error: 'Billing unavailable' }, 503);
+      return c.json(BILLING_UNAVAILABLE_RESPONSE, 503);
     }
   });
 

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -113,6 +113,7 @@ const ADMIN_BODY_LIMIT = 64 * 1024;
 const PROXY_BODY_LIMIT = 10 * 1024 * 1024;
 const CLERK_SCRIPT_ORIGIN = 'https://clerk.matrix-os.com';
 const PROXY_TIMEOUT_MS = 30_000;
+const AUTH_SHELL_PROXY_TIMEOUT_MS = 20_000;
 const EDGE_SECRET_HEADER = 'x-matrix-edge-secret';
 const VPS_RELEASE_PROBE_TIMEOUT_MS = 10_000;
 const CLERK_USER_LOOKUP_TIMEOUT_MS = 10_000;
@@ -2318,6 +2319,14 @@ function getAuthPage(
         startBillingCheckoutFromClerkSession
       );
     }
+    function showCheckoutUnavailableState() {
+      renderSessionState(
+        'Checkout unavailable',
+        'Billing checkout is temporarily unavailable. Try again shortly.',
+        'Try again',
+        startBillingCheckoutFromClerkSession
+      );
+    }
     function rememberBillingCheckoutAttempt() {
       try {
         window.sessionStorage.setItem(checkoutAttemptStorageKey, String(Date.now()));
@@ -2364,7 +2373,11 @@ function getAuthPage(
             return null;
           }).then(function(body) {
             if (!res.ok || !body || typeof body.url !== 'string') {
-              showBillingRequiredState();
+              if (body && body.code === 'billing_unavailable') {
+                showCheckoutUnavailableState();
+                return;
+              }
+              showCheckoutUnavailableState();
               return;
             }
             rememberBillingCheckoutAttempt();
@@ -2373,7 +2386,7 @@ function getAuthPage(
         })
         .catch(function(err) {
           console.error('[matrix] Billing checkout failed', err instanceof Error ? err.message : String(err));
-          showBillingRequiredState();
+          showCheckoutUnavailableState();
         });
     }
     function pollProvisioningSession() {
@@ -3250,7 +3263,7 @@ export function createApp(deps: {
         method: c.req.method,
         headers,
         redirect: 'manual',
-        signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
+        signal: AbortSignal.timeout(AUTH_SHELL_PROXY_TIMEOUT_MS),
       });
       return new Response(response.body, {
         status: response.status,

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2373,10 +2373,6 @@ function getAuthPage(
             return null;
           }).then(function(body) {
             if (!res.ok || !body || typeof body.url !== 'string') {
-              if (body && body.code === 'billing_unavailable') {
-                showCheckoutUnavailableState();
-                return;
-              }
               showCheckoutUnavailableState();
               return;
             }

--- a/scripts/start-platform-cloud-run.sh
+++ b/scripts/start-platform-cloud-run.sh
@@ -2,36 +2,81 @@
 set -eu
 
 auth_shell_port="${AUTH_SHELL_PORT:-3200}"
+auth_shell_ready_timeout_sec="${AUTH_SHELL_READY_TIMEOUT_SEC:-60}"
 auth_shell_pid=""
-
-if [ "${AUTH_SHELL_ENABLED:-true}" = "true" ]; then
-  HOSTNAME=127.0.0.1 \
-    node node_modules/next/dist/bin/next start shell -p "$auth_shell_port" -H 127.0.0.1 &
-  auth_shell_pid="$!"
-fi
-
-node packages/platform/dist/main.js &
-platform_pid="$!"
+platform_pid=""
 
 shutdown() {
   if [ -n "$auth_shell_pid" ]; then
     kill "$auth_shell_pid" 2>/dev/null || true
   fi
-  kill "$platform_pid" 2>/dev/null || true
-  wait "$platform_pid" 2>/dev/null || true
+  if [ -n "$platform_pid" ]; then
+    kill "$platform_pid" 2>/dev/null || true
+  fi
+  if [ -n "$platform_pid" ]; then
+    wait "$platform_pid" 2>/dev/null || true
+  fi
   if [ -n "$auth_shell_pid" ]; then
     wait "$auth_shell_pid" 2>/dev/null || true
   fi
 }
 
-trap shutdown INT TERM
+trap 'shutdown; exit 143' INT TERM
 
-wait "$platform_pid"
-status="$?"
+wait_for_auth_shell() {
+  deadline="$(( $(date +%s) + auth_shell_ready_timeout_sec ))"
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:$auth_shell_port/sign-in" >/dev/null 2>&1; then
+      echo "Auth shell is ready"
+      return 0
+    fi
+    if ! kill -0 "$auth_shell_pid" 2>/dev/null; then
+      echo "Auth shell exited before readiness" >&2
+      return 1
+    fi
+    sleep 1
+  done
+  echo "Auth shell did not become ready" >&2
+  return 1
+}
 
-if [ -n "$auth_shell_pid" ]; then
-  kill "$auth_shell_pid" 2>/dev/null || true
-  wait "$auth_shell_pid" 2>/dev/null || true
+if [ "${AUTH_SHELL_ENABLED:-true}" = "true" ]; then
+  HOSTNAME=127.0.0.1 \
+    node node_modules/next/dist/bin/next start shell -p "$auth_shell_port" -H 127.0.0.1 &
+  auth_shell_pid="$!"
+
+  if ! wait_for_auth_shell; then
+    shutdown
+    exit 1
+  fi
 fi
 
-exit "$status"
+node packages/platform/dist/main.js &
+platform_pid="$!"
+
+while :; do
+  if ! kill -0 "$platform_pid" 2>/dev/null; then
+    set +e
+    wait "$platform_pid"
+    status="$?"
+    set -e
+    echo "Platform server exited unexpectedly with status $status" >&2
+    shutdown
+    if [ "$status" -eq 0 ]; then
+      exit 1
+    fi
+    exit "$status"
+  fi
+
+  if [ -n "$auth_shell_pid" ] && ! kill -0 "$auth_shell_pid" 2>/dev/null; then
+    set +e
+    wait "$auth_shell_pid"
+    status="$?"
+    set -e
+    echo "Auth shell exited unexpectedly with status $status" >&2
+    shutdown
+    exit 1
+  fi
+
+  sleep 1
+done

--- a/tests/edge-router/edge-router.test.ts
+++ b/tests/edge-router/edge-router.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   buildEdgeResponseInit,
   classifyEdgeRoute,
@@ -23,8 +25,14 @@ describe("edge router worker", () => {
     expect(classifyEdgeRoute("alice.matrix-os.com")).toBe("unknown");
   });
 
-  it("matches the platform proxy timeout budget", () => {
-    expect(UPSTREAM_TIMEOUT_MS).toBe(30_000);
+  it("keeps the edge timeout budget above the platform auth-shell proxy budget", () => {
+    const root = process.cwd();
+    const platformMain = readFileSync(join(root, "packages/platform/src/main.ts"), "utf8");
+    const match = platformMain.match(/AUTH_SHELL_PROXY_TIMEOUT_MS\s*=\s*([\d_]+)/);
+    expect(match?.[1]).toBeDefined();
+    const authShellProxyTimeoutMs = Number(match![1].replace(/_/g, ""));
+
+    expect(UPSTREAM_TIMEOUT_MS).toBeGreaterThan(authShellProxyTimeoutMs);
   });
 
   it("forwards app-domain requests to Cloud Run with external host preserved", async () => {

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -85,6 +85,39 @@ describe('platform billing routes', () => {
     );
   });
 
+  it('creates the default pre-VPS checkout session from the Builder monthly price', async () => {
+    const app = createApp();
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly', regionSlug: 'region_fsn1' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(stripe.createCheckoutSession).toHaveBeenCalledWith(expect.objectContaining({
+      priceId: 'price_builder_monthly',
+      regionSlug: 'region_fsn1',
+    }));
+  });
+
+  it('returns a generic allowlisted code when checkout price config is missing', async () => {
+    const app = createApp('user_123', { STRIPE_WEBHOOK_SECRET: 'whsec_test' } as NodeJS.ProcessEnv);
+
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
+    });
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Billing unavailable',
+      code: 'billing_unavailable',
+    });
+    expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
   it('uses a validated same-origin returnPath for checkout return URLs', async () => {
     const app = createApp();
 
@@ -287,7 +320,10 @@ describe('platform billing routes', () => {
     });
 
     expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ error: 'Billing unavailable' });
+    expect(await res.json()).toEqual({
+      error: 'Billing unavailable',
+      code: 'billing_unavailable',
+    });
     expect(stripe.createCheckoutSession).not.toHaveBeenCalled();
   });
 

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -383,6 +383,19 @@ describe('platform billing routes', () => {
     });
   });
 
+  it('returns the generic unavailable code when billing status lookup fails', async () => {
+    const app = createApp();
+    await destroyTestPlatformDb(db);
+
+    const res = await app.request('/billing/status', { method: 'GET' });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: 'Billing unavailable',
+      code: 'billing_unavailable',
+    });
+  });
+
   it('rejects portal creation when the Stripe client timeout exceeds the API budget', async () => {
     await upsertBillingCustomer(db, {
       clerkUserId: 'user_123',

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -396,7 +396,10 @@ describe('platform billing routes', () => {
     const res = await app.request('/billing/portal', { method: 'POST' });
 
     expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ error: 'Billing unavailable' });
+    expect(await res.json()).toEqual({
+      error: 'Billing unavailable',
+      code: 'billing_unavailable',
+    });
     expect(stripe.createPortalSession).not.toHaveBeenCalled();
   });
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -61,6 +61,7 @@ describe('CI workflows', () => {
 
     expect(workflow).toContain('Verify Stripe billing price secrets');
     expect(workflow).toContain('gcloud secrets describe "$secret_name"');
+    expect(workflow).toContain('price_secret_tmpfile="$(mktemp)"');
     expect(workflow).toContain('gcloud secrets versions access latest --secret "$secret_name"');
     expect(workflow).toContain('roles/secretmanager.secretAccessor');
     expect(workflow).toContain('CLOUD_RUN_SERVICE_ACCOUNT');
@@ -85,7 +86,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('$CANDIDATE_URL/sign-in');
     expect(workflow).toContain('pre-VPS auth shell');
     expect(workflow).toContain("fetch('/billing/checkout'");
-    expect(workflow).toContain('billing_unavailable');
+    expect(workflow).toContain('Checkout unavailable');
   });
 
   it('verifies platform Cloud Run promotion sends all traffic to the candidate revision', () => {

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -3,6 +3,17 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 describe('CI workflows', () => {
+  const stripePriceSecrets = [
+    ['STRIPE_PRICE_MATRIX_STARTER_MONTHLY', 'stripe-price-matrix-starter-monthly'],
+    ['STRIPE_PRICE_MATRIX_STARTER_ANNUAL', 'stripe-price-matrix-starter-annual'],
+    ['STRIPE_PRICE_MATRIX_BUILDER_MONTHLY', 'stripe-price-matrix-builder-monthly'],
+    ['STRIPE_PRICE_MATRIX_BUILDER_ANNUAL', 'stripe-price-matrix-builder-annual'],
+    ['STRIPE_PRICE_MATRIX_MAX_MONTHLY', 'stripe-price-matrix-max-monthly'],
+    ['STRIPE_PRICE_MATRIX_MAX_ANNUAL', 'stripe-price-matrix-max-annual'],
+    ['STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY', 'stripe-price-extra-runtime-monthly'],
+    ['STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL', 'stripe-price-extra-runtime-annual'],
+  ] as const;
+
   it('exposes a stable aggregate CI result job for branch protection', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/ci.yml'), 'utf8');
@@ -32,5 +43,57 @@ describe('CI workflows', () => {
     expect(readme).toContain('host bundle release tests are blocking');
     expect(readme).toContain('React Doctor');
     expect(readme).toContain('Screenshot workflow removed');
+  });
+
+  it('wires every required Stripe price secret into platform Cloud Run', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    for (const [envName, secretName] of stripePriceSecrets) {
+      expect(workflow).toContain(`${envName}=${secretName}:latest`);
+      expect(workflow).toContain(`${envName}=${secretName}`);
+    }
+  });
+
+  it('preflights billing price secrets before deploying platform Cloud Run', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('Verify Stripe billing price secrets');
+    expect(workflow).toContain('gcloud secrets describe "$secret_name"');
+    expect(workflow).toContain('gcloud secrets versions access latest --secret "$secret_name"');
+    expect(workflow).toContain('roles/secretmanager.secretAccessor');
+    expect(workflow).toContain('CLOUD_RUN_SERVICE_ACCOUNT');
+  });
+
+  it('keeps production platform Cloud Run warm while allowing staging to scale to zero', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('DEPLOY_ENVIRONMENT: ${{ github.event_name == \'workflow_dispatch\' && inputs.environment || \'production\' }}');
+    expect(workflow).toContain('min_instances=0');
+    expect(workflow).toContain('if [ "$DEPLOY_ENVIRONMENT" = "production" ]; then');
+    expect(workflow).toContain('min_instances=1');
+    expect(workflow).toContain('--min-instances "$min_instances"');
+  });
+
+  it('smokes the pre-VPS auth and billing shell surface before promotion', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('Smoke candidate revision');
+    expect(workflow).toContain('$CANDIDATE_URL/sign-in');
+    expect(workflow).toContain('pre-VPS auth shell');
+    expect(workflow).toContain("fetch('/billing/checkout'");
+    expect(workflow).toContain('billing_unavailable');
+  });
+
+  it('verifies platform Cloud Run promotion sends all traffic to the candidate revision', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('Verify promoted revision traffic');
+    expect(workflow).toContain('select(.revisionName == env.CANDIDATE_REVISION) | .percent');
+    expect(workflow).toContain('select(.revisionName != env.CANDIDATE_REVISION and (.percent // 0) > 0)');
   });
 });

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2474,7 +2474,6 @@ describe("platform proxy routing", () => {
     expect(html).toContain("fetch('/billing/checkout'");
     expect(html).toContain("planSlug: 'matrix_builder'");
     expect(html).toContain("Checkout unavailable");
-    expect(html).toContain("billing_unavailable");
     expect(html).toContain("showCheckoutUnavailableState();");
     expect(html).toContain("Opening secure checkout");
     expect(html).toContain("retryProvisioningAfterBillingDelay()");

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -406,7 +406,10 @@ describe("platform proxy routing", () => {
     });
 
     expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ error: "Billing unavailable" });
+    expect(await res.json()).toEqual({
+      error: "Billing unavailable",
+      code: "billing_unavailable",
+    });
   });
 
   it("builds customer VPS websocket upgrade headers without leaking browser credentials or query JWTs", async () => {
@@ -2470,6 +2473,9 @@ describe("platform proxy routing", () => {
     expect(html).toContain("Billing required");
     expect(html).toContain("fetch('/billing/checkout'");
     expect(html).toContain("planSlug: 'matrix_builder'");
+    expect(html).toContain("Checkout unavailable");
+    expect(html).toContain("billing_unavailable");
+    expect(html).toContain("showCheckoutUnavailableState();");
     expect(html).toContain("Opening secure checkout");
     expect(html).toContain("retryProvisioningAfterBillingDelay()");
     expect(html).toContain("Confirming billing");

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('start-platform-cloud-run.sh', () => {
+  it('waits for the auth shell before starting the platform server', () => {
+    const root = process.cwd();
+    const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');
+
+    expect(script).toContain('AUTH_SHELL_READY_TIMEOUT_SEC');
+    expect(script).toContain('curl --fail --silent --show-error --max-time 2');
+    expect(script).toContain('http://127.0.0.1:$auth_shell_port/sign-in');
+
+    const authStartIndex = script.indexOf('node node_modules/next/dist/bin/next start shell');
+    const readinessIndex = script.indexOf('if ! wait_for_auth_shell; then');
+    const platformStartIndex = script.indexOf('node packages/platform/dist/main.js');
+    expect(authStartIndex).toBeGreaterThanOrEqual(0);
+    expect(readinessIndex).toBeGreaterThan(authStartIndex);
+    expect(platformStartIndex).toBeGreaterThan(readinessIndex);
+  });
+
+  it('exits nonzero when the auth shell never becomes ready', () => {
+    const root = process.cwd();
+    const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');
+
+    expect(script).toContain('Auth shell did not become ready');
+    expect(script).toContain('exit 1');
+    expect(script).toContain('kill -0 "$auth_shell_pid"');
+  });
+
+  it('stops the sibling process when either child exits unexpectedly', () => {
+    const root = process.cwd();
+    const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');
+
+    expect(script).toContain('Platform server exited unexpectedly');
+    expect(script).toContain('Auth shell exited unexpectedly');
+    expect(script).toContain('shutdown');
+    expect(script).toContain("trap 'shutdown; exit 143' INT TERM");
+  });
+});

--- a/www/content/docs/deployment/billing.mdx
+++ b/www/content/docs/deployment/billing.mdx
@@ -44,6 +44,24 @@ Required platform environment:
 | `STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY` / `STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL` | Optional extra-machine add-on Price IDs. |
 | `PLATFORM_PUBLIC_URL` | Used to build checkout and portal return URLs. |
 
+Production Cloud Run deployments read the Price IDs from Secret Manager. The
+required secret names are:
+
+| Environment variable | Secret Manager name |
+| --- | --- |
+| `STRIPE_PRICE_MATRIX_STARTER_MONTHLY` | `stripe-price-matrix-starter-monthly` |
+| `STRIPE_PRICE_MATRIX_STARTER_ANNUAL` | `stripe-price-matrix-starter-annual` |
+| `STRIPE_PRICE_MATRIX_BUILDER_MONTHLY` | `stripe-price-matrix-builder-monthly` |
+| `STRIPE_PRICE_MATRIX_BUILDER_ANNUAL` | `stripe-price-matrix-builder-annual` |
+| `STRIPE_PRICE_MATRIX_MAX_MONTHLY` | `stripe-price-matrix-max-monthly` |
+| `STRIPE_PRICE_MATRIX_MAX_ANNUAL` | `stripe-price-matrix-max-annual` |
+| `STRIPE_PRICE_EXTRA_RUNTIME_MONTHLY` | `stripe-price-extra-runtime-monthly` |
+| `STRIPE_PRICE_EXTRA_RUNTIME_ANNUAL` | `stripe-price-extra-runtime-annual` |
+
+The signed-in pre-VPS path defaults to Builder monthly checkout. Missing price
+secret access should block deployment rather than letting new users reach a
+broken billing gate.
+
 Webhook events to subscribe:
 
 - `customer.subscription.created`


### PR DESCRIPTION
## Summary

- add fail-closed Cloud Run wiring for all hosted billing Stripe price secrets
- harden the Cloud Run platform launcher so the auth shell must become ready before the platform server starts
- return a generic `billing_unavailable` checkout code and show a visible checkout failure state on the pre-VPS auth page
- stagger auth-shell proxy and edge-router timeout budgets so the platform can return controlled proxy errors first
- expand deployment smoke/static coverage for pre-VPS auth/billing, price secrets, min instances, and traffic promotion
- document the required Secret Manager names for Stripe prices

## Tests

- `pnpm exec vitest run tests/platform/billing-routes.test.ts tests/platform/ci-workflows.test.ts tests/scripts/start-platform-cloud-run.test.ts tests/edge-router/edge-router.test.ts tests/platform/proxy-routing.test.ts`
- `git diff --check`
- `sh -n scripts/start-platform-cloud-run.sh`
- `bun run check:patterns`
- `bun run typecheck`
- `bun run test`

React Doctor was not run because this PR does not change `.tsx` or `.jsx` files.

## Review/Monitoring

- Created from manual worktree `/home/deploy/matrix-os.worktrees/fix-pre-vps-billing-availability`
- Branch: `codex/fix-pre-vps-billing-availability`
- Will monitor CI and Greptile; latest trusted Greptile must be `5/5` before merge.

## Invariants

- Source of truth: Stripe Price IDs remain Secret Manager-backed platform environment values; billing entitlements remain projected from Stripe webhooks into platform Postgres.
- Lock/transaction scope: no new multi-write runtime transaction is introduced; checkout session creation still reads the existing customer link before calling Stripe and webhooks keep the existing billing transaction path.
- Acceptable orphan states: checkout creation can fail without writing local state; Cloud Run deployment now fails before promotion if required price secrets or auth-shell readiness are missing.
- Auth source of truth: Clerk remains the browser identity source; `/billing/checkout` still requires a resolved Clerk user before creating Stripe checkout.
- Deferred scope: this PR does not deploy Cloud Run or create the production Secret Manager values; it only enforces and documents the required wiring.
