### PR TITLE
fix(observability): same-origin PostHog /relay proxy and cross-surface identity

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -164,7 +164,10 @@ jobs:
       NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY || vars.NEXT_PUBLIC_POSTHOG_KEY }}
       NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN }}
       NEXT_PUBLIC_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com' }}
-      NEXT_PUBLIC_POSTHOG_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || 'https://eu.i.posthog.com' }}
+      # Relative /relay rides the shell's same-origin PostHog rewrite, so
+      # capture calls stay first-party on every user subdomain (ad blockers
+      # block *.posthog.com and shared proxy hosts).
+      NEXT_PUBLIC_POSTHOG_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || '/relay' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
       channel: ${{ steps.channel.outputs.channel }}

--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -54,7 +54,7 @@ jobs:
       MATRIX_CODE_DOMAIN_HOSTS: ${{ vars.MATRIX_CODE_DOMAIN_HOSTS }}
       CUSTOMER_VPS_IMAGE_VERSION: ${{ vars.CUSTOMER_VPS_IMAGE_VERSION }}
       POSTHOG_PUBLIC_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com' }}
-      POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || 'https://neo.matrix-os.com' }}
+      POSTHOG_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || '/relay' }}
       DEPLOY_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
     steps:
       - name: Checkout

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -14,7 +14,7 @@ import { bodyLimit } from "hono/body-limit";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
-import { installPostHogHonoErrorTracking } from "@matrix-os/observability";
+import { installPostHogHonoErrorTracking, resolveOwnerTelemetryDistinctId } from "@matrix-os/observability";
 import { createDispatcher, type Dispatcher, type BatchEntry, type DispatchContext, type SpawnFn } from "./dispatcher.js";
 import { createWatcher, type Watcher } from "./watcher.js";
 import { createPtyHandler, type PtyMessage } from "./pty.js";
@@ -522,11 +522,13 @@ export async function createGateway(config: GatewayConfig) {
     scrollbackStore: shellScrollbackStore,
   });
   const forwardTunnelHub = createForwardTunnelHub();
