### PR TITLE
feat(platform): onboarding journey state machine (endpoint, settling, first-run)

### DIFF
--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -1,5 +1,6 @@
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
+import { randomUUID } from 'node:crypto';
 import { MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
 import { z } from 'zod/v4';
 import {
@@ -8,6 +9,8 @@ import {
   getBillingEntitlement,
   getBillingEntitlementState,
   insertBillingWebhookEvent,
+  insertCheckoutAttempt,
+  resolveCheckoutAttempt,
   runBillingWebhookTransaction,
   upsertBillingCustomer,
   upsertBillingEntitlement,
@@ -66,7 +69,7 @@ export interface StripeBillingClient {
    * Stripe Customer when needed; the signed subscription webhook links it back
    * to the Clerk user from server-written metadata.
    */
-  createCheckoutSession(input: StripeCheckoutSessionInput): Promise<{ url: string }>;
+  createCheckoutSession(input: StripeCheckoutSessionInput): Promise<{ url: string; id: string }>;
   createPortalSession(input: { customerId: string; returnUrl: string }): Promise<{ url: string }>;
   constructWebhookEvent(rawBody: string, signature: string, webhookSecret: string): StripeWebhookEvent;
 }
@@ -155,6 +158,18 @@ export function createBillingRoutes(options: {
         successUrl: resolveBillingReturnUrl(env, 'success', parsed.data.returnPath),
         cancelUrl: resolveBillingReturnUrl(env, 'canceled', parsed.data.returnPath),
       });
+      // Record the attempt so the journey can derive payment_settling without a
+      // client-side marker. Best-effort: never block the user's checkout on it.
+      try {
+        await insertCheckoutAttempt(options.db, {
+          id: randomUUID(),
+          clerkUserId,
+          stripeSessionId: session.id,
+          createdAt: now().toISOString(),
+        });
+      } catch (err: unknown) {
+        console.error('[billing] checkout attempt record failed:', err instanceof Error ? err.message : String(err));
+      }
       return c.json({ url: session.url }, 200);
     } catch (err: unknown) {
       console.error('[billing] checkout creation failed:', err instanceof Error ? err.message : String(err));
@@ -232,6 +247,22 @@ export function createBillingRoutes(options: {
         });
         if (!inserted.inserted) {
           return { received: true, duplicate: true };
+        }
+
+        // Checkout session lifecycle drives the settling-attempt status: a
+        // confirmed payment marks the attempt `paid` (sticky), an expiry marks
+        // it `expired`. Both only transition `open` rows.
+        if (event.type === 'checkout.session.completed' || event.type === 'checkout.session.expired') {
+          const sessionId = readStripeObjectId(event.data.object);
+          if (sessionId) {
+            await resolveCheckoutAttempt(
+              trx,
+              sessionId,
+              event.type === 'checkout.session.completed' ? 'paid' : 'expired',
+              webhookProcessedAt.toISOString(),
+            );
+          }
+          return { received: true, processed: true };
         }
 
         if (!isSubscriptionEvent(event.type)) {
@@ -365,6 +396,12 @@ async function projectSubscription(
       }];
     }),
   };
