### PR TITLE
fix(shell): use canonical app origin for auth redirects

### DIFF
--- a/shell/src/lib/public-origin.ts
+++ b/shell/src/lib/public-origin.ts
@@ -1,0 +1,50 @@
+export interface PublicOriginRequestLike {
+  headers: { get(name: string): string | null };
+  nextUrl: {
+    host: string;
+    protocol: string;
+  };
+}
+
+/**
+ * Origin of NEXT_PUBLIC_MATRIX_APP_URL, or null when unset/unparsable.
+ *
+ * In hosted deployments this is baked into the bundle at build time
+ * (https://app.matrix-os.com), making it the canonical public origin. Local
+ * dev leaves it unset and falls back to request-derived origins.
+ */
+export function getConfiguredAppOrigin(
+  configuredAppUrl: string | undefined = process.env.NEXT_PUBLIC_MATRIX_APP_URL,
+): string | null {
+  if (!configuredAppUrl || !URL.canParse(configuredAppUrl)) return null;
+  return new URL(configuredAppUrl).origin;
+}
+
+/**
+ * Public origin for redirect URLs handed to Clerk and browsers.
+ *
+ * The configured app origin always wins: the auth shell sits behind the
+ * platform proxy, which rewrites x-forwarded-proto to "http" (Next 16
+ * self-proxy workaround), and Next 16 internal self-proxy hops re-enter the
+ * proxy with the internal localhost origin and no forwarded headers. Deriving
+ * the origin from those requests produces redirect URLs like
+ * http://localhost:3200/?billing=setup, which Clerk rejects.
+ */
+export function getPublicOrigin(
+  request: PublicOriginRequestLike,
+  configuredAppUrl: string | undefined = process.env.NEXT_PUBLIC_MATRIX_APP_URL,
+): string {
+  const canonical = getConfiguredAppOrigin(configuredAppUrl);
+  if (canonical) return canonical;
+
+  const host =
+    request.headers.get("x-forwarded-host") ??
+    request.headers.get("host") ??
+    request.nextUrl.host;
+  const proto =
+    request.headers.get("x-forwarded-proto") ??
+    request.nextUrl.protocol.replace(":", "") ??
+    "https";
+
+  return `${proto}://${host}`;
+}

--- a/shell/src/lib/public-origin.ts
+++ b/shell/src/lib/public-origin.ts
@@ -43,8 +43,7 @@ export function getPublicOrigin(
     request.nextUrl.host;
   const proto =
     request.headers.get("x-forwarded-proto") ??
-    request.nextUrl.protocol.replace(":", "") ??
-    "https";
+    request.nextUrl.protocol.replace(":", "");
 
   return `${proto}://${host}`;
 }

--- a/shell/src/proxy.ts
+++ b/shell/src/proxy.ts
@@ -9,6 +9,7 @@ import {
   isPlatformMobileAppSessionRequest,
   isPublicShellPath,
 } from "./lib/proxy-routes";
+import { getPublicOrigin } from "./lib/public-origin";
 
 const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
 const authToken = process.env.MATRIX_AUTH_TOKEN;
