### PR TITLE
fix(vps): make brew and gh baseline tools

### DIFF
--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -32,6 +32,7 @@ write_files:
         export HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar"
         export HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew"
         export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"
+        export MANPATH="/home/linuxbrew/.linuxbrew/share/man:${MANPATH:-}:"
         export INFOPATH="/home/linuxbrew/.linuxbrew/share/info:${INFOPATH:-}"
       fi
   - path: /opt/matrix/postgres-compose.yml

--- a/distro/customer-vps/cloud-init.yaml
+++ b/distro/customer-vps/cloud-init.yaml
@@ -27,7 +27,13 @@ write_files:
       else
         export PATH="/opt/matrix/bin:/opt/matrix/runtime/node/bin:$PATH"
       fi
-      test -x /home/linuxbrew/.linuxbrew/bin/brew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"
+      if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+        export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
+        export HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar"
+        export HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew"
+        export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"
+        export INFOPATH="/home/linuxbrew/.linuxbrew/share/info:${INFOPATH:-}"
+      fi
   - path: /opt/matrix/postgres-compose.yml
     owner: root:root
     permissions: "0644"

--- a/distro/customer-vps/host-bin/matrix-install-linux-tools
+++ b/distro/customer-vps/host-bin/matrix-install-linux-tools
@@ -40,6 +40,7 @@ case ":\${PATH:-}:" in
   *:"$BREW_PREFIX/bin":*) ;;
   *) export PATH="$BREW_PREFIX/bin:$BREW_PREFIX/sbin\${PATH:+:\$PATH}" ;;
 esac
+export MANPATH="$BREW_PREFIX/share/man:\${MANPATH:-}:"
 export INFOPATH="$BREW_PREFIX/share/info:\${INFOPATH:-}"
 EOF
 }
@@ -48,6 +49,7 @@ install_user_shell_config() {
   local path="$1"
   local tmp
   tmp="$(mktemp)"
+  trap 'rm -f "${tmp:-}"' RETURN
   if [ -f "$path" ]; then
     awk '
       /^# >>> matrix homebrew >>>$/ { skip = 1; next }
@@ -63,6 +65,7 @@ install_user_shell_config() {
     printf '# <<< matrix homebrew <<<\n'
   } | sudo tee "$path" >/dev/null
   rm -f "$tmp"
+  trap - RETURN
   sudo chown matrix:matrix "$path"
   sudo chmod 0644 "$path"
 }
@@ -105,6 +108,7 @@ export HOMEBREW_PREFIX="$BREW_PREFIX"
 export HOMEBREW_CELLAR="$BREW_PREFIX/Cellar"
 export HOMEBREW_REPOSITORY="$BREW_PREFIX/Homebrew"
 export PATH="$BREW_PREFIX/bin:$BREW_PREFIX/sbin:$PATH"
+export MANPATH="$BREW_PREFIX/share/man:${MANPATH:-}:"
 export INFOPATH="$BREW_PREFIX/share/info:${INFOPATH:-}"
 
 if ! "$BREW_BIN" list --versions gh >/dev/null 2>&1; then

--- a/distro/customer-vps/host-bin/matrix-install-linux-tools
+++ b/distro/customer-vps/host-bin/matrix-install-linux-tools
@@ -27,6 +27,60 @@ retry() {
   done
 }
 
+homebrew_shell_config() {
+  cat <<EOF
+# Homebrew on Linux
+if [ -n "\${PWD:-}" ] && [ ! -r "\${PWD}" ]; then
+  cd "\${HOME:-/home/matrix/home}" || true
+fi
+export HOMEBREW_PREFIX="$BREW_PREFIX"
+export HOMEBREW_CELLAR="$BREW_PREFIX/Cellar"
+export HOMEBREW_REPOSITORY="$BREW_PREFIX/Homebrew"
+case ":\${PATH:-}:" in
+  *:"$BREW_PREFIX/bin":*) ;;
+  *) export PATH="$BREW_PREFIX/bin:$BREW_PREFIX/sbin\${PATH:+:\$PATH}" ;;
+esac
+export INFOPATH="$BREW_PREFIX/share/info:\${INFOPATH:-}"
+EOF
+}
+
+install_user_shell_config() {
+  local path="$1"
+  local tmp
+  tmp="$(mktemp)"
+  if [ -f "$path" ]; then
+    awk '
+      /^# >>> matrix homebrew >>>$/ { skip = 1; next }
+      /^# <<< matrix homebrew <<<$/ { skip = 0; next }
+      skip { next }
+      { print }
+    ' "$path" > "$tmp"
+  fi
+  {
+    cat "$tmp"
+    printf '\n# >>> matrix homebrew >>>\n'
+    homebrew_shell_config
+    printf '# <<< matrix homebrew <<<\n'
+  } | sudo tee "$path" >/dev/null
+  rm -f "$tmp"
+  sudo chown matrix:matrix "$path"
+  sudo chmod 0644 "$path"
+}
+
+write_homebrew_shell_config() {
+  sudo install -d -o root -g root -m 0755 /etc/profile.d
+  homebrew_shell_config | sudo tee /etc/profile.d/homebrew.sh >/dev/null
+  sudo chmod 0644 /etc/profile.d/homebrew.sh
+
+  sudo install -d -o matrix -g matrix -m 0755 /home/matrix /home/matrix/home
+  for shell_config in /home/matrix/.profile /home/matrix/.bashrc /home/matrix/home/.profile /home/matrix/home/.bashrc; do
+    if [ ! -e "$shell_config" ]; then
+      sudo install -o matrix -g matrix -m 0644 /dev/null "$shell_config"
+    fi
+    install_user_shell_config "$shell_config"
+  done
+}
+
 if [ "$(id -u)" = "0" ]; then
   echo "matrix-install-linux-tools: run as the matrix user, not root" >&2
   exit 1
