### PR TITLE
chore(distro): drop legacy platform tunnel routes after Cloud Run cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,7 @@ Every backend PR must include an "Invariants" section:
 ### CI Timeouts
 
 - **Timeouts must cover observed runtime with margin**. If a CI job completes all tests successfully but is canceled by `timeout-minutes`, raise or split the job instead of treating it as a product test failure.
+- **Screenshot jobs are expensive and often stall on browser install**. If the `Screenshots` workflow hangs, first check whether it is stuck at `pnpm exec playwright install chromium`; Playwright docs note browser cache restore can be as slow as download on Linux. For headless-only screenshot tests, prefer `pnpm exec playwright install --only-shell chromium`. For non-visual PRs, use the `skip-screenshots`/`no-screenshots` label or cancel optional screenshot runs rather than blocking a release.
 
 ### Branch Freeze
 

--- a/distro/cloudflared.yml
+++ b/distro/cloudflared.yml
@@ -10,10 +10,4 @@ ingress:
     service: http://matrixos-staging:3000
   - hostname: api-staging.matrix-os.com
     service: http://matrixos-staging:4000
-  - hostname: api.matrix-os.com
-    service: http://platform:9000
-  - hostname: code.matrix-os.com
-    service: http://platform:9000
-  - hostname: "*.matrix-os.com"
-    service: http://platform:9000
   - service: http_status:404


### PR DESCRIPTION
## Summary

- Remove the `api.matrix-os.com`, `code.matrix-os.com`, and `*.matrix-os.com` wildcard ingress entries from `distro/cloudflared.yml`. These pointed at the legacy local `platform:9000` container, which was retired in the 2026-06-06 Cloud Run cutover; the domains now route through the managed edge. The running tunnel on the VPS already uses this trimmed config (the file is bind-mounted into `distro-cloudflared-1`), so this commits the live state and follows the cutover doc's instruction to remove stale tunnel entries in a PR.
- Document the Playwright screenshot-job stall workaround (`--only-shell` install, `skip-screenshots` label) in the AGENTS.md CI Timeouts section.

## Invariants

- **Source of truth**: `distro/cloudflared.yml` is the live tunnel ingress config (bind-mounted into the cloudflared container). This PR reconciles the repo with what is already running.
- **Lock/transaction scope**: n/a — config and docs only, no code paths.
- **Acceptable orphan states**: none; remaining routes (grafana, staging) are unchanged and unmatched hosts fail closed to `http_status:404`.
- **Auth source of truth**: unchanged; platform domains authenticate via the Cloud Run edge path.
- **Deferred scope**: deciding the fate of the remaining grafana/staging tunnel routes and the legacy tunnel itself (tracked by the cutover doc's staging/Grafana plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)