### PR TITLE
fix(platform): proxy anonymous auth shell routes

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -20,7 +20,7 @@ jobs:
   changes:
     name: Detect Docker-relevant changes
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     outputs:
       should_run: ${{ steps.changed.outputs.should_run }}
     steps:

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -1919,7 +1919,11 @@ export function createApp(deps: {
   }
   app.capturePlatformEvent = capturePlatformEvent;
 
-  async function proxyAuthShell(c: Context, host: string): Promise<Response> {
+  async function proxyAuthShell(
+    c: Context,
+    host: string,
+    opts: { redirectToBillingOnFailure?: boolean } = {},
+  ): Promise<Response> {
     const upstream = new URL(c.req.url);
     const targetUrl = `${getAuthShellOrigin(appEnv)}${upstream.pathname}${upstream.search}`;
     const headers = new Headers();
@@ -1950,7 +1954,7 @@ export function createApp(deps: {
       });
     } catch (err: unknown) {
       logPlatformRouteError('app-domain auth-shell proxy', err);
-      if (!isBillingSetupPath(c.req.url)) {
+      if (opts.redirectToBillingOnFailure !== false && !isBillingSetupPath(c.req.url)) {
         return c.redirect(buildBillingSetupPath(c.req.url), 302);
       }
       const publishableKey = appEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
@@ -2770,6 +2774,9 @@ export function createApp(deps: {
     // No session/JWT -- serve Clerk auth directly from the platform.
     if (!identity) {
       console.log(`[${isCodeDomain ? 'code' : 'app'}] no token path=${path}`);
+      if (isAppDomain && allowAuthShellUnroutedIdentity) {
+        return proxyAuthShell(c, host, { redirectToBillingOnFailure: false });
+      }
       if (isCodeDomain && isCodeDomainStaticAssetPath(path)) {
         applyNoStoreHeaders(c);
         return c.text('Unauthorized', 401);

--- a/packages/platform/src/request-routing.ts
+++ b/packages/platform/src/request-routing.ts
@@ -129,11 +129,10 @@ export function shouldProxyAuthShellForUnroutedUser(input: {
   return (
     input.isAppDomain &&
     (input.method === 'GET' || input.method === 'HEAD') &&
-    !input.path.startsWith('/api/') &&
+    !isRuntimeDataPath(input.path) &&
     !input.path.startsWith('/vps') &&
     !input.path.startsWith('/internal/') &&
     !input.path.startsWith('/billing/') &&
-    !input.path.startsWith('/ws') &&
     input.path !== '/metrics'
   );
 }

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -2610,6 +2610,111 @@ describe("platform proxy routing", () => {
     delete process.env.AUTH_SHELL_PORT;
   });
 
+  it("serves anonymous app-domain sign-in from auth-shell before a VPS exists", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('<main data-matrix-auth-shell="true">sign in</main>', {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth(),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/sign-in", {
+      headers: {
+        host: "app.matrix-os.com",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('data-matrix-auth-shell="true"');
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://auth-shell.test:3200/sign-in");
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        method: "GET",
+        redirect: "manual",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    const proxiedHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers | undefined;
+    expect(proxiedHeaders?.get("host")).toBe("auth-shell.test:3200");
+    expect(proxiedHeaders?.get("x-forwarded-host")).toBe("app.matrix-os.com");
+    expect(proxiedHeaders?.get("x-forwarded-proto")).toBe("http");
+    delete process.env.AUTH_SHELL_HOST;
+    delete process.env.AUTH_SHELL_PORT;
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  });
+
+  it("falls back to the inline auth page when anonymous auth-shell sign-in fails", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_matrix";
+    const timeout = new Error("The operation was aborted due to timeout");
+    timeout.name = "TimeoutError";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(timeout);
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth(),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/sign-in", {
+      headers: {
+        host: "app.matrix-os.com",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
+    const html = await res.text();
+    expect(fetchMock).toHaveBeenCalled();
+    expect(html).toContain('data-matrix-platform-fallback-auth="true"');
+    expect(html).toContain("Welcome back to Matrix");
+    delete process.env.AUTH_SHELL_HOST;
+    delete process.env.AUTH_SHELL_PORT;
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  });
+
+  it("keeps anonymous app-domain file requests on the gateway 401 path", async () => {
+    process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
+    process.env.AUTH_SHELL_HOST = "auth-shell.test";
+    process.env.AUTH_SHELL_PORT = "3200";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("auth shell", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth(),
+      platformSecret: "platform-secret-123",
+    });
+
+    const res = await app.request("/files/system/config.json", {
+      headers: {
+        host: "app.matrix-os.com",
+      },
+    });
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(fetchMock).not.toHaveBeenCalled();
+    delete process.env.AUTH_SHELL_HOST;
+    delete process.env.AUTH_SHELL_PORT;
+  });
+
   it("redirects to automatic billing setup when the no-VPS auth-shell proxy times out", async () => {
     process.env.MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED = "false";
     process.env.AUTH_SHELL_HOST = "auth-shell.test";


### PR DESCRIPTION
## Summary
- Proxy anonymous app-domain GET/HEAD routes like `/sign-in` through the platform-owned auth shell before falling back to the inline platform auth page.
- Keep signed-in no-VPS auth-shell failures redirecting to `?billing=setup`, but let anonymous auth routes fall back to the inline auth page if the auth shell is actually unavailable.
- Keep anonymous runtime data/gateway paths such as `/files/*` off the auth-shell proxy so they continue returning machine-readable gateway errors.
- Add regression tests for anonymous `app.matrix-os.com/sign-in`, auth-shell failure fallback, and anonymous file-route 401 behavior.
- Raise the Docker change-detector timeout from 2 to 5 minutes after checkout was canceled before detector logic ran.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter '@matrix-os/platform' build`
- `bun run check:patterns` (0 violations; existing warnings only)
- `pnpm exec vitest run tests/platform/proxy-routing.test.ts tests/platform/ci-workflows.test.ts tests/shell/shell-metadata.test.ts`
- `pnpm exec vitest run tests/platform/ci-workflows.test.ts`

## Invariants
- Source of truth: app-domain routing remains owned by `packages/platform/src/main.ts` and `packages/platform/src/request-routing.ts`; the auth shell remains the renderer for pre-VPS Clerk/billing shell pages.
- Lock/transaction scope: no database writes or transactions are introduced; this only changes request routing before the existing fallback auth page.
- Acceptable orphan states: if the auth shell is unavailable for anonymous auth routes, the platform still serves the existing inline Clerk fallback page instead of redirecting anonymous sign-in users to billing setup.
- Auth source of truth: Clerk/session identity resolution remains unchanged; unauthenticated eligible app-domain shell routes are proxied only through trusted app-domain host detection, while runtime data paths stay on gateway-style error handling.
- Deferred scope: this does not address unrelated Pipedream 401 log noise or R2 vps-meta write retries observed on the candidate revision.