@@ -47,38 +101,24 @@ if [ ! -x "$BREW_BIN" ]; then
   trap - EXIT
 fi
 
-eval "$("$BREW_BIN" shellenv bash)"
-
-if ! "$BREW_BIN" list --versions graphite >/dev/null 2>&1; then
-  retry 3 30 timeout 600 "$BREW_BIN" install withgraphite/tap/graphite
-fi
+export HOMEBREW_PREFIX="$BREW_PREFIX"
+export HOMEBREW_CELLAR="$BREW_PREFIX/Cellar"
+export HOMEBREW_REPOSITORY="$BREW_PREFIX/Homebrew"
+export PATH="$BREW_PREFIX/bin:$BREW_PREFIX/sbin:$PATH"
+export INFOPATH="$BREW_PREFIX/share/info:${INFOPATH:-}"
 
 if ! "$BREW_BIN" list --versions gh >/dev/null 2>&1; then
   retry 3 30 timeout 600 "$BREW_BIN" install gh
 fi
 
-sudo install -d -o root -g root -m 0755 /etc/profile.d
-printf '%s\n' \
-  '# Homebrew on Linux' \
-  'if [ -n "${PWD:-}" ] && [ ! -r "${PWD}" ]; then' \
-  '  cd "${HOME:-/home/matrix/home}" || true' \
-  'fi' \
-  "eval \"\$(${BREW_BIN} shellenv bash)\"" \
-  | sudo tee /etc/profile.d/homebrew.sh >/dev/null
-sudo chmod 0644 /etc/profile.d/homebrew.sh
+write_homebrew_shell_config
 
 sudo ln -sf "$BREW_BIN" /usr/local/bin/brew
-if [ -x "$BREW_PREFIX/bin/gt" ]; then
-  sudo ln -sf "$BREW_PREFIX/bin/gt" /usr/local/bin/gt
-fi
 if [ -x "$BREW_PREFIX/bin/gh" ]; then
   sudo ln -sf "$BREW_PREFIX/bin/gh" /usr/local/bin/gh
 fi
 
 "$BREW_BIN" --version
-if [ -x "$BREW_PREFIX/bin/gt" ]; then
-  "$BREW_PREFIX/bin/gt" --version
-fi
 if [ -x "$BREW_PREFIX/bin/gh" ]; then
   "$BREW_PREFIX/bin/gh" --version
 fi

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -351,6 +351,7 @@ exit 99
     expect(cloudInit).not.toContain('sudo -H -u matrix /opt/matrix/bin/matrix-install-linux-tools');
     expect(cloudInit).toContain('export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"');
     expect(cloudInit).toContain('export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"');
+    expect(cloudInit).toContain('export MANPATH="/home/linuxbrew/.linuxbrew/share/man:${MANPATH:-}:"');
     expect(cloudInit).not.toContain('brew shellenv');
     expect(gateway).toContain('matrix_prepend_path_once "/opt/matrix/app/node_modules/.bin"');
     expect(gateway).toContain('MATRIX_SKILL_TARGETS=matrix,claude,codex');
@@ -391,7 +392,10 @@ exit 99
     expect(installer).not.toContain('brew install cos');
     expect(installer).toContain('/etc/profile.d/homebrew.sh');
     expect(installer).toContain('if [ -n "\\${PWD:-}" ] && [ ! -r "\\${PWD}" ]; then');
+    expect(installer).toContain('trap \'rm -f "${tmp:-}"\' RETURN');
     expect(installer).toContain('write_homebrew_shell_config');
+    expect(installer).toContain('export MANPATH="$BREW_PREFIX/share/man:${MANPATH:-}:"');
+    expect(installer).toContain('export MANPATH="$BREW_PREFIX/share/man:\\${MANPATH:-}:"');
     expect(installer).not.toContain('brew shellenv');
     expect(installer).toContain('sudo ln -sf "$BREW_BIN" /usr/local/bin/brew');
     expect(installer).toContain('sudo ln -sf "$BREW_PREFIX/bin/gh" /usr/local/bin/gh');

--- a/tests/platform/customer-vps-cloud-init.test.ts
+++ b/tests/platform/customer-vps-cloud-init.test.ts
@@ -349,7 +349,9 @@ exit 99
     expect(cloudInit).toContain('Restart=on-failure');
     expect(cloudInit).toContain('systemctl start --no-block matrix-linux-tools.service || echo "matrix-host: optional Linux tools install will retry via systemd" >&2');
     expect(cloudInit).not.toContain('sudo -H -u matrix /opt/matrix/bin/matrix-install-linux-tools');
