### PR TITLE
fix(platform): send CLI device billing failures to setup

### DIFF
--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -375,8 +375,9 @@ function approvalPage(
           showConfirm();
           return;
         }
-        if (res.status === 404) {
-          if (nativeApp) {
+        if (res.status === 402 || res.status === 404) {
+          // Billing-required clients enter browser billing; only native no-runtime 404s keep dedicated setup copy.
+          if (nativeApp && res.status === 404) {
             showRuntimeSetupState();
             return;
           }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -563,14 +563,42 @@ export function buildPostAuthRedirectPath(rawUrl: string): string {
     const url = new URL(rawUrl, 'https://app.matrix-os.com');
     const normalizedPath = url.pathname.replace(/^\/{2,}/, '/');
     const path = /^\/sign-(?:in|up)(?:\/.*)?$/.test(normalizedPath) ? '/' : normalizedPath;
+    const params = new URLSearchParams();
     const runtime = url.searchParams.get('runtime');
     if (runtime && RuntimeSlotSchema.safeParse(runtime).success) {
-      return `${path}?runtime=${encodeURIComponent(runtime)}`;
+      params.set('runtime', runtime);
     }
-    return path;
+    const deviceReturn = normalizeDeviceReturnPath(url.searchParams.get('device_return'));
+    if (deviceReturn) params.set('device_return', deviceReturn);
+    const query = params.toString();
+    return query ? `${path}?${query}` : path;
   } catch (err: unknown) {
     console.warn('[platform] Failed to build post-auth redirect:', err instanceof Error ? err.message : String(err));
     return '/';
+  }
+}
+
+function normalizeDeviceReturnPath(value: string | null): string | null {
+  if (!value || value.length > 2048 || !value.startsWith('/') || value.startsWith('//')) {
+    return null;
+  }
+  try {
+    const url = new URL(value, 'https://app.matrix-os.com');
+    if (url.origin !== 'https://app.matrix-os.com' || url.pathname !== '/auth/device') return null;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch (err: unknown) {
+    console.warn('[platform] Failed to normalize device return path:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+function deviceReturnTargetFromRedirectPath(redirectTarget: string): string {
+  try {
+    const url = new URL(redirectTarget, 'https://app.matrix-os.com');
+    return normalizeDeviceReturnPath(url.searchParams.get('device_return')) ?? '';
+  } catch (err: unknown) {
+    console.warn('[platform] Failed to extract device return target:', err instanceof Error ? err.message : String(err));
+    return '';
   }
 }
 
@@ -1938,6 +1966,7 @@ function getAuthPage(
 ) {
   const escapedPublishableKey = escapeHtmlAttr(publishableKey);
   const redirectTargetJson = escapeInlineScriptJson(redirectTarget);
+  const deviceReturnTargetJson = escapeInlineScriptJson(deviceReturnTargetFromRedirectPath(redirectTarget));
   const signOutTargetJson = escapeInlineScriptJson(mode === 'sign-up' ? '/sign-up' : '/sign-in');
   const modeLabel = mode === 'sign-up' ? 'Create your free Matrix account' : 'Welcome back to Matrix';
   const modeDetail = mode === 'sign-up'
@@ -2160,6 +2189,7 @@ function getAuthPage(
   ></script>
   <script nonce="${scriptNonce}">
     var redirectTarget = ${redirectTargetJson};
+    var deviceReturnTarget = ${deviceReturnTargetJson};
     var signOutTarget = ${signOutTargetJson};
     var SIGN_OUT_TIMEOUT_MS = ${BROWSER_CLERK_SIGN_OUT_TIMEOUT_MS};
     var requestedRuntime = new URLSearchParams(redirectTarget.split('?')[1] || '').get('runtime');
@@ -2348,6 +2378,12 @@ function getAuthPage(
           }
           var controller = new AbortController();
           var timeoutId = window.setTimeout(function() { controller.abort(); }, 10000);
+          var checkoutBody = {
+            planSlug: 'matrix_builder',
+            interval: 'monthly',
+            regionSlug: 'region_fsn1'
+          };
+          if (deviceReturnTarget) checkoutBody.returnPath = redirectTarget;
           return fetch('/billing/checkout', {
             method: 'POST',
             headers: {
@@ -2355,11 +2391,7 @@ function getAuthPage(
               'Content-Type': 'application/json',
               Accept: 'application/json'
             },
-            body: JSON.stringify({
-              planSlug: 'matrix_builder',
-              interval: 'monthly',
-              regionSlug: 'region_fsn1'
-            }),
+            body: JSON.stringify(checkoutBody),
             credentials: 'same-origin',
             signal: controller.signal
           }).finally(function() {
@@ -2533,7 +2565,7 @@ function getAuthPage(
         })
         .then(function(payload) {
           if (!payload) return;
-          window.location.replace(payload.redirectTo ?? redirectTarget);
+          window.location.replace(deviceReturnTarget || payload.redirectTo || redirectTarget);
         })
         .catch(function(err) {
           console.error('[matrix] Clerk session exchange failed', err instanceof Error ? err.message : String(err));

--- a/tests/platform/device-routes.test.ts
+++ b/tests/platform/device-routes.test.ts
@@ -668,6 +668,7 @@ describe("device routes", () => {
       expect(html).toContain("signUpUrl: deviceAuthUrl('sign-up')");
       expect(html).toContain("fallbackRedirectUrl: approvalUrl");
       expect(html).toContain("fetchWithTimeout('/api/auth/app-session'");
+      expect(html).toContain("if (res.status === 402 || res.status === 404) {");
       expect(html).toContain("redirectToBillingSetup()");
       expect(html).toContain("device_return");
       expect(html).not.toContain("fetchWithTimeout('/api/auth/provision-runtime'");
@@ -683,6 +684,24 @@ describe("device routes", () => {
       );
       expect(html).toContain(
         '<form id="confirm-area" method="POST" action="/auth/device/approve" style="display:none">',
+      );
+    });
+
+    it("routes non-native missing-runtime responses through billing setup before recovery", async () => {
+      const res = await app.request("/auth/device?user_code=BCDF-GHJK");
+      const html = await res.text();
+
+      const branchStart = html.indexOf("if (res.status === 402 || res.status === 404) {");
+      const nativeRuntimeSetup = html.indexOf("if (nativeApp && res.status === 404)", branchStart);
+      const billingRedirect = html.indexOf("redirectToBillingSetup();", branchStart);
+      const fallbackRecovery = html.indexOf("showSignedInRecoveryState();", branchStart);
+
+      expect(branchStart).toBeGreaterThanOrEqual(0);
+      expect(nativeRuntimeSetup).toBeGreaterThan(branchStart);
+      expect(billingRedirect).toBeGreaterThan(nativeRuntimeSetup);
+      expect(fallbackRecovery).toBeGreaterThan(billingRedirect);
+      expect(html).toContain(
+        "Billing-required clients enter browser billing; only native no-runtime 404s keep dedicated setup copy.",
       );
     });
 

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2619,6 +2619,10 @@ describe("platform proxy routing", () => {
 
     expect(res.status).toBe(200);
     const html = await res.text();
+    expect(html).toContain('var redirectTarget = "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK";');
+    expect(html).toContain('var deviceReturnTarget = "/auth/device?user_code=BCDF-GHJK";');
+    expect(html).toContain("if (deviceReturnTarget) checkoutBody.returnPath = redirectTarget;");
+    expect(html).toContain("window.location.replace(deviceReturnTarget || payload.redirectTo || redirectTarget);");
     expect(html).toContain("fetch('/api/auth/provision-runtime'");
     expect(html).toContain("Billing required");
     expect(html).not.toBe("auth shell");


### PR DESCRIPTION
## Summary
- Send CLI device-auth `402 billing_required` responses into the setup/billing handoff instead of the generic refresh state.
- Preserve validated `/auth/device` return paths through the platform auth page, Stripe checkout, and final app-session redirect.
- Keep auth-page checkout return overrides scoped to device-auth flows so configured Stripe success/cancel URLs still apply to normal auth-page checkout.
- Intentionally route non-native CLI `404` missing-runtime responses to the same setup/billing handoff, while preserving the native app's dedicated runtime setup state.

## Tests
- `bun run test tests/platform/device-routes.test.ts`
- `bun run test tests/platform/proxy-routing.test.ts -t "only preserves the runtime selector after auth|does not persist a selected runtime slot|keeps legacy no-container app-domain users"`
- `bun run typecheck`
- `bun run check:patterns`
- `git diff --check`

## Review/Monitoring
- Ready-for-CI label applied.
- Addressed Greptile's `4/5` finding about unconditional checkout return-path overrides by adding `returnPath` only when a validated device return target exists.

## Invariants
- Source of truth: platform Postgres remains the source for billing entitlement, runtime identity, and active machine state; this change only adjusts browser handoff behavior around existing `/api/auth/app-session` and `/billing/checkout` decisions.
- Lock/transaction scope: no database writes or transaction boundaries changed; the route still delegates provisioning/session decisions to existing platform services.
- Acceptable orphan states: if checkout/provisioning fails or billing has not propagated, the existing auth page retry states remain in place; no device code is approved until `/auth/device/approve` succeeds.
- Auth source of truth: Clerk session tokens remain the browser auth source; device approval still requires Clerk bearer auth plus CSRF, and device return paths are restricted to same-origin `/auth/device`.
- Deferred scope: this PR does not change billing plan selection, Stripe webhook timing, or VPS provisioning semantics.
