### PR TITLE
fix(platform): package gateway modules in cloud run image

### DIFF
--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -65,6 +65,7 @@ COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/sync
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/shell/package.json ./shell/package.json
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/src ./packages/clerk-sync/src
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/gateway/dist ./packages/gateway/dist
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/kernel/dist ./packages/kernel/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/platform/dist ./packages/platform/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/shell ./shell

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -7,14 +7,18 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
 COPY packages/clerk-sync/package.json packages/clerk-sync/package.json
+COPY packages/gateway/package.json packages/gateway/package.json
+COPY packages/kernel/package.json packages/kernel/package.json
+COPY packages/mcp-browser/package.json packages/mcp-browser/package.json
 COPY packages/observability/package.json packages/observability/package.json
 COPY packages/platform/package.json packages/platform/package.json
+COPY packages/sync-client/package.json packages/sync-client/package.json
 COPY shell/package.json shell/package.json
 COPY scripts/fix-node-pty-perms.mjs scripts/fix-node-pty-perms.mjs
 
 FROM base AS deps
 
-RUN pnpm install --frozen-lockfile --ignore-scripts --filter '@matrix-os/platform...' --filter './shell...'
+RUN pnpm install --frozen-lockfile --ignore-scripts --filter '@matrix-os/platform...' --filter '@matrix-os/gateway...' --filter './shell...'
 
 FROM deps AS builder
 
@@ -32,12 +36,14 @@ ENV NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST
 ENV NEXT_PUBLIC_POSTHOG_API_HOST=$NEXT_PUBLIC_POSTHOG_API_HOST
 ENV NEXT_PUBLIC_MATRIX_APP_URL=$NEXT_PUBLIC_MATRIX_APP_URL
 RUN pnpm --filter '@matrix-os/observability' build
+RUN pnpm --filter '@matrix-os/kernel' build
+RUN pnpm --filter '@matrix-os/gateway' build
 RUN pnpm --filter '@matrix-os/platform' build
 RUN pnpm --dir shell exec next build --webpack
 
 FROM base AS prod-deps
 
-RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/platform...' --filter './shell...'
+RUN pnpm install --frozen-lockfile --ignore-scripts --prod --filter '@matrix-os/platform...' --filter '@matrix-os/gateway...' --filter './shell...'
 
 FROM node:24-alpine AS runtime
 
@@ -50,10 +56,12 @@ RUN adduser -D -u 1001 -h /home/matrix-platform -s /sbin/nologin matrix-platform
 
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/node_modules ./node_modules
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/package.json ./packages/clerk-sync/package.json
+COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/gateway/package.json ./packages/gateway/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/observability/package.json ./packages/observability/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/packages/platform/package.json ./packages/platform/package.json
 COPY --from=prod-deps --chown=matrix-platform:matrix-platform /app/shell/package.json ./shell/package.json
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/clerk-sync/src ./packages/clerk-sync/src
+COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/gateway/dist ./packages/gateway/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/observability/dist ./packages/observability/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/packages/platform/dist ./packages/platform/dist
 COPY --from=builder --chown=matrix-platform:matrix-platform /app/shell ./shell

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -5342,9 +5342,9 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
       { createPipedreamClient },
       { createPlatformDb: createGatewayPlatformDb },
     ] = await Promise.all([
-      importRuntimeModule<GatewayIntegrationRoutesModule>('../../gateway/src/integrations/routes.js'),
-      importRuntimeModule<GatewayPipedreamModule>('../../gateway/src/integrations/pipedream.js'),
-      importRuntimeModule<GatewayPlatformDbModule>('../../gateway/src/platform-db.js'),
+      importRuntimeModule<GatewayIntegrationRoutesModule>('../../gateway/dist/integrations/routes.js'),
+      importRuntimeModule<GatewayPipedreamModule>('../../gateway/dist/integrations/pipedream.js'),
+      importRuntimeModule<GatewayPlatformDbModule>('../../gateway/dist/platform-db.js'),
     ]);
 
     const trustedPlatformDb = createGatewayPlatformDb(integrationConfig.platformDatabaseUrl);

