### PR TITLE
feat(platform): device-token Clerk profile + Hermes agent model/effort config

### DIFF
--- a/packages/clerk-sync/src/index.ts
+++ b/packages/clerk-sync/src/index.ts
@@ -10,6 +10,7 @@ export interface ClerkUserProfile {
   username?: string | null;
   first_name?: string | null;
   last_name?: string | null;
+  image_url?: string | null;
   primary_email_address_id?: string | null;
   email_addresses?: ClerkEmailAddress[];
 }

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -43,6 +43,17 @@ const KernelPatchSchema = z
     effort: z.enum(KERNEL_EFFORTS).optional(),
   })
   .strict();
+
+function normalizeKernelModel(value: unknown): string | null {
+  return typeof value === "string" && KERNEL_MODEL_IDS.includes(value) ? value : null;
+}
+
+function normalizeKernelEffort(value: unknown): string | null {
+  return typeof value === "string" && (KERNEL_EFFORTS as readonly string[]).includes(value)
+    ? value
+    : null;
+}
+
 const WALLPAPER_FILE_EXTENSIONS = new Set([
   ".avif",
   ".gif",
@@ -233,8 +244,8 @@ export function createSettingsRoutes(opts: {
     return c.json({
       identity: handle,
       kernel: {
-        model: typeof kernel.model === "string" ? kernel.model : null,
-        effort: typeof kernel.effort === "string" ? kernel.effort : null,
+        model: normalizeKernelModel(kernel.model),
+        effort: normalizeKernelEffort(kernel.effort),
       },
       availableModels: KERNEL_MODELS,
       availableEfforts: KERNEL_EFFORTS,

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -276,8 +276,8 @@ export function createSettingsRoutes(opts: {
     return c.json({
       ok: true,
       kernel: {
-        model: typeof kernel.model === "string" ? kernel.model : null,
-        effort: typeof kernel.effort === "string" ? kernel.effort : null,
+        model: normalizeKernelModel(kernel.model),
+        effort: normalizeKernelEffort(kernel.effort),
       },
     });
   });

--- a/packages/gateway/src/routes/settings.ts
+++ b/packages/gateway/src/routes/settings.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import { z } from "zod/v4";
 import {
   access,
   mkdir,
@@ -24,6 +25,24 @@ const DESKTOP_DEFAULTS = {
 
 const THEME_DEFAULTS = {};
 const SETTINGS_BODY_LIMIT = 256 * 1024;
+
+// Curated kernel model allowlist surfaced to the agent-config UI. Keep in sync
+// with the kernel runtime; users may only persist a model from this list.
+const KERNEL_MODELS = [
+  { id: "claude-opus-4-6", label: "Claude Opus 4.6", tier: "Most capable" },
+  { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5", tier: "Balanced" },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", tier: "Fastest" },
+] as const;
+const KERNEL_MODEL_IDS = KERNEL_MODELS.map((m) => m.id) as [string, ...string[]];
+const KERNEL_EFFORTS = ["low", "medium", "high", "max"] as const;
+const KERNEL_DEFAULTS = { model: "claude-opus-4-6", effort: "high" } as const;
+
+const KernelPatchSchema = z
+  .object({
+    model: z.enum(KERNEL_MODEL_IDS).optional(),
+    effort: z.enum(KERNEL_EFFORTS).optional(),
+  })
+  .strict();
 const WALLPAPER_FILE_EXTENSIONS = new Set([
   ".avif",
   ".gif",
@@ -210,7 +229,46 @@ export function createSettingsRoutes(opts: {
     const cfg = await readConfig();
     const handlePath = join(homePath, "system/handle.json");
     const handle = await readJson(handlePath, {}, "handle");
-    return c.json({ identity: handle, kernel: cfg.kernel ?? {} });
+    const kernel = (cfg.kernel ?? {}) as Record<string, unknown>;
+    return c.json({
+      identity: handle,
+      kernel: {
+        model: typeof kernel.model === "string" ? kernel.model : null,
+        effort: typeof kernel.effort === "string" ? kernel.effort : null,
+      },
+      availableModels: KERNEL_MODELS,
+      availableEfforts: KERNEL_EFFORTS,
+      defaults: KERNEL_DEFAULTS,
+    });
+  });
+
+  app.put("/agent", bodyLimit({ maxSize: SETTINGS_BODY_LIMIT }), async (c) => {
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch (err) {
+      if (!(err instanceof SyntaxError)) {
+        console.warn("[settings] Failed to parse agent config request:", err);
+      }
+      return c.json({ error: "Invalid JSON" }, 400);
+    }
+    const parsed = KernelPatchSchema.safeParse(raw);
+    if (!parsed.success) {
+      return c.json({ error: "Invalid kernel settings" }, 400);
+    }
+    const cfg = await readConfig();
+    const kernel = { ...((cfg.kernel ?? {}) as Record<string, unknown>) };
+    if (parsed.data.model !== undefined) kernel.model = parsed.data.model;
+    if (parsed.data.effort !== undefined) kernel.effort = parsed.data.effort;
+    cfg.kernel = kernel;
+    await writeJsonAtomic(configPath, cfg);
+    return c.json({
+      ok: true,
+      kernel: {
+        model: typeof kernel.model === "string" ? kernel.model : null,
+        effort: typeof kernel.effort === "string" ? kernel.effort : null,
+      },
+    });
   });
 
   app.get("/skills", async (c) => {

--- a/packages/kernel/src/options.ts
+++ b/packages/kernel/src/options.ts
@@ -69,6 +69,28 @@ function loadBrowserConfig(homePath: string): {
   }
 }
 
+const KERNEL_EFFORT_VALUES = ["low", "medium", "high", "max"] as const;
+type KernelEffort = (typeof KERNEL_EFFORT_VALUES)[number];
+
+// User-tunable kernel settings persisted by the gateway settings UI under the
+// `kernel` key of ~/system/config.json (Everything Is a File). Read at spawn so
+// changes take effect on the next kernel turn without a code change.
+export function loadKernelConfigFile(homePath: string): { model?: string; effort?: KernelEffort } {
+  try {
+    const configPath = join(homePath, "system", "config.json");
+    if (!existsSync(configPath)) return {};
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const kernel = config.kernel;
+    if (!kernel || typeof kernel !== "object") return {};
+    const model = typeof kernel.model === "string" && kernel.model.length > 0 ? kernel.model : undefined;
+    const effort = KERNEL_EFFORT_VALUES.includes(kernel.effort) ? (kernel.effort as KernelEffort) : undefined;
+    return { ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
+  } catch (err: unknown) {
+    console.warn("[kernel-options] Could not load kernel config:", err instanceof Error ? err.message : String(err));
+    return {};
+  }
+}
+
 export async function tryCreateBrowserServer(
   homePath: string,
   browserConfig: { headless: boolean; timeout: number; idleTimeout: number; defaultProfile: string },
@@ -100,6 +122,12 @@ export async function kernelOptions(config: KernelConfig) {
   // One source of truth (.agents/skills), two discovery paths (SDK + IPC).
   ensureSdkSkillsMirror(homePath);
 
+  // Explicit per-call config wins; otherwise fall back to the persisted
+  // ~/system/config.json kernel settings, then hardcoded defaults.
+  const fileKernel = loadKernelConfigFile(homePath);
+  const effort = (config.effort ?? fileKernel.effort) as KernelEffort | undefined;
+  const resolvedEffort = effort && KERNEL_EFFORT_VALUES.includes(effort) ? effort : undefined;
+
   const ipcServer = await createIpcServer(db, homePath);
   const coreAgents = getCoreAgents(homePath);
   const customAgents = loadCustomAgents(`${homePath}/agents/custom`, homePath);
@@ -123,7 +151,8 @@ export async function kernelOptions(config: KernelConfig) {
   }
 
   return {
-    model: config.model ?? "claude-opus-4-6",
+    model: config.model ?? fileKernel.model ?? "claude-opus-4-6",
+    ...(resolvedEffort ? { effort: resolvedEffort } : {}),
     systemPrompt,
     cwd: homePath,
     ...(config.env ? { env: config.env } : {}),

--- a/packages/platform/src/auth-routes.ts
+++ b/packages/platform/src/auth-routes.ts
@@ -4,6 +4,7 @@ import { bodyLimit } from 'hono/body-limit';
 import {
   createDeviceFlow,
   type DeviceFlow,
+  type DeviceProfile,
   normalizeUserCode,
 } from './device-flow.js';
 import {
@@ -33,6 +34,10 @@ export interface AuthRoutesConfig {
   jwtSecret: string;
   platformUrl: string; // e.g. https://platform.matrix-os.com
   gatewayUrlForHandle: (handle: string) => string;
+  // Optional non-secret display profile (name/avatar) for the signing-in
+  // client. Must NEVER throw or block token issuance — return null on any
+  // failure (the avatar is a nice-to-have, the token is not).
+  fetchUserProfile?: (clerkUserId: string) => Promise<DeviceProfile | null>;
   captureEvent?: (
     event: string,
     properties: Record<string, string | number | boolean | null | undefined>,
@@ -723,10 +728,23 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
         handle,
         gatewayUrl,
       });
+      // Best-effort display profile; never let it break sign-in.
+      let profile: DeviceProfile | null = null;
+      if (config.fetchUserProfile) {
+        try {
+          profile = await config.fetchUserProfile(clerkUserId);
+        } catch (err: unknown) {
+          console.error(
+            '[device/token] profile lookup failed:',
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
       return {
         token: issued.token,
         expiresAt: issued.expiresAt,
         handle,
+        ...(profile ? { profile } : {}),
       };
     },
   });
@@ -823,6 +841,9 @@ export function createAuthRoutes(config: AuthRoutesConfig): Hono {
               expiresAt: result.expiresAt,
               userId: result.clerkUserId,
               handle: result.handle,
+              ...(result.profile?.displayName ? { displayName: result.profile.displayName } : {}),
+              ...(result.profile?.imageUrl ? { imageUrl: result.profile.imageUrl } : {}),
+              ...(result.profile?.email ? { email: result.profile.email } : {}),
             });
         }
       } catch (err) {

--- a/packages/platform/src/device-flow.ts
+++ b/packages/platform/src/device-flow.ts
@@ -17,10 +17,20 @@ export interface DeviceCodeIssue {
   interval: number;
 }
 
+// Non-secret display data surfaced to the signing-in client (e.g. the desktop
+// app's sidebar). Never includes anything sensitive — just what we'd show on a
+// profile chip.
+export interface DeviceProfile {
+  displayName?: string;
+  imageUrl?: string;
+  email?: string;
+}
+
 export interface IssuedToken {
   token: string;
   expiresAt: number; // epoch ms
   handle: string;
+  profile?: DeviceProfile;
 }
 
 export interface IssueTokenInput {
@@ -31,7 +41,14 @@ export type DevicePollResult =
   | { status: 'pending' }
   | { status: 'slow_down' }
   | { status: 'expired' }
-  | { status: 'approved'; token: string; expiresAt: number; handle: string; clerkUserId: string };
+  | {
+      status: 'approved';
+      token: string;
+      expiresAt: number;
+      handle: string;
+      clerkUserId: string;
+      profile?: DeviceProfile;
+    };
 
 export interface DeviceFlowConfig {
   db: PlatformDB;
@@ -278,6 +295,7 @@ export function createDeviceFlow(config: DeviceFlowConfig): DeviceFlow {
             expiresAt: issued.expiresAt,
             handle: issued.handle,
             clerkUserId: claimed.clerkUserId,
+            ...(issued.profile ? { profile: issued.profile } : {}),
           });
         } catch (err: unknown) {
           rejectIssue(err);

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -49,6 +49,7 @@ import { createSocialFeedApi } from './social-api.js';
 import { createClerkAuth, createClerkSessionRevoker, type ClerkAuth } from './clerk-auth.js';
 import type { MatrixProvisioner } from './matrix-provisioning.js';
 import { createAuthRoutes } from './auth-routes.js';
+import type { DeviceProfile } from './device-flow.js';
 import { issueSyncJwt, verifySyncJwt } from './sync-jwt.js';
 import {
   getSessionRoutedWebSocketHost,
@@ -260,6 +261,7 @@ const ClerkUserProfileSchema = z.object({
   username: z.string().nullable().optional(),
   first_name: z.string().nullable().optional(),
   last_name: z.string().nullable().optional(),
+  image_url: z.string().url().nullable().optional(),
   primary_email_address_id: z.string().nullable().optional(),
   email_addresses: z.array(z.object({
     id: z.string().optional(),
@@ -774,6 +776,54 @@ async function fetchClerkProvisionProfile(
     throw new CustomerVpsError(503, 'provider_unavailable', 'Provisioning unavailable');
   }
   return { secretKey, profile: profile.data };
+}
+
+// Best-effort, non-secret display profile (name/avatar/email) for the device
+// flow's signing-in client. Returns null on any failure or when Clerk is not
+// configured — the caller MUST treat the avatar as optional and never block
+// token issuance on it.
+async function fetchDeviceDisplayProfile(
+  clerkUserId: string,
+  env: NodeJS.ProcessEnv,
+): Promise<DeviceProfile | null> {
+  const secretKey = env.CLERK_SECRET_KEY;
+  if (!secretKey) return null;
+
+  let response: Response;
+  try {
+    response = await fetch(`https://api.clerk.com/v1/users/${encodeURIComponent(clerkUserId)}`, {
+      headers: { authorization: `Bearer ${secretKey}`, accept: 'application/json' },
+      signal: AbortSignal.timeout(CLERK_USER_LOOKUP_TIMEOUT_MS),
+      redirect: 'error',
+    });
+  } catch (err: unknown) {
+    logPlatformRouteError('device display profile clerk lookup', err);
+    return null;
+  }
+  if (!response.ok) {
+    logPlatformRouteError(
+      'device display profile clerk lookup',
+      new Error(`Clerk user lookup failed with status ${response.status}`),
+    );
+    return null;
+  }
+
+  const parsed = ClerkUserProfileSchema.safeParse(await response.json());
+  if (!parsed.success) return null;
+  const profile = parsed.data;
+
+  const displayName =
+    [profile.first_name, profile.last_name].filter(Boolean).join(' ') ||
+    profile.username ||
+    undefined;
+  const imageUrl = typeof profile.image_url === 'string' ? profile.image_url : undefined;
+  const email = getPrimaryClerkEmail(profile);
+  if (!displayName && !imageUrl && !email) return null;
+  return {
+    ...(displayName ? { displayName } : {}),
+    ...(imageUrl ? { imageUrl } : {}),
+    ...(email ? { email } : {}),
+  };
 }
 
 function resolveProvisionHandleCandidatesFromClerkProfile(
@@ -2356,6 +2406,7 @@ export function createApp(deps: {
         jwtSecret: platformJwtSecret,
         platformUrl: deviceAuthPublicUrl,
         gatewayUrlForHandle: getGatewayUrlForHandle,
+        fetchUserProfile: (clerkUserId) => fetchDeviceDisplayProfile(clerkUserId, process.env),
         captureEvent: (event, properties) => {
           capturePlatformEvent(MATRIX_TELEMETRY_EVENTS.CLI_COMMAND_RUN, {
             auth_event: event,

--- a/packages/platform/src/main.ts
+++ b/packages/platform/src/main.ts
@@ -257,11 +257,25 @@ const AppSessionProvisionBodySchema = z.object({
   runtime: RuntimeSlotSchema.optional().default('primary'),
 }).strict();
 
+const ClerkImageUrlSchema = z.preprocess((value) => {
+  if (value === undefined || value === null) return value;
+  if (typeof value !== 'string' || value.length === 0) return null;
+  try {
+    new URL(value);
+    return value;
+  } catch (err) {
+    if (!(err instanceof TypeError)) {
+      throw err;
+    }
+    return null;
+  }
+}, z.string().url().nullable().optional());
+
 const ClerkUserProfileSchema = z.object({
   username: z.string().nullable().optional(),
   first_name: z.string().nullable().optional(),
   last_name: z.string().nullable().optional(),
-  image_url: z.string().url().nullable().optional(),
+  image_url: ClerkImageUrlSchema,
   primary_email_address_id: z.string().nullable().optional(),
   email_addresses: z.array(z.object({
     id: z.string().optional(),

--- a/tests/gateway/settings-desktop.test.ts
+++ b/tests/gateway/settings-desktop.test.ts
@@ -448,6 +448,18 @@ describe("Settings: desktop + theme + wallpapers", () => {
       const data = await res.json();
       expect(data.kernel).toEqual({ model: "claude-sonnet-4-5", effort: "low" });
     });
+
+    it("normalizes hand-edited model and effort values outside the allowlists", async () => {
+      writeFileSync(
+        join(homePath, "system/config.json"),
+        JSON.stringify({ kernel: { model: "gpt-4o", effort: "ludicrous" } }),
+      );
+
+      const res = await app.request("/api/settings/agent");
+      const data = await res.json();
+
+      expect(data.kernel).toEqual({ model: null, effort: null });
+    });
   });
 
   describe("PUT /agent (kernel config)", () => {

--- a/tests/gateway/settings-desktop.test.ts
+++ b/tests/gateway/settings-desktop.test.ts
@@ -482,6 +482,22 @@ describe("Settings: desktop + theme + wallpapers", () => {
       expect(saved.channels.telegram.enabled).toBe(true);
     });
 
+    it("normalizes the response after partial updates to hand-edited kernel config", async () => {
+      writeFileSync(
+        join(homePath, "system/config.json"),
+        JSON.stringify({ kernel: { model: "gpt-4o", effort: "medium" } }),
+      );
+
+      const res = await app.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ effort: "max" }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, kernel: { model: null, effort: "max" } });
+    });
+
     it("rejects a model outside the allowlist", async () => {
       const res = await app.request("/api/settings/agent", {
         method: "PUT",

--- a/tests/gateway/settings-desktop.test.ts
+++ b/tests/gateway/settings-desktop.test.ts
@@ -427,4 +427,74 @@ describe("Settings: desktop + theme + wallpapers", () => {
       expect(await res.json()).toEqual({ error: "Failed to restart channel" });
     });
   });
+
+  describe("GET /agent (kernel config)", () => {
+    it("returns null model/effort, the model allowlist, and defaults when unset", async () => {
+      const res = await app.request("/api/settings/agent");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.kernel).toEqual({ model: null, effort: null });
+      expect(data.availableModels.map((m: { id: string }) => m.id)).toContain("claude-opus-4-6");
+      expect(data.availableEfforts).toEqual(["low", "medium", "high", "max"]);
+      expect(data.defaults).toEqual({ model: "claude-opus-4-6", effort: "high" });
+    });
+
+    it("reflects persisted kernel config", async () => {
+      writeFileSync(
+        join(homePath, "system/config.json"),
+        JSON.stringify({ kernel: { model: "claude-sonnet-4-5", effort: "low" } }),
+      );
+      const res = await app.request("/api/settings/agent");
+      const data = await res.json();
+      expect(data.kernel).toEqual({ model: "claude-sonnet-4-5", effort: "low" });
+    });
+  });
+
+  describe("PUT /agent (kernel config)", () => {
+    it("persists model + effort and preserves other config keys", async () => {
+      writeFileSync(
+        join(homePath, "system/config.json"),
+        JSON.stringify({ channels: { telegram: { enabled: true } } }),
+      );
+      const res = await app.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "claude-haiku-4-5", effort: "max" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, kernel: { model: "claude-haiku-4-5", effort: "max" } });
+
+      const saved = JSON.parse(readFileSync(join(homePath, "system/config.json"), "utf-8"));
+      expect(saved.kernel).toEqual({ model: "claude-haiku-4-5", effort: "max" });
+      // Unrelated config (channels) is preserved.
+      expect(saved.channels.telegram.enabled).toBe(true);
+    });
+
+    it("rejects a model outside the allowlist", async () => {
+      const res = await app.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "gpt-4o" }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects an invalid reasoning effort", async () => {
+      const res = await app.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ effort: "ludicrous" }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects unknown fields (strict schema)", async () => {
+      const res = await app.request("/api/settings/agent", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "claude-opus-4-6", systemPrompt: "pwn" }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/tests/kernel/options.test.ts
+++ b/tests/kernel/options.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
-import { tryCreateBrowserServer } from "../../packages/kernel/src/options.js";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadKernelConfigFile, tryCreateBrowserServer } from "../../packages/kernel/src/options.js";
 
 const browserServerMocks = vi.hoisted(() => ({
   createBrowserMcpServer: vi.fn((config: unknown) => ({
@@ -34,5 +37,49 @@ describe("kernel options", () => {
       },
     });
     expect(browserServerMocks.createBrowserMcpServer).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("loadKernelConfigFile", () => {
+  let homePath: string;
+  beforeEach(() => {
+    homePath = mkdtempSync(join(tmpdir(), "kernel-cfg-"));
+    mkdirSync(join(homePath, "system"), { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(homePath, { recursive: true, force: true });
+  });
+
+  function writeConfig(obj: unknown) {
+    writeFileSync(join(homePath, "system", "config.json"), JSON.stringify(obj));
+  }
+
+  it("returns empty when config.json is missing", () => {
+    expect(loadKernelConfigFile(homePath)).toEqual({});
+  });
+
+  it("reads a valid model + effort from the kernel section", () => {
+    writeConfig({ kernel: { model: "claude-sonnet-4-5", effort: "high" } });
+    expect(loadKernelConfigFile(homePath)).toEqual({ model: "claude-sonnet-4-5", effort: "high" });
+  });
+
+  it("ignores an invalid effort value", () => {
+    writeConfig({ kernel: { model: "claude-opus-4-6", effort: "ludicrous" } });
+    expect(loadKernelConfigFile(homePath)).toEqual({ model: "claude-opus-4-6" });
+  });
+
+  it("ignores an empty/non-string model", () => {
+    writeConfig({ kernel: { model: "", effort: "max" } });
+    expect(loadKernelConfigFile(homePath)).toEqual({ effort: "max" });
+  });
+
+  it("returns empty when there is no kernel section", () => {
+    writeConfig({ channels: { telegram: { enabled: true } } });
+    expect(loadKernelConfigFile(homePath)).toEqual({});
+  });
+
+  it("does not throw on malformed JSON", () => {
+    writeFileSync(join(homePath, "system", "config.json"), "{not json");
+    expect(loadKernelConfigFile(homePath)).toEqual({});
   });
 });

--- a/tests/platform/device-flow.test.ts
+++ b/tests/platform/device-flow.test.ts
@@ -123,6 +123,42 @@ describe("device flow: polling", () => {
     expect(result.token).toBe("jwt-for-user_alice");
   });
 
+  it("passes through an optional display profile from issueToken", async () => {
+    flow = createDeviceFlow({
+      db,
+      now: () => now,
+      verificationBase: VERIFY_BASE,
+      issueToken: async ({ clerkUserId }) => ({
+        token: `jwt-for-${clerkUserId}`,
+        expiresAt: now + 24 * 3_600_000,
+        handle: "neo",
+        profile: { displayName: "Thomas Anderson", imageUrl: "https://img.clerk.com/neo.png" },
+      }),
+    });
+    const issued = await flow.createDeviceCode();
+    await flow.approveDeviceCode(issued.userCode, "user_neo");
+    now += 5_000;
+    const result = await flow.pollDeviceCode(issued.deviceCode);
+
+    expect(result.status).toBe("approved");
+    if (result.status !== "approved") throw new Error("unreachable");
+    expect(result.profile).toEqual({
+      displayName: "Thomas Anderson",
+      imageUrl: "https://img.clerk.com/neo.png",
+    });
+  });
+
+  it("omits the profile when issueToken provides none", async () => {
+    const issued = await flow.createDeviceCode();
+    await flow.approveDeviceCode(issued.userCode, "user_alice");
+    now += 5_000;
+    const result = await flow.pollDeviceCode(issued.deviceCode);
+
+    expect(result.status).toBe("approved");
+    if (result.status !== "approved") throw new Error("unreachable");
+    expect(result.profile).toBeUndefined();
+  });
+
   it("consumes the approved device code before token issuance succeeds", async () => {
     let resolveIssue: (() => void) | null = null;
     flow = createDeviceFlow({

--- a/tests/platform/proxy-routing.test.ts
+++ b/tests/platform/proxy-routing.test.ts
@@ -1951,6 +1951,62 @@ describe("platform proxy routing", () => {
     });
   });
 
+  it("does not block hosted runtime provisioning when Clerk returns an empty avatar URL", async () => {
+    process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
+    await deleteContainer(db, "alice");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        username: "newuser",
+        first_name: "New",
+        last_name: "User",
+        image_url: "",
+        primary_email_address_id: "email_1",
+        email_addresses: [{ id: "email_1", email_address: "new@example.com" }],
+      }),
+    );
+    const customerVpsService = {
+      provision: vi.fn().mockResolvedValue({
+        machineId: "9f05824c-8d0a-4d83-9cb4-b312d43ff151",
+        status: "provisioning",
+        etaSeconds: 90,
+      }),
+    };
+    const app = createApp({
+      db,
+      orchestrator: stubOrchestrator(),
+      clerkAuth: createClerkAuth({
+        verifyToken: vi.fn().mockResolvedValue({ sub: "user_new_avatar" }),
+      }),
+      platformSecret: "platform-secret-123",
+      customerVpsService: customerVpsService as unknown as CustomerVpsService,
+      env: { ...process.env, CLERK_SECRET_KEY: "sk_test_matrix" },
+    });
+
+    const provision = await app.request("/api/auth/provision-runtime", {
+      method: "POST",
+      headers: {
+        host: "app.matrix-os.com",
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(provision.status).toBe(202);
+    expect(customerVpsService.provision).toHaveBeenCalledWith({
+      handle: "newuser",
+      clerkUserId: "user_new_avatar",
+      runtimeSlot: "primary",
+    });
+    await expect(getPlatformUserByClerkId(db, "user_new_avatar")).resolves.toMatchObject({
+      clerkId: "user_new_avatar",
+      handle: "newuser",
+      displayName: "New User",
+      email: "new@example.com",
+      containerId: "vps:9f05824c-8d0a-4d83-9cb4-b312d43ff151",
+    });
+  });
+
   it("selects another handle before provisioning when the preferred handle is already in users", async () => {
     process.env.PLATFORM_JWT_SECRET = JWT_SECRET;
     await ensurePlatformUser(db, {


### PR DESCRIPTION
Backend slice of the Operator (094 macOS) work, extracted so the platform/gateway/kernel changes can ship and be consumed independently of the local-only desktop branch. Bottom of the 094 stack; the desktop PR sits on top of this branch.

## What ships here (9 files, no new deps, no lockfile churn)

**Device-flow display profile** — for the desktop sidebar avatar/name:
- `POST /api/auth/device/token` response now carries an optional, non-secret display profile (`displayName` / `imageUrl` / `email`) fetched best-effort from Clerk at issue time. A Clerk lookup failure logs server-side and degrades to no profile — it **never blocks token issuance**.
- Threaded `IssuedToken` → approved poll result → token response. `@matrix-os/clerk-sync` `ClerkUserProfile` gains `image_url`; the platform schema parses it.

**Hermes agent configuration** — model + reasoning effort:
- Kernel reads `kernel.model` + `kernel.effort` from `~/system/config.json` at spawn (explicit `KernelConfig` wins, then file, then default) and wires the Agent SDK `effort` option (`low`/`medium`/`high`/`max`).
- Gateway `GET /api/settings/agent` returns the current model/effort, a curated model allowlist, available efforts, and defaults; new `PUT /api/settings/agent` persists model/effort to `config.json` (zod-validated, `bodyLimit`, strict schema, preserves other config keys).

## Invariants
- **Source of truth**: `~/system/config.json` `kernel.{model,effort}` (owner file); device profile is request-scoped, fetched live from Clerk per sign-in.
- **Acceptable orphan state**: Clerk profile lookup failure → token still issued, profile omitted (avatar falls back to initials client-side).
- **Auth source of truth**: unchanged — device flow + platform JWT. Profile fields are additive/optional; older clients ignore them.
- **Deferred scope**: the desktop UI that consumes these (sidebar avatar, AgentSection model/effort pickers) ships in the stacked desktop PR.

## Tests
- device-flow: profile passthrough + omit-when-absent
- kernel: `loadKernelConfigFile` valid / invalid-effort / non-string-model / malformed-JSON
- gateway: `GET`/`PUT /api/settings/agent` — defaults, persist + preserve keys, allowlist rejection, strict-schema rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)