### PR TITLE
feat(cli,mobile): journey-aware login and onboarding screens

### DIFF
--- a/apps/mobile/__tests__/JourneyGate.test.tsx
+++ b/apps/mobile/__tests__/JourneyGate.test.tsx
@@ -27,12 +27,15 @@ describe("JourneyGate", () => {
     expect(onOpenUrl).toHaveBeenCalledWith("https://app.matrix-os.com/?plans=1");
   });
 
-  it("account_required prompts re-sign-in instead of a stuck spinner", () => {
-    const { getByText, queryByTestId } = render(
-      <JourneyGate result={ok({ phase: "account_required", detail: "Sign in to continue." })} onRetry={noop} onOpenUrl={noop} />,
+  it("account_required prompts re-sign-in with an actionable button", () => {
+    const onSignOut = jest.fn();
+    const { getByText, queryByTestId, getByTestId } = render(
+      <JourneyGate result={ok({ phase: "account_required", detail: "Sign in to continue." })} onRetry={noop} onOpenUrl={noop} onSignOut={onSignOut} />,
     );
     expect(getByText("Please sign in again")).toBeTruthy();
     expect(queryByTestId("journey-loading")).toBeNull();
+    fireEvent.press(getByTestId("journey-sign-in"));
+    expect(onSignOut).toHaveBeenCalled();
   });
 
   it("plan_required always offers a Check again CTA, even without a URL", () => {
@@ -84,8 +87,11 @@ describe("JourneyGate", () => {
     expect(onRetry).toHaveBeenCalled();
   });
 
-  it("prompts re-sign-in when unauthorized", () => {
-    const { getByText } = render(<JourneyGate result={{ status: "unauthorized" }} onRetry={noop} onOpenUrl={noop} />);
+  it("prompts re-sign-in when unauthorized, with a sign-in action", () => {
+    const onSignOut = jest.fn();
+    const { getByText, getByTestId } = render(<JourneyGate result={{ status: "unauthorized" }} onRetry={noop} onOpenUrl={noop} onSignOut={onSignOut} />);
     expect(getByText("Please sign in again")).toBeTruthy();
+    fireEvent.press(getByTestId("journey-sign-in"));
+    expect(onSignOut).toHaveBeenCalled();
   });
 });

--- a/apps/mobile/__tests__/JourneyGate.test.tsx
+++ b/apps/mobile/__tests__/JourneyGate.test.tsx
@@ -72,15 +72,18 @@ describe("JourneyGate", () => {
     expect(onRetry).toHaveBeenCalled();
   });
 
-  it("offers contact-support (not retry) once exhausted", () => {
+  it("offers contact-support and refresh (not retry) once exhausted", () => {
     const onOpenUrl = jest.fn();
+    const onRefresh = jest.fn();
     const { queryByTestId, getByText, getByTestId } = render(
-      <JourneyGate result={ok({ phase: "provisioning_failed", failure: { retryable: false, attempt: 3 } })} onRetry={noop} onOpenUrl={onOpenUrl} />,
+      <JourneyGate result={ok({ phase: "provisioning_failed", failure: { retryable: false, attempt: 3 } })} onRetry={noop} onOpenUrl={onOpenUrl} onRefresh={onRefresh} />,
     );
     expect(getByText("Setup needs attention")).toBeTruthy();
     expect(queryByTestId("journey-retry")).toBeNull();
     fireEvent.press(getByTestId("journey-support"));
     expect(onOpenUrl).toHaveBeenCalledWith("mailto:support@matrix-os.com");
+    fireEvent.press(getByTestId("journey-refresh"));
+    expect(onRefresh).toHaveBeenCalled();
   });
 
   it("offers contact-support when payment settling is delayed", () => {

--- a/apps/mobile/__tests__/JourneyGate.test.tsx
+++ b/apps/mobile/__tests__/JourneyGate.test.tsx
@@ -27,6 +27,14 @@ describe("JourneyGate", () => {
     expect(onOpenUrl).toHaveBeenCalledWith("https://app.matrix-os.com/?plans=1");
   });
 
+  it("account_required prompts re-sign-in instead of a stuck spinner", () => {
+    const { getByText, queryByTestId } = render(
+      <JourneyGate result={ok({ phase: "account_required", detail: "Sign in to continue." })} onRetry={noop} onOpenUrl={noop} />,
+    );
+    expect(getByText("Please sign in again")).toBeTruthy();
+    expect(queryByTestId("journey-loading")).toBeNull();
+  });
+
   it("shows a calm settling state within the window", () => {
     const { getByText, getByTestId } = render(
       <JourneyGate result={ok({ phase: "payment_settling", detail: "Activating…", settling: { since: "x", delayed: false } })} onRetry={noop} onOpenUrl={noop} />,

--- a/apps/mobile/__tests__/JourneyGate.test.tsx
+++ b/apps/mobile/__tests__/JourneyGate.test.tsx
@@ -35,6 +35,16 @@ describe("JourneyGate", () => {
     expect(queryByTestId("journey-loading")).toBeNull();
   });
 
+  it("plan_required always offers a Check again CTA, even without a URL", () => {
+    const onRefresh = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <JourneyGate result={ok({ phase: "plan_required", nextAction: { kind: "open_plans" } })} onRetry={noop} onOpenUrl={noop} onRefresh={onRefresh} />,
+    );
+    expect(queryByTestId("journey-open-plans")).toBeNull();
+    fireEvent.press(getByTestId("journey-refresh"));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
   it("shows a calm settling state within the window", () => {
     const { getByText, getByTestId } = render(
       <JourneyGate result={ok({ phase: "payment_settling", detail: "Activating…", settling: { since: "x", delayed: false } })} onRetry={noop} onOpenUrl={noop} />,

--- a/apps/mobile/__tests__/JourneyGate.test.tsx
+++ b/apps/mobile/__tests__/JourneyGate.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { JourneyGate } from "../components/JourneyGate";
+import type { JourneyFetchResult, MobileJourneyState } from "../lib/journey";
+
+function ok(journey: Partial<MobileJourneyState>): JourneyFetchResult {
+  return {
+    status: "ok",
+    journey: { phase: "plan_required", detail: "detail", nextAction: { kind: "open_plans" }, ...journey } as MobileJourneyState,
+  };
+}
+
+const noop = () => {};
+
+describe("JourneyGate", () => {
+  it("shows a loading state before the first result", () => {
+    const { getByTestId } = render(<JourneyGate result={null} onRetry={noop} onOpenUrl={noop} />);
+    expect(getByTestId("journey-loading")).toBeTruthy();
+  });
+
+  it("plan_required opens plans via the URL callback", () => {
+    const onOpenUrl = jest.fn();
+    const { getByTestId } = render(
+      <JourneyGate result={ok({ phase: "plan_required", nextAction: { kind: "open_plans", url: "https://app.matrix-os.com/?plans=1" } })} onRetry={noop} onOpenUrl={onOpenUrl} />,
+    );
+    fireEvent.press(getByTestId("journey-open-plans"));
+    expect(onOpenUrl).toHaveBeenCalledWith("https://app.matrix-os.com/?plans=1");
+  });
+
+  it("shows a calm settling state within the window", () => {
+    const { getByText, getByTestId } = render(
+      <JourneyGate result={ok({ phase: "payment_settling", detail: "Activating…", settling: { since: "x", delayed: false } })} onRetry={noop} onOpenUrl={noop} />,
+    );
+    expect(getByText("Activating your subscription")).toBeTruthy();
+    expect(getByTestId("journey-loading")).toBeTruthy();
+  });
+
+  it("shows the build stage during provisioning", () => {
+    const { getByText } = render(
+      <JourneyGate result={ok({ phase: "provisioning", detail: "Building…", progress: { stage: "booting", startedAt: "x" } })} onRetry={noop} onOpenUrl={noop} />,
+    );
+    expect(getByText("Booting your computer")).toBeTruthy();
+  });
+
+  it("offers retry on a retryable failure", () => {
+    const onRetry = jest.fn();
+    const { getByTestId } = render(
+      <JourneyGate result={ok({ phase: "provisioning_failed", failure: { retryable: true, attempt: 1 } })} onRetry={onRetry} onOpenUrl={noop} />,
+    );
+    fireEvent.press(getByTestId("journey-retry"));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("offers no retry once exhausted", () => {
+    const { queryByTestId, getByText } = render(
+      <JourneyGate result={ok({ phase: "provisioning_failed", failure: { retryable: false, attempt: 3 } })} onRetry={noop} onOpenUrl={noop} />,
+    );
+    expect(getByText("Setup needs attention")).toBeTruthy();
+    expect(queryByTestId("journey-retry")).toBeNull();
+  });
+
+  it("shows a retry on an unreachable result", () => {
+    const onRetry = jest.fn();
+    const { getByTestId } = render(<JourneyGate result={{ status: "unreachable" }} onRetry={onRetry} onOpenUrl={noop} />);
+    fireEvent.press(getByTestId("journey-retry"));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("prompts re-sign-in when unauthorized", () => {
+    const { getByText } = render(<JourneyGate result={{ status: "unauthorized" }} onRetry={noop} onOpenUrl={noop} />);
+    expect(getByText("Please sign in again")).toBeTruthy();
+  });
+});

--- a/apps/mobile/__tests__/JourneyGate.test.tsx
+++ b/apps/mobile/__tests__/JourneyGate.test.tsx
@@ -72,12 +72,26 @@ describe("JourneyGate", () => {
     expect(onRetry).toHaveBeenCalled();
   });
 
-  it("offers no retry once exhausted", () => {
-    const { queryByTestId, getByText } = render(
-      <JourneyGate result={ok({ phase: "provisioning_failed", failure: { retryable: false, attempt: 3 } })} onRetry={noop} onOpenUrl={noop} />,
+  it("offers contact-support (not retry) once exhausted", () => {
+    const onOpenUrl = jest.fn();
+    const { queryByTestId, getByText, getByTestId } = render(
+      <JourneyGate result={ok({ phase: "provisioning_failed", failure: { retryable: false, attempt: 3 } })} onRetry={noop} onOpenUrl={onOpenUrl} />,
     );
     expect(getByText("Setup needs attention")).toBeTruthy();
     expect(queryByTestId("journey-retry")).toBeNull();
+    fireEvent.press(getByTestId("journey-support"));
+    expect(onOpenUrl).toHaveBeenCalledWith("mailto:support@matrix-os.com");
+  });
+
+  it("offers contact-support when payment settling is delayed", () => {
+    const onOpenUrl = jest.fn();
+    const { getByText, getByTestId, queryByTestId } = render(
+      <JourneyGate result={ok({ phase: "payment_settling", detail: "Delayed…", settling: { since: "x", delayed: true } })} onRetry={noop} onOpenUrl={onOpenUrl} />,
+    );
+    expect(getByText("Taking longer than expected")).toBeTruthy();
+    expect(queryByTestId("journey-loading")).toBeNull();
+    fireEvent.press(getByTestId("journey-support"));
+    expect(onOpenUrl).toHaveBeenCalledWith("mailto:support@matrix-os.com");
   });
 
   it("shows a retry on an unreachable result", () => {

--- a/apps/mobile/__tests__/journey.test.ts
+++ b/apps/mobile/__tests__/journey.test.ts
@@ -1,0 +1,44 @@
+import { fetchMobileJourney, isConnectablePhase } from "../lib/journey";
+
+describe("fetchMobileJourney", () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  it("returns unauthorized when there is no token (never calls the network)", async () => {
+    const spy = jest.fn();
+    global.fetch = spy as unknown as typeof fetch;
+    const res = await fetchMobileJourney("https://app.matrix-os.com", null);
+    expect(res).toEqual({ status: "unauthorized" });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns ok with the journey on 200", async () => {
+    global.fetch = (async () => new Response(JSON.stringify({ phase: "provisioning", detail: "d", nextAction: { kind: "wait" } }), { status: 200 })) as unknown as typeof fetch;
+    const res = await fetchMobileJourney("https://app.matrix-os.com", "tok");
+    expect(res.status).toBe("ok");
+    if (res.status === "ok") expect(res.journey.phase).toBe("provisioning");
+  });
+
+  it("maps 401/403 to unauthorized (re-sign-in, not a dead retry)", async () => {
+    global.fetch = (async () => new Response("", { status: 401 })) as unknown as typeof fetch;
+    expect((await fetchMobileJourney("https://app.matrix-os.com", "tok")).status).toBe("unauthorized");
+  });
+
+  it("maps a 5xx / network failure to unreachable", async () => {
+    global.fetch = (async () => new Response("", { status: 503 })) as unknown as typeof fetch;
+    expect((await fetchMobileJourney("https://app.matrix-os.com", "tok")).status).toBe("unreachable");
+    global.fetch = (async () => { throw new Error("network"); }) as unknown as typeof fetch;
+    expect((await fetchMobileJourney("https://app.matrix-os.com", "tok")).status).toBe("unreachable");
+  });
+});
+
+describe("isConnectablePhase", () => {
+  it("is true only for first_run and ready", () => {
+    expect(isConnectablePhase("ready")).toBe(true);
+    expect(isConnectablePhase("first_run")).toBe(true);
+    expect(isConnectablePhase("provisioning")).toBe(false);
+    expect(isConnectablePhase("plan_required")).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/journey.test.ts
+++ b/apps/mobile/__tests__/journey.test.ts
@@ -29,7 +29,7 @@ describe("fetchMobileJourney", () => {
   it("maps a 5xx / network failure to unreachable", async () => {
     global.fetch = (async () => new Response("", { status: 503 })) as unknown as typeof fetch;
     expect((await fetchMobileJourney("https://app.matrix-os.com", "tok")).status).toBe("unreachable");
-    global.fetch = (async () => { throw new Error("network"); }) as unknown as typeof fetch;
+    global.fetch = (async () => { throw new TypeError("network"); }) as unknown as typeof fetch;
     expect((await fetchMobileJourney("https://app.matrix-os.com", "tok")).status).toBe("unreachable");
   });
 });

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -22,14 +22,21 @@ function SignedInJourneyGate() {
   useEffect(() => {
     let active = true;
     void (async () => {
-      const token = await getToken();
-      const next = await fetchMobileJourney(HOSTED_GATEWAY_URL, token);
-      if (!active) return;
-      if (next.status === "ok" && isConnectablePhase(next.journey.phase)) {
-        router.replace("/(tabs)/apps" as any);
-        return;
+      try {
+        const token = await getToken();
+        const next = await fetchMobileJourney(HOSTED_GATEWAY_URL, token);
+        if (!active) return;
+        if (next.status === "ok" && isConnectablePhase(next.journey.phase)) {
+          router.replace("/(tabs)/apps" as any);
+          return;
+        }
+        setResult(next);
+      } catch (err: unknown) {
+        // getToken() (Clerk token refresh) can reject; don't strand the user on
+        // a permanent spinner — surface a retryable unreachable state instead.
+        console.warn("[mobile] journey load failed", err instanceof Error ? err.name : typeof err);
+        if (active) setResult({ status: "unreachable" });
       }
-      setResult(next);
     })();
     return () => {
       active = false;

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -9,6 +9,10 @@ import { HOSTED_GATEWAY_URL } from "@/lib/storage";
 import { JourneyGate } from "@/components/JourneyGate";
 import { fetchMobileJourney, isConnectablePhase, type JourneyFetchResult } from "@/lib/journey";
 
+// Re-poll cadence while the machine is building / payment is settling, so the
+// user isn't stranded on a static spinner waiting for a phase transition.
+const JOURNEY_POLL_INTERVAL_MS = 5_000;
+
 // Signed-in users are routed through the journey gate: only a connectable phase
 // (first_run/ready) enters the shell tabs; otherwise the user sees their
 // onboarding phase (plan / settling / building / retry) instead of a broken shell.
@@ -21,6 +25,7 @@ function SignedInJourneyGate() {
 
   useEffect(() => {
     let active = true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     void (async () => {
       try {
         const token = await getToken();
@@ -31,6 +36,11 @@ function SignedInJourneyGate() {
           return;
         }
         setResult(next);
+        // Auto-poll transitional phases so the spinner actually progresses and
+        // hands off to the shell once ready; terminal phases wait on the user.
+        if (next.status === "ok" && (next.journey.phase === "provisioning" || next.journey.phase === "payment_settling")) {
+          timer = setTimeout(() => { if (active) setNonce((n) => n + 1); }, JOURNEY_POLL_INTERVAL_MS);
+        }
       } catch (err: unknown) {
         // getToken() (Clerk token refresh) can reject; don't strand the user on
         // a permanent spinner — surface a retryable unreachable state instead.
@@ -40,8 +50,14 @@ function SignedInJourneyGate() {
     })();
     return () => {
       active = false;
+      if (timer) clearTimeout(timer);
     };
   }, [getToken, router, nonce]);
+
+  function reload() {
+    setResult(null);
+    setNonce((n) => n + 1);
+  }
 
   async function handleRetry() {
     setWorking(true);
@@ -60,8 +76,7 @@ function SignedInJourneyGate() {
       console.warn("[mobile] retry-provision failed", err instanceof Error ? err.name : typeof err);
     } finally {
       setWorking(false);
-      setResult(null);
-      setNonce((n) => n + 1);
+      reload();
     }
   }
 
@@ -70,6 +85,7 @@ function SignedInJourneyGate() {
       result={result}
       working={working}
       onRetry={handleRetry}
+      onRefresh={reload}
       onOpenUrl={(url) => { void Linking.openURL(url); }}
     />
   );

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -18,7 +18,7 @@ const JOURNEY_POLL_INTERVAL_MS = 5_000;
 // onboarding phase (plan / settling / building / retry) instead of a broken shell.
 function SignedInJourneyGate() {
   const router = useRouter();
-  const { getToken } = useAuth();
+  const { getToken, signOut } = useAuth();
   const [result, setResult] = useState<JourneyFetchResult | null>(null);
   const [working, setWorking] = useState(false);
   const [nonce, setNonce] = useState(0);
@@ -59,6 +59,16 @@ function SignedInJourneyGate() {
     setNonce((n) => n + 1);
   }
 
+  async function handleSignOut() {
+    // Clearing the Clerk session flips isSignedIn → false, so Index re-renders
+    // the landing screen where the user can sign in again.
+    try {
+      await signOut();
+    } catch (err: unknown) {
+      console.warn("[mobile] sign-out failed", err instanceof Error ? err.name : typeof err);
+    }
+  }
+
   async function handleRetry() {
     setWorking(true);
     try {
@@ -86,6 +96,7 @@ function SignedInJourneyGate() {
       working={working}
       onRetry={handleRetry}
       onRefresh={reload}
+      onSignOut={handleSignOut}
       onOpenUrl={(url) => { void Linking.openURL(url); }}
     />
   );

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,25 +1,79 @@
-import { View, Text, Pressable, StyleSheet } from "react-native";
+import { View, Text, Pressable, StyleSheet, Linking } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { Image } from "expo-image";
 import { useAuth } from "@clerk/clerk-expo";
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { colors, fonts, spacing, radius } from "@/lib/theme";
+import { HOSTED_GATEWAY_URL } from "@/lib/storage";
+import { JourneyGate } from "@/components/JourneyGate";
+import { fetchMobileJourney, isConnectablePhase, type JourneyFetchResult } from "@/lib/journey";
+
+// Signed-in users are routed through the journey gate: only a connectable phase
+// (first_run/ready) enters the shell tabs; otherwise the user sees their
+// onboarding phase (plan / settling / building / retry) instead of a broken shell.
+function SignedInJourneyGate() {
+  const router = useRouter();
+  const { getToken } = useAuth();
+  const [result, setResult] = useState<JourneyFetchResult | null>(null);
+  const [working, setWorking] = useState(false);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const token = await getToken();
+      const next = await fetchMobileJourney(HOSTED_GATEWAY_URL, token);
+      if (!active) return;
+      if (next.status === "ok" && isConnectablePhase(next.journey.phase)) {
+        router.replace("/(tabs)/apps" as any);
+        return;
+      }
+      setResult(next);
+    })();
+    return () => {
+      active = false;
+    };
+  }, [getToken, router, nonce]);
+
+  async function handleRetry() {
+    setWorking(true);
+    try {
+      const token = await getToken();
+      if (token) {
+        await fetch(`${HOSTED_GATEWAY_URL.replace(/\/+$/, "")}/api/journey/retry-provision`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+          body: "{}",
+          signal: AbortSignal.timeout(10_000),
+        });
+      }
+    } catch (err: unknown) {
+      // Best-effort trigger; the refetch below reflects the real state.
+      console.warn("[mobile] retry-provision failed", err instanceof Error ? err.name : typeof err);
+    } finally {
+      setWorking(false);
+      setResult(null);
+      setNonce((n) => n + 1);
+    }
+  }
+
+  return (
+    <JourneyGate
+      result={result}
+      working={working}
+      onRetry={handleRetry}
+      onOpenUrl={(url) => { void Linking.openURL(url); }}
+    />
+  );
+}
 
 export default function Index() {
   const { isSignedIn } = useAuth();
   const router = useRouter();
-  const redirectedRef = useRef(false);
-
-  useEffect(() => {
-    if (isSignedIn && !redirectedRef.current) {
-      redirectedRef.current = true;
-      router.replace("/(tabs)/apps" as any);
-    }
-  }, [isSignedIn, router]);
 
   if (isSignedIn) {
-    return null;
+    return <SignedInJourneyGate />;
   }
 
   return (

--- a/apps/mobile/components/JourneyGate.tsx
+++ b/apps/mobile/components/JourneyGate.tsx
@@ -134,7 +134,10 @@ export function JourneyGate({ result, onRetry, onOpenUrl, onRefresh = () => {}, 
           {journey.failure?.retryable ? (
             <PrimaryButton label={working ? "Retrying…" : "Retry setup"} testID="journey-retry" onPress={onRetry} />
           ) : (
-            <PrimaryButton label="Contact support" testID="journey-support" onPress={() => onOpenUrl(SUPPORT_URL)} />
+            <>
+              <PrimaryButton label="Contact support" testID="journey-support" onPress={() => onOpenUrl(SUPPORT_URL)} />
+              <PrimaryButton label="Check again" testID="journey-refresh" onPress={onRefresh} />
+            </>
           )}
         </Centered>
       );

--- a/apps/mobile/components/JourneyGate.tsx
+++ b/apps/mobile/components/JourneyGate.tsx
@@ -12,6 +12,8 @@ interface JourneyGateProps {
   onOpenUrl: (url: string) => void;
   /** Re-fetch the journey (no side effects) — used as a manual poll fallback. */
   onRefresh?: () => void;
+  /** Clear the local Clerk session so the user can sign in again. */
+  onSignOut?: () => void;
   working?: boolean;
 }
 
@@ -48,7 +50,7 @@ function PrimaryButton({ label, onPress, testID }: { label: string; onPress: () 
  * screens for plan selection, payment settling, machine build, and retry —
  * `first_run`/`ready` are handled by the caller (it hands off to the shell).
  */
-export function JourneyGate({ result, onRetry, onOpenUrl, onRefresh = () => {}, working = false }: JourneyGateProps) {
+export function JourneyGate({ result, onRetry, onOpenUrl, onRefresh = () => {}, onSignOut = () => {}, working = false }: JourneyGateProps) {
   if (!result) {
     return (
       <Centered>
@@ -63,6 +65,7 @@ export function JourneyGate({ result, onRetry, onOpenUrl, onRefresh = () => {}, 
       <Centered>
         <Title>Please sign in again</Title>
         <Body>Your session expired.</Body>
+        <PrimaryButton label="Sign in again" testID="journey-sign-in" onPress={onSignOut} />
       </Centered>
     );
   }
@@ -86,6 +89,7 @@ export function JourneyGate({ result, onRetry, onOpenUrl, onRefresh = () => {}, 
         <Centered>
           <Title>Please sign in again</Title>
           <Body>{journey.detail || "Your session needs to be refreshed to continue."}</Body>
+          <PrimaryButton label="Sign in again" testID="journey-sign-in" onPress={onSignOut} />
         </Centered>
       );
     case "plan_required":

--- a/apps/mobile/components/JourneyGate.tsx
+++ b/apps/mobile/components/JourneyGate.tsx
@@ -1,0 +1,135 @@
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
+import { colors, fonts, radius, spacing } from "@/lib/theme";
+import {
+  PROVISIONING_STAGE_LABEL,
+  type JourneyFetchResult,
+} from "@/lib/journey";
+
+interface JourneyGateProps {
+  /** null while the first fetch is in flight. */
+  result: JourneyFetchResult | null;
+  onRetry: () => void;
+  onOpenUrl: (url: string) => void;
+  working?: boolean;
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <View style={styles.container} testID="journey-gate">
+      <View style={styles.card}>{children}</View>
+    </View>
+  );
+}
+
+function Title({ children }: { children: React.ReactNode }) {
+  return <Text style={styles.title}>{children}</Text>;
+}
+
+function Body({ children }: { children: React.ReactNode }) {
+  return <Text style={styles.body}>{children}</Text>;
+}
+
+function PrimaryButton({ label, onPress, testID }: { label: string; onPress: () => void; testID: string }) {
+  return (
+    <Pressable
+      testID={testID}
+      onPress={onPress}
+      style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+    >
+      <Text style={styles.buttonLabel}>{label}</Text>
+    </Pressable>
+  );
+}
+
+/**
+ * Renders the user's onboarding phase on mobile (spec 092). Phase-appropriate
+ * screens for plan selection, payment settling, machine build, and retry —
+ * `first_run`/`ready` are handled by the caller (it hands off to the shell).
+ */
+export function JourneyGate({ result, onRetry, onOpenUrl, working = false }: JourneyGateProps) {
+  if (!result) {
+    return (
+      <Centered>
+        <ActivityIndicator color={colors.light.primary} testID="journey-loading" />
+        <Body>Loading your Matrix computer…</Body>
+      </Centered>
+    );
+  }
+
+  if (result.status === "unauthorized") {
+    return (
+      <Centered>
+        <Title>Please sign in again</Title>
+        <Body>Your session expired.</Body>
+      </Centered>
+    );
+  }
+
+  if (result.status === "unreachable") {
+    return (
+      <Centered>
+        <Title>Can’t reach Matrix</Title>
+        <Body>We couldn’t reach Matrix right now.</Body>
+        <PrimaryButton label="Try again" onPress={onRetry} testID="journey-retry" />
+      </Centered>
+    );
+  }
+
+  const journey = result.journey;
+  switch (journey.phase) {
+    case "plan_required":
+      return (
+        <Centered>
+          <Title>Choose your plan</Title>
+          <Body>{journey.detail}</Body>
+          {journey.nextAction.url ? (
+            <PrimaryButton label="View plans" testID="journey-open-plans" onPress={() => onOpenUrl(journey.nextAction.url as string)} />
+          ) : null}
+        </Centered>
+      );
+    case "payment_settling":
+      return (
+        <Centered>
+          {journey.settling?.delayed ? null : <ActivityIndicator color={colors.light.primary} testID="journey-loading" />}
+          <Title>{journey.settling?.delayed ? "Taking longer than expected" : "Activating your subscription"}</Title>
+          <Body>{journey.detail}</Body>
+        </Centered>
+      );
+    case "provisioning":
+      return (
+        <Centered>
+          <ActivityIndicator color={colors.light.primary} testID="journey-loading" />
+          <Title>Building your Matrix computer</Title>
+          <Body>{journey.progress ? (PROVISIONING_STAGE_LABEL[journey.progress.stage] ?? journey.detail) : journey.detail}</Body>
+        </Centered>
+      );
+    case "provisioning_failed":
+      return (
+        <Centered>
+          <Title>Setup needs attention</Title>
+          <Body>{journey.detail}</Body>
+          {journey.failure?.retryable ? (
+            <PrimaryButton label={working ? "Retrying…" : "Retry setup"} testID="journey-retry" onPress={onRetry} />
+          ) : null}
+        </Centered>
+      );
+    default:
+      // first_run / ready / account_required — the caller redirects.
+      return (
+        <Centered>
+          <ActivityIndicator color={colors.light.primary} testID="journey-loading" />
+          <Body>Opening your Matrix computer…</Body>
+        </Centered>
+      );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.light.background, padding: spacing.lg },
+  card: { alignItems: "center", gap: spacing.md, maxWidth: 360 },
+  title: { fontFamily: fonts.sansSemiBold, fontSize: 20, color: colors.light.forest, textAlign: "center" },
+  body: { fontFamily: fonts.sans, fontSize: 14, color: colors.light.forest, opacity: 0.8, textAlign: "center" },
+  button: { backgroundColor: colors.light.primary, paddingVertical: spacing.sm, paddingHorizontal: spacing.lg, borderRadius: radius.md },
+  buttonPressed: { opacity: 0.85 },
+  buttonLabel: { fontFamily: fonts.sansSemiBold, fontSize: 15, color: colors.light.primaryForeground },
+});

--- a/apps/mobile/components/JourneyGate.tsx
+++ b/apps/mobile/components/JourneyGate.tsx
@@ -77,6 +77,15 @@ export function JourneyGate({ result, onRetry, onOpenUrl, working = false }: Jou
 
   const journey = result.journey;
   switch (journey.phase) {
+    case "account_required":
+      // The local Clerk session no longer resolves to a platform account; the
+      // only way forward is to re-authenticate, not to wait on a spinner.
+      return (
+        <Centered>
+          <Title>Please sign in again</Title>
+          <Body>{journey.detail || "Your session needs to be refreshed to continue."}</Body>
+        </Centered>
+      );
     case "plan_required":
       return (
         <Centered>

--- a/apps/mobile/components/JourneyGate.tsx
+++ b/apps/mobile/components/JourneyGate.tsx
@@ -5,6 +5,8 @@ import {
   type JourneyFetchResult,
 } from "@/lib/journey";
 
+const SUPPORT_URL = "mailto:support@matrix-os.com";
+
 interface JourneyGateProps {
   /** null while the first fetch is in flight. */
   result: JourneyFetchResult | null;
@@ -111,6 +113,9 @@ export function JourneyGate({ result, onRetry, onOpenUrl, onRefresh = () => {}, 
           {journey.settling?.delayed ? null : <ActivityIndicator color={colors.light.primary} testID="journey-loading" />}
           <Title>{journey.settling?.delayed ? "Taking longer than expected" : "Activating your subscription"}</Title>
           <Body>{journey.detail}</Body>
+          {journey.settling?.delayed ? (
+            <PrimaryButton label="Contact support" testID="journey-support" onPress={() => onOpenUrl(SUPPORT_URL)} />
+          ) : null}
         </Centered>
       );
     case "provisioning":
@@ -128,7 +133,9 @@ export function JourneyGate({ result, onRetry, onOpenUrl, onRefresh = () => {}, 
           <Body>{journey.detail}</Body>
           {journey.failure?.retryable ? (
             <PrimaryButton label={working ? "Retrying…" : "Retry setup"} testID="journey-retry" onPress={onRetry} />
-          ) : null}
+          ) : (
+            <PrimaryButton label="Contact support" testID="journey-support" onPress={() => onOpenUrl(SUPPORT_URL)} />
+          )}
         </Centered>
       );
     default:

--- a/apps/mobile/components/JourneyGate.tsx
+++ b/apps/mobile/components/JourneyGate.tsx
@@ -10,6 +10,8 @@ interface JourneyGateProps {
   result: JourneyFetchResult | null;
   onRetry: () => void;
   onOpenUrl: (url: string) => void;
+  /** Re-fetch the journey (no side effects) — used as a manual poll fallback. */
+  onRefresh?: () => void;
   working?: boolean;
 }
 
@@ -46,7 +48,7 @@ function PrimaryButton({ label, onPress, testID }: { label: string; onPress: () 
  * screens for plan selection, payment settling, machine build, and retry —
  * `first_run`/`ready` are handled by the caller (it hands off to the shell).
  */
-export function JourneyGate({ result, onRetry, onOpenUrl, working = false }: JourneyGateProps) {
+export function JourneyGate({ result, onRetry, onOpenUrl, onRefresh = () => {}, working = false }: JourneyGateProps) {
   if (!result) {
     return (
       <Centered>
@@ -94,6 +96,9 @@ export function JourneyGate({ result, onRetry, onOpenUrl, working = false }: Jou
           {journey.nextAction.url ? (
             <PrimaryButton label="View plans" testID="journey-open-plans" onPress={() => onOpenUrl(journey.nextAction.url as string)} />
           ) : null}
+          {/* Always offer a way forward — the user picks a plan elsewhere (web),
+              then taps to re-check, even when the server omits a URL. */}
+          <PrimaryButton label="Check again" testID="journey-refresh" onPress={onRefresh} />
         </Centered>
       );
     case "payment_settling":

--- a/apps/mobile/components/JourneyGate.tsx
+++ b/apps/mobile/components/JourneyGate.tsx
@@ -123,7 +123,7 @@ export function JourneyGate({ result, onRetry, onOpenUrl, working = false }: Jou
         </Centered>
       );
     default:
-      // first_run / ready / account_required — the caller redirects.
+      // first_run / ready — the caller redirects.
       return (
         <Centered>
           <ActivityIndicator color={colors.light.primary} testID="journey-loading" />

--- a/apps/mobile/lib/journey.ts
+++ b/apps/mobile/lib/journey.ts
@@ -1,0 +1,62 @@
+// Mobile consumer of the platform journey contract (spec 092). The app renders
+// the user's onboarding phase instead of assuming a running machine exists.
+
+export type JourneyPhase =
+  | "account_required"
+  | "plan_required"
+  | "payment_settling"
+  | "provisioning"
+  | "provisioning_failed"
+  | "first_run"
+  | "ready";
+
+export interface MobileJourneyState {
+  phase: JourneyPhase;
+  detail: string;
+  nextAction: { kind: string; url?: string };
+  progress?: { stage: string; startedAt: string };
+  failure?: { retryable: boolean; attempt: number };
+  settling?: { since: string; delayed: boolean };
+}
+
+export type JourneyFetchResult =
+  | { status: "ok"; journey: MobileJourneyState }
+  | { status: "unauthorized" }
+  | { status: "unreachable" };
+
+const JOURNEY_TIMEOUT_MS = 10_000;
+
+/**
+ * Fetches the caller's journey state. Distinguishes auth failure (401/403 →
+ * re-sign-in) from transient unreachability so the gate can react correctly.
+ */
+export async function fetchMobileJourney(baseUrl: string, token: string | null): Promise<JourneyFetchResult> {
+  if (!token) return { status: "unauthorized" };
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), JOURNEY_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/journey`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (res.status === 401 || res.status === 403) return { status: "unauthorized" };
+    if (!res.ok) return { status: "unreachable" };
+    return { status: "ok", journey: (await res.json()) as MobileJourneyState };
+  } catch (err: unknown) {
+    return { status: "unreachable" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Phases where the app should hand off to the connected shell experience. */
+export function isConnectablePhase(phase: JourneyPhase): boolean {
+  return phase === "first_run" || phase === "ready";
+}
+
+export const PROVISIONING_STAGE_LABEL: Record<string, string> = {
+  creating_server: "Creating your server",
+  booting: "Booting your computer",
+  registering: "Connecting your computer",
+  finalizing: "Finishing setup",
+};

--- a/apps/mobile/lib/journey.ts
+++ b/apps/mobile/lib/journey.ts
@@ -43,6 +43,11 @@ export async function fetchMobileJourney(baseUrl: string, token: string | null):
     if (!res.ok) return { status: "unreachable" };
     return { status: "ok", journey: (await res.json()) as MobileJourneyState };
   } catch (err: unknown) {
+    // Timeouts/aborts (DOMException) and network drops (TypeError) are expected
+    // and surface as `unreachable` (the gate offers retry). Log anything else.
+    if (!(err instanceof DOMException) && !(err instanceof TypeError)) {
+      console.warn(`[matrix] unexpected journey fetch error: ${err instanceof Error ? err.message : String(err)}`);
+    }
     return { status: "unreachable" };
   } finally {
     clearTimeout(timer);

--- a/packages/sync-client/src/cli/commands/login.ts
+++ b/packages/sync-client/src/cli/commands/login.ts
@@ -2,7 +2,6 @@ import { defineCommand } from "citty";
 import { login } from "../../auth/oauth.js";
 import {
   authFilePathForProfile,
-  clearProfileAuth,
   saveProfileAuth,
 } from "../../auth/token-store.js";
 import {
@@ -21,6 +20,7 @@ import {
   formatCliErrorMessage,
   formatCliSuccess,
 } from "../output.js";
+import { fetchJourney, journeyGuidance } from "../journey.js";
 import { getCliTelemetry } from "../telemetry.js";
 
 function localProfileFromArgs(args: Record<string, unknown>) {
@@ -183,26 +183,24 @@ export const loginCommand = defineCommand({
     }
 
     if (meRes.status === 404) {
-      // User signed in but no Matrix container exists. Wipe the just-written
-      // auth.json (pollForToken persisted it inside `login()`) — otherwise
-      // `matrix sync` would appear to work while every gateway call 404s.
-      await clearProfileAuth(profileName);
+      // Signed in but no machine yet. KEEP the valid auth token (the journey +
+      // `mos setup` both need it; deleting it forces a needless re-login) and
+      // consult the journey to tell the user exactly what to do next instead of
+      // dead-ending at "sign up on the website". We still skip writing config.json
+      // (no gateway yet), so `mos sync` won't point at a guessed gateway.
+      const journey = await fetchJourney(platformUrl, auth.accessToken);
+      const guidance = journeyGuidance(journey);
       if (json) {
-        console.error(formatCliError(
-          "instance_not_found",
-          "Matrix instance not found. Sign up at https://app.matrix-os.com, then rerun `mos login`.",
-        ));
-        process.exitCode = 1;
-        return;
+        console.log(formatCliSuccess({
+          authenticated: true,
+          connected: false,
+          journey: journey ?? null,
+          suggestedCommand: guidance.suggestedCommand ?? null,
+        }));
+      } else {
+        for (const line of guidance.lines) console.log(line);
       }
-      console.log(
-        "You're signed in, but there's no Matrix instance for this account yet.",
-      );
-      console.log("");
-      console.log(
-        "Sign up at https://app.matrix-os.com first, then re-run `mos login`.",
-      );
-      process.exitCode = 1;
+      process.exitCode = guidance.exitCode;
       return;
     }
 

--- a/packages/sync-client/src/cli/commands/login.ts
+++ b/packages/sync-client/src/cli/commands/login.ts
@@ -190,8 +190,12 @@ export const loginCommand = defineCommand({
       // (no gateway yet), so `mos sync` won't point at a guessed gateway.
       const journey = await fetchJourney(platformUrl, auth.accessToken);
       const guidance = journeyGuidance(journey);
+      const guidanceMessage = guidance.lines.reduce(
+        (message, line) => (message ? `${message} ${line}` : line),
+        "",
+      );
       if (json) {
-        console.log(formatCliSuccess({
+        console.error(formatCliError("login_failed", guidanceMessage, {
           authenticated: true,
           connected: false,
           journey: journey ?? null,

--- a/packages/sync-client/src/cli/commands/setup.ts
+++ b/packages/sync-client/src/cli/commands/setup.ts
@@ -6,6 +6,10 @@ import { fetchJourney, journeyGuidance, describeProgress } from "../journey.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
 const MAX_POLLS = 180; // ~15 min ceiling at the default interval
+// fetchJourney collapses every non-200 (including a 401 auth expiry) to null.
+// Bail after this many consecutive failures instead of sleeping the full ceiling
+// in silence — a mid-provision token expiry otherwise looks like a 15-min hang.
+const MAX_CONSECUTIVE_FAILURES = 5;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -74,36 +78,52 @@ export const setupCommand = defineCommand({
 
       if (!json) console.log("Building your Matrix computer…");
       let lastStage = "";
+      let consecutiveFailures = 0;
       for (let i = 0; i < MAX_POLLS; i += 1) {
         const journey = await fetchJourney(platformUrl, token);
-        if (journey) {
-          if (journey.phase === "first_run" || journey.phase === "ready") {
-            if (json) console.log(formatCliSuccess({ phase: journey.phase, connected: false }));
-            else console.log("Your Matrix computer is ready. Run `mos login` to connect.");
-            return;
-          }
-          if (journey.phase === "provisioning_failed") {
-            console.error(journey.failure?.retryable
-              ? "Setup hit a problem — run `mos setup` again to retry."
-              : "Setup failed after several attempts. Contact support@matrix-os.com.");
+        if (!journey) {
+          consecutiveFailures += 1;
+          if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            console.error(json
+              ? formatCliError("platform_unreachable")
+              : "Lost contact with Matrix (your session may have expired). Run `mos login`, then `mos setup` again.");
             process.exitCode = 1;
             return;
           }
-          if (journey.phase === "provisioning") {
-            const stage = describeProgress(journey);
-            if (stage !== lastStage) {
-              lastStage = stage;
-              if (!json) console.log(`… ${stage}`);
-            }
-          } else {
-            // plan_required / payment_settling — provisioning can't proceed yet.
-            const guidance = journeyGuidance(journey);
-            if (!json) for (const line of guidance.lines) console.log(line);
-            process.exitCode = 1;
-            return;
-          }
+          if (!json && consecutiveFailures === 1) console.log("… waiting for status…");
+          await sleep(pollIntervalMs);
+          continue;
         }
-        await sleep(pollIntervalMs);
+        consecutiveFailures = 0;
+        if (journey.phase === "first_run" || journey.phase === "ready") {
+          if (json) console.log(formatCliSuccess({ phase: journey.phase, connected: false }));
+          else console.log("Your Matrix computer is ready. Run `mos login` to connect.");
+          return;
+        }
+        if (journey.phase === "provisioning_failed") {
+          console.error(journey.failure?.retryable
+            ? "Setup hit a problem — run `mos setup` again to retry."
+            : "Setup failed after several attempts. Contact support@matrix-os.com.");
+          process.exitCode = 1;
+          return;
+        }
+        if (journey.phase === "provisioning" || journey.phase === "payment_settling") {
+          // Both are "keep waiting" states; payment_settling rolls into
+          // provisioning, so don't dead-end the user mid-setup.
+          const stage = journey.phase === "provisioning" ? describeProgress(journey) : "confirming your payment";
+          if (stage !== lastStage) {
+            lastStage = stage;
+            if (!json) console.log(`… ${stage}`);
+          }
+          await sleep(pollIntervalMs);
+          continue;
+        }
+        // plan_required / account_required — can't proceed without the user, so
+        // guide and exit rather than poll indefinitely.
+        const guidance = journeyGuidance(journey);
+        if (!json) for (const line of guidance.lines) console.log(line);
+        process.exitCode = 1;
+        return;
       }
       console.error(json ? formatCliError("setup_timeout") : "Setup is taking longer than expected. Re-run `mos login` shortly to check.");
       process.exitCode = 1;

--- a/packages/sync-client/src/cli/commands/setup.ts
+++ b/packages/sync-client/src/cli/commands/setup.ts
@@ -101,9 +101,13 @@ export const setupCommand = defineCommand({
           return;
         }
         if (journey.phase === "provisioning_failed") {
-          console.error(journey.failure?.retryable
-            ? "Setup hit a problem — run `mos setup` again to retry."
-            : "Setup failed after several attempts. Contact support@matrix-os.com.");
+          if (json) {
+            console.error(formatCliError(journey.failure?.retryable ? "setup_failed" : "retry_exhausted"));
+          } else {
+            console.error(journey.failure?.retryable
+              ? "Setup hit a problem — run `mos setup` again to retry."
+              : "Setup failed after several attempts. Contact support@matrix-os.com.");
+          }
           process.exitCode = 1;
           return;
         }
@@ -120,8 +124,12 @@ export const setupCommand = defineCommand({
         }
         // plan_required / account_required — can't proceed without the user, so
         // guide and exit rather than poll indefinitely.
-        const guidance = journeyGuidance(journey);
-        if (!json) for (const line of guidance.lines) console.log(line);
+        if (json) {
+          console.error(formatCliError(journey.phase === "plan_required" ? "billing_required" : "auth_expired"));
+        } else {
+          const guidance = journeyGuidance(journey);
+          for (const line of guidance.lines) console.log(line);
+        }
         process.exitCode = 1;
         return;
       }

--- a/packages/sync-client/src/cli/commands/setup.ts
+++ b/packages/sync-client/src/cli/commands/setup.ts
@@ -1,0 +1,112 @@
+import { defineCommand } from "citty";
+import { formatCliError, formatCliSuccess } from "../output.js";
+import { resolveCliProfile } from "../profiles.js";
+import { resolveCliAuthStatus } from "../auth-state.js";
+import { fetchJourney, journeyGuidance, describeProgress } from "../journey.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const MAX_POLLS = 180; // ~15 min ceiling at the default interval
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const setupCommand = defineCommand({
+  meta: {
+    name: "setup",
+    description: "Create (or retry) your Matrix computer and watch it build",
+  },
+  args: {
+    profile: { type: "string", required: false },
+    dev: { type: "boolean", required: false, default: false },
+    gateway: { type: "string", required: false },
+    platform: { type: "string", required: false },
+    token: { type: "string", required: false },
+    json: { type: "boolean", required: false, default: false },
+    "poll-interval-ms": { type: "string", required: false },
+  },
+  run: async ({ args }) => {
+    const json = args.json === true;
+    const pollIntervalMs = typeof args["poll-interval-ms"] === "string"
+      ? Math.max(0, Number(args["poll-interval-ms"]) || DEFAULT_POLL_INTERVAL_MS)
+      : DEFAULT_POLL_INTERVAL_MS;
+    try {
+      const profile = await resolveCliProfile(args);
+      const authStatus = await resolveCliAuthStatus(profile);
+      if (authStatus.status !== "authenticated") {
+        console.error(json ? formatCliError("not_authenticated") : "Not signed in. Run `mos login` first.");
+        process.exitCode = 1;
+        return;
+      }
+      const token = authStatus.token;
+      const platformUrl = profile.platformUrl.replace(/\/+$/, "");
+
+      // Trigger provisioning. retry-provision is idempotent: it converges on an
+      // in-flight attempt and retries a failed one.
+      const trigger = await fetch(`${platformUrl}/api/journey/retry-provision`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+        body: "{}",
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (trigger.status === 402) {
+        const guidance = journeyGuidance(await fetchJourney(platformUrl, token));
+        if (json) console.log(formatCliError("billing_required"));
+        else for (const line of guidance.lines) console.log(line);
+        process.exitCode = 1;
+        return;
+      }
+      if (trigger.status === 409) {
+        console.error(json ? formatCliError("retry_exhausted") : "Setup has failed repeatedly. Contact support@matrix-os.com.");
+        process.exitCode = 1;
+        return;
+      }
+      if (!trigger.ok) {
+        console.error(json ? formatCliError("setup_failed") : "Couldn't start setup. Please try again shortly.");
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!json) console.log("Building your Matrix computer…");
+      let lastStage = "";
+      for (let i = 0; i < MAX_POLLS; i += 1) {
+        const journey = await fetchJourney(platformUrl, token);
+        if (journey) {
+          if (journey.phase === "first_run" || journey.phase === "ready") {
+            if (json) console.log(formatCliSuccess({ phase: journey.phase, connected: false }));
+            else console.log("Your Matrix computer is ready. Run `mos login` to connect.");
+            return;
+          }
+          if (journey.phase === "provisioning_failed") {
+            console.error(journey.failure?.retryable
+              ? "Setup hit a problem — run `mos setup` again to retry."
+              : "Setup failed after several attempts. Contact support@matrix-os.com.");
+            process.exitCode = 1;
+            return;
+          }
+          if (journey.phase === "provisioning") {
+            const stage = describeProgress(journey);
+            if (stage !== lastStage) {
+              lastStage = stage;
+              if (!json) console.log(`… ${stage}`);
+            }
+          } else {
+            // plan_required / payment_settling — provisioning can't proceed yet.
+            const guidance = journeyGuidance(journey);
+            if (!json) for (const line of guidance.lines) console.log(line);
+            process.exitCode = 1;
+            return;
+          }
+        }
+        await sleep(pollIntervalMs);
+      }
+      console.error(json ? formatCliError("setup_timeout") : "Setup is taking longer than expected. Re-run `mos login` shortly to check.");
+      process.exitCode = 1;
+    } catch (err: unknown) {
+      console.error(json
+        ? formatCliError("setup_failed")
+        : `Error: setup failed (${err instanceof Error ? err.name : typeof err})`);
+      process.exitCode = 1;
+    }
+  },
+});

--- a/packages/sync-client/src/cli/commands/setup.ts
+++ b/packages/sync-client/src/cli/commands/setup.ts
@@ -27,9 +27,11 @@ export const setupCommand = defineCommand({
   },
   run: async ({ args }) => {
     const json = args.json === true;
-    const pollIntervalMs = typeof args["poll-interval-ms"] === "string"
-      ? Math.max(0, Number(args["poll-interval-ms"]) || DEFAULT_POLL_INTERVAL_MS)
-      : DEFAULT_POLL_INTERVAL_MS;
+    const rawPollMs = Number(args["poll-interval-ms"]);
+    const pollIntervalMs =
+      typeof args["poll-interval-ms"] === "string" && Number.isFinite(rawPollMs) && rawPollMs > 0
+        ? rawPollMs
+        : DEFAULT_POLL_INTERVAL_MS;
     try {
       const profile = await resolveCliProfile(args);
       const authStatus = await resolveCliAuthStatus(profile);
@@ -50,9 +52,12 @@ export const setupCommand = defineCommand({
         signal: AbortSignal.timeout(10_000),
       });
       if (trigger.status === 402) {
-        const guidance = journeyGuidance(await fetchJourney(platformUrl, token));
-        if (json) console.log(formatCliError("billing_required"));
-        else for (const line of guidance.lines) console.log(line);
+        if (json) {
+          console.log(formatCliError("billing_required"));
+        } else {
+          const guidance = journeyGuidance(await fetchJourney(platformUrl, token));
+          for (const line of guidance.lines) console.log(line);
+        }
         process.exitCode = 1;
         return;
       }

--- a/packages/sync-client/src/cli/commands/setup.ts
+++ b/packages/sync-client/src/cli/commands/setup.ts
@@ -111,6 +111,18 @@ export const setupCommand = defineCommand({
           process.exitCode = 1;
           return;
         }
+        if (journey.phase === "payment_settling" && journey.settling?.delayed) {
+          // Abnormally long settle — stop watching and point the user at support
+          // instead of spinning silently until the poll ceiling.
+          if (json) {
+            console.error(formatCliError("payment_delayed"));
+          } else {
+            const guidance = journeyGuidance(journey);
+            for (const line of guidance.lines) console.log(line);
+          }
+          process.exitCode = 1;
+          return;
+        }
         if (journey.phase === "provisioning" || journey.phase === "payment_settling") {
           // Both are "keep waiting" states; payment_settling rolls into
           // provisioning, so don't dead-end the user mid-setup.

--- a/packages/sync-client/src/cli/commands/setup.ts
+++ b/packages/sync-client/src/cli/commands/setup.ts
@@ -57,7 +57,7 @@ export const setupCommand = defineCommand({
       });
       if (trigger.status === 402) {
         if (json) {
-          console.log(formatCliError("billing_required"));
+          console.error(formatCliError("billing_required"));
         } else {
           const guidance = journeyGuidance(await fetchJourney(platformUrl, token));
           for (const line of guidance.lines) console.log(line);

--- a/packages/sync-client/src/cli/index.ts
+++ b/packages/sync-client/src/cli/index.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import { defineCommand, runMain } from "citty";
 import { loginCommand } from "./commands/login.js";
+import { setupCommand } from "./commands/setup.js";
 import { logoutCommand } from "./commands/logout.js";
 import { syncCommand } from "./commands/sync.js";
 import { peersCommand } from "./commands/peers.js";
@@ -24,6 +25,7 @@ const pkg = require("../../package.json") as { version: string };
 
 const subCommands = {
   login: loginCommand,
+  setup: setupCommand,
   logout: logoutCommand,
   sync: syncCommand,
   peers: peersCommand,

--- a/packages/sync-client/src/cli/journey.ts
+++ b/packages/sync-client/src/cli/journey.ts
@@ -36,7 +36,7 @@ export interface JourneyGuidance {
   lines: string[];
   /** Suggested next CLI step the user should run, if any. */
   suggestedCommand?: "setup" | "login";
-  /** Process exit code: 0 when connected/ready, non-zero when action is needed. */
+  /** Process exit code: 0 when `mos login` completes a live connection, non-zero when further action is needed. */
   exitCode: number;
 }
 
@@ -86,7 +86,7 @@ export function journeyGuidance(journey: CliJourneyState | null): JourneyGuidanc
       };
     case "provisioning":
       return {
-        lines: ["No Matrix computer yet. Run `mos setup` to build one."],
+        lines: ["Your Matrix computer is being built. Run `mos setup` to watch progress."],
         suggestedCommand: "setup",
         exitCode: 1,
       };

--- a/packages/sync-client/src/cli/journey.ts
+++ b/packages/sync-client/src/cli/journey.ts
@@ -64,6 +64,13 @@ export function journeyGuidance(journey: CliJourneyState | null): JourneyGuidanc
     };
   }
   switch (journey.phase) {
+    case "account_required":
+      // The token no longer maps to a platform account; `mos setup` can't help.
+      return {
+        lines: ["Your session is no longer valid for this account. Run `mos login` to sign in again."],
+        suggestedCommand: "login",
+        exitCode: 1,
+      };
     case "plan_required":
       return {
         lines: [

--- a/packages/sync-client/src/cli/journey.ts
+++ b/packages/sync-client/src/cli/journey.ts
@@ -1,0 +1,130 @@
+// CLI consumer of the platform journey contract (spec 092). The CLI renders the
+// user's onboarding phase instead of dead-ending when no machine exists yet.
+
+export interface CliJourneyState {
+  phase:
+    | "account_required"
+    | "plan_required"
+    | "payment_settling"
+    | "provisioning"
+    | "provisioning_failed"
+    | "first_run"
+    | "ready";
+  detail: string;
+  nextAction: { kind: string; url?: string };
+  progress?: { stage: string; startedAt: string };
+  failure?: { retryable: boolean; attempt: number };
+  settling?: { since: string; delayed: boolean };
+}
+
+/** Fetches the caller's journey state; returns null on any failure (the CLI
+ *  falls back to generic guidance — it never blocks on the journey). */
+export async function fetchJourney(platformUrl: string, token: string): Promise<CliJourneyState | null> {
+  try {
+    const res = await fetch(`${platformUrl.replace(/\/+$/, "")}/api/journey`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as CliJourneyState;
+  } catch (err: unknown) {
+    return null;
+  }
+}
+
+export interface JourneyGuidance {
+  lines: string[];
+  /** Suggested next CLI step the user should run, if any. */
+  suggestedCommand?: "setup" | "login";
+  /** Process exit code: 0 when connected/ready, non-zero when action is needed. */
+  exitCode: number;
+}
+
+const STAGE_LABEL: Record<string, string> = {
+  creating_server: "creating your server",
+  booting: "booting your computer",
+  registering: "connecting your computer",
+  finalizing: "finishing setup",
+};
+
+/**
+ * Turns a journey state (or null) into human guidance for the terminal. Pure —
+ * returns lines + the suggested next command so login/setup can render and the
+ * tests can assert without capturing stdout.
+ */
+export function journeyGuidance(journey: CliJourneyState | null): JourneyGuidance {
+  if (!journey) {
+    return {
+      lines: [
+        "You're signed in, but there's no Matrix computer for this account yet.",
+        "Run `mos setup` to create one.",
+      ],
+      suggestedCommand: "setup",
+      exitCode: 1,
+    };
+  }
+  switch (journey.phase) {
+    case "plan_required":
+      return {
+        lines: [
+          "You're signed in. Choose a plan to create your Matrix computer:",
+          journey.nextAction.url ?? "https://app.matrix-os.com/?plans=1",
+          "Then run `mos setup`.",
+        ],
+        suggestedCommand: "setup",
+        exitCode: 1,
+      };
+    case "payment_settling":
+      return {
+        lines: [
+          journey.settling?.delayed
+            ? "Your payment is taking longer than expected to confirm — contact support@matrix-os.com if it persists."
+            : "Your payment is confirming. Run `mos setup` once it's active.",
+        ],
+        suggestedCommand: "setup",
+        exitCode: 1,
+      };
+    case "provisioning":
+      return {
+        lines: ["No Matrix computer yet. Run `mos setup` to build one."],
+        suggestedCommand: "setup",
+        exitCode: 1,
+      };
+    case "provisioning_failed":
+      return {
+        lines: journey.failure?.retryable
+          ? ["Your last setup attempt failed. Run `mos setup` to retry."]
+          : ["Setup failed after several attempts. Contact support@matrix-os.com."],
+        suggestedCommand: journey.failure?.retryable ? "setup" : undefined,
+        exitCode: 1,
+      };
+    case "first_run":
+      return {
+        lines: [
+          "Your Matrix computer is being set up. Re-run `mos login` to connect once it's ready,",
+          `or finish first-run setup at ${journey.nextAction.url ?? "https://app.matrix-os.com/"}.`,
+        ],
+        suggestedCommand: "login",
+        exitCode: 1,
+      };
+    case "ready":
+      return {
+        lines: ["Your Matrix computer is ready. Re-run `mos login` to connect."],
+        suggestedCommand: "login",
+        exitCode: 1,
+      };
+    default:
+      return {
+        lines: ["You're signed in, but there's no Matrix computer yet. Run `mos setup` to create one."],
+        suggestedCommand: "setup",
+        exitCode: 1,
+      };
+  }
+}
+
+export function describeProgress(journey: CliJourneyState): string {
+  if (journey.phase === "provisioning" && journey.progress) {
+    return STAGE_LABEL[journey.progress.stage] ?? "building your computer";
+  }
+  return journey.detail;
+}

--- a/packages/sync-client/src/cli/journey.ts
+++ b/packages/sync-client/src/cli/journey.ts
@@ -28,6 +28,12 @@ export async function fetchJourney(platformUrl: string, token: string): Promise<
     if (!res.ok) return null;
     return (await res.json()) as CliJourneyState;
   } catch (err: unknown) {
+    // Timeouts (DOMException) and network drops (TypeError) are expected
+    // transient failures — the caller falls back to guidance and the setup poll
+    // loop bails after repeated nulls. Surface anything else.
+    if (!(err instanceof DOMException) && !(err instanceof TypeError)) {
+      console.warn(`[mos] unexpected journey fetch error: ${err instanceof Error ? err.message : String(err)}`);
+    }
     return null;
   }
 }

--- a/packages/sync-client/src/cli/output.ts
+++ b/packages/sync-client/src/cli/output.ts
@@ -13,6 +13,11 @@ const GENERIC_MESSAGES: Record<string, string> = {
   unknown_command: "Request failed",
   unsupported_version: "Request failed",
   auth_expired: "Matrix CLI auth expired. Run `mos login` to refresh your session.",
+  billing_required: "Choose a plan before running setup. Visit https://app.matrix-os.com/?plans=1.",
+  not_authenticated: "Not signed in. Run `mos login` first.",
+  retry_exhausted: "Setup has failed repeatedly. Contact support@matrix-os.com.",
+  setup_failed: "Couldn't start setup. Please try again shortly.",
+  setup_timeout: "Setup is taking longer than expected. Re-run `mos login` shortly to check.",
   payment_delayed: "Payment is taking longer than expected to confirm. Contact support@matrix-os.com if it persists.",
 };
 

--- a/packages/sync-client/src/cli/output.ts
+++ b/packages/sync-client/src/cli/output.ts
@@ -29,12 +29,17 @@ export function formatCliErrorMessage(code: string, message?: string): string {
   return message ?? GENERIC_MESSAGES[code] ?? "Request failed";
 }
 
-export function formatCliError(code: string, message?: string): string {
+export function formatCliError(
+  code: string,
+  message?: string,
+  details?: Record<string, unknown>,
+): string {
   return JSON.stringify({
     v: CLI_OUTPUT_VERSION,
     error: {
       code,
       message: formatCliErrorMessage(code, message),
+      ...details,
     },
   });
 }

--- a/packages/sync-client/src/cli/output.ts
+++ b/packages/sync-client/src/cli/output.ts
@@ -13,6 +13,7 @@ const GENERIC_MESSAGES: Record<string, string> = {
   unknown_command: "Request failed",
   unsupported_version: "Request failed",
   auth_expired: "Matrix CLI auth expired. Run `mos login` to refresh your session.",
+  payment_delayed: "Payment is taking longer than expected to confirm. Contact support@matrix-os.com if it persists.",
 };
 
 export function formatCliSuccess(data: Record<string, unknown>): string {

--- a/packages/sync-client/tests/unit/journey.test.ts
+++ b/packages/sync-client/tests/unit/journey.test.ts
@@ -23,6 +23,13 @@ describe("cli journeyGuidance", () => {
     expect(g.lines.join(" ")).toMatch(/mos setup/);
   });
 
+  it("account_required tells the user to re-authenticate, not to run setup", () => {
+    const g = journeyGuidance(state({ phase: "account_required" }));
+    expect(g.suggestedCommand).toBe("login");
+    expect(g.lines.join(" ")).toMatch(/sign in again/i);
+    expect(g.lines.join(" ")).not.toMatch(/mos setup/);
+  });
+
   it("plan_required prints the plans URL and suggests setup", () => {
     const g = journeyGuidance(state({ phase: "plan_required", nextAction: { kind: "open_plans", url: "https://app.matrix-os.com/?plans=1" } }));
     expect(g.lines.join("\n")).toContain("https://app.matrix-os.com/?plans=1");

--- a/packages/sync-client/tests/unit/journey.test.ts
+++ b/packages/sync-client/tests/unit/journey.test.ts
@@ -46,6 +46,13 @@ describe("cli journeyGuidance", () => {
     expect(journeyGuidance(state({ phase: "ready" })).suggestedCommand).toBe("login");
   });
 
+  it("provisioning says the machine is building, not that none exists", () => {
+    const g = journeyGuidance(state({ phase: "provisioning", progress: { stage: "booting", startedAt: "x" } }));
+    expect(g.lines.join(" ")).toMatch(/being built/i);
+    expect(g.lines.join(" ")).not.toMatch(/no matrix computer/i);
+    expect(g.suggestedCommand).toBe("setup");
+  });
+
   it("describeProgress maps the provisioning stage to a human label", () => {
     expect(describeProgress(state({ phase: "provisioning", progress: { stage: "booting", startedAt: "x" } }))).toBe("booting your computer");
   });

--- a/packages/sync-client/tests/unit/journey.test.ts
+++ b/packages/sync-client/tests/unit/journey.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchJourney,
+  journeyGuidance,
+  describeProgress,
+  type CliJourneyState,
+} from "../../src/cli/journey.js";
+
+function state(partial: Partial<CliJourneyState>): CliJourneyState {
+  return {
+    phase: "plan_required",
+    detail: "detail",
+    nextAction: { kind: "open_plans" },
+    ...partial,
+  } as CliJourneyState;
+}
+
+describe("cli journeyGuidance", () => {
+  it("guides an unknown (null) journey to `mos setup`", () => {
+    const g = journeyGuidance(null);
+    expect(g.suggestedCommand).toBe("setup");
+    expect(g.exitCode).toBe(1);
+    expect(g.lines.join(" ")).toMatch(/mos setup/);
+  });
+
+  it("plan_required prints the plans URL and suggests setup", () => {
+    const g = journeyGuidance(state({ phase: "plan_required", nextAction: { kind: "open_plans", url: "https://app.matrix-os.com/?plans=1" } }));
+    expect(g.lines.join("\n")).toContain("https://app.matrix-os.com/?plans=1");
+    expect(g.suggestedCommand).toBe("setup");
+  });
+
+  it("delayed payment_settling points at support", () => {
+    const g = journeyGuidance(state({ phase: "payment_settling", settling: { since: "x", delayed: true } }));
+    expect(g.lines.join(" ")).toMatch(/support@matrix-os.com/);
+  });
+
+  it("retryable provisioning_failed suggests setup; exhausted points at support", () => {
+    expect(journeyGuidance(state({ phase: "provisioning_failed", failure: { retryable: true, attempt: 1 } })).suggestedCommand).toBe("setup");
+    const exhausted = journeyGuidance(state({ phase: "provisioning_failed", failure: { retryable: false, attempt: 3 } }));
+    expect(exhausted.suggestedCommand).toBeUndefined();
+    expect(exhausted.lines.join(" ")).toMatch(/support@matrix-os.com/);
+  });
+
+  it("first_run / ready suggest re-running login", () => {
+    expect(journeyGuidance(state({ phase: "first_run" })).suggestedCommand).toBe("login");
+    expect(journeyGuidance(state({ phase: "ready" })).suggestedCommand).toBe("login");
+  });
+
+  it("describeProgress maps the provisioning stage to a human label", () => {
+    expect(describeProgress(state({ phase: "provisioning", progress: { stage: "booting", startedAt: "x" } }))).toBe("booting your computer");
+  });
+});
+
+describe("cli fetchJourney", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the journey state on 200", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ phase: "plan_required", detail: "d", nextAction: { kind: "open_plans" } }), { status: 200 })));
+    const j = await fetchJourney("https://api.matrix-os.com", "tok");
+    expect(j?.phase).toBe("plan_required");
+  });
+
+  it("returns null on a non-200 (e.g. 401) without throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("", { status: 401 })));
+    expect(await fetchJourney("https://api.matrix-os.com", "tok")).toBeNull();
+  });
+
+  it("returns null when the request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("network"); }));
+    expect(await fetchJourney("https://api.matrix-os.com", "tok")).toBeNull();
+  });
+});

--- a/packages/sync-client/tests/unit/journey.test.ts
+++ b/packages/sync-client/tests/unit/journey.test.ts
@@ -81,8 +81,8 @@ describe("cli fetchJourney", () => {
     expect(await fetchJourney("https://api.matrix-os.com", "tok")).toBeNull();
   });
 
-  it("returns null when the request throws", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("network"); }));
+  it("returns null when the request throws (network drop)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new TypeError("network"); }));
     expect(await fetchJourney("https://api.matrix-os.com", "tok")).toBeNull();
   });
 });

--- a/packages/sync-client/tests/unit/login.test.ts
+++ b/packages/sync-client/tests/unit/login.test.ts
@@ -60,10 +60,22 @@ const AUTH = {
   handle: "alice",
 };
 
-async function runLogin(): Promise<void> {
+async function runLogin(args: Record<string, unknown> = {}): Promise<void> {
   const mod = await import("../../src/cli/commands/login.js");
   // citty commands expose a `run` fn; we pass no args so the non-dev path runs.
-  await mod.loginCommand.run!({ args: { dev: false } } as never);
+  await mod.loginCommand.run!({ args: { dev: false, ...args } } as never);
+}
+
+function lastJsonError(): {
+  code: string;
+  message: string;
+  authenticated?: boolean;
+  connected?: boolean;
+  journey?: unknown;
+  suggestedCommand?: string | null;
+} {
+  const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
+  return JSON.parse(errArg as string).error;
 }
 
 beforeEach(() => {
@@ -80,25 +92,54 @@ beforeEach(() => {
   // side-effect calls, not stdout.
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = 0;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  process.exitCode = 0;
 });
 
 describe("loginCommand /api/me handling", () => {
-  it("clears auth and does NOT save config when /api/me returns 404", async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(
-      new Response("not found", { status: 404 }),
-    );
+  it("preserves auth and does NOT save config when /api/me returns 404", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/me")) return new Response("not found", { status: 404 });
+      return new Response(
+        JSON.stringify({ phase: "provisioning", detail: "d", nextAction: { kind: "wait" } }),
+        { status: 200 },
+      );
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     await runLogin();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(clearProfileAuthMock).toHaveBeenCalledTimes(1);
-    expect(clearProfileAuthMock).toHaveBeenCalledWith("cloud");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(clearProfileAuthMock).not.toHaveBeenCalled();
+    expect(saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("emits JSON error output when /api/me returns 404 in --json mode", async () => {
+    const journey = { phase: "plan_required", detail: "d", nextAction: { kind: "open_plans", url: "https://app.matrix-os.com/?plans=1" } };
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/me")) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(journey), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runLogin({ json: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(console.log).not.toHaveBeenCalled();
+    expect(lastJsonError()).toMatchObject({
+      code: "login_failed",
+      authenticated: true,
+      connected: false,
+      journey,
+      suggestedCommand: "setup",
+    });
+    expect(lastJsonError().message).toContain("Choose a plan");
+    expect(clearProfileAuthMock).not.toHaveBeenCalled();
     expect(saveConfigMock).not.toHaveBeenCalled();
   });
 

--- a/packages/sync-client/tests/unit/setup.test.ts
+++ b/packages/sync-client/tests/unit/setup.test.ts
@@ -19,6 +19,11 @@ async function runSetup(args: Record<string, unknown>): Promise<void> {
   await mod.setupCommand.run!({ args } as never);
 }
 
+function lastJsonError(): { code: string; message: string } {
+  const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
+  return JSON.parse(errArg as string).error;
+}
+
 beforeEach(() => {
   resolveCliProfileMock.mockReset().mockResolvedValue({ platformUrl: "https://platform.example" });
   resolveCliAuthStatusMock.mockReset().mockResolvedValue({ status: "authenticated", token: "tok" });
@@ -49,7 +54,10 @@ describe("mos setup poll loop", () => {
     expect(process.exitCode).toBe(1);
     // 1 retry-provision + 5 (MAX_CONSECUTIVE_FAILURES) journey polls — NOT 180.
     expect(fetchMock).toHaveBeenCalledTimes(6);
-    expect(console.error).toHaveBeenCalled();
+    expect(lastJsonError()).toMatchObject({
+      code: "platform_unreachable",
+      message: "Platform unreachable. Matrix CLI could not contact the Matrix OS platform.",
+    });
   });
 
   it("recovers when a transient failure is followed by a terminal phase", async () => {
@@ -83,9 +91,39 @@ describe("mos setup poll loop", () => {
     expect(process.exitCode).toBe(1);
     // Only retry-provision runs; the journey is not fetched in JSON mode.
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
-    expect(JSON.parse(errArg as string).error.code).toBe("billing_required");
+    expect(lastJsonError()).toMatchObject({
+      code: "billing_required",
+      message: "Choose a plan before running setup. Visit https://app.matrix-os.com/?plans=1.",
+    });
     expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it("emits a structured error in --json mode when not authenticated", async () => {
+    resolveCliAuthStatusMock.mockResolvedValueOnce({ status: "missing" });
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonError()).toMatchObject({
+      code: "not_authenticated",
+      message: "Not signed in. Run `mos login` first.",
+    });
+  });
+
+  it("emits a structured error in --json mode when setup cannot start", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("", { status: 503 });
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonError()).toMatchObject({
+      code: "setup_failed",
+      message: "Couldn't start setup. Please try again shortly.",
+    });
   });
 
   it("emits a structured error in --json mode when provisioning fails", async () => {
@@ -101,8 +139,10 @@ describe("mos setup poll loop", () => {
     await runSetup({ json: true, "poll-interval-ms": "1" });
 
     expect(process.exitCode).toBe(1);
-    const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
-    expect(JSON.parse(errArg as string).error.code).toBe("retry_exhausted");
+    expect(lastJsonError()).toMatchObject({
+      code: "retry_exhausted",
+      message: "Setup has failed repeatedly. Contact support@matrix-os.com.",
+    });
   });
 
   it("breaks out with support guidance when payment settling is delayed", async () => {
@@ -120,8 +160,10 @@ describe("mos setup poll loop", () => {
     expect(process.exitCode).toBe(1);
     // retry-provision + a single journey poll — does NOT loop to the ceiling.
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
-    expect(JSON.parse(errArg as string).error.code).toBe("payment_delayed");
+    expect(lastJsonError()).toMatchObject({
+      code: "payment_delayed",
+      message: "Payment is taking longer than expected to confirm. Contact support@matrix-os.com if it persists.",
+    });
   });
 
   it("emits a structured error in --json mode when a plan is still required", async () => {
@@ -137,8 +179,29 @@ describe("mos setup poll loop", () => {
     await runSetup({ json: true, "poll-interval-ms": "1" });
 
     expect(process.exitCode).toBe(1);
-    const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
-    expect(JSON.parse(errArg as string).error.code).toBe("billing_required");
+    expect(lastJsonError()).toMatchObject({
+      code: "billing_required",
+      message: "Choose a plan before running setup. Visit https://app.matrix-os.com/?plans=1.",
+    });
+  });
+
+  it("emits a structured timeout error in --json mode when setup never finishes", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });
+      return new Response(
+        JSON.stringify({ phase: "provisioning", detail: "d", nextAction: { kind: "wait" }, provisioning: { stage: "installing" } }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonError()).toMatchObject({
+      code: "setup_timeout",
+      message: "Setup is taking longer than expected. Re-run `mos login` shortly to check.",
+    });
   });
 
   it("rejects a non-finite --poll-interval-ms instead of hanging", async () => {

--- a/packages/sync-client/tests/unit/setup.test.ts
+++ b/packages/sync-client/tests/unit/setup.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock the profile/auth resolvers so `mos setup` runs as an authenticated user
+// and we can drive only the fetch behavior under test.
+const { resolveCliProfileMock, resolveCliAuthStatusMock } = vi.hoisted(() => ({
+  resolveCliProfileMock: vi.fn(),
+  resolveCliAuthStatusMock: vi.fn(),
+}));
+
+vi.mock("../../src/cli/profiles.js", () => ({
+  resolveCliProfile: resolveCliProfileMock,
+}));
+vi.mock("../../src/cli/auth-state.js", () => ({
+  resolveCliAuthStatus: resolveCliAuthStatusMock,
+}));
+
+async function runSetup(args: Record<string, unknown>): Promise<void> {
+  const mod = await import("../../src/cli/commands/setup.js");
+  await mod.setupCommand.run!({ args } as never);
+}
+
+beforeEach(() => {
+  resolveCliProfileMock.mockReset().mockResolvedValue({ platformUrl: "https://platform.example" });
+  resolveCliAuthStatusMock.mockReset().mockResolvedValue({ status: "authenticated", token: "tok" });
+  vi.resetModules();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  process.exitCode = 0;
+});
+
+describe("mos setup poll loop", () => {
+  it("bails after repeated journey failures instead of sleeping the full ceiling", async () => {
+    // retry-provision succeeds, then every journey poll 401s (auth expired
+    // mid-provision) and fetchJourney collapses it to null.
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });
+      return new Response("", { status: 401 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    expect(process.exitCode).toBe(1);
+    // 1 retry-provision + 5 (MAX_CONSECUTIVE_FAILURES) journey polls — NOT 180.
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("recovers when a transient failure is followed by a terminal phase", async () => {
+    let journeyCalls = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });
+      journeyCalls += 1;
+      if (journeyCalls <= 2) return new Response("", { status: 503 }); // transient
+      return new Response(
+        JSON.stringify({ phase: "ready", detail: "d", nextAction: { kind: "login" } }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    // Two transient failures didn't trip the bail; the loop reached `ready`.
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("rejects a non-finite --poll-interval-ms instead of hanging", async () => {
+    // Reaching `ready` immediately proves the loop ran with a sane interval and
+    // did not hang on setTimeout(Infinity).
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });
+      return new Response(
+        JSON.stringify({ phase: "ready", detail: "d", nextAction: { kind: "login" } }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "Infinity" });
+
+    expect(process.exitCode).toBe(0);
+  });
+});

--- a/packages/sync-client/tests/unit/setup.test.ts
+++ b/packages/sync-client/tests/unit/setup.test.ts
@@ -105,6 +105,25 @@ describe("mos setup poll loop", () => {
     expect(JSON.parse(errArg as string).error.code).toBe("retry_exhausted");
   });
 
+  it("breaks out with support guidance when payment settling is delayed", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });
+      return new Response(
+        JSON.stringify({ phase: "payment_settling", detail: "d", nextAction: { kind: "wait" }, settling: { since: "x", delayed: true } }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    expect(process.exitCode).toBe(1);
+    // retry-provision + a single journey poll — does NOT loop to the ceiling.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
+    expect(JSON.parse(errArg as string).error.code).toBe("payment_delayed");
+  });
+
   it("emits a structured error in --json mode when a plan is still required", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });

--- a/packages/sync-client/tests/unit/setup.test.ts
+++ b/packages/sync-client/tests/unit/setup.test.ts
@@ -71,6 +71,40 @@ describe("mos setup poll loop", () => {
     expect(process.exitCode).toBe(0);
   });
 
+  it("emits a structured error in --json mode when provisioning fails", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });
+      return new Response(
+        JSON.stringify({ phase: "provisioning_failed", detail: "d", nextAction: { kind: "contact_support" }, failure: { retryable: false, attempt: 3 } }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    expect(process.exitCode).toBe(1);
+    const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
+    expect(JSON.parse(errArg as string).error.code).toBe("retry_exhausted");
+  });
+
+  it("emits a structured error in --json mode when a plan is still required", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });
+      return new Response(
+        JSON.stringify({ phase: "plan_required", detail: "d", nextAction: { kind: "open_plans" } }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    expect(process.exitCode).toBe(1);
+    const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
+    expect(JSON.parse(errArg as string).error.code).toBe("billing_required");
+  });
+
   it("rejects a non-finite --poll-interval-ms instead of hanging", async () => {
     // Reaching `ready` immediately proves the loop ran with a sane interval and
     // did not hang on setTimeout(Infinity).

--- a/packages/sync-client/tests/unit/setup.test.ts
+++ b/packages/sync-client/tests/unit/setup.test.ts
@@ -71,6 +71,23 @@ describe("mos setup poll loop", () => {
     expect(process.exitCode).toBe(0);
   });
 
+  it("routes the initial 402 billing error to stderr (not stdout) in --json mode", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/api/journey/retry-provision")) return new Response("", { status: 402 });
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runSetup({ json: true, "poll-interval-ms": "1" });
+
+    expect(process.exitCode).toBe(1);
+    // Only retry-provision runs; the journey is not fetched in JSON mode.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const errArg = (console.error as unknown as { mock: { calls: string[][] } }).mock.calls.at(-1)?.[0];
+    expect(JSON.parse(errArg as string).error.code).toBe("billing_required");
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
   it("emits a structured error in --json mode when provisioning fails", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.includes("/api/journey/retry-provision")) return new Response("{}", { status: 200 });


### PR DESCRIPTION
## Summary

Phase E of spec 092 (unified onboarding). Extends the server-owned onboarding
journey (`GET /api/journey`, shipped in 092b) to the **CLI** and **mobile**
surfaces so neither dead-ends when a user has signed in but no machine exists
yet. Both surfaces are pure consumers of the journey projection — no new
server state.

Stacked on #500 (092d). Review/merge bottom-up: 092a → 092b → 092c → 092d → this.

### CLI (`packages/sync-client`)
- `cli/journey.ts` (new): `fetchJourney` + `journeyGuidance` turn a journey
  phase into next-step guidance and a suggested command/exit code.
- `cli/commands/setup.ts` (new): `mos setup` triggers provisioning via
  `POST /api/journey/retry-provision`, then polls `/api/journey` printing
  per-stage progress. `402` → plan guidance, `409` → contact support.
- `cli/commands/login.ts`: the `404` path no longer clears the token and
  dead-ends; it now renders journey guidance and keeps the user signed in.
- `cli/index.ts`: registers `setup`.

### Mobile (`apps/mobile`)
- `lib/journey.ts` (new): `fetchMobileJourney` distinguishes **unauthorized**
  (re-sign-in) from **unreachable** (retry); `isConnectablePhase` gates the
  shell hand-off.
- `components/JourneyGate.tsx` (new) + `app/index.tsx`: signed-in users render
  their onboarding phase (plan / settling / building / retry) and only enter
  the shell tabs on a connectable phase (`first_run`/`ready`), instead of
  assuming a live VPS.

## Tests
- `packages/sync-client/tests/unit/journey.test.ts` — 9 unit tests (vitest), pass.
- `apps/mobile/__tests__/journey.test.ts` + `JourneyGate.test.tsx` — 13 jest tests, pass.
- `apps/mobile` + `packages/sync-client` `tsc --noEmit` clean.
- `scripts/review/check-patterns.sh` — 0 violations.

## Review/Monitoring
- Greptile to 5/5 before merge (constitution X).
- macOS native app reuses the same journey contract via sync-JWT bearer auth
  (observe-only here; consumed by the upcoming macOS PR) — `fetchMobileJourney`
  and `fetchJourney` both authenticate with `Authorization: Bearer <token>`,
  which the platform resolver accepts for Clerk sessions and platform sync JWTs.

## Invariants
- **Source of truth**: the platform journey projection (`GET /api/journey`),
  derived server-side from billing/entitlement + `user_machines`. CLI and
  mobile hold no canonical onboarding state; they re-fetch.
- **Lock/transaction scope**: none added — both surfaces are read-only against
  the journey endpoint plus the existing idempotent `retry-provision` trigger
  (which owns its own atomicity, added in 092a/092b). No network calls inside a
  lock here.
- **Acceptable orphan states**: a `retry-provision` POST that succeeds but whose
  follow-up poll fails leaves the server mid-provision; the next journey fetch
  reflects the true phase, so the client self-heals on refresh.
- **Auth source of truth**: `Authorization: Bearer <token>` — Clerk session
  token (mobile via Clerk Expo `getToken`, CLI via stored profile token) or a
  platform sync JWT; the platform journey resolver accepts both. On `401/403`
  the client treats it as re-sign-in, never as a dead retry loop.
- **Deferred scope**: no www/page changes, no merge of the A–D stack (gated on
  live A–D verification), no macOS app code (this only proves the contract is
  consumable by a sync-JWT bearer client).