--- a/tests/scripts/start-platform-cloud-run.test.ts
+++ b/tests/scripts/start-platform-cloud-run.test.ts
@@ -44,6 +44,7 @@ describe('start-platform-cloud-run.sh', () => {
     expect(dockerfile).toContain("COPY packages/sync-client/package.json packages/sync-client/package.json");
     expect(dockerfile).toContain("RUN pnpm --filter '@matrix-os/gateway' build");
     expect(dockerfile).toContain("/app/packages/gateway/dist ./packages/gateway/dist");
+    expect(dockerfile).toContain("/app/packages/kernel/dist ./packages/kernel/dist");
     expect(dockerfile).toContain("/app/packages/gateway/package.json ./packages/gateway/package.json");
     expect(dockerfile).toContain("/app/packages/kernel/package.json ./packages/kernel/package.json");
     expect(dockerfile).toContain("/app/packages/mcp-browser/package.json ./packages/mcp-browser/package.json");


### PR DESCRIPTION
## Summary
- Build gateway `dist` as part of the platform Cloud Run image.
- Copy gateway and kernel runtime modules into the platform image so platform startup can resolve its integration route imports and workspace package symlinks.
- Point platform's dynamic integration imports at packaged `gateway/dist` files instead of non-existent `gateway/src/*.js` files.

## Tests
- `pnpm exec vitest run tests/scripts/start-platform-cloud-run.test.ts`
- `docker build -f Dockerfile.platform -t matrix-platform:gateway-modules-smoke .`
- `docker run --rm --entrypoint node matrix-platform:gateway-modules-smoke -e "await import('/app/packages/gateway/dist/integrations/routes.js'); await import('/app/packages/gateway/dist/integrations/pipedream.js'); await import('/app/packages/gateway/dist/platform-db.js'); console.log('gateway runtime imports ok')"`
- `docker run --rm --entrypoint node matrix-platform:gateway-modules-smoke -e "await import('@matrix-os/kernel'); console.log('kernel workspace import ok')"`
- `docker run --rm --entrypoint sh matrix-platform:gateway-modules-smoke -c "test -f /app/packages/kernel/dist/index.js && test -f /app/packages/gateway/dist/integrations/routes.js && echo packaged-runtime-dists-ok"`
- `docker run --rm --entrypoint sh matrix-platform:gateway-modules-smoke -c "grep -F '../../gateway/dist/integrations/routes.js' /app/packages/platform/dist/main.js && test -f /app/packages/gateway/dist/integrations/routes.js && test -f /app/packages/gateway/dist/integrations/pipedream.js && test -f /app/packages/gateway/dist/platform-db.js && echo packaged-gateway-dist-ok"`
- `git diff --check`

## Production evidence
- Post-merge Platform Cloud Run deploy for `d4ecc0973f4903937840723197a4ee42523e81e3` failed while creating revision `matrix-platform-00059-wet`.
- Cloud Run stderr showed: `Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/packages/gateway/src/integrations/routes.js' imported from /app/packages/platform/dist/main.js`.
- Existing production traffic stayed on `matrix-platform-00054-bit`; the failed candidate was not promoted.

## Invariants
- Source of truth: the platform image remains the deployable artifact for the pre-VPS auth/app shell; this change only packages modules already imported by platform startup.
- Lock/transaction scope: no database writes or runtime transaction behavior changed.
- Acceptable orphan states: if a future candidate revision fails startup, the workflow still keeps existing traffic on the last promoted revision.
- Auth source of truth: unchanged; Clerk/session/device approval behavior remains from the previously merged PR.
- Deferred scope: this PR does not refactor integration routes or change Pipedream behavior; it only makes the existing runtime imports available in Cloud Run.
