### PR TITLE
feat(ci): per-PR preview VPS and platform preview pipelines, preview-env skill and docs

### DIFF
--- a/.claude/skills/preview-env/SKILL.md
+++ b/.claude/skills/preview-env/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: preview-env
+description: Spin up, observe, and tear down Matrix OS preview environments — per-PR preview VPSes, platform Cloud Run preview revisions, HMR staging slots — and query their centralized logs. Use when a change needs to be seen running (shell/gateway/onboarding/CLI/macOS features), when asked to deploy a branch for testing, or when you need logs from any preview, staging, or fleet VPS.
+---
+
+# Preview Environments
+
+Production Matrix OS is VPS-native + Cloud Run; previews mirror that. Full
+reference: `docs/dev/preview-environments.md`. Spec: `specs/093-preview-environments/`.
+
+## Pick the surface
+
+| You changed | Use | How |
+|---|---|---|
+| Shell/gateway/kernel UI, fast iteration | **Staging slot** (HMR, seconds per change) | `./scripts/staging-slot.sh up <worktree>` |
+| Shell/gateway/kernel, production-shaped verify; onboarding (needs virgin VPS) | **Preview VPS** | add the `preview-vps` label to the PR |
+| Platform (packages/platform) | **Platform preview revision** | add the `preview-platform` label to the PR |
+| macOS app | CI artifact + any preview VPS via `app.matrix-os.com/vm/<handle>` | build artifact from `macos-086.yml` |
+| CLI | npm dist-tag paired with a preview VPS profile | see docs |
+
+## Staging slots (inner loop)
+
+Run from the ops VPS, repo root or any checkout:
+
+```bash
+./scripts/staging-slot.sh up ~/matrix-os.worktrees/<branch>   # claims slot N
+# -> https://staging-<N>.matrix-os.com (HMR: edits in the worktree hot-reload)
+./scripts/staging-slot.sh status            # who owns what
+./scripts/staging-slot.sh down <N>          # release when done — slots are shared!
+```
+
+4 slots max. Always `down` your slot when finished; `status --reap` frees slots
+idle past TTL.
+
+## Preview VPS (verify loop)
+
+Label the PR `preview-vps`. CI builds bundle `0.0.0-pr<N>.<sha7>`, registers it
+**without any channel** (it can never reach real users), provisions VPS `pr-<N>`,
+deploys, and comments the URL. Closed PR ⇒ VPS deleted (daily reaper as backstop,
+72h TTL). Manual run: `gh workflow run preview-vps.yml -f pr=<N>`.
+
+## Logs — one interface for everything
+
+```bash
+./scripts/preview-logs.sh --handle pr-123 [--unit matrix-gateway] [--grep ERROR] [--since 1h]
+./scripts/preview-logs.sh --slot 2 --since 30m
+./scripts/preview-logs.sh --selector '{env="preview"}' --grep "unhandled"
+```
+
+Runs against the central Loki (loopback on the ops VPS). Slot logs ship
+automatically (promtail docker discovery). A preview/fleet VPS ships logs after
+one-time enrollment:
+
+```bash
+PLATFORM_SECRET=... LOGS_INGEST_USER=fleet LOGS_INGEST_PASSWORD=... \
+  ./scripts/enable-vps-logship.sh pr-123 preview
+```
+
+(`LOGS_INGEST_*` live in `~/matrix-os/.env` on the ops VPS.)
+
+## Rules
+
+- Never promote a preview bundle to a channel; never deploy channel-wide from a PR.
+- Never point a preview at production secrets or the production platform service.
+- Tear down what you spin up: `staging-slot.sh down`, close the PR, or delete the
+  VPS via `DELETE /vps/<machineId>` — never directly in Hetzner.
+- Browser-level inspection: drive the preview URL with Playwright/chrome-devtools
+  MCP; passive browser-log forwarding is deferred (spec 093).

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -1,0 +1,127 @@
+# Platform preview revision per PR (spec 093) -- scaffold
+#
+# Label a same-repo PR with `preview-platform` to deploy the platform image to
+# a DEDICATED preview Cloud Run service as a tagged, zero-traffic revision:
+#   https://pr-<N>---<preview-service-url>
+#
+# Safety model: the preview service (vars.CLOUD_RUN_PREVIEW_SERVICE) is a
+# separate Cloud Run service with its own preview-scoped Secret Manager
+# entries (notably platform-preview-database-url -- intended pairing is a
+# Neon branch database). Production CLOUD_RUN_SERVICE and its secrets are
+# never referenced here. The job no-ops with a clear message until the
+# preview service vars/secrets are configured.
+
+name: Preview Platform
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to deploy a platform preview for"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: preview-platform-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Deploy preview revision
+    if: >-
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.pull_request.head.repo.full_name == github.repository &&
+        ((github.event.action == 'labeled' && github.event.label.name == 'preview-platform') ||
+         (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview-platform')))))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ vars.GCP_REGION }}
+      ARTIFACT_REPOSITORY: ${{ vars.ARTIFACT_REPOSITORY }}
+      CLOUD_RUN_PREVIEW_SERVICE: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE }}
+      CLOUD_RUN_SERVICE_ACCOUNT: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT || vars.CLOUD_RUN_SERVICE_ACCOUNT }}
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+    steps:
+      - name: Check preview configuration
+        id: config
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUD_RUN_PREVIEW_SERVICE:-}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLOUD_RUN_PREVIEW_SERVICE is not configured; platform previews are disabled. See specs/093-preview-environments/."
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+        if: steps.config.outputs.configured == 'true'
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        if: steps.config.outputs.configured == 'true'
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Build platform image
+        if: steps.config.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:pr-${PR_NUMBER}-${GITHUB_SHA::12}"
+          gcloud builds submit . \
+            --project "$GCP_PROJECT_ID" \
+            --config cloudbuild.platform.yaml \
+            --substitutions "_IMAGE=$image" \
+            --quiet
+          echo "IMAGE=$image" >> "$GITHUB_ENV"
+
+      - name: Deploy zero-traffic tagged revision to preview service
+        if: steps.config.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          gcloud run deploy "$CLOUD_RUN_PREVIEW_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --image "$IMAGE" \
+            --service-account "$CLOUD_RUN_SERVICE_ACCOUNT" \
+            --tag "pr-${PR_NUMBER}" \
+            --no-traffic \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-preview-database-url:latest,PLATFORM_SECRET=platform-preview-secret:latest" \
+            --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 \
+            --quiet
+          url="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
+            --project "$GCP_PROJECT_ID" --region "$GCP_REGION" \
+            --format json | jq -r --arg tag "pr-${PR_NUMBER}" \
+            '.status.traffic[] | select(.tag == $tag) | .url')"
+          echo "PREVIEW_URL=$url" >> "$GITHUB_ENV"
+
+      - name: Comment preview URL on PR
+        if: steps.config.outputs.configured == 'true' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          body="**Platform preview revision deployed**
+
+          - URL: ${PREVIEW_URL}
+          - Service: \`${CLOUD_RUN_PREVIEW_SERVICE}\` (zero traffic, tag \`pr-${PR_NUMBER}\`)
+
+          Preview revisions use preview-scoped secrets and database; production is untouched."
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | startswith("**Platform preview revision deployed**"))] | .[0].id // ""')"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body" > /dev/null
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" > /dev/null
+          fi

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -15,7 +15,7 @@ name: Preview Platform
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled, synchronize, closed]
   workflow_dispatch:
     inputs:
       pr:
@@ -38,6 +38,7 @@ jobs:
     if: >-
       (github.event_name == 'workflow_dispatch' ||
        (github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.action != 'closed' &&
         ((github.event.action == 'labeled' && github.event.label.name == 'preview-platform') ||
          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview-platform')))))
     runs-on: ubuntu-latest
@@ -125,3 +126,55 @@ jobs:
           else
             gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" > /dev/null
           fi
+
+  teardown:
+    name: Remove preview revision
+    if: >-
+      github.event.action == 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'preview-platform')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ vars.GCP_REGION }}
+      CLOUD_RUN_PREVIEW_SERVICE: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Check preview configuration
+        id: config
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUD_RUN_PREVIEW_SERVICE:-}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLOUD_RUN_PREVIEW_SERVICE is not configured; nothing to tear down."
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        if: steps.config.outputs.configured == 'true'
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Remove tag and delete tagged revisions
+        if: steps.config.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          revisions="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
+            --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json |
+            jq -r --arg tag "pr-${PR_NUMBER}" \
+              '[.status.traffic[] | select(.tag == $tag) | .revisionName] | unique | .[]')"
+          if [ -z "$revisions" ]; then
+            echo "No revisions tagged pr-${PR_NUMBER}; nothing to tear down."
+            exit 0
+          fi
+          gcloud run services update-traffic "$CLOUD_RUN_PREVIEW_SERVICE" \
+            --project "$GCP_PROJECT_ID" --region "$GCP_REGION" \
+            --remove-tags "pr-${PR_NUMBER}" --quiet
+          for rev in $revisions; do
+            gcloud run revisions delete "$rev" \
+              --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --quiet
+            echo "Deleted revision $rev"
+          done

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -78,7 +78,8 @@ jobs:
         if: steps.config.outputs.configured == 'true'
         run: |
           set -euo pipefail
-          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:pr-${PR_NUMBER}-${GITHUB_SHA::12}"
+          head_sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          image="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REPOSITORY}/matrix-platform:pr-${PR_NUMBER}-${head_sha::12}"
           gcloud builds submit . \
             --project "$GCP_PROJECT_ID" \
             --config cloudbuild.platform.yaml \
@@ -101,10 +102,15 @@ jobs:
             --set-secrets "PLATFORM_DATABASE_URL=platform-preview-database-url:latest,PLATFORM_SECRET=platform-preview-secret:latest" \
             --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 \
             --quiet
-          url="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
-            --project "$GCP_PROJECT_ID" --region "$GCP_REGION" \
-            --format json | jq -r --arg tag "pr-${PR_NUMBER}" \
-            '.status.traffic[] | select(.tag == $tag) | .url')"
+          desc="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
+            --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json)"
+          url="$(jq -r --arg tag "pr-${PR_NUMBER}" \
+            '[.status.traffic[] | select(.tag == $tag) | .url] | first // ""' <<< "$desc")"
+          if [ -z "$url" ]; then
+            # Describe can lag a fresh deploy; tagged URLs are deterministic.
+            base="$(jq -r '.status.url' <<< "$desc")"
+            url="https://pr-${PR_NUMBER}---${base#https://}"
+          fi
           echo "PREVIEW_URL=$url" >> "$GITHUB_ENV"
 
       - name: Comment preview URL on PR

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -105,7 +105,7 @@ jobs:
           desc="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
             --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json)"
           url="$(jq -r --arg tag "pr-${PR_NUMBER}" \
-            '[.status.traffic[] | select(.tag == $tag) | .url] | first // ""' <<< "$desc")"
+            '[(.status.traffic // [])[] | select(.tag == $tag) | .url] | first // ""' <<< "$desc")"
           if [ -z "$url" ]; then
             # Describe can lag a fresh deploy; tagged URLs are deterministic.
             base="$(jq -r '.status.url' <<< "$desc")"
@@ -171,7 +171,7 @@ jobs:
           revisions="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
             --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json |
             jq -r --arg tag "pr-${PR_NUMBER}" \
-              '[.status.traffic[] | select(.tag == $tag) | .revisionName] | unique | .[]')"
+              '[(.status.traffic // [])[] | select(.tag == $tag) | .revisionName] | unique | .[]')"
           if [ -z "$revisions" ]; then
             echo "No revisions tagged pr-${PR_NUMBER}; nothing to tear down."
             exit 0

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -334,6 +334,8 @@ jobs:
           set -euo pipefail
           now="$(date +%s)"
           ttl_secs=$((PREVIEW_TTL_HOURS * 3600))
+          lookup_failures=/tmp/reaper-lookup-failures
+          : > "$lookup_failures"
           curl -fsS --max-time 30 \
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
@@ -344,11 +346,17 @@ jobs:
               provisioned="$(jq -r .provisionedAt <<< "$machine")"
               pr="${handle#pr-}"
               pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .state 2>/dev/null || echo unknown)"
+              # Fail-safe: never delete on unconfirmed PR state (spec 093).
+              if [ "$pr_state" = "unknown" ]; then
+                echo "Skipping ${handle}: could not confirm PR #${pr} state" >&2
+                echo "$handle" >> "$lookup_failures"
+                continue
+              fi
               age=$((now - $(date -d "$provisioned" +%s)))
               reason=""
               if [ "$pr_state" = "closed" ]; then
                 reason="PR #${pr} is closed"
-              elif [ "$age" -gt "$ttl_secs" ] && [ "$pr_state" != "unknown" ]; then
+              elif [ "$age" -gt "$ttl_secs" ]; then
                 reason="older than ${PREVIEW_TTL_HOURS}h"
               fi
               if [ -z "$reason" ]; then
@@ -363,3 +371,8 @@ jobs:
                 echo "Failed to delete ${handle} (HTTP ${code})" >&2
               fi
             done
+          if [ -s "$lookup_failures" ]; then
+            echo "Reaper could not confirm PR state for: $(tr '\n' ' ' < "$lookup_failures")" >&2
+            echo "Those VPSes were skipped (fail-safe); failing the job so the skips are visible." >&2
+            exit 1
+          fi

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -348,7 +348,7 @@ jobs:
             while IFS= read -r machine; do
               handle="$(jq -r .handle <<< "$machine")"
               machine_id="$(jq -r .machineId <<< "$machine")"
-              provisioned="$(jq -r .provisionedAt <<< "$machine")"
+              provisioned="$(jq -r '.provisionedAt // empty' <<< "$machine")"
               pr="${handle#pr-}"
               pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .state 2>/dev/null || echo unknown)"
               # Fail-safe: never delete on unconfirmed PR state (spec 093).
@@ -357,15 +357,21 @@ jobs:
                 echo "$handle" >> "$lookup_failures"
                 continue
               fi
-              age=$((now - $(date -d "$provisioned" +%s)))
               reason=""
               if [ "$pr_state" = "closed" ]; then
                 reason="PR #${pr} is closed"
-              elif [ "$age" -gt "$ttl_secs" ]; then
-                reason="older than ${PREVIEW_TTL_HOURS}h"
-              fi
-              if [ -z "$reason" ]; then
-                echo "Keeping ${handle} (PR ${pr_state}, age $((age / 3600))h)"
+              # failed/provisioning VPSes can have a null provisionedAt; a
+              # date crash here would abort the whole sweep under set -e.
+              elif provisioned_epoch="$(date -d "$provisioned" +%s 2>/dev/null)" && [ -n "$provisioned" ]; then
+                age=$((now - provisioned_epoch))
+                if [ "$age" -gt "$ttl_secs" ]; then
+                  reason="older than ${PREVIEW_TTL_HOURS}h"
+                else
+                  echo "Keeping ${handle} (PR ${pr_state}, age $((age / 3600))h)"
+                  continue
+                fi
+              else
+                echo "Keeping ${handle} (PR ${pr_state}, no valid provisionedAt; age-based reaping skipped)"
                 continue
               fi
               echo "Reaping ${handle}: ${reason}"

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -223,6 +223,9 @@ jobs:
             echo "Provision accepted; waiting for the VPS to come up..."
             deadline=$((SECONDS + 600))
             while true; do
+              # Let the record settle before reading; a fresh provision can
+              # transiently read as absent.
+              sleep 15
               status="$(curl -fsS --max-time 30 \
                 -H "authorization: Bearer ${PLATFORM_SECRET}" \
                 "${PLATFORM_PUBLIC_URL}/vps/fleet" |
@@ -335,7 +338,9 @@ jobs:
           now="$(date +%s)"
           ttl_secs=$((PREVIEW_TTL_HOURS * 3600))
           lookup_failures=/tmp/reaper-lookup-failures
+          delete_failures=/tmp/reaper-delete-failures
           : > "$lookup_failures"
+          : > "$delete_failures"
           curl -fsS --max-time 30 \
             -H "authorization: Bearer ${PLATFORM_SECRET}" \
             "${PLATFORM_PUBLIC_URL}/vps/fleet" |
@@ -369,10 +374,20 @@ jobs:
                 -H "authorization: Bearer ${PLATFORM_SECRET}")"
               if [ "$code" != "200" ]; then
                 echo "Failed to delete ${handle} (HTTP ${code})" >&2
+                echo "$handle" >> "$delete_failures"
               fi
             done
+          failed=0
           if [ -s "$lookup_failures" ]; then
             echo "Reaper could not confirm PR state for: $(tr '\n' ' ' < "$lookup_failures")" >&2
-            echo "Those VPSes were skipped (fail-safe); failing the job so the skips are visible." >&2
+            echo "Those VPSes were skipped (fail-safe)." >&2
+            failed=1
+          fi
+          if [ -s "$delete_failures" ]; then
+            echo "Reaper could not delete: $(tr '\n' ' ' < "$delete_failures")" >&2
+            failed=1
+          fi
+          if [ "$failed" -ne 0 ]; then
+            echo "Failing the job so skips/failed deletes are visible instead of silently accumulating cost." >&2
             exit 1
           fi

--- a/.github/workflows/preview-vps.yml
+++ b/.github/workflows/preview-vps.yml
@@ -1,0 +1,365 @@
+# Preview VPS per PR (spec 093)
+#
+# Label a same-repo PR with `preview-vps` to get a disposable Hetzner VPS
+# running that PR's host bundle, reachable at app.matrix-os.com/vm/pr-<N>.
+#
+# Flow:
+#   deploy   — on label / push while labeled: build bundle 0.0.0-pr<N>.<sha7>,
+#              publish register-only (--channel none, never promoted),
+#              provision pr-<N> if absent, deploy the exact version, comment.
+#   teardown — on PR close: delete the pr-<N> VPS.
+#   reaper   — daily: delete any pr-* VPS whose PR is closed or older than 72h,
+#              so orphans cannot accumulate Hetzner cost.
+#
+# Centralized logs: enroll once from the ops box with
+#   ./scripts/enable-vps-logship.sh pr-<N> preview
+# then query with ./scripts/preview-logs.sh --handle pr-<N>.
+
+name: Preview VPS
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened, closed]
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to deploy a preview VPS for"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: preview-vps-${{ github.event.pull_request.number || inputs.pr || 'reaper' }}
+  cancel-in-progress: ${{ github.event.action != 'closed' && github.event_name != 'schedule' }}
+
+env:
+  PREVIEW_TTL_HOURS: 72
+
+jobs:
+  gate:
+    name: Gate
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      action: ${{ steps.decide.outputs.action }}
+      pr: ${{ steps.decide.outputs.pr }}
+      handle: ${{ steps.decide.outputs.handle }}
+    steps:
+      - name: Decide action
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+          LABELED_NAME: ${{ github.event.label.name }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'preview-vps') }}
+          SAME_REPO: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          set -euo pipefail
+          action="skip"
+          if [ "$SAME_REPO" != "true" ]; then
+            echo "Fork PRs never get preview VPSes (secrets are not exposed to them anyway)."
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            action="deploy"
+          elif [ "$EVENT_ACTION" = "closed" ]; then
+            if [ "$HAS_LABEL" = "true" ]; then action="teardown"; fi
+          elif [ "$EVENT_ACTION" = "labeled" ]; then
+            if [ "$LABELED_NAME" = "preview-vps" ]; then action="deploy"; fi
+          elif [ "$HAS_LABEL" = "true" ]; then
+            action="deploy"
+          fi
+          if ! printf '%s' "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
+            echo "Invalid PR number" >&2
+            exit 1
+          fi
+          {
+            echo "action=$action"
+            echo "pr=$PR_NUMBER"
+            echo "handle=pr-$PR_NUMBER"
+          } >> "$GITHUB_OUTPUT"
+          echo "action=$action pr=$PR_NUMBER"
+
+  build:
+    name: Build preview bundle
+    needs: gate
+    if: needs.gate.outputs.action == 'deploy'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY || vars.NEXT_PUBLIC_POSTHOG_KEY }}
+      NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN || vars.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN }}
+      NEXT_PUBLIC_POSTHOG_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com' }}
+      NEXT_PUBLIC_POSTHOG_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || 'https://eu.i.posthog.com' }}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: 28
+          elixir-version: 1.19
+
+      - name: Validate public build environment
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}" ]; then
+            echo "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is required." >&2
+            exit 1
+          fi
+          if [ "$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" = "pk_test_Y2xlcmsuZXhhbXBsZS5jb20k" ]; then
+            echo "Refusing to build a preview bundle with the example Clerk key." >&2
+            exit 1
+          fi
+
+      - name: Generate preview version
+        id: version
+        env:
+          PR_NUMBER: ${{ needs.gate.outputs.pr }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          VERSION="0.0.0-pr${PR_NUMBER}.${HEAD_SHA:0:7}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Preview version: $VERSION"
+
+      - name: Build host bundle
+        env:
+          HOST_BUNDLE_VERSION: ${{ steps.version.outputs.version }}
+          HOST_BUNDLE_CHANNEL: none
+          MATRIX_BUILD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          MATRIX_BUILD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          ./scripts/build-host-bundle.sh
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-bundle-${{ needs.gate.outputs.pr }}
+          path: |
+            dist/host-bundle/matrix-host-bundle.tar.gz
+            dist/host-bundle/matrix-host-bundle.tar.gz.sha256
+            dist/host-bundle/manifest.json
+            dist/host-bundle/release.json
+          if-no-files-found: error
+          retention-days: 3
+
+  deploy:
+    name: Publish and deploy preview VPS
+    needs: [gate, build]
+    if: needs.gate.outputs.action == 'deploy'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      R2_ACCOUNT_ID: ${{ secrets.R2_BUNDLES_ACCOUNT_ID || secrets.R2_ACCOUNT_ID }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_BUNDLES_ACCESS_KEY_ID || secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BUNDLES_SECRET_ACCESS_KEY || secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET: ${{ vars.R2_BUNDLES_BUCKET || vars.R2_BUCKET || 'matrixos-sync' }}
+      R2_ENDPOINT: ${{ vars.R2_BUNDLES_ENDPOINT || vars.R2_ENDPOINT || format('https://{0}.r2.cloudflarestorage.com', secrets.R2_BUNDLES_ACCOUNT_ID || secrets.R2_ACCOUNT_ID) }}
+      PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
+      PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
+      PREVIEW_CLERK_USER_ID: ${{ secrets.PREVIEW_CLERK_USER_ID }}
+      HANDLE: ${{ needs.gate.outputs.handle }}
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Download bundle artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: preview-bundle-${{ needs.gate.outputs.pr }}
+          path: dist/host-bundle
+
+      - name: Publish release (register-only, no channel)
+        run: |
+          set -euo pipefail
+          ./scripts/publish-release.sh "$VERSION" --channel none \
+            --changelog "Preview bundle for PR #${{ needs.gate.outputs.pr }}"
+
+      - name: Provision preview VPS if absent
+        run: |
+          set -euo pipefail
+          if [ -z "${PREVIEW_CLERK_USER_ID:-}" ]; then
+            echo "PREVIEW_CLERK_USER_ID secret is not configured." >&2
+            exit 1
+          fi
+          status="$(curl -fsS --max-time 30 \
+            -H "authorization: Bearer ${PLATFORM_SECRET}" \
+            "${PLATFORM_PUBLIC_URL}/vps/fleet" |
+            jq -r --arg h "$HANDLE" \
+              '[.machines[] | select(.handle == $h and .status != "deleted")] | .[0].status // "absent"')"
+          echo "Fleet status for ${HANDLE}: ${status}"
+          if [ "$status" = "absent" ]; then
+            code="$(curl -sS --max-time 60 -o /tmp/provision.json -w '%{http_code}' \
+              -X POST "${PLATFORM_PUBLIC_URL}/vps/provision" \
+              -H "authorization: Bearer ${PLATFORM_SECRET}" \
+              -H "content-type: application/json" \
+              -d "{\"clerkUserId\":\"${PREVIEW_CLERK_USER_ID}\",\"handle\":\"${HANDLE}\",\"runtimeSlot\":\"preview\"}")"
+            if [ "$code" != "202" ] && [ "$code" != "200" ]; then
+              echo "Provision failed with HTTP ${code} (body in workflow log)" >&2
+              cat /tmp/provision.json >&2
+              exit 1
+            fi
+            echo "Provision accepted; waiting for the VPS to come up..."
+            deadline=$((SECONDS + 600))
+            while true; do
+              status="$(curl -fsS --max-time 30 \
+                -H "authorization: Bearer ${PLATFORM_SECRET}" \
+                "${PLATFORM_PUBLIC_URL}/vps/fleet" |
+                jq -r --arg h "$HANDLE" \
+                  '[.machines[] | select(.handle == $h)] | .[0].status // "absent"')"
+              [ "$status" = "running" ] && break
+              if [ "$status" = "failed" ]; then
+                echo "Provisioning failed for ${HANDLE}" >&2
+                exit 1
+              fi
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "Timed out waiting for ${HANDLE} to reach running (last: ${status})" >&2
+                exit 1
+              fi
+              sleep 15
+            done
+          fi
+
+      - name: Deploy preview bundle to preview VPS
+        run: |
+          set -euo pipefail
+          attempt() {
+            curl -sS --max-time 120 -o /tmp/deploy.json -w '%{http_code}' \
+              -X POST "${PLATFORM_PUBLIC_URL}/vps/deploy" \
+              -H "authorization: Bearer ${PLATFORM_SECRET}" \
+              -H "content-type: application/json" \
+              -d "{\"version\":\"${VERSION}\",\"handle\":\"${HANDLE}\"}"
+          }
+          code="$(attempt)"
+          if [ "$code" != "200" ]; then
+            echo "Deploy returned HTTP ${code}; retrying once in 30s..."
+            sleep 30
+            code="$(attempt)"
+          fi
+          if [ "$code" != "200" ]; then
+            echo "Deploy failed with HTTP ${code} (body in workflow log)" >&2
+            cat /tmp/deploy.json >&2
+            exit 1
+          fi
+          jq . /tmp/deploy.json
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ needs.gate.outputs.pr }}
+        run: |
+          set -euo pipefail
+          body="**Preview VPS deployed**
+
+          - Shell: https://app.matrix-os.com/vm/${HANDLE}
+          - Bundle: \`${VERSION}\`
+          - Logs (from the ops box): \`./scripts/preview-logs.sh --handle ${HANDLE}\` (enroll first with \`./scripts/enable-vps-logship.sh ${HANDLE} preview\`)
+
+          The VPS is deleted when this PR closes, or by the daily reaper after ${PREVIEW_TTL_HOURS}h."
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+            --jq '[.[] | select(.body | startswith("**Preview VPS deployed**"))] | .[0].id // ""')"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body" > /dev/null
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -f body="$body" > /dev/null
+          fi
+
+  teardown:
+    name: Teardown preview VPS
+    needs: gate
+    if: needs.gate.outputs.action == 'teardown'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
+      PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
+      HANDLE: ${{ needs.gate.outputs.handle }}
+    steps:
+      - name: Delete preview VPS
+        run: |
+          set -euo pipefail
+          machine_id="$(curl -fsS --max-time 30 \
+            -H "authorization: Bearer ${PLATFORM_SECRET}" \
+            "${PLATFORM_PUBLIC_URL}/vps/fleet" |
+            jq -r --arg h "$HANDLE" \
+              '[.machines[] | select(.handle == $h and .status != "deleted")] | .[0].machineId // ""')"
+          if [ -z "$machine_id" ]; then
+            echo "No active VPS for ${HANDLE}; nothing to tear down."
+            exit 0
+          fi
+          code="$(curl -sS --max-time 60 -o /tmp/delete.json -w '%{http_code}' \
+            -X DELETE "${PLATFORM_PUBLIC_URL}/vps/${machine_id}" \
+            -H "authorization: Bearer ${PLATFORM_SECRET}")"
+          if [ "$code" != "200" ]; then
+            echo "Delete failed with HTTP ${code} (body in workflow log)" >&2
+            cat /tmp/delete.json >&2
+            exit 1
+          fi
+          echo "Deleted ${HANDLE} (${machine_id})"
+
+  reaper:
+    name: Reap stale preview VPSes
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PLATFORM_PUBLIC_URL: ${{ vars.PLATFORM_PUBLIC_URL || 'https://app.matrix-os.com' }}
+      PLATFORM_SECRET: ${{ secrets.PLATFORM_SECRET }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Delete previews for closed PRs and expired previews
+        run: |
+          set -euo pipefail
+          now="$(date +%s)"
+          ttl_secs=$((PREVIEW_TTL_HOURS * 3600))
+          curl -fsS --max-time 30 \
+            -H "authorization: Bearer ${PLATFORM_SECRET}" \
+            "${PLATFORM_PUBLIC_URL}/vps/fleet" |
+            jq -c '.machines[] | select((.handle | test("^pr-[0-9]+$")) and .status != "deleted")' |
+            while IFS= read -r machine; do
+              handle="$(jq -r .handle <<< "$machine")"
+              machine_id="$(jq -r .machineId <<< "$machine")"
+              provisioned="$(jq -r .provisionedAt <<< "$machine")"
+              pr="${handle#pr-}"
+              pr_state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .state 2>/dev/null || echo unknown)"
+              age=$((now - $(date -d "$provisioned" +%s)))
+              reason=""
+              if [ "$pr_state" = "closed" ]; then
+                reason="PR #${pr} is closed"
+              elif [ "$age" -gt "$ttl_secs" ] && [ "$pr_state" != "unknown" ]; then
+                reason="older than ${PREVIEW_TTL_HOURS}h"
+              fi
+              if [ -z "$reason" ]; then
+                echo "Keeping ${handle} (PR ${pr_state}, age $((age / 3600))h)"
+                continue
+              fi
+              echo "Reaping ${handle}: ${reason}"
+              code="$(curl -sS --max-time 60 -o /dev/null -w '%{http_code}' \
+                -X DELETE "${PLATFORM_PUBLIC_URL}/vps/${machine_id}" \
+                -H "authorization: Bearer ${PLATFORM_SECRET}")"
+              if [ "$code" != "200" ]; then
+                echo "Failed to delete ${handle} (HTTP ${code})" >&2
+              fi
+            done

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ paper/*.log
 paper/*.out
 paper/*.pdf
 .gstack/
+distro/observability/logs-edge/logs-edge.env

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ www/next-env.d.ts
 .zencoder/
 .agents/skills/
 .claude/skills/*
+# Repo-shared agent skills are explicitly re-included (preview environments)
+!.claude/skills/preview-env/
 /skills/
 skills-lock.json
 # Symphony worker skills must be present in unattended repo clones

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,7 @@ Read these on demand, not every session:
 - `docs/dev/pr-review-analysis.md` -- when triaging review comments or understanding recurring defect patterns
 - `docs/dev/docker-development.md` -- when working on Docker setup or debugging container issues
 - `docs/dev/vps-deployment.md` -- when deploying to production or managing the VPS
+- `docs/dev/preview-environments.md` -- when a change needs to be seen running: per-PR preview VPSes (`preview-vps` label), platform preview revisions, HMR staging slots, and centralized log queries via `scripts/preview-logs.sh`
 - `docs/dev/releases.md` -- when tagging a release or managing versions
 - `specs/quality-gates.md` -- when writing a new spec or reviewing a PR
 - `specs/ux-guide.md` -- when working on shell/frontend UI

--- a/distro/cloudflared.yml
+++ b/distro/cloudflared.yml
@@ -4,9 +4,29 @@ credentials-file: /etc/cloudflared/credentials.json
 ingress:
   - hostname: grafana.matrix-os.com
     service: http://grafana:3000
+  # Authenticated push-only Loki ingest edge (basic auth in logs-edge).
+  - hostname: logs.matrix-os.com
+    service: http://logs-edge:8080
   # Staging dev container (HMR shell).
   - hostname: staging.matrix-os.com
     service: http://matrixos-staging:3000
   - hostname: api-staging.matrix-os.com
     service: http://matrixos-staging:4000
+  # Per-worktree HMR staging slots (scripts/staging-slot.sh).
+  - hostname: staging-1.matrix-os.com
+    service: http://matrixos-staging-1:3000
+  - hostname: api-staging-1.matrix-os.com
+    service: http://matrixos-staging-1:4000
+  - hostname: staging-2.matrix-os.com
+    service: http://matrixos-staging-2:3000
+  - hostname: api-staging-2.matrix-os.com
+    service: http://matrixos-staging-2:4000
+  - hostname: staging-3.matrix-os.com
+    service: http://matrixos-staging-3:3000
+  - hostname: api-staging-3.matrix-os.com
+    service: http://matrixos-staging-3:4000
+  - hostname: staging-4.matrix-os.com
+    service: http://matrixos-staging-4:3000
+  - hostname: api-staging-4.matrix-os.com
+    service: http://matrixos-staging-4:4000
   - service: http_status:404

--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -73,7 +73,8 @@ case "$ARCH" in
 esac
 
 install_alloy() {
-  if [ -x /usr/local/bin/alloy ] && /usr/local/bin/alloy --version 2>/dev/null | grep -q "$ALLOY_VERSION"; then
+  # Exact token match so v1.16.3 does not false-hit v1.16.30.
+  if [ -x /usr/local/bin/alloy ] && /usr/local/bin/alloy --version 2>/dev/null | tr ' ' '\n' | grep -qx "$ALLOY_VERSION"; then
     return 0
   fi
   tmpdir="$(mktemp -d)"

--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -2,13 +2,15 @@
 # Install and enable the Grafana Alloy log shipper on a Matrix OS VPS.
 #
 # Usage:
-#   matrix-install-logship <ingest-url> <user> <password> <handle> <env>
+#   LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... \
+#     matrix-install-logship <ingest-url> <handle> <env>
 #
 #   ingest-url  https URL of the Loki push edge (e.g. https://logs.matrix-os.com)
-#   user        basic-auth user for the ingest edge
-#   password    basic-auth password for the ingest edge
 #   handle      this VPS's matrix handle (labels every stream)
 #   env         one of: preview | prod | staging
+#
+# Credentials come via environment variables, never argv: /proc/<pid>/cmdline
+# is world-readable, /proc/<pid>/environ is owner/root-only.
 #
 # Self-contained: downloads a pinned, checksum-verified Alloy binary, writes
 # /etc/alloy/matrix-logship.alloy, /opt/matrix/env/logship.env (0600), and the
@@ -26,16 +28,16 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-if [ "$#" -ne 5 ]; then
-  echo "usage: matrix-install-logship <ingest-url> <user> <password> <handle> <env>" >&2
+if [ "$#" -ne 3 ]; then
+  echo "usage: LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... matrix-install-logship <ingest-url> <handle> <env>" >&2
   exit 64
 fi
 
 INGEST_URL="$1"
-INGEST_USER="$2"
-INGEST_PASSWORD="$3"
-HANDLE="$4"
-MATRIX_ENV="$5"
+HANDLE="$2"
+MATRIX_ENV="$3"
+INGEST_USER="${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set in the environment}"
+INGEST_PASSWORD="${LOGS_INGEST_PASSWORD:?LOGS_INGEST_PASSWORD must be set in the environment}"
 
 case "$INGEST_URL" in
   https://*) ;;

--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -167,11 +167,10 @@ EOF
 chmod 0640 /etc/alloy/matrix-logship.alloy
 
 umask 077
-cat > /opt/matrix/env/logship.env << EOF
-LOGS_INGEST_URL=${INGEST_URL}
-LOGS_INGEST_USER=${INGEST_USER}
-LOGS_INGEST_PASSWORD=${INGEST_PASSWORD}
-EOF
+# printf %s writes values byte-for-byte; no heredoc/expansion semantics to
+# reason about for credentials containing shell-special characters.
+printf 'LOGS_INGEST_URL=%s\nLOGS_INGEST_USER=%s\nLOGS_INGEST_PASSWORD=%s\n' \
+  "$INGEST_URL" "$INGEST_USER" "$INGEST_PASSWORD" > /opt/matrix/env/logship.env
 chmod 0600 /opt/matrix/env/logship.env
 
 cat > /etc/systemd/system/matrix-logship.service << 'EOF'

--- a/distro/customer-vps/host-bin/matrix-install-logship
+++ b/distro/customer-vps/host-bin/matrix-install-logship
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Install and enable the Grafana Alloy log shipper on a Matrix OS VPS.
+#
+# Usage:
+#   matrix-install-logship <ingest-url> <user> <password> <handle> <env>
+#
+#   ingest-url  https URL of the Loki push edge (e.g. https://logs.matrix-os.com)
+#   user        basic-auth user for the ingest edge
+#   password    basic-auth password for the ingest edge
+#   handle      this VPS's matrix handle (labels every stream)
+#   env         one of: preview | prod | staging
+#
+# Self-contained: downloads a pinned, checksum-verified Alloy binary, writes
+# /etc/alloy/matrix-logship.alloy, /opt/matrix/env/logship.env (0600), and the
+# matrix-logship systemd unit, then enables the service. Idempotent: re-running
+# updates config/credentials in place. Log shipping never blocks Matrix
+# services; the unit is independent and restarts on failure.
+set -euo pipefail
+
+ALLOY_VERSION="v1.16.3"
+ALLOY_SHA256_AMD64="65f408f830e46d6a13c348f07b24f1763b083e711ea38384dc2938f792a93045"
+ALLOY_SHA256_ARM64="37063858b2707c865081e8f8abce44cbadc7368e3aea71382b50c7dddc6a3051"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "matrix-install-logship: must run as root" >&2
+  exit 1
+fi
+
+if [ "$#" -ne 5 ]; then
+  echo "usage: matrix-install-logship <ingest-url> <user> <password> <handle> <env>" >&2
+  exit 64
+fi
+
+INGEST_URL="$1"
+INGEST_USER="$2"
+INGEST_PASSWORD="$3"
+HANDLE="$4"
+MATRIX_ENV="$5"
+
+case "$INGEST_URL" in
+  https://*) ;;
+  *)
+    echo "matrix-install-logship: ingest-url must be https://" >&2
+    exit 64
+    ;;
+esac
+if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
+  echo "matrix-install-logship: invalid handle" >&2
+  exit 64
+fi
+case "$MATRIX_ENV" in
+  preview | prod | staging) ;;
+  *)
+    echo "matrix-install-logship: env must be preview|prod|staging" >&2
+    exit 64
+    ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)
+    ALLOY_ARCH="amd64"
+    ALLOY_SHA256="$ALLOY_SHA256_AMD64"
+    ;;
+  aarch64)
+    ALLOY_ARCH="arm64"
+    ALLOY_SHA256="$ALLOY_SHA256_ARM64"
+    ;;
+  *)
+    echo "matrix-install-logship: unsupported arch $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+install_alloy() {
+  if [ -x /usr/local/bin/alloy ] && /usr/local/bin/alloy --version 2>/dev/null | grep -q "$ALLOY_VERSION"; then
+    return 0
+  fi
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+  url="https://github.com/grafana/alloy/releases/download/${ALLOY_VERSION}/alloy-linux-${ALLOY_ARCH}.zip"
+  echo "matrix-install-logship: downloading alloy ${ALLOY_VERSION} (${ALLOY_ARCH})"
+  curl -fsSL --max-time 300 --retry 3 -o "$tmpdir/alloy.zip" "$url"
+  echo "${ALLOY_SHA256}  $tmpdir/alloy.zip" | sha256sum -c - >/dev/null
+  unzip -oq "$tmpdir/alloy.zip" -d "$tmpdir"
+  install -m 0755 "$tmpdir/alloy-linux-${ALLOY_ARCH}" /usr/local/bin/alloy
+}
+
+install_alloy
+
+install -d -m 0750 /etc/alloy /var/lib/alloy
+
+MATRIX_HOME_LOGS="/home/matrix/home/system/logs"
+
+cat > /etc/alloy/matrix-logship.alloy << EOF
+// Matrix OS log shipper. Managed by matrix-install-logship; do not hand-edit.
+
+loki.write "central" {
+  endpoint {
+    url = sys.env("LOGS_INGEST_URL") + "/loki/api/v1/push"
+    basic_auth {
+      username = sys.env("LOGS_INGEST_USER")
+      password = sys.env("LOGS_INGEST_PASSWORD")
+    }
+  }
+  external_labels = {
+    handle = "${HANDLE}",
+    env    = "${MATRIX_ENV}",
+  }
+}
+
+loki.relabel "journal" {
+  forward_to = []
+  rule {
+    source_labels = ["__journal__systemd_unit"]
+    target_label  = "unit"
+  }
+}
+
+loki.source.journal "matrix_units" {
+  matches       = "_SYSTEMD_UNIT=matrix-gateway.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+loki.source.journal "matrix_shell" {
+  matches       = "_SYSTEMD_UNIT=matrix-shell.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+loki.source.journal "matrix_sync" {
+  matches       = "_SYSTEMD_UNIT=matrix-sync-agent.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+loki.source.journal "matrix_code" {
+  matches       = "_SYSTEMD_UNIT=matrix-code.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+loki.source.journal "matrix_symphony" {
+  matches       = "_SYSTEMD_UNIT=matrix-symphony.service"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = { source = "journal" }
+  forward_to    = [loki.write.central.receiver]
+}
+
+local.file_match "kernel_jsonl" {
+  path_targets = [{ __path__ = "${MATRIX_HOME_LOGS}/*.jsonl" }]
+}
+
+loki.source.file "kernel_logs" {
+  targets    = local.file_match.kernel_jsonl.targets
+  forward_to = [loki.write.central.receiver]
+}
+EOF
+chmod 0640 /etc/alloy/matrix-logship.alloy
+
+umask 077
+cat > /opt/matrix/env/logship.env << EOF
+LOGS_INGEST_URL=${INGEST_URL}
+LOGS_INGEST_USER=${INGEST_USER}
+LOGS_INGEST_PASSWORD=${INGEST_PASSWORD}
+EOF
+chmod 0600 /opt/matrix/env/logship.env
+
+cat > /etc/systemd/system/matrix-logship.service << 'EOF'
+[Unit]
+Description=Matrix OS log shipper (Grafana Alloy)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/opt/matrix/env/logship.env
+ExecStart=/usr/local/bin/alloy run --storage.path=/var/lib/alloy /etc/alloy/matrix-logship.alloy
+Restart=on-failure
+RestartSec=10
+# Read-only view of the system; writable state only under /var/lib/alloy.
+ProtectSystem=full
+ReadWritePaths=/var/lib/alloy
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now matrix-logship.service
+echo "matrix-install-logship: enabled matrix-logship.service (handle=${HANDLE} env=${MATRIX_ENV})"

--- a/distro/observability/docker-compose.observability.yml
+++ b/distro/observability/docker-compose.observability.yml
@@ -40,9 +40,12 @@ services:
     image: caddy:2-alpine
     # Authenticated push-only front for Loki, reachable only via the
     # cloudflared tunnel (logs.matrix-os.com). No host port on purpose.
-    environment:
-      - LOGS_INGEST_USER=${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set}
-      - LOGS_INGEST_PASSWORD_HASH=${LOGS_INGEST_PASSWORD_HASH:?LOGS_INGEST_PASSWORD_HASH must be set}
+    # Credentials come via env_file with format: raw -- the bcrypt hash
+    # contains `$` sequences that compose interpolation would mangle.
+    # Copy logs-edge.env.example to logs-edge.env.
+    env_file:
+      - path: ./observability/logs-edge/logs-edge.env
+        format: raw
     volumes:
       - ./observability/logs-edge/Caddyfile:/etc/caddy/Caddyfile:ro
     depends_on:

--- a/distro/observability/docker-compose.observability.yml
+++ b/distro/observability/docker-compose.observability.yml
@@ -36,6 +36,27 @@ services:
       - observability
       - matrixos-net
 
+  logs-edge:
+    image: caddy:2-alpine
+    # Authenticated push-only front for Loki, reachable only via the
+    # cloudflared tunnel (logs.matrix-os.com). No host port on purpose.
+    environment:
+      - LOGS_INGEST_USER=${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set}
+      - LOGS_INGEST_PASSWORD_HASH=${LOGS_INGEST_PASSWORD_HASH:?LOGS_INGEST_PASSWORD_HASH must be set}
+    volumes:
+      - ./observability/logs-edge/Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - loki
+    healthcheck:
+      test: wget -qO- http://localhost:8080/healthz || exit 1
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - observability
+      - matrixos-net
+
   grafana:
     image: grafana/grafana:latest
     # Loopback only: public access goes through the cloudflared tunnel

--- a/distro/observability/logs-edge/Caddyfile
+++ b/distro/observability/logs-edge/Caddyfile
@@ -19,6 +19,8 @@
 		basic_auth {
 			{$LOGS_INGEST_USER} {$LOGS_INGEST_PASSWORD_HASH}
 		}
+		# Senders must not steer Loki multi-tenancy.
+		request_header -X-Scope-OrgID
 		reverse_proxy loki:3100
 	}
 

--- a/distro/observability/logs-edge/Caddyfile
+++ b/distro/observability/logs-edge/Caddyfile
@@ -1,0 +1,32 @@
+# Authenticated push-only ingest edge for Loki.
+# Exposed exclusively through the cloudflared tunnel as logs.matrix-os.com;
+# the container publishes no host port. Only POST /loki/api/v1/push is
+# forwarded; every other path returns 404 so the Loki query API is never
+# reachable from outside the docker network.
+
+{
+	admin off
+	auto_https off
+}
+
+:8080 {
+	@push {
+		method POST
+		path /loki/api/v1/push
+	}
+
+	handle @push {
+		basic_auth {
+			{$LOGS_INGEST_USER} {$LOGS_INGEST_PASSWORD_HASH}
+		}
+		reverse_proxy loki:3100
+	}
+
+	handle /healthz {
+		respond "ok" 200
+	}
+
+	handle {
+		respond 404
+	}
+}

--- a/distro/observability/logs-edge/logs-edge.env.example
+++ b/distro/observability/logs-edge/logs-edge.env.example
@@ -1,0 +1,6 @@
+# Copy to logs-edge.env (gitignored) next to this file.
+# Generate the hash with:
+#   docker run --rm caddy:2-alpine caddy hash-password --plaintext '<password>'
+# Values are passed verbatim (env_file) -- do NOT escape the $ in the hash.
+LOGS_INGEST_USER=fleet
+LOGS_INGEST_PASSWORD_HASH=$2a$14$replace-with-real-bcrypt-hash

--- a/docker-compose.staging-db.yml
+++ b/docker-compose.staging-db.yml
@@ -1,0 +1,39 @@
+# Shared dev Postgres for staging slots on the ops VPS.
+#
+# The legacy platform postgres was retired in the Cloud Run cutover, so
+# staging slots get their own dev database server. It joins matrixos-net
+# with the network alias "postgres" (what the slot containers' DATABASE_URL
+# expects). Each slot uses its own database: matrixos_staging_<n>, created
+# by scripts/staging-slot.sh on claim. No host port -- docker-network only.
+#
+# Managed by scripts/staging-slot.sh; manual usage:
+#   docker compose -f docker-compose.staging-db.yml --env-file .env up -d
+
+services:
+  staging-postgres:
+    image: postgres:16-alpine
+    container_name: matrixos-staging-postgres
+    environment:
+      - POSTGRES_USER=${STAGING_DB_USER:-matrixos}
+      - POSTGRES_PASSWORD=${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}
+      - POSTGRES_DB=matrixos_staging
+    volumes:
+      - staging-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -U ${STAGING_DB_USER:-matrixos}
+      interval: 10s
+      timeout: 5s
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      matrixos-net:
+        aliases:
+          - postgres
+
+volumes:
+  staging-pgdata:
+
+networks:
+  matrixos-net:
+    external: true
+    name: matrixos-net

--- a/docker-compose.staging-slot.yml
+++ b/docker-compose.staging-slot.yml
@@ -1,0 +1,75 @@
+# Matrix OS -- Per-worktree staging slot (1..4) on the ops VPS
+#
+# Parameterized variant of docker-compose.staging.yml driven by
+# scripts/staging-slot.sh. Each slot is a hot-reloading dev container whose
+# source is bind-mounted from a git worktree, exposed through the existing
+# cloudflared tunnel as staging-<SLOT>.matrix-os.com /
+# api-staging-<SLOT>.matrix-os.com.
+#
+# Do not invoke directly; scripts/staging-slot.sh sets SLOT, the project
+# name (mx-staging-<SLOT>), and the project directory (the worktree), and
+# records ownership in ~/.matrixos/staging-slots/.
+#
+# Reuses the platform postgres on matrixos-net with database
+# matrixos_staging_<SLOT>.
+
+services:
+  staging-dev:
+    container_name: matrixos-staging-${SLOT:?staging-slot.sh sets SLOT}
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./packages:/app/packages
+      - ./shell:/app/shell
+      - ./home:/app/home
+      - ./skills:/app/skills
+      - ./tests:/app/tests
+      - ./specs:/app/specs
+      - ./docs:/app/docs
+      - ./distro:/app/distro
+      - ./scripts:/app/scripts
+      - ./package.json:/app/package.json
+      - ./pnpm-workspace.yaml:/app/pnpm-workspace.yaml
+      - ./pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
+      - ./tsconfig.json:/app/tsconfig.json
+      - ./vitest.config.ts:/app/vitest.config.ts
+      - slot-node-modules:/app/node_modules
+      - slot-home:/home/matrixos/home
+    environment:
+      - NODE_ENV=development
+      - MATRIX_HOME=/home/matrixos/home
+      - MATRIX_HANDLE=staging-${SLOT}
+      - MATRIX_DISPLAY_NAME=Staging ${SLOT}
+      - PORT=4000
+      # Public URLs the browser will see. Cloudflared terminates TLS.
+      - NEXT_PUBLIC_GATEWAY_WS=wss://api-staging-${SLOT}.matrix-os.com/ws
+      - NEXT_PUBLIC_GATEWAY_URL=https://api-staging-${SLOT}.matrix-os.com
+      - GATEWAY_URL=http://localhost:4000
+      - POSTHOG_TOKEN=${POSTHOG_TOKEN:-}
+      - POSTHOG_HOST=${POSTHOG_HOST:-}
+      - NEXT_PUBLIC_POSTHOG_KEY=${NEXT_PUBLIC_POSTHOG_KEY:-}
+      - NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=${NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN:-}
+      - NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST:-}
+      - NEXT_PUBLIC_POSTHOG_API_HOST=${NEXT_PUBLIC_POSTHOG_API_HOST:-}
+      # Reuse platform postgres on matrixos-net. Password stays in .env.
+      - DATABASE_URL=${STAGING_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/matrixos_staging_${SLOT}}
+      - PLATFORM_DATABASE_URL=${STAGING_PLATFORM_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/matrixos_staging_${SLOT}}
+    networks:
+      - matrixos-net
+    restart: unless-stopped
+    healthcheck:
+      test: wget -qO- http://localhost:4000/health || exit 1
+      interval: 15s
+      timeout: 5s
+      start_period: 60s
+
+volumes:
+  # Named per compose project (mx-staging-<SLOT>), so each slot keeps its own.
+  slot-node-modules:
+  slot-home:
+
+networks:
+  matrixos-net:
+    external: true
+    name: matrixos-net

--- a/docker-compose.staging-slot.yml
+++ b/docker-compose.staging-slot.yml
@@ -10,8 +10,9 @@
 # name (mx-staging-<SLOT>), and the project directory (the worktree), and
 # records ownership in ~/.matrixos/staging-slots/.
 #
-# Reuses the platform postgres on matrixos-net with database
-# matrixos_staging_<SLOT>.
+# Uses the dedicated staging postgres (docker-compose.staging-db.yml, network
+# alias "postgres" on matrixos-net) with database matrixos_staging_<SLOT>,
+# created by staging-slot.sh on claim.
 
 services:
   staging-dev:
@@ -52,7 +53,7 @@ services:
       - NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=${NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN:-}
       - NEXT_PUBLIC_POSTHOG_HOST=${NEXT_PUBLIC_POSTHOG_HOST:-}
       - NEXT_PUBLIC_POSTHOG_API_HOST=${NEXT_PUBLIC_POSTHOG_API_HOST:-}
-      # Reuse platform postgres on matrixos-net. Password stays in .env.
+      # Dedicated staging postgres (alias "postgres"). Password stays in .env.
       - DATABASE_URL=${STAGING_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/matrixos_staging_${SLOT}}
       - PLATFORM_DATABASE_URL=${STAGING_PLATFORM_DATABASE_URL:-postgresql://${STAGING_DB_USER:-matrixos}:${STAGING_DB_PASSWORD:?set STAGING_DB_PASSWORD in .env}@postgres:5432/matrixos_staging_${SLOT}}
     networks:

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -60,7 +60,8 @@ Add the **`preview-vps`** label to a same-repo PR. The `Preview VPS` workflow:
 
 Teardown is automatic on PR close. A daily reaper deletes any `pr-*` VPS whose
 PR is closed or that is older than 72h — orphaned previews cannot accumulate
-Hetzner cost. Manual deploy: `gh workflow run preview-vps.yml -f pr=<N>`.
+Hetzner cost. The reaper is fail-safe: a VPS whose PR state cannot be confirmed
+is skipped, and the job fails so the skip is visible. Manual deploy: `gh workflow run preview-vps.yml -f pr=<N>`.
 
 Required repo secrets (beyond the existing release secrets):
 `PREVIEW_CLERK_USER_ID` — the Clerk user that owns preview VPSes.
@@ -76,9 +77,10 @@ to the dedicated preview Cloud Run service (`vars.CLOUD_RUN_PREVIEW_SERVICE`)
 as a zero-traffic tagged revision (`https://pr-<N>---<service-url>`), using
 preview-scoped Secret Manager entries (`platform-preview-database-url`,
 `platform-preview-secret`). The intended database pairing is a Neon branch per
