### PR TITLE
fix(platform): auto-open billing setup after auth

### DIFF
--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -114,7 +114,7 @@ const ADMIN_BODY_LIMIT = 64 * 1024;
 const PROXY_BODY_LIMIT = 10 * 1024 * 1024;
 const CLERK_SCRIPT_ORIGIN = 'https://clerk.matrix-os.com';
 const PROXY_TIMEOUT_MS = 30_000;
-const AUTH_SHELL_PROXY_TIMEOUT_MS = 20_000;
+const AUTH_SHELL_PROXY_TIMEOUT_MS = 5_000;
 const EDGE_SECRET_HEADER = 'x-matrix-edge-secret';
 const VPS_RELEASE_PROBE_TIMEOUT_MS = 10_000;
 const CLERK_USER_LOOKUP_TIMEOUT_MS = 10_000;
@@ -660,6 +660,30 @@ function shouldProxyAuthShellForUnroutedUser(input: {
     !input.path.startsWith('/ws') &&
     input.path !== '/metrics'
   );
+}
+
+function buildBillingSetupPath(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl, 'https://app.matrix-os.com');
+    const deviceReturn = url.searchParams.get('device_return');
+    const target = new URL('/', url.origin);
+    target.searchParams.set('billing', 'setup');
+    if (deviceReturn) target.searchParams.set('device_return', deviceReturn);
+    return `${target.pathname}${target.search}`;
+  } catch (err: unknown) {
+    console.warn('[platform] Failed to build billing setup URL:', err instanceof Error ? err.message : String(err));
+    return '/?billing=setup';
+  }
+}
+
+function isBillingSetupPath(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl, 'https://app.matrix-os.com');
+    return url.pathname === '/' && url.searchParams.get('billing') === 'setup';
+  } catch (err: unknown) {
+    console.warn('[platform] Failed to parse billing setup URL:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
 }
 
 function getAuthShellOrigin(env: NodeJS.ProcessEnv): string {
@@ -2343,24 +2367,66 @@ function getAuthPage(
       );
     }
     function showBillingRequiredState() {
-      if (deviceReturnTarget) {
-        renderSessionState(
-          'Billing setup required',
-          'Open Billing settings to choose a hosted runtime plan, then return here to approve this terminal.',
-          'Open Billing settings',
-          openBillingSettingsFromClerkSession
-        );
-        return;
+      showLoadingState('Opening Billing settings...');
+      openBillingSettingsFromClerkSession();
+    }
+    var billingSetupRetryStorageKey = 'matrix.billing.setupRetryCount';
+    var maxBillingSetupReloads = 3;
+    function readBillingSetupRetryCount() {
+      try {
+        var raw = window.sessionStorage.getItem(billingSetupRetryStorageKey);
+        var count = raw ? Number(raw) : 0;
+        return Number.isFinite(count) && count > 0 ? count : 0;
+      } catch (err) {
+        console.warn('[matrix] Unable to read billing setup retry state', err instanceof Error ? err.message : String(err));
+        return 0;
       }
+    }
+    function writeBillingSetupRetryCount(count) {
+      try {
+        window.sessionStorage.setItem(billingSetupRetryStorageKey, String(count));
+      } catch (err) {
+        console.warn('[matrix] Unable to write billing setup retry state', err instanceof Error ? err.message : String(err));
+      }
+    }
+    function clearBillingSetupRetryCount() {
+      try {
+        window.sessionStorage.removeItem(billingSetupRetryStorageKey);
+      } catch (err) {
+        console.warn('[matrix] Unable to clear billing setup retry state', err instanceof Error ? err.message : String(err));
+      }
+    }
+    function showBillingSetupRetryLimitState() {
       renderSessionState(
-        'Billing setup required',
-        'Open Billing settings to choose a hosted runtime plan. Stripe opens only after you continue from Billing.',
-        'Open Billing settings',
-        openBillingSettingsFromClerkSession
+        'Billing settings are still loading',
+        'Matrix is reconnecting the billing settings panel. Try again after a moment.',
+        'Try again',
+        function() {
+          clearBillingSetupRetryCount();
+          window.location.reload();
+        }
       );
     }
+    function billingSetupPath() {
+      var url = new URL('/', window.location.origin);
+      url.searchParams.set('billing', 'setup');
+      if (deviceReturnTarget) url.searchParams.set('device_return', deviceReturnTarget);
+      return url.pathname + url.search;
+    }
     function openBillingSettingsFromClerkSession() {
-      window.location.assign(redirectTarget);
+      var target = billingSetupPath();
+      if (window.location.pathname + window.location.search === target) {
+        var retryCount = readBillingSetupRetryCount();
+        if (retryCount >= maxBillingSetupReloads) {
+          showBillingSetupRetryLimitState();
+          return;
+        }
+        writeBillingSetupRetryCount(retryCount + 1);
+        window.setTimeout(function() { window.location.reload(); }, 2000 + retryCount * 1000);
+        return;
+      }
+      clearBillingSetupRetryCount();
+      window.location.replace(target);
     }
     function showCheckoutUnavailableState() {
       renderSessionState(
@@ -3312,7 +3378,18 @@ export function createApp(deps: {
       });
     } catch (err: unknown) {
       logPlatformRouteError('app-domain auth-shell proxy', err);
-      return c.text('Matrix OS shell unavailable', 502);
+      if (!isBillingSetupPath(c.req.url)) {
+        return c.redirect(buildBillingSetupPath(c.req.url), 302);
+      }
+      const publishableKey = appEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+      if (!publishableKey) {
+        return c.text('Matrix OS shell unavailable', 503);
+      }
+      applyNoStoreHeaders(c);
+      const scriptNonce = randomBytes(16).toString('base64');
+      applyAuthPageHeaders(c, scriptNonce);
+      const authMode = c.req.path.startsWith('/sign-up') ? 'sign-up' : 'sign-in';
+      return c.html(getAuthPage(publishableKey, authMode, scriptNonce, buildPostAuthRedirectPath(c.req.url)), 200);
     }
   }
 

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2470,9 +2470,15 @@ describe("platform proxy routing", () => {
     expect(html).toContain("if (provisionStarted)");
     expect(html).toContain("maxBillingConfirmationPolls");
     expect(html).toContain("provisioningPolls = 0;");
-    expect(html).toContain("Billing setup required");
-    expect(html).toContain("Open Billing settings");
-    expect(html).toContain("Stripe opens only after you continue from Billing.");
+    expect(html).toContain("Opening Billing settings");
+    expect(html).toContain("matrix.billing.setupRetryCount");
+    expect(html).toContain("var maxBillingSetupReloads = 3;");
+    expect(html).toContain("Billing settings are still loading");
+    expect(html).toContain("2000 + retryCount * 1000");
+    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("window.location.replace(target);");
+    expect(html).not.toContain("Open Billing settings");
+    expect(html).not.toContain("Stripe opens only after you continue from Billing.");
     expect(html).toContain("fetch('/billing/checkout'");
     expect(html).toContain("planSlug: 'matrix_builder'");
     expect(html).toContain("Checkout unavailable");
@@ -2509,9 +2515,13 @@ describe("platform proxy routing", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("if (res.status === 402) {\n            showBillingRequiredState();");
-    expect(html).toContain("Billing setup required");
-    expect(html).toContain("Open Billing settings");
-    expect(html).toContain("openBillingSettingsFromClerkSession");
+    expect(html).toContain("Opening Billing settings");
+    expect(html).toContain("matrix.billing.setupRetryCount");
+    expect(html).toContain("var maxBillingSetupReloads = 3;");
+    expect(html).toContain("Billing settings are still loading");
+    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("window.location.replace(target);");
+    expect(html).not.toContain("Open Billing settings");
     expect(html).not.toContain("'Start checkout',\n        startBillingCheckoutFromClerkSession");
   });
 
@@ -2595,6 +2605,76 @@ describe("platform proxy routing", () => {
     delete process.env.AUTH_SHELL_PORT;
   });
 
+  it("redirects to automatic billing setup when the no-VPS auth-shell proxy times out", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
+    await deleteContainer(db, "alice");
+    const timeout = new Error("The operation was aborted due to timeout");
+    timeout.name = "TimeoutError";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(timeout);
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: "__session=clerk-new",
+      },
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/?billing=setup");
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("shows a controlled auto-retry page when billing setup cannot reach auth-shell", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
+    await deleteContainer(db, "alice");
+    const timeout = new Error("The operation was aborted due to timeout");
+    timeout.name = "TimeoutError";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(timeout);
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new" }),
+      }),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/?billing=setup", {
+      headers: {
+        host: "app.matrix-os.com",
+        cookie: "__session=clerk-new",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(fetchMock).toHaveBeenCalled();
+    expect(html).toContain("Loading your Matrix computer");
+    expect(html).toContain("Opening Billing settings");
+    expect(html).toContain("matrix.billing.setupRetryCount");
+    expect(html).toContain("var maxBillingSetupReloads = 3;");
+    expect(html).toContain("Billing settings are still loading");
+    expect(html).toContain("2000 + retryCount * 1000");
+    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("window.location.replace(target);");
+    expect(html).not.toContain("Matrix OS shell unavailable");
+    expect(html).not.toContain("Open Billing settings");
+  });
+
   it("keeps legacy no-container app-domain users on the platform auth page", async () => {
     process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "true";
     process.env.AUTH_SHELL_HOST = "auth-shell.test";
@@ -2627,11 +2707,12 @@ describe("platform proxy routing", () => {
     const html = await res.text();
     expect(html).toContain('var redirectTarget = "/?device_return=%2Fauth%2Fdevice%3Fuser_code%3DBCDF-GHJK";');
     expect(html).toContain('var deviceReturnTarget = "/auth/device?user_code=BCDF-GHJK";');
-    expect(html).toContain("function openBillingSettingsFromClerkSession()");
-    expect(html).toContain("Billing setup required");
-    expect(html).toContain("Open Billing settings");
+    expect(html).toContain("Opening Billing settings");
+    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("window.location.replace(target);");
     expect(html).toContain("window.location.replace(deviceReturnTarget || payload.redirectTo || redirectTarget);");
     expect(html).toContain("fetch('/api/auth/provision-runtime'");
+    expect(html).not.toContain("Open Billing settings");
     expect(html).not.toBe("auth shell");
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -2668,10 +2749,11 @@ describe("platform proxy routing", () => {
     const html = await res.text();
     expect(html).toContain('var redirectTarget = "/";');
     expect(html).toContain('var deviceReturnTarget = "";');
-    expect(html).toContain("function openBillingSettingsFromClerkSession()");
-    expect(html).toContain("Billing setup required");
-    expect(html).toContain("Open Billing settings");
-    expect(html).toContain("Stripe opens only after you continue from Billing.");
+    expect(html).toContain("Opening Billing settings");
+    expect(html).toContain("url.searchParams.set('billing', 'setup');");
+    expect(html).toContain("window.location.replace(target);");
+    expect(html).not.toContain("Open Billing settings");
+    expect(html).not.toContain("Stripe opens only after you continue from Billing.");
     expect(html).not.toContain("'Start checkout',\n        startBillingCheckoutFromClerkSession");
     expect(html).not.toBe("auth shell");
     expect(fetchMock).not.toHaveBeenCalled();


### PR DESCRIPTION
Summary
- Auto-redirect no-billing/no-VPS users from the platform auth page to the shell billing setup route instead of showing an intermediate button.
- Fail over auth-shell proxy timeouts to `/?billing=setup` before Cloudflare can show a 502, and render a controlled retry page if that setup route also cannot reach auth-shell.
- Shorten the auth-shell proxy timeout from 20s to 5s for faster recovery.

Tests
- `pnpm exec vitest run tests/platform/proxy-routing.test.ts -t "continues signed-in auth pages|opens billing settings|auth-shell proxy times out|billing setup cannot reach auth-shell|keeps legacy no-container app-domain|serves the shell billing gate"`
- `pnpm --filter @matrix-os/platform exec tsc --noEmit -p tsconfig.typecheck.json`
- `bun run check:patterns`
- `git diff --check`
- Full `tests/platform/proxy-routing.test.ts` was run before the final stale assertion update: 104/105 passed, with the only failure being the old expectation for manual Billing button copy; the focused slice above passed after updating that assertion.

Review/Monitoring
- Waiting for CI and Greptile on this PR.

Invariants
- Source of truth: Clerk session remains the browser auth source; Stripe billing entitlement remains authoritative for runtime access; this change only redirects the pre-VPS shell surface.
- Lock/transaction scope: no database writes or transactions are added.
- Acceptable orphan states: if auth-shell is unreachable, users stay on a controlled platform auth/retry page and are not sent to Stripe directly or a Cloudflare 502.
- Auth source of truth: signed-in app-domain requests still resolve through Clerk/app-session validation before billing setup; no new anonymous billing access is introduced.
- Deferred scope: splitting `packages/platform/src/main.ts` and investigating auth-shell slowness/root cause are deferred to separate follow-up work so this hotfix stays deployable.