### PR TITLE
feat(shell): journey-driven boot sequence

### DIFF
--- a/.github/workflows/platform-cloud-run.yml
+++ b/.github/workflows/platform-cloud-run.yml
@@ -361,8 +361,12 @@ jobs:
             --header "x-forwarded-host: ${app_domain_host}" \
             --header "x-matrix-edge-secret: ${edge_router_secret}" \
             "$CANDIDATE_URL/?billing=setup")"
-          if ! printf '%s\n' "$billing_shell_html" | grep -Fq 'data-matrix-billing-gate="true"'; then
-            echo "Candidate pre-VPS billing shell did not serve the settings billing gate." >&2
+          # Spec 092 Phase C: the journey-driven BootSequence replaces the billing
+          # gate on the web path, so accept either marker (the old billing gate or
+          # the new boot sequence) — both prove the shell gate rendered, not the
+          # platform fallback auth page.
+          if ! printf '%s\n' "$billing_shell_html" | grep -Eq 'data-matrix-(billing-gate|boot-sequence)="true"'; then
+            echo "Candidate pre-VPS billing shell did not serve the billing gate or boot sequence." >&2
             exit 1
           fi
           if printf '%s\n' "$billing_shell_html" | grep -Fq 'data-matrix-platform-fallback-auth="true"'; then

--- a/shell/src/app/page.tsx
+++ b/shell/src/app/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { Suspense } from "react";
-import { BillingGate } from "@/components/BillingGate";
+import { OnboardingGate } from "@/components/OnboardingGate";
 import { ShellHome } from "@/components/ShellHome";
 import { hasServerVerifiedMatrixSession } from "@/lib/platform-session";
 
@@ -10,22 +9,12 @@ export const metadata: Metadata = {
   description: "Your AI operating system: desktop, messaging, social, and agents in one computer you own.",
 };
 
