### PR TITLE
fix(ci): send edge-router headers in Cloud Run sign-in smoke

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/workflows/platform-cloud-run.yml"
       - "packages/platform/**"
       - "packages/observability/**"
       - "packages/clerk-sync/**"
@@ -289,7 +290,27 @@ jobs:
             exit 1
           fi
           curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/health" >/dev/null
-          auth_shell_html="$(curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/sign-in")"
+          # /sign-in is only served as the pre-VPS auth shell on app-domain hosts.
+          # The raw candidate tag URL is not an app-domain host, so simulate the
+          # edge router with x-forwarded-host + x-matrix-edge-secret instead of
+          # broadening MATRIX_APP_DOMAIN_HOSTS to Cloud Run tag URLs.
+          edge_router_secret="$(gcloud secrets versions access latest \
+            --secret edge-router-secret \
+            --project "$GCP_PROJECT_ID" | tr -d '\r\n')"
+          if [ -z "$edge_router_secret" ]; then
+            echo "Could not read edge-router-secret for the app-domain smoke request." >&2
+            exit 1
+          fi
+          echo "::add-mask::$edge_router_secret"
+          app_domain_host="$(printf '%s' "${MATRIX_APP_DOMAIN_HOSTS%%,*}" | tr -d '[:space:]')"
+          if [ -z "$app_domain_host" ]; then
+            echo "MATRIX_APP_DOMAIN_HOSTS did not yield an app-domain host for the smoke request." >&2
+            exit 1
+          fi
+          auth_shell_html="$(curl --fail --silent --show-error --max-time 10 \
+            --header "x-forwarded-host: ${app_domain_host}" \
+            --header "x-matrix-edge-secret: ${edge_router_secret}" \
+            "$CANDIDATE_URL/sign-in")"
           if ! printf '%s\n' "$auth_shell_html" | grep -Fq "fetch('/billing/checkout'"; then
             echo "Candidate pre-VPS auth shell does not expose the billing checkout handoff." >&2
             exit 1

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -89,6 +89,24 @@ describe('CI workflows', () => {
     expect(workflow).toContain('Checkout unavailable');
   });
 
+  it('smokes /sign-in through trusted edge-router headers instead of the raw candidate host', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('--secret edge-router-secret');
+    expect(workflow).toContain('echo "::add-mask::$edge_router_secret"');
+    expect(workflow).toContain('--header "x-forwarded-host: ${app_domain_host}"');
+    expect(workflow).toContain('--header "x-matrix-edge-secret: ${edge_router_secret}"');
+    expect(workflow).not.toContain('--max-time 10 "$CANDIDATE_URL/sign-in"');
+  });
+
+  it('redeploys the platform when the Cloud Run workflow itself changes', () => {
+    const root = process.cwd();
+    const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');
+
+    expect(workflow).toContain('- ".github/workflows/platform-cloud-run.yml"');
+  });
+
   it('verifies platform Cloud Run promotion sends all traffic to the candidate revision', () => {
     const root = process.cwd();
     const workflow = readFileSync(join(root, '.github/workflows/platform-cloud-run.yml'), 'utf8');


### PR DESCRIPTION
## Summary

The platform Cloud Run deploy has failed at "Smoke candidate revision" on every run since #458 (runs for #458, #460, #461, #462). After #462 fixed container startup, the remaining failure is the smoke itself: it curls `$CANDIDATE_URL/sign-in` on the raw Cloud Run tag URL with no headers. The platform only serves the pre-VPS auth shell for app-domain hosts, and it only trusts `x-forwarded-host` when the request carries a matching `x-matrix-edge-secret` (`getTrustedSessionRouteHost`, `packages/platform/src/main.ts`). The bare candidate hostname is therefore routed as a non-app-domain request and returns `{"error":"Unauthorized"}` 401, so curl exits 22 and the deploy never promotes.

This PR fixes the smoke request shape, not the product route:

- Fetch `edge-router-secret` from Secret Manager in the smoke step (the deploy SA already reads secrets in this step), mask it with `::add-mask::`, and send `x-forwarded-host: <first MATRIX_APP_DOMAIN_HOSTS entry>` plus `x-matrix-edge-secret` on the `/sign-in` smoke request. This simulates exactly what the real edge router sends, instead of broadening `MATRIX_APP_DOMAIN_HOSTS` to Cloud Run tag URLs.
- Add `.github/workflows/platform-cloud-run.yml` to the workflow's own `paths` trigger so workflow fixes (like this one) deploy themselves on merge instead of waiting for the next platform change.

Manual verification against the live candidate revision (`matrix-platform-00053-nap`) already confirmed `/sign-in` with these two headers returns 200 HTML containing `fetch('/billing/checkout'` and `Checkout unavailable`, so the existing smoke grep assertions will pass.

## Tests

- New regression tests in `tests/platform/ci-workflows.test.ts`: smoke must read `edge-router-secret`, mask it, send both edge headers, and must not curl `/sign-in` bare; workflow must trigger on its own path.
- `bun run vitest run tests/platform` — 52 files, 762 tests passed.
- `bun run typecheck` — clean.
- `bun run check:patterns` — 0 violations (5 pre-existing warnings).
- Full `bun run test` not run locally (platform suite alone takes ~7 min; CI runs the full suite). No React changes, so react-doctor not required.

## Invariants

- **Source of truth**: `MATRIX_APP_DOMAIN_HOSTS` (GitHub environment var, also passed to the Cloud Run service) defines trusted app-domain hosts; the smoke uses its first entry rather than hardcoding a hostname.
- **Auth source of truth**: `edge-router-secret` in Secret Manager is the only way a forwarded host is trusted; the smoke authenticates the same way the production edge router does. The secret is read at smoke time, masked in logs, and never persisted.
- **Lock/transaction scope**: n/a (CI workflow only; no product code changes).
- **Acceptable orphan states**: if the secret read or smoke fails, the candidate revision stays deployed at 0% traffic and is never promoted — same failure mode as today, with clearer errors.
- **Deferred scope**: a dedicated internal smoke endpoint (option 2 from the incident analysis) is not added; simulating the edge router covers the same surface with no new product code. The original new-user OTP/billing UX bug fix from #458 ships unchanged once this unblocks promotion.

## Review/Monitoring

Will monitor CI and Greptile on this PR and fix findings until 5/5. After merge, the added paths trigger will run the production deploy automatically; I will verify the run promotes and that `https://app.matrix-os.com/sign-in` serves the billing gate for new users.