-preview (deferred; see spec 093). The job no-ops with a notice until the
-preview service is configured. Production `CLOUD_RUN_SERVICE` and its secrets
-are never referenced.
+preview (deferred; see spec 093). On PR close the workflow removes the
+`pr-<N>` tag and deletes its revisions, mirroring the VPS teardown model. The
+jobs no-op with a notice until the preview service is configured. Production
+`CLOUD_RUN_SERVICE` and its secrets are never referenced.
 
 ## Centralized logs
 

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -1,0 +1,129 @@
+# Preview Environments
+
+How to see a change running, production-shaped, and read its logs — for humans
+and coding agents. Spec: `specs/093-preview-environments/`.
+
+Production Matrix OS is VPS-native per user (host systemd services from a host
+bundle) with the platform on Cloud Run. Previews mirror that architecture
+instead of approximating it with local containers. All previews ship logs to
+the central Loki on the ops VPS, queryable through one script.
+
+## Decision table
+
+| Feature type | Surface | Latency per change | Cost |
+|---|---|---|---|
+| Shell/gateway UI iteration | Staging slot (HMR) | seconds | none (ops VPS) |
+| Shell/gateway/kernel verification | Preview VPS | ~20 min (bundle build + deploy) | 1 small Hetzner VPS until PR close |
+| Onboarding flows | Preview VPS (virgin by construction) | ~20 min | same |
+| Platform changes | Cloud Run preview revision | ~10 min | Cloud Run free-tier-ish |
+| macOS app | CI artifact + preview VPS runtime | n/a | none extra |
+| CLI beta x shell | npm dist-tag + preview VPS profile | minutes | none extra |
+
+## Staging slots — the inner loop
+
+Four hot-reloading dev containers on the ops VPS behind the existing tunnel,
+one per git worktree:
+
+```bash
+./scripts/staging-slot.sh up ~/matrix-os.worktrees/my-feature
+# claimed slot 2:
+#   shell: https://staging-2.matrix-os.com
+#   api:   https://api-staging-2.matrix-os.com
+```
+
+Edits in the worktree hit Turbopack/`tsx watch` directly — no rebuild. Each
+slot gets its own database (`matrixos_staging_<n>` on the dedicated staging
+postgres) and its own named volumes. Slot ownership lives in
+`~/.matrixos/staging-slots/`; claims are race-safe (`O_EXCL`).
+
+- `staging-slot.sh status` — list owners; `status --reap` frees slots idle past
+  `STAGING_SLOT_TTL_HOURS` (default 72).
+- `staging-slot.sh down <n>` — release. Slots are a shared resource; release
+  them when done.
+- `staging-slot.sh logs <n> -f` — raw compose logs; or use `preview-logs.sh
+  --slot <n>` (slot containers ship to Loki automatically via the
+  observability promtail's docker discovery).
+
+## Preview VPS — the verify loop
+
+Add the **`preview-vps`** label to a same-repo PR. The `Preview VPS` workflow:
+
+1. Builds the host bundle as `0.0.0-pr<N>.<sha7>` (re-runs on every push while
+   the label is present).
+2. Publishes it **register-only** (`publish-release.sh --channel none`): the
+   release exists in R2 + platform DB but no channel pointer can ever select
+   it, so it cannot reach real users.
+3. Provisions VPS `pr-<N>` (runtime slot `preview`, bound to the
+   `PREVIEW_CLERK_USER_ID` Clerk user) if absent, then deploys exactly that
+   version to exactly that handle.
+4. Comments the URL on the PR: `https://app.matrix-os.com/vm/pr-<N>`.
+
+Teardown is automatic on PR close. A daily reaper deletes any `pr-*` VPS whose
+PR is closed or that is older than 72h — orphaned previews cannot accumulate
+Hetzner cost. Manual deploy: `gh workflow run preview-vps.yml -f pr=<N>`.
+
+Required repo secrets (beyond the existing release secrets):
+`PREVIEW_CLERK_USER_ID` — the Clerk user that owns preview VPSes.
+
+For richer branch testing flows (staging platform container + feature VPS with
+SSH verification) see the `staging-platform-vps` command, which predates this
+pipeline and remains the manual/deep-debug path.
+
+## Platform preview revisions
+
+Add the **`preview-platform`** label. The workflow deploys the platform image
+to the dedicated preview Cloud Run service (`vars.CLOUD_RUN_PREVIEW_SERVICE`)
+as a zero-traffic tagged revision (`https://pr-<N>---<service-url>`), using
+preview-scoped Secret Manager entries (`platform-preview-database-url`,
+`platform-preview-secret`). The intended database pairing is a Neon branch per
+preview (deferred; see spec 093). The job no-ops with a notice until the
+preview service is configured. Production `CLOUD_RUN_SERVICE` and its secrets
+are never referenced.
+
+## Centralized logs
+
+Everything funnels into the ops-VPS Loki and is queryable one way:
+
+```bash
+./scripts/preview-logs.sh --handle pr-123                      # whole VPS
+./scripts/preview-logs.sh --handle pr-123 --unit matrix-gateway --grep ERROR
+./scripts/preview-logs.sh --slot 2 --since 30m                 # staging slot
+./scripts/preview-logs.sh --selector '{env="preview"}'         # everything preview
+```
+
+Runs against `http://127.0.0.1:3100` on the ops VPS (`LOKI_URL` to override).
+Grafana (`grafana.matrix-os.com`) has the same Loki as a datasource for
+dashboards.
+
+### How logs get there
+
+- **Staging slots / ops containers**: the observability promtail's docker
+  discovery ships any container with `matrixos` in its name. Nothing to do.
+- **VPSes (preview or fleet)**: Grafana Alloy, installed by
+  `matrix-install-logship` (ships in the host bundle `bin/`). It tails the
+  matrix systemd units and the kernel JSONL logs, labels streams with
+  `handle` and `env`, and pushes to `https://logs.matrix-os.com` — a Caddy
+  edge that accepts only authenticated `POST /loki/api/v1/push` (basic auth;
+  Loki's query API is not exposed). Enroll a VPS once from the ops box:
+
+  ```bash
+  PLATFORM_SECRET=... LOGS_INGEST_USER=fleet LOGS_INGEST_PASSWORD=... \
+    ./scripts/enable-vps-logship.sh <handle> <preview|prod|staging>
+  ```
+
+  Credentials live in `~/matrix-os/.env`; the edge's bcrypt hash lives in
+  `distro/observability/logs-edge/logs-edge.env` (gitignored; see the
+  `.example`). Rotate by regenerating both and recreating `logs-edge`, then
+  re-running enrollment.
+- **Fleet auto-enrollment** (every new customer VPS ships logs from first
+  boot) requires platform cloud-init templating and is deferred — spec 093.
+
+## Operational notes
+
+- The tunnel config (`distro/cloudflared.yml`) and observability compose are
+  live, bind-mounted configs on the ops VPS — merged changes there must be
+  applied by restarting the respective containers.
+- Staging slot DNS (`staging-<1..4>`, `api-staging-<1..4>`, `logs`) was created
+  once via `cloudflared tunnel route dns matrix-os <hostname>`.
+- Preview bundles in R2 (`system-bundles/0.0.0-pr*`) can be cleaned after PR
+  close; they are never referenced by channel pointers.

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Enroll a Matrix OS VPS in centralized log shipping from the ops box.
+#
+# Usage:
+#   PLATFORM_SECRET=... LOGS_INGEST_USER=... LOGS_INGEST_PASSWORD=... \
+#     ./scripts/enable-vps-logship.sh <handle> <env>
+#
+#   handle  matrix handle of the VPS (looked up in /vps/fleet)
+#   env     preview | prod | staging
+#
+# Optional env:
+#   PLATFORM_PUBLIC_URL  (default https://app.matrix-os.com)
+#   LOGS_INGEST_URL      (default https://logs.matrix-os.com)
+#   VPS_SSH_KEY          (default ~/.ssh/customer_vps_smoke)
+#
+# Looks up the VPS public IP via the platform fleet API, then runs the
+# bundled matrix-install-logship on the VPS over SSH. v1 enrollment is
+# explicit per-VPS; platform-side auto-enrollment is deferred (spec 093).
+set -euo pipefail
+
+HANDLE="${1:?usage: enable-vps-logship.sh <handle> <env>}"
+MATRIX_ENV="${2:?usage: enable-vps-logship.sh <handle> <env>}"
+PLATFORM_PUBLIC_URL="${PLATFORM_PUBLIC_URL:-https://app.matrix-os.com}"
+LOGS_INGEST_URL="${LOGS_INGEST_URL:-https://logs.matrix-os.com}"
+VPS_SSH_KEY="${VPS_SSH_KEY:-$HOME/.ssh/customer_vps_smoke}"
+
+: "${PLATFORM_SECRET:?PLATFORM_SECRET must be set}"
+: "${LOGS_INGEST_USER:?LOGS_INGEST_USER must be set}"
+: "${LOGS_INGEST_PASSWORD:?LOGS_INGEST_PASSWORD must be set}"
+
+if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
+  echo "enable-vps-logship: invalid handle" >&2
+  exit 64
+fi
+case "$MATRIX_ENV" in
+  preview | prod | staging) ;;
+  *)
+    echo "enable-vps-logship: env must be preview|prod|staging" >&2
+    exit 64
+    ;;
+esac
+
+ip="$(curl -fsS --max-time 10 \
+  -H "authorization: Bearer ${PLATFORM_SECRET}" \
+  "${PLATFORM_PUBLIC_URL}/vps/fleet" |
+  jq -r --arg h "$HANDLE" \
+    '.machines[] | select(.handle == $h and .status == "running") | .publicIPv4' |
+  head -1)"
+
+if [ -z "$ip" ] || [ "$ip" = "null" ]; then
+  echo "enable-vps-logship: no running VPS found for handle ${HANDLE}" >&2
+  exit 1
+fi
+
+echo "enable-vps-logship: enrolling ${HANDLE} (${ip}) as env=${MATRIX_ENV}"
+# Credentials go via stdin, not argv, so they never appear in remote ps output.
+printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
+  ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new "root@${ip}" \
+    "IFS= read -r u && IFS= read -r p && /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' \"\$u\" \"\$p\" '${HANDLE}' '${MATRIX_ENV}'"
+
+echo "enable-vps-logship: done. Verify with: ./scripts/preview-logs.sh --handle ${HANDLE} --since 5m"

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -58,4 +58,13 @@ printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
   ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new "root@${ip}" \
     "IFS= read -r u && IFS= read -r p && /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' \"\$u\" \"\$p\" '${HANDLE}' '${MATRIX_ENV}'"
 