-function BillingGateFallback() {
-  return (
-    <main className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
-      <output className="text-sm">Loading billing status</output>
-    </main>
-  );
-}
-
 export default async function Home() {
   const platformSessionActive = hasServerVerifiedMatrixSession(await headers());
 
   return (
-    <Suspense fallback={<BillingGateFallback />}>
-      <BillingGate platformSessionActive={platformSessionActive}>
-        <ShellHome />
-      </BillingGate>
-    </Suspense>
+    <OnboardingGate platformSessionActive={platformSessionActive}>
+      <ShellHome />
+    </OnboardingGate>
   );
 }

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useAuth } from "@clerk/nextjs";
+import { AlertCircleIcon, Loader2Icon, RefreshCwIcon } from "lucide-react";
+import { useJourney, type JourneyState } from "@/hooks/useJourney";
+
+// Phases where the shell (Desktop) takes over — first-run UI is owned by Desktop,
+// ready is the running shell. BootSequence only renders the billing/build steps.
+const PASSTHROUGH_PHASES = new Set<JourneyState["phase"]>(["first_run", "ready"]);
+
+const STAGE_LABEL: Record<string, string> = {
+  creating_server: "Creating your server",
+  booting: "Booting your computer",
+  registering: "Connecting your computer",
+  finalizing: "Finishing setup",
+};
+
+async function authHeaders(getToken: () => Promise<string | null>): Promise<HeadersInit> {
+  const token = await getToken();
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+function BootShell({ children }: { children: ReactNode }) {
+  return (
+    <main
+      data-matrix-boot-sequence="true"
+      className="flex min-h-screen flex-col items-center justify-center gap-4 bg-page-bg px-6 text-center text-forest/80"
+    >
+      {children}
+    </main>
+  );
+}
+
+function Spinner() {
+  return <Loader2Icon className="size-5 animate-spin text-ember" aria-hidden="true" />;
+}
+
+/**
+ * Unified signup-to-ready boot sequence (spec 092 Phase C). Renders one
+ * continuous flow driven by GET /api/journey: plan selection, payment settling,
+ * machine build progress, and retry — then hands off to the shell once the
+ * journey reaches first_run/ready. Replaces the billing wall + provisioning
+ * poll. The device-flow (`device_return`) and platform-session short-circuits
+ * remain the caller's responsibility during the page.tsx cutover.
+ */
+export function BootSequence({
+  children,
+  platformSessionActive = false,
+  e2eBypass = false,
+}: {
+  children: ReactNode;
+  platformSessionActive?: boolean;
+  e2eBypass?: boolean;
+}) {
+  // Server-verified session or e2e bypass: the journey is already past billing.
+  if (platformSessionActive || e2eBypass) {
+    return <>{children}</>;
+  }
+  return <BootSequenceInner>{children}</BootSequenceInner>;
+}
+
+function BootSequenceInner({ children }: { children: ReactNode }) {
+  const { isLoaded, isSignedIn, getToken } = useAuth();
+  const { state, status, refetch } = useJourney({ enabled: isLoaded && isSignedIn });
+  const [working, setWorking] = useState(false);
+  const provisionStarted = useRef(false);
+
+  const phase = state?.phase;
+
+  // Auto-start provisioning once, when entitled but no machine exists yet.
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- a deliberate one-time side effect (guarded by provisionStarted ref + disposed flag): when the journey reports an entitled user with no machine, kick off provisioning, then refetch. This is an effect, not user-event-driven, because it must fire on the derived journey phase, not a click.
+  useEffect(() => {
+    if (status !== "ready" || phase !== "provisioning") return;
+    if (state?.nextAction.kind !== "start_provision" || provisionStarted.current) return;
+    provisionStarted.current = true;
+    let disposed = false;
+    void (async () => {
+      // react-doctor-disable-next-line react-doctor/async-defer-await -- the post-await `disposed` guard discards the result if the component unmounted during the request; it can only change during this await, so the await cannot be hoisted past it.
+      try {
+        const res = await fetch("/api/auth/provision-runtime", {
+          method: "POST",
+          credentials: "include",
+          headers: await authHeaders(getToken),
+          body: JSON.stringify({}),
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!disposed && !res.ok && res.status !== 409) {
+          provisionStarted.current = false;
+        }
+      } catch (err: unknown) {
+        if (!disposed) provisionStarted.current = false;
+        console.warn("[boot] provision start failed", err instanceof Error ? err.name : typeof err);
+      } finally {
+        if (!disposed) refetch();
+      }
+    })();
+    return () => {
+      disposed = true;
+    };
+  }, [status, phase, state?.nextAction.kind, getToken, refetch]);
+
+  async function retryProvision(): Promise<void> {
+    setWorking(true);
+    // react-doctor-disable-next-line react-doctor/async-defer-await -- the request must complete before the finally block clears `working` and refetches the journey; the await is the operation being awaited, not a deferrable guard.
+    try {
+      await fetch("/api/journey/retry-provision", {
+        method: "POST",
+        credentials: "include",
+        headers: await authHeaders(getToken),
+        body: JSON.stringify({}),
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch (err: unknown) {
+      console.warn("[boot] retry-provision failed", err instanceof Error ? err.name : typeof err);
+    } finally {
+      setWorking(false);
+      refetch();
+    }
+  }
+
+  if (!isLoaded || status === "loading") {
+    return (
+      <BootShell>
+        <Spinner />
+        <p className="text-sm">Loading your Matrix computer…</p>
+      </BootShell>
+    );
+  }
+
+  if (status === "unreachable") {
+    return (
+      <BootShell>
+        <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
+        <p className="text-sm">We can’t reach Matrix right now.</p>
+        <button type="button" onClick={refetch} className="inline-flex items-center gap-2 rounded-md border border-forest/20 px-3 py-1.5 text-sm hover:bg-forest/5">
+          <RefreshCwIcon className="size-4" aria-hidden="true" /> Try again
+        </button>
+      </BootShell>
+    );
+  }
+
+  if (!state || PASSTHROUGH_PHASES.has(state.phase)) {
+    // first_run/ready (or, defensively, no state): hand off to the shell, which
+    // owns the first-run experience and the running desktop.
+    return <>{children}</>;
+  }
+
+  switch (state.phase) {
+    case "plan_required":
+      return (
+        <BootShell>
+          <h1 className="text-lg font-medium text-forest">Choose your plan</h1>
+          <p className="max-w-sm text-sm">{state.detail}</p>
+          {state.nextAction.url ? (
+            <a href={state.nextAction.url} className="rounded-md bg-ember px-4 py-2 text-sm font-medium text-white hover:opacity-90">
+              View plans
+            </a>
+          ) : null}
+        </BootShell>
+      );
+    case "payment_settling":
+      return (
+        <BootShell>
+          {state.settling?.delayed ? (
+            <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
+          ) : (
+            <Spinner />
+          )}
+          <h1 className="text-lg font-medium text-forest">
+            {state.settling?.delayed ? "Taking longer than expected" : "Activating your subscription"}
+          </h1>
+          <p className="max-w-sm text-sm">{state.detail}</p>
+          {state.settling?.delayed ? (
+            <a href="mailto:support@matrix-os.com" className="text-sm underline">Contact support</a>
+          ) : null}
+        </BootShell>
+      );
+    case "provisioning":
+      return (
+        <BootShell>
+          <Spinner />
+          <h1 className="text-lg font-medium text-forest">Building your Matrix computer</h1>
+          <p className="max-w-sm text-sm">
+            {state.progress ? (STAGE_LABEL[state.progress.stage] ?? state.detail) : state.detail}
+          </p>
+        </BootShell>
+      );
+    case "provisioning_failed":
+      return (
+        <BootShell>
+          <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
+          <h1 className="text-lg font-medium text-forest">Setup needs attention</h1>
+          <p className="max-w-sm text-sm">{state.detail}</p>
+          {state.failure?.retryable ? (
+            <button type="button" disabled={working} onClick={() => void retryProvision()} className="inline-flex items-center gap-2 rounded-md bg-ember px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-60">
+              {working ? <Spinner /> : <RefreshCwIcon className="size-4" aria-hidden="true" />} Retry setup
+            </button>
+          ) : (
+            <a href="mailto:support@matrix-os.com" className="text-sm underline">Contact support</a>
+          )}
+        </BootShell>
+      );
+    default:
+      return <>{children}</>;
+  }
+}

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -225,8 +225,19 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
         </BootShell>
       );
     case "account_required":
-      // No account yet — never render the shell; send to the sign-in/up door.
-      return <RedirectToSignIn />;
+      return (
+        <BootShell>
+          <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
+          <h1 className="text-lg font-medium text-forest">Finishing account setup</h1>
+          <p className="max-w-sm text-sm">{state.detail || "We are finishing your Matrix account setup."}</p>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <button type="button" onClick={refreshJourney} className="inline-flex items-center gap-2 rounded-md border border-forest/20 px-3 py-1.5 text-sm hover:bg-forest/5">
+              <RefreshCwIcon className="size-4" aria-hidden="true" /> Try again
+            </button>
+            <a href="mailto:support@matrix-os.com" className="text-sm underline">Contact support</a>
+          </div>
+        </BootShell>
+      );
     default:
       // Unknown phase: do NOT fall through to the shell. Show a safe wait state.
       return (

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { useAuth } from "@clerk/nextjs";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
 import { AlertCircleIcon, Loader2Icon, RefreshCwIcon } from "lucide-react";
 import { useJourney, type JourneyState } from "@/hooks/useJourney";
 
@@ -123,7 +123,22 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
     }
   }
 
-  if (!isLoaded || status === "loading") {
+  if (!isLoaded) {
+    return (
+      <BootShell>
+        <Spinner />
+        <p className="text-sm">Loading your Matrix computer…</p>
+      </BootShell>
+    );
+  }
+
+  // Signed-out / session-expired: the journey hook is disabled, so without this
+  // branch the user would spin forever. Send them to the sign-in door.
+  if (!isSignedIn) {
+    return <RedirectToSignIn />;
+  }
+
+  if (status === "loading") {
     return (
       <BootShell>
         <Spinner />
@@ -205,7 +220,16 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
           )}
         </BootShell>
       );
+    case "account_required":
+      // No account yet — never render the shell; send to the sign-in/up door.
+      return <RedirectToSignIn />;
     default:
-      return <>{children}</>;
+      // Unknown phase: do NOT fall through to the shell. Show a safe wait state.
+      return (
+        <BootShell>
+          <Spinner />
+          <p className="text-sm">Loading your Matrix computer…</p>
+        </BootShell>
+      );
   }
 }

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -147,6 +147,12 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
     );
   }
 
