### PR TITLE
feat(observability): centralized log ingest edge, VPS log shipper, staging slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ paper/*.log
 paper/*.out
 paper/*.pdf
 .gstack/
+distro/observability/logs-edge/logs-edge.env

--- a/distro/cloudflared.yml
+++ b/distro/cloudflared.yml
@@ -4,9 +4,29 @@ credentials-file: /etc/cloudflared/credentials.json
 ingress:
   - hostname: grafana.matrix-os.com
     service: http://grafana:3000
+  # Authenticated push-only Loki ingest edge (basic auth in logs-edge).
+  - hostname: logs.matrix-os.com
+    service: http://logs-edge:8080
   # Staging dev container (HMR shell).
   - hostname: staging.matrix-os.com
     service: http://matrixos-staging:3000
   - hostname: api-staging.matrix-os.com
     service: http://matrixos-staging:4000
+  # Per-worktree HMR staging slots (scripts/staging-slot.sh).
+  - hostname: staging-1.matrix-os.com
+    service: http://matrixos-staging-1:3000
+  - hostname: api-staging-1.matrix-os.com
+    service: http://matrixos-staging-1:4000
+  - hostname: staging-2.matrix-os.com
+    service: http://matrixos-staging-2:3000
+  - hostname: api-staging-2.matrix-os.com
+    service: http://matrixos-staging-2:4000
+  - hostname: staging-3.matrix-os.com
+    service: http://matrixos-staging-3:3000
+  - hostname: api-staging-3.matrix-os.com
+    service: http://matrixos-staging-3:4000
+  - hostname: staging-4.matrix-os.com
+    service: http://matrixos-staging-4:3000
+  - hostname: api-staging-4.matrix-os.com
+    service: http://matrixos-staging-4:4000
   - service: http_status:404

--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -73,7 +73,8 @@ case "$ARCH" in
 esac
 
 install_alloy() {
-  if [ -x /usr/local/bin/alloy ] && /usr/local/bin/alloy --version 2>/dev/null | grep -q "$ALLOY_VERSION"; then
+  # Exact token match so v1.16.3 does not false-hit v1.16.30.
+  if [ -x /usr/local/bin/alloy ] && /usr/local/bin/alloy --version 2>/dev/null | tr ' ' '\n' | grep -qx "$ALLOY_VERSION"; then
     return 0
   fi
   tmpdir="$(mktemp -d)"

--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -2,13 +2,15 @@
 # Install and enable the Grafana Alloy log shipper on a Matrix OS VPS.
 #
 # Usage:
-#   matrix-install-logship <ingest-url> <user> <password> <handle> <env>
+#   LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... \
+#     matrix-install-logship <ingest-url> <handle> <env>
 #
 #   ingest-url  https URL of the Loki push edge (e.g. https://logs.matrix-os.com)
-#   user        basic-auth user for the ingest edge
-#   password    basic-auth password for the ingest edge
 #   handle      this VPS's matrix handle (labels every stream)
 #   env         one of: preview | prod | staging
+#
+# Credentials come via environment variables, never argv: /proc/<pid>/cmdline
+# is world-readable, /proc/<pid>/environ is owner/root-only.
 #
 # Self-contained: downloads a pinned, checksum-verified Alloy binary, writes
 # /etc/alloy/matrix-logship.alloy, /opt/matrix/env/logship.env (0600), and the
@@ -26,16 +28,16 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-if [ "$#" -ne 5 ]; then
-  echo "usage: matrix-install-logship <ingest-url> <user> <password> <handle> <env>" >&2
+if [ "$#" -ne 3 ]; then
+  echo "usage: LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... matrix-install-logship <ingest-url> <handle> <env>" >&2
   exit 64
 fi
 
 INGEST_URL="$1"
-INGEST_USER="$2"
-INGEST_PASSWORD="$3"
-HANDLE="$4"
-MATRIX_ENV="$5"
+HANDLE="$2"
+MATRIX_ENV="$3"
+INGEST_USER="${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set in the environment}"
+INGEST_PASSWORD="${LOGS_INGEST_PASSWORD:?LOGS_INGEST_PASSWORD must be set in the environment}"
 
 case "$INGEST_URL" in
   https://*) ;;

--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -167,11 +167,10 @@ EOF
 chmod 0640 /etc/alloy/matrix-logship.alloy
 
 umask 077
-cat > /opt/matrix/env/logship.env << EOF
-LOGS_INGEST_URL=${INGEST_URL}
-LOGS_INGEST_USER=${INGEST_USER}
-LOGS_INGEST_PASSWORD=${INGEST_PASSWORD}
-EOF
+# printf %s writes values byte-for-byte; no heredoc/expansion semantics to
+# reason about for credentials containing shell-special characters.
+printf 'LOGS_INGEST_URL=%s\nLOGS_INGEST_USER=%s\nLOGS_INGEST_PASSWORD=%s\n' \
+  "$INGEST_URL" "$INGEST_USER" "$INGEST_PASSWORD" > /opt/matrix/env/logship.env
 chmod 0600 /opt/matrix/env/logship.env
 
 cat > /etc/systemd/system/matrix-logship.service << 'EOF'

--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Install and enable the Grafana Alloy log shipper on a Matrix OS VPS.
+#
+# Usage:
+#   matrix-install-logship <ingest-url> <user> <password> <handle> <env>
+#
+#   ingest-url  https URL of the Loki push edge (e.g. https://logs.matrix-os.com)
+#   user        basic-auth user for the ingest edge
+#   password    basic-auth password for the ingest edge
+#   handle      this VPS's matrix handle (labels every stream)
+#   env         one of: preview | prod | staging
+#
+# Self-contained: downloads a pinned, checksum-verified Alloy binary, writes
+# /etc/alloy/matrix-logship.alloy, /opt/matrix/env/logship.env (0600), and the
+# matrix-logship systemd unit, then enables the service. Idempotent: re-running
+# updates config/credentials in place. Log shipping never blocks Matrix
+# services; the unit is independent and restarts on failure.
+set -euo pipefail
+
+ALLOY_VERSION="v1.16.3"
+ALLOY_SHA256_AMD64="65f408f830e46d6a13c348f07b24f1763b083e711ea38384dc2938f792a93045"
+ALLOY_SHA256_ARM64="37063858b2707c865081e8f8abce44cbadc7368e3aea71382b50c7dddc6a3051"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "matrix-install-logship: must run as root" >&2
+  exit 1
+fi
+
+if [ "$#" -ne 5 ]; then
+  echo "usage: matrix-install-logship <ingest-url> <user> <password> <handle> <env>" >&2
+  exit 64
+fi
+
+INGEST_URL="$1"
+INGEST_USER="$2"
+INGEST_PASSWORD="$3"
+HANDLE="$4"
+MATRIX_ENV="$5"
+
+case "$INGEST_URL" in
+  https://*) ;;
+  *)
+    echo "matrix-install-logship: ingest-url must be https://" >&2
+    exit 64
+    ;;
+esac
+if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
+  echo "matrix-install-logship: invalid handle" >&2
+  exit 64
+fi
+case "$MATRIX_ENV" in
+  preview | prod | staging) ;;
+  *)
+    echo "matrix-install-logship: env must be preview|prod|staging" >&2
+    exit 64
+    ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)
+    ALLOY_ARCH="amd64"
+    ALLOY_SHA256="$ALLOY_SHA256_AMD64"
+    ;;
+  aarch64)
+    ALLOY_ARCH="arm64"
+    ALLOY_SHA256="$ALLOY_SHA256_ARM64"
+    ;;
+  *)
+    echo "matrix-install-logship: unsupported arch $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+install_alloy() {
+  if [ -x /usr/local/bin/alloy ] && /usr/local/bin/alloy --version 2>/dev/null | grep -q "$ALLOY_VERSION"; then
+    return 0
+  fi
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+  url="https://github.com/grafana/alloy/releases/download/${ALLOY_VERSION}/alloy-linux-${ALLOY_ARCH}.zip"
+  echo "matrix-install-logship: downloading alloy ${ALLOY_VERSION} (${ALLOY_ARCH})"
+  curl -fsSL --max-time 300 --retry 3 -o "$tmpdir/alloy.zip" "$url"
+  echo "${ALLOY_SHA256}  $tmpdir/alloy.zip" | sha256sum -c - >/dev/null
+  unzip -oq "$tmpdir/alloy.zip" -d "$tmpdir"
+  install -m 0755 "$tmpdir/alloy-linux-${ALLOY_ARCH}" /usr/local/bin/alloy
+}
+
+install_alloy
+
+install -d -m 0750 /etc/alloy /var/lib/alloy
+
+MATRIX_HOME_LOGS="/home/matrix/home/system/logs"
+
+cat > /etc/alloy/matrix-logship.alloy << EOF
+// Matrix OS log shipper. Managed by matrix-install-logship; do not hand-edit.
+
+loki.write "central" {
+  endpoint {
+    url = sys.env("LOGS_INGEST_URL") + "/loki/api/v1/push"
+    basic_auth {
+      username = sys.env("LOGS_INGEST_USER")
+      password = sys.env("LOGS_INGEST_PASSWORD")
+    }
+  }
+  external_labels = {
+    handle = "${HANDLE}",
+    env    = "${MATRIX_ENV}",
+  }
+}
+
+loki.relabel "journal" {
+  forward_to = []
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+}
+
+loki.source.journal "matrix_units" {
+  matches       = "_SYSTEMD_UNIT=matrix-gateway.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+loki.source.journal "matrix_shell" {
+  matches       = "_SYSTEMD_UNIT=matrix-shell.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+loki.source.journal "matrix_sync" {
+  matches       = "_SYSTEMD_UNIT=matrix-sync-agent.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+loki.source.journal "matrix_code" {
+  matches       = "_SYSTEMD_UNIT=matrix-code.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+loki.source.journal "matrix_symphony" {
+  matches       = "_SYSTEMD_UNIT=matrix-symphony.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+local.file_match "kernel_jsonl" {
+  path_targets = [{ __path__ = "${MATRIX_HOME_LOGS}/*.jsonl" }]
+}
+
+loki.source.file "kernel_logs" {
+  targets    = local.file_match.kernel_jsonl.targets
+  forward_to = [loki.write.central.receiver]
+}
+EOF
+chmod 0640 /etc/alloy/matrix-logship.alloy
+
+umask 077
+cat > /opt/matrix/env/logship.env << EOF
+LOGS_INGEST_URL=${INGEST_URL}
+LOGS_INGEST_USER=${INGEST_USER}
+LOGS_INGEST_PASSWORD=${INGEST_PASSWORD}
+EOF
+chmod 0600 /opt/matrix/env/logship.env
+
+cat > /etc/systemd/system/matrix-logship.service << 'EOF'
+[Unit]
+Description=Matrix OS log shipper (Grafana Alloy)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/opt/matrix/env/logship.env
+ExecStart=/usr/local/bin/alloy run --storage.path=/var/lib/alloy /etc/alloy/matrix-logship.alloy
+Restart=on-failure
+RestartSec=10
+# Read-only view of the system; writable state only under /var/lib/alloy.
+ProtectSystem=full
+ReadWritePaths=/var/lib/alloy
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now matrix-logship.service
+echo "matrix-install-logship: enabled matrix-logship.service (handle=${HANDLE} env=${MATRIX_ENV})"

--- a/distro/observability/docker-compose.observability.yml
+++ b/distro/observability/docker-compose.observability.yml
@@ -40,9 +40,12 @@ services:
     image: caddy:2-alpine
     # Authenticated push-only front for Loki, reachable only via the
     # cloudflared tunnel (logs.matrix-os.com). No host port on purpose.
-    environment:
-      - LOGS_INGEST_USER=${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set}
-      - LOGS_INGEST_PASSWORD_HASH=${LOGS_INGEST_PASSWORD_HASH:?LOGS_INGEST_PASSWORD_HASH must be set}
+    # Credentials come via env_file with format: raw -- the bcrypt hash
+    # contains `$` sequences that compose interpolation would mangle.
+    # Copy logs-edge.env.example to logs-edge.env.
+    env_file:
+      - path: ./observability/logs-edge/logs-edge.env
+        format: raw
     volumes:
       - ./observability/logs-edge/Caddyfile:/etc/caddy/Caddyfile:ro
     depends_on:

--- a/distro/observability/docker-compose.observability.yml
+++ b/distro/observability/docker-compose.observability.yml
@@ -36,6 +36,27 @@ services:
       - observability
       - matrixos-net
 
+  logs-edge:
+    image: caddy:2-alpine
+    # Authenticated push-only front for Loki, reachable only via the
+    # cloudflared tunnel (logs.matrix-os.com). No host port on purpose.
+    environment:
+      - LOGS_INGEST_USER=${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set}
+      - LOGS_INGEST_PASSWORD_HASH=${LOGS_INGEST_PASSWORD_HASH:?LOGS_INGEST_PASSWORD_HASH must be set}
+    volumes:
+      - ./observability/logs-edge/Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - loki
+    healthcheck:
+      test: wget -qO- http://localhost:8080/healthz || exit 1
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - observability
+      - matrixos-net
+
   grafana:
     image: grafana/grafana:latest
     # Loopback only: public access goes through the cloudflared tunnel

--- a/distro/observability/logs-edge/Caddyfile
+++ b/distro/observability/logs-edge/Caddyfile
@@ -19,6 +19,8 @@
 		basic_auth {
 			{$LOGS_INGEST_USER} {$LOGS_INGEST_PASSWORD_HASH}
 		}
+		# Senders must not steer Loki multi-tenancy.
+		request_header -X-Scope-OrgID
 		reverse_proxy loki:3100
 	}
 

--- a/distro/observability/logs-edge/Caddyfile
+++ b/distro/observability/logs-edge/Caddyfile
@@ -1,0 +1,32 @@
+# Authenticated push-only ingest edge for Loki.
+# Exposed exclusively through the cloudflared tunnel as logs.matrix-os.com;
+# the container publishes no host port. Only POST /loki/api/v1/push is
+# forwarded; every other path returns 404 so the Loki query API is never
+# reachable from outside the docker network.
+
+{
+	admin off
+	auto_https off
+}
+
+:8080 {
+	@push {
+		method POST
+		path /loki/api/v1/push
+	}
+
+	handle @push {
+		basic_auth {
+			{$LOGS_INGEST_USER} {$LOGS_INGEST_PASSWORD_HASH}
+		}
+		reverse_proxy loki:3100
+	}
+
+	handle /healthz {
+		respond "ok" 200
+	}
+
+	handle {
+		respond 404
+	}
+}

--- a/distro/observability/logs-edge/logs-edge.env.example
+++ b/distro/observability/logs-edge/logs-edge.env.example
@@ -1,0 +1,6 @@
+# Copy to logs-edge.env (gitignored) next to this file.
+# Generate the hash with:
+#   docker run --rm caddy:2-alpine caddy hash-password --plaintext '<password>'
+# Values are passed verbatim (env_file) -- do NOT escape the $ in the hash.
+LOGS_INGEST_USER=fleet
+LOGS_INGEST_PASSWORD_HASH=$2a$14$replace-with-real-bcrypt-hash

--- a/docker-compose.staging-db.yml
+++ b/docker-compose.staging-db.yml
@@ -1,0 +1,39 @@
+# Shared dev Postgres for staging slots on the ops VPS.
+#
+# The legacy platform postgres was retired in the Cloud Run cutover, so
+# staging slots get their own dev database server. It joins matrixos-net
+# with the network alias "postgres" (what the slot containers' DATABASE_URL
+# expects). Each slot uses its own database: matrixos_staging_<n>, created
+# by scripts/staging-slot.sh on claim. No host port -- docker-network only.
+#
+# Managed by scripts/staging-slot.sh; manual usage:
+#   docker compose -f docker-compose.staging-db.yml --env-file .env up -d
+
+services:
+  staging-postgres:
+    image: postgres:16-alpine
+    container_name: matrixos-staging-postgres
+    environment:
+      - POSTGRES_USER=${STAGING_DB_USER:-matrixos}
+      - POSTGRES_PASSWORD=${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}
+      - POSTGRES_DB=matrixos_staging
+    volumes:
+      - staging-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -U ${STAGING_DB_USER:-matrixos}
+      interval: 10s
+      timeout: 5s
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      matrixos-net:
+        aliases:
+          - postgres
+
+volumes:
+  staging-pgdata:
+
+networks:
+  matrixos-net:
+    external: true
+    name: matrixos-net

--- a/docker-compose.staging-slot.yml
+++ b/docker-compose.staging-slot.yml
@@ -1,0 +1,75 @@
+# Matrix OS -- Per-worktree staging slot (1..4) on the ops VPS
+#
+# Parameterized variant of docker-compose.staging.yml driven by
+# scripts/staging-slot.sh. Each slot is a hot-reloading dev container whose
+# source is bind-mounted from a git worktree, exposed through the existing
+# cloudflared tunnel as staging-<SLOT>.matrix-os.com /
+# api-staging-<SLOT>.matrix-os.com.
+#
+# Do not invoke directly; scripts/staging-slot.sh sets SLOT, the project
+# name (mx-staging-<SLOT>), and the project directory (the worktree), and
+# records ownership in ~/.matrixos/staging-slots/.
+#
+# Reuses the platform postgres on matrixos-net with database
+# matrixos_staging_<SLOT>.
+
+services:
+  staging-dev:
+    container_name: matrixos-staging-${SLOT:?staging-slot.sh sets SLOT}
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./packages:/app/packages
+      - ./shell:/app/shell
+      - ./home:/app/home
+      - ./skills:/app/skills
+      - ./tests:/app/tests
+      - ./specs:/app/specs
+      - ./docs:/app/docs
+      - ./distro:/app/distro
+      - ./scripts:/app/scripts
+      - ./package.json:/app/package.json
+      - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
+      - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./tsconfig.json:/app/tsconfig.json
+      - ./vitest.config.ts:/app/vitest.config.ts
+      - slot-node-modules:/app/node_modules
+      - slot-home:/home/matrixos/home
+    environment:
+      - NODE_ENV=development
+      - MATRIX_HOME=/home/matrixos/home
+      - MATRIX_HANDLE=staging-${SLOT}
+      - MATRIX_DISPLAY_NAME=Staging ${SLOT}
+      - PORT=4000
+      # Public URLs the browser will see. Cloudflared terminates TLS.
+      - NEXT_PUBLIC_GATEWAY_WS=wss://api-staging-${SLOT}.matrix-os.com/ws
+      - NEXT_PUBLIC_GATEWAY_URL=https://api-staging-${SLOT}.matrix-os.com
+      - GATEWAY_URL=http://localhost:4000
+      - POSTHOG_TOKEN=${POSTHOG_TOKEN:-}
+      - POSTHOG_HOST=${POSTHOG_HOST:-}
+      - NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY:-}
+      - NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=${NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN:-}
+      - NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST:-}
+      - NEXT_PUBLIC_POSTHOG_API_HOST=${NEXT_PUBLIC_POSTHOG_API_HOST:-}
+      # Reuse platform postgres on matrixos-net. Password stays in .env.
+      - DATABASE_URL=${STAGING_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/matrixos_staging_${SLOT}}
+      - PLATFORM_DATABASE_URL=${STAGING_PLATFORM_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/matrixos_staging_${SLOT}}
+    networks:
+      - matrixos-net
+    restart: unless-stopped
+    healthcheck:
+      test: wget -qO- http://localhost:4000/health || exit 1
+      interval: 15s
+      timeout: 5s
+      start_period: 60s
+
+volumes:
+  # Named per compose project (mx-staging-<SLOT>), so each slot keeps its own.
+  slot-node-modules:
+  slot-home:
+
+networks:
+  matrixos-net:
+    external: true
+    name: matrixos-net

--- a/docker-compose.staging-slot.yml
+++ b/docker-compose.staging-slot.yml
@@ -10,8 +10,9 @@
 # name (mx-staging-<SLOT>), and the project directory (the worktree), and
 # records ownership in ~/.matrixos/staging-slots/.
 #
-# Reuses the platform postgres on matrixos-net with database
-# matrixos_staging_<SLOT>.
+# Uses the dedicated staging postgres (docker-compose.staging-db.yml, network
+# alias "postgres" on matrixos-net) with database matrixos_staging_<SLOT>,
+# created by staging-slot.sh on claim.
 
 services:
   staging-dev:
@@ -52,7 +53,7 @@ services:
       - NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=${NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN:-}
       - NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST:-}
       - NEXT_PUBLIC_POSTHOG_API_HOST=${NEXT_PUBLIC_POSTHOG_API_HOST:-}
-      # Reuse platform postgres on matrixos-net. Password stays in .env.
+      # Dedicated staging postgres (alias "postgres"). Password stays in .env.
       - DATABASE_URL=${STAGING_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/matrixos_staging_${SLOT}}
       - PLATFORM_DATABASE_URL=${STAGING_PLATFORM_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/matrixos_staging_${SLOT}}
     networks:

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Enroll a Matrix OS VPS in centralized log shipping from the ops box.
+#
+# Usage:
+#   PLATFORM_SECRET=... LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... \
+#     ./scripts/enable-vps-logship.sh <handle> <env>
+#
+#   handle  matrix handle of the VPS (looked up in /vps/fleet)
+#   env     preview | prod | staging
+#
+# Optional env:
+#   PLATFORM_PUBLIC_URL  (default https://app.matrix-os.com)
+#   LOGS_INGEST_URL      (default https://logs.matrix-os.com)
+#   VPS_SSH_KEY          (default ~/.ssh/customer_vps_smoke)
+#
+# Looks up the VPS public IP via the platform fleet API, then runs the
+# bundled matrix-install-logship on the VPS over SSH. v1 enrollment is
+# explicit per-VPS; platform-side auto-enrollment is deferred (spec 093).
+set -euo pipefail
+
+HANDLE="${1:?usage: enable-vps-logship.sh <handle> <env>}"
+MATRIX_ENV="${2:?usage: enable-vps-logship.sh <handle> <env>}"
+PLATFORM_PUBLIC_URL="${PLATFORM_PUBLIC_URL:-https://app.matrix-os.com}"
+LOGS_INGEST_URL="${LOGS_INGEST_URL:-https://logs.matrix-os.com}"
+VPS_SSH_KEY="${VPS_SSH_KEY:-$HOME/.ssh/customer_vps_smoke}"
+
+: "${PLATFORM_SECRET:?PLATFORM_SECRET must be set}"
+: "${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set}"
+: "${LOGS_INGEST_PASSWORD:?LOGS_INGEST_PASSWORD must be set}"
+
+if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
+  echo "enable-vps-logship: invalid handle" >&2
+  exit 64
+fi
+case "$MATRIX_ENV" in
+  preview | prod | staging) ;;
+  *)
+    echo "enable-vps-logship: env must be preview|prod|staging" >&2
+    exit 64
+    ;;
+esac
+
+ip="$(curl -fsS --max-time 10 \
+  -H "authorization: Bearer ${PLATFORM_SECRET}" \
+  "${PLATFORM_PUBLIC_URL}/vps/fleet" |
+  jq -r --arg h "$HANDLE" \
+    '.machines[] | select(.handle == $h and .status == "running") | .publicIPv4' |
+  head -1)"
+
+if [ -z "$ip" ] || [ "$ip" = "null" ]; then
+  echo "enable-vps-logship: no running VPS found for handle ${HANDLE}" >&2
+  exit 1
+fi
+
+echo "enable-vps-logship: enrolling ${HANDLE} (${ip}) as env=${MATRIX_ENV}"
+# Credentials go via stdin, not argv, so they never appear in remote ps output.
+printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
+  ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new "root@${ip}" \
+    "IFS= read -r u && IFS= read -r p && /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' \"\$u\" \"\$p\" '${HANDLE}' '${MATRIX_ENV}'"
+
+echo "enable-vps-logship: done. Verify with: ./scripts/preview-logs.sh --handle ${HANDLE} --since 5m"

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -58,4 +58,13 @@ printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
   ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new "root@${ip}" \
     "IFS= read -r u && IFS= read -r p && /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' \"\$u\" \"\$p\" '${HANDLE}' '${MATRIX_ENV}'"
 
+# Record enrollment in the ops-side inventory so credential rotation has a
+# concrete target list (spec 093). Idempotent: one line per handle.
+INVENTORY="${LOGSHIP_INVENTORY:-$HOME/.matrixos/logship-enrolled.tsv}"
+mkdir -p "$(dirname "$INVENTORY")"
+touch "$INVENTORY"
+if ! cut -f1 "$INVENTORY" | grep -qx "$HANDLE"; then
+  printf '%s\t%s\t%s\n' "$HANDLE" "$MATRIX_ENV" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$INVENTORY"
+fi
+
 echo "enable-vps-logship: done. Verify with: ./scripts/preview-logs.sh --handle ${HANDLE} --since 5m"

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -32,6 +32,13 @@ if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
   echo "enable-vps-logship: invalid handle" >&2
   exit 64
 fi
+# Strict character allowlist: this value is interpolated into a root SSH
+# command on the VPS, so anything outside [A-Za-z0-9.:/_-] (notably quotes,
+# spaces, $, ;) must be rejected, not just the scheme.
+if ! printf '%s' "$LOGS_INGEST_URL" | grep -Eq '^https://[A-Za-z0-9.-]+(:[0-9]+)?(/[A-Za-z0-9._/-]*)?$'; then
+  echo "enable-vps-logship: LOGS_INGEST_URL must be a plain https URL (no quotes, spaces, or shell metacharacters)" >&2
+  exit 64
+fi
 case "$MATRIX_ENV" in
   preview | prod | staging) ;;
   *)

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -53,7 +53,9 @@ if [ -z "$ip" ] || [ "$ip" = "null" ]; then
 fi
 
 echo "enable-vps-logship: enrolling ${HANDLE} (${ip}) as env=${MATRIX_ENV}"
-# Credentials go via stdin, not argv, so they never appear in remote ps output.
+# Credentials travel via stdin and become ENVIRONMENT variables on the remote
+# (never argv on either side): /proc/<pid>/cmdline is world-readable, while
+# /proc/<pid>/environ is owner/root-only.
 # accept-new trusts a host on FIRST contact only; a changed key for a known IP
 # is rejected loudly (it is not StrictHostKeyChecking=no). Keys are pinned in a
 # dedicated known-hosts file so a rebuilt VPS on a reused IP fails closed until
@@ -63,7 +65,7 @@ mkdir -p "$(dirname "$KNOWN_HOSTS")"
 printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
   ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new \
     -o UserKnownHostsFile="$KNOWN_HOSTS" "root@${ip}" \
-    "IFS= read -r u && IFS= read -r p && /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' \"\$u\" \"\$p\" '${HANDLE}' '${MATRIX_ENV}'"
+    "IFS= read -r u && IFS= read -r p && LOGS_INGEST_USER=\"\$u\" LOGS_INGEST_PASSWORD=\"\$p\" /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' '${HANDLE}' '${MATRIX_ENV}'"
 
 # Record enrollment in the ops-side inventory so credential rotation has a
 # concrete target list (spec 093). Idempotent: one line per handle.

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -54,8 +54,15 @@ fi
 
 echo "enable-vps-logship: enrolling ${HANDLE} (${ip}) as env=${MATRIX_ENV}"
 # Credentials go via stdin, not argv, so they never appear in remote ps output.
+# accept-new trusts a host on FIRST contact only; a changed key for a known IP
+# is rejected loudly (it is not StrictHostKeyChecking=no). Keys are pinned in a
+# dedicated known-hosts file so a rebuilt VPS on a reused IP fails closed until
+# the operator removes the stale entry.
+KNOWN_HOSTS="${LOGSHIP_KNOWN_HOSTS:-$HOME/.matrixos/logship-known-hosts}"
+mkdir -p "$(dirname "$KNOWN_HOSTS")"
 printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
-  ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new "root@${ip}" \
+  ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new \
+    -o UserKnownHostsFile="$KNOWN_HOSTS" "root@${ip}" \
     "IFS= read -r u && IFS= read -r p && /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' \"\$u\" \"\$p\" '${HANDLE}' '${MATRIX_ENV}'"
 
 # Record enrollment in the ops-side inventory so credential rotation has a

--- a/scripts/preview-logs.sh
+++ b/scripts/preview-logs.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Query centralized logs for any Matrix OS preview/staging/fleet environment.
+# The one log interface coding agents should use (see docs/dev/preview-environments.md).
+#
+# Usage:
+#   ./scripts/preview-logs.sh --handle pr-123 [--unit matrix-gateway] [--since 15m] [--grep ERROR] [--limit 200]
+#   ./scripts/preview-logs.sh --slot 2 [--since 1h]
+#   ./scripts/preview-logs.sh --selector '{env="preview"}' --since 30m
+#
+# Runs against the ops-VPS Loki (loopback) by default; override with LOKI_URL.
+set -euo pipefail
+
+LOKI_URL="${LOKI_URL:-http://127.0.0.1:3100}"
+SINCE="15m"
+LIMIT="200"
+GREP=""
+SELECTOR=""
+HANDLE=""
+SLOT=""
+UNIT=""
+
+usage() {
+  sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+  exit 64
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --handle)
+      HANDLE="${2:?}"
+      shift 2
+      ;;
+    --slot)
+      SLOT="${2:?}"
+      shift 2
+      ;;
+    --unit)
+      UNIT="${2:?}"
+      shift 2
+      ;;
+    --selector)
+      SELECTOR="${2:?}"
+      shift 2
+      ;;
+    --since)
+      SINCE="${2:?}"
+      shift 2
+      ;;
+    --grep)
+      GREP="${2:?}"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="${2:?}"
+      shift 2
+      ;;
+    -h | --help) usage ;;
+    *)
+      echo "preview-logs: unknown flag $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [ -z "$SELECTOR" ]; then
+  if [ -n "$HANDLE" ]; then
+    if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
+      echo "preview-logs: invalid handle" >&2
+      exit 64
+    fi
+    SELECTOR="{handle=\"${HANDLE}\"}"
+    if [ -n "$UNIT" ]; then
+      SELECTOR="{handle=\"${HANDLE}\", unit=\"${UNIT}.service\"}"
+    fi
+  elif [ -n "$SLOT" ]; then
+    case "$SLOT" in
+      1 | 2 | 3 | 4) ;;
+      *)
+        echo "preview-logs: slot must be 1-4" >&2
+        exit 64
+        ;;
+    esac
+    SELECTOR="{container=~\".*matrixos-staging-${SLOT}.*\"}"
+  else
+    echo "preview-logs: one of --handle, --slot, --selector is required" >&2
+    usage
+  fi
+fi
+
+QUERY="$SELECTOR"
+if [ -n "$GREP" ]; then
+  QUERY="${SELECTOR} |~ \"$(printf '%s' "$GREP" | sed 's/[\\"]/\\&/g')\""
+fi
+
+case "$SINCE" in
+  *m) START_SECS=$((${SINCE%m} * 60)) ;;
+  *h) START_SECS=$((${SINCE%h} * 3600)) ;;
+  *d) START_SECS=$((${SINCE%d} * 86400)) ;;
+  *)
+    echo "preview-logs: --since must end in m, h, or d" >&2
+    exit 64
+    ;;
+esac
+NOW_NS="$(date +%s)000000000"
+START_NS="$(($(date +%s) - START_SECS))000000000"
+
+curl -fsS --max-time 30 -G "${LOKI_URL}/loki/api/v1/query_range" \
+  ${LOKI_AUTH:+-u "$LOKI_AUTH"} \
+  --data-urlencode "query=${QUERY}" \
+  --data-urlencode "start=${START_NS}" \
+  --data-urlencode "end=${NOW_NS}" \
+  --data-urlencode "limit=${LIMIT}" \
+  --data-urlencode "direction=backward" |
+  jq -r '.data.result[] as $s | $s.values[] | "\(. [0] | tonumber / 1e9 | strftime("%Y-%m-%dT%H:%M:%SZ")) [\($s.stream.unit // $s.stream.container // $s.stream.source // "-")] \(.[1])"' |
+  sort

--- a/scripts/preview-logs.sh
+++ b/scripts/preview-logs.sh
@@ -70,6 +70,11 @@ if [ -z "$SELECTOR" ]; then
     fi
     SELECTOR="{handle=\"${HANDLE}\"}"
     if [ -n "$UNIT" ]; then
+      # systemd unit-name charset; blocks selector breakout via quotes/braces.
+      if ! printf '%s' "$UNIT" | grep -Eq '^[a-zA-Z0-9@._-]+$'; then
+        echo "preview-logs: invalid unit name" >&2
+        exit 64
+      fi
       SELECTOR="{handle=\"${HANDLE}\", unit=\"${UNIT}.service\"}"
     fi
   elif [ -n "$SLOT" ]; then

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -186,7 +186,11 @@ cmd_status() {
     echo "slot $i: $branch ($worktree) claimed ${claimed} (${age_hours}h ago)"
     if [ "$reap" = "--reap" ] && [ "$age_hours" -ge "$IDLE_TTL_HOURS" ]; then
       echo "slot $i: idle past ${IDLE_TTL_HOURS}h TTL, reaping"
-      cmd_down "$i"
+      # Subshell: cmd_down exits non-zero on a failed DB drop; one bad slot
+      # must not abort reaping of the remaining expired slots.
+      if ! (cmd_down "$i"); then
+        echo "slot $i: reap failed; continuing with remaining slots" >&2
+      fi
     fi
   done
 }

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Per-worktree HMR staging slots on the ops VPS (spec 093).
+#
+# Usage:
+#   ./scripts/staging-slot.sh up <worktree-path>   # claim lowest free slot, start HMR container
+#   ./scripts/staging-slot.sh down <slot>          # stop and release a slot
+#   ./scripts/staging-slot.sh status [--reap]      # list slots; --reap frees slots idle > TTL
+#   ./scripts/staging-slot.sh logs <slot> [args]   # follow container logs (docker compose logs)
+#
+# Four fixed slots map to staging-<n>.matrix-os.com / api-staging-<n>.matrix-os.com
+# through the cloudflared tunnel. Slot state lives in ~/.matrixos/staging-slots/:
+# claim files are created with O_EXCL so two concurrent `up` calls cannot win
+# the same slot. Slot containers are named matrixos-staging-<n>, which the
+# observability promtail's docker discovery ships to Loki automatically.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STATE_DIR="${STAGING_SLOT_STATE_DIR:-$HOME/.matrixos/staging-slots}"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.staging-slot.yml"
+ENV_FILE="${STAGING_SLOT_ENV_FILE:-$REPO_ROOT/.env}"
+MAX_SLOTS=4
+IDLE_TTL_HOURS="${STAGING_SLOT_TTL_HOURS:-72}"
+
+mkdir -p "$STATE_DIR"
+
+compose() {
+  local slot="$1" project_dir="$2"
+  shift 2
+  SLOT="$slot" docker compose \
+    -f "$COMPOSE_FILE" \
+    --project-name "mx-staging-${slot}" \
+    --project-directory "$project_dir" \
+    --env-file "$ENV_FILE" \
+    "$@"
+}
+
+validate_slot() {
+  case "$1" in
+    1 | 2 | 3 | 4) ;;
+    *)
+      echo "staging-slot: slot must be 1-$MAX_SLOTS" >&2
+      exit 64
+      ;;
+  esac
+}
+
+slot_file() { echo "$STATE_DIR/slot-$1.json"; }
+
+cmd_up() {
+  local worktree="${1:?usage: staging-slot.sh up <worktree-path>}"
+  worktree="$(cd "$worktree" && pwd)" || {
+    echo "staging-slot: worktree path does not exist" >&2
+    exit 64
+  }
+  if ! git -C "$worktree" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "staging-slot: $worktree is not a git worktree" >&2
+    exit 64
+  fi
+  if [ ! -f "$worktree/Dockerfile.dev" ]; then
+    echo "staging-slot: $worktree does not look like a matrix-os checkout" >&2
+    exit 64
+  fi
+
+  local slot="" f branch
+  for i in $(seq 1 "$MAX_SLOTS"); do
+    f="$(slot_file "$i")"
+    # O_EXCL claim: loser of a race moves on to the next slot.
+    if (set -o noclobber && : > "$f") 2> /dev/null; then
+      slot="$i"
+      break
+    fi
+  done
+  if [ -z "$slot" ]; then
+    echo "staging-slot: no free slots. Current owners:" >&2
+    cmd_status >&2
+    exit 1
+  fi
+
+  branch="$(git -C "$worktree" rev-parse --abbrev-ref HEAD)"
+  jq -n --arg worktree "$worktree" --arg branch "$branch" \
+    --arg claimedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{worktree: $worktree, branch: $branch, claimedAt: $claimedAt}' > "$(slot_file "$slot")"
+
+  echo "staging-slot: claimed slot $slot for $branch"
+  if ! compose "$slot" "$worktree" up -d --build; then
+    rm -f "$(slot_file "$slot")"
+    echo "staging-slot: start failed; slot $slot released" >&2
+    exit 1
+  fi
+  echo "staging-slot: slot $slot up"
+  echo "  shell: https://staging-${slot}.matrix-os.com"
+  echo "  api:   https://api-staging-${slot}.matrix-os.com"
+  echo "  logs:  ./scripts/preview-logs.sh --slot ${slot}   (or: staging-slot.sh logs ${slot} -f)"
+}
+
+cmd_down() {
+  local slot="${1:?usage: staging-slot.sh down <slot>}"
+  validate_slot "$slot"
+  local f worktree
+  f="$(slot_file "$slot")"
+  if [ ! -f "$f" ]; then
+    echo "staging-slot: slot $slot is not claimed" >&2
+    exit 1
+  fi
+  worktree="$(jq -r .worktree "$f")"
+  # The worktree may already be deleted; fall back to repo root so compose
+  # can still resolve the project by name and remove containers.
+  [ -d "$worktree" ] || worktree="$REPO_ROOT"
+  compose "$slot" "$worktree" down --remove-orphans
+  rm -f "$f"
+  echo "staging-slot: slot $slot released"
+}
+
+cmd_status() {
+  local reap="${1:-}" f worktree branch claimed age_hours
+  for i in $(seq 1 "$MAX_SLOTS"); do
+    f="$(slot_file "$i")"
+    if [ ! -f "$f" ]; then
+      echo "slot $i: free"
+      continue
+    fi
+    worktree="$(jq -r .worktree "$f")"
+    branch="$(jq -r .branch "$f")"
+    claimed="$(jq -r .claimedAt "$f")"
+    age_hours=$((($(date +%s) - $(date -d "$claimed" +%s)) / 3600))
+    echo "slot $i: $branch ($worktree) claimed ${claimed} (${age_hours}h ago)"
+    if [ "$reap" = "--reap" ] && [ "$age_hours" -ge "$IDLE_TTL_HOURS" ]; then
+      echo "slot $i: idle past ${IDLE_TTL_HOURS}h TTL, reaping"
+      cmd_down "$i"
+    fi
+  done
+}
+
+cmd_logs() {
+  local slot="${1:?usage: staging-slot.sh logs <slot> [compose-logs-args]}"
+  validate_slot "$slot"
+  shift
+  local f worktree
+  f="$(slot_file "$slot")"
+  if [ ! -f "$f" ]; then
+    echo "staging-slot: slot $slot is not claimed" >&2
+    exit 1
+  fi
+  worktree="$(jq -r .worktree "$f")"
+  [ -d "$worktree" ] || worktree="$REPO_ROOT"
+  compose "$slot" "$worktree" logs "$@"
+}
+
+case "${1:-}" in
+  up)
+    shift
+    cmd_up "$@"
+    ;;
+  down)
+    shift
+    cmd_down "$@"
+    ;;
+  status)
+    shift || true
+    cmd_status "${1:-}"
+    ;;
+  logs)
+    shift
+    cmd_logs "$@"
+    ;;
+  *)
+    sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+    exit 64
+    ;;
+esac

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -34,6 +34,42 @@ compose() {
     "$@"
 }
 
+# The dev image runs as the matrixos user (uid 100); on Linux hosts the
+# bind-mounted worktree is owned by the invoking user, so Next/tsx watchers
+# could not write build output (next-env.d.ts, .next, dist). Grant the
+# container uid an ACL on the worktree, with inheritance for new files.
+# Docker Desktop (macOS) maps uids transparently and never hits this.
+ensure_worktree_writable() {
+  local worktree="$1" uid="${SLOT_CONTAINER_UID:-100}"
+  if ! command -v setfacl > /dev/null 2>&1; then
+    echo "staging-slot: setfacl not found; container writes to the worktree may fail (sudo apt install acl)" >&2
+    return 0
+  fi
+  # Files created by the container itself are owned by the container uid;
+  # the invoking user cannot set ACLs on those, but they are already
+  # writable by the container -- so per-file failures here are benign.
+  if ! setfacl -R -m "u:${uid}:rwX" -m "d:u:${uid}:rwX" "$worktree" 2> /dev/null; then
+    echo "staging-slot: some ACL entries could not be set (container-owned files); continuing"
+  fi
+}
+
+# The legacy platform postgres is gone (Cloud Run cutover); slots share a
+# dedicated dev postgres (network alias "postgres" on matrixos-net) with one
+# database per slot.
+ensure_staging_db() {
+  local slot="$1" db_user
+  db_user="${STAGING_DB_USER:-matrixos}"
+  docker compose -f "$REPO_ROOT/docker-compose.staging-db.yml" \
+    --env-file "$ENV_FILE" up -d --wait staging-postgres
+  if ! docker exec matrixos-staging-postgres \
+    psql -U "$db_user" -d matrixos_staging -tAc \
+    "SELECT 1 FROM pg_database WHERE datname = 'matrixos_staging_${slot}'" | grep -q 1; then
+    docker exec matrixos-staging-postgres \
+      psql -U "$db_user" -d matrixos_staging -c \
+      "CREATE DATABASE matrixos_staging_${slot}"
+  fi
+}
+
 validate_slot() {
   case "$1" in
     1 | 2 | 3 | 4) ;;
@@ -86,6 +122,8 @@ cmd_up() {
     '{worktree: $worktree, branch: $branch, claimedAt: $claimedAt}' > "$(slot_file "$slot")"
 
   echo "staging-slot: claimed slot $slot for $branch"
+  ensure_worktree_writable "$worktree"
+  ensure_staging_db "$slot"
   if ! compose "$slot" "$worktree" up -d --build; then
     echo "staging-slot: start failed; slot $slot released" >&2
     exit 1

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -124,8 +124,10 @@ cmd_up() {
   echo "staging-slot: claimed slot $slot for $branch"
   ensure_worktree_writable "$worktree"
   ensure_staging_db "$slot"
-  if ! compose "$slot" "$worktree" up -d --build; then
-    echo "staging-slot: start failed; slot $slot released" >&2
+  # --wait holds until healthchecks pass, so the EXIT trap still releases
+  # the slot when the container starts but never becomes healthy.
+  if ! compose "$slot" "$worktree" up -d --build --wait --wait-timeout 600; then
+    echo "staging-slot: start failed or unhealthy; slot $slot released" >&2
     exit 1
   fi
   trap - EXIT
@@ -158,7 +160,10 @@ cmd_down() {
   if ! docker exec matrixos-staging-postgres \
     psql -U "$db_user" -d matrixos_staging -c \
     "DROP DATABASE IF EXISTS matrixos_staging_${slot}" > /dev/null 2>&1; then
-    echo "staging-slot: warning: could not drop matrixos_staging_${slot}; next claim will reuse it" >&2
+    echo "staging-slot: could not drop matrixos_staging_${slot}; keeping the claim so the next" >&2
+    echo "staging-slot: occupant cannot inherit stale data. Start matrixos-staging-postgres and" >&2
+    echo "staging-slot: rerun 'staging-slot.sh down ${slot}'." >&2
+    exit 1
   fi
   docker volume rm -f "mx-staging-${slot}_slot-home" > /dev/null 2>&1 || true
   rm -f "$f"

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -76,6 +76,10 @@ cmd_up() {
     exit 1
   fi
 
+  # Any failure between winning the claim and a healthy start must release
+  # the slot, or it stays locked until --reap. Cleared after compose succeeds.
+  trap 'rm -f "$(slot_file "$slot")"' EXIT
+
   branch="$(git -C "$worktree" rev-parse --abbrev-ref HEAD)"
   jq -n --arg worktree "$worktree" --arg branch "$branch" \
     --arg claimedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -83,10 +87,10 @@ cmd_up() {
 
   echo "staging-slot: claimed slot $slot for $branch"
   if ! compose "$slot" "$worktree" up -d --build; then
-    rm -f "$(slot_file "$slot")"
     echo "staging-slot: start failed; slot $slot released" >&2
     exit 1
   fi
+  trap - EXIT
   echo "staging-slot: slot $slot up"
   echo "  shell: https://staging-${slot}.matrix-os.com"
   echo "  api:   https://api-staging-${slot}.matrix-os.com"
@@ -122,6 +126,7 @@ cmd_status() {
     worktree="$(jq -r .worktree "$f")"
     branch="$(jq -r .branch "$f")"
     claimed="$(jq -r .claimedAt "$f")"
+    # GNU date (-d): this script targets the Linux ops VPS only.
     age_hours=$((($(date +%s) - $(date -d "$claimed" +%s)) / 3600))
     echo "slot $i: $branch ($worktree) claimed ${claimed} (${age_hours}h ago)"
     if [ "$reap" = "--reap" ] && [ "$age_hours" -ge "$IDLE_TTL_HOURS" ]; then

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -149,6 +149,18 @@ cmd_down() {
   # can still resolve the project by name and remove containers.
   [ -d "$worktree" ] || worktree="$REPO_ROOT"
   compose "$slot" "$worktree" down --remove-orphans
+  # Clean slate for the next claimant: drop the per-slot database and the
+  # slot-home volume (prior occupant's MATRIX_HOME). node_modules volume is
+  # kept on purpose -- it only caches dependencies and saves minutes on the
+  # next claim.
+  local db_user
+  db_user="${STAGING_DB_USER:-matrixos}"
+  if ! docker exec matrixos-staging-postgres \
+    psql -U "$db_user" -d matrixos_staging -c \
+    "DROP DATABASE IF EXISTS matrixos_staging_${slot}" > /dev/null 2>&1; then
+    echo "staging-slot: warning: could not drop matrixos_staging_${slot}; next claim will reuse it" >&2
+  fi
+  docker volume rm -f "mx-staging-${slot}_slot-home" > /dev/null 2>&1 || true
   rm -f "$f"
   echo "staging-slot: slot $slot released"
 }

--- a/specs/093-preview-environments/plan.md
+++ b/specs/093-preview-environments/plan.md
@@ -1,0 +1,87 @@
+# Plan 093: Preview Environments and Centralized Dev Logging
+
+## Slices
+
+### Slice 1 — Logging spine (this stack, layer 2)
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Ingest edge | `distro/observability/logs-edge/Caddyfile` + `logs-edge` service in `distro/observability/docker-compose.observability.yml` | basic auth, push-only path allowlist, tunnel-only |
+| Tunnel route | `distro/cloudflared.yml` | `logs.matrix-os.com -> logs-edge:8080` |
+| Shipper installer | `distro/customer-vps/host-bin/matrix-install-logship` | downloads pinned Alloy, sha256-verified; writes config + systemd unit + env; idempotent |
+| Ops enroll helper | `scripts/enable-vps-logship.sh` | SSH wrapper: pushes installer invocation to a VPS by handle (fleet IP lookup) |
+| Query contract | `scripts/preview-logs.sh` | curl/jq over Loki query_range; selector flags |
+
+Verification: push a test line through `logs.matrix-os.com` with the credential
+(expect 204), without it (expect 401), query it back via `preview-logs.sh`.
+
+### Slice 2 — Staging slots (layer 2)
+
+| Artifact | Path |
+|---|---|
+| Slot compose | `docker-compose.staging-slot.yml` (parameterized by `SLOT`, project `mx-staging-<n>`) |
+| Lifecycle script | `scripts/staging-slot.sh` (`up <worktree>` / `down <n>` / `status [--reap]` / `logs <n>`) |
+| Tunnel routes | `distro/cloudflared.yml`: `staging-<1..4>` + `api-staging-<1..4>` hostnames |
+| DNS | one-time `cloudflared tunnel route dns` per hostname (ops runbook step) |
+
+Verification: claim slot 1 from a worktree, confirm HMR shell responds via tunnel,
+confirm slot logs appear in Loki via promtail docker discovery, release the slot.
+
+### Slice 3 — CI pipelines (layer 3)
+
+| Artifact | Path |
+|---|---|
+| Preview VPS | `.github/workflows/preview-vps.yml` (label `preview-vps`; build/publish/provision/deploy/comment; teardown on close; daily reaper) |
+| Platform preview | `.github/workflows/preview-platform.yml` (label `preview-platform`; dedicated preview service; no-ops without preview secrets) |
+
+Verification: workflow YAML lint; dry-run the platform API calls from the ops box with
+a throwaway handle; full E2E on the first labeled PR (costs one small Hetzner VPS).
+
+### Slice 4 — Discovery layer (layer 3)
+
+| Artifact | Path |
+|---|---|
+| Agent skill | `.claude/skills/preview-env/SKILL.md` |
+| Dev guide | `docs/dev/preview-environments.md` |
+| Pointer | `AGENTS.md` reference-docs row |
+
+## Stack / PR layout (Graphite)
+
+1. `093-preview-environments` — spec + plan (this directory)
+2. `feat/preview-logging-spine` — slices 1 + 2
+3. `feat/preview-envs-ci` — slices 3 + 4
+
+## Decisions
+
+- **Alloy over promtail**: promtail is EOL (Feb 2026); Alloy is the supported shipper.
+  Pinned `v1.16.3`, downloaded at install time (keeps the host bundle small),
+  checksum-verified.
+- **Push-only ingest edge**: queries stay loopback/Grafana-only; the public surface is
+  a single POST path behind basic auth. Smallest credible attack surface for v1.
+- **No platform code changes in v1**: logship enrollment is ops-side via SSH. The
+  cloud-init template-var route requires platform changes and ships as a follow-up.
+- **Releases without channel**: PR bundles are registered version-only so no channel
+  pointer can ever resolve to a PR build.
+- **Fixed staging slots over wildcard DNS**: `cloudflared tunnel route dns` cannot
+  create wildcards without the Cloudflare API; four pre-registered hostnames need
+  zero runtime DNS mutations and cap concurrency by construction.
+- **Dedicated Cloud Run preview service**: preview revisions must never share the
+  production service or its secrets (a preview revision with the production DB would
+  be a critical incident waiting to happen).
+
+## Test plan
+
+- Unit-ish: `staging-slot.sh` slot-claim race (two concurrent `up` calls -> distinct
+  slots), input validation rejects bad slot index / foreign path.
+- Live: ingest auth positive/negative, log round-trip, slot HMR round-trip.
+- CI: `actionlint` on new workflows; platform API smoke from ops box.
+
+## Rollout
+
+1. Merge stack; apply logs-edge + tunnel config live on ops VPS (config is
+   bind-mounted, same pattern as PR #484).
+2. Enroll the staging slots implicitly (promtail) and one feature VPS explicitly via
+   `scripts/enable-vps-logship.sh` to validate the fleet path.
+3. First labeled PR exercises preview-vps E2E; reaper observed over the next 3 days.
+4. Follow-up issues: platform cloud-init enrollment, metrics remote-write, Neon
+   branch automation, browser-console forwarding.

--- a/specs/093-preview-environments/spec.md
+++ b/specs/093-preview-environments/spec.md
@@ -1,0 +1,188 @@
+# Spec 093: Preview Environments and Centralized Dev Logging
+
+## Problem
+
+Production Matrix OS is VPS-native per user (host systemd services) with the platform
+on Cloud Run. Local Docker stacks are therefore not production-shaped, and coding
+agents working on feature branches have no way to observe a running stack: dev process
+output evaporates in terminals, customer VPSes ship no logs anywhere, and browser
+console output is invisible. Every feature type needs a different test surface (shell
+changes need a runtime, onboarding needs a virgin VPS, the macOS app needs a runtime to
+connect to, CLI betas need a paired shell), and today each is assembled by hand.
+
+## Goals
+
+1. One preview surface per feature type, all cloud-based and production-shaped.
+2. Centralized logs: every preview environment (and, by rollout, the production fleet)
+   ships logs to the existing Loki on the ops VPS, queryable by one agent-facing
+   contract.
+3. Agents discover and operate all of this through a skill and dev docs, without human
+   hand-holding.
+
+## Non-Goals
+
+- Replacing the local `bun run dev` inner loop for sub-second HMR on a laptop.
+- Metrics shipping (Prometheus remote-write) — logs first; metrics are a follow-up.
+- Per-VPS unique ingest credentials in v1 (single rotating credential; see Security).
+- Production fleet auto-enrollment in v1 (explicit per-VPS enablement; see Rollout).
+
+## Surfaces by Feature Type
+
+| Feature type | Surface | Mechanism |
+|---|---|---|
+| Shell / gateway / kernel | Preview VPS `pr-<N>` | CI label `preview-vps`: build bundle `0.0.0-pr<N>.<sha7>`, publish to R2, provision + deploy via platform API, PR comment with `app.matrix-os.com/vm/pr-<N>` |
+| Onboarding | Fresh preview VPS | Same pipeline; a newly provisioned VPS is virgin by construction |
+| Platform (Cloud Run) | Tagged preview revision | CI label `preview-platform`: build image, deploy to the dedicated preview service with `--tag pr-<N> --no-traffic` |
+| macOS app | CI `.app` artifact + any preview VPS | `macos-086.yml` artifact, runtime switcher `app.matrix-os.com/vm/<handle>` |
+| CLI beta x shell | npm dist-tag + preview VPS | `matrixos@pr-<N>` dist-tag paired via `~/.matrixos` profiles (068) |
+| Fast UI iteration (HMR) | Staging slot `staging-<1..4>.matrix-os.com` | Per-worktree HMR container on the ops VPS behind the existing tunnel |
+
+## Architecture
+
+### Logging spine
+
+- **Ingest edge**: a Caddy container (`logs-edge`) on the ops VPS, exposed only through
+  the cloudflared tunnel as `logs.matrix-os.com`. It forwards exactly one path prefix —
+  `POST /loki/api/v1/push` — to the internal Loki, behind HTTP basic auth. Everything
+  else returns 404. Loki itself stays loopback-bound (PR #484).
+- **Shipper**: Grafana Alloy (pinned version, checksum-verified) on each enrolled VPS,
+  installed by a new self-contained host-bin script `matrix-install-logship`. It tails
+  journald units (`matrix-gateway`, `matrix-shell`, `matrix-sync-agent`, `matrix-code`,
+  `matrix-symphony`) and the kernel JSONL logs under the Matrix home, labeling streams
+  with `handle`, `env` (`preview` | `prod` | `staging`), `source`, and `unit`.
+- **Ops VPS local logs**: the existing promtail continues to ship docker container logs
+  (which now include staging slots) directly to Loki on the internal network.
+- **Query contract**: `scripts/preview-logs.sh` — curl/jq wrapper over the Loki query
+  API (loopback on the ops VPS; `LOKI_URL`/credentials overridable). Selectors:
+  `--handle pr-123`, `--slot 2`, `--unit matrix-gateway`, `--grep`, `--since`.
+
+### Preview VPS pipeline (`.github/workflows/preview-vps.yml`)
+
+- Trigger: PR labeled `preview-vps` (on label add and on synchronize while labeled),
+  plus `workflow_dispatch` for manual runs.
+- Build: reuse `scripts/build-host-bundle.sh` with
+  `HOST_BUNDLE_VERSION=0.0.0-pr<N>.<sha7>`; version format passes the platform's
+  release validation (`/^[A-Za-z0-9._-]{1,128}$/`).
+- Publish: `scripts/publish-release.sh` **without** `--channel` — the release is
+  registered but never promoted; no channel pointer can ever select a PR bundle.
+- Provision: `POST /vps/provision` with `handle: pr-<N>`, a dedicated
+  `PREVIEW_CLERK_USER_ID` secret, `runtimeSlot: preview`. Idempotent: if the handle
+  already exists in `/vps/fleet`, skip provision and deploy only.
+- Deploy: `POST /vps/deploy {"version": "...", "handle": "pr-<N>"}` — version-pinned,
+  single-handle. Never channel-wide.
+- Report: PR comment with the VM URL, bundle version, and log-query one-liner.
+- Teardown: on PR `closed`, look up the machineId for `pr-<N>` in `/vps/fleet` and
+  `DELETE /vps/<machineId>`. A scheduled reaper job (daily) deletes any `pr-*` VPS
+  whose PR is closed or whose age exceeds 72h, so orphans cannot accumulate Hetzner
+  cost.
+
+### Platform preview revisions (`.github/workflows/preview-platform.yml`, scaffold)
+
+- Trigger: PR labeled `preview-platform`.
+- Deploys the platform image to a **dedicated preview Cloud Run service**
+  (`CLOUD_RUN_PREVIEW_SERVICE`), never the production service, with
+  `--tag pr-<N> --no-traffic`, using preview-scoped secrets (separate database URL —
+  Neon branch databases are the intended pairing, deferred). The job no-ops with a
+  clear message when preview secrets are not configured.
+
+### Staging slots (`scripts/staging-slot.sh` + `docker-compose.staging-slot.yml`)
+
+- Four fixed slots: `staging-<n>.matrix-os.com` / `api-staging-<n>.matrix-os.com`
+  (n = 1..4), pre-registered in the tunnel config and DNS — no Cloudflare API calls at
+  slot-claim time.
+- `staging-slot.sh up <worktree-path>` claims the lowest free slot (state file with an
+  exclusive-create lock), runs the HMR dev container from that worktree's source with
+  `COMPOSE_PROJECT_NAME=mx-staging-<n>`, and prints the URL. `down`, `status`, and
+  `logs` subcommands complete the lifecycle. Slots idle longer than the TTL are
+  reclaimable by `status --reap`.
+- Slot containers match the existing promtail docker discovery (name contains
+  `matrixos`), so slot logs flow to Loki with no extra wiring.
+
+## Security Architecture
+
+### Auth matrix
+
+| Surface | AuthN | AuthZ | Notes |
+|---|---|---|---|
+| `logs.matrix-os.com` (ingest) | HTTP basic auth (bcrypt hash in Caddy config, secret from `.env`) | push-only: `POST /loki/api/v1/push`; all other paths 404 | Tunnel-only; no host port. Query APIs are NOT exposed. |
+| Loki query | none (loopback) | reachable only from ops VPS / docker network | Agents query via `preview-logs.sh` on the ops box or via Grafana |
+| Platform API calls in CI | `Authorization: Bearer PLATFORM_SECRET` (repo secret) | existing platform route guards | Same secret host-bundle-release.yml already uses |
+| Preview VPS shell | Clerk (existing) | VPS bound to `PREVIEW_CLERK_USER_ID` | Team members use the runtime switcher with their own Clerk session per existing platform rules |
+| Staging slots | Tunnel hostname only | no new auth (matches existing `staging.matrix-os.com` posture) | Slots run branch code with dev credentials only; never production secrets |
+| Cloud Run preview | gcloud OIDC (existing workflow auth) | dedicated preview service + preview secrets | Production service and secrets are never referenced |
+
+### Input validation
+
+- `staging-slot.sh`: slot index validated against `[1-4]`; worktree path must resolve
+  inside `~/matrix-os.worktrees/` or be an existing registered git worktree; PR/branch
+  metadata stored, never interpolated into shell unquoted.
+- Workflow inputs: PR number comes from the GitHub event payload (integer), handle is
+  constructed as `pr-<N>` and therefore always matches the platform's handle regex.
+- `matrix-install-logship`: URL must be `https://`, handle must match
+  `^[a-z0-9][a-z0-9-]{1,62}$`, env must be one of `preview|prod|staging`; the Alloy
+  binary download is pinned to an exact version and verified against a recorded
+  sha256 before install.
+
+### Error policy
+
+- CI jobs surface platform API failures with status codes only; response bodies are
+  not echoed into PR comments (they can contain infrastructure details). Full bodies
+  go to the workflow log, which is repo-private.
+- `preview-logs.sh` prints Loki errors verbatim (operator tool on the ops box).
+- `logs-edge` returns generic 401/404; no upstream details.
+
+## Failure Modes
+
+- **Bundle build fails**: no publish, no deploy; PR comment is only posted on success.
+- **Provision succeeds, deploy fails**: VPS exists with channel-default bundle. The
+  deploy step retries once; on persistent failure the job fails loudly and the PR
+  comment is replaced by a failure note with the handle so teardown still works.
+  Orphan state is acceptable: the reaper deletes it within 72h regardless.
+- **Teardown fails on PR close**: the scheduled reaper is the backstop (same deletion
+  code path). Reaper failures alert via workflow failure notifications.
+- **Two PRs race for a staging slot**: slot claim uses `O_EXCL` lock-file creation;
+  the loser gets the next slot or a clear "no free slots" error listing current owners.
+- **logs-edge or Loki down**: Alloy buffers and retries with backoff (bounded WAL);
+  VPS services are never blocked by log shipping (shipper is an independent unit,
+  `Wants=`/`After=` only).
+- **Credential leak of ingest secret**: blast radius is log injection (write-only
+  endpoint). Rotate by updating `.env` + restarting `logs-edge`, then re-running
+  `matrix-install-logship` on enrolled VPSes. Documented in runbook.
+- **Reaper deletes a VPS still in use**: only `pr-*` handles are eligible, never
+  `primary` runtime slots, and PR-open state is checked before age-based deletion.
+
+## Resource Management
+
+- Loki retention: existing config; preview labels make `{env="preview"}` streams
+  cheap to delete; retention policy documented (follow-up: per-tenant limits).
+- Alloy: bounded WAL/backpressure; install pinned and idempotent (re-running upgrades
+  config in place).
+- Staging slots: hard cap of 4 concurrent; slot state file caps entries at 4; TTL reap
+  for idle slots; `down` removes containers and the per-slot named volumes are reused
+  per slot (bounded count).
+- Preview VPSes: hard TTL 72h via reaper; one VPS per PR (idempotent provision).
+- CI: preview jobs use `concurrency: preview-vps-<N>` with cancel-in-progress to avoid
+  pile-ups on rapid pushes.
+
+## Integration Wiring
+
+- `logs-edge` joins the existing `observability` docker network next to Loki; tunnel
+  ingress added in `distro/cloudflared.yml` (live config, bind-mounted).
+- `matrix-install-logship` ships in the host bundle `bin/` (build-host-bundle.sh
+  already copies `distro/customer-vps/host-bin/`). Enablement v1: invoked over SSH
+  from the ops box (extension of the `staging-platform-vps` flow) with the ingest URL
+  and credential. Follow-up (deferred): platform writes `/opt/matrix/env/logship.env`
+  at provision time via cloud-init template vars so new VPSes auto-enroll.
+- `preview-vps.yml` mirrors `host-bundle-release.yml` secrets exactly; one new secret
+  (`PREVIEW_CLERK_USER_ID`), no new permissions.
+- Skill `.claude/skills/preview-env/` + `docs/dev/preview-environments.md` are the
+  discovery layer; AGENTS.md gets a one-line reference.
+
+## Deferred Scope
+
+- Platform-side cloud-init templating for automatic logship enrollment of every new
+  VPS (follow-up issue; v1 is explicit per-VPS enablement).
+- Prometheus remote-write (metrics) from VPSes.
+- Neon branch-database automation for platform previews.
+- Browser-console forwarding from preview shells into Loki (debug build flag).
+- Per-VPS unique ingest credentials / Loki multi-tenancy.

--- a/specs/093-preview-environments/spec.md
+++ b/specs/093-preview-environments/spec.md
@@ -34,7 +34,7 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
 | Onboarding | Fresh preview VPS | Same pipeline; a newly provisioned VPS is virgin by construction |
 | Platform (Cloud Run) | Tagged preview revision | CI label `preview-platform`: build image, deploy to the dedicated preview service with `--tag pr-<N> --no-traffic` |
 | macOS app | CI `.app` artifact + any preview VPS | `macos-086.yml` artifact, runtime switcher `app.matrix-os.com/vm/<handle>` |
-| CLI beta x shell | npm dist-tag + preview VPS | `matrixos@pr-<N>` dist-tag paired via `~/.matrixos` profiles (068) |
+| CLI beta x shell | npm dist-tag + preview VPS | `matrixos@pr-<N>` dist-tag paired via `~/.matrixos` profiles (068). Deferred: dist-tag automation ships publish AND removal together (`npm dist-tag rm` on PR close) -- a dangling dist-tag is publicly reachable forever |
 | Fast UI iteration (HMR) | Staging slot `staging-<1..4>.matrix-os.com` | Per-worktree HMR container on the ops VPS behind the existing tunnel |
 
 ## Architecture
@@ -84,6 +84,10 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   `--tag pr-<N> --no-traffic`, using preview-scoped secrets (separate database URL —
   Neon branch databases are the intended pairing, deferred). The job no-ops with a
   clear message when preview secrets are not configured.
+- Teardown mirrors the VPS model: on PR close the workflow removes the `pr-<N>`
+  traffic tag and deletes its revision(s), so labeled PRs cannot accumulate
+  revisions in the preview service. A periodic sweeper for revisions that escape
+  close-teardown ships with the Neon automation (deferred).
 
 ### Staging slots (`scripts/staging-slot.sh` + `docker-compose.staging-slot.yml`)
 
@@ -150,6 +154,11 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   `matrix-install-logship` on enrolled VPSes. Documented in runbook.
 - **Reaper deletes a VPS still in use**: only `pr-*` handles are eligible, never
   `primary` runtime slots, and PR-open state is checked before age-based deletion.
+- **Reaper cannot confirm PR state** (GitHub API failure/rate limit): fail-safe —
+  that VPS is skipped, never deleted on unknown state, and age-based deletion also
+  requires a confirmed state. The reaper job exits non-zero after processing when
+  any lookup failed, so repeated skips surface as workflow failures instead of
+  silently accumulating orphans.
 
 ## Resource Management
 
@@ -161,6 +170,11 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   for idle slots; `down` removes containers and the per-slot named volumes are reused
   per slot (bounded count).
 - Preview VPSes: hard TTL 72h via reaper; one VPS per PR (idempotent provision).
+- Cloud Run preview revisions: deleted on PR close (see Architecture); bounded by
+  open labeled PRs.
+- Logship enrollment inventory: `enable-vps-logship.sh` records every enrolled
+  handle in an ops-side inventory file (`~/.matrixos/logship-enrolled.tsv`), giving
+  credential rotation a concrete target list for the re-enrollment runbook.
 - CI: preview jobs use `concurrency: preview-vps-<N>` with cancel-in-progress to avoid
   pile-ups on rapid pushes.
 


### PR DESCRIPTION
## Summary

Implements the spec-093 logging spine and staging slots (live-applied on the ops VPS and verified):

- **logs-edge**: Caddy basic-auth front for Loki, exposed only through the cloudflared tunnel as `logs.matrix-os.com`. Push path only — `POST /loki/api/v1/push`; every other path 404s, so the unauthenticated Loki query API is never internet-reachable. Credentials via `env_file` with `format: raw` (compose v5 interpolation mangles bcrypt `$` sequences — found live).
- **matrix-install-logship**: self-contained Grafana Alloy v1.16.3 installer for VPSes (checksum-verified download, journald units + kernel JSONL shipping, `handle`/`env` labels, independent systemd unit that never blocks matrix services).
- **enable-vps-logship.sh**: ops-side enrollment over SSH (fleet IP lookup; credentials passed via stdin, never argv).
- **preview-logs.sh**: the one log-query contract for agents (`--handle`, `--slot`, `--selector`, `--grep`, `--since`).
- **staging-slot.sh + docker-compose.staging-slot.yml + docker-compose.staging-db.yml**: four fixed per-worktree HMR slots behind `staging-<n>.matrix-os.com` with O_EXCL race-safe claiming, TTL reaping, per-slot databases on a dedicated staging postgres (the platform postgres was retired in the Cloud Run cutover).

Live verification: authed push 204, unauthed 401, query path 404, round-trip query via preview-logs.sh; tunnel DNS routes created for `logs` + 8 slot hostnames.

## Invariants

- **Source of truth**: `distro/cloudflared.yml` and the observability compose are the live bind-mounted configs on the ops VPS; this PR commits what is already running. Slot ownership state lives in `~/.matrixos/staging-slots/` (lock files are the lock).
- **Lock/transaction scope**: slot claim is a single O_EXCL file create; compose/network calls happen after the claim and release it on failure.
- **Acceptable orphan states**: a crashed `up` leaves a claimed-but-dead slot — visible in `status`, reclaimable via `down`/`--reap`. A failed logship install leaves no unit enabled (installer is sequential; rerun is idempotent).
- **Auth source of truth**: ingest edge basic auth (bcrypt hash in gitignored `logs-edge.env`, plaintext only in ops `.env`); blast radius of credential leak is log injection on a write-only endpoint, rotation documented.
- **Deferred scope**: platform cloud-init auto-enrollment, metrics remote-write, per-VPS unique credentials / Loki multi-tenancy, browser-console forwarding (spec 093 Deferred Scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)