### PR TITLE
fix(ci): wire preview-platform to the live Preview environment

### DIFF
--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -4,12 +4,19 @@
 # a DEDICATED preview Cloud Run service as a tagged, zero-traffic revision:
 #   https://pr-<N>---<preview-service-url>
 #
-# Safety model: the preview service (vars.CLOUD_RUN_PREVIEW_SERVICE) is a
-# separate Cloud Run service with its own preview-scoped Secret Manager
-# entries (notably platform-preview-database-url -- intended pairing is a
-# Neon branch database). Production CLOUD_RUN_SERVICE and its secrets are
-# never referenced here. The job no-ops with a clear message until the
-# preview service vars/secrets are configured.
+# Safety model: the preview service (matrix-platform-preview) is a separate
+# Cloud Run service running as a dedicated runtime SA
+# (matrix-platform-preview-runner) that can only read preview/staging
+# secrets: the staging database, preview-generated platform/jwt/edge-router
+# secrets, the Clerk keys, and the R2 bundles credentials (required for
+# CUSTOMER_VPS_ENABLED=true boot validation -- no Hetzner token is mounted,
+# so previews cannot provision real VPSes). Production CLOUD_RUN_SERVICE,
+# its runtime SA, and its secrets are never referenced. The service is
+# IAM-authenticated only (no public ingress); reach a preview with
+#   gcloud run services proxy matrix-platform-preview --region europe-west3
+# or an identity token. Config lives in the GitHub "Preview" environment;
+# the jobs no-op with a notice when it is absent. Neon branch databases per
+# PR remain deferred (spec 093).
 
 name: Preview Platform
 
@@ -43,6 +50,7 @@ jobs:
          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview-platform')))))
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: Preview
     env:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_REGION: ${{ vars.GCP_REGION }}
@@ -98,9 +106,10 @@ jobs:
             --service-account "$CLOUD_RUN_SERVICE_ACCOUNT" \
             --tag "pr-${PR_NUMBER}" \
             --no-traffic \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true" \
-            --set-secrets "PLATFORM_DATABASE_URL=platform-preview-database-url:latest,PLATFORM_SECRET=platform-preview-secret:latest" \
-            --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 \
+            --no-allow-unauthenticated \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,PLATFORM_PUBLIC_URL=https://${CLOUD_RUN_PREVIEW_SERVICE}-515970864382.${GCP_REGION}.run.app" \
+            --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest" \
+            --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 --min-instances 0 --max-instances 2 \
             --quiet
           desc="$(gcloud run services describe "$CLOUD_RUN_PREVIEW_SERVICE" \
             --project "$GCP_PROJECT_ID" --region "$GCP_REGION" --format json)"
@@ -121,10 +130,10 @@ jobs:
           set -euo pipefail
           body="**Platform preview revision deployed**
 