+  // Journey said the session is no longer valid — re-authenticate rather than
+  // showing a dead retry loop.
+  if (status === "unauthorized") {
+    return <RedirectToSignIn />;
+  }
+
   if (status === "unreachable") {
     return (
       <BootShell>

--- a/shell/src/components/BootSequence.tsx
+++ b/shell/src/components/BootSequence.tsx
@@ -66,14 +66,14 @@ export function BootSequence({
 
 function BootSequenceInner({ children }: { children: ReactNode }) {
   const { isLoaded, isSignedIn, getToken } = useAuth();
-  const { state, status, refetch } = useJourney({ enabled: isLoaded && isSignedIn });
+  const { state, status, refreshJourney } = useJourney({ enabled: isLoaded && isSignedIn });
   const [working, setWorking] = useState(false);
   const provisionStarted = useRef(false);
 
   const phase = state?.phase;
 
   // Auto-start provisioning once, when entitled but no machine exists yet.
-  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- a deliberate one-time side effect (guarded by provisionStarted ref + disposed flag): when the journey reports an entitled user with no machine, kick off provisioning, then refetch. This is an effect, not user-event-driven, because it must fire on the derived journey phase, not a click.
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- a deliberate one-time side effect (guarded by provisionStarted ref + disposed flag): when the journey reports an entitled user with no machine, kick off provisioning, then refreshJourney. This is an effect, not user-event-driven, because it must fire on the derived journey phase, not a click.
   useEffect(() => {
     if (status !== "ready" || phase !== "provisioning") return;
     if (state?.nextAction.kind !== "start_provision" || provisionStarted.current) return;
@@ -95,18 +95,17 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       } catch (err: unknown) {
         if (!disposed) provisionStarted.current = false;
         console.warn("[boot] provision start failed", err instanceof Error ? err.name : typeof err);
-      } finally {
-        if (!disposed) refetch();
       }
+      if (!disposed) refreshJourney();
     })();
     return () => {
       disposed = true;
     };
-  }, [status, phase, state?.nextAction.kind, getToken, refetch]);
+  }, [status, phase, state?.nextAction.kind, getToken, refreshJourney]);
 
   async function retryProvision(): Promise<void> {
     setWorking(true);
-    // react-doctor-disable-next-line react-doctor/async-defer-await -- the request must complete before the finally block clears `working` and refetches the journey; the await is the operation being awaited, not a deferrable guard.
+    // react-doctor-disable-next-line react-doctor/async-defer-await -- the request must complete before clearing `working` and refreshing the journey; the await is the operation being awaited, not a deferrable guard.
     try {
       await fetch("/api/journey/retry-provision", {
         method: "POST",
@@ -117,10 +116,9 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       });
     } catch (err: unknown) {
       console.warn("[boot] retry-provision failed", err instanceof Error ? err.name : typeof err);
-    } finally {
-      setWorking(false);
-      refetch();
     }
+    setWorking(false);
+    refreshJourney();
   }
 
   if (!isLoaded) {
@@ -158,7 +156,7 @@ function BootSequenceInner({ children }: { children: ReactNode }) {
       <BootShell>
         <AlertCircleIcon className="size-6 text-ember" aria-hidden="true" />
         <p className="text-sm">We can’t reach Matrix right now.</p>
-        <button type="button" onClick={refetch} className="inline-flex items-center gap-2 rounded-md border border-forest/20 px-3 py-1.5 text-sm hover:bg-forest/5">
+        <button type="button" onClick={refreshJourney} className="inline-flex items-center gap-2 rounded-md border border-forest/20 px-3 py-1.5 text-sm hover:bg-forest/5">
           <RefreshCwIcon className="size-4" aria-hidden="true" /> Try again
         </button>
       </BootShell>

--- a/shell/src/components/OnboardingGate.tsx
+++ b/shell/src/components/OnboardingGate.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Suspense, type ReactNode } from "react";
+import { useSearchParams } from "next/navigation";
+import { BillingGate } from "@/components/BillingGate";
+import { BootSequence } from "@/components/BootSequence";
+
+const e2eBypass = process.env.NEXT_PUBLIC_E2E_TEST_BYPASS === "1";
+
+/**
+ * Chooses the onboarding gate (spec 092 Phase C):
+ * - Device-flow returns (`device_return`, used by the CLI and native macOS app)
+ *   keep the proven BillingGate handoff that provisions and redirects back to the
+ *   approving device — unchanged to avoid regressing that flow.
+ * - Every other (web) entry uses the journey-driven BootSequence.
+ *
+ * The page.tsx cutover is intentionally conservative; the web BootSequence path
+ * is validated end-to-end with a preview VPS before this gate becomes the only one.
+ */
+function OnboardingGateInner({
+  children,
+  platformSessionActive,
+}: {
+  children: ReactNode;
+  platformSessionActive: boolean;
+}) {
+  const searchParams = useSearchParams();
+  const isDeviceFlow = searchParams.get("device_return") !== null;
+
+  if (isDeviceFlow) {
+    return <BillingGate platformSessionActive={platformSessionActive}>{children}</BillingGate>;
+  }
+  return (
+    <BootSequence platformSessionActive={platformSessionActive} e2eBypass={e2eBypass}>
+      {children}
+    </BootSequence>
+  );
+}
+
+function OnboardingGateFallback() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-page-bg text-forest/70">
+      <output className="text-sm">Loading your Matrix computer…</output>
+    </main>
+  );
+}
+
+export function OnboardingGate({
+  children,
+  platformSessionActive = false,
+}: {
+  children: ReactNode;
+  platformSessionActive?: boolean;
+}) {
+  // useSearchParams requires a Suspense boundary so the page is not forced into
+  // full client-side rendering.
+  return (
+    <Suspense fallback={<OnboardingGateFallback />}>
+      <OnboardingGateInner platformSessionActive={platformSessionActive}>
+        {children}
+      </OnboardingGateInner>
+    </Suspense>
+  );
+}