+  const ownerTelemetryDistinctId = resolveOwnerTelemetryDistinctId();
   const captureTerminalEvent = (
     event: string,
     properties: Record<string, string | number | boolean | undefined> = {},
   ) => {
     void posthogErrorTracker.captureEvent("gateway_terminal_ws", {
+      distinctId: ownerTelemetryDistinctId,
       properties: {
         source: "gateway-terminal-ws",
         event,
@@ -539,6 +541,7 @@ export async function createGateway(config: GatewayConfig) {
     properties: Record<string, string | number | boolean | undefined> = {},
   ) => {
     void posthogErrorTracker.captureEvent("gateway_product", {
+      distinctId: ownerTelemetryDistinctId,
       properties: {
         source: "gateway",
         event,
@@ -4057,7 +4060,7 @@ export async function createGateway(config: GatewayConfig) {
         ? { channel: parsedTarget.target.value }
         : { version: parsedTarget.target.value };
     void posthogErrorTracker.captureEvent("matrix_system_update_requested", {
-      distinctId: process.env.MATRIX_HANDLE ?? "matrix-gateway",
+      distinctId: resolveOwnerTelemetryDistinctId() ?? "matrix-gateway",
       properties: {
         ...targetProperty,
         targetType: parsedTarget.target.type,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -522,7 +522,9 @@ export async function createGateway(config: GatewayConfig) {
     scrollbackStore: shellScrollbackStore,
   });
   const forwardTunnelHub = createForwardTunnelHub();
-  const ownerTelemetryDistinctId = resolveOwnerTelemetryDistinctId();
+  // One distinct id for every gateway telemetry event so all events on a
+  // dev gateway without owner env vars land under the same person.
+  const ownerTelemetryDistinctId = resolveOwnerTelemetryDistinctId() ?? "matrix-gateway";
   const captureTerminalEvent = (
     event: string,
     properties: Record<string, string | number | boolean | undefined> = {},
@@ -4060,7 +4062,7 @@ export async function createGateway(config: GatewayConfig) {
         ? { channel: parsedTarget.target.value }
         : { version: parsedTarget.target.value };
     void posthogErrorTracker.captureEvent("matrix_system_update_requested", {
-      distinctId: resolveOwnerTelemetryDistinctId() ?? "matrix-gateway",
+      distinctId: ownerTelemetryDistinctId,
       properties: {
         ...targetProperty,
         targetType: parsedTarget.target.type,

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -82,6 +82,7 @@ const TOKEN_ENV_KEYS = [
   "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
   "NEXT_PUBLIC_POSTHOG_KEY",
 ];
+const OWNER_DISTINCT_ID_ENV_KEYS = ["MATRIX_USER_ID", "MATRIX_HANDLE"];
 const HOST_ENV_KEYS = ["POSTHOG_HOST", "NEXT_PUBLIC_POSTHOG_HOST"];
 const DEFAULT_CLIENT_ERROR_MESSAGE = "Internal Server Error";
 const MAX_PROPERTY_LENGTH = 512;
@@ -92,6 +93,13 @@ export function getPostHogConfig(env: EnvSource = process.env): PostHogConfig | 
   if (!token) return null;
   const host = firstEnv(env, HOST_ENV_KEYS);
   return host ? { token, host } : { token };
+}
+
+// Single-owner runtimes (customer VPS gateway) attribute telemetry to their
+// owner. MATRIX_USER_ID is the Clerk user id; MATRIX_HANDLE is aliased to the
+// same person during signup, so either resolves to one PostHog person.
+export function resolveOwnerTelemetryDistinctId(env: EnvSource = process.env): string | undefined {
+  return firstEnv(env, OWNER_DISTINCT_ID_ENV_KEYS);
 }
 
 export function createPostHogErrorTracker(

--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -26,6 +26,22 @@ const nextConfig: NextConfig = {
   },
   async rewrites() {
     return [
+      // Same-origin PostHog proxy. Ad blockers blocklist *.posthog.com and
+      // known proxy paths (/ingest, /ingress, /hog ship in uBlock's default
+      // privacy list), so analytics must ride an unremarkable first-party
+      // path on every shell origin. Asset rules must precede the catch-all.
+      {
+        source: "/relay/static/:path*",
+        destination: "https://eu-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/relay/array/:path*",
+        destination: "https://eu-assets.i.posthog.com/array/:path*",
+      },
+      {
+        source: "/relay/:path*",
+        destination: "https://eu.i.posthog.com/:path*",
+      },
       {
         source: "/gateway/:path*",
         destination: `${gatewayUrl}/:path*`,

--- a/shell/src/app/layout.tsx
+++ b/shell/src/app/layout.tsx
@@ -12,6 +12,7 @@ import "@fontsource/fira-code/500.css";
 import "./globals.css";
 import { PwaRegister } from "@/components/pwa/PwaRegister";
 import { InstallPrompt } from "@/components/pwa/InstallPrompt";
+import { PostHogIdentify } from "@/components/PostHogIdentify";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -63,6 +64,7 @@ export default async function RootLayout({
       <html lang="en" data-posthog-visitor-country={visitorCountry ?? undefined}>
         <body className={`${inter.variable} ${jetbrainsMono.variable} ${cormorant.variable} ${orbitron.variable}`}>
           {children}
+          <PostHogIdentify />
           <PwaRegister />
           <InstallPrompt />
         </body>

--- a/shell/src/components/PostHogIdentify.tsx
+++ b/shell/src/components/PostHogIdentify.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
+import { identifyPostHogUser, resetPostHogIdentity } from "@/lib/posthog-client";
+
+// Aligns the client-side PostHog person with the Clerk user so shell events,
+// gateway server events, and signup-funnel events resolve to one person.
+export function PostHogIdentify() {
+  const { isLoaded, isSignedIn, user } = useUser();
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (isSignedIn && user) {
+      identifyPostHogUser(user.id, {
+        email: user.primaryEmailAddress?.emailAddress,
+        username: user.username ?? undefined,
+      });
+      return;
+    }
+    resetPostHogIdentity();
+  }, [isLoaded, isSignedIn, user]);
+
+  return null;
+}

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -18,7 +18,7 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
   NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
   NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
+  NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/relay",
 });
 const CLIENT_ERROR_REPORT_TIMEOUT_MS = 10_000;
 let initialized = false;
@@ -99,6 +99,33 @@ export function capturePostHogLog(
   }
 }
 
+export function identifyPostHogUser(
+  distinctId: string,
+  properties: ClientProperties = {},
+  currentConfig: typeof config = config,
+) {
+  if (!currentConfig || !distinctId) return;
+  try {
+    ensurePostHogInitialized(currentConfig);
+    posthog.identify(distinctId, sanitizeProperties(properties));
+  } catch (err: unknown) {
+    console.warn("[posthog] Failed to identify user:", err instanceof Error ? err.name : typeof err);
+  }
+}
+
+export function resetPostHogIdentity(currentConfig: typeof config = config) {
+  if (!currentConfig || !initialized) return;
+  try {
+    // Only reset identified sessions; resetting an anonymous session would
+    // rotate its distinct id on every signed-out page load.
+    const withIdentity = posthog as typeof posthog & { _isIdentified?: () => boolean };
+    if (typeof withIdentity._isIdentified === "function" && !withIdentity._isIdentified()) return;
+    posthog.reset();
+  } catch (err: unknown) {
+    console.warn("[posthog] Failed to reset identity:", err instanceof Error ? err.name : typeof err);
+  }
+}
+
 function ensurePostHogInitialized(currentConfig: NonNullable<typeof config>) {
   initializeShellPostHog(getPostHogVisitorCountry(), currentConfig);
 }
@@ -108,10 +135,10 @@ export function initializeShellPostHog(
   currentConfig: typeof config = config,
 ) {
   if (!currentConfig || initialized) return;
-  const apiHost = resolvePostHogClientApiHost(currentConfig, { allowRelativeApiHost: false });
+  // The shell serves a same-origin PostHog proxy at /relay (see next.config
+  // rewrites), so relative api hosts are first-party on every user subdomain.
+  const apiHost = resolvePostHogClientApiHost(currentConfig, { allowRelativeApiHost: true });
   posthog.init(currentConfig.token, {
-    // Shell has no local PostHog /ingest proxy, so an unset api_host lets
-    // posthog-js use its default endpoint.
     ...(apiHost ? { api_host: apiHost } : {}),
     ui_host: currentConfig.uiHost,
     defaults: "2026-01-30",

--- a/shell/src/lib/posthog-client.ts
+++ b/shell/src/lib/posthog-client.ts
@@ -116,10 +116,11 @@ export function identifyPostHogUser(
 export function resetPostHogIdentity(currentConfig: typeof config = config) {
   if (!currentConfig || !initialized) return;
   try {
-    // Only reset identified sessions; resetting an anonymous session would
-    // rotate its distinct id on every signed-out page load.
+    // Only reset provably identified sessions; resetting an anonymous session
+    // would rotate its distinct id on every signed-out page load. If the
+    // identity check is unavailable, skip the reset rather than risk it.
     const withIdentity = posthog as typeof posthog & { _isIdentified?: () => boolean };
-    if (typeof withIdentity._isIdentified === "function" && !withIdentity._isIdentified()) return;
+    if (typeof withIdentity._isIdentified !== "function" || !withIdentity._isIdentified()) return;
     posthog.reset();
   } catch (err: unknown) {
     console.warn("[posthog] Failed to reset identity:", err instanceof Error ? err.name : typeof err);

--- a/tests/gateway/telemetry-distinct-id.test.ts
+++ b/tests/gateway/telemetry-distinct-id.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// The gateway runs on a single-owner VPS, so product/terminal telemetry must
+// be attributed to the owner (Clerk user id, falling back to the handle)
+// instead of an anonymous service-level distinct id.
+describe("gateway telemetry distinct id wiring", () => {
+  const source = readFileSync(join(process.cwd(), "packages/gateway/src/server.ts"), "utf8");
+
+  it("resolves the owner distinct id from the observability helper", () => {
+    expect(source).toMatch(/resolveOwnerTelemetryDistinctId/);
+  });
+
+  it("stamps the owner distinct id on terminal websocket events", () => {
+    const wrapper = extractFunction(source, "captureTerminalEvent");
+    expect(wrapper).toMatch(/distinctId/);
+  });
+
+  it("stamps the owner distinct id on gateway product events", () => {
+    const wrapper = extractFunction(source, "captureGatewayProductEvent");
+    expect(wrapper).toMatch(/distinctId/);
+  });
+
+  it("does not attribute system update requests to the raw handle env only", () => {
+    expect(source).not.toMatch(/distinctId:\s*process\.env\.MATRIX_HANDLE\s*\?\?\s*"matrix-gateway"/);
+  });
+});
+
+function extractFunction(source: string, name: string): string {
+  const start = source.indexOf(`const ${name} = (`);
+  expect(start, `${name} must exist in server.ts`).toBeGreaterThanOrEqual(0);
+  const openBrace = source.indexOf("{", source.indexOf("=>", start));
+  expect(openBrace).toBeGreaterThan(start);
+
+  let depth = 0;
+  for (let i = openBrace; i < source.length; i += 1) {
+    if (source[i] === "{") depth += 1;
+    if (source[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`Could not find end of ${name}`);
+}

--- a/tests/gateway/telemetry-distinct-id.test.ts
+++ b/tests/gateway/telemetry-distinct-id.test.ts
@@ -25,6 +25,12 @@ describe("gateway telemetry distinct id wiring", () => {
   it("does not attribute system update requests to the raw handle env only", () => {
     expect(source).not.toMatch(/distinctId:\s*process\.env\.MATRIX_HANDLE\s*\?\?\s*"matrix-gateway"/);
   });
+
+  it("resolves the owner distinct id once so all gateway events share one person", () => {
+    const calls = source.match(/resolveOwnerTelemetryDistinctId\(\)/g) ?? [];
+    expect(calls).toHaveLength(1);
+    expect(source).toMatch(/resolveOwnerTelemetryDistinctId\(\)\s*\?\?\s*"matrix-gateway"/);
+  });
 });
 
 function extractFunction(source: string, name: string): string {

--- a/tests/observability/owner-distinct-id.test.ts
+++ b/tests/observability/owner-distinct-id.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resolveOwnerTelemetryDistinctId } from "../../packages/observability/src/index.ts";
+
+describe("resolveOwnerTelemetryDistinctId", () => {
+  it("prefers the Clerk user id over the handle", () => {
+    expect(
+      resolveOwnerTelemetryDistinctId({
+        MATRIX_USER_ID: "user_2abcDEF",
+        MATRIX_HANDLE: "neo",
+      }),
+    ).toBe("user_2abcDEF");
+  });
+
+  it("falls back to the Matrix handle when no user id is set", () => {
+    expect(resolveOwnerTelemetryDistinctId({ MATRIX_HANDLE: "neo" })).toBe("neo");
+  });
+
+  it("returns undefined when neither env var is set", () => {
+    expect(resolveOwnerTelemetryDistinctId({})).toBeUndefined();
+  });
+
+  it("ignores blank values", () => {
+    expect(
+      resolveOwnerTelemetryDistinctId({
+        MATRIX_USER_ID: "   ",
+        MATRIX_HANDLE: "neo",
+      }),
+    ).toBe("neo");
+    expect(resolveOwnerTelemetryDistinctId({ MATRIX_USER_ID: "", MATRIX_HANDLE: "  " })).toBeUndefined();
+  });
+});

--- a/tests/observability/posthog-error-tracking.test.ts
+++ b/tests/observability/posthog-error-tracking.test.ts
@@ -32,7 +32,7 @@ describe("PostHog error tracking", () => {
     expect(getPostHogClientConfig({})).toBeNull();
   });
 
-  it("lets shell ignore relative PostHog API hosts that it cannot proxy", async () => {
+  it("resolves relative PostHog API hosts for shells that proxy them", async () => {
     const relativeConfig = getPostHogClientConfig({
       NEXT_PUBLIC_POSTHOG_KEY: "phc_test",
       NEXT_PUBLIC_POSTHOG_API_HOST: "/ingest",
@@ -64,7 +64,9 @@ describe("PostHog error tracking", () => {
     const shellLayout = await readFile("shell/src/app/layout.tsx", "utf8");
     const wwwLayout = await readFile("www/src/app/layout.tsx", "utf8");
     expect(shellClient).toContain("resolvePostHogClientApiHost");
-    expect(shellClient).toContain("allowRelativeApiHost: false");
+    // The shell ships a same-origin /relay rewrite, so it opts into relative
+    // API hosts to keep capture calls first-party on user subdomains.
+    expect(shellClient).toContain("allowRelativeApiHost: true");
     expect(shellClient).toContain("buildPostHogCookieConsentInitOptions");
     expect(wwwClient).toContain("buildPostHogCookieConsentInitOptions");
     expect(shellLayout).not.toContain("PostHogCookieBanner");
@@ -471,7 +473,8 @@ describe("PostHog error tracking", () => {
     expect(shellClient).toContain("initializeShellPostHog");
 
     const shellPostHogClient = await readFile("shell/src/lib/posthog-client.ts", "utf8");
-    expect(shellPostHogClient).toContain("Shell has no local PostHog /ingest proxy");
+    expect(shellPostHogClient).toContain("same-origin PostHog proxy at /relay");
+    expect(shellPostHogClient).toContain('NEXT_PUBLIC_POSTHOG_API_HOST ?? "/relay"');
     expect(shellPostHogClient).toContain("buildPostHogCookieConsentInitOptions");
     expect(shellPostHogClient).not.toContain("__loaded");
 
@@ -480,7 +483,7 @@ describe("PostHog error tracking", () => {
     expect(wwwPostHogClient).toContain("posthog.init(currentConfig.token");
     expect(wwwPostHogClient).toContain("buildPostHogCookieConsentInitOptions");
     expect(wwwPostHogClient).not.toContain("__loaded");
-    expect(wwwPostHogClient).toContain('NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest"');
+    expect(wwwPostHogClient).toContain('NEXT_PUBLIC_POSTHOG_API_HOST ?? "/relay"');
 
     const wwwClient = await readFile("www/instrumentation-client.ts", "utf8");
     expect(wwwClient).toContain("initializeWwwPostHog");

--- a/tests/shell/posthog-identify.test.tsx
+++ b/tests/shell/posthog-identify.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const clerkState = vi.hoisted(() => ({
+  isLoaded: true,
+  isSignedIn: true as boolean,
+  user: {
+    id: "user_2abcDEF",
+    username: "neo" as string | null,
+    primaryEmailAddress: { emailAddress: "neo@example.com" } as { emailAddress: string } | null,
+  } as {
+    id: string;
+    username: string | null;
+    primaryEmailAddress: { emailAddress: string } | null;
+  } | null,
+}));
+
+vi.mock("@clerk/nextjs", () => ({
+  useUser: () => ({
+    isLoaded: clerkState.isLoaded,
+    isSignedIn: clerkState.isSignedIn,
+    user: clerkState.user,
+  }),
+}));
+
+const posthogClientMock = vi.hoisted(() => ({
+  identifyPostHogUser: vi.fn(),
+  resetPostHogIdentity: vi.fn(),
+}));
+
+vi.mock("@/lib/posthog-client", () => posthogClientMock);
+
+import { PostHogIdentify } from "@/components/PostHogIdentify";
+
+describe("PostHogIdentify", () => {
+  beforeEach(() => {
+    posthogClientMock.identifyPostHogUser.mockReset();
+    posthogClientMock.resetPostHogIdentity.mockReset();
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = true;
+    clerkState.user = {
+      id: "user_2abcDEF",
+      username: "neo",
+      primaryEmailAddress: { emailAddress: "neo@example.com" },
+    };
+  });
+
+  it("identifies the signed-in Clerk user with email and username", () => {
+    render(<PostHogIdentify />);
+
+    expect(posthogClientMock.identifyPostHogUser).toHaveBeenCalledTimes(1);
+    expect(posthogClientMock.identifyPostHogUser).toHaveBeenCalledWith("user_2abcDEF", {
+      email: "neo@example.com",
+      username: "neo",
+    });
+    expect(posthogClientMock.resetPostHogIdentity).not.toHaveBeenCalled();
+  });
+
+  it("resets identity when the visitor is signed out", () => {
+    clerkState.isSignedIn = false;
+    clerkState.user = null;
+
+    render(<PostHogIdentify />);
+
+    expect(posthogClientMock.identifyPostHogUser).not.toHaveBeenCalled();
+    expect(posthogClientMock.resetPostHogIdentity).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing while Clerk is still loading", () => {
+    clerkState.isLoaded = false;
+
+    render(<PostHogIdentify />);
+
+    expect(posthogClientMock.identifyPostHogUser).not.toHaveBeenCalled();
+    expect(posthogClientMock.resetPostHogIdentity).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing", () => {
+    const { container } = render(<PostHogIdentify />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/tests/shell/posthog-proxy.test.ts
+++ b/tests/shell/posthog-proxy.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import nextConfig from "../../shell/next.config";
+
+const posthogMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: posthogMock,
+}));
+
+type RewriteRule = { source: string; destination: string };
+
+async function getRewrites(): Promise<RewriteRule[]> {
+  const rewrites = await nextConfig.rewrites?.();
+  expect(Array.isArray(rewrites)).toBe(true);
+  return rewrites as RewriteRule[];
+}
+
+describe("shell PostHog same-origin proxy", () => {
+  it("rewrites /relay asset and ingest paths to PostHog EU", async () => {
+    const rewrites = await getRewrites();
+    const staticRule = rewrites.find((rule) => rule.source === "/relay/static/:path*");
+    const arrayRule = rewrites.find((rule) => rule.source === "/relay/array/:path*");
+    const ingestRule = rewrites.find((rule) => rule.source === "/relay/:path*");
+
+    expect(staticRule?.destination).toBe("https://eu-assets.i.posthog.com/static/:path*");
+    expect(arrayRule?.destination).toBe("https://eu-assets.i.posthog.com/array/:path*");
+    expect(ingestRule?.destination).toBe("https://eu.i.posthog.com/:path*");
+  });
+
+  it("orders asset rewrites before the ingest catch-all", async () => {
+    const rewrites = await getRewrites();
+    const sources = rewrites.map((rule) => rule.source);
+    const staticIndex = sources.indexOf("/relay/static/:path*");
+    const arrayIndex = sources.indexOf("/relay/array/:path*");
+    const ingestIndex = sources.indexOf("/relay/:path*");
+
+    expect(staticIndex).toBeGreaterThanOrEqual(0);
+    expect(arrayIndex).toBeGreaterThanOrEqual(0);
+    expect(ingestIndex).toBeGreaterThan(staticIndex);
+    expect(ingestIndex).toBeGreaterThan(arrayIndex);
+  });
+
+  it("does not use blocklisted proxy paths (/ingest, /ingress, /hog)", async () => {
+    const rewrites = await getRewrites();
+    const blocked = rewrites.filter((rule) =>
+      /^\/(ingest|ingress|hog)\//.test(rule.source) || /^\/(ingest|ingress|hog)$/.test(rule.source),
+    );
+    expect(blocked).toEqual([]);
+  });
+
+  it("initializes posthog-js with a relative api_host", async () => {
+    const { initializeShellPostHog } = await import("../../shell/src/lib/posthog-client");
+
+    initializeShellPostHog("US", { token: "phc_test", apiHost: "/relay", uiHost: "https://eu.posthog.com" });
+
+    expect(posthogMock.init).toHaveBeenCalledTimes(1);
+    const [token, options] = posthogMock.init.mock.calls[0] as [string, Record<string, unknown>];
+    expect(token).toBe("phc_test");
+    expect(options.api_host).toBe("/relay");
+    expect(options.ui_host).toBe("https://eu.posthog.com");
+  });
+
+  it("defaults the shell api host to the /relay same-origin proxy", () => {
+    // Source-level invariant: the env read must fall back to "/relay" so host
+    // bundles built without NEXT_PUBLIC_POSTHOG_API_HOST stay un-blockable.
+    const source = readPostHogClientSource();
+    expect(source).toMatch(/NEXT_PUBLIC_POSTHOG_API_HOST\s*\?\?\s*"\/relay"/);
+    expect(source).toMatch(/allowRelativeApiHost:\s*true/);
+  });
+});
+
+function readPostHogClientSource(): string {
+  return readFileSync(join(process.cwd(), "shell/src/lib/posthog-client.ts"), "utf8");
+}

--- a/tests/shell/posthog-proxy.test.ts
+++ b/tests/shell/posthog-proxy.test.ts
@@ -68,6 +68,30 @@ describe("shell PostHog same-origin proxy", () => {
     expect(options.ui_host).toBe("https://eu.posthog.com");
   });
 
+  it("only resets identity for provably identified sessions", async () => {
+    const { initializeShellPostHog, resetPostHogIdentity } = await import(
+      "../../shell/src/lib/posthog-client"
+    );
+    const config = { token: "phc_test", apiHost: "/relay", uiHost: "https://eu.posthog.com" };
+    initializeShellPostHog("US", config);
+    const mock = posthogMock as typeof posthogMock & { _isIdentified?: () => boolean };
+
+    // Identity check unavailable: never reset (would rotate anonymous ids).
+    delete mock._isIdentified;
+    resetPostHogIdentity(config);
+    expect(posthogMock.reset).not.toHaveBeenCalled();
+
+    // Anonymous session: no reset.
+    mock._isIdentified = () => false;
+    resetPostHogIdentity(config);
+    expect(posthogMock.reset).not.toHaveBeenCalled();
+
+    // Identified session: reset.
+    mock._isIdentified = () => true;
+    resetPostHogIdentity(config);
+    expect(posthogMock.reset).toHaveBeenCalledTimes(1);
+  });
+
   it("defaults the shell api host to the /relay same-origin proxy", () => {
     // Source-level invariant: the env read must fall back to "/relay" so host
     // bundles built without NEXT_PUBLIC_POSTHOG_API_HOST stay un-blockable.

--- a/tests/www/posthog-proxy.test.ts
+++ b/tests/www/posthog-proxy.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// uBlock Origin's default privacy list blocks "/ingest/*^ip=" (a known
+// PostHog reverse-proxy signature), so www must serve PostHog through the
+// same /relay path the shell uses while keeping /ingest alive for cached
+// bundles that still point at it.
+describe("www PostHog proxy path", () => {
+  const nextConfigSource = readFileSync(join(process.cwd(), "www/next.config.ts"), "utf8");
+  const clientSource = readFileSync(join(process.cwd(), "www/src/lib/posthog-client.ts"), "utf8");
+
+  it("rewrites /relay asset and ingest paths to PostHog EU", () => {
+    expect(nextConfigSource).toContain("'/relay/static/:path*'");
+    expect(nextConfigSource).toContain("'/relay/array/:path*'");
+    expect(nextConfigSource).toContain("'/relay/:path*'");
+    expect(nextConfigSource).toContain("https://eu-assets.i.posthog.com/static/:path*");
+    expect(nextConfigSource).toContain("https://eu.i.posthog.com/:path*");
+  });
+
+  it("keeps legacy /ingest rewrites for cached client bundles", () => {
+    expect(nextConfigSource).toContain("'/ingest/:path*'");
+  });
+
+  it("defaults the client api host to /relay instead of the blocklisted /ingest", () => {
+    expect(clientSource).toMatch(/NEXT_PUBLIC_POSTHOG_API_HOST\s*\?\?\s*"\/relay"/);
+    expect(clientSource).not.toMatch(/\?\?\s*"\/ingest"/);
+  });
+});
+
+describe("www PostHog identify wiring", () => {
+  const clientSource = readFileSync(join(process.cwd(), "www/src/lib/posthog-client.ts"), "utf8");
+  const layoutSource = readFileSync(join(process.cwd(), "www/src/app/layout.tsx"), "utf8");
+  const identifySource = readFileSync(
+    join(process.cwd(), "www/src/components/PostHogIdentify.tsx"),
+    "utf8",
+  );
+
+  it("exposes identify and reset helpers on the client wrapper", () => {
+    expect(clientSource).toMatch(/export function identifyPostHogUser\(/);
+    expect(clientSource).toMatch(/export function resetPostHogIdentity\(/);
+  });
+
+  it("mounts PostHogIdentify inside the Clerk provider", () => {
+    expect(layoutSource).toMatch(/<PostHogIdentify\s*\/>/);
+    const clerkOpen = layoutSource.indexOf("<ClerkProvider>");
+    const identify = layoutSource.indexOf("<PostHogIdentify");
+    const clerkClose = layoutSource.indexOf("</ClerkProvider>");
+    expect(clerkOpen).toBeGreaterThanOrEqual(0);
+    expect(identify).toBeGreaterThan(clerkOpen);
+    expect(identify).toBeLessThan(clerkClose);
+  });
+
+  it("identifies with the Clerk user id and resets on sign-out", () => {
+    expect(identifySource).toMatch(/useUser\(\)/);
+    expect(identifySource).toMatch(/identifyPostHogUser\(user\.id/);
+    expect(identifySource).toMatch(/resetPostHogIdentity\(\)/);
+  });
+});

--- a/tests/www/provision-user.test.ts
+++ b/tests/www/provision-user.test.ts
@@ -56,6 +56,20 @@ describe("provisionUser", () => {
     expect(signupEvent).toBeLessThan(syncStep);
   });
 
+  it("aliases the Matrix handle to the Clerk user id during signup", () => {
+    // Gateway telemetry on the customer VPS may only know the handle; the
+    // alias merges handle-keyed events into the Clerk person.
+    const source = readFileSync(join(process.cwd(), "www/src/inngest/provision-user.ts"), "utf8");
+    const recordSignup = findStepRunRange(source, "record-signup");
+    const alias = source.indexOf("posthog.alias(");
+
+    expect(alias).toBeGreaterThan(recordSignup.start);
+    expect(alias).toBeLessThan(recordSignup.end);
+    const aliasBlock = source.slice(alias, source.indexOf(")", alias) + 1);
+    expect(aliasBlock).toContain("distinctId: user.id");
+    expect(aliasBlock).toContain("alias: handle");
+  });
+
   it("keeps PostHog operations scoped to deterministic Inngest steps", () => {
     const source = readFileSync(join(process.cwd(), "www/src/inngest/provision-user.ts"), "utf8");
     const stepRanges = [
@@ -64,7 +78,7 @@ describe("provisionUser", () => {
     ].map((stepName) => findStepRunRange(source, stepName));
 
     const posthogOperations = [
-      ...source.matchAll(/getPostHogClient\(\)|posthog\.(?:capture|identify)\(/g),
+      ...source.matchAll(/getPostHogClient\(\)|posthog\.(?:capture|identify|alias)\(/g),
     ];
     expect(posthogOperations.length).toBeGreaterThan(0);
 

--- a/tests/www/provision-user.test.ts
+++ b/tests/www/provision-user.test.ts
@@ -56,18 +56,21 @@ describe("provisionUser", () => {
     expect(signupEvent).toBeLessThan(syncStep);
   });
 
-  it("aliases the Matrix handle to the Clerk user id during signup", () => {
+  it("aliases the assigned handle to the Clerk user id after a successful sync", () => {
     // Gateway telemetry on the customer VPS may only know the handle; the
-    // alias merges handle-keyed events into the Clerk person.
+    // alias merges handle-keyed events into the Clerk person. It must use the
+    // handle the platform actually assigned (candidateHandle), not the first
+    // candidate, which can 409 and be replaced.
     const source = readFileSync(join(process.cwd(), "www/src/inngest/provision-user.ts"), "utf8");
-    const recordSignup = findStepRunRange(source, "record-signup");
+    const syncStep = findStepRunRange(source, "sync-platform-user");
     const alias = source.indexOf("posthog.alias(");
 
-    expect(alias).toBeGreaterThan(recordSignup.start);
-    expect(alias).toBeLessThan(recordSignup.end);
+    expect(alias).toBeGreaterThan(syncStep.start);
+    expect(alias).toBeLessThan(syncStep.end);
     const aliasBlock = source.slice(alias, source.indexOf(")", alias) + 1);
     expect(aliasBlock).toContain("distinctId: user.id");
-    expect(aliasBlock).toContain("alias: handle");
+    expect(aliasBlock).toContain("alias: candidateHandle");
+    expect(aliasBlock).not.toContain("alias: handle,");
   });
 
   it("keeps PostHog operations scoped to deterministic Inngest steps", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
     conditions: ["node"],
     alias: {
       "@": path.resolve(__dirname, "shell/src"),
+      "@matrix-os/observability/client": path.resolve(
+        __dirname,
+        "packages/observability/src/client.ts",
+      ),
+      "@matrix-os/observability/events": path.resolve(
+        __dirname,
+        "packages/observability/src/events.ts",
+      ),
       "@matrix-os/kernel/security/external-content": path.resolve(
         __dirname,
         "packages/kernel/src/security/external-content.ts",

--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -10,6 +10,21 @@ const nextConfig: NextConfig = {
         source: '/docs/:path*.mdx',
         destination: '/llms.mdx/docs/:path*',
       },
+      // Same-origin PostHog proxy. uBlock's default privacy list blocks
+      // "/ingest/*^ip=" (a known PostHog proxy signature), so new bundles use
+      // /relay; the /ingest rules stay for cached bundles that still point at it.
+      {
+        source: '/relay/static/:path*',
+        destination: 'https://eu-assets.i.posthog.com/static/:path*',
+      },
+      {
+        source: '/relay/array/:path*',
+        destination: 'https://eu-assets.i.posthog.com/array/:path*',
+      },
+      {
+        source: '/relay/:path*',
+        destination: 'https://eu.i.posthog.com/:path*',
+      },
       {
         source: '/ingest/static/:path*',
         destination: 'https://eu-assets.i.posthog.com/static/:path*',

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { Analytics } from "@vercel/analytics/react";
 import { getPostHogVisitorCountry } from "@matrix-os/observability/client";
 import { PostHogCookieBanner } from "@/components/PostHogCookieBanner";
+import { PostHogIdentify } from "@/components/PostHogIdentify";
 import "./globals.css";
 
 const inter = Inter({
@@ -102,6 +103,7 @@ export default async function RootLayout({
       <body className={`${inter.variable} ${instrumentSans.variable} ${jetbrainsMono.variable} ${caveat.variable} ${cormorant.variable} ${orbitron.variable}`}>
         <ClerkProvider>
           {children}
+          <PostHogIdentify />
           <PostHogCookieBanner visitorCountry={visitorCountry} />
           <Analytics />
         </ClerkProvider>

--- a/www/src/components/PostHogIdentify.tsx
+++ b/www/src/components/PostHogIdentify.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useUser } from "@clerk/nextjs";
+import { identifyPostHogUser, resetPostHogIdentity } from "@/lib/posthog-client";
+
+// Aligns the client-side PostHog person with the Clerk user so marketing
+// events join the same person as signup-funnel and runtime events.
+export function PostHogIdentify() {
+  const { isLoaded, isSignedIn, user } = useUser();
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (isSignedIn && user) {
+      identifyPostHogUser(user.id, {
+        email: user.primaryEmailAddress?.emailAddress,
+        username: user.username ?? undefined,
+      });
+      return;
+    }
+    resetPostHogIdentity();
+  }, [isLoaded, isSignedIn, user]);
+
+  return null;
+}

--- a/www/src/inngest/provision-user.ts
+++ b/www/src/inngest/provision-user.ts
@@ -39,13 +39,6 @@ export const provisionUser = inngest.createFunction(
           created_via: "clerk_signup",
         },
       });
-
-      // Customer VPS gateways may only know the handle (MATRIX_HANDLE); the
-      // alias merges handle-keyed server events into the Clerk person.
-      posthog.alias({
-        distinctId: user.id,
-        alias: handle,
-      });
     });
 
     await step.run("sync-platform-user", async () => {
@@ -100,6 +93,15 @@ export const provisionUser = inngest.createFunction(
             has_instance: false,
             billing_required: true,
           },
+        });
+
+        // Customer VPS gateways may only know the handle (MATRIX_HANDLE); the
+        // alias merges handle-keyed server events into the Clerk person. It
+        // must use the handle the platform actually assigned, which is only
+        // known after a successful sync (earlier candidates may 409).
+        posthog.alias({
+          distinctId: user.id,
+          alias: candidateHandle,
         });
 
         await shutdownPostHog();

--- a/www/src/inngest/provision-user.ts
+++ b/www/src/inngest/provision-user.ts
@@ -39,6 +39,13 @@ export const provisionUser = inngest.createFunction(
           created_via: "clerk_signup",
         },
       });
+
+      // Customer VPS gateways may only know the handle (MATRIX_HANDLE); the
+      // alias merges handle-keyed server events into the Clerk person.
+      posthog.alias({
+        distinctId: user.id,
+        alias: handle,
+      });
     });
 
     await step.run("sync-platform-user", async () => {

--- a/www/src/lib/posthog-client.ts
+++ b/www/src/lib/posthog-client.ts
@@ -55,10 +55,11 @@ export function identifyPostHogUser(
 export function resetPostHogIdentity(currentConfig: typeof config = config) {
   if (!currentConfig || !initialized) return;
   try {
-    // Only reset identified sessions; resetting an anonymous session would
-    // rotate its distinct id on every signed-out page load.
+    // Only reset provably identified sessions; resetting an anonymous session
+    // would rotate its distinct id on every signed-out page load. If the
+    // identity check is unavailable, skip the reset rather than risk it.
     const withIdentity = posthog as typeof posthog & { _isIdentified?: () => boolean };
-    if (typeof withIdentity._isIdentified === "function" && !withIdentity._isIdentified()) return;
+    if (typeof withIdentity._isIdentified !== "function" || !withIdentity._isIdentified()) return;
     posthog.reset();
   } catch (err: unknown) {
     console.warn("[posthog] Failed to reset identity:", err instanceof Error ? err.name : typeof err);

--- a/www/src/lib/posthog-client.ts
+++ b/www/src/lib/posthog-client.ts
@@ -14,7 +14,7 @@ const config = getPostHogClientConfig({
   NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
   NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
   NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-  NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/ingest",
+  NEXT_PUBLIC_POSTHOG_API_HOST: process.env.NEXT_PUBLIC_POSTHOG_API_HOST ?? "/relay",
 });
 let initialized = false;
 
@@ -35,6 +35,33 @@ export function capturePostHogEvent(event: string, properties: ClientProperties 
     posthog.capture(event, sanitizeProperties(properties));
   } catch (err: unknown) {
     console.warn("[posthog] Failed to capture client event:", err instanceof Error ? err.name : typeof err);
+  }
+}
+
+export function identifyPostHogUser(
+  distinctId: string,
+  properties: ClientProperties = {},
+  currentConfig: typeof config = config,
+) {
+  if (!currentConfig || !distinctId) return;
+  try {
+    ensurePostHogInitialized(currentConfig);
+    posthog.identify(distinctId, sanitizeProperties(properties));
+  } catch (err: unknown) {
+    console.warn("[posthog] Failed to identify user:", err instanceof Error ? err.name : typeof err);
+  }
+}
+
+export function resetPostHogIdentity(currentConfig: typeof config = config) {
+  if (!currentConfig || !initialized) return;
+  try {
+    // Only reset identified sessions; resetting an anonymous session would
+    // rotate its distinct id on every signed-out page load.
+    const withIdentity = posthog as typeof posthog & { _isIdentified?: () => boolean };
+    if (typeof withIdentity._isIdentified === "function" && !withIdentity._isIdentified()) return;
+    posthog.reset();
+  } catch (err: unknown) {
+    console.warn("[posthog] Failed to reset identity:", err instanceof Error ? err.name : typeof err);
   }
 }
 

--- a/www/src/lib/posthog-server.ts
+++ b/www/src/lib/posthog-server.ts
@@ -1,11 +1,12 @@
 import { createPostHogServerExceptionReporter, getPostHogConfig } from '@matrix-os/observability';
 import { PostHog } from 'posthog-node';
 
-type AnalyticsClient = Pick<PostHog, 'capture' | 'identify' | 'captureException' | 'flush' | 'shutdown'>;
+type AnalyticsClient = Pick<PostHog, 'capture' | 'identify' | 'alias' | 'captureException' | 'flush' | 'shutdown'>;
 
 const noopClient: AnalyticsClient = {
   capture: (..._args: Parameters<PostHog['capture']>) => undefined,
   identify: (..._args: Parameters<PostHog['identify']>) => undefined,
+  alias: (..._args: Parameters<PostHog['alias']>) => undefined,
   captureException: (..._args: Parameters<PostHog['captureException']>) => undefined,
   flush: async () => undefined,
   shutdown: async () => undefined,


### PR DESCRIPTION
## Summary

PostHog client events were being eaten by ad blockers on two fronts:
- **www**: the `/ingest` reverse-proxy path is a known PostHog signature — uBlock Origin's default privacy list ships `/ingest/*^ip=` (plus `/ingress/` and `/hog/`), and posthog-js appends `?ip=1` to capture calls, so any uBlock user's marketing events were dropped.
- **shell**: customer-VPS shells send analytics cross-origin to the shared `neo.matrix-os.com` Worker proxy, which blockers flag (visible as blocked requests in the console on user subdomains).

This PR makes ingestion first-party everywhere and unifies identity across surfaces:

- **Same-origin `/relay` proxy**: shell and www both rewrite `/relay/static/*` + `/relay/array/*` → `eu-assets.i.posthog.com` and `/relay/*` → `eu.i.posthog.com`. Client api_host defaults to `/relay`; the shell now allows relative API hosts. www keeps the legacy `/ingest` rewrites for cached bundles.
- **Clerk identity**: new `PostHogIdentify` client component (shell + www) calls `posthog.identify(clerkUserId, { email, username })` after sign-in and resets only identified sessions on sign-out.
- **Handle alias**: the Inngest signup flow now calls `posthog.alias({ distinctId: user.id, alias: handle })` so handle-keyed server events merge into the Clerk person.
- **Gateway attribution**: terminal/product/system-update events are stamped with `resolveOwnerTelemetryDistinctId()` (`MATRIX_USER_ID` → `MATRIX_HANDLE`) instead of being anonymous/service-level.
- **Workflow defaults**: host-bundle and cloud-run builds fall back to `/relay` instead of `eu.i.posthog.com` / `neo.matrix-os.com`.

## Rollout (required after merge)

1. Update the GitHub repo var `NEXT_PUBLIC_POSTHOG_API_HOST` from `https://neo.matrix-os.com` to `/relay` (it overrides the workflow fallbacks).
2. Rebuild + publish a host bundle and refresh existing VPSes; redeploy platform Cloud Run; www picks it up on next Vercel deploy.
3. Keep the neo.matrix-os.com Worker deployed for old cached bundles; decommission later.

## Invariants

- **Source of truth**: PostHog EU is the analytics store; `/relay` is a stateless pass-through rewrite. The neo Worker remains a legacy fallback path.
- **Lock/transaction scope**: none — all telemetry is fire-and-forget; capture failures log a warning and never affect request/response paths.
- **Acceptable orphan states**: events captured before `identify`/`alias` land remain attributed to the anonymous person (PostHog merges on identify); gateway events keyed by handle before the signup alias exist as a separate person until alias runs.
- **Auth source of truth**: Clerk user id is the canonical distinct_id; `MATRIX_HANDLE` is an alias of it. No auth behavior changes.
- **Deferred scope**: funnel failure events (provision/billing/onboarding) land in a follow-up PR; session replay, source-map upload, and CLI telemetry are tracked separately.

## Testing

- `bun run typecheck` exit 0; `bun run check:patterns` 0 violations.
- New tests: shell/www rewrite + relative-host invariants, PostHogIdentify behavior (identify/reset/loading), owner distinct-id resolution, gateway wiring, signup alias scoping.
- Full unit suite: 6365 passed; 1 pre-existing failure (`tests/platform/middleware-shortcircuit.test.ts`) reproduces identically on pristine `origin/main` in this environment and is unrelated.
- `npx react-doctor@latest shell` / `www`: no findings on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)