@@ -33,19 +34,6 @@ interface ProxyRequestLike {
 // gateway.
 function isGatewayProxy(request: ProxyRequestLike): boolean {
   return isGatewayProxyPath(request.nextUrl.pathname);
-}
-
-function getPublicOrigin(request: ProxyRequestLike) {
-  const host =
-    request.headers.get("x-forwarded-host") ??
-    request.headers.get("host") ??
-    request.nextUrl.host;
-  const proto =
-    request.headers.get("x-forwarded-proto") ??
-    request.nextUrl.protocol.replace(":", "") ??
-    "https";
-
-  return `${proto}://${host}`;
 }
 
 function rewriteGatewayRequest(request: ProxyRequestLike) {

--- a/tests/shell/public-origin.test.ts
+++ b/tests/shell/public-origin.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import {
+  getConfiguredAppOrigin,
+  getPublicOrigin,
+} from "../../shell/src/lib/public-origin";
+
+function requestLike(input: {
+  headers?: Record<string, string>;
+  host?: string;
+  protocol?: string;
+}) {
+  const headers = new Headers(input.headers ?? {});
+  return {
+    headers,
+    nextUrl: {
+      host: input.host ?? "localhost:3200",
+      protocol: input.protocol ?? "http:",
+    },
+  };
+}
+
+describe("getConfiguredAppOrigin", () => {
+  it("returns the origin of a configured app URL", () => {
+    expect(getConfiguredAppOrigin("https://app.matrix-os.com")).toBe(
+      "https://app.matrix-os.com",
+    );
+    expect(getConfiguredAppOrigin("https://app.matrix-os.com/some/path")).toBe(
+      "https://app.matrix-os.com",
+    );
+  });
+
+  it("returns null when the app URL is missing or unparsable", () => {
+    expect(getConfiguredAppOrigin(undefined)).toBeNull();
+    expect(getConfiguredAppOrigin("")).toBeNull();
+    expect(getConfiguredAppOrigin("not a url")).toBeNull();
+  });
+});
+
+describe("getPublicOrigin", () => {
+  it("prefers the configured app origin over every header", () => {
+    const request = requestLike({
+      headers: {
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "http",
+        host: "127.0.0.1:3200",
+      },
+    });
+    expect(getPublicOrigin(request, "https://app.matrix-os.com")).toBe(
+      "https://app.matrix-os.com",
+    );
+  });
+
+  it("never leaks the internal auth shell origin when the app URL is configured", () => {
+    // Next 16 internal self-proxy hops re-enter the proxy without the
+    // platform's forwarded headers; the redirect target must still be public.
+    const request = requestLike({
+      headers: { host: "localhost:3200" },
+      host: "localhost:3200",
+      protocol: "http:",
+    });
+    const origin = getPublicOrigin(request, "https://app.matrix-os.com");
+    expect(origin).toBe("https://app.matrix-os.com");
+    expect(origin).not.toMatch(/localhost|127\.0\.0\.1/);
+  });
+
+  it("upgrades the platform's forced http forwarded proto to the canonical https origin", () => {
+    // proxyAuthShell forwards x-forwarded-proto: http to keep Next 16 from
+    // self-proxying over https; Clerk redirect URLs must still be https.
+    const request = requestLike({
+      headers: {
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "http",
+      },
+    });
+    expect(getPublicOrigin(request, "https://app.matrix-os.com")).toBe(
+      "https://app.matrix-os.com",
+    );
+  });
+
+  it("falls back to forwarded headers when no app URL is configured", () => {
+    const request = requestLike({
+      headers: {
+        "x-forwarded-host": "app.example.test",
+        "x-forwarded-proto": "https",
+        host: "127.0.0.1:3200",
+      },
+    });
+    expect(getPublicOrigin(request, undefined)).toBe("https://app.example.test");
+  });
+
+  it("falls back to the host header, then nextUrl, in local dev", () => {
+    expect(
+      getPublicOrigin(
+        requestLike({ headers: { host: "localhost:3000" }, protocol: "http:" }),
+        undefined,
+      ),
+    ).toBe("http://localhost:3000");
+    expect(
+      getPublicOrigin(
+        requestLike({ host: "localhost:3000", protocol: "http:" }),
+        undefined,
+      ),
+    ).toBe("http://localhost:3000");
+  });
+
+  it("ignores an unparsable configured app URL and uses the header chain", () => {
+    const request = requestLike({
+      headers: {
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+    expect(getPublicOrigin(request, "not a url")).toBe(
+      "https://app.matrix-os.com",
+    );
+  });
+
+  it("builds sign-in redirect URLs with a public https origin for proxied billing setup requests", () => {
+    // Regression for the post-OTP flow: a platform-proxied /?billing=setup
+    // request must never produce /sign-in?redirect_url=http://localhost:3200/...
+    const request = requestLike({
+      headers: {
+        host: "127.0.0.1:3200",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "http",
+      },
+    });
+    const publicOrigin = getPublicOrigin(request, "https://app.matrix-os.com");
+    const signInUrl = new URL("/sign-in", publicOrigin);
+    signInUrl.searchParams.set(
+      "redirect_url",
+      new URL("/?billing=setup", publicOrigin).toString(),
+    );
+    expect(signInUrl.toString()).toBe(
+      "https://app.matrix-os.com/sign-in?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F%3Fbilling%3Dsetup",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining gap in the post-OTP billing flow that #470/#471/#474/#475 did not cover: the auth shell can still generate Clerk redirect URLs from its internal origin.

`getPublicOrigin()` in `shell/src/proxy.ts` derived the origin for `/sign-in?redirect_url=...` from `x-forwarded-host`/`x-forwarded-proto` with a fallback to `request.nextUrl`. Behind the platform's auth-shell proxy that chain is poisoned twice:

- the platform deliberately rewrites `x-forwarded-proto` to `http` (Next 16 self-proxy workaround, `proxyAuthShell` in `packages/platform/src/main.ts`), so derived origins come out as `http://app.matrix-os.com`;
- Next 16 internal self-proxy hops re-enter the proxy without the platform's forwarded headers at all, so the fallback produces the internal origin and the shell emits `/sign-in?redirect_url=http://localhost:3200/?billing=setup`, which Clerk rejects. This is the exact error observed in production after OTP, and it landed on the critical path when #470/#471/#474 changed the post-402 flow to navigate to `/?billing=setup` (a Clerk-protected shell route) instead of rendering billing inline on the platform auth page.

Fix: a new pure helper `shell/src/lib/public-origin.ts`. When `NEXT_PUBLIC_MATRIX_APP_URL` is configured (baked into every hosted bundle as `https://app.matrix-os.com` at build time, also set on the Cloud Run service), its origin is canonical and always wins. When it is unset (local dev), the previous header-derivation chain is preserved unchanged. This also removes a minor open-redirect-shaped surface where a spoofed `x-forwarded-host` on a direct request could steer `redirect_url`.

## Tests

- New `tests/shell/public-origin.test.ts` (TDD, red first): canonical origin wins over forwarded/internal headers; internal `localhost:3200` origins never leak; forced-http forwarded proto upgrades to canonical https; dev fallback chain preserved; unparsable configured URL falls back; end-to-end regression asserting a platform-proxied `/?billing=setup` request produces `https://app.matrix-os.com/sign-in?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F%3Fbilling%3Dsetup`.
- `bun run vitest run tests/shell` — 941 tests passed.
- `bun run typecheck` — clean.
- `bun run check:patterns` — 0 violations (5 pre-existing warnings).
- No `.tsx`/`.jsx` changes, so react-doctor is not required.

## Invariants

- **Source of truth**: `NEXT_PUBLIC_MATRIX_APP_URL` is the canonical public origin for the shell wherever it is configured; request headers are a dev-only fallback.
- **Auth source of truth**: unchanged — Clerk middleware still authenticates; this only fixes the origin used when building redirect URLs around it.
- **Lock/transaction scope**: n/a (pure URL derivation, no I/O).
- **Acceptable orphan states**: n/a.
- **Deferred scope**: Clerk's internal handshake URL derivation still sees `x-forwarded-proto: http` from `proxyAuthShell`, so handshake round-trips traverse one extra http→https redirect hop. Fixing that requires forwarding `https` again and solving the Next 16 self-proxy behavior that ffc9cca12 worked around — left as a follow-up so this PR stays a pure shell-side fix with no platform blast radius.

## Review/Monitoring

Will monitor CI and Greptile and fix findings until 5/5. Note: merging triggers the production Cloud Run deploy (paths include `shell/**`); post-merge verification is the full new-user OTP → billing-gate flow on app.matrix-os.com.