--- a/shell/src/hooks/useJourney.ts
+++ b/shell/src/hooks/useJourney.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
 
 // Mirrors the platform GET /api/journey contract (spec 092). Kept structural so
@@ -59,23 +59,25 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
   const [state, setState] = useState<JourneyState | null>(null);
   const [status, setStatus] = useState<JourneyStatus>("loading");
   const [nonce, setNonce] = useState(0);
-  const activeRef = useRef(true);
 
   // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity is consumed by the polling useEffect dependency array below and returned to callers (BootSequence effect deps); a stable refreshJourney keeps the poller from re-subscribing every render.
   const refreshJourney = useCallback(() => setNonce((n) => n + 1), []);
 
-  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- this hook IS the journey poller; there is no data-fetching library in the shell. Races/leaks are guarded by activeRef + AbortController + single-timer scheduling, and it self-stops in terminal phases.
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- this hook IS the journey poller; there is no data-fetching library in the shell. Races/leaks are guarded by a per-effect disposed flag + AbortController + single-timer scheduling, and it self-stops in terminal phases.
   useEffect(() => {
     if (!enabled || !isLoaded || !isSignedIn) return;
-    activeRef.current = true;
+    let disposed = false;
     let pollTimer: number | undefined;
+    let inFlightController: AbortController | undefined;
 
     async function fetchOnce(): Promise<void> {
       const controller = new AbortController();
+      inFlightController = controller;
       const timeoutId = window.setTimeout(() => controller.abort(), JOURNEY_TIMEOUT_MS);
-      // react-doctor-disable-next-line react-doctor/async-defer-await -- ordered flow: the token is needed for the request that follows, and the post-await `activeRef.current` guards discard a response received after unmount/refreshJourney, so these awaits cannot be deferred past them.
+      // react-doctor-disable-next-line react-doctor/async-defer-await -- ordered flow: the token is needed for the request that follows, and the post-await `disposed` guards discard a response received after unmount/refreshJourney, so these awaits cannot be deferred past them.
       try {
         const token = await getToken();
+        if (disposed) return;
         const res = await fetch("/api/journey", {
           method: "GET",
           credentials: "include",
@@ -86,36 +88,37 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
           },
           signal: controller.signal,
         });
-        if (!activeRef.current) return;
+        if (disposed) return;
         if (res.status === 401 || res.status === 403) {
-          // Auth no longer valid — STOP polling (do not hammer the endpoint
+          // Auth no longer valid - STOP polling (do not hammer the endpoint
           // under a persistent auth failure) and let the gate re-authenticate.
           setStatus("unauthorized");
           return;
         }
         if (!res.ok) {
-          // 5xx/other → transient; cannot trust a phase, keep retrying.
+          // 5xx/other -> transient; cannot trust a phase, keep retrying.
           setStatus("unreachable");
           scheduleNext(ACTIVE_POLL_MS);
           return;
         }
         const body = (await res.json()) as JourneyState;
-        if (!activeRef.current) return;
+        if (disposed) return;
         setState(body);
         setStatus("ready");
         if (ACTIVE_PHASES.has(body.phase)) scheduleNext(ACTIVE_POLL_MS);
       } catch (err: unknown) {
-        if (!activeRef.current) return;
-        // Network/timeout/abort → unreachable; keep trying while mounted.
+        if (disposed) return;
+        // Network/timeout/abort -> unreachable; keep trying while mounted.
         setStatus((prev) => (prev === "ready" ? prev : "unreachable"));
         scheduleNext(ACTIVE_POLL_MS);
       } finally {
+        if (inFlightController === controller) inFlightController = undefined;
         window.clearTimeout(timeoutId);
       }
     }
 
     function scheduleNext(delayMs: number): void {
-      if (!activeRef.current) return;
+      if (disposed) return;
       pollTimer = window.setTimeout(() => {
         void fetchOnce();
       }, delayMs);
@@ -124,8 +127,9 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
     void fetchOnce();
 
     return () => {
-      activeRef.current = false;
+      disposed = true;
       if (pollTimer !== undefined) window.clearTimeout(pollTimer);
+      inFlightController?.abort();
     };
   }, [enabled, isLoaded, isSignedIn, getToken, nonce]);
 