+# Record enrollment in the ops-side inventory so credential rotation has a
+# concrete target list (spec 093). Idempotent: one line per handle.
+INVENTORY="${LOGSHIP_INVENTORY:-$HOME/.matrixos/logship-enrolled.tsv}"
+mkdir -p "$(dirname "$INVENTORY")"
+touch "$INVENTORY"
+if ! cut -f1 "$INVENTORY" | grep -qx "$HANDLE"; then
+  printf '%s\t%s\t%s\n' "$HANDLE" "$MATRIX_ENV" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$INVENTORY"
+fi
+
 echo "enable-vps-logship: done. Verify with: ./scripts/preview-logs.sh --handle ${HANDLE} --since 5m"

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -32,6 +32,13 @@ if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
   echo "enable-vps-logship: invalid handle" >&2
   exit 64
 fi
+# Strict character allowlist: this value is interpolated into a root SSH
+# command on the VPS, so anything outside [A-Za-z0-9.:/_-] (notably quotes,
+# spaces, $, ;) must be rejected, not just the scheme.
+if ! printf '%s' "$LOGS_INGEST_URL" | grep -Eq '^https://[A-Za-z0-9.-]+(:[0-9]+)?(/[A-Za-z0-9._/-]*)?$'; then
+  echo "enable-vps-logship: LOGS_INGEST_URL must be a plain https URL (no quotes, spaces, or shell metacharacters)" >&2
+  exit 64
+fi
 case "$MATRIX_ENV" in
   preview | prod | staging) ;;
   *)

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -53,7 +53,9 @@ if [ -z "$ip" ] || [ "$ip" = "null" ]; then
 fi
 
 echo "enable-vps-logship: enrolling ${HANDLE} (${ip}) as env=${MATRIX_ENV}"