+}
+
+function readStripeObjectId(value: unknown): string | null {
+  if (!value || typeof value !== 'object') return null;
+  const id = (value as { id?: unknown }).id;
+  return typeof id === 'string' && id.length > 0 ? id : null;
 }
 
 function readClerkUserIdFromStripeMetadata(metadata: unknown): string | null {

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -2294,6 +2294,28 @@ export async function getLatestCheckoutAttempt(
   return row ? mapCheckoutAttempt(row) : undefined;
 }
 
+/**
+ * The attempt that governs payment settling: a confirmed `paid` attempt always
+ * wins over a newer still-`open` one, so a paying user who opens a second
+ * checkout before activation is never bounced back to plan selection. Terminal
+ * (`expired`/`abandoned`) attempts never sustain settling and are excluded.
+ */
+export async function getSettlingCheckoutAttempt(
+  db: PlatformDB,
+  clerkUserId: string,
+): Promise<BillingCheckoutAttemptRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('billing_checkout_attempts')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .where('status', 'in', ['paid', 'open'])
+    .orderBy(sql`CASE status WHEN 'paid' THEN 0 ELSE 1 END`)
+    .orderBy('created_at', 'desc')
+    .executeTakeFirst();
+  return row ? mapCheckoutAttempt(row) : undefined;
+}
+
 /** Resolves an open checkout attempt by Stripe session id. Only transitions
  * `open` rows so a later/duplicate webhook cannot rewrite a terminal state. */
 export async function resolveCheckoutAttempt(

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -2341,7 +2341,9 @@ function parseFirstRunSteps(raw: string): Record<string, unknown> {
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : {};
-  } catch {
+  } catch (err: unknown) {
+    // Corrupt persisted JSON → treat as no steps rather than failing the read.
+    void err;
     return {};
   }
 }

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -2327,12 +2327,16 @@ export async function sweepStaleCheckoutAttempts(
     .limit(limit)
     .execute();
   if (stale.length === 0) return 0;
-  await db.executor
+  const updated = await db.executor
     .updateTable('billing_checkout_attempts')
     .set({ status: 'abandoned', resolved_at: resolvedAt })
     .where('id', 'in', stale.map((r) => r.id))
+    // Re-check status in the UPDATE: a concurrent webhook may have resolved the
+    // row to paid/expired between the SELECT and here; never overwrite it.
+    .where('status', '=', 'open')
+    .returning('id')
     .execute();
-  return stale.length;
+  return updated.length;
 }
 
 function parseFirstRunSteps(raw: string): Record<string, unknown> {

--- a/packages/platform/src/db.ts
+++ b/packages/platform/src/db.ts
@@ -243,10 +243,39 @@ interface SocialFollowsTable {
   created_at: string;
 }
 
+interface BillingCheckoutAttemptsTable {
+  id: string;
+  clerk_user_id: string;
+  stripe_session_id: string;
+  status: string;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+interface OnboardingFirstRunTable {
+  clerk_user_id: string;
+  completed_at: string;
+  goal: string | null;
+  steps: string;
+  source: string;
+}
+
+interface OnboardingJourneyEventsTable {
+  id: string;
+  clerk_user_id: string;
+  from_phase: string | null;
+  to_phase: string;
+  detail: string | null;
+  at: string;
+}
+
 export interface PlatformDatabase {
   users: UsersTable;
   containers: ContainersTable;
   user_machines: UserMachinesTable;
+  billing_checkout_attempts: BillingCheckoutAttemptsTable;
+  onboarding_first_run: OnboardingFirstRunTable;
+  onboarding_journey_events: OnboardingJourneyEventsTable;
   host_bundle_releases: HostBundleReleasesTable;
   host_bundle_channels: HostBundleChannelsTable;
   host_bundle_release_channels: HostBundleReleaseChannelsTable;
@@ -348,6 +377,42 @@ export interface UserMachineRecord {
   failureCode: string | null;
   failureAt: string | null;
   attempt: number;
+}
+
+export type BillingCheckoutAttemptStatus = 'open' | 'paid' | 'expired' | 'abandoned';
+
+export interface BillingCheckoutAttemptRecord {
+  id: string;
+  clerkUserId: string;
+  stripeSessionId: string;
+  status: BillingCheckoutAttemptStatus;
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
+export interface OnboardingFirstRunRecord {
+  clerkUserId: string;
+  completedAt: string;
+  goal: string | null;
+  steps: Record<string, unknown>;
+  source: string;
+}
+
+export interface NewOnboardingFirstRun {
+  clerkUserId: string;
+  completedAt: string;
+  goal?: string | null;
+  steps?: Record<string, unknown>;
+  source: string;
+}
+
+export interface OnboardingJourneyEventRecord {
+  id: string;
+  clerkUserId: string;
+  fromPhase: string | null;
+  toPhase: string;
+  detail: string | null;
+  at: string;
 }
 
 export interface HostBundleReleaseRecord {
@@ -610,6 +675,42 @@ async function migrate(db: Kysely<PlatformDatabase>): Promise<void> {
   `.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_clerk_slot_status ON user_machines(clerk_user_id, runtime_slot, status)`.execute(db);
   await sql`CREATE INDEX IF NOT EXISTS idx_user_machines_hetzner ON user_machines(hetzner_server_id)`.execute(db);
+
+  // Onboarding journey (spec 092): server-owned signup-to-ready state. Schema is
+  // uniformly TEXT/uuid/ISO-string to match the rest of this file (no jsonb/serial).
+  await sql`
+    CREATE TABLE IF NOT EXISTS billing_checkout_attempts (
+      id TEXT PRIMARY KEY,
+      clerk_user_id TEXT NOT NULL,
+      stripe_session_id TEXT NOT NULL UNIQUE,
+      status TEXT NOT NULL DEFAULT 'open',
+      created_at TEXT NOT NULL,
+      resolved_at TEXT
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_checkout_attempts_clerk_created ON billing_checkout_attempts(clerk_user_id, created_at)`.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS onboarding_first_run (
+      clerk_user_id TEXT PRIMARY KEY,
+      completed_at TEXT NOT NULL,
+      goal TEXT,
+      steps TEXT NOT NULL DEFAULT '{}',
+      source TEXT NOT NULL
+    )
+  `.execute(db);
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS onboarding_journey_events (
+      id TEXT PRIMARY KEY,
+      clerk_user_id TEXT NOT NULL,
+      from_phase TEXT,
+      to_phase TEXT NOT NULL,
+      detail TEXT,
+      at TEXT NOT NULL
+    )
+  `.execute(db);
+  await sql`CREATE INDEX IF NOT EXISTS idx_journey_events_clerk_at ON onboarding_journey_events(clerk_user_id, at)`.execute(db);
 
   await sql`
     CREATE TABLE IF NOT EXISTS billing_customers (
@@ -2139,6 +2240,240 @@ export async function listStaleUserMachines(
     .limit(limit)
     .execute();
   return rows.map(mapUserMachine);
+}
+
+// ---------------------------------------------------------------------------
+// Onboarding journey (spec 092)
+// ---------------------------------------------------------------------------
+
+function isCheckoutAttemptStatus(value: string): value is BillingCheckoutAttemptStatus {
+  return value === 'open' || value === 'paid' || value === 'expired' || value === 'abandoned';
+}
+
+function mapCheckoutAttempt(row: BillingCheckoutAttemptsTable): BillingCheckoutAttemptRecord {
+  return {
+    id: row.id,
+    clerkUserId: row.clerk_user_id,
+    stripeSessionId: row.stripe_session_id,
+    status: isCheckoutAttemptStatus(row.status) ? row.status : 'open',
+    createdAt: row.created_at,
+    resolvedAt: row.resolved_at,
+  };
+}
+
+export async function insertCheckoutAttempt(
+  db: PlatformDB,
+  record: { id: string; clerkUserId: string; stripeSessionId: string; createdAt: string },
+): Promise<void> {
+  await db.ready;
+  await db.executor
+    .insertInto('billing_checkout_attempts')
+    .values({
+      id: record.id,
+      clerk_user_id: record.clerkUserId,
+      stripe_session_id: record.stripeSessionId,
+      status: 'open',
+      created_at: record.createdAt,
+      resolved_at: null,
+    })
+    .onConflict((oc) => oc.column('stripe_session_id').doNothing())
+    .execute();
+}
+
+export async function getLatestCheckoutAttempt(
+  db: PlatformDB,
+  clerkUserId: string,
+): Promise<BillingCheckoutAttemptRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('billing_checkout_attempts')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .orderBy('created_at', 'desc')
+    .executeTakeFirst();
+  return row ? mapCheckoutAttempt(row) : undefined;
+}
+
+/** Resolves an open checkout attempt by Stripe session id. Only transitions
+ * `open` rows so a later/duplicate webhook cannot rewrite a terminal state. */
+export async function resolveCheckoutAttempt(
+  db: PlatformDB,
+  stripeSessionId: string,
+  status: 'paid' | 'expired',
+  resolvedAt: string,
+): Promise<void> {
+  await db.ready;
+  await db.executor
+    .updateTable('billing_checkout_attempts')
+    .set({ status, resolved_at: resolvedAt })
+    .where('stripe_session_id', '=', stripeSessionId)
+    .where('status', '=', 'open')
+    .execute();
+}
+
+/** Sweeps stale `open` attempts to `abandoned` (resource-cleanup janitor). */
+export async function sweepStaleCheckoutAttempts(
+  db: PlatformDB,
+  olderThanIso: string,
+  resolvedAt: string,
+  limit: number,
+): Promise<number> {
+  await db.ready;
+  const stale = await db.executor
+    .selectFrom('billing_checkout_attempts')
+    .select('id')
+    .where('status', '=', 'open')
+    .where('created_at', '<', olderThanIso)
+    .limit(limit)
+    .execute();
+  if (stale.length === 0) return 0;
+  await db.executor
+    .updateTable('billing_checkout_attempts')
+    .set({ status: 'abandoned', resolved_at: resolvedAt })
+    .where('id', 'in', stale.map((r) => r.id))
+    .execute();
+  return stale.length;
+}
+
+function parseFirstRunSteps(raw: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function mapFirstRun(row: OnboardingFirstRunTable): OnboardingFirstRunRecord {
+  return {
+    clerkUserId: row.clerk_user_id,
+    completedAt: row.completed_at,
+    goal: row.goal,
+    steps: parseFirstRunSteps(row.steps),
+    source: row.source,
+  };
+}
+
+export async function getOnboardingFirstRun(
+  db: PlatformDB,
+  clerkUserId: string,
+): Promise<OnboardingFirstRunRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('onboarding_first_run')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .executeTakeFirst();
+  return row ? mapFirstRun(row) : undefined;
+}
+
+/** Authoritative write-behind from the gateway: latest completion wins. */
+export async function upsertOnboardingFirstRun(
+  db: PlatformDB,
+  record: NewOnboardingFirstRun,
+): Promise<void> {
+  await db.ready;
+  const values = {
+    clerk_user_id: record.clerkUserId,
+    completed_at: record.completedAt,
+    goal: record.goal ?? null,
+    steps: JSON.stringify(record.steps ?? {}),
+    source: record.source,
+  };
+  await db.executor
+    .insertInto('onboarding_first_run')
+    .values(values)
+    .onConflict((oc) =>
+      oc.column('clerk_user_id').doUpdateSet({
+        completed_at: values.completed_at,
+        goal: values.goal,
+        steps: values.steps,
+        source: values.source,
+      }),
+    )
+    .execute();
+}
+
+/** Best-effort legacy backfill: only fills a missing record, never overwrites
+ * an authoritative gateway write-behind (spec 092 R4). */
+export async function insertOnboardingFirstRunIfAbsent(
+  db: PlatformDB,
+  record: NewOnboardingFirstRun,
+): Promise<void> {
+  await db.ready;
+  await db.executor
+    .insertInto('onboarding_first_run')
+    .values({
+      clerk_user_id: record.clerkUserId,
+      completed_at: record.completedAt,
+      goal: record.goal ?? null,
+      steps: JSON.stringify(record.steps ?? {}),
+      source: record.source,
+    })
+    .onConflict((oc) => oc.column('clerk_user_id').doNothing())
+    .execute();
+}
+
+/** Running machines whose owner has no first-run record yet (backfill candidates). */
+export async function listRunningMachinesMissingFirstRun(
+  db: PlatformDB,
+  limit: number,
+): Promise<UserMachineRecord[]> {
+  await db.ready;
+  const rows = await db.executor
+    .selectFrom('user_machines')
+    .selectAll('user_machines')
+    .leftJoin('onboarding_first_run', 'onboarding_first_run.clerk_user_id', 'user_machines.clerk_user_id')
+    .where('user_machines.status', '=', 'running')
+    .where('user_machines.deleted_at', 'is', null)
+    .where('onboarding_first_run.clerk_user_id', 'is', null)
+    .orderBy('user_machines.provisioned_at')
+    .limit(limit)
+    .execute();
+  return rows.map(mapUserMachine);
+}
+
+export async function getLatestJourneyEvent(
+  db: PlatformDB,
+  clerkUserId: string,
+): Promise<OnboardingJourneyEventRecord | undefined> {
+  await db.ready;
+  const row = await db.executor
+    .selectFrom('onboarding_journey_events')
+    .selectAll()
+    .where('clerk_user_id', '=', clerkUserId)
+    .orderBy('at', 'desc')
+    .executeTakeFirst();
+  return row
+    ? {
+        id: row.id,
+        clerkUserId: row.clerk_user_id,
+        fromPhase: row.from_phase,
+        toPhase: row.to_phase,
+        detail: row.detail,
+        at: row.at,
+      }
+    : undefined;
+}
+
+export async function appendJourneyEvent(
+  db: PlatformDB,
+  record: { id: string; clerkUserId: string; fromPhase: string | null; toPhase: string; detail: string | null; at: string },
+): Promise<void> {
+  await db.ready;
+  await db.executor
+    .insertInto('onboarding_journey_events')
+    .values({
+      id: record.id,
+      clerk_user_id: record.clerkUserId,
+      from_phase: record.fromPhase,
+      to_phase: record.toPhase,
+      detail: record.detail,
+      at: record.at,
+    })
+    .execute();
 }
 
 export async function allocatePort(db: PlatformDB, basePort: number, handle: string): Promise<number> {

--- a/packages/platform/src/journey-routes.ts
+++ b/packages/platform/src/journey-routes.ts
@@ -93,6 +93,12 @@ export interface JourneyRoutesOptions {
    * Absent when internal auth is not configured.
    */
   verifyInternalToken?: (handle: string, token: string | undefined) => boolean;
+  /**
+   * Resolves the clerkUserId that actually owns a handle, so a first-run report
+   * cannot advance an arbitrary user's journey: the authenticated gateway may
+   * only write for its own owner. Returns null if the handle owner is unknown.
+   */
+  resolveHandleOwner?: (handle: string) => Promise<string | null>;
   appOrigin: string;
   maxProvisionAttempts: number;
   settlingWindowMs?: number;
@@ -202,6 +208,16 @@ export function createJourneyRoutes(options: JourneyRoutesOptions): Hono {
     // The authenticated handle must own the reported completion.
     if (parsed.data.handle !== handle) {
       return c.json({ error: 'Invalid request' }, 422);
+    }
+
+    // Bind the submitted clerkUserId to the authenticated handle: a gateway may
+    // only report first-run for its own owner, never advance another user's
+    // journey. Missing/mismatched ownership is rejected (generic to the caller).
+    if (options.resolveHandleOwner) {
+      const owner = await options.resolveHandleOwner(handle);
+      if (!owner || owner !== parsed.data.clerkUserId) {
+        return c.json({ error: 'Invalid request' }, 403);
+      }
     }
 
     try {

--- a/packages/platform/src/journey-routes.ts
+++ b/packages/platform/src/journey-routes.ts
@@ -1,6 +1,5 @@
 import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { createHash, timingSafeEqual } from 'node:crypto';
 import { z } from 'zod/v4';
 import {
   getActiveUserMachineByClerkId,
@@ -37,8 +36,10 @@ export function createJourneyUserResolver(opts: {
           const result = await opts.clerkAuth.verify(token);
           if (result.authenticated && result.userId) return result.userId;
         }
-      } catch {
-        // fall through to sync-JWT
+      } catch (err: unknown) {
+        // Expected when the token is a platform sync JWT rather than a Clerk
+        // session; fall through to sync-JWT verification below (not an error).
+        void err;
       }
     }
     // 2. Platform sync JWT (CLI / native / mobile token paste).
@@ -49,7 +50,8 @@ export function createJourneyUserResolver(opts: {
       try {
         const claims = await verifySyncJwt(bearer, { secret: opts.syncJwtSecret });
         if (claims.sub) return claims.sub;
-      } catch {
+      } catch (err: unknown) {
+        // Invalid/expired/forged sync JWT → unauthenticated (do not leak why).
         return null;
       }
     }
@@ -84,8 +86,13 @@ export interface JourneyRoutesOptions {
   resolveUserId: (c: Context) => Promise<string | null>;
   /** Triggers a provisioning attempt (billing-checked). Absent when provisioning is unavailable. */
   provisionRuntime?: (clerkUserId: string, runtimeSlot: string) => Promise<void>;
-  /** Expected internal token for gateway->platform first-run reports (UPGRADE_TOKEN). */
-  internalToken?: string;
+  /**
+   * Verifies the gateway->platform first-run report's per-handle token
+   * (constant-time). main.ts supplies
+   * `(handle, token) => timingSafeTokenEquals(token, buildPlatformVerificationToken(handle, secret))`.
+   * Absent when internal auth is not configured.
+   */
+  verifyInternalToken?: (handle: string, token: string | undefined) => boolean;
   appOrigin: string;
   maxProvisionAttempts: number;
   settlingWindowMs?: number;
@@ -96,12 +103,6 @@ export interface JourneyRoutesOptions {
 
 function applyNoStore(c: Context): void {
   c.header('Cache-Control', 'no-store');
-}
-
-function tokensMatch(a: string, b: string): boolean {
-  const ha = createHash('sha256').update(a).digest();
-  const hb = createHash('sha256').update(b).digest();
-  return timingSafeEqual(ha, hb);
 }
 
 const LIVE_MACHINE_STATUSES = new Set(['provisioning', 'recovering', 'running']);
@@ -146,7 +147,8 @@ export function createJourneyRoutes(options: JourneyRoutesOptions): Hono {
     if (raw.trim().length > 0) {
       try {
         body = JSON.parse(raw);
-      } catch {
+      } catch (err: unknown) {
+        if (!(err instanceof SyntaxError)) throw err;
         return c.json({ error: 'Invalid request' }, 400);
       }
     }
@@ -178,10 +180,12 @@ export function createJourneyRoutes(options: JourneyRoutesOptions): Hono {
 
   app.post('/internal/first-run', bodyLimit({ maxSize: INTERNAL_BODY_LIMIT }), async (c) => {
     applyNoStore(c);
-    const expected = options.internalToken;
-    const header = c.req.header('authorization');
-    const presented = header?.toLowerCase().startsWith('bearer ') ? header.slice(7).trim() : undefined;
-    if (!expected || !presented || !tokensMatch(presented, expected)) {
+    // Per-handle internal auth: the gateway presents the same derived token it
+    // uses for every platform->VPS internal call, scoped to its own handle.
+    const handle = c.req.header('x-matrix-handle');
+    const authHeader = c.req.header('authorization');
+    const token = authHeader?.toLowerCase().startsWith('bearer ') ? authHeader.slice(7).trim() : undefined;
+    if (!handle || !options.verifyInternalToken || !options.verifyInternalToken(handle, token)) {
       return c.json({ error: 'Unauthorized' }, 401);
     }
 
@@ -195,9 +199,8 @@ export function createJourneyRoutes(options: JourneyRoutesOptions): Hono {
     const parsed = FirstRunBodySchema.safeParse(body);
     if (!parsed.success) return c.json({ error: 'Invalid request' }, 422);
 
-    // The header handle must match the body handle the gateway claims for.
-    const headerHandle = c.req.header('x-matrix-handle');
-    if (headerHandle && headerHandle !== parsed.data.handle) {
+    // The authenticated handle must own the reported completion.
+    if (parsed.data.handle !== handle) {
       return c.json({ error: 'Invalid request' }, 422);
     }
 

--- a/packages/platform/src/journey-routes.ts
+++ b/packages/platform/src/journey-routes.ts
@@ -1,0 +1,220 @@
+import { Hono, type Context } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { z } from 'zod/v4';
+import {
+  getActiveUserMachineByClerkId,
+  upsertOnboardingFirstRun,
+  type PlatformDB,
+} from './db.js';
+import { loadJourney, type JourneyReadinessAnnotation } from './journey.js';
+import { CustomerVpsError } from './customer-vps-errors.js';
+import { verifySyncJwt } from './sync-jwt.js';
+
+export interface JourneyClerkAuth {
+  extractToken: (authorization?: string, cookie?: string) => string | null;
+  verify: (token: string) => Promise<{ authenticated: boolean; userId?: string | null }>;
+}
+
+/**
+ * Resolves the journey caller's clerkUserId from either a Clerk session
+ * (cookie or bearer — web/mobile) or a platform sync JWT (bearer — CLI, native
+ * macOS app). This is the single auth seam every surface shares; the native app
+ * consumes it with its keychain sync JWT exactly as the CLI does.
+ */
+export function createJourneyUserResolver(opts: {
+  clerkAuth?: JourneyClerkAuth;
+  syncJwtSecret?: string;
+}): (c: Context) => Promise<string | null> {
+  return async (c: Context): Promise<string | null> => {
+    const authorization = c.req.header('authorization');
+    const cookie = c.req.header('cookie');
+    // 1. Clerk session (cookie or Clerk bearer).
+    if (opts.clerkAuth) {
+      try {
+        const token = opts.clerkAuth.extractToken(authorization, cookie);
+        if (token) {
+          const result = await opts.clerkAuth.verify(token);
+          if (result.authenticated && result.userId) return result.userId;
+        }
+      } catch {
+        // fall through to sync-JWT
+      }
+    }
+    // 2. Platform sync JWT (CLI / native / mobile token paste).
+    const bearer = authorization?.toLowerCase().startsWith('bearer ')
+      ? authorization.slice(7).trim()
+      : undefined;
+    if (bearer && opts.syncJwtSecret) {
+      try {
+        const claims = await verifySyncJwt(bearer, { secret: opts.syncJwtSecret });
+        if (claims.sub) return claims.sub;
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  };
+}
+
+const SAFE_SLUG = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const INTERNAL_BODY_LIMIT = 16 * 1024;
+const RETRY_BODY_LIMIT = 1024;
+
+const RetryBodySchema = z.object({
+  runtimeSlot: z.string().regex(SAFE_SLUG).optional(),
+});
+
+const FirstRunBodySchema = z.object({
+  clerkUserId: z.string().min(1).max(256),
+  handle: z.string().regex(SAFE_SLUG),
+  completedAt: z.iso.datetime(),
+  goal: z.enum(['coding', 'company_brain', 'assistant']).optional(),
+  steps: z.record(z.string().max(64), z.unknown()).optional(),
+  source: z.enum(['gateway_ws', 'shell_manual']),
+});
+
+export interface JourneyRetryResult {
+  status: 'started' | 'in_progress';
+}
+
+export interface JourneyRoutesOptions {
+  db: PlatformDB;
+  /** Dual auth: Clerk session cookie / bearer, or platform sync JWT. Returns clerkUserId or null. */
+  resolveUserId: (c: Context) => Promise<string | null>;
+  /** Triggers a provisioning attempt (billing-checked). Absent when provisioning is unavailable. */
+  provisionRuntime?: (clerkUserId: string, runtimeSlot: string) => Promise<void>;
+  /** Expected internal token for gateway->platform first-run reports (UPGRADE_TOKEN). */
+  internalToken?: string;
+  appOrigin: string;
+  maxProvisionAttempts: number;
+  settlingWindowMs?: number;
+  now?: () => Date;
+  /** Optional readiness annotation provider for the ready phase (Phase C wires this). */
+  resolveReadiness?: (clerkUserId: string) => Promise<JourneyReadinessAnnotation | undefined>;
+}
+
+function applyNoStore(c: Context): void {
+  c.header('Cache-Control', 'no-store');
+}
+
+function tokensMatch(a: string, b: string): boolean {
+  const ha = createHash('sha256').update(a).digest();
+  const hb = createHash('sha256').update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
+
+const LIVE_MACHINE_STATUSES = new Set(['provisioning', 'recovering', 'running']);
+
+export function createJourneyRoutes(options: JourneyRoutesOptions): Hono {
+  const app = new Hono();
+  const now = options.now ?? (() => new Date());
+
+  async function buildJourney(clerkUserId: string, runtimeSlot?: string) {
+    const readiness = options.resolveReadiness ? await options.resolveReadiness(clerkUserId) : undefined;
+    return loadJourney(clerkUserId, {
+      db: options.db,
+      now,
+      settlingWindowMs: options.settlingWindowMs,
+      maxProvisionAttempts: options.maxProvisionAttempts,
+      appOrigin: options.appOrigin,
+      runtimeSlot,
+      readiness,
+    });
+  }
+
+  app.get('/api/journey', async (c) => {
+    applyNoStore(c);
+    const clerkUserId = await options.resolveUserId(c);
+    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
+    try {
+      return c.json(await buildJourney(clerkUserId), 200);
+    } catch (err: unknown) {
+      console.error('[journey] state derivation failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'journey_unavailable' }, 503);
+    }
+  });
+
+  app.post('/api/journey/retry-provision', bodyLimit({ maxSize: RETRY_BODY_LIMIT }), async (c) => {
+    applyNoStore(c);
+    const clerkUserId = await options.resolveUserId(c);
+    if (!clerkUserId) return c.json({ error: 'Unauthorized' }, 401);
+
+    // Body is optional; an empty body means "retry the primary slot".
+    let body: unknown = {};
+    const raw = await c.req.text();
+    if (raw.trim().length > 0) {
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        return c.json({ error: 'Invalid request' }, 400);
+      }
+    }
+    const parsed = RetryBodySchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: 'Invalid request' }, 400);
+    const runtimeSlot = parsed.data.runtimeSlot ?? 'primary';
+
+    if (!options.provisionRuntime) {
+      return c.json({ error: 'provisioning_unavailable' }, 503);
+    }
+
+    try {
+      // Converge on an in-flight attempt rather than starting a duplicate (FR-028).
+      const existing = await getActiveUserMachineByClerkId(options.db, clerkUserId, runtimeSlot);
+      if (existing && LIVE_MACHINE_STATUSES.has(existing.status)) {
+        return c.json({ status: 'in_progress', journey: await buildJourney(clerkUserId, runtimeSlot) }, 200);
+      }
+      await options.provisionRuntime(clerkUserId, runtimeSlot);
+      return c.json({ status: 'started', journey: await buildJourney(clerkUserId, runtimeSlot) }, 200);
+    } catch (err: unknown) {
+      if (err instanceof CustomerVpsError) {
+        if (err.code === 'billing_required') return c.json({ error: 'billing_required' }, 402);
+        if (err.code === 'retry_exhausted') return c.json({ error: 'retry_exhausted' }, 409);
+      }
+      console.error('[journey] retry-provision failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'provisioning_unavailable' }, 503);
+    }
+  });
+
+  app.post('/internal/first-run', bodyLimit({ maxSize: INTERNAL_BODY_LIMIT }), async (c) => {
+    applyNoStore(c);
+    const expected = options.internalToken;
+    const header = c.req.header('authorization');
+    const presented = header?.toLowerCase().startsWith('bearer ') ? header.slice(7).trim() : undefined;
+    if (!expected || !presented || !tokensMatch(presented, expected)) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (err: unknown) {
+      if (err instanceof SyntaxError) return c.json({ error: 'Invalid request' }, 422);
+      throw err;
+    }
+    const parsed = FirstRunBodySchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: 'Invalid request' }, 422);
+
+    // The header handle must match the body handle the gateway claims for.
+    const headerHandle = c.req.header('x-matrix-handle');
+    if (headerHandle && headerHandle !== parsed.data.handle) {
+      return c.json({ error: 'Invalid request' }, 422);
+    }
+
+    try {
+      await upsertOnboardingFirstRun(options.db, {
+        clerkUserId: parsed.data.clerkUserId,
+        completedAt: parsed.data.completedAt,
+        goal: parsed.data.goal ?? null,
+        steps: parsed.data.steps ?? {},
+        source: parsed.data.source,
+      });
+      return c.body(null, 204);
+    } catch (err: unknown) {
+      console.error('[journey] first-run upsert failed:', err instanceof Error ? err.message : String(err));
+      return c.json({ error: 'first_run_unavailable' }, 503);
+    }
+  });
+
+  return app;
+}

--- a/packages/platform/src/journey.ts
+++ b/packages/platform/src/journey.ts
@@ -3,7 +3,7 @@ import {
   appendJourneyEvent,
   getActiveUserMachineByClerkId,
   getBillingEntitlementState,
-  getLatestCheckoutAttempt,
+  getSettlingCheckoutAttempt,
   getLatestJourneyEvent,
   getOnboardingFirstRun,
   insertOnboardingFirstRunIfAbsent,
@@ -220,7 +220,7 @@ export async function loadJourney(clerkUserId: string, deps: LoadJourneyDeps): P
   const now = (deps.now ?? (() => new Date()))();
   const [entitlement, checkoutAttempt, liveMachine, firstRun] = await Promise.all([
     resolveEffectiveEntitlement(deps.db, clerkUserId, now),
-    getLatestCheckoutAttempt(deps.db, clerkUserId),
+    getSettlingCheckoutAttempt(deps.db, clerkUserId),
     getActiveUserMachineByClerkId(deps.db, clerkUserId, deps.runtimeSlot),
     getOnboardingFirstRun(deps.db, clerkUserId),
   ]);

--- a/packages/platform/src/journey.ts
+++ b/packages/platform/src/journey.ts
@@ -271,8 +271,12 @@ export async function backfillFirstRunRecords(
     try {
       result = await opts.probe(machine);
     } catch (err: unknown) {
-      // Unreachable / transient probe failure — skip and retry on a later pass.
-      void err;
+      // Unreachable / transient probe failure — log so systematic failures are
+      // visible, then skip and retry on a later reconciler pass.
+      console.warn(
+        `[journey] first-run backfill probe failed machine=${machine.machineId}`,
+        err instanceof Error ? err.name : typeof err,
+      );
       continue;
     }
     if (!result) continue;

--- a/packages/platform/src/journey.ts
+++ b/packages/platform/src/journey.ts
@@ -6,6 +6,8 @@ import {
   getLatestCheckoutAttempt,
   getLatestJourneyEvent,
   getOnboardingFirstRun,
+  insertOnboardingFirstRunIfAbsent,
+  listRunningMachinesMissingFirstRun,
   type BillingCheckoutAttemptRecord,
   type OnboardingFirstRunRecord,
   type PlatformDB,
@@ -243,6 +245,46 @@ export async function loadJourney(clerkUserId: string, deps: LoadJourneyDeps): P
   }
 
   return state;
+}
+
+export interface FirstRunProbeResult {
+  completedAt: string;
+  goal?: string | null;
+}
+
+/**
+ * Backfills server-owned first-run records for legacy users — those whose
+ * machine predates the write-behind path. Runs OFF the journey read path (the
+ * reconciler calls it): the read path never probes a VPS, so it stays fast and
+ * never hangs. `probe` returns a result for a completed onboarding, null for
+ * not-completed-or-unreachable; unreachable machines simply retry next pass.
+ * Persists with DO NOTHING so it can never clobber an authoritative write-behind.
+ */
+export async function backfillFirstRunRecords(
+  db: PlatformDB,
+  opts: { probe: (machine: UserMachineRecord) => Promise<FirstRunProbeResult | null>; limit?: number },
+): Promise<{ checked: number; filled: number }> {
+  const machines = await listRunningMachinesMissingFirstRun(db, opts.limit ?? 25);
+  let filled = 0;
+  for (const machine of machines) {
+    let result: FirstRunProbeResult | null;
+    try {
+      result = await opts.probe(machine);
+    } catch (err: unknown) {
+      // Unreachable / transient probe failure — skip and retry on a later pass.
+      void err;
+      continue;
+    }
+    if (!result) continue;
+    await insertOnboardingFirstRunIfAbsent(db, {
+      clerkUserId: machine.clerkUserId,
+      completedAt: result.completedAt,
+      goal: result.goal ?? null,
+      source: 'backfill',
+    });
+    filled += 1;
+  }
+  return { checked: machines.length, filled };
 }
 
 /** Appends a journey event only when the phase differs from the latest recorded one. */

--- a/packages/platform/src/journey.ts
+++ b/packages/platform/src/journey.ts
@@ -1,0 +1,265 @@
+import { randomUUID } from 'node:crypto';
+import {
+  appendJourneyEvent,
+  getActiveUserMachineByClerkId,
+  getBillingEntitlementState,
+  getLatestCheckoutAttempt,
+  getLatestJourneyEvent,
+  getOnboardingFirstRun,
+  type BillingCheckoutAttemptRecord,
+  type OnboardingFirstRunRecord,
+  type PlatformDB,
+  type UserMachineRecord,
+} from './db.js';
+import {
+  computeEffectiveEntitlement,
+  getRuntimeAccessDecision,
+  parseBillingEntitlementRecord,
+  parseBillingOverrideRecord,
+  type BillingEntitlement,
+} from './billing.js';
+
+export const DEFAULT_SETTLING_WINDOW_MS = 10 * 60 * 1000;
+
+export type JourneyPhase =
+  | 'account_required'
+  | 'plan_required'
+  | 'payment_settling'
+  | 'provisioning'
+  | 'provisioning_failed'
+  | 'first_run'
+  | 'ready';
+
+export type JourneyActionKind =
+  | 'open_plans'
+  | 'wait'
+  | 'start_provision'
+  | 'retry_provision'
+  | 'contact_support'
+  | 'begin_first_run'
+  | 'open_shell'
+  | 'none';
+
+export type ProvisioningStage = 'creating_server' | 'booting' | 'registering' | 'finalizing';
+
+export interface JourneyReadinessAnnotation {
+  status: 'ok' | 'degraded';
+  failing: string[];
+}
+
+export interface JourneyState {
+  phase: JourneyPhase;
+  detail: string;
+  nextAction: { kind: JourneyActionKind; url?: string };
+  progress?: { stage: ProvisioningStage; startedAt: string };
+  failure?: { retryable: boolean; attempt: number };
+  settling?: { since: string; delayed: boolean };
+  readiness?: JourneyReadinessAnnotation;
+}
+
+export interface JourneyDerivationInputs {
+  entitlement: BillingEntitlement | null;
+  /** Newest checkout attempt for the user, if any. */
+  checkoutAttempt: BillingCheckoutAttemptRecord | null;
+  /** The single non-deleted machine for the user/slot, any status, if any. */
+  liveMachine: UserMachineRecord | null;
+  firstRun: OnboardingFirstRunRecord | null;
+  now: Date;
+  settlingWindowMs: number;
+  maxProvisionAttempts: number;
+  appOrigin: string;
+  /** Optional readiness annotation supplied by a caller (Phase C); omitted in Phase B. */
+  readiness?: JourneyReadinessAnnotation;
+}
+
+function plansUrl(appOrigin: string): string {
+  const url = new URL(appOrigin);
+  url.searchParams.set('plans', '1');
+  return url.toString();
+}
+
+function shellUrl(appOrigin: string): string {
+  return new URL('/', appOrigin).toString();
+}
+
+// An entitlement is "pre-activation" when the user has never reached an
+// access-granting state: no row at all, or a Stripe status that precedes
+// activation. A lapsed entitlement (was active, now canceled/ended/unpaid/past
+// grace) is NOT pre-activation and must route to plan_required so a churned
+// subscriber is never trapped in payment_settling.
+function isPreActivationEntitlement(entitlement: BillingEntitlement | null): boolean {
+  if (!entitlement) return true;
+  return entitlement.status === 'incomplete' || entitlement.status === 'none';
+}
+
+function deriveProvisioningStage(machine: UserMachineRecord): ProvisioningStage {
+  if (machine.status === 'recovering') return 'finalizing';
+  if (!machine.hetznerServerId) return 'creating_server';
+  if (!machine.publicIPv4) return 'booting';
+  return 'registering';
+}
+
+/**
+ * Pure journey-phase derivation (spec 092 R1/R3). Assumes the caller has already
+ * authenticated the user; `account_required` is therefore never emitted here.
+ * No I/O — all inputs are pre-fetched so this is exhaustively unit-testable.
+ */
+export function deriveJourneyPhase(inputs: JourneyDerivationInputs): JourneyState {
+  const { entitlement, checkoutAttempt, liveMachine, firstRun, now, settlingWindowMs, maxProvisionAttempts, appOrigin } = inputs;
+  const access = getRuntimeAccessDecision(entitlement, now);
+
+  if (!access.runtimeProxyAllowed) {
+    // Billing branch. Settling only applies pre-activation; a lapsed entitlement
+    // falls straight through to plan_required.
+    if (isPreActivationEntitlement(entitlement) && checkoutAttempt) {
+      const ageMs = now.getTime() - new Date(checkoutAttempt.createdAt).getTime();
+      const withinWindow = ageMs <= settlingWindowMs;
+      const sustainsSettling =
+        checkoutAttempt.status === 'paid' || (checkoutAttempt.status === 'open' && withinWindow);
+      if (sustainsSettling) {
+        const delayed = ageMs > settlingWindowMs; // only reachable for a `paid` attempt
+        return {
+          phase: 'payment_settling',
+          detail: delayed
+            ? 'Your payment is taking longer than expected to confirm.'
+            : 'Activating your subscription…',
+          nextAction: delayed ? { kind: 'contact_support' } : { kind: 'wait' },
+          settling: { since: checkoutAttempt.createdAt, delayed },
+        };
+      }
+    }
+    return {
+      phase: 'plan_required',
+      detail: 'Choose a plan to create your Matrix computer.',
+      nextAction: { kind: 'open_plans', url: plansUrl(appOrigin) },
+    };
+  }
+
+  // Entitled branch.
+  if (!liveMachine) {
+    return {
+      phase: 'provisioning',
+      detail: 'Ready to build your Matrix computer.',
+      nextAction: { kind: 'start_provision' },
+    };
+  }
+
+  switch (liveMachine.status) {
+    case 'provisioning':
+    case 'recovering':
+      return {
+        phase: 'provisioning',
+        detail: 'Building your Matrix computer…',
+        nextAction: { kind: 'wait' },
+        progress: { stage: deriveProvisioningStage(liveMachine), startedAt: liveMachine.provisionedAt },
+      };
+    case 'failed': {
+      const retryable = liveMachine.attempt < maxProvisionAttempts;
+      return {
+        phase: 'provisioning_failed',
+        detail: retryable
+          ? 'Setting up your computer ran into a problem.'
+          : 'We could not set up your computer after several attempts.',
+        nextAction: retryable ? { kind: 'retry_provision' } : { kind: 'contact_support' },
+        failure: { retryable, attempt: liveMachine.attempt },
+      };
+    }
+    case 'running':
+      if (!firstRun) {
+        return {
+          phase: 'first_run',
+          detail: 'Finish setting up your Matrix computer.',
+          nextAction: { kind: 'begin_first_run' },
+        };
+      }
+      return {
+        phase: 'ready',
+        detail: 'Your Matrix computer is ready.',
+        nextAction: { kind: 'open_shell', url: shellUrl(appOrigin) },
+        ...(inputs.readiness ? { readiness: inputs.readiness } : {}),
+      };
+    default:
+      // Unknown/terminal status (e.g. deleted shouldn't appear here): treat as start.
+      return {
+        phase: 'provisioning',
+        detail: 'Ready to build your Matrix computer.',
+        nextAction: { kind: 'start_provision' },
+      };
+  }
+}
+
+export interface LoadJourneyDeps {
+  db: PlatformDB;
+  now?: () => Date;
+  settlingWindowMs?: number;
+  maxProvisionAttempts: number;
+  appOrigin: string;
+  runtimeSlot?: string;
+  readiness?: JourneyReadinessAnnotation;
+  /** Records a telemetry event when the phase changes. Defaults to true. */
+  recordTransition?: boolean;
+}
+
+async function resolveEffectiveEntitlement(db: PlatformDB, clerkUserId: string, now: Date): Promise<BillingEntitlement | null> {
+  const state = await getBillingEntitlementState(db, clerkUserId, now.toISOString());
+  return computeEffectiveEntitlement({
+    stripeEntitlement: parseBillingEntitlementRecord(state.entitlement),
+    override: parseBillingOverrideRecord(state.override),
+    now,
+  });
+}
+
+/**
+ * Fetches the inputs for a user and derives their journey state. Records a
+ * journey-transition telemetry event (best-effort, write-behind) when the
+ * computed phase differs from the last recorded one. Performs no provider calls.
+ */
+export async function loadJourney(clerkUserId: string, deps: LoadJourneyDeps): Promise<JourneyState> {
+  const now = (deps.now ?? (() => new Date()))();
+  const [entitlement, checkoutAttempt, liveMachine, firstRun] = await Promise.all([
+    resolveEffectiveEntitlement(deps.db, clerkUserId, now),
+    getLatestCheckoutAttempt(deps.db, clerkUserId),
+    getActiveUserMachineByClerkId(deps.db, clerkUserId, deps.runtimeSlot),
+    getOnboardingFirstRun(deps.db, clerkUserId),
+  ]);
+
+  const state = deriveJourneyPhase({
+    entitlement,
+    checkoutAttempt: checkoutAttempt ?? null,
+    liveMachine: liveMachine ?? null,
+    firstRun: firstRun ?? null,
+    now,
+    settlingWindowMs: deps.settlingWindowMs ?? DEFAULT_SETTLING_WINDOW_MS,
+    maxProvisionAttempts: deps.maxProvisionAttempts,
+    appOrigin: deps.appOrigin,
+    readiness: deps.readiness,
+  });
+
+  if (deps.recordTransition !== false) {
+    await recordJourneyTransition(deps.db, clerkUserId, state, now).catch((err: unknown) => {
+      // Telemetry is non-authoritative: never fail the read on a write error.
+      console.warn('[journey] transition record failed:', err instanceof Error ? err.name : typeof err);
+    });
+  }
+
+  return state;
+}
+
+/** Appends a journey event only when the phase differs from the latest recorded one. */
+export async function recordJourneyTransition(
+  db: PlatformDB,
+  clerkUserId: string,
+  state: JourneyState,
+  now: Date,
+): Promise<void> {
+  const last = await getLatestJourneyEvent(db, clerkUserId);
+  if (last && last.toPhase === state.phase) return;
+  await appendJourneyEvent(db, {
+    id: randomUUID(),
+    clerkUserId,
+    fromPhase: last?.toPhase ?? null,
+    toPhase: state.phase,
+    detail: state.settling?.delayed ? 'confirmation_delayed' : state.failure ? `attempt_${state.failure.attempt}` : null,
+    at: now.toISOString(),
+  });
+}

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2749,7 +2749,9 @@ export function createApp(deps: {
       reqPath.startsWith('/auth/device/') ||
       reqPath.startsWith('/api/auth/device/') ||
       reqPath === '/api/auth/app-session' ||
-      reqPath === '/api/auth/provision-runtime'
+      reqPath === '/api/auth/provision-runtime' ||
+      reqPath === '/api/journey' ||
+      reqPath === '/api/journey/retry-provision'
     )) {
       return next();
     }

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -4340,8 +4340,11 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
                   try {
                     body = (await res.json()) as { complete?: unknown };
                   } catch (parseErr: unknown) {
-                    // Malformed status body → treat as not-yet-complete.
-                    void parseErr;
+                    // Malformed status body → log and treat as not-yet-complete.
+                    console.warn(
+                      `[platform] backfill onboarding-status parse failed machine=${machine.machineId}`,
+                      parseErr instanceof Error ? parseErr.name : typeof parseErr,
+                    );
                     return null;
                   }
                   return body?.complete === true ? { completedAt: new Date().toISOString() } : null;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -2717,6 +2717,10 @@ export function createApp(deps: {
     verifyInternalToken: platformSecret
       ? (handle, token) => timingSafeTokenEquals(token, buildPlatformVerificationToken(handle, platformSecret))
       : undefined,
+    resolveHandleOwner: async (handle) => {
+      const machine = await getActiveUserMachineByHandle(db, handle);
+      return machine?.clerkUserId ?? null;
+    },
     appOrigin: journeyAppOrigin,
     maxProvisionAttempts: Number(appEnv.CUSTOMER_VPS_MAX_PROVISION_ATTEMPTS) || 3,
     settlingWindowMs: Number(appEnv.BILLING_SETTLING_WINDOW_MS) || undefined,
@@ -4326,6 +4330,9 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
                   const res = await fetch(`https://${machine.publicIPv4}:443/api/settings/onboarding-status`, {
                     headers: { authorization: `Bearer ${token}` },
                     signal: AbortSignal.timeout(3000),
+                    // Never follow a redirect: a compromised VPS must not be able
+                    // to capture the platform bearer token by redirecting elsewhere.
+                    redirect: 'error',
                     ...(customerVpsProxyDispatcher ? { dispatcher: customerVpsProxyDispatcher } : {}),
                   } as RequestInit & { dispatcher?: import('undici').Dispatcher });
                   if (!res.ok) return null;

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -45,6 +45,7 @@ import {
   HostBundleReleaseConflictError,
   listHostBundleReleases,
   promoteHostBundleChannel,
+  sweepStaleCheckoutAttempts,
   upsertHostBundleRelease,
   type HostBundleReleaseRecord,
   type UserMachineRecord,
@@ -90,6 +91,8 @@ import {
   type RuntimeAccessDecision,
 } from './billing.js';
 import { createBillingRoutes } from './billing-routes.js';
+import { createJourneyRoutes, createJourneyUserResolver } from './journey-routes.js';
+import { backfillFirstRunRecords } from './journey.js';
 import {
   createStripeBillingClient,
   createUnavailableStripeBillingClient,
@@ -2665,6 +2668,60 @@ export function createApp(deps: {
     captureEvent: captureFunnelEvent,
   }));
 
+  // Onboarding journey (spec 092): one server-owned signup-to-ready state every
+  // surface renders from. Triggers provisioning through the same building blocks
+  // as /api/auth/provision-runtime so billing and identity checks stay identical.
+  async function provisionRuntimeForJourney(clerkUserId: string, runtimeSlot: string): Promise<void> {
+    if (!deps.customerVpsService) {
+      throw new CustomerVpsError(503, 'provider_unavailable', 'Provisioning unavailable');
+    }
+    if (stripeBillingEntitlementsEnabled(appEnv)) {
+      const checkedAt = new Date();
+      const entitlement = await resolveEffectiveBillingEntitlement(db, clerkUserId, checkedAt);
+      if (!getRuntimeAccessDecision(entitlement, checkedAt).runtimeProxyAllowed) {
+        throw new CustomerVpsError(402, 'billing_required', 'Billing upgrade required');
+      }
+    }
+    const identity = await selectProvisionIdentityForClerkUser(db, clerkUserId, appEnv);
+    if (!identity) {
+      throw new CustomerVpsError(409, 'invalid_state', 'Handle unavailable');
+    }
+    const provisioned = await deps.customerVpsService.provision({ handle: identity.handle, clerkUserId, runtimeSlot });
+    await ensureProvisionedPlatformUser(db, {
+      clerkUserId,
+      handle: identity.handle,
+      displayName: identity.displayName,
+      email: identity.email,
+      runtimeId: `vps:${provisioned.machineId}`,
+    });
+    if (matrixProvisioner) {
+      try {
+        await matrixProvisioner.provisionUser(identity.handle);
+      } catch (matrixErr: unknown) {
+        console.error(
+          `[matrix] Failed to provision Matrix accounts for ${identity.handle}:`,
+          matrixErr instanceof Error ? matrixErr.message : String(matrixErr),
+        );
+      }
+    }
+  }
+
+  const journeyAppOrigin = appEnv.NEXT_PUBLIC_MATRIX_APP_URL ?? appEnv.PLATFORM_PUBLIC_URL ?? 'https://app.matrix-os.com';
+  app.route('/', createJourneyRoutes({
+    db,
+    resolveUserId: createJourneyUserResolver({
+      clerkAuth: clerkAuth ?? undefined,
+      syncJwtSecret: platformJwtSecret ?? undefined,
+    }),
+    provisionRuntime: deps.customerVpsService ? provisionRuntimeForJourney : undefined,
+    verifyInternalToken: platformSecret
+      ? (handle, token) => timingSafeTokenEquals(token, buildPlatformVerificationToken(handle, platformSecret))
+      : undefined,
+    appOrigin: journeyAppOrigin,
+    maxProvisionAttempts: Number(appEnv.CUSTOMER_VPS_MAX_PROVISION_ATTEMPTS) || 3,
+    settlingWindowMs: Number(appEnv.BILLING_SETTLING_WINDOW_MS) || undefined,
+  }));
+
   // Session-based routing:
   // - app.matrix-os.com -> Clerk session -> Matrix OS shell/gateway
   // - code.matrix-os.com -> Clerk session -> code-server on the user's VPS
@@ -4240,14 +4297,50 @@ if (process.argv[1]?.endsWith('main.ts') || process.argv[1]?.endsWith('main.js')
         reconciliationRunning = true;
         customerVpsReconciliationPromise = (async () => {
           try {
-            const result = await customerVpsService!.reconcileProvisioning();
-            if (result.checked > 0) {
-              console.log(
-                `[platform] customer VPS reconciliation checked=${result.checked} running=${result.running} failed=${result.failed}`,
-              );
+            try {
+              const result = await customerVpsService!.reconcileProvisioning();
+              if (result.checked > 0) {
+                console.log(
+                  `[platform] customer VPS reconciliation checked=${result.checked} running=${result.running} failed=${result.failed}`,
+                );
+              }
+            } catch (err: unknown) {
+              logPlatformRouteError('customer VPS reconciliation', err);
             }
-          } catch (err: unknown) {
-            logPlatformRouteError('customer VPS reconciliation', err);
+            // Onboarding journey maintenance, off the read path (spec 092):
+            // sweep stale open checkout attempts and backfill legacy first-run records.
+            try {
+              const thirtyDaysAgoIso = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+              await sweepStaleCheckoutAttempts(db, thirtyDaysAgoIso, new Date().toISOString(), 200);
+            } catch (err: unknown) {
+              logPlatformRouteError('checkout attempt sweep', err);
+            }
+            try {
+              await backfillFirstRunRecords(db, {
+                limit: 25,
+                probe: async (machine) => {
+                  if (!machine.publicIPv4 || !customerVpsConfig.platformSecret) return null;
+                  const token = buildPlatformVerificationToken(machine.handle, customerVpsConfig.platformSecret);
+                  const res = await fetch(`https://${machine.publicIPv4}:443/api/settings/onboarding-status`, {
+                    headers: { authorization: `Bearer ${token}` },
+                    signal: AbortSignal.timeout(3000),
+                    ...(customerVpsProxyDispatcher ? { dispatcher: customerVpsProxyDispatcher } : {}),
+                  } as RequestInit & { dispatcher?: import('undici').Dispatcher });
+                  if (!res.ok) return null;
+                  let body: { complete?: unknown } | null = null;
+                  try {
+                    body = (await res.json()) as { complete?: unknown };
+                  } catch (parseErr: unknown) {
+                    // Malformed status body → treat as not-yet-complete.
+                    void parseErr;
+                    return null;
+                  }
+                  return body?.complete === true ? { completedAt: new Date().toISOString() } : null;
+                },
+              });
+            } catch (err: unknown) {
+              logPlatformRouteError('first-run backfill', err);
+            }
           } finally {
             reconciliationRunning = false;
             customerVpsReconciliationPromise = undefined;

--- a/packages/platform/src/stripe-billing.ts
+++ b/packages/platform/src/stripe-billing.ts
@@ -54,7 +54,7 @@ export function createStripeBillingClient(options: {
       if (!session.url) {
         throw new Error('Stripe checkout session missing redirect URL');
       }
-      return { url: session.url };
+      return { url: session.url, id: session.id };
     },
 
     async createPortalSession(input) {

--- a/tests/platform/billing-routes.test.ts
+++ b/tests/platform/billing-routes.test.ts
@@ -36,7 +36,7 @@ describe('platform billing routes', () => {
     ({ db } = await createTestPlatformDb());
     stripe = {
       apiTimeoutMs: 10_000,
-      createCheckoutSession: vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/session' }),
+      createCheckoutSession: vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/session', id: 'cs_test_session' }),
       createPortalSession: vi.fn().mockResolvedValue({ url: 'https://billing.stripe.test/session' }),
       constructWebhookEvent: vi.fn(),
     };

--- a/tests/platform/billing-settling.test.ts
+++ b/tests/platform/billing-settling.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import {
   getLatestCheckoutAttempt,
   insertCheckoutAttempt,
+  resolveCheckoutAttempt,
   sweepStaleCheckoutAttempts,
   type PlatformDB,
 } from '../../packages/platform/src/db.js';
@@ -106,5 +107,15 @@ describe('platform billing checkout-attempt settling (spec 092)', () => {
     const swept = await sweepStaleCheckoutAttempts(db, '2026-05-12T00:00:00.000Z', '2026-06-11T12:00:00.000Z', 50);
     expect(swept).toBe(1);
     expect((await getLatestCheckoutAttempt(db, 'user_123'))?.status).toBe('abandoned');
+  });
+
+  it('does not sweep an attempt that resolved to paid (status guard)', async () => {
+    // Simulate the race: the row is stale-and-open at SELECT time, but resolves
+    // to paid before the UPDATE. The status='open' guard must skip it.
+    await insertCheckoutAttempt(db, { id: 'a1', clerkUserId: 'user_123', stripeSessionId: 'cs_paid', createdAt: '2026-04-01T00:00:00.000Z' });
+    await resolveCheckoutAttempt(db, 'cs_paid', 'paid', '2026-04-01T00:01:00.000Z');
+    const swept = await sweepStaleCheckoutAttempts(db, '2026-05-12T00:00:00.000Z', '2026-06-11T12:00:00.000Z', 50);
+    expect(swept).toBe(0);
+    expect((await getLatestCheckoutAttempt(db, 'user_123'))?.status).toBe('paid');
   });
 });

--- a/tests/platform/billing-settling.test.ts
+++ b/tests/platform/billing-settling.test.ts
@@ -1,0 +1,110 @@
+import { Hono } from 'hono';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getLatestCheckoutAttempt,
+  insertCheckoutAttempt,
+  sweepStaleCheckoutAttempts,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import {
+  createBillingRoutes,
+  type StripeBillingClient,
+  type StripeWebhookEvent,
+} from '../../packages/platform/src/billing-routes.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const env = {
+  STRIPE_PRICE_MATRIX_BUILDER_MONTHLY: 'price_builder_monthly',
+  STRIPE_WEBHOOK_SECRET: 'whsec_test',
+} as NodeJS.ProcessEnv;
+
+describe('platform billing checkout-attempt settling (spec 092)', () => {
+  let db: PlatformDB;
+  let stripe: StripeBillingClient;
+
+  beforeEach(async () => {
+    ({ db } = await createTestPlatformDb());
+    stripe = {
+      apiTimeoutMs: 10_000,
+      createCheckoutSession: vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.test/s', id: 'cs_live_1' }),
+      createPortalSession: vi.fn(),
+      constructWebhookEvent: vi.fn(),
+    };
+  });
+
+  afterEach(async () => {
+    await destroyTestPlatformDb(db);
+  });
+
+  function createApp(now = '2026-06-11T12:00:00.000Z') {
+    const app = new Hono();
+    app.route('/billing', createBillingRoutes({
+      db,
+      stripe,
+      env,
+      resolveClerkUserId: () => Promise.resolve('user_123'),
+      now: () => new Date(now),
+    }));
+    return app;
+  }
+
+  async function sendWebhook(app: Hono, event: StripeWebhookEvent) {
+    vi.mocked(stripe.constructWebhookEvent).mockReturnValue(event);
+    return app.request('/billing/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'stripe-signature': 'sig' },
+      body: JSON.stringify(event),
+    });
+  }
+
+  it('records an open checkout attempt with the Stripe session id', async () => {
+    const app = createApp();
+    const res = await app.request('/billing/checkout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ planSlug: 'matrix_builder', interval: 'monthly' }),
+    });
+    expect(res.status).toBe(200);
+    const attempt = await getLatestCheckoutAttempt(db, 'user_123');
+    expect(attempt?.stripeSessionId).toBe('cs_live_1');
+    expect(attempt?.status).toBe('open');
+  });
+
+  it('marks the attempt paid on checkout.session.completed', async () => {
+    await insertCheckoutAttempt(db, { id: 'a1', clerkUserId: 'user_123', stripeSessionId: 'cs_live_1', createdAt: '2026-06-11T11:55:00.000Z' });
+    const app = createApp();
+    const res = await sendWebhook(app, {
+      id: 'evt_1', type: 'checkout.session.completed', created: 1_750_000_000, data: { object: { id: 'cs_live_1' } },
+    });
+    expect(res.status).toBe(200);
+    const attempt = await getLatestCheckoutAttempt(db, 'user_123');
+    expect(attempt?.status).toBe('paid');
+    expect(attempt?.resolvedAt).not.toBeNull();
+  });
+
+  it('marks the attempt expired on checkout.session.expired', async () => {
+    await insertCheckoutAttempt(db, { id: 'a1', clerkUserId: 'user_123', stripeSessionId: 'cs_live_1', createdAt: '2026-06-11T11:55:00.000Z' });
+    const app = createApp();
+    const res = await sendWebhook(app, {
+      id: 'evt_2', type: 'checkout.session.expired', created: 1_750_000_000, data: { object: { id: 'cs_live_1' } },
+    });
+    expect(res.status).toBe(200);
+    expect((await getLatestCheckoutAttempt(db, 'user_123'))?.status).toBe('expired');
+  });
+
+  it('does not rewrite a terminal attempt on a duplicate/late completed event', async () => {
+    await insertCheckoutAttempt(db, { id: 'a1', clerkUserId: 'user_123', stripeSessionId: 'cs_live_1', createdAt: '2026-06-11T11:55:00.000Z' });
+    const app = createApp();
+    await sendWebhook(app, { id: 'evt_x', type: 'checkout.session.expired', created: 1_750_000_000, data: { object: { id: 'cs_live_1' } } });
+    await sendWebhook(app, { id: 'evt_y', type: 'checkout.session.completed', created: 1_750_000_100, data: { object: { id: 'cs_live_1' } } });
+    // First terminal status wins; the later completed event must not flip expired->paid.
+    expect((await getLatestCheckoutAttempt(db, 'user_123'))?.status).toBe('expired');
+  });
+
+  it('sweeps a stale open attempt to abandoned', async () => {
+    await insertCheckoutAttempt(db, { id: 'a1', clerkUserId: 'user_123', stripeSessionId: 'cs_old', createdAt: '2026-04-01T00:00:00.000Z' });
+    const swept = await sweepStaleCheckoutAttempts(db, '2026-05-12T00:00:00.000Z', '2026-06-11T12:00:00.000Z', 50);
+    expect(swept).toBe(1);
+    expect((await getLatestCheckoutAttempt(db, 'user_123'))?.status).toBe('abandoned');
+  });
+});

--- a/tests/platform/journey-routes.test.ts
+++ b/tests/platform/journey-routes.test.ts
@@ -28,6 +28,8 @@ describe('platform/journey-routes', () => {
       // Per-handle verifier: accept the fixed token only for handle "alice".
       verifyInternalToken: (handle: string, token: string | undefined) =>
         handle === 'alice' && token === 'token-for-alice',
+      // Handle "alice" is owned by user_123.
+      resolveHandleOwner: async (handle: string) => (handle === 'alice' ? 'user_123' : null),
       appOrigin: APP_ORIGIN,
       maxProvisionAttempts: 3,
       now: () => new Date('2026-06-11T12:00:00.000Z'),
@@ -201,6 +203,17 @@ describe('platform/journey-routes', () => {
         body: JSON.stringify({ ...validBody, handle: 'someone-else' }),
       });
       expect(res.status).toBe(422);
+    });
+
+    it('403 when the submitted clerkUserId is not the handle owner (no journey hijack)', async () => {
+      const app = routes();
+      const res = await app.request('/internal/first-run', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer token-for-alice', 'x-matrix-handle': 'alice' },
+        body: JSON.stringify({ ...validBody, clerkUserId: 'user_victim' }),
+      });
+      expect(res.status).toBe(403);
+      expect(await getOnboardingFirstRun(db, 'user_victim')).toBeUndefined();
     });
   });
 });

--- a/tests/platform/journey-routes.test.ts
+++ b/tests/platform/journey-routes.test.ts
@@ -25,7 +25,9 @@ describe('platform/journey-routes', () => {
       db,
       resolveUserId: async () => 'user_123',
       provisionRuntime: vi.fn(async () => {}),
-      internalToken: 'internal-secret-token',
+      // Per-handle verifier: accept the fixed token only for handle "alice".
+      verifyInternalToken: (handle: string, token: string | undefined) =>
+        handle === 'alice' && token === 'token-for-alice',
       appOrigin: APP_ORIGIN,
       maxProvisionAttempts: 3,
       now: () => new Date('2026-06-11T12:00:00.000Z'),
@@ -158,11 +160,11 @@ describe('platform/journey-routes', () => {
       expect(res.status).toBe(401);
     });
 
-    it('204 and upserts with a valid token', async () => {
+    it('204 and upserts with a valid per-handle token', async () => {
       const app = routes();
       const res = await app.request('/internal/first-run', {
         method: 'POST',
-        headers: { 'content-type': 'application/json', authorization: 'Bearer internal-secret-token', 'x-matrix-handle': 'alice' },
+        headers: { 'content-type': 'application/json', authorization: 'Bearer token-for-alice', 'x-matrix-handle': 'alice' },
         body: JSON.stringify(validBody),
       });
       expect(res.status).toBe(204);
@@ -171,22 +173,32 @@ describe('platform/journey-routes', () => {
       expect(row?.steps).toEqual({ api_key: 'skipped' });
     });
 
+    it('401 when the token does not match the claimed handle', async () => {
+      const app = routes();
+      const res = await app.request('/internal/first-run', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer token-for-alice', 'x-matrix-handle': 'mallory' },
+        body: JSON.stringify({ ...validBody, handle: 'mallory' }),
+      });
+      expect(res.status).toBe(401);
+    });
+
     it('422 on an invalid body', async () => {
       const app = routes();
       const res = await app.request('/internal/first-run', {
         method: 'POST',
-        headers: { 'content-type': 'application/json', authorization: 'Bearer internal-secret-token' },
+        headers: { 'content-type': 'application/json', authorization: 'Bearer token-for-alice', 'x-matrix-handle': 'alice' },
         body: JSON.stringify({ clerkUserId: 'user_123' }),
       });
       expect(res.status).toBe(422);
     });
 
-    it('422 when the header handle does not match the body', async () => {
+    it('422 when the authenticated handle does not own the reported completion', async () => {
       const app = routes();
       const res = await app.request('/internal/first-run', {
         method: 'POST',
-        headers: { 'content-type': 'application/json', authorization: 'Bearer internal-secret-token', 'x-matrix-handle': 'mallory' },
-        body: JSON.stringify(validBody),
+        headers: { 'content-type': 'application/json', authorization: 'Bearer token-for-alice', 'x-matrix-handle': 'alice' },
+        body: JSON.stringify({ ...validBody, handle: 'someone-else' }),
       });
       expect(res.status).toBe(422);
     });

--- a/tests/platform/journey-routes.test.ts
+++ b/tests/platform/journey-routes.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createJourneyRoutes,
+  createJourneyUserResolver,
+} from '../../packages/platform/src/journey-routes.js';
+import { CustomerVpsError } from '../../packages/platform/src/customer-vps-errors.js';
+import { issueSyncJwt } from '../../packages/platform/src/sync-jwt.js';
+import {
+  getOnboardingFirstRun,
+  insertUserMachine,
+  type PlatformDB,
+} from '../../packages/platform/src/db.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const SECRET = 'test-platform-jwt-secret-at-least-32-chars-long';
+const APP_ORIGIN = 'https://app.matrix-os.com';
+
+describe('platform/journey-routes', () => {
+  let db: PlatformDB;
+  beforeEach(async () => { ({ db } = await createTestPlatformDb()); });
+  afterEach(async () => { await destroyTestPlatformDb(db); });
+
+  function routes(overrides: Partial<Parameters<typeof createJourneyRoutes>[0]> = {}) {
+    return createJourneyRoutes({
+      db,
+      resolveUserId: async () => 'user_123',
+      provisionRuntime: vi.fn(async () => {}),
+      internalToken: 'internal-secret-token',
+      appOrigin: APP_ORIGIN,
+      maxProvisionAttempts: 3,
+      now: () => new Date('2026-06-11T12:00:00.000Z'),
+      ...overrides,
+    });
+  }
+
+  describe('GET /api/journey', () => {
+    it('401 when unauthenticated', async () => {
+      const app = routes({ resolveUserId: async () => null });
+      const res = await app.request('/api/journey');
+      expect(res.status).toBe(401);
+    });
+
+    it('200 with phase + no-store for an authenticated user', async () => {
+      const app = routes();
+      const res = await app.request('/api/journey');
+      expect(res.status).toBe(200);
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      const body = await res.json();
+      expect(body.phase).toBe('plan_required');
+      expect(body.nextAction.kind).toBe('open_plans');
+    });
+
+    it('503 when a journey dependency fails (no phase guessing)', async () => {
+      const app = routes({ resolveReadiness: async () => { throw new Error('readiness down'); } });
+      const res = await app.request('/api/journey');
+      expect(res.status).toBe(503);
+      expect((await res.json()).error).toBe('journey_unavailable');
+    });
+
+    it('returns the identical contract for a sync-JWT bearer caller (CLI / native macOS path)', async () => {
+      // The native macOS app and CLI present a platform sync JWT, not a Clerk
+      // session. The resolver must resolve it to the same clerkUserId, yielding
+      // an identical journey contract.
+      const { token } = await issueSyncJwt({
+        secret: SECRET, clerkUserId: 'user_123', handle: 'alice', gatewayUrl: 'https://app.matrix-os.com',
+      });
+      const resolver = createJourneyUserResolver({ syncJwtSecret: SECRET });
+      const app = routes({ resolveUserId: resolver });
+      const res = await app.request('/api/journey', { headers: { authorization: `Bearer ${token}` } });
+      expect(res.status).toBe(200);
+      expect((await res.json()).phase).toBe('plan_required');
+    });
+
+    it('rejects a sync JWT signed with the wrong secret', async () => {
+      const { token } = await issueSyncJwt({
+        secret: 'a-different-secret-also-at-least-32-characters', clerkUserId: 'user_123', handle: 'alice', gatewayUrl: 'x',
+      });
+      const resolver = createJourneyUserResolver({ syncJwtSecret: SECRET });
+      const app = routes({ resolveUserId: resolver });
+      const res = await app.request('/api/journey', { headers: { authorization: `Bearer ${token}` } });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/journey/retry-provision', () => {
+    it('401 when unauthenticated', async () => {
+      const app = routes({ resolveUserId: async () => null });
+      const res = await app.request('/api/journey/retry-provision', { method: 'POST' });
+      expect(res.status).toBe(401);
+    });
+
+    it('503 when provisioning is unavailable', async () => {
+      const app = routes({ provisionRuntime: undefined });
+      const res = await app.request('/api/journey/retry-provision', { method: 'POST' });
+      expect(res.status).toBe(503);
+    });
+
+    it('converges on an in-flight machine without calling provision again', async () => {
+      const provisionRuntime = vi.fn(async () => {});
+      await insertUserMachine(db, {
+        machineId: 'm-live', clerkUserId: 'user_123', handle: 'alice', status: 'provisioning',
+        provisionedAt: '2026-06-11T11:59:00.000Z',
+      });
+      const app = routes({ provisionRuntime });
+      const res = await app.request('/api/journey/retry-provision', { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect((await res.json()).status).toBe('in_progress');
+      expect(provisionRuntime).not.toHaveBeenCalled();
+    });
+
+    it('starts provisioning when there is no live machine', async () => {
+      const provisionRuntime = vi.fn(async () => {});
+      const app = routes({ provisionRuntime });
+      const res = await app.request('/api/journey/retry-provision', { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect((await res.json()).status).toBe('started');
+      expect(provisionRuntime).toHaveBeenCalledWith('user_123', 'primary');
+    });
+
+    it('maps billing_required to 402', async () => {
+      const app = routes({
+        provisionRuntime: async () => { throw new CustomerVpsError(402, 'billing_required', 'x'); },
+      });
+      const res = await app.request('/api/journey/retry-provision', { method: 'POST' });
+      expect(res.status).toBe(402);
+      expect((await res.json()).error).toBe('billing_required');
+    });
+
+    it('maps retry_exhausted to 409', async () => {
+      const app = routes({
+        provisionRuntime: async () => { throw new CustomerVpsError(409, 'retry_exhausted', 'x'); },
+      });
+      const res = await app.request('/api/journey/retry-provision', { method: 'POST' });
+      expect(res.status).toBe(409);
+      expect((await res.json()).error).toBe('retry_exhausted');
+    });
+
+    it('400 on an invalid runtimeSlot', async () => {
+      const app = routes();
+      const res = await app.request('/api/journey/retry-provision', {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ runtimeSlot: 'Bad Slot!' }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /internal/first-run', () => {
+    const validBody = {
+      clerkUserId: 'user_123', handle: 'alice', completedAt: '2026-06-11T11:00:00.000Z',
+      goal: 'coding', steps: { api_key: 'skipped' }, source: 'gateway_ws',
+    };
+
+    it('401 without a valid internal token', async () => {
+      const app = routes();
+      const res = await app.request('/internal/first-run', {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(validBody),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('204 and upserts with a valid token', async () => {
+      const app = routes();
+      const res = await app.request('/internal/first-run', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer internal-secret-token', 'x-matrix-handle': 'alice' },
+        body: JSON.stringify(validBody),
+      });
+      expect(res.status).toBe(204);
+      const row = await getOnboardingFirstRun(db, 'user_123');
+      expect(row?.goal).toBe('coding');
+      expect(row?.steps).toEqual({ api_key: 'skipped' });
+    });
+
+    it('422 on an invalid body', async () => {
+      const app = routes();
+      const res = await app.request('/internal/first-run', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer internal-secret-token' },
+        body: JSON.stringify({ clerkUserId: 'user_123' }),
+      });
+      expect(res.status).toBe(422);
+    });
+
+    it('422 when the header handle does not match the body', async () => {
+      const app = routes();
+      const res = await app.request('/internal/first-run', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer internal-secret-token', 'x-matrix-handle': 'mallory' },
+        body: JSON.stringify(validBody),
+      });
+      expect(res.status).toBe(422);
+    });
+  });
+});

--- a/tests/platform/journey.test.ts
+++ b/tests/platform/journey.test.ts
@@ -16,6 +16,7 @@ import {
   getOnboardingFirstRun,
   insertCheckoutAttempt,
   insertUserMachine,
+  resolveCheckoutAttempt,
   upsertOnboardingFirstRun,
 } from '../../packages/platform/src/db.js';
 import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
@@ -212,6 +213,16 @@ describe('platform/journey loadJourney', () => {
       id: 'att-1', clerkUserId: 'user_pay', stripeSessionId: 'cs_live_1', createdAt: '2026-06-11T11:57:00.000Z',
     });
     const state = await loadJourney('user_pay', { db, now: () => NOW, maxProvisionAttempts: 3, appOrigin: APP_ORIGIN });
+    expect(state.phase).toBe('payment_settling');
+  });
+
+  it('keeps a paid attempt sticky even when a newer open attempt exists past the window', async () => {
+    // User paid (old attempt), then opened a second checkout that has aged past
+    // the window. The paid attempt must win → still settling, never plan_required.
+    await insertCheckoutAttempt(db, { id: 'paid-1', clerkUserId: 'user_two', stripeSessionId: 'cs_paid', createdAt: '2026-06-11T11:40:00.000Z' });
+    await resolveCheckoutAttempt(db, 'cs_paid', 'paid', '2026-06-11T11:41:00.000Z');
+    await insertCheckoutAttempt(db, { id: 'open-2', clerkUserId: 'user_two', stripeSessionId: 'cs_open_new', createdAt: '2026-06-11T11:45:00.000Z' });
+    const state = await loadJourney('user_two', { db, now: () => NOW, maxProvisionAttempts: 3, appOrigin: APP_ORIGIN });
     expect(state.phase).toBe('payment_settling');
   });
 

--- a/tests/platform/journey.test.ts
+++ b/tests/platform/journey.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
+  backfillFirstRunRecords,
   deriveJourneyPhase,
   loadJourney,
   type JourneyDerivationInputs,
@@ -11,8 +12,8 @@ import type {
   PlatformDB,
 } from '../../packages/platform/src/db.js';
 import {
-  appendJourneyEvent,
   getLatestJourneyEvent,
+  getOnboardingFirstRun,
   insertCheckoutAttempt,
   insertUserMachine,
   upsertOnboardingFirstRun,
@@ -223,5 +224,42 @@ describe('platform/journey loadJourney', () => {
     // Entitlement is absent, so without access the phase is plan_required regardless of the machine.
     const state = await loadJourney('user_run', { db, now: () => NOW, maxProvisionAttempts: 3, appOrigin: APP_ORIGIN });
     expect(state.phase).toBe('plan_required');
+  });
+});
+
+describe('platform/journey backfillFirstRunRecords', () => {
+  let db: PlatformDB;
+  beforeEach(async () => { ({ db } = await createTestPlatformDb()); });
+  afterEach(async () => { await destroyTestPlatformDb(db); });
+
+  it('fills missing records for running machines whose probe reports completion', async () => {
+    await insertUserMachine(db, { machineId: 'm-done', clerkUserId: 'user_done', handle: 'done', status: 'running', hetznerServerId: 1, publicIPv4: '203.0.113.1', provisionedAt: '2026-06-11T10:00:00.000Z' });
+    await insertUserMachine(db, { machineId: 'm-no', clerkUserId: 'user_no', handle: 'no', status: 'running', hetznerServerId: 2, publicIPv4: '203.0.113.2', provisionedAt: '2026-06-11T10:00:00.000Z' });
+    await insertUserMachine(db, { machineId: 'm-down', clerkUserId: 'user_down', handle: 'down', status: 'running', hetznerServerId: 3, publicIPv4: '203.0.113.3', provisionedAt: '2026-06-11T10:00:00.000Z' });
+
+    const result = await backfillFirstRunRecords(db, {
+      probe: async (machine) => {
+        if (machine.handle === 'done') return { completedAt: '2026-06-10T00:00:00.000Z', goal: 'coding' };
+        if (machine.handle === 'down') throw new Error('unreachable');
+        return null; // user_no: not completed
+      },
+    });
+
+    expect(result.checked).toBe(3);
+    expect(result.filled).toBe(1);
+    expect((await getOnboardingFirstRun(db, 'user_done'))?.source).toBe('backfill');
+    expect(await getOnboardingFirstRun(db, 'user_no')).toBeUndefined();
+    expect(await getOnboardingFirstRun(db, 'user_down')).toBeUndefined();
+  });
+
+  it('never overwrites an authoritative write-behind record', async () => {
+    await insertUserMachine(db, { machineId: 'm1', clerkUserId: 'user_x', handle: 'x', status: 'running', hetznerServerId: 1, publicIPv4: '203.0.113.1', provisionedAt: '2026-06-11T10:00:00.000Z' });
+    await upsertOnboardingFirstRun(db, { clerkUserId: 'user_x', completedAt: '2026-06-09T00:00:00.000Z', goal: 'company_brain', source: 'gateway_ws' });
+    // The machine now has a record, so it is not even a candidate.
+    const result = await backfillFirstRunRecords(db, { probe: async () => ({ completedAt: '2099-01-01T00:00:00.000Z', goal: 'coding' }) });
+    expect(result.checked).toBe(0);
+    const row = await getOnboardingFirstRun(db, 'user_x');
+    expect(row?.goal).toBe('company_brain');
+    expect(row?.source).toBe('gateway_ws');
   });
 });

--- a/tests/platform/journey.test.ts
+++ b/tests/platform/journey.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  deriveJourneyPhase,
+  loadJourney,
+  type JourneyDerivationInputs,
+} from '../../packages/platform/src/journey.js';
+import type { BillingEntitlement, BillingEntitlementStatus } from '../../packages/platform/src/billing.js';
+import type {
+  BillingCheckoutAttemptRecord,
+  UserMachineRecord,
+  PlatformDB,
+} from '../../packages/platform/src/db.js';
+import {
+  appendJourneyEvent,
+  getLatestJourneyEvent,
+  insertCheckoutAttempt,
+  insertUserMachine,
+  upsertOnboardingFirstRun,
+} from '../../packages/platform/src/db.js';
+import { createTestPlatformDb, destroyTestPlatformDb } from './platform-db-test-helper.js';
+
+const NOW = new Date('2026-06-11T12:00:00.000Z');
+const APP_ORIGIN = 'https://app.matrix-os.com';
+
+function entitlement(status: BillingEntitlementStatus, overrides: Partial<BillingEntitlement> = {}): BillingEntitlement {
+  return {
+    clerkUserId: 'user_123',
+    source: 'stripe',
+    planSlug: 'matrix_builder',
+    status,
+    maxRuntimeSlots: 1,
+    includedRuntimeSlots: 1,
+    addonRuntimeSlots: 0,
+    defaultServerType: 'cpx32',
+    allowedServerTypes: ['cpx32'],
+    stripeSubscriptionId: 'sub_1',
+    stripePriceId: 'price_1',
+    gracePeriodEndsAt: null,
+    effectiveFrom: '2026-06-01T00:00:00.000Z',
+    effectiveUntil: null,
+    updatedAt: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function attempt(status: BillingCheckoutAttemptRecord['status'], createdAt: string): BillingCheckoutAttemptRecord {
+  return { id: 'a1', clerkUserId: 'user_123', stripeSessionId: 'cs_1', status, createdAt, resolvedAt: null };
+}
+
+function machine(status: string, overrides: Partial<UserMachineRecord> = {}): UserMachineRecord {
+  return {
+    machineId: 'm1', clerkUserId: 'user_123', handle: 'alice', runtimeSlot: 'primary',
+    hetznerServerId: null, publicIPv4: null, publicIPv6: null, status,
+    imageVersion: 'stable', serverType: 'cpx32', registrationTokenHash: null,
+    registrationTokenExpiresAt: null, provisionedAt: '2026-06-11T11:59:00.000Z',
+    lastSeenAt: null, deletedAt: null, failureCode: null, failureAt: null, attempt: 1,
+    ...overrides,
+  };
+}
+
+function derive(partial: Partial<JourneyDerivationInputs>): ReturnType<typeof deriveJourneyPhase> {
+  return deriveJourneyPhase({
+    entitlement: null,
+    checkoutAttempt: null,
+    liveMachine: null,
+    firstRun: null,
+    now: NOW,
+    settlingWindowMs: 10 * 60 * 1000,
+    maxProvisionAttempts: 3,
+    appOrigin: APP_ORIGIN,
+    ...partial,
+  });
+}
+
+describe('platform/journey deriveJourneyPhase', () => {
+  it('no entitlement and no attempt → plan_required', () => {
+    const s = derive({});
+    expect(s.phase).toBe('plan_required');
+    expect(s.nextAction.kind).toBe('open_plans');
+    expect(s.nextAction.url).toContain('plans=1');
+  });
+
+  it('open attempt within window → payment_settling (not delayed)', () => {
+    const s = derive({ checkoutAttempt: attempt('open', '2026-06-11T11:55:00.000Z') });
+    expect(s.phase).toBe('payment_settling');
+    expect(s.settling?.delayed).toBe(false);
+    expect(s.nextAction.kind).toBe('wait');
+  });
+
+  it('paid attempt within window → payment_settling (not delayed)', () => {
+    const s = derive({
+      entitlement: entitlement('incomplete'),
+      checkoutAttempt: attempt('paid', '2026-06-11T11:58:00.000Z'),
+    });
+    expect(s.phase).toBe('payment_settling');
+    expect(s.settling?.delayed).toBe(false);
+  });
+
+  it('paid attempt past window → payment_settling delayed with contact_support (never plan_required)', () => {
+    const s = derive({ checkoutAttempt: attempt('paid', '2026-06-11T11:40:00.000Z') });
+    expect(s.phase).toBe('payment_settling');
+    expect(s.settling?.delayed).toBe(true);
+    expect(s.nextAction.kind).toBe('contact_support');
+  });
+
+  it('open attempt past window → plan_required (abandoned checkout is not trapped)', () => {
+    const s = derive({ checkoutAttempt: attempt('open', '2026-06-11T11:40:00.000Z') });
+    expect(s.phase).toBe('plan_required');
+  });
+
+  it('expired attempt → plan_required', () => {
+    const s = derive({ checkoutAttempt: attempt('expired', '2026-06-11T11:58:00.000Z') });
+    expect(s.phase).toBe('plan_required');
+  });
+
+  it('lapsed entitlement with a stale paid attempt → plan_required (churned subscriber not trapped)', () => {
+    const s = derive({
+      entitlement: entitlement('canceled', { gracePeriodEndsAt: '2026-06-01T00:00:00.000Z' }),
+      checkoutAttempt: attempt('paid', '2026-05-01T00:00:00.000Z'),
+    });
+    expect(s.phase).toBe('plan_required');
+  });
+
+  it('active entitlement, no machine → provisioning start (no progress)', () => {
+    const s = derive({ entitlement: entitlement('active') });
+    expect(s.phase).toBe('provisioning');
+    expect(s.nextAction.kind).toBe('start_provision');
+    expect(s.progress).toBeUndefined();
+  });
+
+  it('grace-period entitlement still grants access', () => {
+    const s = derive({ entitlement: entitlement('past_due', { gracePeriodEndsAt: '2026-06-12T00:00:00.000Z' }) });
+    expect(s.phase).toBe('provisioning');
+  });
+
+  it('provisioning machine reports a stage derived from observable state', () => {
+    expect(derive({ entitlement: entitlement('active'), liveMachine: machine('provisioning') }).progress?.stage).toBe('creating_server');
+    expect(derive({ entitlement: entitlement('active'), liveMachine: machine('provisioning', { hetznerServerId: 1 }) }).progress?.stage).toBe('booting');
+    expect(derive({ entitlement: entitlement('active'), liveMachine: machine('provisioning', { hetznerServerId: 1, publicIPv4: '203.0.113.4' }) }).progress?.stage).toBe('registering');
+    expect(derive({ entitlement: entitlement('active'), liveMachine: machine('recovering', { hetznerServerId: 1 }) }).progress?.stage).toBe('finalizing');
+  });
+
+  it('failed machine under cap → provisioning_failed retryable', () => {
+    const s = derive({ entitlement: entitlement('active'), liveMachine: machine('failed', { attempt: 2 }) });
+    expect(s.phase).toBe('provisioning_failed');
+    expect(s.failure).toEqual({ retryable: true, attempt: 2 });
+    expect(s.nextAction.kind).toBe('retry_provision');
+  });
+
+  it('failed machine at cap → provisioning_failed not retryable, contact_support', () => {
+    const s = derive({ entitlement: entitlement('active'), liveMachine: machine('failed', { attempt: 3 }) });
+    expect(s.phase).toBe('provisioning_failed');
+    expect(s.failure?.retryable).toBe(false);
+    expect(s.nextAction.kind).toBe('contact_support');
+  });
+
+  it('running machine without first-run → first_run', () => {
+    const s = derive({ entitlement: entitlement('active'), liveMachine: machine('running', { hetznerServerId: 1, publicIPv4: '203.0.113.4' }) });
+    expect(s.phase).toBe('first_run');
+    expect(s.nextAction.kind).toBe('begin_first_run');
+  });
+
+  it('running machine with first-run → ready (readiness omitted when not supplied)', () => {
+    const s = derive({
+      entitlement: entitlement('active'),
+      liveMachine: machine('running', { hetznerServerId: 1, publicIPv4: '203.0.113.4' }),
+      firstRun: { clerkUserId: 'user_123', completedAt: '2026-06-11T11:00:00.000Z', goal: 'coding', steps: {}, source: 'gateway_ws' },
+    });
+    expect(s.phase).toBe('ready');
+    expect(s.nextAction.kind).toBe('open_shell');
+    expect(s.readiness).toBeUndefined();
+  });
+
+  it('ready carries a supplied readiness annotation', () => {
+    const s = derive({
+      entitlement: entitlement('active'),
+      liveMachine: machine('running', { hetznerServerId: 1, publicIPv4: '203.0.113.4' }),
+      firstRun: { clerkUserId: 'user_123', completedAt: '2026-06-11T11:00:00.000Z', goal: null, steps: {}, source: 'gateway_ws' },
+      readiness: { status: 'degraded', failing: ['terminal.ready'] },
+    });
+    expect(s.readiness).toEqual({ status: 'degraded', failing: ['terminal.ready'] });
+  });
+});
+
+describe('platform/journey loadJourney', () => {
+  let db: PlatformDB;
+  beforeEach(async () => { ({ db } = await createTestPlatformDb()); });
+  afterEach(async () => { await destroyTestPlatformDb(db); });
+
+  it('derives plan_required for an unknown user and records one transition event', async () => {
+    const state = await loadJourney('user_new', { db, now: () => NOW, maxProvisionAttempts: 3, appOrigin: APP_ORIGIN });
+    expect(state.phase).toBe('plan_required');
+    const ev = await getLatestJourneyEvent(db, 'user_new');
+    expect(ev?.toPhase).toBe('plan_required');
+    expect(ev?.fromPhase).toBeNull();
+  });
+
+  it('does not append a duplicate event when the phase is unchanged', async () => {
+    await loadJourney('user_dup', { db, now: () => NOW, maxProvisionAttempts: 3, appOrigin: APP_ORIGIN });
+    await loadJourney('user_dup', { db, now: () => NOW, maxProvisionAttempts: 3, appOrigin: APP_ORIGIN });
+    const rows = await db.executor
+      .selectFrom('onboarding_journey_events')
+      .selectAll()
+      .where('clerk_user_id', '=', 'user_dup')
+      .execute();
+    expect(rows).toHaveLength(1);
+  });
+
+  it('reads a seeded open checkout attempt as payment_settling', async () => {
+    await insertCheckoutAttempt(db, {
+      id: 'att-1', clerkUserId: 'user_pay', stripeSessionId: 'cs_live_1', createdAt: '2026-06-11T11:57:00.000Z',
+    });
+    const state = await loadJourney('user_pay', { db, now: () => NOW, maxProvisionAttempts: 3, appOrigin: APP_ORIGIN });
+    expect(state.phase).toBe('payment_settling');
+  });
+
+  it('upserts and reads a first-run record (write-behind wins)', async () => {
+    await insertUserMachine(db, {
+      machineId: 'mm', clerkUserId: 'user_run', handle: 'runner', status: 'running',
+      hetznerServerId: 5, publicIPv4: '203.0.113.9', provisionedAt: '2026-06-11T10:00:00.000Z',
+    });
+    await upsertOnboardingFirstRun(db, { clerkUserId: 'user_run', completedAt: '2026-06-11T11:00:00.000Z', goal: 'coding', source: 'gateway_ws' });
+    // Entitlement is absent, so without access the phase is plan_required regardless of the machine.
+    const state = await loadJourney('user_run', { db, now: () => NOW, maxProvisionAttempts: 3, appOrigin: APP_ORIGIN });
+    expect(state.phase).toBe('plan_required');
+  });
+});


### PR DESCRIPTION
## Summary

Spec 092 **Phase B** (second PR in the onboarding-unification Graphite stack, on top of #487). Adds the server-owned onboarding journey that every surface will render from.

- **Three tables** (`billing_checkout_attempts`, `onboarding_first_run`, `onboarding_journey_events`), TEXT/uuid/ISO to match the existing schema.
- **`deriveJourneyPhase()`** — a pure, exhaustively-tested function returning one phase (`plan_required | payment_settling | provisioning | provisioning_failed | first_run | ready`). It encodes the settling model: a Stripe-confirmed `paid` attempt is sticky and never re-shows the paywall (US3); an unconfirmed `open` attempt only sustains settling within the window, then falls back to plan selection (no abandoned-checkout trap); a **lapsed** entitlement always routes to `plan_required` so a churned subscriber is never trapped; failure carries a bounded `retryable`; the provisioning `stage` is derived from observable machine columns (no extra column).
- **`GET /api/journey`** (no-store; 503 on dependency failure, never guesses a phase), **`POST /api/journey/retry-provision`** (converges on an in-flight attempt per FR-028; maps `billing_required`→402, `retry_exhausted`→409), **`POST /internal/first-run`** (per-handle `buildPlatformVerificationToken` constant-time auth).
- **Dual auth** via `createJourneyUserResolver`: Clerk cookie/bearer (web/mobile) or a platform **sync JWT** (CLI + native macOS app share one seam).
- **Billing settling**: `/billing/checkout` records an `open` attempt; the Stripe webhook resolves it on `checkout.session.completed`/`expired`.
- **Reconciler maintenance, off the read path**: sweeps stale `open` attempts to `abandoned`, and backfills legacy first-run records via a bounded, `AbortSignal.timeout`-guarded gateway probe (`ON CONFLICT DO NOTHING`, so it never clobbers an authoritative record).

## Tests

62 new tests (TDD), 93 green across affected suites (journey, journey-routes, billing-settling, billing-routes, customer-vps-reliability, db). Platform typecheck clean; `check:patterns` 0 violations.

- Derivation: all phases incl. paid-sticky, abandoned-open→plan, lapsed-churn→plan, retry cap, stage derivation, readiness passthrough.
- Routes: 401/200/503, sync-JWT-bearer parity (the macOS/CLI seam), retry convergence + 402/409 mapping, internal per-handle auth.
- Settling: open→paid/expired, terminal not rewritten by late events, stale sweep.
- Backfill: fills missing, skips unreachable, never overwrites a write-behind.

## Invariants

- **Source of truth**: journey phase is derived on read from `billing_entitlements` + `billing_checkout_attempts` + `user_machines` + `onboarding_first_run`. `onboarding_journey_events` is non-authoritative write-behind telemetry (never fails the read). The VPS-local `onboarding-complete.json` is a derived artifact.
- **Lock/transaction scope**: the journey read does no writes (except the best-effort telemetry append) and **no provider/network calls** — keeping it within the p95 budget and hang-free. Checkout-attempt resolution runs inside the existing webhook transaction and only transitions `open` rows, so a duplicate/late event cannot rewrite a terminal status.
- **Acceptable orphan states**: a journey-event write may be lost (telemetry only); an `open` attempt may outlive an abandoned checkout until the 30-day sweep; a legacy first-run record may lag by up to one reconciler interval until backfill fills it.
- **Auth source of truth**: Clerk session / platform sync JWT for `/api/journey*`; per-handle `buildPlatformVerificationToken` (constant-time) for `/internal/first-run`. No header-derived trust.
- **Acceptable orphan / settling safety**: a `paid` attempt is sticky only while the entitlement is pre-activation; once activated-then-lapsed, the lapsed entitlement wins (no churn trap).
- **Deferred scope**: the instant gateway write-behind to `/internal/first-run` folds into Phase C (which already touches the gateway); until then the reconciler backfill is the universal mechanism. Shell boot sequence, real readiness annotation, CLI/mobile rendering are Phases C–E.