### PR TITLE
feat(observability): forward client and runtime errors to PostHog with source maps

### DIFF
--- a/.github/workflows/host-bundle-release.yml
+++ b/.github/workflows/host-bundle-release.yml
@@ -168,6 +168,13 @@ jobs:
       # capture calls stay first-party on every user subdomain (ad blockers
       # block *.posthog.com and shared proxy hosts).
       NEXT_PUBLIC_POSTHOG_API_HOST: ${{ vars.NEXT_PUBLIC_POSTHOG_API_HOST || '/relay' }}
+      # Optional PostHog source-map upload credentials. When absent, next.config
+      # exports the plain config and the build is byte-identical to today.
+      # POSTHOG_HOST is the private API host (EU: https://eu.posthog.com), not
+      # the eu.i.posthog.com ingestion host used above.
+      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY || '' }}
+      POSTHOG_PROJECT_ID: ${{ vars.POSTHOG_PROJECT_ID || '' }}
+      POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://eu.posthog.com' }}
     outputs:
       version: ${{ steps.version.outputs.version }}
       channel: ${{ steps.channel.outputs.channel }}

--- a/distro/observability/promtail.yml
+++ b/distro/observability/promtail.yml
@@ -16,6 +16,9 @@ scrape_configs:
           job: matrixos
           type: interaction
           __path__: /var/log/matrixos/system/logs/*.jsonl
+          # client-errors.jsonl ships under its own job below; excluding it
+          # here keeps the two jobs from fighting over file positions.
+          __path_exclude__: /var/log/matrixos/system/logs/client-errors.jsonl
     pipeline_stages:
       - json:
           expressions:
@@ -23,6 +26,27 @@ scrape_configs:
             source: source
             costUsd: costUsd
             durationMs: durationMs
+      - labels:
+          source:
+      - timestamp:
+          source: timestamp
+          format: RFC3339
+
+  - job_name: matrixos-client-errors
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: matrixos-client-errors
+          type: client-error
+          __path__: /var/log/matrixos/system/logs/client-errors.jsonl
+    pipeline_stages:
+      - json:
+          expressions:
+            timestamp: timestamp
+            source: source
+            errorId: errorId
+            digest: digest
       - labels:
           source:
       - timestamp:

--- a/packages/gateway/src/app-runtime/dispatcher.ts
+++ b/packages/gateway/src/app-runtime/dispatcher.ts
@@ -280,10 +280,10 @@ async function dispatchNode(
     });
   } catch (err: unknown) {
     const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
-    // Upstream failures map to the ProxyError class (backend_timeout,
-    // backend_unreachable, upstream_closed); the raw fetch error carries
-    // hosts/ports and must not be forwarded.
-    reportAppError("ProxyError", slug);
+    // Upstream failures map to the ProxyError class; timeouts get their own
+    // kind so dashboards can split slow backends from unreachable ones. The
+    // raw fetch error carries hosts/ports and must not be forwarded.
+    reportAppError(isTimeout ? "ProxyTimeoutError" : "ProxyError", slug);
     return c.json(
       { error: "upstream error", correlationId },
       isTimeout ? 504 : 502,

--- a/packages/gateway/src/app-runtime/dispatcher.ts
+++ b/packages/gateway/src/app-runtime/dispatcher.ts
@@ -57,9 +57,38 @@ export function sanitizeAppResponseHeaders(headers: Headers): Headers {
   return sanitized;
 }
 
+export interface AppRuntimeErrorReport {
+  /** Stable error class name (ManifestError, BuildError, SpawnError, ...). Never a raw message. */
+  errorKind: string;
+  /** SAFE_SLUG-validated app slug, when known. */
+  appSlug?: string;
+}
+
 export interface DispatcherConfig {
   publicHost?: string;
   processManager?: ProcessManager;
+  /**
+   * Optional failure telemetry sink invoked when app-runtime errors funnel
+   * through the dispatcher (manifest failures, process start failures,
+   * upstream proxy failures). Receives only the error class name and the
+   * validated slug -- never raw error messages or filesystem paths.
+   * Fire-and-forget: callback errors are logged by name and swallowed.
+   */
+  onAppError?: (failure: AppRuntimeErrorReport) => void;
+}
+
+type ReportAppError = (errorKind: string, appSlug?: string) => void;
+
+function createAppErrorReporter(onAppError?: (failure: AppRuntimeErrorReport) => void): ReportAppError {
+  return (errorKind, appSlug) => {
+    if (!onAppError) return;
+    try {
+      onAppError(appSlug ? { errorKind, appSlug } : { errorKind });
+    } catch (err: unknown) {
+      const kind = err instanceof Error ? err.name : typeof err;
+      console.warn(`[app-runtime] error telemetry capture failed (${errorKind}): ${kind}`);
+    }
+  };
 }
 
 function isWithinRealPath(baseReal: string, candidateReal: string): boolean {
@@ -96,6 +125,7 @@ export function createAppDispatcher(homeDir: string, config?: DispatcherConfig) 
   const app = new Hono();
   const pm = config?.processManager;
   const publicHost = config?.publicHost ?? "localhost";
+  const reportAppError = createAppErrorReporter(config?.onAppError);
 
   app.use("*", bodyLimit({ maxSize: MAX_BODY_SIZE }));
 
@@ -111,6 +141,7 @@ export function createAppDispatcher(homeDir: string, config?: DispatcherConfig) 
       if (result.error.code === "not_found") {
         return c.json({ error: "not found" }, 404);
       }
+      reportAppError(result.error.name, slug);
       return c.json({ error: "manifest error" }, 500);
     }
 