--- a/shell/src/hooks/useJourney.ts
+++ b/shell/src/hooks/useJourney.ts
@@ -34,7 +34,7 @@ export interface JourneyState {
   readiness?: { status: "ok" | "degraded"; failing: string[] };
 }
 
-export type JourneyStatus = "loading" | "ready" | "unreachable";
+export type JourneyStatus = "loading" | "ready" | "unreachable" | "unauthorized";
 
 export interface UseJourneyResult {
   state: JourneyState | null;
@@ -87,8 +87,14 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
           signal: controller.signal,
         });
         if (!activeRef.current) return;
+        if (res.status === 401 || res.status === 403) {
+          // Auth no longer valid — STOP polling (do not hammer the endpoint
+          // under a persistent auth failure) and let the gate re-authenticate.
+          setStatus("unauthorized");
+          return;
+        }
         if (!res.ok) {
-          // 401/403/5xx → cannot trust a phase; surface as unreachable.
+          // 5xx/other → transient; cannot trust a phase, keep retrying.
           setStatus("unreachable");
           scheduleNext(ACTIVE_POLL_MS);
           return;

--- a/shell/src/hooks/useJourney.ts
+++ b/shell/src/hooks/useJourney.ts
@@ -1,0 +1,127 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuth } from "@clerk/nextjs";
+
+// Mirrors the platform GET /api/journey contract (spec 092). Kept structural so
+// the shell never hard-codes provider/internal details.
+export type JourneyPhase =
+  | "account_required"
+  | "plan_required"
+  | "payment_settling"
+  | "provisioning"
+  | "provisioning_failed"
+  | "first_run"
+  | "ready";
+
+export type JourneyActionKind =
+  | "open_plans"
+  | "wait"
+  | "start_provision"
+  | "retry_provision"
+  | "contact_support"
+  | "begin_first_run"
+  | "open_shell"
+  | "none";
+
+export interface JourneyState {
+  phase: JourneyPhase;
+  detail: string;
+  nextAction: { kind: JourneyActionKind; url?: string };
+  progress?: { stage: string; startedAt: string };
+  failure?: { retryable: boolean; attempt: number };
+  settling?: { since: string; delayed: boolean };
+  readiness?: { status: "ok" | "degraded"; failing: string[] };
+}
+
+export type JourneyStatus = "loading" | "ready" | "unreachable";
+
+export interface UseJourneyResult {
+  state: JourneyState | null;
+  status: JourneyStatus;
+  refetch: () => void;
+}
+
+const JOURNEY_TIMEOUT_MS = 10_000;
+const ACTIVE_POLL_MS = 4_000;
+// Phases that are still moving on the server — poll until they settle.
+const ACTIVE_PHASES = new Set<JourneyPhase>(["payment_settling", "provisioning"]);
+
+/**
+ * Polls GET /api/journey for the signed-in user. Polls only while the phase is
+ * still moving (settling/provisioning) and stops in terminal phases; on a 503 or
+ * network failure it reports `unreachable` rather than guessing a phase. The
+ * request is same-origin (proxied to the platform) and Clerk-bearer authed.
+ */
+export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResult {
+  const enabled = options.enabled ?? true;
+  const { isLoaded, isSignedIn, getToken } = useAuth();
+  const [state, setState] = useState<JourneyState | null>(null);
+  const [status, setStatus] = useState<JourneyStatus>("loading");
+  const [nonce, setNonce] = useState(0);
+  const activeRef = useRef(true);
+
+  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity is consumed by the polling useEffect dependency array below and returned to callers (BootSequence effect deps); a stable refetch keeps the poller from re-subscribing every render.
+  const refetch = useCallback(() => setNonce((n) => n + 1), []);
+
+  // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- this hook IS the journey poller; there is no data-fetching library in the shell. Races/leaks are guarded by activeRef + AbortController + single-timer scheduling, and it self-stops in terminal phases.
+  useEffect(() => {
+    if (!enabled || !isLoaded || !isSignedIn) return;
+    activeRef.current = true;
+    let pollTimer: number | undefined;
+
+    async function fetchOnce(): Promise<void> {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), JOURNEY_TIMEOUT_MS);
+      // react-doctor-disable-next-line react-doctor/async-defer-await -- ordered flow: the token is needed for the request that follows, and the post-await `activeRef.current` guards discard a response received after unmount/refetch, so these awaits cannot be deferred past them.
+      try {
+        const token = await getToken();
+        const res = await fetch("/api/journey", {
+          method: "GET",
+          credentials: "include",
+          cache: "no-store",
+          headers: {
+            Accept: "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          signal: controller.signal,
+        });
+        if (!activeRef.current) return;
+        if (!res.ok) {
+          // 401/403/5xx → cannot trust a phase; surface as unreachable.
+          setStatus("unreachable");
+          scheduleNext(ACTIVE_POLL_MS);
+          return;
+        }
+        const body = (await res.json()) as JourneyState;
+        if (!activeRef.current) return;
+        setState(body);
+        setStatus("ready");
+        if (ACTIVE_PHASES.has(body.phase)) scheduleNext(ACTIVE_POLL_MS);
+      } catch (err: unknown) {
+        if (!activeRef.current) return;
+        // Network/timeout/abort → unreachable; keep trying while mounted.
+        setStatus((prev) => (prev === "ready" ? prev : "unreachable"));
+        scheduleNext(ACTIVE_POLL_MS);
+      } finally {
+        window.clearTimeout(timeoutId);
+      }
+    }
+
+    function scheduleNext(delayMs: number): void {
+      if (!activeRef.current) return;
+      pollTimer = window.setTimeout(() => {
+        void fetchOnce();
+      }, delayMs);
+    }
+
+    void fetchOnce();
+
+    return () => {
+      activeRef.current = false;
+      if (pollTimer !== undefined) window.clearTimeout(pollTimer);
+    };
+  }, [enabled, isLoaded, isSignedIn, getToken, nonce]);
+
+  return { state, status, refetch };
+}

