### PR TITLE
fix(platform): self-heal stuck provisioning and unblock failed-machine retries

### DIFF
--- a/packages/platform/src/customer-vps-config.ts
+++ b/packages/platform/src/customer-vps-config.ts
@@ -23,6 +23,7 @@ export interface CustomerVpsConfig {
   registrationTokenTtlMs: number;
   reconciliationBatchSize: number;
   reconciliationStaleAfterMs: number;
+  maxProvisionAttempts: number;
 }
 
 function numberFromEnv(value: string | undefined, fallback: number): number {
@@ -67,5 +68,6 @@ export function loadCustomerVpsConfig(env: NodeJS.ProcessEnv = process.env): Cus
     registrationTokenTtlMs: numberFromEnv(env.CUSTOMER_VPS_REGISTRATION_TOKEN_TTL_MS, 15 * 60 * 1000),
     reconciliationBatchSize: numberFromEnv(env.CUSTOMER_VPS_RECONCILIATION_BATCH_SIZE, 50),
     reconciliationStaleAfterMs: numberFromEnv(env.CUSTOMER_VPS_RECONCILIATION_STALE_AFTER_MS, 10 * 60 * 1000),
+    maxProvisionAttempts: numberFromEnv(env.CUSTOMER_VPS_MAX_PROVISION_ATTEMPTS, 3),
   };
 }

--- a/packages/platform/src/customer-vps-errors.ts
+++ b/packages/platform/src/customer-vps-errors.ts
@@ -7,6 +7,8 @@ export type CustomerVpsFailureCode =
   | 'billing_required'
   | 'not_found'
   | 'registration_rejected'
+  | 'registration_timeout'
+  | 'retry_exhausted'
   | 'unknown';
 
 export class CustomerVpsError extends Error {

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -15,6 +15,7 @@ import {
   listRunningUserMachines,
   listStaleUserMachines,
   lockUserMachineProvisioning,
+  retireUserMachine,
   markProviderDeletionCompleted,
   markProviderDeletionFailed,
   runInPlatformTransaction,
@@ -468,12 +469,15 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
       const postgresPassword = postgresPasswordFactory();
       const billingContext = await resolveBillingProvisionContext(deps, request, currentTime);
 
+      // A non-failed active machine (provisioning/running converge; recovering
+      // is rejected by activeProvisionResponse). A `failed` row is retryable, so
+      // it must NOT short-circuit here — it is retired inside the transaction.
       const existingBeforeBundleResolve = await getActiveUserMachineByClerkId(
         deps.db,
         request.clerkUserId,
         request.runtimeSlot,
       );
-      if (existingBeforeBundleResolve) {
+      if (existingBeforeBundleResolve && existingBeforeBundleResolve.status !== 'failed') {
         return activeProvisionResponse(existingBeforeBundleResolve, deps.config.provisionEtaSeconds);
       }
 
@@ -492,8 +496,23 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           await lockUserMachineProvisioning(trx, request.clerkUserId);
         }
         const existing = await getActiveUserMachineByClerkId(trx, request.clerkUserId, request.runtimeSlot);
+        let attempt = 1;
+        let retiredServerId: number | null = null;
+        let retiredMachineId: string | null = null;
         if (existing) {
-          return { existing };
+          if (existing.status !== 'failed') {
+            return { existing, retiredServerId: null, retiredMachineId: null };
+          }
+          // The active slot is held by a failed attempt. Retire it and provision
+          // a fresh one in the same transaction so the unique (clerk, slot) slot
+          // is satisfied at every instant and the user is never blocked.
+          attempt = existing.attempt + 1;
+          if (attempt > deps.config.maxProvisionAttempts) {
+            throw new CustomerVpsError(409, 'retry_exhausted', 'Provisioning retry limit reached');
+          }
+          await retireUserMachine(trx, existing.machineId, currentTime.toISOString());
+          retiredServerId = existing.hetznerServerId;
+          retiredMachineId = existing.machineId;
         }
         if (billingContext) {
           const activeMachines = await listActiveUserMachinesByClerkId(trx, request.clerkUserId);
@@ -512,11 +531,23 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           registrationTokenHash: registration.hash,
           registrationTokenExpiresAt: registration.expiresAt,
           provisionedAt: currentTime.toISOString(),
+          attempt,
         });
-        return { existing: null };
+        return { existing: null, retiredServerId, retiredMachineId };
       });
       if (provisionRow.existing) {
         return activeProvisionResponse(provisionRow.existing, deps.config.provisionEtaSeconds);
+      }
+      // Reap the retired failed attempt's server outside the transaction so the
+      // abandoned VPS does not accrue cost (network call never inside the txn).
+      if (provisionRow.retiredServerId !== null) {
+        await queueProviderDeletion({
+          providerServerId: provisionRow.retiredServerId,
+          reason: 'failed_retry_retire',
+          machineId: provisionRow.retiredMachineId,
+          handle: request.handle,
+          err: new Error('retiring failed machine before retry'),
+        });
       }
 
       const userData = renderCloudInitTemplate(
@@ -882,6 +913,28 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
             status: 'failed',
             failureCode: 'not_found',
             failureAt: now().toISOString(),
+          });
+          failed += 1;
+          continue;
+        }
+        // The server booted but the host never called register() before its
+        // registration token expired. It can never become routable, so fail it
+        // (freeing the slot for retry) and reap the abandoned server.
+        if (
+          row.registrationTokenExpiresAt &&
+          new Date(row.registrationTokenExpiresAt).getTime() < now().getTime()
+        ) {
+          await updateUserMachine(deps.db, row.machineId, {
+            status: 'failed',
+            failureCode: 'registration_timeout',
+            failureAt: now().toISOString(),
+          });
+          await queueProviderDeletion({
+            providerServerId: row.hetznerServerId,
+            reason: 'registration_timeout',
+            machineId: row.machineId,
+            handle: row.handle,
+            err: new Error('registration token expired before register()'),
           });
           failed += 1;
           continue;

--- a/packages/platform/src/customer-vps.ts
+++ b/packages/platform/src/customer-vps.ts
@@ -387,6 +387,34 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
     }
   }
 