-          - URL: ${PREVIEW_URL}
+          - URL: ${PREVIEW_URL} (IAM-authenticated; use \`gcloud run services proxy ${CLOUD_RUN_PREVIEW_SERVICE} --region ${GCP_REGION}\` or an identity token)
           - Service: \`${CLOUD_RUN_PREVIEW_SERVICE}\` (zero traffic, tag \`pr-${PR_NUMBER}\`)
 
-          Preview revisions use preview-scoped secrets and database; production is untouched."
+          Preview revisions run as the preview runtime SA against the staging database; production service, SA, and secrets are untouched."
           existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --jq '[.[] | select(.body | startswith("**Platform preview revision deployed**"))] | .[0].id // ""')"
           if [ -n "$existing" ]; then
@@ -140,6 +149,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'preview-platform')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: Preview
     env:
       GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
       GCP_REGION: ${{ vars.GCP_REGION }}

--- a/.github/workflows/preview-platform.yml
+++ b/.github/workflows/preview-platform.yml
@@ -56,7 +56,7 @@ jobs:
       GCP_REGION: ${{ vars.GCP_REGION }}
       ARTIFACT_REPOSITORY: ${{ vars.ARTIFACT_REPOSITORY }}
       CLOUD_RUN_PREVIEW_SERVICE: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE }}
-      CLOUD_RUN_SERVICE_ACCOUNT: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT || vars.CLOUD_RUN_SERVICE_ACCOUNT }}
+      CLOUD_RUN_SERVICE_ACCOUNT: ${{ vars.CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT }}
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
     steps:
       - name: Check preview configuration
@@ -67,6 +67,10 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "::notice::CLOUD_RUN_PREVIEW_SERVICE is not configured; platform previews are disabled. See specs/093-preview-environments/."
             exit 0
+          fi
+          if [ -z "${CLOUD_RUN_SERVICE_ACCOUNT:-}" ]; then
+            echo "CLOUD_RUN_PREVIEW_SERVICE_ACCOUNT must be set in the Preview environment; refusing to fall back to another SA." >&2
+            exit 1
           fi
           echo "configured=true" >> "$GITHUB_OUTPUT"
 
@@ -99,6 +103,9 @@ jobs:
         if: steps.config.outputs.configured == 'true'
         run: |
           set -euo pipefail
+          # Derive the deterministic service URL (no hardcoded project number).
+          project_number="$(gcloud projects describe "$GCP_PROJECT_ID" --format='value(projectNumber)')"
+          public_url="https://${CLOUD_RUN_PREVIEW_SERVICE}-${project_number}.${GCP_REGION}.run.app"
           gcloud run deploy "$CLOUD_RUN_PREVIEW_SERVICE" \
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
@@ -107,7 +114,7 @@ jobs:
             --tag "pr-${PR_NUMBER}" \
             --no-traffic \
             --no-allow-unauthenticated \
-            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,PLATFORM_PUBLIC_URL=https://${CLOUD_RUN_PREVIEW_SERVICE}-515970864382.${GCP_REGION}.run.app" \
+            --set-env-vars "PLATFORM_RUNTIME_MODE=cloud_run,PLATFORM_PORT=8080,PLATFORM_PREVIEW=true,CUSTOMER_VPS_ENABLED=true,CUSTOMER_VPS_IMAGE_VERSION=dev,CUSTOMER_VPS_CLOUD_INIT_PATH=distro/customer-vps/cloud-init.yaml,AUTH_SHELL_HOST=127.0.0.1,AUTH_SHELL_PORT=3200,MATRIX_LEGACY_CONTAINER_ROUTING_ENABLED=false,PLATFORM_PUBLIC_URL=${public_url}" \
             --set-secrets "PLATFORM_DATABASE_URL=platform-database-url-staging:latest,PLATFORM_SECRET=platform-preview-secret:latest,PLATFORM_JWT_SECRET=platform-preview-jwt-secret:latest,EDGE_ROUTER_SECRET=edge-router-preview-secret:latest,CLERK_SECRET_KEY=clerk-secret-key:latest,NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=next-public-clerk-publishable-key:latest,R2_BUNDLES_ACCOUNT_ID=r2-bundles-account-id:latest,R2_BUNDLES_BUCKET=r2-bundles-bucket:latest,R2_BUNDLES_ENDPOINT=r2-bundles-endpoint:latest,R2_BUNDLES_ACCESS_KEY_ID=r2-bundles-access-key-id:latest,R2_BUNDLES_SECRET_ACCESS_KEY=r2-bundles-secret-access-key:latest" \
             --cpu 1 --memory 1Gi --concurrency 10 --timeout 300 --min-instances 0 --max-instances 2 \
             --quiet

--- a/docs/dev/preview-environments.md
+++ b/docs/dev/preview-environments.md
@@ -72,15 +72,21 @@ pipeline and remains the manual/deep-debug path.
 
 ## Platform preview revisions
 
-Add the **`preview-platform`** label. The workflow deploys the platform image
-to the dedicated preview Cloud Run service (`vars.CLOUD_RUN_PREVIEW_SERVICE`)
-as a zero-traffic tagged revision (`https://pr-<N>---<service-url>`), using
-preview-scoped Secret Manager entries (`platform-preview-database-url`,
-`platform-preview-secret`). The intended database pairing is a Neon branch per
-preview (deferred; see spec 093). On PR close the workflow removes the
-`pr-<N>` tag and deletes its revisions, mirroring the VPS teardown model. The
-jobs no-op with a notice until the preview service is configured. Production
-`CLOUD_RUN_SERVICE` and its secrets are never referenced.
+Add the **`preview-platform`** label. The workflow (bound to the GitHub
+`Preview` environment) deploys the platform image to the dedicated
+`matrix-platform-preview` Cloud Run service as a zero-traffic tagged revision
+(`https://pr-<N>---<service-url>`). The service is **IAM-authenticated only**
+— reach it with `gcloud run services proxy matrix-platform-preview --region
+europe-west3` or an identity token. It runs as the dedicated
+`matrix-platform-preview-runner` SA, which can read only: the **staging**
+database (`platform-database-url-staging` — previews share it; Neon branch
+per PR is deferred, spec 093), preview-generated platform/JWT/edge-router
+secrets, the Clerk keys, and the R2 bundles credentials (required by
+`CUSTOMER_VPS_ENABLED=true` boot validation). No Hetzner token is mounted, so
+a preview platform cannot provision real VPSes. On PR close the workflow
+removes the `pr-<N>` tag and deletes its revisions, mirroring the VPS
+teardown model. Production `CLOUD_RUN_SERVICE`, its runtime SA, and its
+secrets are never referenced.
 
 ## Centralized logs
 


### PR DESCRIPTION
## Summary

Follow-up to #491: replaces the scaffold's guessed configuration with the recipe proven by standing up `matrix-platform-preview` live (revision serves `{"status":"ok"}`, 403 unauthenticated):

- Jobs bind to the GitHub **Preview** environment (vars/secrets now populated there).
- Runtime is the dedicated `matrix-platform-preview-runner` SA — its Secret Manager grants are exactly: staging DB, preview-generated `platform-preview-secret`/`platform-preview-jwt-secret`/`edge-router-preview-secret`, Clerk keys, and the R2 bundles credentials. `CUSTOMER_VPS_ENABLED=true` is mandatory in `cloud_run` mode and its boot validation requires bundles storage; no Hetzner token is mounted, so previews cannot provision real VPSes.
- Service stays `--no-allow-unauthenticated` (IAM-only) with scale-to-zero; PR comment explains proxy/identity-token access.
- Docs updated to match.

## Invariants

- **Source of truth**: the live `matrix-platform-preview` service config (deployed and health-verified) — this PR encodes it.
- **Lock/transaction scope**: n/a, workflow + docs only.
- **Acceptable orphan states**: preview revisions are removed on PR close (existing teardown job); the service itself scales to zero between uses.
- **Auth source of truth**: Cloud Run IAM (no public ingress); platform-internal auth via preview-generated secrets; Clerk shared with staging.
- **Deferred scope**: Neon branch database per PR; public/Access-fronted preview ingress if proxy access proves too inconvenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)