### PR TITLE
fix(platform): package gateway integrations for Cloud Run

### DIFF
--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -56,8 +56,11 @@ RUN adduser -D -u 1001 -h /home/matrix-platform -s /sbin/nologin matrix-platform
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/node_modules ./node_modules
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/package.json ./packages/clerk-sync/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/gateway/package.json ./packages/gateway/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/kernel/package.json ./packages/kernel/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/mcp-browser/package.json ./packages/mcp-browser/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/observability/package.json ./packages/observability/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/platform/package.json ./packages/platform/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/sync-client/package.json ./packages/sync-client/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/shell/package.json ./shell/package.json
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/src ./packages/clerk-sync/src
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/gateway/dist ./packages/gateway/dist

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -7,14 +7,18 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY packages/clerk-sync/package.json packages/clerk-sync/package.json
+COPY packages/gateway/package.json packages/gateway/package.json
+COPY packages/kernel/package.json packages/kernel/package.json
+COPY packages/mcp-browser/package.json packages/mcp-browser/package.json
 COPY packages/observability/package.json packages/observability/package.json
 COPY packages/platform/package.json packages/platform/package.json
+COPY packages/sync-client/package.json packages/sync-client/package.json
 COPY shell/package.json shell/package.json
 COPY scripts/fix-node-pty-perms.mjs scripts/fix-node-pty-perms.mjs
 
 FROM base AS deps
 
-RUN pnpm install --frozen-lockfile --ignore-scripts --filter '@matrix-os/platform...' --filter './shell...'
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter '@matrix-os/platform...' --filter '@matrix-os/gateway...' --filter './shell...'
 
 FROM deps AS builder
 
@@ -32,12 +36,13 @@ ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
 ENV NEXT_PUBLIC_POSTHOG_API_HOST=$NEXT_PUBLIC_POSTHOG_API_HOST
 ENV NEXT_PUBLIC_MATRIX_APP_URL=$NEXT_PUBLIC_MATRIX_APP_URL
 RUN pnpm --filter '@matrix-os/observability' build
+RUN pnpm --filter '@matrix-os/gateway' build
 RUN pnpm --filter '@matrix-os/platform' build
 RUN pnpm --dir shell exec next build --webpack
 
 FROM base AS prod-deps
 
-RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/platform...' --filter './shell...'
+RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/platform...' --filter '@matrix-os/gateway...' --filter './shell...'
 
 FROM node:24-alpine AS runtime
 
@@ -50,10 +55,12 @@ RUN adduser -D -u 1001 -h /home/matrix-platform -s /sbin/nologin matrix-platform
 
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/node_modules ./node_modules
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/package.json ./packages/clerk-sync/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/gateway/package.json ./packages/gateway/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/observability/package.json ./packages/observability/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/platform/package.json ./packages/platform/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/shell/package.json ./shell/package.json
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/src ./packages/clerk-sync/src
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/gateway/dist ./packages/gateway/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/platform/dist ./packages/platform/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/shell ./shell

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -5342,9 +5342,9 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       { createPipedreamClient },
       { createPlatformDb: createGatewayPlatformDb },
     ] = await Promise.all([
-      importRuntimeModule<GatewayIntegrationRoutesModule>('../../gateway/src/integrations/routes.js'),
-      importRuntimeModule<GatewayPipedreamModule>('../../gateway/src/integrations/pipedream.js'),
-      importRuntimeModule<GatewayPlatformDbModule>('../../gateway/src/platform-db.js'),
+      importRuntimeModule<GatewayIntegrationRoutesModule>('../../gateway/dist/integrations/routes.js'),
+      importRuntimeModule<GatewayPipedreamModule>('../../gateway/dist/integrations/pipedream.js'),
+      importRuntimeModule<GatewayPlatformDbModule>('../../gateway/dist/platform-db.js'),
     ]);
 
     const trustedPlatformDb = createGatewayPlatformDb(integrationConfig.platformDatabaseUrl);

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -45,6 +45,9 @@ describe('start-platform-cloud-run.sh', () => {
     expect(dockerfile).toContain("RUN pnpm --filter '@matrix-os/gateway' build");
     expect(dockerfile).toContain("/app/packages/gateway/dist ./packages/gateway/dist");
     expect(dockerfile).toContain("/app/packages/gateway/package.json ./packages/gateway/package.json");
+    expect(dockerfile).toContain("/app/packages/kernel/package.json ./packages/kernel/package.json");
+    expect(dockerfile).toContain("/app/packages/mcp-browser/package.json ./packages/mcp-browser/package.json");
+    expect(dockerfile).toContain("/app/packages/sync-client/package.json ./packages/sync-client/package.json");
   });
 
   it('exits nonzero when the auth shell never becomes ready', () => {

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -30,6 +30,23 @@ describe('start-platform-cloud-run.sh', () => {
     expect(dockerfile).toContain('curl');
   });
 
+  it('packages compiled gateway integration modules used by platform startup', () => {
+    const root = process.cwd();
+    const dockerfile = readFileSync(join(root, 'Dockerfile.platform'), 'utf8');
+    const main = readFileSync(join(root, 'packages/platform/src/main.ts'), 'utf8');
+
+    expect(main).toContain("../../gateway/dist/integrations/routes.js");
+    expect(main).toContain("../../gateway/dist/integrations/pipedream.js");
+    expect(main).toContain("../../gateway/dist/platform-db.js");
+    expect(dockerfile).toContain("COPY packages/gateway/package.json packages/gateway/package.json");
+    expect(dockerfile).toContain("COPY packages/kernel/package.json packages/kernel/package.json");
+    expect(dockerfile).toContain("COPY packages/mcp-browser/package.json packages/mcp-browser/package.json");
+    expect(dockerfile).toContain("COPY packages/sync-client/package.json packages/sync-client/package.json");
+    expect(dockerfile).toContain("RUN pnpm --filter '@matrix-os/gateway' build");
+    expect(dockerfile).toContain("/app/packages/gateway/dist ./packages/gateway/dist");
+    expect(dockerfile).toContain("/app/packages/gateway/package.json ./packages/gateway/package.json");
+  });
+
   it('exits nonzero when the auth shell never becomes ready', () => {
     const root = process.cwd();
     const script = readFileSync(join(root, 'scripts/start-platform-cloud-run.sh'), 'utf8');


### PR DESCRIPTION
## Summary
- import gateway integration modules from compiled gateway dist in platform startup
- build the gateway package in the platform Cloud Run image
- copy gateway package metadata and dist output into the runtime image

## Tests
- bun run test tests/scripts/start-platform-cloud-run.test.ts
- pnpm --filter '@matrix-os/gateway' build
- bun run typecheck
- bun run check:patterns

## Review/Monitoring
- Follow-up hotfix for the post-merge Cloud Run failure on latest main where the platform revision could not start because /app/packages/gateway/src/integrations/routes.js was not present in the runtime image.
- Monitor CI and Greptile to 5/5 before merge.

## Invariants
- Source of truth: Pipedream integration configuration remains platform-owned via Cloud Run environment and Secret Manager; customer VPSes only proxy through the platform.
- Lock/transaction scope: no database writes or transactional behavior changed.
- Acceptable orphan states: if gateway integration modules fail to compile, the Docker build fails before deployment; if runtime imports fail, Cloud Run rejects the revision without serving it.
- Auth source of truth: unchanged; integration route auth and platform trusted DB wiring remain in the gateway integration modules.
- Deferred scope: this does not refactor integration ownership or duplicate gateway route code into platform.