### PR TITLE
fix(shell): canonicalize auth redirect origin

### DIFF
--- a/shell/src/lib/public-origin.ts
+++ b/shell/src/lib/public-origin.ts
@@ -1,0 +1,32 @@
+export interface PublicOriginRequestLike {
+  headers: { get(name: string): string | null };
+  nextUrl: {
+    host: string;
+    protocol: string;
+  };
+}
+
+export function getConfiguredAppOrigin(
+  configuredAppUrl: string | undefined = process.env.NEXT_PUBLIC_MATRIX_APP_URL,
+): string | null {
+  if (!configuredAppUrl || !URL.canParse(configuredAppUrl)) return null;
+  return new URL(configuredAppUrl).origin;
+}
+
+export function getPublicOrigin(
+  request: PublicOriginRequestLike,
+  configuredAppUrl: string | undefined = process.env.NEXT_PUBLIC_MATRIX_APP_URL,
+): string {
+  const canonical = getConfiguredAppOrigin(configuredAppUrl);
+  if (canonical) return canonical;
+
+  const host =
+    request.headers.get("x-forwarded-host") ??
+    request.headers.get("host") ??
+    request.nextUrl.host;
+  const proto =
+    request.headers.get("x-forwarded-proto") ??
+    request.nextUrl.protocol.replace(":", "");
+
+  return `${proto}://${host}`;
+}

