### PR TITLE
fix(gateway): preserve versioned VPS update targets

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -114,6 +114,7 @@ import {
   checkForSystemUpdate,
   listSystemReleases,
   parseInternalUpgradeTarget,
+  resolveInternalUpgradeStartTarget,
   resolveSystemUpdateChannel,
   startSystemUpdate,
   writeInternalUpgradeTrigger,
@@ -4040,30 +4041,33 @@ export async function createGateway(config: GatewayConfig) {
         console.warn("[system-update] Failed to parse update request:", err);
       }
     }
-    const requestedChannel =
-      body && typeof body === "object" && "channel" in body ? (body as { channel?: unknown }).channel : undefined;
     const info = getSystemInfo(homePath);
-    const channel = resolveSystemUpdateChannel(requestedChannel, {
+    const parsedTarget = resolveInternalUpgradeStartTarget(body, {
       envChannel: process.env.MATRIX_UPDATE_CHANNEL,
       installedChannel: info.release?.channel,
     });
-    if (!channel) return c.json({ error: "Invalid update channel" }, 400);
+    if (!parsedTarget.ok) return c.json({ error: "Invalid request" }, 400);
 
-    const result = await startSystemUpdate({ channel });
+    const result = await startSystemUpdate({ target: parsedTarget.target });
     if (!result.ok) {
       return c.json({ error: "Update not configured" }, 503);
     }
+    const targetProperty =
+      parsedTarget.target.type === "channel"
+        ? { channel: parsedTarget.target.value }
+        : { version: parsedTarget.target.value };
     void posthogErrorTracker.captureEvent("matrix_system_update_requested", {
       distinctId: process.env.MATRIX_HANDLE ?? "matrix-gateway",
       properties: {
-        channel,
+        ...targetProperty,
+        targetType: parsedTarget.target.type,
         handle: process.env.MATRIX_HANDLE,
       },
     }).catch((err: unknown) => {
       const kind = err instanceof Error ? err.name : typeof err;
       console.warn(`[posthog] Failed to queue system update event: ${kind}`);
     });
-    return c.json({ ok: true, status: result.status, channel }, 202);
+    return c.json({ ok: true, status: result.status, ...targetProperty }, 202);
   }
 
   app.post("/api/system/update", upgradeBodyLimit, startUpdateFromRequest);

--- a/packages/gateway/src/system-update.ts
+++ b/packages/gateway/src/system-update.ts
@@ -138,9 +138,13 @@ export function resolveInternalUpgradeStartTarget(
   if (!parsed.ok) return parsed;
   if (parsed.target) return { ok: true, target: parsed.target };
 
-  const channel = resolveSystemUpdateChannel(undefined, options);
-  if (!channel) return { ok: false, error: "Invalid update channel" };
-  return { ok: true, target: { type: "channel", value: channel } };
+  return {
+    ok: true,
+    target: {
+      type: "channel",
+      value: resolveSystemUpdateChannel(undefined, options) ?? "stable",
+    },
+  };
 }
 
 export async function writeInternalUpgradeTrigger(options: {

--- a/packages/gateway/src/system-update.ts
+++ b/packages/gateway/src/system-update.ts
@@ -125,6 +125,24 @@ export function parseInternalUpgradeTarget(body: unknown):
   return { ok: true, target: null };
 }
 
+export function resolveInternalUpgradeStartTarget(
+  body: unknown,
+  options: {
+    envChannel?: unknown;
+    installedChannel?: unknown;
+  } = {},
+):
+  | { ok: true; target: InternalUpgradeTarget }
+  | { ok: false; error: string } {
+  const parsed = parseInternalUpgradeTarget(body);
+  if (!parsed.ok) return parsed;
+  if (parsed.target) return { ok: true, target: parsed.target };
+
+  const channel = resolveSystemUpdateChannel(undefined, options);
+  if (!channel) return { ok: false, error: "Invalid update channel" };
+  return { ok: true, target: { type: "channel", value: channel } };
+}
+
 export async function writeInternalUpgradeTrigger(options: {
   body: unknown;
   appDir?: string;

--- a/tests/gateway/system-update.test.ts
+++ b/tests/gateway/system-update.test.ts
@@ -10,6 +10,7 @@ import {
   parseUpdateChannel,
   parseInternalUpgradeTarget,
   parseUpdateVersion,
+  resolveInternalUpgradeStartTarget,
   resolveSystemUpdateChannel,
   startSystemUpdate,
   writeInternalUpgradeTrigger,
@@ -74,6 +75,31 @@ describe("system update checks", () => {
     expect(parseInternalUpgradeTarget({ channel: "nightly" })).toEqual({
       ok: false,
       error: "Invalid update channel",
+    });
+  });
+
+  it("resolves internal update starts without losing explicit versions", () => {
+    expect(resolveInternalUpgradeStartTarget(
+      { version: "v2026.06.11-359" },
+      { envChannel: "dev", installedChannel: "stable" },
+    )).toEqual({
+      ok: true,
+      target: { type: "version", value: "v2026.06.11-359" },
+    });
+    expect(resolveInternalUpgradeStartTarget(
+      { channel: "beta" },
+      { envChannel: "dev", installedChannel: "stable" },
+    )).toEqual({
+      ok: true,
+      target: { type: "channel", value: "beta" },
+    });
+    expect(resolveInternalUpgradeStartTarget({}, { envChannel: "dev", installedChannel: "stable" })).toEqual({
+      ok: true,
+      target: { type: "channel", value: "dev" },
+    });
+    expect(resolveInternalUpgradeStartTarget({ version: "v2026.06.11-359", channel: "dev" })).toEqual({
+      ok: false,
+      error: "Specify either version or channel",
     });
   });
 


### PR DESCRIPTION
## Summary
- preserve explicit host-bundle version targets when /api/system/update starts a VPS update
- reuse the existing internal upgrade target validation for gateway update requests
- return/report either channel or version in update-trigger responses and telemetry

## Tests
- `/home/deploy/matrix-os/node_modules/.bin/vitest run tests/gateway/system-update.test.ts`
- `git diff --check`

## Invariants
- **Source of truth**: published host-bundle release metadata remains the canonical source for versions and channels; this PR only preserves the requested target when starting the local updater.
- **Lock/transaction scope**: no database writes, locks, or transactions are introduced.
- **Acceptable orphan states**: if the local updater command is unavailable, the route still returns the existing 503-style response and does not create partial update state.
- **Auth source of truth**: existing gateway auth middleware and platform verification token handling remain unchanged.
- **Deferred scope**: this does not change platform fleet selection, sync-agent apply behavior, or release publishing.