-# Credentials go via stdin, not argv, so they never appear in remote ps output.
+# Credentials travel via stdin and become ENVIRONMENT variables on the remote
+# (never argv on either side): /proc/<pid>/cmdline is world-readable, while
+# /proc/<pid>/environ is owner/root-only.
 # accept-new trusts a host on FIRST contact only; a changed key for a known IP
 # is rejected loudly (it is not StrictHostKeyChecking=no). Keys are pinned in a
 # dedicated known-hosts file so a rebuilt VPS on a reused IP fails closed until
@@ -63,7 +65,7 @@ mkdir -p "$(dirname "$KNOWN_HOSTS")"
 printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
   ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new \
     -o UserKnownHostsFile="$KNOWN_HOSTS" "root@${ip}" \
-    "IFS= read -r u && IFS= read -r p && /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' \"\$u\" \"\$p\" '${HANDLE}' '${MATRIX_ENV}'"
+    "IFS= read -r u && IFS= read -r p && LOGS_INGEST_USER=\"\$u\" LOGS_INGEST_PASSWORD=\"\$p\" /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' '${HANDLE}' '${MATRIX_ENV}'"
 
 # Record enrollment in the ops-side inventory so credential rotation has a
 # concrete target list (spec 093). Idempotent: one line per handle.

--- a/scripts/enable-vps-logship.sh
+++ b/scripts/enable-vps-logship.sh
@@ -54,8 +54,15 @@ fi
 
 echo "enable-vps-logship: enrolling ${HANDLE} (${ip}) as env=${MATRIX_ENV}"
 # Credentials go via stdin, not argv, so they never appear in remote ps output.
