### PR TITLE
fix(shell): quiet runtime setup console noise

### DIFF
--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -62,6 +62,7 @@ interface SymphonyIssueDetail {
 
 interface MatrixOSBridge {
   openApp?: (name: string, path: string) => void;
+  gatewayFetch?: <T>(url: string, init?: RequestInit, timeoutMs?: number) => Promise<T>;
 }
 
 declare global {
@@ -84,13 +85,15 @@ const EMPTY_SERVICE_CONTROL: SymphonyServiceControl = {
 };
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(url, {
-    ...init,
-    headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
-    signal: init?.signal ?? AbortSignal.timeout(10_000),
-  });
-  if (!response.ok) throw new Error("request_failed");
-  return await response.json() as T;
+  if (window.MatrixOS?.gatewayFetch) {
+    const { signal: _signal, ...bridgeInit } = init ?? {};
+    return await window.MatrixOS.gatewayFetch<T>(url, {
+      ...bridgeInit,
+      headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
+    }, 10_000);
+  }
+
+  throw new Error("matrix_bridge_unavailable");
 }
 
 function allRuns(state: SymphonyState): SymphonyRun[] {
@@ -148,6 +151,12 @@ function flattenLogs(logs: unknown): string[] {
 
 function isAbortError(err: unknown): boolean {
   return err instanceof DOMException && err.name === "AbortError";
+}
+
+function logSymphonyDebug(label: string, err: unknown): void {
+  if (!import.meta.env.PROD) {
+    console.debug(label, err instanceof Error ? err.message : String(err));
+  }
 }
 
 function withTimeoutSignal(signal: AbortSignal, timeoutMs: number): AbortSignal {
@@ -214,7 +223,7 @@ export default function App() {
     const [next] = await Promise.all([
       fetchJson<SymphonyState>("/api/symphony/state"),
       loadServiceControl().catch((err: unknown) => {
-        console.warn("[symphony] service status failed:", err instanceof Error ? err.message : String(err));
+        logSymphonyDebug("[symphony] service status failed:", err);
         return null;
       }),
     ]);
@@ -227,7 +236,7 @@ export default function App() {
         await loadIssueDetail(nextActive);
       } catch (err: unknown) {
         if (isAbortError(err)) return;
-        console.warn("[symphony] issue detail failed:", err instanceof Error ? err.message : String(err));
+        logSymphonyDebug("[symphony] issue detail failed:", err);
         setError("Issue detail could not be loaded.");
       }
     } else {
@@ -238,11 +247,11 @@ export default function App() {
 
   useEffect(() => {
     void loadState().catch((err: unknown) => {
-      console.warn("[symphony] state load failed:", err instanceof Error ? err.message : String(err));
+      logSymphonyDebug("[symphony] state load failed:", err);
       setError("Symphony is unavailable.");
       setLoading(false);
       void loadServiceControl().catch((serviceErr: unknown) => {
-        console.warn("[symphony] service status failed:", serviceErr instanceof Error ? serviceErr.message : String(serviceErr));
+        logSymphonyDebug("[symphony] service status failed:", serviceErr);
       });
     });
   }, [loadState, loadServiceControl]);
@@ -258,7 +267,7 @@ export default function App() {
       await fetchJson("/api/symphony/refresh", { method: "POST", body: "{}" });
       await loadState(activeIssue);
     } catch (err: unknown) {
-      console.warn("[symphony] refresh failed:", err instanceof Error ? err.message : String(err));
+      logSymphonyDebug("[symphony] refresh failed:", err);
       setError("Symphony refresh failed.");
     } finally {
       setBusy(null);
@@ -273,7 +282,7 @@ export default function App() {
       await fetchJson(`/api/symphony/runs/${activeIssue}/stop`, { method: "POST", body: "{}" });
       await loadState(activeIssue);
     } catch (err: unknown) {
-      console.warn("[symphony] stop failed:", err instanceof Error ? err.message : String(err));
+      logSymphonyDebug("[symphony] stop failed:", err);
       setError("Symphony stop failed.");
     } finally {
       setBusy(null);
@@ -287,15 +296,15 @@ export default function App() {
       const next = await fetchJson<SymphonyServiceControlResponse>("/api/symphony/service/start", { method: "POST", body: "{}" });
       setServiceControl(next.service);
       await loadState(activeIssue).catch((stateErr: unknown) => {
-        console.warn("[symphony] state load after service start failed:", stateErr instanceof Error ? stateErr.message : String(stateErr));
+        logSymphonyDebug("[symphony] state load after service start failed:", stateErr);
         setLoading(false);
         setError("Symphony is starting.");
       });
     } catch (err: unknown) {
-      console.warn("[symphony] service start failed:", err instanceof Error ? err.message : String(err));
+      logSymphonyDebug("[symphony] service start failed:", err);
       setError("Symphony start failed.");
       await loadServiceControl().catch((serviceErr: unknown) => {
-        console.warn("[symphony] service status failed:", serviceErr instanceof Error ? serviceErr.message : String(serviceErr));
+        logSymphonyDebug("[symphony] service status failed:", serviceErr);
       });
     } finally {
       setBusy(null);
@@ -312,10 +321,10 @@ export default function App() {
       setActiveIssue(null);
       setDetail(null);
     } catch (err: unknown) {
-      console.warn("[symphony] service stop failed:", err instanceof Error ? err.message : String(err));
+      logSymphonyDebug("[symphony] service stop failed:", err);
       setError("Symphony stop failed.");
       await loadServiceControl().catch((serviceErr: unknown) => {
-        console.warn("[symphony] service status failed:", serviceErr instanceof Error ? serviceErr.message : String(serviceErr));
+        logSymphonyDebug("[symphony] service status failed:", serviceErr);
       });
     } finally {
       setBusy(null);
@@ -332,7 +341,7 @@ export default function App() {
     void detailPromise
       .catch((err: unknown) => {
         if (isAbortError(err)) return;
-        console.warn("[symphony] issue detail failed:", err instanceof Error ? err.message : String(err));
+        logSymphonyDebug("[symphony] issue detail failed:", err);
         setError("Issue detail could not be loaded.");
       })
       .finally(() => {

--- a/home/apps/symphony/src/App.tsx
+++ b/home/apps/symphony/src/App.tsx
@@ -150,26 +150,21 @@ function flattenLogs(logs: unknown): string[] {
 }
 
 function isAbortError(err: unknown): boolean {
-  return err instanceof DOMException && err.name === "AbortError";
+  return err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError");
+}
+
+function isBridgeTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.message === "MatrixOS bridge fetch timed out";
+}
+
+function isDetailAbort(err: unknown): boolean {
+  return isAbortError(err) || isBridgeTimeoutError(err);
 }
 
 function logSymphonyDebug(label: string, err: unknown): void {
   if (!import.meta.env.PROD) {
     console.debug(label, err instanceof Error ? err.message : String(err));
   }
-}
-
-function withTimeoutSignal(signal: AbortSignal, timeoutMs: number): AbortSignal {
-  const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  if (typeof AbortSignal.any === "function") return AbortSignal.any([signal, timeoutSignal]);
-  if (signal.aborted) return signal;
-  if (timeoutSignal.aborted) return timeoutSignal;
-
-  const controller = new AbortController();
-  const abort = () => controller.abort();
-  signal.addEventListener("abort", abort, { once: true });
-  timeoutSignal.addEventListener("abort", abort, { once: true });
-  return controller.signal;
 }
 
 export default function App() {
@@ -200,11 +195,13 @@ export default function App() {
     detailAbortRef.current = controller;
 
     try {
-      const signal = withTimeoutSignal(controller.signal, 10_000);
-      const nextDetail = await fetchJson<SymphonyIssueDetail>(`/api/symphony/issues/${issueIdentifier}`, { signal });
+      // react-doctor-disable-next-line react-doctor/async-defer-await -- the bridge request cannot receive AbortSignal over postMessage, so this post-await guard prevents late/stale detail writes after a newer request or unmount aborts the controller.
+      const nextDetail = await fetchJson<SymphonyIssueDetail>(`/api/symphony/issues/${issueIdentifier}`);
+      if (controller.signal.aborted) return;
       if (detailRequestRef.current === requestId) setDetail(nextDetail);
     } catch (err: unknown) {
       if (controller.signal.aborted) return;
+      if (isBridgeTimeoutError(err)) return;
       throw err;
     } finally {
       if (detailRequestRef.current === requestId) detailAbortRef.current = null;
@@ -235,7 +232,7 @@ export default function App() {
       try {
         await loadIssueDetail(nextActive);
       } catch (err: unknown) {
-        if (isAbortError(err)) return;
+        if (isDetailAbort(err)) return;
         logSymphonyDebug("[symphony] issue detail failed:", err);
         setError("Issue detail could not be loaded.");
       }
@@ -340,7 +337,7 @@ export default function App() {
     const thisRequestId = detailRequestRef.current;
     void detailPromise
       .catch((err: unknown) => {
-        if (isAbortError(err)) return;
+        if (isDetailAbort(err)) return;
         logSymphonyDebug("[symphony] issue detail failed:", err);
         setError("Issue detail could not be loaded.");
       })

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -663,19 +663,6 @@ self.addEventListener("activate", (event) => {
     await self.registration.unregister();
   })());
 });
-
-self.addEventListener("fetch", (event) => {
-  event.respondWith(fetch(event.request).catch((err) => {
-    console.warn("[app cleanup sw] fetch failed:", err?.message ?? err);
-    return new Response("offline", {
-      status: 504,
-      headers: {
-        "content-type": "text/plain; charset=utf-8",
-        "cache-control": "no-store",
-      },
-    });
-  }));
-});
 `.trim();
 
 function appDomainServiceWorkerResponse(): Response {

--- a/shell/src/components/AppViewer.tsx
+++ b/shell/src/components/AppViewer.tsx
@@ -20,6 +20,7 @@ import {
   shouldRenderAppIframe,
   injectBridgeIntoAppHtml,
 } from "./app-viewer-helpers";
+import { isAllowedBridgeFetchUrl } from "./app-viewer-bridge-policy";
 
 const GATEWAY_URL = getGatewayUrl();
 const SESSION_REFRESH_DEBOUNCE_MS = 2000;
@@ -44,13 +45,13 @@ function readCurrentTheme(): ThemeVars {
   return getThemeVariables(style);
 }
 
-async function handleBridgeFetch(payload: unknown, port: MessagePort): Promise<void> {
+async function handleBridgeFetch(appName: string, payload: unknown, port: MessagePort): Promise<void> {
   try {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid bridge fetch payload");
     }
     const { url, init } = payload as { url?: unknown; init?: unknown };
-    if (typeof url !== "string" || !url.startsWith("/api/bridge/")) {
+    if (typeof url !== "string" || !isAllowedBridgeFetchUrl(appName, url)) {
       throw new Error("Blocked bridge fetch URL");
     }
     const requestInit = init && typeof init === "object" ? init as RequestInit : {};
@@ -180,7 +181,7 @@ export function AppViewer({ path, sessionId, onOpenApp }: AppViewerProps) {
         && data.app === appName
         && event.ports[0]
       ) {
-        void handleBridgeFetch(data.payload, event.ports[0]);
+        void handleBridgeFetch(appName, data.payload, event.ports[0]);
         return;
       }
       handleBridgeMessage(event, handler, {

--- a/shell/src/components/ConnectionIndicator.tsx
+++ b/shell/src/components/ConnectionIndicator.tsx
@@ -21,7 +21,9 @@ function classifyRuntimeStatusError(error: unknown): string {
 }
 
 function logRuntimeStatusError(stage: string, error: unknown): void {
-  console.warn(`[connection-indicator] ${stage} failed: ${classifyRuntimeStatusError(error)}`);
+  if (process.env.NODE_ENV !== "production") {
+    console.debug(`[connection-indicator] ${stage} failed: ${classifyRuntimeStatusError(error)}`);
+  }
 }
 
 async function loadRuntimeStatus(): Promise<RuntimeStatus> {

--- a/shell/src/components/Desktop.tsx
+++ b/shell/src/components/Desktop.tsx
@@ -49,6 +49,7 @@ import { MenuBar } from "./MenuBar";
 import { CanvasToolbar } from "./canvas/CanvasToolbar";
 import { VocalPanel } from "./VocalPanel";
 import { getGatewayUrl } from "@/lib/gateway";
+import { isPreVpsBillingSetupRoute } from "@/lib/pre-vps-shell";
 import { ChatApp } from "./ChatApp";
 import { ChatPopover } from "./ChatPopover";
 import { OnboardingScreen } from "./OnboardingScreen";
@@ -758,7 +759,11 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
       } else {
         regenerateIcon(slug);
       }
-    }).catch((err) => console.warn(`[desktop] Failed to check icon for "${slug}":`, err));
+    }).catch((err) => {
+      if (process.env.NODE_ENV !== "production") {
+        console.debug(`[desktop] Failed to check icon for "${slug}":`, err instanceof Error ? err.message : String(err));
+      }
+    });
   }, [wmSetApps, regenerateIcon]);
 
   const renameAppOnServer = (slug: string, newName: string) => {
@@ -955,12 +960,16 @@ export function Desktop({ launchAppPath, onOpenCommandPalette, chat }: DesktopPr
   const loadModules = useCallback(async () => {
     try {
       const [layoutRes, modulesRes, appsRes] = await Promise.all([
-        fetch(`${GATEWAY_URL}/api/layout`, {
-          signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
-        }).catch((err) => {
-          console.warn("[desktop] Failed to fetch layout:", err);
-          return null;
-        }),
+        isPreVpsBillingSetupRoute()
+          ? Promise.resolve(null)
+          : fetch(`${GATEWAY_URL}/api/layout`, {
+              signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
+            }).catch((err) => {
+              if (process.env.NODE_ENV !== "production") {
+                console.debug("[desktop] Failed to fetch layout:", err instanceof Error ? err.message : String(err));
+              }
+              return null;
+            }),
         fetch(`${GATEWAY_URL}/files/system/modules.json`, {
           signal: AbortSignal.timeout(GATEWAY_FETCH_TIMEOUT_MS),
         }).catch((err) => {

--- a/shell/src/components/app-viewer-bridge-policy.ts
+++ b/shell/src/components/app-viewer-bridge-policy.ts
@@ -1,0 +1,11 @@
+const SYMPHONY_API_PATH = /^\/api\/symphony(?:\/|$)/;
+
+function appSlugFromName(appName: string): string {
+  const parts = appName.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? appName;
+}
+
+export function isAllowedBridgeFetchUrl(appName: string, url: string): boolean {
+  if (url.startsWith("/api/bridge/")) return true;
+  return appSlugFromName(appName) === "symphony" && SYMPHONY_API_PATH.test(url);
+}

--- a/shell/src/hooks/useConversation.ts
+++ b/shell/src/hooks/useConversation.ts
@@ -29,6 +29,12 @@ const GATEWAY_URL = getGatewayUrl();
 
 const CONV_PATTERN = /^system\/conversations\//;
 
+function logConversationFetchError(label: string, err: unknown): void {
+  if (process.env.NODE_ENV !== "production") {
+    console.debug(label, err instanceof Error ? err.message : String(err));
+  }
+}
+
 async function fetchConversations(): Promise<ConversationMeta[]> {
   try {
     const res = await fetch(`${GATEWAY_URL}/api/conversations`, {
@@ -36,7 +42,7 @@ async function fetchConversations(): Promise<ConversationMeta[]> {
     });
     if (res.ok) return res.json();
   } catch (err: unknown) {
-    console.warn("[conversation] Failed to fetch conversations:", err instanceof Error ? err.message : String(err));
+    logConversationFetchError("[conversation] Failed to fetch conversations:", err);
   }
   return [];
 }
@@ -51,7 +57,7 @@ async function fetchConversation(
     );
     if (res.ok) return res.json();
   } catch (err: unknown) {
-    console.warn("[conversation] Failed to fetch conversation:", err instanceof Error ? err.message : String(err));
+    logConversationFetchError("[conversation] Failed to fetch conversation:", err);
   }
   return null;
 }

--- a/shell/src/hooks/useWindowManager.ts
+++ b/shell/src/hooks/useWindowManager.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getGatewayUrl } from "@/lib/gateway";
+import { isPreVpsBillingSetupRoute } from "@/lib/pre-vps-shell";
 
 export interface AppWindow {
   id: string;
@@ -82,6 +83,7 @@ let saveTimer: ReturnType<typeof setTimeout> | undefined;
 function debouncedSave(state: WindowManagerState) {
   clearTimeout(saveTimer);
   saveTimer = setTimeout(() => {
+    if (isPreVpsBillingSetupRoute()) return;
     const gatewayUrl = getGatewayUrl();
     const layoutWindows: LayoutWindow[] = state.windows.map((w) => ({
       path: w.path,
@@ -116,7 +118,9 @@ function debouncedSave(state: WindowManagerState) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ windows: layoutWindows }),
     }).catch((err: unknown) => {
-      console.warn("[window-manager] failed to save layout:", err instanceof Error ? err.message : String(err));
+      if (process.env.NODE_ENV !== "production") {
+        console.debug("[window-manager] failed to save layout:", err instanceof Error ? err.message : String(err));
+      }
     });
   }, 500);
 }

--- a/shell/src/lib/os-bridge.ts
+++ b/shell/src/lib/os-bridge.ts
@@ -251,12 +251,16 @@ export function buildBridgeScript(appName: string, themeVars?: ThemeVars): strin
 	        .then(function(d) { return d.services || []; });
 	    },
 
-	    service: function(service, action, params, label) {
+    service: function(service, action, params, label) {
 	      return parentFetch("/api/bridge/service", {
 	        method: "POST",
 	        headers: { "Content-Type": "application/json" },
 	        body: JSON.stringify({ service: service, action: action, params: params || {}, label: label })
 	      }, 35000).then(function(r) { return r.json(); });
+	    },
+
+	    gatewayFetch: function(url, init, timeoutMs) {
+	      return parentFetch(url, init || {}, timeoutMs || 10000).then(function(r) { return r.json(); });
 	    },
 
 	    proxyFetch: function(url) {

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -116,6 +116,9 @@ export function initializeShellPostHog(
     ui_host: currentConfig.uiHost,
     defaults: "2026-01-30",
     capture_exceptions: true,
+    capture_dead_clicks: false,
+    rageclick: false,
+    disable_session_recording: true,
     debug: process.env.NODE_ENV === "development",
     logs: {
       captureConsoleLogs: false,

--- a/shell/src/lib/pre-vps-shell.ts
+++ b/shell/src/lib/pre-vps-shell.ts
@@ -1,0 +1,4 @@
+export function isPreVpsBillingSetupRoute(): boolean {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).get("billing") === "setup";
+}

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -254,6 +254,20 @@ describe("Symphony app", () => {
     expect(screen.getByText("Issue detail could not be loaded.")).toBeTruthy();
   });
 
+  it("does not show an issue-detail error for bridge timeouts", async () => {
+    gatewayFetchMock().mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url === "/api/symphony/state") return symphonyState();
+      if (url === "/api/symphony/issues/MAT-32") throw new Error("MatrixOS bridge fetch timed out");
+      return { service: { available: true, running: true, status: "running", canStart: false, canStop: true, credentialConfigured: true } };
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getAllByText("Queue").length).toBeGreaterThan(0));
+    expect(screen.queryByText("Issue detail could not be loaded.")).toBeNull();
+  });
+
   it("clears initial loading once state is ready before issue detail resolves", async () => {
     let resolveDetail: (detail: Record<string, unknown>) => void = () => {};
     const detailResponse = new Promise<Record<string, unknown>>((resolve) => {
@@ -309,12 +323,11 @@ describe("Symphony app", () => {
     expect(appSource).toContain("matrix_bridge_unavailable");
     expect(appSource).toContain('"/api/symphony/service/start"');
     expect(appSource).toContain('"/api/symphony/service/stop"');
-    expect(appSource).toContain("withTimeoutSignal(controller.signal, 10_000)");
-    expect(appSource).toContain("AbortSignal.any([signal, timeoutSignal])");
     expect(appSource).toContain("window.MatrixOS.gatewayFetch");
     expect(appSource).not.toContain("await fetch(url");
     expect(appSource).toContain("if (controller.signal.aborted) return;");
-    expect(appSource).not.toContain("controller.signal.aborted || isAbortError(err)");
+    expect(appSource).toContain("isBridgeTimeoutError(err)");
+    expect(appSource).not.toContain("withTimeoutSignal(");
     expect(appSource).toContain('setError("Issue detail could not be loaded.")');
     expect(appSource).toContain("detailAbortRef.current?.abort()");
     expect(appSource).toContain("selectedIssueRef.current");

--- a/tests/default-apps/symphony-app.test.tsx
+++ b/tests/default-apps/symphony-app.test.tsx
@@ -2,7 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../../home/apps/symphony/src/App.js";
 
@@ -13,13 +13,6 @@ vi.mock("@/components/ui/button", () => ({
 vi.mock("@/components/ui/badge", () => ({
   Badge: ({ children, className }: { children: React.ReactNode; className?: string }) => <span className={className}>{children}</span>,
 }));
-
-function json(body: unknown, init?: ResponseInit): Response {
-  return new Response(JSON.stringify(body), {
-    status: init?.status ?? 200,
-    headers: { "Content-Type": "application/json" },
-  });
-}
 
 function symphonyState() {
   return {
@@ -33,66 +26,74 @@ function symphonyState() {
   };
 }
 
+function gatewayFetchMock() {
+  return vi.mocked(window.MatrixOS!.gatewayFetch!);
+}
+
 describe("Symphony app", () => {
   let calls: Array<{ url: string; init?: RequestInit }> = [];
 
   beforeEach(() => {
     calls = [];
     vi.stubGlobal("open", vi.fn());
-    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      calls.push({ url, init });
-      if (url === "/api/symphony/state") {
-        return json(symphonyState());
-      }
-      if (url === "/api/symphony/issues/MAT-32") {
-        return json({
-          issueIdentifier: "MAT-32",
-          issueId: "issue_32",
-          status: "running",
-          sessionId: "thread-1-turn-2",
-          turnCount: 2,
-          latestEvent: "session_started",
-          latestMessage: "Agent session started",
-          workspacePath: "/home/matrix/home/projects/matrix-os/symphony-workspaces/MAT-32",
-          workpadUrl: "https://linear.app/acme/issue/MAT-32#comment",
-          logs: { codexSessionLogs: ["session started", "tool call"] },
-          recentEvents: [{ event: "session_started", message: "Agent session started" }],
-          retry: null,
-          allowedActions: ["refresh", "open_workspace", "stop"],
-        });
-      }
-      if (url === "/api/symphony/issues/MAT-33") {
-        return json({
-          issueIdentifier: "MAT-33",
-          issueId: "issue_33",
-          status: "needs_attention",
-          sessionId: null,
-          turnCount: 0,
-          latestEvent: "retrying",
-          latestMessage: "Retry detail",
-          workspacePath: "/home/matrix/home/projects/matrix-os/symphony-workspaces/MAT-33",
-          workpadUrl: null,
-          logs: { codexSessionLogs: ["retry detail"] },
-          recentEvents: [{ event: "retrying", message: "Retry detail" }],
-          retry: { attempt: 2, dueAt: null },
-          allowedActions: ["refresh", "open_workspace"],
-        });
-      }
-      if (url === "/api/symphony/refresh") {
-        return json({ requested: true, requestedAt: "2026-05-25T00:00:01Z" }, { status: 202 });
-      }
-      if (url === "/api/symphony/runs/MAT-32/stop") {
-        return json({ stopped: true });
-      }
-      if (url === "/api/symphony/service") {
-        return json({ service: { available: true, running: true, status: "running", canStart: false, canStop: true, credentialConfigured: true } });
-      }
-      if (url === "/api/symphony/service/start" || url === "/api/symphony/service/stop") {
-        return json({ service: { available: true, running: url.endsWith("/start"), status: url.endsWith("/start") ? "running" : "stopped", canStart: !url.endsWith("/start"), canStop: url.endsWith("/start"), credentialConfigured: true } });
-      }
-      return json({ ok: true });
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("Symphony app must use the MatrixOS bridge");
     }));
+    window.MatrixOS = {
+      gatewayFetch: vi.fn(async (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        if (url === "/api/symphony/state") {
+          return symphonyState();
+        }
+        if (url === "/api/symphony/issues/MAT-32") {
+          return {
+            issueIdentifier: "MAT-32",
+            issueId: "issue_32",
+            status: "running",
+            sessionId: "thread-1-turn-2",
+            turnCount: 2,
+            latestEvent: "session_started",
+            latestMessage: "Agent session started",
+            workspacePath: "/home/matrix/home/projects/matrix-os/symphony-workspaces/MAT-32",
+            workpadUrl: "https://linear.app/acme/issue/MAT-32#comment",
+            logs: { codexSessionLogs: ["session started", "tool call"] },
+            recentEvents: [{ event: "session_started", message: "Agent session started" }],
+            retry: null,
+            allowedActions: ["refresh", "open_workspace", "stop"],
+          };
+        }
+        if (url === "/api/symphony/issues/MAT-33") {
+          return {
+            issueIdentifier: "MAT-33",
+            issueId: "issue_33",
+            status: "needs_attention",
+            sessionId: null,
+            turnCount: 0,
+            latestEvent: "retrying",
+            latestMessage: "Retry detail",
+            workspacePath: "/home/matrix/home/projects/matrix-os/symphony-workspaces/MAT-33",
+            workpadUrl: null,
+            logs: { codexSessionLogs: ["retry detail"] },
+            recentEvents: [{ event: "retrying", message: "Retry detail" }],
+            retry: { attempt: 2, dueAt: null },
+            allowedActions: ["refresh", "open_workspace"],
+          };
+        }
+        if (url === "/api/symphony/refresh") {
+          return { requested: true, requestedAt: "2026-05-25T00:00:01Z" };
+        }
+        if (url === "/api/symphony/runs/MAT-32/stop") {
+          return { stopped: true };
+        }
+        if (url === "/api/symphony/service") {
+          return { service: { available: true, running: true, status: "running", canStart: false, canStop: true, credentialConfigured: true } };
+        }
+        if (url === "/api/symphony/service/start" || url === "/api/symphony/service/stop") {
+          return { service: { available: true, running: url.endsWith("/start"), status: url.endsWith("/start") ? "running" : "stopped", canStart: !url.endsWith("/start"), canStop: url.endsWith("/start"), credentialConfigured: true } };
+        }
+        return { ok: true };
+      }),
+    };
   });
 
   afterEach(() => {
@@ -138,20 +139,19 @@ describe("Symphony app", () => {
 
   it("disables issue selection while refresh state is in flight", async () => {
     let stateCalls = 0;
-    let resolveRefreshState: ((response: Response) => void) | null = null;
-    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
+    let resolveRefreshState: ((state: ReturnType<typeof symphonyState>) => void) | null = null;
+    gatewayFetchMock().mockImplementation(async (url: string, init?: RequestInit) => {
       calls.push({ url, init });
       if (url === "/api/symphony/state") {
         stateCalls += 1;
-        if (stateCalls === 1) return json(symphonyState());
-        return await new Promise<Response>((resolve) => {
+        if (stateCalls === 1) return symphonyState();
+        return await new Promise<ReturnType<typeof symphonyState>>((resolve) => {
           resolveRefreshState = resolve;
         });
       }
-      if (url === "/api/symphony/refresh") return json({ requested: true }, { status: 202 });
+      if (url === "/api/symphony/refresh") return { requested: true };
       if (url === "/api/symphony/issues/MAT-32") {
-        return json({
+        return {
           issueIdentifier: "MAT-32",
           issueId: "issue_32",
           status: "running",
@@ -165,10 +165,10 @@ describe("Symphony app", () => {
           recentEvents: [],
           retry: null,
           allowedActions: ["refresh", "open_workspace", "stop"],
-        });
+        };
       }
       if (url === "/api/symphony/issues/MAT-33") {
-        return json({
+        return {
           issueIdentifier: "MAT-33",
           issueId: "issue_33",
           status: "needs_attention",
@@ -182,9 +182,9 @@ describe("Symphony app", () => {
           recentEvents: [],
           retry: { attempt: 2, dueAt: null },
           allowedActions: ["refresh", "open_workspace"],
-        });
+        };
       }
-      return json({ ok: true });
+      return { ok: true };
     });
 
     render(<App />);
@@ -198,7 +198,7 @@ describe("Symphony app", () => {
 
     fireEvent.click(screen.getByText("MAT-33"));
     expect(calls.some((call) => call.url === "/api/symphony/issues/MAT-33")).toBe(false);
-    resolveRefreshState?.(json(symphonyState()));
+    resolveRefreshState?.(symphonyState());
 
     await waitFor(() => expect(screen.getAllByText("session started").length).toBeGreaterThan(0));
     expect(calls.some((call) => call.url === "/api/symphony/issues/MAT-33")).toBe(false);
@@ -213,21 +213,20 @@ describe("Symphony app", () => {
 
     fireEvent.click(screen.getByText("Stop Run"));
     await waitFor(() => expect(calls.some((call) => call.url === "/api/symphony/runs/MAT-32/stop" && call.init?.method === "POST")).toBe(true));
-    expect(calls.every((call) => call.init?.signal instanceof AbortSignal)).toBe(true);
+    expect(calls.every((call) => !("signal" in (call.init ?? {})))).toBe(true);
   });
 
   it("lets the user start Symphony when the service is stopped", async () => {
-    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
+    gatewayFetchMock().mockImplementation(async (url: string, init?: RequestInit) => {
       calls.push({ url, init });
-      if (url === "/api/symphony/state") return json({ error: { code: "service_unavailable" } }, { status: 503 });
+      if (url === "/api/symphony/state") throw new Error("request_failed");
       if (url === "/api/symphony/service") {
-        return json({ service: { available: true, running: false, status: "stopped", canStart: true, canStop: false, credentialConfigured: true } });
+        return { service: { available: true, running: false, status: "stopped", canStart: true, canStop: false, credentialConfigured: true } };
       }
       if (url === "/api/symphony/service/start") {
-        return json({ service: { available: true, running: true, status: "running", canStart: false, canStop: true, credentialConfigured: true } });
+        return { service: { available: true, running: true, status: "running", canStart: false, canStop: true, credentialConfigured: true } };
       }
-      return json({ ok: true });
+      return { ok: true };
     });
 
     render(<App />);
@@ -241,12 +240,11 @@ describe("Symphony app", () => {
   });
 
   it("keeps rendered state when the active issue detail endpoint fails", async () => {
-    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
+    gatewayFetchMock().mockImplementation(async (url: string, init?: RequestInit) => {
       calls.push({ url, init });
-      if (url === "/api/symphony/state") return json(symphonyState());
-      if (url === "/api/symphony/issues/MAT-32") return json({ error: "temporarily unavailable" }, { status: 503 });
-      return json({ ok: true });
+      if (url === "/api/symphony/state") return symphonyState();
+      if (url === "/api/symphony/issues/MAT-32") throw new Error("request_failed");
+      return { ok: true };
     });
 
     render(<App />);
@@ -257,15 +255,14 @@ describe("Symphony app", () => {
   });
 
   it("clears initial loading once state is ready before issue detail resolves", async () => {
-    let resolveDetail: (response: Response) => void = () => {};
-    const detailResponse = new Promise<Response>((resolve) => {
+    let resolveDetail: (detail: Record<string, unknown>) => void = () => {};
+    const detailResponse = new Promise<Record<string, unknown>>((resolve) => {
       resolveDetail = resolve;
     });
 
-    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
+    gatewayFetchMock().mockImplementation(async (url: string) => {
       if (url === "/api/symphony/state") {
-        return json({
+        return {
           service: { status: "ready", credentialStatus: "setup_required", generatedAt: "2026-05-25T00:00:00Z" },
           groups: {
             queue: [],
@@ -273,13 +270,13 @@ describe("Symphony app", () => {
             needsAttention: [],
             done: [],
           },
-        });
+        };
       }
       if (url === "/api/symphony/issues/MAT-32") {
         return detailResponse;
       }
-      return json({ ok: true });
-    }));
+      return { ok: true };
+    });
 
     render(<App />);
 
@@ -288,13 +285,16 @@ describe("Symphony app", () => {
     });
     expect(screen.queryByText("Loading Symphony state...")).toBeNull();
 
-    resolveDetail(json({
-      issueIdentifier: "MAT-32",
-      status: "running",
-      allowedActions: ["refresh"],
-      logs: { codexSessionLogs: [] },
-      recentEvents: [],
-    }));
+    await act(async () => {
+      resolveDetail({
+        issueIdentifier: "MAT-32",
+        status: "running",
+        allowedActions: ["refresh"],
+        logs: { codexSessionLogs: [] },
+        recentEvents: [],
+      });
+      await Promise.resolve();
+    });
   });
 
   it("keeps long session and workspace text visible for mobile-friendly layouts", async () => {
@@ -306,11 +306,13 @@ describe("Symphony app", () => {
     expect(appSource).toContain("break-words");
     expect(appSource).toContain("minmax(0,1fr)");
     expect(appSource).toContain('const RUN_GROUPS: RunGroup[] = ["queue", "running", "needsAttention", "done"]');
-    expect(appSource).toContain("AbortSignal.timeout(10_000)");
+    expect(appSource).toContain("matrix_bridge_unavailable");
     expect(appSource).toContain('"/api/symphony/service/start"');
     expect(appSource).toContain('"/api/symphony/service/stop"');
     expect(appSource).toContain("withTimeoutSignal(controller.signal, 10_000)");
     expect(appSource).toContain("AbortSignal.any([signal, timeoutSignal])");
+    expect(appSource).toContain("window.MatrixOS.gatewayFetch");
+    expect(appSource).not.toContain("await fetch(url");
     expect(appSource).toContain("if (controller.signal.aborted) return;");
     expect(appSource).not.toContain("controller.signal.aborted || isAbortError(err)");
     expect(appSource).toContain('setError("Issue detail could not be loaded.")');

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -4316,8 +4316,8 @@ describe("platform proxy routing", () => {
       expect(res.headers.get("service-worker-allowed")).toBe("/");
       const body = await res.text();
       expect(body).toContain("registration.unregister()");
-      expect(body).toContain(".catch((err) =>");
-      expect(body).toContain('new Response("offline",');
+      expect(body).not.toContain("[app cleanup sw] fetch failed");
+      expect(body).not.toContain('new Response("offline",');
       expect(verifyToken).not.toHaveBeenCalled();
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {

--- a/tests/shell/app-viewer-runtime-modes.test.ts
+++ b/tests/shell/app-viewer-runtime-modes.test.ts
@@ -3,6 +3,7 @@ import {
   APP_IFRAME_SANDBOX,
   injectBridgeIntoAppHtml,
 } from "../../shell/src/components/app-viewer-helpers.js";
+import { isAllowedBridgeFetchUrl } from "../../shell/src/components/app-viewer-bridge-policy.js";
 
 describe("AppViewer bridged runtime loading", () => {
   describe("bridge guarantee: slug apps only ever load via bridged srcDoc", () => {
@@ -151,6 +152,15 @@ describe("AppViewer bridged runtime loading", () => {
       expect(result).toContain('src="./assets/app.js"');
       expect(result).toContain('href="./assets/app.css"');
       expect(result).toContain("crossorigin");
+    });
+
+    it("only allows Symphony to bridge its first-party API routes", () => {
+      expect(isAllowedBridgeFetchUrl("symphony", "/api/symphony/state")).toBe(true);
+      expect(isAllowedBridgeFetchUrl("apps/symphony", "/api/symphony/service/start")).toBe(true);
+      expect(isAllowedBridgeFetchUrl("notes", "/api/symphony/state")).toBe(false);
+      expect(isAllowedBridgeFetchUrl("symphony", "https://app.matrix-os.com/api/symphony/state")).toBe(false);
+      expect(isAllowedBridgeFetchUrl("symphony", "/api/auth/app-session")).toBe(false);
+      expect(isAllowedBridgeFetchUrl("notes", "/api/bridge/query")).toBe(true);
     });
   });
 });

--- a/tests/shell/os-bridge.test.ts
+++ b/tests/shell/os-bridge.test.ts
@@ -240,6 +240,7 @@ describe("OS Bridge", () => {
       const script = buildBridgeScript("test-app");
       expect(script).toContain('parentFetch("/api/bridge/service", {}, 10000)');
       expect(script).toContain("}, 35000).then");
+      expect(script).toContain("gatewayFetch: function(url, init, timeoutMs)");
       expect(script).toContain("MatrixOS bridge fetch timed out");
     });
   });

--- a/tests/shell/window-manager.test.ts
+++ b/tests/shell/window-manager.test.ts
@@ -23,6 +23,7 @@ function resetStore() {
 describe("Window Manager Store", () => {
   beforeEach(() => {
     resetStore();
+    window.history.pushState(null, "", "/");
     fetchSpy.mockClear();
     vi.useFakeTimers();
   });
@@ -178,6 +179,16 @@ describe("Window Manager Store", () => {
         expect.stringContaining("/api/layout"),
         expect.objectContaining({ method: "PUT" }),
       );
+    });
+
+    it("does not save layout on the pre-VPS billing setup route", () => {
+      window.history.pushState(null, "", "/?billing=setup");
+      useWindowManager.getState().openWindow("Settings", "__settings__", 80);
+      vi.advanceTimersByTime(500);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      window.history.pushState(null, "", "/");
     });
 
     it("includes closed paths in layout save", () => {


### PR DESCRIPTION
## Summary
- remove app-domain cleanup service worker fetch interception so unregister cleanup does not emit 504 console warnings
- route Symphony's first-party API calls through the MatrixOS iframe bridge instead of raw sandboxed fetches
- disable PostHog dead-click/session-recording client loaders and quiet expected production reconnect/setup timeout logs
- skip layout load/save on the pre-VPS `?billing=setup` shell so the browser does not issue `/api/layout` 410 requests there

## Tests
- `bun run check:patterns`
- `pnpm --filter './shell' exec tsc --noEmit`
- `pnpm --filter '@matrix-os/platform' exec tsc --noEmit -p tsconfig.typecheck.json`
- `./node_modules/.bin/vitest run tests/default-apps/symphony-app.test.tsx tests/shell/app-viewer-runtime-modes.test.ts tests/shell/os-bridge.test.ts tests/shell/window-manager.test.ts tests/shell/connection-indicator.test.tsx --testTimeout=30000`
- `./node_modules/.bin/vitest run tests/platform/proxy-routing.test.ts --testNamePattern "serves an unregistering app-domain service worker without auth" --testTimeout=30000`
- `node scripts/build-default-apps.mjs home/apps`
- `npx react-doctor@latest shell --verbose --diff`
- `npx react-doctor@latest home/apps/symphony --verbose --diff`
- `npx react-doctor@latest home/apps/symphony`

Full `bun run typecheck` is currently blocked by a pre-existing gateway error on `packages/gateway/src/server.ts` where `{ slug, icon, name }[]` is passed to a `string[]` parameter.

## Invariants
- **Source of truth**: runtime app data and Symphony service state remain served by existing gateway/platform APIs; this PR only changes browser transport/logging around those calls.
- **Lock/transaction scope**: no database writes, locks, or transactions are introduced.
- **Acceptable orphan states**: if the iframe bridge is unavailable, Symphony renders its existing unavailable state; no partial runtime mutation is performed.
- **Auth source of truth**: app iframe API access continues through the existing app session/shell route cookies; the parent bridge only allows `/api/bridge/*` generally and `/api/symphony/*` for the first-party Symphony app.
- **Deferred scope**: broader React Doctor baseline warnings, the existing gateway typecheck failure, and non-Matrix browser-extension console logs are not addressed here.
