### PR TITLE
fix(shell): avoid auth shell metadata timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
     name: Pattern Scan
     needs: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - name: Skip expensive CI for docs-only changes
         if: needs.changes.outputs.should_run != 'true'

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -361,11 +361,11 @@ jobs:
             --header "x-forwarded-host: ${app_domain_host}" \
             --header "x-matrix-edge-secret: ${edge_router_secret}" \
             "$CANDIDATE_URL/?billing=setup")"
-          if ! printf '%s\n' "$billing_shell_html" | grep -Fq "Loading billing status"; then
+          if ! printf '%s\n' "$billing_shell_html" | grep -Fq 'data-matrix-billing-gate="true"'; then
             echo "Candidate pre-VPS billing shell did not serve the settings billing gate." >&2
             exit 1
           fi
-          if printf '%s\n' "$billing_shell_html" | grep -Fq "Welcome back to Matrix"; then
+          if printf '%s\n' "$billing_shell_html" | grep -Fq 'data-matrix-platform-fallback-auth="true"'; then
             echo "Candidate pre-VPS billing shell served the platform fallback auth page." >&2
             exit 1
           fi

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -353,7 +353,7 @@ jobs:
             --header "x-forwarded-host: ${app_domain_host}" \
             --header "x-matrix-edge-secret: ${edge_router_secret}" \
             "$CANDIDATE_URL/sign-in")"
-          if ! printf '%s\n' "$auth_shell_html" | grep -Fq "Come back to your computer."; then
+          if ! printf '%s\n' "$auth_shell_html" | grep -Fq 'data-matrix-auth-shell="true"'; then
             echo "Candidate pre-VPS auth shell did not serve the Next sign-in surface." >&2
             exit 1
           fi

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -353,12 +353,20 @@ jobs:
             --header "x-forwarded-host: ${app_domain_host}" \
             --header "x-matrix-edge-secret: ${edge_router_secret}" \
             "$CANDIDATE_URL/sign-in")"
-          if ! printf '%s\n' "$auth_shell_html" | grep -Fq "fetch('/billing/checkout'"; then
-            echo "Candidate pre-VPS auth shell does not expose the billing checkout handoff." >&2
+          if ! printf '%s\n' "$auth_shell_html" | grep -Fq "Come back to your computer."; then
+            echo "Candidate pre-VPS auth shell did not serve the Next sign-in surface." >&2
             exit 1
           fi
-          if ! printf '%s\n' "$auth_shell_html" | grep -Fq "Checkout unavailable"; then
-            echo "Candidate pre-VPS auth shell does not expose the controlled checkout failure state." >&2
+          billing_shell_html="$(curl --fail --silent --show-error --max-time 10 \
+            --header "x-forwarded-host: ${app_domain_host}" \
+            --header "x-matrix-edge-secret: ${edge_router_secret}" \
+            "$CANDIDATE_URL/?billing=setup")"
+          if ! printf '%s\n' "$billing_shell_html" | grep -Fq "Loading billing status"; then
+            echo "Candidate pre-VPS billing shell did not serve the settings billing gate." >&2
+            exit 1
+          fi
+          if printf '%s\n' "$billing_shell_html" | grep -Fq "Welcome back to Matrix"; then
+            echo "Candidate pre-VPS billing shell served the platform fallback auth page." >&2
             exit 1
           fi
           manifest="$(curl --fail --silent --show-error --max-time 10 "$CANDIDATE_URL/system-bundles/channels/dev.json")"

