### PR TITLE
fix(shell): load sourcemap plugin lazily so pruned runtimes can boot

### DIFF
--- a/shell/next.config.ts
+++ b/shell/next.config.ts
@@ -1,6 +1,6 @@
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import type { NextConfig } from "next";
-import { withPostHogConfig } from "@posthog/nextjs-config";
 
 const gatewayUrl = process.env.GATEWAY_URL ?? "http://localhost:4000";
 
@@ -82,15 +82,23 @@ const nextConfig: NextConfig = {
 // PostHog source-map upload runs only when build credentials are present so
 // uploads happen in release builds while local/dev builds stay byte-identical
 // to a build without the plugin (the plain object is exported unchanged).
+// @posthog/nextjs-config is a devDependency, so it MUST NOT be imported at
+// module top level: `next start` loads this file at runtime in pruned
+// production images (platform Cloud Run) where dev deps are absent.
 const posthogPersonalApiKey = process.env.POSTHOG_API_KEY;
 const posthogProjectId = process.env.POSTHOG_PROJECT_ID;
 
-export default posthogPersonalApiKey && posthogProjectId
-  ? withPostHogConfig(nextConfig, {
-      personalApiKey: posthogPersonalApiKey,
-      projectId: posthogProjectId,
-      // Private API host (not the ingestion host): EU is https://eu.posthog.com.
-      host: process.env.POSTHOG_HOST ?? "https://eu.posthog.com",
-      sourcemaps: { enabled: true },
-    })
-  : nextConfig;
+function withSourcemapUpload(config: NextConfig): NextConfig {
+  if (!posthogPersonalApiKey || !posthogProjectId) return config;
+  const require = createRequire(import.meta.url);
+  const { withPostHogConfig } = require("@posthog/nextjs-config") as typeof import("@posthog/nextjs-config");
+  return withPostHogConfig(config, {
+    personalApiKey: posthogPersonalApiKey,
+    projectId: posthogProjectId,
+    // Private API host (not the ingestion host): EU is https://eu.posthog.com.
+    host: process.env.POSTHOG_HOST ?? "https://eu.posthog.com",
+    sourcemaps: { enabled: true },
+  });
+}
+
+export default withSourcemapUpload(nextConfig);

--- a/tests/observability/sourcemap-upload-config.test.ts
+++ b/tests/observability/sourcemap-upload-config.test.ts
@@ -65,8 +65,25 @@ describe("www source-map upload config", () => {
   it("keeps withPostHogConfig as the outermost wrapper around withMDX", () => {
     // The package warns when another wrapper swallows its config function:
     // PostHog must wrap withMDX(...), never the other way around.
-    expect(source).toMatch(/withPostHogConfig\(\s*withMDX\(/);
+    expect(source).toMatch(/withSourcemapUpload\(withMDX\(/);
     expect(source).not.toMatch(/withMDX\(\s*withPostHogConfig\(/);
+    expect(source).toMatch(/withPostHogConfig\(config/);
+  });
+});
+
+describe("runtime-safe sourcemap plugin loading", () => {
+  // @posthog/nextjs-config is a devDependency. `next start` evaluates
+  // next.config at runtime, and pruned production images (platform Cloud Run)
+  // have no dev deps -- a top-level import crashes the auth shell and the
+  // container never listens on its port. The plugin must load lazily behind
+  // the credential gate.
+  const configs = ["shell/next.config.ts", "www/next.config.ts"];
+
+  it.each(configs)("%s does not import @posthog/nextjs-config at top level", (file) => {
+    const source = readFileSync(join(process.cwd(), file), "utf8");
+    expect(source).not.toMatch(/^import\s+[^;]*@posthog\/nextjs-config/m);
+    expect(source).toMatch(/createRequire/);
+    expect(source).toMatch(/require\(['"]@posthog\/nextjs-config['"]\)/);
   });
 });
 

--- a/www/next.config.ts
+++ b/www/next.config.ts
@@ -1,6 +1,6 @@
+import { createRequire } from 'node:module';
 import { createMDX } from 'fumadocs-mdx/next';
 import type { NextConfig } from 'next';
-import { withPostHogConfig } from '@posthog/nextjs-config';
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
@@ -45,15 +45,23 @@ const withMDX = createMDX();
 // uploads happen in release builds while builds without credentials stay
 // byte-identical to today. withPostHogConfig must stay the OUTERMOST wrapper
 // (wrapping it in withMDX would drop its build hooks; the package warns).
+// @posthog/nextjs-config is a devDependency, so it MUST NOT be imported at
+// module top level: `next start` loads this file at runtime in pruned
+// production images where dev deps are absent.
 const posthogPersonalApiKey = process.env.POSTHOG_API_KEY;
 const posthogProjectId = process.env.POSTHOG_PROJECT_ID;
 
-export default posthogPersonalApiKey && posthogProjectId
-  ? withPostHogConfig(withMDX(nextConfig), {
-      personalApiKey: posthogPersonalApiKey,
-      projectId: posthogProjectId,
-      // Private API host (not the ingestion host): EU is https://eu.posthog.com.
-      host: process.env.POSTHOG_HOST ?? 'https://eu.posthog.com',
-      sourcemaps: { enabled: true },
-    })
-  : withMDX(nextConfig);
+function withSourcemapUpload(config: NextConfig): NextConfig {
+  if (!posthogPersonalApiKey || !posthogProjectId) return config;
+  const require = createRequire(import.meta.url);
+  const { withPostHogConfig } = require('@posthog/nextjs-config') as typeof import('@posthog/nextjs-config');
+  return withPostHogConfig(config, {
+    personalApiKey: posthogPersonalApiKey,
+    projectId: posthogProjectId,
+    // Private API host (not the ingestion host): EU is https://eu.posthog.com.
+    host: process.env.POSTHOG_HOST ?? 'https://eu.posthog.com',
+    sourcemaps: { enabled: true },
+  });
+}
+
+export default withSourcemapUpload(withMDX(nextConfig));


### PR DESCRIPTION
## Summary

Platform Cloud Run deploys have failed since #496 merged (16:19Z): the container fails to start and never listens on its port. Root cause: #496 added a **top-level** `import { withPostHogConfig } from "@posthog/nextjs-config"` to `shell/next.config.ts` and `www/next.config.ts`. The package is a devDependency, `next start` evaluates `next.config` at runtime, and `Dockerfile.platform` installs prod deps only — so the auth shell crashed on module load and the start script never brought the platform up. No user-facing outage (Cloud Run kept serving the last healthy revision), but all platform deploys are blocked.

Fix: load the plugin lazily via `createRequire` inside the existing credential gate — the module is only resolved when both `POSTHOG_API_KEY` and `POSTHOG_PROJECT_ID` are set (CI release builds, where dev deps exist). Runtime images without credentials never touch the package. Behavior with credentials is unchanged, including PostHog-outermost wrapping order for www.

## Invariants

- **Source of truth**: unchanged; config exports are byte-identical without credentials.
- **Lock/transaction scope**: n/a.
- **Acceptable orphan states**: n/a.
- **Auth source of truth**: unchanged.
- **Deferred scope**: none — adds a regression test (`runtime-safe sourcemap plugin loading`) banning top-level imports of the plugin in both configs.

## Testing

- All sourcemap-config tests pass, including the updated www wrapper-order assertions and the new top-level-import ban.
- `bun run typecheck` exit 0. Timeline evidence: cloud-run deploys succeeded through #488 (15:27Z) and failed from #496 (16:19Z) onward with "container failed to start and listen on PORT=8080".

🤖 Generated with [Claude Code](https://claude.com/claude-code)