--- a/shell/src/hooks/useJourney.ts
+++ b/shell/src/hooks/useJourney.ts
@@ -39,7 +39,7 @@ export type JourneyStatus = "loading" | "ready" | "unreachable" | "unauthorized"
 export interface UseJourneyResult {
   state: JourneyState | null;
   status: JourneyStatus;
-  refetch: () => void;
+  refreshJourney: () => void;
 }
 
 const JOURNEY_TIMEOUT_MS = 10_000;
@@ -61,8 +61,8 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
   const [nonce, setNonce] = useState(0);
   const activeRef = useRef(true);
 
-  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity is consumed by the polling useEffect dependency array below and returned to callers (BootSequence effect deps); a stable refetch keeps the poller from re-subscribing every render.
-  const refetch = useCallback(() => setNonce((n) => n + 1), []);
+  // react-doctor-disable-next-line react-doctor/react-compiler-no-manual-memoization -- identity is consumed by the polling useEffect dependency array below and returned to callers (BootSequence effect deps); a stable refreshJourney keeps the poller from re-subscribing every render.
+  const refreshJourney = useCallback(() => setNonce((n) => n + 1), []);
 
   // react-doctor-disable-next-line react-doctor/no-fetch-in-effect -- this hook IS the journey poller; there is no data-fetching library in the shell. Races/leaks are guarded by activeRef + AbortController + single-timer scheduling, and it self-stops in terminal phases.
   useEffect(() => {
@@ -73,7 +73,7 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
     async function fetchOnce(): Promise<void> {
       const controller = new AbortController();
       const timeoutId = window.setTimeout(() => controller.abort(), JOURNEY_TIMEOUT_MS);
-      // react-doctor-disable-next-line react-doctor/async-defer-await -- ordered flow: the token is needed for the request that follows, and the post-await `activeRef.current` guards discard a response received after unmount/refetch, so these awaits cannot be deferred past them.
+      // react-doctor-disable-next-line react-doctor/async-defer-await -- ordered flow: the token is needed for the request that follows, and the post-await `activeRef.current` guards discard a response received after unmount/refreshJourney, so these awaits cannot be deferred past them.
       try {
         const token = await getToken();
         const res = await fetch("/api/journey", {
@@ -129,5 +129,5 @@ export function useJourney(options: { enabled?: boolean } = {}): UseJourneyResul
     };
   }, [enabled, isLoaded, isSignedIn, getToken, nonce]);
 
-  return { state, status, refetch };
+  return { state, status, refreshJourney };
 }

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@clerk/nextjs", () => ({
     isSignedIn: clerkState.isSignedIn,
     getToken: clerkState.getToken,
   }),
+  RedirectToSignIn: () => <div data-testid="redirect-to-sign-in">redirecting to sign in</div>,
 }));
 
 import { BootSequence } from "../../shell/src/components/BootSequence";
