### PR TITLE
fix(shell): allow billing setup shell entry

### DIFF
--- a/shell/src/lib/proxy-routes.ts
+++ b/shell/src/lib/proxy-routes.ts
@@ -1,9 +1,11 @@
-export function isPublicShellPath(pathname: string): boolean {
+export function isPublicShellPath(pathname: string, search = ""): boolean {
+  const searchParams = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
   return (
     pathname === "/health" ||
     pathname === "/manifest.json" ||
     pathname === "/og.png" ||
     pathname === "/favicon.ico" ||
+    (pathname === "/" && searchParams.get("billing") === "setup") ||
     pathname === "/sign-in" ||
     pathname.startsWith("/sign-in/") ||
     pathname === "/sign-up" ||

--- a/shell/src/proxy.ts
+++ b/shell/src/proxy.ts
@@ -97,7 +97,7 @@ function platformVerifiedResponse(request: ProxyRequestLike): NextResponse | nul
 // Clerk handler for authenticated routes
 const withClerk = clerkMiddleware(async (auth, request) => {
   // Layer 1: Clerk authentication (skip public routes)
-  if (!isPublicShellPath(request.nextUrl.pathname)) {
+  if (!isPublicShellPath(request.nextUrl.pathname, request.nextUrl.search)) {
     const { userId } = await auth();
     if (!userId) {
       const publicOrigin = getPublicOrigin(request);
@@ -112,7 +112,7 @@ const withClerk = clerkMiddleware(async (auth, request) => {
   }
 
   // Layer 2: Owner verification -- fail closed when configured (skip public routes)
-  if (expectedClerkUserId && !isPublicShellPath(request.nextUrl.pathname)) {
+  if (expectedClerkUserId && !isPublicShellPath(request.nextUrl.pathname, request.nextUrl.search)) {
     const { userId } = await auth();
     if (userId !== expectedClerkUserId) {
       return new NextResponse("Forbidden: you do not own this instance", {
@@ -151,7 +151,7 @@ export function proxy(
   ) {
     return new NextResponse("Forbidden", { status: 403 });
   }
-  if (isPublicShellPath(request.nextUrl.pathname)) {
+  if (isPublicShellPath(request.nextUrl.pathname, request.nextUrl.search)) {
     return NextResponse.next();
   }
   // All requests -- including gateway-proxy paths -- flow through Clerk so the

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -65,6 +65,13 @@ describe("proxy auth: route classification", () => {
     expect(isPublicShellPath("/sign-up/verify-email-address")).toBe(true);
   });
 
+  it("classifies the billing setup shell entry as public without exposing the normal shell", () => {
+    expect(isPublicShellPath("/", "?billing=setup")).toBe(true);
+    expect(isPublicShellPath("/", "billing=setup")).toBe(true);
+    expect(isPublicShellPath("/", "?billing=other")).toBe(false);
+    expect(isPublicShellPath("/")).toBe(false);
+  });
+
   it("non-public paths require auth", () => {
     expect(isPublicPath("/")).toBe(false);
     expect(isPublicPath("/api/message")).toBe(false);
@@ -305,6 +312,53 @@ describe("proxy auth: trusted platform native app sessions", () => {
 
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(403);
+  });
+});
+
+describe("proxy auth: billing setup entry", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.doUnmock("@clerk/nextjs/server");
+    vi.doUnmock("next/server");
+  });
+
+  it("lets the anonymous billing setup URL render the shell gate instead of Clerk-redirecting", async () => {
+    vi.resetModules();
+
+    const clerkMiddleware = vi.fn((handler) => async (request: unknown, event: unknown) =>
+      handler(async () => ({ userId: null }), request, event)
+    );
+    vi.doMock("@clerk/nextjs/server", () => ({ clerkMiddleware }));
+
+    const nextResponseNext = vi.fn((init?: unknown) => ({ kind: "next", init }));
+    const nextResponseRedirect = vi.fn((url: URL) => ({ kind: "redirect", url }));
+    class MockNextResponse extends Response {
+      static next = nextResponseNext;
+      static rewrite = vi.fn((url: URL, init?: unknown) => ({ kind: "rewrite", url, init }));
+      static redirect = nextResponseRedirect;
+    }
+    vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
+
+    const { proxy } = await import("../../shell/src/proxy");
+
+    const response = proxy({
+      headers: new Headers({
+        host: "app.matrix-os.com",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "https",
+      }),
+      nextUrl: {
+        host: "app.matrix-os.com",
+        pathname: "/",
+        protocol: "https:",
+        search: "?billing=setup",
+      },
+    } as Parameters<typeof proxy>[0], {} as Parameters<typeof proxy>[1]);
+
+    expect(response).toEqual({ kind: "next", init: undefined });
+    expect(clerkMiddleware).toHaveBeenCalledTimes(1);
+    expect(nextResponseRedirect).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Allow `/?billing=setup` through the shell proxy as a public pre-VPS entry point so the BillingGate can render instead of Clerk redirecting to sign-in.
- Keep the normal `/` shell route protected.
- Add route-classification and proxy-level regression coverage for the exact candidate smoke failure.

## Evidence
- Merged PR #477 fixed the anonymous `/sign-in` auth-shell path, but the main Platform Cloud Run candidate `matrix-platform-00075-ruq` failed smoke with: `Candidate pre-VPS billing shell did not serve the settings billing gate.`
- Direct candidate probe showed `/?billing=setup` returned `307 Location: http://app.matrix-os.com/sign-in?...`, so Next/Clerk redirected before the billing gate rendered.

## Invariants
- Source of truth: shell proxy route classification controls which pre-VPS shell entry points may render without Clerk middleware redirecting first.
- Lock/transaction scope: no persistence or transactions changed.
- Acceptable orphan states: none introduced; a missing/invalid Clerk session still cannot access the normal shell, API, files, apps, modules, or websockets.
- Auth source of truth: Clerk remains the auth source for protected shell routes; only the billing setup entry HTML is public so its client-side billing/auth gate can render.
- Deferred scope: this does not change Stripe entitlement decisions, platform `/api/auth/app-session` behavior, or customer VPS routing.

## Validation
- `/home/deploy/matrix-os/node_modules/.bin/vitest run tests/shell/proxy-auth.test.ts`
- `pnpm --filter ./shell exec tsc --noEmit`
- `bun run check:patterns`
- `/home/deploy/matrix-os/node_modules/.bin/vitest run tests/shell/proxy-auth.test.ts tests/platform/ci-workflows.test.ts`

Note: this worktree could not run a fresh `pnpm install` because the host is inode-exhausted (`df -i` showed 100% inode use); targeted tests used the root checkout's existing installed toolchain via a temporary symlink that was removed before commit.