### PR TITLE
fix(auth): open billing settings for no-billing users

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2343,12 +2343,24 @@ function getAuthPage(
       );
     }
     function showBillingRequiredState() {
+      if (deviceReturnTarget) {
+        renderSessionState(
+          'Billing setup required',
+          'Open Billing settings to choose a hosted runtime plan, then return here to approve this terminal.',
+          'Open Billing settings',
+          openBillingSettingsFromClerkSession
+        );
+        return;
+      }
       renderSessionState(
         'Billing required',
         'Start hosted billing before Matrix provisions your cloud computer.',
         'Start checkout',
         startBillingCheckoutFromClerkSession
       );
+    }
+    function openBillingSettingsFromClerkSession() {
+      window.location.assign(redirectTarget);
     }
     function showCheckoutUnavailableState() {
       renderSessionState(

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2353,10 +2353,10 @@ function getAuthPage(
         return;
       }
       renderSessionState(
-        'Billing required',
-        'Start hosted billing before Matrix provisions your cloud computer.',
-        'Start checkout',
-        startBillingCheckoutFromClerkSession
+        'Billing setup required',
+        'Open Billing settings to choose a hosted runtime plan. Stripe opens only after you continue from Billing.',
+        'Open Billing settings',
+        openBillingSettingsFromClerkSession
       );
     }
     function openBillingSettingsFromClerkSession() {

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -90,7 +90,7 @@ function BillingRequired({ checkoutReturnPath }: { checkoutReturnPath?: string }
       lockedSection="billing"
       billingActiveOverride={false}
       closeDisabled
-      billingMode="provisioning"
+      billingMode={checkoutReturnPath ? "device-setup" : "provisioning"}
       onBillingCheckoutIntent={rememberBillingCheckoutAttempt}
       billingCheckoutReturnPath={checkoutReturnPath}
     />

--- a/shell/src/components/Settings.tsx
+++ b/shell/src/components/Settings.tsx
@@ -100,7 +100,7 @@ interface SettingsProps {
   lockedSection?: SectionId;
   billingActiveOverride?: boolean | null;
   closeDisabled?: boolean;
-  billingMode?: "settings" | "provisioning";
+  billingMode?: "settings" | "provisioning" | "device-setup";
   onBillingCheckoutIntent?: () => void;
   billingCheckoutReturnPath?: string;
 }

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -840,7 +840,7 @@ export function BillingPanel({
       <section className="grid gap-4 rounded-[22px] border border-forest/15 bg-[#fbf7ed] p-3 sm:p-4 xl:grid-cols-[minmax(0,1fr)_340px]">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-forest/60">
-            {mode === "settings" ? "Billing" : "Provisioning"}
+            {mode === "provisioning" ? "Provisioning" : "Billing"}
           </p>
           <h3 className="mt-2 max-w-3xl text-xl font-semibold tracking-tight text-deep sm:text-2xl lg:text-3xl">
             {mode === "device-setup"

--- a/shell/src/components/settings/sections/BillingPanel.tsx
+++ b/shell/src/components/settings/sections/BillingPanel.tsx
@@ -29,7 +29,7 @@ import {
 import type { BillingEntitlementSummary } from "@/hooks/useMatrixBillingAccess";
 import { capturePostHogEvent, capturePostHogLog } from "@/lib/posthog-client";
 
-export type BillingPanelMode = "settings" | "provisioning";
+export type BillingPanelMode = "settings" | "provisioning" | "device-setup";
 type BillingInterval = "monthly" | "annual";
 
 const profileLabels = ["Starter", "Recommended", "Scale"] as const;
@@ -160,11 +160,15 @@ function CheckoutPanel({
 
   return (
     <div className="rounded-2xl border border-forest/15 bg-card p-3 sm:p-4">
-      {mode === "provisioning" && (
+      {mode !== "settings" && (
         <div className="mb-2">
-          <p className="text-sm font-semibold text-deep">Start checkout &amp; provision</p>
+          <p className="text-sm font-semibold text-deep">
+            {mode === "device-setup" ? "Billing settings" : "Start checkout & provision"}
+          </p>
           <p className="mt-0.5 text-xs leading-5 text-forest/60">
-            Secure checkout opens before Matrix provisions this computer.
+            {mode === "device-setup"
+              ? "Review your plan and region here. Stripe opens only after you choose Continue to pay."
+              : "Secure checkout opens before Matrix provisions this computer."}
           </p>
         </div>
       )}
@@ -836,10 +840,12 @@ export function BillingPanel({
       <section className="grid gap-4 rounded-[22px] border border-forest/15 bg-[#fbf7ed] p-3 sm:p-4 xl:grid-cols-[minmax(0,1fr)_340px]">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-forest/60">
-            {mode === "provisioning" ? "Provisioning" : "Billing"}
+            {mode === "settings" ? "Billing" : "Provisioning"}
           </p>
           <h3 className="mt-2 max-w-3xl text-xl font-semibold tracking-tight text-deep sm:text-2xl lg:text-3xl">
-            {mode === "provisioning"
+            {mode === "device-setup"
+              ? "Finish billing to approve CLI login"
+              : mode === "provisioning"
               ? "Pick the cloud computer Matrix boots on"
               : "Manage your hosted Matrix computer"}
           </h3>

--- a/shell/src/components/settings/sections/BillingSection.tsx
+++ b/shell/src/components/settings/sections/BillingSection.tsx
@@ -21,7 +21,9 @@ export function BillingSection({
         <div className="min-w-0">
           <h2 className="text-lg font-semibold">Billing</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            {mode === "provisioning"
+            {mode === "device-setup"
+              ? "Choose billing in Settings, then Matrix returns to CLI device approval."
+              : mode === "provisioning"
               ? "Choose a hosted runtime plan and launch through secure checkout."
               : "Manage Matrix OS hosted runtime billing and payment details."}
           </p>

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2621,10 +2621,11 @@ describe("platform proxy routing", () => {
     const html = await res.text();
     expect(html).toContain('var redirectTarget = "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK";');
     expect(html).toContain('var deviceReturnTarget = "/auth/device?user_code=BCDF-GHJK";');
-    expect(html).toContain("if (deviceReturnTarget) checkoutBody.returnPath = redirectTarget;");
+    expect(html).toContain("function openBillingSettingsFromClerkSession()");
+    expect(html).toContain("Billing setup required");
+    expect(html).toContain("Open Billing settings");
     expect(html).toContain("window.location.replace(deviceReturnTarget || payload.redirectTo || redirectTarget);");
     expect(html).toContain("fetch('/api/auth/provision-runtime'");
-    expect(html).toContain("Billing required");
     expect(html).not.toBe("auth shell");
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2470,7 +2470,9 @@ describe("platform proxy routing", () => {
     expect(html).toContain("if (provisionStarted)");
     expect(html).toContain("maxBillingConfirmationPolls");
     expect(html).toContain("provisioningPolls = 0;");
-    expect(html).toContain("Billing required");
+    expect(html).toContain("Billing setup required");
+    expect(html).toContain("Open Billing settings");
+    expect(html).toContain("Stripe opens only after you continue from Billing.");
     expect(html).toContain("fetch('/billing/checkout'");
     expect(html).toContain("planSlug: 'matrix_builder'");
     expect(html).toContain("Checkout unavailable");
@@ -2489,7 +2491,7 @@ describe("platform proxy routing", () => {
     expect(html).not.toContain("You are already signed in");
   });
 
-  it("shows checkout instead of the no-runtime provision CTA when app-session billing is required", async () => {
+  it("opens billing settings instead of direct checkout when app-session billing is required", async () => {
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
     const app = createApp({
       db,
@@ -2507,6 +2509,10 @@ describe("platform proxy routing", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("if (res.status === 402) {\n            showBillingRequiredState();");
+    expect(html).toContain("Billing setup required");
+    expect(html).toContain("Open Billing settings");
+    expect(html).toContain("openBillingSettingsFromClerkSession");
+    expect(html).not.toContain("'Start checkout',\n        startBillingCheckoutFromClerkSession");
   });
 
   it("returns billing_required for signed-in app-session exchange before a Stripe entitlement exists", async () => {
@@ -2626,6 +2632,47 @@ describe("platform proxy routing", () => {
     expect(html).toContain("Open Billing settings");
     expect(html).toContain("window.location.replace(deviceReturnTarget || payload.redirectTo || redirectTarget);");
     expect(html).toContain("fetch('/api/auth/provision-runtime'");
+    expect(html).not.toBe("auth shell");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps legacy no-container app-domain billing users on the settings handoff", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "true";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
+    await deleteContainer(db, "alice");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("auth shell", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: "__session=clerk-new",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('var redirectTarget = "/";');
+    expect(html).toContain('var deviceReturnTarget = "";');
+    expect(html).toContain("function openBillingSettingsFromClerkSession()");
+    expect(html).toContain("Billing setup required");
+    expect(html).toContain("Open Billing settings");
+    expect(html).toContain("Stripe opens only after you continue from Billing.");
+    expect(html).not.toContain("'Start checkout',\n        startBillingCheckoutFromClerkSession");
     expect(html).not.toBe("auth shell");
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/tests/shell/billing-gate.test.tsx
+++ b/tests/shell/billing-gate.test.tsx
@@ -197,6 +197,33 @@ describe("BillingGate", () => {
     expect(screen.queryByTestId("pricing-table")).toBeNull();
   });
 
+  it("opens device login billing in Settings without starting Stripe checkout", async () => {
+    vi.unstubAllEnvs();
+    window.history.replaceState({}, "", "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK");
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = true;
+    clerkState.activePlan = null;
+    vi.resetModules();
+
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const { BillingGate } = await import("../../shell/src/components/BillingGate.js");
+
+    render(
+      <BillingGate>
+        <div>Matrix workspace</div>
+      </BillingGate>,
+    );
+
+    expect(await screen.findByText("Matrix workspace")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Billing" })).toBeTruthy();
+    expect(await screen.findByText("Finish billing to approve CLI login")).toBeTruthy();
+    expect(screen.getByText("Billing settings")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue to pay" })).toBeTruthy();
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes("/billing/checkout")),
+    ).toBe(false);
+  });
+
   it("shows confirmation feedback after a completed checkout redirect", async () => {
     vi.unstubAllEnvs();
     window.history.replaceState({}, "", "/?checkout=success");

--- a/tests/shell/billing-section.test.tsx
+++ b/tests/shell/billing-section.test.tsx
@@ -203,6 +203,34 @@ describe("BillingSection", () => {
     expect(screen.queryByTestId("pricing-table")).toBeNull();
   });
 
+  it("uses device setup copy when billing is opened from CLI login", async () => {
+    clerkState.isLoaded = true;
+    clerkState.activePlan = null;
+
+    const { BillingSection } = await import(
+      "../../shell/src/components/settings/sections/BillingSection.js"
+    );
+
+    render(
+      <BillingSection
+        mode="device-setup"
+        checkoutReturnPath="/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Billing" })).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("Not active")).toBeTruthy());
+    expect(
+      screen.getByText("Choose billing in Settings, then Matrix returns to CLI device approval."),
+    ).toBeTruthy();
+    expect(screen.getByText("Finish billing to approve CLI login")).toBeTruthy();
+    expect(screen.getByText("Billing settings")).toBeTruthy();
+    expect(
+      screen.getByText("Review your plan and region here. Stripe opens only after you choose Continue to pay."),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue to pay" })).toBeTruthy();
+  });
+
   it.each(["matrix_starter", "matrix_builder", "matrix_max"])(
     "marks billing as active when Clerk grants the %s plan",
     async (plan) => {


### PR DESCRIPTION
## Summary
- Send signed-in no-billing users to Billing settings from the platform fallback page instead of offering a direct Stripe checkout action.
- Keep the same Settings/Billing handoff for CLI device-login users, with device-specific copy and return-path preservation.
- Add regression coverage for both normal Clerk login and device login so Stripe opens only after the user continues from Billing.

## Tests
- `pnpm exec vitest run tests/platform/proxy-routing.test.ts -t "continues signed-in auth pages|opens billing settings instead of direct checkout|keeps legacy no-container app-domain"`
- `pnpm exec vitest run tests/shell/billing-gate.test.tsx tests/shell/billing-section.test.tsx`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `node_modules/.bin/tsc --noEmit --incremental false -p shell/tsconfig.json`
- `bun run check:patterns`
- `git diff --check`

## Validation notes
- `bun run typecheck` could not complete in this worktree because the machine is inode-constrained and the lightweight test symlink setup does not include `@cloudflare/workers-types` for the unrelated `edge-router` package.
- `pnpm dlx react-doctor@latest shell` reported an existing Socket supply-chain score failure for `@clerk/nextjs@6.39.0`; CI React Doctor passed on this PR.

## Invariants
- Source of truth: Billing entitlement remains checked by the existing BillingGate and platform `/api/auth/app-session` exchange.
- Lock/transaction scope: no database writes or transaction behavior changed.
- Acceptable orphan states: if checkout or provisioning fails, the user stays on the existing Billing/settings or retry surfaces with the device return path preserved when present.
- Auth source of truth: Clerk remains the browser auth source; platform app-session cookie exchange remains unchanged.
- Deferred scope: this PR does not change Stripe checkout creation, entitlement polling, or VPS provisioning behavior.