+  // Enqueues a provider-server deletion on the given transaction-or-db handle.
+  // Unlike queueProviderDeletion, this propagates insert failures so a caller
+  // can keep the status change and the deletion enqueue in one atomic unit —
+  // if the enqueue fails the whole transaction rolls back and the machine is
+  // retried on the next reconciler pass instead of orphaning its server.
+  async function enqueueProviderDeletionTx(
+    handle: PlatformDB,
+    input: {
+      providerServerId: number;
+      reason: string;
+      machineId?: string | null;
+      handle?: string | null;
+      detail: string;
+    },
+  ): Promise<void> {
+    const currentTime = now().toISOString();
+    await insertProviderDeletion(handle, {
+      id: randomUUID(),
+      providerServerId: input.providerServerId,
+      reason: input.reason,
+      machineId: input.machineId ?? null,
+      handle: input.handle ?? null,
+      nextAttemptAt: currentTime,
+      createdAt: currentTime,
+      lastError: input.detail,
+    });
+  }
+
   async function retryProviderDeletions(): Promise<void> {
     const pending = await listPendingProviderDeletions(
       deps.db,
@@ -497,22 +525,29 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
         }
         const existing = await getActiveUserMachineByClerkId(trx, request.clerkUserId, request.runtimeSlot);
         let attempt = 1;
-        let retiredServerId: number | null = null;
-        let retiredMachineId: string | null = null;
         if (existing) {
           if (existing.status !== 'failed') {
-            return { existing, retiredServerId: null, retiredMachineId: null };
+            return { existing };
           }
-          // The active slot is held by a failed attempt. Retire it and provision
-          // a fresh one in the same transaction so the unique (clerk, slot) slot
-          // is satisfied at every instant and the user is never blocked.
+          // The active slot is held by a failed attempt. Retire it, enqueue its
+          // server for reaping, and provision a fresh one — all in one
+          // transaction so the unique (clerk, slot) slot is satisfied at every
+          // instant, the user is never blocked, and the retired server is never
+          // orphaned (a failed enqueue rolls back the whole retry).
           attempt = existing.attempt + 1;
           if (attempt > deps.config.maxProvisionAttempts) {
             throw new CustomerVpsError(409, 'retry_exhausted', 'Provisioning retry limit reached');
           }
           await retireUserMachine(trx, existing.machineId, currentTime.toISOString());
-          retiredServerId = existing.hetznerServerId;
-          retiredMachineId = existing.machineId;
+          if (existing.hetznerServerId !== null) {
+            await enqueueProviderDeletionTx(trx, {
+              providerServerId: existing.hetznerServerId,
+              reason: 'failed_retry_retire',
+              machineId: existing.machineId,
+              handle: request.handle,
+              detail: 'retiring failed machine before retry',
+            });
+          }
         }
         if (billingContext) {
           const activeMachines = await listActiveUserMachinesByClerkId(trx, request.clerkUserId);
@@ -533,21 +568,10 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           provisionedAt: currentTime.toISOString(),
           attempt,
         });