--- a/packages/platform/src/auth-pages.ts
+++ b/packages/platform/src/auth-pages.ts
@@ -234,7 +234,7 @@ export function getAuthPage(
   </style>
 </head>
 <body>
-  <main class="page">
+  <main class="page" data-matrix-platform-fallback-auth="true">
     <section class="story">
       <div class="story-inner">
         <div class="brand"><span class="logo">M</span><span>Matrix OS</span></div>

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { Inter, JetBrains_Mono, Cormorant_Garamond, Orbitron } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import { getPostHogVisitorCountry } from "@matrix-os/observability/client";
+import { buildShellMetadata } from "@/lib/shell-metadata";
 import "@xterm/xterm/css/xterm.css";
 import "@fontsource/jetbrains-mono/400.css";
 import "@fontsource/jetbrains-mono/500.css";
@@ -34,58 +35,8 @@ const orbitron = Orbitron({
   weight: ["400", "500", "600", "700"],
 });
 
-const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
-
 export async function generateMetadata(): Promise<Metadata> {
-  let handle = "";
-  let displayName = "";
-  try {
-    const res = await fetch(`${gatewayUrl}/api/identity`, {
-      next: { revalidate: 60 },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      handle = data.handle ?? "";
-      displayName = data.displayName ?? "";
-    }
-  } catch (err) {
-    console.warn("[shell] identity metadata unavailable:", err instanceof Error ? err.message : String(err));
-    // Gateway not available (build time or offline)
-  }
-
-  const title = handle ? `Matrix OS — @${handle}` : "Matrix OS";
-  const description = displayName
-    ? `${displayName}'s AI operating system`
-    : "Your AI operating system";
-
-  return {
-    title,
-    description,
-    manifest: "/manifest.json",
-    appleWebApp: {
-      capable: true,
-      statusBarStyle: "black-translucent",
-      title: "Matrix OS",
-      // `startupImage` requires per-device {url, media} entries matching real
-      // iPhone/iPad pixel dimensions; iOS ignores a single PNG. Omit until
-      // proper per-device splash images are generated.
-    },
-    formatDetection: { telephone: false, email: false, address: false },
-    openGraph: {
-      title,
-      description,
-      siteName: "Matrix OS",
-      type: "website",
-      images: [{ url: "/og.png", width: 1469, height: 1526, alt: "Matrix OS" }],
-    },
-    twitter: {
-      card: "summary",
-      title,
-      description,
-      images: ["/og.png"],
-    },
-  };
+  return buildShellMetadata(process.env.GATEWAY_URL);
 }
 
 export const viewport: Viewport = {

--- a/shell/src/components/BillingGate.tsx
+++ b/shell/src/components/BillingGate.tsx
@@ -205,7 +205,7 @@ function SubscriptionConfirmationPending({
 
 function BillingStatusLoading() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-page-bg text-forest/70">
+    <main data-matrix-billing-gate="true" className="flex min-h-screen items-center justify-center bg-page-bg text-forest/70">
       <output className="flex items-center gap-2 text-sm">
         <Loader2Icon className="size-4 animate-spin text-ember" aria-hidden="true" />
         Loading billing status
@@ -420,7 +420,7 @@ function BillingGateInner({ children }: { children: ReactNode }) {
 
   if (!hasBillingAccess && checkoutReturnRequested && !checkoutAttemptChecked) {
     return (
-      <main className="flex min-h-screen items-center justify-center bg-page-bg text-forest/70">
+      <main data-matrix-billing-gate="true" className="flex min-h-screen items-center justify-center bg-page-bg text-forest/70">
         <output className="flex items-center gap-2 text-sm">
           <Loader2Icon className="size-4 animate-spin text-ember" aria-hidden="true" />
           Checking billing status...

--- a/shell/src/components/auth/ShellAuthLayout.tsx
+++ b/shell/src/components/auth/ShellAuthLayout.tsx
@@ -12,7 +12,7 @@ interface ShellAuthLayoutProps {
 
 export function ShellAuthLayout({ eyebrow, title, body, children }: ShellAuthLayoutProps) {
   return (
-    <main className="relative min-h-screen overflow-hidden bg-[#E0E1CA] text-[#323D2E]">
+    <main data-matrix-auth-shell="true" className="relative min-h-screen overflow-hidden bg-[#E0E1CA] text-[#323D2E]">
       <div
         className="pointer-events-none absolute inset-0"
         style={{

--- a/shell/src/lib/shell-metadata.ts
+++ b/shell/src/lib/shell-metadata.ts
@@ -1,0 +1,63 @@
+import type { Metadata } from "next";
+
+interface ShellIdentity {
+  handle?: unknown;
+  displayName?: unknown;
+}
+
+const identityMetadataTimeoutMs = 2_000;
+
+function metadataFromIdentity(identity: ShellIdentity | null): Metadata {
+  const handle = typeof identity?.handle === "string" ? identity.handle : "";
+  const displayName = typeof identity?.displayName === "string" ? identity.displayName : "";
+  const title = handle ? `Matrix OS — @${handle}` : "Matrix OS";
+  const description = displayName ? `${displayName}'s AI operating system` : "Your AI operating system";
+
+  return {
+    title,
+    description,
+    manifest: "/manifest.json",
+    appleWebApp: {
+      capable: true,
+      statusBarStyle: "black-translucent",
+      title: "Matrix OS",
+      // `startupImage` requires per-device {url, media} entries matching real
+      // iPhone/iPad pixel dimensions; iOS ignores a single PNG. Omit until
+      // proper per-device splash images are generated.
+    },
+    formatDetection: { telephone: false, email: false, address: false },
+    openGraph: {
+      title,
+      description,
+      siteName: "Matrix OS",
+      type: "website",
+      images: [{ url: "/og.png", width: 1469, height: 1526, alt: "Matrix OS" }],
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+      images: ["/og.png"],
+    },
+  };
+}
+
+export async function buildShellMetadata(gatewayUrl: string | undefined): Promise<Metadata> {
+  const normalizedGatewayUrl = gatewayUrl?.trim();
+  if (!normalizedGatewayUrl) return metadataFromIdentity(null);
+
+  try {
+    const res = await fetch(`${normalizedGatewayUrl}/api/identity`, {
+      next: { revalidate: 60 },
+      signal: AbortSignal.timeout(identityMetadataTimeoutMs),
+    });
+    if (res.ok) {
+      return metadataFromIdentity(await res.json() as ShellIdentity);
+    }
+  } catch (err) {
+    console.warn("[shell] identity metadata unavailable:", err instanceof Error ? err.message : String(err));
+    // Gateway not available (build time, Cloud Run auth shell, or offline).
+  }
+
+  return metadataFromIdentity(null);
+}

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -101,8 +101,8 @@ describe('CI workflows', () => {
     expect(workflow).toContain('$CANDIDATE_URL/?billing=setup');
     expect(workflow).toContain('pre-VPS auth shell');
     expect(workflow).toContain('data-matrix-auth-shell="true"');
-    expect(workflow).toContain('Loading billing status');
-    expect(workflow).toContain('Welcome back to Matrix');
+    expect(workflow).toContain('data-matrix-billing-gate="true"');
+    expect(workflow).toContain('data-matrix-platform-fallback-auth="true"');
     expect(workflow).toContain('served the platform fallback auth page');
   });
 

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -98,9 +98,12 @@ describe('CI workflows', () => {
 
     expect(workflow).toContain('Smoke candidate revision');
     expect(workflow).toContain('$CANDIDATE_URL/sign-in');
+    expect(workflow).toContain('$CANDIDATE_URL/?billing=setup');
     expect(workflow).toContain('pre-VPS auth shell');
-    expect(workflow).toContain("fetch('/billing/checkout'");
-    expect(workflow).toContain('Checkout unavailable');
+    expect(workflow).toContain('Come back to your computer.');
+    expect(workflow).toContain('Loading billing status');
+    expect(workflow).toContain('Welcome back to Matrix');
+    expect(workflow).toContain('served the platform fallback auth page');
   });
 
   it('smokes /sign-in through trusted edge-router headers instead of the raw candidate host', () => {

--- a/tests/platform/ci-workflows.test.ts
+++ b/tests/platform/ci-workflows.test.ts
@@ -100,7 +100,7 @@ describe('CI workflows', () => {
     expect(workflow).toContain('$CANDIDATE_URL/sign-in');
     expect(workflow).toContain('$CANDIDATE_URL/?billing=setup');
     expect(workflow).toContain('pre-VPS auth shell');
-    expect(workflow).toContain('Come back to your computer.');
+    expect(workflow).toContain('data-matrix-auth-shell="true"');
     expect(workflow).toContain('Loading billing status');
     expect(workflow).toContain('Welcome back to Matrix');
     expect(workflow).toContain('served the platform fallback auth page');

--- a/tests/shell/shell-metadata.test.ts
+++ b/tests/shell/shell-metadata.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildShellMetadata } from "@/lib/shell-metadata";
+
+describe("shell metadata", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("does not fetch localhost identity metadata when no gateway URL is configured", async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    const metadata = await buildShellMetadata(undefined);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(metadata.title).toBe("Matrix OS");
+    expect(metadata.description).toBe("Your AI operating system");
+  });
+
+  it("uses configured gateway identity metadata when available", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ handle: "alice", displayName: "Alice" }),
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const metadata = await buildShellMetadata("http://gateway.test");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://gateway.test/api/identity",
+      expect.objectContaining({
+        next: { revalidate: 60 },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(metadata.title).toBe("Matrix OS — @alice");
+    expect(metadata.description).toBe("Alice's AI operating system");
+  });
+});

--- a/tests/shell/shell-metadata.test.ts
+++ b/tests/shell/shell-metadata.test.ts
@@ -40,4 +40,31 @@ describe("shell metadata", () => {
     expect(metadata.title).toBe("Matrix OS — @alice");
     expect(metadata.description).toBe("Alice's AI operating system");
   });
+
+  it("falls back to generic metadata when the configured gateway returns a non-ok response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: vi.fn(),
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const metadata = await buildShellMetadata("http://gateway.test");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(metadata.title).toBe("Matrix OS");
+    expect(metadata.description).toBe("Your AI operating system");
+  });
+
+  it("falls back to generic metadata when the configured gateway fetch fails", async () => {
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.fn().mockRejectedValue(new Error("gateway timeout"));
+    global.fetch = fetchMock as typeof fetch;
+
+    const metadata = await buildShellMetadata("http://gateway.test");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(warnMock).toHaveBeenCalledWith("[shell] identity metadata unavailable:", "gateway timeout");
+    expect(metadata.title).toBe("Matrix OS");
+    expect(metadata.description).toBe("Your AI operating system");
+  });
 });


### PR DESCRIPTION
## Summary

- Stop shell metadata from defaulting to `http://localhost:4000` when `GATEWAY_URL` is unset, so Cloud Run auth/billing shell SSR does not stall before no-VPS routes render.
- Move metadata construction into `buildShellMetadata`, with no fetch when the gateway URL is absent, a bounded 2s fetch when configured, and tested generic fallbacks.
- Harden Platform Cloud Run smoke coverage with structural markers for the Next auth shell, billing gate, and fallback auth page; also give Pattern Scan enough timeout margin for checkout.

## Tests

- `pnpm exec vitest run tests/shell/shell-metadata.test.ts tests/platform/ci-workflows.test.ts tests/scripts/start-platform-cloud-run.test.ts`
- `pnpm --dir shell exec tsc --noEmit`
- `bun run check:patterns`
- `npx react-doctor@latest shell --diff`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_matrix NEXT_PUBLIC_MATRIX_APP_URL=https://app.matrix-os.com pnpm --dir shell exec next build --webpack`
- GitHub CI on `e06270a4f`: CI Results, all unit shards, E2E, Type Check, Pattern Scan, React Doctor, Sync Client Package, Docker Smoke, Vercel, PR Title all passed.
- Greptile on `e06270a4f`: 5/5.

## Invariants

- **Source of truth**: shell metadata comes from the configured gateway only; there is no implicit localhost gateway for the platform-owned auth shell.
- **Lock/transaction scope**: no writes or transactions are introduced; this is read-only metadata generation plus CI smoke coverage.
- **Acceptable orphan states**: if `GATEWAY_URL` is unset or identity fetch fails, the shell serves generic Matrix OS metadata instead of blocking SSR or changing auth/billing state.
- **Auth source of truth**: Clerk and platform routing remain unchanged; Cloud Run smoke requests use the existing trusted edge-secret headers.
- **Deferred scope**: checkout/provisioning behavior is unchanged; this PR only fixes the pre-VPS shell render stall and makes the deploy smoke gate catch fallback-auth regressions.