@@ -159,7 +190,7 @@ export function createAppDispatcher(homeDir: string, config?: DispatcherConfig) 
       }
 
       case "node": {
-        return dispatchNode(c, slug, subPath, pm, publicHost);
+        return dispatchNode(c, slug, subPath, pm, publicHost, reportAppError);
       }
 
       default: {
@@ -177,6 +208,7 @@ async function dispatchNode(
   subPath: string,
   pm: ProcessManager | undefined,
   publicHost: string,
+  reportAppError: ReportAppError,
 ): Promise<Response> {
   const correlationId = randomUUID();
 
@@ -191,6 +223,9 @@ async function dispatchNode(
   try {
     record = await pm.ensureRunning(slug);
   } catch (err: unknown) {
+    // ensureRunning funnels SpawnError / BuildError / HealthCheckError /
+    // ManifestError; report the class name only, never the message.
+    reportAppError(err instanceof Error ? err.name : "UnknownError", slug);
     return c.json(
       { error: "app failed to start", correlationId },
       503,
@@ -245,6 +280,10 @@ async function dispatchNode(
     });
   } catch (err: unknown) {
     const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
+    // Upstream failures map to the ProxyError class (backend_timeout,
+    // backend_unreachable, upstream_closed); the raw fetch error carries
+    // hosts/ports and must not be forwarded.
+    reportAppError("ProxyError", slug);
     return c.json(
       { error: "upstream error", correlationId },
       isTimeout ? 504 : 502,

--- a/packages/gateway/src/client-error-log.ts
+++ b/packages/gateway/src/client-error-log.ts
@@ -26,6 +26,60 @@ export function clientErrorLogPath(homePath: string): string {
   return join(homePath, "system", "logs", "client-errors.jsonl");
 }
 
+export interface ClientErrorExceptionTracker {
+  captureException(
+    error: unknown,
+    options?: {
+      distinctId?: string;
+      properties?: Record<string, string | number | boolean | null | undefined>;
+    },
+  ): Promise<boolean>;
+}
+
+function logForwardFailure(err: unknown): void {
+  // Error NAME only: capture failures must never echo provider details,
+  // messages, or paths into gateway logs.
+  const kind = err instanceof Error ? err.name : typeof err;
+  console.warn(`[client-error-log] PostHog forward failed: ${kind}`);
+}
+
+/**
+ * Forward a validated shell client error report to PostHog error tracking as
+ * a reconstructed exception. Fire-and-forget: failures are logged by error
+ * name only and never affect the HTTP response or the local JSONL append.
+ * The reconstructed message/stack are the error-tracking payload itself;
+ * event properties stay free of raw messages and paths.
+ */
+export function forwardClientErrorToPostHog(
+  tracker: ClientErrorExceptionTracker,
+  distinctId: string,
+  report: ClientErrorReport,
+): void {
+  try {
+    const error = new Error(report.message ?? "Client error report without message");
+    error.name = report.name ?? "ClientError";
+    if (report.stack) {
+      error.stack = report.stack;
+    }
+    void tracker
+      .captureException(error, {
+        distinctId,
+        properties: {
+          source: "shell-client-error",
+          report_source: report.source,
+          digest: report.digest,
+          errorId: report.errorId,
+          path: report.path,
+          build_sha: report.buildSha,
+          user_agent: report.userAgent,
+        },
+      })
+      .catch(logForwardFailure);
+  } catch (err: unknown) {
+    logForwardFailure(err);
+  }
+}
+
 export async function writeClientErrorReport(
   homePath: string,
   report: ClientErrorReport,

--- a/packages/gateway/src/client-error-log.ts
+++ b/packages/gateway/src/client-error-log.ts
@@ -36,6 +36,12 @@ export interface ClientErrorExceptionTracker {
   ): Promise<boolean>;
 }
 
+function stripQuery(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  const queryIndex = path.indexOf("?");
+  return queryIndex === -1 ? path : path.slice(0, queryIndex);
+}
+
 function logForwardFailure(err: unknown): void {
   // Error NAME only: capture failures must never echo provider details,
   // messages, or paths into gateway logs.
@@ -48,7 +54,12 @@ function logForwardFailure(err: unknown): void {
  * a reconstructed exception. Fire-and-forget: failures are logged by error
  * name only and never affect the HTTP response or the local JSONL append.
  * The reconstructed message/stack are the error-tracking payload itself;
- * event properties stay free of raw messages and paths.
+ * event properties stay free of raw error messages. `path` is a deliberate
+ * exception to the no-paths rule: it is the in-app route the shell reporter
+ * captured (bounded to 512 chars, already persisted locally), and locating
+ * the failing screen is the point of the report. It can contain handle or
+ * resource slugs, so it lives under the same PostHog retention policy as
+ * the exception payload itself -- never filesystem paths or query strings.
  */
 export function forwardClientErrorToPostHog(
   tracker: ClientErrorExceptionTracker,
@@ -69,7 +80,7 @@ export function forwardClientErrorToPostHog(
           report_source: report.source,
           digest: report.digest,
           errorId: report.errorId,
-          path: report.path,
+          path: stripQuery(report.path),
           build_sha: report.buildSha,
           user_agent: report.userAgent,
         },

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -220,6 +220,7 @@ import {
 import {
   CLIENT_ERROR_LOG_BODY_LIMIT,
   ClientErrorReportSchema,
+  forwardClientErrorToPostHog,
   writeClientErrorReport,
 } from "./client-error-log.js";
 import { createForwardTunnelHub } from "./forward-ws.js";
@@ -1977,6 +1978,19 @@ export async function createGateway(config: GatewayConfig) {
   const appDispatcher = createAppDispatcher(homePath, {
     processManager,
     publicHost: process.env.PUBLIC_HOST ?? "localhost",
+    // App-runtime failure telemetry: stable error class names only, never
+    // raw error messages or filesystem paths.
+    onAppError: ({ errorKind, appSlug }) => {
+      void posthogErrorTracker.captureEvent("gateway_app_runtime", {
+        distinctId: ownerTelemetryDistinctId,
+        properties: {
+          source: "gateway-app-runtime",
+          event: "app_error",
+          error_kind: errorKind,
+          app_slug: appSlug,
+        },
+      });
+    },
   });
   app.route("/apps/:slug", appDispatcher);
 
@@ -4146,6 +4160,9 @@ export async function createGateway(config: GatewayConfig) {
 
     try {
       await writeClientErrorReport(homePath, parsed.data);
+      // Fire-and-forget PostHog forwarding so client exceptions are visible
+      // beyond the owner-local JSONL. Must never affect the 2xx response.
+      forwardClientErrorToPostHog(posthogErrorTracker, ownerTelemetryDistinctId, parsed.data);
       return c.json({ ok: true });
     } catch (err: unknown) {
       console.warn("[client-error-log] Failed to persist client error report:", err instanceof Error ? err.message : String(err));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,9 @@ importers:
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.58.2
+      '@posthog/nextjs-config':
+        specifier: 1.9.47
+        version: 1.9.47(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.51.0))(webpack@5.107.2(lightningcss@1.32.0))
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -914,6 +917,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@posthog/nextjs-config':
+        specifier: 1.9.47
+        version: 1.9.47(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.51.0))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -4212,17 +4218,42 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/cli@0.7.18':
+    resolution: {integrity: sha512-G3GkXHdAnvmbsujx30wYapovvJuh5kp65DuajG+K+VUlprakRg03reAKTOg/CaHMZ2TZY9sNJf7v/EDcJDni8g==}
+    engines: {node: '>=14.14', npm: '>=6'}
+    hasBin: true
+
   '@posthog/core@1.24.0':
     resolution: {integrity: sha512-Wkp9mgNfgdf6+G4C1VMKakm2RXKQFf4bb5/CPQRAjpqv9l6BY36zZrD1+X5Y2XIAzZqbMKRxsDu3V1r6uKu7/A==}
 
   '@posthog/core@1.29.9':
     resolution: {integrity: sha512-DjvuIyBZ2Z/gBhtZlITlM2D8PlnMsHSQ1D78dbUYoVsgGguvanpJTobZObjLlFkybyvfZFYkpoJkFNI/2Pw4IQ==}
 
+  '@posthog/core@1.30.5':
+    resolution: {integrity: sha512-NGBRhqyMOpiSKd8xtg8dckUxh+kB02LdtnxKYW7ngycJmgM4GBGzSDaATbMQDKaNS9m2FJ9QRZ8nJyelGCoqNQ==}
+
+  '@posthog/nextjs-config@1.9.47':
+    resolution: {integrity: sha512-Aiumj1u43iNkpmuNnOH+p2tcUgZhFBqMCp2P72P/ayMFmxK6DV2rv0lhWOE5kic5oanHHu+z6vxMYlbRiWjCqQ==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      next: '>12.1.0'
+
+  '@posthog/plugin-utils@1.1.1':
+    resolution: {integrity: sha512-vCbaFeuwf9Pc0gI5bkCGvkOn2Bxru2KbZJtOa6loTJjanCNoMsjECEPijr7X5oln1IIg+VKnGiwV4tKY2b7NuQ==}
+
   '@posthog/types@1.362.0':
     resolution: {integrity: sha512-15wOI5uulkfzpkSQKVN4atZecAla2Hxr8IBIB8islqDvqY+42vbR+tMeDKMman9+FUoAqMzE0OnB8VIbM1QY0w==}
 
   '@posthog/types@1.376.0':
     resolution: {integrity: sha512-gbFfxCuZDs/D4QZMwdE+smD1jsuqgGpS6yKGHZZ19foxMy8RYHsU1E47iG1b88n/uN02fAabLibVwuxLtq8juw==}
+
+  '@posthog/types@1.379.2':
+    resolution: {integrity: sha512-quGXOeNewmaGqTxE/eH8MgM/niW1jfgCyzh4bwpXFpDwuQPvWA8WkCFo6k1oKGYV03Go0udw49aGUz6s58cRsA==}
+
+  '@posthog/webpack-plugin@1.5.3':
+    resolution: {integrity: sha512-vh1GSMpxfHI8Rg6lDptwFlAA26dV95joI/O014pF1faRnbxCyvUnLF8yEYz8ZYdWP8hxHHqiwpAylTRBmn1OLg==}
+    peerDependencies:
+      webpack: ^5
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -7066,6 +7097,51 @@ packages:
     resolution: {integrity: sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==}
     engines: {node: '>=16'}
 
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
@@ -7091,6 +7167,12 @@ packages:
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
   '@zxcvbn-ts/core@3.0.4':
     resolution: {integrity: sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw==}
@@ -7137,6 +7219,12 @@ packages:
     peerDependencies:
       acorn: ^8
 
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -7169,6 +7257,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -7176,6 +7272,11 @@ packages:
     peerDependenciesMeta:
       ajv:
         optional: true
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -7728,6 +7829,10 @@ packages:
     resolution: {integrity: sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
 
   chromium-edge-launcher@0.2.0:
     resolution: {integrity: sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==}
@@ -8627,6 +8732,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.22.2:
+    resolution: {integrity: sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==}
+    engines: {node: '>=10.13.0'}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -8674,6 +8783,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -8837,6 +8949,10 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -8878,6 +8994,10 @@ packages:
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
@@ -8931,6 +9051,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -10561,6 +10685,10 @@ packages:
     resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -10906,6 +11034,10 @@ packages:
 
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
+    engines: {node: '>=6.11.5'}
 
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
@@ -11586,6 +11718,9 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -12935,6 +13070,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
@@ -13461,6 +13600,10 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -13488,6 +13631,49 @@ packages:
   terminal-size@4.0.1:
     resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
     engines: {node: '>=18'}
+
+  terser-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
 
   terser@5.46.1:
     resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
@@ -14144,6 +14330,10 @@ packages:
   warn-once@0.1.1:
     resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
 
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+    engines: {node: '>=10.13.0'}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -14177,6 +14367,20 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  webpack-sources@3.5.0:
+    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.107.2:
+    resolution: {integrity: sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
 
   webworkify@1.5.0:
     resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
@@ -16865,7 +17069,7 @@ snapshots:
       progress: 2.0.3
       prompts: 2.4.2
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.0
       send: 0.19.2
       slugify: 1.6.8
       source-map-support: 0.5.21
@@ -16941,7 +17145,7 @@ snapshots:
       progress: 2.0.3
       prompts: 2.4.2
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.0
       send: 0.19.2
       slugify: 1.6.8
       source-map-support: 0.5.21
@@ -16983,7 +17187,7 @@ snapshots:
       getenv: 2.0.0
       glob: 13.0.6
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.0
       slugify: 1.6.8
       xcode: 3.0.1
       xml2js: 0.6.0
@@ -17003,7 +17207,7 @@ snapshots:
       glob: 13.0.6
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.1
-      semver: 7.7.4
+      semver: 7.8.0
       slugify: 1.6.8
     transitivePeerDependencies:
       - supports-color
@@ -17062,7 +17266,7 @@ snapshots:
       ignore: 5.3.2
       minimatch: 10.2.5
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17074,7 +17278,7 @@ snapshots:
       jimp-compact: 0.16.1
       parse-png: 2.1.0
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.0
 
   '@expo/json-file@10.0.12':
     dependencies:
@@ -17218,7 +17422,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       expo: 55.0.8(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.7)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.9.3)(utf-8-validate@6.0.6)
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.0
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -18789,6 +18993,10 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/cli@0.7.18':
+    dependencies:
+      detect-libc: 2.1.2
+
   '@posthog/core@1.24.0':
     dependencies:
       cross-spawn: 7.0.6
@@ -18797,9 +19005,53 @@ snapshots:
     dependencies:
       '@posthog/types': 1.376.0
 
+  '@posthog/core@1.30.5':
+    dependencies:
+      '@posthog/types': 1.379.2
+
+  '@posthog/nextjs-config@1.9.47(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.51.0))(webpack@5.107.2(lightningcss@1.32.0))':
+    dependencies:
+      '@posthog/cli': 0.7.18
+      '@posthog/plugin-utils': 1.1.1
+      '@posthog/webpack-plugin': 1.5.3(webpack@5.107.2(lightningcss@1.32.0))
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.51.0)
+      semver: 7.8.0
+    transitivePeerDependencies:
+      - webpack
+
+  '@posthog/nextjs-config@1.9.47(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.51.0))(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
+    dependencies:
+      '@posthog/cli': 0.7.18
+      '@posthog/plugin-utils': 1.1.1
+      '@posthog/webpack-plugin': 1.5.3(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.51.0)
+      semver: 7.8.0
+    transitivePeerDependencies:
+      - webpack
+
+  '@posthog/plugin-utils@1.1.1':
+    dependencies:
+      cross-spawn: 7.0.6
+
   '@posthog/types@1.362.0': {}
 
   '@posthog/types@1.376.0': {}
+
+  '@posthog/types@1.379.2': {}
+
+  '@posthog/webpack-plugin@1.5.3(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))':
+    dependencies:
+      '@posthog/cli': 0.7.18
+      '@posthog/core': 1.30.5
+      '@posthog/plugin-utils': 1.1.1
+      webpack: 5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)
+
+  '@posthog/webpack-plugin@1.5.3(webpack@5.107.2(lightningcss@1.32.0))':
+    dependencies:
+      '@posthog/cli': 0.7.18
+      '@posthog/core': 1.30.5
+      '@posthog/plugin-utils': 1.1.1
+      webpack: 5.107.2(lightningcss@1.32.0)
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -20161,7 +20413,7 @@ snapshots:
       metro: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-config: 0.83.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.83.5
-      semver: 7.7.4
+      semver: 7.8.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -22393,6 +22645,82 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.0
 
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
   '@webgpu/types@0.1.69': {}
 
   '@xmldom/xmldom@0.8.11': {}
@@ -22408,6 +22736,10 @@ snapshots:
   '@xterm/addon-webgl@0.19.0': {}
 
   '@xterm/xterm@6.0.0': {}
+
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
 
   '@zxcvbn-ts/core@3.0.4':
     dependencies:
@@ -22447,6 +22779,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-import-phases@1.0.4(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -22477,9 +22813,18 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.4.3
 
+  ajv-formats@2.1.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
+
+  ajv-keywords@5.1.0(ajv@8.18.0):
+    dependencies:
+      ajv: 8.18.0
+      fast-deep-equal: 3.1.3
 
   ajv@6.14.0:
     dependencies:
@@ -23141,6 +23486,8 @@ snapshots:
       lighthouse-logger: 1.4.2
     transitivePeerDependencies:
       - supports-color
+
+  chrome-trace-event@1.0.4: {}
 
   chromium-edge-launcher@0.2.0:
     dependencies:
@@ -23950,6 +24297,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  enhanced-resolve@5.22.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -24052,6 +24404,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -24395,6 +24749,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -24463,6 +24822,8 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
+  estraverse@4.3.0: {}
+
   estraverse@5.3.0: {}
 
   estree-util-attach-comments@3.0.0:
@@ -24515,6 +24876,8 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   eventemitter3@5.0.4: {}
+
+  events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -26701,7 +27064,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.4
+      semver: 7.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -26750,6 +27113,12 @@ snapshots:
       emittery: 0.13.1
       jest-util: 29.7.0
       string-length: 4.0.2
+
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 25.5.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
@@ -27091,6 +27460,8 @@ snapshots:
       uhyphen: 0.2.0
 
   linkifyjs@4.3.2: {}
+
+  loader-runner@4.3.2: {}
 
   locate-path@3.0.0:
     dependencies:
@@ -28296,6 +28667,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  neo-async@2.6.2: {}
+
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -28420,7 +28793,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.4
+      semver: 7.8.0
       validate-npm-package-name: 5.0.1
 
   npm-run-path@4.0.1:
@@ -30225,6 +30598,13 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
+
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
@@ -30867,6 +31247,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tapable@2.3.3: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -30906,6 +31288,27 @@ snapshots:
       supports-hyperlinks: 2.3.0
 
   terminal-size@4.0.1: {}
+
+  terser-webpack-plugin@5.6.1(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.1
+      webpack: 5.107.2(esbuild@0.27.7)(lightningcss@1.32.0)
+    optionalDependencies:
+      esbuild: 0.27.7
+      lightningcss: 1.32.0
+
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(webpack@5.107.2(lightningcss@1.32.0)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.1
+      webpack: 5.107.2(lightningcss@1.32.0)
+    optionalDependencies:
+      lightningcss: 1.32.0
 
   terser@5.46.1:
     dependencies:
@@ -31591,6 +31994,11 @@ snapshots:
 
   warn-once@0.1.1: {}
 
+  watchpack@2.5.1:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -31612,6 +32020,86 @@ snapshots:
   webidl-conversions@7.0.0: {}
 
   webidl-conversions@8.0.1: {}
+
+  webpack-sources@3.5.0: {}
+
+  webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.22.2
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.6.1(esbuild@0.27.7)(lightningcss@1.32.0)(webpack@5.107.2(esbuild@0.27.7)(lightningcss@1.32.0))
+      watchpack: 2.5.1
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.107.2(lightningcss@1.32.0):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.22.2
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(webpack@5.107.2(lightningcss@1.32.0))
+      watchpack: 2.5.1
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   webworkify@1.5.0: {}
 

--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -90,7 +90,7 @@ export default posthogPersonalApiKey && posthogProjectId
       personalApiKey: posthogPersonalApiKey,
       projectId: posthogProjectId,
       // Private API host (not the ingestion host): EU is https://eu.posthog.com.
-      host: process.env.POSTHOG_HOST ?? process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.posthog.com",
+      host: process.env.POSTHOG_HOST ?? "https://eu.posthog.com",
       sourcemaps: { enabled: true },
     })
   : nextConfig;

--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { NextConfig } from "next";
+import { withPostHogConfig } from "@posthog/nextjs-config";
 
 const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
 
@@ -78,4 +79,18 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+// PostHog source-map upload runs only when build credentials are present so
+// uploads happen in release builds while local/dev builds stay byte-identical
+// to a build without the plugin (the plain object is exported unchanged).
+const posthogPersonalApiKey = process.env.POSTHOG_API_KEY;
+const posthogProjectId = process.env.POSTHOG_PROJECT_ID;
+
+export default posthogPersonalApiKey && posthogProjectId
+  ? withPostHogConfig(nextConfig, {
+      personalApiKey: posthogPersonalApiKey,
+      projectId: posthogProjectId,
+      // Private API host (not the ingestion host): EU is https://eu.posthog.com.
+      host: process.env.POSTHOG_HOST ?? process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.posthog.com",
+      sourcemaps: { enabled: true },
+    })
+  : nextConfig;

--- a/shell/package.json
+++ b/shell/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@clerk/testing": "^1.14.1",
     "@playwright/test": "^1.52.0",
+    "@posthog/nextjs-config": "1.9.47",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/tests/gateway/app-runtime/dispatcher.test.ts
+++ b/tests/gateway/app-runtime/dispatcher.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, writeFile, mkdir, rm, cp, symlink, truncate } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
-import { createAppDispatcher } from "../../../packages/gateway/src/app-runtime/dispatcher.js";
+import { createAppDispatcher, type AppRuntimeErrorReport } from "../../../packages/gateway/src/app-runtime/dispatcher.js";
+import { SpawnError } from "../../../packages/gateway/src/app-runtime/errors.js";
 import { invalidateManifestCache } from "../../../packages/gateway/src/app-runtime/manifest-loader.js";
 import { ProcessManager } from "../../../packages/gateway/src/app-runtime/process-manager.js";
 import { PortPool } from "../../../packages/gateway/src/app-runtime/port-pool.js";
@@ -320,6 +321,113 @@ describe("App Runtime Dispatcher", () => {
       expect(r1.status).toBe(200);
       expect(r2.status).toBe(200);
     }, 15_000);
+  });
+
+  describe("app error telemetry", () => {
+    function dispatcherWithHook(
+      onAppError: (failure: AppRuntimeErrorReport) => void,
+      processManager?: ProcessManager,
+    ): Hono {
+      const hookedApp = new Hono();
+      hookedApp.route(
+        "/apps/:slug",
+        createAppDispatcher(homeDir, { onAppError, processManager }),
+      );
+      return hookedApp;
+    }
+
+    it("reports ManifestError kind for manifest failures other than not_found", async () => {
+      const appDir = join(homeDir, "apps", "broken-manifest");
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, "matrix.json"), "{ not valid json");
+
+      const failures: AppRuntimeErrorReport[] = [];
+      const hookedApp = dispatcherWithHook((failure) => failures.push(failure));
+
+      const res = await hookedApp.request("/apps/broken-manifest/");
+      expect(res.status).toBe(500);
+      expect(failures).toEqual([{ errorKind: "ManifestError", appSlug: "broken-manifest" }]);
+    });
+
+    it("does not report manifest not_found lookups", async () => {
+      const failures: AppRuntimeErrorReport[] = [];
+      const hookedApp = dispatcherWithHook((failure) => failures.push(failure));
+
+      const res = await hookedApp.request("/apps/nonexistent/");
+      expect(res.status).toBe(404);
+      expect(failures).toEqual([]);
+    });
+
+    async function installNodeManifest(slug: string) {
+      const appDir = join(homeDir, "apps", slug);
+      await mkdir(appDir, { recursive: true });
+      await writeFile(
+        join(appDir, "matrix.json"),
+        JSON.stringify({
+          name: slug,
+          slug,
+          version: "1.0.0",
+          runtime: "node",
+          runtimeVersion: "^1.0.0",
+          build: { command: "echo ok", output: "dist" },
+          serve: { start: "node server.js", healthCheck: "/", startTimeout: 3, idleShutdown: 300 },
+        }),
+      );
+    }
+
+    it("reports the thrown error class when the process manager fails to start an app", async () => {
+      await installNodeManifest("spawn-fails");
+
+      const failures: AppRuntimeErrorReport[] = [];
+      const pm = {
+        ensureRunning: async () => {
+          throw new SpawnError("spawn_failed", "raw detail /home/matrix/apps/spawn-fails");
+        },
+        markUsed: () => {},
+      } as unknown as ProcessManager;
+      const hookedApp = dispatcherWithHook((failure) => failures.push(failure), pm);
+
+      const res = await hookedApp.request("/apps/spawn-fails/");
+      expect(res.status).toBe(503);
+      expect(failures).toEqual([{ errorKind: "SpawnError", appSlug: "spawn-fails" }]);
+      // Properties must never carry raw messages or paths.
+      expect(JSON.stringify(failures)).not.toContain("raw detail");
+      expect(JSON.stringify(failures)).not.toContain("/home/matrix");
+    });
+
+    it("reports ProxyError kind when the upstream fetch fails", async () => {
+      await installNodeManifest("proxy-fails");
+
+      const failures: AppRuntimeErrorReport[] = [];
+      const pm = {
+        // Port 1 is never listening; the proxy fetch fails fast with ECONNREFUSED.
+        ensureRunning: async () => ({ port: 1 }),
+        markUsed: () => {},
+      } as unknown as ProcessManager;
+      const hookedApp = dispatcherWithHook((failure) => failures.push(failure), pm);
+
+      const res = await hookedApp.request("/apps/proxy-fails/api/data");
+      expect([502, 504]).toContain(res.status);
+      expect(failures).toEqual([{ errorKind: "ProxyError", appSlug: "proxy-fails" }]);
+    });
+
+    it("isolates throwing telemetry hooks from the response path", async () => {
+      const appDir = join(homeDir, "apps", "broken-manifest2");
+      await mkdir(appDir, { recursive: true });
+      await writeFile(join(appDir, "matrix.json"), "{ not valid json");
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const hookedApp = dispatcherWithHook(() => {
+        throw new RangeError("hook-detail-leak");
+      });
+
+      const res = await hookedApp.request("/apps/broken-manifest2/");
+      expect(res.status).toBe(500);
+      const logged = warn.mock.calls.map((call) => call.join(" ")).join(" ");
+      expect(logged).toContain("RangeError");
+      expect(logged).not.toContain("hook-detail-leak");
+      warn.mockRestore();
+    });
   });
 
   // T056: WebSocket tests for node mode

--- a/tests/gateway/client-error-log.test.ts
+++ b/tests/gateway/client-error-log.test.ts
@@ -106,6 +106,22 @@ describe("client error PostHog forwarding", () => {
     });
   });
 
+  it("strips query strings from the forwarded path", () => {
+    const captureException = vi.fn().mockResolvedValue(true);
+    const reportWithQuery = ClientErrorReportSchema.parse({
+      ...report,
+      path: "/vm/hamed-billing-staging?token=secret&tab=billing",
+    });
+
+    forwardClientErrorToPostHog({ captureException }, "user_123", reportWithQuery);
+
+    const [, options] = captureException.mock.calls[0] as [Error, {
+      properties?: Record<string, unknown>;
+    }];
+    expect(options.properties?.path).toBe("/vm/hamed-billing-staging");
+    expect(JSON.stringify(options.properties)).not.toContain("token=secret");
+  });
+
   it("falls back to a generic error shape when name and message are absent", () => {
     const captureException = vi.fn().mockResolvedValue(true);
 

--- a/tests/gateway/client-error-log.test.ts
+++ b/tests/gateway/client-error-log.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   ClientErrorReportSchema,
   clientErrorLogPath,
+  forwardClientErrorToPostHog,
   writeClientErrorReport,
 } from "../../packages/gateway/src/client-error-log.js";
 
@@ -59,5 +60,91 @@ describe("client error log", () => {
     expect(entry.errorId).toBe("mx-339sbf-bdf7b985");
     expect(entry.source).toBe("shell-error-boundary");
     expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+});
+
+describe("client error PostHog forwarding", () => {
+  const report = ClientErrorReportSchema.parse({
+    errorId: "mx-339sbf-bdf7b985",
+    source: "shell-error-boundary",
+    name: "TypeError",
+    message: "Cannot read properties of undefined",
+    stack: "TypeError: Cannot read properties of undefined\n    at App (app.js:1:1)",
+    digest: "digest-123",
+    path: "/vm/hamed-billing-staging",
+    userAgent: "Mozilla/5.0",
+    buildSha: "ea89261d59362753accd577f9d56a0c85e611cc2",
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards a reconstructed exception with safe properties to the tracker", () => {
+    const captureException = vi.fn().mockResolvedValue(true);
+
+    forwardClientErrorToPostHog({ captureException }, "user_123", report);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [error, options] = captureException.mock.calls[0] as [Error, {
+      distinctId?: string;
+      properties?: Record<string, unknown>;
+    }];
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("TypeError");
+    expect(error.message).toBe("Cannot read properties of undefined");
+    expect(error.stack).toContain("at App (app.js:1:1)");
+    expect(options.distinctId).toBe("user_123");
+    expect(options.properties).toMatchObject({
+      source: "shell-client-error",
+      report_source: "shell-error-boundary",
+      digest: "digest-123",
+      errorId: "mx-339sbf-bdf7b985",
+      path: "/vm/hamed-billing-staging",
+      build_sha: "ea89261d59362753accd577f9d56a0c85e611cc2",
+      user_agent: "Mozilla/5.0",
+    });
+  });
+
+  it("falls back to a generic error shape when name and message are absent", () => {
+    const captureException = vi.fn().mockResolvedValue(true);
+
+    forwardClientErrorToPostHog({ captureException }, "user_123", {
+      errorId: "mx-anon-1",
+    });
+
+    const [error] = captureException.mock.calls[0] as [Error];
+    expect(error.name).toBe("ClientError");
+    expect(error.message.length).toBeGreaterThan(0);
+  });
+
+  it("never throws when capture rejects and logs only the error name", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const captureException = vi
+      .fn()
+      .mockRejectedValue(new Error("secret-flush-detail /home/matrix/private"));
+
+    expect(() => forwardClientErrorToPostHog({ captureException }, "user_123", report)).not.toThrow();
+    await new Promise((resolveSettle) => setImmediate(resolveSettle));
+
+    expect(warn).toHaveBeenCalled();
+    const logged = warn.mock.calls.map((call) => call.join(" ")).join(" ");
+    expect(logged).toContain("Error");
+    expect(logged).not.toContain("secret-flush-detail");
+    expect(logged).not.toContain("/home/matrix/private");
+  });
+
+  it("isolates trackers that throw synchronously", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const captureException = vi.fn(() => {
+      throw new TypeError("sync-capture-detail");
+    });
+
+    const tracker = { captureException } as unknown as Parameters<typeof forwardClientErrorToPostHog>[0];
+    expect(() => forwardClientErrorToPostHog(tracker, "user_123", report)).not.toThrow();
+
+    const logged = warn.mock.calls.map((call) => call.join(" ")).join(" ");
+    expect(logged).toContain("TypeError");
+    expect(logged).not.toContain("sync-capture-detail");
   });
 });

--- a/tests/observability/promtail-client-errors.test.ts
+++ b/tests/observability/promtail-client-errors.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Shell client errors land in ~/system/logs/client-errors.jsonl via the
+// gateway's /api/client-errors route. The observability stack must ship that
+// file into Loki under its own job so dashboards and alerts can query it
+// separately from interaction logs.
+describe("promtail client error shipping", () => {
+  const promtail = readFileSync(
+    join(process.cwd(), "distro/observability/promtail.yml"),
+    "utf8",
+  );
+
+  it("scrapes the client error JSONL under a dedicated job", () => {
+    expect(promtail).toContain("job_name: matrixos-client-errors");
+    expect(promtail).toContain("job: matrixos-client-errors");
+    expect(promtail).toContain(
+      "__path__: /var/log/matrixos/system/logs/client-errors.jsonl",
+    );
+  });
+
+  it("excludes client errors from the generic interaction-log job to avoid double-scraping", () => {
+    expect(promtail).toContain(
+      "__path_exclude__: /var/log/matrixos/system/logs/client-errors.jsonl",
+    );
+  });
+
+  it("parses the JSONL timestamp and source like the interaction job", () => {
+    const clientErrorsJob = promtail.slice(promtail.indexOf("job_name: matrixos-client-errors"));
+    const jobBlock = clientErrorsJob.slice(
+      0,
+      clientErrorsJob.indexOf("- job_name:", 1) === -1
+        ? undefined
+        : clientErrorsJob.indexOf("- job_name:", 1),
+    );
+    expect(jobBlock).toContain("pipeline_stages:");
+    expect(jobBlock).toContain("format: RFC3339");
+  });
+});

--- a/tests/observability/sourcemap-upload-config.test.ts
+++ b/tests/observability/sourcemap-upload-config.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// PostHog exceptions from shell and www arrive minified unless production
+// source maps are uploaded at build time. withPostHogConfig must only wrap
+// the Next.js config when both POSTHOG_API_KEY and POSTHOG_PROJECT_ID are
+// present so builds without credentials stay byte-identical to today.
+describe("shell source-map upload config", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("exports the plain config object when PostHog build env is absent", async () => {
+    vi.stubEnv("POSTHOG_API_KEY", "");
+    vi.stubEnv("POSTHOG_PROJECT_ID", "");
+    vi.resetModules();
+
+    const mod = await import("../../shell/next.config.ts");
+    expect(typeof mod.default).toBe("object");
+    expect(typeof (mod.default as { rewrites?: unknown }).rewrites).toBe("function");
+  });
+
+  it("exports the plain config when only one of the two env vars is set", async () => {
+    vi.stubEnv("POSTHOG_API_KEY", "phx_test_personal_key");
+    vi.stubEnv("POSTHOG_PROJECT_ID", "");
+    vi.resetModules();
+
+    const mod = await import("../../shell/next.config.ts");
+    expect(typeof mod.default).toBe("object");
+  });
+
+  it("wraps the config with withPostHogConfig when both env vars are set", async () => {
+    vi.stubEnv("POSTHOG_API_KEY", "phx_test_personal_key");
+    vi.stubEnv("POSTHOG_PROJECT_ID", "12345");
+    vi.resetModules();
+
+    const mod = await import("../../shell/next.config.ts");
+    // withPostHogConfig returns a Next.js config *function*, not the plain object.
+    expect(typeof mod.default).toBe("function");
+  });
+
+  it("passes personalApiKey, projectId, host, and sourcemaps options", () => {
+    const source = readFileSync(join(process.cwd(), "shell/next.config.ts"), "utf8");
+    expect(source).toContain("@posthog/nextjs-config");
+    expect(source).toMatch(/personalApiKey/);
+    expect(source).toMatch(/projectId/);
+    expect(source).toMatch(/POSTHOG_HOST/);
+    expect(source).toMatch(/eu\.posthog\.com/);
+    expect(source).toMatch(/sourcemaps:\s*\{\s*enabled:\s*true/);
+  });
+});
+
+describe("www source-map upload config", () => {
+  const source = readFileSync(join(process.cwd(), "www/next.config.ts"), "utf8");
+
+  it("gates withPostHogConfig on both POSTHOG_API_KEY and POSTHOG_PROJECT_ID", () => {
+    expect(source).toContain("@posthog/nextjs-config");
+    expect(source).toMatch(/POSTHOG_API_KEY/);
+    expect(source).toMatch(/POSTHOG_PROJECT_ID/);
+    expect(source).toMatch(/sourcemaps:\s*\{\s*enabled:\s*true/);
+  });
+
+  it("keeps withPostHogConfig as the outermost wrapper around withMDX", () => {
+    // The package warns when another wrapper swallows its config function:
+    // PostHog must wrap withMDX(...), never the other way around.
+    expect(source).toMatch(/withPostHogConfig\(\s*withMDX\(/);
+    expect(source).not.toMatch(/withMDX\(\s*withPostHogConfig\(/);
+  });
+});
+
+describe("host bundle build wiring", () => {
+  const workflow = readFileSync(
+    join(process.cwd(), ".github/workflows/host-bundle-release.yml"),
+    "utf8",
+  );
+
+  it("passes optional PostHog source-map credentials to the build job", () => {
+    expect(workflow).toMatch(/POSTHOG_API_KEY:\s*\$\{\{\s*secrets\.POSTHOG_API_KEY\s*\|\|\s*''\s*\}\}/);
+    expect(workflow).toMatch(/POSTHOG_PROJECT_ID:\s*\$\{\{\s*vars\.POSTHOG_PROJECT_ID\s*\|\|\s*''\s*\}\}/);
+  });
+
+  it("declares dev dependencies on @posthog/nextjs-config for shell and www", () => {
+    const shellPkg = JSON.parse(readFileSync(join(process.cwd(), "shell/package.json"), "utf8"));
+    const wwwPkg = JSON.parse(readFileSync(join(process.cwd(), "www/package.json"), "utf8"));
+    expect(shellPkg.devDependencies["@posthog/nextjs-config"]).toBeDefined();
+    expect(wwwPkg.devDependencies["@posthog/nextjs-config"]).toBeDefined();
+  });
+});

--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -1,5 +1,6 @@
 import { createMDX } from 'fumadocs-mdx/next';
 import type { NextConfig } from 'next';
+import { withPostHogConfig } from '@posthog/nextjs-config';
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
@@ -40,4 +41,19 @@ const nextConfig: NextConfig = {
 
 const withMDX = createMDX();
 
-export default withMDX(nextConfig);
+// PostHog source-map upload runs only when build credentials are present so
+// uploads happen in release builds while builds without credentials stay
+// byte-identical to today. withPostHogConfig must stay the OUTERMOST wrapper
+// (wrapping it in withMDX would drop its build hooks; the package warns).
+const posthogPersonalApiKey = process.env.POSTHOG_API_KEY;
+const posthogProjectId = process.env.POSTHOG_PROJECT_ID;
+
+export default posthogPersonalApiKey && posthogProjectId
+  ? withPostHogConfig(withMDX(nextConfig), {
+      personalApiKey: posthogPersonalApiKey,
+      projectId: posthogProjectId,
+      // Private API host (not the ingestion host): EU is https://eu.posthog.com.
+      host: process.env.POSTHOG_HOST ?? process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://eu.posthog.com',
+      sourcemaps: { enabled: true },
+    })
+  : withMDX(nextConfig);

--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -53,7 +53,7 @@ export default posthogPersonalApiKey && posthogProjectId
       personalApiKey: posthogPersonalApiKey,
       projectId: posthogProjectId,
       // Private API host (not the ingestion host): EU is https://eu.posthog.com.
-      host: process.env.POSTHOG_HOST ?? process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://eu.posthog.com',
+      host: process.env.POSTHOG_HOST ?? 'https://eu.posthog.com',
       sourcemaps: { enabled: true },
     })
   : withMDX(nextConfig);

--- a/www/package.json
+++ b/www/package.json
@@ -36,6 +36,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@posthog/nextjs-config": "1.9.47",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",


### PR DESCRIPTION
## Summary

Errors on customer VPSes currently die in local JSONL files, and exceptions that do reach PostHog are minified. This PR completes the error pipeline:

- **Client errors → PostHog**: `/api/client-errors` reports are reconstructed as exceptions (`name`/`message`/`stack` from the shell report) and forwarded via the gateway's existing PostHog tracker with the owner distinct id, after the local JSONL append succeeds. Fire-and-forget; capture failures log error names only.
- **Client errors → Loki**: new `matrixos-client-errors` promtail job ships `client-errors.jsonl` (with `__path_exclude__` on the interaction job so the two don't fight over positions).
- **App-runtime errors**: the app-runtime dispatcher gains an injectable `onAppError` hook (manifest failures other than not_found, ensureRunning throws covering Build/Spawn/HealthCheck errors, proxy upstream failures) wired to a `gateway_app_runtime` event with `{event: app_error, error_kind, app_slug}` — error class names only, never messages or paths.
- **Source maps**: shell and www next configs wrap with `@posthog/nextjs-config` `withPostHogConfig` **only when both `POSTHOG_API_KEY` and `POSTHOG_PROJECT_ID` are set** — without the env the exported config is byte-identical to today. www order is `withPostHogConfig(withMDX(config))` per the package's requirement that it be outermost. Pinned `1.9.47` (satisfies the 7-day `minimumReleaseAge`). Host-bundle workflow passes the env optionally.

## Activation (post-merge)

Set GitHub secret `POSTHOG_API_KEY` (personal API key) and variable `POSTHOG_PROJECT_ID`; `POSTHOG_HOST` defaults to `https://eu.posthog.com`. Note: pnpm ignores `@posthog/cli` build scripts (no `onlyBuiltDependencies` allowlist in this repo); if the first credentialed upload fails to find the CLI binary, approve it in the allowlist — deliberately not changed here.

## Invariants

- **Source of truth**: local JSONL remains the durable record; PostHog/Loki are derived sinks. Forwarding only happens after a successful local append.
- **Lock/transaction scope**: none; all forwarding is fire-and-forget outside the response path.
- **Acceptable orphan states**: reports that fail local persistence are not forwarded; PostHog capture failures lose that event (still in JSONL + Loki).
- **Auth source of truth**: unchanged; route validation and response behavior untouched.
- **Deferred scope**: `manifest not_found` is deliberately not captured (404 noise); `@posthog/cli` build-script allowlisting; PostHog UI alert config (PR 4's scope).

## Testing

- TDD (13 assertions red first). New/extended: client-error-log (7), app-runtime dispatcher (25), source-map config wrap/no-wrap via dynamic import (8), promtail config (3) — 43 green.
- Full `tests/gateway` + `tests/observability`: 2667 tests pass. `bun run typecheck` clean, `bun run check:patterns` 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)