-    expect(cloudInit).toContain('test -x /home/linuxbrew/.linuxbrew/bin/brew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"');
+    expect(cloudInit).toContain('export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"');
+    expect(cloudInit).toContain('export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH"');
+    expect(cloudInit).not.toContain('brew shellenv');
     expect(gateway).toContain('matrix_prepend_path_once "/opt/matrix/app/node_modules/.bin"');
     expect(gateway).toContain('MATRIX_SKILL_TARGETS=matrix,claude,codex');
     expect(cloudInit).toContain('DATABASE_URL=postgresql://matrix:{{postgresPassword}}@127.0.0.1:5432/matrix');
@@ -375,7 +377,7 @@ exit 99
     expect(cloudInit).toContain('ensure_owner_link .config 0755');
   });
 
-  it('installs Homebrew, Graphite CLI, and GitHub CLI on customer Linux hosts', () => {
+  it('installs Homebrew and GitHub CLI on customer Linux hosts', () => {
     const root = process.cwd();
     const installer = readFileSync(join(root, 'distro/customer-vps/host-bin/matrix-install-linux-tools'), 'utf8');
     const bundleScript = readFileSync(join(root, 'scripts/build-host-bundle.sh'), 'utf8');
@@ -383,14 +385,17 @@ exit 99
     expect(installer).toContain('https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh');
     expect(installer).toContain('retry 2 30 env NONINTERACTIVE=1 timeout 600 /bin/bash "$tmp_installer"');
     expect(installer).toContain('cd "${HOME:-/home/matrix/home}"');
-    expect(installer).toContain('retry 3 30 timeout 600 "$BREW_BIN" install withgraphite/tap/graphite');
     expect(installer).toContain('retry 3 30 timeout 600 "$BREW_BIN" install gh');
+    expect(installer).not.toContain('withgraphite/tap/graphite');
+    expect(installer).not.toContain('cosineai/tap');
+    expect(installer).not.toContain('brew install cos');
     expect(installer).toContain('/etc/profile.d/homebrew.sh');
-    expect(installer).toContain('if [ -n "${PWD:-}" ] && [ ! -r "${PWD}" ]; then');
-    expect(installer).toContain('"eval \\"\\$(${BREW_BIN} shellenv bash)\\""');
+    expect(installer).toContain('if [ -n "\\${PWD:-}" ] && [ ! -r "\\${PWD}" ]; then');
+    expect(installer).toContain('write_homebrew_shell_config');
+    expect(installer).not.toContain('brew shellenv');
     expect(installer).toContain('sudo ln -sf "$BREW_BIN" /usr/local/bin/brew');
-    expect(installer).toContain('sudo ln -sf "$BREW_PREFIX/bin/gt" /usr/local/bin/gt');
     expect(installer).toContain('sudo ln -sf "$BREW_PREFIX/bin/gh" /usr/local/bin/gh');
+    expect(installer).not.toContain('sudo ln -sf "$BREW_PREFIX/bin/gt" /usr/local/bin/gt');
     expect(bundleScript).toContain('matrix-install-linux-tools');
   });
 


### PR DESCRIPTION
## Summary
- make Homebrew for Linux and GitHub CLI the default customer VPS Linux-tools baseline
- stop installing Graphite/gt as part of the default Linux-tools installer
- wire Homebrew into cloud-init and Matrix shell startup files with static environment exports instead of running `brew shellenv` during shell startup
- add regression coverage that the default installer does not install Cosine/cos or Graphite

## Tests
- `vitest run tests/platform/customer-vps-cloud-init.test.ts tests/platform/customer-vps-host-bundle.test.ts` via the existing root Vitest binary: passed, 56 tests
- `bash -n distro/customer-vps/host-bin/matrix-install-linux-tools && bash -n scripts/build-host-bundle.sh && git diff --check`: passed
- `bun run check:patterns`: passed with existing warnings only

## Review/Monitoring
- Opening PR now; CI and Greptile will be monitored until the latest trusted Greptile result is 5/5.
- Broad `bun run test` and `bun run typecheck` were not run locally because this VPS has inode exhaustion and the worktree cannot install its own dependency tree; narrow deploy tests and syntax checks were run instead.

## Invariants
- Source of truth: customer VPS host bundles carry the Linux-tools installer; Homebrew/gh installation state lives on each VPS under `/home/linuxbrew/.linuxbrew` and `/usr/local/bin` symlinks.
- Lock/transaction scope: this PR does not change release publication or update transaction semantics; the installer remains idempotent and rerunnable by `matrix-linux-tools.service`.
- Acceptable orphan states: if Homebrew install succeeds but `gh` install fails, the systemd service remains failed/retryable; rerunning the installer repairs missing symlinks and shell startup files.
- Auth source of truth: no auth boundary changes; installer still runs as the `matrix` user with existing passwordless sudo on customer VPSes.
- Deferred scope: Cosine/cos stays user-installed only; Graphite/gt is no longer defaulted here and can be handled by a separate optional developer tool-pack decision.