+# accept-new trusts a host on FIRST contact only; a changed key for a known IP
+# is rejected loudly (it is not StrictHostKeyChecking=no). Keys are pinned in a
+# dedicated known-hosts file so a rebuilt VPS on a reused IP fails closed until
+# the operator removes the stale entry.
+KNOWN_HOSTS="${LOGSHIP_KNOWN_HOSTS:-$HOME/.matrixos/logship-known-hosts}"
+mkdir -p "$(dirname "$KNOWN_HOSTS")"
 printf '%s\n%s\n' "$LOGS_INGEST_USER" "$LOGS_INGEST_PASSWORD" |
-  ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new "root@${ip}" \
+  ssh -i "$VPS_SSH_KEY" -o StrictHostKeyChecking=accept-new \
+    -o UserKnownHostsFile="$KNOWN_HOSTS" "root@${ip}" \
     "IFS= read -r u && IFS= read -r p && /opt/matrix/app/bin/matrix-install-logship '${LOGS_INGEST_URL}' \"\$u\" \"\$p\" '${HANDLE}' '${MATRIX_ENV}'"
 
 # Record enrollment in the ops-side inventory so credential rotation has a

--- a/scripts/preview-logs.sh
+++ b/scripts/preview-logs.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Query centralized logs for any Matrix OS preview/staging/fleet environment.
+# The one log interface coding agents should use (see docs/dev/preview-environments.md).
+#
+# Usage:
+#   ./scripts/preview-logs.sh --handle pr-123 [--unit matrix-gateway] [--since 15m] [--grep ERROR] [--limit 200]
+#   ./scripts/preview-logs.sh --slot 2 [--since 1h]
+#   ./scripts/preview-logs.sh --selector '{env="preview"}' --since 30m
+#
+# Runs against the ops-VPS Loki (loopback) by default; override with LOKI_URL.
+set -euo pipefail
+
+LOKI_URL="${LOKI_URL:-http://127.0.0.1:3100}"
+SINCE="15m"
+LIMIT="200"
+GREP=""
+SELECTOR=""
+HANDLE=""
+SLOT=""
+UNIT=""
+
+usage() {
+  sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+  exit 64
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --handle)
+      HANDLE="${2:?}"
+      shift 2
+      ;;
+    --slot)
+      SLOT="${2:?}"
+      shift 2
+      ;;
+    --unit)
+      UNIT="${2:?}"
+      shift 2
+      ;;
+    --selector)
+      SELECTOR="${2:?}"
+      shift 2
+      ;;
+    --since)
+      SINCE="${2:?}"
+      shift 2
+      ;;
+    --grep)
+      GREP="${2:?}"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="${2:?}"
+      shift 2
+      ;;
+    -h | --help) usage ;;
+    *)
+      echo "preview-logs: unknown flag $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [ -z "$SELECTOR" ]; then
+  if [ -n "$HANDLE" ]; then
+    if ! printf '%s' "$HANDLE" | grep -Eq '^[a-z0-9][a-z0-9-]{1,62}$'; then
+      echo "preview-logs: invalid handle" >&2
+      exit 64
+    fi
+    SELECTOR="{handle=\"${HANDLE}\"}"
+    if [ -n "$UNIT" ]; then
+      SELECTOR="{handle=\"${HANDLE}\", unit=\"${UNIT}.service\"}"
+    fi
+  elif [ -n "$SLOT" ]; then
+    case "$SLOT" in
+      1 | 2 | 3 | 4) ;;
+      *)
+        echo "preview-logs: slot must be 1-4" >&2
+        exit 64
+        ;;
+    esac
+    SELECTOR="{container=~\".*matrixos-staging-${SLOT}.*\"}"
+  else
+    echo "preview-logs: one of --handle, --slot, --selector is required" >&2
+    usage
+  fi
+fi
+
+QUERY="$SELECTOR"
+if [ -n "$GREP" ]; then
+  QUERY="${SELECTOR} |~ \"$(printf '%s' "$GREP" | sed 's/[\\"]/\\&/g')\""
+fi
+
+case "$SINCE" in
+  *m) START_SECS=$((${SINCE%m} * 60)) ;;
+  *h) START_SECS=$((${SINCE%h} * 3600)) ;;
+  *d) START_SECS=$((${SINCE%d} * 86400)) ;;
+  *)
+    echo "preview-logs: --since must end in m, h, or d" >&2
+    exit 64
+    ;;
+esac
+NOW_NS="$(date +%s)000000000"
+START_NS="$(($(date +%s) - START_SECS))000000000"
+
+curl -fsS --max-time 30 -G "${LOKI_URL}/loki/api/v1/query_range" \
+  ${LOKI_AUTH:+-u "$LOKI_AUTH"} \
+  --data-urlencode "query=${QUERY}" \
+  --data-urlencode "start=${START_NS}" \
+  --data-urlencode "end=${NOW_NS}" \
+  --data-urlencode "limit=${LIMIT}" \
+  --data-urlencode "direction=backward" |
+  jq -r '.data.result[] as $s | $s.values[] | "\(. [0] | tonumber / 1e9 | strftime("%Y-%m-%dT%H:%M:%SZ")) [\($s.stream.unit // $s.stream.container // $s.stream.source // "-")] \(.[1])"' |
+  sort

