### PR TITLE
fix(platform): probe static auth shell asset

### DIFF
--- a/scripts/start-platform-cloud-run.sh
+++ b/scripts/start-platform-cloud-run.sh
@@ -2,7 +2,7 @@
 set -eu
 
 auth_shell_port="${AUTH_SHELL_PORT:-3200}"
-auth_shell_ready_path="${AUTH_SHELL_READY_PATH:-/}"
+auth_shell_ready_path="${AUTH_SHELL_READY_PATH:-/icon.png}"
 auth_shell_ready_timeout_sec="${AUTH_SHELL_READY_TIMEOUT_SEC:-60}"
 auth_shell_pid=""
 platform_pid=""

--- a/scripts/start-platform-cloud-run.sh
+++ b/scripts/start-platform-cloud-run.sh
@@ -2,7 +2,7 @@
 set -eu
 
 auth_shell_port="${AUTH_SHELL_PORT:-3200}"
-auth_shell_ready_path="${AUTH_SHELL_READY_PATH:-/icon.png}"
+auth_shell_ready_path="${AUTH_SHELL_READY_PATH:-/icon-192.png}"
 auth_shell_ready_timeout_sec="${AUTH_SHELL_READY_TIMEOUT_SEC:-60}"
 auth_shell_pid=""
 platform_pid=""

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -8,7 +8,7 @@ describe('start-platform-cloud-run.sh', () => {
     const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');
 
     expect(script).toContain('AUTH_SHELL_READY_TIMEOUT_SEC');
-    expect(script).toContain('AUTH_SHELL_READY_PATH:-/icon.png');
+    expect(script).toContain('AUTH_SHELL_READY_PATH:-/icon-192.png');
     expect(script).toContain('curl --fail --silent --show-error --max-time 2');
     expect(script).toContain('http://127.0.0.1:$auth_shell_port$auth_shell_ready_path');
     expect(script).not.toContain('http://127.0.0.1:$auth_shell_port/sign-in');

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -8,7 +8,7 @@ describe('start-platform-cloud-run.sh', () => {
     const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');
 
     expect(script).toContain('AUTH_SHELL_READY_TIMEOUT_SEC');
-    expect(script).toContain('AUTH_SHELL_READY_PATH:-/');
+    expect(script).toContain('AUTH_SHELL_READY_PATH:-/icon.png');
     expect(script).toContain('curl --fail --silent --show-error --max-time 2');
     expect(script).toContain('http://127.0.0.1:$auth_shell_port$auth_shell_ready_path');
     expect(script).not.toContain('http://127.0.0.1:$auth_shell_port/sign-in');


### PR DESCRIPTION
## Summary
- change the Cloud Run auth-shell readiness default from `/` to `/icon.png`
- use a static shell-owned asset that bypasses the Next proxy/auth matcher
- keep `AUTH_SHELL_READY_PATH` configurable and preserve candidate `/sign-in` smoke coverage after the platform starts

## Tests
- `pnpm exec vitest run tests/scripts/start-platform-cloud-run.test.ts`
- `sh -n scripts/start-platform-cloud-run.sh`
- `git diff --check`
- `bun run check:patterns` (0 violations; existing warnings only)

## Review/Monitoring
- Follow-up to failed Platform Cloud Run revision `matrix-platform-00049-fij`: after PR #460, `/` still did not become ready because it flows through the shell proxy/auth path. The shell static app icon is served outside that matcher and is a better raw Next readiness endpoint.
- Live Cloud Run traffic remains 100% on previous healthy revision `matrix-platform-00045-tes`; failed candidate was not promoted.

## Invariants
- Source of truth: startup readiness only verifies the raw Next auth shell process can serve a shell-owned static asset; platform route correctness remains covered by candidate smoke tests.
- Lock/transaction scope: no database or transaction changes.
- Acceptable orphan states: failed candidate revisions remain unpromoted; current live traffic remains on the previous healthy revision.
- Auth source of truth: no auth changes; `/sign-in` remains platform-owned after the platform process starts.
- Deferred scope: this PR does not change Stripe secrets, billing logic, or Cloud Run traffic promotion.