--- a/shell/src/lib/public-origin.ts
+++ b/shell/src/lib/public-origin.ts
@@ -10,7 +10,9 @@ export function getConfiguredAppOrigin(
   configuredAppUrl: string | undefined = process.env.NEXT_PUBLIC_MATRIX_APP_URL,
 ): string | null {
   if (!configuredAppUrl || !URL.canParse(configuredAppUrl)) return null;
-  return new URL(configuredAppUrl).origin;
+  const url = new URL(configuredAppUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  return url.origin;
 }
 
 export function getPublicOrigin(

--- a/shell/src/proxy.ts
+++ b/shell/src/proxy.ts
@@ -9,6 +9,7 @@ import {
   isPlatformMobileAppSessionRequest,
   isPublicShellPath,
 } from "./lib/proxy-routes";
+import { getPublicOrigin } from "./lib/public-origin";
 
 const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
 const authToken = process.env.MATRIX_AUTH_TOKEN;
@@ -33,19 +34,6 @@ interface ProxyRequestLike {
 // gateway.
 function isGatewayProxy(request: ProxyRequestLike): boolean {
   return isGatewayProxyPath(request.nextUrl.pathname);
-}
-
-function getPublicOrigin(request: ProxyRequestLike) {
-  const host =
-    request.headers.get("x-forwarded-host") ??
-    request.headers.get("host") ??
-    request.nextUrl.host;
-  const proto =
-    request.headers.get("x-forwarded-proto") ??
-    request.nextUrl.protocol.replace(":", "") ??
-    "https";
-
-  return `${proto}://${host}`;
 }
 
 function rewriteGatewayRequest(request: ProxyRequestLike) {

--- a/tests/shell/proxy-auth.test.ts
+++ b/tests/shell/proxy-auth.test.ts
@@ -365,6 +365,57 @@ describe("proxy auth: billing setup entry", () => {
   });
 });
 
+describe("proxy auth: sign-in redirects", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.doUnmock("@clerk/nextjs/server");
+    vi.doUnmock("next/server");
+  });
+
+  it("uses the configured public HTTPS app origin for anonymous redirects", async () => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_MATRIX_APP_URL", "https://app.matrix-os.com");
+
+    const clerkMiddleware = vi.fn((handler) => async (request: unknown, event: unknown) =>
+      handler(async () => ({ userId: null }), request, event)
+    );
+    vi.doMock("@clerk/nextjs/server", () => ({ clerkMiddleware }));
+
+    const nextResponseRedirect = vi.fn((url: URL) => ({ kind: "redirect", url }));
+    class MockNextResponse extends Response {
+      static next = vi.fn((init?: unknown) => ({ kind: "next", init }));
+      static rewrite = vi.fn((url: URL, init?: unknown) => ({ kind: "rewrite", url, init }));
+      static redirect = nextResponseRedirect;
+    }
+    vi.doMock("next/server", () => ({ NextResponse: MockNextResponse }));
+
+    const { proxy } = await import("../../shell/src/proxy");
+
+    const response = await proxy({
+      headers: new Headers({
+        host: "127.0.0.1:3200",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "http",
+      }),
+      nextUrl: {
+        host: "127.0.0.1:3200",
+        pathname: "/",
+        protocol: "http:",
+        search: "",
+      },
+    } as Parameters<typeof proxy>[0], {} as Parameters<typeof proxy>[1]);
+
+    expect(response).toEqual({
+      kind: "redirect",
+      url: new URL(
+        "https://app.matrix-os.com/sign-in?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F",
+      ),
+    });
+    expect(nextResponseRedirect).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("proxy auth: Layer 3 bearer token injection", () => {
   it("injects token on gateway proxy paths when token is set", () => {
     expect(shouldInjectAuthToken("/api/message", "secret-token")).toBe(true);

--- a/tests/shell/public-origin.test.ts
+++ b/tests/shell/public-origin.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  getConfiguredAppOrigin,
+  getPublicOrigin,
+} from "../../shell/src/lib/public-origin";
+
+function requestLike(input: {
+  headers?: Record<string, string>;
+  host?: string;
+  protocol?: string;
+}) {
+  const headers = new Headers(input.headers ?? {});
+  return {
+    headers,
+    nextUrl: {
+      host: input.host ?? "localhost:3200",
+      protocol: input.protocol ?? "http:",
+    },
+  };
+}
+
+describe("getConfiguredAppOrigin", () => {
+  it("returns the origin of a configured app URL", () => {
+    expect(getConfiguredAppOrigin("https://app.matrix-os.com")).toBe(
+      "https://app.matrix-os.com",
+    );
+    expect(getConfiguredAppOrigin("https://app.matrix-os.com/some/path")).toBe(
+      "https://app.matrix-os.com",
+    );
+  });
+
+  it("returns null when the app URL is missing or unparsable", () => {
+    expect(getConfiguredAppOrigin(undefined)).toBeNull();
+    expect(getConfiguredAppOrigin("")).toBeNull();
+    expect(getConfiguredAppOrigin("not a url")).toBeNull();
+  });
+});
+
+describe("getPublicOrigin", () => {
+  it("prefers the configured app origin over forwarded headers", () => {
+    const request = requestLike({
+      headers: {
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "http",
+        host: "127.0.0.1:3200",
+      },
+    });
+
+    expect(getPublicOrigin(request, "https://app.matrix-os.com")).toBe(
+      "https://app.matrix-os.com",
+    );
+  });
+
+  it("never leaks the internal auth shell origin when the app URL is configured", () => {
+    const request = requestLike({
+      headers: { host: "localhost:3200" },
+      host: "localhost:3200",
+      protocol: "http:",
+    });
+
+    const origin = getPublicOrigin(request, "https://app.matrix-os.com");
+    expect(origin).toBe("https://app.matrix-os.com");
+    expect(origin).not.toMatch(/localhost|127\.0\.0\.1/);
+  });
+
+  it("falls back to forwarded headers when no app URL is configured", () => {
+    const request = requestLike({
+      headers: {
+        "x-forwarded-host": "app.example.test",
+        "x-forwarded-proto": "https",
+        host: "127.0.0.1:3200",
+      },
+    });
+
+    expect(getPublicOrigin(request, undefined)).toBe("https://app.example.test");
+  });
+
+  it("falls back to the host header, then nextUrl, in local dev", () => {
+    expect(
+      getPublicOrigin(
+        requestLike({ headers: { host: "localhost:3000" }, protocol: "http:" }),
+        undefined,
+      ),
+    ).toBe("http://localhost:3000");
+    expect(
+      getPublicOrigin(
+        requestLike({ host: "localhost:3000", protocol: "http:" }),
+        undefined,
+      ),
+    ).toBe("http://localhost:3000");
+  });
+
+  it("ignores an unparsable configured app URL and uses the header chain", () => {
+    const request = requestLike({
+      headers: {
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(getPublicOrigin(request, "not a url")).toBe(
+      "https://app.matrix-os.com",
+    );
+  });
+
+  it("builds sign-in redirect URLs with the public https origin", () => {
+    const request = requestLike({
+      headers: {
+        host: "127.0.0.1:3200",
+        "x-forwarded-host": "app.matrix-os.com",
+        "x-forwarded-proto": "http",
+      },
+    });
+    const publicOrigin = getPublicOrigin(request, "https://app.matrix-os.com");
+    const signInUrl = new URL("/sign-in", publicOrigin);
+    signInUrl.searchParams.set(
+      "redirect_url",
+      new URL("/", publicOrigin).toString(),
+    );
+
+    expect(signInUrl.toString()).toBe(
+      "https://app.matrix-os.com/sign-in?redirect_url=https%3A%2F%2Fapp.matrix-os.com%2F",
+    );
+  });
+});

--- a/tests/shell/public-origin.test.ts
+++ b/tests/shell/public-origin.test.ts
@@ -34,6 +34,12 @@ describe("getConfiguredAppOrigin", () => {
     expect(getConfiguredAppOrigin("")).toBeNull();
     expect(getConfiguredAppOrigin("not a url")).toBeNull();
   });
+
+  it("returns null for non-http app URL schemes", () => {
+    expect(getConfiguredAppOrigin("data:text/plain,matrix")).toBeNull();
+    expect(getConfiguredAppOrigin("file:///tmp/matrix")).toBeNull();
+    expect(getConfiguredAppOrigin("blob:https://app.matrix-os.com/id")).toBeNull();
+  });
 });
 
 describe("getPublicOrigin", () => {


### PR DESCRIPTION
## Summary
- Use the configured public app URL as the canonical origin for shell auth redirects.
- Prevent platform-internal `x-forwarded-proto: http` / localhost auth-shell hops from leaking into Clerk `redirect_url` values.
- Add helper and proxy-level regression tests for the production `http://app.matrix-os.com/sign-in?...` redirect.

## Evidence
- After PR #479 deployed, `https://app.matrix-os.com/?billing=setup` returned `200` with `data-matrix-billing-gate="true"`, but anonymous `https://app.matrix-os.com/` still returned `307 Location: http://app.matrix-os.com/sign-in?redirect_url=http%3A%2F%2Fapp.matrix-os.com%2F`.
- The redirect path was deriving public origin from forwarded/internal request metadata instead of the configured public app origin.

## Invariants
- Source of truth: `NEXT_PUBLIC_MATRIX_APP_URL` is the canonical public shell origin when configured; request headers remain a local-dev fallback.
- Lock/transaction scope: no persistence or transactions changed.
- Acceptable orphan states: none introduced; this changes only redirect URL construction for unauthenticated protected shell requests.
- Auth source of truth: Clerk remains the auth source for protected shell routes; this only canonicalizes the browser-visible sign-in and `redirect_url` origins.
- Deferred scope: this does not change billing entitlement checks, Stripe checkout behavior, platform session creation, or customer VPS routing.

## Validation
- `/home/deploy/matrix-os/node_modules/.bin/vitest run tests/shell/public-origin.test.ts tests/shell/proxy-auth.test.ts`
- `pnpm --filter ./shell exec tsc --noEmit`
- `bun run check:patterns`

Note: this worktree used the root checkout's existing `node_modules` via a temporary symlink for focused tests because the host hit inode pressure earlier; the symlink was removed before commit.