@@ -159,6 +160,21 @@ describe("BootSequence", () => {
     mockJourney(baseState, false);
     render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
     expect(await screen.findByText("We can’t reach Matrix right now.")).toBeTruthy();
+    expect(screen.queryByTestId("shell")).toBeNull();
+  });
+
+  it("redirects a signed-out user to sign-in instead of spinning forever", async () => {
+    clerkState.isSignedIn = false;
+    mockJourney(baseState);
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByTestId("redirect-to-sign-in")).toBeTruthy();
+    expect(screen.queryByTestId("shell")).toBeNull();
+  });
+
+  it("never hands the shell to an account_required phase", async () => {
+    mockJourney({ phase: "account_required", detail: "Create your account.", nextAction: { kind: "none" } });
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByTestId("redirect-to-sign-in")).toBeTruthy();
     expect(screen.queryByTestId("shell")).toBeNull();
   });
 });

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -22,11 +22,11 @@ vi.mock("@clerk/nextjs", () => ({
 import { BootSequence } from "../../shell/src/components/BootSequence";
 import type { JourneyState } from "../../shell/src/hooks/useJourney";
 
-function mockJourney(state: JourneyState, ok = true) {
+function mockJourney(state: JourneyState, journeyStatus = 200) {
   const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
     if (url.includes("/api/journey")) {
-      return new Response(JSON.stringify(state), { status: ok ? 200 : 503, headers: { "content-type": "application/json" } });
+      return new Response(JSON.stringify(state), { status: journeyStatus, headers: { "content-type": "application/json" } });
     }
     return new Response(JSON.stringify({ status: "started" }), { status: 200, headers: { "content-type": "application/json" } });
   });
@@ -157,10 +157,19 @@ describe("BootSequence", () => {
   });
 
   it("shows an unreachable state on a 503 (never guesses a phase)", async () => {
-    mockJourney(baseState, false);
+    mockJourney(baseState, 503);
     render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
     expect(await screen.findByText("We can’t reach Matrix right now.")).toBeTruthy();
     expect(screen.queryByTestId("shell")).toBeNull();
+  });
+
+  it("re-authenticates (does not loop) when the journey returns 401", async () => {
+    const fetchMock = mockJourney(baseState, 401);
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByTestId("redirect-to-sign-in")).toBeTruthy();
+    // Stops polling under persistent auth failure: exactly one journey fetch.
+    const journeyCalls = fetchMock.mock.calls.filter((c) => String(c[0]).includes("/api/journey"));
+    expect(journeyCalls).toHaveLength(1);
   });
 
   it("redirects a signed-out user to sign-in instead of spinning forever", async () => {

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -180,10 +180,13 @@ describe("BootSequence", () => {
     expect(screen.queryByTestId("shell")).toBeNull();
   });
 
-  it("never hands the shell to an account_required phase", async () => {
+  it("keeps a signed-in account_required phase out of the Clerk redirect loop", async () => {
     mockJourney({ phase: "account_required", detail: "Create your account.", nextAction: { kind: "none" } });
     render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
-    expect(await screen.findByTestId("redirect-to-sign-in")).toBeTruthy();
+    expect(await screen.findByText("Finishing account setup")).toBeTruthy();
+    expect(screen.getByText("Try again")).toBeTruthy();
+    expect(screen.getByText("Contact support")).toBeTruthy();
+    expect(screen.queryByTestId("redirect-to-sign-in")).toBeNull();
     expect(screen.queryByTestId("shell")).toBeNull();
   });
 });

--- a/tests/shell/boot-sequence.test.tsx
+++ b/tests/shell/boot-sequence.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const clerkState = vi.hoisted(() => ({
+  isLoaded: true,
+  isSignedIn: true,
+  getToken: vi.fn(async () => "clerk-token"),
+}));
+
+vi.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({
+    isLoaded: clerkState.isLoaded,
+    isSignedIn: clerkState.isSignedIn,
+    getToken: clerkState.getToken,
+  }),
+}));
+
+import { BootSequence } from "../../shell/src/components/BootSequence";
+import type { JourneyState } from "../../shell/src/hooks/useJourney";
+
+function mockJourney(state: JourneyState, ok = true) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/api/journey")) {
+      return new Response(JSON.stringify(state), { status: ok ? 200 : 503, headers: { "content-type": "application/json" } });
+    }
+    return new Response(JSON.stringify({ status: "started" }), { status: 200, headers: { "content-type": "application/json" } });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const baseState: JourneyState = {
+  phase: "plan_required",
+  detail: "Choose a plan to create your Matrix computer.",
+  nextAction: { kind: "open_plans", url: "https://app.matrix-os.com/?plans=1" },
+};
+
+describe("BootSequence", () => {
+  beforeEach(() => {
+    clerkState.isLoaded = true;
+    clerkState.isSignedIn = true;
+  });
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("renders children immediately when a platform session is already verified", () => {
+    mockJourney(baseState);
+    render(
+      <BootSequence platformSessionActive>
+        <div data-testid="shell">SHELL</div>
+      </BootSequence>,
+    );
+    expect(screen.getByTestId("shell")).toBeTruthy();
+  });
+
+  it("renders children under the e2e bypass", () => {
+    mockJourney(baseState);
+    render(
+      <BootSequence e2eBypass>
+        <div data-testid="shell">SHELL</div>
+      </BootSequence>,
+    );
+    expect(screen.getByTestId("shell")).toBeTruthy();
+  });
+
+  it("shows the plan step for plan_required", async () => {
+    mockJourney(baseState);
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByText("Choose your plan")).toBeTruthy();
+    const link = screen.getByText("View plans") as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toContain("plans=1");
+    expect(screen.queryByTestId("shell")).toBeNull();
+  });
+
+  it("shows a calm settling state within the window (never the paywall)", async () => {
+    mockJourney({
+      phase: "payment_settling",
+      detail: "Activating your subscription…",
+      nextAction: { kind: "wait" },
+      settling: { since: "2026-06-11T12:00:00.000Z", delayed: false },
+    });
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByText("Activating your subscription")).toBeTruthy();
+    expect(screen.queryByText("Choose your plan")).toBeNull();
+  });
+
+  it("escalates to support when settling is delayed", async () => {
+    mockJourney({
+      phase: "payment_settling",
+      detail: "Your payment is taking longer than expected to confirm.",
+      nextAction: { kind: "contact_support" },
+      settling: { since: "2026-06-11T11:00:00.000Z", delayed: true },
+    });
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByText("Taking longer than expected")).toBeTruthy();
+    expect(screen.getByText("Contact support")).toBeTruthy();
+  });
+
+  it("shows build progress with a stage label during provisioning", async () => {
+    mockJourney({
+      phase: "provisioning",
+      detail: "Building your Matrix computer…",
+      nextAction: { kind: "wait" },
+      progress: { stage: "booting", startedAt: "2026-06-11T12:00:00.000Z" },
+    });
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByText("Building your Matrix computer")).toBeTruthy();
+    expect(screen.getByText("Booting your computer")).toBeTruthy();
+  });
+
+  it("offers retry on a retryable failure and calls retry-provision", async () => {
+    const fetchMock = mockJourney({
+      phase: "provisioning_failed",
+      detail: "Setting up your computer ran into a problem.",
+      nextAction: { kind: "retry_provision" },
+      failure: { retryable: true, attempt: 1 },
+    });
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    const retry = await screen.findByText("Retry setup");
+    fireEvent.click(retry);
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/api/journey/retry-provision"))).toBe(true);
+    });
+  });
+
+  it("shows support (no retry) once retries are exhausted", async () => {
+    mockJourney({
+      phase: "provisioning_failed",
+      detail: "We could not set up your computer after several attempts.",
+      nextAction: { kind: "contact_support" },
+      failure: { retryable: false, attempt: 3 },
+    });
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByText("Setup needs attention")).toBeTruthy();
+    expect(screen.getByText("Contact support")).toBeTruthy();
+    expect(screen.queryByText("Retry setup")).toBeNull();
+  });
+
+  it("hands off to the shell on first_run (Desktop owns first-run UI)", async () => {
+    mockJourney({ phase: "first_run", detail: "Finish setting up.", nextAction: { kind: "begin_first_run" } });
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByTestId("shell")).toBeTruthy();
+  });
+
+  it("renders the shell when ready", async () => {
+    mockJourney({ phase: "ready", detail: "Your Matrix computer is ready.", nextAction: { kind: "open_shell", url: "https://app.matrix-os.com/" } });
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByTestId("shell")).toBeTruthy();
+  });
+
+  it("shows an unreachable state on a 503 (never guesses a phase)", async () => {
+    mockJourney(baseState, false);
+    render(<BootSequence><div data-testid="shell">SHELL</div></BootSequence>);
+    expect(await screen.findByText("We can’t reach Matrix right now.")).toBeTruthy();
+    expect(screen.queryByTestId("shell")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Spec 092 **Phase C** (draft, third PR in the stack, on top of #494). Replaces the billing-wall + provisioning-poll with one continuous, journey-driven boot sequence in the shell.

- **`useJourney`** — polls `GET /api/journey` (same-origin, Clerk-bearer), only while the phase is still moving (settling/provisioning), stops in terminal phases, and reports `unreachable` on 503/network failure rather than guessing a phase.
- **`BootSequence`** — renders one flow per phase: plan selection → calm "activating your subscription" (delayed → contact support, **never re-shows the paywall**) → live machine-build progress with a human stage label → retryable failure. Hands off to the shell on `first_run`/`ready` (Desktop keeps owning the first-run UI). Auto-starts provisioning once when entitled-with-no-machine; retry calls `/api/journey/retry-provision`.
- **`OnboardingGate`** — conservative cutover: the **device-flow** path (`device_return`, used by the CLI and native macOS app) keeps the proven `BillingGate` handoff untouched; the common **web** path uses `BootSequence`.

## Why draft

The web path replaces the product's most integration-sensitive gate. Per the agreed test plan, it is validated **end-to-end on a disposable preview VPS** (the `preview-vps` label from #491, once merged) — signup → pay → build → first-run → ready — before this becomes the sole gate. Marking ready is gated on that run.

## Tests

11 `BootSequence` component tests (jsdom + @testing-library/react): platform-session/e2e passthrough, plan step, calm vs delayed settling, build progress + stage label, retryable vs exhausted failure, first_run/ready handoff, and the 503 → unreachable (no phase guessing) case. Shell typecheck clean; `check:patterns` 0 violations. react-doctor: `no-fetch-in-effect` and `no-manual-memoization` suppressed with justifications (matching the codebase convention); residual advisory `async-defer-await` findings are the standard polling pattern and are non-blocking in CI.

## Deferred to the validated cutover (this PR, before ready)

- Gateway **write-behind** to `/internal/first-run` (instant first-run; until then the Phase B reconciler backfill covers it within one interval).
- Real **readiness annotation** feeding the `ready` phase (Phase B passes it through; gateway readiness checks wire here).
- Removing `BillingGate` once the device-flow is reimplemented inside `BootSequence` and preview-VPS-verified.

## Invariants

- **Source of truth**: the shell renders only what `GET /api/journey` reports; it never re-derives billing/machine/first-run state. On `unreachable` it shows a retry, never a paywall or a destructive action.
- **Auth**: Clerk bearer via `getToken()`; same-origin requests proxied to the platform (journey routes are short-circuited to the platform in #494).
- **Deferred scope**: device-flow stays on BillingGate this PR; gateway write-behind + readiness annotation + BillingGate removal land here after preview-VPS validation.