### PR TITLE
fix(platform): use shell root for readiness probe

### DIFF
--- a/scripts/start-platform-cloud-run.sh
+++ b/scripts/start-platform-cloud-run.sh
@@ -2,6 +2,7 @@
 set -eu
 
 auth_shell_port="${AUTH_SHELL_PORT:-3200}"
+auth_shell_ready_path="${AUTH_SHELL_READY_PATH:-/}"
 auth_shell_ready_timeout_sec="${AUTH_SHELL_READY_TIMEOUT_SEC:-60}"
 auth_shell_pid=""
 platform_pid=""
@@ -25,8 +26,12 @@ trap 'shutdown; exit 143' INT TERM
 
 wait_for_auth_shell() {
   deadline="$(( $(date +%s) + auth_shell_ready_timeout_sec ))"
+  case "$auth_shell_ready_path" in
+    /*) ;;
+    *) auth_shell_ready_path="/$auth_shell_ready_path" ;;
+  esac
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    if curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:$auth_shell_port/sign-in" >/dev/null 2>&1; then
+    if curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:$auth_shell_port$auth_shell_ready_path" >/dev/null 2>&1; then
       echo "Auth shell is ready"
       return 0
     fi

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -8,8 +8,10 @@ describe('start-platform-cloud-run.sh', () => {
     const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');
 
     expect(script).toContain('AUTH_SHELL_READY_TIMEOUT_SEC');
+    expect(script).toContain('AUTH_SHELL_READY_PATH:-/');
     expect(script).toContain('curl --fail --silent --show-error --max-time 2');
-    expect(script).toContain('http://127.0.0.1:$auth_shell_port/sign-in');
+    expect(script).toContain('http://127.0.0.1:$auth_shell_port$auth_shell_ready_path');
+    expect(script).not.toContain('http://127.0.0.1:$auth_shell_port/sign-in');
 
     const authStartIndex = script.indexOf('node node_modules/next/dist/bin/next start shell');
     const readinessIndex = script.indexOf('if ! wait_for_auth_shell; then');
@@ -26,6 +28,7 @@ describe('start-platform-cloud-run.sh', () => {
     expect(script).toContain('Auth shell did not become ready');
     expect(script).toContain('exit 1');
     expect(script).toContain('kill -0 "$auth_shell_pid"');
+    expect(script).toContain('*) auth_shell_ready_path="/$auth_shell_ready_path" ;;');
   });
 
   it('stops the sibling process when either child exits unexpectedly', () => {

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -12,6 +12,7 @@ describe('start-platform-cloud-run.sh', () => {
     expect(script).toContain('curl --fail --silent --show-error --max-time 2');
     expect(script).toContain('http://127.0.0.1:$auth_shell_port$auth_shell_ready_path');
     expect(script).not.toContain('http://127.0.0.1:$auth_shell_port/sign-in');
+    expect(script).toContain('*) auth_shell_ready_path="/$auth_shell_ready_path" ;;');
 
     const authStartIndex = script.indexOf('node node_modules/next/dist/bin/next start shell');
     const readinessIndex = script.indexOf('if ! wait_for_auth_shell; then');
@@ -28,7 +29,6 @@ describe('start-platform-cloud-run.sh', () => {
     expect(script).toContain('Auth shell did not become ready');
     expect(script).toContain('exit 1');
     expect(script).toContain('kill -0 "$auth_shell_pid"');
-    expect(script).toContain('*) auth_shell_ready_path="/$auth_shell_ready_path" ;;');
   });
 
   it('stops the sibling process when either child exits unexpectedly', () => {


### PR DESCRIPTION
## Summary
- change the Cloud Run auth-shell startup readiness probe from raw `/sign-in` to the shell root `/`
- keep `AUTH_SHELL_READY_PATH` configurable for future stable route changes
- preserve the external candidate smoke coverage for `/sign-in` after the platform server is running

## Tests
- `pnpm exec vitest run tests/scripts/start-platform-cloud-run.test.ts`
- `sh -n scripts/start-platform-cloud-run.sh`
- `git diff --check`
- `bun run check:patterns` (0 violations; existing warnings only)

## Review/Monitoring
- Follow-up for failed Platform Cloud Run revision `matrix-platform-00048-fox`: Next auth shell logged ready on `127.0.0.1:3200`, then `Auth shell did not become ready` because the startup script probed raw Next `/sign-in`, which is owned by the platform layer rather than the shell app.
- After merge, rerun Platform Cloud Run; the Stripe price secret preflight already passes on rerun.

## Invariants
- Source of truth: Cloud Run startup readiness checks only that the auth shell process is serving a stable shell route; platform route correctness remains covered by candidate smoke tests.
- Lock/transaction scope: no database or transaction changes.
- Acceptable orphan states: a failed candidate revision must remain unpromoted; current Cloud Run traffic remains on the previous healthy revision.
- Auth source of truth: no auth changes; `/sign-in` continues to be handled by the platform/auth flow after the platform server starts.
- Deferred scope: this PR does not change Stripe secrets, billing logic, or Cloud Run traffic promotion.