### PR TITLE
fix(platform): install curl for auth shell readiness

### DIFF
--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -41,7 +41,7 @@ RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/
 
 FROM node:24-alpine AS runtime
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates curl
 
 WORKDIR /app
 

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -22,6 +22,14 @@ describe('start-platform-cloud-run.sh', () => {
     expect(platformStartIndex).toBeGreaterThan(readinessIndex);
   });
 
+  it('installs the readiness probe client in the platform runtime image', () => {
+    const root = process.cwd();
+    const dockerfile = readFileSync(join(root, 'Dockerfile.platform'), 'utf8');
+
+    expect(dockerfile).toContain('ca-certificates');
+    expect(dockerfile).toContain('curl');
+  });
+
   it('exits nonzero when the auth shell never becomes ready', () => {
     const root = process.cwd();
     const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');


### PR DESCRIPTION
## Summary
- Install `curl` in the platform Cloud Run runtime image because `start-platform-cloud-run.sh` uses it for the auth-shell readiness probe.
- Add a regression assertion tying the startup script dependency to `Dockerfile.platform`.

## Tests
- `pnpm exec vitest run tests/scripts/start-platform-cloud-run.test.ts`
- `sh -n scripts/start-platform-cloud-run.sh`
- `git diff --check`
- `bun run check:patterns` (0 violations, existing warnings only)

## Review/Monitoring
- Created after the merged #461 deploy failed at Cloud Run revision `matrix-platform-00050-nid`.
- Cloud Run logs show Next became ready on port 3200, then the script timed out with `Auth shell did not become ready`.
- `Dockerfile.platform` runtime image installed only `ca-certificates`, while the script probes with `curl`.

## Invariants
- **Source of truth**: `scripts/start-platform-cloud-run.sh` defines the startup readiness command; `Dockerfile.platform` must provide the runtime tools it invokes.
- **Lock/transaction scope**: No database writes or transactions are touched.
- **Acceptable orphan states**: A failed candidate revision remains unpromoted by the workflow; production traffic stays on the previous healthy revision.
- **Auth source of truth**: Unchanged; this only affects container startup readiness.
- **Deferred scope**: This does not change the auth shell readiness path, billing configuration, or Cloud Run promotion logic.
