### PR TITLE
chore(distro): post-cutover tunnel cleanup and observability hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,7 @@ Every backend PR must include an "Invariants" section:
 ### CI Timeouts
 
 - **Timeouts must cover observed runtime with margin**. If a CI job completes all tests successfully but is canceled by `timeout-minutes`, raise or split the job instead of treating it as a product test failure.
+- **Screenshot jobs are expensive and often stall on browser install**. If the `Screenshots` workflow hangs, first check whether it is stuck at `pnpm exec playwright install chromium`; Playwright docs note browser cache restore can be as slow as download on Linux. For headless-only screenshot tests, prefer `pnpm exec playwright install --only-shell chromium`. For non-visual PRs, use the `skip-screenshots`/`no-screenshots` label or cancel optional screenshot runs rather than blocking a release.
 
 ### Branch Freeze
 

--- a/distro/cloudflared.yml
+++ b/distro/cloudflared.yml
@@ -4,8 +4,7 @@ credentials-file: /etc/cloudflared/credentials.json
 ingress:
   - hostname: grafana.matrix-os.com
     service: http://grafana:3000
-  # Staging dev container (HMR shell). MUST come before the *.matrix-os.com
-  # wildcard or it would be swallowed by the platform router.
+  # Staging dev container (HMR shell).
   - hostname: staging.matrix-os.com
     service: http://matrixos-staging:3000
   - hostname: api-staging.matrix-os.com

--- a/distro/cloudflared.yml
+++ b/distro/cloudflared.yml
@@ -10,10 +10,4 @@ ingress:
     service: http://matrixos-staging:3000
   - hostname: api-staging.matrix-os.com
     service: http://matrixos-staging:4000
-  - hostname: api.matrix-os.com
-    service: http://platform:9000
-  - hostname: code.matrix-os.com
-    service: http://platform:9000
-  - hostname: "*.matrix-os.com"
-    service: http://platform:9000
   - service: http_status:404

--- a/distro/observability/docker-compose.observability.yml
+++ b/distro/observability/docker-compose.observability.yml
@@ -4,8 +4,9 @@
 services:
   prometheus:
     image: prom/prometheus:latest
+    # Loopback only: no auth on the Prometheus API; reach it via SSH tunnel.
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./observability/alerting/rules.yml:/etc/prometheus/rules.yml:ro
@@ -22,8 +23,10 @@ services:
 
   loki:
     image: grafana/loki:latest
+    # Loopback only: Loki has no auth; local promtail reaches it over the
+    # docker network, remote shippers must come through an authenticated edge.
     ports:
-      - "3100:3100"
+      - "127.0.0.1:3100:3100"
     volumes:
       - ./observability/loki.yml:/etc/loki/local-config.yaml:ro
       - loki-data:/loki
@@ -35,8 +38,10 @@ services:
 
   grafana:
     image: grafana/grafana:latest
+    # Loopback only: public access goes through the cloudflared tunnel
+    # (grafana.matrix-os.com -> grafana:3000 on the docker network).
     ports:
-      - "3200:3000"
+      - "127.0.0.1:3200:3000"
     volumes:
       - ./observability/provisioning/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
       - ./observability/provisioning/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
@@ -44,8 +49,13 @@ services:
       - grafana-data:/var/lib/grafana
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=false
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-matrixos}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD must be set}
       - GF_SERVER_ROOT_URL=https://grafana.matrix-os.com
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SECURITY_COOKIE_SECURE=true
+      - GF_SECURITY_DISABLE_GRAVATAR=true
+      - GF_SNAPSHOTS_EXTERNAL_ENABLED=false
+      - GF_ANALYTICS_REPORTING_ENABLED=false
     healthcheck:
       test: curl -sf http://localhost:3000/api/health || exit 1
       interval: 15s


### PR DESCRIPTION
## Summary

- Remove the `api.matrix-os.com`, `code.matrix-os.com`, and `*.matrix-os.com` wildcard ingress entries from `distro/cloudflared.yml`. These pointed at the legacy local `platform:9000` container, retired in the 2026-06-06 Cloud Run cutover; the domains now route through the managed edge. The live tunnel already runs this trimmed config (the file is bind-mounted into the cloudflared container), so this commits the live state per the cutover doc's instruction to remove stale tunnel entries in a PR. Also drops the now-stale wildcard-ordering comment.
- Harden the observability overlay: bind Grafana/Loki/Prometheus host ports to `127.0.0.1` (ufw is inactive on the VPS, so the unauthenticated Loki and Prometheus APIs were internet-reachable), require `GRAFANA_ADMIN_PASSWORD` instead of a weak default fallback, and disable sign-up, external snapshots, gravatar, and analytics reporting. Applied live on the VPS and verified: loopback-only bindings, tunnel route healthy.
- Document the Playwright screenshot-job stall workaround (`--only-shell` install, `skip-screenshots` label) in the AGENTS.md CI Timeouts section.

## Invariants

- **Source of truth**: `distro/cloudflared.yml` and the observability overlay are the live configs (bind-mounted/applied on the ops VPS). This PR reconciles the repo with what is running.
- **Lock/transaction scope**: n/a — config and docs only.
- **Acceptable orphan states**: none; unmatched tunnel hosts fail closed to `http_status:404`; Grafana keeps serving via the docker network if host bindings change.
- **Auth source of truth**: platform domains authenticate via the Cloud Run edge path; Grafana auth is local admin login (Cloudflare Access in front of `grafana.matrix-os.com` is the recommended follow-up).
- **Deferred scope**: Cloudflare Access for Grafana, fate of the dead `staging.matrix-os.com` routes, and central log aggregation from customer VPSes / Cloud Run / Clerk / Stripe (separate proposal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)