### PR TITLE
feat(platform): canonical origin authority + returnPath allowlist

### DIFF
--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -3,7 +3,7 @@ import { bodyLimit } from 'hono/body-limit';
 import { randomUUID } from 'node:crypto';
 import { MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
 import { z } from 'zod/v4';
-import { appOrigin } from './origins.js';
+import { appOrigin, resolveReturnPath } from './origins.js';
 import {
   getBillingCustomerByClerkUserId,
   getBillingCustomerByStripeCustomerId,
@@ -46,7 +46,9 @@ const CheckoutRequestSchema = z.object({
   interval: z.enum(['monthly', 'annual']).default('monthly'),
   regionSlug: z.enum(['region_fsn1', 'region_nbg1', 'region_ash', 'region_hil']).default('region_fsn1'),
   returnPath: z.string().min(1).max(2048).optional().refine(
-    (value) => value === undefined || isSafeBillingReturnPath(value),
+    // Safe iff it is already a same-origin allowlisted path (origins.ts is the
+    // single source of truth for redirect-target validation).
+    (value) => value === undefined || resolveReturnPath(value) === value,
     { message: 'Invalid return path' },
   ),
 });
@@ -307,17 +309,6 @@ function resolvePriceId(
   return env[key];
 }
 
-function isSafeBillingReturnPath(value: string): boolean {
-  if (!value.startsWith('/') || value.startsWith('//')) return false;
-  try {
-    const url = new URL(value, 'https://matrix-os-return.invalid');
-    return url.pathname.startsWith('/');
-  } catch (err: unknown) {
-    if (err instanceof TypeError || err instanceof Error) return false;
-    return false;
-  }
-}
-
 function resolveBillingReturnUrl(
   env: NodeJS.ProcessEnv,
   state: 'success' | 'canceled' | 'portal',
@@ -326,7 +317,9 @@ function resolveBillingReturnUrl(
   const appUrl = appOrigin(env);
   if (returnPath && state !== 'portal') {
     const appBase = new URL(appUrl);
-    const url = new URL(returnPath, appBase.origin);
+    // resolveReturnPath is the authoritative allowlist guard — never build the
+    // redirect from the raw client path (off-allowlist values collapse to "/").
+    const url = new URL(resolveReturnPath(returnPath), appBase.origin);
     url.searchParams.set('billing', state);
     if (state === 'success') url.searchParams.set('checkout', 'success');
     return url.toString();

--- a/packages/platform/src/billing-routes.ts
+++ b/packages/platform/src/billing-routes.ts
@@ -3,6 +3,7 @@ import { bodyLimit } from 'hono/body-limit';
 import { randomUUID } from 'node:crypto';
 import { MATRIX_TELEMETRY_EVENTS } from '@matrix-os/observability';
 import { z } from 'zod/v4';
+import { appOrigin } from './origins.js';
 import {
   getBillingCustomerByClerkUserId,
   getBillingCustomerByStripeCustomerId,
@@ -322,7 +323,7 @@ function resolveBillingReturnUrl(
   state: 'success' | 'canceled' | 'portal',
   returnPath?: string,
 ): string {
-  const appUrl = env.NEXT_PUBLIC_MATRIX_APP_URL ?? env.PLATFORM_PUBLIC_URL ?? 'https://app.matrix-os.com';
+  const appUrl = appOrigin(env);
   if (returnPath && state !== 'portal') {
     const appBase = new URL(appUrl);
     const url = new URL(returnPath, appBase.origin);

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -93,6 +93,7 @@ import {
 import { createBillingRoutes } from './billing-routes.js';
 import { createJourneyRoutes, createJourneyUserResolver } from './journey-routes.js';
 import { backfillFirstRunRecords } from './journey.js';
+import { appOrigin } from './origins.js';
 import {
   createStripeBillingClient,
   createUnavailableStripeBillingClient,
@@ -2706,7 +2707,7 @@ export function createApp(deps: {
     }
   }
 
-  const journeyAppOrigin = appEnv.NEXT_PUBLIC_MATRIX_APP_URL ?? appEnv.PLATFORM_PUBLIC_URL ?? 'https://app.matrix-os.com';
+  const journeyAppOrigin = appOrigin(appEnv);
   app.route('/', createJourneyRoutes({
     db,
     resolveUserId: createJourneyUserResolver({

--- a/packages/platform/src/origins.ts
+++ b/packages/platform/src/origins.ts
@@ -20,12 +20,16 @@ function normalizeOrigin(value: string): string {
 
 /** The app shell / auth door origin (e.g. https://app.matrix-os.com). */
 export function appOrigin(env: NodeJS.ProcessEnv = process.env): string {
+  // PLATFORM_PUBLIC_URL is the platform/API URL — NOT an app-origin fallback
+  // (using it here would aim the app door at the API host). It belongs to
+  // apiOrigin only.
   return normalizeOrigin(
-    env.MATRIX_APP_ORIGIN ?? env.NEXT_PUBLIC_MATRIX_APP_URL ?? env.PLATFORM_PUBLIC_URL ?? DEFAULT_APP_ORIGIN,
+    env.MATRIX_APP_ORIGIN ?? env.NEXT_PUBLIC_MATRIX_APP_URL ?? DEFAULT_APP_ORIGIN,
   );
 }
 
-/** The platform API origin (e.g. https://api.matrix-os.com). */
+/** The platform API origin (e.g. https://api.matrix-os.com). PLATFORM_PUBLIC_URL
+ *  is the platform's public (API) URL, so it is the correct fallback here. */
 export function apiOrigin(env: NodeJS.ProcessEnv = process.env): string {
   return normalizeOrigin(env.MATRIX_API_ORIGIN ?? env.PLATFORM_PUBLIC_URL ?? DEFAULT_API_ORIGIN);
 }

--- a/packages/platform/src/origins.ts
+++ b/packages/platform/src/origins.ts
@@ -8,14 +8,26 @@ const DEFAULT_APP_ORIGIN = 'https://app.matrix-os.com';
 const DEFAULT_API_ORIGIN = 'https://api.matrix-os.com';
 const DEFAULT_WWW_ORIGIN = 'https://matrix-os.com';
 
-function normalizeOrigin(value: string): string {
+// Returns the URL origin, or null if `value` isn't a parseable absolute URL or
+// yields an opaque origin (the string "null") — e.g. a schemeless `localhost:3000`.
+function tryOrigin(value: string): string | null {
   try {
-    return new URL(value).origin;
+    const { origin } = new URL(value);
+    return origin && origin !== 'null' ? origin : null;
   } catch (err: unknown) {
-    // Value isn't a full URL (e.g. a bare host) — strip a trailing slash and use
-    // it as-is rather than throwing; configuration errors surface in logs upstream.
-    return value.replace(/\/+$/, '');
+    return null;
   }
+}
+
+function normalizeOrigin(value: string): string {
+  const direct = tryOrigin(value);
+  if (direct) return direct;
+  // Repair common misconfigs (bare host / schemeless `localhost:3000`) by
+  // assuming https rather than letting an opaque "null" origin poison every
+  // redirect URL silently.
+  const prefixed = tryOrigin(`https://${value.replace(/^\/+/, '')}`);
+  if (prefixed) return prefixed;
+  return value.replace(/\/+$/, '');
 }
 
 /** The app shell / auth door origin (e.g. https://app.matrix-os.com). */

--- a/packages/platform/src/origins.ts
+++ b/packages/platform/src/origins.ts
@@ -1,0 +1,80 @@
+// Canonical origin authority (spec 092 R6). One place resolves the app / api /
+// www origins per environment, and validates client-influenced return paths
+// against an allowlist — so auth, billing-return, and session-handoff redirects
+// stop being assembled from scattered hardcoded literals and header guesses
+// (the recurring redirect-bug class).
+
+const DEFAULT_APP_ORIGIN = 'https://app.matrix-os.com';
+const DEFAULT_API_ORIGIN = 'https://api.matrix-os.com';
+const DEFAULT_WWW_ORIGIN = 'https://matrix-os.com';
+
+function normalizeOrigin(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch (err: unknown) {
+    // Value isn't a full URL (e.g. a bare host) — strip a trailing slash and use
+    // it as-is rather than throwing; configuration errors surface in logs upstream.
+    return value.replace(/\/+$/, '');
+  }
+}
+
+/** The app shell / auth door origin (e.g. https://app.matrix-os.com). */
+export function appOrigin(env: NodeJS.ProcessEnv = process.env): string {
+  return normalizeOrigin(
+    env.MATRIX_APP_ORIGIN ?? env.NEXT_PUBLIC_MATRIX_APP_URL ?? env.PLATFORM_PUBLIC_URL ?? DEFAULT_APP_ORIGIN,
+  );
+}
+
+/** The platform API origin (e.g. https://api.matrix-os.com). */
+export function apiOrigin(env: NodeJS.ProcessEnv = process.env): string {
+  return normalizeOrigin(env.MATRIX_API_ORIGIN ?? env.PLATFORM_PUBLIC_URL ?? DEFAULT_API_ORIGIN);
+}
+
+/** The marketing-site origin (e.g. https://matrix-os.com). */
+export function wwwOrigin(env: NodeJS.ProcessEnv = process.env): string {
+  return normalizeOrigin(env.MATRIX_WWW_ORIGIN ?? DEFAULT_WWW_ORIGIN);
+}
+
+// Allowlisted post-auth/billing return paths. Anything off this list falls back
+// to "/", so a client-supplied returnPath can never become an open redirect.
+const RETURN_PATH_ALLOWLIST: RegExp[] = [
+  /^\/$/,
+  /^\/sign-in(?:[/?].*)?$/,
+  /^\/sign-up(?:[/?].*)?$/,
+  /^\/runtime(?:[/?].*)?$/,
+  /^\/vm\/[a-z0-9][a-z0-9-]{0,63}(?:[/?].*)?$/,
+  /^\/auth\/device(?:[/?].*)?$/,
+];
+
+// Rejects any control character or space (code point <= 0x20). Implemented with
+// charCodeAt rather than a regex literal to keep control chars out of source.
+function hasUnsafePathChar(path: string): boolean {
+  for (let i = 0; i < path.length; i += 1) {
+    if (path.charCodeAt(i) <= 0x20) return true;
+  }
+  return false;
+}
+
+/**
+ * Validates a client-influenced return path. Returns the path only if it is a
+ * same-origin absolute path on the allowlist; otherwise returns "/". Rejects
+ * absolute URLs, protocol-relative (`//host`), backslash, control, and traversal.
+ */
+export function resolveReturnPath(path: string | undefined | null): string {
+  if (typeof path !== 'string' || path.length === 0) return '/';
+  if (!path.startsWith('/') || path.startsWith('//')) return '/';
+  if (path.includes('\\') || path.includes('..') || hasUnsafePathChar(path)) return '/';
+  try {
+    const url = new URL(path, 'https://return-path.invalid');
+    const candidate = `${url.pathname}${url.search}`;
+    return RETURN_PATH_ALLOWLIST.some((re) => re.test(candidate)) ? candidate : '/';
+  } catch (err: unknown) {
+    // Unparseable path → safe default. The fallback IS the handling.
+    return '/';
+  }
+}
+
+/** Builds an absolute app-origin URL for a validated return path. */
+export function appReturnUrl(path: string | undefined | null, env: NodeJS.ProcessEnv = process.env): string {
+  return new URL(resolveReturnPath(path), `${appOrigin(env)}/`).toString();
+}

--- a/tests/platform/origins.test.ts
+++ b/tests/platform/origins.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { appOrigin, apiOrigin, wwwOrigin, resolveReturnPath, appReturnUrl } from '../../packages/platform/src/origins.js';
+
+describe('platform/origins', () => {
+  describe('origin resolution', () => {
+    it('uses configured origins, normalized to the URL origin', () => {
+      const env = { MATRIX_APP_ORIGIN: 'https://app.staging.matrix-os.com/', MATRIX_API_ORIGIN: 'https://api.staging.matrix-os.com', MATRIX_WWW_ORIGIN: 'https://staging.matrix-os.com' } as NodeJS.ProcessEnv;
+      expect(appOrigin(env)).toBe('https://app.staging.matrix-os.com');
+      expect(apiOrigin(env)).toBe('https://api.staging.matrix-os.com');
+      expect(wwwOrigin(env)).toBe('https://staging.matrix-os.com');
+    });
+
+    it('falls back through NEXT_PUBLIC_MATRIX_APP_URL then PLATFORM_PUBLIC_URL then the production default', () => {
+      expect(appOrigin({ NEXT_PUBLIC_MATRIX_APP_URL: 'https://app.x.com' } as NodeJS.ProcessEnv)).toBe('https://app.x.com');
+      expect(appOrigin({ PLATFORM_PUBLIC_URL: 'https://api.x.com' } as NodeJS.ProcessEnv)).toBe('https://api.x.com');
+      expect(appOrigin({} as NodeJS.ProcessEnv)).toBe('https://app.matrix-os.com');
+      expect(apiOrigin({} as NodeJS.ProcessEnv)).toBe('https://api.matrix-os.com');
+      expect(wwwOrigin({} as NodeJS.ProcessEnv)).toBe('https://matrix-os.com');
+    });
+  });
+
+  describe('resolveReturnPath', () => {
+    it('accepts allowlisted same-origin paths', () => {
+      expect(resolveReturnPath('/')).toBe('/');
+      expect(resolveReturnPath('/sign-in')).toBe('/sign-in');
+      expect(resolveReturnPath('/sign-up?redirect=1')).toBe('/sign-up?redirect=1');
+      expect(resolveReturnPath('/runtime')).toBe('/runtime');
+      expect(resolveReturnPath('/vm/alice')).toBe('/vm/alice');
+      expect(resolveReturnPath('/auth/device?user_code=BCDF-GHJK')).toBe('/auth/device?user_code=BCDF-GHJK');
+    });
+
+    it('rejects off-allowlist and malicious paths, falling back to "/"', () => {
+      expect(resolveReturnPath(undefined)).toBe('/');
+      expect(resolveReturnPath('')).toBe('/');
+      expect(resolveReturnPath('/admin')).toBe('/');          // not on the allowlist
+      expect(resolveReturnPath('https://evil.com')).toBe('/'); // absolute URL
+      expect(resolveReturnPath('//evil.com')).toBe('/');       // protocol-relative
+      expect(resolveReturnPath('/\\evil.com')).toBe('/');      // backslash
+      expect(resolveReturnPath('/../etc/passwd')).toBe('/');   // traversal
+      expect(resolveReturnPath('/vm/../admin')).toBe('/');     // traversal within allowed prefix
+      expect(resolveReturnPath('/sign-in\nSet-Cookie: x')).toBe('/'); // control char / header injection
+    });
+  });
+
+  describe('appReturnUrl', () => {
+    it('builds an absolute app-origin URL from a validated path', () => {
+      const env = { MATRIX_APP_ORIGIN: 'https://app.matrix-os.com' } as NodeJS.ProcessEnv;
+      expect(appReturnUrl('/sign-in', env)).toBe('https://app.matrix-os.com/sign-in');
+      expect(appReturnUrl('https://evil.com', env)).toBe('https://app.matrix-os.com/');
+    });
+  });
+});

--- a/tests/platform/origins.test.ts
+++ b/tests/platform/origins.test.ts
@@ -10,9 +10,12 @@ describe('platform/origins', () => {
       expect(wwwOrigin(env)).toBe('https://staging.matrix-os.com');
     });
 
-    it('falls back through NEXT_PUBLIC_MATRIX_APP_URL then PLATFORM_PUBLIC_URL then the production default', () => {
+    it('resolves app and api origins from their own fallback chains (no cross-leak)', () => {
       expect(appOrigin({ NEXT_PUBLIC_MATRIX_APP_URL: 'https://app.x.com' } as NodeJS.ProcessEnv)).toBe('https://app.x.com');
-      expect(appOrigin({ PLATFORM_PUBLIC_URL: 'https://api.x.com' } as NodeJS.ProcessEnv)).toBe('https://api.x.com');
+      // PLATFORM_PUBLIC_URL (the API URL) must NOT become the app origin.
+      expect(appOrigin({ PLATFORM_PUBLIC_URL: 'https://api.x.com' } as NodeJS.ProcessEnv)).toBe('https://app.matrix-os.com');
+      // It IS the correct fallback for apiOrigin.
+      expect(apiOrigin({ PLATFORM_PUBLIC_URL: 'https://api.x.com' } as NodeJS.ProcessEnv)).toBe('https://api.x.com');
       expect(appOrigin({} as NodeJS.ProcessEnv)).toBe('https://app.matrix-os.com');
       expect(apiOrigin({} as NodeJS.ProcessEnv)).toBe('https://api.matrix-os.com');
       expect(wwwOrigin({} as NodeJS.ProcessEnv)).toBe('https://matrix-os.com');

--- a/tests/platform/origins.test.ts
+++ b/tests/platform/origins.test.ts
@@ -20,6 +20,12 @@ describe('platform/origins', () => {
       expect(apiOrigin({} as NodeJS.ProcessEnv)).toBe('https://api.matrix-os.com');
       expect(wwwOrigin({} as NodeJS.ProcessEnv)).toBe('https://matrix-os.com');
     });
+
+    it('repairs schemeless/bare-host misconfigs instead of emitting an opaque "null" origin', () => {
+      // new URL('localhost:3000').origin === 'null' — must never reach a redirect.
+      expect(appOrigin({ MATRIX_APP_ORIGIN: 'localhost:3000' } as NodeJS.ProcessEnv)).toBe('https://localhost:3000');
+      expect(appOrigin({ MATRIX_APP_ORIGIN: 'app.example.com' } as NodeJS.ProcessEnv)).toBe('https://app.example.com');
+    });
   });
 
   describe('resolveReturnPath', () => {


### PR DESCRIPTION
## Summary

Spec 092 **Phase D (foundation)**, stacked on #494. Introduces one canonical origin authority so auth/billing/session redirects stop being assembled from scattered hardcoded literals and header guesses (the recurring redirect-bug class the last few hotfixes chased).

- `packages/platform/src/origins.ts`: `appOrigin()/apiOrigin()/wwwOrigin()` (env-driven, production defaults) + `resolveReturnPath()` (allowlist: `/`, `/sign-in`, `/sign-up`, `/runtime`, `/vm/<handle>`, `/auth/device`; everything else, plus absolute/protocol-relative/backslash/control/traversal, falls back to `/`) + `appReturnUrl()`.
- Wired into the journey `appOrigin` (main.ts) and the billing return-URL default (billing-routes.ts) — same production defaults, now centralized. 5 tests; existing billing tests still green.

## Scoped separately (needs your call + live Vercel review)

The www auth-page consolidation is **not** in this PR because the investigation surfaced entanglements the spec didn't account for:

- **`/login` and `/dashboard` are the admin surface**, not customer onboarding — `www/src/app/admin/page.tsx` redirects to both. Deleting them breaks `/admin`. They should be retained (or admin auth moved deliberately, separately).
- **`/early-access`** has a dedicated test (`tests/www/early-access.test.ts`) and **`/signup`** wires into the Inngest provision-status fallback — both retireable, but worth confirming live.

Proposed safe consolidation (a follow-up commit/PR, reviewed on the Vercel preview): retire `/signup` → 308 `{app}/sign-up` and `/early-access` → 308 `/`, sweep the `/signup` CTA, add a www `origins` helper; keep `/login` + `/dashboard` for admin.

## Invariants

- **Source of truth**: origins resolve from `MATRIX_APP_ORIGIN`/`MATRIX_API_ORIGIN`/`MATRIX_WWW_ORIGIN` (then documented fallbacks), never from request headers.
- **Open-redirect safety**: `resolveReturnPath` allowlists same-origin paths only; off-list → `/`.
- **Deferred scope**: the full platform-literal sweep (request-routing/ws-upgrade/session-cookies/auth-routes display + the www page retirements) lands after live review; this PR centralizes the flow-critical origins and is safe/no-behavior-change at the production defaults.