--- a/scripts/preview-logs.sh
+++ b/scripts/preview-logs.sh
@@ -70,6 +70,11 @@ if [ -z "$SELECTOR" ]; then
     fi
     SELECTOR="{handle=\"${HANDLE}\"}"
     if [ -n "$UNIT" ]; then
+      # systemd unit-name charset; blocks selector breakout via quotes/braces.
+      if ! printf '%s' "$UNIT" | grep -Eq '^[a-zA-Z0-9@._-]+$'; then
+        echo "preview-logs: invalid unit name" >&2
+        exit 64
+      fi
       SELECTOR="{handle=\"${HANDLE}\", unit=\"${UNIT}.service\"}"
     fi
   elif [ -n "$SLOT" ]; then

--- a/scripts/publish-release-r2.mjs
+++ b/scripts/publish-release-r2.mjs
@@ -57,7 +57,8 @@ if (!version) {
   process.exit(2);
 }
 
-if (!["dev", "canary", "beta", "stable"].includes(channel)) {
+// "none" registers the release without promoting any channel (preview/PR bundles).
+if (!["dev", "canary", "beta", "stable", "none"].includes(channel)) {
   console.error(`Invalid channel: ${channel}`);
   process.exit(1);
 }
@@ -176,7 +177,7 @@ const registrationBody = {
   severity,
   updateType,
   changelog: changelog || null,
-  channel,
+  ...(channel === "none" ? {} : { channel }),
 };
 
 console.log(`Publishing ${version} to channel ${channel}...`);

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -50,6 +50,7 @@ fi
 
 case "$CHANNEL" in
   dev|canary|beta|stable) ;;
+  none) ;; # register-only: no channel promotion (preview/PR bundles)
   *) echo "Invalid channel: $CHANNEL" >&2; exit 1 ;;
 esac
 
@@ -112,7 +113,7 @@ print(json.dumps({
     'severity': sys.argv[9],
     'updateType': sys.argv[10],
     'changelog': sys.argv[11] or None,
-    'channel': sys.argv[12],
+    **({} if sys.argv[12] == 'none' else {'channel': sys.argv[12]}),
 }, indent=2))
 " "$VERSION" "$GIT_COMMIT" "$GIT_REF" "$BUILD_TIME" "$BUNDLE_KEY" "$CHECKSUM_KEY" "$SHA256" "$SIZE" "$SEVERITY" "$UPDATE_TYPE" "$CHANGELOG" "$CHANNEL")
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -247,7 +247,13 @@ printf '%s' "$REGISTRATION_BODY" | curl --fail --silent --show-error --max-time 
   --data-binary @-
 
 echo ""
-echo "Published $VERSION to $CHANNEL"
-echo "  Release metadata: ${PLATFORM_PUBLIC_URL%/}/system-bundles/releases/$VERSION.json"
-echo "  Sync agents will discover this within 5 minutes."
-echo "  To deploy now: curl -X POST https://app.matrix-os.com/vps/deploy -H 'Authorization: Bearer \$PLATFORM_SECRET' -d '{\"version\":\"$VERSION\"}'"
+if [ "$CHANNEL" = "none" ]; then
+  echo "Registered $VERSION (no channel promotion; deploy is version-pinned only)"
+  echo "  Release metadata: ${PLATFORM_PUBLIC_URL%/}/system-bundles/releases/$VERSION.json"
+  echo "  To deploy to one handle: curl -X POST https://app.matrix-os.com/vps/deploy -H 'Authorization: Bearer \$PLATFORM_SECRET' -d '{\"version\":\"$VERSION\",\"handle\":\"<handle>\"}'"
+else
+  echo "Published $VERSION to $CHANNEL"
+  echo "  Release metadata: ${PLATFORM_PUBLIC_URL%/}/system-bundles/releases/$VERSION.json"
+  echo "  Sync agents will discover this within 5 minutes."
+  echo "  To deploy now: curl -X POST https://app.matrix-os.com/vps/deploy -H 'Authorization: Bearer \$PLATFORM_SECRET' -d '{\"version\":\"$VERSION\"}'"
+fi

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -186,7 +186,11 @@ cmd_status() {
     echo "slot $i: $branch ($worktree) claimed ${claimed} (${age_hours}h ago)"
     if [ "$reap" = "--reap" ] && [ "$age_hours" -ge "$IDLE_TTL_HOURS" ]; then
       echo "slot $i: idle past ${IDLE_TTL_HOURS}h TTL, reaping"
-      cmd_down "$i"
+      # Subshell: cmd_down exits non-zero on a failed DB drop; one bad slot
+      # must not abort reaping of the remaining expired slots.
+      if ! (cmd_down "$i"); then
+        echo "slot $i: reap failed; continuing with remaining slots" >&2
+      fi
     fi
   done
 }

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Per-worktree HMR staging slots on the ops VPS (spec 093).
+#
+# Usage:
+#   ./scripts/staging-slot.sh up <worktree-path>   # claim lowest free slot, start HMR container
+#   ./scripts/staging-slot.sh down <slot>          # stop and release a slot
+#   ./scripts/staging-slot.sh status [--reap]      # list slots; --reap frees slots idle > TTL
+#   ./scripts/staging-slot.sh logs <slot> [args]   # follow container logs (docker compose logs)
+#
+# Four fixed slots map to staging-<n>.matrix-os.com / api-staging-<n>.matrix-os.com
+# through the cloudflared tunnel. Slot state lives in ~/.matrixos/staging-slots/:
+# claim files are created with O_EXCL so two concurrent `up` calls cannot win
+# the same slot. Slot containers are named matrixos-staging-<n>, which the
+# observability promtail's docker discovery ships to Loki automatically.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STATE_DIR="${STAGING_SLOT_STATE_DIR:-$HOME/.matrixos/staging-slots}"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.staging-slot.yml"
+ENV_FILE="${STAGING_SLOT_ENV_FILE:-$REPO_ROOT/.env}"
+MAX_SLOTS=4
+IDLE_TTL_HOURS="${STAGING_SLOT_TTL_HOURS:-72}"
+
+mkdir -p "$STATE_DIR"
+
+compose() {
+  local slot="$1" project_dir="$2"
+  shift 2
+  SLOT="$slot" docker compose \
+    -f "$COMPOSE_FILE" \
+    --project-name "mx-staging-${slot}" \
+    --project-directory "$project_dir" \
+    --env-file "$ENV_FILE" \
+    "$@"
+}
+
+validate_slot() {
+  case "$1" in
+    1 | 2 | 3 | 4) ;;
+    *)
+      echo "staging-slot: slot must be 1-$MAX_SLOTS" >&2
+      exit 64
+      ;;
+  esac
+}
+
+slot_file() { echo "$STATE_DIR/slot-$1.json"; }
+
+cmd_up() {
+  local worktree="${1:?usage: staging-slot.sh up <worktree-path>}"
+  worktree="$(cd "$worktree" && pwd)" || {
+    echo "staging-slot: worktree path does not exist" >&2
+    exit 64
+  }
+  if ! git -C "$worktree" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "staging-slot: $worktree is not a git worktree" >&2
+    exit 64
+  fi
+  if [ ! -f "$worktree/Dockerfile.dev" ]; then
+    echo "staging-slot: $worktree does not look like a matrix-os checkout" >&2
+    exit 64
+  fi
+
+  local slot="" f branch
+  for i in $(seq 1 "$MAX_SLOTS"); do
+    f="$(slot_file "$i")"
+    # O_EXCL claim: loser of a race moves on to the next slot.
+    if (set -o noclobber && : > "$f") 2> /dev/null; then
+      slot="$i"
+      break
+    fi
+  done
+  if [ -z "$slot" ]; then
+    echo "staging-slot: no free slots. Current owners:" >&2
+    cmd_status >&2
+    exit 1
+  fi
+
+  branch="$(git -C "$worktree" rev-parse --abbrev-ref HEAD)"
+  jq -n --arg worktree "$worktree" --arg branch "$branch" \
+    --arg claimedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{worktree: $worktree, branch: $branch, claimedAt: $claimedAt}' > "$(slot_file "$slot")"
+
+  echo "staging-slot: claimed slot $slot for $branch"
+  if ! compose "$slot" "$worktree" up -d --build; then
+    rm -f "$(slot_file "$slot")"
+    echo "staging-slot: start failed; slot $slot released" >&2
+    exit 1
+  fi
+  echo "staging-slot: slot $slot up"
+  echo "  shell: https://staging-${slot}.matrix-os.com"
+  echo "  api:   https://api-staging-${slot}.matrix-os.com"
+  echo "  logs:  ./scripts/preview-logs.sh --slot ${slot}   (or: staging-slot.sh logs ${slot} -f)"
+}
+
+cmd_down() {
+  local slot="${1:?usage: staging-slot.sh down <slot>}"
+  validate_slot "$slot"
+  local f worktree
+  f="$(slot_file "$slot")"
+  if [ ! -f "$f" ]; then
+    echo "staging-slot: slot $slot is not claimed" >&2
+    exit 1
+  fi
+  worktree="$(jq -r .worktree "$f")"
+  # The worktree may already be deleted; fall back to repo root so compose
+  # can still resolve the project by name and remove containers.
+  [ -d "$worktree" ] || worktree="$REPO_ROOT"
+  compose "$slot" "$worktree" down --remove-orphans
+  rm -f "$f"
+  echo "staging-slot: slot $slot released"
+}
+
+cmd_status() {
+  local reap="${1:-}" f worktree branch claimed age_hours
+  for i in $(seq 1 "$MAX_SLOTS"); do
+    f="$(slot_file "$i")"
+    if [ ! -f "$f" ]; then
+      echo "slot $i: free"
+      continue
+    fi
+    worktree="$(jq -r .worktree "$f")"
+    branch="$(jq -r .branch "$f")"
+    claimed="$(jq -r .claimedAt "$f")"
+    age_hours=$((($(date +%s) - $(date -d "$claimed" +%s)) / 3600))
+    echo "slot $i: $branch ($worktree) claimed ${claimed} (${age_hours}h ago)"
+    if [ "$reap" = "--reap" ] && [ "$age_hours" -ge "$IDLE_TTL_HOURS" ]; then
+      echo "slot $i: idle past ${IDLE_TTL_HOURS}h TTL, reaping"
+      cmd_down "$i"
+    fi
+  done
+}
+
+cmd_logs() {
+  local slot="${1:?usage: staging-slot.sh logs <slot> [compose-logs-args]}"
+  validate_slot "$slot"
+  shift
+  local f worktree
+  f="$(slot_file "$slot")"
+  if [ ! -f "$f" ]; then
+    echo "staging-slot: slot $slot is not claimed" >&2
+    exit 1
+  fi
+  worktree="$(jq -r .worktree "$f")"
+  [ -d "$worktree" ] || worktree="$REPO_ROOT"
+  compose "$slot" "$worktree" logs "$@"
+}
+
+case "${1:-}" in
+  up)
+    shift
+    cmd_up "$@"
+    ;;
+  down)
+    shift
+    cmd_down "$@"
+    ;;
+  status)
+    shift || true
+    cmd_status "${1:-}"
+    ;;
+  logs)
+    shift
+    cmd_logs "$@"
+    ;;
+  *)
+    sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+    exit 64
+    ;;
+esac

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -34,6 +34,42 @@ compose() {
     "$@"
 }
 
+# The dev image runs as the matrixos user (uid 100); on Linux hosts the
+# bind-mounted worktree is owned by the invoking user, so Next/tsx watchers
+# could not write build output (next-env.d.ts, .next, dist). Grant the
+# container uid an ACL on the worktree, with inheritance for new files.
+# Docker Desktop (macOS) maps uids transparently and never hits this.
+ensure_worktree_writable() {
+  local worktree="$1" uid="${SLOT_CONTAINER_UID:-100}"
+  if ! command -v setfacl > /dev/null 2>&1; then
+    echo "staging-slot: setfacl not found; container writes to the worktree may fail (sudo apt install acl)" >&2
+    return 0
+  fi
+  # Files created by the container itself are owned by the container uid;
+  # the invoking user cannot set ACLs on those, but they are already
+  # writable by the container -- so per-file failures here are benign.
+  if ! setfacl -R -m "u:${uid}:rwX" -m "d:u:${uid}:rwX" "$worktree" 2> /dev/null; then
+    echo "staging-slot: some ACL entries could not be set (container-owned files); continuing"
+  fi
+}
+
+# The legacy platform postgres is gone (Cloud Run cutover); slots share a
+# dedicated dev postgres (network alias "postgres" on matrixos-net) with one
+# database per slot.
+ensure_staging_db() {
+  local slot="$1" db_user
+  db_user="${STAGING_DB_USER:-matrixos}"
+  docker compose -f "$REPO_ROOT/docker-compose.staging-db.yml" \
+    --env-file "$ENV_FILE" up -d --wait staging-postgres
+  if ! docker exec matrixos-staging-postgres \
+    psql -U "$db_user" -d matrixos_staging -tAc \
+    "SELECT 1 FROM pg_database WHERE datname = 'matrixos_staging_${slot}'" | grep -q 1; then
+    docker exec matrixos-staging-postgres \
+      psql -U "$db_user" -d matrixos_staging -c \
+      "CREATE DATABASE matrixos_staging_${slot}"
+  fi
+}
+
 validate_slot() {
   case "$1" in
     1 | 2 | 3 | 4) ;;