-        return { existing: null, retiredServerId, retiredMachineId };
+        return { existing: null };
       });
       if (provisionRow.existing) {
         return activeProvisionResponse(provisionRow.existing, deps.config.provisionEtaSeconds);
-      }
-      // Reap the retired failed attempt's server outside the transaction so the
-      // abandoned VPS does not accrue cost (network call never inside the txn).
-      if (provisionRow.retiredServerId !== null) {
-        await queueProviderDeletion({
-          providerServerId: provisionRow.retiredServerId,
-          reason: 'failed_retry_retire',
-          machineId: provisionRow.retiredMachineId,
-          handle: request.handle,
-          err: new Error('retiring failed machine before retry'),
-        });
       }
 
       const userData = renderCloudInitTemplate(
@@ -924,17 +948,24 @@ export function createCustomerVpsService(deps: CustomerVpsServiceDeps): Customer
           row.registrationTokenExpiresAt &&
           new Date(row.registrationTokenExpiresAt).getTime() < now().getTime()
         ) {
-          await updateUserMachine(deps.db, row.machineId, {
-            status: 'failed',
-            failureCode: 'registration_timeout',
-            failureAt: now().toISOString(),
-          });
-          await queueProviderDeletion({
-            providerServerId: row.hetznerServerId,
-            reason: 'registration_timeout',
-            machineId: row.machineId,
-            handle: row.handle,
-            err: new Error('registration token expired before register()'),
+          // Mark failed and enqueue the server for reaping atomically: once the
+          // row is `failed` it leaves listStaleUserMachines, so if the enqueue
+          // were a separate write that failed, the server would be orphaned
+          // forever. Rolling back keeps the row reconcilable next pass.
+          const serverId = row.hetznerServerId;
+          await runInPlatformTransaction(deps.db, async (trx) => {
+            await updateUserMachine(trx, row.machineId, {
+              status: 'failed',
+              failureCode: 'registration_timeout',
+              failureAt: now().toISOString(),
+            });
+            await enqueueProviderDeletionTx(trx, {
+              providerServerId: serverId,
+              reason: 'registration_timeout',
+              machineId: row.machineId,
+              handle: row.handle,
+              detail: 'registration token expired before register()',
+            });
           });
           failed += 1;
           continue;

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -1853,6 +1853,9 @@ export async function claimUserMachineRecovery(
  * Soft-deletes a failed machine row so it stops occupying the active
  * (clerk_user_id, runtime_slot) unique slot, letting a retry provision a fresh
  * machine. The failure status is preserved for audit; only `deleted_at` is set.
+ * The `status = 'failed'` guard encodes the invariant at the DB layer: this
+ * helper must never silently retire a live (provisioning/recovering/running)
+ * machine, even if a future caller forgets the status check.
  */
 export async function retireUserMachine(
   db: PlatformDB,
@@ -1865,6 +1868,7 @@ export async function retireUserMachine(
     .set({ deleted_at: retiredAt })
     .where('machine_id', '=', machineId)
     .where('deleted_at', 'is', null)
+    .where('status', '=', 'failed')
     .execute();
 }
 

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -57,6 +57,7 @@ interface UserMachinesTable {
   deleted_at: string | null;
   failure_code: string | null;
   failure_at: string | null;
+  attempt: number;
 }
 
 interface HostBundleReleasesTable {
@@ -346,6 +347,7 @@ export interface UserMachineRecord {
   deletedAt: string | null;
   failureCode: string | null;
   failureAt: string | null;
+  attempt: number;
 }
 
 export interface HostBundleReleaseRecord {
@@ -493,6 +495,7 @@ export interface NewUserMachine {
   deletedAt?: string | null;
   failureCode?: string | null;
   failureAt?: string | null;
+  attempt?: number;
 }
 
 export interface NewProviderDeletionQueueRecord {
@@ -580,11 +583,13 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
       last_seen_at TEXT,
       deleted_at TEXT,
       failure_code TEXT,
-      failure_at TEXT
+      failure_at TEXT,
+      attempt INTEGER NOT NULL DEFAULT 1
     )
   `.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS runtime_slot TEXT NOT NULL DEFAULT 'primary'`.execute(db);
   await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS server_type TEXT`.execute(db);
+  await sql`ALTER TABLE user_machines ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 1`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_status ON user_machines(status)`.execute(db);
   await sql`ALTER TABLE user_machines DROP CONSTRAINT IF EXISTS user_machines_clerk_user_id_key`.execute(db);
   await sql`DROP INDEX IF EXISTS idx_user_machines_clerk`.execute(db);
@@ -1023,6 +1028,7 @@ function mapUserMachine(row: UserMachinesTable): UserMachineRecord {
     deletedAt: row.deleted_at,
     failureCode: row.failure_code,
     failureAt: row.failure_at,
+    attempt: row.attempt,
   };
 }
 
@@ -1045,6 +1051,7 @@ function toUserMachineRow(record: NewUserMachine): UserMachinesTable {
     deleted_at: record.deletedAt ?? null,
     failure_code: record.failureCode ?? null,
     failure_at: record.failureAt ?? null,
+    attempt: record.attempt ?? 1,
   };
 }
 
@@ -1067,6 +1074,7 @@ function toUserMachineUpdate(values: Partial<NewUserMachine>): Partial<UserMachi
   if (values.deletedAt !== undefined) update.deleted_at = values.deletedAt;
   if (values.failureCode !== undefined) update.failure_code = values.failureCode;
   if (values.failureAt !== undefined) update.failure_at = values.failureAt;
+  if (values.attempt !== undefined) update.attempt = values.attempt;
   return update;
 }
 
@@ -1839,6 +1847,25 @@ export async function claimUserMachineRecovery(
     .returningAll()
     .executeTakeFirst();
   return row ? mapUserMachine(row) : undefined;
+}
+
+/**
+ * Soft-deletes a failed machine row so it stops occupying the active
+ * (clerk_user_id, runtime_slot) unique slot, letting a retry provision a fresh
+ * machine. The failure status is preserved for audit; only `deleted_at` is set.
+ */
+export async function retireUserMachine(
+  db: PlatformDB,
+  machineId: string,
+  retiredAt: string,
+): Promise<void> {
+  await db.ready;
+  await db.executor
+    .updateTable('user_machines')
+    .set({ deleted_at: retiredAt })
+    .where('machine_id', '=', machineId)
+    .where('deleted_at', 'is', null)
+    .execute();
 }
 
 export async function claimUserMachineDelete(

--- a/tests/platform/customer-vps-reliability.test.ts
+++ b/tests/platform/customer-vps-reliability.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  getActiveUserMachineByClerkId,
+  getUserMachine,
+  listUserMachines,
+  listPendingProviderDeletions,
+  updateUserMachine,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import { createCustomerVpsService } from '../../packages/platform/src/customer-vps.js';
+import { loadCustomerVpsConfig } from '../../packages/platform/src/customer-vps-config.js';
+import { hashRegistrationToken } from '../../packages/platform/src/customer-vps-auth.js';
+import { CustomerVpsError } from '../../packages/platform/src/customer-vps-errors.js';
+import type { BillingEntitlement } from '../../packages/platform/src/billing.js';
+import { createMockCustomerVpsSystemStore, createMockHetznerClient } from './customer-vps-fixtures.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+// Phase A (spec 092): provisioning reliability — stuck rows fail automatically,
+// failed rows never block retries, retries are bounded, retired rows cannot register.
+describe('platform/customer-vps reliability', () => {
+  let db: PlatformDB;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  function activeEntitlement(overrides: Partial<BillingEntitlement> = {}): BillingEntitlement {
+    return {
+      clerkUserId: 'user_123',
+      source: 'stripe',
+      planSlug: 'matrix_builder',
+      status: 'active',
+      maxRuntimeSlots: 1,
+      includedRuntimeSlots: 1,
+      addonRuntimeSlots: 0,
+      defaultServerType: 'cpx32',
+      allowedServerTypes: ['cpx22', 'cpx32'],
+      stripeSubscriptionId: 'sub_123',
+      stripePriceId: 'price_builder_monthly',
+      gracePeriodEndsAt: '2099-01-01T00:00:00.000Z',
+      effectiveFrom: '2026-01-01T00:00:00.000Z',
+      effectiveUntil: null,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  interface Harness {
+    service: ReturnType<typeof createCustomerVpsService>;
+    hetzner: ReturnType<typeof createMockHetznerClient>;
+    setClock: (iso: string) => void;
+  }
+
+  function createHarness(opts: {
+    env?: Record<string, string>;
+    hetzner?: Parameters<typeof createMockHetznerClient>[0];
+    entitled?: boolean;
+  } = {}): Harness {
+    let clock = new Date('2026-04-26T12:00:00.000Z');
+    const setClock = (iso: string) => {
+      clock = new Date(iso);
+    };
+    let machineSeq = 0;
+    const hetzner = createMockHetznerClient(opts.hetzner);
+    const systemStore = createMockCustomerVpsSystemStore();
+    const service = createCustomerVpsService({
+      db,
+      config: loadCustomerVpsConfig({
+        PLATFORM_PORT: '9000',
+        PLATFORM_SECRET: 'platform-secret',
+        HETZNER_API_TOKEN: 'token',
+        S3_ACCESS_KEY_ID: 'r2-access-key',
+        S3_SECRET_ACCESS_KEY: 'r2-secret-key',
+        S3_ENDPOINT: 'https://r2.example',
+        R2_BUCKET: 'matrixos-sync',
+        POSTHOG_TOKEN: 'phc_public',
+        POSTHOG_PROJECT_TOKEN: 'phc_project',
+        POSTHOG_HOST: 'https://eu.i.posthog.com',
+        NEXT_PUBLIC_POSTHOG_API_HOST: '/ingest',
+        ...opts.env,
+      }),
+      hetzner,
+      systemStore,
+      // Deterministic registration token whose expiry honors the configured TTL,
+      // so reconcile can detect a booted-but-never-registered machine.
+      tokenFactory: (nowDate: Date, ttlMs: number) => ({
+        token: 'reg-token',
+        hash: hashRegistrationToken('reg-token'),
+        expiresAt: new Date(nowDate.getTime() + ttlMs).toISOString(),
+      }),
+      machineIdFactory: () => `machine-${++machineSeq}`,
+      postgresPasswordFactory: () => 'postgres-secret',
+      now: () => clock,
+      ...(opts.entitled === false
+        ? {}
+        : { resolveBillingEntitlement: async () => activeEntitlement() }),
+    });
+    return { service, hetzner, setClock };
+  }
+
+  it('fails a booted-but-never-registered machine once its registration token expires (gap 1)', async () => {
+    // Hetzner reports the VM as running, but the host never called register().
+    const { service, hetzner, setClock } = createHarness();
+    await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    // Advance past the 15-minute registration token TTL and the 10-minute stale window.
+    setClock('2026-04-26T12:16:00.000Z');
+    const result = await service.reconcileProvisioning();
+
+    expect(result.failed).toBe(1);
+    const row = await getActiveUserMachineByClerkId(db, 'user_123');
+    expect(row?.status).toBe('failed');
+    expect(row?.failureCode).toBe('registration_timeout');
+    // The abandoned server must be reaped so it does not accrue cost.
+    expect(hetzner.deleteServer).toHaveBeenCalledWith(123456);
+  });
+
+  it('does not fail a stale machine while its registration token is still valid', async () => {
+    const { service, setClock } = createHarness();
+    await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    // 12 minutes: stale (>10m) but token still valid (<15m).
+    setClock('2026-04-26T12:12:00.000Z');
+    const result = await service.reconcileProvisioning();
+
+    expect(result.failed).toBe(0);
+    const row = await getActiveUserMachineByClerkId(db, 'user_123');
+    expect(row?.status).toBe('provisioning');
+  });
+
+  it('retries a failed machine by retiring it and provisioning a fresh one (gap 2)', async () => {
+    const { service, hetzner } = createHarness();
+    const first = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    await updateUserMachine(db, first.machineId, {
+      status: 'failed',
+      failureCode: 'provider_unavailable',
+      failureAt: '2026-04-26T12:05:00.000Z',
+    });
+
+    const retry = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    expect(retry.machineId).not.toBe(first.machineId);
+    expect(retry.status).toBe('provisioning');
+
+    const active = await getActiveUserMachineByClerkId(db, 'user_123');
+    expect(active?.machineId).toBe(retry.machineId);
+    expect(active?.attempt).toBe(2);
+
+    // Exactly one live row for the user/slot after the retry.
+    const live = (await listUserMachines(db)).filter(
+      (m) => m.clerkUserId === 'user_123' && m.deletedAt === null,
+    );
+    expect(live).toHaveLength(1);
+
+    // The retired machine is soft-deleted and its server queued for reaping.
+    const retired = await getUserMachine(db, first.machineId);
+    expect(retired?.deletedAt).not.toBeNull();
+    expect(hetzner.createServer).toHaveBeenCalledTimes(2);
+  });
+
+  it('converges concurrent retries on a failed row to a single live machine', async () => {
+    const { service } = createHarness();
+    const first = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    await updateUserMachine(db, first.machineId, {
+      status: 'failed',
+      failureCode: 'provider_unavailable',
+      failureAt: '2026-04-26T12:05:00.000Z',
+    });
+
+    const results = await Promise.allSettled([
+      service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
+      service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
+    ]);
+
+    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+    const live = (await listUserMachines(db)).filter(
+      (m) => m.clerkUserId === 'user_123' && m.deletedAt === null,
+    );
+    expect(live).toHaveLength(1);
+  });
+
+  it('stops retrying after the attempt cap is reached', async () => {
+    const { service } = createHarness({ env: { CUSTOMER_VPS_MAX_PROVISION_ATTEMPTS: '2' } });
+
+    const a1 = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    await updateUserMachine(db, a1.machineId, { status: 'failed', failureAt: '2026-04-26T12:05:00.000Z' });
+    const a2 = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    expect(a2.machineId).not.toBe(a1.machineId);
+    await updateUserMachine(db, a2.machineId, { status: 'failed', failureAt: '2026-04-26T12:06:00.000Z' });
+
+    await expect(
+      service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
+    ).rejects.toMatchObject({ code: 'retry_exhausted' });
+  });
+
+  it('rejects registration for a retired machine', async () => {
+    const { service } = createHarness();
+    const first = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    await updateUserMachine(db, first.machineId, { status: 'failed', failureAt: '2026-04-26T12:05:00.000Z' });
+    // Retire it by provisioning a replacement.
+    await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    await expect(
+      service.register('reg-token', {
+        machineId: first.machineId,
+        hetznerServerId: 123456,
+        publicIPv4: '203.0.113.10',
+        publicIPv6: '2001:db8::/64',
+        imageVersion: 'stable',
+      }),
+    ).rejects.toBeInstanceOf(CustomerVpsError);
+
+    const retired = await getUserMachine(db, first.machineId);
+    expect(retired?.status).not.toBe('running');
+  });
+
+  it('rejects registration once the registration token has expired', async () => {
+    const { service, setClock } = createHarness();
+    const first = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    setClock('2026-04-26T12:16:00.000Z'); // past 15-minute TTL
+    await expect(
+      service.register('reg-token', {
+        machineId: first.machineId,
+        hetznerServerId: 123456,
+        publicIPv4: '203.0.113.10',
+        publicIPv6: '2001:db8::/64',
+        imageVersion: 'stable',
+      }),
+    ).rejects.toBeInstanceOf(CustomerVpsError);
+
+    const row = await getUserMachine(db, first.machineId);
+    expect(row?.status).toBe('provisioning');
+  });
+});

--- a/tests/platform/customer-vps-reliability.test.ts
+++ b/tests/platform/customer-vps-reliability.test.ts
@@ -160,6 +160,9 @@ describe('platform/customer-vps reliability', () => {
     const retired = await getUserMachine(db, first.machineId);
     expect(retired?.deletedAt).not.toBeNull();
     expect(hetzner.createServer).toHaveBeenCalledTimes(2);
+
+    const pending = await listPendingProviderDeletions(db, '2099-01-01T00:00:00.000Z', 50);
+    expect(pending.some((d) => d.reason === 'failed_retry_retire' && d.providerServerId === 123456)).toBe(true);
   });
 
   it('converges concurrent retries on a failed row to a single live machine', async () => {
@@ -177,6 +180,32 @@ describe('platform/customer-vps reliability', () => {
     ]);
 
     expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+    const live = (await listUserMachines(db)).filter(
+      (m) => m.clerkUserId === 'user_123' && m.deletedAt === null,
+    );
+    expect(live).toHaveLength(1);
+  });
+
+  it('converges concurrent retries with no billing lock via the unique index alone', async () => {
+    // entitled:false skips lockUserMachineProvisioning, so the unique partial
+    // index on (clerk_user_id, runtime_slot) WHERE deleted_at IS NULL is the
+    // sole safety net. A losing racer must surface an error, never a silent
+    // second live machine.
+    const { service } = createHarness({ entitled: false });
+    const first = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+    await updateUserMachine(db, first.machineId, { status: 'failed', failureAt: '2026-04-26T12:05:00.000Z' });
+
+    const results = await Promise.allSettled([
+      service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
+      service.provision({ clerkUserId: 'user_123', handle: 'alice' }),
+    ]);
+
+    expect(results.some((r) => r.status === 'fulfilled')).toBe(true);
+    for (const r of results) {
+      if (r.status === 'rejected') {
+        expect(r.reason).toBeInstanceOf(Error);
+      }
+    }
     const live = (await listUserMachines(db)).filter(
       (m) => m.clerkUserId === 'user_123' && m.deletedAt === null,
     );

--- a/tests/platform/customer-vps-reliability.test.ts
+++ b/tests/platform/customer-vps-reliability.test.ts
@@ -4,6 +4,7 @@ import {
   getUserMachine,
   listUserMachines,
   listPendingProviderDeletions,
+  retireUserMachine,
   updateUserMachine,
   type PlatformDB,
 } from '../../packages/platform/src/db.js';
@@ -210,6 +211,18 @@ describe('platform/customer-vps reliability', () => {
       (m) => m.clerkUserId === 'user_123' && m.deletedAt === null,
     );
     expect(live).toHaveLength(1);
+  });
+
+  it('never retires a live (non-failed) machine', async () => {
+    const { service } = createHarness();
+    const first = await service.provision({ clerkUserId: 'user_123', handle: 'alice' });
+
+    // The machine is still 'provisioning'; retiring it must be a no-op.
+    await retireUserMachine(db, first.machineId, '2026-04-26T12:30:00.000Z');
+
+    const row = await getUserMachine(db, first.machineId);
+    expect(row?.deletedAt).toBeNull();
+    expect(row?.status).toBe('provisioning');
   });
 
   it('stops retrying after the attempt cap is reached', async () => {


### PR DESCRIPTION
## Summary

Spec 092 **Phase A** (provisioning reliability — first PR in the onboarding-unification Graphite stack). Fixes the two failure modes that strand paying users at the moment of highest intent, with no UI change:

1. **Stuck-forever provisioning.** `reconcileProvisioning()` previously refreshed IP metadata for a booted-but-never-registered machine and left it `provisioning` indefinitely. It now transitions such a machine to `failed` with `registration_timeout` once its registration token expires, and reaps the abandoned Hetzner server via the existing deletion queue.
2. **Failed rows permanently blocking re-provisioning.** A `failed` row (with `deleted_at IS NULL`) held the active `(clerk_user_id, runtime_slot)` unique slot, so `provision()` hit `activeProvisionResponse` → 409 forever. `provision()` now retires the failed row (soft-delete) and inserts a fresh attempt **in the same transaction**, so the unique slot is satisfied at every instant and the user can self-retry. Retries are bounded by `CUSTOMER_VPS_MAX_PROVISION_ATTEMPTS` (default 3); past the cap, provision returns `retry_exhausted` (409) for a support escalation.

Adds `user_machines.attempt` (int, default 1) and a `retireUserMachine()` DB helper. `failure_code`/`failure_at` already existed.

Deferred to later phases (declared so there is no dead code): the `/api/journey` endpoint, `billing_checkout_attempts`/settling, and `recover()` work (verified already atomic — single row mutated in place inside `runInPlatformTransaction`, so no change needed).

## Tests

New `tests/platform/customer-vps-reliability.test.ts` (7 cases, TDD red→green): registration-timeout reconcile + reap, still-valid-token not failed, failed-row retire+retry, concurrent-retry convergence to one live row, attempt cap, retired-row registration rejection, expired-token registration rejection.

- `vitest run` new file: 7/7 pass
- `vitest run` existing `customer-vps*` + `db` suites: 72/72 pass (no regression)
- `tsc --noEmit` (platform `tsconfig.typecheck.json`): clean
- `scripts/review/check-patterns.sh`: 0 violations (5 pre-existing gateway warnings, not in this diff)

## Invariants

- **Source of truth**: `user_machines` is canonical for machine lifecycle. The active machine for a `(clerk_user_id, runtime_slot)` is the single row with `deleted_at IS NULL` (enforced by `idx_user_machines_clerk_slot_active`). A `failed` row is non-routable but still occupies the slot until retired.
- **Lock/transaction scope**: retire-failed + insert-new-attempt runs inside `runInPlatformTransaction` under the per-user `pg_advisory_xact_lock` (`lockUserMachineProvisioning`) when billing is enabled. The Hetzner `createServer` call happens *after* the row insert (existing flow); the retired server's deletion is queued *outside* the transaction. No network call occurs inside the transaction.
- **Acceptable orphan states**: a retired failed machine's Hetzner server may briefly outlive its soft-deleted DB row — it is queued for reaping (`failed_retry_retire`) and drained by the reconciler's existing `retryProviderDeletions()`. Double-queueing a server already reaped during `registration_timeout` is harmless (idempotent delete).
- **Auth source of truth**: unchanged. `/vps/register` still requires a valid, unexpired registration token matching the row; retired (soft-deleted, `status='failed'`) rows are rejected by the existing status + `deleted_at IS NULL` guards.
- **Deferred scope**: journey endpoint, checkout-attempt/settling records, and shell/CLI/mobile rendering ship in Phases B–E of the stack.