### PR TITLE
fix(cli): make shell attach reconnect after drops

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -214,6 +214,7 @@ import {
   createShellWsHandler,
   createZellijAdapter,
   ShellRegistry as ZellijShellRegistry,
+  shellWsMessageDataToString,
 } from "./shell/index.js";
 import {
   CLIENT_ERROR_LOG_BODY_LIMIT,
@@ -2363,7 +2364,10 @@ export async function createGateway(config: GatewayConfig) {
           });
         },
         onMessage(evt, ws) {
-          const raw = typeof evt.data === "string" ? evt.data : "";
+          const raw = shellWsMessageDataToString(evt.data);
+          if (raw === null) {
+            return;
+          }
           if (namedHandle) {
             namedHandle.onMessage(raw);
             return;
@@ -2517,7 +2521,10 @@ export async function createGateway(config: GatewayConfig) {
         },
 
         onMessage(evt, ws) {
-          const raw = typeof evt.data === "string" ? evt.data : "";
+          const raw = shellWsMessageDataToString(evt.data);
+          if (raw === null) {
+            return;
+          }
           if (namedSession) {
             namedHandle?.onMessage(raw);
             return;

--- a/packages/gateway/src/shell/ws.ts
+++ b/packages/gateway/src/shell/ws.ts
@@ -66,6 +66,22 @@ export interface ShellWsSession {
   onClose(): void;
 }
 
+export function shellWsMessageDataToString(data: unknown): string | null {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString("utf8");
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf8");
+  }
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf8");
+  }
+  return null;
+}
+
 class ReplayBufferCache {
   private readonly buffers = new Map<string, ShellReplayBuffer>();
   private readonly maxBuffers: number;

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -506,6 +506,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           heartbeatInterval = undefined;
           heartbeatTimeout = undefined;
           heartbeatPending = false;
+          missedHeartbeats = 0;
         };
         const noteRemoteActivity = () => {
           clearTimeout(heartbeatTimeout);

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -744,6 +744,10 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             const code = typeof msg.code === "string" && SAFE_SHELL_SERVER_ERROR_CODES.has(msg.code)
               ? msg.code
               : "attach_failed";
+            if (everAttached && code === "attach_failed") {
+              currentWs?.close();
+              return;
+            }
             settle(() => reject(Object.assign(new Error("Request failed"), { code })));
           } else if (msg.type === "exit") {
             settle(() => resolve({ detached: false }));

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -65,6 +65,10 @@ export interface ShellAttachOptions {
   errorOutput?: NodeJS.WriteStream;
   detachSequence?: string;
   mouse?: boolean;
+  heartbeatIntervalMs?: number;
+  heartbeatTimeoutMs?: number;
+  reconnectBaseDelayMs?: number;
+  reconnectMaxDelayMs?: number;
   WebSocketImpl?: new (url: string, options?: { headers?: Record<string, string> }) => AttachWebSocket;
 }
 
@@ -72,6 +76,10 @@ export const SHELL_ATTACH_MAX_QUEUED_BYTES = 65_536;
 export { SHELL_ATTACH_LIVE_TAIL_FROM_SEQ };
 const DEFAULT_RUN_TIMEOUT_MS = 10 * 60 * 1000;
 const RUN_RESPONSE_GRACE_MS = 30_000;
+const SHELL_ATTACH_HEARTBEAT_INTERVAL_MS = 20_000;
+const SHELL_ATTACH_HEARTBEAT_TIMEOUT_MS = 60_000;
+const SHELL_ATTACH_RECONNECT_BASE_DELAY_MS = 500;
+const SHELL_ATTACH_RECONNECT_MAX_DELAY_MS = 5_000;
 const LOCAL_TERMINAL_INPUT_RESET = [
   "\u001b[?1000l",
   "\u001b[?1002l",
@@ -418,10 +426,6 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       }
 
       const headers = options.token ? { Authorization: `Bearer ${options.token}` } : undefined;
-      const ws = new WebSocketImpl(createAttachUrl(name, {
-        ...attachOptions,
-        fromSeq: attachOptions.fromSeq ?? SHELL_ATTACH_LIVE_TAIL_FROM_SEQ,
-      }), { headers });
       const output = attachOptions.output ?? process.stdout;
       const errorOutput = attachOptions.errorOutput ?? process.stderr;
       const input = (attachOptions.input ?? process.stdin) as MaybeTtyStream;
@@ -434,31 +438,38 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         dropMouse,
         resetLocalInputModes,
       });
+      const heartbeatIntervalMs = attachOptions.heartbeatIntervalMs ?? SHELL_ATTACH_HEARTBEAT_INTERVAL_MS;
+      const heartbeatTimeoutMs = attachOptions.heartbeatTimeoutMs ?? SHELL_ATTACH_HEARTBEAT_TIMEOUT_MS;
+      const reconnectBaseDelayMs = attachOptions.reconnectBaseDelayMs ?? SHELL_ATTACH_RECONNECT_BASE_DELAY_MS;
+      const reconnectMaxDelayMs = attachOptions.reconnectMaxDelayMs ?? SHELL_ATTACH_RECONNECT_MAX_DELAY_MS;
       let pendingInput = "";
 
       return new Promise<{ detached: boolean }>((resolve, reject) => {
         let settled = false;
+        let currentWs: AttachWebSocket | null = null;
         let socketOpen = false;
-        let remoteAttached = false;
+        let everAttached = false;
         let rawModeEnabled = false;
+        let reconnecting = false;
+        let reconnectAttempt = 0;
+        let lastSeq: number | undefined;
         const queuedFrames: string[] = [];
         let queuedFrameBytes = 0;
-        const timeout = setTimeout(() => {
-          settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_timeout" })));
-          ws.close();
-        }, timeoutMs);
-        timeout.unref?.();
+        let attachTimeout: ReturnType<typeof setTimeout> | undefined;
+        let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+        let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+        let heartbeatTimeout: ReturnType<typeof setTimeout> | undefined;
+        let heartbeatPending = false;
         const cleanup = () => {
-          clearTimeout(timeout);
+          clearTimeout(attachTimeout);
+          clearTimeout(reconnectTimer);
+          stopHeartbeat();
+          cleanupSocket();
           input.off?.("data", onInput);
           process.off("SIGWINCH", onResize);
           process.off("SIGINT", onSignal);
           process.off("SIGTERM", onSignal);
           process.off("exit", onProcessExit);
-          ws.off?.("open", onOpen);
-          ws.off?.("message", onMessage);
-          ws.off?.("close", onClose);
-          ws.off?.("error", onError);
           pendingInput = "";
           inputFilter.reset();
           resetLocalInputModes();
@@ -476,12 +487,111 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           cleanup();
           fn();
         };
+        const currentFromSeq = () => {
+          if (lastSeq !== undefined && lastSeq < Number.MAX_SAFE_INTEGER) {
+            return lastSeq + 1;
+          }
+          return attachOptions.fromSeq ?? SHELL_ATTACH_LIVE_TAIL_FROM_SEQ;
+        };
+        const stopHeartbeat = () => {
+          clearInterval(heartbeatInterval);
+          clearTimeout(heartbeatTimeout);
+          heartbeatInterval = undefined;
+          heartbeatTimeout = undefined;
+          heartbeatPending = false;
+        };
+        const noteRemoteActivity = () => {
+          clearTimeout(heartbeatTimeout);
+          heartbeatTimeout = undefined;
+          heartbeatPending = false;
+        };
+        const startHeartbeat = () => {
+          if (heartbeatInterval || heartbeatIntervalMs < 1 || heartbeatTimeoutMs < 1) {
+            return;
+          }
+          heartbeatInterval = setInterval(() => {
+            if (settled || !currentWs || !socketOpen || heartbeatPending) {
+              return;
+            }
+            try {
+              currentWs.send(JSON.stringify({ type: "ping" }));
+              heartbeatPending = true;
+              heartbeatTimeout = setTimeout(() => {
+                if (!settled && heartbeatPending) {
+                  currentWs?.close();
+                }
+              }, heartbeatTimeoutMs);
+              heartbeatTimeout.unref?.();
+            } catch (err: unknown) {
+              if (!everAttached) {
+                settle(() => reject(Object.assign(new Error("Request failed"), {
+                  code: err instanceof Error ? "attach_failed" : "request_failed",
+                })));
+                return;
+              }
+              currentWs?.close();
+            }
+          }, heartbeatIntervalMs);
+          heartbeatInterval.unref?.();
+        };
+        const cleanupSocket = () => {
+          if (!currentWs) {
+            return;
+          }
+          clearTimeout(attachTimeout);
+          stopHeartbeat();
+          currentWs.off?.("open", onOpen);
+          currentWs.off?.("message", onMessage);
+          currentWs.off?.("close", onClose);
+          currentWs.off?.("error", onError);
+          currentWs = null;
+          socketOpen = false;
+        };
+        const connect = () => {
+          if (settled) {
+            return;
+          }
+          cleanupSocket();
+          currentWs = new WebSocketImpl(createAttachUrl(name, {
+            ...attachOptions,
+            fromSeq: currentFromSeq(),
+          }), { headers });
+          attachTimeout = setTimeout(() => {
+            currentWs?.close();
+            settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_timeout" })));
+          }, timeoutMs);
+          attachTimeout.unref?.();
+          currentWs.on("open", onOpen);
+          currentWs.on("message", onMessage);
+          currentWs.on("close", onClose);
+          currentWs.on("error", onError);
+        };
+        const scheduleReconnect = () => {
+          if (settled) {
+            return;
+          }
+          if (reconnectTimer) {
+            return;
+          }
+          if (!reconnecting) {
+            errorOutput.write("\r\nConnection lost. Reconnecting...\r\n");
+          }
+          reconnecting = true;
+          const delay = Math.min(reconnectBaseDelayMs * (2 ** reconnectAttempt), reconnectMaxDelayMs);
+          reconnectAttempt += 1;
+          reconnectTimer = setTimeout(() => {
+            reconnectTimer = undefined;
+            connect();
+          }, delay);
+          reconnectTimer.unref?.();
+        };
         const markOpen = () => {
           if (socketOpen) {
             return;
           }
           socketOpen = true;
-          clearTimeout(timeout);
+          clearTimeout(attachTimeout);
+          startHeartbeat();
           sendResizeFrame();
           for (const frame of queuedFrames.splice(0)) {
             sendFrame(frame);
@@ -496,10 +606,10 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             const nextQueuedBytes = queuedFrameBytes + Buffer.byteLength(frame, "utf8");
             if (nextQueuedBytes > SHELL_ATTACH_MAX_QUEUED_BYTES) {
               errorOutput.write("Shell attach failed\n");
+              currentWs?.close();
               settle(() => reject(Object.assign(new Error("Request failed"), {
                 code: "attach_failed",
               })));
-              ws.close();
               return;
             }
             queuedFrameBytes = nextQueuedBytes;
@@ -507,8 +617,12 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             return;
           }
           try {
-            ws.send(frame);
+            currentWs?.send(frame);
           } catch (err: unknown) {
+            if (everAttached) {
+              currentWs?.close();
+              return;
+            }
             errorOutput.write("Shell attach failed\n");
             settle(() => reject(Object.assign(new Error("Request failed"), {
               code: err instanceof Error ? "attach_failed" : "request_failed",
@@ -516,13 +630,14 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           }
         };
         const detachLocal = () => {
+          const wsToClose = currentWs;
           sendFrame(JSON.stringify({ type: "detach" }));
-          ws.close();
           settle(() => resolve({ detached: true }));
+          wsToClose?.close();
         };
         const onInput = (chunk: Buffer | string) => {
           const rawData = Buffer.isBuffer(chunk) ? chunk.toString("utf-8") : String(chunk);
-          if (rawModeEnabled && !remoteAttached && rawData.includes("\u0003")) {
+          if (rawModeEnabled && !everAttached && rawData.includes("\u0003")) {
             detachLocal();
             return;
           }
@@ -565,7 +680,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           sendResizeFrame();
         };
         const onSignal = (signal?: NodeJS.Signals) => {
-          if (signal === "SIGTERM" || !remoteAttached) {
+          if (signal === "SIGTERM" || !everAttached) {
             detachLocal();
             return;
           }
@@ -599,12 +714,23 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           }
           const msg = parsed as Record<string, unknown>;
           if (msg.type === "attached") {
-            remoteAttached = true;
+            everAttached = true;
+            reconnectAttempt = 0;
             markOpen();
+            if (reconnecting) {
+              reconnecting = false;
+              errorOutput.write("\r\nConnection restored.\r\n");
+            }
             schedulePostAttachResizeFrames();
           } else if (msg.type === "output" && typeof msg.data === "string") {
+            if (Number.isSafeInteger(msg.seq) && (msg.seq as number) >= 0) {
+              lastSeq = msg.seq as number;
+            }
+            noteRemoteActivity();
             inputFilter.noteRemoteOutput();
             output.write(msg.data);
+          } else if (msg.type === "pong") {
+            noteRemoteActivity();
           } else if (msg.type === "error") {
             const code = typeof msg.code === "string" && SAFE_SHELL_SERVER_ERROR_CODES.has(msg.code)
               ? msg.code
@@ -615,23 +741,25 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           }
         };
         const onClose = () => {
-          if (!remoteAttached) {
+          const shouldReconnect = everAttached;
+          cleanupSocket();
+          if (!shouldReconnect) {
             settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_failed" })));
             return;
           }
-          settle(() => resolve({ detached: true }));
+          scheduleReconnect();
         };
         const onError = (err: unknown) => {
+          if (everAttached) {
+            currentWs?.close();
+            return;
+          }
           errorOutput.write("Shell attach failed\n");
           settle(() => reject(Object.assign(new Error("Request failed"), {
             code: err instanceof Error ? "attach_failed" : "request_failed",
           })));
         };
 
-        ws.on("open", onOpen);
-        ws.on("message", onMessage);
-        ws.on("close", onClose);
-        ws.on("error", onError);
         if (input.isTTY && typeof input.setRawMode === "function") {
           resetLocalInputModes();
           input.setRawMode(true);
@@ -643,6 +771,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         process.once("SIGTERM", onSignal);
         process.once("exit", onProcessExit);
         input.on?.("data", onInput);
+        connect();
       });
     },
   };

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -488,8 +488,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           fn();
         };
         const currentFromSeq = () => {
-          if (lastSeq !== undefined && lastSeq < Number.MAX_SAFE_INTEGER) {
-            return lastSeq + 1;
+          if (lastSeq !== undefined) {
+            return Math.min(lastSeq + 1, Number.MAX_SAFE_INTEGER);
           }
           return attachOptions.fromSeq ?? SHELL_ATTACH_LIVE_TAIL_FROM_SEQ;
         };
@@ -557,7 +557,15 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             fromSeq: currentFromSeq(),
           }), { headers });
           attachTimeout = setTimeout(() => {
-            currentWs?.close();
+            const timedOutWs = currentWs;
+            timedOutWs?.close();
+            if (everAttached) {
+              if (currentWs === timedOutWs) {
+                cleanupSocket();
+              }
+              scheduleReconnect();
+              return;
+            }
             settle(() => reject(Object.assign(new Error("Request failed"), { code: "attach_timeout" })));
           }, timeoutMs);
           attachTimeout.unref?.();
@@ -577,7 +585,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             errorOutput.write("\r\nConnection lost. Reconnecting...\r\n");
           }
           reconnecting = true;
-          const delay = Math.min(reconnectBaseDelayMs * (2 ** reconnectAttempt), reconnectMaxDelayMs);
+          const backoffExponent = Math.min(reconnectAttempt, 31);
+          const delay = Math.min(reconnectBaseDelayMs * (2 ** backoffExponent), reconnectMaxDelayMs);
           reconnectAttempt += 1;
           reconnectTimer = setTimeout(() => {
             reconnectTimer = undefined;

--- a/packages/sync-client/src/cli/shell-client.ts
+++ b/packages/sync-client/src/cli/shell-client.ts
@@ -67,6 +67,7 @@ export interface ShellAttachOptions {
   mouse?: boolean;
   heartbeatIntervalMs?: number;
   heartbeatTimeoutMs?: number;
+  heartbeatMissesBeforeReconnect?: number;
   reconnectBaseDelayMs?: number;
   reconnectMaxDelayMs?: number;
   WebSocketImpl?: new (url: string, options?: { headers?: Record<string, string> }) => AttachWebSocket;
@@ -80,6 +81,9 @@ const SHELL_ATTACH_HEARTBEAT_INTERVAL_MS = 20_000;
 const SHELL_ATTACH_HEARTBEAT_TIMEOUT_MS = 60_000;
 const SHELL_ATTACH_RECONNECT_BASE_DELAY_MS = 500;
 const SHELL_ATTACH_RECONNECT_MAX_DELAY_MS = 5_000;
+const SHELL_ATTACH_HEARTBEAT_MISSES_BEFORE_RECONNECT = 2;
+const SHELL_ATTACH_RECONNECT_NOTICE = "\r\n\u001b[7m Matrix shell disconnected. Waiting for the gateway to come back; this session will reconnect automatically. \u001b[0m\r\n";
+const SHELL_ATTACH_RESTORED_NOTICE = "\r\n\u001b[7m Matrix shell connection restored. \u001b[0m\r\n";
 const LOCAL_TERMINAL_INPUT_RESET = [
   "\u001b[?1000l",
   "\u001b[?1002l",
@@ -440,6 +444,8 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
       });
       const heartbeatIntervalMs = attachOptions.heartbeatIntervalMs ?? SHELL_ATTACH_HEARTBEAT_INTERVAL_MS;
       const heartbeatTimeoutMs = attachOptions.heartbeatTimeoutMs ?? SHELL_ATTACH_HEARTBEAT_TIMEOUT_MS;
+      const heartbeatMissesBeforeReconnect =
+        attachOptions.heartbeatMissesBeforeReconnect ?? SHELL_ATTACH_HEARTBEAT_MISSES_BEFORE_RECONNECT;
       const reconnectBaseDelayMs = attachOptions.reconnectBaseDelayMs ?? SHELL_ATTACH_RECONNECT_BASE_DELAY_MS;
       const reconnectMaxDelayMs = attachOptions.reconnectMaxDelayMs ?? SHELL_ATTACH_RECONNECT_MAX_DELAY_MS;
       let pendingInput = "";
@@ -460,6 +466,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
         let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
         let heartbeatTimeout: ReturnType<typeof setTimeout> | undefined;
         let heartbeatPending = false;
+        let missedHeartbeats = 0;
         const cleanup = () => {
           clearTimeout(attachTimeout);
           clearTimeout(reconnectTimer);
@@ -504,6 +511,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           clearTimeout(heartbeatTimeout);
           heartbeatTimeout = undefined;
           heartbeatPending = false;
+          missedHeartbeats = 0;
         };
         const startHeartbeat = () => {
           if (heartbeatInterval || heartbeatIntervalMs < 1 || heartbeatTimeoutMs < 1) {
@@ -518,7 +526,12 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
               heartbeatPending = true;
               heartbeatTimeout = setTimeout(() => {
                 if (!settled && heartbeatPending) {
-                  currentWs?.close();
+                  missedHeartbeats += 1;
+                  heartbeatPending = false;
+                  heartbeatTimeout = undefined;
+                  if (missedHeartbeats >= heartbeatMissesBeforeReconnect) {
+                    currentWs?.close();
+                  }
                 }
               }, heartbeatTimeoutMs);
               heartbeatTimeout.unref?.();
@@ -583,6 +596,7 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           }
           if (!reconnecting) {
             errorOutput.write("\r\nConnection lost. Reconnecting...\r\n");
+            output.write(SHELL_ATTACH_RECONNECT_NOTICE);
           }
           reconnecting = true;
           const backoffExponent = Math.min(reconnectAttempt, 31);
@@ -600,7 +614,6 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
           }
           socketOpen = true;
           clearTimeout(attachTimeout);
-          startHeartbeat();
           sendResizeFrame();
           for (const frame of queuedFrames.splice(0)) {
             sendFrame(frame);
@@ -726,9 +739,11 @@ export function createShellClient(options: ShellClientOptions): ShellClient {
             everAttached = true;
             reconnectAttempt = 0;
             markOpen();
+            startHeartbeat();
             if (reconnecting) {
               reconnecting = false;
               errorOutput.write("\r\nConnection restored.\r\n");
+              output.write(SHELL_ATTACH_RESTORED_NOTICE);
             }
             schedulePostAttachResizeFrames();
           } else if (msg.type === "output" && typeof msg.data === "string") {

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -332,7 +332,37 @@ describe("shell REST client", () => {
     await expect(attached).resolves.toEqual({ detached: false });
   });
 
-  it("closes and reconnects when heartbeat pong or output is missing", async () => {
+  it("keeps the socket open across repeated heartbeat pongs", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      heartbeatIntervalMs: 20,
+      heartbeatTimeoutMs: 60,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+
+    for (let i = 0; i < 3; i += 1) {
+      await vi.advanceTimersByTimeAsync(20);
+      ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "pong" }));
+    }
+    await vi.advanceTimersByTimeAsync(59);
+
+    expect(ControlledWebSocket.instances).toHaveLength(1);
+    expect(ControlledWebSocket.last?.closed).toBe(false);
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
+  it("closes and reconnects after consecutive missed heartbeat pongs or output", async () => {
     vi.useFakeTimers();
     const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
     const input = new EventEmitter() as NodeJS.ReadStream;
@@ -354,14 +384,18 @@ describe("shell REST client", () => {
     const first = ControlledWebSocket.last!;
 
     await vi.advanceTimersByTimeAsync(80);
+    expect(first.closed).toBe(false);
+    await vi.advanceTimersByTimeAsync(80);
     expect(first.closed).toBe(true);
     await vi.advanceTimersByTimeAsync(5);
 
     expect(ControlledWebSocket.instances).toHaveLength(2);
     expect(errorOutput.write).toHaveBeenCalledWith("\r\nConnection lost. Reconnecting...\r\n");
+    expect(output.write).toHaveBeenCalledWith(expect.stringContaining("Matrix shell disconnected"));
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     expect(errorOutput.write).toHaveBeenCalledWith("\r\nConnection restored.\r\n");
+    expect(output.write).toHaveBeenCalledWith(expect.stringContaining("connection restored"));
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
     await expect(attached).resolves.toEqual({ detached: false });
   });

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -12,6 +12,7 @@ class ControlledWebSocket {
   static last: ControlledWebSocket | null = null;
   static lastUrl: string | null = null;
   static lastOptions: unknown = null;
+  static instances: ControlledWebSocket[] = [];
   closed = false;
   listeners = new Map<string, (...args: unknown[]) => void>();
   sent: string[] = [];
@@ -20,6 +21,7 @@ class ControlledWebSocket {
     ControlledWebSocket.last = this;
     ControlledWebSocket.lastUrl = url;
     ControlledWebSocket.lastOptions = options;
+    ControlledWebSocket.instances.push(this);
   }
 
   send(data: string) {
@@ -65,6 +67,17 @@ class FakeTtyInput extends EventEmitter {
 }
 
 describe("shell REST client", () => {
+  beforeEach(() => {
+    ControlledWebSocket.last = null;
+    ControlledWebSocket.lastUrl = null;
+    ControlledWebSocket.lastOptions = null;
+    ControlledWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("lists sessions with bearer auth, JSON parsing, and fetch timeout", async () => {
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ sessions: [] })));
     const client = createShellClient({
@@ -241,9 +254,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("open");
     await new Promise((resolve) => setTimeout(resolve, 10));
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(ControlledWebSocket.lastUrl).toBe(
       `ws://gateway/ws/terminal/session?session=main&fromSeq=${SHELL_ATTACH_LIVE_TAIL_FROM_SEQ}`,
     );
@@ -267,9 +280,9 @@ describe("shell REST client", () => {
     });
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(ControlledWebSocket.lastUrl).toBe("ws://gateway/ws/terminal/session?session=main&fromSeq=0");
   });
 
@@ -289,6 +302,152 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("close");
 
     await expect(attached).rejects.toMatchObject({ code: "attach_failed" });
+  });
+
+  it("sends heartbeat pings and accepts pong frames while attached", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      heartbeatIntervalMs: 20,
+      heartbeatTimeoutMs: 60,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toContainEqual({ type: "ping" });
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "pong" }));
+    await vi.advanceTimersByTimeAsync(19);
+    expect(ControlledWebSocket.instances).toHaveLength(1);
+
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
+  it("closes and reconnects when heartbeat pong or output is missing", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      heartbeatIntervalMs: 20,
+      heartbeatTimeoutMs: 60,
+      reconnectBaseDelayMs: 5,
+      reconnectMaxDelayMs: 5,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    const first = ControlledWebSocket.last!;
+
+    await vi.advanceTimersByTimeAsync(80);
+    expect(first.closed).toBe(true);
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(ControlledWebSocket.instances).toHaveLength(2);
+    expect(errorOutput.write).toHaveBeenCalledWith("\r\nConnection lost. Reconnecting...\r\n");
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    expect(errorOutput.write).toHaveBeenCalledWith("\r\nConnection restored.\r\n");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
+  it("reconnects instead of resolving detached after an unexpected close once attached", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      reconnectBaseDelayMs: 5,
+      reconnectMaxDelayMs: 5,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("close");
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(ControlledWebSocket.instances).toHaveLength(2);
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
+  it("reconnects with fromSeq set after the last output sequence", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      reconnectBaseDelayMs: 5,
+      reconnectMaxDelayMs: 5,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready", seq: 41 }));
+    ControlledWebSocket.last?.emit("close");
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(ControlledWebSocket.lastUrl).toBe("ws://gateway/ws/terminal/session?session=main&fromSeq=42");
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
+  it("resends terminal resize after reconnect", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new FakeTtyInput() as unknown as NodeJS.ReadStream;
+    const output = { write: vi.fn(), columns: 120, rows: 40 } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("setup", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      reconnectBaseDelayMs: 5,
+      reconnectMaxDelayMs: 5,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    const first = ControlledWebSocket.last!;
+    ControlledWebSocket.last?.emit("close");
+    await vi.advanceTimersByTimeAsync(5);
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+
+    expect(first.sent.map((frame) => JSON.parse(frame))).toContainEqual({ type: "resize", cols: 120, rows: 40 });
+    expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toContainEqual({ type: "resize", cols: 120, rows: 40 });
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
   });
 
   it("allowlists terminal websocket error frame codes", async () => {
@@ -348,8 +507,8 @@ describe("shell REST client", () => {
       JSON.stringify({ type: "input", data: "pwd\r" }),
     ]);
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
-    ControlledWebSocket.last?.emit("close");
-    await expect(attached).resolves.toEqual({ detached: true });
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
   });
 
   it("rejects when pre-open stdin exceeds the queued frame cap", async () => {
@@ -389,9 +548,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     process.emit("SIGWINCH", "SIGWINCH");
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect((input as unknown as FakeTtyInput).rawModes).toEqual([true, false]);
     expect((input as unknown as FakeTtyInput).resumed).toBe(true);
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
@@ -422,6 +581,7 @@ describe("shell REST client", () => {
 
     await expect(attached).resolves.toEqual({ detached: true });
     expect(ControlledWebSocket.last?.closed).toBe(true);
+    expect(errorOutput.write).not.toHaveBeenCalledWith("\r\nConnection lost. Reconnecting...\r\n");
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
       { type: "input", data: "a" },
@@ -466,9 +626,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "a\u001b[<0;10;20M\u001b[Mabc\u001b[I\u001b[O");
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
       { type: "input", data: "a" },
@@ -490,9 +650,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "\u001b[Ia\u001b[O\u001b[<0;10;20M");
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
       { type: "input", data: "a" },
@@ -517,9 +677,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready" }));
     nowSpy.mockReturnValue(6_000);
     input.emit("data", "\u001b[I\u001b[<0;10;20M\u001b[Mabcx");
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(output.write).toHaveBeenCalledWith(LOCAL_TERMINAL_INPUT_RESET);
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
@@ -546,9 +706,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "output", data: "ready" }));
     nowSpy.mockReturnValue(6_000);
     input.emit("data", "\u001b[I\u001b[99;5u\u001b[100;5uok");
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(output.write).toHaveBeenCalledWith(LOCAL_TERMINAL_INPUT_RESET);
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
@@ -572,9 +732,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "\u001b[99;5u");
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
       { type: "input", data: "\u001b[99;5u" },
@@ -597,9 +757,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "a\u001b[99");
     input.emit("data", ";5ub");
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
       { type: "input", data: "a" },
@@ -624,9 +784,9 @@ describe("shell REST client", () => {
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     input.emit("data", "a\u001b[<0;10;");
     input.emit("data", "20Mbc");
-    ControlledWebSocket.last?.emit("close");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
 
-    await expect(attached).resolves.toEqual({ detached: true });
+    await expect(attached).resolves.toEqual({ detached: false });
     expect(ControlledWebSocket.last?.sent.map((frame) => JSON.parse(frame))).toEqual([
       { type: "resize", cols: 80, rows: 24 },
       { type: "input", data: "a" },

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -426,6 +426,39 @@ describe("shell REST client", () => {
     await expect(attached).resolves.toEqual({ detached: false });
   });
 
+  it("retries transient attach failures after a prior attach", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      reconnectBaseDelayMs: 5,
+      reconnectMaxDelayMs: 5,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("close");
+    await vi.advanceTimersByTimeAsync(5);
+
+    const transientFailure = ControlledWebSocket.last!;
+    transientFailure.emit("open");
+    transientFailure.emit("message", JSON.stringify({ type: "error", code: "attach_failed" }));
+    expect(transientFailure.closed).toBe(true);
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(ControlledWebSocket.instances).toHaveLength(3);
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
   it("reconnects with fromSeq set after the last output sequence", async () => {
     vi.useFakeTimers();
     const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -393,6 +393,39 @@ describe("shell REST client", () => {
     await expect(attached).resolves.toEqual({ detached: false });
   });
 
+  it("keeps retrying when a reconnect attempt times out", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      fromSeq: 0,
+      reconnectBaseDelayMs: 5,
+      reconnectMaxDelayMs: 5,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("close");
+    await vi.advanceTimersByTimeAsync(5);
+    const timedOutReconnect = ControlledWebSocket.last!;
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(timedOutReconnect.closed).toBe(true);
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(ControlledWebSocket.instances).toHaveLength(3);
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
   it("reconnects with fromSeq set after the last output sequence", async () => {
     vi.useFakeTimers();
     const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
@@ -415,6 +448,40 @@ describe("shell REST client", () => {
     await vi.advanceTimersByTimeAsync(5);
 
     expect(ControlledWebSocket.lastUrl).toBe("ws://gateway/ws/terminal/session?session=main&fromSeq=42");
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
+    await expect(attached).resolves.toEqual({ detached: false });
+  });
+
+  it("clamps reconnect replay cursors at the maximum safe sequence", async () => {
+    vi.useFakeTimers();
+    const client = createShellClient({ gatewayUrl: "http://gateway", timeoutMs: 50 });
+    const input = new EventEmitter() as NodeJS.ReadStream;
+    const output = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const errorOutput = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const attached = client.attachSession("main", {
+      WebSocketImpl: ControlledWebSocket,
+      input,
+      output,
+      errorOutput,
+      reconnectBaseDelayMs: 5,
+      reconnectMaxDelayMs: 5,
+    });
+    ControlledWebSocket.last?.emit("open");
+    ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    ControlledWebSocket.last?.emit("message", JSON.stringify({
+      type: "output",
+      data: "ready",
+      seq: Number.MAX_SAFE_INTEGER,
+    }));
+    ControlledWebSocket.last?.emit("close");
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(ControlledWebSocket.lastUrl).toBe(
+      `ws://gateway/ws/terminal/session?session=main&fromSeq=${Number.MAX_SAFE_INTEGER}`,
+    );
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));

--- a/tests/cli/shell-client.test.ts
+++ b/tests/cli/shell-client.test.ts
@@ -394,8 +394,11 @@ describe("shell REST client", () => {
     expect(output.write).toHaveBeenCalledWith(expect.stringContaining("Matrix shell disconnected"));
     ControlledWebSocket.last?.emit("open");
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "attached" }));
+    const second = ControlledWebSocket.last!;
     expect(errorOutput.write).toHaveBeenCalledWith("\r\nConnection restored.\r\n");
     expect(output.write).toHaveBeenCalledWith(expect.stringContaining("connection restored"));
+    await vi.advanceTimersByTimeAsync(80);
+    expect(second.closed).toBe(false);
     ControlledWebSocket.last?.emit("message", JSON.stringify({ type: "exit", code: 0 }));
     await expect(attached).resolves.toEqual({ detached: false });
   });

--- a/tests/cli/shell.test.ts
+++ b/tests/cli/shell.test.ts
@@ -28,7 +28,10 @@ async function createFakeAttachGateway() {
   wss.on("connection", (ws) => {
     wsConnections += 1;
     ws.send(JSON.stringify({ type: "attached" }));
-    setTimeout(() => ws.close(), 10).unref?.();
+    setTimeout(() => {
+      ws.send(JSON.stringify({ type: "exit", code: 0 }));
+      ws.close();
+    }, 10).unref?.();
   });
 
   await new Promise<void>((resolve) => {
@@ -356,7 +359,7 @@ describe("shell CLI command", () => {
       expect(JSON.parse(result.stdout)).toEqual({
         v: 1,
         ok: true,
-        data: { detached: true },
+        data: { detached: false },
       });
       expect(result.stderr).toContain("\u001b[?1000l");
       expect(gateway.wsConnections).toBe(1);
@@ -457,9 +460,7 @@ describe("shell CLI command", () => {
         if (event === "message") {
           queueMicrotask(() => listener(JSON.stringify({ type: "attached" })));
           queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "REMOTE_BYTES" })));
-        }
-        if (event === "close") {
-          queueMicrotask(() => listener());
+          queueMicrotask(() => listener(JSON.stringify({ type: "exit", code: 0 })));
         }
         return this;
       }
@@ -488,7 +489,7 @@ describe("shell CLI command", () => {
 
     expect(OutputWebSocket.instances).toBe(1);
     expect(logs.map((line) => JSON.parse(line))).toEqual([
-      { v: 1, ok: true, data: { created: { name: "main", created: true }, detached: true } },
+      { v: 1, ok: true, data: { created: { name: "main", created: true }, detached: false } },
     ]);
     expect(stdoutWrites.join("")).not.toContain("REMOTE_BYTES");
     expect(stderrWrites.join("")).toContain("REMOTE_BYTES");
@@ -509,9 +510,7 @@ describe("shell CLI command", () => {
         if (event === "message") {
           queueMicrotask(() => listener(JSON.stringify({ type: "attached" })));
           queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "CONNECT_BYTES" })));
-        }
-        if (event === "close") {
-          queueMicrotask(() => listener());
+          queueMicrotask(() => listener(JSON.stringify({ type: "exit", code: 0 })));
         }
         return this;
       }
@@ -540,7 +539,7 @@ describe("shell CLI command", () => {
 
     expect(OutputWebSocket.instances).toBe(1);
     expect(logs.map((line) => JSON.parse(line))).toEqual([
-      { v: 1, ok: true, data: { detached: true } },
+      { v: 1, ok: true, data: { detached: false } },
     ]);
     expect(stdoutWrites.join("")).not.toContain("CONNECT_BYTES");
     expect(stderrWrites.join("")).toContain("CONNECT_BYTES");
@@ -573,9 +572,7 @@ describe("shell CLI command", () => {
         if (event === "message" && this.instance === 2) {
           queueMicrotask(() => listener(JSON.stringify({ type: "attached" })));
           queueMicrotask(() => listener(JSON.stringify({ type: "output", data: "CREATED_CONNECT_BYTES" })));
-        }
-        if (event === "close" && this.instance === 2) {
-          queueMicrotask(() => listener());
+          queueMicrotask(() => listener(JSON.stringify({ type: "exit", code: 0 })));
         }
         return this;
       }
@@ -608,7 +605,7 @@ describe("shell CLI command", () => {
       expect.objectContaining({ method: "POST" }),
     );
     expect(logs.map((line) => JSON.parse(line))).toEqual([
-      { v: 1, ok: true, data: { created: { name: "main", created: true }, detached: true } },
+      { v: 1, ok: true, data: { created: { name: "main", created: true }, detached: false } },
     ]);
     expect(stdoutWrites.join("")).not.toContain("CREATED_CONNECT_BYTES");
     expect(stderrWrites.join("")).toContain("CREATED_CONNECT_BYTES");

--- a/tests/gateway/terminal-zellij-ws.test.ts
+++ b/tests/gateway/terminal-zellij-ws.test.ts
@@ -4,6 +4,7 @@ import {
   createShellWsHandler,
   SHELL_ATTACH_LIVE_TAIL_FROM_SEQ,
   SHELL_ATTACH_RECENT_REPLAY_EVENTS,
+  shellWsMessageDataToString,
   type ShellWsSocket,
 } from "../../packages/gateway/src/shell/ws.js";
 
@@ -131,6 +132,39 @@ describe("zellij terminal WebSocket", () => {
 
     expect(ws.sent).toContainEqual({ type: "pong" });
     expect(pty.writes).toEqual([]);
+  });
+
+  it("normalizes binary websocket frames before protocol parsing", async () => {
+    const pty = new FakePty();
+    const ws = socket();
+    const handler = createShellWsHandler({
+      registry: {
+        list: vi.fn(async () => [{ name: "main", status: "active" }]),
+      },
+      adapter: {
+        attachSession: vi.fn(() => pty),
+      },
+    });
+
+    const session = await handler.open({ ws, session: "main", fromSeq: 0 });
+    const rawPing = shellWsMessageDataToString(Buffer.from(JSON.stringify({ type: "ping" })));
+    expect(rawPing).toBe(JSON.stringify({ type: "ping" }));
+    session.onMessage(rawPing!);
+
+    expect(ws.sent).toContainEqual({ type: "pong" });
+    expect(pty.writes).toEqual([]);
+  });
+
+  it("normalizes websocket BufferSource frame variants", () => {
+    const json = JSON.stringify({ type: "ping" });
+    const arrayBuffer = new TextEncoder().encode(json).buffer;
+    const uint8 = new Uint8Array(arrayBuffer);
+
+    expect(shellWsMessageDataToString(json)).toBe(json);
+    expect(shellWsMessageDataToString(Buffer.from(json))).toBe(json);
+    expect(shellWsMessageDataToString(arrayBuffer)).toBe(json);
+    expect(shellWsMessageDataToString(uint8)).toBe(json);
+    expect(shellWsMessageDataToString({})).toBeNull();
   });
 
   it("maps live-tail attach to a bounded recent replay window", async () => {


### PR DESCRIPTION
## Summary

- Make `matrix shell connect` / `mos shell attach` keep attached zellij sessions alive across unexpected WebSocket drops.
- Add CLI heartbeat frames using the existing `{ "type": "ping" }` / `{ "type": "pong" }` protocol and reconnect when remote activity stops.
- Reconnect with `fromSeq = lastSeq + 1` after observed output, resend resize frames, and keep explicit detach distinct from remote exit.

## Tests

- `pnpm exec vitest run tests/cli/shell-client.test.ts tests/cli/shell.test.ts`
- `pnpm exec vitest run tests/cli/shell-client.test.ts`
- `pnpm exec tsc --noEmit --project packages/sync-client/tsconfig.json`
- `pnpm run check:patterns` (0 violations; existing repo warnings only)

`bun` is not available on this runner, so validation used the equivalent direct `pnpm` commands for the touched CLI package and focused test coverage.

## Review/Monitoring

- Greptile initially reviewed commit `a7db70a1` at `3/5`.
- Addressed all Greptile findings in `b8ad6080`:
  - reconnect attempts that time out after attach now retry instead of rejecting
  - replay cursors clamp at `Number.MAX_SAFE_INTEGER`
  - reconnect backoff exponent arithmetic is capped before delay calculation
- Awaiting the next Greptile review on the latest commit.

## Invariants

- **Source of truth**: the durable zellij session remains canonical. The CLI WebSocket is only a transport and reconnects to the same session instead of treating transport loss as detach.
- **Lock/transaction scope**: no database or filesystem writes are introduced. Reconnect state is in-process only: current socket, heartbeat timers, queued pre-open input, and the last observed output sequence.
- **Acceptable orphan states**: if the CLI process exits or receives SIGTERM, local terminal state is restored and the durable zellij session may continue running for later reattach. If a reconnect happens before any output sequence is known, the existing live-tail cursor behavior is preserved.
- **Auth source of truth**: existing gateway WebSocket auth remains authoritative. Auth/session/error frames still reject immediately and do not retry.
- **Deferred scope**: no gateway API/schema changes, no proxy/platform timeout tuning, and no new CLI flag for v1.