@@ -86,6 +122,8 @@ cmd_up() {
     '{worktree: $worktree, branch: $branch, claimedAt: $claimedAt}' > "$(slot_file "$slot")"
 
   echo "staging-slot: claimed slot $slot for $branch"
+  ensure_worktree_writable "$worktree"
+  ensure_staging_db "$slot"
   if ! compose "$slot" "$worktree" up -d --build; then
     echo "staging-slot: start failed; slot $slot released" >&2
     exit 1

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -124,8 +124,10 @@ cmd_up() {
   echo "staging-slot: claimed slot $slot for $branch"
   ensure_worktree_writable "$worktree"
   ensure_staging_db "$slot"
-  if ! compose "$slot" "$worktree" up -d --build; then
-    echo "staging-slot: start failed; slot $slot released" >&2
+  # --wait holds until healthchecks pass, so the EXIT trap still releases
+  # the slot when the container starts but never becomes healthy.
+  if ! compose "$slot" "$worktree" up -d --build --wait --wait-timeout 600; then
+    echo "staging-slot: start failed or unhealthy; slot $slot released" >&2
     exit 1
   fi
   trap - EXIT
@@ -158,7 +160,10 @@ cmd_down() {
   if ! docker exec matrixos-staging-postgres \
     psql -U "$db_user" -d matrixos_staging -c \
     "DROP DATABASE IF EXISTS matrixos_staging_${slot}" > /dev/null 2>&1; then
-    echo "staging-slot: warning: could not drop matrixos_staging_${slot}; next claim will reuse it" >&2
+    echo "staging-slot: could not drop matrixos_staging_${slot}; keeping the claim so the next" >&2
+    echo "staging-slot: occupant cannot inherit stale data. Start matrixos-staging-postgres and" >&2
+    echo "staging-slot: rerun 'staging-slot.sh down ${slot}'." >&2
+    exit 1
   fi
   docker volume rm -f "mx-staging-${slot}_slot-home" > /dev/null 2>&1 || true
   rm -f "$f"

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -76,6 +76,10 @@ cmd_up() {
     exit 1
   fi
 
+  # Any failure between winning the claim and a healthy start must release
+  # the slot, or it stays locked until --reap. Cleared after compose succeeds.
+  trap 'rm -f "$(slot_file "$slot")"' EXIT
+
   branch="$(git -C "$worktree" rev-parse --abbrev-ref HEAD)"
   jq -n --arg worktree "$worktree" --arg branch "$branch" \
     --arg claimedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -83,10 +87,10 @@ cmd_up() {
 
   echo "staging-slot: claimed slot $slot for $branch"
   if ! compose "$slot" "$worktree" up -d --build; then
-    rm -f "$(slot_file "$slot")"
     echo "staging-slot: start failed; slot $slot released" >&2
     exit 1
   fi
+  trap - EXIT
   echo "staging-slot: slot $slot up"
   echo "  shell: https://staging-${slot}.matrix-os.com"
   echo "  api:   https://api-staging-${slot}.matrix-os.com"
@@ -122,6 +126,7 @@ cmd_status() {
     worktree="$(jq -r .worktree "$f")"
     branch="$(jq -r .branch "$f")"
     claimed="$(jq -r .claimedAt "$f")"
+    # GNU date (-d): this script targets the Linux ops VPS only.
     age_hours=$((($(date +%s) - $(date -d "$claimed" +%s)) / 3600))
     echo "slot $i: $branch ($worktree) claimed ${claimed} (${age_hours}h ago)"
     if [ "$reap" = "--reap" ] && [ "$age_hours" -ge "$IDLE_TTL_HOURS" ]; then

--- a/scripts/staging-slot.sh
+++ b/scripts/staging-slot.sh
@@ -149,6 +149,18 @@ cmd_down() {
   # can still resolve the project by name and remove containers.
   [ -d "$worktree" ] || worktree="$REPO_ROOT"
   compose "$slot" "$worktree" down --remove-orphans
+  # Clean slate for the next claimant: drop the per-slot database and the
+  # slot-home volume (prior occupant's MATRIX_HOME). node_modules volume is
+  # kept on purpose -- it only caches dependencies and saves minutes on the
+  # next claim.
+  local db_user
+  db_user="${STAGING_DB_USER:-matrixos}"
+  if ! docker exec matrixos-staging-postgres \
+    psql -U "$db_user" -d matrixos_staging -c \
+    "DROP DATABASE IF EXISTS matrixos_staging_${slot}" > /dev/null 2>&1; then
+    echo "staging-slot: warning: could not drop matrixos_staging_${slot}; next claim will reuse it" >&2
+  fi
+  docker volume rm -f "mx-staging-${slot}_slot-home" > /dev/null 2>&1 || true
   rm -f "$f"
   echo "staging-slot: slot $slot released"
 }

--- a/specs/093-preview-environments/plan.md
+++ b/specs/093-preview-environments/plan.md
@@ -1,0 +1,87 @@
+# Plan 093: Preview Environments and Centralized Dev Logging
+
+## Slices
+
+### Slice 1 — Logging spine (this stack, layer 2)
+
+| Artifact | Path | Notes |
+|---|---|---|
+| Ingest edge | `distro/observability/logs-edge/Caddyfile` + `logs-edge` service in `distro/observability/docker-compose.observability.yml` | basic auth, push-only path allowlist, tunnel-only |
+| Tunnel route | `distro/cloudflared.yml` | `logs.matrix-os.com -> logs-edge:8080` |
+| Shipper installer | `distro/customer-vps/host-bin/matrix-install-logship` | downloads pinned Alloy, sha256-verified; writes config + systemd unit + env; idempotent |
+| Ops enroll helper | `scripts/enable-vps-logship.sh` | SSH wrapper: pushes installer invocation to a VPS by handle (fleet IP lookup) |
+| Query contract | `scripts/preview-logs.sh` | curl/jq over Loki query_range; selector flags |
+
+Verification: push a test line through `logs.matrix-os.com` with the credential
+(expect 204), without it (expect 401), query it back via `preview-logs.sh`.
+
+### Slice 2 — Staging slots (layer 2)
+
+| Artifact | Path |
+|---|---|
+| Slot compose | `docker-compose.staging-slot.yml` (parameterized by `SLOT`, project `mx-staging-<n>`) |
+| Lifecycle script | `scripts/staging-slot.sh` (`up <worktree>` / `down <n>` / `status [--reap]` / `logs <n>`) |
+| Tunnel routes | `distro/cloudflared.yml`: `staging-<1..4>` + `api-staging-<1..4>` hostnames |
+| DNS | one-time `cloudflared tunnel route dns` per hostname (ops runbook step) |
+
+Verification: claim slot 1 from a worktree, confirm HMR shell responds via tunnel,
+confirm slot logs appear in Loki via promtail docker discovery, release the slot.
+
+### Slice 3 — CI pipelines (layer 3)
+
+| Artifact | Path |
+|---|---|
+| Preview VPS | `.github/workflows/preview-vps.yml` (label `preview-vps`; build/publish/provision/deploy/comment; teardown on close; daily reaper) |
+| Platform preview | `.github/workflows/preview-platform.yml` (label `preview-platform`; dedicated preview service; no-ops without preview secrets) |
+
+Verification: workflow YAML lint; dry-run the platform API calls from the ops box with
+a throwaway handle; full E2E on the first labeled PR (costs one small Hetzner VPS).
+
+### Slice 4 — Discovery layer (layer 3)
+
+| Artifact | Path |
+|---|---|
+| Agent skill | `.claude/skills/preview-env/SKILL.md` |
+| Dev guide | `docs/dev/preview-environments.md` |
+| Pointer | `AGENTS.md` reference-docs row |
+
+## Stack / PR layout (Graphite)
+
+1. `093-preview-environments` — spec + plan (this directory)
+2. `feat/preview-logging-spine` — slices 1 + 2
+3. `feat/preview-envs-ci` — slices 3 + 4
+
+## Decisions
+
+- **Alloy over promtail**: promtail is EOL (Feb 2026); Alloy is the supported shipper.
+  Pinned `v1.16.3`, downloaded at install time (keeps the host bundle small),
+  checksum-verified.
+- **Push-only ingest edge**: queries stay loopback/Grafana-only; the public surface is
+  a single POST path behind basic auth. Smallest credible attack surface for v1.
+- **No platform code changes in v1**: logship enrollment is ops-side via SSH. The
+  cloud-init template-var route requires platform changes and ships as a follow-up.
+- **Releases without channel**: PR bundles are registered version-only so no channel
+  pointer can ever resolve to a PR build.
+- **Fixed staging slots over wildcard DNS**: `cloudflared tunnel route dns` cannot
+  create wildcards without the Cloudflare API; four pre-registered hostnames need
+  zero runtime DNS mutations and cap concurrency by construction.
+- **Dedicated Cloud Run preview service**: preview revisions must never share the
+  production service or its secrets (a preview revision with the production DB would
+  be a critical incident waiting to happen).
+
+## Test plan
+
+- Unit-ish: `staging-slot.sh` slot-claim race (two concurrent `up` calls -> distinct
+  slots), input validation rejects bad slot index / foreign path.
+- Live: ingest auth positive/negative, log round-trip, slot HMR round-trip.
+- CI: `actionlint` on new workflows; platform API smoke from ops box.
+
+## Rollout
+
+1. Merge stack; apply logs-edge + tunnel config live on ops VPS (config is
+   bind-mounted, same pattern as PR #484).
+2. Enroll the staging slots implicitly (promtail) and one feature VPS explicitly via
+   `scripts/enable-vps-logship.sh` to validate the fleet path.
+3. First labeled PR exercises preview-vps E2E; reaper observed over the next 3 days.
+4. Follow-up issues: platform cloud-init enrollment, metrics remote-write, Neon
+   branch automation, browser-console forwarding.

--- a/specs/093-preview-environments/spec.md
+++ b/specs/093-preview-environments/spec.md
@@ -1,0 +1,188 @@
+# Spec 093: Preview Environments and Centralized Dev Logging
+
+## Problem
+
+Production Matrix OS is VPS-native per user (host systemd services) with the platform
+on Cloud Run. Local Docker stacks are therefore not production-shaped, and coding
+agents working on feature branches have no way to observe a running stack: dev process
+output evaporates in terminals, customer VPSes ship no logs anywhere, and browser
+console output is invisible. Every feature type needs a different test surface (shell
+changes need a runtime, onboarding needs a virgin VPS, the macOS app needs a runtime to
+connect to, CLI betas need a paired shell), and today each is assembled by hand.
+
+## Goals
+
+1. One preview surface per feature type, all cloud-based and production-shaped.
+2. Centralized logs: every preview environment (and, by rollout, the production fleet)
+   ships logs to the existing Loki on the ops VPS, queryable by one agent-facing
+   contract.
+3. Agents discover and operate all of this through a skill and dev docs, without human
+   hand-holding.
+
+## Non-Goals
+
+- Replacing the local `bun run dev` inner loop for sub-second HMR on a laptop.
+- Metrics shipping (Prometheus remote-write) — logs first; metrics are a follow-up.
+- Per-VPS unique ingest credentials in v1 (single rotating credential; see Security).
+- Production fleet auto-enrollment in v1 (explicit per-VPS enablement; see Rollout).
+
+## Surfaces by Feature Type
+
+| Feature type | Surface | Mechanism |
+|---|---|---|
+| Shell / gateway / kernel | Preview VPS `pr-<N>` | CI label `preview-vps`: build bundle `0.0.0-pr<N>.<sha7>`, publish to R2, provision + deploy via platform API, PR comment with `app.matrix-os.com/vm/pr-<N>` |
+| Onboarding | Fresh preview VPS | Same pipeline; a newly provisioned VPS is virgin by construction |
+| Platform (Cloud Run) | Tagged preview revision | CI label `preview-platform`: build image, deploy to the dedicated preview service with `--tag pr-<N> --no-traffic` |
+| macOS app | CI `.app` artifact + any preview VPS | `macos-086.yml` artifact, runtime switcher `app.matrix-os.com/vm/<handle>` |
+| CLI beta x shell | npm dist-tag + preview VPS | `matrixos@pr-<N>` dist-tag paired via `~/.matrixos` profiles (068) |
+| Fast UI iteration (HMR) | Staging slot `staging-<1..4>.matrix-os.com` | Per-worktree HMR container on the ops VPS behind the existing tunnel |
+
+## Architecture
+
+### Logging spine
+
+- **Ingest edge**: a Caddy container (`logs-edge`) on the ops VPS, exposed only through
+  the cloudflared tunnel as `logs.matrix-os.com`. It forwards exactly one path prefix —
+  `POST /loki/api/v1/push` — to the internal Loki, behind HTTP basic auth. Everything
+  else returns 404. Loki itself stays loopback-bound (PR #484).
+- **Shipper**: Grafana Alloy (pinned version, checksum-verified) on each enrolled VPS,
+  installed by a new self-contained host-bin script `matrix-install-logship`. It tails
+  journald units (`matrix-gateway`, `matrix-shell`, `matrix-sync-agent`, `matrix-code`,
+  `matrix-symphony`) and the kernel JSONL logs under the Matrix home, labeling streams
+  with `handle`, `env` (`preview` | `prod` | `staging`), `source`, and `unit`.
+- **Ops VPS local logs**: the existing promtail continues to ship docker container logs
+  (which now include staging slots) directly to Loki on the internal network.
+- **Query contract**: `scripts/preview-logs.sh` — curl/jq wrapper over the Loki query
+  API (loopback on the ops VPS; `LOKI_URL`/credentials overridable). Selectors:
+  `--handle pr-123`, `--slot 2`, `--unit matrix-gateway`, `--grep`, `--since`.
+
+### Preview VPS pipeline (`.github/workflows/preview-vps.yml`)
+
+- Trigger: PR labeled `preview-vps` (on label add and on synchronize while labeled),
+  plus `workflow_dispatch` for manual runs.
+- Build: reuse `scripts/build-host-bundle.sh` with
+  `HOST_BUNDLE_VERSION=0.0.0-pr<N>.<sha7>`; version format passes the platform's
+  release validation (`/^[A-Za-z0-9._-]{1,128}$/`).
+- Publish: `scripts/publish-release.sh` **without** `--channel` — the release is
+  registered but never promoted; no channel pointer can ever select a PR bundle.
+- Provision: `POST /vps/provision` with `handle: pr-<N>`, a dedicated
+  `PREVIEW_CLERK_USER_ID` secret, `runtimeSlot: preview`. Idempotent: if the handle
+  already exists in `/vps/fleet`, skip provision and deploy only.
+- Deploy: `POST /vps/deploy {"version": "...", "handle": "pr-<N>"}` — version-pinned,
+  single-handle. Never channel-wide.
+- Report: PR comment with the VM URL, bundle version, and log-query one-liner.
+- Teardown: on PR `closed`, look up the machineId for `pr-<N>` in `/vps/fleet` and
+  `DELETE /vps/<machineId>`. A scheduled reaper job (daily) deletes any `pr-*` VPS
+  whose PR is closed or whose age exceeds 72h, so orphans cannot accumulate Hetzner
+  cost.
+
+### Platform preview revisions (`.github/workflows/preview-platform.yml`, scaffold)
+
+- Trigger: PR labeled `preview-platform`.
+- Deploys the platform image to a **dedicated preview Cloud Run service**
+  (`CLOUD_RUN_PREVIEW_SERVICE`), never the production service, with
+  `--tag pr-<N> --no-traffic`, using preview-scoped secrets (separate database URL —
+  Neon branch databases are the intended pairing, deferred). The job no-ops with a
+  clear message when preview secrets are not configured.
+
+### Staging slots (`scripts/staging-slot.sh` + `docker-compose.staging-slot.yml`)
+
+- Four fixed slots: `staging-<n>.matrix-os.com` / `api-staging-<n>.matrix-os.com`
+  (n = 1..4), pre-registered in the tunnel config and DNS — no Cloudflare API calls at
+  slot-claim time.
+- `staging-slot.sh up <worktree-path>` claims the lowest free slot (state file with an
+  exclusive-create lock), runs the HMR dev container from that worktree's source with
+  `COMPOSE_PROJECT_NAME=mx-staging-<n>`, and prints the URL. `down`, `status`, and
+  `logs` subcommands complete the lifecycle. Slots idle longer than the TTL are
+  reclaimable by `status --reap`.
+- Slot containers match the existing promtail docker discovery (name contains
+  `matrixos`), so slot logs flow to Loki with no extra wiring.
+
+## Security Architecture
+
+### Auth matrix
+
+| Surface | AuthN | AuthZ | Notes |
+|---|---|---|---|
+| `logs.matrix-os.com` (ingest) | HTTP basic auth (bcrypt hash in Caddy config, secret from `.env`) | push-only: `POST /loki/api/v1/push`; all other paths 404 | Tunnel-only; no host port. Query APIs are NOT exposed. |
+| Loki query | none (loopback) | reachable only from ops VPS / docker network | Agents query via `preview-logs.sh` on the ops box or via Grafana |
+| Platform API calls in CI | `Authorization: Bearer PLATFORM_SECRET` (repo secret) | existing platform route guards | Same secret host-bundle-release.yml already uses |
+| Preview VPS shell | Clerk (existing) | VPS bound to `PREVIEW_CLERK_USER_ID` | Team members use the runtime switcher with their own Clerk session per existing platform rules |
+| Staging slots | Tunnel hostname only | no new auth (matches existing `staging.matrix-os.com` posture) | Slots run branch code with dev credentials only; never production secrets |
+| Cloud Run preview | gcloud OIDC (existing workflow auth) | dedicated preview service + preview secrets | Production service and secrets are never referenced |
+
+### Input validation
+
+- `staging-slot.sh`: slot index validated against `[1-4]`; worktree path must resolve
+  inside `~/matrix-os.worktrees/` or be an existing registered git worktree; PR/branch
+  metadata stored, never interpolated into shell unquoted.
+- Workflow inputs: PR number comes from the GitHub event payload (integer), handle is
+  constructed as `pr-<N>` and therefore always matches the platform's handle regex.
+- `matrix-install-logship`: URL must be `https://`, handle must match
+  `^[a-z0-9][a-z0-9-]{1,62}$`, env must be one of `preview|prod|staging`; the Alloy
+  binary download is pinned to an exact version and verified against a recorded
+  sha256 before install.
+
+### Error policy
+
+- CI jobs surface platform API failures with status codes only; response bodies are
+  not echoed into PR comments (they can contain infrastructure details). Full bodies
+  go to the workflow log, which is repo-private.
+- `preview-logs.sh` prints Loki errors verbatim (operator tool on the ops box).
+- `logs-edge` returns generic 401/404; no upstream details.
+
+## Failure Modes
+
+- **Bundle build fails**: no publish, no deploy; PR comment is only posted on success.
+- **Provision succeeds, deploy fails**: VPS exists with channel-default bundle. The
+  deploy step retries once; on persistent failure the job fails loudly and the PR
+  comment is replaced by a failure note with the handle so teardown still works.
+  Orphan state is acceptable: the reaper deletes it within 72h regardless.
+- **Teardown fails on PR close**: the scheduled reaper is the backstop (same deletion
+  code path). Reaper failures alert via workflow failure notifications.
+- **Two PRs race for a staging slot**: slot claim uses `O_EXCL` lock-file creation;
+  the loser gets the next slot or a clear "no free slots" error listing current owners.
+- **logs-edge or Loki down**: Alloy buffers and retries with backoff (bounded WAL);
+  VPS services are never blocked by log shipping (shipper is an independent unit,
+  `Wants=`/`After=` only).
+- **Credential leak of ingest secret**: blast radius is log injection (write-only
+  endpoint). Rotate by updating `.env` + restarting `logs-edge`, then re-running
+  `matrix-install-logship` on enrolled VPSes. Documented in runbook.
+- **Reaper deletes a VPS still in use**: only `pr-*` handles are eligible, never
+  `primary` runtime slots, and PR-open state is checked before age-based deletion.
+
+## Resource Management
+
+- Loki retention: existing config; preview labels make `{env="preview"}` streams
+  cheap to delete; retention policy documented (follow-up: per-tenant limits).
+- Alloy: bounded WAL/backpressure; install pinned and idempotent (re-running upgrades
+  config in place).
+- Staging slots: hard cap of 4 concurrent; slot state file caps entries at 4; TTL reap
+  for idle slots; `down` removes containers and the per-slot named volumes are reused
+  per slot (bounded count).
+- Preview VPSes: hard TTL 72h via reaper; one VPS per PR (idempotent provision).
+- CI: preview jobs use `concurrency: preview-vps-<N>` with cancel-in-progress to avoid
+  pile-ups on rapid pushes.
+
+## Integration Wiring
+
+- `logs-edge` joins the existing `observability` docker network next to Loki; tunnel
+  ingress added in `distro/cloudflared.yml` (live config, bind-mounted).
+- `matrix-install-logship` ships in the host bundle `bin/` (build-host-bundle.sh
+  already copies `distro/customer-vps/host-bin/`). Enablement v1: invoked over SSH
+  from the ops box (extension of the `staging-platform-vps` flow) with the ingest URL
+  and credential. Follow-up (deferred): platform writes `/opt/matrix/env/logship.env`
+  at provision time via cloud-init template vars so new VPSes auto-enroll.
+- `preview-vps.yml` mirrors `host-bundle-release.yml` secrets exactly; one new secret
+  (`PREVIEW_CLERK_USER_ID`), no new permissions.
+- Skill `.claude/skills/preview-env/` + `docs/dev/preview-environments.md` are the
+  discovery layer; AGENTS.md gets a one-line reference.
+
+## Deferred Scope
+
+- Platform-side cloud-init templating for automatic logship enrollment of every new
+  VPS (follow-up issue; v1 is explicit per-VPS enablement).
+- Prometheus remote-write (metrics) from VPSes.
+- Neon branch-database automation for platform previews.
+- Browser-console forwarding from preview shells into Loki (debug build flag).
+- Per-VPS unique ingest credentials / Loki multi-tenancy.

--- a/specs/093-preview-environments/spec.md
+++ b/specs/093-preview-environments/spec.md
@@ -34,7 +34,7 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
 | Onboarding | Fresh preview VPS | Same pipeline; a newly provisioned VPS is virgin by construction |
 | Platform (Cloud Run) | Tagged preview revision | CI label `preview-platform`: build image, deploy to the dedicated preview service with `--tag pr-<N> --no-traffic` |
 | macOS app | CI `.app` artifact + any preview VPS | `macos-086.yml` artifact, runtime switcher `app.matrix-os.com/vm/<handle>` |
-| CLI beta x shell | npm dist-tag + preview VPS | `matrixos@pr-<N>` dist-tag paired via `~/.matrixos` profiles (068) |
+| CLI beta x shell | npm dist-tag + preview VPS | `matrixos@pr-<N>` dist-tag paired via `~/.matrixos` profiles (068). Deferred: dist-tag automation ships publish AND removal together (`npm dist-tag rm` on PR close) -- a dangling dist-tag is publicly reachable forever |
 | Fast UI iteration (HMR) | Staging slot `staging-<1..4>.matrix-os.com` | Per-worktree HMR container on the ops VPS behind the existing tunnel |
 
 ## Architecture
@@ -84,6 +84,10 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   `--tag pr-<N> --no-traffic`, using preview-scoped secrets (separate database URL —
   Neon branch databases are the intended pairing, deferred). The job no-ops with a
   clear message when preview secrets are not configured.
+- Teardown mirrors the VPS model: on PR close the workflow removes the `pr-<N>`
+  traffic tag and deletes its revision(s), so labeled PRs cannot accumulate
+  revisions in the preview service. A periodic sweeper for revisions that escape
+  close-teardown ships with the Neon automation (deferred).
 
 ### Staging slots (`scripts/staging-slot.sh` + `docker-compose.staging-slot.yml`)
 
@@ -150,6 +154,11 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   `matrix-install-logship` on enrolled VPSes. Documented in runbook.
 - **Reaper deletes a VPS still in use**: only `pr-*` handles are eligible, never
   `primary` runtime slots, and PR-open state is checked before age-based deletion.
+- **Reaper cannot confirm PR state** (GitHub API failure/rate limit): fail-safe —
+  that VPS is skipped, never deleted on unknown state, and age-based deletion also
+  requires a confirmed state. The reaper job exits non-zero after processing when
+  any lookup failed, so repeated skips surface as workflow failures instead of
+  silently accumulating orphans.
 
 ## Resource Management
 
@@ -161,6 +170,11 @@ connect to, CLI betas need a paired shell), and today each is assembled by hand.
   for idle slots; `down` removes containers and the per-slot named volumes are reused
   per slot (bounded count).
 - Preview VPSes: hard TTL 72h via reaper; one VPS per PR (idempotent provision).
+- Cloud Run preview revisions: deleted on PR close (see Architecture); bounded by
+  open labeled PRs.
+- Logship enrollment inventory: `enable-vps-logship.sh` records every enrolled
+  handle in an ops-side inventory file (`~/.matrixos/logship-enrolled.tsv`), giving
+  credential rotation a concrete target list for the re-enrollment runbook.
 - CI: preview jobs use `concurrency: preview-vps-<N>` with cancel-in-progress to avoid
   pile-ups on rapid pushes.
 


### PR DESCRIPTION
## Summary

CI pipelines + agent discovery layer for spec 093:

- **preview-vps.yml**: `preview-vps` label on a same-repo PR builds host bundle `0.0.0-pr<N>.<sha7>`, publishes it **register-only** (new `--channel none` mode), provisions VPS `pr-<N>` (runtime slot `preview`, `PREVIEW_CLERK_USER_ID`) if absent, deploys exactly that version to exactly that handle, and comments the URL. Teardown on PR close + daily reaper (deletes `pr-*` VPSes with closed PRs or age > 72h) so orphans cannot accumulate Hetzner cost. Fork PRs are excluded.
- **preview-platform.yml** (scaffold): `preview-platform` label deploys a zero-traffic tagged revision to a **dedicated preview Cloud Run service** with preview-scoped secrets; production service/secrets are never referenced; no-ops with a notice until `CLOUD_RUN_PREVIEW_SERVICE` is configured.
- **publish-release.sh / publish-release-r2.mjs**: `--channel none` registers a release without any channel promotion — without this, the script defaults to promoting `dev`, which would point real VPSes at a PR bundle.
- **.claude/skills/preview-env/** + **docs/dev/preview-environments.md** + AGENTS.md pointer: the contract future agents use to pick a surface, spin it up, query logs, and tear down.

actionlint-clean.

## Invariants

- **Source of truth**: platform DB releases table + R2 objects for bundles; `/vps/fleet` for preview VPS existence. The PR comment is informational only.
- **Lock/transaction scope**: per-PR `concurrency` groups serialize deploys; provision is check-then-create against the fleet API with the platform's own handle uniqueness as the backstop.
- **Acceptable orphan states**: provision-succeeded/deploy-failed leaves a VPS on the channel-default bundle — job fails loudly and the reaper deletes it within 72h. Preview R2 objects (`system-bundles/0.0.0-pr*`) outlive PRs and are safe to clean manually; never referenced by channel pointers.
- **Auth source of truth**: `PLATFORM_SECRET` bearer for all platform calls (same as host-bundle-release.yml); GCP via existing workload identity; one new secret: `PREVIEW_CLERK_USER_ID`.
- **Deferred scope**: Neon branch databases for platform previews, fleet log auto-enrollment, CLI dist-tag automation, browser-console forwarding (spec 093).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review notes

- Greptile's `cancel-in-progress` expression finding is addressed by explanation (inline reply): expressions evaluating to booleans are the documented GitHub pattern and match `host-bundle-release.yml`; no code change.
- Greptile's upload-artifact@v7 / download-artifact@v8 mismatch finding is addressed by explanation (PR comment): identical pairing to host-bundle-release.yml, which succeeded with it the same day; no code change.
