### PR TITLE
feat(desktop): add trusted core foundation

### DIFF
--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -58,8 +58,22 @@ export class AuthService {
     if (this.credential && !this.isCredentialValid(this.credential)) {
       this.credential = null;
       this.profile = null;
-      await this.deps.credentialStore.clear();
-      await this.deps.clearProfile();
+      try {
+        await this.deps.credentialStore.clear();
+      } catch (err: unknown) {
+        console.warn(
+          "[auth] failed to clear expired credential:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      try {
+        await this.deps.clearProfile();
+      } catch (err: unknown) {
+        console.warn(
+          "[auth] failed to clear expired profile:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
     }
   }
 
@@ -115,15 +129,31 @@ export class AuthService {
     })
       .then(async (token) => {
         if (nonce !== this.flowNonce) return;
-        this.credential = token;
-        this.profile = {
+        const profile = {
           handle: token.handle,
           userId: token.userId,
           platformHost: baseUrl,
           runtimeSlot: this.profile?.runtimeSlot ?? "primary",
         };
-        await this.deps.credentialStore.save(token);
-        await this.deps.saveProfile(this.profile);
+        this.credential = token;
+        this.profile = profile;
+        try {
+          await this.deps.credentialStore.save(token);
+        } catch (err: unknown) {
+          console.warn(
+            "[auth] failed to persist credential:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+        try {
+          await this.deps.saveProfile(profile);
+        } catch (err: unknown) {
+          console.warn(
+            "[auth] failed to persist profile:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+        if (nonce !== this.flowNonce) return;
         this.flowState = "authorized";
         this.pendingDeviceCode = null;
         this.deps.onAuthChanged(this.getStatus());

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -88,9 +88,16 @@ export class AuthService {
     }
     const fetchFn = this.deps.fetchFn ?? ((input: string, init?: RequestInit) => fetch(input, init));
     const baseUrl = this.getGatewayOrigin();
-    const code = await requestDeviceCode({ fetchFn, baseUrl });
-    this.flowState = "pending";
     const nonce = ++this.flowNonce;
+    let code: DeviceCodeResponse;
+    try {
+      code = await requestDeviceCode({ fetchFn, baseUrl });
+    } catch (err: unknown) {
+      if (nonce !== this.flowNonce) throw new Error("Sign-in request was canceled.");
+      throw err;
+    }
+    if (nonce !== this.flowNonce) throw new Error("Sign-in request was canceled.");
+    this.flowState = "pending";
     this.pendingDeviceCode = {
       userCode: code.userCode,
       verificationUri: code.verificationUri,

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -44,6 +44,8 @@ export class AuthService {
   private credential: StoredCredential | null = null;
   private profile: ConnectionProfile | null = null;
   private flowState: "idle" | "pending" | "authorized" | "expired" = "idle";
+  private flowNonce = 0;
+  private pendingDeviceCode: Pick<DeviceCodeResponse, "userCode" | "verificationUri" | "expiresIn"> | null = null;
   private readonly deps: AuthServiceDeps;
 
   constructor(deps: AuthServiceDeps) {
@@ -53,10 +55,17 @@ export class AuthService {
   async init(): Promise<void> {
     this.credential = await this.deps.credentialStore.load();
     this.profile = await this.deps.loadProfile();
+    if (this.credential && !this.isCredentialValid(this.credential)) {
+      this.credential = null;
+      this.profile = null;
+      await this.deps.credentialStore.clear();
+      await this.deps.clearProfile();
+    }
   }
 
   getToken(): string | null {
-    return this.credential?.accessToken ?? null;
+    if (!this.credential || !this.isCredentialValid(this.credential)) return null;
+    return this.credential.accessToken;
   }
 
   getGatewayOrigin(): string {
@@ -64,7 +73,7 @@ export class AuthService {
   }
 
   getStatus(): AuthStatus {
-    const signedIn = this.credential !== null;
+    const signedIn = this.credential !== null && this.isCredentialValid(this.credential);
     return {
       signedIn,
       ...(signedIn && this.profile ? { handle: this.profile.handle } : {}),
@@ -74,10 +83,19 @@ export class AuthService {
   }
 
   async startDeviceFlow(): Promise<Pick<DeviceCodeResponse, "userCode" | "verificationUri" | "expiresIn">> {
+    if (this.flowState === "pending" && this.pendingDeviceCode) {
+      return this.pendingDeviceCode;
+    }
     const fetchFn = this.deps.fetchFn ?? ((input: string, init?: RequestInit) => fetch(input, init));
     const baseUrl = this.getGatewayOrigin();
     const code = await requestDeviceCode({ fetchFn, baseUrl });
     this.flowState = "pending";
+    const nonce = ++this.flowNonce;
+    this.pendingDeviceCode = {
+      userCode: code.userCode,
+      verificationUri: code.verificationUri,
+      expiresIn: code.expiresIn,
+    };
 
     // Background poll loop; auth:poll reads flowState snapshots.
     void pollForToken({
@@ -89,6 +107,7 @@ export class AuthService {
       sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     })
       .then(async (token) => {
+        if (nonce !== this.flowNonce) return;
         this.credential = token;
         this.profile = {
           handle: token.handle,
@@ -99,11 +118,14 @@ export class AuthService {
         await this.deps.credentialStore.save(token);
         await this.deps.saveProfile(this.profile);
         this.flowState = "authorized";
+        this.pendingDeviceCode = null;
         this.deps.onAuthChanged(this.getStatus());
       })
       .catch((err: unknown) => {
+        if (nonce !== this.flowNonce) return;
         if (err instanceof DeviceFlowError) {
           this.flowState = "expired";
+          this.pendingDeviceCode = null;
           return;
         }
         console.warn(
@@ -111,6 +133,7 @@ export class AuthService {
           err instanceof Error ? err.message : String(err),
         );
         this.flowState = "expired";
+        this.pendingDeviceCode = null;
       });
 
     void this.deps.openExternal(code.verificationUri).catch((err: unknown) => {
@@ -120,11 +143,7 @@ export class AuthService {
       );
     });
 
-    return {
-      userCode: code.userCode,
-      verificationUri: code.verificationUri,
-      expiresIn: code.expiresIn,
-    };
+    return this.pendingDeviceCode;
   }
 
   poll(): PollResult {
@@ -145,11 +164,17 @@ export class AuthService {
   }
 
   async signOut(): Promise<void> {
+    this.flowNonce += 1;
+    this.pendingDeviceCode = null;
     this.credential = null;
     this.profile = null;
     this.flowState = "idle";
     await this.deps.credentialStore.clear();
     await this.deps.clearProfile();
     this.deps.onAuthChanged(this.getStatus());
+  }
+
+  private isCredentialValid(credential: StoredCredential): boolean {
+    return credential.expiresAt > Date.now();
   }
 }

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -118,11 +118,12 @@ export class AuthService {
     }
     if (nonce !== this.flowNonce) throw new Error("Sign-in request was canceled.");
     this.flowState = "pending";
-    this.pendingDeviceCode = {
+    const pendingDeviceCode = {
       userCode: code.userCode,
       verificationUri: code.verificationUri,
       expiresIn: code.expiresIn,
     };
+    this.pendingDeviceCode = pendingDeviceCode;
 
     // Background poll loop; auth:poll reads flowState snapshots.
     void pollForToken({
@@ -186,7 +187,7 @@ export class AuthService {
       );
     });
 
-    return this.pendingDeviceCode;
+    return pendingDeviceCode;
   }
 
   poll(): PollResult {

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -176,9 +176,28 @@ export class AuthService {
     this.credential = null;
     this.profile = null;
     this.flowState = "idle";
-    await this.deps.credentialStore.clear();
-    await this.deps.clearProfile();
     this.deps.onAuthChanged(this.getStatus());
+
+    let cleanupError: unknown = null;
+    try {
+      await this.deps.credentialStore.clear();
+    } catch (err: unknown) {
+      cleanupError = err;
+      console.warn(
+        "[auth] failed to clear credential store:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    try {
+      await this.deps.clearProfile();
+    } catch (err: unknown) {
+      cleanupError ??= err;
+      console.warn(
+        "[auth] failed to clear connection profile:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    if (cleanupError) throw cleanupError;
   }
 
   private isCredentialValid(credential: StoredCredential): boolean {

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -1,0 +1,155 @@
+// Trusted-core auth orchestration: owns the device flow, the credential, and
+// the connection profile. The renderer only ever sees status snapshots.
+import type { CredentialStore, StoredCredential } from "./credential-store";
+import {
+  DeviceFlowError,
+  pollForToken,
+  requestDeviceCode,
+  type DeviceCodeResponse,
+} from "./device-auth";
+
+export interface ConnectionProfile {
+  handle: string;
+  userId: string;
+  platformHost: string;
+  runtimeSlot: string;
+}
+
+export interface AuthStatus {
+  signedIn: boolean;
+  handle?: string;
+  runtimeSlot: string;
+  platformHost: string;
+}
+
+export type PollResult = {
+  status: "pending" | "authorized" | "expired";
+  profile?: { handle: string; userId: string };
+};
+
+type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
+
+interface AuthServiceDeps {
+  credentialStore: CredentialStore;
+  platformHost: string;
+  fetchFn?: FetchFn;
+  openExternal: (url: string) => Promise<void>;
+  loadProfile: () => Promise<ConnectionProfile | null>;
+  saveProfile: (profile: ConnectionProfile) => Promise<void>;
+  clearProfile: () => Promise<void>;
+  onAuthChanged: (status: AuthStatus) => void;
+}
+
+export class AuthService {
+  private credential: StoredCredential | null = null;
+  private profile: ConnectionProfile | null = null;
+  private flowState: "idle" | "pending" | "authorized" | "expired" = "idle";
+  private readonly deps: AuthServiceDeps;
+
+  constructor(deps: AuthServiceDeps) {
+    this.deps = deps;
+  }
+
+  async init(): Promise<void> {
+    this.credential = await this.deps.credentialStore.load();
+    this.profile = await this.deps.loadProfile();
+  }
+
+  getToken(): string | null {
+    return this.credential?.accessToken ?? null;
+  }
+
+  getGatewayOrigin(): string {
+    return this.profile?.platformHost ?? this.deps.platformHost;
+  }
+
+  getStatus(): AuthStatus {
+    const signedIn = this.credential !== null;
+    return {
+      signedIn,
+      ...(signedIn && this.profile ? { handle: this.profile.handle } : {}),
+      runtimeSlot: this.profile?.runtimeSlot ?? "primary",
+      platformHost: this.getGatewayOrigin(),
+    };
+  }
+
+  async startDeviceFlow(): Promise<Pick<DeviceCodeResponse, "userCode" | "verificationUri" | "expiresIn">> {
+    const fetchFn = this.deps.fetchFn ?? ((input: string, init?: RequestInit) => fetch(input, init));
+    const baseUrl = this.getGatewayOrigin();
+    const code = await requestDeviceCode({ fetchFn, baseUrl });
+    this.flowState = "pending";
+
+    // Background poll loop; auth:poll reads flowState snapshots.
+    void pollForToken({
+      fetchFn,
+      baseUrl,
+      deviceCode: code.deviceCode,
+      intervalSeconds: code.interval,
+      expiresInSeconds: code.expiresIn,
+      sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    })
+      .then(async (token) => {
+        this.credential = token;
+        this.profile = {
+          handle: token.handle,
+          userId: token.userId,
+          platformHost: baseUrl,
+          runtimeSlot: this.profile?.runtimeSlot ?? "primary",
+        };
+        await this.deps.credentialStore.save(token);
+        await this.deps.saveProfile(this.profile);
+        this.flowState = "authorized";
+        this.deps.onAuthChanged(this.getStatus());
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DeviceFlowError) {
+          this.flowState = "expired";
+          return;
+        }
+        console.warn(
+          "[auth] device flow failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+        this.flowState = "expired";
+      });
+
+    void this.deps.openExternal(code.verificationUri).catch((err: unknown) => {
+      console.warn(
+        "[auth] failed to open verification url:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+
+    return {
+      userCode: code.userCode,
+      verificationUri: code.verificationUri,
+      expiresIn: code.expiresIn,
+    };
+  }
+
+  poll(): PollResult {
+    if (this.flowState === "authorized" && this.profile) {
+      return {
+        status: "authorized",
+        profile: { handle: this.profile.handle, userId: this.profile.userId },
+      };
+    }
+    if (this.flowState === "expired") return { status: "expired" };
+    return { status: "pending" };
+  }
+
+  async selectRuntime(slot: string): Promise<void> {
+    if (!this.profile) return;
+    this.profile = { ...this.profile, runtimeSlot: slot };
+    await this.deps.saveProfile(this.profile);
+  }
+
+  async signOut(): Promise<void> {
+    this.credential = null;
+    this.profile = null;
+    this.flowState = "idle";
+    await this.deps.credentialStore.clear();
+    await this.deps.clearProfile();
+    this.deps.onAuthChanged(this.getStatus());
+  }
+}

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -145,7 +145,12 @@ export class AuthService {
         this.credential = token;
         this.profile = profile;
         try {
+          if (nonce !== this.flowNonce) return;
           await this.deps.credentialStore.save(token);
+          if (nonce !== this.flowNonce) {
+            await this.clearStaleFlowPersistence();
+            return;
+          }
         } catch (err: unknown) {
           console.warn(
             "[auth] failed to persist credential:",
@@ -153,7 +158,15 @@ export class AuthService {
           );
         }
         try {
+          if (nonce !== this.flowNonce) {
+            await this.clearStaleFlowPersistence();
+            return;
+          }
           await this.deps.saveProfile(profile);
+          if (nonce !== this.flowNonce) {
+            await this.clearStaleFlowPersistence();
+            return;
+          }
         } catch (err: unknown) {
           console.warn(
             "[auth] failed to persist profile:",
@@ -235,6 +248,25 @@ export class AuthService {
       );
     }
     if (cleanupError) throw cleanupError;
+  }
+
+  private async clearStaleFlowPersistence(): Promise<void> {
+    try {
+      await this.deps.credentialStore.clear();
+    } catch (err: unknown) {
+      console.warn(
+        "[auth] failed to clear stale credential after canceled sign-in:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    try {
+      await this.deps.clearProfile();
+    } catch (err: unknown) {
+      console.warn(
+        "[auth] failed to clear stale profile after canceled sign-in:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
   }
 
   private isCredentialValid(credential: StoredCredential): boolean {

--- a/desktop/src/main/auth/auth-service.ts
+++ b/desktop/src/main/auth/auth-service.ts
@@ -78,7 +78,8 @@ export class AuthService {
   }
 
   getToken(): string | null {
-    if (!this.credential || !this.isCredentialValid(this.credential)) return null;
+    this.expireCredentialIfNeeded();
+    if (!this.credential) return null;
     return this.credential.accessToken;
   }
 
@@ -87,6 +88,11 @@ export class AuthService {
   }
 
   getStatus(): AuthStatus {
+    this.expireCredentialIfNeeded();
+    return this.currentStatus();
+  }
+
+  private currentStatus(): AuthStatus {
     const signedIn = this.credential !== null && this.isCredentialValid(this.credential);
     return {
       signedIn,
@@ -232,5 +238,27 @@ export class AuthService {
 
   private isCredentialValid(credential: StoredCredential): boolean {
     return credential.expiresAt > Date.now();
+  }
+
+  private expireCredentialIfNeeded(): void {
+    if (!this.credential || this.isCredentialValid(this.credential)) return;
+    this.flowNonce += 1;
+    this.pendingDeviceCode = null;
+    this.credential = null;
+    this.profile = null;
+    this.flowState = "idle";
+    this.deps.onAuthChanged(this.currentStatus());
+    void this.deps.credentialStore.clear().catch((err: unknown) => {
+      console.warn(
+        "[auth] failed to clear expired credential:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+    void this.deps.clearProfile().catch((err: unknown) => {
+      console.warn(
+        "[auth] failed to clear expired profile:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
   }
 }

--- a/desktop/src/main/auth/credential-store.ts
+++ b/desktop/src/main/auth/credential-store.ts
@@ -1,0 +1,83 @@
+// OS-encrypted credential persistence (FR-002). Electron safeStorage uses the
+// macOS Keychain-backed encryption key; the blob lives in userData. The
+// credential never crosses the IPC boundary.
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+export interface StoredCredential {
+  accessToken: string;
+  expiresAt: number;
+  userId: string;
+  handle: string;
+}
+
+export interface SafeStorageLike {
+  isEncryptionAvailable(): boolean;
+  encryptString(plainText: string): Buffer;
+  decryptString(encrypted: Buffer): string;
+}
+
+export interface CredentialStore {
+  save(credential: StoredCredential): Promise<void>;
+  load(): Promise<StoredCredential | null>;
+  clear(): Promise<void>;
+}
+
+export function createCredentialStore(options: {
+  dir: string;
+  safeStorage: SafeStorageLike;
+}): CredentialStore {
+  const filePath = join(options.dir, "credential.bin");
+
+  return {
+    async save(credential) {
+      if (!options.safeStorage.isEncryptionAvailable()) {
+        throw new Error("OS encryption unavailable; refusing to store credential in plain text");
+      }
+      await mkdir(options.dir, { recursive: true });
+      const encrypted = options.safeStorage.encryptString(JSON.stringify(credential));
+      const tmpPath = `${filePath}.${randomBytes(6).toString("hex")}.tmp`;
+      await writeFile(tmpPath, encrypted);
+      await rename(tmpPath, filePath);
+    },
+
+    async load() {
+      let blob: Buffer;
+      try {
+        blob = await readFile(filePath);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+        console.warn(
+          "[credential-store] failed to read credential:",
+          err instanceof Error ? err.message : String(err),
+        );
+        return null;
+      }
+      try {
+        const parsed: unknown = JSON.parse(options.safeStorage.decryptString(blob));
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof (parsed as StoredCredential).accessToken === "string" &&
+          typeof (parsed as StoredCredential).expiresAt === "number" &&
+          typeof (parsed as StoredCredential).userId === "string" &&
+          typeof (parsed as StoredCredential).handle === "string"
+        ) {
+          return parsed as StoredCredential;
+        }
+      } catch (err: unknown) {
+        // Decryption fails after OS keychain resets; treat as signed out.
+        console.warn(
+          "[credential-store] failed to decrypt credential, treating as signed out:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      return null;
+    },
+
+    async clear() {
+      await rm(filePath, { force: true });
+    },
+  };
+}

--- a/desktop/src/main/auth/device-auth.ts
+++ b/desktop/src/main/auth/device-auth.ts
@@ -1,0 +1,128 @@
+// Platform device-authorization flow (FR-001), pure logic with injected fetch
+// and clock so it is fully unit-testable. Contract verified by the 092
+// prototype: specs/094-electron-macos-shell/contracts/gateway-contract.md.
+import { AppError, classifyHttpStatus, classifyTransportError } from "../../shared/app-error";
+
+export const DEVICE_CLIENT_ID = "matrix-os-desktop";
+export const DEVICE_REDIRECT_URI = "matrix-os://device-auth";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export interface DeviceCodeResponse {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  expiresIn: number;
+  interval: number;
+}
+
+export interface DeviceTokenResponse {
+  accessToken: string;
+  expiresAt: number;
+  userId: string;
+  handle: string;
+}
+
+export class DeviceFlowError extends Error {
+  readonly code: "expired" | "denied";
+
+  constructor(code: "expired" | "denied") {
+    super(code === "expired" ? "Sign-in request expired. Start again." : "Sign-in was denied.");
+    this.name = "DeviceFlowError";
+    this.code = code;
+  }
+}
+
+type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
+
+async function postJson(fetchFn: FetchFn, url: string, body: unknown): Promise<Response> {
+  try {
+    return await fetchFn(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (err: unknown) {
+    throw new AppError(classifyTransportError(err), { cause: err });
+  }
+}
+
+async function parseJson(response: Response): Promise<Record<string, unknown>> {
+  try {
+    const data: unknown = await response.json();
+    if (data && typeof data === "object") return data as Record<string, unknown>;
+  } catch (err: unknown) {
+    throw new AppError("server", { cause: err });
+  }
+  throw new AppError("server");
+}
+
+export async function requestDeviceCode(options: {
+  fetchFn: FetchFn;
+  baseUrl: string;
+}): Promise<DeviceCodeResponse> {
+  const response = await postJson(options.fetchFn, `${options.baseUrl}/api/auth/device/code`, {
+    clientId: DEVICE_CLIENT_ID,
+    redirectUri: DEVICE_REDIRECT_URI,
+  });
+  if (!response.ok) {
+    throw new AppError(classifyHttpStatus(response.status));
+  }
+  const data = await parseJson(response);
+  const { deviceCode, userCode, verificationUri, expiresIn, interval } = data;
+  if (
+    typeof deviceCode !== "string" ||
+    typeof userCode !== "string" ||
+    typeof verificationUri !== "string" ||
+    typeof expiresIn !== "number" ||
+    typeof interval !== "number"
+  ) {
+    throw new AppError("server");
+  }
+  return { deviceCode, userCode, verificationUri, expiresIn, interval };
+}
+
+export async function pollForToken(options: {
+  fetchFn: FetchFn;
+  baseUrl: string;
+  deviceCode: string;
+  intervalSeconds: number;
+  expiresInSeconds: number;
+  sleep: (ms: number) => Promise<void>;
+  clock?: () => number;
+}): Promise<DeviceTokenResponse> {
+  const clock = options.clock ?? Date.now;
+  const deadline = clock() + options.expiresInSeconds * 1000;
+  let intervalMs = Math.max(1, options.intervalSeconds) * 1000;
+
+  for (;;) {
+    const response = await postJson(options.fetchFn, `${options.baseUrl}/api/auth/device/token`, {
+      deviceCode: options.deviceCode,
+    });
+
+    if (response.status === 200) {
+      const data = await parseJson(response);
+      const { accessToken, expiresAt, userId, handle } = data;
+      if (
+        typeof accessToken !== "string" ||
+        typeof expiresAt !== "number" ||
+        typeof userId !== "string" ||
+        typeof handle !== "string"
+      ) {
+        throw new AppError("server");
+      }
+      return { accessToken, expiresAt, userId, handle };
+    }
+
+    if (response.status === 410) throw new DeviceFlowError("expired");
+    if (response.status === 429) {
+      intervalMs += 5000;
+    } else if (response.status !== 428) {
+      throw new AppError(classifyHttpStatus(response.status));
+    }
+
+    if (clock() + intervalMs > deadline) throw new DeviceFlowError("expired");
+    await options.sleep(intervalMs);
+  }
+}

--- a/desktop/src/main/auth/header-injection.ts
+++ b/desktop/src/main/auth/header-injection.ts
@@ -1,0 +1,55 @@
+// Origin-scoped Authorization injection (FR-002/FR-003): the renderer never
+// holds the credential; the trusted core attaches it at the network layer for
+// the active gateway origin ONLY — and only on the renderer session. Embed
+// partitions never get this hook (lesson L1: remote content can never ride the
+// native principal).
+
+interface WebRequestLike {
+  onBeforeSendHeaders(
+    listener: (
+      details: { url: string; requestHeaders: Record<string, string> },
+      callback: (response: { requestHeaders: Record<string, string> }) => void,
+    ) => void,
+  ): void;
+}
+
+interface SessionLike {
+  webRequest: WebRequestLike;
+}
+
+function normalizeWsScheme(url: URL): string {
+  if (url.protocol === "ws:") return "http:";
+  if (url.protocol === "wss:") return "https:";
+  return url.protocol;
+}
+
+export function shouldInjectAuth(requestUrl: string, gatewayOrigin: string | null): boolean {
+  if (!gatewayOrigin) return false;
+  let request: URL;
+  let gateway: URL;
+  try {
+    request = new URL(requestUrl);
+    gateway = new URL(gatewayOrigin);
+  } catch {
+    return false;
+  }
+  return (
+    normalizeWsScheme(request) === normalizeWsScheme(gateway) &&
+    request.hostname === gateway.hostname &&
+    request.port === gateway.port
+  );
+}
+
+export function installHeaderInjection(
+  rendererSession: SessionLike,
+  getToken: () => string | null,
+  getGatewayOrigin: () => string | null,
+): void {
+  rendererSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    const token = getToken();
+    if (token && shouldInjectAuth(details.url, getGatewayOrigin())) {
+      details.requestHeaders["Authorization"] = `Bearer ${token}`;
+    }
+    callback({ requestHeaders: details.requestHeaders });
+  });
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -99,7 +99,6 @@ if (!gotLock) {
 
       const platformHost = process.env.OPERATOR_GATEWAY_URL ?? DEFAULT_PLATFORM_HOST;
 
-<<<<<<< HEAD
       const auth = new AuthService({
         credentialStore,
         platformHost,
@@ -144,9 +143,6 @@ if (!gotLock) {
         onRuntimeChanged: (slot) => sendEvent("runtime:changed", { slot }),
       });
 
-      const savedBounds = await store.get("windowBounds");
-      mainWindow = createWindow(savedBounds ?? { width: 1280, height: 820 });
-
       let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;
       const persistBounds = () => {
         if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
@@ -163,100 +159,27 @@ if (!gotLock) {
             });
         }, 500);
       };
-      mainWindow.on("resize", persistBounds);
-      mainWindow.on("move", persistBounds);
-      mainWindow.on("closed", () => {
-        if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
-        mainWindow = null;
-      });
+      const openMainWindow = async () => {
+        const savedBounds = await store.get("windowBounds");
+        mainWindow = createWindow(savedBounds ?? { width: 1280, height: 820 });
+        mainWindow.on("resize", persistBounds);
+        mainWindow.on("move", persistBounds);
+        mainWindow.on("closed", () => {
+          if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
+          mainWindow = null;
+        });
+      };
+
+      await openMainWindow();
 
       app.on("activate", () => {
         if (BrowserWindow.getAllWindows().length === 0) {
-          mainWindow = createWindow({ width: 1280, height: 820 });
+          void openMainWindow();
         }
       });
     })
     .catch((err: unknown) => {
       logMainError("failed to start app", err);
-=======
-    const auth = new AuthService({
-      credentialStore,
-      platformHost,
-      openExternal: openExternalHttps,
-      loadProfile: () => store.get("profile"),
-      saveProfile: (profile) => store.set("profile", profile),
-      clearProfile: () => store.delete("profile"),
-      onAuthChanged: (status) => {
-        sendEvent("auth:changed", {
-          signedIn: status.signedIn,
-          ...(status.handle ? { handle: status.handle } : {}),
-        });
-      },
-    });
-    await auth.init();
-
-    // Renderer session gets origin-scoped bearer injection; embed partitions
-    // (separate sessions) never do (lesson L1).
-    installHeaderInjection(
-      session.defaultSession,
-      () => auth.getToken(),
-      () => auth.getGatewayOrigin(),
-    );
-
-    registerIpcHandlers(ipcMain, {
-      auth,
-      store,
-      openExternal: openExternalHttps,
-      setBadgeCount: (count) => {
-        app.setBadgeCount(count);
-      },
-      notify: ({ threadId, title, body }) => {
-        if (!Notification.isSupported()) return;
-        const notification = new Notification({ title, body, silent: false });
-        notification.on("click", () => {
-          mainWindow?.show();
-          mainWindow?.focus();
-          sendEvent("notification:clicked", { threadId });
-        });
-        notification.show();
-      },
-      onRuntimeChanged: (slot) => sendEvent("runtime:changed", { slot }),
-    });
-
-    let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;
-    const persistBounds = () => {
-      if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
-      boundsSaveTimer = setTimeout(() => {
-        if (!mainWindow || mainWindow.isDestroyed()) return;
-        const b = mainWindow.getBounds();
-        void store
-          .set("windowBounds", { x: b.x, y: b.y, width: b.width, height: b.height })
-          .catch((err: unknown) => {
-            console.warn(
-              "[main] failed to persist window bounds:",
-              err instanceof Error ? err.message : String(err),
-            );
-          });
-      }, 500);
-    };
-    const openMainWindow = async () => {
-      const savedBounds = await store.get("windowBounds");
-      mainWindow = createWindow(savedBounds ?? { width: 1280, height: 820 });
-      mainWindow.on("resize", persistBounds);
-      mainWindow.on("move", persistBounds);
-      mainWindow.on("closed", () => {
-        if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
-        mainWindow = null;
-      });
-    };
-
-    await openMainWindow();
-
-    app.on("activate", () => {
-      if (BrowserWindow.getAllWindows().length === 0) {
-        void openMainWindow();
-      }
->>>>>>> fed695049 (fix(desktop): harden auth and state core)
     });
 
   app.on("window-all-closed", () => {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,5 +1,77 @@
-import { app, BrowserWindow, shell } from "electron";
+import { app, BrowserWindow, ipcMain, Notification, safeStorage, session, shell } from "electron";
 import { join } from "node:path";
+import { AuthService } from "./auth/auth-service";
+import { createCredentialStore } from "./auth/credential-store";
+import { installHeaderInjection } from "./auth/header-injection";
+import { registerIpcHandlers } from "./ipc/handlers";
+import { createLocalStore } from "./persistence/local-store";
+import { EVENT_CHANNELS, type EventChannel, type EventPayload } from "../shared/ipc-contract";
+
+const DEFAULT_PLATFORM_HOST = "https://app.matrix-os.com";
+
+let mainWindow: BrowserWindow | null = null;
+
+function sendEvent<C extends EventChannel>(channel: C, payload: EventPayload<C>): void {
+  const parsed = EVENT_CHANNELS[channel].safeParse(payload);
+  if (!parsed.success) {
+    console.warn(`[ipc] refusing to send invalid event on ${channel}`);
+    return;
+  }
+  mainWindow?.webContents.send(channel, parsed.data);
+}
+
+async function openExternalHttps(url: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
+  }
+  if (parsed.protocol !== "https:") return;
+  await shell.openExternal(parsed.toString());
+}
+
+function createWindow(bounds: { x?: number; y?: number; width: number; height: number }): BrowserWindow {
+  const win = new BrowserWindow({
+    ...bounds,
+    minWidth: 880,
+    minHeight: 560,
+    titleBarStyle: "hiddenInset",
+    trafficLightPosition: { x: 14, y: 13 },
+    backgroundColor: "#0e0e13",
+    show: false,
+    webPreferences: {
+      preload: join(__dirname, "../preload/index.cjs"),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+    },
+  });
+
+  win.once("ready-to-show", () => win.show());
+
+  // window.open / target=_blank from the renderer goes to the system browser only.
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    void openExternalHttps(url).catch((err: unknown) => {
+      logMainError("failed to open external URL", err);
+    });
+    return { action: "deny" };
+  });
+
+  win.on("focus", () => sendEvent("window:focus-changed", { focused: true }));
+  win.on("blur", () => sendEvent("window:focus-changed", { focused: false }));
+
+  if (process.env.ELECTRON_RENDERER_URL) {
+    void win.loadURL(process.env.ELECTRON_RENDERER_URL).catch((err: unknown) => {
+      logMainError("failed to load renderer URL", err);
+    });
+  } else {
+    void win.loadFile(join(__dirname, "../renderer/index.html")).catch((err: unknown) => {
+      logMainError("failed to load renderer file", err);
+    });
+  }
+  return win;
+}
 
 function logMainError(label: string, err: unknown): void {
   console.warn(`[main] ${label}:`, err instanceof Error ? err.message : String(err));
@@ -18,55 +90,89 @@ if (!gotLock) {
     }
   });
 
-  function createWindow(): BrowserWindow {
-    const win = new BrowserWindow({
-      width: 1280,
-      height: 820,
-      minWidth: 880,
-      minHeight: 560,
-      titleBarStyle: "hiddenInset",
-      trafficLightPosition: { x: 14, y: 13 },
-      backgroundColor: "#0e0e13",
-      show: false,
-      webPreferences: {
-        preload: join(__dirname, "../preload/index.cjs"),
-        contextIsolation: true,
-        sandbox: true,
-        nodeIntegration: false,
-      },
-    });
-
-    win.once("ready-to-show", () => win.show());
-
-    // All target=_blank / window.open from the renderer goes to the system browser.
-    win.webContents.setWindowOpenHandler(({ url }) => {
-      if (url.startsWith("https://")) {
-        void shell.openExternal(url).catch((err: unknown) => {
-          logMainError("failed to open external URL", err);
-        });
-      }
-      return { action: "deny" };
-    });
-
-    if (process.env.ELECTRON_RENDERER_URL) {
-      void win.loadURL(process.env.ELECTRON_RENDERER_URL).catch((err: unknown) => {
-        logMainError("failed to load renderer URL", err);
-      });
-    } else {
-      void win.loadFile(join(__dirname, "../renderer/index.html")).catch((err: unknown) => {
-        logMainError("failed to load renderer file", err);
-      });
-    }
-    return win;
-  }
-
   void app
     .whenReady()
-    .then(() => {
-      createWindow();
+    .then(async () => {
+      const userData = app.getPath("userData");
+      const store = createLocalStore({ dir: userData });
+      const credentialStore = createCredentialStore({ dir: userData, safeStorage });
+
+      const platformHost = process.env.OPERATOR_GATEWAY_URL ?? DEFAULT_PLATFORM_HOST;
+
+      const auth = new AuthService({
+        credentialStore,
+        platformHost,
+        openExternal: openExternalHttps,
+        loadProfile: () => store.get("profile"),
+        saveProfile: (profile) => store.set("profile", profile),
+        clearProfile: () => store.delete("profile"),
+        onAuthChanged: (status) => {
+          sendEvent("auth:changed", {
+            signedIn: status.signedIn,
+            ...(status.handle ? { handle: status.handle } : {}),
+          });
+        },
+      });
+      await auth.init();
+
+      // Renderer session gets origin-scoped bearer injection; embed partitions
+      // (separate sessions) never do (lesson L1).
+      installHeaderInjection(
+        session.defaultSession,
+        () => auth.getToken(),
+        () => auth.getGatewayOrigin(),
+      );
+
+      registerIpcHandlers(ipcMain, {
+        auth,
+        store,
+        openExternal: openExternalHttps,
+        setBadgeCount: (count) => {
+          app.setBadgeCount(count);
+        },
+        notify: ({ threadId, title, body }) => {
+          if (!Notification.isSupported()) return;
+          const notification = new Notification({ title, body, silent: false });
+          notification.on("click", () => {
+            mainWindow?.show();
+            mainWindow?.focus();
+            sendEvent("notification:clicked", { threadId });
+          });
+          notification.show();
+        },
+        onRuntimeChanged: (slot) => sendEvent("runtime:changed", { slot }),
+      });
+
+      const savedBounds = await store.get("windowBounds");
+      mainWindow = createWindow(savedBounds ?? { width: 1280, height: 820 });
+
+      let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;
+      const persistBounds = () => {
+        if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
+        boundsSaveTimer = setTimeout(() => {
+          if (!mainWindow || mainWindow.isDestroyed()) return;
+          const b = mainWindow.getBounds();
+          void store
+            .set("windowBounds", { x: b.x, y: b.y, width: b.width, height: b.height })
+            .catch((err: unknown) => {
+              console.warn(
+                "[main] failed to persist window bounds:",
+                err instanceof Error ? err.message : String(err),
+              );
+            });
+        }, 500);
+      };
+      mainWindow.on("resize", persistBounds);
+      mainWindow.on("move", persistBounds);
+      mainWindow.on("closed", () => {
+        if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
+        mainWindow = null;
+      });
 
       app.on("activate", () => {
-        if (BrowserWindow.getAllWindows().length === 0) createWindow();
+        if (BrowserWindow.getAllWindows().length === 0) {
+          mainWindow = createWindow({ width: 1280, height: 820 });
+        }
       });
     })
     .catch((err: unknown) => {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -99,6 +99,7 @@ if (!gotLock) {
 
       const platformHost = process.env.OPERATOR_GATEWAY_URL ?? DEFAULT_PLATFORM_HOST;
 
+<<<<<<< HEAD
       const auth = new AuthService({
         credentialStore,
         platformHost,
@@ -177,6 +178,85 @@ if (!gotLock) {
     })
     .catch((err: unknown) => {
       logMainError("failed to start app", err);
+=======
+    const auth = new AuthService({
+      credentialStore,
+      platformHost,
+      openExternal: openExternalHttps,
+      loadProfile: () => store.get("profile"),
+      saveProfile: (profile) => store.set("profile", profile),
+      clearProfile: () => store.delete("profile"),
+      onAuthChanged: (status) => {
+        sendEvent("auth:changed", {
+          signedIn: status.signedIn,
+          ...(status.handle ? { handle: status.handle } : {}),
+        });
+      },
+    });
+    await auth.init();
+
+    // Renderer session gets origin-scoped bearer injection; embed partitions
+    // (separate sessions) never do (lesson L1).
+    installHeaderInjection(
+      session.defaultSession,
+      () => auth.getToken(),
+      () => auth.getGatewayOrigin(),
+    );
+
+    registerIpcHandlers(ipcMain, {
+      auth,
+      store,
+      openExternal: openExternalHttps,
+      setBadgeCount: (count) => {
+        app.setBadgeCount(count);
+      },
+      notify: ({ threadId, title, body }) => {
+        if (!Notification.isSupported()) return;
+        const notification = new Notification({ title, body, silent: false });
+        notification.on("click", () => {
+          mainWindow?.show();
+          mainWindow?.focus();
+          sendEvent("notification:clicked", { threadId });
+        });
+        notification.show();
+      },
+      onRuntimeChanged: (slot) => sendEvent("runtime:changed", { slot }),
+    });
+
+    let boundsSaveTimer: ReturnType<typeof setTimeout> | null = null;
+    const persistBounds = () => {
+      if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
+      boundsSaveTimer = setTimeout(() => {
+        if (!mainWindow || mainWindow.isDestroyed()) return;
+        const b = mainWindow.getBounds();
+        void store
+          .set("windowBounds", { x: b.x, y: b.y, width: b.width, height: b.height })
+          .catch((err: unknown) => {
+            console.warn(
+              "[main] failed to persist window bounds:",
+              err instanceof Error ? err.message : String(err),
+            );
+          });
+      }, 500);
+    };
+    const openMainWindow = async () => {
+      const savedBounds = await store.get("windowBounds");
+      mainWindow = createWindow(savedBounds ?? { width: 1280, height: 820 });
+      mainWindow.on("resize", persistBounds);
+      mainWindow.on("move", persistBounds);
+      mainWindow.on("closed", () => {
+        if (boundsSaveTimer) clearTimeout(boundsSaveTimer);
+        mainWindow = null;
+      });
+    };
+
+    await openMainWindow();
+
+    app.on("activate", () => {
+      if (BrowserWindow.getAllWindows().length === 0) {
+        void openMainWindow();
+      }
+>>>>>>> fed695049 (fix(desktop): harden auth and state core)
     });
 
   app.on("window-all-closed", () => {

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -62,7 +62,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
   }));
   handle("state:set", async ({ key, value }) => {
     try {
-      await ctx.store.set(key as LocalStoreKey, value as never);
+      await ctx.store.setUnknown(key as LocalStoreKey, value);
     } catch (err: unknown) {
       console.warn(
         `[ipc] state:set rejected for key ${key}:`,

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -1,0 +1,100 @@
+// IPC handler registration. Every request and response is validated against
+// the shared contract (FR-081); failures are rejected with generic messages
+// and logged with detail on the trusted side only.
+import { INVOKE_CHANNELS, type InvokeChannel, type InvokeRequest, type InvokeResponse } from "../../shared/ipc-contract";
+import type { AuthService } from "../auth/auth-service";
+import type { LocalStore, LocalStoreKey } from "../persistence/local-store";
+
+interface IpcMainLike {
+  handle(
+    channel: string,
+    listener: (event: unknown, payload: unknown) => Promise<unknown> | unknown,
+  ): void;
+}
+
+export interface HandlerContext {
+  auth: AuthService;
+  store: LocalStore;
+  openExternal: (url: string) => Promise<void>;
+  setBadgeCount: (count: number) => void;
+  notify: (input: { threadId: string; title: string; body: string; kind: string }) => void;
+  onRuntimeChanged: (slot: string) => void;
+}
+
+type Handler<C extends InvokeChannel> = (
+  payload: InvokeRequest<C>,
+) => Promise<InvokeResponse<C>> | InvokeResponse<C>;
+
+export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): void {
+  function handle<C extends InvokeChannel>(channel: C, handler: Handler<C>): void {
+    ipcMain.handle(channel, async (_event, rawPayload) => {
+      const parsedRequest = INVOKE_CHANNELS[channel].request.safeParse(rawPayload ?? {});
+      if (!parsedRequest.success) {
+        console.warn(`[ipc] rejected malformed request on ${channel}`);
+        throw new Error("invalid request");
+      }
+      const result = await handler(parsedRequest.data as InvokeRequest<C>);
+      const parsedResponse = INVOKE_CHANNELS[channel].response.safeParse(result);
+      if (!parsedResponse.success) {
+        console.warn(`[ipc] handler for ${channel} produced an invalid response`);
+        throw new Error("internal error");
+      }
+      return parsedResponse.data;
+    });
+  }
+
+  handle("auth:start-device-flow", () => ctx.auth.startDeviceFlow());
+  handle("auth:poll", () => ctx.auth.poll());
+  handle("auth:status", () => ctx.auth.getStatus());
+  handle("auth:sign-out", async () => {
+    await ctx.auth.signOut();
+    return { ok: true };
+  });
+
+  handle("runtime:select", async ({ slot }) => {
+    await ctx.auth.selectRuntime(slot);
+    ctx.onRuntimeChanged(slot);
+    return { ok: true };
+  });
+
+  handle("state:get", async ({ key }) => ({
+    value: await ctx.store.get(key as LocalStoreKey),
+  }));
+  handle("state:set", async ({ key, value }) => {
+    try {
+      await ctx.store.set(key as LocalStoreKey, value as never);
+    } catch (err: unknown) {
+      console.warn(
+        `[ipc] state:set rejected for key ${key}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+      throw new Error("invalid request");
+    }
+    return { ok: true };
+  });
+
+  handle("shell:open-external", async ({ url }) => {
+    await ctx.openExternal(url);
+    return { ok: true };
+  });
+
+  handle("badge:set", ({ count }) => {
+    ctx.setBadgeCount(count);
+    return { ok: true };
+  });
+
+  handle("notify", (payload) => {
+    ctx.notify(payload);
+    return { ok: true };
+  });
+
+  // Embeds land in Phase 7 (US5); until then the channels exist but refuse.
+  handle("embed:open", () => {
+    throw new Error("not available");
+  });
+  handle("embed:set-bounds", () => ({ ok: false }));
+  handle("embed:close", () => ({ ok: false }));
+  handle("embed:retry-auth", () => ({ ok: false }));
+
+  handle("update:check", () => ({ status: "disabled" as const }));
+}

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -104,7 +104,7 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
 
   // Embeds land in Phase 7 (US5); until then the channels exist but refuse.
   handle("embed:open", () => {
-    throw new Error("not available");
+    throw new Error("embed unavailable");
   });
   handle("embed:set-bounds", () => ({ ok: false }));
   handle("embed:close", () => ({ ok: false }));

--- a/desktop/src/main/ipc/handlers.ts
+++ b/desktop/src/main/ipc/handlers.ts
@@ -25,6 +25,8 @@ type Handler<C extends InvokeChannel> = (
   payload: InvokeRequest<C>,
 ) => Promise<InvokeResponse<C>> | InvokeResponse<C>;
 
+const PUBLIC_IPC_ERRORS = new Set(["invalid request", "internal error", "embed unavailable"]);
+
 export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): void {
   function handle<C extends InvokeChannel>(channel: C, handler: Handler<C>): void {
     ipcMain.handle(channel, async (_event, rawPayload) => {
@@ -33,7 +35,19 @@ export function registerIpcHandlers(ipcMain: IpcMainLike, ctx: HandlerContext): 
         console.warn(`[ipc] rejected malformed request on ${channel}`);
         throw new Error("invalid request");
       }
-      const result = await handler(parsedRequest.data as InvokeRequest<C>);
+      let result: InvokeResponse<C>;
+      try {
+        result = await handler(parsedRequest.data as InvokeRequest<C>);
+      } catch (err: unknown) {
+        console.warn(
+          `[ipc] handler for ${channel} failed:`,
+          err instanceof Error ? err.message : String(err),
+        );
+        if (err instanceof Error && PUBLIC_IPC_ERRORS.has(err.message)) {
+          throw err;
+        }
+        throw new Error("internal error");
+      }
       const parsedResponse = INVOKE_CHANNELS[channel].response.safeParse(result);
       if (!parsedResponse.success) {
         console.warn(`[ipc] handler for ${channel} produced an invalid response`);

--- a/desktop/src/main/persistence/local-store.ts
+++ b/desktop/src/main/persistence/local-store.ts
@@ -1,0 +1,162 @@
+// Local UI state (FR-084): only recreatable data lives here — profile pointer,
+// window bounds, panel layouts, appearance. Atomic writes (tmp + rename),
+// schema-validated keys, bounded panel-layout retention.
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { z } from "zod/v4";
+
+export const PANEL_LAYOUT_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+
+const AppearanceSchema = z
+  .object({ theme: z.enum(["dark", "light", "system"]) })
+  .strict();
+
+const WindowBoundsSchema = z
+  .object({
+    x: z.number().int(),
+    y: z.number().int(),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
+  })
+  .strict();
+
+const PanelLayoutSchema = z
+  .object({
+    order: z.array(z.string().max(32)).max(12),
+    visible: z.record(z.string().max(32), z.boolean()),
+    sizes: z.record(z.string().max(32), z.number().min(0).max(100)),
+    touchedAt: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const PanelLayoutsSchema = z.record(z.string().max(256), PanelLayoutSchema);
+
+const RecentsSchema = z.array(z.string().max(512)).max(50);
+
+const ProfileSchema = z
+  .object({
+    handle: z.string().min(1).max(64),
+    userId: z.string().min(1).max(128),
+    platformHost: z.string().min(1).max(256),
+    runtimeSlot: z.string().min(1).max(64),
+  })
+  .strict();
+
+const KEY_SCHEMAS = {
+  profile: ProfileSchema,
+  windowBounds: WindowBoundsSchema,
+  lastProjectSlug: z.string().max(256),
+  panelLayouts: PanelLayoutsSchema,
+  appearance: AppearanceSchema,
+  recents: RecentsSchema,
+} as const;
+
+export type LocalStoreKey = keyof typeof KEY_SCHEMAS;
+export type LocalStoreValue<K extends LocalStoreKey> = z.infer<(typeof KEY_SCHEMAS)[K]>;
+export type PanelLayout = z.infer<typeof PanelLayoutSchema>;
+
+interface LocalStoreOptions {
+  dir: string;
+  clock?: () => number;
+}
+
+export interface LocalStore {
+  get<K extends LocalStoreKey>(key: K): Promise<LocalStoreValue<K> | null>;
+  set<K extends LocalStoreKey>(key: K, value: LocalStoreValue<K>): Promise<void>;
+  delete(key: LocalStoreKey): Promise<void>;
+  setPanelLayout(taskKey: string, layout: PanelLayout): Promise<void>;
+}
+
+export function createLocalStore(options: LocalStoreOptions): LocalStore {
+  const filePath = join(options.dir, "state.json");
+  const clock = options.clock ?? Date.now;
+  // Serialize writes so concurrent set() calls cannot interleave tmp files.
+  let writeChain: Promise<void> = Promise.resolve();
+
+  async function readState(): Promise<Record<string, unknown>> {
+    try {
+      const raw = await readFile(filePath, "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+      return {};
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        // Corrupt or unreadable state is recoverable: start fresh, keep the
+        // bad file out of the way rather than crashing the app.
+        console.warn(
+          "[local-store] unreadable state file, starting fresh:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      return {};
+    }
+  }
+
+  async function writeState(state: Record<string, unknown>): Promise<void> {
+    await mkdir(options.dir, { recursive: true });
+    const tmpPath = `${filePath}.${randomBytes(6).toString("hex")}.tmp`;
+    await writeFile(tmpPath, JSON.stringify(state, null, 2), "utf8");
+    await rename(tmpPath, filePath);
+  }
+
+  function enqueue(mutate: (state: Record<string, unknown>) => void): Promise<void> {
+    const task = writeChain.then(async () => {
+      const state = await readState();
+      mutate(state);
+      await writeState(state);
+    });
+    // Keep the chain alive even if a write fails; the failure still
+    // propagates to this call's awaiter.
+    writeChain = task.catch(() => undefined);
+    return task;
+  }
+
+  function prunePanelLayouts(
+    layouts: Record<string, PanelLayout>,
+    now: number,
+  ): Record<string, PanelLayout> {
+    const pruned: Record<string, PanelLayout> = {};
+    for (const [key, layout] of Object.entries(layouts)) {
+      if (now - layout.touchedAt <= PANEL_LAYOUT_MAX_AGE_MS) {
+        pruned[key] = layout;
+      }
+    }
+    return pruned;
+  }
+
+  return {
+    async get(key) {
+      const state = await readState();
+      const result = KEY_SCHEMAS[key].safeParse(state[key]);
+      if (!result.success) return null;
+      return result.data as LocalStoreValue<typeof key> | null;
+    },
+
+    async set(key, value) {
+      const parsed = KEY_SCHEMAS[key].parse(value);
+      await enqueue((state) => {
+        state[key] = parsed;
+      });
+    },
+
+    async delete(key) {
+      await enqueue((state) => {
+        delete state[key];
+      });
+    },
+
+    async setPanelLayout(taskKey, layout) {
+      const parsedLayout = PanelLayoutSchema.parse(layout);
+      await enqueue((state) => {
+        const existing = PanelLayoutsSchema.safeParse(state.panelLayouts);
+        const layouts = existing.success ? existing.data : {};
+        layouts[taskKey.slice(0, 256)] = parsedLayout;
+        state.panelLayouts = prunePanelLayouts(layouts, clock());
+      });
+    },
+  };
+}

--- a/desktop/src/main/persistence/local-store.ts
+++ b/desktop/src/main/persistence/local-store.ts
@@ -64,6 +64,7 @@ interface LocalStoreOptions {
 export interface LocalStore {
   get<K extends LocalStoreKey>(key: K): Promise<LocalStoreValue<K> | null>;
   set<K extends LocalStoreKey>(key: K, value: LocalStoreValue<K>): Promise<void>;
+  setUnknown(key: LocalStoreKey, value: unknown): Promise<void>;
   delete(key: LocalStoreKey): Promise<void>;
   setPanelLayout(taskKey: string, layout: PanelLayout): Promise<void>;
 }
@@ -137,6 +138,13 @@ export function createLocalStore(options: LocalStoreOptions): LocalStore {
     },
 
     async set(key, value) {
+      const parsed = KEY_SCHEMAS[key].parse(value);
+      await enqueue((state) => {
+        state[key] = parsed;
+      });
+    },
+
+    async setUnknown(key, value) {
       const parsed = KEY_SCHEMAS[key].parse(value);
       await enqueue((state) => {
         state[key] = parsed;

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,7 +1,37 @@
-import { contextBridge } from "electron";
+// The only bridge between renderer and trusted core. Exposes exactly the
+// typed contract — payloads are validated here AND in main (defense in depth,
+// FR-081). The credential never crosses this boundary.
+import { contextBridge, ipcRenderer } from "electron";
+import {
+  EVENT_CHANNELS,
+  INVOKE_CHANNELS,
+  type EventChannel,
+  type InvokeChannel,
+} from "../shared/ipc-contract";
 
-// Placeholder bridge — replaced by the typed, zod-validated contract in Phase 2
-// (specs/094-electron-macos-shell/contracts/ipc-contract.md).
-contextBridge.exposeInMainWorld("operator", {
-  version: process.env.npm_package_version ?? "dev",
-});
+const api = {
+  invoke(channel: string, payload: unknown): Promise<unknown> {
+    const entry = INVOKE_CHANNELS[channel as InvokeChannel];
+    if (!entry) return Promise.reject(new Error("unknown channel"));
+    const parsed = entry.request.safeParse(payload ?? {});
+    if (!parsed.success) return Promise.reject(new Error("invalid request"));
+    return ipcRenderer.invoke(channel, parsed.data);
+  },
+
+  on(channel: string, callback: (payload: unknown) => void): () => void {
+    const schema = EVENT_CHANNELS[channel as EventChannel];
+    if (!schema) return () => undefined;
+    const listener = (_event: unknown, payload: unknown) => {
+      const parsed = schema.safeParse(payload);
+      if (parsed.success) callback(parsed.data);
+    };
+    ipcRenderer.on(channel, listener);
+    return () => {
+      ipcRenderer.removeListener(channel, listener);
+    };
+  },
+};
+
+export type OperatorBridge = typeof api;
+
+contextBridge.exposeInMainWorld("operator", api);

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -1,17 +1,33 @@
+import { useEffect } from "react";
+import SignIn from "./features/signin/SignIn";
+import MissionControl from "./features/mission-control/MissionControl";
+import { useConnection, wireConnectionEvents } from "./stores/connection";
+
 export default function App() {
+  const status = useConnection((s) => s.status);
+  const refresh = useConnection((s) => s.refresh);
+
+  useEffect(() => {
+    wireConnectionEvents();
+    void refresh();
+  }, [refresh]);
+
   return (
-    <div className="flex h-full flex-col">
-      <header
-        className="titlebar-drag flex items-center justify-center border-b"
-        style={{ height: "var(--titlebar-height)", borderColor: "var(--border-subtle)" }}
-      >
-        <span className="text-sm" style={{ color: "var(--text-tertiary)" }}>
-          Matrix OS
-        </span>
-      </header>
-      <main className="flex flex-1 items-center justify-center">
-        <p style={{ color: "var(--text-secondary)" }}>Operator scaffold — Phase 1</p>
-      </main>
+    <div className="flex h-full flex-col" style={{ background: "var(--bg-app)" }}>
+      {status === "loading" ? (
+        <div className="flex flex-1 items-center justify-center">
+          <span className="status-pulse text-sm" style={{ color: "var(--text-tertiary)" }}>
+            Connecting…
+          </span>
+        </div>
+      ) : status === "signed-out" ? (
+        <>
+          <header className="titlebar-drag" style={{ height: "var(--titlebar-height)" }} />
+          <SignIn />
+        </>
+      ) : (
+        <MissionControl />
+      )}
     </div>
   );
 }

--- a/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
+++ b/desktop/src/renderer/src/features/mission-control/MissionControl.tsx
@@ -1,0 +1,10 @@
+export default function MissionControl() {
+  return (
+    <div className="flex flex-1 flex-col">
+      <header className="titlebar-drag" style={{ height: "var(--titlebar-height)" }} />
+      <div className="flex flex-1 items-center justify-center">
+        <span style={{ color: "var(--text-tertiary)" }}>Mission control — Phase 3</span>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/signin/SignIn.tsx
+++ b/desktop/src/renderer/src/features/signin/SignIn.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "../../lib/operator";
+import { useConnection } from "../../stores/connection";
+
+type FlowPhase = "idle" | "starting" | "waiting" | "expired" | "error";
+
+const POLL_INTERVAL_MS = 2000;
+
+export default function SignIn() {
+  const refresh = useConnection((s) => s.refresh);
+  const [phase, setPhase] = useState<FlowPhase>("idle");
+  const [userCode, setUserCode] = useState<string | null>(null);
+  const [verificationUri, setVerificationUri] = useState<string | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimer.current) {
+      clearInterval(pollTimer.current);
+      pollTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const start = useCallback(async () => {
+    setPhase("starting");
+    try {
+      const code = await invoke("auth:start-device-flow", {});
+      setUserCode(code.userCode);
+      setVerificationUri(code.verificationUri);
+      setPhase("waiting");
+      stopPolling();
+      pollTimer.current = setInterval(() => {
+        void invoke("auth:poll", {}).then((result) => {
+          if (result.status === "authorized") {
+            stopPolling();
+            void refresh();
+          } else if (result.status === "expired") {
+            stopPolling();
+            setPhase("expired");
+          }
+        });
+      }, POLL_INTERVAL_MS);
+    } catch {
+      setPhase("error");
+    }
+  }, [refresh, stopPolling]);
+
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div
+        className="fade-in flex w-[380px] flex-col items-center gap-6 rounded-xl border p-10"
+        style={{
+          background: "var(--bg-surface)",
+          borderColor: "var(--border-subtle)",
+          boxShadow: "var(--shadow-2)",
+        }}
+      >
+        <div className="flex flex-col items-center gap-1.5">
+          <div
+            className="flex h-12 w-12 items-center justify-center rounded-xl text-lg font-semibold"
+            style={{ background: "var(--accent-muted)", color: "var(--accent)" }}
+          >
+            M
+          </div>
+          <h1 className="text-lg font-semibold" style={{ color: "var(--text-primary)" }}>
+            Matrix OS
+          </h1>
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            Sign in to connect to your computer
+          </p>
+        </div>
+
+        {phase === "waiting" && userCode ? (
+          <div className="flex flex-col items-center gap-4">
+            <div
+              className="rounded-lg border px-5 py-3 font-mono text-xl tracking-[0.2em]"
+              style={{
+                borderColor: "var(--border-default)",
+                background: "var(--bg-raised)",
+                color: "var(--text-primary)",
+              }}
+              data-selectable
+            >
+              {userCode}
+            </div>
+            <p className="max-w-[280px] text-center text-sm" style={{ color: "var(--text-secondary)" }}>
+              Approve this code in the browser window that just opened.
+            </p>
+            {verificationUri ? (
+              <button
+                type="button"
+                className="text-sm underline-offset-2 hover:underline"
+                style={{ color: "var(--accent)" }}
+                onClick={() => void invoke("shell:open-external", { url: verificationUri })}
+              >
+                Open approval page again
+              </button>
+            ) : null}
+            <span className="status-pulse text-xs" style={{ color: "var(--text-tertiary)" }}>
+              Waiting for approval…
+            </span>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-3">
+            {phase === "expired" ? (
+              <p className="text-sm" style={{ color: "var(--warning)" }}>
+                Sign-in request expired. Start again.
+              </p>
+            ) : null}
+            {phase === "error" ? (
+              <p className="text-sm" style={{ color: "var(--danger)" }}>
+                Can't reach Matrix OS. Check your connection.
+              </p>
+            ) : null}
+            <button
+              type="button"
+              autoFocus
+              disabled={phase === "starting"}
+              onClick={() => void start()}
+              className="rounded-md px-5 py-2 text-sm font-medium transition-colors disabled:opacity-60"
+              style={{ background: "var(--accent)", color: "var(--text-on-accent)" }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = "var(--accent-hover)")}
+              onMouseLeave={(e) => (e.currentTarget.style.background = "var(--accent)")}
+            >
+              {phase === "starting" ? "Starting…" : "Sign in with Matrix OS"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/renderer/src/features/signin/SignIn.tsx
+++ b/desktop/src/renderer/src/features/signin/SignIn.tsx
@@ -31,15 +31,20 @@ export default function SignIn() {
       setPhase("waiting");
       stopPolling();
       pollTimer.current = setInterval(() => {
-        void invoke("auth:poll", {}).then((result) => {
-          if (result.status === "authorized") {
+        void invoke("auth:poll", {})
+          .then((result) => {
+            if (result.status === "authorized") {
+              stopPolling();
+              void refresh();
+            } else if (result.status === "expired") {
+              stopPolling();
+              setPhase("expired");
+            }
+          })
+          .catch(() => {
             stopPolling();
-            void refresh();
-          } else if (result.status === "expired") {
-            stopPolling();
-            setPhase("expired");
-          }
-        });
+            setPhase("error");
+          });
       }, POLL_INTERVAL_MS);
     } catch {
       setPhase("error");

--- a/desktop/src/renderer/src/lib/api.ts
+++ b/desktop/src/renderer/src/lib/api.ts
@@ -1,0 +1,79 @@
+// Typed gateway client (contracts/gateway-contract.md). Auth rides the
+// Authorization header injected by the trusted core at the network layer —
+// this module never sees the credential. Every call has a timeout.
+import { AppError, classifyHttpStatus, classifyTransportError } from "../../../shared/app-error";
+
+const API_TIMEOUT_MS = 10_000;
+
+export function buildGatewayUrl(baseUrl: string, path: string, runtimeSlot: string): string {
+  const base = baseUrl.replace(/\/$/, "");
+  if (runtimeSlot === "primary") return `${base}${path}`;
+  const sep = path.includes("?") ? "&" : "?";
+  return `${base}${path}${sep}runtime=${encodeURIComponent(runtimeSlot)}`;
+}
+
+type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface ApiClientOptions {
+  baseUrl: string;
+  getRuntimeSlot: () => string;
+  fetchFn?: FetchFn;
+}
+
+export interface ApiClient {
+  get<T>(path: string): Promise<T>;
+  post<T>(path: string, body: unknown): Promise<T>;
+  patch<T>(path: string, body: unknown): Promise<T>;
+  delete<T>(path: string): Promise<T>;
+  putText<T>(path: string, body: string): Promise<T>;
+  baseUrl: string;
+}
+
+export function createApiClient(options: ApiClientOptions): ApiClient {
+  const fetchFn: FetchFn = options.fetchFn ?? ((input, init) => fetch(input, init));
+
+  async function request<T>(path: string, init: RequestInit): Promise<T> {
+    const url = buildGatewayUrl(options.baseUrl, path, options.getRuntimeSlot());
+    let response: Response;
+    try {
+      response = await fetchFn(url, {
+        ...init,
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      });
+    } catch (err: unknown) {
+      throw new AppError(classifyTransportError(err), { cause: err });
+    }
+    if (!response.ok) {
+      throw new AppError(classifyHttpStatus(response.status));
+    }
+    try {
+      return (await response.json()) as T;
+    } catch (err: unknown) {
+      throw new AppError("server", { cause: err });
+    }
+  }
+
+  return {
+    baseUrl: options.baseUrl,
+    get: (path) => request(path, { method: "GET" }),
+    post: (path, body) =>
+      request(path, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    patch: (path, body) =>
+      request(path, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    delete: (path) => request(path, { method: "DELETE" }),
+    putText: (path, body) =>
+      request(path, {
+        method: "PUT",
+        headers: { "content-type": "text/plain" },
+        body,
+      }),
+  };
+}

--- a/desktop/src/renderer/src/lib/errors.ts
+++ b/desktop/src/renderer/src/lib/errors.ts
@@ -1,0 +1,37 @@
+// Display boundary for all user-facing errors (FR-080, CLAUDE.md client-store
+// rule). Unknown, long, or provider/path/database-looking strings are replaced
+// with generic copy here even if upstream normalization regresses.
+import { AppError, categoryMessage } from "../../../shared/app-error";
+
+export { AppError } from "../../../shared/app-error";
+export type { AppErrorCategory } from "../../../shared/app-error";
+
+const MAX_SERVER_MESSAGE_LENGTH = 300;
+
+// Markers that indicate a raw upstream error leaked: filesystem paths, syscall
+// codes, database/provider names, stack traces (092 prototype rule).
+const FORBIDDEN_MARKERS = [
+  "/home/",
+  "/users/",
+  "/opt/",
+  "enoent",
+  "econn",
+  "stack",
+  "postgres",
+  "sql",
+  "traceback",
+];
+
+export function sanitizeServerMessage(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_SERVER_MESSAGE_LENGTH) return null;
+  const lower = trimmed.toLowerCase();
+  if (FORBIDDEN_MARKERS.some((marker) => lower.includes(marker))) return null;
+  return trimmed;
+}
+
+export function toUserMessage(err: unknown): string {
+  if (err instanceof AppError) return categoryMessage(err.category);
+  return categoryMessage("server");
+}

--- a/desktop/src/renderer/src/lib/operator.ts
+++ b/desktop/src/renderer/src/lib/operator.ts
@@ -1,0 +1,34 @@
+// Typed access to the preload bridge. All payloads are re-validated in the
+// preload and in main; this wrapper provides compile-time types.
+import type {
+  EventChannel,
+  EventPayload,
+  InvokeChannel,
+  InvokeRequest,
+  InvokeResponse,
+} from "../../../shared/ipc-contract";
+
+interface OperatorBridgeRaw {
+  invoke(channel: string, payload: unknown): Promise<unknown>;
+  on(channel: string, callback: (payload: unknown) => void): () => void;
+}
+
+declare global {
+  interface Window {
+    operator: OperatorBridgeRaw;
+  }
+}
+
+export function invoke<C extends InvokeChannel>(
+  channel: C,
+  payload: InvokeRequest<C>,
+): Promise<InvokeResponse<C>> {
+  return window.operator.invoke(channel, payload) as Promise<InvokeResponse<C>>;
+}
+
+export function onEvent<C extends EventChannel>(
+  channel: C,
+  callback: (payload: EventPayload<C>) => void,
+): () => void {
+  return window.operator.on(channel, callback as (payload: unknown) => void);
+}

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -25,20 +25,25 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
   api: null,
 
   refresh: async () => {
-    const status = await invoke("auth:status", {});
-    const api = status.signedIn
-      ? createApiClient({
-          baseUrl: status.platformHost,
-          getRuntimeSlot: () => get().runtimeSlot,
-        })
-      : null;
-    set({
-      status: status.signedIn ? "signed-in" : "signed-out",
-      handle: status.handle ?? null,
-      platformHost: status.platformHost,
-      runtimeSlot: status.runtimeSlot,
-      api,
-    });
+    try {
+      const status = await invoke("auth:status", {});
+      const api = status.signedIn
+        ? createApiClient({
+            baseUrl: status.platformHost,
+            getRuntimeSlot: () => get().runtimeSlot,
+          })
+        : null;
+      set({
+        status: status.signedIn ? "signed-in" : "signed-out",
+        handle: status.handle ?? null,
+        platformHost: status.platformHost,
+        runtimeSlot: status.runtimeSlot,
+        api,
+      });
+    } catch (err: unknown) {
+      console.warn("[connection] failed to refresh auth status:", err instanceof Error ? err.message : String(err));
+      set({ status: "signed-out", handle: null, api: null });
+    }
   },
 
   selectRuntime: async (slot) => {

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -1,0 +1,66 @@
+// Connection/auth status store. Holds NO credential — only status snapshots
+// from the trusted core (FR-002).
+import { create } from "zustand";
+import { invoke, onEvent } from "../lib/operator";
+import { createApiClient, type ApiClient } from "../lib/api";
+
+export type ConnectionStatus = "loading" | "signed-out" | "signed-in";
+
+interface ConnectionState {
+  status: ConnectionStatus;
+  handle: string | null;
+  platformHost: string;
+  runtimeSlot: string;
+  api: ApiClient | null;
+  refresh: () => Promise<void>;
+  selectRuntime: (slot: string) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+export const useConnection = create<ConnectionState>()((set, get) => ({
+  status: "loading",
+  handle: null,
+  platformHost: "",
+  runtimeSlot: "primary",
+  api: null,
+
+  refresh: async () => {
+    const status = await invoke("auth:status", {});
+    const api = status.signedIn
+      ? createApiClient({
+          baseUrl: status.platformHost,
+          getRuntimeSlot: () => get().runtimeSlot,
+        })
+      : null;
+    set({
+      status: status.signedIn ? "signed-in" : "signed-out",
+      handle: status.handle ?? null,
+      platformHost: status.platformHost,
+      runtimeSlot: status.runtimeSlot,
+      api,
+    });
+  },
+
+  selectRuntime: async (slot) => {
+    await invoke("runtime:select", { slot });
+    set({ runtimeSlot: slot });
+  },
+
+  signOut: async () => {
+    await invoke("auth:sign-out", {});
+    set({ status: "signed-out", handle: null, api: null });
+  },
+}));
+
+let wired = false;
+
+export function wireConnectionEvents(): void {
+  if (wired) return;
+  wired = true;
+  onEvent("auth:changed", () => {
+    void useConnection.getState().refresh();
+  });
+  onEvent("runtime:changed", () => {
+    void useConnection.getState().refresh();
+  });
+}

--- a/desktop/src/renderer/src/stores/connection.ts
+++ b/desktop/src/renderer/src/stores/connection.ts
@@ -53,14 +53,30 @@ export const useConnection = create<ConnectionState>()((set, get) => ({
 }));
 
 let wired = false;
+let connectionEventCleanups: Array<() => void> = [];
+
+function refreshFromConnectionEvent(): void {
+  void useConnection
+    .getState()
+    .refresh()
+    .catch((err: unknown) => {
+      console.warn("[connection] failed to refresh after connection event:", err instanceof Error ? err.message : String(err));
+    });
+}
 
 export function wireConnectionEvents(): void {
   if (wired) return;
   wired = true;
-  onEvent("auth:changed", () => {
-    void useConnection.getState().refresh();
-  });
-  onEvent("runtime:changed", () => {
-    void useConnection.getState().refresh();
-  });
+  connectionEventCleanups = [
+    onEvent("auth:changed", refreshFromConnectionEvent),
+    onEvent("runtime:changed", refreshFromConnectionEvent),
+  ];
+}
+
+export function unwireConnectionEvents(): void {
+  for (const cleanup of connectionEventCleanups) {
+    cleanup();
+  }
+  connectionEventCleanups = [];
+  wired = false;
 }

--- a/desktop/src/shared/app-error.ts
+++ b/desktop/src/shared/app-error.ts
@@ -1,0 +1,50 @@
+// One error taxonomy for the whole app (FR-080). Categories cross the IPC
+// boundary; raw error text never does.
+
+export type AppErrorCategory =
+  | "unauthorized"
+  | "offline"
+  | "timeout"
+  | "notFound"
+  | "server"
+  | "misconfigured"
+  | "fatalSession";
+
+const CATEGORY_MESSAGES: Record<AppErrorCategory, string> = {
+  unauthorized: "Your session has expired. Please sign in again.",
+  offline: "Can't reach Matrix OS. Check your connection.",
+  timeout: "The request timed out. Please try again.",
+  notFound: "That item could not be found.",
+  server: "Something went wrong. Please try again.",
+  misconfigured: "No computer is connected. Select a runtime to continue.",
+  fatalSession: "This session has ended.",
+};
+
+export class AppError extends Error {
+  readonly category: AppErrorCategory;
+
+  constructor(category: AppErrorCategory, options?: { cause?: unknown }) {
+    // The message is always the generic copy — the cause stays internal.
+    super(CATEGORY_MESSAGES[category], options);
+    this.name = "AppError";
+    this.category = category;
+  }
+}
+
+export function categoryMessage(category: AppErrorCategory): string {
+  return CATEGORY_MESSAGES[category];
+}
+
+export function classifyHttpStatus(status: number): AppErrorCategory {
+  if (status === 401 || status === 403) return "unauthorized";
+  if (status === 404) return "notFound";
+  return "server";
+}
+
+export function classifyTransportError(err: unknown): AppErrorCategory {
+  if (err instanceof DOMException && (err.name === "TimeoutError" || err.name === "AbortError")) {
+    return "timeout";
+  }
+  if (err instanceof TypeError) return "offline";
+  return "server";
+}

--- a/desktop/src/shared/ipc-contract.ts
+++ b/desktop/src/shared/ipc-contract.ts
@@ -1,0 +1,184 @@
+// Single source of truth for the renderer ↔ trusted-core IPC contract
+// (specs/094-electron-macos-shell/contracts/ipc-contract.md). Both main and
+// preload import this module; every channel is validated on both sides
+// (FR-081). The credential never appears in any schema.
+import { z } from "zod/v4";
+
+const Empty = z.object({}).strict();
+
+const Ok = z.object({ ok: z.boolean() }).strict();
+
+const ProfileSchema = z
+  .object({
+    handle: z.string().min(1).max(64),
+    userId: z.string().min(1).max(128),
+  })
+  .strict();
+
+const BoundsSchema = z
+  .object({
+    x: z.number().int().min(-16_384).max(16_384),
+    y: z.number().int().min(-16_384).max(16_384),
+    width: z.number().int().min(0).max(16_384),
+    height: z.number().int().min(0).max(16_384),
+  })
+  .strict();
+
+const STATE_KEYS = [
+  "windowBounds",
+  "lastProjectSlug",
+  "panelLayouts",
+  "appearance",
+  "recents",
+] as const;
+
+const MAX_STATE_VALUE_BYTES = 64 * 1024;
+
+const BoundedJsonValue = z.unknown().refine(
+  (value) => {
+    try {
+      return JSON.stringify(value).length <= MAX_STATE_VALUE_BYTES;
+    } catch {
+      return false;
+    }
+  },
+  { message: "state value too large" },
+);
+
+export const INVOKE_CHANNELS = {
+  "auth:start-device-flow": {
+    request: Empty,
+    response: z
+      .object({
+        userCode: z.string().min(1).max(32),
+        verificationUri: z.string().max(512),
+        expiresIn: z.number().int().positive(),
+      })
+      .strict(),
+  },
+  "auth:poll": {
+    request: Empty,
+    response: z
+      .object({
+        status: z.enum(["pending", "authorized", "expired"]),
+        profile: ProfileSchema.optional(),
+      })
+      .strict(),
+  },
+  "auth:status": {
+    request: Empty,
+    response: z
+      .object({
+        signedIn: z.boolean(),
+        handle: z.string().max(64).optional(),
+        runtimeSlot: z.string().max(64),
+        platformHost: z.string().max(256),
+      })
+      .strict(),
+  },
+  "auth:sign-out": { request: Empty, response: Ok },
+  "runtime:select": {
+    request: z.object({ slot: z.string().min(1).max(64) }).strict(),
+    response: Ok,
+  },
+  "state:get": {
+    request: z.object({ key: z.enum(STATE_KEYS) }).strict(),
+    response: z.object({ value: z.unknown() }).strict(),
+  },
+  "state:set": {
+    request: z
+      .object({ key: z.enum(STATE_KEYS), value: BoundedJsonValue })
+      .strict(),
+    response: Ok,
+  },
+  "embed:open": {
+    request: z
+      .object({
+        kind: z.enum(["hosted-shell", "app"]),
+        slug: z.string().min(1).max(128).optional(),
+        bounds: BoundsSchema,
+      })
+      .strict(),
+    response: z.object({ embedId: z.string().min(1).max(64) }).strict(),
+  },
+  "embed:set-bounds": {
+    request: z
+      .object({ embedId: z.string().min(1).max(64), bounds: BoundsSchema })
+      .strict(),
+    response: Ok,
+  },
+  "embed:close": {
+    request: z.object({ embedId: z.string().min(1).max(64) }).strict(),
+    response: Ok,
+  },
+  "embed:retry-auth": {
+    request: z.object({ embedId: z.string().min(1).max(64) }).strict(),
+    response: Ok,
+  },
+  notify: {
+    request: z
+      .object({
+        threadId: z.string().min(1).max(128),
+        title: z.string().min(1).max(80),
+        body: z.string().max(200),
+        kind: z.enum(["done", "failed", "attention", "connection"]),
+      })
+      .strict(),
+    response: Ok,
+  },
+  "badge:set": {
+    request: z.object({ count: z.number().int().min(0).max(999) }).strict(),
+    response: Ok,
+  },
+  "shell:open-external": {
+    request: z
+      .object({
+        url: z
+          .string()
+          .max(2048)
+          .refine((value) => {
+            try {
+              return new URL(value).protocol === "https:";
+            } catch {
+              return false;
+            }
+          }, "https urls only"),
+      })
+      .strict(),
+    response: Ok,
+  },
+  "update:check": {
+    request: Empty,
+    response: z
+      .object({ status: z.enum(["disabled", "checking", "up-to-date", "downloading", "ready"]) })
+      .strict(),
+  },
+} as const;
+
+export const EVENT_CHANNELS = {
+  "auth:changed": z
+    .object({ signedIn: z.boolean(), handle: z.string().max(64).optional() })
+    .strict(),
+  "runtime:changed": z.object({ slot: z.string().min(1).max(64) }).strict(),
+  "embed:state": z
+    .object({
+      embedId: z.string().min(1).max(64),
+      state: z.enum(["loading", "ready", "auth-required", "failed"]),
+    })
+    .strict(),
+  "notification:clicked": z.object({ threadId: z.string().min(1).max(128) }).strict(),
+  "update:available": z.object({ version: z.string().max(64) }).strict(),
+  "update:ready": z.object({ version: z.string().max(64) }).strict(),
+  "window:focus-changed": z.object({ focused: z.boolean() }).strict(),
+} as const;
+
+export type InvokeChannel = keyof typeof INVOKE_CHANNELS;
+export type EventChannel = keyof typeof EVENT_CHANNELS;
+
+export type InvokeRequest<C extends InvokeChannel> = z.infer<
+  (typeof INVOKE_CHANNELS)[C]["request"]
+>;
+export type InvokeResponse<C extends InvokeChannel> = z.infer<
+  (typeof INVOKE_CHANNELS)[C]["response"]
+>;
+export type EventPayload<C extends EventChannel> = z.infer<(typeof EVENT_CHANNELS)[C]>;

--- a/tests/desktop/api-client.test.ts
+++ b/tests/desktop/api-client.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildGatewayUrl, createApiClient } from "@desktop/renderer/src/lib/api";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("buildGatewayUrl", () => {
+  it("joins base and path", () => {
+    expect(buildGatewayUrl("https://app.matrix-os.com", "/api/workspace/projects", "primary")).toBe(
+      "https://app.matrix-os.com/api/workspace/projects",
+    );
+  });
+
+  it("appends runtime only when slot is not primary", () => {
+    expect(buildGatewayUrl("https://app.matrix-os.com", "/api/apps", "vm-2")).toBe(
+      "https://app.matrix-os.com/api/apps?runtime=vm-2",
+    );
+    expect(buildGatewayUrl("https://app.matrix-os.com", "/api/apps", "primary")).toBe(
+      "https://app.matrix-os.com/api/apps",
+    );
+  });
+
+  it("merges runtime with existing query params", () => {
+    expect(
+      buildGatewayUrl("https://app.matrix-os.com", "/api/projects/x/tasks?limit=50", "vm-2"),
+    ).toBe("https://app.matrix-os.com/api/projects/x/tasks?limit=50&runtime=vm-2");
+  });
+});
+
+describe("createApiClient", () => {
+  it("fetches and parses JSON with a timeout signal", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { projects: [{ slug: "matrix-os" }] }));
+    const client = createApiClient({
+      baseUrl: "https://app.matrix-os.com",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    const data = await client.get<{ projects: Array<{ slug: string }> }>("/api/workspace/projects");
+    expect(data.projects[0]!.slug).toBe("matrix-os");
+    const [, init] = fetchFn.mock.calls[0]!;
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("maps 401 to unauthorized AppError", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(401, {}));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    await expect(client.get("/api/apps")).rejects.toMatchObject({ category: "unauthorized" });
+  });
+
+  it("maps network failure to offline", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    await expect(client.get("/api/apps")).rejects.toMatchObject({ category: "offline" });
+  });
+
+  it("maps timeout aborts to timeout", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValue(new DOMException("The operation timed out.", "TimeoutError"));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    await expect(client.get("/api/apps")).rejects.toMatchObject({ category: "timeout" });
+  });
+
+  it("sends JSON bodies on post/patch and parses responses", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200, { id: "t1", title: "Fix" }));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "vm-2",
+      fetchFn,
+    });
+    await client.post("/api/projects/p/tasks", { title: "Fix" });
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe("https://x.test/api/projects/p/tasks?runtime=vm-2");
+    expect((init as RequestInit).method).toBe("POST");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ title: "Fix" });
+  });
+
+  it("treats non-JSON success bodies as server errors", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response("<html>", { status: 200 }));
+    const client = createApiClient({
+      baseUrl: "https://x.test",
+      getRuntimeSlot: () => "primary",
+      fetchFn,
+    });
+    await expect(client.get("/api/apps")).rejects.toMatchObject({ category: "server" });
+  });
+});

--- a/tests/desktop/app-scaffold.test.tsx
+++ b/tests/desktop/app-scaffold.test.tsx
@@ -6,11 +6,11 @@ import { describe, expect, it } from "vitest";
 import App from "@renderer/App";
 
 describe("desktop app scaffold", () => {
-  it("renders the Matrix OS scaffold shell", () => {
+  it("renders the initial app shell", () => {
     const html = renderToStaticMarkup(createElement(App));
 
-    expect(html).toContain("Matrix OS");
-    expect(html).toContain("Operator scaffold");
+    expect(html).toContain("bg-app");
+    expect(html).toContain("Connecting");
   });
 
   it("keeps Node globals out of the sandboxed renderer tsconfig", () => {

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -106,6 +106,46 @@ describe("AuthService", () => {
     expect(console.warn).toHaveBeenCalledWith("[auth] failed to clear expired profile:", "profile clear failed");
   });
 
+  it("emits signed-out status when an in-memory credential expires mid-session", async () => {
+    const now = Date.now();
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
+    const credentialStore = makeCredentialStore(makeCredential({ expiresAt: now + 1000 }));
+    const clearProfile = vi.fn(async () => undefined);
+    const onAuthChanged = vi.fn();
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      openExternal: vi.fn(async () => undefined),
+      loadProfile: async () => makeProfile(),
+      saveProfile: vi.fn(async () => undefined),
+      clearProfile,
+      onAuthChanged,
+    });
+    await auth.init();
+    expect(auth.getStatus().signedIn).toBe(true);
+
+    dateNow.mockReturnValue(now + 2000);
+
+    expect(auth.getStatus()).toEqual({
+      signedIn: false,
+      runtimeSlot: "primary",
+      platformHost: "https://app.matrix-os.com",
+    });
+    expect(auth.getToken()).toBeNull();
+    expect(onAuthChanged).toHaveBeenCalledTimes(1);
+    expect(onAuthChanged).toHaveBeenCalledWith({
+      signedIn: false,
+      runtimeSlot: "primary",
+      platformHost: "https://app.matrix-os.com",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(credentialStore.cleared).toBe(true);
+    expect(clearProfile).toHaveBeenCalledOnce();
+
+    dateNow.mockRestore();
+  });
+
   it("reuses a pending device flow instead of launching parallel poll loops", async () => {
     const credentialStore = makeCredentialStore(null);
     let codeRequests = 0;

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -155,6 +155,35 @@ describe("AuthService", () => {
     expect(onAuthChanged).toHaveBeenCalledTimes(1);
   });
 
+  it("emits signed-out status before persistent sign-out cleanup can fail", async () => {
+    const credentialStore = makeCredentialStore(makeCredential());
+    const onAuthChanged = vi.fn();
+    const cleanupError = new Error("credential clear failed");
+    credentialStore.clear = vi.fn(async () => {
+      throw cleanupError;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      openExternal: vi.fn(async () => undefined),
+      loadProfile: async () => makeProfile(),
+      saveProfile: vi.fn(async () => undefined),
+      clearProfile: vi.fn(async () => undefined),
+      onAuthChanged,
+    });
+    await auth.init();
+
+    await expect(auth.signOut()).rejects.toThrow(cleanupError);
+
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(onAuthChanged).toHaveBeenCalledWith({
+      signedIn: false,
+      runtimeSlot: "primary",
+      platformHost: "https://app.matrix-os.com",
+    });
+  });
+
   it("does not start polling when sign-out races an in-flight device-code request", async () => {
     const credentialStore = makeCredentialStore(null);
     const saveProfile = vi.fn(async () => undefined);

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -22,6 +22,16 @@ function makeProfile(overrides: Partial<ConnectionProfile> = {}): ConnectionProf
   };
 }
 
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeCredentialStore(initial: StoredCredential | null): CredentialStore & {
   saved: StoredCredential | null;
   cleared: boolean;
@@ -224,6 +234,61 @@ describe("AuthService", () => {
     );
     await Promise.resolve();
     await Promise.resolve();
+
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(credentialStore.saved).toBeNull();
+    expect(saveProfile).not.toHaveBeenCalled();
+    expect(onAuthChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears a credential save that completes after sign-out invalidates the device flow", async () => {
+    const credentialStore = makeCredentialStore(null);
+    const saveStarted = deferred<void>();
+    const finishSave = deferred<void>();
+    credentialStore.save = vi.fn(async (credential) => {
+      saveStarted.resolve();
+      await finishSave.promise;
+      credentialStore.saved = credential;
+    });
+    credentialStore.clear = vi.fn(async () => {
+      credentialStore.cleared = true;
+      credentialStore.saved = null;
+    });
+    const saveProfile = vi.fn(async () => undefined);
+    const onAuthChanged = vi.fn();
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/auth/device/code")) {
+        return jsonResponse({
+          deviceCode: "device-1",
+          userCode: "ABCD",
+          verificationUri: "https://app.matrix-os.com/device",
+          expiresIn: 600,
+          interval: 5,
+        });
+      }
+      return jsonResponse({
+        accessToken: "late-token",
+        expiresAt: Date.now() + 60_000,
+        userId: "user-1",
+        handle: "neo",
+      });
+    });
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      fetchFn,
+      openExternal: vi.fn(async () => undefined),
+      loadProfile: async () => null,
+      saveProfile,
+      clearProfile: vi.fn(async () => undefined),
+      onAuthChanged,
+    });
+
+    await auth.startDeviceFlow();
+    await saveStarted.promise;
+    await auth.signOut();
+    finishSave.resolve();
+    await flushAuthFlow();
 
     expect(auth.getStatus().signedIn).toBe(false);
     expect(credentialStore.saved).toBeNull();

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -48,6 +48,13 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+async function flushAuthFlow(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("AuthService", () => {
   it("treats expired persisted credentials as signed out", async () => {
     const credentialStore = makeCredentialStore(makeCredential({ expiresAt: Date.now() - 1000 }));
@@ -68,6 +75,35 @@ describe("AuthService", () => {
     expect(auth.getToken()).toBeNull();
     expect(credentialStore.cleared).toBe(true);
     expect(clearProfile).toHaveBeenCalledOnce();
+  });
+
+  it("does not throw when expired credential cleanup fails during init", async () => {
+    const credentialStore = makeCredentialStore(makeCredential({ expiresAt: Date.now() - 1000 }));
+    credentialStore.clear = vi.fn(async () => {
+      throw new Error("credential clear failed");
+    });
+    const clearProfile = vi.fn(async () => {
+      throw new Error("profile clear failed");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      openExternal: vi.fn(async () => undefined),
+      loadProfile: async () => makeProfile(),
+      saveProfile: vi.fn(async () => undefined),
+      clearProfile,
+      onAuthChanged: vi.fn(),
+    });
+
+    await expect(auth.init()).resolves.toBeUndefined();
+
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(auth.getToken()).toBeNull();
+    expect(credentialStore.clear).toHaveBeenCalledOnce();
+    expect(clearProfile).toHaveBeenCalledOnce();
+    expect(console.warn).toHaveBeenCalledWith("[auth] failed to clear expired credential:", "credential clear failed");
+    expect(console.warn).toHaveBeenCalledWith("[auth] failed to clear expired profile:", "profile clear failed");
   });
 
   it("reuses a pending device flow instead of launching parallel poll loops", async () => {
@@ -182,6 +218,64 @@ describe("AuthService", () => {
       runtimeSlot: "primary",
       platformHost: "https://app.matrix-os.com",
     });
+  });
+
+  it("emits signed-in status even when persistence fails after device authorization", async () => {
+    const credentialStore = makeCredentialStore(null);
+    credentialStore.save = vi.fn(async () => {
+      throw new Error("credential save failed");
+    });
+    const saveProfile = vi.fn(async () => {
+      throw new Error("profile save failed");
+    });
+    const onAuthChanged = vi.fn();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/auth/device/code")) {
+        return jsonResponse({
+          deviceCode: "device-1",
+          userCode: "ABCD",
+          verificationUri: "https://app.matrix-os.com/device",
+          expiresIn: 600,
+          interval: 5,
+        });
+      }
+      return jsonResponse({
+        accessToken: "token-1",
+        expiresAt: Date.now() + 60_000,
+        userId: "user-1",
+        handle: "neo",
+      });
+    });
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      fetchFn,
+      openExternal: vi.fn(async () => undefined),
+      loadProfile: async () => null,
+      saveProfile,
+      clearProfile: vi.fn(async () => undefined),
+      onAuthChanged,
+    });
+
+    await auth.startDeviceFlow();
+    await flushAuthFlow();
+
+    expect(auth.getStatus()).toEqual({
+      signedIn: true,
+      handle: "neo",
+      runtimeSlot: "primary",
+      platformHost: "https://app.matrix-os.com",
+    });
+    expect(auth.poll()).toEqual({ status: "authorized", profile: { handle: "neo", userId: "user-1" } });
+    expect(onAuthChanged).toHaveBeenCalledWith({
+      signedIn: true,
+      handle: "neo",
+      runtimeSlot: "primary",
+      platformHost: "https://app.matrix-os.com",
+    });
+    expect(console.warn).toHaveBeenCalledWith("[auth] failed to persist credential:", "credential save failed");
+    expect(console.warn).toHaveBeenCalledWith("[auth] failed to persist profile:", "profile save failed");
   });
 
   it("does not start polling when sign-out races an in-flight device-code request", async () => {

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -154,4 +154,55 @@ describe("AuthService", () => {
     expect(saveProfile).not.toHaveBeenCalled();
     expect(onAuthChanged).toHaveBeenCalledTimes(1);
   });
+
+  it("does not start polling when sign-out races an in-flight device-code request", async () => {
+    const credentialStore = makeCredentialStore(null);
+    const saveProfile = vi.fn(async () => undefined);
+    const openExternal = vi.fn(async () => undefined);
+    let resolveCode!: (response: Response) => void;
+    const codePromise = new Promise<Response>((resolve) => {
+      resolveCode = resolve;
+    });
+    let tokenRequests = 0;
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/auth/device/code")) return codePromise;
+      tokenRequests += 1;
+      return jsonResponse({
+        accessToken: "late-token",
+        expiresAt: Date.now() + 60_000,
+        userId: "user-1",
+        handle: "neo",
+      });
+    });
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      fetchFn,
+      openExternal,
+      loadProfile: async () => null,
+      saveProfile,
+      clearProfile: vi.fn(async () => undefined),
+      onAuthChanged: vi.fn(),
+    });
+
+    const flow = auth.startDeviceFlow();
+    await Promise.resolve();
+    await auth.signOut();
+    resolveCode(
+      jsonResponse({
+        deviceCode: "device-1",
+        userCode: "ABCD",
+        verificationUri: "https://app.matrix-os.com/device",
+        expiresIn: 600,
+        interval: 5,
+      }),
+    );
+
+    await expect(flow).rejects.toThrow("Sign-in request was canceled.");
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(tokenRequests).toBe(0);
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(credentialStore.saved).toBeNull();
+    expect(saveProfile).not.toHaveBeenCalled();
+  });
 });

--- a/tests/desktop/auth-service.test.ts
+++ b/tests/desktop/auth-service.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { AuthService, type ConnectionProfile } from "@desktop/main/auth/auth-service";
+import type { CredentialStore, StoredCredential } from "@desktop/main/auth/credential-store";
+
+function makeCredential(overrides: Partial<StoredCredential> = {}): StoredCredential {
+  return {
+    accessToken: "token-1",
+    expiresAt: Date.now() + 60_000,
+    userId: "user-1",
+    handle: "neo",
+    ...overrides,
+  };
+}
+
+function makeProfile(overrides: Partial<ConnectionProfile> = {}): ConnectionProfile {
+  return {
+    handle: "neo",
+    userId: "user-1",
+    platformHost: "https://app.matrix-os.com",
+    runtimeSlot: "primary",
+    ...overrides,
+  };
+}
+
+function makeCredentialStore(initial: StoredCredential | null): CredentialStore & {
+  saved: StoredCredential | null;
+  cleared: boolean;
+} {
+  return {
+    saved: null,
+    cleared: false,
+    async load() {
+      return initial;
+    },
+    async save(credential) {
+      this.saved = credential;
+    },
+    async clear() {
+      this.cleared = true;
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("AuthService", () => {
+  it("treats expired persisted credentials as signed out", async () => {
+    const credentialStore = makeCredentialStore(makeCredential({ expiresAt: Date.now() - 1000 }));
+    const clearProfile = vi.fn(async () => undefined);
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      openExternal: vi.fn(async () => undefined),
+      loadProfile: async () => makeProfile(),
+      saveProfile: vi.fn(async () => undefined),
+      clearProfile,
+      onAuthChanged: vi.fn(),
+    });
+
+    await auth.init();
+
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(auth.getToken()).toBeNull();
+    expect(credentialStore.cleared).toBe(true);
+    expect(clearProfile).toHaveBeenCalledOnce();
+  });
+
+  it("reuses a pending device flow instead of launching parallel poll loops", async () => {
+    const credentialStore = makeCredentialStore(null);
+    let codeRequests = 0;
+    const tokenPromise = new Promise<Response>(() => undefined);
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/auth/device/code")) {
+        codeRequests += 1;
+        return jsonResponse({
+          deviceCode: "device-1",
+          userCode: "ABCD",
+          verificationUri: "https://app.matrix-os.com/device",
+          expiresIn: 600,
+          interval: 5,
+        });
+      }
+      return tokenPromise;
+    });
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      fetchFn,
+      openExternal: vi.fn(async () => undefined),
+      loadProfile: async () => null,
+      saveProfile: vi.fn(async () => undefined),
+      clearProfile: vi.fn(async () => undefined),
+      onAuthChanged: vi.fn(),
+    });
+
+    const first = await auth.startDeviceFlow();
+    const second = await auth.startDeviceFlow();
+
+    expect(first).toEqual(second);
+    expect(codeRequests).toBe(1);
+  });
+
+  it("does not restore credentials when an in-flight poll resolves after sign-out", async () => {
+    const credentialStore = makeCredentialStore(null);
+    const saveProfile = vi.fn(async () => undefined);
+    const onAuthChanged = vi.fn();
+    let resolveToken!: (response: Response) => void;
+    const tokenPromise = new Promise<Response>((resolve) => {
+      resolveToken = resolve;
+    });
+    const fetchFn = vi.fn(async (url: string) => {
+      if (url.endsWith("/api/auth/device/code")) {
+        return jsonResponse({
+          deviceCode: "device-1",
+          userCode: "ABCD",
+          verificationUri: "https://app.matrix-os.com/device",
+          expiresIn: 600,
+          interval: 5,
+        });
+      }
+      return tokenPromise;
+    });
+    const auth = new AuthService({
+      credentialStore,
+      platformHost: "https://app.matrix-os.com",
+      fetchFn,
+      openExternal: vi.fn(async () => undefined),
+      loadProfile: async () => null,
+      saveProfile,
+      clearProfile: vi.fn(async () => undefined),
+      onAuthChanged,
+    });
+
+    await auth.startDeviceFlow();
+    await auth.signOut();
+    resolveToken(
+      jsonResponse({
+        accessToken: "late-token",
+        expiresAt: Date.now() + 60_000,
+        userId: "user-1",
+        handle: "neo",
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(auth.getStatus().signedIn).toBe(false);
+    expect(credentialStore.saved).toBeNull();
+    expect(saveProfile).not.toHaveBeenCalled();
+    expect(onAuthChanged).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/desktop/connection-store.test.ts
+++ b/tests/desktop/connection-store.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  unwireConnectionEvents,
+  useConnection,
+  wireConnectionEvents,
+} from "@desktop/renderer/src/stores/connection";
+
+type Listener = (payload: unknown) => void;
+
+beforeEach(() => {
+  useConnection.setState({
+    status: "loading",
+    handle: null,
+    platformHost: "",
+    runtimeSlot: "primary",
+    api: null,
+  });
+});
+
+afterEach(() => {
+  unwireConnectionEvents();
+  vi.restoreAllMocks();
+});
+
+describe("connection event wiring", () => {
+  it("unwires auth and runtime listeners so tests can reinitialize the bridge", async () => {
+    const listeners = new Map<string, Listener>();
+    const invoke = vi.fn().mockResolvedValue({
+      signedIn: false,
+      platformHost: "https://platform.test",
+      runtimeSlot: "primary",
+    });
+    window.operator = {
+      invoke,
+      on: vi.fn((channel: string, callback: Listener) => {
+        listeners.set(channel, callback);
+        return () => {
+          listeners.delete(channel);
+        };
+      }),
+    };
+
+    wireConnectionEvents();
+    listeners.get("auth:changed")?.({});
+    await Promise.resolve();
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(listeners.has("auth:changed")).toBe(true);
+    expect(listeners.has("runtime:changed")).toBe(true);
+
+    unwireConnectionEvents();
+
+    expect(listeners.has("auth:changed")).toBe(false);
+    expect(listeners.has("runtime:changed")).toBe(false);
+
+    wireConnectionEvents();
+    listeners.get("runtime:changed")?.({});
+    await Promise.resolve();
+
+    expect(window.operator.on).toHaveBeenCalledTimes(4);
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/desktop/connection-store.test.ts
+++ b/tests/desktop/connection-store.test.ts
@@ -25,6 +25,20 @@ afterEach(() => {
 });
 
 describe("connection event wiring", () => {
+  it("recovers from an initial auth status failure instead of staying loading", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    window.operator = {
+      invoke: vi.fn().mockRejectedValue(new Error("ipc unavailable")),
+      on: vi.fn(),
+    };
+
+    await useConnection.getState().refresh();
+
+    expect(useConnection.getState().status).toBe("signed-out");
+    expect(useConnection.getState().api).toBeNull();
+    expect(warn).toHaveBeenCalledWith("[connection] failed to refresh auth status:", "ipc unavailable");
+  });
+
   it("unwires auth and runtime listeners so tests can reinitialize the bridge", async () => {
     const listeners = new Map<string, Listener>();
     const invoke = vi.fn().mockResolvedValue({

--- a/tests/desktop/device-auth.test.ts
+++ b/tests/desktop/device-auth.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { requestDeviceCode, pollForToken, DEVICE_CLIENT_ID } from "@desktop/main/auth/device-auth";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("requestDeviceCode", () => {
+  it("posts clientId and parses the device code payload", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        deviceCode: "dc1",
+        userCode: "ABCD-1234",
+        verificationUri: "https://app.matrix-os.com/activate",
+        expiresIn: 600,
+        interval: 5,
+      }),
+    );
+    const result = await requestDeviceCode({
+      fetchFn,
+      baseUrl: "https://app.matrix-os.com",
+    });
+    expect(result.userCode).toBe("ABCD-1234");
+    const [url, init] = fetchFn.mock.calls[0]!;
+    expect(url).toBe("https://app.matrix-os.com/api/auth/device/code");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.clientId).toBe(DEVICE_CLIENT_ID);
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("maps failures to typed errors", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(500, {}));
+    await expect(
+      requestDeviceCode({ fetchFn, baseUrl: "https://app.matrix-os.com" }),
+    ).rejects.toMatchObject({ category: "server" });
+  });
+});
+
+describe("pollForToken", () => {
+  const base = { baseUrl: "https://app.matrix-os.com", deviceCode: "dc1" };
+
+  it("polls at the given interval until authorized", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(428, { error: "authorization_pending" }))
+      .mockResolvedValueOnce(jsonResponse(428, { error: "authorization_pending" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { accessToken: "tok", expiresAt: 1750000000000, userId: "u1", handle: "neo" }),
+      );
+    const sleeps: number[] = [];
+    const result = await pollForToken({
+      ...base,
+      fetchFn,
+      intervalSeconds: 5,
+      expiresInSeconds: 600,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    expect(result.accessToken).toBe("tok");
+    expect(result.handle).toBe("neo");
+    expect(sleeps).toEqual([5000, 5000]);
+  });
+
+  it("adds 5 seconds to the interval on 429 slow_down", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(429, { error: "slow_down" }))
+      .mockResolvedValueOnce(jsonResponse(428, { error: "authorization_pending" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { accessToken: "tok", expiresAt: 1, userId: "u", handle: "h" }),
+      );
+    const sleeps: number[] = [];
+    await pollForToken({
+      ...base,
+      fetchFn,
+      intervalSeconds: 5,
+      expiresInSeconds: 600,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    expect(sleeps).toEqual([10000, 10000]);
+  });
+
+  it("throws expired on 410", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(410, { error: "expired_token" }));
+    await expect(
+      pollForToken({ ...base, fetchFn, intervalSeconds: 5, expiresInSeconds: 600, sleep: async () => {} }),
+    ).rejects.toMatchObject({ code: "expired" });
+  });
+
+  it("gives up when the device code lifetime is exhausted", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(428, { error: "authorization_pending" }));
+    let now = 0;
+    await expect(
+      pollForToken({
+        ...base,
+        fetchFn,
+        intervalSeconds: 5,
+        expiresInSeconds: 12,
+        sleep: async (ms) => {
+          now += ms;
+        },
+        clock: () => now,
+      }),
+    ).rejects.toMatchObject({ code: "expired" });
+    expect(fetchFn.mock.calls.length).toBeLessThan(10);
+  });
+
+  it("maps 401 to unauthorized", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(401, {}));
+    await expect(
+      pollForToken({ ...base, fetchFn, intervalSeconds: 5, expiresInSeconds: 600, sleep: async () => {} }),
+    ).rejects.toMatchObject({ category: "unauthorized" });
+  });
+});

--- a/tests/desktop/errors.test.ts
+++ b/tests/desktop/errors.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  AppError,
+  classifyHttpStatus,
+  classifyTransportError,
+} from "@desktop/shared/app-error";
+import { sanitizeServerMessage, toUserMessage } from "@desktop/renderer/src/lib/errors";
+
+describe("classifyHttpStatus", () => {
+  it("maps statuses to categories", () => {
+    expect(classifyHttpStatus(401)).toBe("unauthorized");
+    expect(classifyHttpStatus(403)).toBe("unauthorized");
+    expect(classifyHttpStatus(404)).toBe("notFound");
+    expect(classifyHttpStatus(500)).toBe("server");
+    expect(classifyHttpStatus(502)).toBe("server");
+    expect(classifyHttpStatus(418)).toBe("server");
+  });
+});
+
+describe("classifyTransportError", () => {
+  it("maps timeout aborts to timeout", () => {
+    const err = new DOMException("The operation timed out.", "TimeoutError");
+    expect(classifyTransportError(err)).toBe("timeout");
+  });
+
+  it("maps abort to timeout", () => {
+    const err = new DOMException("Aborted", "AbortError");
+    expect(classifyTransportError(err)).toBe("timeout");
+  });
+
+  it("maps fetch TypeError to offline", () => {
+    expect(classifyTransportError(new TypeError("fetch failed"))).toBe("offline");
+  });
+
+  it("maps unknown errors to server", () => {
+    expect(classifyTransportError(new Error("boom"))).toBe("server");
+  });
+});
+
+describe("AppError", () => {
+  it("carries a category and never exposes cause text in message", () => {
+    const err = new AppError("server", { cause: new Error("pg: connection refused at /home/x") });
+    expect(err.category).toBe("server");
+    expect(err.message).not.toContain("pg");
+    expect(err.message).not.toContain("/home/");
+  });
+});
+
+describe("toUserMessage", () => {
+  it("returns generic copy per category", () => {
+    expect(toUserMessage(new AppError("unauthorized"))).toMatch(/sign in/i);
+    expect(toUserMessage(new AppError("offline"))).toMatch(/connection/i);
+    expect(toUserMessage(new AppError("timeout"))).toMatch(/timed out/i);
+    expect(toUserMessage(new AppError("notFound"))).toMatch(/not.*found/i);
+    expect(toUserMessage(new AppError("misconfigured"))).toMatch(/runtime/i);
+    expect(toUserMessage(new AppError("fatalSession"))).toMatch(/session/i);
+  });
+
+  it("collapses raw errors to the generic server message", () => {
+    expect(toUserMessage(new Error("ECONNREFUSED 10.0.0.1:5432"))).toMatch(/something went wrong/i);
+    expect(toUserMessage("postgres exploded")).toMatch(/something went wrong/i);
+    expect(toUserMessage(undefined)).toMatch(/something went wrong/i);
+  });
+});
+
+describe("sanitizeServerMessage (display boundary, FR-080)", () => {
+  it("passes short clean messages", () => {
+    expect(sanitizeServerMessage("Task title is required")).toBe("Task title is required");
+  });
+
+  it("rejects messages over 300 chars", () => {
+    expect(sanitizeServerMessage("a".repeat(301))).toBeNull();
+  });
+
+  it("rejects path, db, and stack markers regardless of case", () => {
+    for (const bad of [
+      "ENOENT: no such file /home/matrix/x",
+      "error at /Users/hamed/dev",
+      "/opt/matrix/app failed",
+      "ECONNREFUSED",
+      "Postgres connection lost",
+      "syntax error in SQL statement",
+      "Error\n    at stack frame",
+      "Traceback (most recent call last)",
+    ]) {
+      expect(sanitizeServerMessage(bad)).toBeNull();
+    }
+  });
+
+  it("rejects non-strings", () => {
+    expect(sanitizeServerMessage(42)).toBeNull();
+    expect(sanitizeServerMessage({ message: "x" })).toBeNull();
+  });
+});

--- a/tests/desktop/header-injection.test.ts
+++ b/tests/desktop/header-injection.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { shouldInjectAuth } from "@desktop/main/auth/header-injection";
+
+const GATEWAY = "https://app.matrix-os.com";
+
+describe("shouldInjectAuth", () => {
+  it("injects for exact-origin https requests", () => {
+    expect(shouldInjectAuth("https://app.matrix-os.com/api/workspace/projects", GATEWAY)).toBe(true);
+    expect(shouldInjectAuth("https://app.matrix-os.com/ws?x=1", GATEWAY)).toBe(true);
+  });
+
+  it("injects for websocket upgrades to the same host", () => {
+    expect(shouldInjectAuth("wss://app.matrix-os.com/ws/terminal/session?session=x", GATEWAY)).toBe(true);
+  });
+
+  it("never injects for other origins", () => {
+    expect(shouldInjectAuth("https://evil.example.com/api", GATEWAY)).toBe(false);
+    expect(shouldInjectAuth("https://matrix-os.com/", GATEWAY)).toBe(false);
+    expect(shouldInjectAuth("https://app.matrix-os.com.attacker.tld/api", GATEWAY)).toBe(false);
+    expect(shouldInjectAuth("https://sub.app.matrix-os.com/api", GATEWAY)).toBe(false);
+  });
+
+  it("never downgrades to plain http for a https gateway", () => {
+    expect(shouldInjectAuth("http://app.matrix-os.com/api", GATEWAY)).toBe(false);
+    expect(shouldInjectAuth("ws://app.matrix-os.com/ws", GATEWAY)).toBe(false);
+  });
+
+  it("supports http+ws for localhost dev gateways", () => {
+    const dev = "http://localhost:18789";
+    expect(shouldInjectAuth("http://localhost:18789/api/apps", dev)).toBe(true);
+    expect(shouldInjectAuth("ws://localhost:18789/ws", dev)).toBe(true);
+    expect(shouldInjectAuth("http://localhost:9999/api", dev)).toBe(false);
+  });
+
+  it("handles ports strictly", () => {
+    expect(shouldInjectAuth("https://app.matrix-os.com:8443/api", GATEWAY)).toBe(false);
+  });
+
+  it("rejects garbage urls and null origins", () => {
+    expect(shouldInjectAuth("not a url", GATEWAY)).toBe(false);
+    expect(shouldInjectAuth("https://app.matrix-os.com/api", null)).toBe(false);
+  });
+});

--- a/tests/desktop/ipc-contract.test.ts
+++ b/tests/desktop/ipc-contract.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  INVOKE_CHANNELS,
+  EVENT_CHANNELS,
+  type InvokeChannel,
+} from "@desktop/shared/ipc-contract";
+
+describe("IPC contract", () => {
+  it("defines every invoke channel from the contract doc", () => {
+    const expected: InvokeChannel[] = [
+      "auth:start-device-flow",
+      "auth:poll",
+      "auth:status",
+      "auth:sign-out",
+      "runtime:select",
+      "state:get",
+      "state:set",
+      "embed:open",
+      "embed:set-bounds",
+      "embed:close",
+      "embed:retry-auth",
+      "notify",
+      "badge:set",
+      "shell:open-external",
+      "update:check",
+    ];
+    for (const ch of expected) {
+      expect(INVOKE_CHANNELS[ch], ch).toBeDefined();
+    }
+  });
+
+  it("validates auth:poll responses and rejects token leakage shapes", () => {
+    const schema = INVOKE_CHANNELS["auth:poll"].response;
+    expect(schema.safeParse({ status: "authorized", profile: { handle: "neo", userId: "u1" } }).success).toBe(true);
+    expect(schema.safeParse({ status: "pending" }).success).toBe(true);
+    // Strict schemas refuse extra fields so a credential can never ride along.
+    expect(
+      schema.safeParse({ status: "authorized", profile: { handle: "n", userId: "u" }, accessToken: "tok" }).success,
+    ).toBe(false);
+  });
+
+  it("bounds runtime:select slot", () => {
+    const schema = INVOKE_CHANNELS["runtime:select"].request;
+    expect(schema.safeParse({ slot: "primary" }).success).toBe(true);
+    expect(schema.safeParse({ slot: "" }).success).toBe(false);
+    expect(schema.safeParse({ slot: "x".repeat(65) }).success).toBe(false);
+    expect(schema.safeParse({}).success).toBe(false);
+  });
+
+  it("bounds notify payloads", () => {
+    const schema = INVOKE_CHANNELS.notify.request;
+    expect(
+      schema.safeParse({ threadId: "t1", title: "Done", body: "ok", kind: "done" }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({ threadId: "t1", title: "x".repeat(81), body: "ok", kind: "done" }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({ threadId: "t1", title: "t", body: "y".repeat(201), kind: "done" }).success,
+    ).toBe(false);
+    expect(schema.safeParse({ threadId: "t1", title: "t", body: "b", kind: "weird" }).success).toBe(false);
+  });
+
+  it("bounds embed bounds rects", () => {
+    const schema = INVOKE_CHANNELS["embed:set-bounds"].request;
+    expect(
+      schema.safeParse({ embedId: "e1", bounds: { x: 0, y: 38, width: 800, height: 600 } }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({ embedId: "e1", bounds: { x: 0, y: 0, width: 99999, height: 1 } }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({ embedId: "e1", bounds: { x: 0.5, y: 0, width: 10, height: 10 } }).success,
+    ).toBe(false);
+  });
+
+  it("caps state:set values at 64KB and only allows known keys", () => {
+    const schema = INVOKE_CHANNELS["state:set"].request;
+    expect(schema.safeParse({ key: "appearance", value: { theme: "dark" } }).success).toBe(true);
+    expect(schema.safeParse({ key: "nope", value: 1 }).success).toBe(false);
+    const big = { blob: "x".repeat(70_000) };
+    expect(schema.safeParse({ key: "panelLayouts", value: big }).success).toBe(false);
+  });
+
+  it("only allows https urls on shell:open-external", () => {
+    const schema = INVOKE_CHANNELS["shell:open-external"].request;
+    expect(schema.safeParse({ url: "https://matrix-os.com" }).success).toBe(true);
+    expect(schema.safeParse({ url: "http://matrix-os.com" }).success).toBe(false);
+    expect(schema.safeParse({ url: "file:///etc/passwd" }).success).toBe(false);
+    expect(schema.safeParse({ url: "javascript:alert(1)" }).success).toBe(false);
+  });
+
+  it("defines event channels with schemas", () => {
+    for (const ch of [
+      "auth:changed",
+      "runtime:changed",
+      "embed:state",
+      "notification:clicked",
+      "update:available",
+      "update:ready",
+      "window:focus-changed",
+    ] as const) {
+      expect(EVENT_CHANNELS[ch], ch).toBeDefined();
+    }
+    expect(
+      EVENT_CHANNELS["embed:state"].safeParse({ embedId: "e", state: "auth-required" }).success,
+    ).toBe(true);
+    expect(EVENT_CHANNELS["embed:state"].safeParse({ embedId: "e", state: "??" }).success).toBe(false);
+  });
+});

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerIpcHandlers, type HandlerContext } from "../../desktop/src/main/ipc/handlers";
+
+type IpcListener = (event: unknown, payload: unknown) => Promise<unknown> | unknown;
+
+function makeHarness(overrides: Partial<HandlerContext> = {}) {
+  const listeners = new Map<string, IpcListener>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, listener: IpcListener) => {
+      listeners.set(channel, listener);
+    }),
+  };
+  const ctx = {
+    auth: {
+      startDeviceFlow: vi.fn(),
+      poll: vi.fn(),
+      getStatus: vi.fn(),
+      signOut: vi.fn(),
+      expireSession: vi.fn(),
+      selectRuntime: vi.fn(),
+    },
+    store: {
+      get: vi.fn(),
+      setUnknown: vi.fn(),
+      setPanelLayout: vi.fn(),
+    },
+    embeds: {
+      open: vi.fn(),
+      setBounds: vi.fn(),
+      setActive: vi.fn(),
+      close: vi.fn(),
+      retryAuth: vi.fn(),
+    },
+    openExternal: vi.fn(),
+    setBadgeCount: vi.fn(),
+    notify: vi.fn(),
+    onRuntimeChanged: vi.fn(),
+    ...overrides,
+  } as unknown as HandlerContext;
+
+  registerIpcHandlers(ipcMain, ctx);
+
+  return {
+    ctx,
+    invoke(channel: string, payload: unknown = {}) {
+      const listener = listeners.get(channel);
+      if (!listener) throw new Error(`missing listener: ${channel}`);
+      return listener({}, payload);
+    },
+  };
+}
+
+describe("registerIpcHandlers", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("returns a generic error when handler implementations throw raw errors", async () => {
+    const harness = makeHarness();
+    vi.mocked(harness.ctx.auth.signOut).mockRejectedValue(
+      new Error("EACCES: permission denied, unlink '/home/user/.matrix/credential.json'"),
+    );
+
+    await expect(harness.invoke("auth:sign-out")).rejects.toThrow("internal error");
+    await expect(harness.invoke("auth:sign-out")).rejects.not.toThrow("/home/user");
+    expect(console.warn).toHaveBeenCalledWith(
+      "[ipc] handler for auth:sign-out failed:",
+      "EACCES: permission denied, unlink '/home/user/.matrix/credential.json'",
+    );
+  });
+
+  it("keeps malformed requests generic", async () => {
+    const harness = makeHarness();
+
+    await expect(harness.invoke("shell:open-external", { url: "file:///tmp/secret" })).rejects.toThrow(
+      "invalid request",
+    );
+  });
+});

--- a/tests/desktop/ipc-handlers.test.ts
+++ b/tests/desktop/ipc-handlers.test.ts
@@ -76,4 +76,16 @@ describe("registerIpcHandlers", () => {
       "invalid request",
     );
   });
+
+  it("returns the public embed unavailable error for the phase stub", async () => {
+    const harness = makeHarness();
+
+    await expect(
+      harness.invoke("embed:open", {
+        kind: "app",
+        slug: "workspace",
+        bounds: { x: 0, y: 0, width: 640, height: 480 },
+      }),
+    ).rejects.toThrow("embed unavailable");
+  });
 });

--- a/tests/desktop/local-store.test.ts
+++ b/tests/desktop/local-store.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createLocalStore, PANEL_LAYOUT_MAX_AGE_MS } from "@desktop/main/persistence/local-store";
+
+async function makeDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "operator-store-"));
+}
+
+describe("local store", () => {
+  it("round-trips typed keys", async () => {
+    const dir = await makeDir();
+    const store = createLocalStore({ dir });
+    await store.set("appearance", { theme: "dark" });
+    await store.set("lastProjectSlug", "matrix-os");
+    expect(await store.get("appearance")).toEqual({ theme: "dark" });
+    expect(await store.get("lastProjectSlug")).toBe("matrix-os");
+  });
+
+  it("returns null for unset keys", async () => {
+    const store = createLocalStore({ dir: await makeDir() });
+    expect(await store.get("lastProjectSlug")).toBeNull();
+  });
+
+  it("writes atomically (no partial files left behind)", async () => {
+    const dir = await makeDir();
+    const store = createLocalStore({ dir });
+    await store.set("windowBounds", { x: 1, y: 2, width: 800, height: 600 });
+    const files = await readdir(dir);
+    expect(files.some((f) => f.includes(".tmp"))).toBe(false);
+    const raw = JSON.parse(await readFile(join(dir, "state.json"), "utf8"));
+    expect(raw.windowBounds.width).toBe(800);
+  });
+
+  it("recovers from a corrupt state file", async () => {
+    const dir = await makeDir();
+    await writeFile(join(dir, "state.json"), "{not json", "utf8");
+    const store = createLocalStore({ dir });
+    expect(await store.get("appearance")).toBeNull();
+    await store.set("appearance", { theme: "light" });
+    expect(await store.get("appearance")).toEqual({ theme: "light" });
+  });
+
+  it("rejects invalid values for known keys", async () => {
+    const store = createLocalStore({ dir: await makeDir() });
+    await expect(store.set("appearance", { theme: "neon" } as never)).rejects.toThrow();
+    await expect(store.set("windowBounds", { x: "a" } as never)).rejects.toThrow();
+  });
+
+  it("prunes panel layouts not touched within the max age", async () => {
+    const dir = await makeDir();
+    const now = 1_750_000_000_000;
+    const store = createLocalStore({ dir, clock: () => now });
+    await store.setPanelLayout("proj/task-fresh", {
+      order: ["terminal"],
+      visible: { terminal: true },
+      sizes: { terminal: 100 },
+      touchedAt: now - 1000,
+    });
+    await store.setPanelLayout("proj/task-stale", {
+      order: ["terminal"],
+      visible: { terminal: true },
+      sizes: { terminal: 100 },
+      touchedAt: now - PANEL_LAYOUT_MAX_AGE_MS - 1,
+    });
+    const layouts = await store.get("panelLayouts");
+    expect(layouts).not.toBeNull();
+    expect(Object.keys(layouts!)).toEqual(["proj/task-fresh"]);
+  });
+});

--- a/tests/desktop/local-store.test.ts
+++ b/tests/desktop/local-store.test.ts
@@ -48,6 +48,13 @@ describe("local store", () => {
     await expect(store.set("windowBounds", { x: "a" } as never)).rejects.toThrow();
   });
 
+  it("validates unknown IPC state values before writing", async () => {
+    const store = createLocalStore({ dir: await makeDir() });
+    await store.setUnknown("appearance", { theme: "system" });
+    await expect(store.setUnknown("appearance", { theme: "neon" })).rejects.toThrow();
+    expect(await store.get("appearance")).toEqual({ theme: "system" });
+  });
+
   it("prunes panel layouts not touched within the max age", async () => {
     const dir = await makeDir();
     const now = 1_750_000_000_000;


### PR DESCRIPTION
## Summary
- Adds trusted desktop main-process auth, device flow, credential persistence, IPC contracts, and baseline tests.
- Part of the 094 Operator desktop stack split from original PR #507.
- Draft until the full stack validation and screenshots are refreshed.

## Validation
- Rebased onto current main after #506 merged.
- Rebuilt stack final tree matches the original #507 tree exactly.
- Per-layer CI/Greptile still needs to settle before review-ready.

## Invariants
- Source of truth: desktop app source under desktop/, specs/docs, and root workspace metadata in this stack; no owner runtime data is modified.
- Lock/transaction scope: no Postgres transaction scope is introduced in this layer; desktop local state remains scoped to the Electron app and existing gateway/platform APIs.
- Acceptable orphan states: stack PRs are draft and must land in order; partial stack landing is not a supported release state.
- Auth source of truth: Clerk/device auth and existing gateway token handling remain authoritative; this stack does not add a second auth authority.
- Deferred scope: packaged distribution, production desktop rollout, and customer VPS host-bundle deploy are outside this stack.